### PR TITLE
feat(dashboard): add live admin data hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes
 | [Contributing](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing)             | Development setup, PR process, code style                  |
 | [CLI Reference](https://hermes-agent.nousresearch.com/docs/reference/cli-commands)                  | All commands and flags                                     |
 | [Environment Variables](https://hermes-agent.nousresearch.com/docs/reference/environment-variables) | Complete env var reference                                 |
+| [Dashboard API Reference](docs/dashboard-apis.md)                                                   | Endpoints, hooks, and request/response shapes for the dashboard (agent profiles, Kanban, memory) |
 
 ---
 

--- a/docs/dashboard-api-integration.md
+++ b/docs/dashboard-api-integration.md
@@ -1,0 +1,567 @@
+# Dashboard API Integration
+
+Developer reference for the three backend services consumed by the Hermes web
+dashboard. Covers the base URL env var, endpoints, request/response shapes,
+hook usage, and error handling.
+
+All three services live on the **same Hermes dashboard server** and are reached
+via a shared `fetchJSON<T>()` helper (`web/src/lib/api.ts`) that handles auth
+and base-path injection automatically.
+
+---
+
+## Quick start: point the dashboard at a local backend
+
+```bash
+cd web
+
+# Default: connects to http://127.0.0.1:9119 (same host as hermes dashboard)
+npm run dev
+
+# Remote host:
+HERMES_DASHBOARD_URL=http://remote-host:9119 npm run dev
+```
+
+The Vite dev plugin (`hermesDevToken` in `web/vite.config.ts`) scrapes the
+session token from the running backend's `index.html` automatically — no
+manual token management needed in dev.
+
+In production (`hermes dashboard`) the Python server injects
+`window.__HERMES_SESSION_TOKEN__` and `window.__HERMES_BASE_PATH__` into
+`index.html`; no extra configuration is required.
+
+### Env vars
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `HERMES_DASHBOARD_URL` | `http://127.0.0.1:9119` | Backend origin for the Vite dev proxy. Set in shell or `web/.env.local`. Not used in the built bundle (same-origin). |
+
+---
+
+## Authentication
+
+All `/api/` requests must carry a short-lived session token issued by the
+Python server. The `fetchJSON<T>()` helper handles this transparently:
+
+```
+X-Hermes-Session-Token: <token>
+```
+
+- In loopback mode the token is injected via `window.__HERMES_SESSION_TOKEN__`.
+- In gated mode (OAuth, `hermes dashboard --auth`) cookies are used; the
+  helper adds `credentials: "include"` on every call.
+- A 401 in loopback mode triggers a one-shot page reload to pick up a
+  fresh token (server restart rotates the token). A 401 in gated mode
+  redirects to `/login` via the `login_url` field in the error body.
+
+### Error format
+
+Any non-2xx response throws:
+
+```ts
+new Error(`${status}: ${body}`)
+```
+
+All three hooks surface this message as the `error: string | null` field in
+their state. Consumers can render it directly or inspect it to distinguish
+network errors from API validation failures.
+
+---
+
+## 1. Agent Profiles service
+
+Manages Hermes profiles (named configuration directories under `~/.hermes/`).
+
+### API client module
+
+`web/src/lib/api.ts` — `api.getProfiles()` and the other `api.*Profile*`
+methods. Import `fetchJSON` from the same file for one-off calls.
+
+### Endpoints
+
+#### List profiles
+
+```
+GET /api/profiles
+```
+
+No request body or query parameters.
+
+Response — `{ profiles: ProfileInfo[] }`:
+
+```ts
+export interface ProfileInfo {
+  name: string;        // profile directory name, e.g. "default"
+  path: string;        // absolute path to the profile directory
+  is_default: boolean;
+  model: string | null;      // currently configured model slug
+  provider: string | null;   // currently configured provider
+  has_env: boolean;          // true when a .env file exists for this profile
+  skill_count: number;
+}
+```
+
+#### Create profile
+
+```
+POST /api/profiles
+Content-Type: application/json
+
+{ "name": "my-profile", "clone_from_default": true }
+```
+
+Response — `{ ok: boolean; name: string; path: string }`.
+
+#### Rename profile
+
+```
+PATCH /api/profiles/{name}
+Content-Type: application/json
+
+{ "new_name": "better-name" }
+```
+
+Response — `{ ok: boolean; name: string; path: string }`.
+
+#### Delete profile
+
+```
+DELETE /api/profiles/{name}
+```
+
+Response — `{ ok: boolean }`.
+
+#### Get setup command
+
+```
+GET /api/profiles/{name}/setup-command
+```
+
+Response — `{ command: string }`.
+
+#### Read profile soul (system prompt)
+
+```
+GET /api/profiles/{name}/soul
+```
+
+Response — `{ content: string; exists: boolean }`.
+
+#### Update profile soul
+
+```
+PUT /api/profiles/{name}/soul
+Content-Type: application/json
+
+{ "content": "You are a helpful assistant." }
+```
+
+Response — `{ ok: boolean }`.
+
+### Hook: `useAgentProfiles`
+
+File: `web/src/hooks/useAgentProfiles.ts`
+
+```ts
+import { useAgentProfiles } from "@/hooks/useAgentProfiles";
+
+function MyComponent() {
+  const { profiles, loading, error, refreshProfiles } = useAgentProfiles();
+
+  if (loading) return <Spinner />;
+  if (error)   return <ErrorBanner message={error} />;
+
+  return (
+    <ul>
+      {profiles.map(p => <li key={p.name}>{p.name}</li>)}
+    </ul>
+  );
+}
+```
+
+State shape — `AgentProfilesState`:
+
+```ts
+type AgentProfilesState = {
+  profiles: ProfileInfo[];
+  loading: boolean;
+  error: string | null;
+  // Call with keepExisting: true for background refresh without list flicker.
+  refreshProfiles: (options?: { keepExisting?: boolean }) => Promise<void>;
+};
+```
+
+Adapter interface — `AgentProfilesClient`:
+
+```ts
+type AgentProfilesClient = {
+  listProfiles: () => Promise<{ profiles: ProfileInfo[] }>;
+};
+
+// Live REST (default):
+useAgentProfiles()
+
+// Injected mock for tests or alternate transports:
+const mockClient = { listProfiles: async () => ({ profiles: [] }) };
+useAgentProfiles(mockClient)
+```
+
+Loading/error contract:
+
+- `loading: true` from mount until the first response arrives.
+- Success: `loading` false, `profiles` populated, `error` null.
+- Failure: `loading` false, `error` holds the message, `profiles` reset to
+  `[]` (unless `keepExisting: true` was passed).
+- Stale-request guard: a newer in-flight request causes the stale response to
+  be silently discarded — no interleaved state writes.
+
+---
+
+## 2. Kanban board state service
+
+Reads the active Kanban board from the Kanban plugin API.
+
+### Base URL
+
+`/api/plugins/kanban/board` — served by the Kanban plugin on the same Hermes
+server. No separate env var.
+
+### API client module
+
+`web/src/hooks/useKanbanState.ts` — the hook calls `fetchJSON<RawBoardResponse>`
+directly (not via `api.*`). Import `fetchJSON` from `web/src/lib/api.ts` for
+imperative calls.
+
+### Endpoint
+
+#### Get board state
+
+```
+GET /api/plugins/kanban/board
+```
+
+Optional query parameters:
+
+| Param | Type | Description |
+|---|---|---|
+| `board` | string | Board slug. Omit to use the server's active board. |
+
+Raw response — `RawBoardResponse` (internal to the hook):
+
+```ts
+type RawBoardResponse = {
+  columns: Array<{ name: string; tasks: KanbanTask[] }>;
+  tenants: string[];
+  assignees: string[];
+  latest_event_id: number;
+  now: number;
+};
+```
+
+The hook normalises `name` to `status` before exposing the data:
+
+```ts
+export type KanbanTask = {
+  id: string;
+  title: string | null;
+  status: string;
+  assignee: string | null;
+  priority: number;
+};
+
+export type KanbanColumn = {
+  status: string;  // e.g. "running", "blocked", "done" — mapped from raw `name`
+  tasks: KanbanTask[];
+};
+
+export type KanbanStateSnapshot = {
+  columns: KanbanColumn[];
+  tenants: string[];
+  assignees: string[];
+  latest_event_id: number;  // monotonically increasing; useful for change detection
+  now: number;              // server-side Unix timestamp (seconds)
+};
+```
+
+### Hook: `useKanbanState`
+
+File: `web/src/hooks/useKanbanState.ts`
+
+```ts
+import { useKanbanState } from "@/hooks/useKanbanState";
+
+function SidebarWidget() {
+  const { data, loading, error, refresh } = useKanbanState({
+    pollingIntervalMs: 30_000,
+  });
+
+  const running =
+    data?.columns.find(c => c.status === "running")?.tasks.length ?? 0;
+
+  if (loading && !data) return <Skeleton />;
+
+  return (
+    <div>
+      <p>{running} tasks running</p>
+      <button onClick={refresh}>Refresh</button>
+    </div>
+  );
+}
+```
+
+Options — `KanbanStateOptions`:
+
+```ts
+type KanbanStateOptions = {
+  /** Poll the board every N milliseconds. 0 or omitted = no automatic polling. */
+  pollingIntervalMs?: number;
+  /** Board slug. Omit to use the server's active board. */
+  board?: string;
+};
+```
+
+State shape — `KanbanStateResult`:
+
+```ts
+type KanbanStateResult = {
+  data: KanbanStateSnapshot | null;
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+};
+```
+
+Loading/error contract:
+
+- `loading: true` from mount until the first response.
+- Success: `loading` false, `data` populated, `error` null.
+- Failure: `loading` false, `error` holds the message. `data` is NOT reset on
+  failure — the last successful snapshot is preserved so the UI doesn't blank
+  on a transient network glitch. This makes the hook safe for sidebars that
+  should degrade gracefully rather than show a hard error.
+- Stale-request guard: uses a monotonic `requestId` ref; interleaved responses
+  from concurrent `refresh()` calls are discarded.
+- Polling: a `setInterval` runs `refresh()` every `pollingIntervalMs` ms. The
+  interval is cleared on unmount. Polling is skipped when `pollingIntervalMs`
+  is 0 or omitted.
+
+---
+
+## 3. Memory service
+
+Surfaces the agent's persistent memory stores and allows provider management.
+
+### Base URL
+
+`/api/memory` — served directly by the Hermes FastAPI server. No separate env var.
+
+### API client module
+
+`web/src/lib/api.ts` — `api.getMemory()`, `api.getMemoryContent()`,
+`api.updateMemory()`, `api.setMemoryProvider()`, `api.resetMemory()`.
+
+### Endpoints
+
+#### Get memory status
+
+```
+GET /api/memory
+```
+
+No request body or query parameters.
+
+Response — `MemoryStatus`:
+
+```ts
+export interface MemoryStatus {
+  active: string;   // name of the currently active memory provider, e.g. "builtin" or ""
+  providers: MemoryProviderInfo[];
+  builtin_files: {
+    memory: number;  // byte size of MEMORY.md (0 if not present)
+    user: number;    // byte size of USER.md   (0 if not present)
+  };
+}
+
+export interface MemoryProviderInfo {
+  name: string;         // e.g. "honcho", "mem0", "supermemory"
+  description: string;
+  configured: boolean;  // true when the provider's credentials are set
+}
+```
+
+#### Set memory provider
+
+```
+PUT /api/memory/provider
+Content-Type: application/json
+
+{ "provider": "honcho" }
+```
+
+Pass `"builtin"`, `"none"`, or `""` to revert to the built-in file store.
+
+Response — `{ ok: boolean; active: string }`.
+
+Error: 400 if the named provider is not installed.
+
+#### Reset memory
+
+```
+POST /api/memory/reset
+Content-Type: application/json
+
+{ "target": "all" }
+```
+
+`target` must be one of `"all"`, `"memory"` (MEMORY.md only), or `"user"`
+(USER.md only). Deletes the specified built-in memory file(s).
+
+Response — `{ ok: boolean; deleted: string[] }`.
+
+Error: 400 on invalid `target`.
+
+#### Read memory content
+
+```
+GET /api/memory/content?target=memory
+```
+
+`target` must be `"memory"` (MEMORY.md) or `"user"` (USER.md). Missing files
+return an empty store rather than 404.
+
+Response — `MemorySnapshot`:
+
+```ts
+{
+  content: string;
+  entries: Array<{ text: string }>;
+  char_count: number;
+  char_limit: number;
+  target: "memory" | "user";
+}
+```
+
+#### Write memory content
+
+```
+PUT /api/memory/content
+Content-Type: application/json
+
+{ "target": "memory", "content": "raw markdown" }
+```
+
+Response — `{ ok: boolean; char_count: number; char_limit: number }`.
+
+Error: 400 on invalid `target`.
+
+### Hook: `useMemory` / `useMemoryData`
+
+File: `web/src/hooks/useMemory.ts` re-exports `useMemoryData` from
+`web/src/hooks/useMemoryData.ts` under the hook-trio name.
+
+```ts
+import { useMemory } from "@/hooks/useMemory";
+
+function MemoryWidget() {
+  const { data, loading, error, refetch, save } = useMemory("memory");
+
+  if (loading) return <Skeleton />;
+  if (error)   return <ErrorBanner message={error} />;
+  if (!data)   return null;
+
+  return (
+    <div>
+      <p>{data.char_count} / {data.char_limit} chars used</p>
+      <textarea defaultValue={data.content} />
+      <button onClick={() => refetch({ keepExisting: true })}>Reload</button>
+    </div>
+  );
+}
+```
+
+The hook accepts a `target` argument (`"memory"` or `"user"`) and an optional
+`MemoryDataClient` adapter for test injection.
+
+Adapter interface — `MemoryDataClient` (alias: `MemoryClient`):
+
+```ts
+type MemoryDataClient = {
+  fetchMemoryState: (target: MemoryTarget) => Promise<MemorySnapshot>;
+  updateMemoryState: (target: MemoryTarget, content: string) => Promise<{
+    success: boolean;
+    char_count: number;
+    char_limit: number;
+  }>;
+};
+```
+
+The default adapter is wired to `api.getMemoryContent()`
+(`GET /api/memory/content`) and `api.updateMemory()`
+(`PUT /api/memory/content`). Pass a custom implementation to swap transport or
+mock in tests.
+
+`MemoryTarget`:
+
+```ts
+type MemoryTarget = "memory" | "user";
+```
+
+`MemorySnapshot` (as the hook expects from the adapter):
+
+```ts
+type MemorySnapshot = {
+  content: string;   // raw memory file contents
+  entries: Array<{ text: string }>;  // parsed entry list
+  char_count: number;
+  char_limit: number;
+  target: MemoryTarget;
+};
+```
+
+State shape — `MemoryDataState` (alias: `MemoryState`):
+
+```ts
+type MemoryDataState = {
+  data: MemorySnapshot | null;
+  loading: boolean;
+  error: string | null;
+  // Pull fresh data. keepExisting: true avoids clearing the stale snapshot
+  // while the request is in-flight (no flicker for background refreshes).
+  refetch: (options?: { keepExisting?: boolean }) => Promise<void>;
+  // Persist new content, then auto-refetch to stay in sync.
+  save: (content: string) => Promise<void>;
+};
+```
+
+Loading/error contract:
+
+- `loading: true` from mount until the first response.
+- Success: `loading` false, `data` populated, `error` null.
+- Failure: `loading` false, `error` holds the message, `data` null (unless
+  `keepExisting: true` was passed to `refetch`).
+- `save(content)` sets `loading: true`, calls `updateMemoryState`, then calls
+  `refetch({ keepExisting: true })` to sync state. On error it sets `error` and
+  drops `loading`.
+- Stale-request guard: a monotonic `requestId` ref discards interleaved responses.
+- Re-fetches automatically whenever `target` changes.
+
+---
+
+## Cross-reference
+
+| Service | Hook file | Default API calls | Endpoint |
+|---|---|---|---|
+| Agent profiles | `web/src/hooks/useAgentProfiles.ts` | `api.getProfiles()` — `web/src/lib/api.ts` | `GET /api/profiles` |
+| Kanban board | `web/src/hooks/useKanbanState.ts` | `fetchJSON` directly | `GET /api/plugins/kanban/board` |
+| Memory | `web/src/hooks/useMemory.ts` (re-exports `useMemoryData`) | `api.getMemoryContent()`, `api.updateMemory()` — `web/src/lib/api.ts` | `GET/PUT /api/memory/content` |
+
+TypeScript interfaces for service API responses live in `web/src/lib/api.ts`:
+`ProfileInfo`, `MemoryStatus`, `MemoryProviderInfo`.
+
+Kanban-specific types (`KanbanTask`, `KanbanColumn`, `KanbanStateSnapshot`)
+are defined in `web/src/hooks/useKanbanState.ts`.
+
+Memory hook-layer types (`MemorySnapshot`, `MemoryEntry`, `MemoryTarget`,
+`MemoryDataClient`, `MemoryDataState`) are defined in
+`web/src/hooks/useMemoryData.ts` and re-exported from
+`web/src/hooks/useMemory.ts`.

--- a/docs/dashboard-apis.md
+++ b/docs/dashboard-apis.md
@@ -1,0 +1,521 @@
+# Dashboard API Integrations
+
+Developer reference for the three backend services consumed by the Hermes web
+dashboard. Covers base URL configuration, endpoints, request/response shapes,
+and how to use the corresponding React hooks.
+
+---
+
+## Quick setup
+
+All three services are hosted on the **same Hermes dashboard server** — no
+separate origins to configure. The only env var you need is:
+
+```
+HERMES_DASHBOARD_URL=http://127.0.0.1:9119   # default; change for remote host
+```
+
+Set it in your shell or in `web/.env.local` before running the Vite dev server.
+
+```bash
+cd web
+HERMES_DASHBOARD_URL=http://your-remote-host:9119 npm run dev
+```
+
+In production (when `hermes dashboard` serves the built bundle directly), the
+Python server injects `window.__HERMES_SESSION_TOKEN__` and
+`window.__HERMES_BASE_PATH__` into `index.html` automatically — no further
+configuration needed.
+
+All API calls use the shared `fetchJSON<T>()` helper in `web/src/lib/api.ts`,
+which prepends `window.__HERMES_BASE_PATH__` to every URL and attaches the
+session token header (`X-Hermes-Session-Token`) to all `/api/` requests.
+
+---
+
+## 1. Agent Profiles service
+
+### Base URL
+
+Relative to the dashboard origin. No separate env var — served on the same
+host as the dashboard.
+
+### API client module
+
+`web/src/lib/api.ts` — `api.getProfiles()` and the other `api.profiles*`
+methods. Import `fetchJSON` from the same file if you need a one-off call.
+
+### Endpoints
+
+#### List profiles
+
+```
+GET /api/profiles
+```
+
+Response — `{ profiles: ProfileInfo[] }`:
+
+```ts
+export interface ProfileInfo {
+  name: string;              // profile directory name, e.g. "default"
+  path: string;              // absolute path to profile directory
+  is_default: boolean;
+  gateway_running: boolean;
+  model: string | null;      // currently configured model
+  provider: string | null;
+  has_env: boolean;          // whether a .env file exists for this profile
+  skill_count: number;
+  alias_path?: string | null;
+  distribution_name?: string | null;
+  distribution_version?: string | null;
+  distribution_source?: string | null;
+  description?: string;
+  description_auto?: boolean;
+}
+```
+
+#### Create profile
+
+```
+POST /api/profiles
+Content-Type: application/json
+
+{ "name": "my-profile", "clone_from_default": true }
+```
+
+Response — `{ ok: boolean; name: string; path: string }`.
+
+#### Rename profile
+
+```
+PATCH /api/profiles/{name}
+Content-Type: application/json
+
+{ "new_name": "better-name" }
+```
+
+#### Delete profile
+
+```
+DELETE /api/profiles/{name}
+```
+
+Response — `{ ok: boolean }`.
+
+### Hook: `useAgentProfiles`
+
+File: `web/src/hooks/useAgentProfiles.ts`
+
+```ts
+import { useAgentProfiles } from "@/hooks/useAgentProfiles";
+
+function MyComponent() {
+  const { profiles, loading, error, refreshProfiles } = useAgentProfiles();
+
+  if (loading) return <Spinner />;
+  if (error)   return <ErrorBanner message={error} />;
+
+  return (
+    <ul>
+      {profiles.map(p => <li key={p.name}>{p.name}</li>)}
+    </ul>
+  );
+}
+```
+
+**State shape** (`AgentProfilesState`):
+
+```ts
+type AgentProfilesState = {
+  profiles: ProfileInfo[];
+  loading: boolean;
+  error: string | null;
+  // Call with keepExisting: true for background refresh without list flicker.
+  refreshProfiles: (options?: { keepExisting?: boolean }) => Promise<void>;
+};
+```
+
+**Adapter injection** — the hook accepts an optional `AgentProfilesClient`
+argument, making it easy to swap transport or mock in tests:
+
+```ts
+type AgentProfilesClient = {
+  listProfiles: () => Promise<{ profiles: ProfileInfo[] }>;
+};
+
+// Use default (live REST):
+useAgentProfiles()
+
+// Use a mock in tests:
+const mockClient = { listProfiles: async () => ({ profiles: [] }) };
+useAgentProfiles(mockClient)
+```
+
+**Loading / error contract**:
+
+- `loading: true` from mount until the first response arrives.
+- On success: `loading` drops to `false`, `profiles` is populated, `error`
+  is `null`.
+- On failure: `loading` drops to `false`, `error` holds the message string,
+  `profiles` is reset to `[]` (unless `keepExisting: true` was passed).
+- Stale-request guard: if a newer request is already in-flight the stale
+  response is silently discarded.
+
+---
+
+## 2. Kanban board state service
+
+### Base URL
+
+Relative path: `/api/plugins/kanban/board`. Served by the Kanban dashboard
+plugin on the same Hermes server. No separate env var.
+
+### Endpoint
+
+#### Get board state
+
+```
+GET /api/plugins/kanban/board
+```
+
+Optional query parameters:
+
+| Param | Type | Description |
+|---|---|---|
+| `board` | string | Board slug (default: active board) |
+| `tenant` | string | Filter tasks by tenant namespace |
+| `include_archived` | boolean | Include archived tasks (default: false) |
+
+Response — raw board JSON with `columns[]` each containing a `name` (column
+id string) and `tasks[]`. The hook normalises `name` → `status` for consumers.
+
+Raw server shape:
+
+```ts
+type RawBoardResponse = {
+  columns: Array<{
+    name: string;   // "triage" | "todo" | "ready" | "running" | "blocked" | "done" | ...
+    tasks: KanbanTask[];
+  }>;
+  tenants: string[];
+  assignees: string[];
+  latest_event_id: number;
+  now: number;      // server-side Unix timestamp (seconds)
+};
+```
+
+### Hook: `useKanbanState`
+
+File: `web/src/hooks/useKanbanState.ts`
+
+```ts
+import { useKanbanState } from "@/hooks/useKanbanState";
+
+function KanbanWidget() {
+  const { data, loading, error, refresh } = useKanbanState({
+    board: "ai-dev",
+    pollingIntervalMs: 30_000,
+  });
+
+  if (loading) return <Spinner />;
+  if (error)   return <ErrorBanner message={error} />;
+
+  const running = data?.columns.find(c => c.status === "running")?.tasks.length ?? 0;
+
+  return <div>{running} tasks running</div>;
+}
+```
+
+**State shape** (`KanbanStateResult`):
+
+```ts
+type KanbanStateResult = {
+  data: KanbanStateSnapshot | null;
+  loading: boolean;
+  error: string | null;      // string, not Error instance
+  refresh: () => Promise<void>;
+};
+
+type KanbanStateSnapshot = {
+  columns: KanbanColumn[];
+  tenants: string[];
+  assignees: string[];
+  latest_event_id: number;
+  now: number;
+};
+
+/** Note: the hook normalises raw `name` → `status` on each column. */
+type KanbanColumn = {
+  status: string;   // "triage" | "todo" | "ready" | "running" | "blocked" | "done" | ...
+  tasks: KanbanTask[];
+};
+
+type KanbanTask = {
+  id: string;
+  title: string | null;
+  status: string;
+  assignee: string | null;
+  priority: number;
+};
+```
+
+**Options** (`KanbanStateOptions`):
+
+```ts
+type KanbanStateOptions = {
+  pollingIntervalMs?: number;  // 0 or omitted = no polling
+  board?: string;              // board slug; omit for server's active board
+};
+```
+
+**Loading / error contract**:
+
+- `loading: true` from mount until first response.
+- On success: `loading: false`, `data` populated, `error: null`.
+- On failure: `loading: false`, `error` is a string message, `data: null`.
+  Errors are suppressed silently in the sidebar — callers inspect `error`
+  for optional error badges.
+- Stale-request guard: interleaved responses from overlapping `refresh()`
+  calls are discarded via a per-call request ID.
+- `refresh()` resets `loading` and re-fetches; safe to call on user demand
+  or on a polling interval.
+
+**Polling**:
+
+```ts
+// Poll every 30 seconds automatically:
+const { data } = useKanbanState({ pollingIntervalMs: 30_000 });
+
+// Poll manually:
+const { data, refresh } = useKanbanState();
+setInterval(refresh, 30_000);
+```
+
+---
+
+## 3. Memory service
+
+Surfaces the agent's built-in memory stores (`memory` and `user` targets)
+so the dashboard can display and edit the durable facts the agent writes about
+itself and the user.
+
+### Base URL
+
+Relative paths: `/api/memory` for provider/status and `/api/memory/content`
+for per-target built-in memory read/write. No separate env var.
+
+### Endpoints
+
+#### Get memory status
+
+```
+GET /api/memory
+```
+
+Response — `MemoryStatus`:
+
+```ts
+export interface MemoryStatus {
+  active: string;                  // active provider name, or "" for built-in
+  providers: MemoryProviderInfo[];
+  builtin_files: { memory: number; user: number };  // file sizes in bytes
+}
+
+export interface MemoryProviderInfo {
+  name: string;
+  description: string;
+  configured: boolean;
+}
+```
+
+#### Reset memory
+
+```
+POST /api/memory/reset
+Content-Type: application/json
+
+{ "target": "all" | "memory" | "user" }
+```
+
+Response — `{ ok: boolean; deleted: string[] }`.
+
+#### Set memory provider
+
+```
+PUT /api/memory/provider
+Content-Type: application/json
+
+{ "provider": "honcho" }
+```
+
+Response — `{ ok: boolean; active: string }`.
+
+#### Read memory content
+
+```
+GET /api/memory/content?target=memory
+```
+
+`target` must be `"memory"` (MEMORY.md) or `"user"` (USER.md). Missing files
+return an empty store.
+
+Response — `MemorySnapshot`.
+
+#### Write memory content
+
+```
+PUT /api/memory/content
+Content-Type: application/json
+
+{ "target": "memory", "content": "raw markdown" }
+```
+
+Response — `{ ok: boolean; char_count: number; char_limit: number }`.
+
+### Hook: `useMemory` / `useMemoryData`
+
+File: `web/src/hooks/useMemoryData.ts` (core implementation)
+Re-export: `web/src/hooks/useMemory.ts` (`useMemory` = alias for `useMemoryData`)
+
+`useMemory` is a thin re-export of `useMemoryData` for import-path alignment.
+Both names refer to the same hook.
+
+```ts
+import { useMemory } from "@/hooks/useMemory";
+// or equivalently:
+import { useMemoryData } from "@/hooks/useMemoryData";
+
+function MemoryWidget() {
+  const { data, loading, error, refetch, save } = useMemory("memory");
+
+  if (loading) return <Spinner />;
+  if (error)   return <ErrorBanner message={error} />;
+  if (!data)   return null;
+
+  return (
+    <div>
+      <p>{data.char_count} / {data.char_limit} chars used</p>
+      <ul>
+        {data.entries.map((e, i) => <li key={i}>{e.text}</li>)}
+      </ul>
+    </div>
+  );
+}
+```
+
+**State shape** (`MemoryDataState`):
+
+```ts
+type MemoryDataState = {
+  data: MemorySnapshot | null;
+  loading: boolean;
+  error: string | null;
+  refetch: (options?: { keepExisting?: boolean }) => Promise<void>;
+  save: (content: string) => Promise<void>;
+};
+
+type MemorySnapshot = {
+  content: string;           // raw markdown content
+  entries: MemoryEntry[];    // parsed entries
+  char_count: number;
+  char_limit: number;
+  target: MemoryTarget;
+};
+
+type MemoryEntry = {
+  text: string;
+};
+
+type MemoryTarget = "memory" | "user";
+```
+
+**Adapter injection** — the hook accepts an optional `MemoryDataClient`
+argument for testing or transport swapping:
+
+```ts
+type MemoryDataClient = {
+  fetchMemoryState: (target: MemoryTarget) => Promise<MemorySnapshot>;
+  updateMemoryState: (
+    target: MemoryTarget,
+    content: string,
+  ) => Promise<{ success: boolean; char_count: number; char_limit: number }>;
+};
+
+// Use default (live REST):
+useMemory("memory")
+
+// Use a mock in tests:
+const mockClient = {
+  fetchMemoryState: async () => mockSnapshot,
+  updateMemoryState: async () => ({ success: true, char_count: 0, char_limit: 2200 }),
+};
+useMemoryData("memory", mockClient)
+```
+
+The default live adapter calls `api.getMemoryContent()`
+(`GET /api/memory/content`) and `api.updateMemory()`
+(`PUT /api/memory/content`).
+
+**Loading / error contract**:
+
+- `loading: true` from mount until first response.
+- On success: `loading: false`, `data` populated, `error: null`.
+- On failure: `loading: false`, `error` holds the message string, `data: null`
+  (unless `keepExisting: true` was passed to `refetch`).
+- Auto-refetches when `target` changes.
+- `save(content)` sends the updated string to the backend, then calls
+  `refetch({ keepExisting: true })` so local state stays consistent.
+- Stale-request guard: overlapping `refetch()` calls are deduplicated via
+  request IDs; stale responses are silently discarded.
+
+---
+
+## Authentication
+
+The dashboard uses a short-lived session token injected by the Python server
+into `window.__HERMES_SESSION_TOKEN__`. The `fetchJSON` helper reads this value
+and attaches it to every `/api/` request as:
+
+```
+X-Hermes-Session-Token: <token>
+```
+
+You do not need to handle this manually — `fetchJSON` (and therefore all `api.*`
+methods and the hooks above) does it automatically. Endpoints that require
+elevated auth (e.g. `api.revealEnvVar`) call `getSessionToken()` explicitly and
+pass the header directly.
+
+**Errors**: any non-2xx response throws `new Error("<status>: <body>")`. All
+hooks surface this as the `error` field (string for `useAgentProfiles` and
+`useMemory`; Error instance for `useKanbanState`).
+
+---
+
+## Local vs production
+
+| Mode | Backend origin | How to configure |
+|---|---|---|
+| Local dev (Vite) | `http://127.0.0.1:9119` (default) | Set `HERMES_DASHBOARD_URL` env var or `web/.env.local` |
+| Local dev (remote) | your remote Hermes host | `HERMES_DASHBOARD_URL=http://remote:9119 npm run dev` |
+| Production | same origin as the dashboard | No config needed — `hermes dashboard` handles it |
+
+The Vite dev plugin (`hermesDevToken` in `web/vite.config.ts`) automatically
+scrapes the session token from the running backend's `index.html` so dev-mode
+`/api/` calls are authenticated without manual token management.
+
+---
+
+## Cross-reference
+
+| Service | Hook file | Client methods | Endpoint |
+|---|---|---|---|
+| Agent profiles | `web/src/hooks/useAgentProfiles.ts` | `api.getProfiles()`, `api.createProfile()`, `api.renameProfile()`, `api.deleteProfile()` — `web/src/lib/api.ts` | `GET /api/profiles` |
+| Kanban board state | `web/src/hooks/useKanbanState.ts` | `fetchJSON("/api/plugins/kanban/board")` — called directly inside the hook | `GET /api/plugins/kanban/board` |
+| Memory | `web/src/hooks/useMemoryData.ts` (re-exported as `useMemory` from `useMemory.ts`) | `api.getMemoryContent()`, `api.updateMemory()` — `web/src/lib/api.ts` | `GET/PUT /api/memory/content` |
+
+TypeScript interfaces for all three services:
+
+- `ProfileInfo` — `web/src/lib/api.ts`
+- `KanbanStateSnapshot`, `KanbanTask`, `KanbanColumn` — `web/src/hooks/useKanbanState.ts`
+- `MemorySnapshot`, `MemoryEntry`, `MemoryTarget`, `MemoryDataState` — `web/src/hooks/useMemoryData.ts`
+- `MemoryStatus`, `MemoryProviderInfo` — `web/src/lib/api.ts`

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4565,6 +4565,57 @@ async def reset_memory(body: MemoryReset):
 
 
 # ---------------------------------------------------------------------------
+# Memory content endpoints — read/write MEMORY.md and USER.md files.
+# ---------------------------------------------------------------------------
+
+_MEMORY_FILES: dict[str, str] = {
+    "memory": "MEMORY.md",
+    "user": "USER.md",
+}
+
+_CHAR_LIMIT = 2_200  # roughly matches the in-agent limit shown in the sidebar
+
+
+@app.get("/api/memory/content")
+async def get_memory_content(target: str = "memory"):
+    """Return the raw markdown content of a memory store (memory or user)."""
+    if target not in _MEMORY_FILES:
+        raise HTTPException(status_code=400, detail="target must be 'memory' or 'user'")
+    fname = _MEMORY_FILES[target]
+    path = get_hermes_home() / "memories" / fname
+    content = path.read_text(encoding="utf-8") if path.exists() else ""
+    # Parse entries: split on "§" delimiter used by the memory tool.
+    raw_entries = [e.strip() for e in content.split("§") if e.strip()]
+    entries = [{"text": e} for e in raw_entries]
+    return {
+        "content": content,
+        "entries": entries,
+        "char_count": len(content),
+        "char_limit": _CHAR_LIMIT,
+        "target": target,
+    }
+
+
+class MemoryContentUpdate(BaseModel):
+    content: str
+    target: str = "memory"
+
+
+@app.put("/api/memory/content")
+async def update_memory_content(body: MemoryContentUpdate):
+    """Write new content to a memory store (memory or user)."""
+    target = (body.target or "memory").strip().lower()
+    if target not in _MEMORY_FILES:
+        raise HTTPException(status_code=400, detail="target must be 'memory' or 'user'")
+    fname = _MEMORY_FILES[target]
+    mem_dir = get_hermes_home() / "memories"
+    mem_dir.mkdir(parents=True, exist_ok=True)
+    path = mem_dir / fname
+    path.write_text(body.content, encoding="utf-8")
+    return {"ok": True, "char_count": len(body.content), "char_limit": _CHAR_LIMIT}
+
+
+# ---------------------------------------------------------------------------
 # Operations endpoints — doctor / security audit / backup / import /
 # checkpoints / hooks.
 #

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -480,6 +480,8 @@
     const [config, setConfig] = useState(null);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
+    const [connectionStatus, setConnectionStatus] = useState("loading");
+    const [nextRetryMs, setNextRetryMs] = useState(null);
 
     const [tenantFilter, setTenantFilter] = useState("");
     const [assigneeFilter, setAssigneeFilter] = useState("");
@@ -503,9 +505,44 @@
 
     const cursorRef = useRef(0);
     const reloadTimerRef = useRef(null);
+    const boardRetryTimerRef = useRef(null);
+    const boardRetryDelayRef = useRef(2000);
+    const wsReconnectTimerRef = useRef(null);
     const wsRef = useRef(null);
     const wsBackoffRef = useRef(1000);
     const wsClosedRef = useRef(false);
+
+    function browserIsOffline() {
+      return typeof navigator !== "undefined" && navigator.onLine === false;
+    }
+
+    function clearBoardRetry() {
+      if (boardRetryTimerRef.current) {
+        clearTimeout(boardRetryTimerRef.current);
+        boardRetryTimerRef.current = null;
+      }
+      setNextRetryMs(null);
+    }
+
+    function clearWsReconnect() {
+      if (wsReconnectTimerRef.current) {
+        clearTimeout(wsReconnectTimerRef.current);
+        wsReconnectTimerRef.current = null;
+      }
+    }
+
+    function scheduleBoardRetry() {
+      if (boardRetryTimerRef.current) return;
+      const delay = Math.min(boardRetryDelayRef.current || 2000, 10000);
+      setNextRetryMs(delay);
+      boardRetryTimerRef.current = setTimeout(function () {
+        boardRetryTimerRef.current = null;
+        setNextRetryMs(null);
+        boardRetryDelayRef.current = Math.min(delay * 2, 10000);
+        loadBoard();
+        loadBoardList();
+      }, delay);
+    }
 
     // --- load config once ---------------------------------------------------
     useEffect(function () {
@@ -533,9 +570,14 @@
           setBoardData(data);
           cursorRef.current = data.latest_event_id || 0;
           setError(null);
+          setConnectionStatus("connected");
+          boardRetryDelayRef.current = 2000;
+          clearBoardRetry();
         })
         .catch(function (err) {
           setError(String(err && err.message ? err.message : err));
+          setConnectionStatus(browserIsOffline() ? "offline" : "reconnecting");
+          scheduleBoardRetry();
         })
         .finally(function () { setLoading(false); });
     }, [tenantFilter, includeArchived, board]);
@@ -559,7 +601,11 @@
             writeSelectedBoard("default");
           }
         })
-        .catch(function () { /* non-fatal */ });
+        .catch(function (err) {
+          setConnectionStatus(browserIsOffline() ? "offline" : "reconnecting");
+          setError(String(err && err.message ? err.message : err));
+          scheduleBoardRetry();
+        });
     }, [board]);
 
     useEffect(function () { loadBoardList(); }, [loadBoardList]);
@@ -579,14 +625,38 @@
           clearTimeout(reloadTimerRef.current);
           reloadTimerRef.current = null;
         }
+        clearBoardRetry();
       };
     }, [loadBoard]);
+
+    useEffect(function () {
+      function handleOffline() {
+        setConnectionStatus("offline");
+        setError("Browser is offline — reconnecting automatically when the network returns.");
+        scheduleBoardRetry();
+      }
+      function handleOnline() {
+        setConnectionStatus("reconnecting");
+        boardRetryDelayRef.current = 2000;
+        clearBoardRetry();
+        loadBoard();
+        loadBoardList();
+      }
+      window.addEventListener("offline", handleOffline);
+      window.addEventListener("online", handleOnline);
+      if (browserIsOffline()) handleOffline();
+      return function () {
+        window.removeEventListener("offline", handleOffline);
+        window.removeEventListener("online", handleOnline);
+      };
+    }, [loadBoard, loadBoardList]);
 
     // --- WebSocket ---------------------------------------------------------
     useEffect(function () {
       if (!boardData) return undefined;
       wsClosedRef.current = false;
       function openWs() {
+        clearWsReconnect();
         if (wsClosedRef.current) return;
         const token = window.__HERMES_SESSION_TOKEN__ || "";
         const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
@@ -605,7 +675,10 @@
         let ws;
         try { ws = new WebSocket(url); } catch (_e) { return; }
         wsRef.current = ws;
-        ws.onopen = function () { wsBackoffRef.current = 1000; };
+        ws.onopen = function () {
+          wsBackoffRef.current = 1000;
+          if (!error) setConnectionStatus("connected");
+        };
         ws.onmessage = function (ev) {
           try {
             const msg = JSON.parse(ev.data);
@@ -632,12 +705,15 @@
           }
           const delay = Math.min(wsBackoffRef.current, 30000);
           wsBackoffRef.current = Math.min(wsBackoffRef.current * 2, 30000);
-          setTimeout(openWs, delay);
+          setConnectionStatus(browserIsOffline() ? "offline" : "reconnecting");
+          clearWsReconnect();
+          wsReconnectTimerRef.current = setTimeout(openWs, delay);
         };
       }
       openWs();
       return function () {
         wsClosedRef.current = true;
+        clearWsReconnect();
         try { wsRef.current && wsRef.current.close(); } catch (_e) { /* noop */ }
       };
     }, [!!boardData, board, scheduleReload]);
@@ -964,10 +1040,13 @@
       return h(Card, null,
         h(CardContent, { className: "p-6" },
           h("div", { className: "text-sm text-destructive" },
-            tx(t, "loadFailed", "Failed to load Kanban board: "), error),
+            connectionStatus === "offline" ? "Disconnected: " : "Reconnecting: ", error),
           h("div", { className: "text-xs text-muted-foreground mt-2" },
-            tx(t, "loadFailedHint",
-              "The backend auto-creates kanban.db on first read. If this persists, check the dashboard logs.")),
+            nextRetryMs ? `Retrying automatically in ${Math.ceil(nextRetryMs / 1000)}s.` :
+              tx(t, "loadFailedHint",
+                "The backend auto-creates kanban.db on first read. If this persists, check the dashboard logs.")),
+          h(Button, { className: "mt-4 uppercase", size: "sm", onClick: loadBoard },
+            tx(t, "refresh", "Refresh")),
         ),
       );
     }
@@ -990,6 +1069,14 @@
             return createNewBoard(payload).then(function () { setShowNewBoard(false); });
           },
         }) : null,
+        (error || connectionStatus === "offline" || connectionStatus === "reconnecting") ? h("div", {
+          role: "status",
+          "aria-live": "polite",
+          className: "rounded-md border border-warning/40 bg-warning/10 px-4 py-3 text-xs text-warning",
+        },
+          connectionStatus === "offline" ? "Disconnected" : "Reconnecting",
+          error ? `: ${error}` : "",
+          nextRetryMs ? ` — retrying in ${Math.ceil(nextRetryMs / 1000)}s` : "") : null,
         h(OrchestrationPanel, null),
         h(AttentionStrip, {
           boardData,
@@ -1017,7 +1104,7 @@
          onSelectAllVisible: selectAllVisible,
          onDelete: deleteSelected,
        }) : null,
-        error ? h("div", { className: "text-xs text-destructive px-2" }, error) : null,
+        error ? h("div", { className: "text-xs text-warning px-2" }, error) : null,
         h(BoardColumns, {
           board: filteredBoard,
           laneByProfile,

--- a/plugins/profile-manager/dashboard/dist/index.js
+++ b/plugins/profile-manager/dashboard/dist/index.js
@@ -1,0 +1,83 @@
+(function () {
+  "use strict";
+  const SDK = window.__HERMES_PLUGIN_SDK__;
+  const Registry = window.__HERMES_PLUGINS__;
+  if (!SDK || !Registry) return;
+
+  const { React, fetchJSON } = SDK;
+  const h = React.createElement;
+  const { useEffect, useState } = SDK.hooks;
+  const { Card, CardHeader, CardTitle, CardContent, Badge, Button } = SDK.components;
+
+  function Field(props) {
+    return h("div", { className: "text-sm" },
+      h("div", { className: "text-xs uppercase tracking-wide text-muted-foreground" }, props.label),
+      h("div", { className: "font-mono break-all" }, props.value == null ? "—" : String(props.value))
+    );
+  }
+
+  function StatBlock(props) {
+    const meta = props.meta || {};
+    const status = meta.exists ? "present" : "missing";
+    return h("div", { className: "rounded-md border p-3 space-y-1" },
+      h("div", { className: "flex items-center justify-between gap-2" },
+        h("span", { className: "font-medium" }, props.label),
+        h(Badge, { variant: meta.exists ? "default" : "secondary" }, status)
+      ),
+      h("div", { className: "text-xs text-muted-foreground" }, meta.exists ? `size ${meta.size} · mode ${meta.mode}` : "not found")
+    );
+  }
+
+  function ProfileManagerPage() {
+    const [state, setState] = useState({ loading: true, error: null, data: null });
+    function load() {
+      setState((s) => Object.assign({}, s, { loading: true, error: null }));
+      fetchJSON("/api/plugins/profile-manager/inventory")
+        .then((data) => setState({ loading: false, error: null, data }))
+        .catch((err) => setState({ loading: false, error: String(err && err.message || err), data: null }));
+    }
+    useEffect(load, []);
+    const profiles = (state.data && state.data.profiles) || [];
+    return h("div", { className: "space-y-6" },
+      h("div", { className: "flex items-start justify-between gap-4" },
+        h("div", null,
+          h("h1", { className: "text-2xl font-semibold" }, "Profiles (GSSAI)"),
+          h("p", { className: "text-sm text-muted-foreground" }, "Read-only profile inventory. Secret files are metadata-only; no token values are displayed.")
+        ),
+        h(Button, { onClick: load, disabled: state.loading }, state.loading ? "Refreshing…" : "Refresh")
+      ),
+      state.error && h(Card, { className: "border-destructive" }, h(CardContent, { className: "pt-6 text-sm text-destructive" }, state.error)),
+      state.data && h("div", { className: "flex flex-wrap gap-2" },
+        h(Badge, null, state.data.scope),
+        h(Badge, { variant: "secondary" }, state.data.policy),
+        h(Badge, { variant: "outline" }, `${profiles.length} profiles`)
+      ),
+      h("div", { className: "grid gap-4 md:grid-cols-2 xl:grid-cols-3" }, profiles.map((profile) =>
+        h(Card, { key: profile.name },
+          h(CardHeader, null,
+            h("div", { className: "flex items-start justify-between gap-2" },
+              h("div", null,
+                h(CardTitle, null, profile.name),
+                h("p", { className: "text-xs text-muted-foreground" }, profile.boundary_label)
+              ),
+              h(Badge, { variant: profile.lifecycle === "active" ? "default" : "secondary" }, profile.lifecycle)
+            )
+          ),
+          h(CardContent, { className: "space-y-3" },
+            h(Field, { label: "Path", value: profile.path }),
+            h("div", { className: "grid grid-cols-2 gap-2" },
+              h(StatBlock, { label: ".env", meta: profile.env }),
+              h(StatBlock, { label: "config.yaml", meta: profile.config_yaml }),
+              h(StatBlock, { label: "SOUL.md", meta: profile.soul_md }),
+              h(StatBlock, { label: "state.db", meta: profile.state_db }),
+              h(StatBlock, { label: "gateway.log", meta: profile.gateway_log })
+            )
+          )
+        )
+      )),
+      state.loading && h("p", { className: "text-sm text-muted-foreground" }, "Loading profile inventory…")
+    );
+  }
+
+  Registry.register("profile-manager", ProfileManagerPage);
+})();

--- a/plugins/profile-manager/dashboard/manifest.json
+++ b/plugins/profile-manager/dashboard/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "profile-manager",
+  "label": "Profiles (GSSAI)",
+  "description": "LOCAL GSSAI profile inventory — read-only and secret-free",
+  "icon": "Users",
+  "version": "0.1.0",
+  "tab": {
+    "path": "/profile-manager",
+    "position": "end"
+  },
+  "slots": [],
+  "entry": "dist/index.js",
+  "api": "plugin_api.py"
+}

--- a/plugins/profile-manager/dashboard/plugin_api.py
+++ b/plugins/profile-manager/dashboard/plugin_api.py
@@ -1,0 +1,174 @@
+"""LOCAL GSSAI profile-manager dashboard plugin.
+
+Mounted at /api/plugins/profile-manager/ by the dashboard plugin system.
+
+This first surface is intentionally read-only and secret-free: it reports file
+presence, size, mode, and coarse lifecycle/boundary labels for known local GSSAI
+Hermes profiles. It never returns .env contents, token values, full process
+arguments, or log contents.
+"""
+
+from __future__ import annotations
+
+import os
+import pwd
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+ACTIVE_LOCAL_PROFILES: tuple[str, ...] = (
+    "ivan_bb",
+    "storm",
+    "neo",
+    "gssai_admin",
+    "assettiger",
+)
+
+ARCHIVED_LOCAL_PROFILES: tuple[str, ...] = (
+    "business",
+    "hr",
+    "mailguard",
+    "planner",
+    "research",
+)
+
+PROFILE_BOUNDARIES: dict[str, str] = {
+    "ivan_bb": "LOCAL GSSAI PROJECT — CEO/orchestrator",
+    "storm": "LOCAL GSSAI PROJECT — CCO / communications",
+    "neo": "LOCAL GSSAI PROJECT — CTO / technical escalation",
+    "gssai_admin": "LOCAL GSSAI PROJECT — office/admin coordination",
+    "assettiger": "LOCAL GSSAI PROJECT — AssetTiger/C-Track monitor/report-only",
+}
+
+EXCLUDED_NAME_FRAGMENTS: tuple[str, ...] = (
+    "aria",
+    "lilspa",
+    "lil_pa",
+    "lils-pa",
+    "vps",
+    "openclaw",
+)
+
+SECRET_FILE_NAMES: frozenset[str] = frozenset({".env", "auth.json"})
+
+
+def _real_user_home() -> Path:
+    """Return the OS user's real home, ignoring profile-virtualized HOME."""
+
+    try:
+        return Path(pwd.getpwuid(os.getuid()).pw_dir)
+    except Exception:
+        return Path.home()
+
+
+def _hermes_root() -> Path:
+    override = os.environ.get("PROFILE_MANAGER_HERMES_ROOT")
+    if override:
+        return Path(override).expanduser().resolve()
+    return (_real_user_home() / ".hermes").resolve()
+
+
+def _safe_stat(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"exists": False}
+    stat = path.stat()
+    return {
+        "exists": True,
+        "size": stat.st_size,
+        "mode": oct(stat.st_mode & 0o777),
+        "mtime": stat.st_mtime,
+    }
+
+
+def _profile_lifecycle(profile_path: Path, profiles_root: Path) -> str:
+    try:
+        rel_parts = profile_path.resolve().relative_to(profiles_root.resolve()).parts
+    except ValueError:
+        rel_parts = profile_path.parts
+    if "_archived" in rel_parts or profile_path.name.startswith("_archived"):
+        return "archived"
+    return "active"
+
+
+def _is_excluded_profile(name: str, path: Path) -> bool:
+    candidates = (name.lower(), path.name.lower())
+    return any(fragment in candidate for candidate in candidates for fragment in EXCLUDED_NAME_FRAGMENTS)
+
+
+def _profile_record(name: str, profile_path: Path, profiles_root: Path) -> dict[str, Any]:
+    env_stat = _safe_stat(profile_path / ".env")
+    return {
+        "name": name,
+        "path": str(profile_path),
+        "boundary_label": PROFILE_BOUNDARIES.get(name, "NEEDS HUMAN REVIEW — PROJECT OWNERSHIP UNCLEAR"),
+        "lifecycle": _profile_lifecycle(profile_path, profiles_root),
+        "env": env_stat,
+        "config_yaml": _safe_stat(profile_path / "config.yaml"),
+        "soul_md": _safe_stat(profile_path / "SOUL.md"),
+        "state_db": _safe_stat(profile_path / "state.db"),
+        "gateway_log": _safe_stat(profile_path / "logs" / "gateway.log"),
+    }
+
+
+def _discover_profile_paths(profiles_root: Path) -> list[tuple[str, Path]]:
+    profile_paths: list[tuple[str, Path]] = []
+    for name in ACTIVE_LOCAL_PROFILES:
+        path = profiles_root / name
+        if path.exists() and not _is_excluded_profile(name, path):
+            profile_paths.append((name, path))
+
+    archived_root = profiles_root / "_archived"
+    if archived_root.exists():
+        for path in sorted(archived_root.iterdir()):
+            if not path.is_dir():
+                continue
+            name = path.name
+            if name not in ARCHIVED_LOCAL_PROFILES:
+                continue
+            if _is_excluded_profile(name, path):
+                continue
+            profile_paths.append((name, path))
+
+    return profile_paths
+
+
+@router.get("/inventory")
+async def inventory() -> dict[str, Any]:
+    """Return a read-only, secret-free LOCAL GSSAI profile inventory."""
+
+    hermes_root = _hermes_root()
+    profiles_root = hermes_root / "profiles"
+    records = [
+        _profile_record(name, path, profiles_root)
+        for name, path in _discover_profile_paths(profiles_root)
+    ]
+    return {
+        "scope": "LOCAL GSSAI PROJECT ONLY",
+        "policy": "read-only; secret-free; file metadata only",
+        "hermes_root": str(hermes_root),
+        "profiles_root": str(profiles_root),
+        "profiles": records,
+    }
+
+
+@router.get("/guardrails")
+async def guardrails() -> dict[str, Any]:
+    """Document the safety boundary enforced by this plugin."""
+
+    return {
+        "scope": "LOCAL GSSAI PROJECT ONLY",
+        "read_only": True,
+        "secret_values_returned": False,
+        "excluded_name_fragments": list(EXCLUDED_NAME_FRAGMENTS),
+        "secret_files_metadata_only": sorted(SECRET_FILE_NAMES),
+        "guarded_actions_deferred": [
+            "archive profile",
+            "blank archived .env",
+            "restore profile from backup",
+            "rename profile",
+            "delete/quarantine retired profile",
+        ],
+    }

--- a/plugins/startup-recovery/dashboard/dist/index.js
+++ b/plugins/startup-recovery/dashboard/dist/index.js
@@ -1,0 +1,80 @@
+(function () {
+  "use strict";
+  const SDK = window.__HERMES_PLUGIN_SDK__;
+  const Registry = window.__HERMES_PLUGINS__;
+  if (!SDK || !Registry) return;
+
+  const { React, fetchJSON } = SDK;
+  const h = React.createElement;
+  const { useEffect, useState } = SDK.hooks;
+  const { Card, CardHeader, CardTitle, CardContent, Badge, Button } = SDK.components;
+
+  function LogMeta(props) {
+    const log = props.log || {};
+    return h("div", { className: "rounded-md border p-3 text-sm space-y-1" },
+      h("div", { className: "font-medium" }, "gateway.log"),
+      h("div", { className: "text-xs text-muted-foreground break-all" }, log.path || "—"),
+      h("div", null, log.exists ? `present · size ${log.size} · errors counted ${log.recent_error_count_tail_2000}` : "missing")
+    );
+  }
+
+  function StartupRecoveryPage() {
+    const [state, setState] = useState({ loading: true, error: null, data: null });
+    function load() {
+      setState((s) => Object.assign({}, s, { loading: true, error: null }));
+      fetchJSON("/api/plugins/startup-recovery/status")
+        .then((data) => setState({ loading: false, error: null, data }))
+        .catch((err) => setState({ loading: false, error: String(err && err.message || err), data: null }));
+    }
+    useEffect(load, []);
+    const profiles = (state.data && state.data.profiles) || [];
+    return h("div", { className: "space-y-6" },
+      h("div", { className: "flex items-start justify-between gap-4" },
+        h("div", null,
+          h("h1", { className: "text-2xl font-semibold" }, "Startup Recovery"),
+          h("p", { className: "text-sm text-muted-foreground" }, "Read-only local gateway health. No Telegram sends, restarts, process kills, or log contents.")
+        ),
+        h(Button, { onClick: load, disabled: state.loading }, state.loading ? "Refreshing…" : "Refresh")
+      ),
+      state.error && h(Card, { className: "border-destructive" }, h(CardContent, { className: "pt-6 text-sm text-destructive" }, state.error)),
+      state.data && h("div", { className: "flex flex-wrap gap-2" },
+        h(Badge, { variant: state.data.overall === "OK" ? "default" : "destructive" }, `Overall: ${state.data.overall}`),
+        h(Badge, { variant: state.data.problem_count ? "destructive" : "secondary" }, `${state.data.problem_count} problem(s)`),
+        h(Badge, { variant: "outline" }, `Telegram TCP: ${state.data.telegram_tcp_connections_detected == null ? "unknown" : state.data.telegram_tcp_connections_detected}`),
+        h(Badge, { variant: "outline" }, state.data.scope)
+      ),
+      h("div", { className: "grid gap-4 md:grid-cols-2" }, profiles.map((profile) =>
+        h(Card, { key: profile.profile },
+          h(CardHeader, null,
+            h("div", { className: "flex items-start justify-between gap-2" },
+              h("div", null,
+                h(CardTitle, null, profile.profile),
+                h("p", { className: "text-xs text-muted-foreground" }, profile.bot)
+              ),
+              h("div", { className: "flex gap-2" },
+                h(Badge, { variant: profile.tmux_status === "OK" ? "default" : "destructive" }, `tmux ${profile.tmux_status}`),
+                h(Badge, { variant: profile.process_status === "OK" ? "default" : "destructive" }, `process ${profile.process_status}`)
+              )
+            )
+          ),
+          h(CardContent, { className: "space-y-3" },
+            h("div", { className: "text-sm" }, "Matched session: ", h("span", { className: "font-mono" }, profile.matched_session || "—")),
+            h("div", { className: "text-xs text-muted-foreground" }, "Expected: ", (profile.expected_sessions || []).join(", ")),
+            h(LogMeta, { log: profile.log_file }),
+            (function () {
+              const stateDb = profile.state_db || {};
+              return h("div", { className: "rounded-md border p-3 text-sm" },
+                h("div", { className: "font-medium" }, "state.db"),
+                h("div", { className: "text-xs text-muted-foreground break-all" }, stateDb.path || "—"),
+                h("div", null, stateDb.exists ? `present · size ${stateDb.size}` : "missing")
+              );
+            })()
+          )
+        )
+      )),
+      state.loading && h("p", { className: "text-sm text-muted-foreground" }, "Loading gateway health…")
+    );
+  }
+
+  Registry.register("startup-recovery", StartupRecoveryPage);
+})();

--- a/plugins/startup-recovery/dashboard/manifest.json
+++ b/plugins/startup-recovery/dashboard/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "startup-recovery",
+  "label": "Startup Recovery",
+  "description": "LOCAL GSSAI gateway/tmux health — read-only and secret-free",
+  "icon": "Activity",
+  "version": "0.1.0",
+  "tab": {
+    "path": "/startup-recovery",
+    "position": "end"
+  },
+  "slots": [],
+  "entry": "dist/index.js",
+  "api": "plugin_api.py"
+}

--- a/plugins/startup-recovery/dashboard/plugin_api.py
+++ b/plugins/startup-recovery/dashboard/plugin_api.py
@@ -1,0 +1,180 @@
+"""LOCAL GSSAI startup-recovery dashboard plugin.
+
+Mounted at /api/plugins/startup-recovery/ by the dashboard plugin system.
+
+This v0.1 surface is read-only: it checks expected local Hermes Telegram
+gateway tmux sessions, process presence, log/state metadata, bounded error
+counts, and Telegram TCP connection count. It never sends Telegram messages,
+prints tokens, returns full process arguments, or returns log contents.
+"""
+
+from __future__ import annotations
+
+import os
+import pwd
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+
+router = APIRouter()
+
+ERROR_PATTERN = re.compile(r"Unauthorized|409 Conflict|Forbidden|Traceback|reconnect|error|critical|exception", re.I)
+TELEGRAM_TCP_PATTERN = re.compile(r"149\.154\.16|91\.108\.")
+
+
+@dataclass(frozen=True)
+class GatewayProfile:
+    profile: str
+    bot: str
+    sessions: tuple[str, ...]
+    process_pattern: str
+
+
+GATEWAYS: tuple[GatewayProfile, ...] = (
+    GatewayProfile("ivan_bb", "@Ivanbigboy_bot", ("hermes-gateway", "default-gateway"), "hermes --profile ivan_bb gateway run"),
+    GatewayProfile("storm", "@Storm_CCO_bot", ("storm-gateway",), "hermes --profile storm gateway run"),
+    GatewayProfile("neo", "@Neo_GSSAI_CTO_bot", ("neo-gateway",), "hermes --profile neo gateway run"),
+    GatewayProfile("gssai_admin", "@GSSAI_Admin_bot", ("gssai-admin-gateway",), "hermes --profile gssai_admin gateway run"),
+)
+
+
+def _real_user_home() -> Path:
+    try:
+        return Path(pwd.getpwuid(os.getuid()).pw_dir)
+    except Exception:
+        return Path.home()
+
+
+def _hermes_root() -> Path:
+    override = os.environ.get("STARTUP_RECOVERY_HERMES_ROOT")
+    if override:
+        return Path(override).expanduser().resolve()
+    return (_real_user_home() / ".hermes").resolve()
+
+
+def _run_command(args: list[str], timeout: float = 2.0) -> subprocess.CompletedProcess[str] | None:
+    try:
+        return subprocess.run(args, check=False, capture_output=True, text=True, timeout=timeout)
+    except (FileNotFoundError, subprocess.SubprocessError, OSError):
+        return None
+
+
+def _file_metadata(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"exists": False}
+    stat = path.stat()
+    return {"exists": True, "size": stat.st_size, "mtime": stat.st_mtime, "mode": oct(stat.st_mode & 0o777)}
+
+
+def _tmux_sessions() -> set[str]:
+    proc = _run_command(["tmux", "ls"])
+    if proc is None or proc.returncode != 0:
+        return set()
+    sessions: set[str] = set()
+    for line in proc.stdout.splitlines():
+        name = line.split(":", 1)[0].strip()
+        if name:
+            sessions.add(name)
+    return sessions
+
+
+def _process_present(pattern: str) -> bool:
+    # Patterns are fixed local allowlist literals. Keep this guard if they ever
+    # become configurable; pgrep receives list-form args, never shell strings.
+    if "\n" in pattern:
+        return False
+    proc = _run_command(["pgrep", "-f", pattern])
+    return bool(proc and proc.returncode == 0)
+
+
+def _recent_error_count(path: Path, max_lines: int = 2000, max_bytes: int = 512 * 1024) -> int | None:
+    if not path.is_file():
+        return None
+    try:
+        size = path.stat().st_size
+        with path.open("rb") as handle:
+            if size > max_bytes:
+                handle.seek(-max_bytes, os.SEEK_END)
+                handle.readline()
+            lines = handle.read().decode("utf-8", errors="replace").splitlines()[-max_lines:]
+    except OSError:
+        return None
+    return sum(1 for line in lines if ERROR_PATTERN.search(line))
+
+
+def _telegram_tcp_count() -> int | None:
+    proc = _run_command(["ss", "-tn"])
+    if proc is None or proc.returncode != 0:
+        return None
+    return sum(1 for line in proc.stdout.splitlines() if TELEGRAM_TCP_PATTERN.search(line))
+
+
+def _profile_status(gateway: GatewayProfile, tmux_session_names: set[str], hermes_root: Path) -> dict[str, Any]:
+    profile_root = hermes_root / "profiles" / gateway.profile
+    matched_session = next((session for session in gateway.sessions if session in tmux_session_names), None)
+    log_file = profile_root / "logs" / "gateway.log"
+    state_db = profile_root / "state.db"
+    process_present = _process_present(gateway.process_pattern)
+    tmux_present = matched_session is not None
+    return {
+        "profile": gateway.profile,
+        "bot": gateway.bot,
+        "expected_sessions": list(gateway.sessions),
+        "matched_session": matched_session,
+        "tmux_status": "OK" if tmux_present else "CHECK",
+        "process_status": "OK" if process_present else "CHECK",
+        "log_file": {"path": str(log_file), **_file_metadata(log_file), "recent_error_count_tail_2000": _recent_error_count(log_file)},
+        "state_db": {"path": str(state_db), **_file_metadata(state_db)},
+    }
+
+
+@router.get("/sessions")
+async def sessions() -> dict[str, Any]:
+    allowed = {session for gateway in GATEWAYS for session in gateway.sessions}
+    found = _tmux_sessions()
+    return {
+        "scope": "LOCAL GSSAI PROJECT ONLY",
+        "policy": "read-only; allowlisted local tmux names only; no process args",
+        "sessions": sorted(found & allowed),
+    }
+
+
+@router.get("/status")
+async def status() -> dict[str, Any]:
+    hermes_root = _hermes_root()
+    tmux_session_names = _tmux_sessions()
+    profiles = [_profile_status(gateway, tmux_session_names, hermes_root) for gateway in GATEWAYS]
+    problems = sum(
+        1
+        for item in profiles
+        if item["tmux_status"] != "OK" or item["process_status"] != "OK"
+    )
+    return {
+        "scope": "LOCAL GSSAI PROJECT ONLY",
+        "policy": "local status only; no Telegram sends; no secrets or log contents returned",
+        "hermes_root": str(hermes_root),
+        "profiles": profiles,
+        "telegram_tcp_connections_detected": _telegram_tcp_count(),
+        "overall": "OK" if problems == 0 else "CHECK",
+        "problem_count": problems,
+    }
+
+
+@router.get("/logs/{profile}/recent")
+async def recent_log_counts(profile: str) -> dict[str, Any]:
+    allowed = {gateway.profile for gateway in GATEWAYS}
+    if profile not in allowed:
+        raise HTTPException(status_code=404, detail="Unknown local GSSAI gateway profile")
+    log_file = _hermes_root() / "profiles" / profile / "logs" / "gateway.log"
+    return {
+        "scope": "LOCAL GSSAI PROJECT ONLY",
+        "profile": profile,
+        "log_file": str(log_file),
+        "metadata": _file_metadata(log_file),
+        "recent_error_count_tail_2000": _recent_error_count(log_file),
+        "log_contents_returned": False,
+    }

--- a/plugins/vault-sync/dashboard/dist/index.js
+++ b/plugins/vault-sync/dashboard/dist/index.js
@@ -1,0 +1,85 @@
+(function () {
+  "use strict";
+  const SDK = window.__HERMES_PLUGIN_SDK__;
+  const Registry = window.__HERMES_PLUGINS__;
+  if (!SDK || !Registry) return;
+
+  const { React, fetchJSON } = SDK;
+  const h = React.createElement;
+  const { useEffect, useState } = SDK.hooks;
+  const { Card, CardHeader, CardTitle, CardContent, Badge, Button } = SDK.components;
+
+  function ArtefactCard(props) {
+    const item = props.item || {};
+    return h(Card, null,
+      h(CardHeader, null,
+        h("div", { className: "flex items-start justify-between gap-2" },
+          h(CardTitle, null, props.title),
+          h(Badge, { variant: item.exists ? "default" : "secondary" }, item.exists ? "present" : "missing")
+        )
+      ),
+      h(CardContent, { className: "space-y-2 text-sm" },
+        h("div", { className: "font-mono break-all text-xs text-muted-foreground" }, item.path || "—"),
+        item.exists && h("div", null, `size ${item.size} · mode ${item.mode}`),
+        item.sha256 && h("div", { className: "font-mono break-all text-xs" }, `sha256 ${item.sha256}`),
+        h("div", { className: "text-xs text-muted-foreground" }, item.allowed ? "within allowlist" : "outside allowlist")
+      )
+    );
+  }
+
+  function VaultSyncPage() {
+    const [state, setState] = useState({ loading: true, error: null, artefacts: null, status: null, dirs: null });
+    function load() {
+      setState((s) => Object.assign({}, s, { loading: true, error: null }));
+      Promise.all([
+        fetchJSON("/api/plugins/vault-sync/status"),
+        fetchJSON("/api/plugins/vault-sync/artefacts"),
+        fetchJSON("/api/plugins/vault-sync/expected-dirs"),
+      ]).then(([status, artefacts, dirs]) => {
+        setState({ loading: false, error: null, status, artefacts, dirs });
+      }).catch((err) => {
+        setState({ loading: false, error: String(err && err.message || err), status: null, artefacts: null, dirs: null });
+      });
+    }
+    useEffect(load, []);
+    const dirs = (state.dirs && state.dirs.directories) || [];
+    return h("div", { className: "space-y-6" },
+      h("div", { className: "flex items-start justify-between gap-4" },
+        h("div", null,
+          h("h1", { className: "text-2xl font-semibold" }, "Vault Sync"),
+          h("p", { className: "text-sm text-muted-foreground" }, "Read-only vault artefact health. No sync, move, delete, copy, or file-content display.")
+        ),
+        h(Button, { onClick: load, disabled: state.loading }, state.loading ? "Refreshing…" : "Refresh")
+      ),
+      state.error && h(Card, { className: "border-destructive" }, h(CardContent, { className: "pt-6 text-sm text-destructive" }, state.error)),
+      state.status && h("div", { className: "flex flex-wrap gap-2" },
+        h(Badge, { variant: state.status.vault_root_exists ? "default" : "destructive" }, `Vault root: ${state.status.vault_root_exists ? "present" : "missing"}`),
+        h(Badge, { variant: state.status.tmp_root_exists ? "default" : "secondary" }, `Temp root: ${state.status.tmp_root_exists ? "present" : "missing"}`),
+        h(Badge, { variant: "outline" }, state.status.scope)
+      ),
+      state.artefacts && h("div", { className: "flex flex-wrap gap-2" },
+        h(Badge, { variant: state.artefacts.temporary_copy_duplicates_canonical ? "destructive" : "default" }, `Temp duplicate: ${state.artefacts.temporary_copy_duplicates_canonical ? "yes" : "no"}`),
+        h(Badge, { variant: "secondary" }, state.artefacts.policy)
+      ),
+      state.artefacts && h("div", { className: "grid gap-4 md:grid-cols-2" },
+        h(ArtefactCard, { title: "Canonical SOP", item: state.artefacts.canonical }),
+        h(ArtefactCard, { title: "Temporary copy", item: state.artefacts.temporary_copy })
+      ),
+      h(Card, null,
+        h(CardHeader, null, h(CardTitle, null, "Expected directories")),
+        h(CardContent, { className: "grid gap-2 md:grid-cols-2" }, dirs.map((dir) =>
+          h("div", { key: dir.name, className: "rounded-md border p-3 text-sm" },
+            h("div", { className: "flex items-center justify-between gap-2" },
+              h("span", { className: "font-medium" }, dir.name),
+              h(Badge, { variant: dir.exists ? "default" : "secondary" }, dir.exists ? "present" : "missing")
+            ),
+            h("div", { className: "mt-1 font-mono text-xs text-muted-foreground break-all" }, dir.path)
+          )
+        ))
+      ),
+      state.loading && h("p", { className: "text-sm text-muted-foreground" }, "Loading vault artefact health…")
+    );
+  }
+
+  Registry.register("vault-sync", VaultSyncPage);
+})();

--- a/plugins/vault-sync/dashboard/manifest.json
+++ b/plugins/vault-sync/dashboard/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "vault-sync",
+  "label": "Vault Sync",
+  "description": "LOCAL GSSAI vault artefact health — read-only",
+  "icon": "Folder",
+  "version": "0.1.0",
+  "tab": {
+    "path": "/vault-sync",
+    "position": "end"
+  },
+  "slots": [],
+  "entry": "dist/index.js",
+  "api": "plugin_api.py"
+}

--- a/plugins/vault-sync/dashboard/plugin_api.py
+++ b/plugins/vault-sync/dashboard/plugin_api.py
@@ -74,6 +74,40 @@ def _sha256(path: Path) -> str | None:
     return h.hexdigest()
 
 
+def _read_text_for_comparison(path: Path) -> str | None:
+    if path.is_symlink() or not path.is_file():
+        return None
+    try:
+        if path.stat().st_size > MAX_HASH_BYTES:
+            return None
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _strip_yaml_frontmatter(text: str) -> str:
+    lines = text.splitlines(keepends=True)
+    if not lines or lines[0].strip() != "---":
+        return text
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            remainder = "".join(lines[index + 1 :])
+            return remainder.lstrip("\r\n")
+    return text
+
+
+def _content_relation(canonical_path: Path, tmp_path: Path) -> str:
+    canonical = _read_text_for_comparison(canonical_path)
+    tmp = _read_text_for_comparison(tmp_path)
+    if canonical is None or tmp is None:
+        return "unavailable"
+    if canonical == tmp:
+        return "identical"
+    if _strip_yaml_frontmatter(canonical) == tmp:
+        return "same_except_canonical_frontmatter"
+    return "different"
+
+
 def _metadata(path: Path, allowed_roots: tuple[Path, ...]) -> dict[str, Any]:
     if path.is_symlink():
         return {"path": str(path), "allowed": False, "exists": False, "error": "symlink not permitted"}
@@ -142,12 +176,16 @@ async def artefacts() -> dict[str, Any]:
         and canonical.get("sha256")
         and canonical.get("sha256") == tmp_copy.get("sha256")
     )
+    relation = "unavailable"
+    if canonical.get("exists") and tmp_copy.get("exists"):
+        relation = _content_relation(_canonical_path(), _tmp_copy_path())
     return {
         "scope": "LOCAL GSSAI PROJECT ONLY",
         "policy": "metadata and hashes only; no file contents returned",
         "canonical": canonical,
         "temporary_copy": tmp_copy,
         "temporary_copy_duplicates_canonical": duplicate,
+        "content_relation": relation,
     }
 
 
@@ -162,6 +200,7 @@ async def duplicates() -> dict[str, Any]:
                 "canonical": artefact_data["canonical"]["path"],
                 "temporary_copy": artefact_data["temporary_copy"]["path"],
                 "same_sha256": duplicate,
+                "content_relation": artefact_data.get("content_relation", "unavailable"),
                 "action_required": "review before any move/delete" if duplicate else "none or manual review",
             }
         ],

--- a/plugins/vault-sync/dashboard/plugin_api.py
+++ b/plugins/vault-sync/dashboard/plugin_api.py
@@ -1,0 +1,168 @@
+"""LOCAL GSSAI vault-sync dashboard plugin.
+
+Mounted at /api/plugins/vault-sync/ by the dashboard plugin system.
+
+This v0.1 surface is read-only and allowlist-bound. It reports the health of
+known Obsidian/vault artefacts created during Phase 2.1 without syncing,
+copying, moving, deleting, or reading secrets.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import pwd
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+MAX_HASH_BYTES = 16 * 1024 * 1024
+CANONICAL_REL = Path("06-sops/phase-2-1-execution-checklist-approved-cleanup-with-controls.md")
+TMP_REL = Path("phase2_1_execution_checklist_approved_cleanup_with_controls.md")
+EXPECTED_DIRS = (
+    "06-sops",
+    "09-logs",
+    "13-runtime-state",
+    "agent-ecosystem",
+)
+
+
+def _real_user_home() -> Path:
+    try:
+        return Path(pwd.getpwuid(os.getuid()).pw_dir)
+    except Exception:
+        return Path.home()
+
+
+def _vault_root() -> Path:
+    override = os.environ.get("VAULT_SYNC_VAULT_ROOT")
+    if override:
+        return Path(override).expanduser().resolve()
+    return (_real_user_home() / ".hermes" / "obsidian-vault").resolve()
+
+
+def _tmp_root() -> Path:
+    override = os.environ.get("VAULT_SYNC_TMP_ROOT")
+    if override:
+        return Path(override).expanduser().resolve()
+    return (_real_user_home() / ".hermes" / "profiles" / "ivan_bb" / "tmp").resolve()
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _sha256(path: Path) -> str | None:
+    if path.is_symlink() or not path.is_file():
+        return None
+    try:
+        if path.stat().st_size > MAX_HASH_BYTES:
+            return None
+        h = hashlib.sha256()
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                h.update(chunk)
+    except OSError:
+        return None
+    return h.hexdigest()
+
+
+def _metadata(path: Path, allowed_roots: tuple[Path, ...]) -> dict[str, Any]:
+    if path.is_symlink():
+        return {"path": str(path), "allowed": False, "exists": False, "error": "symlink not permitted"}
+    resolved = path.resolve()
+    allowed = any(_is_relative_to(resolved, root) for root in allowed_roots)
+    base: dict[str, Any] = {"path": str(resolved), "allowed": allowed}
+    if not allowed:
+        return {**base, "exists": False, "error": "path outside allowlist"}
+    if not resolved.exists():
+        return {**base, "exists": False}
+    stat = resolved.stat()
+    return {
+        **base,
+        "exists": True,
+        "size": stat.st_size,
+        "mtime": stat.st_mtime,
+        "mode": oct(stat.st_mode & 0o777),
+        "sha256": _sha256(resolved),
+    }
+
+
+def _canonical_path() -> Path:
+    return _vault_root() / CANONICAL_REL
+
+
+def _tmp_copy_path() -> Path:
+    return _tmp_root() / TMP_REL
+
+
+@router.get("/status")
+async def status() -> dict[str, Any]:
+    vault = _vault_root()
+    tmp = _tmp_root()
+    return {
+        "scope": "LOCAL GSSAI PROJECT ONLY",
+        "policy": "read-only; allowlisted vault artefact metadata only; no sync/move/delete",
+        "vault_root": str(vault),
+        "vault_root_exists": vault.exists(),
+        "tmp_root": str(tmp),
+        "tmp_root_exists": tmp.exists(),
+    }
+
+
+@router.get("/expected-dirs")
+async def expected_dirs() -> dict[str, Any]:
+    vault = _vault_root()
+    return {
+        "scope": "LOCAL GSSAI PROJECT ONLY",
+        "directories": [
+            {"path": str((vault / rel).resolve()), "name": rel, "exists": (vault / rel).is_dir()}
+            for rel in EXPECTED_DIRS
+        ],
+    }
+
+
+@router.get("/artefacts")
+async def artefacts() -> dict[str, Any]:
+    vault = _vault_root()
+    tmp = _tmp_root()
+    allowed_roots = (vault, tmp)
+    canonical = _metadata(_canonical_path(), allowed_roots)
+    tmp_copy = _metadata(_tmp_copy_path(), allowed_roots)
+    duplicate = bool(
+        canonical.get("exists")
+        and tmp_copy.get("exists")
+        and canonical.get("sha256")
+        and canonical.get("sha256") == tmp_copy.get("sha256")
+    )
+    return {
+        "scope": "LOCAL GSSAI PROJECT ONLY",
+        "policy": "metadata and hashes only; no file contents returned",
+        "canonical": canonical,
+        "temporary_copy": tmp_copy,
+        "temporary_copy_duplicates_canonical": duplicate,
+    }
+
+
+@router.get("/duplicates")
+async def duplicates() -> dict[str, Any]:
+    artefact_data = await artefacts()
+    duplicate = artefact_data["temporary_copy_duplicates_canonical"]
+    return {
+        "scope": "LOCAL GSSAI PROJECT ONLY",
+        "duplicates": [
+            {
+                "canonical": artefact_data["canonical"]["path"],
+                "temporary_copy": artefact_data["temporary_copy"]["path"],
+                "same_sha256": duplicate,
+                "action_required": "review before any move/delete" if duplicate else "none or manual review",
+            }
+        ],
+    }

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -146,6 +146,49 @@ class TestMemoryEndpoints:
             "/api/memory/reset", json={"target": "bogus"}
         ).status_code == 400
 
+    def test_content_missing_file_returns_empty_store(self):
+        r = self.client.get("/api/memory/content?target=memory")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["target"] == "memory"
+        assert data["content"] == ""
+        assert data["entries"] == []
+        assert data["char_count"] == 0
+        assert data["char_limit"] > 0
+
+    def test_content_write_read_roundtrip_for_each_target(self):
+        from hermes_constants import get_hermes_home
+
+        mem_dir = get_hermes_home() / "memories"
+        cases = {
+            "memory": ("MEMORY.md", "first note\n§\nsecond note"),
+            "user": ("USER.md", "Phil prefers concise ops summaries."),
+        }
+        for target, (fname, content) in cases.items():
+            r = self.client.put(
+                "/api/memory/content", json={"target": target, "content": content}
+            )
+            assert r.status_code == 200
+            assert r.json()["char_count"] == len(content)
+            assert (mem_dir / fname).read_text(encoding="utf-8") == content
+
+            readback = self.client.get(f"/api/memory/content?target={target}")
+            assert readback.status_code == 200
+            data = readback.json()
+            assert data["content"] == content
+            assert data["char_count"] == len(content)
+
+        assert self.client.get("/api/memory/content?target=memory").json()["entries"] == [
+            {"text": "first note"},
+            {"text": "second note"},
+        ]
+
+    def test_content_rejects_invalid_target(self):
+        assert self.client.get("/api/memory/content?target=bogus").status_code == 400
+        assert self.client.put(
+            "/api/memory/content", json={"target": "bogus", "content": "x"}
+        ).status_code == 400
+
 
 class TestPairingEndpoints:
     @pytest.fixture(autouse=True)

--- a/tests/plugins/test_profile_manager_dashboard_plugin.py
+++ b/tests/plugins/test_profile_manager_dashboard_plugin.py
@@ -1,0 +1,128 @@
+"""Tests for the LOCAL GSSAI profile-manager dashboard plugin."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _load_plugin_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_file = repo_root / "plugins" / "profile-manager" / "dashboard" / "plugin_api.py"
+    assert plugin_file.exists(), f"plugin file missing: {plugin_file}"
+
+    spec = importlib.util.spec_from_file_location(
+        "hermes_dashboard_plugin_profile_manager_test", plugin_file,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_plugin_router():
+    return _load_plugin_module().router
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    hermes_root = tmp_path / ".hermes"
+    profiles_root = hermes_root / "profiles"
+    ivan = profiles_root / "ivan_bb"
+    aria = profiles_root / "aria-vps"
+    archived = profiles_root / "_archived" / "business"
+    unrelated_archived = profiles_root / "_archived" / "client-x"
+
+    (ivan / "logs").mkdir(parents=True)
+    (aria / "logs").mkdir(parents=True)
+    archived.mkdir(parents=True)
+    unrelated_archived.mkdir(parents=True)
+
+    (ivan / ".env").write_text("TELEGRAM_BOT_TOKEN=123456:SECRET_SHOULD_NOT_LEAK\n")
+    (ivan / "config.yaml").write_text("model:\n  default: test\n")
+    (ivan / "SOUL.md").write_text("# Ivan\n")
+    (ivan / "state.db").write_bytes(b"sqlite-ish")
+    (ivan / "logs" / "gateway.log").write_text("Traceback: should not leak full log lines\n")
+
+    (aria / ".env").write_text("ARIA_SECRET=must-not-appear\n")
+    (archived / ".env").write_text("ARCHIVED_SECRET=must-not-appear\n")
+    (unrelated_archived / ".env").write_text("CLIENT_SECRET=must-not-appear\n")
+
+    monkeypatch.setenv("PROFILE_MANAGER_HERMES_ROOT", str(hermes_root))
+
+    app = FastAPI()
+    app.include_router(_load_plugin_router(), prefix="/api/plugins/profile-manager")
+    return TestClient(app)
+
+
+def test_inventory_is_secret_free_and_file_metadata_only(client):
+    response = client.get("/api/plugins/profile-manager/inventory")
+    assert response.status_code == 200
+    data = response.json()
+    rendered = response.text
+
+    assert data["scope"] == "LOCAL GSSAI PROJECT ONLY"
+    assert "SECRET_SHOULD_NOT_LEAK" not in rendered
+    assert "ARIA_SECRET" not in rendered
+    assert "ARCHIVED_SECRET" not in rendered
+    assert "CLIENT_SECRET" not in rendered
+    assert "Traceback: should not leak" not in rendered
+
+    profiles = {profile["name"]: profile for profile in data["profiles"]}
+    assert "ivan_bb" in profiles
+    assert profiles["ivan_bb"]["env"]["exists"] is True
+    assert profiles["ivan_bb"]["env"]["size"] > 0
+    assert profiles["ivan_bb"]["boundary_label"].startswith("LOCAL GSSAI PROJECT")
+
+
+def test_inventory_includes_allowlisted_archived_profiles_only(client):
+    response = client.get("/api/plugins/profile-manager/inventory")
+    assert response.status_code == 200
+    profiles = {profile["name"]: profile for profile in response.json()["profiles"]}
+    assert profiles["business"]["lifecycle"] == "archived"
+    assert "client-x" not in profiles
+
+
+def test_inventory_excludes_side_project_profile_fragments(client):
+    response = client.get("/api/plugins/profile-manager/inventory")
+    assert response.status_code == 200
+    names = {profile["name"] for profile in response.json()["profiles"]}
+    assert "aria-vps" not in names
+
+
+def test_exclusion_does_not_match_parent_path_fragments(tmp_path, monkeypatch):
+    hermes_root = tmp_path / "vps-parent-name" / ".hermes"
+    profile_path = hermes_root / "profiles" / "ivan_bb"
+    profile_path.mkdir(parents=True)
+    monkeypatch.setenv("PROFILE_MANAGER_HERMES_ROOT", str(hermes_root))
+
+    app = FastAPI()
+    app.include_router(_load_plugin_router(), prefix="/api/plugins/profile-manager")
+    response = TestClient(app).get("/api/plugins/profile-manager/inventory")
+
+    assert response.status_code == 200
+    names = {profile["name"] for profile in response.json()["profiles"]}
+    assert "ivan_bb" in names
+
+
+def test_guardrails_are_read_only(client):
+    response = client.get("/api/plugins/profile-manager/guardrails")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["read_only"] is True
+    assert data["secret_values_returned"] is False
+    assert ".env" in data["secret_files_metadata_only"]
+
+
+def test_registered_routes_are_get_only():
+    router = _load_plugin_router()
+    methods = set()
+    for route in router.routes:
+        methods.update(getattr(route, "methods", set()))
+    assert methods <= {"GET", "HEAD"}

--- a/tests/plugins/test_startup_recovery_dashboard_plugin.py
+++ b/tests/plugins/test_startup_recovery_dashboard_plugin.py
@@ -1,0 +1,156 @@
+"""Tests for the LOCAL GSSAI startup-recovery dashboard plugin."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _load_plugin_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_file = repo_root / "plugins" / "startup-recovery" / "dashboard" / "plugin_api.py"
+    assert plugin_file.exists(), f"plugin file missing: {plugin_file}"
+
+    spec = importlib.util.spec_from_file_location(
+        "hermes_dashboard_plugin_startup_recovery_test", plugin_file,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def plugin_module():
+    return _load_plugin_module()
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch, plugin_module):
+    hermes_root = tmp_path / ".hermes"
+    monkeypatch.setenv("STARTUP_RECOVERY_HERMES_ROOT", str(hermes_root))
+
+    for profile in ("ivan_bb", "storm", "neo", "gssai_admin"):
+        root = hermes_root / "profiles" / profile
+        (root / "logs").mkdir(parents=True)
+        (root / "logs" / "gateway.log").write_text(
+            "normal startup line\nTraceback: simulated but line must not be returned\n"
+        )
+        (root / "state.db").write_bytes(b"state")
+
+    class Completed:
+        def __init__(self, returncode=0, stdout=""):
+            self.returncode = returncode
+            self.stdout = stdout
+
+    def fake_run_command(args, timeout=2.0):
+        if args == ["tmux", "ls"]:
+            return Completed(
+                0,
+                "hermes-gateway: 1 windows\n"
+                "storm-gateway: 1 windows\n"
+                "neo-gateway: 1 windows\n"
+                "gssai-admin-gateway: 1 windows\n"
+                "client-side-project: 1 windows\n",
+            )
+        if args[:2] == ["pgrep", "-f"]:
+            return Completed(0, "123\n")
+        if args == ["ss", "-tn"]:
+            return Completed(0, "ESTAB 0 0 127.0.0.1:1 149.154.167.220:443\n")
+        return Completed(1, "")
+
+    monkeypatch.setattr(plugin_module, "_run_command", fake_run_command)
+
+    app = FastAPI()
+    app.include_router(plugin_module.router, prefix="/api/plugins/startup-recovery")
+    return TestClient(app)
+
+
+def test_status_is_read_only_secret_free_and_ok(client):
+    response = client.get("/api/plugins/startup-recovery/status")
+    assert response.status_code == 200
+    data = response.json()
+    rendered = response.text
+
+    assert data["scope"] == "LOCAL GSSAI PROJECT ONLY"
+    assert data["overall"] == "OK"
+    assert data["problem_count"] == 0
+    assert data["telegram_tcp_connections_detected"] == 1
+    assert "Traceback: simulated" not in rendered
+    assert all(profile["tmux_status"] == "OK" for profile in data["profiles"])
+    assert all(profile["process_status"] == "OK" for profile in data["profiles"])
+
+
+def test_sessions_returns_allowlisted_names_not_process_args(client):
+    response = client.get("/api/plugins/startup-recovery/sessions")
+    assert response.status_code == 200
+    data = response.json()
+    rendered = response.text
+    assert "hermes-gateway" in data["sessions"]
+    assert "client-side-project" not in data["sessions"]
+    assert "hermes --profile" not in rendered
+
+
+def test_status_reports_problem_count_when_gateway_missing(tmp_path, monkeypatch, plugin_module):
+    hermes_root = tmp_path / ".hermes"
+    monkeypatch.setenv("STARTUP_RECOVERY_HERMES_ROOT", str(hermes_root))
+
+    class Completed:
+        def __init__(self, returncode=0, stdout=""):
+            self.returncode = returncode
+            self.stdout = stdout
+
+    def fake_run_command(args, timeout=2.0):
+        if args == ["tmux", "ls"]:
+            return Completed(0, "storm-gateway: 1 windows\n")
+        if args[:2] == ["pgrep", "-f"]:
+            return Completed(1, "")
+        if args == ["ss", "-tn"]:
+            return Completed(1, "")
+        return Completed(1, "")
+
+    monkeypatch.setattr(plugin_module, "_run_command", fake_run_command)
+    app = FastAPI()
+    app.include_router(plugin_module.router, prefix="/api/plugins/startup-recovery")
+
+    response = TestClient(app).get("/api/plugins/startup-recovery/status")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["overall"] == "CHECK"
+    assert data["problem_count"] == 4
+    assert any(profile["tmux_status"] == "CHECK" for profile in data["profiles"])
+    assert all(profile["process_status"] == "CHECK" for profile in data["profiles"])
+
+
+def test_recent_error_count_reads_bounded_tail(tmp_path, plugin_module):
+    log_file = tmp_path / "gateway.log"
+    log_file.write_text(("startup near start\n" * 5000) + "normal tail line\ncritical tail line\n")
+
+    assert plugin_module._recent_error_count(log_file, max_lines=20, max_bytes=128) == 1
+
+
+def test_recent_log_counts_do_not_return_log_contents(client):
+    response = client.get("/api/plugins/startup-recovery/logs/ivan_bb/recent")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["recent_error_count_tail_2000"] == 1
+    assert data["log_contents_returned"] is False
+    assert "Traceback: simulated" not in response.text
+
+
+def test_unknown_profile_log_is_404(client):
+    response = client.get("/api/plugins/startup-recovery/logs/aria/recent")
+    assert response.status_code == 404
+
+
+def test_registered_routes_are_get_only(plugin_module):
+    methods = set()
+    for route in plugin_module.router.routes:
+        methods.update(getattr(route, "methods", set()))
+    assert methods <= {"GET", "HEAD"}

--- a/tests/plugins/test_vault_sync_dashboard_plugin.py
+++ b/tests/plugins/test_vault_sync_dashboard_plugin.py
@@ -1,0 +1,156 @@
+"""Tests for the LOCAL GSSAI vault-sync dashboard plugin."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _load_plugin_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    plugin_file = repo_root / "plugins" / "vault-sync" / "dashboard" / "plugin_api.py"
+    assert plugin_file.exists(), f"plugin file missing: {plugin_file}"
+
+    spec = importlib.util.spec_from_file_location(
+        "hermes_dashboard_plugin_vault_sync_test", plugin_file,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def plugin_module():
+    return _load_plugin_module()
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch, plugin_module):
+    vault = tmp_path / "obsidian-vault"
+    tmp = tmp_path / "ivan-tmp"
+    canonical = vault / "06-sops" / "phase-2-1-execution-checklist-approved-cleanup-with-controls.md"
+    temp_copy = tmp / "phase2_1_execution_checklist_approved_cleanup_with_controls.md"
+    canonical.parent.mkdir(parents=True)
+    tmp.mkdir(parents=True)
+    for rel in ("09-logs", "13-runtime-state", "agent-ecosystem"):
+        (vault / rel).mkdir(parents=True)
+    content = "LOCAL GSSAI PROJECT ONLY\nNo secrets here.\n"
+    canonical.write_text(content)
+    temp_copy.write_text(content)
+
+    monkeypatch.setenv("VAULT_SYNC_VAULT_ROOT", str(vault))
+    monkeypatch.setenv("VAULT_SYNC_TMP_ROOT", str(tmp))
+
+    app = FastAPI()
+    app.include_router(plugin_module.router, prefix="/api/plugins/vault-sync")
+    return TestClient(app)
+
+
+def test_status_reports_roots_read_only(client):
+    response = client.get("/api/plugins/vault-sync/status")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["scope"] == "LOCAL GSSAI PROJECT ONLY"
+    assert data["vault_root_exists"] is True
+    assert "no sync/move/delete" in data["policy"]
+
+
+def test_artefacts_are_metadata_only_and_duplicate_is_flagged(client):
+    response = client.get("/api/plugins/vault-sync/artefacts")
+    assert response.status_code == 200
+    data = response.json()
+    rendered = response.text
+    assert data["temporary_copy_duplicates_canonical"] is True
+    assert data["canonical"]["exists"] is True
+    assert data["temporary_copy"]["exists"] is True
+    assert "LOCAL GSSAI PROJECT ONLY\\nNo secrets here" not in rendered
+    assert "sha256" in data["canonical"]
+
+
+def test_duplicates_endpoint_reports_review_only(client):
+    response = client.get("/api/plugins/vault-sync/duplicates")
+    assert response.status_code == 200
+    duplicate = response.json()["duplicates"][0]
+    assert duplicate["same_sha256"] is True
+    assert duplicate["action_required"] == "review before any move/delete"
+
+
+def test_artefacts_non_matching_temp_copy_is_not_duplicate(tmp_path, monkeypatch, plugin_module):
+    vault = tmp_path / "obsidian-vault"
+    tmp = tmp_path / "ivan-tmp"
+    canonical = vault / plugin_module.CANONICAL_REL
+    temp_copy = tmp / plugin_module.TMP_REL
+    canonical.parent.mkdir(parents=True)
+    tmp.mkdir(parents=True)
+    canonical.write_text("canonical\n")
+    temp_copy.write_text("different\n")
+    monkeypatch.setenv("VAULT_SYNC_VAULT_ROOT", str(vault))
+    monkeypatch.setenv("VAULT_SYNC_TMP_ROOT", str(tmp))
+
+    app = FastAPI()
+    app.include_router(plugin_module.router, prefix="/api/plugins/vault-sync")
+    response = TestClient(app).get("/api/plugins/vault-sync/artefacts")
+
+    assert response.status_code == 200
+    assert response.json()["temporary_copy_duplicates_canonical"] is False
+
+
+def test_metadata_rejects_symlink_and_skips_hash(tmp_path, plugin_module):
+    root = tmp_path / "root"
+    root.mkdir()
+    target = root / "target.md"
+    target.write_text("safe but symlinked\n")
+    link = root / "linked.md"
+    link.symlink_to(target)
+
+    meta = plugin_module._metadata(link, (root,))
+
+    assert meta["exists"] is False
+    assert meta["allowed"] is False
+    assert meta["error"] == "symlink not permitted"
+    assert "sha256" not in meta
+
+
+def test_metadata_rejects_paths_outside_allowlist(tmp_path, plugin_module):
+    allowed = tmp_path / "allowed"
+    outside = tmp_path / "outside"
+    allowed.mkdir()
+    outside.mkdir()
+    target = outside / "file.md"
+    target.write_text("outside\n")
+
+    meta = plugin_module._metadata(target, (allowed,))
+
+    assert meta["exists"] is False
+    assert meta["allowed"] is False
+    assert meta["error"] == "path outside allowlist"
+
+
+def test_sha256_skips_large_files(tmp_path, monkeypatch, plugin_module):
+    target = tmp_path / "large.md"
+    target.write_bytes(b"x" * 32)
+    monkeypatch.setattr(plugin_module, "MAX_HASH_BYTES", 16)
+
+    assert plugin_module._sha256(target) is None
+
+
+def test_expected_dirs_are_reported(client):
+    response = client.get("/api/plugins/vault-sync/expected-dirs")
+    assert response.status_code == 200
+    dirs = {item["name"]: item["exists"] for item in response.json()["directories"]}
+    assert dirs["06-sops"] is True
+    assert dirs["09-logs"] is True
+
+
+def test_registered_routes_are_get_only(plugin_module):
+    methods = set()
+    for route in plugin_module.router.routes:
+        methods.update(getattr(route, "methods", set()))
+    assert methods <= {"GET", "HEAD"}

--- a/tests/plugins/test_vault_sync_dashboard_plugin.py
+++ b/tests/plugins/test_vault_sync_dashboard_plugin.py
@@ -68,6 +68,7 @@ def test_artefacts_are_metadata_only_and_duplicate_is_flagged(client):
     data = response.json()
     rendered = response.text
     assert data["temporary_copy_duplicates_canonical"] is True
+    assert data["content_relation"] == "identical"
     assert data["canonical"]["exists"] is True
     assert data["temporary_copy"]["exists"] is True
     assert "LOCAL GSSAI PROJECT ONLY\\nNo secrets here" not in rendered
@@ -79,7 +80,32 @@ def test_duplicates_endpoint_reports_review_only(client):
     assert response.status_code == 200
     duplicate = response.json()["duplicates"][0]
     assert duplicate["same_sha256"] is True
+    assert duplicate["content_relation"] == "identical"
     assert duplicate["action_required"] == "review before any move/delete"
+
+
+def test_frontmatter_only_difference_reports_content_relation(tmp_path, monkeypatch, plugin_module):
+    vault = tmp_path / "obsidian-vault"
+    tmp = tmp_path / "ivan-tmp"
+    canonical = vault / plugin_module.CANONICAL_REL
+    temp_copy = tmp / plugin_module.TMP_REL
+    canonical.parent.mkdir(parents=True)
+    tmp.mkdir(parents=True)
+    body = "## Phase 2.1\n\nNo secrets here.\n"
+    canonical.write_text("---\ntitle: Phase 2.1\n---\n\n" + body)
+    temp_copy.write_text(body)
+    monkeypatch.setenv("VAULT_SYNC_VAULT_ROOT", str(vault))
+    monkeypatch.setenv("VAULT_SYNC_TMP_ROOT", str(tmp))
+
+    app = FastAPI()
+    app.include_router(plugin_module.router, prefix="/api/plugins/vault-sync")
+    response = TestClient(app).get("/api/plugins/vault-sync/duplicates")
+
+    assert response.status_code == 200
+    duplicate = response.json()["duplicates"][0]
+    assert duplicate["same_sha256"] is False
+    assert duplicate["content_relation"] == "same_except_canonical_frontmatter"
+    assert duplicate["action_required"] == "none or manual review"
 
 
 def test_artefacts_non_matching_temp_copy_is_not_duplicate(tmp_path, monkeypatch, plugin_module):
@@ -99,7 +125,9 @@ def test_artefacts_non_matching_temp_copy_is_not_duplicate(tmp_path, monkeypatch
     response = TestClient(app).get("/api/plugins/vault-sync/artefacts")
 
     assert response.status_code == 200
-    assert response.json()["temporary_copy_duplicates_canonical"] is False
+    data = response.json()
+    assert data["temporary_copy_duplicates_canonical"] is False
+    assert data["content_relation"] == "different"
 
 
 def test_metadata_rejects_symlink_and_skips_hash(tmp_path, plugin_module):

--- a/web/README.md
+++ b/web/README.md
@@ -2,6 +2,14 @@
 
 Browser-based dashboard for managing Hermes Agent configuration, API keys, and monitoring active sessions.
 
+## API Integration
+
+The dashboard fetches live data from three backend services: Agent Profiles,
+Kanban board state, and Memory. See
+[docs/dashboard-apis.md](../docs/dashboard-apis.md)
+for endpoint specs, request/response shapes, hook usage, and how to point the
+dashboard at a local backend.
+
 ## Stack
 
 - **Vite** + **React 19** + **TypeScript**
@@ -35,11 +43,23 @@ npm run build
 
 This outputs to `../hermes_cli/web_dist/`, which the FastAPI server serves as a static SPA. The built assets are included in the Python package via `pyproject.toml` package-data.
 
+## API integrations
+
+The dashboard fetches live data from three backend services:
+
+- **Agent Profiles** — `GET /api/profiles` → `useAgentProfiles` hook
+- **Kanban board state** — `GET /api/plugins/kanban/board` → `useKanbanState` hook
+- **Memory** — `GET /api/memory` → `useMemory` / `useMemoryData` hook
+
+Full developer reference (endpoints, request/response shapes, env vars, hook APIs, error conventions):
+**[`../docs/dashboard-apis.md`](../docs/dashboard-apis.md)**
+
 ## Structure
 
 ```
 src/
 ├── components/ui/   # Reusable UI primitives (Card, Badge, Button, Input, etc.)
+├── hooks/           # React hooks — useAgentProfiles, useKanbanState, useMemory, etc.
 ├── lib/
 │   ├── api.ts       # API client — typed fetch wrappers for all backend endpoints
 │   └── utils.ts     # cn() helper for Tailwind class merging
@@ -51,6 +71,12 @@ src/
 ├── main.tsx         # React entry point
 └── index.css        # Tailwind imports and theme variables
 ```
+
+## API Documentation
+
+See [../docs/dashboard-apis.md](../docs/dashboard-apis.md) for a full reference
+covering the three integrated services (agent profiles, Kanban board state, and
+memory), including endpoint shapes, TypeScript types, and hook usage examples.
 
 ## Typography & contrast rules
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,6 +12,7 @@
         "@observablehq/plot": "^0.6.17",
         "@react-three/fiber": "^9.6.0",
         "@tailwindcss/vite": "^4.2.1",
+        "@testing-library/jest-dom": "^6.9.1",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-unicode11": "^0.9.0",
         "@xterm/addon-web-links": "^0.12.0",
@@ -32,6 +33,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -40,11 +42,70 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
+        "jsdom": "^29.1.1",
         "three": "^0.180.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.56.1",
-        "vite": "^7.3.1"
+        "vite": "^7.3.1",
+        "vitest": "^4.1.8"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -77,7 +138,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -336,6 +396,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -911,6 +1124,24 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
@@ -1128,7 +1359,6 @@
       "resolved": "https://registry.npmjs.org/@observablehq/plot/-/plot-0.6.17.tgz",
       "integrity": "sha512-/qaXP/7mc4MUS0s4cPPFASDRjtsWp85/TbfsciqDgU1HwYixbSbbytNuInD8AcTYC3xaxACgVX06agdfQy9W+g==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "d3": "^7.9.0",
         "interval-tree-1d": "^1.0.0",
@@ -4367,7 +4597,6 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.6.0.tgz",
       "integrity": "sha512-90abYK2q5/qDM+GACs9zRvc5KhEEpEWqWlHSd64zTPNxg+9wCJvTfyD9x2so7hlQhjRYO1Fa6flR3BC/kpTFkA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/webxr": "*",
@@ -4743,6 +4972,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@stitches/react": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@stitches/react/-/react-1.2.8.tgz",
@@ -5009,6 +5245,101 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -5054,6 +5385,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -5073,7 +5422,6 @@
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -5083,7 +5431,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5094,7 +5441,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5159,7 +5505,6 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -5449,6 +5794,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xterm/addon-fit": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
@@ -5488,7 +5946,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5521,6 +5978,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -5556,6 +6024,25 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/assign-symbols": {
@@ -5616,6 +6103,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-search-bounds": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.5.tgz",
@@ -5653,7 +6150,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5722,6 +6218,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -5837,6 +6343,26 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -6161,7 +6687,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6246,6 +6771,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.20",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
@@ -6269,6 +6808,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -6317,6 +6863,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "license": "MIT"
     },
     "node_modules/dom-serializer": {
@@ -6418,6 +6970,13 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
@@ -6487,7 +7046,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6656,6 +7214,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -6664,6 +7232,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend-shallow": {
@@ -6902,8 +7480,7 @@
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.15.0.tgz",
       "integrity": "sha512-dMW4CWBTUK1AEEDeZc1g4xpPGIrSf9fJF960qbTZmN/QwZIWY5wgliS6JWl9/25fpTGJrMRtSjGtOmPnfjZB+A==",
-      "license": "Standard 'no charge' license: https://gsap.com/standard-license.",
-      "peer": true
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -6930,6 +7507,19 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/htmlparser2": {
@@ -7020,6 +7610,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -7085,6 +7684,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -7145,6 +7751,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -7218,7 +7875,6 @@
       "resolved": "https://registry.npmjs.org/leva/-/leva-0.10.1.tgz",
       "integrity": "sha512-BcjnfUX8jpmwZUz2L7AfBtF9vn4ggTH33hmeufDULbP3YgNZ/C+ss/oO3stbrqRQyaOmRwy70y7BGTGO81S3rA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@radix-ui/react-portal": "^1.1.4",
         "@radix-ui/react-tooltip": "^1.1.8",
@@ -7571,6 +8227,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -7579,6 +8246,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge-value": {
       "version": "1.0.0",
@@ -7593,6 +8267,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -7626,7 +8309,6 @@
       "resolved": "https://registry.npmjs.org/motion/-/motion-12.38.0.tgz",
       "integrity": "sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "framer-motion": "^12.38.0",
         "tslib": "^2.4.0"
@@ -7699,7 +8381,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }
@@ -7725,6 +8406,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
+      "integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/optionator": {
@@ -7796,6 +8491,32 @@
       "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -7816,6 +8537,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -7827,7 +8555,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7872,6 +8599,44 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -8041,7 +8806,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8061,7 +8825,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8224,6 +8987,29 @@
         }
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -8320,6 +9106,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -8389,6 +9188,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -8421,6 +9227,32 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -8458,6 +9290,13 @@
         "react": ">=17.0"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
@@ -8491,8 +9330,24 @@
       "version": "0.180.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.180.0.tgz",
       "integrity": "sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
       "license": "MIT",
-      "peer": true
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
@@ -8508,6 +9363,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
+      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.2"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -8557,7 +9468,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8588,6 +9498,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.1.tgz",
+      "integrity": "sha512-UDdpiex+mzigiyrXrGbiUaF4HzTNhKbh2vRNFaTMzcqmLIPrZxaCtwo/1TMSuWoM1Xz3WiTo9KdgI3kRqYzJGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -8714,7 +9634,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -8784,6 +9703,144 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8800,6 +9857,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -8809,6 +9883,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",
@@ -8836,7 +9927,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,7 @@
     "@observablehq/plot": "^0.6.17",
     "@react-three/fiber": "^9.6.0",
     "@tailwindcss/vite": "^4.2.1",
+    "@testing-library/jest-dom": "^6.9.1",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/addon-web-links": "^0.12.0",
@@ -34,6 +35,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
@@ -42,9 +44,11 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "jsdom": "^29.1.1",
     "three": "^0.180.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.56.1",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vitest": "^4.1.8"
   }
 }

--- a/web/src/components/SidebarStatusStrip.tsx
+++ b/web/src/components/SidebarStatusStrip.tsx
@@ -2,10 +2,32 @@ import { Link } from "react-router-dom";
 import type { StatusResponse } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { useI18n } from "@/i18n";
+import { useKanbanState } from "@/hooks/useKanbanState";
+import { useMemoryData } from "@/hooks/useMemoryData";
 
 /** Gateway + session summary for the System sidebar block (no separate strip chrome). */
 export function SidebarStatusStrip({ status }: SidebarStatusStripProps) {
   const { t } = useI18n();
+
+  // Live Kanban board state (poll every 30s)
+  const {
+    data: kanban,
+    loading: kanbanLoading,
+    error: kanbanError,
+    connectionStatus: kanbanConnectionStatus,
+    unauthorized: kanbanUnauthorized,
+  } = useKanbanState({ pollingIntervalMs: 30_000 });
+
+  // Live memory content state. Future real-time transports can subscribe here
+  // and call useMemoryData's refetch() from a WS/SSE callback without changing
+  // the rendering branch below.
+  const {
+    data: memoryData,
+    loading: memoryLoading,
+    error: memoryError,
+    connectionStatus: memoryConnectionStatus,
+    unauthorized: memoryUnauthorized,
+  } = useMemoryData("memory");
 
   if (status === null) {
     return (
@@ -17,6 +39,18 @@ export function SidebarStatusStrip({ status }: SidebarStatusStripProps) {
 
   const gw = gatewayLine(status, t);
   const { activeSessionsLabel, gatewayStatusLabel } = t.app;
+
+  // Derive running task count from kanban columns
+  const runningTasks =
+    kanban?.columns.find((c) => c.status === "running")?.tasks.length ?? null;
+  const blockedTasks =
+    kanban?.columns.find((c) => c.status === "blocked")?.tasks.length ?? 0;
+
+  // Memory utilisation percentage
+  const memPct =
+    memoryData && memoryData.char_limit > 0
+      ? Math.round((memoryData.char_count / memoryData.char_limit) * 100)
+      : null;
 
   return (
     <Link
@@ -43,11 +77,67 @@ export function SidebarStatusStrip({ status }: SidebarStatusStripProps) {
             {status.active_sessions}
           </span>
         </p>
+
+        {/* Kanban task summary */}
+        {kanbanLoading && !kanban && (
+          <p className="break-words">
+            <span className="text-text-tertiary">tasks</span>{" "}
+            <span className="h-2 w-6 animate-pulse rounded-sm bg-midground/10 inline-block align-middle" />
+          </p>
+        )}
+        {kanbanError && (
+          <p className="break-words text-warning text-[10px]">
+            kanban {kanbanUnauthorized ? "unauthorized" : kanbanConnectionStatus === "offline" ? "disconnected" : "reconnecting"}
+          </p>
+        )}
+        {!kanbanUnauthorized && !kanbanLoading && runningTasks !== null && (
+          <p className="break-words">
+            <span className="text-text-tertiary">tasks</span>{" "}
+            <span className="tabular-nums text-text-secondary">
+              {runningTasks} running
+              {blockedTasks > 0 && (
+                <span className="text-warning"> · {blockedTasks} blocked</span>
+              )}
+            </span>
+          </p>
+        )}
+
+        {/* Memory utilisation */}
+        {memoryLoading && !memoryData && (
+          <p className="break-words">
+            <span className="text-text-tertiary">memory</span>{" "}
+            <span className="h-2 w-8 animate-pulse rounded-sm bg-midground/10 inline-block align-middle" />
+          </p>
+        )}
+        {memoryError && (
+          <p className="break-words text-warning text-[10px]">
+            memory {memoryUnauthorized ? "unauthorized" : memoryConnectionStatus === "offline" ? "disconnected" : "reconnecting"}
+          </p>
+        )}
+        {!memoryUnauthorized && !memoryLoading && memPct !== null && (
+          <p className="break-words">
+            <span className="text-text-tertiary">memory</span>{" "}
+            <span
+              className={cn(
+                "tabular-nums",
+                memPct >= 90
+                  ? "text-destructive"
+                  : memPct >= 70
+                    ? "text-warning"
+                    : "text-text-secondary",
+              )}
+            >
+              {memPct}%
+            </span>
+          </p>
+        )}
       </div>
     </Link>
   );
 }
 
+// Shared with the legacy App sidebar summary until that call site moves to its own helper file.
+// eslint-disable-next-line react-refresh/only-export-components
 export function gatewayLine(
   status: StatusResponse,
   t: ReturnType<typeof useI18n>["t"],

--- a/web/src/components/UnauthorizedState.test.tsx
+++ b/web/src/components/UnauthorizedState.test.tsx
@@ -1,0 +1,28 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { UnauthorizedState } from "@/components/UnauthorizedState";
+
+describe("UnauthorizedState", () => {
+  it("renders a human-readable unauthorized message with retry", async () => {
+    const retry = vi.fn();
+
+    render(<UnauthorizedState service="Kanban" onRetry={retry} />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Authentication required. Sign in again or retry the request.",
+    );
+    expect(screen.queryByText("t_001")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a login affordance when loginUrl is provided", () => {
+    render(<UnauthorizedState service="Profiles" loginUrl="/login" />);
+
+    expect(screen.getByRole("link", { name: /sign in/i })).toHaveAttribute(
+      "href",
+      "/login",
+    );
+  });
+});

--- a/web/src/components/UnauthorizedState.tsx
+++ b/web/src/components/UnauthorizedState.tsx
@@ -1,0 +1,59 @@
+import { Button } from "@nous-research/ui/ui/components/button";
+import { AUTH_UNAUTHORIZED_MESSAGE } from "@/lib/api";
+
+interface UnauthorizedStateProps {
+  service: string;
+  message?: string | null;
+  loginUrl?: string;
+  onRetry?: () => void;
+  compact?: boolean;
+}
+
+export function UnauthorizedState({
+  service,
+  message = AUTH_UNAUTHORIZED_MESSAGE,
+  loginUrl,
+  onRetry,
+  compact = false,
+}: UnauthorizedStateProps) {
+  const detail = message || AUTH_UNAUTHORIZED_MESSAGE;
+
+  return (
+    <div
+      role="alert"
+      className={
+        compact
+          ? "rounded-md border border-destructive/40 bg-destructive/10 p-2 text-xs text-destructive"
+          : "flex flex-col gap-3 rounded-lg border border-destructive/40 bg-destructive/10 p-5 text-destructive"
+      }
+    >
+      <div>
+        <p className="font-mondwest uppercase tracking-wide">
+          {service} access unauthorized
+        </p>
+        <p className="mt-1 text-sm text-destructive/90">{detail}</p>
+      </div>
+      {(loginUrl || onRetry) && (
+        <div className="flex flex-wrap gap-2">
+          {loginUrl && (
+            <a
+              href={loginUrl}
+              className="inline-flex h-9 w-fit items-center justify-center rounded-md bg-primary px-3 text-xs font-medium uppercase text-primary-foreground ring-offset-background transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              Sign in
+            </a>
+          )}
+          {onRetry && (
+            <Button
+              size="sm"
+              className="w-fit uppercase"
+              onClick={onRetry}
+            >
+              Retry
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/hooks/useAgentProfiles.test.tsx
+++ b/web/src/hooks/useAgentProfiles.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * Unit tests for useAgentProfiles hook.
+ *
+ * Tests run against a mocked AgentProfilesClient so no real network calls
+ * are made. The hook exposes { profiles, loading, error, refreshProfiles }.
+ */
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { useAgentProfiles } from "@/hooks/useAgentProfiles";
+import type { AgentProfilesClient, AgentProfilesSnapshot } from "@/hooks/useAgentProfiles";
+import type { ProfileInfo } from "@/lib/api";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mockProfile: ProfileInfo = {
+  name: "default",
+  path: "/home/user/.hermes",
+  is_default: true,
+  model: "claude-sonnet-4-6",
+  provider: "anthropic",
+  has_env: true,
+  skill_count: 3,
+};
+
+function makeClient(
+  impl?: () => Promise<AgentProfilesSnapshot>,
+): AgentProfilesClient {
+  return {
+    listProfiles:
+      impl ??
+      vi
+        .fn<() => Promise<AgentProfilesSnapshot>>()
+        .mockResolvedValue({ profiles: [mockProfile] }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useAgentProfiles", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts with loading=true and no profiles", () => {
+    // Hang indefinitely so we can observe the initial state before resolution.
+    const neverResolves: () => Promise<AgentProfilesSnapshot> = () =>
+      new Promise(() => {});
+    const client = makeClient(neverResolves);
+    const { result } = renderHook(() => useAgentProfiles(client));
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.profiles).toHaveLength(0);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("populates profiles after a successful fetch", async () => {
+    const client = makeClient();
+    const { result } = renderHook(() => useAgentProfiles(client));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.profiles).toHaveLength(1);
+    expect(result.current.profiles[0].name).toBe("default");
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces a typed error string when fetch fails", async () => {
+    const failing: () => Promise<AgentProfilesSnapshot> = () =>
+      Promise.reject(new Error("Network failure"));
+    const client = makeClient(failing);
+    const { result } = renderHook(() => useAgentProfiles(client));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe("Network failure");
+    expect(result.current.profiles).toHaveLength(0);
+  });
+
+  it("clears error and re-populates on a successful refreshProfiles call", async () => {
+    let call = 0;
+    const impl: () => Promise<AgentProfilesSnapshot> = () => {
+      call++;
+      if (call === 1) return Promise.reject(new Error("First failure"));
+      return Promise.resolve({ profiles: [mockProfile] });
+    };
+
+    const client = makeClient(impl);
+    const { result } = renderHook(() => useAgentProfiles(client));
+
+    // Wait for the initial failing fetch to settle.
+    await waitFor(() => expect(result.current.error).toBe("First failure"));
+
+    // Manually refresh — should succeed now.
+    await act(async () => {
+      await result.current.refreshProfiles();
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.profiles).toHaveLength(1);
+  });
+
+  it("keepExisting=true preserves existing profiles during re-fetch", async () => {
+    const profilesV2: ProfileInfo[] = [{ ...mockProfile, name: "updated" }];
+    let call = 0;
+    const impl: () => Promise<AgentProfilesSnapshot> = () => {
+      call++;
+      return call === 1
+        ? Promise.resolve({ profiles: [mockProfile] })
+        : Promise.resolve({ profiles: profilesV2 });
+    };
+
+    const client = makeClient(impl);
+    const { result } = renderHook(() => useAgentProfiles(client));
+
+    // Wait for initial fetch.
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.profiles[0].name).toBe("default");
+
+    // Trigger a background refresh that keeps existing profiles visible.
+    await act(async () => {
+      await result.current.refreshProfiles({ keepExisting: true });
+    });
+
+    expect(result.current.profiles[0].name).toBe("updated");
+    expect(result.current.error).toBeNull();
+  });
+
+  it("clears cached profiles and marks unauthorized when auth fails", async () => {
+    const { AuthUnauthorizedError } = await import("@/lib/api");
+    let call = 0;
+    const impl: () => Promise<AgentProfilesSnapshot> = () => {
+      call++;
+      return call === 1
+        ? Promise.resolve({ profiles: [mockProfile] })
+        : Promise.reject(new AuthUnauthorizedError(403));
+    };
+
+    const client = makeClient(impl);
+    const { result } = renderHook(() => useAgentProfiles(client));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.profiles).toHaveLength(1);
+
+    await act(async () => {
+      await result.current.refreshProfiles({ keepExisting: true });
+    });
+
+    expect(result.current.unauthorized).toBe(true);
+    expect(result.current.profiles).toHaveLength(0);
+    expect(result.current.error).toBe("Authentication required. Sign in again or retry the request.");
+  });
+
+
+  it("auto-recovers after a transient fetch failure without manual refresh", async () => {
+    vi.useFakeTimers();
+    let call = 0;
+    const impl: () => Promise<AgentProfilesSnapshot> = () => {
+      call++;
+      if (call === 1) return Promise.reject(new Error("backend down"));
+      return Promise.resolve({ profiles: [mockProfile] });
+    };
+    const client = makeClient(impl);
+    const { result } = renderHook(() => useAgentProfiles(client));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.error).toBe("backend down");
+    expect(result.current.connectionStatus).toBe("reconnecting");
+    expect(result.current.nextRetryMs).toBe(2000);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+      await Promise.resolve();
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.connectionStatus).toBe("connected");
+    expect(result.current.profiles[0].name).toBe("default");
+    expect(call).toBe(2);
+  });
+
+  it("exposes refreshProfiles for on-demand re-fetch (adapter-agnostic)", async () => {
+    let callCount = 0;
+    const impl: () => Promise<AgentProfilesSnapshot> = () => {
+      callCount++;
+      return Promise.resolve({ profiles: [mockProfile] });
+    };
+
+    const client = makeClient(impl);
+    const { result } = renderHook(() => useAgentProfiles(client));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(callCount).toBe(1);
+
+    await act(async () => {
+      await result.current.refreshProfiles();
+    });
+
+    expect(callCount).toBe(2);
+  });
+
+  it("accepts a custom adapter for WebSocket/polling without changing internal state shape", async () => {
+    // Simulate a WebSocket-backed adapter that resolves immediately.
+    const wsProfiles: ProfileInfo[] = [{ ...mockProfile, name: "ws-profile" }];
+    const wsAdapter: AgentProfilesClient = {
+      listProfiles: () => Promise.resolve({ profiles: wsProfiles }),
+    };
+
+    const { result } = renderHook(() => useAgentProfiles(wsAdapter));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.profiles[0].name).toBe("ws-profile");
+    // State shape is identical regardless of adapter.
+    expect(result.current).toMatchObject({
+      profiles: expect.any(Array),
+      loading: expect.any(Boolean),
+      error: null,
+      refreshProfiles: expect.any(Function),
+    });
+  });
+});

--- a/web/src/hooks/useAgentProfiles.ts
+++ b/web/src/hooks/useAgentProfiles.ts
@@ -1,0 +1,145 @@
+import { useCallback, useState } from "react";
+import { isAuthUnauthorizedError } from "@/lib/api";
+import { listAgentProfiles } from "@/lib/clients/agentProfiles";
+import type { AgentProfileInfo } from "@/lib/clients/agentProfiles";
+import { useRetryFetch } from "@/hooks/useRetryFetch";
+import type { RetryFetchStatus } from "@/hooks/useRetryFetch";
+
+/**
+ * Snapshot type returned by the data-source adapter.
+ * Keeping it in one place makes it easy to extend later (e.g. cursor, etag).
+ */
+export type AgentProfilesSnapshot = {
+  profiles: AgentProfileInfo[];
+};
+
+/**
+ * Thin client/adapter interface.
+ * Pass a custom implementation to swap transport (REST → WebSocket/polling)
+ * without touching this hook's internals.
+ */
+export type AgentProfilesClient = {
+  listProfiles: () => Promise<AgentProfilesSnapshot>;
+};
+
+/**
+ * State shape exposed to consumers.
+ * `refreshProfiles` is callable on-demand (e.g. after a CRUD operation).
+ * `keepExisting: true` is useful for background refreshes where you don't
+ * want the list to flicker back to empty while the request is in-flight.
+ */
+export type AgentProfilesState = {
+  profiles: AgentProfileInfo[];
+  loading: boolean;
+  error: string | null;
+  connectionStatus: RetryFetchStatus;
+  nextRetryMs: number | null;
+  unauthorized: boolean;
+  refreshProfiles: (options?: { keepExisting?: boolean }) => Promise<void>;
+};
+
+// Default adapter wired to the live REST endpoint.
+const defaultClient: AgentProfilesClient = {
+  listProfiles: () => listAgentProfiles(),
+};
+
+function toErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+/**
+ * useAgentProfiles — fetches agent profiles from the live REST API with
+ * exponential-backoff retry so the UI recovers automatically after a backend
+ * kill/restore or transient network drop.
+ *
+ * - Polls every 30s on success.
+ * - On error: retries with 30s → 60s → 120s backoff (capped at 2 minutes).
+ * - Shows `loading=true` only on the initial fetch; background polls and
+ *   retries never flicker the spinner.
+ *
+ * Accepts an optional `client` adapter so callers can inject a mocked
+ * transport in tests, or swap to WebSocket/polling later without internal
+ * refactoring.
+ *
+ * @example
+ *   const { profiles, loading, error, refreshProfiles } = useAgentProfiles();
+ *
+ * @example (custom adapter for tests / WS)
+ *   const client = { listProfiles: myWebSocketAdapter };
+ *   const state = useAgentProfiles(client);
+ */
+export function useAgentProfiles(
+  client: AgentProfilesClient = defaultClient,
+): AgentProfilesState {
+  const [profiles, setProfiles] = useState<AgentProfileInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [connectionStatus, setConnectionStatus] = useState<RetryFetchStatus>("idle");
+  const [nextRetryMs, setNextRetryMs] = useState<number | null>(null);
+  const [unauthorized, setUnauthorized] = useState(false);
+
+  const handleSuccess = useCallback((snapshot: AgentProfilesSnapshot) => {
+    setProfiles(snapshot.profiles);
+    setError(null);
+    setUnauthorized(false);
+  }, []);
+
+  const handleError = useCallback((message: string, err: unknown) => {
+    setError(message);
+    if (isAuthUnauthorizedError(err)) {
+      setUnauthorized(true);
+      setProfiles([]);
+      return;
+    }
+    setUnauthorized(false);
+    // Keep existing profiles visible so the UI degrades gracefully rather
+    // than collapsing to an empty list during a transient backend restart.
+  }, []);
+
+  // Auto-retry loop: polls every 30s on success, backs off on error (30→60→120s).
+  useRetryFetch({
+    fetchFn: client.listProfiles,
+    onSuccess: handleSuccess,
+    onError: handleError,
+    setLoading,
+    baseIntervalMs: 30_000,
+    retryIntervalMs: 2_000,
+    maxIntervalMs: 10_000,
+    onStatusChange: setConnectionStatus,
+    onNextRetryMsChange: setNextRetryMs,
+  });
+
+  // Manual imperative refresh (e.g. after creating a profile).
+  const refreshProfiles = useCallback(
+    async (options: { keepExisting?: boolean } = {}) => {
+      if (!options.keepExisting) {
+        setLoading(true);
+      }
+      setError(null);
+      try {
+        const snapshot = await client.listProfiles();
+        setProfiles(snapshot.profiles);
+        setUnauthorized(false);
+        setConnectionStatus("connected");
+      } catch (err) {
+        setError(toErrorMessage(err));
+        setConnectionStatus(typeof navigator !== "undefined" && navigator.onLine === false ? "offline" : "reconnecting");
+        if (isAuthUnauthorizedError(err)) {
+          setUnauthorized(true);
+          setProfiles([]);
+        } else {
+          setUnauthorized(false);
+          if (!options.keepExisting) {
+            setProfiles([]);
+          }
+        }
+      } finally {
+        setLoading(false);
+      }
+    },
+    [client],
+  );
+
+  return { profiles, loading, error, connectionStatus, nextRetryMs, unauthorized, refreshProfiles };
+}

--- a/web/src/hooks/useKanbanState.test.tsx
+++ b/web/src/hooks/useKanbanState.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * Tests for useKanbanState hook.
+ *
+ * Tests run against a mocked fetch so no real network calls are made.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useKanbanState } from "./useKanbanState";
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  fetchMock.mockReset();
+  vi.unstubAllGlobals();
+});
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? "OK" : "Error",
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+    headers: new Headers({ "content-type": "application/json" }),
+  } as unknown as Response;
+}
+
+const MOCK_BOARD_RESPONSE = {
+  columns: [
+    {
+      name: "running",
+      tasks: [
+        { id: "t_001", title: "Build something", status: "running", assignee: "coder", priority: 0, created_at: 1780000000 },
+        { id: "t_002", title: "Write docs", status: "running", assignee: "writer", priority: 0, created_at: 1780000001 },
+      ],
+    },
+    {
+      name: "done",
+      tasks: [
+        { id: "t_003", title: "Shipped it", status: "done", assignee: "coder", priority: 0, created_at: 1779999000 },
+      ],
+    },
+  ],
+  board: "ai-dev",
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useKanbanState", () => {
+  it("starts with loading=true and null data", () => {
+    // Hang the request so we can observe the loading state.
+    fetchMock.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useKanbanState());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("fetches board state from /api/plugins/kanban/board and exposes data", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(MOCK_BOARD_RESPONSE));
+
+    const { result } = renderHook(() => useKanbanState());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/plugins/kanban/board",
+      expect.objectContaining({
+        credentials: "include",
+        headers: expect.any(Headers),
+      }),
+    );
+    expect(result.current.data).not.toBeNull();
+    expect(result.current.data?.columns).toHaveLength(2);
+    expect(result.current.data?.board).toBe("ai-dev");
+    expect(result.current.error).toBeNull();
+  });
+
+  it("exposes running task count via columns", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse(MOCK_BOARD_RESPONSE));
+
+    const { result } = renderHook(() => useKanbanState());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const runningCol = result.current.data?.columns.find(
+      (c) => c.status === "running",
+    );
+    expect(runningCol?.tasks).toHaveLength(2);
+  });
+
+  it("sets error and clears data on HTTP error response", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ detail: "Not found" }, false, 404),
+    );
+
+    const { result } = renderHook(() => useKanbanState());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBeTruthy();
+    expect(result.current.data).toBeNull();
+  });
+
+  it("sets error and clears data on network failure", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("Network down"));
+
+    const { result } = renderHook(() => useKanbanState());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toMatch(/Network down/i);
+    expect(result.current.data).toBeNull();
+  });
+
+  it("refresh() re-fetches board state", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(MOCK_BOARD_RESPONSE));
+
+    const { result } = renderHook(() => useKanbanState());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.refresh();
+    });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).not.toBeNull();
+  });
+
+  it.each([401, 403])("clears cached board data and marks unauthorized on HTTP %s", async (status) => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(MOCK_BOARD_RESPONSE))
+      .mockResolvedValueOnce(jsonResponse({ detail: "denied" }, false, status));
+
+    const { result } = renderHook(() => useKanbanState());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data?.columns[0].tasks).toHaveLength(2);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(result.current.unauthorized).toBe(true);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBe("Authentication required. Sign in again or retry the request.");
+  });
+
+  it("does not call fetch after unmount (no setState on stale request)", async () => {
+    let resolveRequest!: (r: Response) => void;
+    fetchMock.mockReturnValueOnce(
+      new Promise<Response>((res) => {
+        resolveRequest = res;
+      }),
+    );
+
+    const { result, unmount } = renderHook(() => useKanbanState());
+
+    expect(result.current.loading).toBe(true);
+    unmount();
+
+    // Resolve AFTER unmount — should not trigger setState.
+    act(() => resolveRequest(jsonResponse(MOCK_BOARD_RESPONSE)));
+
+    // Give the microtask queue a tick to flush.
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Hook is unmounted; as long as no unhandled error is thrown the test passes.
+    // (Would throw "cannot update state on an unmounted component" in older React.)
+  });
+});

--- a/web/src/hooks/useKanbanState.ts
+++ b/web/src/hooks/useKanbanState.ts
@@ -1,0 +1,166 @@
+import { useCallback, useRef, useState } from "react";
+import { isAuthUnauthorizedError } from "@/lib/api";
+import type { RetryFetchStatus } from "@/hooks/useRetryFetch";
+import { useRealtimeFetch } from "@/hooks/useRealtimeFetch";
+import {
+  buildKanbanEventsPath,
+  fetchKanbanState,
+} from "@/lib/clients/kanban";
+import type {
+  KanbanColumn,
+  KanbanStateSnapshot,
+  KanbanTask,
+} from "@/lib/clients/kanban";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type { KanbanColumn, KanbanStateSnapshot, KanbanTask };
+
+/** State shape exposed to consumers. */
+export type KanbanStateResult = {
+  data: KanbanStateSnapshot | null;
+  loading: boolean;
+  error: string | null;
+  connectionStatus: RetryFetchStatus;
+  nextRetryMs: number | null;
+  unauthorized: boolean;
+  refresh: () => Promise<void>;
+};
+
+/** Options accepted by the hook. */
+export type KanbanStateOptions = {
+  /**
+   * Poll the board every N milliseconds on success.
+   * Also serves as the base retry delay on error (doubles up to maxRetryMs).
+   * @default 30_000
+   */
+  pollingIntervalMs?: number;
+  /**
+   * Maximum retry backoff delay (ms).
+   * @default 120_000
+   */
+  maxRetryMs?: number;
+  /** Board slug. Omit to use the server's active board. */
+  board?: string;
+  /** Disable the Kanban WebSocket stream, primarily for tests. */
+  disableWebSocket?: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function toErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * useKanbanState — fetches the active Kanban board with exponential-backoff
+ * retry so the sidebar recovers automatically after a backend kill/restore
+ * or transient network drop.
+ *
+ * - Polls every `pollingIntervalMs` ms on success (default 30s).
+ * - On error: retries with pollingIntervalMs → 2× → 4× backoff (capped at
+ *   `maxRetryMs`, default 2 minutes).
+ * - Suppresses errors silently so the sidebar doesn't break when the kanban
+ *   plugin isn't installed. Callers can inspect `error` for error badges.
+ *
+ * @example
+ *   const { data, loading } = useKanbanState();
+ *   const running = data?.columns.find(c => c.status === "running")?.tasks.length ?? 0;
+ */
+export function useKanbanState(
+  options: KanbanStateOptions = {},
+): KanbanStateResult {
+  const {
+    pollingIntervalMs = 30_000,
+    maxRetryMs = 120_000,
+    board,
+    disableWebSocket = false,
+  } = options;
+
+  const [data, setData] = useState<KanbanStateSnapshot | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [connectionStatus, setConnectionStatus] = useState<RetryFetchStatus>("idle");
+  const [nextRetryMs, setNextRetryMs] = useState<number | null>(null);
+  const [unauthorized, setUnauthorized] = useState(false);
+  const latestEventIdRef = useRef(0);
+
+  const fetchFn = useCallback(
+    () => fetchKanbanState({ board }),
+    [board],
+  );
+
+  const websocketPath = useCallback(
+    () => (disableWebSocket ? null : buildKanbanEventsPath({ board, since: latestEventIdRef.current })),
+    [board, disableWebSocket],
+  );
+
+  const handleSuccess = useCallback((snapshot: KanbanStateSnapshot) => {
+    latestEventIdRef.current = snapshot.latest_event_id;
+    setData(snapshot);
+    setError(null);
+    setUnauthorized(false);
+  }, []);
+
+  const handleError = useCallback((message: string, err: unknown) => {
+    setError(message);
+    if (isAuthUnauthorizedError(err)) {
+      setUnauthorized(true);
+      setData(null);
+      return;
+    }
+    setUnauthorized(false);
+    // Keep last known data visible so the sidebar degrades gracefully.
+  }, []);
+
+  // Prefer the Kanban plugin WebSocket event stream. Socket messages are
+  // invalidation signals that trigger an immediate REST snapshot refresh; if
+  // the socket is unavailable/reconnecting, fall back to interval polling.
+  useRealtimeFetch({
+    fetchFn,
+    onSuccess: handleSuccess,
+    onError: handleError,
+    setLoading,
+    websocketPath,
+    pollingIntervalMs,
+    retryIntervalMs: 2_000,
+    maxRetryMs: Math.min(maxRetryMs, 10_000),
+    onStatusChange: setConnectionStatus,
+    onNextRetryMsChange: setNextRetryMs,
+  });
+
+  // Imperative refresh for consumers that want to trigger an immediate poll
+  // (e.g. after a mutation, or on a user-initiated "refresh" button click).
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const snapshot = await fetchKanbanState({ board });
+      latestEventIdRef.current = snapshot.latest_event_id;
+      setData(snapshot);
+      setUnauthorized(false);
+      setConnectionStatus("connected");
+    } catch (err) {
+      setError(toErrorMessage(err));
+      if (isAuthUnauthorizedError(err)) {
+        setUnauthorized(true);
+        setData(null);
+      } else {
+        setUnauthorized(false);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [board]);
+
+  return { data, loading, error, connectionStatus, nextRetryMs, unauthorized, refresh };
+}

--- a/web/src/hooks/useMemory.ts
+++ b/web/src/hooks/useMemory.ts
@@ -1,0 +1,19 @@
+/**
+ * useMemory — thin re-export wrapper around useMemoryData.
+ *
+ * Exists so callers can import from `@/hooks/useMemory` (the name that
+ * matches the hook trio described in the acceptance criteria) without
+ * having to change `useMemoryData` internals.
+ *
+ * @example
+ *   const { data, loading, error, refetch, save } = useMemory("memory");
+ *   const charCount = data?.char_count ?? 0;
+ */
+export {
+  useMemoryData as useMemory,
+  type MemoryDataClient as MemoryClient,
+  type MemoryDataState as MemoryState,
+  type MemoryEntry,
+  type MemorySnapshot,
+  type MemoryTarget,
+} from "@/hooks/useMemoryData";

--- a/web/src/hooks/useMemoryData.test.tsx
+++ b/web/src/hooks/useMemoryData.test.tsx
@@ -1,0 +1,291 @@
+/**
+ * Unit tests for useMemoryData hook.
+ *
+ * Tests run against a mocked MemoryDataClient so no real network calls
+ * are made. The hook exposes { data, loading, error, refetch, save }.
+ */
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { useMemoryData } from "@/hooks/useMemoryData";
+import type { MemoryDataClient, MemorySnapshot, MemoryTarget } from "@/hooks/useMemoryData";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mockSnapshot: MemorySnapshot = {
+  content: "entry one\n§\nentry two",
+  entries: [{ text: "entry one" }, { text: "entry two" }],
+  char_count: 21,
+  char_limit: 2200,
+  target: "memory",
+};
+
+const mockUpdateResult = {
+  success: true,
+  char_count: 21,
+  char_limit: 2200,
+};
+
+function makeClient(overrides?: {
+  fetchMemoryState?: (target: MemoryTarget) => Promise<MemorySnapshot>;
+  updateMemoryState?: (target: MemoryTarget, content: string) => Promise<typeof mockUpdateResult>;
+}): MemoryDataClient {
+  return {
+    fetchMemoryState:
+      overrides?.fetchMemoryState ??
+      vi
+        .fn<(target: MemoryTarget) => Promise<MemorySnapshot>>()
+        .mockResolvedValue(mockSnapshot),
+    updateMemoryState:
+      overrides?.updateMemoryState ??
+      vi
+        .fn<(target: MemoryTarget, content: string) => Promise<typeof mockUpdateResult>>()
+        .mockResolvedValue(mockUpdateResult),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useMemoryData", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts with loading=true and data=null", () => {
+    const neverResolves = (): Promise<MemorySnapshot> => new Promise(() => {});
+    const client = makeClient({ fetchMemoryState: neverResolves });
+    const { result } = renderHook(() => useMemoryData("memory", client));
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("populates data after a successful fetch", async () => {
+    const client = makeClient();
+    const { result } = renderHook(() => useMemoryData("memory", client));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data).not.toBeNull();
+    expect(result.current.data?.entries).toHaveLength(2);
+    expect(result.current.data?.entries[0].text).toBe("entry one");
+    expect(result.current.data?.char_limit).toBe(2200);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces a typed error string when fetch fails", async () => {
+    const failing = (): Promise<MemorySnapshot> =>
+      Promise.reject(new Error("Network failure"));
+    const client = makeClient({ fetchMemoryState: failing });
+    const { result } = renderHook(() => useMemoryData("memory", client));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe("Network failure");
+    expect(result.current.data).toBeNull();
+  });
+
+  it("handles non-Error thrown values gracefully", async () => {
+    const client = makeClient({
+      fetchMemoryState: () => Promise.reject("string error"),
+    });
+    const { result } = renderHook(() => useMemoryData("memory", client));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe("string error");
+    expect(result.current.data).toBeNull();
+  });
+
+  it("clears error and re-populates on a successful refetch call", async () => {
+    let call = 0;
+    const impl = (): Promise<MemorySnapshot> => {
+      call++;
+      if (call === 1) return Promise.reject(new Error("First failure"));
+      return Promise.resolve(mockSnapshot);
+    };
+    const client = makeClient({ fetchMemoryState: impl });
+    const { result } = renderHook(() => useMemoryData("memory", client));
+
+    await waitFor(() => expect(result.current.error).toBe("First failure"));
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.data?.entries).toHaveLength(2);
+  });
+
+  it("keepExisting=true preserves existing data during re-fetch", async () => {
+    const snapshotV2: MemorySnapshot = {
+      ...mockSnapshot,
+      content: "updated",
+      entries: [{ text: "updated" }],
+    };
+    let call = 0;
+    const impl = (): Promise<MemorySnapshot> => {
+      call++;
+      return call === 1
+        ? Promise.resolve(mockSnapshot)
+        : Promise.resolve(snapshotV2);
+    };
+    const client = makeClient({ fetchMemoryState: impl });
+    const { result } = renderHook(() => useMemoryData("memory", client));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data?.entries[0].text).toBe("entry one");
+
+    await act(async () => {
+      await result.current.refetch({ keepExisting: true });
+    });
+
+    expect(result.current.data?.entries[0].text).toBe("updated");
+    expect(result.current.error).toBeNull();
+  });
+
+  it("refetch is callable on demand and triggers another API call", async () => {
+    let callCount = 0;
+    const impl = (): Promise<MemorySnapshot> => {
+      callCount++;
+      return Promise.resolve(mockSnapshot);
+    };
+    const client = makeClient({ fetchMemoryState: impl });
+    const { result } = renderHook(() => useMemoryData("memory", client));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(callCount).toBe(1);
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(callCount).toBe(2);
+  });
+
+  it("save calls updateMemoryState then refetches", async () => {
+    const updateFn = vi
+      .fn<(target: MemoryTarget, content: string) => Promise<typeof mockUpdateResult>>()
+      .mockResolvedValue(mockUpdateResult);
+    let fetchCallCount = 0;
+    const fetchFn = vi
+      .fn<(target: MemoryTarget) => Promise<MemorySnapshot>>()
+      .mockImplementation(() => {
+        fetchCallCount++;
+        return Promise.resolve(mockSnapshot);
+      });
+
+    const client = makeClient({ fetchMemoryState: fetchFn, updateMemoryState: updateFn });
+    const { result } = renderHook(() => useMemoryData("memory", client));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(fetchCallCount).toBe(1); // initial fetch
+
+    await act(async () => {
+      await result.current.save("new content");
+    });
+
+    expect(updateFn).toHaveBeenCalledWith("memory", "new content");
+    expect(fetchCallCount).toBeGreaterThanOrEqual(2); // save triggered refetch
+    expect(result.current.error).toBeNull();
+  });
+
+  it("save surfaces an error if updateMemoryState rejects", async () => {
+    const client = makeClient({
+      updateMemoryState: () => Promise.reject(new Error("Save failed")),
+    });
+    const { result } = renderHook(() => useMemoryData("memory", client));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.save("bad content");
+    });
+
+    expect(result.current.error).toBe("Save failed");
+  });
+
+  it("clears cached memory data and marks unauthorized when auth fails", async () => {
+    const { AuthUnauthorizedError } = await import("@/lib/api");
+    let call = 0;
+    const client = makeClient({
+      fetchMemoryState: () => {
+        call++;
+        return call === 1
+          ? Promise.resolve(mockSnapshot)
+          : Promise.reject(new AuthUnauthorizedError(401));
+      },
+    });
+    const { result } = renderHook(() => useMemoryData("memory", client));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data?.entries).toHaveLength(2);
+
+    await act(async () => {
+      await result.current.refetch({ keepExisting: true });
+    });
+
+    expect(result.current.unauthorized).toBe(true);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBe("Authentication required. Sign in again or retry the request.");
+  });
+
+  it("works with the 'user' memory target", async () => {
+    const userSnapshot: MemorySnapshot = {
+      ...mockSnapshot,
+      target: "user",
+      char_limit: 1375,
+    };
+    const client = makeClient({
+      fetchMemoryState: vi.fn().mockResolvedValue(userSnapshot),
+    });
+    const { result } = renderHook(() => useMemoryData("user", client));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data?.target).toBe("user");
+    expect(result.current.data?.char_limit).toBe(1375);
+  });
+
+  it("accepts a custom adapter for WebSocket/SSE/polling without changing state shape", async () => {
+    const wsSnapshot: MemorySnapshot = {
+      ...mockSnapshot,
+      content: "ws content",
+      entries: [{ text: "ws content" }],
+    };
+    const wsAdapter: MemoryDataClient = {
+      fetchMemoryState: () => Promise.resolve(wsSnapshot),
+      updateMemoryState: () => Promise.resolve(mockUpdateResult),
+    };
+
+    const { result } = renderHook(() => useMemoryData("memory", wsAdapter));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data?.content).toBe("ws content");
+    // State shape is stable regardless of adapter.
+    expect(result.current).toMatchObject({
+      data: expect.any(Object),
+      loading: expect.any(Boolean),
+      error: null,
+      refetch: expect.any(Function),
+      save: expect.any(Function),
+    });
+  });
+
+  it("exposes both refetch and save functions (real-time integration point)", async () => {
+    const client = makeClient();
+    const { result } = renderHook(() => useMemoryData("memory", client));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // A future WS/SSE layer can call refetch() from a subscription callback.
+    expect(typeof result.current.refetch).toBe("function");
+    // The save path is separate so UI call sites are not coupled to transport.
+    expect(typeof result.current.save).toBe("function");
+  });
+});

--- a/web/src/hooks/useMemoryData.ts
+++ b/web/src/hooks/useMemoryData.ts
@@ -1,0 +1,196 @@
+import { useCallback, useMemo, useState } from "react";
+import { useRetryFetch } from "@/hooks/useRetryFetch";
+import type { RetryFetchStatus } from "@/hooks/useRetryFetch";
+import { isAuthUnauthorizedError } from "@/lib/api";
+import { fetchMemoryData, updateMemoryData } from "@/lib/clients/memory";
+import type { MemoryEntry, MemorySnapshot, MemoryTarget } from "@/lib/clients/memory";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type { MemoryEntry, MemorySnapshot, MemoryTarget };
+
+/**
+ * Thin client/adapter interface.
+ *
+ * Pass a custom implementation to swap transport (REST → WebSocket/polling/SSE)
+ * without touching this hook's internals.
+ */
+export type MemoryDataClient = {
+  fetchMemoryState: (target: MemoryTarget) => Promise<MemorySnapshot>;
+  updateMemoryState: (target: MemoryTarget, content: string) => Promise<{ success: boolean; char_count: number; char_limit: number }>;
+};
+
+/**
+ * State shape exposed to consumers.
+ *
+ * - `data`    — the last successfully fetched snapshot, or null before the
+ *               first successful fetch.
+ * - `loading` — true while a fetch is in-flight.
+ * - `error`   — human-readable error string if the last fetch failed, else null.
+ * - `refetch` — trigger a fresh fetch on demand (e.g. after an edit).
+ *               Pass `keepExisting: true` to avoid flicker during background
+ *               refreshes.
+ * - `save`    — send an updated content string to the backend, then refetch
+ *               so state stays consistent.
+ */
+export type MemoryDataState = {
+  data: MemorySnapshot | null;
+  loading: boolean;
+  error: string | null;
+  connectionStatus: RetryFetchStatus;
+  nextRetryMs: number | null;
+  unauthorized: boolean;
+  refetch: (options?: { keepExisting?: boolean }) => Promise<void>;
+  /** Backwards-compatible alias for older callers/tests. */
+  refresh: (options?: { keepExisting?: boolean }) => Promise<void>;
+  save: (content: string) => Promise<void>;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function toErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+function makeDefaultClient(): MemoryDataClient {
+  return {
+    fetchMemoryState: (target) => fetchMemoryData(target),
+    updateMemoryState: (target, content) => updateMemoryData(target, content),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * useMemoryData — fetches Hermes agent memory for a given target store with
+ * exponential-backoff retry so the UI recovers automatically after a backend
+ * kill/restore or transient network drop.
+ *
+ * - Polls every 60s on success.
+ * - On error: retries with 60s → 120s backoff (capped at 2 minutes).
+ * - Shows `loading=true` only on the initial fetch; background polls and
+ *   retries do not flicker the spinner.
+ *
+ * Accepts an optional `client` adapter so callers can inject a mocked
+ * transport in tests, or swap to WebSocket/SSE/polling later without
+ * changing any call sites.
+ *
+ * @example
+ *   const { data, loading, error, refetch, save } = useMemoryData("memory");
+ *
+ * @example (custom adapter for tests / WS)
+ *   const client = { fetchMemoryState: myWsAdapter, updateMemoryState: myWsUpdater };
+ *   const state = useMemoryData("memory", client);
+ */
+export function useMemoryData(
+  target: MemoryTarget = "memory",
+  client?: MemoryDataClient,
+): MemoryDataState {
+  const defaultClient = useMemo(() => makeDefaultClient(), []);
+  const resolvedClient: MemoryDataClient = client ?? defaultClient;
+
+  const [data, setData] = useState<MemorySnapshot | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [connectionStatus, setConnectionStatus] = useState<RetryFetchStatus>("idle");
+  const [nextRetryMs, setNextRetryMs] = useState<number | null>(null);
+  const [unauthorized, setUnauthorized] = useState(false);
+
+  const fetchFn = useCallback(
+    () => resolvedClient.fetchMemoryState(target),
+    [resolvedClient, target],
+  );
+
+  const handleSuccess = useCallback((snapshot: MemorySnapshot) => {
+    setData(snapshot);
+    setError(null);
+    setUnauthorized(false);
+    setConnectionStatus("connected");
+  }, []);
+
+  const handleError = useCallback((message: string, err: unknown) => {
+    setError(message);
+    if (isAuthUnauthorizedError(err)) {
+      setUnauthorized(true);
+      setData(null);
+      return;
+    }
+    setUnauthorized(false);
+    // Keep last known data visible so the UI degrades gracefully.
+  }, []);
+
+  // Auto-retry loop: polls every 60s on success, backs off on error (60→120s).
+  useRetryFetch({
+    fetchFn,
+    onSuccess: handleSuccess,
+    onError: handleError,
+    setLoading,
+    baseIntervalMs: 60_000,
+    retryIntervalMs: 2_000,
+    maxIntervalMs: 10_000,
+    onStatusChange: setConnectionStatus,
+    onNextRetryMsChange: setNextRetryMs,
+  });
+
+  // Imperative refetch (e.g. after a save, or user-triggered refresh).
+  const refetch = useCallback(
+    async (options: { keepExisting?: boolean } = {}) => {
+      if (!options.keepExisting) {
+        setLoading(true);
+      }
+      setError(null);
+      try {
+        const snapshot = await resolvedClient.fetchMemoryState(target);
+        setData(snapshot);
+        setUnauthorized(false);
+        setConnectionStatus("connected");
+      } catch (err) {
+        setError(toErrorMessage(err));
+        setConnectionStatus(typeof navigator !== "undefined" && navigator.onLine === false ? "offline" : "reconnecting");
+        if (isAuthUnauthorizedError(err)) {
+          setUnauthorized(true);
+          setData(null);
+        } else {
+          setUnauthorized(false);
+          if (!options.keepExisting) {
+            setData(null);
+          }
+        }
+      } finally {
+        setLoading(false);
+      }
+    },
+    [resolvedClient, target],
+  );
+
+  const save = useCallback(
+    async (content: string) => {
+      setLoading(true);
+      setError(null);
+      try {
+        await resolvedClient.updateMemoryState(target, content);
+        setUnauthorized(false);
+        // Refetch to keep local state consistent with the server's parsed
+        // representation (entry list, char_count, etc.).
+        await refetch({ keepExisting: true });
+      } catch (err) {
+        setError(toErrorMessage(err));
+        if (isAuthUnauthorizedError(err)) {
+          setUnauthorized(true);
+          setData(null);
+        }
+        setLoading(false);
+      }
+    },
+    [resolvedClient, target, refetch],
+  );
+
+  return { data, loading, error, connectionStatus, nextRetryMs, unauthorized, refetch, refresh: refetch, save };
+}

--- a/web/src/hooks/useRealtimeFetch.test.tsx
+++ b/web/src/hooks/useRealtimeFetch.test.tsx
@@ -1,0 +1,164 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useRealtimeFetch } from "./useRealtimeFetch";
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  static instances: MockWebSocket[] = [];
+
+  readonly url: string;
+  readyState = MockWebSocket.CONNECTING;
+  onopen: (() => void) | null = null;
+  onmessage: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  close = vi.fn(() => {
+    this.readyState = MockWebSocket.CLOSED;
+  });
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  open(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  message(): void {
+    this.onmessage?.();
+  }
+
+  closeFromServer(): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.();
+  }
+}
+
+const fetchFn = vi.fn<() => Promise<string>>();
+const onSuccess = vi.fn<(value: string) => void>();
+const onError = vi.fn<(message: string, err: unknown) => void>();
+const setLoading = vi.fn<(loading: boolean) => void>();
+const onStatusChange = vi.fn();
+const onNextRetryMsChange = vi.fn();
+
+function renderRealtime(options: Partial<Parameters<typeof useRealtimeFetch<string>>[0]> = {}) {
+  return renderHook(() =>
+    useRealtimeFetch<string>({
+      fetchFn,
+      onSuccess,
+      onError,
+      setLoading,
+      onStatusChange,
+      onNextRetryMsChange,
+      pollingIntervalMs: 1_000,
+      retryIntervalMs: 500,
+      maxRetryMs: 2_000,
+      ...options,
+    }),
+  );
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+  MockWebSocket.instances = [];
+  vi.stubGlobal("WebSocket", MockWebSocket);
+  window.__HERMES_SESSION_TOKEN__ = "test-token";
+  window.__HERMES_AUTH_REQUIRED__ = false;
+  fetchFn.mockResolvedValue("snapshot");
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("useRealtimeFetch", () => {
+  it("falls back to interval polling when no WebSocket path is supplied", async () => {
+    renderRealtime({ websocketPath: undefined });
+
+    await flushEffects();
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(onSuccess).toHaveBeenCalledWith("snapshot");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(MockWebSocket.instances).toHaveLength(0);
+  });
+
+  it("opens an authenticated WebSocket and refetches when a message arrives", async () => {
+    const { unmount } = renderRealtime({ websocketPath: "/api/plugins/kanban/events?since=7" });
+
+    await flushEffects();
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(MockWebSocket.instances).toHaveLength(1);
+
+    const socket = MockWebSocket.instances[0];
+    expect(socket.url).toContain("/api/plugins/kanban/events?since=7");
+    expect(socket.url).toContain("token=test-token");
+
+    act(() => socket.open());
+    expect(onStatusChange).toHaveBeenLastCalledWith("connected");
+
+    await act(async () => {
+      socket.message();
+      await Promise.resolve();
+    });
+
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+
+    unmount();
+    expect(socket.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes the original error object to onError for auth-aware consumers", async () => {
+    const err = new Error("denied");
+    fetchFn.mockRejectedValueOnce(err);
+
+    renderRealtime({ websocketPath: undefined });
+
+    await flushEffects();
+    expect(onError).toHaveBeenCalledWith("denied", err);
+    expect(setLoading).toHaveBeenLastCalledWith(false);
+  });
+
+  it("falls back to polling and schedules reconnect when the socket closes", async () => {
+    renderRealtime({ websocketPath: "/api/plugins/kanban/events?since=0" });
+
+    await flushEffects();
+    expect(MockWebSocket.instances).toHaveLength(1);
+    const socket = MockWebSocket.instances[0];
+    act(() => socket.open());
+
+    act(() => socket.closeFromServer());
+    expect(onStatusChange).toHaveBeenLastCalledWith("reconnecting");
+    expect(onNextRetryMsChange).toHaveBeenLastCalledWith(500);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(fetchFn.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+    expect(MockWebSocket.instances.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/web/src/hooks/useRealtimeFetch.ts
+++ b/web/src/hooks/useRealtimeFetch.ts
@@ -1,0 +1,265 @@
+import { useCallback, useEffect, useRef } from "react";
+import { HERMES_BASE_PATH, buildWsAuthParam } from "@/lib/api";
+import type { RetryFetchStatus } from "@/hooks/useRetryFetch";
+
+export interface UseRealtimeFetchOptions<T> {
+  fetchFn: () => Promise<T>;
+  onSuccess: (data: T) => void;
+  onError: (message: string, err: unknown) => void;
+  setLoading: (loading: boolean) => void;
+  onStatusChange?: (status: RetryFetchStatus) => void;
+  onNextRetryMsChange?: (delayMs: number | null) => void;
+  /** Preferred WebSocket endpoint. If omitted/null, the hook uses polling only. */
+  websocketPath?: string | (() => string | null | undefined);
+  /** Poll cadence when no WebSocket endpoint is available, or while reconnecting. */
+  pollingIntervalMs?: number;
+  /** First reconnect delay after a WebSocket drop. */
+  retryIntervalMs?: number;
+  /** Maximum reconnect delay. */
+  maxRetryMs?: number;
+  enabled?: boolean;
+}
+
+function toErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+function browserIsOffline(): boolean {
+  return typeof navigator !== "undefined" && navigator.onLine === false;
+}
+
+function resolvePath(path: string | (() => string | null | undefined) | undefined): string | null {
+  if (!path) return null;
+  const resolved = typeof path === "function" ? path() : path;
+  return resolved || null;
+}
+
+function wsUrl(path: string): string {
+  const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+  // Contract: callers pass root-relative API paths without HERMES_BASE_PATH.
+  // REST uses fetchJSON to prepend the base path; WebSocket URLs are built here.
+  const basePath = path.startsWith("/") ? path : `/${path}`;
+  return `${proto}//${window.location.host}${HERMES_BASE_PATH}${basePath}`;
+}
+
+async function withWsAuth(path: string): Promise<string> {
+  const url = new URL(wsUrl(path));
+  const [key, value] = await buildWsAuthParam();
+  if (value) {
+    url.searchParams.set(key, value);
+  }
+  return url.toString();
+}
+
+/**
+ * Real-time dashboard data driver.
+ *
+ * Prefer a WebSocket subscription when `websocketPath` is supplied. Socket
+ * messages are invalidation signals that trigger an immediate REST refresh, so
+ * consumers keep using the same snapshot normalizers. If no socket exists, or
+ * while a socket is reconnecting, the hook falls back to interval polling.
+ * All timers/sockets/listeners are cancelled on unmount or option changes.
+ */
+export function useRealtimeFetch<T>({
+  fetchFn,
+  onSuccess,
+  onError,
+  setLoading,
+  onStatusChange,
+  onNextRetryMsChange,
+  websocketPath,
+  pollingIntervalMs = 30_000,
+  retryIntervalMs = 2_000,
+  maxRetryMs = 10_000,
+  enabled = true,
+}: UseRealtimeFetchOptions<T>): void {
+  const fetchSeqRef = useRef(0);
+  const websocketRef = useRef<WebSocket | null>(null);
+  const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectDelayRef = useRef(retryIntervalMs);
+  const mountedRef = useRef(false);
+  const hasLoadedRef = useRef(false);
+
+  const clearPoll = useCallback(() => {
+    if (pollTimerRef.current !== null) {
+      clearInterval(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+  }, []);
+
+  const clearReconnect = useCallback(() => {
+    if (reconnectTimerRef.current !== null) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+    onNextRetryMsChange?.(null);
+  }, [onNextRetryMsChange]);
+
+  const closeSocket = useCallback(() => {
+    const socket = websocketRef.current;
+    websocketRef.current = null;
+    if (socket && (socket.readyState === WebSocket.CONNECTING || socket.readyState === WebSocket.OPEN)) {
+      socket.close();
+    }
+  }, []);
+
+  const runFetch = useCallback(
+    async (showLoading: boolean) => {
+      if (!mountedRef.current || !enabled) return;
+      if (browserIsOffline()) {
+        onStatusChange?.("offline");
+        setLoading(false);
+        return;
+      }
+      const seq = ++fetchSeqRef.current;
+      if (showLoading) {
+        onStatusChange?.("loading");
+        setLoading(true);
+      }
+      try {
+        const data = await fetchFn();
+        if (!mountedRef.current || seq !== fetchSeqRef.current) return;
+        hasLoadedRef.current = true;
+        onSuccess(data);
+        onStatusChange?.("connected");
+        setLoading(false);
+      } catch (err) {
+        if (!mountedRef.current || seq !== fetchSeqRef.current) return;
+        onError(toErrorMessage(err), err);
+        onStatusChange?.(browserIsOffline() ? "offline" : "reconnecting");
+        setLoading(false);
+      }
+    },
+    [enabled, fetchFn, onError, onStatusChange, onSuccess, setLoading],
+  );
+
+  useEffect(() => {
+    if (!enabled) return;
+    mountedRef.current = true;
+    hasLoadedRef.current = false;
+    reconnectDelayRef.current = retryIntervalMs;
+
+    let cancelled = false;
+
+    const startPolling = () => {
+      if (cancelled || pollTimerRef.current !== null) return;
+      pollTimerRef.current = setInterval(() => {
+        void runFetch(false);
+      }, pollingIntervalMs);
+    };
+
+    const stopPolling = () => clearPoll();
+
+    const scheduleReconnect = () => {
+      if (cancelled || reconnectTimerRef.current !== null) return;
+      const delay = Math.min(reconnectDelayRef.current, maxRetryMs);
+      reconnectDelayRef.current = Math.min(delay * 2, maxRetryMs);
+      onNextRetryMsChange?.(delay);
+      reconnectTimerRef.current = setTimeout(() => {
+        reconnectTimerRef.current = null;
+        onNextRetryMsChange?.(null);
+        void connectSocket();
+      }, delay);
+    };
+
+    const connectSocket = async () => {
+      const path = resolvePath(websocketPath);
+      if (!path || typeof WebSocket === "undefined") {
+        onStatusChange?.("connected");
+        startPolling();
+        return;
+      }
+      if (browserIsOffline()) {
+        onStatusChange?.("offline");
+        startPolling();
+        scheduleReconnect();
+        return;
+      }
+      try {
+        closeSocket();
+        onStatusChange?.(hasLoadedRef.current ? "reconnecting" : "loading");
+        const socket = new WebSocket(await withWsAuth(path));
+        websocketRef.current = socket;
+
+        socket.onopen = () => {
+          if (cancelled || websocketRef.current !== socket) return;
+          reconnectDelayRef.current = retryIntervalMs;
+          clearReconnect();
+          stopPolling();
+          onStatusChange?.("connected");
+        };
+
+        socket.onmessage = () => {
+          if (cancelled || websocketRef.current !== socket) return;
+          void runFetch(false);
+        };
+
+        socket.onerror = () => {
+          if (cancelled || websocketRef.current !== socket) return;
+          onStatusChange?.("reconnecting");
+        };
+
+        socket.onclose = () => {
+          if (cancelled || websocketRef.current !== socket) return;
+          websocketRef.current = null;
+          onStatusChange?.(browserIsOffline() ? "offline" : "reconnecting");
+          startPolling();
+          scheduleReconnect();
+        };
+      } catch (err) {
+        onError(toErrorMessage(err), err);
+        onStatusChange?.("reconnecting");
+        startPolling();
+        scheduleReconnect();
+      }
+    };
+
+    const handleOnline = () => {
+      onStatusChange?.("reconnecting");
+      clearReconnect();
+      void runFetch(false);
+      void connectSocket();
+    };
+
+    const handleOffline = () => {
+      onStatusChange?.("offline");
+      closeSocket();
+      startPolling();
+    };
+
+    void runFetch(true);
+    void connectSocket();
+
+    if (typeof window !== "undefined") {
+      window.addEventListener("online", handleOnline);
+      window.addEventListener("offline", handleOffline);
+    }
+
+    return () => {
+      cancelled = true;
+      mountedRef.current = false;
+      if (typeof window !== "undefined") {
+        window.removeEventListener("online", handleOnline);
+        window.removeEventListener("offline", handleOffline);
+      }
+      clearPoll();
+      clearReconnect();
+      closeSocket();
+    };
+  }, [
+    clearPoll,
+    clearReconnect,
+    closeSocket,
+    enabled,
+    maxRetryMs,
+    onError,
+    onNextRetryMsChange,
+    onStatusChange,
+    pollingIntervalMs,
+    retryIntervalMs,
+    runFetch,
+    websocketPath,
+  ]);
+}

--- a/web/src/hooks/useRetryFetch.ts
+++ b/web/src/hooks/useRetryFetch.ts
@@ -1,0 +1,228 @@
+/**
+ * useRetryFetch — shared polling-with-backoff utility for dashboard data hooks.
+ *
+ * Drives a repeated fetch cycle:
+ *   - Fetches immediately on mount (and whenever `fetchFn` identity changes).
+ *   - On success: resets delay to `baseIntervalMs`, schedules the next fetch.
+ *   - On error:   backs off exponentially (delay × 2) up to `maxIntervalMs`,
+ *                 then retries.
+ *   - Set `enabled: false` to pause all fetching (e.g. while offline).
+ *
+ * The hook is intentionally transport-agnostic — pass any async function that
+ * resolves to T on success and throws on error.
+ *
+ * @example
+ *   useRetryFetch({
+ *     fetchFn: () => api.getProfiles(),
+ *     onSuccess: (data) => setProfiles(data.profiles),
+ *     onError: (msg) => setError(msg),
+ *     setLoading,
+ *     baseIntervalMs: 30_000,
+ *     maxIntervalMs:  120_000,
+ *   });
+ */
+
+import { useCallback, useEffect, useRef } from "react";
+
+export type RetryFetchStatus = "idle" | "loading" | "connected" | "reconnecting" | "offline";
+
+export interface UseRetryFetchOptions<T> {
+  /** The async function to call on every fetch cycle. */
+  fetchFn: () => Promise<T>;
+  /** Called with the resolved value on a successful fetch. */
+  onSuccess: (data: T) => void;
+  /** Called with an error message and the original thrown value when the fetch throws. */
+  onError: (message: string, error: unknown) => void;
+  /** Called with true at the start of the first fetch and false after any
+   *  resolution (success or error). On retries, loading is NOT re-set to true
+   *  so the UI doesn't flicker during background recovery. */
+  setLoading: (loading: boolean) => void;
+  /**
+   * Base poll interval on success (ms). The hook also uses this as the
+   * starting retry delay after a first failure.
+   * @default 30_000
+   */
+  baseIntervalMs?: number;
+  /**
+   * Maximum backoff delay (ms).
+   * @default 120_000
+   */
+  maxIntervalMs?: number;
+  /**
+   * First retry delay after a failed request. Defaults to 2 seconds so
+   * backend kill/restore and browser offline/online tests recover within the
+   * dashboard's 12–15 second verification window while successful polling can
+   * remain much quieter.
+   * @default 2_000
+   */
+  retryIntervalMs?: number;
+  /** Called whenever the retry loop enters loading/connected/reconnecting/offline. */
+  onStatusChange?: (status: RetryFetchStatus) => void;
+  /** Called with the next retry delay in milliseconds, or null when idle/successful. */
+  onNextRetryMsChange?: (delayMs: number | null) => void;
+  /**
+   * When false, no fetches are issued. Useful for pausing while the user
+   * has taken the UI offline intentionally.
+   * @default true
+   */
+  enabled?: boolean;
+}
+
+function toErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+export function useRetryFetch<T>({
+  fetchFn,
+  onSuccess,
+  onError,
+  setLoading,
+  baseIntervalMs = 30_000,
+  maxIntervalMs = 120_000,
+  retryIntervalMs = 2_000,
+  onStatusChange,
+  onNextRetryMsChange,
+  enabled = true,
+}: UseRetryFetchOptions<T>): void {
+  // Generation counter — incremented whenever the effect re-runs so stale
+  // callbacks from a previous interval never write state.
+  const genRef = useRef(0);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const delayRef = useRef(baseIntervalMs);
+  const isFirstFetch = useRef(true);
+  const inFailureRef = useRef(false);
+  // Monotonic request id for the current effect generation. Online events,
+  // timers, and manual refreshes can overlap; only the newest background
+  // request is allowed to publish state.
+  const requestSeqRef = useRef(0);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const gen = ++genRef.current;
+    isFirstFetch.current = true;
+    delayRef.current = retryIntervalMs;
+
+    let cancelled = false;
+
+    function browserIsOffline(): boolean {
+      return typeof navigator !== "undefined" && navigator.onLine === false;
+    }
+
+    function scheduleNext(delayMs: number) {
+      if (cancelled || genRef.current !== gen) return;
+      onNextRetryMsChange?.(delayMs);
+      clearTimer();
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        onNextRetryMsChange?.(null);
+        void runCycle();
+      }, delayMs);
+    }
+
+    async function runCycle() {
+      if (cancelled || genRef.current !== gen) return;
+
+      if (browserIsOffline()) {
+        onStatusChange?.("offline");
+        setLoading(false);
+        isFirstFetch.current = false;
+        scheduleNext(retryIntervalMs);
+        return;
+      }
+
+      // Show loading spinner only on the very first fetch, not on retries/polls
+      // so the UI doesn't flicker on background refreshes.
+      if (isFirstFetch.current) {
+        onStatusChange?.("loading");
+        setLoading(true);
+      } else if (inFailureRef.current) {
+        onStatusChange?.("reconnecting");
+      } else {
+        onStatusChange?.("connected");
+      }
+
+      const requestId = ++requestSeqRef.current;
+
+      try {
+        const data = await fetchFn();
+        if (cancelled || genRef.current !== gen || requestId !== requestSeqRef.current) return;
+
+        inFailureRef.current = false;
+        onSuccess(data);
+        onStatusChange?.("connected");
+        onNextRetryMsChange?.(null);
+        setLoading(false);
+        isFirstFetch.current = false;
+
+        // Quiet poll cadence after a successful request.
+        delayRef.current = retryIntervalMs;
+        scheduleNext(baseIntervalMs);
+      } catch (err) {
+        if (cancelled || genRef.current !== gen || requestId !== requestSeqRef.current) return;
+
+        inFailureRef.current = true;
+        onError(toErrorMessage(err), err);
+        onStatusChange?.(browserIsOffline() ? "offline" : "reconnecting");
+        setLoading(false);
+        isFirstFetch.current = false;
+
+        const retryDelay = Math.min(delayRef.current, maxIntervalMs);
+        delayRef.current = Math.min(retryDelay * 2, maxIntervalMs);
+        scheduleNext(retryDelay);
+      }
+    }
+
+    function handleOnline() {
+      inFailureRef.current = true;
+      delayRef.current = retryIntervalMs;
+      clearTimer();
+      onNextRetryMsChange?.(null);
+      void runCycle();
+    }
+
+    function handleOffline() {
+      inFailureRef.current = true;
+      onStatusChange?.("offline");
+      setLoading(false);
+      if (!timerRef.current) scheduleNext(retryIntervalMs);
+    }
+
+    if (typeof window !== "undefined") {
+      window.addEventListener("online", handleOnline);
+      window.addEventListener("offline", handleOffline);
+    }
+
+    void runCycle();
+
+    return () => {
+      cancelled = true;
+      if (typeof window !== "undefined") {
+        window.removeEventListener("online", handleOnline);
+        window.removeEventListener("offline", handleOffline);
+      }
+      onNextRetryMsChange?.(null);
+      clearTimer();
+    };
+  }, [
+    fetchFn,
+    onSuccess,
+    onError,
+    setLoading,
+    baseIntervalMs,
+    maxIntervalMs,
+    retryIntervalMs,
+    onStatusChange,
+    onNextRetryMsChange,
+    enabled,
+    clearTimer,
+  ]);
+}

--- a/web/src/lib/api.auth.test.ts
+++ b/web/src/lib/api.auth.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AuthUnauthorizedError,
+  fetchJSON,
+  getWsTicket,
+  isAuthUnauthorizedError,
+} from "@/lib/api";
+
+const fetchMock = vi.fn();
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? "OK" : "Error",
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+    clone() {
+      return this;
+    },
+    headers: new Headers({ "content-type": "application/json" }),
+  } as unknown as Response;
+}
+
+describe("dashboard API auth handling", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    window.__HERMES_SESSION_TOKEN__ = "session-token";
+    window.__HERMES_AUTH_REQUIRED__ = false;
+    window.__HERMES_BASE_PATH__ = "";
+  });
+
+  afterEach(() => {
+    fetchMock.mockReset();
+    vi.unstubAllGlobals();
+    delete window.__HERMES_SESSION_TOKEN__;
+    delete window.__HERMES_AUTH_REQUIRED__;
+    delete window.__HERMES_BASE_PATH__;
+  });
+
+  it("attaches existing auth credentials to dashboard API fetches", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+    await fetchJSON<{ ok: boolean }>("/api/profiles", { method: "POST" });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/profiles",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "include",
+        headers: expect.any(Headers),
+      }),
+    );
+    const headers = fetchMock.mock.calls[0][1].headers as Headers;
+    expect(headers.get("X-Hermes-Session-Token")).toBe("session-token");
+  });
+
+  it.each([401, 403])("throws typed unauthorized errors for HTTP %s", async (status) => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ detail: "denied" }, false, status));
+
+    await expect(fetchJSON("/api/memory/content")).rejects.toMatchObject({
+      status,
+      message: "Authentication required. Sign in again or retry the request.",
+    });
+  });
+
+  it("recognizes unauthorized errors without matching arbitrary strings", () => {
+    const error = new AuthUnauthorizedError(403, "Forbidden");
+
+    expect(isAuthUnauthorizedError(error)).toBe(true);
+    expect(isAuthUnauthorizedError(new Error("403: Forbidden"))).toBe(false);
+  });
+
+  it("uses the same auth layer for WebSocket ticket requests", async () => {
+    window.__HERMES_AUTH_REQUIRED__ = true;
+    fetchMock.mockResolvedValueOnce(jsonResponse({ detail: "forbidden" }, false, 403));
+
+    await expect(getWsTicket()).rejects.toBeInstanceOf(AuthUnauthorizedError);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/auth/ws-ticket",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "include",
+        headers: expect.any(Headers),
+      }),
+    );
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -34,6 +34,30 @@ declare global {
 }
 let _sessionToken: string | null = null;
 const SESSION_HEADER = "X-Hermes-Session-Token";
+export const AUTH_UNAUTHORIZED_MESSAGE = "Authentication required. Sign in again or retry the request.";
+
+export class AuthUnauthorizedError extends Error {
+  readonly status: 401 | 403;
+
+  constructor(status: 401 | 403, message = AUTH_UNAUTHORIZED_MESSAGE) {
+    super(message);
+    this.name = "AuthUnauthorizedError";
+    this.status = status;
+  }
+}
+
+export function isAuthUnauthorizedError(err: unknown): err is AuthUnauthorizedError {
+  return err instanceof AuthUnauthorizedError;
+}
+
+function isAuthManagedEndpoint(url: string): boolean {
+  return (
+    url.startsWith("/api/profiles") ||
+    url.startsWith("/api/plugins/kanban") ||
+    url.startsWith("/api/memory") ||
+    url.startsWith("/api/auth/ws-ticket")
+  );
+}
 
 function setSessionHeader(headers: Headers, token: string): void {
   if (!headers.has(SESSION_HEADER)) {
@@ -95,6 +119,9 @@ export async function fetchJSON<T>(
       // Never resolve — the page is about to unload.
       return new Promise<T>(() => {});
     }
+    if (isAuthManagedEndpoint(url) && !options?.allowUnauthorized) {
+      throw new AuthUnauthorizedError(401);
+    }
     // Loopback mode: ``_SESSION_TOKEN`` rotates on every server restart
     // (``hermes update``, ``hermes gateway restart``, etc.). A tab kept
     // open across the restart holds the OLD token in
@@ -134,6 +161,9 @@ export async function fetchJSON<T>(
     }
   }
   if (!res.ok) {
+    if (res.status === 403 && isAuthManagedEndpoint(url) && !options?.allowUnauthorized) {
+      throw new AuthUnauthorizedError(403);
+    }
     const text = await res.text().catch(() => res.statusText);
     throw new Error(`${res.status}: ${text}`);
   }
@@ -168,14 +198,9 @@ async function getSessionToken(): Promise<string> {
  * fetch a fresh ticket.
  */
 export async function getWsTicket(): Promise<{ ticket: string; ttl_seconds: number }> {
-  const res = await fetch(`${BASE}/api/auth/ws-ticket`, {
+  return fetchJSON<{ ticket: string; ttl_seconds: number }>("/api/auth/ws-ticket", {
     method: "POST",
-    credentials: "include",
   });
-  if (!res.ok) {
-    throw new Error(`/api/auth/ws-ticket: HTTP ${res.status}`);
-  }
-  return res.json();
 }
 
 /**
@@ -579,6 +604,23 @@ export const api = {
 
   // ── Admin: Memory provider ──────────────────────────────────────────
   getMemory: () => fetchJSON<MemoryStatus>("/api/memory"),
+  getMemoryContent: (target: "memory" | "user" = "memory") =>
+    fetchJSON<{
+      content: string;
+      entries: { text: string }[];
+      char_count: number;
+      char_limit: number;
+      target: string;
+    }>(`/api/memory/content?target=${encodeURIComponent(target)}`),
+  updateMemory: (target: "memory" | "user", content: string) =>
+    fetchJSON<{ ok: boolean; char_count: number; char_limit: number }>(
+      "/api/memory/content",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ target, content }),
+      },
+    ),
   setMemoryProvider: (provider: string) =>
     fetchJSON<{ ok: boolean; active: string }>("/api/memory/provider", {
       method: "PUT",

--- a/web/src/lib/clients/agentProfiles.ts
+++ b/web/src/lib/clients/agentProfiles.ts
@@ -1,0 +1,29 @@
+import { serviceFetchJSON } from "@/lib/clients/serviceFetch";
+import type { DashboardServiceClientConfig } from "@/lib/clients/serviceFetch";
+
+export const AGENT_PROFILES_API_BASE_URL_ENV = "VITE_AGENT_PROFILES_API_BASE_URL";
+
+export interface AgentProfileInfo {
+  name: string;
+  path: string;
+  is_default: boolean;
+  model: string | null;
+  provider: string | null;
+  has_env: boolean;
+  skill_count: number;
+}
+
+export interface AgentProfilesResponse {
+  profiles: AgentProfileInfo[];
+}
+
+export function listAgentProfiles(
+  config?: DashboardServiceClientConfig,
+): Promise<AgentProfilesResponse> {
+  return serviceFetchJSON<AgentProfilesResponse>(
+    AGENT_PROFILES_API_BASE_URL_ENV,
+    "/api/profiles",
+    undefined,
+    config,
+  );
+}

--- a/web/src/lib/clients/dashboard-services.test.ts
+++ b/web/src/lib/clients/dashboard-services.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { listAgentProfiles } from "@/lib/clients/agentProfiles";
+import { buildKanbanEventsPath, fetchKanbanState } from "@/lib/clients/kanban";
+import { fetchMemoryData, updateMemoryData } from "@/lib/clients/memory";
+import { DashboardServiceError } from "@/lib/clients/serviceFetch";
+
+const fetchMock = vi.fn();
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? "OK" : "Error",
+    headers: new Headers({ "content-type": "application/json" }),
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+function textResponse(body: string, status = 500): Response {
+  return {
+    ok: false,
+    status,
+    statusText: "Error",
+    headers: new Headers({ "content-type": "text/plain" }),
+    json: () => Promise.reject(new Error("not json")),
+    text: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+describe("dashboard service clients", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubEnv("VITE_AGENT_PROFILES_API_BASE_URL", "https://profiles.example.test/root/");
+    vi.stubEnv("VITE_KANBAN_API_BASE_URL", "https://kanban.example.test/base");
+    vi.stubEnv("VITE_MEMORY_API_BASE_URL", "https://memory.example.test/api-root/");
+    window.__HERMES_SESSION_TOKEN__ = "session-token";
+  });
+
+  afterEach(() => {
+    fetchMock.mockReset();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    delete window.__HERMES_SESSION_TOKEN__;
+  });
+
+  it("fetches agent profiles from the configured profiles service base URL", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ profiles: [{ name: "coder", path: "/tmp/coder", is_default: false, model: null, provider: null, has_env: true, skill_count: 4 }] }));
+
+    const result = await listAgentProfiles();
+
+    expect(result.profiles[0].name).toBe("coder");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://profiles.example.test/root/api/profiles",
+      expect.objectContaining({ credentials: "include", headers: expect.any(Headers) }),
+    );
+    const headers = fetchMock.mock.calls[0][1].headers as Headers;
+    expect(headers.get("X-Hermes-Session-Token")).toBe("session-token");
+  });
+
+  it("fetches Kanban board state from the configured Kanban service base URL", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      columns: [{ name: "running", tasks: [{ id: "t_1", title: "Build", status: "running", assignee: "coder", priority: 2 }] }],
+      tenants: ["global"],
+      assignees: ["coder"],
+      latest_event_id: 12,
+      now: 1234,
+      board: "ai-dev",
+    }));
+
+    const result = await fetchKanbanState({ board: "ai-dev" });
+
+    expect(result.columns[0].status).toBe("running");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://kanban.example.test/base/api/plugins/kanban/board?board=ai-dev",
+      expect.any(Object),
+    );
+    expect(buildKanbanEventsPath({ board: "ai-dev", since: 12 })).toBe(
+      "/api/plugins/kanban/events?since=12&board=ai-dev",
+    );
+  });
+
+  it("fetches and updates memory through the configured memory service base URL", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ content: "remember this", entries: [{ text: "remember this" }], char_count: 13, char_limit: 2200, target: "memory" }))
+      .mockResolvedValueOnce(jsonResponse({ ok: true, char_count: 14, char_limit: 2200 }));
+
+    const snapshot = await fetchMemoryData("memory");
+    const update = await updateMemoryData("user", "updated memory");
+
+    expect(snapshot.entries[0].text).toBe("remember this");
+    expect(update.success).toBe(true);
+    expect(fetchMock.mock.calls[0][0]).toBe("https://memory.example.test/api-root/api/memory/content?target=memory");
+    expect(fetchMock.mock.calls[1][0]).toBe("https://memory.example.test/api-root/api/memory/content");
+    expect(fetchMock.mock.calls[1][1]).toEqual(expect.objectContaining({ method: "PUT" }));
+  });
+
+  it("throws a predictable typed error for non-2xx service responses", async () => {
+    fetchMock.mockResolvedValueOnce(textResponse("backend unavailable", 503));
+
+    const promise = listAgentProfiles();
+
+    await expect(promise).rejects.toMatchObject({
+      name: "DashboardServiceError",
+      status: 503,
+      body: "backend unavailable",
+    });
+
+    fetchMock.mockResolvedValueOnce(textResponse("backend unavailable", 503));
+    await expect(listAgentProfiles()).rejects.toBeInstanceOf(DashboardServiceError);
+  });
+});

--- a/web/src/lib/clients/kanban.ts
+++ b/web/src/lib/clients/kanban.ts
@@ -1,0 +1,79 @@
+import { serviceFetchJSON } from "@/lib/clients/serviceFetch";
+import type { DashboardServiceClientConfig } from "@/lib/clients/serviceFetch";
+
+export const KANBAN_API_BASE_URL_ENV = "VITE_KANBAN_API_BASE_URL";
+
+export interface KanbanTask {
+  id: string;
+  title: string | null;
+  status: string;
+  assignee: string | null;
+  priority: number;
+}
+
+export interface KanbanColumn {
+  status: string;
+  tasks: KanbanTask[];
+}
+
+export interface KanbanStateSnapshot {
+  columns: KanbanColumn[];
+  tenants: string[];
+  assignees: string[];
+  latest_event_id: number;
+  now: number;
+  board?: string;
+}
+
+export interface KanbanStateOptions {
+  board?: string;
+}
+
+interface RawBoardColumn {
+  name: string;
+  tasks: KanbanTask[];
+}
+
+interface RawBoardResponse {
+  columns: RawBoardColumn[];
+  tenants: string[];
+  assignees: string[];
+  latest_event_id: number;
+  now: number;
+  board?: string;
+}
+
+function normalise(raw: RawBoardResponse): KanbanStateSnapshot {
+  return {
+    ...raw,
+    columns: raw.columns.map((column) => ({
+      status: column.name,
+      tasks: column.tasks,
+    })),
+  };
+}
+
+function buildBoardPath(board?: string): string {
+  const query = board ? `?board=${encodeURIComponent(board)}` : "";
+  return `/api/plugins/kanban/board${query}`;
+}
+
+export function buildKanbanEventsPath(options: KanbanStateOptions & { since: number }): string {
+  const params = new URLSearchParams();
+  params.set("since", String(options.since));
+  if (options.board) params.set("board", options.board);
+  return `/api/plugins/kanban/events?${params.toString()}`;
+}
+
+export async function fetchKanbanState(
+  options: KanbanStateOptions = {},
+  config?: DashboardServiceClientConfig,
+): Promise<KanbanStateSnapshot> {
+  const raw = await serviceFetchJSON<RawBoardResponse>(
+    KANBAN_API_BASE_URL_ENV,
+    buildBoardPath(options.board),
+    undefined,
+    config,
+  );
+  return normalise(raw);
+}

--- a/web/src/lib/clients/memory.ts
+++ b/web/src/lib/clients/memory.ts
@@ -1,0 +1,84 @@
+import { serviceFetchJSON } from "@/lib/clients/serviceFetch";
+import type { DashboardServiceClientConfig } from "@/lib/clients/serviceFetch";
+
+export const MEMORY_API_BASE_URL_ENV = "VITE_MEMORY_API_BASE_URL";
+
+export type MemoryTarget = "memory" | "user";
+
+export interface MemoryEntry {
+  text: string;
+}
+
+export interface MemorySnapshot {
+  content: string;
+  entries: MemoryEntry[];
+  char_count: number;
+  char_limit: number;
+  target: MemoryTarget;
+}
+
+export interface MemoryUpdateResponse {
+  success: boolean;
+  char_count: number;
+  char_limit: number;
+}
+
+interface RawMemorySnapshot {
+  content?: string;
+  entries?: MemoryEntry[];
+  char_count?: number;
+  char_limit?: number;
+  target?: string;
+}
+
+interface RawMemoryUpdateResponse {
+  ok?: boolean;
+  success?: boolean;
+  char_count: number;
+  char_limit: number;
+}
+
+function normalizeMemorySnapshot(snapshot: RawMemorySnapshot, fallbackTarget: MemoryTarget): MemorySnapshot {
+  return {
+    content: snapshot.content ?? "",
+    entries: Array.isArray(snapshot.entries) ? snapshot.entries : [],
+    char_count: typeof snapshot.char_count === "number" && Number.isFinite(snapshot.char_count) ? snapshot.char_count : 0,
+    char_limit: typeof snapshot.char_limit === "number" && Number.isFinite(snapshot.char_limit) ? snapshot.char_limit : 0,
+    target: snapshot.target === "memory" || snapshot.target === "user" ? snapshot.target : fallbackTarget,
+  };
+}
+
+export async function fetchMemoryData(
+  target: MemoryTarget = "memory",
+  config?: DashboardServiceClientConfig,
+): Promise<MemorySnapshot> {
+  const raw = await serviceFetchJSON<RawMemorySnapshot>(
+    MEMORY_API_BASE_URL_ENV,
+    `/api/memory/content?target=${encodeURIComponent(target)}`,
+    undefined,
+    config,
+  );
+  return normalizeMemorySnapshot(raw, target);
+}
+
+export async function updateMemoryData(
+  target: MemoryTarget,
+  content: string,
+  config?: DashboardServiceClientConfig,
+): Promise<MemoryUpdateResponse> {
+  const raw = await serviceFetchJSON<RawMemoryUpdateResponse>(
+    MEMORY_API_BASE_URL_ENV,
+    "/api/memory/content",
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ target, content }),
+    },
+    config,
+  );
+  return {
+    success: raw.ok ?? raw.success ?? false,
+    char_count: raw.char_count,
+    char_limit: raw.char_limit,
+  };
+}

--- a/web/src/lib/clients/serviceFetch.ts
+++ b/web/src/lib/clients/serviceFetch.ts
@@ -1,0 +1,67 @@
+import { AuthUnauthorizedError, HERMES_BASE_PATH } from "@/lib/api";
+
+export interface DashboardServiceClientConfig {
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export class DashboardServiceError extends Error {
+  readonly status: number;
+  readonly statusText: string;
+  readonly body: string;
+
+  constructor(status: number, statusText: string, body: string) {
+    super(`${status}: ${body || statusText}`);
+    this.name = "DashboardServiceError";
+    this.status = status;
+    this.statusText = statusText;
+    this.body = body;
+  }
+}
+
+function readEnvValue(key: string): string | undefined {
+  const env = import.meta.env as Record<string, string | undefined>;
+  const value = env[key]?.trim();
+  return value || undefined;
+}
+
+export function resolveServiceBaseUrl(envKey: string, explicitBaseUrl?: string): string {
+  const raw = explicitBaseUrl ?? readEnvValue(envKey) ?? HERMES_BASE_PATH;
+  if (!raw) return "";
+  return raw.replace(/\/+$/, "");
+}
+
+export function buildServiceUrl(baseUrl: string, path: string): string {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${baseUrl}${normalizedPath}`;
+}
+
+export async function serviceFetchJSON<T>(
+  envKey: string,
+  path: string,
+  init: RequestInit = {},
+  config: DashboardServiceClientConfig = {},
+): Promise<T> {
+  const headers = new Headers(init.headers);
+  const token = typeof window === "undefined" ? undefined : window.__HERMES_SESSION_TOKEN__;
+  if (token && !headers.has("X-Hermes-Session-Token")) {
+    headers.set("X-Hermes-Session-Token", token);
+  }
+
+  const fetchImpl = config.fetchImpl ?? fetch;
+  const response = await fetchImpl(buildServiceUrl(resolveServiceBaseUrl(envKey, config.baseUrl), path), {
+    ...init,
+    headers,
+    credentials: init.credentials ?? "include",
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => response.statusText);
+    if (response.status === 401 || response.status === 403) {
+      throw new AuthUnauthorizedError(response.status);
+    }
+    throw new DashboardServiceError(response.status, response.statusText, body);
+  }
+
+  return response.json() as Promise<T>;
+}

--- a/web/src/pages/CronPage.tsx
+++ b/web/src/pages/CronPage.tsx
@@ -6,7 +6,7 @@ import { Select, SelectOption } from "@nous-research/ui/ui/components/select";
 import { Spinner } from "@nous-research/ui/ui/components/spinner";
 import { H2 } from "@nous-research/ui/ui/components/typography/h2";
 import { api } from "@/lib/api";
-import type { CronJob, ProfileInfo } from "@/lib/api";
+import type { CronJob } from "@/lib/api";
 import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
 import { useToast } from "@nous-research/ui/hooks/use-toast";
 import { useConfirmDelete } from "@nous-research/ui/hooks/use-confirm-delete";
@@ -19,6 +19,7 @@ import { useI18n } from "@/i18n";
 import { usePageHeader } from "@/contexts/usePageHeader";
 import { PluginSlot } from "@/plugins";
 import { cn, themedBody } from "@/lib/utils";
+import { useAgentProfiles } from "@/hooks/useAgentProfiles";
 
 function formatTime(iso?: string | null): string {
   if (!iso) return "—";
@@ -98,12 +99,14 @@ const STATUS_TONE: Record<string, "success" | "warning" | "destructive"> = {
 
 export default function CronPage() {
   const [jobs, setJobs] = useState<CronJob[]>([]);
-  const [profiles, setProfiles] = useState<ProfileInfo[]>([]);
   const [selectedProfile, setSelectedProfile] = useState("all");
   const [loading, setLoading] = useState(true);
   const { toast, showToast } = useToast();
   const { t } = useI18n();
   const { setEnd } = usePageHeader();
+
+  // Live profiles from hook — replaces direct api.getProfiles() call
+  const { profiles } = useAgentProfiles();
 
   // New job modal state
   const [createModalOpen, setCreateModalOpen] = useState(false);
@@ -126,13 +129,6 @@ export default function CronPage() {
       .catch(() => showToast(t.common.loading, "error"))
       .finally(() => setLoading(false));
   }, [selectedProfile, showToast, t.common.loading]);
-
-  useEffect(() => {
-    api
-      .getProfiles()
-      .then((res) => setProfiles(res.profiles))
-      .catch(() => setProfiles([]));
-  }, []);
 
   useEffect(() => {
     loadJobs();

--- a/web/src/pages/PluginsPage.tsx
+++ b/web/src/pages/PluginsPage.tsx
@@ -20,6 +20,8 @@ import { useI18n } from "@/i18n";
 import { PluginSlot } from "@/plugins";
 import { cn } from "@/lib/utils";
 import { usePageHeader } from "@/contexts/usePageHeader";
+import { useRetryFetch } from "@/hooks/useRetryFetch";
+import type { RetryFetchStatus } from "@/hooks/useRetryFetch";
 
 /** Select value for built-in memory (`config` uses empty string). Never use `""` — UI Select maps empty value to an empty label. */
 const MEMORY_PROVIDER_BUILTIN = "__hermes_memory_builtin__";
@@ -27,6 +29,9 @@ const MEMORY_PROVIDER_BUILTIN = "__hermes_memory_builtin__";
 export default function PluginsPage() {
   const [hub, setHub] = useState<PluginsHubResponse | null>(null);
   const [loading, setLoading] = useState(true);
+  const [hubError, setHubError] = useState<string | null>(null);
+  const [hubConnectionStatus, setHubConnectionStatus] = useState<RetryFetchStatus>("idle");
+  const [hubNextRetryMs, setHubNextRetryMs] = useState<number | null>(null);
   const [installId, setInstallId] = useState("");
   const [installForce, setInstallForce] = useState(false);
   const [installEnable, setInstallEnable] = useState(true);
@@ -41,22 +46,32 @@ export default function PluginsPage() {
   const { t } = useI18n();
   const { setAfterTitle } = usePageHeader();
 
-  const loadHub = useCallback(() => {
-    return api
-      .getPluginsHub()
-      .then((h) => {
-        setHub(h);
-        const p = h.providers;
-        setMemorySel(p.memory_provider ? p.memory_provider : MEMORY_PROVIDER_BUILTIN);
-        setContextSel(p.context_engine || "compressor");
-      })
-      .catch(() => showToast(t.common.loading, "error"));
-  }, [showToast, t.common.loading]);
+  const applyHub = useCallback((h: PluginsHubResponse) => {
+    setHub(h);
+    setHubError(null);
+    const p = h.providers;
+    setMemorySel(p.memory_provider ? p.memory_provider : MEMORY_PROVIDER_BUILTIN);
+    setContextSel(p.context_engine || "compressor");
+  }, []);
 
-  useEffect(() => {
-    setLoading(true);
-    void loadHub().finally(() => setLoading(false));
-  }, [loadHub]);
+  const loadHub = useCallback(async () => {
+    const h = await api.getPluginsHub();
+    applyHub(h);
+    setHubConnectionStatus("connected");
+    return h;
+  }, [applyHub]);
+
+  useRetryFetch({
+    fetchFn: api.getPluginsHub,
+    onSuccess: applyHub,
+    onError: setHubError,
+    setLoading,
+    baseIntervalMs: 30_000,
+    retryIntervalMs: 2_000,
+    maxIntervalMs: 10_000,
+    onStatusChange: setHubConnectionStatus,
+    onNextRetryMsChange: setHubNextRetryMs,
+  });
 
   useEffect(() => {
     setAfterTitle(
@@ -110,6 +125,8 @@ export default function PluginsPage() {
       );
       await loadHub();
     } catch (e) {
+      setHubError(e instanceof Error ? e.message : "Rescan failed");
+      setHubConnectionStatus(typeof navigator !== "undefined" && navigator.onLine === false ? "offline" : "reconnecting");
       showToast(e instanceof Error ? e.message : "Rescan failed", "error");
     } finally {
       setRescanBusy(false);
@@ -147,10 +164,26 @@ export default function PluginsPage() {
 
   const rows = hub?.plugins ?? [];
   const providers = hub?.providers;
+  const hubRetrySeconds = hubNextRetryMs ? Math.ceil(hubNextRetryMs / 1000) : null;
+  const showHubConnectionBanner =
+    !!hubError || hubConnectionStatus === "offline" || hubConnectionStatus === "reconnecting";
 
   return (
     <div className="flex flex-col gap-4">
       <PluginSlot name="plugins:top" />
+
+      {showHubConnectionBanner && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="rounded-md border border-warning/40 bg-warning/10 px-4 py-3 text-xs text-warning"
+        >
+          {hubConnectionStatus === "offline" ? "Disconnected" : "Reconnecting"}
+          {hubError ? `: ${hubError}` : ""}
+          {hubRetrySeconds ? ` — retrying in ${hubRetrySeconds}s` : ""}
+          {!hub && " — plugin/provider data will restore automatically"}
+        </div>
+      )}
 
       <div className={cn("flex w-full flex-col gap-8")}>
 

--- a/web/src/pages/ProfilesPage.tsx
+++ b/web/src/pages/ProfilesPage.tsx
@@ -16,8 +16,9 @@ import {
 import spinners from "unicode-animations";
 import { H2 } from "@nous-research/ui/ui/components/typography/h2";
 import { api } from "@/lib/api";
-import type { ProfileInfo } from "@/lib/api";
+import { useAgentProfiles } from "@/hooks/useAgentProfiles";
 import { DeleteConfirmDialog } from "@/components/DeleteConfirmDialog";
+import { UnauthorizedState } from "@/components/UnauthorizedState";
 import { useToast } from "@nous-research/ui/hooks/use-toast";
 import { useConfirmDelete } from "@nous-research/ui/hooks/use-confirm-delete";
 import { useModalBehavior } from "@/hooks/useModalBehavior";
@@ -66,8 +67,15 @@ function ProfilesLoadingSpinner() {
 }
 
 export default function ProfilesPage() {
-  const [profiles, setProfiles] = useState<ProfileInfo[]>([]);
-  const [loading, setLoading] = useState(true);
+  const {
+    profiles,
+    loading,
+    error: profilesError,
+    connectionStatus: profilesConnectionStatus,
+    nextRetryMs: profilesNextRetryMs,
+    unauthorized: profilesUnauthorized,
+    refreshProfiles,
+  } = useAgentProfiles();
   const { toast, showToast } = useToast();
   const { t } = useI18n();
   const { setEnd } = usePageHeader();
@@ -95,18 +103,6 @@ export default function ProfilesPage() {
   // newer state when the user switches profiles or closes the editor.
   const activeSoulRequest = useRef<string | null>(null);
 
-  const load = useCallback(() => {
-    api
-      .getProfiles()
-      .then((res) => setProfiles(res.profiles))
-      .catch((e) => showToast(`${t.status.error}: ${e}`, "error"))
-      .finally(() => setLoading(false));
-  }, [showToast, t.status.error]);
-
-  useEffect(() => {
-    load();
-  }, [load]);
-
   const handleCreate = async () => {
     const name = newName.trim();
     if (!name) {
@@ -123,7 +119,7 @@ export default function ProfilesPage() {
       showToast(`${t.profiles.created}: ${name}`, "success");
       setNewName("");
       setCreateModalOpen(false);
-      load();
+      void refreshProfiles({ keepExisting: true });
     } catch (e) {
       showToast(`${t.status.error}: ${e}`, "error");
     } finally {
@@ -151,7 +147,7 @@ export default function ProfilesPage() {
       );
       setRenamingFrom(null);
       setRenameTo("");
-      load();
+      void refreshProfiles({ keepExisting: true });
     } catch (e) {
       showToast(`${t.status.error}: ${e}`, "error");
     }
@@ -216,20 +212,24 @@ export default function ProfilesPage() {
         try {
           await api.deleteProfile(name);
           showToast(`${t.profiles.deleted}: ${name}`, "success");
-          load();
+          void refreshProfiles({ keepExisting: true });
         } catch (e) {
           showToast(`${t.status.error}: ${e}`, "error");
           throw e;
         }
       },
-      [load, showToast, t.profiles.deleted, t.status.error],
+      [refreshProfiles, showToast, t.profiles.deleted, t.status.error],
     ),
   });
 
   const pendingName = profileDelete.pendingId;
 
-  // Put "Create" button in page header
+  // Put "Create" button in page header when profile data is authorized.
   useLayoutEffect(() => {
+    if (loading || profilesUnauthorized) {
+      setEnd(null);
+      return;
+    }
     setEnd(
       <Button
         className="uppercase"
@@ -242,7 +242,7 @@ export default function ProfilesPage() {
     return () => {
       setEnd(null);
     };
-  }, [setEnd, t.common.create, loading]);
+  }, [setEnd, t.common.create, loading, profilesUnauthorized]);
 
   if (loading) {
     return (
@@ -258,9 +258,58 @@ export default function ProfilesPage() {
     );
   }
 
+  const profilesRetrySeconds = profilesNextRetryMs
+    ? Math.ceil(profilesNextRetryMs / 1000)
+    : null;
+  const showProfilesConnectionBanner =
+    !!profilesError || profilesConnectionStatus === "offline" || profilesConnectionStatus === "reconnecting";
+
+  if (profilesUnauthorized) {
+    return (
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 py-10">
+        <UnauthorizedState
+          service="Agent profiles"
+          message={profilesError}
+          loginUrl={window.__HERMES_AUTH_REQUIRED__ ? "/login" : undefined}
+          onRetry={() => void refreshProfiles()}
+        />
+      </div>
+    );
+  }
+
+  if (profilesError && profiles.length === 0) {
+    return (
+      <div
+        role="alert"
+        aria-live="polite"
+        className="flex flex-col gap-3 rounded-md border border-destructive/40 bg-destructive/10 px-5 py-4 text-sm text-destructive"
+      >
+        <div>
+          {profilesConnectionStatus === "offline" ? "Disconnected" : "Reconnecting"}: {profilesError}
+          {profilesRetrySeconds ? ` — retrying in ${profilesRetrySeconds}s` : ""}
+        </div>
+        <Button className="w-fit uppercase" size="sm" onClick={() => void refreshProfiles()}>
+          {t.common.retry}
+        </Button>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col gap-6">
       <Toast toast={toast} />
+
+      {showProfilesConnectionBanner && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="rounded-md border border-warning/40 bg-warning/10 px-4 py-3 text-xs text-warning"
+        >
+          {profilesConnectionStatus === "offline" ? "Disconnected" : "Reconnecting"}
+          {profilesError ? `: ${profilesError}` : ""}
+          {profilesRetrySeconds ? ` — retrying in ${profilesRetrySeconds}s` : ""}
+        </div>
+      )}
 
       <DeleteConfirmDialog
         open={profileDelete.isOpen}

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,0 +1,2 @@
+/// <reference types="vitest/globals" />
+import "@testing-library/jest-dom";

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "node:path";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(import.meta.dirname ?? __dirname, "./src"),
+    },
+    // Prevent duplicate React instances (which cause "Invalid hook call" errors)
+    // when @testing-library/react is resolved from a different node_modules copy.
+    dedupe: ["react", "react-dom"],
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/test/setup.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
- add resilient dashboard service hooks/clients for profiles, Kanban, memory, and retry/realtime recovery
- add memory content API endpoints and dashboard docs for `/api/memory/content`
- surface sidebar status for active profiles/sessions, Kanban tasks, and memory usage
- add vault-sync content-relation metadata and tests for duplicate/artefact comparison

## Verification
- `uv run pytest tests/hermes_cli/test_dashboard_admin_endpoints.py tests/plugins/test_vault_sync_dashboard_plugin.py -q` — 33 passed
- `cd web && npm exec vitest run src/lib/api.auth.test.ts src/lib/clients/dashboard-services.test.ts src/hooks/useAgentProfiles.test.tsx src/hooks/useKanbanState.test.tsx src/hooks/useMemoryData.test.tsx src/hooks/useRealtimeFetch.test.tsx src/components/UnauthorizedState.test.tsx` — 46 passed
- `cd web && npm run build` — passed; Vite emitted existing large chunk warning
- `cd web && npm run lint` — blocked by pre-existing React compiler/lint findings outside this change set (`App.tsx`, switchers, OAuth card, i18n/theme/context, several pages, PluginPage)

## Notes
- Upstream repo permission is READ; branch is pushed to the ZillaShieldAI fork.
- Staging was explicit to avoid unrelated local ops/OpenRouter/PA-confidentiality artefacts in the working tree.