### PR TITLE
fix: use _env_float() helper for env var timeout parsing in chat_completion_helpers.py

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1761,14 +1761,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         _base_timeout = (
             _provider_timeout_cfg
             if _provider_timeout_cfg is not None
-            else float(os.getenv("HERMES_API_TIMEOUT", 1800.0))
+            else _env_float("HERMES_API_TIMEOUT", 1800.0)
         )
         # Read timeout: config wins here too.  Otherwise use
         # HERMES_STREAM_READ_TIMEOUT (default 120s) for cloud providers.
         if _provider_timeout_cfg is not None:
             _stream_read_timeout = _provider_timeout_cfg
         else:
-            _stream_read_timeout = float(os.getenv("HERMES_STREAM_READ_TIMEOUT", 120.0))
+            _stream_read_timeout = _env_float("HERMES_STREAM_READ_TIMEOUT", 120.0)
             # Local providers (Ollama, llama.cpp, vLLM) can take minutes for
             # prefill on large contexts before producing the first token.
             # Auto-increase the httpx read timeout unless the user explicitly
@@ -2508,7 +2508,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     if _cfg_stale is not None:
         _stream_stale_timeout_base = _cfg_stale
     else:
-        _stream_stale_timeout_base = float(os.getenv("HERMES_STREAM_STALE_TIMEOUT", 180.0))
+        _stream_stale_timeout_base = _env_float("HERMES_STREAM_STALE_TIMEOUT", 180.0)
     # Local providers (Ollama, oMLX, llama-cpp) can take 300+ seconds
     # for prefill on large contexts.  Disable the stale detector unless
     # the user explicitly set HERMES_STREAM_STALE_TIMEOUT.


### PR DESCRIPTION
## Bug

Three call sites in `chat_completion_helpers.py` use raw `float(os.getenv(...))` instead of the existing `_env_float()` helper (line 118). If a user sets any of these env vars to a non-numeric value, the streaming API call crashes with unhandled `ValueError`.

## Changes

| Line | Env Var | Purpose |
|------|---------|---------|
| 1764 | `HERMES_API_TIMEOUT` | Base timeout for chat completions |
| 1771 | `HERMES_STREAM_READ_TIMEOUT` | httpx read timeout |
| 2511 | `HERMES_STREAM_STALE_TIMEOUT` | Stale stream detector |

All 3 replaced with `_env_float("VAR", default)` which already exists at line 118.

## Test Plan
- [x] `py_compile` passes
- [ ] `HERMES_API_TIMEOUT=abc` falls back to 1800.0 instead of crashing
