### PR TITLE
feat(auth): add credential pool switch command

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1515,6 +1515,29 @@ class CredentialPool:
             self._current_id = None
         return removed
 
+    def activate_index(self, index: int) -> Optional[PooledCredential]:
+        """Make the 1-based entry at *index* the first credential in the pool.
+
+        Credential-pool selection is intentionally priority/order based for the
+        default ``fill_first`` strategy and as the stable tie-breaker for lease
+        selection. Persisting the selected credential at priority 0 gives the
+        CLI a durable, profile-local way to choose the next credential without
+        introducing a second "active credential" state that could drift from
+        the on-disk pool order.
+        """
+        with self._lock:
+            if index < 1 or index > len(self._entries):
+                return None
+            selected = self._entries[index - 1]
+            ordered = [selected, *self._entries[: index - 1], *self._entries[index:]]
+            self._entries = [
+                replace(entry, priority=new_priority)
+                for new_priority, entry in enumerate(ordered)
+            ]
+            self._current_id = selected.id
+            self._persist()
+            return self._entries[0]
+
     def resolve_target(self, target: Any) -> Tuple[Optional[int], Optional[PooledCredential], Optional[str]]:
         raw = str(target or "").strip()
         if not raw:

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -51,6 +51,7 @@ Examples:
     hermes auth add <provider>    Add a pooled credential
     hermes auth list              List pooled credentials
     hermes auth remove <p> <t>    Remove pooled credential by index, id, or label
+    hermes auth switch <p> <t>    Move pooled credential to first by index, id, or label
     hermes auth reset <provider>  Clear exhaustion status for a provider
     hermes model                  Select default model
     hermes fallback [list]        Show fallback provider chain

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import math
 import sys
 import time
+from dataclasses import replace
 from types import SimpleNamespace
 import uuid
 
@@ -14,6 +15,7 @@ from agent.credential_pool import (
     CUSTOM_POOL_PREFIX,
     SOURCE_MANUAL,
     SOURCE_MANUAL_DEVICE_CODE,
+    STATUS_DEAD,
     STATUS_EXHAUSTED,
     STRATEGY_FILL_FIRST,
     STRATEGY_ROUND_ROBIN,
@@ -499,6 +501,126 @@ def auth_remove_command(args) -> None:
         print(line)
 
 
+def _switch_codex_pool_and_singleton(
+    selected_id: str,
+) -> PooledCredential | None:
+    """Atomically promote a Codex OAuth pool entry and mirror singleton state.
+
+    Codex still has singleton-auth paths for token refresh and usage/status
+    checks.  If the user switches to an independent manual Codex account, the
+    selected entry must become the singleton-backed ``device_code`` entry rather
+    than merely copying its tokens into ``providers.openai-codex``. Otherwise
+    the next ``load_pool('openai-codex')`` would seed a duplicate device_code
+    entry and leave the old account mislabeled.
+    """
+    with auth_mod._auth_store_lock():
+        auth_store = auth_mod._load_auth_store()
+        pool_store = auth_store.get("credential_pool")
+        if not isinstance(pool_store, dict):
+            return None
+        payloads = pool_store.get("openai-codex")
+        if not isinstance(payloads, list):
+            return None
+        entries = [
+            PooledCredential.from_dict("openai-codex", payload)
+            for payload in payloads
+            if isinstance(payload, dict)
+        ]
+        selected = next((entry for entry in entries if entry.id == selected_id), None)
+        if selected is None or selected.auth_type != AUTH_TYPE_OAUTH:
+            return None
+        access_token = (selected.access_token or "").strip()
+        refresh_token = (selected.refresh_token or "").strip()
+        if not access_token:
+            return None
+        if not refresh_token:
+            raise SystemExit(
+                "Selected openai-codex OAuth credential is missing refresh_token. "
+                "Re-authenticate it with `hermes auth add openai-codex` before switching."
+            )
+
+        promoted_entries: list[PooledCredential] = []
+        for entry in entries:
+            updated = entry
+            if entry.id == selected_id:
+                updated = replace(entry, source="device_code")
+            elif entry.source == "device_code":
+                updated = replace(entry, source=SOURCE_MANUAL_DEVICE_CODE)
+            promoted_entries.append(updated)
+
+        selected_promoted = next(entry for entry in promoted_entries if entry.id == selected_id)
+        ordered = [
+            selected_promoted,
+            *[entry for entry in promoted_entries if entry.id != selected_id],
+        ]
+        ordered = [
+            replace(entry, priority=new_priority)
+            for new_priority, entry in enumerate(ordered)
+        ]
+        selected_promoted = ordered[0]
+        pool_store["openai-codex"] = [entry.to_dict() for entry in ordered]
+
+        state = auth_mod._load_provider_state(auth_store, "openai-codex") or {}
+        if not isinstance(state, dict):
+            state = {}
+        tokens = state.get("tokens")
+        if not isinstance(tokens, dict):
+            tokens = {}
+        tokens["access_token"] = access_token
+        tokens["refresh_token"] = refresh_token
+        state["tokens"] = tokens
+        state["auth_mode"] = state.get("auth_mode") or "chatgpt"
+        if selected_promoted.last_refresh:
+            state["last_refresh"] = selected_promoted.last_refresh
+        else:
+            state.pop("last_refresh", None)
+        if selected_promoted.label:
+            state["label"] = selected_promoted.label
+        auth_mod._store_provider_state(
+            auth_store,
+            "openai-codex",
+            state,
+            set_active=False,
+        )
+        auth_mod._save_auth_store(auth_store)
+    return selected_promoted
+
+
+def auth_switch_command(args) -> None:
+    provider = _normalize_provider(getattr(args, "provider", ""))
+    target = getattr(args, "target", None)
+    pool = load_pool(provider)
+    index, matched, error = pool.resolve_target(target)
+    if matched is None or index is None:
+        raise SystemExit(f"{error} Provider: {provider}.")
+
+    selected = None
+    synced_singleton = False
+    if provider == "openai-codex" and matched.auth_type == AUTH_TYPE_OAUTH:
+        selected = _switch_codex_pool_and_singleton(matched.id)
+        synced_singleton = selected is not None
+    else:
+        selected = pool.activate_index(index)
+    if selected is None:
+        raise SystemExit(f'No credential matching "{target}" for provider {provider}.')
+
+    print(f"Switched {provider} to credential \"{selected.label}\" (now #1)")
+    strategy = get_pool_strategy(provider)
+    if strategy in {STRATEGY_ROUND_ROBIN, STRATEGY_RANDOM, STRATEGY_LEAST_USED}:
+        print(
+            f"Note: {provider} uses {strategy}; later requests may select "
+            "another credential according to that strategy."
+        )
+    if selected.last_status in {STATUS_EXHAUSTED, STATUS_DEAD}:
+        print(
+            "Note: selected credential is currently marked "
+            f"{selected.last_status}; run `hermes auth reset {provider}` "
+            "if you intentionally want to clear cooldown state."
+        )
+    if synced_singleton:
+        print("Synchronized openai-codex singleton auth state with the selected credential.")
+
+
 def auth_reset_command(args) -> None:
     provider = _normalize_provider(getattr(args, "provider", ""))
     pool = load_pool(provider)
@@ -785,6 +907,9 @@ def auth_command(args) -> None:
         return
     if action == "remove":
         auth_remove_command(args)
+        return
+    if action == "switch":
+        auth_switch_command(args)
         return
     if action == "reset":
         auth_reset_command(args)

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -748,6 +748,7 @@ def _interactive_auth() -> None:
     choices = [
         "Add a credential",
         "Remove a credential",
+        "Switch active credential for a provider",
         "Reset cooldowns for a provider",
         "Set rotation strategy for a provider",
         "Exit",
@@ -769,8 +770,10 @@ def _interactive_auth() -> None:
     elif raw == "2":
         _interactive_remove()
     elif raw == "3":
-        _interactive_reset()
+        _interactive_switch()
     elif raw == "4":
+        _interactive_reset()
+    elif raw == "5":
         _interactive_strategy()
 
 
@@ -847,6 +850,29 @@ def _interactive_remove() -> None:
         return
 
     auth_remove_command(SimpleNamespace(provider=provider, target=raw))
+
+
+def _interactive_switch() -> None:
+    provider = _pick_provider("Provider to switch credential for")
+    pool = load_pool(provider)
+    if not pool.has_credentials():
+        print(f"No credentials for {provider}.")
+        return
+
+    current = pool.peek()
+    for i, e in enumerate(pool.entries(), 1):
+        marker = " ←" if current is not None and e.id == current.id else ""
+        exhausted = _format_exhausted_status(e)
+        print(f"  #{i}  {e.label:25s} {e.auth_type:10s} {e.source}{exhausted} [id:{e.id}]{marker}")
+
+    try:
+        raw = input("Switch to #, id, or label (blank to cancel): ").strip()
+    except (EOFError, KeyboardInterrupt):
+        return
+    if not raw:
+        return
+
+    auth_switch_command(SimpleNamespace(provider=provider, target=raw))
 
 
 def _interactive_reset() -> None:

--- a/hermes_cli/subcommands/auth.py
+++ b/hermes_cli/subcommands/auth.py
@@ -69,6 +69,13 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
     auth_remove.add_argument(
         "target", help="Credential index, entry id, or exact label"
     )
+    auth_switch = auth_subparsers.add_parser(
+        "switch", help="Move a pooled credential to #1 for a provider"
+    )
+    auth_switch.add_argument("provider", help="Provider id")
+    auth_switch.add_argument(
+        "target", help="Credential index, entry id, or exact label"
+    )
     auth_reset = auth_subparsers.add_parser(
         "reset", help="Clear exhaustion status for all credentials for a provider"
     )

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import json
+import time
 from datetime import datetime, timezone
 from unittest.mock import patch
 
@@ -23,6 +24,37 @@ def _jwt_with_email(email: str) -> str:
         json.dumps({"email": email}).encode()
     ).rstrip(b"=").decode()
     return f"{header}.{payload}.signature"
+
+
+def _codex_pool_only_store(*, exhausted: bool = False) -> dict:
+    entry = {
+        "id": "codex-1",
+        "label": "codex@example.com",
+        "auth_type": "oauth",
+        "priority": 0,
+        "source": "manual:device_code",
+        "access_token": _jwt_with_email("codex@example.com"),
+        "refresh_token": "refresh-token",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "last_refresh": "2026-06-15T10:00:00Z",
+    }
+    if exhausted:
+        entry.update(
+            {
+                "last_status": "exhausted",
+                "last_status_at": time.time(),
+                "last_error_code": 429,
+                "last_error_reason": "usage_limit_reached",
+                "last_error_message": "The usage limit has been reached",
+                "last_error_reset_at": time.time() + 3600,
+            }
+        )
+    return {
+        "version": 1,
+        "active_provider": "openai-codex",
+        "providers": {},
+        "credential_pool": {"openai-codex": [entry]},
+    }
 
 
 @pytest.fixture(autouse=True)
@@ -483,6 +515,44 @@ def test_auth_add_codex_oauth_keeps_distinct_pool_accounts(tmp_path, monkeypatch
     assert payload["active_provider"] == "openai-codex"
 
 
+def test_codex_auth_status_reports_pool_only_credential(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, _codex_pool_only_store())
+
+    from hermes_cli.auth import get_codex_auth_status
+
+    status = get_codex_auth_status()
+
+    assert status["logged_in"] is True
+    assert status["source"] == "pool:codex@example.com"
+
+
+def test_codex_auth_status_reports_pool_only_rate_limit(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, _codex_pool_only_store(exhausted=True))
+
+    from hermes_cli.auth import get_codex_auth_status
+
+    status = get_codex_auth_status()
+
+    assert status["logged_in"] is True
+    assert status["rate_limited"] is True
+    assert status["error_code"] == "codex_rate_limited"
+
+
+def test_codex_runtime_pool_only_rate_limit_is_not_missing_auth(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, _codex_pool_only_store(exhausted=True))
+
+    from hermes_cli.auth import AuthError, CODEX_RATE_LIMITED_CODE, resolve_codex_runtime_credentials
+
+    with pytest.raises(AuthError) as exc_info:
+        resolve_codex_runtime_credentials()
+
+    assert exc_info.value.code == CODEX_RATE_LIMITED_CODE
+    assert exc_info.value.relogin_required is False
+
+
 def test_auth_add_xai_oauth_sets_active_provider(tmp_path, monkeypatch):
     """hermes auth add xai-oauth must write providers singleton and set active_provider.
 
@@ -743,6 +813,55 @@ def test_auth_switch_reorders_provider_pool(tmp_path, monkeypatch, capsys):
     entries = payload["credential_pool"]["openrouter"]
     assert [entry["label"] for entry in entries] == ["backup", "primary", "third"]
     assert [entry["priority"] for entry in entries] == [0, 1, 2]
+
+
+def test_interactive_auth_menu_exposes_switch(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(
+        "agent.credential_pool._seed_from_singletons",
+        lambda provider, entries: (False, set()),
+    )
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openrouter": [
+                    {
+                        "id": "cred-a",
+                        "label": "primary",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-or-primary",
+                    },
+                    {
+                        "id": "cred-b",
+                        "label": "backup",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "sk-or-backup",
+                    },
+                ]
+            },
+        },
+    )
+    answers = iter(["3", "openrouter", "backup"])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+
+    from hermes_cli.auth_commands import _interactive_auth
+
+    _interactive_auth()
+
+    out = capsys.readouterr().out
+    assert "3. Switch active credential for a provider" in out
+    assert 'Switched openrouter to credential "backup" (now #1)' in out
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert [entry["label"] for entry in payload["credential_pool"]["openrouter"]] == [
+        "backup",
+        "primary",
+    ]
 
 
 def test_auth_switch_accepts_id_target(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -688,6 +688,315 @@ def test_auth_remove_prefers_exact_numeric_label_over_index(tmp_path, monkeypatc
     assert labels == ["first", "third"]
 
 
+def test_auth_switch_reorders_provider_pool(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(
+        "agent.credential_pool._seed_from_singletons",
+        lambda provider, entries: (False, set()),
+    )
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openrouter": [
+                    {
+                        "id": "cred-a",
+                        "label": "primary",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-or-primary",
+                    },
+                    {
+                        "id": "cred-b",
+                        "label": "backup",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "sk-or-backup",
+                    },
+                    {
+                        "id": "cred-c",
+                        "label": "third",
+                        "auth_type": "api_key",
+                        "priority": 2,
+                        "source": "manual",
+                        "access_token": "sk-or-third",
+                    },
+                ]
+            },
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_switch_command
+
+    class _Args:
+        provider = "openrouter"
+        target = "backup"
+
+    auth_switch_command(_Args())
+
+    out = capsys.readouterr().out
+    assert 'Switched openrouter to credential "backup" (now #1)' in out
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entries = payload["credential_pool"]["openrouter"]
+    assert [entry["label"] for entry in entries] == ["backup", "primary", "third"]
+    assert [entry["priority"] for entry in entries] == [0, 1, 2]
+
+
+def test_auth_switch_accepts_id_target(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr(
+        "agent.credential_pool._seed_from_singletons",
+        lambda provider, entries: (False, set()),
+    )
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openrouter": [
+                    {
+                        "id": "first-id",
+                        "label": "first",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-or-first",
+                    },
+                    {
+                        "id": "second-id",
+                        "label": "second",
+                        "auth_type": "api_key",
+                        "priority": 1,
+                        "source": "manual",
+                        "access_token": "sk-or-second",
+                    },
+                ]
+            },
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_switch_command
+
+    class _Args:
+        provider = "openrouter"
+        target = "second-id"
+
+    auth_switch_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entries = payload["credential_pool"]["openrouter"]
+    assert [entry["id"] for entry in entries] == ["second-id", "first-id"]
+    assert [entry["priority"] for entry in entries] == [0, 1]
+
+
+def test_auth_switch_syncs_codex_singleton_without_changing_active_provider(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "active_provider": "openrouter",
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "acctA-at",
+                        "refresh_token": "acctA-rt",
+                    },
+                    "auth_mode": "chatgpt",
+                    "label": "account-A",
+                },
+            },
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "acctA",
+                        "label": "account-A",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "device_code",
+                        "access_token": "acctA-at",
+                        "refresh_token": "acctA-rt",
+                    },
+                    {
+                        "id": "acctB",
+                        "label": "account-B",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "source": "manual:device_code",
+                        "access_token": "acctB-at",
+                        "refresh_token": "acctB-rt",
+                        "last_refresh": "2026-06-13T00:00:00Z",
+                    },
+                ]
+            },
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_switch_command
+
+    class _Args:
+        provider = "openai-codex"
+        target = "account-B"
+
+    auth_switch_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert payload["active_provider"] == "openrouter"
+    entries = payload["credential_pool"]["openai-codex"]
+    assert [entry["id"] for entry in entries] == ["acctB", "acctA"]
+    assert [entry["source"] for entry in entries] == [
+        "device_code",
+        "manual:device_code",
+    ]
+    singleton = payload["providers"]["openai-codex"]
+    assert singleton["tokens"] == {
+        "access_token": "acctB-at",
+        "refresh_token": "acctB-rt",
+    }
+    assert singleton["label"] == "account-B"
+    assert singleton["last_refresh"] == "2026-06-13T00:00:00Z"
+
+    from agent.credential_pool import load_pool
+
+    reloaded = load_pool("openai-codex").entries()
+    assert [(entry.id, entry.label, entry.source) for entry in reloaded] == [
+        ("acctB", "account-B", "device_code"),
+        ("acctA", "account-A", "manual:device_code"),
+    ]
+
+
+def test_auth_switch_codex_uses_fresh_on_disk_tokens(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "acctA-at",
+                        "refresh_token": "acctA-rt",
+                    },
+                    "auth_mode": "chatgpt",
+                },
+            },
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "acctA",
+                        "label": "account-A",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "device_code",
+                        "access_token": "acctA-at",
+                        "refresh_token": "acctA-rt",
+                    },
+                    {
+                        "id": "acctB",
+                        "label": "account-B",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "source": "manual:device_code",
+                        "access_token": "acctB-stale-at",
+                        "refresh_token": "acctB-stale-rt",
+                    },
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+    import hermes_cli.auth_commands as auth_commands
+
+    # Simulate a command that resolved acctB from an older in-memory pool before
+    # another process refreshed acctB's single-use OAuth tokens on disk.
+    _idx, matched, _error = load_pool("openai-codex").resolve_target("account-B")
+    assert matched is not None
+    assert matched.id == "acctB"
+    auth_path = tmp_path / "hermes" / "auth.json"
+    payload = json.loads(auth_path.read_text())
+    acct_b = next(entry for entry in payload["credential_pool"]["openai-codex"] if entry["id"] == "acctB")
+    acct_b["access_token"] = "acctB-fresh-at"
+    acct_b["refresh_token"] = "acctB-fresh-rt"
+    auth_path.write_text(json.dumps(payload, indent=2))
+
+    selected = getattr(auth_commands, "_switch_codex_pool_and_singleton")("acctB")
+
+    assert selected is not None
+    payload = json.loads(auth_path.read_text())
+    singleton = payload["providers"]["openai-codex"]
+    assert singleton["tokens"] == {
+        "access_token": "acctB-fresh-at",
+        "refresh_token": "acctB-fresh-rt",
+    }
+    acct_b = payload["credential_pool"]["openai-codex"][0]
+    assert acct_b["id"] == "acctB"
+    assert acct_b["access_token"] == "acctB-fresh-at"
+    assert acct_b["refresh_token"] == "acctB-fresh-rt"
+
+
+def test_auth_switch_codex_requires_refresh_token(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "acctA-at",
+                        "refresh_token": "acctA-rt",
+                    },
+                    "auth_mode": "chatgpt",
+                },
+            },
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "acctA",
+                        "label": "account-A",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "device_code",
+                        "access_token": "acctA-at",
+                        "refresh_token": "acctA-rt",
+                    },
+                    {
+                        "id": "acctB",
+                        "label": "account-B",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "source": "manual:device_code",
+                        "access_token": "acctB-at",
+                    },
+                ]
+            },
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_switch_command
+
+    class _Args:
+        provider = "openai-codex"
+        target = "account-B"
+
+    with pytest.raises(SystemExit, match="missing refresh_token"):
+        auth_switch_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert payload["providers"]["openai-codex"]["tokens"] == {
+        "access_token": "acctA-at",
+        "refresh_token": "acctA-rt",
+    }
+    assert [entry["id"] for entry in payload["credential_pool"]["openai-codex"]] == [
+        "acctA",
+        "acctB",
+    ]
+
+
 def test_auth_reset_clears_provider_statuses(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -494,6 +494,7 @@ hermes auth list openrouter                              # Show specific provide
 hermes auth add openrouter --api-key sk-or-v1-xxx        # Add API key
 hermes auth add anthropic --type oauth                   # Add OAuth credential
 hermes auth remove openrouter 2                          # Remove by index
+hermes auth switch openrouter 2                          # Move credential #2 to first
 hermes auth reset openrouter                             # Clear cooldowns
 hermes auth status anthropic                             # Show auth status for a provider
 hermes auth logout anthropic                             # Log out and clear stored auth state

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -111,6 +111,7 @@ Type [1/2]:
 | `hermes auth add <provider> --type api-key --api-key <key>` | Add an API key non-interactively |
 | `hermes auth add <provider> --type oauth` | Add an OAuth credential via browser login |
 | `hermes auth remove <provider> <index>` | Remove credential by 1-based index |
+| `hermes auth switch <provider> <target>` | Move an index, id, or exact-label credential to #1 (the next choice under `fill_first`) |
 | `hermes auth reset <provider>` | Clear all cooldowns/exhaustion status |
 
 ## Rotation Strategies

--- a/website/docs/user-guide/features/credential-pools.md
+++ b/website/docs/user-guide/features/credential-pools.md
@@ -86,9 +86,10 @@ This shows your full pool status and offers a menu:
 What would you like to do?
   1. Add a credential
   2. Remove a credential
-  3. Reset cooldowns for a provider
-  4. Set rotation strategy for a provider
-  5. Exit
+  3. Switch active credential for a provider
+  4. Reset cooldowns for a provider
+  5. Set rotation strategy for a provider
+  6. Exit
 ```
 
 For providers that support both API keys and OAuth (Anthropic, Nous, Codex), the add flow asks which type:


### PR DESCRIPTION
## Summary

Adds a focused `hermes auth switch <provider> <target>` command for manually choosing which credential in a same-provider credential pool should be tried first.

The command:
- accepts the same target forms as `hermes auth remove`: 1-based index, credential id, or exact label
- persists the selected credential as priority `0` instead of adding a second active-credential state
- warns when the configured strategy (`least_used`, `round_robin`, or `random`) may choose a different credential later
- updates CLI help and credential-pool docs

For `openai-codex`, switching an OAuth credential also keeps the singleton Codex auth block aligned with the selected pool entry, because some Codex paths still read that singleton state. That path is intentionally guarded so it:
- promotes the selected entry to the singleton-backed `device_code` source
- demotes the previous `device_code` entry to `manual:device_code` so the old account is preserved
- updates pool + singleton state under one auth-store lock
- preserves `active_provider`
- refuses Codex OAuth entries that lack required refresh material, avoiding silent credential loss

## Issues / relation to existing work

Fixes #22407.
Fixes #37224.

Related: #22916, #42798, #43747.

This is a smaller, refreshed alternative to stale PR #17527. It keeps the public surface to one command plus docs/tests, and adds extra Codex regression coverage around singleton/pool drift and independent account preservation.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_auth_commands.py tests/hermes_cli/test_auth_codex_provider.py`
  - 84 tests passed
- `python -m py_compile agent/credential_pool.py hermes_cli/auth_commands.py hermes_cli/subcommands/auth.py hermes_cli/_parser.py`
- `git diff --check`
- Manual smoke:
  - `python -m hermes_cli.main auth switch openrouter second` against a temp `HERMES_HOME` reordered the pool to `['second', 'first']`
  - `python -m hermes_cli.main auth switch openai-codex account-B` against a temp `HERMES_HOME` promoted account-B to `device_code`, demoted account-A to `manual:device_code`, and kept both credentials after `load_pool('openai-codex')`

## Review

Independent review was run after implementation. Initial review found Codex singleton/pool edge cases; those were fixed with additional regression tests. Final focused review passed with no remaining blockers.
