### PR TITLE
fix: guard float() env var casts in Discord adapter __init__

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -628,8 +628,14 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_clients: Dict[int, Any] = {}  # guild_id -> VoiceClient
         self._voice_locks: Dict[int, asyncio.Lock] = {}  # guild_id -> serialize join/leave
         # Text batching: merge rapid successive messages (Telegram-style)
-        self._text_batch_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", "0.6"))
-        self._text_batch_split_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
+        try:
+            self._text_batch_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", "0.6"))
+        except (ValueError, TypeError):
+            self._text_batch_delay_seconds = 0.6
+        try:
+            self._text_batch_split_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
+        except (ValueError, TypeError):
+            self._text_batch_split_delay_seconds = 2.0
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._voice_text_channels: Dict[int, int] = {}  # guild_id -> text_channel_id


### PR DESCRIPTION
## Bug

Two env var casts in `plugins/platforms/discord/adapter.py` `__init__` use raw `float(os.getenv(...))` without try/except:
- `HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS` (line 631)
- `HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS` (line 632)

If either env var is set to a non-numeric value, the entire Discord adapter fails to initialize — preventing Discord from working at all.

Other platform adapters (e.g. `google_chat`) already guard these with `try/except (ValueError, TypeError)`.

## Fix

Wrap both casts in `try/except (ValueError, TypeError)` with appropriate defaults (0.6 and 2.0).

## Test Plan
- [x] `py_compile` passes
- [ ] `HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS=abc` falls back to 0.6
