### PR TITLE
fix(cli): read fallback_providers nested under model: config key

### DIFF
--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -62,11 +62,19 @@ def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
     seen: set[tuple[str, str, str]] = set()
 
     for key in ("fallback_providers", "fallback_model"):
-        for entry in _iter_fallback_entries(config.get(key)):
-            identity = _entry_identity(entry)
-            if identity in seen:
-                continue
-            seen.add(identity)
-            chain.append(entry)
+        # Check top-level key first (legacy), then nested under ``model:``
+        # (#45309).  The nested form mirrors ``model.default`` / ``model.provider``
+        # and is the natural placement for per-model overrides.
+        model_section = config.get("model")
+        sources = [config]
+        if isinstance(model_section, dict):
+            sources.append(model_section)
+        for source in sources:
+            for entry in _iter_fallback_entries(source.get(key)):
+                identity = _entry_identity(entry)
+                if identity in seen:
+                    continue
+                seen.add(identity)
+                chain.append(entry)
 
     return chain

--- a/tests/hermes_cli/test_fallback_config.py
+++ b/tests/hermes_cli/test_fallback_config.py
@@ -1,0 +1,89 @@
+"""Tests for ``hermes_cli/fallback_config.py`` — fallback chain resolution."""
+
+from hermes_cli.fallback_config import get_fallback_chain
+
+
+class TestGetFallbackChain:
+    """``get_fallback_chain`` reads fallback entries from config."""
+
+    def test_top_level_fallback_providers(self):
+        """Top-level ``fallback_providers`` is still honored (legacy)."""
+        config = {
+            "fallback_providers": [
+                {"provider": "openrouter", "model": "gpt-4o-mini"},
+            ],
+        }
+        chain = get_fallback_chain(config)
+        assert len(chain) == 1
+        assert chain[0]["provider"] == "openrouter"
+        assert chain[0]["model"] == "gpt-4o-mini"
+
+    def test_nested_under_model_is_honored(self):
+        """``fallback_providers`` nested under ``model:`` is now read (#45309)."""
+        config = {
+            "model": {
+                "default": "gpt-5.5",
+                "provider": "openai-codex",
+                "fallback_providers": [
+                    {"provider": "openrouter", "model": "gpt-4o-mini"},
+                ],
+            },
+        }
+        chain = get_fallback_chain(config)
+        assert len(chain) == 1
+        assert chain[0]["provider"] == "openrouter"
+
+    def test_both_layers_merged(self):
+        """Entries from top-level and ``model:`` are merged; duplicates deduped."""
+        config = {
+            "fallback_providers": [
+                {"provider": "openrouter", "model": "gpt-4o-mini"},
+            ],
+            "model": {
+                "fallback_providers": [
+                    {"provider": "anthropic", "model": "claude-sonnet-4"},
+                ],
+            },
+        }
+        chain = get_fallback_chain(config)
+        assert len(chain) == 2
+        providers = [e["provider"] for e in chain]
+        assert "openrouter" in providers
+        assert "anthropic" in providers
+
+    def test_nested_duplicate_deduped_across_layers(self):
+        """Same entry in both layers is only included once."""
+        config = {
+            "fallback_providers": [
+                {"provider": "openrouter", "model": "gpt-4o-mini"},
+            ],
+            "model": {
+                "fallback_providers": [
+                    {"provider": "openrouter", "model": "gpt-4o-mini"},
+                ],
+            },
+        }
+        chain = get_fallback_chain(config)
+        assert len(chain) == 1
+
+    def test_nested_fallback_model(self):
+        """``fallback_model`` nested under ``model:`` is also read."""
+        config = {
+            "model": {
+                "fallback_model": {"provider": "deepseek", "model": "deepseek-chat"},
+            },
+        }
+        chain = get_fallback_chain(config)
+        assert len(chain) == 1
+        assert chain[0]["provider"] == "deepseek"
+
+    def test_empty_config_returns_empty(self):
+        """No fallback config → empty chain."""
+        assert get_fallback_chain({}) == []
+        assert get_fallback_chain(None) == []
+
+    def test_nested_with_missing_model_section(self):
+        """No ``model:`` key at all → only top-level is read (no crash)."""
+        config = {"fallback_providers": [{"provider": "openrouter", "model": "gpt-4o"}]}
+        chain = get_fallback_chain(config)
+        assert len(chain) == 1


### PR DESCRIPTION

## Summary

`get_fallback_chain()` only read `fallback_providers` from the top level of the config dict. When `fallback_providers` was nested under `model:`, it was silently ignored and the fallback chain came back empty. This fix adds a check on `config.get("model", {})` as well, merging entries from both layers while deduplicating by identity.

---

## Changes

**File:** `hermes_cli/fallback_config.py`
- Updated `get_fallback_chain()` to read `fallback_providers` from both the top-level config and the `model:` nested config, merging with deduplication.

**File:** `tests/hermes_cli/test_fallback_config.py`
- Added 7 tests covering: nested-only, top-level-only, merge, dedup, and edge cases.

---

## How to Test

```bash
pytest tests/hermes_cli/test_fallback_config.py -xvs
# ✅ 7/7 passed
```

---

## Checklist

- [x] Tests pass — 7/7
- [x] Regression tests added for all affected config layouts
- [x] Changes scoped to this fix only
- [x] Follows Conventional Commits

---

## Risk & Impact

**Low.** Additive read path only — top-level `fallback_providers` behavior is unchanged. Users with `fallback_providers` nested under `model:` will now have their fallback chain correctly populated instead of silently receiving an empty list.

**Type:** 🐛 Bug fix  
**Closes:** #45309