### PR TITLE
fix: guard float() env var cast in run_agent.py

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1094,7 +1094,10 @@ class AIAgent:
         cfg = get_provider_request_timeout(self.provider, self.model)
         if cfg is not None:
             return cfg
-        return float(os.getenv("HERMES_API_TIMEOUT", 1800.0))
+        try:
+            return float(os.getenv("HERMES_API_TIMEOUT", 1800.0))
+        except (ValueError, TypeError):
+            return 1800.0
 
     def _resolved_api_call_stale_timeout_base(self) -> tuple[float, bool]:
         """Resolve the base non-stream stale timeout and whether it is implicit.


### PR DESCRIPTION
## Bug

`HERMES_API_TIMEOUT` in `run_agent.py:1097` cast via raw `float(os.getenv(...))` without try/except. Non-numeric value crashes every API call with `ValueError`.

## Fix

Wrap in `try/except (ValueError, TypeError)` returning 1800.0 as safe default.

## Test Plan
- [x] `py_compile` passes