### PR TITLE
fix(desktop): route TTS through active profile

### DIFF
--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getSessionMessages, listAllProfileSessions, listSessions } from './hermes'
+import { getSessionMessages, listAllProfileSessions, listSessions, setApiRequestProfile, speakText } from './hermes'
 
 const emptySessionsResponse = {
   limit: 0,
@@ -21,6 +21,7 @@ describe('Hermes REST session helpers', () => {
   })
 
   afterEach(() => {
+    setApiRequestProfile(null)
     vi.restoreAllMocks()
     Reflect.deleteProperty(window, 'hermesDesktop')
   })
@@ -55,6 +56,20 @@ describe('Hermes REST session helpers', () => {
     expect(api).toHaveBeenCalledWith({
       path: '/api/sessions/session-1/messages?profile=xiaoxuxu',
       profile: 'xiaoxuxu'
+    })
+  })
+
+  it('routes TTS requests through the active profile backend', async () => {
+    api.mockResolvedValue({ audio_url: 'file:///tmp/voice.mp3' })
+    setApiRequestProfile('fiona')
+
+    await speakText('Profile voice please')
+
+    expect(api).toHaveBeenCalledWith({
+      path: '/api/audio/speak',
+      method: 'POST',
+      body: { text: 'Profile voice please' },
+      profile: 'fiona'
     })
   })
 })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -731,6 +731,7 @@ export function transcribeAudio(dataUrl: string, mimeType?: string): Promise<Aud
 
 export function speakText(text: string): Promise<AudioSpeakResponse> {
   return window.hermesDesktop.api<AudioSpeakResponse>({
+    ...profileScoped(),
     path: '/api/audio/speak',
     method: 'POST',
     body: { text }


### PR DESCRIPTION
## Summary

Fixes #45506 by routing Desktop text-to-speech requests through the active profile backend.

`speakText()` now includes the same profile scope used by other profile-sensitive Desktop REST helpers, so `/api/audio/speak` reaches Electron with `request.profile` and can be served by the non-default profile backend instead of the primary/default backend.

## Type of Change

- [x] Bug fix
- [x] Tests
- [ ] New feature
- [ ] Documentation

## How to Test

```bash
PATH=/Users/shangyifan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/vitest run apps/desktop/src/hermes.test.ts --environment jsdom
PATH=/Users/shangyifan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run --workspace apps/desktop typecheck
(cd apps/desktop && PATH=/Users/shangyifan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ../../node_modules/.bin/eslint src/hermes.ts src/hermes.test.ts)
git diff --check
```

## Validation

- Failing-before-fix regression recorded: `apps/desktop/src/hermes.test.ts` expected `/api/audio/speak` to include `profile: "fiona"` and failed because the request was unscoped.
- Targeted Vitest passed after fix: 4 tests passed.
- `apps/desktop` typecheck passed.
- Changed-file ESLint passed for `src/hermes.ts` and `src/hermes.test.ts`.
- `git diff --check` passed.

## Duplicate Search

Checked active PRs around profile/TTS/Desktop routing. Adjacent PR #45490 forwards root `.env` values and does not scope `/api/audio/speak` requests. TTS/read-aloud PRs #45478, #44308, #39286, and #43911 address streaming, latency, timeout, or filename issues, not active profile backend routing for Desktop TTS.

## Platform Tested

- macOS local checkout
- Node v24.14.0 for local Desktop tests

