### PR TITLE
fix: guard float() env var casts in auth.py OAuth refresh timeouts

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3745,7 +3745,10 @@ def resolve_codex_runtime_credentials(
 
     tokens = dict(data["tokens"])
     access_token = str(tokens.get("access_token", "") or "").strip()
-    refresh_timeout_seconds = float(os.getenv("HERMES_CODEX_REFRESH_TIMEOUT_SECONDS", "20"))
+    try:
+        refresh_timeout_seconds = float(os.getenv("HERMES_CODEX_REFRESH_TIMEOUT_SECONDS", "20"))
+    except (ValueError, TypeError):
+        refresh_timeout_seconds = 20.0
 
     should_refresh = bool(force_refresh)
     if (not should_refresh) and refresh_if_expiring:
@@ -4195,7 +4198,10 @@ def resolve_xai_oauth_runtime_credentials(
     data = _read_xai_oauth_tokens()
     tokens = dict(data["tokens"])
     access_token = str(tokens.get("access_token", "") or "").strip()
-    refresh_timeout_seconds = float(os.getenv("HERMES_XAI_REFRESH_TIMEOUT_SECONDS", "20"))
+    try:
+        refresh_timeout_seconds = float(os.getenv("HERMES_XAI_REFRESH_TIMEOUT_SECONDS", "20"))
+    except (ValueError, TypeError):
+        refresh_timeout_seconds = 20.0
     discovery = dict(data.get("discovery") or {})
     token_endpoint = str(discovery.get("token_endpoint", "") or "").strip()
     redirect_uri = str(data.get("redirect_uri", "") or "").strip()


### PR DESCRIPTION
## Bug

`HERMES_CODEX_REFRESH_TIMEOUT_SECONDS` (line 3748) and `HERMES_XAI_REFRESH_TIMEOUT_SECONDS` (line 4198) in `hermes_cli/auth.py` are cast via raw `float()` without try/except. Non-numeric values crash credential refresh.

## Fix

Wrap both in `try/except (ValueError, TypeError)` returning 20.0 as default.

## Test Plan
- [x] `py_compile` passes