### PR TITLE
fix: add missing HTML table tags to Matrix sanitizer allowlist

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -209,7 +209,7 @@ class _MatrixHtmlSanitizer(HTMLParser):
     _ALLOWED_TAGS = {
         "a", "b", "blockquote", "br", "code", "del", "em", "h1", "h2", "h3",
         "h4", "h5", "h6", "hr", "i", "li", "ol", "p", "pre", "s", "strike",
-        "strong", "ul",
+        "strong", "table", "tbody", "td", "th", "thead", "tr", "ul",
     }
     _VOID_TAGS = {"br", "hr"}
 


### PR DESCRIPTION
## Summary

`_MatrixHtmlSanitizer._ALLOWED_TAGS` was missing `table`, `thead`, `tbody`, `tr`, `th`, and `td`. When the markdown converter (with the `tables` extension) emitted these tags, the sanitizer stripped them, leaving bare text without table structure in `formatted_body`.

## Fix

Add the six missing table tags to `_ALLOWED_TAGS` in alphabetical order.

## Changes

| File | Change | Lines |
|------|--------|-------|
| `gateway/platforms/matrix.py` | Add 6 table tags to allowlist | +1 / -1 |

Closes #45421