### PR TITLE
fix: custom provider auxiliary client resolution failures

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -168,7 +168,15 @@ def _normalize_aux_provider(provider: Optional[str]) -> str:
         suffix = normalized.split(":", 1)[1].strip()
         if not suffix:
             return "custom"
-        normalized = suffix
+        # Return the bare name WITHOUT applying _PROVIDER_ALIASES.
+        # The "custom:" prefix is the user's explicit signal that they
+        # reference their own named custom provider, not a built-in.
+        # Applying aliases here would rewrite e.g. "custom:kimi" to
+        # "kimi-coding" — routing auxiliary calls to the built-in
+        # Kimi endpoint instead of the user's relay.  Named custom
+        # lookups in resolve_provider_client() must see the raw name
+        # to find the user's entry in config.yaml.  (#45472, #45480)
+        return suffix
     if normalized == "codex":
         return "openai-codex"
     if normalized == "main":

--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -209,7 +209,17 @@ def _supports_vision_override(
     config_provider = str(model_cfg.get("provider") or "").strip()
     providers_raw = cfg.get("providers")
     providers_cfg: Dict[str, Any] = providers_raw if isinstance(providers_raw, dict) else {}
-    for p in dict.fromkeys(filter(None, (provider, config_provider))):
+    # Build candidate keys for providers: dict lookup.  The provider and
+    # config_provider values may carry a "custom:" prefix (runtime-resolved
+    # named custom providers), but providers: dict keys never include that
+    # prefix.  Strip it so e.g. "custom:openclaw-router" correctly matches
+    # the dict key "openclaw-router".  (#45472, #45480)
+    _candidates: list = []
+    for _cand in dict.fromkeys(filter(None, (provider, config_provider))):
+        _candidates.append(_cand)
+        if _cand.startswith("custom:"):
+            _candidates.append(_cand.split(":", 1)[1].strip())
+    for p in dict.fromkeys(_candidates):
         entry_raw = providers_cfg.get(p)
         entry: Dict[str, Any] = entry_raw if isinstance(entry_raw, dict) else {}
         models_raw = entry.get("models")


### PR DESCRIPTION
## Summary

Two related bugs where named custom providers (`custom:<name>`) were not correctly resolved in the auxiliary client and vision routing, causing HTTP 400 errors and silent fallback to wrong endpoints.

### Root Cause 1 — `_normalize_aux_provider` in `agent/auxiliary_client.py`

After stripping the `custom:` prefix (e.g., `custom:kimi` → `kimi`), the function continued to apply `_PROVIDER_ALIASES` rewriting. This meant `custom:kimi` became `kimi-coding` (a built-in), routing auxiliary calls to Kimi's built-in endpoint instead of the user's named custom provider. Similarly `custom:glm` became `zai`.

### Root Cause 2 — `_supports_vision_override` in `agent/image_routing.py`

The vision capability lookup iterated only over the literal `provider` and `config_provider` strings when keying into the `providers:` dict. Config dict keys never include the `custom:` prefix, so `custom:openclaw-router` failed to match the dict key `openclaw-router`.

## Fix

1. **`agent/auxiliary_client.py`**: When the input starts with `custom:`, return the suffix immediately without applying `_PROVIDER_ALIASES`. The `custom:` prefix is the user's explicit signal that they reference their own named provider.

2. **`agent/image_routing.py`**: The providers dict candidate-key loop now also tries each candidate with the `custom:` prefix stripped.

## Changes

| File | Change | Lines |
|------|--------|-------|
| `agent/auxiliary_client.py` | Return custom: suffix without alias rewriting | +8 / -1 |
| `agent/image_routing.py` | Try stripped custom: prefix as dict key | +7 / -1 |

Closes #45472, closes #45480