### PR TITLE
fix: nous provider dash-vs-dot model ID format and uncallable models

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -353,12 +353,14 @@ def init_agent(
 
     try:
         from hermes_cli.model_normalize import (
-            _AGGREGATOR_PROVIDERS,
             normalize_model_for_provider,
         )
 
-        if agent.provider not in _AGGREGATOR_PROVIDERS:
-            agent.model = normalize_model_for_provider(agent.model, agent.provider)
+        # Normalize the model name for all providers, including aggregators.
+        # Aggregators need Anthropic dash-style version numbers repaired to
+        # dot-form (e.g. anthropic/claude-sonnet-4-6 → anthropic/claude-sonnet-4.6).
+        # The normalizer is idempotent, so already-correct names pass through.
+        agent.model = normalize_model_for_provider(agent.model, agent.provider)
     except Exception:
         pass
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -4925,6 +4925,15 @@ def fetch_nous_models(
     if not isinstance(data, list):
         return []
 
+    # Model IDs known to be listed by the Nous API but which are NOT callable
+    # via the chat completions endpoint.  These produce opaque errors like
+    # "Couldn't find that, sorry." when reached through /v1/chat/completions.
+    # Keep this set as small and precise as possible — only add models confirmed
+    # to 404/error on a chat request.
+    _CHAT_UNCALLABLE_MODELS: frozenset[str] = frozenset({
+        "claude-fable-5",
+    })
+
     model_ids: List[str] = []
     for item in data:
         if not isinstance(item, dict):
@@ -4934,6 +4943,9 @@ def fetch_nous_models(
             mid = model_id.strip()
             # Skip Hermes models — they're not reliable for agentic tool-calling
             if "hermes" in mid.lower():
+                continue
+            # Skip models listed by the API but not reachable via chat completions
+            if mid in _CHAT_UNCALLABLE_MODELS:
                 continue
             model_ids.append(mid)
 

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -293,6 +293,51 @@ def detect_vendor(model_name: str) -> Optional[str]:
     return None
 
 
+def _repair_anthropic_dashes_to_dots(model_name: str) -> str:
+    """Repair Anthropic-native dashes in version numbers to dots for aggregator APIs.
+
+    Anthropic's native API uses dashes where marketing/aggregator names use
+    dots: ``claude-sonnet-4-6`` → ``claude-sonnet-4.6``.
+
+    Only rewrites when the model appears to be a Claude model (contains
+    ``claude-`` in the name part after any ``vendor/`` prefix).  This
+    avoids false-positive rewrites on unrelated models.
+
+    The regex matches a single-digit major version followed by a single-digit
+    minor version (``\\d-\\d(?!\\d)``).  Dated models with a single major digit
+    and an 8-digit date suffix (``claude-sonnet-4-20250514``) are NOT touched
+    because the ``(?!)\\d`` lookahead fails when the ``minordigit`` is followed
+    by additional digits (``20250514``):
+
+        >>> _repair_anthropic_dashes_to_dots("claude-sonnet-4-6")
+        'claude-sonnet-4.6'
+        >>> _repair_anthropic_dashes_to_dots("claude-opus-4-8")
+        'claude-opus-4.8'
+        >>> _repair_anthropic_dashes_to_dots("claude-opus-4-5-20251101")
+        'claude-opus-4.5-20251101'
+        >>> _repair_anthropic_dashes_to_dots("claude-haiku-4-5-20251001")
+        'claude-haiku-4.5-20251001'
+        >>> _repair_anthropic_dashes_to_dots("claude-sonnet-4-20250514")
+        'claude-sonnet-4-20250514'
+        >>> _repair_anthropic_dashes_to_dots("claude-sonnet-4.6")
+        'claude-sonnet-4.6'
+        >>> _repair_anthropic_dashes_to_dots("claude-fable-5")
+        'claude-fable-5'
+        >>> _repair_anthropic_dashes_to_dots("anthropic/claude-sonnet-4-6")
+        'anthropic/claude-sonnet-4.6'
+        >>> _repair_anthropic_dashes_to_dots("openai/gpt-5.4-mini")
+        'openai/gpt-5.4-mini'
+    """
+    # Extract the model part (after vendor/ prefix, if any) for Claude detection.
+    model_part = _strip_vendor_prefix(model_name)
+    if not model_part.lower().startswith("claude-"):
+        return model_name
+
+    # Replace version-like patterns: single digit - single digit (not followed
+    # by more digits, which would indicate a date like -20250514).
+    return re.sub(r"(\d)-(\d)(?!\d)", r"\1.\2", model_name)
+
+
 def _prepend_vendor(model_name: str) -> str:
     """Prepend the detected ``vendor/`` prefix if missing.
 
@@ -388,9 +433,14 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
 
     provider = _normalize_provider_alias(target_provider)
 
-    # --- Aggregators: need vendor/model format ---
+    # --- Aggregators: need vendor/model format with dots (not dashes) ---
+    # Anthropic's native API uses dashes in version numbers (claude-sonnet-4-6)
+    # while aggregators (OpenRouter, Nous, Kilo) key models by dot-style IDs
+    # (claude-sonnet-4.6).  Without the repair, a dash-format model ID in
+    # config.yaml produces a 404 from the aggregator API.
     if provider in _AGGREGATOR_PROVIDERS:
-        return _prepend_vendor(name)
+        with_vendor = _prepend_vendor(name)
+        return _repair_anthropic_dashes_to_dots(with_vendor)
 
     # --- OpenCode Zen / OpenCode Go: flat-namespace resellers.
     #     Their /v1/models API returns bare IDs only (no vendor prefix), and


### PR DESCRIPTION
## Summary

Two related model-resolution problems on the **nous** provider:

### 1. Dash-vs-dot model-name format

The Nous inference API keys chat models by **dot-style** IDs (`anthropic/claude-sonnet-4.6`), but `model.default` in `config.yaml` can be written in **dash-style** Anthropic-API form (`anthropic/claude-sonnet-4-6`). The dash form 404s; the dot form works.

**Fix:** Add `_repair_anthropic_dashes_to_dots()` that converts Anthropic-native dash-style version numbers to dots only for Claude models. The regex `\d-\d(?!\d)` matches version pairs (e.g., `4-6` → `4.6`) while preserving date-suffixed models (`claude-sonnet-4-20250514` unchanged). The repair is applied in the aggregator normalization path.

### 2. Uncallable models listed in catalog

The Nous `/models` endpoint lists `claude-fable-5` which is not reachable via chat completions, yielding an opaque `"Couldn't find that, sorry."` error.

**Fix:** Add `_CHAT_UNCALLABLE_MODELS` filter in `fetch_nous_models()` to exclude models known to 404 on the chat completions endpoint.

Also removes the `_AGGREGATOR_PROVIDERS` skip in `agent_init.py` so aggregators run through the normalizer — needed for dash-to-dot repair. The normalizer is idempotent for already-correct names.

## Changes

| File | Change | Lines |
|------|--------|-------|
| `hermes_cli/model_normalize.py` | Add `_repair_anthropic_dashes_to_dots()` + wire into aggregator path | +50 / -2 |
| `hermes_cli/auth.py` | Add `_CHAT_UNCALLABLE_MODELS` filter | +11 |
| `agent/agent_init.py` | Remove aggregator skip from normalization | +4 / -4 |

Closes #45362