### PR TITLE
fix: gateway auto-resume race creating duplicate AIAgent instances

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4544,6 +4544,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if entry.session_key in self._running_agents:
                 continue
 
+            # Place a sentinel NOW, before the async task is created.
+            # The check above passed, but an inbound message arriving in the
+            # ~same 160 ms window can also pass the check in _handle_message
+            # (which places its own sentinel deeper in the call chain).  By
+            # reserving the slot eagerly we close the gap — the inbound
+            # message sees the session as busy and follows the busy-handler
+            # path (queue / interrupt) instead of creating a duplicate
+            # AIAgent.  (#45456)
+            self._running_agents[entry.session_key] = _AGENT_PENDING_SENTINEL
+
             source = entry.origin
             adapter = self.adapters.get(source.platform)
             if adapter is None:


### PR DESCRIPTION
## Summary

When the gateway restarts and auto-resumes an interrupted session, an inbound message arriving in the same window (~160ms observed in production) can create a second AIAgent instance for the same session. Two agents then process messages concurrently, fire hooks twice, and produce interleaved duplicate responses to the user.

Observed in production (2026-06-13):


## Root Cause

`_schedule_resume_pending_sessions` checked `_running_agents` but created the `asyncio.create_task` **without** placing a sentinel. The gap between the check and the first `await` in `_handle_message` (where the sentinel is normally placed at line ~7546) was wide enough for an inbound message to slip through and create a second AIAgent.

The existing guards don't close this gap:
- **Adapter-level guard** (`_active_sessions`): Installed synchronously in `_start_session_processing` — protects against duplicate background tasks on the same adapter
- **Runner-level guard** (`_running_agents` + `_AGENT_PENDING_SENTINEL`): Placed deep inside `_handle_message` after many await points — too late

## Fix

Eagerly place `_AGENT_PENDING_SENTINEL` into `_running_agents` **immediately** after the guard check passes and **before** creating the background task. This atomically closes the gap — any inbound message arriving during task setup sees the session as busy and follows the busy-handler path (queue/interrupt) instead of creating a duplicate AIAgent.

## Changes

| File | Change | Lines |
|------|--------|-------|
| `gateway/run.py` | Place sentinel before create_task in auto-resume path | +10 |

Closes #45456