### PR TITLE
fix(security): gate gateway quick commands

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7361,6 +7361,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not isinstance(quick_commands, dict):
                 quick_commands = {}
             if command in quick_commands:
+                _denied = self._check_slash_access(source, command)
+                if _denied is not None:
+                    return _denied
                 qcmd = quick_commands[command]
                 if qcmd.get("type") == "exec":
                     exec_cmd = qcmd.get("command", "")

--- a/tests/gateway/test_slash_access_dispatch.py
+++ b/tests/gateway/test_slash_access_dispatch.py
@@ -327,6 +327,45 @@ async def test_plugin_registered_command_is_gated(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_quick_command_is_gated_for_non_admin():
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": ["111"],
+            "user_allowed_commands": [],
+        }
+    )
+    runner.config.quick_commands = {
+        "limits": {"type": "exec", "command": "echo quick-command-bypass"}
+    }
+
+    result = await runner._handle_message(
+        _make_event("/limits", _make_source(user_id="999"))
+    )
+
+    assert "quick-command-bypass" not in result
+    assert "/limits is admin-only here" in result
+
+
+@pytest.mark.asyncio
+async def test_listed_quick_command_runs_for_non_admin():
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": ["111"],
+            "user_allowed_commands": ["limits"],
+        }
+    )
+    runner.config.quick_commands = {
+        "limits": {"type": "exec", "command": "echo quick-command-allowed"}
+    }
+
+    result = await runner._handle_message(
+        _make_event("/limits", _make_source(user_id="999"))
+    )
+
+    assert result == "quick-command-allowed"
+
+
+@pytest.mark.asyncio
 async def test_running_agent_fastpath_blocks_non_admin_command():
     """When an agent is running, /restart from a non-admin must be denied."""
     runner = _make_runner(


### PR DESCRIPTION
## Summary
- apply the existing gateway slash access policy to operator-defined quick commands before dispatch
- keep admin behavior unchanged while requiring non-admin users to have the quick command listed in `user_allowed_commands`
- add real `GatewayRunner._handle_message` coverage for denied and explicitly allowed quick commands

Fixes #44727.

## Validation
- `uv run pytest -q tests\gateway\test_slash_access_dispatch.py -o addopts=` -> 20 passed
- `uv run ruff check gateway\run.py tests\gateway\test_slash_access_dispatch.py` -> passed
- `git diff --check` -> passed

Note: `uv run ty check gateway\run.py tests\gateway\test_slash_access_dispatch.py` still reports existing broad `gateway/run.py` diagnostics unrelated to this 3-line policy call; I did not include unrelated type cleanups in this security PR.