### PR TITLE
fix(security): guard provider image URL downloads

### DIFF
--- a/agent/image_gen_provider.py
+++ b/agent/image_gen_provider.py
@@ -35,6 +35,7 @@ import logging
 import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urljoin
 
 logger = logging.getLogger(__name__)
 
@@ -203,6 +204,13 @@ _URL_IMAGE_CONTENT_TYPES = {
     "image/gif": "gif",
 }
 
+_MAX_IMAGE_URL_REDIRECTS = 10
+
+
+def _is_safe_image_url(url: str) -> bool:
+    from tools.url_safety import is_safe_url
+    return is_safe_url(url)
+
 
 def save_url_image(
     url: str,
@@ -225,7 +233,31 @@ def save_url_image(
     """
     import requests
 
-    response = requests.get(url, timeout=timeout, stream=True)
+    current_url = url
+    response = None
+    for _ in range(_MAX_IMAGE_URL_REDIRECTS + 1):
+        if not _is_safe_image_url(current_url):
+            raise ValueError(
+                f"Blocked: image URL targets a private or internal address: {current_url}"
+            )
+        response = requests.get(
+            current_url,
+            timeout=timeout,
+            stream=True,
+            allow_redirects=False,
+        )
+        if not response.is_redirect:
+            break
+        location = response.headers.get("Location")
+        response.close()
+        if not location:
+            raise ValueError(f"Image URL redirect at {current_url} did not include Location.")
+        current_url = urljoin(current_url, location)
+    else:
+        raise ValueError(f"Image URL exceeded {_MAX_IMAGE_URL_REDIRECTS} redirects.")
+
+    if response is None:
+        raise ValueError(f"Image URL at {url} did not return a response.")
     response.raise_for_status()
 
     # Infer extension from the response content-type, falling back to the
@@ -234,7 +266,7 @@ def save_url_image(
     content_type = (response.headers.get("Content-Type") or "").split(";", 1)[0].strip().lower()
     extension = _URL_IMAGE_CONTENT_TYPES.get(content_type)
     if extension is None:
-        url_path = url.split("?", 1)[0].lower()
+        url_path = current_url.split("?", 1)[0].lower()
         for ext in ("png", "jpg", "jpeg", "webp", "gif"):
             if url_path.endswith(f".{ext}"):
                 extension = "jpg" if ext == "jpeg" else ext

--- a/tests/agent/test_save_url_image.py
+++ b/tests/agent/test_save_url_image.py
@@ -65,6 +65,27 @@ class _TinyImageHandler(http.server.BaseHTTPRequestHandler):
             self.send_response(200)
             self.end_headers()
             self.wfile.write(PNG_1PX)
+        elif self.path == "/redirect-image":
+            self.send_response(302)
+            self.send_header("Location", "/image.png")
+            self.end_headers()
+        elif self.path == "/redirect-private":
+            self.send_response(302)
+            self.send_header("Location", "/private")
+            self.end_headers()
+        elif self.path == "/private":
+            self.server.private_hits += 1
+            self.send_response(200)
+            self.send_header("Content-Type", "image/png")
+            self.end_headers()
+            self.wfile.write(PNG_1PX)
+        elif self.path.startswith("/r") and self.path[2:].isdigit():
+            idx = int(self.path[2:])
+            self.send_response(302)
+            self.send_header("Location", f"/r{idx + 1}")
+            self.send_header("Content-Type", "image/png")
+            self.end_headers()
+            self.wfile.write(b"redirect body must not be cached")
         else:
             self.send_response(404)
             self.end_headers()
@@ -86,9 +107,14 @@ def http_server(tmp_path, monkeypatch):
             sys.modules.pop(mod, None)
 
     httpd = socketserver.TCPServer(("127.0.0.1", 0), _TinyImageHandler)
+    httpd.private_hits = 0
     port = httpd.server_address[1]
     thread = threading.Thread(target=httpd.serve_forever, daemon=True)
     thread.start()
+
+    import agent.image_gen_provider as image_gen_provider
+    monkeypatch.setattr(image_gen_provider, "_is_safe_image_url", lambda _url: True)
+
     yield f"http://127.0.0.1:{port}", httpd
     httpd.shutdown()
 
@@ -104,7 +130,7 @@ class TestSaveUrlImage:
         assert path.read_bytes() == PNG_1PX
         # The cache directory must be under HERMES_HOME — gateway cleanup
         # relies on this being the canonical location.
-        assert "cache/images" in str(path)
+        assert path.parts[-3:-1] == ("cache", "images")
         assert path.suffix == ".png"
 
     def test_extension_inferred_from_content_type(self, http_server):
@@ -128,6 +154,56 @@ class TestSaveUrlImage:
 
         path = save_url_image(f"{base}/no-type-no-ext", prefix="xai_test")
         assert path.suffix == ".png"
+
+    def test_safe_redirect_is_followed(self, http_server):
+        base, _ = http_server
+        from agent.image_gen_provider import save_url_image
+
+        path = save_url_image(f"{base}/redirect-image", prefix="xai_redirect")
+        assert path.exists()
+        assert path.read_bytes() == PNG_1PX
+
+    def test_direct_private_url_is_blocked_before_fetch(self, http_server, monkeypatch):
+        base, server = http_server
+        import agent.image_gen_provider as image_gen_provider
+        from agent.image_gen_provider import save_url_image
+
+        monkeypatch.setattr(image_gen_provider, "_is_safe_image_url", lambda _url: False)
+
+        with pytest.raises(ValueError, match="private or internal"):
+            save_url_image(f"{base}/private")
+
+        assert server.private_hits == 0
+
+    def test_private_redirect_is_blocked_before_following(self, http_server, monkeypatch):
+        base, server = http_server
+        import agent.image_gen_provider as image_gen_provider
+        from agent.image_gen_provider import save_url_image
+
+        def safe_url(url: str) -> bool:
+            return not url.endswith("/private")
+
+        monkeypatch.setattr(image_gen_provider, "_is_safe_image_url", safe_url)
+
+        with pytest.raises(ValueError, match="private or internal"):
+            save_url_image(f"{base}/redirect-private")
+
+        assert server.private_hits == 0
+
+    def test_too_many_redirects_raises_without_caching_body(self, http_server, monkeypatch):
+        base, _ = http_server
+        import agent.image_gen_provider as image_gen_provider
+        from agent.image_gen_provider import save_url_image, _images_cache_dir
+
+        monkeypatch.setattr(image_gen_provider, "_MAX_IMAGE_URL_REDIRECTS", 2)
+        cache_dir = _images_cache_dir()
+        before = set(cache_dir.glob("*"))
+
+        with pytest.raises(ValueError, match="exceeded 2 redirects"):
+            save_url_image(f"{base}/r0")
+
+        after = set(cache_dir.glob("*"))
+        assert after == before
 
     def test_404_raises(self, http_server):
         """HTTP errors must propagate — caller decides whether to fall back."""


### PR DESCRIPTION
## Summary
- guard provider-returned image URLs with the repo's URL safety policy before any host-side fetch
- follow redirects manually with `allow_redirects=False`, re-checking each `Location` before requesting it
- fail closed on missing `Location` or redirect budget exhaustion so redirect bodies are not cached as images
- keep the existing real HTTP save-url tests, with additional direct-private, redirect-private, safe-redirect, and too-many-redirect coverage

Fixes #44728.
Supersedes the remaining redirect-safety review gap on #44743.

## Validation
- `uv run pytest -q tests\agent\test_save_url_image.py -o addopts=` -> 12 passed
- `uv run ruff check agent\image_gen_provider.py tests\agent\test_save_url_image.py` -> passed
- `uv run python -m py_compile agent\image_gen_provider.py tests\agent\test_save_url_image.py` -> passed
- `git diff --check` -> passed