### PR TITLE
fix(model_metadata): add GLM-5.2 1M context entry to DEFAULT_CONTEXT_LENGTHS

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -209,7 +209,12 @@ DEFAULT_CONTEXT_LENGTHS = {
     # https://platform.minimax.io/docs/api-reference/text-chat-openai
     "minimax-m3": 1000000,
     "minimax": 204800,
-    # GLM
+    # GLM — GLM-5.2 ships with a 1M context window; GLM-5, GLM-5.1,
+    # and GLM-5-turbo are all ~202K.  Longest-key-first substring
+    # matching ensures "glm-5.2" resolves to 1M while older variants
+    # still hit the generic 202K fallback.
+    # https://open.bigmodel.cn/pricing
+    "glm-5.2": 1048576,
     "glm": 202752,
     # xAI Grok — xAI /v1/models does not return context_length metadata,
     # so these hardcoded fallbacks prevent Hermes from probing-down to

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -220,6 +220,25 @@ class TestDefaultContextLengths:
                     f"{model_id}: expected {expected_ctx}, got {actual}"
                 )
 
+    def test_glm_52_context_1m(self):
+        """GLM-5.2 must resolve to 1M, not the generic GLM fallback of 202K."""
+        from agent.model_metadata import get_model_context_length
+        from unittest.mock import patch as mock_patch
+
+        assert DEFAULT_CONTEXT_LENGTHS["glm-5.2"] == 1_048_576
+        assert DEFAULT_CONTEXT_LENGTHS["glm"] == 202752
+
+        with mock_patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
+             mock_patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
+             mock_patch("agent.model_metadata.get_cached_context_length", return_value=None):
+            # GLM-5.2 (1M) must NOT fall through to the generic 202K entry
+            assert get_model_context_length("glm-5.2") == 1_048_576
+            # Vendor-prefixed form (e.g. ZAI provider)
+            assert get_model_context_length("zhipu/glm-5.2") == 1_048_576
+            # Older GLM variants still resolve to the generic 202K fallback
+            assert get_model_context_length("glm-5") == 202752
+            assert get_model_context_length("glm-5.1") == 202752
+
     def test_openrouter_live_metadata_beats_hardcoded_catchall(self):
         """OpenRouter-routed slugs resolve via the live OR catalog before the
         hardcoded family catch-all.


### PR DESCRIPTION
## What does this PR do?

Adds a specific `glm-5.2: 1048576` entry to `DEFAULT_CONTEXT_LENGTHS` so that GLM-5.2 resolves to its correct 1M context window instead of falling through to the generic `glm: 202752` fallback.

## Related Issue

Fixes #45519

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py`: Added `"glm-5.2": 1048576` before the generic `"glm"` catch-all, with a comment explaining the longest-key-first substring matching behavior
- `tests/agent/test_model_metadata.py`: Added `test_glm_52_context_1m` verifying GLM-5.2 resolves to 1M, vendor-prefixed forms also resolve correctly, and older GLM variants (5, 5.1) still resolve to 202K

## How to Test

1. Run `pytest tests/agent/test_model_metadata.py -k "test_glm_52_context_1m" -xvs` — should pass
2. Verify `DEFAULT_CONTEXT_LENGTHS["glm-5.2"] == 1048576` in Python
3. Verify `get_model_context_length("glm-5.2")` returns 1048576 (not 202752) when all metadata probes are mocked out

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_model_metadata.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable — grep-based fallback used.
- Checked files: `agent/model_metadata.py` (DEFAULT_CONTEXT_LENGTHS dict), `tests/agent/test_model_metadata.py`
- Blast radius: LOW — data-only change to a hardcoded lookup table, no control-flow changes
- Related patterns: Same approach as `deepseek-v4-*` entries (line 190-193) and `minimax-m3` (line 208)
