### PR TITLE
fix(cli): use URL parsing for local-server detection and respect user /v1 rejection

### DIFF
--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -752,11 +752,16 @@ def _model_flow_custom(config):
     # Hint: most local model servers (Ollama, vLLM, llama.cpp) require /v1
     # in the base URL for OpenAI-compatible chat completions.  Prompt the
     # user if the URL looks like a local server without /v1.
+    from urllib.parse import urlparse as _urlparse
+
+    _parsed = _urlparse(effective_url)
+    _local_ports = {11434, 8080, 5000}
+    _is_local_host = _parsed.hostname in ("localhost", "127.0.0.1", "0.0.0.0")
+    _has_known_local_port = _parsed.port in _local_ports
+    _no_port_specified = _parsed.port is None
+    _looks_local = _has_known_local_port or (_is_local_host and _no_port_specified)
+    _user_rejected_v1 = False
     _url_lower = effective_url.rstrip("/").lower()
-    _looks_local = any(
-        h in _url_lower
-        for h in ("localhost", "127.0.0.1", "0.0.0.0", ":11434", ":8080", ":5000")
-    )
     if _looks_local and not _url_lower.endswith("/v1"):
         print()
         print(f"  Hint: Did you mean to add /v1 at the end?")
@@ -771,19 +776,27 @@ def _model_flow_custom(config):
             if base_url:
                 base_url = effective_url
             print(f"  Updated URL: {effective_url}")
+        else:
+            _user_rejected_v1 = True
         print()
 
     from hermes_cli.models import probe_api_models
 
     probe = probe_api_models(effective_key, effective_url)
     if probe.get("used_fallback") and probe.get("resolved_base_url"):
-        print(
-            f"Warning: endpoint verification worked at {probe['resolved_base_url']}/models, "
-            f"not the exact URL you entered. Saving the working base URL instead."
-        )
-        effective_url = probe["resolved_base_url"]
-        if base_url:
-            base_url = effective_url
+        if _user_rejected_v1:
+            print(
+                f"  Note: endpoint also responds at {probe['resolved_base_url']}/models. "
+                f"Keeping your original URL. If you need /v1, re-run with it included."
+            )
+        else:
+            print(
+                f"Warning: endpoint verification worked at {probe['resolved_base_url']}/models, "
+                f"not the exact URL you entered. Saving the working base URL instead."
+            )
+            effective_url = probe["resolved_base_url"]
+            if base_url:
+                base_url = effective_url
     elif probe.get("models") is not None:
         print(
             f"Verified endpoint via {probe.get('probed_url')} "

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -626,6 +626,83 @@ def test_model_flow_custom_persists_selected_api_mode(monkeypatch):
     assert captured_provider["api_mode"] == "codex_responses"
 
 
+def test_model_flow_custom_port_50009_no_false_positive(monkeypatch, capsys):
+    """B1: port 50009 must NOT trigger the /v1 prompt (only exact port 5000)."""
+    monkeypatch.setattr(
+        "hermes_cli.config.get_env_value",
+        lambda key: "",
+    )
+    monkeypatch.setattr("hermes_cli.auth._save_model_choice", lambda model: None)
+    monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda: None)
+    monkeypatch.setattr("hermes_cli.main._save_custom_provider", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        "hermes_cli.models.probe_api_models",
+        lambda api_key, base_url: {
+            "models": [],
+            "probed_url": f"{base_url}/models",
+            "resolved_base_url": None,
+            "suggested_base_url": None,
+            "used_fallback": False,
+        },
+    )
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"model": {}})
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+    monkeypatch.setattr(
+        "hermes_cli.main._prompt_custom_api_mode_selection",
+        lambda *a, **kw: "",
+    )
+
+    # User enters port 50009 — should NOT see /v1 prompt
+    # input sequence: base_url, api_key(=masked), api_mode(select=enter),
+    # model_name, context_length, display_name
+    answers = iter(["http://localhost:50009", "test-model", "", "", ""])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+    monkeypatch.setattr("hermes_cli.secret_prompt.masked_secret_prompt", lambda _prompt="": "test-key")
+
+    hermes_main._model_flow_custom({})
+    output = capsys.readouterr().out
+
+    assert "Did you mean to add /v1" not in output
+
+
+def test_model_flow_custom_respects_user_v1_rejection(monkeypatch, capsys):
+    """B2: when user rejects /v1, probe fallback must NOT override their URL."""
+    monkeypatch.setattr(
+        "hermes_cli.config.get_env_value",
+        lambda key: "",
+    )
+    monkeypatch.setattr("hermes_cli.auth._save_model_choice", lambda model: None)
+    monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda: None)
+    monkeypatch.setattr("hermes_cli.main._save_custom_provider", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        "hermes_cli.models.probe_api_models",
+        lambda api_key, base_url: {
+            "models": ["llm"],
+            "probed_url": "http://localhost:11434/v1/models",
+            "resolved_base_url": "http://localhost:11434/v1",
+            "suggested_base_url": "http://localhost:11434/v1",
+            "used_fallback": True,
+        },
+    )
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"model": {}})
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+    monkeypatch.setattr(
+        "hermes_cli.main._prompt_custom_api_mode_selection",
+        lambda *a, **kw: "",
+    )
+
+    # User enters localhost:11434, rejects /v1 with "n", then confirms model
+    answers = iter(["http://localhost:11434", "test-key", "n", "", "", "", ""])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+    monkeypatch.setattr("hermes_cli.secret_prompt.masked_secret_prompt", lambda _prompt="": next(answers))
+
+    hermes_main._model_flow_custom({})
+    output = capsys.readouterr().out
+
+    assert "Keeping your original URL" in output
+    assert "Saving the working base URL instead" not in output
+
+
 def test_cmd_model_forwards_nous_login_tls_options(monkeypatch):
     monkeypatch.setattr(hermes_main, "_require_tty", lambda *a: None)
     monkeypatch.setattr(


### PR DESCRIPTION
## What does this PR do?

Fixes two related bugs in the custom provider setup wizard (`_model_flow_custom`):
1. Port substring matching (`:5000`) false-positives on ports like 50009/50001
2. User's explicit `/v1` rejection is silently overridden by the probe fallback

## Related Issue

Fixes #45543

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_setup_flows.py`: Replace substring-based local-server detection with `urllib.parse.urlparse` port extraction; track user `/v1` rejection to prevent probe fallback from overriding their choice
- `tests/cli/test_cli_provider_resolution.py`: Add 2 tests — port 50009 false-positive prevention and user `/v1` rejection respect

## How to Test

1. Run `pytest tests/cli/test_cli_provider_resolution.py -x -q` — all 24 tests pass
2. Manual: `hermes model` → Custom → enter `http://localhost:50009` → should NOT see `/v1` prompt
3. Manual: `hermes model` → Custom → enter `http://localhost:11434` → decline `/v1` → probe should NOT overwrite URL

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/model_setup_flows.py::_model_flow_custom` (setup wizard flow)
- Blast radius: LOW — only affects custom provider setup wizard path, no runtime impact
- Related patterns: `probe_api_models` fallback chain; URL parsing best practices
