### PR TITLE
fix(cli): detect self-lock in update recovery to break infinite retry…

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6571,6 +6571,55 @@ def _recover_from_interrupted_install() -> None:
         # the install itself will surface the real problem.
         logger.debug("Could not create install-recovery lock: %s", exc)
 
+    # Windows self-lock guard: if hermes.exe is the launcher that spawned
+    # this Python process, any attempt to pip-install will fail with
+    # "拒绝访问 / WinError 32" because the running .exe cannot be replaced.
+    # Rather than entering the permanent retry loop described in issue
+    # #45542, clear the marker and give the user an offline recovery command.
+    if _is_windows():
+        scripts_dir = _venv_scripts_dir()
+        if scripts_dir is not None:
+            shims = _hermes_exe_shims(scripts_dir)
+            if shims:
+                _shim_set: set[str] = set()
+                for _s in shims:
+                    try:
+                        _shim_set.add(str(_s.resolve()).lower())
+                    except OSError:
+                        _shim_set.add(str(_s).lower())
+                try:
+                    import psutil
+                    _me = psutil.Process()
+                    for _anc in [_me] + list(_me.parents()):
+                        try:
+                            _anc_exe = _anc.exe()
+                            _anc_norm = str(Path(_anc_exe).resolve()).lower()
+                        except Exception:
+                            continue
+                        if _anc_norm in _shim_set:
+                            print(
+                                "✗ Hermes is running from the binary that "
+                                "needs to be replaced — the auto-recovery "
+                                "cannot overwrite a running executable."
+                            )
+                            print(
+                                "  Restart Hermes from a different terminal, "
+                                "then run the manual recovery command below:"
+                            )
+                            print(f"    cd {PROJECT_ROOT}")
+                            print(
+                                f"    {sys.executable} -m pip install "
+                                "-e '.[all]'"
+                            )
+                            _clear_update_incomplete_marker()
+                            try:
+                                lock_path.unlink()
+                            except OSError:
+                                pass
+                            return
+                except Exception:
+                    pass  # psutil is best-effort; fall through to install
+
     saved_stdout_fd = None
     saved_sys_stdout = sys.stdout
     try:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6606,10 +6606,10 @@ def _recover_from_interrupted_install() -> None:
                                 "  Restart Hermes from a different terminal, "
                                 "then run the manual recovery command below:"
                             )
-                            print(f"    cd {PROJECT_ROOT}")
+                            print(f'    cd /d "{PROJECT_ROOT}"')
                             print(
-                                f"    {sys.executable} -m pip install "
-                                "-e '.[all]'"
+                                f'    "{sys.executable}" -m pip install '
+                                '-e ".[all]"'
                             )
                             _clear_update_incomplete_marker()
                             try:
@@ -6618,7 +6618,11 @@ def _recover_from_interrupted_install() -> None:
                                 pass
                             return
                 except Exception:
-                    pass  # psutil is best-effort; fall through to install
+                    logger.debug(
+                        "Self-lock detection skipped (psutil unavailable); "
+                        "falling through to install",
+                        exc_info=True,
+                    )
 
     saved_stdout_fd = None
     saved_sys_stdout = sys.stdout
@@ -6677,9 +6681,9 @@ def _recover_from_interrupted_install() -> None:
             logger.debug("Interrupted-install recovery failed: %s", exc)
             print("✗ Could not auto-recover the interrupted install.")
             print("  Recover manually with:")
-            print(f"    cd {PROJECT_ROOT}")
-            print(f"    {sys.executable} -m ensurepip --upgrade")
-            print(f"    {sys.executable} -m pip install -e '.[all]'")
+            print(f'    cd /d "{PROJECT_ROOT}"')
+            print(f'    "{sys.executable}" -m ensurepip --upgrade')
+            print(f'    "{sys.executable}" -m pip install -e ".[all]"')
     finally:
         sys.stdout = saved_sys_stdout
         if saved_stdout_fd is not None:


### PR DESCRIPTION
## What does this PR do?

On Windows, when `hermes update` is interrupted and a `.update-incomplete` marker is left behind, every subsequent `hermes dashboard` launch triggers the auto-recovery logic that tries to run `uv pip install -e .[all]`. This install needs to replace `hermes.exe` — but that binary is the launcher of the currently running process. The replacement fails with `拒绝访问 (os error 5)`, and because the marker is intentionally left in place on failure (so "the next launch retries"), the process enters an infinite loop.

This PR adds a **Windows self-lock guard** before the recovery install: if `hermes.exe` (or `hermes-gateway.exe`) is detected as an ancestor process of the current Python interpreter, recovery skips the install, clears the marker, and prints a manual recovery command. On non-Windows platforms and when psutil is unavailable, behavior is unchanged.

## Related Issue

Fixes #45542

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py` — added self-lock detection in `_recover_from_interrupted_install()` using psutil to walk the process ancestry chain and match against `_hermes_exe_shims()`

## How to Test

1. On Windows, interrupt a `hermes update` (close the terminal mid-install)
2. Run `hermes dashboard` — observe the recovery attempt
3. Expected: self-lock detected, marker cleared, manual recovery command printed
4. Expected: next `hermes dashboard` launch proceeds normally without re-triggering recovery

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes — N/A: existing recovery tests pass; self-lock path needs live process chain, untestable without a new update
- [x] I've tested on my platform: Windows 10 (Chinese GBK locale)

### Documentation & Housekeeping

- [x] N/A

---

复制进去，点 Create pull request。