### PR TITLE
fix(tts): include feishu in want_opus platforms

### DIFF
--- a/tests/tools/test_tts_opus_routing.py
+++ b/tests/tools/test_tts_opus_routing.py
@@ -68,3 +68,32 @@ def test_edge_telegram_converts_to_opus_voice(tmp_path, monkeypatch):
     assert result["voice_compatible"] is True
     assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{opus}"
     convert.assert_called_once_with(str(out))
+
+
+def test_minimax_feishu_converts_to_opus_voice(tmp_path, monkeypatch):
+    out = tmp_path / "speech.mp3"
+    opus = tmp_path / "speech.ogg"
+
+    def fake_convert(path: str) -> str:
+        assert path == str(out)
+        opus.write_bytes(b"ogg")
+        return str(opus)
+
+    convert = Mock(side_effect=fake_convert)
+
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "feishu")
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "minimax"})
+    monkeypatch.setattr(
+        tts_tool,
+        "_generate_minimax_tts",
+        lambda _text, _output, _cfg: (_ := Path(_output).write_bytes(b"mp3")) or _output,
+    )
+    monkeypatch.setattr(tts_tool, "_convert_to_opus", convert)
+
+    result = json.loads(tts_tool.text_to_speech_tool("hello", output_path=str(out)))
+
+    assert result["success"] is True
+    assert result["file_path"] == str(opus)
+    assert result["voice_compatible"] is True
+    assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{opus}"
+    convert.assert_called_once_with(str(out))

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2064,7 +2064,7 @@ def text_to_speech_tool(
     # and needs ffmpeg for conversion.
     from gateway.session_context import get_session_env
     platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
-    want_opus = (platform == "telegram")
+    want_opus = platform in {"telegram", "feishu"}
 
     # Determine output path
     if output_path:


### PR DESCRIPTION
## What does this PR do?

Extends `want_opus` platform set to include `feishu` alongside `telegram`, so minimax TTS on Feishu converts mp3 → ogg and gets delivered as voice bubble instead of file attachment.

## Related Issue

Fixes #45557

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/tts_tool.py`: changed `want_opus = (platform == 'telegram')` → `want_opus = platform in {'telegram', 'feishu'}`
- `tests/tools/test_tts_opus_routing.py`: added `test_minimax_feishu_converts_to_opus_voice`

## How to Test

1. Send a TTS message via Feishu DM with minimax TTS provider
2. Confirm message arrives as voice bubble (not mp3 attachment)
3. Run: `PYTHONPATH=. venv/bin/python -m pytest tests/tools/test_tts_opus_routing.py -v` — all 3 tests pass

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(tts):`)
- [x] I've searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `PYTHONPATH=. venv/bin/python -m pytest tests/tools/test_tts_opus_routing.py -q` — all pass
- [x] I've added tests for my changes