### PR TITLE
fix(desktop): bump shared tsconfig to ES2023, alias @assistant-ui/tap/react-shim → react

### DIFF
--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+﻿import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
@@ -8,7 +8,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   css: {
     // Pin an explicit (empty) PostCSS config. Tailwind is handled entirely by
-    // `@tailwindcss/vite`, so the renderer needs no PostCSS plugins — and
+    // `@tailwindcss/vite`, so the renderer needs no PostCSS plugins â€” and
     // without this, Vite's `postcss-load-config` walks UP the filesystem
     // looking for a stray `postcss.config.*` / `tailwind.config.*`. The desktop
     // build runs from inside the user's home tree (e.g.
@@ -37,6 +37,7 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src'),
       '@hermes/shared': path.resolve(__dirname, '../shared/src'),
+      '@assistant-ui/tap/react-shim': path.resolve(__dirname, '../../node_modules/react'),
       react: path.resolve(__dirname, '../../node_modules/react'),
       'react-dom': path.resolve(__dirname, '../../node_modules/react-dom'),
       'react/jsx-dev-runtime': path.resolve(__dirname, '../../node_modules/react/jsx-dev-runtime.js'),

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,4 +1,4 @@
-﻿import { defineConfig } from 'vite'
+import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
@@ -8,7 +8,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   css: {
     // Pin an explicit (empty) PostCSS config. Tailwind is handled entirely by
-    // `@tailwindcss/vite`, so the renderer needs no PostCSS plugins â€” and
+    // `@tailwindcss/vite`, so the renderer needs no PostCSS plugins — and
     // without this, Vite's `postcss-load-config` walks UP the filesystem
     // looking for a stray `postcss.config.*` / `tailwind.config.*`. The desktop
     // build runs from inside the user's home tree (e.g.

--- a/apps/shared/tsconfig.json
+++ b/apps/shared/tsconfig.json
@@ -1,8 +1,8 @@
-{
+﻿{
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ES2023",
     "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "lib": ["DOM", "DOM.Iterable", "ES2023"],
     "skipLibCheck": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,

--- a/apps/shared/tsconfig.json
+++ b/apps/shared/tsconfig.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "compilerOptions": {
     "target": "ES2023",
     "useDefineForClassFields": true,


### PR DESCRIPTION
Fixes #45551

Two build blockers on fresh clone:

**Issue 1 — ES2023 methods rejected by ES2022 tsconfig**
`apps/shared/tsconfig.json` had `"target": "ES2022"` and `"lib": ["ES2022"]`.
The desktop source uses `Array.findLast()` / `Array.findLastIndex()` (ES2023),
so `tsc` rejected them. Updated target and lib to ES2023.
(`apps/desktop/tsconfig.json` was already ES2023.)

**Issue 2 — `@assistant-ui/tap/react-shim` not exported in 0.5.10**
`@assistant-ui/store@0.2.16` imports from `@assistant-ui/tap/react-shim`, but
tap 0.5.10 doesn't have that export. Instead of patching node_modules or
bumping tap (which causes cascading type errors), added a Vite resolve alias:

`@assistant-ui/tap/react-shim` → `../../node_modules/react`

This is consistent with the existing react dedup aliases already in
`apps/desktop/vite.config.ts`.