### PR TITLE
feat(desktop): prefer CJK-capable terminal font

### DIFF
--- a/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
@@ -335,7 +335,7 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
       allowTransparency: false,
       convertEol: true,
       cursorBlink: true,
-      fontFamily: "'JetBrains Mono', 'Cascadia Code', 'SF Mono', Menlo, Consolas, monospace",
+      fontFamily: "'Sarasa Mono TC Nerd', 'Sarasa Mono TC', 'JetBrains Mono', 'Cascadia Code', 'SF Mono', Menlo, Consolas, monospace",
       fontSize: 11,
       // VS Code's terminal renders 'normal'/'bold' (400/700); we were using Medium
       // (500) as the base, which reads a touch heavy at this size.


### PR DESCRIPTION
## Summary
- Prefer `Sarasa Mono TC Nerd` / `Sarasa Mono TC` for the Desktop xterm terminal when those fonts are installed.
- Keep the existing bundled/standard monospace fallback stack (`JetBrains Mono`, Cascadia, SF Mono, Menlo, Consolas, monospace) unchanged after the CJK-capable options.

## Why
CJK-heavy terminal output is easier to read when the integrated terminal can use a CJK-capable monospace font. This remains safe for systems without Sarasa installed because xterm/browser font fallback continues through the existing stack.

## Test Plan
- `npx eslint --max-warnings=0 src/app/right-sidebar/terminal/use-terminal-session.ts`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
