### PR TITLE
fix(doctor): stop recommending crashing npm audit fixes

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1543,8 +1543,14 @@ def run_doctor(args):
                 total = critical + high + moderate
                 # Determine a scoped fix command for the remediation hint.
                 if audit_extra and audit_extra[0] == "--workspace":
-                    fix_scope = " ".join(audit_extra)
-                    fix_cmd = f"cd {npm_dir} && npm audit fix {fix_scope}"
+                    # Detection (`npm audit --workspace <name>`) is read-only and
+                    # safe, but `npm audit fix --workspace <name>` crashes on
+                    # current npm with "Cannot read properties of null (reading
+                    # 'edgesOut')" — an arborist bug with workspace-filtered
+                    # audit fix. Recommend the root-level `npm audit fix`, which
+                    # operates over every workspace and does not crash, instead
+                    # of handing the user a command that errors out.
+                    fix_cmd = f"cd {npm_dir} && npm audit fix"
                 elif audit_extra == ["--workspaces=false"]:
                     fix_cmd = f"cd {npm_dir} && npm audit fix --workspaces=false"
                 else:
@@ -1556,6 +1562,19 @@ def run_doctor(args):
                         f"{label} deps",
                         f"({critical} critical, {high} high, {moderate} moderate — run: {fix_cmd})"
                     )
+                    if audit_extra and audit_extra[0] == "--workspace":
+                        # The web/ui-tui workspace advisories are in build-time
+                        # tooling (esbuild/vite, etc.), not runtime code that ships
+                        # to users. `npm audit fix` here may also error with a known
+                        # npm arborist crash (edgesOut / isDescendantOf) on this
+                        # monorepo tree — in that case it is an npm bug, not a
+                        # Hermes one, and the advisories clear via a lockfile bump
+                        # rather than a manual fix.
+                        check_info(
+                            "  ^ build-time tooling (not runtime); if `npm audit fix` "
+                            "errors with an npm arborist crash it's a known npm bug — "
+                            "clears via a lockfile bump"
+                        )
                     issues.append(
                         f"{label} has {total} npm "
                         f"{'vulnerability' if total == 1 else 'vulnerabilities'}"

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1547,10 +1547,10 @@ def run_doctor(args):
                     # safe, but `npm audit fix --workspace <name>` crashes on
                     # current npm with "Cannot read properties of null (reading
                     # 'edgesOut')" — an arborist bug with workspace-filtered
-                    # audit fix. Recommend the root-level `npm audit fix`, which
-                    # operates over every workspace and does not crash, instead
-                    # of handing the user a command that errors out.
-                    fix_cmd = f"cd {npm_dir} && npm audit fix"
+                    # audit fix. The root-level `npm audit fix` can crash on the
+                    # same tree with "isDescendantOf", so do not hand the user a
+                    # manual fix command for these build-tool advisories.
+                    fix_cmd = None
                 elif audit_extra == ["--workspaces=false"]:
                     fix_cmd = f"cd {npm_dir} && npm audit fix --workspaces=false"
                 else:
@@ -1558,22 +1558,29 @@ def run_doctor(args):
                 if total == 0:
                     check_ok(f"{label} deps", "(no known vulnerabilities)")
                 elif critical > 0 or high > 0:
+                    if fix_cmd:
+                        vuln_detail = (
+                            f"{critical} critical, {high} high, {moderate} moderate — run: {fix_cmd}"
+                        )
+                    else:
+                        vuln_detail = (
+                            f"{critical} critical, {high} high, {moderate} moderate — "
+                            "build-tool advisory; clears via lockfile bump"
+                        )
                     check_warn(
                         f"{label} deps",
-                        f"({critical} critical, {high} high, {moderate} moderate — run: {fix_cmd})"
+                        f"({vuln_detail})"
                     )
                     if audit_extra and audit_extra[0] == "--workspace":
                         # The web/ui-tui workspace advisories are in build-time
                         # tooling (esbuild/vite, etc.), not runtime code that ships
-                        # to users. `npm audit fix` here may also error with a known
-                        # npm arborist crash (edgesOut / isDescendantOf) on this
-                        # monorepo tree — in that case it is an npm bug, not a
-                        # Hermes one, and the advisories clear via a lockfile bump
-                        # rather than a manual fix.
+                        # to users. Manual npm remediation may error with a known
+                        # arborist crash (edgesOut / isDescendantOf) on this monorepo
+                        # tree — in that case it is an npm bug, not a Hermes one.
                         check_info(
-                            "  ^ build-time tooling (not runtime); if `npm audit fix` "
-                            "errors with an npm arborist crash it's a known npm bug — "
-                            "clears via a lockfile bump"
+                            "  ^ build-time tooling (not runtime); if manual npm remediation "
+                            "errors with an arborist crash it's a known npm bug — clears "
+                            "via a lockfile bump"
                         )
                     issues.append(
                         f"{label} has {total} npm "

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1406,3 +1406,62 @@ class TestDoctorStaleMaxIterationsDrift:
             monkeypatch, tmp_path, fix=False, ghost=None, cfg_turns=400,
         )
         assert "shadows" not in out
+
+
+def test_npm_audit_fix_hint_avoids_crashing_workspace_flag(monkeypatch, tmp_path):
+    """`hermes doctor` must not hand users `npm audit fix --workspace <name>`:
+    that exact form crashes npm with "Cannot read properties of null (reading
+    'edgesOut')" (an arborist bug with workspace-filtered audit fix). The
+    remediation hint for a workspace vulnerability must be the root-level
+    `npm audit fix`, which works.
+
+    Regression for the Docker reports (Pinched-Nerve / lynch1972) where doctor
+    flagged the web/ui-tui workspaces and the suggested fix command errored out.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    project = tmp_path / "project"
+    (project / "node_modules").mkdir(parents=True)
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+
+    # Only npm is "installed" — keeps the rest of run_doctor's external checks
+    # quiet without affecting the npm-audit branch under test.
+    monkeypatch.setattr(
+        doctor_mod.shutil, "which", lambda cmd: "/usr/bin/npm" if cmd == "npm" else None
+    )
+
+    def mock_run(cmd, **kwargs):
+        if "audit" in cmd:
+            payload = (
+                '{"metadata": {"vulnerabilities": '
+                '{"critical": 0, "high": 2, "moderate": 0}}}'
+            )
+            return SimpleNamespace(returncode=1, stdout=payload, stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    import subprocess
+
+    monkeypatch.setattr(subprocess, "run", mock_run)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    # The workspace vulnerability is still reported ...
+    assert "web workspace" in out
+    # ... but the remediation must NOT use the npm-crashing per-workspace form
+    # (`npm audit fix --workspace web` / `--workspace ui-tui`). The unrelated
+    # root target's `--workspaces=false` is a different, non-crashing command.
+    assert "npm audit fix --workspace web" not in out
+    assert "npm audit fix --workspace ui-tui" not in out
+    # ... it offers the safe root-level command instead.
+    assert "&& npm audit fix)" in out
+    # ... and explains the workspace advisories are build-time tooling whose
+    # `npm audit fix` may itself hit a known npm arborist crash, so the user
+    # isn't left thinking a crashing command means a broken Hermes install.
+    assert "build-time tooling" in out
+    assert "known npm bug" in out

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1411,12 +1411,15 @@ class TestDoctorStaleMaxIterationsDrift:
 def test_npm_audit_fix_hint_avoids_crashing_workspace_flag(monkeypatch, tmp_path):
     """`hermes doctor` must not hand users `npm audit fix --workspace <name>`:
     that exact form crashes npm with "Cannot read properties of null (reading
-    'edgesOut')" (an arborist bug with workspace-filtered audit fix). The
-    remediation hint for a workspace vulnerability must be the root-level
-    `npm audit fix`, which works.
+    'edgesOut')" (an arborist bug with workspace-filtered audit fix).
 
-    Regression for the Docker reports (Pinched-Nerve / lynch1972) where doctor
-    flagged the web/ui-tui workspaces and the suggested fix command errored out.
+    It must not recommend root-level `npm audit fix` for workspace advisories
+    either: current npm can crash there too with "Cannot read properties of null
+    (reading 'isDescendantOf')" on this tree. The safe guidance is that these
+    build-tool advisories clear via the lockfile/package bump.
+
+    Regression for user reports where doctor flagged the web/ui-tui workspaces
+    and the suggested fix command errored out.
     """
     home = tmp_path / ".hermes"
     home.mkdir(parents=True, exist_ok=True)
@@ -1434,12 +1437,18 @@ def test_npm_audit_fix_hint_avoids_crashing_workspace_flag(monkeypatch, tmp_path
     )
 
     def mock_run(cmd, **kwargs):
-        if "audit" in cmd:
+        if "audit" in cmd and "--workspace" in cmd:
             payload = (
                 '{"metadata": {"vulnerabilities": '
                 '{"critical": 0, "high": 2, "moderate": 0}}}'
             )
             return SimpleNamespace(returncode=1, stdout=payload, stderr="")
+        if "audit" in cmd:
+            payload = (
+                '{"metadata": {"vulnerabilities": '
+                '{"critical": 0, "high": 0, "moderate": 0}}}'
+            )
+            return SimpleNamespace(returncode=0, stdout=payload, stderr="")
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
     import subprocess
@@ -1454,14 +1463,15 @@ def test_npm_audit_fix_hint_avoids_crashing_workspace_flag(monkeypatch, tmp_path
     # The workspace vulnerability is still reported ...
     assert "web workspace" in out
     # ... but the remediation must NOT use the npm-crashing per-workspace form
-    # (`npm audit fix --workspace web` / `--workspace ui-tui`). The unrelated
-    # root target's `--workspaces=false` is a different, non-crashing command.
+    # (`npm audit fix --workspace web` / `--workspace ui-tui`).
     assert "npm audit fix --workspace web" not in out
     assert "npm audit fix --workspace ui-tui" not in out
-    # ... it offers the safe root-level command instead.
-    assert "&& npm audit fix)" in out
+    # ... and it must not point at the root-level form either: npm can crash
+    # there too with `isDescendantOf` on this monorepo tree.
+    assert "npm audit fix" not in out
     # ... and explains the workspace advisories are build-time tooling whose
-    # `npm audit fix` may itself hit a known npm arborist crash, so the user
-    # isn't left thinking a crashing command means a broken Hermes install.
+    # manual remediation may hit a known npm arborist crash, so the user isn't
+    # left thinking a crashing command means a broken Hermes install.
     assert "build-time tooling" in out
     assert "known npm bug" in out
+    assert "lockfile bump" in out


### PR DESCRIPTION
## Summary

`hermes doctor` no longer recommends manual npm audit fix commands for workspace advisories that hit npm/arborist crashes.

This salvages #45368's doctor fix and regression test, then tightens the guidance after Pinched-Nerve reported that root-level `npm audit fix` also crashes with `isDescendantOf` on Debian/Trixie.

## Changes

- `hermes_cli/doctor.py`: keep workspace audit detection, but do not print `npm audit fix --workspace ...` or root `npm audit fix` as remediation for `web` / `ui-tui` workspace findings.
- `hermes_cli/doctor.py`: label those workspace findings as build-time tooling advisories that clear via lockfile/package bumps.
- `tests/hermes_cli/test_doctor.py`: preserve #45368's regression coverage and extend it to reject the root-level fallback too.

## Validation

| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/hermes_cli/test_doctor.py` | 65 passed |
| `npm audit --workspace web --json` | reports 2 high workspace advisories |
| `npm audit fix --dry-run` | reproduces npm/arborist `isDescendantOf` crash |

## Contributor credit

Cherry-picked #45368's two commits from @xxxigm with authorship preserved. Follow-up commit is authored separately.

## Original PR

Salvages and supersedes #45368.

## Infographic

![doctor-npm-audit-advice](https://v3b.fal.media/files/b/0a9e209d/7DLp3BQMfVtDpBWq7W5EC_LXloozAv.png)
