### PR TITLE
Add Windows SSH remote backend

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -715,7 +715,7 @@ _BACKEND_FALLBACK_DESCRIPTIONS: dict[str, str] = {
     "modal": "a Modal sandbox (Linux)",
     "managed_modal": "a managed Modal sandbox (Linux)",
     "daytona": "a Daytona workspace (Linux)",
-    "ssh": "a remote host reached over SSH (likely Linux)",
+    "ssh": "a remote host reached over SSH",
 }
 
 
@@ -755,8 +755,8 @@ def _probe_remote_backend(env_type: str) -> str | None:
     try:
         # Import locally: tools/ imports are heavy and only relevant when a
         # non-local backend is actually configured.
-        from tools.terminal_tool import _get_env_config  # type: ignore
-        from tools.environments import get_environment  # type: ignore
+        from tools.terminal_tool import _get_env_config, terminal_tool  # type: ignore
+        from tools.environments.ssh import detect_windows_ssh_host  # type: ignore
     except Exception as e:
         logger.debug("Backend probe unavailable (import failed): %s", e)
         _BACKEND_PROBE_CACHE[cache_key] = ""
@@ -764,17 +764,38 @@ def _probe_remote_backend(env_type: str) -> str | None:
 
     try:
         config = _get_env_config()
-        env = get_environment(config)
-        # Single-line POSIX probe — works on any Unixy backend. Wrapped in
-        # `2>/dev/null` so a missing binary doesn't pollute the output.
-        probe_cmd = (
-            "printf 'os=%s\\nkernel=%s\\nhome=%s\\ncwd=%s\\nuser=%s\\n' "
-            "\"$(uname -s 2>/dev/null || echo unknown)\" "
-            "\"$(uname -r 2>/dev/null || echo unknown)\" "
-            "\"$HOME\" \"$(pwd)\" \"$(whoami 2>/dev/null || id -un 2>/dev/null || echo unknown)\""
-        )
-        result = env.execute(probe_cmd, timeout=4)
-        if result.get("returncode") != 0:
+        is_windows_ssh = False
+        if env_type == "ssh":
+            is_windows_ssh = detect_windows_ssh_host(
+                config.get("ssh_host", ""),
+                config.get("ssh_user", ""),
+                config.get("ssh_port", 22),
+                config.get("ssh_key", ""),
+            )
+        if is_windows_ssh:
+            probe_cmd = r"""
+$kernel = [System.Environment]::OSVersion.VersionString
+$homePath = $HOME
+if (-not $homePath) { $homePath = $env:USERPROFILE }
+$user = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+Write-Output "os=Windows"
+Write-Output ("kernel=" + $kernel)
+Write-Output ("home=" + $homePath)
+Write-Output ("cwd=" + (Get-Location).ProviderPath)
+Write-Output ("user=" + $user)
+Write-Output "shell=Windows PowerShell"
+"""
+        else:
+            # Single-line POSIX probe — works on Unixy remote backends.
+            # Wrapped in `2>/dev/null` so missing binaries don't pollute output.
+            probe_cmd = (
+                "printf 'os=%s\\nkernel=%s\\nhome=%s\\ncwd=%s\\nuser=%s\\n' "
+                "\"$(uname -s 2>/dev/null || echo unknown)\" "
+                "\"$(uname -r 2>/dev/null || echo unknown)\" "
+                "\"$HOME\" \"$(pwd)\" \"$(whoami 2>/dev/null || id -un 2>/dev/null || echo unknown)\""
+            )
+        result = json.loads(terminal_tool(probe_cmd, timeout=15, task_id="default"))
+        if result.get("exit_code") != 0:
             logger.debug("Backend probe returned non-zero: %r", result)
             _BACKEND_PROBE_CACHE[cache_key] = ""
             return None
@@ -804,6 +825,23 @@ def _probe_remote_backend(env_type: str) -> str | None:
         pieces.append(f"Home: {parsed['home']}")
     if parsed.get("cwd"):
         pieces.append(f"Working directory: {parsed['cwd']}")
+    if parsed.get("shell"):
+        pieces.append(f"Shell: {parsed['shell']}")
+    if env_type == "ssh":
+        ssh_host = str(config.get("ssh_host") or "").strip()
+        ssh_user = str(config.get("ssh_user") or "").strip()
+        ssh_port = str(config.get("ssh_port") or "").strip()
+        if ssh_host:
+            target = f"{ssh_user + '@' if ssh_user else ''}{ssh_host}"
+            if ssh_port and ssh_port != "22":
+                target += f":{ssh_port}"
+            pieces.append(f"SSH target: {target}")
+        if is_windows_ssh:
+            pieces.append(
+                "Important: terminal calls are already executing on this SSH "
+                "target. Do not run `ssh` to this same host; run Windows "
+                "PowerShell commands directly instead."
+            )
 
     if not pieces:
         _BACKEND_PROBE_CACHE[cache_key] = ""

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -2,6 +2,7 @@
 
 import builtins
 import importlib
+import json
 import logging
 import sys
 
@@ -1030,6 +1031,50 @@ class TestEnvironmentHints:
         assert "Linux 6.8.0" in result
         assert "/workspace" in result
 
+    def test_ssh_windows_probe_reports_powershell_and_target(self, monkeypatch):
+        import agent.prompt_builder as _pb
+        import tools.environments.ssh as ssh_env
+        import tools.terminal_tool as terminal_tool
+
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(
+            terminal_tool,
+            "_get_env_config",
+            lambda: {
+                "env_type": "ssh",
+                "ssh_host": "192.168.2.5",
+                "ssh_user": "alice",
+                "ssh_port": 22,
+                "ssh_key": "",
+            },
+        )
+        monkeypatch.setattr(ssh_env, "detect_windows_ssh_host", lambda *args: True)
+
+        def fake_terminal(command, **kwargs):
+            assert "Windows PowerShell" in command
+            return json.dumps({
+                "exit_code": 0,
+                "output": (
+                    "os=Windows\n"
+                    "kernel=Microsoft Windows NT 10.0.19045.0\n"
+                    "home=C:\\Users\\alice\n"
+                    "cwd=C:\\Users\\alice\n"
+                    "user=DESKTOP\\alice\n"
+                    "shell=Windows PowerShell\n"
+                ),
+            })
+
+        monkeypatch.setattr(terminal_tool, "terminal_tool", fake_terminal)
+        _pb._clear_backend_probe_cache()
+
+        result = _pb.build_environment_hints()
+
+        assert "Terminal backend: ssh" in result
+        assert "Windows PowerShell" in result
+        assert "SSH target: alice@192.168.2.5" in result
+        assert "Do not run `ssh` to this same host" in result
+
     def test_remote_backend_list_covers_known_sandboxes(self):
         """Regression guard: if someone adds a remote backend, they must list it here."""
         import agent.prompt_builder as _pb
@@ -1335,5 +1380,3 @@ class TestOpenAIModelExecutionGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
-

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -790,6 +790,22 @@ class TestExecuteCodeEdgeCases(unittest.TestCase):
         self.assertIn("error", result)
         self.assertIn("No code", result["error"])
 
+    def test_windows_ssh_backend_returns_actionable_error(self):
+        env_config = {
+            "env_type": "ssh",
+            "ssh_host": "192.168.2.5",
+            "ssh_user": "alice",
+            "ssh_port": 22,
+            "ssh_key": "",
+        }
+        with patch("tools.terminal_tool._get_env_config", return_value=env_config), \
+             patch("tools.environments.ssh.detect_windows_ssh_host", return_value=True):
+            result = json.loads(execute_code("print('hi')", task_id="test"))
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("Windows SSH PowerShell backend", result["error"])
+        self.assertIn("terminal() is already executing there", result["error"])
+
     @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")
     def test_none_enabled_tools_uses_all(self):
         """When enabled_tools is None, all sandbox tools should be available."""

--- a/tests/tools/test_ssh_windows_environment.py
+++ b/tests/tools/test_ssh_windows_environment.py
@@ -1,0 +1,229 @@
+"""Tests for native Windows SSH environment support."""
+
+import base64
+import json
+import subprocess
+import zipfile
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.environments import ssh as ssh_env
+from tools.environments import ssh_windows
+from tools.environments.ssh_windows import WindowsSSHEnvironment
+
+
+class _FakeSyncManager:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def sync(self, **kwargs):
+        pass
+
+    def sync_back(self):
+        pass
+
+
+@pytest.fixture
+def windows_env(monkeypatch):
+    monkeypatch.setattr(ssh_windows, "_ensure_ssh_available", lambda: None)
+    monkeypatch.setattr(WindowsSSHEnvironment, "_establish_connection", lambda self: None)
+    monkeypatch.setattr(WindowsSSHEnvironment, "_detect_remote_home", lambda self: "C:/Users/alice")
+    monkeypatch.setattr(WindowsSSHEnvironment, "_detect_remote_temp", lambda self: "C:/Users/alice/AppData/Local/Temp")
+    monkeypatch.setattr(WindowsSSHEnvironment, "_ensure_remote_dirs", lambda self: None)
+    monkeypatch.setattr(ssh_windows, "FileSyncManager", _FakeSyncManager)
+    return WindowsSSHEnvironment(host="win.example", user="alice")
+
+
+def test_detect_windows_ssh_host_true(monkeypatch):
+    monkeypatch.setattr(ssh_env.shutil, "which", lambda name: "/usr/bin/ssh")
+
+    def fake_run(cmd, **kwargs):
+        assert "powershell" in cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout="hermes-windows-ssh\n", stderr="")
+
+    monkeypatch.setattr(ssh_env.subprocess, "run", fake_run)
+
+    assert ssh_env.detect_windows_ssh_host("host", "user") is True
+
+
+def test_detect_windows_ssh_host_false_on_probe_failure(monkeypatch):
+    monkeypatch.setattr(ssh_env.shutil, "which", lambda name: "/usr/bin/ssh")
+    monkeypatch.setattr(
+        ssh_env.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 127, stdout="", stderr="powershell: not found"),
+    )
+
+    assert ssh_env.detect_windows_ssh_host("host", "user") is False
+
+
+def test_create_environment_uses_windows_backend(monkeypatch):
+    from tools import terminal_tool
+
+    created = {}
+
+    class FakeWindowsEnv:
+        def __init__(self, **kwargs):
+            created.update(kwargs)
+
+    monkeypatch.setattr(terminal_tool, "_detect_windows_ssh_host", lambda *args: True)
+    monkeypatch.setattr(terminal_tool, "_WindowsSSHEnvironment", FakeWindowsEnv)
+
+    env = terminal_tool._create_environment(
+        env_type="ssh",
+        image="",
+        cwd="~",
+        timeout=90,
+        ssh_config={"host": "win.example", "user": "alice", "port": 2222, "key": "/key"},
+    )
+
+    assert isinstance(env, FakeWindowsEnv)
+    assert created == {
+        "host": "win.example",
+        "user": "alice",
+        "port": 2222,
+        "key_path": "/key",
+        "cwd": "~",
+        "timeout": 90,
+    }
+
+
+def test_windows_paths_are_used_for_sync_sources(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(ssh_windows, "_ensure_ssh_available", lambda: None)
+    monkeypatch.setattr(WindowsSSHEnvironment, "_establish_connection", lambda self: None)
+    monkeypatch.setattr(WindowsSSHEnvironment, "_detect_remote_home", lambda self: "C:/Users/alice")
+    monkeypatch.setattr(WindowsSSHEnvironment, "_detect_remote_temp", lambda self: "C:/Users/alice/AppData/Local/Temp")
+    monkeypatch.setattr(WindowsSSHEnvironment, "_ensure_remote_dirs", lambda self: None)
+    monkeypatch.setattr(ssh_windows, "FileSyncManager", _FakeSyncManager)
+
+    def fake_iter_sync_files(container_base):
+        captured["container_base"] = container_base
+        return []
+
+    monkeypatch.setattr(ssh_windows, "iter_sync_files", fake_iter_sync_files)
+
+    env = WindowsSSHEnvironment(host="win.example", user="alice")
+    manager = env._sync_manager
+    manager.kwargs["get_files_fn"]()
+
+    assert captured["container_base"] == "C:/Users/alice/.hermes"
+    assert callable(manager.kwargs["bulk_upload_fn"])
+    assert manager.kwargs["bulk_download_fn"] is None
+
+
+def test_powershell_upload_writes_base64_payload(windows_env, monkeypatch, tmp_path):
+    source = tmp_path / "hello.txt"
+    source.write_text("hello", encoding="utf-8")
+
+    calls = []
+
+    def fake_run(script, *, timeout=30, input_data=None):
+        calls.append((script, input_data))
+        return subprocess.CompletedProcess([], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(windows_env, "_run_powershell_script", fake_run)
+
+    windows_env._powershell_upload(str(source), "C:/Users/alice/.hermes/skills/hello.txt")
+
+    assert "WriteAllBytes" in calls[0][0]
+    assert "New-Item -ItemType Directory -Force -Path" in calls[0][0]
+    payload = json.loads(calls[0][1])
+    assert payload["path"] == "C:/Users/alice/.hermes/skills/hello.txt"
+    assert base64.b64decode(payload["content"]) == b"hello"
+
+
+def test_powershell_delete_uses_literal_paths(windows_env, monkeypatch):
+    calls = []
+
+    def fake_run(script, *, timeout=30, input_data=None):
+        calls.append((script, input_data))
+        return subprocess.CompletedProcess([], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(windows_env, "_run_powershell_script", fake_run)
+
+    windows_env._powershell_delete(["C:\\Users\\alice\\.hermes\\old.txt"])
+
+    assert "Remove-Item -LiteralPath" in calls[0][0]
+    assert json.loads(calls[0][1]) == ["C:/Users/alice/.hermes/old.txt"]
+
+
+def test_powershell_bulk_upload_writes_zip_payload(windows_env, monkeypatch, tmp_path):
+    first = tmp_path / "a.txt"
+    second = tmp_path / "b.txt"
+    first.write_text("aaa", encoding="utf-8")
+    second.write_text("bbb", encoding="utf-8")
+
+    calls = []
+    scp_calls = []
+
+    def fake_run(script, *, timeout=30, input_data=None):
+        calls.append((script, input_data, timeout))
+        return subprocess.CompletedProcess([], 0, stdout="", stderr="")
+
+    def fake_scp(cmd, **kwargs):
+        scp_calls.append(cmd)
+        local_zip = cmd[-2]
+        with zipfile.ZipFile(local_zip) as zf:
+            assert sorted(zf.namelist()) == ["cache/b.txt", "skills/a.txt"]
+            assert zf.read("skills/a.txt") == b"aaa"
+            assert zf.read("cache/b.txt") == b"bbb"
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(windows_env, "_run_powershell_script", fake_run)
+    monkeypatch.setattr(ssh_windows.subprocess, "run", fake_scp)
+
+    windows_env._powershell_bulk_upload([
+        (str(first), "C:/Users/alice/.hermes/skills/a.txt"),
+        (str(second), "C:/Users/alice/.hermes/cache/b.txt"),
+    ])
+
+    script, input_data, timeout = calls[0]
+    assert scp_calls
+    assert scp_calls[0][-1].startswith("alice@win.example:C:/Users/alice/AppData/Local/Temp/hermes-sync-")
+    assert "System.IO.Compression.ZipFile" in script
+    assert timeout >= 120
+    payload = json.loads(input_data)
+    assert payload["destination"] == "C:/Users/alice/.hermes"
+    assert "content" not in payload
+
+
+def test_execute_wraps_command_and_strips_cwd_marker(windows_env, monkeypatch):
+    captured = {}
+    marker = windows_env._cwd_marker
+
+    class FakeProc:
+        stdout = MagicMock()
+        returncode = 0
+
+        def poll(self):
+            return 0
+
+        def kill(self):
+            pass
+
+        def wait(self, timeout=None):
+            return 0
+
+    def fake_run_powershell(script, *, stdin_data=None):
+        captured["script"] = script
+        return FakeProc()
+
+    monkeypatch.setattr(windows_env, "_run_powershell", fake_run_powershell)
+    monkeypatch.setattr(
+        windows_env,
+        "_wait_for_process",
+        lambda proc, timeout=120: {
+            "output": f"ok\n\n{marker}C:\\Users\\alice\\work{marker}\n",
+            "returncode": 0,
+        },
+    )
+
+    result = windows_env.execute("whoami", cwd="C:/Users/alice/work")
+
+    assert "$__hermes_cwd = 'C:/Users/alice/work'" in captured["script"]
+    assert "Set-Location -LiteralPath $__hermes_cwd" in captured["script"]
+    assert "whoami" in captured["script"]
+    assert result["output"] == "ok\n"
+    assert windows_env.cwd == "C:\\Users\\alice\\work"

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -28,6 +28,31 @@ def test_terminal_schema_advertises_persistent_env_state():
     assert "exported environment variables persist between calls" in description
     assert "activate a virtualenv" in description
     assert "do not re-source the same environment before every command" in description
+    assert "already executes commands on the configured SSH target" in description
+    assert "Windows PowerShell" in description
+
+
+def test_nested_ssh_target_parser_handles_common_options():
+    command = 'ssh -o ConnectTimeout=10 -i /tmp/key alice@192.168.2.5 "hostname" 2>&1'
+
+    assert terminal_tool._find_nested_ssh_target(command) == "192.168.2.5"
+
+
+def test_nested_ssh_to_configured_target_is_blocked():
+    config = {"env_type": "ssh", "ssh_host": "192.168.2.5"}
+    command = 'ssh -o ConnectTimeout=10 192.168.2.5 "cmd /c hostname"'
+
+    error = terminal_tool._nested_ssh_to_configured_target_error(command, config)
+
+    assert "already connected" in error
+    assert "Run the remote command directly" in error
+
+
+def test_nested_ssh_to_other_host_is_allowed():
+    config = {"env_type": "ssh", "ssh_host": "192.168.2.5"}
+    command = 'ssh buildbox.example "hostname"'
+
+    assert terminal_tool._nested_ssh_to_configured_target_error(command, config) == ""
 
 
 def test_printf_literal_sudo_does_not_trigger_rewrite(monkeypatch):

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1095,7 +1095,33 @@ def execute_code(
 
     # Dispatch: remote backends use file-based RPC, local uses UDS
     from tools.terminal_tool import _get_env_config
-    env_type = _get_env_config()["env_type"]
+    env_config = _get_env_config()
+    env_type = env_config["env_type"]
+
+    if env_type == "ssh":
+        try:
+            from tools.environments.ssh import detect_windows_ssh_host
+
+            if detect_windows_ssh_host(
+                env_config.get("ssh_host", ""),
+                env_config.get("ssh_user", ""),
+                env_config.get("ssh_port", 22),
+                env_config.get("ssh_key", ""),
+            ):
+                return json.dumps({
+                    "status": "error",
+                    "error": (
+                        "execute_code is not supported on the native Windows SSH "
+                        "PowerShell backend. Use terminal() with direct PowerShell "
+                        "commands instead, for example `hostname; whoami`. Do not "
+                        "run `ssh` to the configured SSH host from inside the "
+                        "terminal backend; terminal() is already executing there."
+                    ),
+                    "tool_calls_made": 0,
+                    "duration_seconds": 0,
+                }, ensure_ascii=False)
+        except Exception as exc:
+            logger.debug("Could not determine whether SSH backend is Windows: %s", exc)
 
     # execute_code runs arbitrary Python (subprocess/os.system/...) that never
     # passes through terminal()/DANGEROUS_PATTERNS, so guard the whole script

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -1,5 +1,6 @@
 """SSH remote execution environment with ControlMaster connection persistence."""
 
+import base64
 import hashlib
 import logging
 import os
@@ -21,16 +22,72 @@ from tools.environments.file_sync import (
 logger = logging.getLogger(__name__)
 
 
-def _ensure_ssh_available() -> None:
+def _ensure_ssh_client_available() -> None:
     """Fail fast with a clear error when the SSH client is unavailable."""
     if not shutil.which("ssh"):
         raise RuntimeError(
             "SSH is not installed or not in PATH. Install OpenSSH client: apt install openssh-client"
         )
+
+
+def _ensure_ssh_available() -> None:
+    """Fail fast with a clear error when SSH/SCP clients are unavailable."""
+    _ensure_ssh_client_available()
     if not shutil.which("scp"):
         raise RuntimeError(
             "SCP is not installed or not in PATH. Install OpenSSH client: apt install openssh-client"
         )
+
+
+def encode_powershell_command(script: str) -> str:
+    """Encode a PowerShell script for ``-EncodedCommand``."""
+    return base64.b64encode(script.encode("utf-16le")).decode("ascii")
+
+
+def detect_windows_ssh_host(host: str, user: str, port: int = 22, key_path: str = "") -> bool:
+    """Return True when the SSH target appears to be native Windows.
+
+    Linux/macOS SSH targets remain on the bash-based SSHEnvironment. The probe
+    is deliberately best-effort: any connection, auth, or PowerShell failure
+    returns False so the normal SSH path can surface its existing diagnostics.
+    """
+    if not host or not user or not shutil.which("ssh"):
+        return False
+
+    script = """
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+if ($env:OS -eq 'Windows_NT' -or $env:USERPROFILE) {
+  Write-Output 'hermes-windows-ssh'
+}
+"""
+    cmd = ["ssh"]
+    cmd.extend(["-o", "BatchMode=yes"])
+    cmd.extend(["-o", "StrictHostKeyChecking=accept-new"])
+    cmd.extend(["-o", "ConnectTimeout=10"])
+    if port != 22:
+        cmd.extend(["-p", str(port)])
+    if key_path:
+        cmd.extend(["-i", key_path])
+    cmd.append(f"{user}@{host}")
+    cmd.extend([
+        "powershell",
+        "-NoProfile",
+        "-NonInteractive",
+        "-EncodedCommand",
+        encode_powershell_command(script),
+    ])
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=15,
+            stdin=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0 and "hermes-windows-ssh" in result.stdout.lower()
 
 
 class SSHEnvironment(BaseEnvironment):

--- a/tools/environments/ssh_windows.py
+++ b/tools/environments/ssh_windows.py
@@ -1,0 +1,440 @@
+"""SSH remote execution environment for native Windows OpenSSH hosts."""
+
+import base64
+import hashlib
+import json
+import logging
+import os
+import posixpath
+import subprocess
+import tempfile
+import zipfile
+from pathlib import Path
+
+from tools.environments.base import BaseEnvironment, _popen_bash
+from tools.environments.file_sync import FileSyncManager, iter_sync_files
+from tools.environments.ssh import _ensure_ssh_available, encode_powershell_command
+
+logger = logging.getLogger(__name__)
+
+
+def _ps_single_quote(value: str) -> str:
+    """Return a PowerShell single-quoted string literal."""
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _normalize_windows_path(path: str) -> str:
+    """Use forward slashes so PowerShell and Python path helpers agree."""
+    return path.strip().replace("\\", "/")
+
+
+class WindowsSSHEnvironment(BaseEnvironment):
+    """Run commands on a native Windows machine over SSH using PowerShell.
+
+    This backend is selected only when the SSH target probes as Windows. It
+    avoids the POSIX assumptions in SSHEnvironment: no remote bash, mkdir -p,
+    rm, tar, or /tmp are required.
+    """
+
+    _powershell_preamble = """
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$OutputEncoding = [System.Text.Encoding]::UTF8
+$ProgressPreference = 'SilentlyContinue'
+"""
+
+    def get_temp_dir(self) -> str:
+        return getattr(self, "_remote_temp", "C:/Windows/Temp")
+
+    def __init__(
+        self,
+        host: str,
+        user: str,
+        cwd: str = "~",
+        timeout: int = 60,
+        port: int = 22,
+        key_path: str = "",
+    ):
+        super().__init__(cwd=cwd, timeout=timeout)
+        self.host = host
+        self.user = user
+        self.port = port
+        self.key_path = key_path
+
+        self.control_dir = Path(tempfile.gettempdir()) / "hermes-ssh"
+        self.control_dir.mkdir(parents=True, exist_ok=True)
+        socket_id = hashlib.sha256(f"{user}@{host}:{port}".encode()).hexdigest()[:16]
+        self.control_socket = self.control_dir / f"{socket_id}.sock"
+
+        _ensure_ssh_available()
+        self._establish_connection()
+        self._remote_home = self._detect_remote_home()
+        self._remote_temp = self._detect_remote_temp()
+        if not cwd or cwd == "~":
+            self.cwd = self._remote_home
+        elif cwd.startswith("~/"):
+            self.cwd = f"{self._remote_home}/{cwd[2:]}"
+        else:
+            self.cwd = self._normalize_cwd(cwd)
+
+        self._ensure_remote_dirs()
+        self._sync_manager = FileSyncManager(
+            get_files_fn=lambda: iter_sync_files(f"{self._remote_home}/.hermes"),
+            upload_fn=self._powershell_upload,
+            delete_fn=self._powershell_delete,
+            bulk_upload_fn=self._powershell_bulk_upload,
+            bulk_download_fn=None,
+        )
+        self._sync_manager.sync(force=True)
+        self.init_session()
+
+    def _build_ssh_command(self, extra_args: list | None = None) -> list:
+        cmd = ["ssh"]
+        cmd.extend(["-o", f"ControlPath={self.control_socket}"])
+        cmd.extend(["-o", "ControlMaster=auto"])
+        cmd.extend(["-o", "ControlPersist=300"])
+        cmd.extend(["-o", "BatchMode=yes"])
+        cmd.extend(["-o", "StrictHostKeyChecking=accept-new"])
+        cmd.extend(["-o", "ConnectTimeout=10"])
+        if self.port != 22:
+            cmd.extend(["-p", str(self.port)])
+        if self.key_path:
+            cmd.extend(["-i", self.key_path])
+        if extra_args:
+            cmd.extend(extra_args)
+        cmd.append(f"{self.user}@{self.host}")
+        return cmd
+
+    def _build_scp_command(self, host_path: str, remote_path: str) -> list:
+        cmd = ["scp", "-o", f"ControlPath={self.control_socket}"]
+        if self.port != 22:
+            cmd.extend(["-P", str(self.port)])
+        if self.key_path:
+            cmd.extend(["-i", self.key_path])
+        cmd.extend([host_path, f"{self.user}@{self.host}:{_normalize_windows_path(remote_path)}"])
+        return cmd
+
+    def _build_powershell_command(self, script: str) -> list[str]:
+        cmd = self._build_ssh_command()
+        cmd.extend([
+            "powershell",
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-OutputFormat",
+            "Text",
+            "-EncodedCommand",
+            encode_powershell_command(self._powershell_preamble + "\n" + script),
+        ])
+        return cmd
+
+    def _run_powershell_script(
+        self,
+        script: str,
+        *,
+        timeout: int = 30,
+        input_data: str | None = None,
+    ) -> subprocess.CompletedProcess:
+        kwargs = {
+            "capture_output": True,
+            "text": True,
+            "encoding": "utf-8",
+            "errors": "replace",
+            "timeout": timeout,
+        }
+        if input_data is None:
+            kwargs["stdin"] = subprocess.DEVNULL
+        else:
+            kwargs["input"] = input_data
+        return subprocess.run(self._build_powershell_command(script), **kwargs)
+
+    def _establish_connection(self) -> None:
+        result = self._run_powershell_script(
+            "Write-Output 'SSH connection established'",
+            timeout=15,
+        )
+        if result.returncode != 0:
+            error = result.stderr.strip() or result.stdout.strip()
+            raise RuntimeError(f"SSH connection failed: {error}")
+
+    def _detect_remote_home(self) -> str:
+        script = """
+$homePath = $HOME
+if (-not $homePath) { $homePath = $env:USERPROFILE }
+Write-Output $homePath
+"""
+        try:
+            result = self._run_powershell_script(script, timeout=10)
+            home = _normalize_windows_path(result.stdout.strip().splitlines()[-1])
+            if home and result.returncode == 0:
+                logger.debug("SSH Windows: remote home = %s", home)
+                return home
+        except Exception:
+            pass
+        return f"C:/Users/{self.user}"
+
+    def _detect_remote_temp(self) -> str:
+        script = """
+$tempPath = $env:TEMP
+if (-not $tempPath) { $tempPath = [System.IO.Path]::GetTempPath() }
+Write-Output $tempPath
+"""
+        try:
+            result = self._run_powershell_script(script, timeout=10)
+            temp = _normalize_windows_path(result.stdout.strip().splitlines()[-1])
+            if temp and result.returncode == 0:
+                return temp.rstrip("/")
+        except Exception:
+            pass
+        return f"{self._remote_home}/AppData/Local/Temp"
+
+    def _normalize_cwd(self, cwd: str) -> str:
+        cwd = _normalize_windows_path(cwd or self._remote_home)
+        if cwd in {"~", "~/"}:
+            return self._remote_home
+        if cwd.startswith("~/"):
+            return f"{self._remote_home}/{cwd[2:]}"
+        if cwd.startswith("/Users/") or cwd.startswith("/home/"):
+            return self._remote_home
+        return cwd
+
+    def _ensure_remote_dirs(self) -> None:
+        base = f"{self._remote_home}/.hermes"
+        dirs = [base, f"{base}/skills", f"{base}/credentials", f"{base}/cache"]
+        self._powershell_mkdir(dirs)
+
+    def _powershell_mkdir(self, dirs: list[str]) -> None:
+        if not dirs:
+            return
+        script = """
+$paths = [Console]::In.ReadToEnd() | ConvertFrom-Json
+foreach ($path in $paths) {
+  if ($path) {
+    New-Item -ItemType Directory -Force -Path ([string]$path) | Out-Null
+  }
+}
+"""
+        result = self._run_powershell_script(
+            script,
+            timeout=30,
+            input_data=json.dumps([_normalize_windows_path(d) for d in dirs]),
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"remote mkdir failed: {result.stderr.strip() or result.stdout.strip()}")
+
+    def _powershell_upload(self, host_path: str, remote_path: str) -> None:
+        with open(host_path, "rb") as f:
+            content_b64 = base64.b64encode(f.read()).decode("ascii")
+        payload = {
+            "path": _normalize_windows_path(remote_path),
+            "content": content_b64,
+        }
+        script = """
+$payload = [Console]::In.ReadToEnd() | ConvertFrom-Json
+$path = [string]$payload.path
+$parent = Split-Path -Parent -Path $path
+if ($parent) {
+  New-Item -ItemType Directory -Force -Path $parent | Out-Null
+}
+[System.IO.File]::WriteAllBytes($path, [Convert]::FromBase64String([string]$payload.content))
+"""
+        result = self._run_powershell_script(
+            script,
+            timeout=60,
+            input_data=json.dumps(payload),
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"PowerShell upload failed: {result.stderr.strip() or result.stdout.strip()}")
+
+    def _powershell_bulk_upload(self, files: list[tuple[str, str]]) -> None:
+        if not files:
+            return
+
+        base = f"{self._remote_home}/.hermes"
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+            zip_path = tmp.name
+
+        try:
+            with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+                for host_path, remote_path in files:
+                    remote_norm = _normalize_windows_path(remote_path)
+                    try:
+                        rel_remote = posixpath.relpath(remote_norm, base)
+                    except ValueError as exc:
+                        raise RuntimeError(
+                            f"remote path {remote_path!r} is not under sync base {base!r}"
+                        ) from exc
+                    if rel_remote == "." or rel_remote.startswith("../"):
+                        raise RuntimeError(
+                            f"remote path {remote_path!r} escapes sync base {base!r}"
+                        )
+                    zf.write(host_path, rel_remote)
+
+            remote_zip = f"{self._remote_temp}/hermes-sync-{os.getpid()}.zip"
+            zip_size = os.path.getsize(zip_path)
+            scp_timeout = max(120, min(900, 120 + (zip_size // (1024 * 1024)) * 60))
+            scp_result = subprocess.run(
+                self._build_scp_command(zip_path, remote_zip),
+                capture_output=True,
+                text=True,
+                timeout=scp_timeout,
+                stdin=subprocess.DEVNULL,
+            )
+            if scp_result.returncode != 0:
+                raise RuntimeError(f"scp zip upload failed: {scp_result.stderr.strip()}")
+
+            payload = {
+                "zip_path": _normalize_windows_path(remote_zip),
+                "destination": base,
+            }
+            script = """
+$payload = [Console]::In.ReadToEnd() | ConvertFrom-Json
+$zipPath = [string]$payload.zip_path
+$destination = [string]$payload.destination
+New-Item -ItemType Directory -Force -Path $destination | Out-Null
+try {
+  Add-Type -AssemblyName System.IO.Compression.FileSystem
+  $zip = [System.IO.Compression.ZipFile]::OpenRead($zipPath)
+  try {
+    foreach ($entry in $zip.Entries) {
+      if ([string]::IsNullOrEmpty($entry.Name)) { continue }
+      $target = Join-Path $destination $entry.FullName
+      $targetParent = Split-Path -Parent -Path $target
+      if ($targetParent) {
+        New-Item -ItemType Directory -Force -Path $targetParent | Out-Null
+      }
+      if (Test-Path -LiteralPath $target) {
+        Remove-Item -LiteralPath $target -Force
+      }
+      [System.IO.Compression.ZipFileExtensions]::ExtractToFile($entry, $target)
+    }
+  } finally {
+    $zip.Dispose()
+  }
+} finally {
+  Remove-Item -LiteralPath $zipPath -Force -ErrorAction SilentlyContinue
+}
+"""
+            timeout = max(120, min(900, 120 + (zip_size // (1024 * 1024)) * 60))
+            result = self._run_powershell_script(
+                script,
+                timeout=timeout,
+                input_data=json.dumps(payload),
+            )
+            if result.returncode != 0:
+                raise RuntimeError(f"PowerShell bulk upload failed: {result.stderr.strip() or result.stdout.strip()}")
+        finally:
+            try:
+                os.unlink(zip_path)
+            except OSError:
+                pass
+
+    def _powershell_delete(self, remote_paths: list[str]) -> None:
+        if not remote_paths:
+            return
+        script = """
+$paths = [Console]::In.ReadToEnd() | ConvertFrom-Json
+foreach ($path in $paths) {
+  if ($path) {
+    Remove-Item -LiteralPath ([string]$path) -Force -ErrorAction SilentlyContinue
+  }
+}
+"""
+        result = self._run_powershell_script(
+            script,
+            timeout=30,
+            input_data=json.dumps([_normalize_windows_path(p) for p in remote_paths]),
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"remote rm failed: {result.stderr.strip() or result.stdout.strip()}")
+
+    def init_session(self) -> None:
+        self._snapshot_ready = True
+        logger.info("Windows SSH session initialized (session=%s, cwd=%s)", self._session_id, self.cwd)
+
+    def _before_execute(self) -> None:
+        self._sync_manager.sync()
+
+    def _wrap_powershell_command(self, command: str, cwd: str) -> str:
+        quoted_cwd = _ps_single_quote(self._normalize_cwd(cwd))
+        return f"""
+$__hermes_cwd = {quoted_cwd}
+try {{
+  Set-Location -LiteralPath $__hermes_cwd
+}} catch {{
+  Write-Error ("cd failed: " + $__hermes_cwd + " - " + $_.Exception.Message)
+  exit 126
+}}
+$global:LASTEXITCODE = $null
+. {{
+{command}
+}}
+$__hermes_success = $?
+if ($global:LASTEXITCODE -is [int]) {{
+  $__hermes_ec = $global:LASTEXITCODE
+}} elseif ($__hermes_success) {{
+  $__hermes_ec = 0
+}} else {{
+  $__hermes_ec = 1
+}}
+$__hermes_pwd = (Get-Location).ProviderPath
+Write-Output ""
+Write-Output ("{self._cwd_marker}" + $__hermes_pwd + "{self._cwd_marker}")
+exit $__hermes_ec
+"""
+
+    def _run_powershell(
+        self,
+        script: str,
+        *,
+        stdin_data: str | None = None,
+    ) -> subprocess.Popen:
+        return _popen_bash(self._build_powershell_command(script), stdin_data=stdin_data)
+
+    def execute(
+        self,
+        command: str,
+        cwd: str = "",
+        *,
+        timeout: int | None = None,
+        stdin_data: str | None = None,
+        rewrite_compound_background: bool = True,
+    ) -> dict:
+        self._before_execute()
+        effective_timeout = timeout or self.timeout
+        effective_cwd = self._normalize_cwd(cwd or self.cwd)
+        wrapped = self._wrap_powershell_command(command, effective_cwd)
+        proc = self._run_powershell(wrapped, stdin_data=stdin_data)
+        result = self._wait_for_process(proc, timeout=effective_timeout)
+        self._update_cwd(result)
+        return result
+
+    def cleanup(self) -> None:
+        sync_manager = getattr(self, "_sync_manager", None)
+        if sync_manager:
+            logger.info("SSH Windows: syncing files from sandbox...")
+            sync_manager.sync_back()
+
+        control_socket = getattr(self, "control_socket", None)
+        if control_socket and control_socket.exists():
+            try:
+                cmd = [
+                    "ssh",
+                    "-o",
+                    f"ControlPath={control_socket}",
+                    "-O",
+                    "exit",
+                    f"{self.user}@{self.host}",
+                ]
+                subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    timeout=5,
+                    stdin=subprocess.DEVNULL,
+                )
+            except (OSError, subprocess.SubprocessError):
+                pass
+            try:
+                control_socket.unlink()
+            except OSError:
+                pass

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -838,7 +838,9 @@ import sys
 
 
 # Tool description for LLM
-TERMINAL_TOOL_DESCRIPTION = """Execute shell commands on a Linux environment. Filesystem, current working directory, and exported environment variables persist between calls.
+TERMINAL_TOOL_DESCRIPTION = """Execute shell commands in the active terminal backend. Filesystem, current working directory, and exported environment variables persist between calls.
+
+When TERMINAL_ENV=ssh, this tool already executes commands on the configured SSH target. Do not run `ssh` to that same host from inside terminal(); run the requested remote command directly instead. If the SSH target is Windows, terminal commands run under Windows PowerShell, so use PowerShell syntax such as `hostname; whoami`, `Get-ChildItem`, and `$env:USERPROFILE` instead of POSIX-only shell syntax such as `&&`, `/Users/...`, or `~/.ssh` on the Hermes host.
 
 Do NOT use cat/head/tail to read files — use read_file instead.
 Do NOT use grep/rg/find to search — use search_files instead.
@@ -860,6 +862,86 @@ PTY mode: Set pty=true for interactive CLI tools (Codex, Claude Code, Python REP
 
 Do NOT use vim/nano/interactive tools without pty=true — they hang without a pseudo-terminal. Pipe git output to cat if it might page.
 """
+
+
+_SSH_OPTIONS_WITH_ARGS = {
+    "-b", "-c", "-D", "-E", "-F", "-I", "-i", "-J", "-L", "-l",
+    "-m", "-O", "-o", "-p", "-Q", "-R", "-S", "-W", "-w",
+}
+
+
+def _ssh_target_host(token: str) -> str:
+    """Extract a hostname from an ssh target token like user@host:port."""
+    target = (token or "").strip()
+    if not target or target.startswith("-"):
+        return ""
+    if "://" in target:
+        # ssh://user@host:22 is rare here, but keep the extraction harmless.
+        target = target.rsplit("://", 1)[-1]
+    target = target.rsplit("@", 1)[-1]
+    if target.startswith("[") and "]" in target:
+        return target[1:target.index("]")].lower()
+    return target.split(":", 1)[0].lower()
+
+
+def _find_nested_ssh_target(command: str) -> str:
+    """Return the first explicit ssh target host in *command*, if any."""
+    try:
+        import shlex
+
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        tokens = command.split()
+
+    for index, token in enumerate(tokens):
+        executable = os.path.basename(token).lower()
+        if executable not in {"ssh", "ssh.exe"}:
+            continue
+
+        cursor = index + 1
+        while cursor < len(tokens):
+            part = tokens[cursor]
+            if part == "--":
+                cursor += 1
+                break
+            if part in _SSH_OPTIONS_WITH_ARGS:
+                cursor += 2
+                continue
+            # Short options with attached args, e.g. -p22, -i/path/key,
+            # -oConnectTimeout=10. Boolean flags (-v, -A, -T, ...) are just
+            # skipped below.
+            if len(part) > 2 and part[:2] in _SSH_OPTIONS_WITH_ARGS:
+                cursor += 1
+                continue
+            if part.startswith("-"):
+                cursor += 1
+                continue
+            break
+
+        if cursor < len(tokens):
+            return _ssh_target_host(tokens[cursor])
+
+    return ""
+
+
+def _nested_ssh_to_configured_target_error(command: str, config: Dict[str, Any]) -> str:
+    """Explain when the model tries to SSH into the active SSH backend again."""
+    if config.get("env_type") != "ssh":
+        return ""
+    configured_host = str(config.get("ssh_host") or "").strip().lower()
+    if not configured_host:
+        return ""
+    target_host = _find_nested_ssh_target(command)
+    if not target_host or target_host != configured_host:
+        return ""
+    return (
+        f"This terminal is already connected to the configured SSH target "
+        f"{configured_host}. Do not run `ssh {configured_host}` from inside "
+        "this backend; that attempts a second SSH connection from the remote "
+        "host and often hangs. Run the remote command directly in terminal() "
+        "instead. For a Windows SSH target, use PowerShell syntax, e.g. "
+        "`hostname; whoami` or `Get-Service sshd`."
+    )
 
 # Global state for environment lifecycle management
 _active_environments: Dict[str, Any] = {}
@@ -1895,6 +1977,15 @@ def terminal_tool(
         # Get configuration
         config = _get_env_config()
         env_type = config["env_type"]
+
+        nested_ssh_error = _nested_ssh_to_configured_target_error(command, config)
+        if nested_ssh_error:
+            return json.dumps({
+                "output": "",
+                "exit_code": -1,
+                "error": nested_ssh_error,
+                "status": "blocked",
+            }, ensure_ascii=False)
 
         # Use task_id for environment isolation. By default all subagent
         # task_ids collapse back to "default" so the top-level agent and

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -825,7 +825,11 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
 # Environment classes now live in tools/environments/
 from tools.environments.local import LocalEnvironment as _LocalEnvironment
 from tools.environments.singularity import SingularityEnvironment as _SingularityEnvironment
-from tools.environments.ssh import SSHEnvironment as _SSHEnvironment
+from tools.environments.ssh import (
+    SSHEnvironment as _SSHEnvironment,
+    detect_windows_ssh_host as _detect_windows_ssh_host,
+)
+from tools.environments.ssh_windows import WindowsSSHEnvironment as _WindowsSSHEnvironment
 from tools.environments.docker import DockerEnvironment as _DockerEnvironment
 from tools.environments.modal import ModalEnvironment as _ModalEnvironment
 from tools.environments.managed_modal import ManagedModalEnvironment as _ManagedModalEnvironment
@@ -1336,11 +1340,25 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     elif env_type == "ssh":
         if not ssh_config or not ssh_config.get("host") or not ssh_config.get("user"):
             raise ValueError("SSH environment requires ssh_host and ssh_user to be configured")
+        host = ssh_config["host"]
+        user = ssh_config["user"]
+        port = ssh_config.get("port", 22)
+        key_path = ssh_config.get("key", "")
+        if _detect_windows_ssh_host(host, user, port, key_path):
+            logger.info("SSH: detected Windows host; using PowerShell backend")
+            return _WindowsSSHEnvironment(
+                host=host,
+                user=user,
+                port=port,
+                key_path=key_path,
+                cwd=cwd,
+                timeout=timeout,
+            )
         return _SSHEnvironment(
-            host=ssh_config["host"],
-            user=ssh_config["user"],
-            port=ssh_config.get("port", 22),
-            key_path=ssh_config.get("key", ""),
+            host=host,
+            user=user,
+            port=port,
+            key_path=key_path,
             cwd=cwd,
             timeout=timeout,
         )


### PR DESCRIPTION
## Summary

- Detect native Windows OpenSSH targets before creating the SSH terminal backend.
- Add a PowerShell-based Windows SSH environment that does not require remote bash, tar, rm, mkdir -p, or Python.
- Sync files to Windows targets by uploading a zip with the local OpenSSH `scp` client, then extracting it remotely with PowerShell/.NET.
- Use Windows home/temp paths and PowerShell wrappers for command execution, cwd tracking, uploads, deletes, and bulk zip sync.
- Teach prompt-building and the terminal schema that an SSH backend may already be the remote Windows PowerShell target, so agents do not run a nested `ssh <same-host>` command from inside the remote host.
- Return an actionable `execute_code` error on native Windows SSH backends instead of attempting POSIX file-RPC commands that cannot run under PowerShell.
- Add focused unit coverage for Windows host probing, backend selection, file sync config, upload/delete, bulk zip sync, command wrapping, prompt hints, nested SSH guardrails, and execute_code guidance.

## Tests

- `uv run --with pytest --with pytest-timeout pytest tests/tools/test_ssh_windows_environment.py tests/tools/test_ssh_environment.py tests/tools/test_ssh_bulk_upload.py -q`
- `uv run --with pytest --with pytest-timeout pytest tests/tools/test_ssh_windows_environment.py tests/tools/test_terminal_tool.py tests/tools/test_code_execution.py tests/agent/test_prompt_builder.py -q`
- `uv run --with ruff ruff check agent/prompt_builder.py tools/terminal_tool.py tools/code_execution_tool.py tests/tools/test_ssh_windows_environment.py tests/tools/test_terminal_tool.py tests/tools/test_code_execution.py tests/agent/test_prompt_builder.py`
- `git diff --check`

## Manual validation

Verified against a native Windows OpenSSH target from a local Hermes configuration:

- Windows probe returns true.
- `hostname; whoami` runs directly through the SSH terminal backend and returns the remote Windows host/user with exit code 0.
- A nested `ssh 192.168.2.5 ...` command is now blocked immediately with guidance to run the command directly in the active SSH backend.
- Prompt environment hints now report Windows PowerShell, the remote home/cwd, and the configured SSH target.
- `execute_code` on the Windows SSH backend returns an actionable unsupported-backend message instead of attempting POSIX shell setup.
- Uploading a temp file to the remote Windows temp directory, reading it, then deleting it succeeds.
- Full `TERMINAL_ENV=ssh` terminal-tool smoke test completes and returns the Windows user/host.