### PR TITLE
fix(vision_tools): check supports_vision_tool_messages in native fast path (#44299)

### DIFF
--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -812,14 +812,21 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
             return True
         return False
 
-    # Check the provider's registered profile for the supports_vision flag.
-    # This covers vision-capable providers like xiaomi, minimax, etc. that
-    # aren't in the hardcoded list above.
+    # Check the provider's registered profile.  Some providers (e.g. Xiaomi
+    # MiMo) support vision in user messages but reject list-type tool content
+    # with HTTP 400.  The ``supports_vision_tool_messages`` flag on the
+    # ProviderProfile gates this: when False, the provider cannot accept
+    # images inside tool-result messages even though it supports vision
+    # generally.
     try:
         from providers import get_provider_profile
         profile = get_provider_profile(p)
         if profile is not None and profile.supports_vision:
-            return True
+            if getattr(profile, "supports_vision_tool_messages", True):
+                return True
+            # Provider supports vision but NOT in tool messages — treat as
+            # unsupported for the purpose of multimodal tool results.
+            return False
     except Exception:
         pass
 
@@ -850,9 +857,15 @@ def _should_use_native_vision_fast_path() -> bool:
         cfg = load_config()
         if decide_image_input_mode(provider, model, cfg) != "native":
             return False
+        # Both checks must pass: the provider must accept images inside tool
+        # results AND the model must be declared vision-capable.  Using OR
+        # here causes false positives — e.g. xiaomi's profile has
+        # supports_vision=True but rejects list-type tool content, so
+        # _supports_media_in_tool_results would pass alone and incorrectly
+        # route images into tool-result messages that get HTTP-400'd.
         return (
             _supports_media_in_tool_results(provider, model)
-            or _lookup_supports_vision(provider, model, cfg) is True
+            and _lookup_supports_vision(provider, model, cfg) is True
         )
     except Exception as exc:
         logger.debug("Native vision fast-path check failed: %s", exc)


### PR DESCRIPTION
## Bug

Two bugs in `tools/vision_tools.py` allowed providers that reject list-type tool content (e.g. Xiaomi MiMo) to be incorrectly routed through the native vision fast path, causing images to be placed in tool-result messages that get HTTP-400'd.

## Root Cause

1. **`_supports_media_in_tool_results()`** checked the provider profile's `supports_vision` flag but ignored `supports_vision_tool_messages`. For MiMo (`supports_vision=True`, `supports_vision_tool_messages=False`), this returned `True` — incorrectly indicating the provider accepts images inside tool-result messages.

2. **`_should_use_native_vision_fast_path()`** used `or` logic between `_supports_media_in_tool_results` and `_lookup_supports_vision`. Since `_lookup_supports_vision` returns `True` for MiMo, the `or` would pass even when `_supports_media_in_tool_results` was incorrectly `True`, routing images into tool-result messages that get HTTP-400'd.

## Fix

- **`_supports_media_in_tool_results`**: Now checks `getattr(profile, 'supports_vision_tool_messages', True)`. When the profile explicitly declares `False`, the function returns `False` — correctly preventing images from being routed into tool-result messages.

- **`_should_use_native_vision_fast_path`**: Changed `or` to `and` so both checks must pass before routing images into tool-result messages.

## Complements

This PR complements [#44305](https://github.com/NousResearch/hermes-agent/pull/44305) which fixes the routing priority in `image_routing.py`. Both fixes are needed: #44305 ensures the main model's vision capability is checked first, while this PR ensures the native fast path doesn't activate for providers that can't handle tool-result images.

## Tests

- `tests/run_agent/test_vision_tool_messages.py`: 17/17 passed
- `tests/agent/test_image_routing.py`: 77/77 passed