### PR TITLE
fix(moonshot): handle union type arrays in tool schemas

### DIFF
--- a/agent/moonshot_schema.py
+++ b/agent/moonshot_schema.py
@@ -135,7 +135,14 @@ def _repair_schema(node: Any, is_schema: bool = True) -> Any:
 
 def _fill_missing_type(node: Dict[str, Any]) -> Dict[str, Any]:
     """Infer a reasonable ``type`` if this schema node has none."""
-    if "type" in node and node["type"] not in {None, ""}:
+    node_type = node.get("type")
+    if isinstance(node_type, list):
+        concrete = next(
+            (t for t in node_type if isinstance(t, str) and t not in {"", "null"}),
+            "string",
+        )
+        return {**node, "type": concrete}
+    if "type" in node and node_type not in {None, ""}:
         return node
 
     # Heuristic: presence of ``properties`` → object, ``items`` → array, ``enum``

--- a/tests/agent/test_moonshot_schema.py
+++ b/tests/agent/test_moonshot_schema.py
@@ -397,3 +397,52 @@ class TestEnumNullStripping:
         assert db_type["type"] == "string"
         assert db_type["enum"] == ["mysql", "postgresql"], \
             "null/empty enum values must be stripped after anyOf collapse"
+
+
+class TestUnionTypeList:
+    """Moonshot sanitizer accepts JSON Schema union type arrays."""
+
+    def test_union_type_list_normalizes_to_first_concrete_type(self):
+        params = {
+            "type": "object",
+            "properties": {
+                "limit": {
+                    "type": ["number", "string"],
+                    "description": "Max results",
+                },
+            },
+        }
+
+        out = sanitize_moonshot_tool_parameters(params)
+
+        assert out["properties"]["limit"]["type"] == "number"
+
+    def test_union_type_list_skips_null_type(self):
+        params = {
+            "type": "object",
+            "properties": {
+                "name": {"type": ["null", "string"]},
+            },
+        }
+
+        out = sanitize_moonshot_tool_parameters(params)
+
+        assert out["properties"]["name"]["type"] == "string"
+
+    def test_union_type_list_with_enum_does_not_crash_or_mutate_input(self):
+        params = {
+            "type": "object",
+            "properties": {
+                "sort": {
+                    "type": ["string", "null"],
+                    "enum": ["asc", "desc", None, ""],
+                },
+            },
+        }
+
+        out = sanitize_moonshot_tool_parameters(params)
+
+        sort = out["properties"]["sort"]
+        assert sort["type"] == "string"
+        assert sort["enum"] == ["asc", "desc"]
+        assert params["properties"]["sort"]["type"] == ["string", "null"]


### PR DESCRIPTION
## Summary
Moonshot/Kimi tool schema sanitization now accepts JSON Schema union `type` arrays instead of crashing before the request is sent.

## Changes
- Normalize `type: [...]` to the first concrete non-null type in the Moonshot schema repair path.
- Preserve existing enum cleanup and input immutability behavior.
- Add regression coverage for concrete unions, nullable unions, and enum-bearing union schemas.

## Validation
| Check | Result |
|---|---|
| `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/agent/test_moonshot_schema.py::TestUnionTypeList -q` | 3 passed |
| `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/agent/test_moonshot_schema.py -q` | 37 passed |
| `scripts/run_tests.sh tests/agent/test_moonshot_schema.py` | 37 passed |
| Moonshot transport kwargs E2E | passed |
| `python3 -m py_compile agent/moonshot_schema.py tests/agent/test_moonshot_schema.py && git diff --check` | passed |

Salvages #30226 by @Tranquil-Flow with authorship preserved.
Closes #30095.

## Infographic

![Moonshot Union Types](https://v3b.fal.media/files/b/0a9e20d9/ESRcE2Ih1bPf8Prbx7vm-_kmhi0LoZ.png)
