### PR TITLE
fix(auxiliary): preserve main provider base url

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3190,7 +3190,7 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
     if (main_provider and main_model
             and main_provider not in {"auto", ""}):
         resolved_provider = main_provider
-        explicit_base_url = None
+        explicit_base_url = runtime_base_url or None
         explicit_api_key = None
         if runtime_base_url and (main_provider == "custom" or main_provider.startswith("custom:")):
             resolved_provider = "custom"

--- a/tests/agent/test_auxiliary_main_first.py
+++ b/tests/agent/test_auxiliary_main_first.py
@@ -161,6 +161,35 @@ class TestResolveAutoMainFirst:
         assert mock_resolve.call_args.args[0] == "anthropic"
         assert mock_resolve.call_args.args[1] == "runtime-model"
 
+    def test_runtime_base_url_passed_for_named_api_key_provider(self):
+        """Named API-key providers inherit the live session endpoint for aux work."""
+        token_plan_url = "https://token-plan-sgp.xiaomimimo.com/v1"
+        with patch(
+            "agent.auxiliary_client._read_main_provider",
+            return_value="openrouter",
+        ), patch(
+            "agent.auxiliary_client._read_main_model", return_value="config-model",
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client"
+        ) as mock_resolve:
+            mock_resolve.return_value = (MagicMock(), "mimo-v2.5-pro")
+
+            from agent.auxiliary_client import _resolve_auto
+
+            _resolve_auto(main_runtime={
+                "provider": "xiaomi",
+                "model": "mimo-v2.5-pro",
+                "base_url": token_plan_url,
+                "api_key": "tp-test-key",
+                "api_mode": "chat_completions",
+            })
+
+        assert mock_resolve.call_args.args[0] == "xiaomi"
+        assert mock_resolve.call_args.args[1] == "mimo-v2.5-pro"
+        assert mock_resolve.call_args.kwargs["explicit_base_url"] == token_plan_url
+        assert mock_resolve.call_args.kwargs["explicit_api_key"] == "tp-test-key"
+        assert mock_resolve.call_args.kwargs["api_mode"] == "chat_completions"
+
 
 # ── Vision — resolve_vision_provider_client ─────────────────────────────────
 


### PR DESCRIPTION
## Summary
Auxiliary tasks now reuse the active main provider endpoint for named API-key providers, so Xiaomi MiMo token-plan sessions keep using the subscription base URL instead of falling back to the default pay-as-you-go URL.

## Changes
- `agent/auxiliary_client.py`: pass the live `main_runtime.base_url` through Step-1 main-provider auxiliary resolution for all providers, not only `custom:` providers.
- `tests/agent/test_auxiliary_main_first.py`: cover Xiaomi token-plan runtime propagation.

## Validation
| Check | Result |
|---|---|
| `python -m py_compile agent/auxiliary_client.py tests/agent/test_auxiliary_main_first.py` | pass |
| `scripts/run_tests.sh tests/agent/test_auxiliary_main_first.py` | 16 passed |
| `scripts/run_tests.sh tests/hermes_cli/test_xiaomi_provider.py` | 52 passed |
| isolated runtime probe | `xiaomi` + `tp-*` resolved to `https://token-plan-sgp.xiaomimimo.com/v1/` |

Root cause: `_resolve_auto()` pinned the live runtime API key for named providers but discarded the live runtime base URL unless the provider was `custom`, so Xiaomi token-plan keys could be reused against the hardcoded default endpoint.

## Infographic

![Auxiliary Routing Stays on Xiaomi Token Plan](https://v3b.fal.media/files/b/0a9e210f/XTBtCOzfPTPOz2EIwmhV7_gjtolaER.png)
