### PR TITLE
fix(installer): clear unmerged index before installer autostash

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1171,6 +1171,20 @@ function Install-Repository {
                 # agent-created dirs (e.g. tinker-atropos/) survive too.
                 $statusOut = git -c windows.appendAtomically=false status --porcelain 2>$null
                 if (-not [string]::IsNullOrWhiteSpace(($statusOut -join "`n"))) {
+                    # A previously interrupted update can leave the index with
+                    # unmerged entries. In that state `git stash` aborts with
+                    # "could not write index" and the following `git checkout`
+                    # aborts with "you need to resolve your current index first"
+                    # -- the GUI "git checkout main failed (exit 1)" install
+                    # failure. Clear the conflict markers with `git reset` first:
+                    # working-tree changes are kept (and stashed just below); only
+                    # the index conflict state is dropped. Mirrors the `hermes
+                    # update` path (#4735).
+                    $unmergedOut = git -c windows.appendAtomically=false ls-files --unmerged 2>$null
+                    if (-not [string]::IsNullOrWhiteSpace(($unmergedOut -join "`n"))) {
+                        Write-Info "Clearing unmerged index entries from a previous conflict..."
+                        git -c windows.appendAtomically=false reset -q 2>$null
+                    }
                     $stashName = "hermes-install-autostash-" + (Get-Date -Format "yyyyMMdd-HHmmss")
                     Write-Info "Local changes detected, stashing before update..."
                     git -c windows.appendAtomically=false stash push --include-untracked -m "$stashName"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1111,6 +1111,19 @@ clone_repo() {
 
             local autostash_ref=""
             if [ -n "$(git status --porcelain)" ]; then
+                # A previously interrupted update can leave the index with
+                # unmerged entries. In that state `git stash` aborts with
+                # "could not write index" and the later `git checkout` aborts
+                # with "you need to resolve your current index first", failing
+                # the whole install at the repository stage. Clear the conflict
+                # markers with `git reset` first -- this keeps working-tree
+                # changes (they're still stashed just below) and only drops the
+                # index-level conflict state. Mirrors the `hermes update` path
+                # (#4735).
+                if [ -n "$(git ls-files --unmerged)" ]; then
+                    log_info "Clearing unmerged index entries from a previous conflict..."
+                    git reset -q
+                fi
                 local stash_name
                 stash_name="hermes-install-autostash-$(date -u +%Y%m%d-%H%M%S)"
                 log_info "Local changes detected, stashing before update..."

--- a/tests/test_install_unmerged_index.py
+++ b/tests/test_install_unmerged_index.py
@@ -1,0 +1,143 @@
+"""Regression: installer fails when the existing checkout has an unmerged index.
+
+A previously interrupted update can leave ``$INSTALL_DIR`` with unmerged index
+entries (files in a conflicted, "needs merge" state). In that state the update
+path's ``git stash`` aborts with "could not write index" and the following
+``git checkout <branch>`` aborts with "you need to resolve your current index
+first" -- surfacing to GUI/bootstrap users as ``git checkout main failed
+(exit 1)`` and failing the whole install at the repository stage.
+
+The ``hermes update`` Python path already clears the conflict with ``git reset``
+before stashing (#4735); both installer scripts must do the same.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+INSTALL_PS1 = REPO_ROOT / "scripts" / "install.ps1"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None or shutil.which("bash") is None,
+    reason="needs git and bash",
+)
+
+
+def _git(cwd: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=cwd,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _extract_autostash_block() -> str:
+    """Pull the autostash if-block from install.sh's update_repo()."""
+    text = INSTALL_SH.read_text()
+    m = re.search(
+        r'local autostash_ref="".*?\n            fi\n',
+        text,
+        re.DOTALL,
+    )
+    assert m is not None, "autostash block not found in install.sh"
+    return m.group(0)
+
+
+def _make_unmerged_repo(repo: Path) -> None:
+    """Leave ``repo`` with a conflicted (unmerged) index, as an interrupted
+    update would."""
+    _git(repo, "init")
+    (repo / "f.txt").write_text("base\n")
+    _git(repo, "add", "f.txt")
+    _git(repo, "commit", "-m", "base")
+    # Capture the default branch name only after the first commit exists
+    # (rev-parse on an unborn HEAD errors).
+    start = _git(repo, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+
+    _git(repo, "checkout", "-b", "feature")
+    (repo / "f.txt").write_text("feature side\n")
+    _git(repo, "add", "f.txt")
+    _git(repo, "commit", "-m", "feature")
+
+    _git(repo, "checkout", start)
+    (repo / "f.txt").write_text("main side\n")
+    _git(repo, "add", "f.txt")
+    _git(repo, "commit", "-m", "mainside")
+
+    # Conflicting merge — exits non-zero and leaves the index unmerged.
+    _git(repo, "merge", "feature", check=False)
+
+
+@pytest.mark.live_system_guard_bypass  # runs against a dedicated throwaway repo
+def test_install_sh_clears_unmerged_index_then_stashes(tmp_path: Path) -> None:
+    repo = tmp_path / "hermes-agent"
+    repo.mkdir()
+    _make_unmerged_repo(repo)
+
+    # Sanity: this is exactly the state that breaks `git stash` / `git checkout`.
+    assert _git(repo, "ls-files", "--unmerged").stdout.strip(), (
+        "test setup failed to produce an unmerged index"
+    )
+
+    block = _extract_autostash_block()
+    script = (
+        "set -e\n"
+        'log_info() { echo "INFO: $*"; }\n'
+        "run() {\n"
+        f"{block}"
+        "}\n"
+        "run\n"
+        "echo BLOCK_OK\n"
+    )
+    res = subprocess.run(
+        ["bash", "-c", script], cwd=repo, capture_output=True, text=True
+    )
+
+    # The block must complete (previously `git stash` failed with "could not
+    # write index" on the unmerged tree).
+    assert res.returncode == 0, res.stderr
+    assert "BLOCK_OK" in res.stdout
+    assert "Clearing unmerged index entries" in res.stdout
+
+    # The conflict state is gone ...
+    assert _git(repo, "ls-files", "--unmerged").stdout.strip() == "", (
+        "unmerged entries should have been cleared"
+    )
+    # ... and the local changes were preserved in a stash, not discarded.
+    assert _git(repo, "stash", "list").stdout.strip(), (
+        "local changes should be preserved in a stash"
+    )
+
+
+def test_install_ps1_clears_unmerged_index_before_stash() -> None:
+    """install.ps1 must clear an unmerged index before stash/checkout, and do
+    so *before* the stash push (order matters — the fix is a no-op otherwise)."""
+    text = INSTALL_PS1.read_text()
+    assert "ls-files --unmerged" in text, (
+        "install.ps1 must detect an unmerged index before updating"
+    )
+    idx_unmerged = text.index("ls-files --unmerged")
+    idx_reset = text.index("reset -q", idx_unmerged)
+    idx_stash = text.index("stash push --include-untracked")
+    assert idx_unmerged < idx_stash, (
+        "the unmerged-index clear must run before `git stash push`"
+    )
+    assert idx_reset < idx_stash, "`git reset` must run before `git stash push`"
+
+
+def test_install_sh_clears_unmerged_index_before_stash_source_order() -> None:
+    """Same ordering contract for install.sh's source."""
+    text = INSTALL_SH.read_text()
+    assert "ls-files --unmerged" in text
+    idx_unmerged = text.index("ls-files --unmerged")
+    idx_stash = text.index("stash push --include-untracked")
+    assert idx_unmerged < idx_stash


### PR DESCRIPTION
## Summary
Installer update paths now recover when an existing managed checkout has an unmerged git index before autostashing.

Salvages #45515 by @xxxigm onto current `main`, preserving contributor authorship. The bug is the same state already handled by the Python `hermes update` path: an interrupted update leaves index conflict markers, so `git stash` fails with `could not write index` and the later `git checkout main` fails.

## Changes
- `scripts/install.sh`: detect `git ls-files --unmerged`, run `git reset -q`, then stash normally.
- `scripts/install.ps1`: same unmerged-index clear before stash for the Windows installer path.
- `tests/test_install_unmerged_index.py`: regression test for the bash autostash block plus source-order checks for both installers.

## Validation
| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/test_install_unmerged_index.py` | 3 passed |
| Live throwaway git repro | before reset: stash rc=1 with `could not write index`; after reset: unmerged cleared, stash rc=0, changes preserved |

Original PR: https://github.com/NousResearch/hermes-agent/pull/45515

## Infographic

![Installer Self-Heal](https://v3b.fal.media/files/b/0a9e211d/VDsxlqH3HeO8Y0bYvw2c5_2cX99yev.png)
