### PR TITLE
fix(kanban): pin assigned profile toolsets for workers

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6675,6 +6675,40 @@ def _worker_terminal_timeout_env(
     return str(desired)
 
 
+def _resolve_worker_cli_toolsets(hermes_home: Optional[str]) -> Optional[list[str]]:
+    """Return the assigned profile's effective CLI toolsets for a worker.
+
+    Dispatcher-spawned workers are launched from a long-lived gateway process,
+    then the child re-enters the CLI with ``-p <assignee>``. Resolve the
+    assignee profile's CLI tool surface at dispatch time and pass it as an
+    explicit ``--toolsets`` pin so worker startup cannot fall back to a stale
+    root/active-profile config or a profile whose top-level ``toolsets`` entry
+    is only the kanban orchestrator surface. ``model_tools`` still appends the
+    task-scoped kanban lifecycle tools when ``HERMES_KANBAN_TASK`` is set.
+    """
+    if not hermes_home:
+        return None
+    try:
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+        from hermes_cli.config import load_config
+        from hermes_cli.tools_config import _get_platform_tools
+
+        token = set_hermes_home_override(hermes_home)
+        try:
+            cfg = load_config()
+            toolsets = sorted(_get_platform_tools(cfg, "cli"))
+        finally:
+            reset_hermes_home_override(token)
+        return toolsets or None
+    except Exception as exc:
+        _log.debug(
+            "kanban worker: could not resolve CLI toolsets for HERMES_HOME=%r (%s)",
+            hermes_home,
+            exc,
+        )
+        return None
+
+
 def _default_spawn(
     task: Task,
     workspace: str,
@@ -6808,6 +6842,9 @@ def _default_spawn(
                 cmd.extend(["--skills", sk])
     if task.model_override:
         cmd.extend(["-m", task.model_override])
+    worker_toolsets = _resolve_worker_cli_toolsets(env.get("HERMES_HOME"))
+    if worker_toolsets:
+        cmd.extend(["--toolsets", ",".join(worker_toolsets)])
     cmd.extend([
         "chat",
         "-q", prompt,

--- a/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
+++ b/tests/hermes_cli/test_kanban_worker_spawn_toolsets.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import subprocess
+
+
+def _make_task(kb, *, assignee: str):
+    return kb.Task(
+        id="t_spawn_tools",
+        title="spawn tools",
+        body=None,
+        assignee=assignee,
+        status="running",
+        priority=0,
+        created_by="test",
+        created_at=1,
+        started_at=None,
+        completed_at=None,
+        workspace_kind="dir",
+        workspace_path=None,
+        claim_lock="lock",
+        claim_expires=None,
+        tenant=None,
+        current_run_id=7,
+    )
+
+
+def test_default_spawn_pins_assignee_profile_cli_toolsets(monkeypatch, tmp_path):
+    """Manual profile assignment should keep that profile's CLI tools.
+
+    Regression guard for dispatcher-spawned workers that boot with
+    HERMES_KANBAN_TASK: the worker must not collapse to only kanban lifecycle
+    tools when the assigned profile's top-level ``toolsets`` is the default
+    composite. The spawned CLI gets an explicit --toolsets pin resolved from
+    platform_toolsets.cli; model_tools appends task-scoped kanban tools later.
+    """
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "elias"
+    profile.mkdir(parents=True)
+    profile.joinpath("config.yaml").write_text(
+        """
+platform_toolsets:
+  cli:
+    - clarify
+    - code_execution
+    - delegation
+    - file
+    - memory
+    - session_search
+    - skills
+    - terminal
+    - web
+toolsets:
+  - hermes-cli
+agent:
+  disabled_toolsets: []
+""".lstrip(),
+        encoding="utf-8",
+    )
+    root.joinpath("config.yaml").write_text("toolsets:\n  - kanban\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+
+    captured = {}
+
+    class FakeProc:
+        pid = 4242
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["cmd"] = list(cmd)
+        captured["env"] = dict(kwargs.get("env") or {})
+        captured["cwd"] = kwargs.get("cwd")
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    pid = kb._default_spawn(_make_task(kb, assignee="elias"), str(workspace))
+
+    assert pid == 4242
+    assert captured["env"]["HERMES_HOME"] == str(profile)
+    assert captured["env"]["HERMES_KANBAN_TASK"] == "t_spawn_tools"
+    assert "--toolsets" in captured["cmd"]
+    pinned = captured["cmd"][captured["cmd"].index("--toolsets") + 1].split(",")
+    for required in ("terminal", "web", "file", "skills", "code_execution", "delegation"):
+        assert required in pinned
+
+
+def test_resolve_worker_cli_toolsets_uses_profile_home_not_parent_config(monkeypatch, tmp_path):
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "elias"
+    profile.mkdir(parents=True)
+    root.joinpath("config.yaml").write_text("platform_toolsets:\n  cli:\n    - kanban\n", encoding="utf-8")
+    profile.joinpath("config.yaml").write_text(
+        """
+platform_toolsets:
+  cli:
+    - terminal
+    - web
+toolsets:
+  - hermes-cli
+""".lstrip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(root))
+
+    from hermes_cli import kanban_db as kb
+
+    resolved = kb._resolve_worker_cli_toolsets(str(profile))
+
+    assert resolved is not None
+    assert "terminal" in resolved
+    assert "web" in resolved
+    assert "kanban" in resolved  # recovered worker lifecycle surface
+    assert resolved != ["kanban"]


### PR DESCRIPTION
## Summary
Kanban-dispatched workers now start with the assigned profile's effective CLI toolsets pinned, so manual profile assignment keeps terminal/web/file/skills access while still adding task-scoped kanban lifecycle tools.

## Changes
- `hermes_cli/kanban_db.py`: resolve `platform_toolsets.cli` for the assignee profile via a context-local `HERMES_HOME` override before spawning the worker, then pass it through `--toolsets`.
- `tests/hermes_cli/test_kanban_worker_spawn_toolsets.py`: regression coverage for manual profile assignment and parent/root config isolation.

## Validation
| Check | Result |
|---|---|
| py_compile | `hermes_cli/kanban_db.py` and new test file passed |
| E2E spawn probe | spawned argv included `--toolsets code_execution,delegation,file,kanban,skills,terminal,web` for the assigned `elias` profile |
| Targeted tests | `scripts/run_tests.sh tests/hermes_cli/test_kanban_worker_spawn_toolsets.py tests/tools/test_kanban_tools.py` → 86 passed |

## Infographic

![Kanban worker toolsets](https://v3b.fal.media/files/b/0a9e2120/0wEuEICuc35Dl74vmGD0V_CDpNJ0sR.png)
