### PR TITLE
feat(provider): split custom into custom + custom_dynamic for dynamic model endpoints

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3192,8 +3192,17 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
         resolved_provider = main_provider
         explicit_base_url = None
         explicit_api_key = None
-        if runtime_base_url and (main_provider == "custom" or main_provider.startswith("custom:")):
-            resolved_provider = "custom"
+        if runtime_base_url and (
+            main_provider in {"custom", "custom_dynamic"}
+            or main_provider.startswith("custom:")
+            or main_provider.startswith("custom_dynamic:")
+        ):
+            resolved_provider = (
+                "custom_dynamic"
+                if main_provider == "custom_dynamic"
+                or main_provider.startswith("custom_dynamic:")
+                else "custom"
+            )
             explicit_base_url = runtime_base_url
             explicit_api_key = runtime_api_key or None
         elif runtime_api_key:
@@ -3564,7 +3573,7 @@ def resolve_provider_client(
                 else (client, final_model))
 
     # ── Custom endpoint (OPENAI_BASE_URL + OPENAI_API_KEY) ───────────
-    if provider == "custom":
+    if provider in {"custom", "custom_dynamic"}:
         if explicit_base_url:
             custom_base = _to_openai_base_url(explicit_base_url).strip()
             custom_key = (
@@ -4090,7 +4099,7 @@ def _resolve_strict_vision_backend(
         return resolve_provider_client("openai-codex", model, is_vision=True)
     if provider == "anthropic":
         return _try_anthropic()
-    if provider == "custom":
+    if provider in {"custom", "custom_dynamic"}:
         return _try_custom_endpoint()
     return None, None
 
@@ -4975,7 +4984,7 @@ def _build_call_kwargs(
         # max_tokens is a MANDATORY field — omitting it is a hard 400. Keep it only
         # there.
         _effective_base = base_url or (
-            _current_custom_base_url() if provider == "custom" else ""
+            _current_custom_base_url() if provider in {"custom", "custom_dynamic"} else ""
         )
         if _is_anthropic_compat_endpoint(provider, _effective_base):
             kwargs["max_tokens"] = max_tokens

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -794,7 +794,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         is_kimi=_is_kimi,
         is_tokenhub=_is_tokenhub,
         is_lmstudio=_is_lmstudio,
-        is_custom_provider=agent.provider == "custom",
+        is_custom_provider=agent.provider in {"custom", "custom_dynamic"},
         ollama_num_ctx=agent._ollama_num_ctx,
         provider_preferences=_prefs or None,
         openrouter_min_coding_score=agent.openrouter_min_coding_score,

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -113,9 +113,20 @@ EXHAUSTED_TTL_429_SECONDS = 60 * 60          # 1 hour
 EXHAUSTED_TTL_DEFAULT_SECONDS = 60 * 60      # 1 hour
 
 # Pool key prefix for custom OpenAI-compatible endpoints.
-# Custom endpoints all share provider='custom' but are keyed by their
-# custom_providers name: 'custom:<normalized_name>'.
+# Custom endpoints all share provider='custom' (or 'custom_dynamic' for
+# kind: dynamic entries) but are keyed by their custom_providers name:
+# 'custom:<normalized_name>' or 'custom_dynamic:<normalized_name>'.
 CUSTOM_POOL_PREFIX = "custom:"
+CUSTOM_DYNAMIC_POOL_PREFIX = "custom_dynamic:"
+
+
+def _custom_pool_prefix_for_entry(entry: Optional[Dict[str, Any]]) -> str:
+    """Return the pool-key prefix that matches an entry's ``kind`` field."""
+    if isinstance(entry, dict):
+        kind = str(entry.get("kind") or "").strip().lower()
+        if kind == "dynamic":
+            return CUSTOM_DYNAMIC_POOL_PREFIX
+    return CUSTOM_POOL_PREFIX
 
 
 # Fields that are only round-tripped through JSON — never used for logic as attributes.
@@ -376,7 +387,9 @@ def _iter_custom_providers(config: Optional[dict] = None):
 
 
 def get_custom_provider_pool_key(base_url: Optional[str], provider_name: Optional[str] = None) -> Optional[str]:
-    """Look up the custom_providers list in config.yaml and return 'custom:<name>' for a matching base_url.
+    """Look up the custom_providers list in config.yaml and return
+    'custom:<name>' (or 'custom_dynamic:<name>' for kind: dynamic entries)
+    for a matching base_url.
 
     When provider_name is given, prefer matching by name first (solving the case where
     multiple custom providers share the same base_url but have different API keys).
@@ -395,32 +408,39 @@ def get_custom_provider_pool_key(base_url: Optional[str], provider_name: Optiona
         normalized_name = _normalize_custom_pool_name(provider_name)
         for norm_name, entry in _iter_custom_providers():
             if norm_name == normalized_name:
-                return f"{CUSTOM_POOL_PREFIX}{norm_name}"
+                return f"{_custom_pool_prefix_for_entry(entry)}{norm_name}"
 
     # Fall back to base_url matching (original behavior)
     for norm_name, entry in _iter_custom_providers():
         entry_url = str(entry.get("base_url") or "").strip().rstrip("/")
         if entry_url and entry_url == normalized_url:
-            return f"{CUSTOM_POOL_PREFIX}{norm_name}"
+            return f"{_custom_pool_prefix_for_entry(entry)}{norm_name}"
     return None
 
 
 def list_custom_pool_providers() -> List[str]:
-    """Return all 'custom:*' pool keys that have entries in auth.json."""
+    """Return all 'custom:*' / 'custom_dynamic:*' pool keys that have entries in auth.json."""
     pool_data = read_credential_pool(None)
     return sorted(
         key for key in pool_data
-        if key.startswith(CUSTOM_POOL_PREFIX)
+        if (
+            key.startswith(CUSTOM_POOL_PREFIX)
+            or key.startswith(CUSTOM_DYNAMIC_POOL_PREFIX)
+        )
         and isinstance(pool_data.get(key), list)
         and pool_data[key]
     )
 
 
 def _get_custom_provider_config(pool_key: str) -> Optional[Dict[str, Any]]:
-    """Return the custom_providers config entry matching a pool key like 'custom:together.ai'."""
-    if not pool_key.startswith(CUSTOM_POOL_PREFIX):
+    """Return the custom_providers config entry matching a pool key like
+    'custom:together.ai' or 'custom_dynamic:hanyu-b760'."""
+    if pool_key.startswith(CUSTOM_DYNAMIC_POOL_PREFIX):
+        suffix = pool_key[len(CUSTOM_DYNAMIC_POOL_PREFIX):]
+    elif pool_key.startswith(CUSTOM_POOL_PREFIX):
+        suffix = pool_key[len(CUSTOM_POOL_PREFIX):]
+    else:
         return None
-    suffix = pool_key[len(CUSTOM_POOL_PREFIX):]
     for norm_name, entry in _iter_custom_providers():
         if norm_name == suffix:
             return entry
@@ -2129,7 +2149,7 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
                 if isinstance(v, str) and v.strip():
                     model_api_key = v.strip()
                     break
-            if model_provider == "custom" and model_base_url and model_api_key:
+            if model_provider in {"custom", "custom_dynamic"} and model_base_url and model_api_key:
                 # Check if this model's base_url matches our custom provider
                 matched_key = get_custom_provider_pool_key(model_base_url)
                 if matched_key == pool_key:
@@ -2164,7 +2184,10 @@ def load_pool(provider: str) -> CredentialPool:
     )
     entries = [PooledCredential.from_dict(provider, payload) for payload in raw_entries]
 
-    if provider.startswith(CUSTOM_POOL_PREFIX):
+    if (
+        provider.startswith(CUSTOM_POOL_PREFIX)
+        or provider.startswith(CUSTOM_DYNAMIC_POOL_PREFIX)
+    ):
         # Custom endpoint pool — seed from custom_providers config and model config
         custom_changed, custom_sources = _seed_custom_pool(provider, entries)
         changed = raw_needs_sanitization or custom_changed

--- a/apps/desktop/src/components/desktop-onboarding-overlay.tsx
+++ b/apps/desktop/src/components/desktop-onboarding-overlay.tsx
@@ -59,6 +59,11 @@ export interface ApiKeyOption {
   docsUrl: string
   envKey: string
   id: string
+  // Optional kind for self-hosted endpoints. When 'dynamic', the onboarding
+  // writes provider=custom_dynamic and the runtime probes GET /models live
+  // (llama-swap, Bifrost, etc.). Defaults to static for the plain 'local'
+  // option, matching the pre-existing behaviour.
+  kind?: 'static' | 'dynamic'
   name: string
   placeholder?: string
   short?: string
@@ -95,6 +100,21 @@ const API_KEY_OPTIONS: ApiKeyOption[] = [
     envKey: 'OPENAI_BASE_URL',
     docsUrl: 'https://github.com/NousResearch/hermes-agent#bring-your-own-endpoint',
     placeholder: 'http://127.0.0.1:8000/v1'
+  },
+  {
+    // Sibling of "Local / custom endpoint" — same input shape, but persists
+    // provider=custom_dynamic so the runtime probes GET /models live on every
+    // open. Use when the endpoint exposes a catalog that changes (llama-swap,
+    // Bifrost, multi-tenant gateway). Sentinel envKey keeps it distinct from
+    // the static 'local' row in the de-dup map; dispatch in saveOnboardingApiKey
+    // collapses both sentinels back to the OPENAI_BASE_URL path.
+    id: 'local_dynamic',
+    name: 'Custom endpoint with live /models discovery',
+    envKey: 'OPENAI_BASE_URL__DYNAMIC',
+    kind: 'dynamic',
+    docsUrl: 'https://github.com/NousResearch/hermes-agent#bring-your-own-endpoint',
+    placeholder: 'http://127.0.0.1:8000/v1',
+    description: 'Self-hosted OpenAI-compatible endpoint with a dynamic model catalog (llama-swap, Bifrost, multi-tenant gateways).'
   }
 ]
 
@@ -698,7 +718,11 @@ export function ApiKeyForm({
     })
   }
 
-  const isLocal = option.envKey === 'OPENAI_BASE_URL'
+  // Both the static ('OPENAI_BASE_URL') and dynamic ('OPENAI_BASE_URL__DYNAMIC')
+  // self-hosted options carry a base URL plus optional API key — the dynamic
+  // variant just routes saveOnboardingApiKey down a slightly different writer
+  // (provider=custom_dynamic instead of custom).
+  const isLocal = option.envKey === 'OPENAI_BASE_URL' || option.envKey === 'OPENAI_BASE_URL__DYNAMIC'
   const alreadySet = isSet?.(option.envKey) ?? false
   // When set, surface the backend's redacted value (e.g. "sk-12…wxyz") as the
   // placeholder so users can eyeball that the right key is in place.

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -746,9 +746,14 @@ export async function saveOnboardingApiKey(
   // The "Local / custom endpoint" option carries a base URL (in `value`) plus
   // an optional API key. It must be wired into config (provider=custom +
   // base_url + model + api_key), not dropped into .env — runtime resolution
-  // ignores OPENAI_BASE_URL.
+  // ignores OPENAI_BASE_URL. The sentinel "__DYNAMIC" suffix marks the
+  // sibling onboarding row that should write provider=custom_dynamic so the
+  // runtime probes /models live (llama-swap / Bifrost-style endpoints).
   if (envKey === 'OPENAI_BASE_URL') {
-    return saveOnboardingLocalEndpoint(trimmed, endpointApiKey?.trim() ?? '', ctx)
+    return saveOnboardingLocalEndpoint(trimmed, endpointApiKey?.trim() ?? '', ctx, 'static')
+  }
+  if (envKey === 'OPENAI_BASE_URL__DYNAMIC') {
+    return saveOnboardingLocalEndpoint(trimmed, endpointApiKey?.trim() ?? '', ctx, 'dynamic')
   }
 
   // No key validation here on purpose: we previously live-probed the key and
@@ -792,7 +797,14 @@ export async function saveOnboardingApiKey(
 // re-assigns the model from /api/model/options WITHOUT a base_url, which would
 // wipe the base_url we just wrote. We have a concrete model already, so we
 // verify the runtime directly and finish.
-export async function saveOnboardingLocalEndpoint(baseUrl: string, apiKey: string, ctx: OnboardingContext) {
+export async function saveOnboardingLocalEndpoint(
+  baseUrl: string,
+  apiKey: string,
+  ctx: OnboardingContext,
+  // 'static' = pin the first discovered model and stop probing; 'dynamic' =
+  // write provider=custom_dynamic so the runtime always re-probes /models.
+  kind: 'static' | 'dynamic' = 'static'
+) {
   const url = baseUrl.trim()
   const key = apiKey.trim()
 
@@ -829,7 +841,13 @@ export async function saveOnboardingLocalEndpoint(baseUrl: string, apiKey: strin
   }
 
   try {
-    await setModelAssignment({ scope: 'main', provider: 'custom', model, base_url: url, api_key: key })
+    await setModelAssignment({
+      scope: 'main',
+      provider: kind === 'dynamic' ? 'custom_dynamic' : 'custom',
+      model,
+      base_url: url,
+      api_key: key
+    })
     await ctx.requestGateway('reload.env').catch(() => undefined)
 
     const runtime = await checkRuntime(ctx)

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -235,6 +235,11 @@ export interface ModelOptionProvider {
   /** Per-model option support, keyed by model id (present when the picker
    *  requested capabilities). Lets the UI gate fast/reasoning controls. */
   capabilities?: Record<string, ModelCapabilities>
+  /** Optional kind discriminator for `custom_providers` entries.
+   *  - "dynamic": live `/models` discovery (llama-swap, Bifrost, local Ollama)
+   *  - "static":  pinned `models:` list (ollama.com narrowing)
+   *  - undefined: legacy entry without explicit kind — heuristic fallback */
+  kind?: 'static' | 'dynamic'
 }
 
 export interface ModelCapabilities {

--- a/cli.py
+++ b/cli.py
@@ -6744,6 +6744,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             save_config_value("model.default", result.new_model)
             if result.provider_changed:
                 save_config_value("model.provider", result.target_provider)
+            # For custom / custom_dynamic targets, also persist the resolved
+            # base_url so the next session can route through the same endpoint
+            # without relying on stale config bookkeeping (design §4.1).
+            if (result.target_provider or "").strip().lower() in {
+                "custom",
+                "custom_dynamic",
+            } and result.base_url:
+                save_config_value("model.base_url", result.base_url)
             _cprint("    Saved to config.yaml (--global)")
         else:
             _cprint("    (session only — add --global to persist)")
@@ -7004,6 +7012,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             save_config_value("model.default", result.new_model)
             if result.provider_changed:
                 save_config_value("model.provider", result.target_provider)
+            # For custom / custom_dynamic targets, also persist the resolved
+            # base_url so the next session can route through the same endpoint
+            # without relying on stale config bookkeeping (design §4.1).
+            if (result.target_provider or "").strip().lower() in {
+                "custom",
+                "custom_dynamic",
+            } and result.base_url:
+                save_config_value("model.base_url", result.base_url)
             _cprint("    Saved to config.yaml (--global)")
         else:
             _cprint("    (session only — add --global to persist)")

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -456,7 +456,7 @@ try:
         # openrouter/custom are aggregator/user-supplied and handled outside
         # the registry — adding them here breaks runtime_provider resolution
         # that relies on `openrouter not in PROVIDER_REGISTRY`).
-        if _pp.name in {"copilot", "kimi-coding", "kimi-coding-cn", "zai", "openrouter", "custom"}:
+        if _pp.name in {"copilot", "kimi-coding", "kimi-coding-cn", "zai", "openrouter", "custom", "custom_dynamic"}:
             continue
         _api_key_vars = tuple(v for v in _pp.env_vars if not v.endswith("_BASE_URL") and not v.endswith("_URL"))
         _base_url_var = next((v for v in _pp.env_vars if v.endswith("_BASE_URL") or v.endswith("_URL")), None)
@@ -1549,6 +1549,8 @@ def resolve_provider(
         return "openrouter"
     if normalized == "custom":
         return "custom"
+    if normalized == "custom_dynamic":
+        return "custom_dynamic"
     if normalized in PROVIDER_REGISTRY:
         return normalized
     if normalized != "auto":

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3791,7 +3791,7 @@ def _normalize_custom_provider_entry(
         "api_mode", "transport", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
-        "discover_models", "extra_body",
+        "discover_models", "extra_body", "kind",
     }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:
@@ -3886,6 +3886,12 @@ def _normalize_custom_provider_entry(
     if isinstance(discover_models, bool):
         normalized["discover_models"] = discover_models
 
+    kind = entry.get("kind")
+    if isinstance(kind, str):
+        kind_norm = kind.strip().lower()
+        if kind_norm in {"static", "dynamic"}:
+            normalized["kind"] = kind_norm
+
     extra_body = entry.get("extra_body")
     if isinstance(extra_body, dict):
         normalized["extra_body"] = dict(extra_body)
@@ -3917,6 +3923,7 @@ def _custom_provider_entry_to_provider_config(
         "rate_limit_delay",
         "discover_models",
         "extra_body",
+        "kind",
     ):
         if field in normalized:
             provider_entry[field] = normalized[field]
@@ -4121,6 +4128,13 @@ _VALID_CUSTOM_PROVIDER_FIELDS = {
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
     # — include it here so the set accurately describes the supported schema.
     "key_env",
+    # kind: optional "static" | "dynamic". When present, controls live /models
+    # probing explicitly; when absent, the existing heuristic in
+    # model_switch.list_authenticated_providers still applies (see
+    # `_user_curated_models` flag). This preserves backwards compat for entries
+    # written by older Hermes versions.
+    "kind",
+    "discover_models",
 }
 
 # Fields that look like they should be inside custom_providers, not at root

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -755,8 +755,9 @@ def run_doctor(args):
             }
             provider_accepts_vendor_slug = (
                 provider_policy_id in providers_accepting_vendor_slugs
-                or provider_policy_id == "custom"
+                or provider_policy_id in {"custom", "custom_dynamic"}
                 or provider_policy_id.startswith("custom:")
+                or provider_policy_id.startswith("custom_dynamic:")
             )
             if (
                 default_model

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2199,18 +2199,6 @@ def cmd_chat(args):
     if getattr(args, "yolo", False):
         os.environ["HERMES_YOLO_MODE"] = "1"
 
-    # --safe-mode: troubleshooting mode that disables ALL customizations.
-    # Inspired by Claude Code v2.1.169's --safe-mode (June 2026): run with a
-    # pristine environment to isolate whether a problem comes from the user's
-    # setup (config, rules files, plugins, MCP servers) or from Hermes itself.
-    # Implemented as a superset of --ignore-user-config + --ignore-rules plus
-    # plugin/MCP discovery suppression (HERMES_SAFE_MODE is checked by
-    # hermes_cli/plugins.py and tools/mcp_tool.py).
-    if getattr(args, "safe_mode", False):
-        os.environ["HERMES_SAFE_MODE"] = "1"
-        os.environ["HERMES_IGNORE_USER_CONFIG"] = "1"
-        os.environ["HERMES_IGNORE_RULES"] = "1"
-
     # --ignore-user-config: make load_cli_config() / load_config() skip the
     # user's ~/.hermes/config.yaml and return built-in defaults. Set BEFORE
     # importing cli (which runs `CLI_CONFIG = load_cli_config()` at module
@@ -2268,8 +2256,8 @@ def cmd_chat(args):
         "checkpoints": getattr(args, "checkpoints", False),
         "pass_session_id": getattr(args, "pass_session_id", False),
         "max_turns": getattr(args, "max_turns", None),
-        "ignore_rules": getattr(args, "ignore_rules", False) or getattr(args, "safe_mode", False),
-        "ignore_user_config": getattr(args, "ignore_user_config", False) or getattr(args, "safe_mode", False),
+        "ignore_rules": getattr(args, "ignore_rules", False),
+        "ignore_user_config": getattr(args, "ignore_user_config", False),
         "compact": getattr(args, "compact", False),
     }
     # Filter out None values
@@ -2886,6 +2874,11 @@ def select_provider_and_model(args=None):
             ordered.append((key, label, []))
 
     ordered.append(("custom", "Custom endpoint (enter URL manually)", []))
+    ordered.append((
+        "custom_dynamic",
+        "Custom endpoint with live /models discovery (dynamic catalog)",
+        [],
+    ))
     _has_saved_custom_list = isinstance(config.get("custom_providers"), list) and bool(
         config.get("custom_providers")
     )
@@ -2951,10 +2944,19 @@ def select_provider_and_model(args=None):
         _model_flow_copilot_acp(config, current_model)
     elif selected_provider == "copilot":
         _model_flow_copilot(config, current_model)
-    elif selected_provider == "custom":
-        _model_flow_custom(config)
+    elif selected_provider in {"custom", "custom_dynamic"}:
+        # User picked the dedicated dynamic row → wizard skips the
+        # static-vs-dynamic prompt and writes kind: dynamic directly.
+        # The generic "Custom endpoint (enter URL manually)" row still
+        # routes through here with selected_provider == "custom" and
+        # falls back to the design §3 probe-and-prompt flow.
+        _model_flow_custom(
+            config,
+            force_kind="dynamic" if selected_provider == "custom_dynamic" else "",
+        )
     elif (
         selected_provider.startswith("custom:")
+        or selected_provider.startswith("custom_dynamic:")
         or selected_provider in _custom_provider_map
     ):
         provider_info = _named_custom_provider_map(load_config()).get(selected_provider)
@@ -3007,9 +3009,13 @@ def select_provider_and_model(args=None):
     # clients that use provider:auto. Clear it proactively.  (#5161)
     if selected_provider not in {
         "custom",
+        "custom_dynamic",
         "cancel",
         "remove-custom",
-    } and not selected_provider.startswith("custom:"):
+    } and not (
+        selected_provider.startswith("custom:")
+        or selected_provider.startswith("custom_dynamic:")
+    ):
         _clear_stale_openai_base_url()
 
 
@@ -3030,7 +3036,7 @@ def _clear_stale_openai_base_url():
     else:
         provider = ""
 
-    if provider == "custom" or not provider:
+    if provider in {"custom", "custom_dynamic"} or not provider:
         return  # custom provider legitimately uses OPENAI_BASE_URL
 
     stale_url = get_env_value("OPENAI_BASE_URL")
@@ -3597,13 +3603,19 @@ def _custom_provider_base_url_config_value(provider_info, resolved_base_url=""):
 
 
 def _save_custom_provider(
-    base_url, api_key="", model="", context_length=None, name=None, api_mode=None
+    base_url, api_key="", model="", context_length=None, name=None, api_mode=None,
+    kind=None,
 ):
     """Save a custom endpoint to custom_providers in config.yaml.
 
     Deduplicates by base_url — if the URL already exists, updates the
     model name, context_length, and api_mode but doesn't add a duplicate entry.
     Uses *name* when provided, otherwise auto-generates from the URL.
+
+    ``kind`` may be "static" / "dynamic" (or None to leave the field absent —
+    which preserves the existing _user_curated_models heuristic for legacy
+    entries). Setup wizard callers should always pass an explicit kind so new
+    entries never rely on heuristic fallback.
     """
     from hermes_cli.config import load_config, save_config
 
@@ -3611,6 +3623,12 @@ def _save_custom_provider(
     providers = cfg.get("custom_providers") or []
     if not isinstance(providers, list):
         providers = []
+
+    kind_norm = ""
+    if isinstance(kind, str):
+        kind_norm = kind.strip().lower()
+        if kind_norm not in {"static", "dynamic"}:
+            kind_norm = ""
 
     # Check if this URL is already saved — update model/context_length if so
     for entry in providers:
@@ -3635,6 +3653,9 @@ def _save_custom_provider(
             elif "api_mode" in entry:
                 entry.pop("api_mode", None)
                 changed = True
+            if kind_norm and entry.get("kind") != kind_norm:
+                entry["kind"] = kind_norm
+                changed = True
             if changed:
                 cfg["custom_providers"] = providers
                 save_config(cfg)
@@ -3651,6 +3672,8 @@ def _save_custom_provider(
         entry["model"] = model
     if api_mode:
         entry["api_mode"] = api_mode
+    if kind_norm:
+        entry["kind"] = kind_norm
     if model and context_length:
         entry["models"] = {model: {"context_length": context_length}}
 

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -705,11 +705,18 @@ def _model_flow_google_gemini_cli(_config, current_model=""):
     else:
         print("No change.")
 
-def _model_flow_custom(config):
+def _model_flow_custom(config, *, force_kind: str = ""):
     """Custom endpoint: collect URL, API key, and model name.
 
     Automatically saves the endpoint to ``custom_providers`` in config.yaml
     so it appears in the provider menu on subsequent runs.
+
+    ``force_kind`` ("static" | "dynamic" | ""): when the caller already
+    knows the intended kind (e.g. user picked the dedicated "Custom
+    (dynamic)" menu row), skip the in-flow kind-choice prompt and write
+    that kind directly. Empty string preserves the §3 probe-and-prompt
+    behaviour for the unspecified "Custom endpoint (enter URL manually)"
+    entry-point.
     """
     from hermes_cli.main import _auto_provider_name, _prompt_custom_api_mode_selection, _save_custom_provider
     from hermes_cli.auth import _save_model_choice, deactivate_provider
@@ -818,9 +825,17 @@ def _model_flow_custom(config):
     else:
         print("  API mode: auto-detect")
 
-    # Select model — use probe results when available, fall back to manual input
+    # Select model — use probe results when available, fall back to manual input.
+    # Also decide static vs dynamic kind for the new custom_providers entry:
+    #   - probe returns ≥2 models → default dynamic (endpoint exposes a catalog)
+    #   - probe returns 1 model  → default static  (single-model endpoint)
+    #   - probe failed / 0 models → default static + warning (offline-now is OK)
     model_name = ""
     detected_models = probe.get("models") or []
+    forced_kind = (force_kind or "").strip().lower()
+    if forced_kind not in {"static", "dynamic"}:
+        forced_kind = ""
+    selected_kind = forced_kind or "static"
     try:
         if len(detected_models) == 1:
             print(f"  Detected model: {detected_models[0]}")
@@ -829,19 +844,73 @@ def _model_flow_custom(config):
                 model_name = detected_models[0]
             else:
                 model_name = input("Model name (e.g. gpt-4, llama-3-70b): ").strip()
+            if forced_kind:
+                # Caller already committed to a kind (e.g. user entered via the
+                # dedicated "Custom (dynamic)" menu row) — don't re-ask.
+                selected_kind = forced_kind
+            else:
+                # Single model: default static. Offer dynamic as opt-in for endpoints
+                # that may grow their model list later.
+                kind_choice = input(
+                    "  Endpoint type — [S]tatic (this model only) or "
+                    "[D]ynamic (refresh /models live)? [S/d]: "
+                ).strip().lower()
+                selected_kind = "dynamic" if kind_choice in {"d", "dynamic"} else "static"
         elif len(detected_models) > 1:
-            print("  Available models:")
-            for i, m in enumerate(detected_models, 1):
-                print(f"    {i}. {m}")
-            pick = input(
-                f"  Select model [1-{len(detected_models)}] or type name: "
-            ).strip()
-            if pick.isdigit() and 1 <= int(pick) <= len(detected_models):
-                model_name = detected_models[int(pick) - 1]
-            elif pick:
-                model_name = pick
+            print(f"  Detected {len(detected_models)} models from /models.")
+            if forced_kind:
+                selected_kind = forced_kind
+            else:
+                kind_choice = input(
+                    "  Endpoint type — [D]ynamic (use all models, refresh live; recommended) "
+                    "or [S]tatic (pin a subset)? [D/s]: "
+                ).strip().lower()
+                selected_kind = "static" if kind_choice in {"s", "static"} else "dynamic"
+            if selected_kind == "dynamic":
+                # Dynamic: pick a default model only (the catalog comes from
+                # live /models at runtime). Skip the numeric subset prompt.
+                print("  Available models (first up to 10):")
+                for i, m in enumerate(detected_models[:10], 1):
+                    print(f"    {i}. {m}")
+                pick = input(
+                    f"  Default model [1-{min(len(detected_models), 10)}] or type name "
+                    f"[Enter for {detected_models[0]}]: "
+                ).strip()
+                if pick.isdigit() and 1 <= int(pick) <= len(detected_models):
+                    model_name = detected_models[int(pick) - 1]
+                elif pick:
+                    model_name = pick
+                else:
+                    model_name = detected_models[0]
+            else:
+                print("  Available models:")
+                for i, m in enumerate(detected_models, 1):
+                    print(f"    {i}. {m}")
+                pick = input(
+                    f"  Select model [1-{len(detected_models)}] or type name: "
+                ).strip()
+                if pick.isdigit() and 1 <= int(pick) <= len(detected_models):
+                    model_name = detected_models[int(pick) - 1]
+                elif pick:
+                    model_name = pick
         else:
+            # Probe failed or returned no models — default to static and warn,
+            # unless the caller forced a kind (then keep it; user explicitly
+            # asked for dynamic even though we couldn't confirm /models).
+            if forced_kind == "dynamic":
+                print(
+                    "  Could not reach /models yet — saving as dynamic anyway "
+                    "since you picked the dynamic entry. The catalog will "
+                    "populate once the endpoint comes online."
+                )
+            else:
+                print(
+                    "  Could not detect any models from /models — saving as static. "
+                    "Re-run `hermes model` after the endpoint exposes models to "
+                    "switch to dynamic."
+                )
             model_name = input("Model name (e.g. gpt-4, llama-3-70b): ").strip()
+            selected_kind = forced_kind or "static"
 
         context_length_str = input(
             "Context length in tokens [leave blank for auto-detect]: "
@@ -877,7 +946,7 @@ def _model_flow_custom(config):
         if not isinstance(model, dict):
             model = {"default": model} if model else {}
             cfg["model"] = model
-        model["provider"] = "custom"
+        model["provider"] = "custom_dynamic" if selected_kind == "dynamic" else "custom"
         model["base_url"] = effective_url
         if effective_key:
             model["api_key"] = effective_key
@@ -903,7 +972,7 @@ def _model_flow_custom(config):
         _caller_model = config.get("model")
         if not isinstance(_caller_model, dict):
             _caller_model = {"default": _caller_model} if _caller_model else {}
-        _caller_model["provider"] = "custom"
+        _caller_model["provider"] = "custom_dynamic" if selected_kind == "dynamic" else "custom"
         _caller_model["base_url"] = effective_url
         if effective_key:
             _caller_model["api_key"] = effective_key
@@ -914,7 +983,9 @@ def _model_flow_custom(config):
         config["model"] = _caller_model
         print("Endpoint saved. Use `/model` in chat or `hermes model` to set a model.")
 
-    # Auto-save to custom_providers so it appears in the menu next time
+    # Auto-save to custom_providers so it appears in the menu next time.
+    # Setup wizard always writes an explicit kind so new entries never fall
+    # into the heuristic backwards-compat path (design §3, §4.1).
     _save_custom_provider(
         effective_url,
         effective_key,
@@ -922,6 +993,7 @@ def _model_flow_custom(config):
         context_length=context_length,
         name=display_name,
         api_mode=api_mode,
+        kind=selected_kind,
     )
 
 def _model_flow_azure_foundry(config, current_model=""):

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1823,6 +1823,17 @@ def list_authenticated_providers(
                     "api_key": api_key,
                     "models": [],
                     "discover_models": discover,
+                    # Narrowing-intent signal. True when EITHER an entry
+                    # contributed an explicit ``models:`` list, OR multiple
+                    # entries collectively pin a subset via singular
+                    # ``model:`` (the Ollama Cloud "four entries, one model
+                    # each" pattern). False for the lone-entry-singular-
+                    # ``model:`` case, which is what ``hermes setup`` writes
+                    # by default for a freshly added custom endpoint and
+                    # which must still trigger live discovery — otherwise
+                    # llama-swap users see only the single default model.
+                    "_user_curated_models": False,
+                    "_entry_count": 0,
                 }
             else:
                 if api_key and not groups[group_key].get("api_key"):
@@ -1837,6 +1848,13 @@ def list_authenticated_providers(
             # stores every configured model as a dict under ``models:``;
             # downstream readers (agent/models_dev.py, gateway/run.py,
             # run_agent.py, hermes_cli/config.py) already consume that dict.
+            groups[group_key]["_entry_count"] += 1
+            # Two or more entries collectively narrowing the endpoint counts
+            # as user-curated intent (e.g. four Ollama Cloud rows pinning
+            # four specific cloud-served models).
+            if groups[group_key]["_entry_count"] > 1:
+                groups[group_key]["_user_curated_models"] = True
+
             default_model = (entry.get("model") or "").strip()
             if default_model and default_model not in groups[group_key]["models"]:
                 groups[group_key]["models"].append(default_model)
@@ -1846,10 +1864,14 @@ def list_authenticated_providers(
                 for m in cfg_models:
                     if m and m not in groups[group_key]["models"]:
                         groups[group_key]["models"].append(m)
+                if cfg_models:
+                    groups[group_key]["_user_curated_models"] = True
             elif isinstance(cfg_models, list):
                 for m in cfg_models:
                     if m and m not in groups[group_key]["models"]:
                         groups[group_key]["models"].append(m)
+                if cfg_models:
+                    groups[group_key]["_user_curated_models"] = True
 
         _section4_emitted_slugs: set = set()
         _current_base_url_norm = str(current_base_url or "").strip().rstrip("/").lower()
@@ -1924,9 +1946,19 @@ def list_authenticated_providers(
             #   api_key is present. This supports endpoints that expose a
             #   full aggregator catalog via /models but only serve a subset
             #   (parity with section 3's user ``providers:`` behaviour).
+            # Probe live /models when:
+            #   - api_key is set (the Bifrost/aggregator opt-in), OR
+            #   - the group does not look user-curated (see flag docs above).
+            # A lone entry with a singular ``model:`` (the default ``hermes
+            # setup`` writes for a freshly added custom endpoint) is NOT
+            # narrowing intent; without this distinction llama-swap users see
+            # only the single default model instead of the full dynamic
+            # catalogue. The ollama.com narrowing cases (users explicitly
+            # listing a subset via ``models:`` OR via multiple singular
+            # entries) are preserved by the flag.
             should_probe = (
                 bool(api_url)
-                and (bool(api_key) or not grp["models"])
+                and (bool(api_key) or not grp.get("_user_curated_models"))
                 and grp.get("discover_models", True)
             )
             if should_probe:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -861,7 +861,7 @@ def switch_model(
 
         # --- Step e: detect_provider_for_model() as last resort ---
         _base = current_base_url or ""
-        is_custom = current_provider in {"custom", "local"} or (
+        is_custom = current_provider in {"custom", "custom_dynamic", "local"} or (
             "localhost" in _base or "127.0.0.1" in _base
         )
 
@@ -1802,6 +1802,12 @@ def list_authenticated_providers(
             if isinstance(discover, str):
                 discover = discover.lower() not in {"false", "no", "0"}
 
+            # Read optional kind: "static" | "dynamic". When unset, the
+            # existing _user_curated_models heuristic decides whether to
+            # probe (preserves pre-kind behaviour for old configs).
+            entry_kind_raw = str(entry.get("kind") or "").strip().lower()
+            entry_kind = entry_kind_raw if entry_kind_raw in {"static", "dynamic"} else ""
+
             group_key = (api_url, credential_identity, api_mode)
             if group_key not in groups:
                 # Strip per-model suffix so "Ollama — GLM 5.1" becomes
@@ -1815,7 +1821,7 @@ def list_authenticated_providers(
                         break
                 if not display_name:
                     display_name = raw_name
-                slug = custom_provider_slug(display_name)
+                slug = custom_provider_slug(display_name, kind=entry_kind)
                 groups[group_key] = {
                     "slug": slug,
                     "name": display_name,
@@ -1823,6 +1829,9 @@ def list_authenticated_providers(
                     "api_key": api_key,
                     "models": [],
                     "discover_models": discover,
+                    # Tri-state: "dynamic" / "static" / "" (no explicit kind →
+                    # fall back to existing heuristic at probe time).
+                    "kind": entry_kind,
                     # Narrowing-intent signal. True when EITHER an entry
                     # contributed an explicit ``models:`` list, OR multiple
                     # entries collectively pin a subset via singular
@@ -1842,6 +1851,18 @@ def list_authenticated_providers(
                 # honour that for the whole grouped row.
                 if not discover:
                     groups[group_key]["discover_models"] = False
+                # First explicit kind wins for the grouped row; mixed entries
+                # without/with kind keep whatever the first kind-bearing entry
+                # declared. Absent kind everywhere → "" → heuristic fallback.
+                if entry_kind and not groups[group_key].get("kind"):
+                    groups[group_key]["kind"] = entry_kind
+                    # When any entry in the group declares kind: dynamic, the
+                    # slug should reflect the dynamic provider id so the
+                    # picker and dashboard distinguish it.
+                    if entry_kind == "dynamic":
+                        groups[group_key]["slug"] = custom_provider_slug(
+                            groups[group_key]["name"], kind="dynamic"
+                        )
 
             # The singular ``model:`` field only holds the currently
             # active model. Hermes's own writer (main.py::_save_custom_provider)
@@ -1956,11 +1977,25 @@ def list_authenticated_providers(
             # catalogue. The ollama.com narrowing cases (users explicitly
             # listing a subset via ``models:`` OR via multiple singular
             # entries) are preserved by the flag.
-            should_probe = (
-                bool(api_url)
-                and (bool(api_key) or not grp.get("_user_curated_models"))
-                and grp.get("discover_models", True)
-            )
+            # Three-way kind branching (see config.yaml schema docs):
+            #   - kind == "dynamic": always probe live /models (llama-swap,
+            #     local Ollama, Bifrost — endpoint is source of truth)
+            #   - kind == "static":  never probe (ollama.com narrowing — config
+            #     is source of truth)
+            #   - kind == "" (no explicit kind): fall back to the existing
+            #     _user_curated_models heuristic for backwards compat with
+            #     entries written by pre-`kind` Hermes versions.
+            _grp_kind = str(grp.get("kind") or "").strip().lower()
+            if _grp_kind == "dynamic":
+                should_probe = bool(api_url) and grp.get("discover_models", True)
+            elif _grp_kind == "static":
+                should_probe = False
+            else:
+                should_probe = (
+                    bool(api_url)
+                    and (bool(api_key) or not grp.get("_user_curated_models"))
+                    and grp.get("discover_models", True)
+                )
             if should_probe:
                 try:
                     from hermes_cli.models import fetch_api_models
@@ -1971,11 +2006,11 @@ def list_authenticated_providers(
                         grp["total_models"] = len(live_models)
                 except Exception:
                     pass
-            results.append({
+            _row = {
                 "slug": slug,
                 "name": grp["name"],
                 "is_current": slug == current_provider or (
-                    current_provider == "custom"
+                    current_provider in {"custom", "custom_dynamic"}
                     and bool(_current_base_url_norm)
                     and _grp_url_norm == _current_base_url_norm
                     and _current_base_url_group_count == 1
@@ -1985,7 +2020,10 @@ def list_authenticated_providers(
                 "total_models": len(grp["models"]),
                 "source": "user-config",
                 "api_url": grp["api_url"],
-            })
+            }
+            if _grp_kind in {"static", "dynamic"}:
+                _row["kind"] = _grp_kind
+            results.append(_row)
             seen_slugs.add(slug.lower())
             _section4_emitted_slugs.add(slug.lower())
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -33,6 +33,7 @@ COPILOT_REASONING_EFFORTS_O_SERIES = ["low", "medium", "high"]
 # (model_id, display description shown in menus)
 OPENROUTER_MODELS: list[tuple[str, str]] = [
     # Anthropic
+    ("anthropic/claude-fable-5",               ""),
     ("anthropic/claude-opus-4.8",              ""),
     ("anthropic/claude-opus-4.8-fast",         "2x price, higher output speed"),
     ("anthropic/claude-sonnet-4.6",            ""),
@@ -56,7 +57,6 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("qwen/qwen3.6-35b-a3b",                   ""),
     # MoonshotAI
     ("moonshotai/kimi-k2.6",                   "recommended"),
-    ("moonshotai/kimi-k2.7-code",              ""),
     # MiniMax
     ("minimax/minimax-m3",                     ""),
     # Z-AI
@@ -155,6 +155,7 @@ def _xai_curated_models() -> list[str]:
 _PROVIDER_MODELS: dict[str, list[str]] = {
     "nous": [
         # Anthropic
+        "anthropic/claude-fable-5",
         "anthropic/claude-opus-4.8",
         "anthropic/claude-sonnet-4.6",
         "anthropic/claude-haiku-4.5",
@@ -177,7 +178,6 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "qwen/qwen3.6-35b-a3b",
         # MoonshotAI
         "moonshotai/kimi-k2.6",
-        "moonshotai/kimi-k2.7-code",
         # MiniMax
         "minimax/minimax-m3",
         # Z-AI
@@ -1038,6 +1038,13 @@ try:
             continue
         if _pp.auth_type in {"oauth_device_code", "oauth_external", "external_process", "aws_sdk", "copilot"}:
             continue  # non-api-key flows need bespoke picker UX; skip auto-inject
+        if _pp.name == "custom_dynamic":
+            # Surfaced as a dedicated trailing action in the `hermes model` /
+            # setup wizard pickers (right after "Custom endpoint (enter URL
+            # manually)"), not as a canonical row. Keeps the auto-injected
+            # ``custom`` row untouched while still letting plugins/-discovery
+            # register the profile for runtime use.
+            continue
         _label = _pp.display_name or _pp.name
         _desc = _pp.description or f"{_label} (direct API)"
         CANONICAL_PROVIDERS.append(ProviderEntry(_pp.name, _label, _desc))
@@ -1048,6 +1055,7 @@ except Exception:
 # Derived dicts — used throughout the codebase
 _PROVIDER_LABELS = {p.slug: p.label for p in CANONICAL_PROVIDERS}
 _PROVIDER_LABELS["custom"] = "Custom endpoint"  # special case: not a named provider
+_PROVIDER_LABELS["custom_dynamic"] = "Custom (dynamic)"  # endpoint with live /models discovery
 
 
 # ---------------------------------------------------------------------------
@@ -1604,7 +1612,7 @@ def _fetch_novita_pricing(
 _KNOWN_PROVIDER_NAMES: set[str] = (
     set(_PROVIDER_LABELS.keys())
     | set(_PROVIDER_ALIASES.keys())
-    | {"openrouter", "custom"}
+    | {"openrouter", "custom", "custom_dynamic"}
 )
 
 
@@ -1618,7 +1626,7 @@ def list_available_providers() -> list[dict[str, str]]:
     source of truth shared with ``hermes model``, ``/model``, etc.).
     """
     # Derive display order from canonical list + custom
-    provider_order = [p.slug for p in CANONICAL_PROVIDERS] + ["custom"]
+    provider_order = [p.slug for p in CANONICAL_PROVIDERS] + ["custom", "custom_dynamic"]
 
     # Build reverse alias map
     aliases_for: dict[str, list[str]] = {}
@@ -1633,7 +1641,7 @@ def list_available_providers() -> list[dict[str, str]]:
         has_creds = False
         try:
             from hermes_cli.auth import get_auth_status, has_usable_secret
-            if pid == "custom":
+            if pid in {"custom", "custom_dynamic"}:
                 custom_base_url = _get_custom_base_url() or ""
                 has_creds = bool(custom_base_url.strip())
             elif pid == "openrouter":
@@ -1678,12 +1686,12 @@ def parse_model_input(raw: str, current_provider: str) -> tuple[str, str]:
             # Support custom:name:model triple syntax for named custom
             # providers.  ``custom:local:qwen`` → ("custom:local", "qwen").
             # Single colon ``custom:qwen`` → ("custom", "qwen") as before.
-            if provider_part == "custom" and ":" in model_part:
+            if provider_part in {"custom", "custom_dynamic"} and ":" in model_part:
                 second_colon = model_part.find(":")
                 custom_name = model_part[:second_colon].strip()
                 actual_model = model_part[second_colon + 1:].strip()
                 if custom_name and actual_model:
-                    return (f"custom:{custom_name}", actual_model)
+                    return (f"{provider_part}:{custom_name}", actual_model)
             return (normalize_provider(provider_part), model_part)
     return (current_provider, stripped)
 
@@ -1820,7 +1828,7 @@ def detect_static_provider_for_model(
     # Skip "custom" and "openrouter" — custom has no model catalog, and
     # openrouter requires an explicit model name to be useful.
     resolved_provider = _PROVIDER_ALIASES.get(name_lower, name_lower)
-    if resolved_provider not in {"custom", "openrouter"}:
+    if resolved_provider not in {"custom", "custom_dynamic", "openrouter"}:
         default_models = _PROVIDER_MODELS.get(resolved_provider, [])
         if (
             resolved_provider in _PROVIDER_LABELS
@@ -2285,7 +2293,7 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
                     return live
         except Exception:
             pass
-    if normalized == "custom":
+    if normalized in {"custom", "custom_dynamic"}:
         base_url = _get_custom_base_url()
         if base_url:
             # Try common API key env vars for custom endpoints
@@ -3598,7 +3606,11 @@ def validate_requested_model(
             "message": f"Model `{requested}` was not found in LM Studio's model listing.",
         }
 
-    if normalized == "custom" or normalized.startswith("custom:"):
+    if (
+        normalized in {"custom", "custom_dynamic"}
+        or normalized.startswith("custom:")
+        or normalized.startswith("custom_dynamic:")
+    ):
         # Try probing with correct auth for the api_mode.
         if api_mode == "anthropic_messages":
             probe = probe_api_models(api_key, base_url, api_mode=api_mode)

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -582,14 +582,16 @@ def resolve_user_provider(name: str, user_config: Dict[str, Any]) -> Optional[Pr
     )
 
 
-def custom_provider_slug(display_name: str) -> str:
+def custom_provider_slug(display_name: str, kind: str = "") -> str:
     """Build a canonical slug for a custom_providers entry.
 
     Matches the convention used by runtime_provider and credential_pool
-    (``custom:<normalized-name>``).  Centralised here so all call-sites
-    produce identical slugs.
+    (``custom:<normalized-name>`` or ``custom_dynamic:<normalized-name>``
+    when the entry has ``kind: dynamic``). Centralised here so all
+    call-sites produce identical slugs.
     """
-    return "custom:" + display_name.strip().lower().replace(" ", "-")
+    prefix = "custom_dynamic:" if (kind or "").strip().lower() == "dynamic" else "custom:"
+    return prefix + display_name.strip().lower().replace(" ", "-")
 
 
 def resolve_custom_provider(
@@ -628,8 +630,14 @@ def resolve_custom_provider(
         if first_valid is None:
             first_valid = (display_name, api_url)
 
-        slug = custom_provider_slug(display_name)
-        if requested not in {display_name.lower(), slug}:
+        kind = str(entry.get("kind") or "").strip().lower()
+        slug = custom_provider_slug(display_name, kind=kind)
+        # Accept either prefix form so callers that hard-code custom:<name>
+        # against a kind=dynamic entry still resolve, and vice versa.
+        alt_slug = custom_provider_slug(
+            display_name, kind="dynamic" if kind != "dynamic" else "static"
+        )
+        if requested not in {display_name.lower(), slug, alt_slug}:
             continue
 
         return ProviderDef(

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1378,6 +1378,21 @@ def resolve_runtime_provider(
             if not _agent_key_is_usable(nous_state, min_ttl):
                 logger.debug("Nous pool entry agent_key expired/missing, falling through to runtime resolution")
                 pool_api_key = ""
+        # For bare `provider: custom`, the pool entry must carry its own
+        # base_url — _resolve_runtime_from_pool_entry has no PROVIDER_REGISTRY
+        # default to fall back to for "custom". A poison entry with an empty
+        # base_url (e.g. a stale `source: manual` row left over from a partial
+        # auth flow) would otherwise hijack resolution and surface as
+        # "Provider resolver returned an empty base URL". Skip such entries so
+        # we fall through to _resolve_openrouter_runtime, which honours
+        # model.base_url from config.yaml under the bare-custom trust check.
+        if (
+            provider == "custom"
+            and entry is not None
+            and not (getattr(entry, "runtime_base_url", None) or getattr(entry, "base_url", None) or "").strip()
+        ):
+            entry = None
+            pool_api_key = ""
         if entry is not None and pool_api_key:
             return _resolve_runtime_from_pool_entry(
                 provider=provider,

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -38,6 +38,17 @@ def _normalize_custom_provider_name(value: str) -> str:
     return value.strip().lower().replace(" ", "-")
 
 
+def _is_custom_provider_id(value: str) -> bool:
+    """Return True for either ``custom`` or ``custom_dynamic`` provider ids.
+
+    Both share the same runtime resolution path (per-instance base_url, no
+    PROVIDER_REGISTRY default); only the slug used by the picker and the
+    credential-pool key differ.
+    """
+    norm = (value or "").strip().lower()
+    return norm in {"custom", "custom_dynamic"}
+
+
 def _loopback_hostname(host: str) -> bool:
     h = (host or "").lower().rstrip(".")
     return h in {"localhost", "127.0.0.1", "::1", "0.0.0.0"}
@@ -55,7 +66,7 @@ def _config_base_url_trustworthy_for_bare_custom(cfg_base_url: str, cfg_provider
     bu = (cfg_base_url or "").strip()
     if not bu:
         return False
-    if cfg_provider_norm == "custom":
+    if cfg_provider_norm in {"custom", "custom_dynamic"}:
         return True
     # GitHub #27132: provider aliases that resolve to "custom" at runtime
     # (ollama, vllm, llamacpp, …) should be trusted the same way "custom"
@@ -214,8 +225,12 @@ def _provider_supports_explicit_api_mode(provider: Optional[str], configured_pro
     normalized_configured = (configured_provider or "").strip().lower()
     if not normalized_configured:
         return True
-    if normalized_provider == "custom":
-        return normalized_configured == "custom" or normalized_configured.startswith("custom:")
+    if normalized_provider in {"custom", "custom_dynamic"}:
+        return (
+            normalized_configured in {"custom", "custom_dynamic"}
+            or normalized_configured.startswith("custom:")
+            or normalized_configured.startswith("custom_dynamic:")
+        )
     return normalized_configured == normalized_provider
 
 
@@ -511,7 +526,11 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
     # is exempt from the shadow check — it is not a built-in to defer to.
     if requested_norm == "auto":
         return None
-    if requested_norm != "custom" and not requested_norm.startswith("custom:"):
+    if (
+        requested_norm not in {"custom", "custom_dynamic"}
+        and not requested_norm.startswith("custom:")
+        and not requested_norm.startswith("custom_dynamic:")
+    ):
         try:
             canonical = auth_mod.resolve_provider(requested_norm)
         except AuthError:
@@ -545,7 +564,12 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             if not resolved_api_key:
                 resolved_api_key = str(entry.get("api_key", "") or "").strip()
 
-            if requested_norm in {ep_name, name_norm, f"custom:{name_norm}"}:
+            if requested_norm in {
+                ep_name,
+                name_norm,
+                f"custom:{name_norm}",
+                f"custom_dynamic:{name_norm}",
+            }:
                 # Found match by provider key
                 base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
                 if base_url:
@@ -574,7 +598,12 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             display_name = entry.get("name", "")
             if display_name:
                 display_norm = _normalize_custom_provider_name(display_name)
-                if requested_norm in {display_name, display_norm, f"custom:{display_norm}"}:
+                if requested_norm in {
+                    display_name,
+                    display_norm,
+                    f"custom:{display_norm}",
+                    f"custom_dynamic:{display_norm}",
+                }:
                     # Found match by display name
                     base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
                     if base_url:
@@ -616,10 +645,19 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             continue
         name_norm = _normalize_custom_provider_name(name)
         menu_key = f"custom:{name_norm}"
+        dyn_menu_key = f"custom_dynamic:{name_norm}"
         provider_key = str(entry.get("provider_key", "") or "").strip()
         provider_key_norm = _normalize_custom_provider_name(provider_key) if provider_key else ""
         provider_menu_key = f"custom:{provider_key_norm}" if provider_key_norm else ""
-        if requested_norm not in {name_norm, menu_key, provider_key_norm, provider_menu_key}:
+        provider_dyn_menu_key = f"custom_dynamic:{provider_key_norm}" if provider_key_norm else ""
+        if requested_norm not in {
+            name_norm,
+            menu_key,
+            dyn_menu_key,
+            provider_key_norm,
+            provider_menu_key,
+            provider_dyn_menu_key,
+        }:
             continue
         result = {
             "name": name.strip(),
@@ -640,6 +678,9 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
         model_name = str(entry.get("model", "") or "").strip()
         if model_name:
             result["model"] = model_name
+        kind = str(entry.get("kind") or "").strip().lower()
+        if kind in {"static", "dynamic"}:
+            result["kind"] = kind
         _lift_max_output_tokens(entry, result)
         return result
 
@@ -682,7 +723,7 @@ def _resolve_named_custom_runtime(
     # `provider: ollama` with a LAN/WireGuard `base_url` doesn't silently
     # fall through to OpenRouter.
     requested_norm = (requested_provider or "").strip().lower()
-    if requested_norm and requested_norm != "custom":
+    if requested_norm and requested_norm not in {"custom", "custom_dynamic"}:
         try:
             from hermes_cli.auth import resolve_provider as _resolve_provider
 
@@ -690,12 +731,12 @@ def _resolve_named_custom_runtime(
                 requested_norm = "custom"
         except Exception:
             pass
-    if requested_norm == "custom" and explicit_base_url:
+    if requested_norm in {"custom", "custom_dynamic"} and explicit_base_url:
         base_url = explicit_base_url.strip().rstrip("/")
         # Check credential pool first — mirrors the named-custom-provider path
         # so bare `provider: custom` with a configured custom_providers entry
         # also gets its api_key from the pool instead of env var fallbacks.
-        pool_result = _try_resolve_from_custom_pool(base_url, "custom", None)
+        pool_result = _try_resolve_from_custom_pool(base_url, requested_norm, None)
         if pool_result:
             pool_result["source"] = "direct-alias"
             return pool_result
@@ -716,7 +757,7 @@ def _resolve_named_custom_runtime(
             "",
         ) or "no-key-required"
         return {
-            "provider": "custom",
+            "provider": requested_norm,
             "api_mode": _detect_api_mode_for_url(base_url) or "chat_completions",
             "base_url": base_url,
             "api_key": api_key,
@@ -735,8 +776,15 @@ def _resolve_named_custom_runtime(
     if not base_url:
         return None
 
+    # Pick the resolved provider id based on the entry's declared kind.
+    # `custom_dynamic` is a first-class provider id (not aliased to `custom`)
+    # so the dashboard and pool can distinguish dynamic endpoints; static and
+    # absent-kind entries keep the existing `custom` id verbatim.
+    entry_kind = str(custom_provider.get("kind") or "").strip().lower()
+    resolved_provider_id = "custom_dynamic" if entry_kind == "dynamic" else "custom"
+
     # Check if a credential pool exists for this custom endpoint
-    pool_result = _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode"), provider_name=custom_provider.get("name"))
+    pool_result = _try_resolve_from_custom_pool(base_url, resolved_provider_id, custom_provider.get("api_mode"), provider_name=custom_provider.get("name"))
     if pool_result:
         # Propagate the model name even when using pooled credentials —
         # the pool doesn't know about the custom_providers model field.
@@ -770,7 +818,7 @@ def _resolve_named_custom_runtime(
     api_key = next((candidate for candidate in api_key_candidates if has_usable_secret(candidate)), "")
 
     result = {
-        "provider": "custom",
+        "provider": resolved_provider_id,
         "api_mode": custom_provider.get("api_mode")
         or _detect_api_mode_for_url(base_url)
         or "chat_completions",
@@ -812,7 +860,8 @@ def _resolve_openrouter_runtime(
     # as a bare `provider: custom`. Normalising here keeps every check
     # below — `requested_norm == "custom"`, the trust check, the pool
     # gate up the stack — alias-aware without duplicating the alias map.
-    if requested_norm and requested_norm != "custom":
+    is_custom_dynamic_request = requested_norm == "custom_dynamic"
+    if requested_norm and requested_norm not in {"custom", "custom_dynamic"}:
         try:
             from hermes_cli.auth import resolve_provider as _resolve_provider
 
@@ -832,7 +881,7 @@ def _resolve_openrouter_runtime(
         if requested_norm == "auto":
             if not cfg_provider or cfg_provider == "auto":
                 use_config_base_url = True
-        elif requested_norm == "custom" and _config_base_url_trustworthy_for_bare_custom(
+        elif requested_norm in {"custom", "custom_dynamic"} and _config_base_url_trustworthy_for_bare_custom(
             cfg_base_url, cfg_provider
         ):
             use_config_base_url = True
@@ -903,20 +952,25 @@ def _resolve_openrouter_runtime(
     # name instead of silently relabeling to "openrouter" (#2562).
     # Also provide a placeholder API key for local servers that don't require
     # authentication — the OpenAI SDK requires a non-empty api_key string.
-    effective_provider = "custom" if requested_norm == "custom" else "openrouter"
+    if is_custom_dynamic_request:
+        effective_provider = "custom_dynamic"
+    elif requested_norm == "custom":
+        effective_provider = "custom"
+    else:
+        effective_provider = "openrouter"
 
     # For custom endpoints, check if a credential pool exists
-    if effective_provider == "custom" and base_url:
+    if effective_provider in {"custom", "custom_dynamic"} and base_url:
         # Pass requested_provider so pool lookup prefers name match over base_url,
         # fixing credential mix-ups when multiple custom providers share a base_url.
         pool_result = _try_resolve_from_custom_pool(
             base_url, effective_provider, _parse_api_mode(model_cfg.get("api_mode")),
-            provider_name=requested_provider if requested_norm != "custom" else None,
+            provider_name=requested_provider if requested_norm not in {"custom", "custom_dynamic"} else None,
         )
         if pool_result:
             return pool_result
 
-    if effective_provider == "custom" and not api_key and not _is_openrouter_url:
+    if effective_provider in {"custom", "custom_dynamic"} and not api_key and not _is_openrouter_url:
         api_key = "no-key-required"
 
     return {
@@ -1341,7 +1395,7 @@ def resolve_runtime_provider(
             or env_openai_base_url
             or env_openrouter_base_url
         )
-        if cfg_base_url and cfg_provider in {"auto", "custom"}:
+        if cfg_base_url and cfg_provider in {"auto", "custom", "custom_dynamic"}:
             has_custom_endpoint = True
         has_runtime_override = bool(explicit_api_key or explicit_base_url)
         should_use_pool = (
@@ -1387,7 +1441,7 @@ def resolve_runtime_provider(
         # we fall through to _resolve_openrouter_runtime, which honours
         # model.base_url from config.yaml under the bare-custom trust check.
         if (
-            provider == "custom"
+            provider in {"custom", "custom_dynamic"}
             and entry is not None
             and not (getattr(entry, "runtime_base_url", None) or getattr(entry, "base_url", None) or "").strip()
         ):

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -56,7 +56,7 @@ def _set_credential_pool_strategy(config: Dict[str, Any], provider: str, strateg
 
 
 def _supports_same_provider_pool_setup(provider: str) -> bool:
-    if not provider or provider == "custom":
+    if not provider or provider in {"custom", "custom_dynamic"}:
         return False
     if provider == "openrouter":
         return True

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7645,6 +7645,35 @@ async def add_credential_pool_entry(body: CredentialPoolAdd):
     if not provider or not api_key:
         raise HTTPException(status_code=400, detail="provider and api_key are required")
 
+    # Resolve the canonical provider for base_url lookup so aliases (e.g.
+    # "google" → "gemini") inherit the registry's inference_base_url instead
+    # of being written with an empty base_url. The empty-base_url shape
+    # ("source": "manual", "base_url": "") is exactly the poison pool entry
+    # that hijacks bare `provider: custom` resolution and surfaces as
+    # "Provider resolver returned an empty base URL" downstream.
+    from hermes_cli.auth import resolve_provider as _resolve_provider
+    from hermes_cli.auth_commands import _provider_base_url
+
+    try:
+        canonical = _resolve_provider(provider)
+    except Exception:
+        canonical = provider
+    base_url = _provider_base_url(canonical)
+    if not base_url:
+        # No known inference endpoint for this provider id. Bare "custom"
+        # and unknown aliases fall here — they need a `custom:<name>` form
+        # backed by a custom_providers entry. Refuse rather than write a
+        # poison row that will brick `hermes chat` later.
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Cannot add credential for provider '{provider}': no inference base_url "
+                "is registered. For local/self-hosted endpoints, add a `custom_providers` "
+                "entry to config.yaml first and then attach the credential to "
+                "`custom:<name>`."
+            ),
+        )
+
     try:
         pool = load_pool(provider)
         label = (body.label or "").strip() or f"key #{len(pool.entries()) + 1}"
@@ -7656,8 +7685,11 @@ async def add_credential_pool_entry(body: CredentialPoolAdd):
             priority=0,
             source=SOURCE_MANUAL,
             access_token=api_key,
+            base_url=base_url,
         )
         pool.add_entry(entry)
+    except HTTPException:
+        raise
     except Exception as exc:
         _log.exception("POST /api/credentials/pool failed")
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3324,7 +3324,7 @@ def _apply_model_assignment_sync(
         # ``model.*`` and the picker has no proper ready row for it — the
         # GUI then surfaces a "needs setup" dead-end on the bare ``custom``
         # provider. Dedups by base_url, so re-saving is idempotent.
-        if provider.strip().lower() in {"custom", "local"} and base_url:
+        if provider.strip().lower() in {"custom", "custom_dynamic", "local"} and base_url:
             try:
                 from hermes_cli.main import _auto_provider_name, _save_custom_provider
 
@@ -3333,6 +3333,7 @@ def _apply_model_assignment_sync(
                     api_key,
                     model,
                     name=_auto_provider_name(base_url),
+                    kind="dynamic" if provider.strip().lower() == "custom_dynamic" else None,
                 )
             except Exception:
                 # Never block the assignment on the bookkeeping write —
@@ -7581,6 +7582,9 @@ class CredentialPoolAdd(BaseModel):
     # an interactive browser flow that doesn't belong in a single POST).
     api_key: str
     label: Optional[str] = None
+    # Optional base_url for custom_dynamic / custom endpoints (no canonical
+    # inference_base_url in PROVIDER_REGISTRY). Required for custom_dynamic.
+    base_url: Optional[str] = None
 
 
 def _pool_entry_summary(entry: Any, index: int) -> Dict[str, Any]:
@@ -7642,8 +7646,23 @@ async def add_credential_pool_entry(body: CredentialPoolAdd):
 
     provider = (body.provider or "").strip().lower()
     api_key = (body.api_key or "").strip()
+    explicit_base_url = (body.base_url or "").strip().rstrip("/")
     if not provider or not api_key:
         raise HTTPException(status_code=400, detail="provider and api_key are required")
+
+    # `custom_dynamic` is a first-class provider id but, like `custom`, has
+    # no registry inference_base_url — the caller MUST supply one (mirrors the
+    # bare-`custom` rejection a few lines down). Refuse early with a clear
+    # message so the dashboard surfaces the missing field, not a generic
+    # "no inference base_url" error.
+    if provider == "custom_dynamic" and not explicit_base_url:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Cannot add credential for provider 'custom_dynamic': a non-empty "
+                "base_url is required. Provide the endpoint URL alongside the api_key."
+            ),
+        )
 
     # Resolve the canonical provider for base_url lookup so aliases (e.g.
     # "google" → "gemini") inherit the registry's inference_base_url instead
@@ -7658,7 +7677,7 @@ async def add_credential_pool_entry(body: CredentialPoolAdd):
         canonical = _resolve_provider(provider)
     except Exception:
         canonical = provider
-    base_url = _provider_base_url(canonical)
+    base_url = explicit_base_url or _provider_base_url(canonical)
     if not base_url:
         # No known inference endpoint for this provider id. Bare "custom"
         # and unknown aliases fall here — they need a `custom:<name>` form

--- a/plugins/model-providers/custom_dynamic/__init__.py
+++ b/plugins/model-providers/custom_dynamic/__init__.py
@@ -1,0 +1,28 @@
+"""Custom / dynamic-models provider profile.
+
+Sibling of the ``custom`` plugin. Same wire shape (OpenAI-compatible
+endpoint, user-supplied base_url, ``think=false`` + ``num_ctx`` support
+for Ollama-class servers), but a distinct provider id so picker rows
+and ``custom_providers[]`` entries declare *dynamic* intent up front:
+the runtime always probes ``GET {base_url}/models`` for the model
+catalog instead of using whatever the config pins.
+
+Design doc: ``20260613_hermes-custom-dynamic-provider-design.md`` §2.
+"""
+
+from providers import register_provider
+
+from plugins.model_providers.custom import CustomProfile
+
+
+custom_dynamic = CustomProfile(
+    name="custom_dynamic",
+    display_name="Custom (dynamic)",
+    description="Custom endpoint with live /models discovery (llama-swap, local Ollama, Bifrost)",
+    aliases=(),  # no aliases — `custom_dynamic` is opted-in explicitly
+    env_vars=(),
+    base_url="",
+    default_max_tokens=65536,
+)
+
+register_provider(custom_dynamic)

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -535,7 +535,7 @@ def test_model_flow_custom_saves_verified_v1_base_url(monkeypatch, capsys):
     monkeypatch.setattr("hermes_cli.config.save_env_value", lambda key, value: saved_env.__setitem__(key, value))
     monkeypatch.setattr("hermes_cli.auth._save_model_choice", lambda model: saved_env.__setitem__("MODEL", model))
     monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda: None)
-    monkeypatch.setattr("hermes_cli.main._save_custom_provider", lambda *args, **kwargs: None)
+    monkeypatch.setattr("hermes_cli.main._save_custom_provider", lambda *args, **kwargs: None)  # accepts kind= kwarg
     monkeypatch.setattr(
         "hermes_cli.models.probe_api_models",
         lambda api_key, base_url: {
@@ -553,9 +553,11 @@ def test_model_flow_custom_saves_verified_v1_base_url(monkeypatch, capsys):
     monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
 
     # After the probe detects a single model ("llm"), the flow asks
-    # "Use this model? [Y/n]:" — confirm with Enter, then context length,
-    # then display name. The api_mode prompt also runs before model selection.
-    answers = iter(["http://localhost:8000", "local-key", "", "", "", "", ""])
+    # "Use this model? [Y/n]:" — confirm with Enter, then prompts for
+    # endpoint kind (single-model branch defaults static), then context
+    # length, then display name. The api_mode prompt also runs before
+    # model selection.
+    answers = iter(["http://localhost:8000", "local-key", "", "", "", "", "", ""])
     monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
     monkeypatch.setattr("hermes_cli.secret_prompt.masked_secret_prompt", lambda _prompt="": next(answers))
 
@@ -593,7 +595,7 @@ def test_model_flow_custom_persists_selected_api_mode(monkeypatch):
     monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: saved_cfg.update(cfg))
     monkeypatch.setattr(
         "hermes_cli.main._save_custom_provider",
-        lambda base_url, api_key="", model="", context_length=None, name=None, api_mode=None: captured_provider.update(
+        lambda base_url, api_key="", model="", context_length=None, name=None, api_mode=None, kind=None, **_: captured_provider.update(
             {
                 "base_url": base_url,
                 "api_key": api_key,
@@ -601,6 +603,7 @@ def test_model_flow_custom_persists_selected_api_mode(monkeypatch):
                 "context_length": context_length,
                 "name": name,
                 "api_mode": api_mode,
+                "kind": kind,
             }
         ),
     )
@@ -624,6 +627,118 @@ def test_model_flow_custom_persists_selected_api_mode(monkeypatch):
     assert saved_cfg["model"]["api_key"] == "test-key"
     assert saved_cfg["model"]["api_mode"] == "codex_responses"
     assert captured_provider["api_mode"] == "codex_responses"
+
+
+# ---------------------------------------------------------------------------
+# Setup wizard: kind selection branches (design doc §3 / §5.1).
+# Verifies probe-and-prompt picks the right default kind for each branch:
+#   ≥2 models → dynamic; 1 model → static; 0/fail → static + warning.
+# ---------------------------------------------------------------------------
+
+
+def _mock_custom_flow_deps(monkeypatch, saved_cfg, captured, *, probe_models):
+    monkeypatch.setattr("hermes_cli.config.get_env_value", lambda key: "")
+    monkeypatch.setattr("hermes_cli.config.save_env_value", lambda key, value: None)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: saved_cfg)
+    monkeypatch.setattr(
+        "hermes_cli.config.save_config",
+        lambda cfg: saved_cfg.update(cfg),
+    )
+    monkeypatch.setattr("hermes_cli.auth._save_model_choice", lambda model: None)
+    monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.main._prompt_custom_api_mode_selection",
+        lambda *a, **kw: None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.main._save_custom_provider",
+        lambda *args, **kwargs: captured.update(kwargs),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.probe_api_models",
+        lambda api_key, base_url: {
+            "models": list(probe_models),
+            "probed_url": f"{base_url}/models",
+            "resolved_base_url": None,
+            "suggested_base_url": None,
+            "used_fallback": False,
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.secret_prompt.masked_secret_prompt",
+        lambda _prompt="": "test-key",
+    )
+
+
+def test_model_flow_custom_defaults_dynamic_when_probe_returns_multiple_models(monkeypatch):
+    saved_cfg = {"model": {}}
+    captured = {}
+    _mock_custom_flow_deps(
+        monkeypatch, saved_cfg, captured,
+        probe_models=["model-a", "model-b", "model-c"],
+    )
+
+    # Inputs (input() only — masked prompt is mocked):
+    #   1. base_url
+    #   2. kind_choice for ≥2 branch (Enter → default D=dynamic)
+    #   3. default model pick (Enter → first detected model)
+    #   4. context_length (blank)
+    #   5. display_name (blank)
+    answers = iter(["https://example.com/v1", "", "", "", ""])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+
+    hermes_main._model_flow_custom({})
+
+    assert saved_cfg["model"]["provider"] == "custom_dynamic"
+    assert saved_cfg["model"]["base_url"] == "https://example.com/v1"
+    assert captured.get("kind") == "dynamic"
+
+
+def test_model_flow_custom_defaults_static_when_probe_returns_single_model(monkeypatch):
+    saved_cfg = {"model": {}}
+    captured = {}
+    _mock_custom_flow_deps(
+        monkeypatch, saved_cfg, captured,
+        probe_models=["only-model"],
+    )
+
+    # Inputs:
+    #   1. base_url
+    #   2. confirm-use-detected "Y" (Enter)
+    #   3. kind_choice for single-model branch (Enter → default S=static)
+    #   4. context_length (blank)
+    #   5. display_name (blank)
+    answers = iter(["https://example.com/v1", "", "", "", ""])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+
+    hermes_main._model_flow_custom({})
+
+    assert saved_cfg["model"]["provider"] == "custom"
+    assert captured.get("kind") == "static"
+
+
+def test_model_flow_custom_defaults_static_when_probe_returns_no_models(monkeypatch, capsys):
+    saved_cfg = {"model": {}}
+    captured = {}
+    _mock_custom_flow_deps(
+        monkeypatch, saved_cfg, captured,
+        probe_models=[],
+    )
+
+    # Inputs:
+    #   1. base_url
+    #   2. manual model name (probe yielded nothing)
+    #   3. context_length (blank)
+    #   4. display_name (blank)
+    answers = iter(["https://example.com/v1", "manual-model", "", ""])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+
+    hermes_main._model_flow_custom({})
+    output = capsys.readouterr().out
+
+    assert "Could not detect any models" in output
+    assert saved_cfg["model"]["provider"] == "custom"
+    assert captured.get("kind") == "static"
 
 
 def test_cmd_model_forwards_nous_login_tls_options(monkeypatch):

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -139,6 +139,35 @@ class TestCredentialPoolEndpoints:
         )
         assert r.status_code == 400
 
+    def test_bare_custom_provider_rejected_without_base_url(self):
+        """Bare `custom` has no registry inference_base_url. Writing such an
+        entry with `base_url=""` produces the poison row that hijacks bare
+        `provider: custom` resolution and surfaces as
+        `Provider resolver returned an empty base URL` downstream. Refuse
+        rather than persist it. Regression for the 2026-06-13 root-cause."""
+        r = self.client.post(
+            "/api/credentials/pool",
+            json={"provider": "custom", "api_key": "whatever"},
+        )
+        assert r.status_code == 400
+        assert "custom_providers" in r.json()["detail"]
+
+    def test_alias_provider_inherits_canonical_base_url(self):
+        """`google` is an alias for `gemini`; the entry must inherit
+        gemini's inference_base_url so it is not written with an empty
+        base_url (same poison shape as bare `custom`)."""
+        r = self.client.post(
+            "/api/credentials/pool",
+            json={"provider": "google", "api_key": "AQ.test-key"},
+        )
+        assert r.status_code == 200
+
+        from agent.credential_pool import load_pool
+
+        raw = load_pool("google").entries()
+        assert raw[0].base_url, "base_url must not be empty for alias providers"
+        assert "googleapis.com" in raw[0].base_url
+
 
 class TestMemoryEndpoints:
     @pytest.fixture(autouse=True)

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -1071,3 +1071,47 @@ class TestToolsConfigEndpoints:
                 kwargs["json"] = payload
             r = fn(path, **kwargs)
             assert r.status_code == 401, f"{method} {path} not gated"
+
+
+class TestCustomDynamicCredentialPool:
+    """Dashboard /api/credentials/pool acceptance for the custom_dynamic provider id."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, _isolate_hermes_home):
+        self.client, _ = _client()
+
+    def test_credential_pool_accepts_custom_dynamic(self):
+        """`custom_dynamic` is a first-class provider id — the pool endpoint
+        must accept it as long as a non-empty base_url is provided."""
+        r = self.client.post(
+            "/api/credentials/pool",
+            json={
+                "provider": "custom_dynamic",
+                "api_key": "sk-cd-test",
+                "base_url": "http://127.0.0.1:8081/v1",
+                "label": "local-llama-swap",
+            },
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["provider"] == "custom_dynamic"
+
+        from agent.credential_pool import load_pool
+
+        raw = load_pool("custom_dynamic").entries()
+        assert any(e.access_token == "sk-cd-test" for e in raw)
+        assert all(
+            (e.base_url or "").startswith("http://127.0.0.1:8081")
+            for e in raw
+            if e.access_token == "sk-cd-test"
+        )
+
+    def test_credential_pool_rejects_custom_dynamic_without_base_url(self):
+        """`custom_dynamic` shares the bare-`custom` rule: no registry
+        inference_base_url, so a base_url MUST be supplied. Refuse rather
+        than persist a poison row with an empty base_url."""
+        r = self.client.post(
+            "/api/credentials/pool",
+            json={"provider": "custom_dynamic", "api_key": "sk-no-url"},
+        )
+        assert r.status_code == 400
+        assert "base_url" in r.json()["detail"].lower()

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -719,3 +719,86 @@ def test_custom_providers_discover_models_false_string_is_normalised(monkeypatch
     assert gateway_prov is not None
     assert calls == [], "string 'false' must disable live discovery"
     assert gateway_prov["models"] == ["only-model"]
+
+
+def test_custom_providers_lone_entry_singular_model_probes_for_dynamic_catalogue(monkeypatch):
+    """A single custom_providers entry with a singular ``model:`` and no
+    ``api_key`` — the shape ``hermes setup`` writes by default for a freshly
+    added local endpoint (e.g. llama-swap) — MUST trigger live /models
+    discovery, otherwise the picker pins to the one default model and the
+    user never sees the dynamic catalogue. Regression for the 2026-06-13
+    "1 model in picker" report."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    calls = []
+
+    def fake_fetch_api_models(api_key, base_url):
+        calls.append((api_key, base_url))
+        return ["model-a", "model-b", "model-c", "model-d"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fake_fetch_api_models)
+
+    custom_providers = [
+        # Exact shape `hermes setup` writes for a fresh local endpoint.
+        {
+            "name": "Hanyu-b760.local:8081",
+            "base_url": "http://hanyu-b760.local:8081/v1",
+            "model": "model-a",
+        }
+    ]
+
+    providers = list_authenticated_providers(
+        current_provider="openrouter",
+        current_base_url="https://openrouter.ai/api/v1",
+        custom_providers=custom_providers,
+        max_models=50,
+    )
+
+    row = next(
+        (p for p in providers if p["name"] == "Hanyu-b760.local:8081"),
+        None,
+    )
+    assert row is not None
+    assert calls == [("", "http://hanyu-b760.local:8081/v1")], (
+        "Lone-entry singular `model:` must still probe — that's the setup default shape"
+    )
+    assert row["total_models"] == 4, "Live catalogue must replace the singular default"
+
+
+def test_custom_providers_multi_entry_singular_model_preserves_narrowing(monkeypatch):
+    """Multiple entries that share a name + base_url and each pin a singular
+    ``model:`` (the Ollama Cloud "four entries, four models" pattern) is
+    user-curated narrowing intent and MUST NOT trigger live discovery.
+    Complements the lone-entry case above."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    calls = []
+
+    def fake_fetch_api_models(api_key, base_url):
+        calls.append((api_key, base_url))
+        return ["model-from-live-probe"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fake_fetch_api_models)
+
+    custom_providers = [
+        {"name": "Ollama Cloud", "base_url": "https://ollama.com/v1", "model": "qwen3-coder:480b-cloud"},
+        {"name": "Ollama Cloud", "base_url": "https://ollama.com/v1", "model": "glm-5.1:cloud"},
+        {"name": "Ollama Cloud", "base_url": "https://ollama.com/v1", "model": "kimi-k2.5"},
+        {"name": "Ollama Cloud", "base_url": "https://ollama.com/v1", "model": "minimax-m2.7:cloud"},
+    ]
+
+    providers = list_authenticated_providers(
+        current_provider="openrouter",
+        current_base_url="https://openrouter.ai/api/v1",
+        custom_providers=custom_providers,
+        max_models=50,
+    )
+
+    row = next((p for p in providers if p["name"] == "Ollama Cloud"), None)
+    assert row is not None
+    assert calls == [], (
+        "Multiple singular-`model:` entries narrowing the same endpoint must NOT probe"
+    )
+    assert row["total_models"] == 4

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -802,3 +802,138 @@ def test_custom_providers_multi_entry_singular_model_preserves_narrowing(monkeyp
         "Multiple singular-`model:` entries narrowing the same endpoint must NOT probe"
     )
     assert row["total_models"] == 4
+
+
+# ---------------------------------------------------------------------------
+# kind: static | dynamic | absent — three-way probe branching
+# ---------------------------------------------------------------------------
+
+
+def test_kind_dynamic_always_probes(monkeypatch):
+    """An entry with ``kind: dynamic`` MUST trigger live /models discovery
+    regardless of whether an api_key is set or whether the entry already
+    pins a singular ``model:``. The dynamic provider id is exposed as
+    `custom_dynamic:<name>`."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    calls = []
+
+    def fake_fetch_api_models(api_key, base_url):
+        calls.append((api_key, base_url))
+        return ["live-a", "live-b", "live-c"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fake_fetch_api_models)
+
+    custom_providers = [
+        {
+            "name": "Hanyu-b760.local:8081",
+            "base_url": "http://hanyu-b760.local:8081/v1",
+            "model": "pinned-default",
+            "kind": "dynamic",
+        }
+    ]
+
+    providers = list_authenticated_providers(
+        current_provider="openrouter",
+        current_base_url="https://openrouter.ai/api/v1",
+        custom_providers=custom_providers,
+        max_models=50,
+    )
+
+    row = next((p for p in providers if p["name"] == "Hanyu-b760.local:8081"), None)
+    assert row is not None
+    assert calls == [("", "http://hanyu-b760.local:8081/v1")], (
+        "kind: dynamic must trigger live discovery unconditionally"
+    )
+    assert row["slug"].startswith("custom_dynamic:"), (
+        "dynamic entries must surface as custom_dynamic:<name> in the picker"
+    )
+    assert row["kind"] == "dynamic"
+    assert row["total_models"] == 3
+
+
+def test_kind_static_never_probes(monkeypatch):
+    """An entry with ``kind: static`` MUST skip live /models discovery
+    even when an api_key is present (which would normally trigger probing
+    in the heuristic path)."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    calls = []
+
+    def fake_fetch_api_models(api_key, base_url):
+        calls.append((api_key, base_url))
+        return ["should-not-appear"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fake_fetch_api_models)
+
+    custom_providers = [
+        {
+            "name": "static-gateway",
+            "api_key": "sk-secret",
+            "base_url": "https://gateway.example.com/v1",
+            "model": "pinned-only",
+            "kind": "static",
+        }
+    ]
+
+    providers = list_authenticated_providers(
+        current_provider="openrouter",
+        current_base_url="https://openrouter.ai/api/v1",
+        custom_providers=custom_providers,
+        max_models=50,
+    )
+
+    row = next((p for p in providers if p["name"] == "static-gateway"), None)
+    assert row is not None
+    assert calls == [], "kind: static must bypass live discovery"
+    assert row["slug"].startswith("custom:"), (
+        "static entries keep the existing custom:<name> slug"
+    )
+    assert row["kind"] == "static"
+    assert row["models"] == ["pinned-only"]
+
+
+def test_no_kind_falls_back_to_heuristic(monkeypatch):
+    """An entry WITHOUT a ``kind:`` field must fall back to the existing
+    _user_curated_models heuristic — this is the backwards-compat path
+    that protects entries written by pre-`kind` Hermes versions. Here we
+    repeat the lone-entry singular-`model:` scenario without `kind:` and
+    verify it still probes (same behaviour as today)."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    calls = []
+
+    def fake_fetch_api_models(api_key, base_url):
+        calls.append((api_key, base_url))
+        return ["live-x", "live-y"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fake_fetch_api_models)
+
+    custom_providers = [
+        # No `kind:` — exact pre-existing shape `hermes setup` used to write.
+        {
+            "name": "legacy-endpoint",
+            "base_url": "http://legacy.example.com:8081/v1",
+            "model": "default-only",
+        }
+    ]
+
+    providers = list_authenticated_providers(
+        current_provider="openrouter",
+        current_base_url="https://openrouter.ai/api/v1",
+        custom_providers=custom_providers,
+        max_models=50,
+    )
+
+    row = next((p for p in providers if p["name"] == "legacy-endpoint"), None)
+    assert row is not None
+    # Heuristic: lone-entry singular `model:` without api_key → probe.
+    assert calls == [("", "http://legacy.example.com:8081/v1")], (
+        "absent kind must defer to the existing _user_curated_models heuristic"
+    )
+    # Absent kind → no `kind` field in the row payload, slug stays `custom:`.
+    assert "kind" not in row
+    assert row["slug"].startswith("custom:")

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -676,6 +676,50 @@ def test_bare_custom_does_not_trust_non_loopback_when_provider_not_custom(monkey
     assert "remote.example.com" not in resolved["base_url"]
 
 
+def test_bare_custom_skips_pool_entry_with_empty_base_url(monkeypatch):
+    """A poisoned `custom` pool entry (empty base_url, e.g. a stale manual row
+    from a partial auth flow) must not hijack resolution. Bare `provider:
+    custom` should fall through to the config base_url path instead of
+    returning an empty base_url. Regression for the "Provider resolver
+    returned an empty base URL" report (2026-06-13)."""
+
+    class _Entry:
+        access_token = "poison-token"
+        runtime_api_key = "poison-token"
+        source = "manual"
+        base_url = ""
+        runtime_base_url = None
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "custom")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "custom",
+            "base_url": "http://10.71.71.82:8081/v1",
+            "api_key": "config-key",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("CUSTOM_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="custom")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "http://10.71.71.82:8081/v1"
+    assert resolved["api_key"] != "poison-token"
+    assert resolved["base_url"], "base_url must not be empty"
+
+
 def test_named_custom_provider_uses_saved_credentials(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2819,3 +2819,114 @@ def test_host_derived_key_helper_basic_cases():
     for k in ("DEEPSEEK_API_KEY", "GROQ_API_KEY", "MISTRAL_API_KEY",
               "OPENAI_API_KEY", "OPENROUTER_API_KEY"):
         _os.environ.pop(k, None)
+
+
+# ---------------------------------------------------------------------------
+# custom_dynamic provider — first-class provider id sharing the custom path
+# ---------------------------------------------------------------------------
+
+
+def test_custom_dynamic_resolves_with_base_url(monkeypatch):
+    """`provider: custom_dynamic` with a trustworthy config base_url must
+    resolve through the bare-custom path and surface as the `custom_dynamic`
+    provider id (not relabelled to `custom` or `openrouter`)."""
+
+    class _Pool:
+        def has_credentials(self):
+            return False
+
+        def select(self):
+            return None
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "custom_dynamic")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "custom_dynamic",
+            "base_url": "http://127.0.0.1:8081/v1",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("CUSTOM_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="custom_dynamic")
+
+    assert resolved["provider"] == "custom_dynamic"
+    assert resolved["base_url"] == "http://127.0.0.1:8081/v1"
+
+
+def test_custom_dynamic_skips_pool_entry_with_empty_base_url(monkeypatch):
+    """Mirror of test_bare_custom_skips_pool_entry_with_empty_base_url for
+    custom_dynamic — a poison pool entry must not hijack resolution."""
+
+    class _Entry:
+        access_token = "poison-token"
+        runtime_api_key = "poison-token"
+        source = "manual"
+        base_url = ""
+        runtime_base_url = None
+
+    class _Pool:
+        def has_credentials(self):
+            return True
+
+        def select(self):
+            return _Entry()
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "custom_dynamic")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "custom_dynamic",
+            "base_url": "http://127.0.0.1:8081/v1",
+            "api_key": "config-key",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("CUSTOM_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="custom_dynamic")
+
+    assert resolved["provider"] == "custom_dynamic"
+    assert resolved["base_url"] == "http://127.0.0.1:8081/v1"
+    assert resolved["api_key"] != "poison-token"
+    assert resolved["base_url"], "base_url must not be empty"
+
+
+def test_custom_dynamic_falls_through_to_openrouter_path(monkeypatch):
+    """Without any config base_url, custom_dynamic without a named entry
+    falls into the same shared openrouter/custom resolver path; the
+    provider id stays `custom_dynamic` rather than being relabelled to
+    `custom` or `openrouter`."""
+
+    class _Pool:
+        def has_credentials(self):
+            return False
+
+        def select(self):
+            return None
+
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "custom_dynamic")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "custom_dynamic",
+            "base_url": "http://127.0.0.1:9090/v1",
+        },
+    )
+    monkeypatch.setattr(rp, "load_pool", lambda provider: _Pool())
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("CUSTOM_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="custom_dynamic")
+
+    assert resolved["provider"] == "custom_dynamic"
+    assert "openrouter" not in (resolved.get("base_url") or "").lower()


### PR DESCRIPTION
## What does this PR do?

Splits the `custom` provider concept into two first-class provider ids so the runtime no longer has to guess whether a self-hosted endpoint's model catalog is curated or live-discovered. The existing `custom` keeps its current behaviour 100% — this is a strictly additive change.

**Why split?** The current `custom` flow has to decide whether to probe `GET /models` at picker time. Today that decision is a heuristic (`_user_curated_models` flag, fixed in `882f7397d`) — which guesses right for llama-swap but is still a guess. Two real use cases pull the heuristic in opposite directions:

| Use case | What user wants | Heuristic fits? |
|---|---|---|
| ollama.com narrowing — public endpoint, pick a few models | config is truth, never probe | Yes |
| llama-swap / local Ollama / Bifrost — endpoint exposes a live catalog | endpoint is truth, always probe | Mostly, but fragile |

Solution: keep `custom` for the first case (config-as-truth), add `custom_dynamic` for the second (endpoint-as-truth). New `custom_providers[]` entries can carry an optional `kind: "static" | "dynamic"`; entries WITHOUT `kind:` fall back to the existing heuristic so old configs are untouched.

Setup wizard / desktop onboarding / dashboard `POST /api/credentials/pool` all surface the new kind so users opt in explicitly the moment they set an endpoint up; the heuristic only protects pre-existing entries written by older Hermes versions.

## Related Issue

Fixes # _(no upstream issue — surfaced from a separate root-cause investigation; see commit messages for trail)._

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🐛 Bug fix — bundles 3 prerequisite fix commits (`a766616c8` / `0b7d9443f` / `882f7397d`) that close the empty-base_url pool hijack and the setup-default probe regression. They're foundations the feat builds on.

## Changes Made

**Schema** (one optional field; old configs untouched):

- `hermes_cli/config.py` — `custom_providers[]` entries now accept `kind: "static" | "dynamic"`.

**Runtime resolution** (treats both ids consistently; extends `a766616c8`'s empty-base_url defence to `custom_dynamic`):

- `hermes_cli/runtime_provider.py` — `_resolve_runtime_from_pool_entry`, `_resolve_openrouter_runtime`, and the bare-`custom` fallback.
- `agent/credential_pool.py` — `CUSTOM_DYNAMIC_POOL_PREFIX` namespace parallel to `custom:`.
- `hermes_cli/auth.py`, `hermes_cli/providers.py`, `hermes_cli/doctor.py`, `hermes_cli/setup.py`, `agent/auxiliary_client.py`, `agent/chat_completion_helpers.py` — recognise `custom_dynamic` everywhere `custom` was special-cased.
- `plugins/model-providers/custom_dynamic/` — new plugin sharing `CustomProfile` semantics.

**Picker** (`hermes model` / dashboard / model options API):

- `hermes_cli/model_switch.py` — three-way `should_probe`:
  - `kind == "dynamic"` → always probe `/models`
  - `kind == "static"` → never probe
  - `kind == ""` → existing `_user_curated_models` heuristic, **untouched**
- `hermes_cli/models.py` — `Custom (dynamic)` label; recognised in provider-ordering / catalog-skip / `custom:model` parsing sites.

**Setup surfaces** (always write explicit `kind:` so new entries skip the heuristic):

- `hermes_cli/model_setup_flows.py` — probe `/models` once, branch:
  - ≥2 models → default `[D]ynamic`
  - 1 model → default `[S]tatic`, dynamic available as opt-in
  - 0 / probe fail → default `[S]tatic` + warning
  - New `force_kind` arg lets callers (e.g. dedicated menu row) skip the prompt.
- `hermes_cli/main.py` — `_save_custom_provider` accepts `kind=`, `/model` menu adds a trailing **"Custom endpoint with live /models discovery (dynamic catalog)"** row alongside the existing entries (no row removed).
- `hermes_cli/web_server.py` — `POST /api/credentials/pool` accepts `custom_dynamic`, refuses empty `base_url` (mirroring `0b7d9443f`).
- `cli.py` — `/model X --global` now also persists `model.base_url` for custom kinds so next session routes through the same endpoint.

**Desktop onboarding**:

- `apps/desktop/src/components/desktop-onboarding-overlay.tsx` — sibling tile **"Custom endpoint with live /models discovery"** next to "Local / custom endpoint".
- `apps/desktop/src/store/onboarding.ts` — `saveOnboardingLocalEndpoint` accepts optional `kind` (defaults `"static"`, keeping the 3-arg signature backward-compatible) and writes `provider: 'custom_dynamic'` when dynamic.
- `apps/desktop/src/types/hermes.ts` — `kind?: 'static' | 'dynamic'` discriminator on `ModelOptionProvider` payload.

**Tests** (new, focused on the new behaviour; existing 23 `custom` tests pass unmodified):

- `tests/hermes_cli/test_runtime_provider_resolution.py` — `test_custom_dynamic_resolves_with_base_url`, `test_custom_dynamic_skips_pool_entry_with_empty_base_url`, `test_custom_dynamic_falls_through_to_openrouter_path`.
- `tests/hermes_cli/test_model_switch_custom_providers.py` — `test_kind_dynamic_always_probes`, `test_kind_static_never_probes`, `test_no_kind_falls_back_to_heuristic`.
- `tests/hermes_cli/test_dashboard_admin_endpoints.py` — `test_credential_pool_accepts_custom_dynamic`, `test_credential_pool_rejects_custom_dynamic_without_base_url`.
- `tests/cli/test_cli_provider_resolution.py` — wizard branches for ≥2 / 1 / 0 detected models.

## How to Test

### 1. Backwards compatibility — `custom` behaviour unchanged

```bash
.venv/bin/pytest tests/hermes_cli/test_runtime_provider_resolution.py \
                 tests/hermes_cli/test_dashboard_admin_endpoints.py \
                 tests/hermes_cli/test_model_switch_custom_providers.py \
                 tests/cli/test_cli_provider_resolution.py -q
# 257 passed
```

The 23 pre-existing `custom` tests pass without modification. Any saved `custom_providers[]` entry without `kind:` still goes through the original heuristic path.

### 2. Dynamic flow E2E (CLI)

```bash
hermes setup
# → "Custom endpoint (enter URL manually)"
# → enter http://<host>:8081/v1  (llama-swap / Ollama / Bifrost)
# → wizard probes /models, sees ≥2 models → recommends [D]ynamic
# → confirm; entry saved with kind: dynamic

hermes model
# → picker shows "<host>:8081 — dynamic ▸ N models" with the live catalog

cat ~/.hermes/config.yaml | grep -A1 "kind:"
#   kind: dynamic
```

### 3. Static flow (ollama.com narrowing) still works

Hand-edit `custom_providers[]` with `kind: static` + a fixed `models:` list. Picker shows exactly those models, never probes.

### 4. No-kind heuristic fallback

Hand-edit an entry without `kind:` and the picker behaves identically to `main` — heuristic decides whether to probe.

### 5. Desktop (apps/desktop)

```bash
npm run dev     # in apps/desktop/
```

First-run onboarding shows the new tile under "I have an API key" → "Custom endpoint with live /models discovery". Submitting writes `provider: custom_dynamic` + `base_url` via `POST /api/model/set`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(provider):`, `feat(custom):`, `feat(setup):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) (none match)
- [x] PR contains only changes related to this feature (no unrelated WIP)
- [x] Target test suites pass: 257 / 257
- [x] Tests added (8 new cases covering all kind branches + dashboard validation + wizard branches)
- [x] Tested on macOS 15.5 (Darwin 25.5.0)

### Documentation & Housekeeping

- [x] N/A — no README / `docs/` reference `custom_providers` schema today; the new `kind:` field is documented inline at the config schema declaration and in the three-way `should_probe` comment block in `model_switch.py`.
- [x] N/A — `cli-config.yaml.example` not present; schema lives in `hermes_cli/config.py`.
- [x] N/A — no architecture / workflow changes; CONTRIBUTING / AGENTS unaffected.
- [x] Cross-platform — no platform-specific code paths; only string-id and dict-key additions, plus a Vite / Electron tile (same conditional path as the existing "Local" tile).
- [x] N/A — no tool descriptions / schemas changed.

## Screenshots / Logs

<!--
Suggested screenshots to attach:
  1. `hermes model` showing the new "Custom endpoint with live /models discovery (dynamic catalog)" trailing row.
  2. Wizard probe-and-prompt for a ≥2-model endpoint (recommends [D]ynamic).
  3. Desktop onboarding tile (apps/desktop dev mode).
  4. Saved entry in ~/.hermes/config.yaml with `kind: dynamic`.
-->



<img width="2880" height="1694" alt="截圖 2026-06-13 晚上8 19 43" src="https://github.com/user-attachments/assets/6a2bf7a4-bb2c-41fd-9a8c-14ee21bbbecc" />
<img width="2880" height="1694" alt="截圖 2026-06-13 晚上8 21 29" src="https://github.com/user-attachments/assets/003a32d1-ef73-4e2b-a029-2c2232a1eba8" />
