### PR TITLE
fix: keep CLI idle timer ticking

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12765,6 +12765,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             style=style,
             full_screen=False,
             mouse_support=False,
+            # The status bar contains wall-clock read-outs (live prompt elapsed
+            # and idle-since-last-turn). Once a turn finishes there may be no
+            # further events to invalidate the app, so prompt_toolkit would keep
+            # rendering the first post-turn value (usually ``✓ 0s``) forever.
+            # A low-rate refresh keeps the clock honest without reintroducing a
+            # custom repaint thread or touching conversation state.
+            refresh_interval=1.0,
             # Erase the live bottom chrome (status bar, input box, separator
             # rules) on exit instead of freezing a final copy into scrollback.
             # Without this, prompt_toolkit's render_as_done teardown repaints


### PR DESCRIPTION
## Summary
The classic CLI status bar now repaints once per second, so the post-turn `✓ Ns` idle timer advances after the first render instead of sticking at `✓ 0s`.

## Changes
- cli.py: set prompt_toolkit `Application(refresh_interval=1.0)` for wall-clock status read-outs.

## Validation
- `scripts/run_tests.sh tests/cli/test_cli_status_bar.py` — 44 passed
- `python3 -m py_compile cli.py`

## Infographic

![Classic CLI Idle Timer Fix](https://v3b.fal.media/files/b/0a9e2128/el2AYwautHg8xcIcVeNwf_GFLWLicN.png)
