### PR TITLE
fix(dashboard): keep local file browser on home

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1230,7 +1230,12 @@ def _managed_files_policy(request: Request, *, create_root: bool = True) -> Mana
         root = _ensure_managed_root(raw_forced_root) if create_root else _canonical_path(Path(raw_forced_root))
         return ManagedFilesPolicy(default_path=root, locked_root=root, can_change_path=False)
 
-    if not _local_dashboard_request(request) or _default_hermes_root_is_opt_data():
+    # Remote/OAuth access does not imply a hosted container. Users can expose a
+    # local dashboard through the auth gate (for example a macOS launchd install)
+    # and still expect the Files page to browse their local home directory. Lock
+    # to /opt/data only when the installation's Hermes root is actually /opt/data
+    # (the container/hosted layout) or when HERMES_DASHBOARD_FILES_ROOT is set.
+    if _default_hermes_root_is_opt_data():
         root = _ensure_managed_root(_HOSTED_MANAGED_FILES_ROOT) if create_root else _HOSTED_MANAGED_FILES_ROOT
         return ManagedFilesPolicy(default_path=root, locked_root=root, can_change_path=False)
 

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -193,6 +193,33 @@ def test_local_mode_defaults_to_home_and_can_jump_to_absolute_path(local_files_c
     assert other_listing.json()["entries"][0]["path"] == str(other / "other.txt")
 
 
+def test_gated_local_mode_still_defaults_to_home(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.delenv("HERMES_DASHBOARD_FILES_ROOT", raising=False)
+    monkeypatch.delenv("HERMES_MANAGED", raising=False)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("HERMES_HOME", str(home / ".hermes"))
+
+    prev_auth_required = getattr(web_server.app.state, "auth_required", None)
+    prev_bound_host = getattr(web_server.app.state, "bound_host", None)
+    web_server.app.state.auth_required = True
+    web_server.app.state.bound_host = "0.0.0.0"
+    try:
+        request = SimpleNamespace(
+            app=web_server.app,
+            client=SimpleNamespace(host="10.0.0.2"),
+            url=SimpleNamespace(hostname="example.com"),
+        )
+        policy = web_server._managed_files_policy(request, create_root=False)
+    finally:
+        _restore_app_state(prev_auth_required, prev_bound_host)
+
+    assert policy.default_path == home.resolve()
+    assert policy.locked_root is None
+    assert policy.can_change_path is True
+
+
 def test_local_mode_upload_read_mkdir_delete_roundtrip(local_files_client):
     client, home = local_files_client
     folder = home / "workspace"


### PR DESCRIPTION
## Summary
Local authenticated dashboards now open the Files page at the user's home directory instead of being mistaken for the hosted `/opt/data` layout.

## Changes
- `hermes_cli/web_server.py`: only locks the file browser to `/opt/data` when the Hermes root is actually `/opt/data` or `HERMES_DASHBOARD_FILES_ROOT` is explicitly set.
- `tests/hermes_cli/test_web_server_files.py`: covers remote/OAuth-gated local dashboards so macOS launchd-style installs keep `locked_root: null` and `can_change_path: true`.

## Validation
| Check | Result |
|---|---|
| `py_compile hermes_cli/web_server.py tests/hermes_cli/test_web_server_files.py` | OK |
| `scripts/run_tests.sh tests/hermes_cli/test_web_server_files.py` | 7/7 passed |
| policy smoke test | OAuth-gated local home stays unlocked; `/opt/data` install remains locked |

Fixes the report on #43512 where a Darwin local install saw `/opt/data` on the dashboard Files page.
## Infographic

![Files Page: Local Home by Default](https://v3b.fal.media/files/b/0a9e212d/yyUR1MmrEjp-XIzqPOwv__r4F71fcz.png)
