### PR TITLE
fix(delegation): touch parent before first subagent heartbeat

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1458,11 +1458,20 @@ def _run_single_child(
     _stale_count = [0]
 
     def _heartbeat_loop():
-        while not _heartbeat_stop.wait(_HEARTBEAT_INTERVAL):
+        # Emit once immediately, then on the configured interval.  Without an
+        # initial touch, short-but-legitimate slow tools can spend almost a full
+        # heartbeat interval with the parent looking idle; tight gateway/test
+        # intervals then miss the final refresh because the child finishes just
+        # before the next wait expires.
+        while not _heartbeat_stop.is_set():
             if parent_agent is None:
+                if _heartbeat_stop.wait(_HEARTBEAT_INTERVAL):
+                    break
                 continue
             touch = getattr(parent_agent, "_touch_activity", None)
             if not touch:
+                if _heartbeat_stop.wait(_HEARTBEAT_INTERVAL):
+                    break
                 continue
             # Pull detail from the child's own activity tracker
             desc = f"delegate_task: subagent {task_index} working"
@@ -1525,6 +1534,8 @@ def _run_single_child(
                 touch(desc)
             except Exception:
                 pass
+            if _heartbeat_stop.wait(_HEARTBEAT_INTERVAL):
+                break
 
     _heartbeat_thread = threading.Thread(target=_heartbeat_loop, daemon=True)
 


### PR DESCRIPTION
## Summary
- Emit the subagent delegation heartbeat immediately before entering the interval wait loop.
- Keeps parent activity fresh during short-but-legitimate slow child tool calls.
- Preserves stale-child detection and still stops refreshing when the stop event is set.

## Test plan
- py -3.11 -m pytest tests/tools/test_delegate.py tests/tools/test_delegate_toolset_scope.py tests/tools/test_delegate_subagent_timeout_diagnostic.py -q --tb=short -n 0 -o 'addopts=' — 152 passed
- python -m py_compile tools/delegate_tool.py

## Notes
- Created from an isolated git worktree: C:/Users/yorki/hermes/worktrees/agent-upgrade-hermes-delegation
- Broader subagent interrupt suite has one pre-existing Windows/local-env failure: tests/run_agent/test_real_interrupt_subagent.py::TestRealSubagentInterrupt::test_interrupt_child_during_api_call times out waiting for child run_conversation to start on current origin/main.