### PR TITLE
feat(guardrails): allow configured custom tool classifications

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -121,6 +121,8 @@ class ToolCallGuardrailConfig:
                 hard_stop_after.get("idempotent_no_progress", data.get("no_progress_block_after")),
                 defaults.no_progress_block_after,
             ),
+            idempotent_tools=defaults.idempotent_tools | _string_set(data.get("idempotent_tools")),
+            mutating_tools=defaults.mutating_tools | _string_set(data.get("mutating_tools")),
         )
 
 
@@ -469,6 +471,24 @@ def _positive_int(value: Any, default: int) -> int:
     except (TypeError, ValueError):
         return default
     return parsed if parsed >= 1 else default
+
+
+def _string_set(value: Any) -> frozenset[str]:
+    """Parse a config value into non-empty tool-name strings.
+
+    Accepts either a list/tuple/set of strings or a comma-separated string so
+    config.yaml can classify custom/plugin/MCP tools without a core code change.
+    Invalid entries are ignored rather than weakening the default guardrails.
+    """
+    if value is None:
+        return frozenset()
+    if isinstance(value, str):
+        items = value.split(",")
+    elif isinstance(value, (list, tuple, set, frozenset)):
+        items = value
+    else:
+        return frozenset()
+    return frozenset(item.strip() for item in items if isinstance(item, str) and item.strip())
 
 
 def _sha256(value: str) -> str:

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -74,6 +74,59 @@ def test_config_parses_nested_warn_and_hard_stop_thresholds():
     assert cfg.no_progress_block_after == 8
 
 
+def test_config_can_classify_custom_tools_without_replacing_defaults():
+    cfg = ToolCallGuardrailConfig.from_mapping(
+        {
+            "idempotent_tools": ["custom_read", "", 123, " web_search "],
+            "mutating_tools": "custom_write, patch ,",
+        }
+    )
+
+    assert "read_file" in cfg.idempotent_tools
+    assert "web_search" in cfg.idempotent_tools
+    assert "custom_read" in cfg.idempotent_tools
+    assert "write_file" in cfg.mutating_tools
+    assert "patch" in cfg.mutating_tools
+    assert "custom_write" in cfg.mutating_tools
+    assert "" not in cfg.idempotent_tools
+    assert 123 not in cfg.idempotent_tools
+
+
+def test_custom_idempotent_tool_gets_no_progress_guardrail():
+    cfg = ToolCallGuardrailConfig.from_mapping(
+        {
+            "hard_stop_enabled": True,
+            "idempotent_tools": ["custom_read"],
+            "hard_stop_after": {"idempotent_no_progress": 2},
+        }
+    )
+    controller = ToolCallGuardrailController(cfg)
+
+    args = {"query": "same"}
+    assert controller.before_call("custom_read", args).action == "allow"
+    assert controller.after_call("custom_read", args, "same", failed=False).action == "allow"
+    assert controller.before_call("custom_read", args).action == "allow"
+    assert controller.after_call("custom_read", args, "same", failed=False).action == "warn"
+    assert controller.before_call("custom_read", args).action == "block"
+
+
+def test_custom_mutating_tool_overrides_custom_idempotent_classification():
+    cfg = ToolCallGuardrailConfig.from_mapping(
+        {
+            "hard_stop_enabled": True,
+            "idempotent_tools": ["custom_sync"],
+            "mutating_tools": ["custom_sync"],
+            "hard_stop_after": {"idempotent_no_progress": 2},
+        }
+    )
+    controller = ToolCallGuardrailController(cfg)
+
+    args = {"target": "same"}
+    for _ in range(3):
+        assert controller.before_call("custom_sync", args).action == "allow"
+        assert controller.after_call("custom_sync", args, "same", failed=False).action == "allow"
+
+
 def test_default_repeated_identical_failed_call_warns_without_blocking():
     controller = ToolCallGuardrailController()
     args = {"query": "same"}


### PR DESCRIPTION
## Summary
- Lets tool_loop_guardrails classify custom/plugin/MCP tools as idempotent or mutating from config.yaml.
- Preserves default built-in classifications and keeps mutating classification dominant when a tool appears in both sets.
- Adds tests for list and comma-separated config parsing plus custom idempotent no-progress blocking.

## Test plan
- py -3.11 -m pytest tests/agent/test_tool_guardrails.py tests/run_agent/test_tool_call_guardrail_runtime.py tests/agent/test_tool_dispatch_helpers.py -q --tb=short -n 0 -o 'addopts=' — 52 passed
- python -m py_compile agent/tool_guardrails.py

## Notes
- Created from isolated git worktree: C:/Users/yorki/hermes/worktrees/agent-upgrade-hermes-guardrails