### PR TITLE
fix(gemini): add role field to systemInstruction

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -330,7 +330,7 @@ def _build_gemini_contents(messages: List[Dict[str, Any]]) -> tuple[List[Dict[st
     system_instruction = None
     joined_system = "\n".join(part for part in system_text_parts if part).strip()
     if joined_system:
-        system_instruction = {"parts": [{"text": joined_system}]}
+        system_instruction = {"role": "system", "parts": [{"text": joined_system}]}
     return contents, system_instruction
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -81,6 +81,7 @@ AUTHOR_MAP = {
     "290859878+synapsesx@users.noreply.github.com": "synapsesx",
     "157689911+itsflownium@users.noreply.github.com": "itsflownium",
     "dirtyren@users.noreply.github.com": "dirtyren",
+    "hbentel@gmail.com": "hbentel",
     "JustinBao@outlook.com": "justinbao19",
     "kdunn926@gmail.com": "kdunn926",
     "mvanhorn@MacBook-Pro.local": "mvanhorn",

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -328,6 +328,25 @@ def test_stream_event_translation_keeps_identical_calls_in_distinct_parts():
     assert tool_chunks[0].choices[0].delta.tool_calls[0].id != tool_chunks[1].choices[0].delta.tool_calls[0].id
 
 
+def test_system_instruction_includes_role_field_and_stays_out_of_contents():
+    from agent.gemini_native_adapter import build_gemini_request
+
+    request = build_gemini_request(
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello"},
+        ],
+        tools=[],
+        tool_choice=None,
+    )
+
+    assert request["systemInstruction"] == {
+        "role": "system",
+        "parts": [{"text": "You are a helpful assistant."}],
+    }
+    assert all(content.get("role") != "system" for content in request["contents"])
+
+
 def test_max_tokens_none_defaults_to_gemini_output_ceiling():
     """max_tokens=None must send the model's full output ceiling, not omit it.
 


### PR DESCRIPTION
## Summary
Gemini native requests now include the required `role: "system"` field on `systemInstruction`, fixing strict Gemma/Gemini API validation failures when a system prompt is present.

## Changes
- Add `role: "system"` to the native Gemini `systemInstruction` payload.
- Add a regression test that keeps system text out of `contents` while asserting the role-bearing instruction shape.
- Add release author mapping for @hbentel.

## Validation
| Check | Result |
|---|---|
| `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/agent/test_gemini_native_adapter.py::test_system_instruction_includes_role_field_and_stays_out_of_contents -q` | 1 passed |
| `scripts/run_tests.sh tests/agent/test_gemini_native_adapter.py` | 14 passed |
| `python3 -m py_compile agent/gemini_native_adapter.py tests/agent/test_gemini_native_adapter.py && git diff --check` | passed |

Salvages #36047 by @hbentel with authorship preserved.
Closes #27121.

## Infographic

![Gemini System Role](https://v3b.fal.media/files/b/0a9e2203/VMXDnYzGcSDmPThHMR-xI_g9OkEfoW.png)
