### PR TITLE
fix(desktop): parse slash commands with multi-line arguments

### DIFF
--- a/apps/desktop/src/lib/chat-runtime.test.ts
+++ b/apps/desktop/src/lib/chat-runtime.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { ComposerAttachment } from '@/store/composer'
 
-import { coerceThinkingText, optimisticAttachmentRef } from './chat-runtime'
+import { coerceThinkingText, optimisticAttachmentRef, parseSlashCommand } from './chat-runtime'
 
 const DATA_URL = 'data:image/png;base64,iVBORw0KGgoAAAANS'
 
@@ -50,5 +50,27 @@ describe('coerceThinkingText', () => {
         "◉_◉ processing... I don't see any current rewritten thinking or next thinking to process. Could you provide the thinking content you'd like me to rewrite?"
       )
     ).toBe('')
+  })
+})
+describe('parseSlashCommand', () => {
+  it('parses a bare command with no argument', () => {
+    expect(parseSlashCommand('/kn-nrr')).toEqual({ name: 'kn-nrr', arg: '' })
+  })
+
+  it('parses a single-line argument', () => {
+    expect(parseSlashCommand('/kn-nrr fix this')).toEqual({ name: 'kn-nrr', arg: 'fix this' })
+  })
+
+  it('parses a multi-line argument (regression: previously returned an empty name)', () => {
+    const input = '/kn-nrr Details below.\nline two\nline three'
+
+    expect(parseSlashCommand(input)).toEqual({
+      name: 'kn-nrr',
+      arg: 'Details below.\nline two\nline three',
+    })
+  })
+
+  it('returns an empty name for slash-only input', () => {
+    expect(parseSlashCommand('/')).toEqual({ name: '', arg: '' })
   })
 })

--- a/apps/desktop/src/lib/chat-runtime.ts
+++ b/apps/desktop/src/lib/chat-runtime.ts
@@ -212,7 +212,7 @@ export function normalizePersonalityValue(value: string): string {
 }
 
 export function parseSlashCommand(command: string) {
-  const match = command.replace(/^\/+/, '').match(/^(\S+)\s*(.*)$/)
+  const match = command.replace(/^\/+/, '').match(/^(\S+)\s*([\s\S]*)$/)
 
   return match ? { name: match[1], arg: match[2].trim() } : { name: '', arg: '' }
 }


### PR DESCRIPTION
## What
A slash command whose argument spans multiple lines is parsed as having no
command name, so the desktop composer shows an "empty slash command" system
message and nothing runs.

## Repro
1. In the desktop composer, type a slash command with a multi-line argument
   — e.g. type `/<command>` then paste several lines of text after it.
2. Submit.

Result: a system message reading "empty slash command"; the command never
dispatches. Single-line arguments work fine.

## Cause
`parseSlashCommand` (`apps/desktop/src/lib/chat-runtime.ts`) matched with
`/^(\S+)\s*(.*)$/`. Because `.` does not match newlines and `$` is not in
multiline mode, any newline in the argument fails the whole match and the
function returns `{ name: '', arg: '' }` — an empty command name, which the
caller renders as "empty slash command".

## Fix
Capture the argument with `[\s\S]*` instead of `.*`:

```ts
const match = command.replace(/^\/+/, '').match(/^(\S+)\s*([\s\S]*)$/)
```

The command name (first `\S+` token) and single-line behavior are unchanged;
the argument now spans subsequent lines. Added unit tests for
`parseSlashCommand` (bare, single-line, multi-line regression, slash-only).

## Test
`npm run test:ui` (vitest) — `chat-runtime` tests.
