### PR TITLE
Add unified ingress normalization thin slice

### DIFF
--- a/gateway/ingress.py
+++ b/gateway/ingress.py
@@ -1,0 +1,153 @@
+"""Shared helpers for HTTP-originated gateway ingress."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import asdict, dataclass
+from typing import Any, Protocol
+
+from gateway.platforms.base import MessageEvent, MessageType
+
+
+class IngressAdapter(Protocol):
+    platform: Any
+    _background_tasks: set
+
+    def build_source(
+        self,
+        chat_id: str,
+        chat_name: str | None = None,
+        chat_type: str = "dm",
+        user_id: str | None = None,
+        user_name: str | None = None,
+        message_id: str | None = None,
+    ) -> Any: ...
+
+    async def handle_message(self, event: MessageEvent) -> None: ...
+
+
+@dataclass(frozen=True)
+class IngressEnvelope:
+    text: str
+    message_id: str
+    chat_id: str
+    chat_name: str | None = None
+    chat_type: str = "webhook"
+    user_id: str | None = None
+    user_name: str | None = None
+    raw_payload: Any = None
+    internal: bool = False
+
+
+@dataclass(frozen=True)
+class HttpIngressRequestContext:
+    remote: str = ""
+    peer_ip: str = ""
+    forwarded_for: str = ""
+    real_ip: str = ""
+    method: str = ""
+    path: str = ""
+    user_agent: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class NormalizedIngressRequest:
+    mode: str
+    request_id: str
+    user_message: Any
+    conversation_history: list[dict[str, Any]]
+    session_id: str | None = None
+    session_key: str | None = None
+    ephemeral_system_prompt: str | None = None
+    metadata: dict[str, Any] | None = None
+    reply_target: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def sanitize_http_ingress_value(value: Any, *, max_len: int = 200) -> str:
+    if value is None:
+        return ""
+    text = str(value).replace("\r", " ").replace("\n", " ").strip()
+    return text[:max_len]
+
+
+def extract_http_ingress_request_context(request: Any) -> HttpIngressRequestContext:
+    peer_ip = ""
+    try:
+        transport = getattr(request, "transport", None)
+        peer = transport.get_extra_info("peername") if transport else None
+        if isinstance(peer, (tuple, list)) and peer:
+            peer_ip = str(peer[0])
+    except Exception:
+        peer_ip = ""
+
+    headers = getattr(request, "headers", {}) or {}
+    remote = getattr(request, "remote", "") or peer_ip
+    return HttpIngressRequestContext(
+        remote=sanitize_http_ingress_value(remote),
+        peer_ip=sanitize_http_ingress_value(peer_ip),
+        forwarded_for=sanitize_http_ingress_value(headers.get("X-Forwarded-For", "")),
+        real_ip=sanitize_http_ingress_value(headers.get("X-Real-IP", "")),
+        method=sanitize_http_ingress_value(getattr(request, "method", ""), max_len=16),
+        path=sanitize_http_ingress_value(getattr(request, "path_qs", ""), max_len=500),
+        user_agent=sanitize_http_ingress_value(headers.get("User-Agent", ""), max_len=300),
+    )
+
+
+def format_http_ingress_request_context(context: HttpIngressRequestContext) -> str:
+    fields = [f"{key}={value!r}" for key, value in context.to_dict().items() if value]
+    return " ".join(fields) if fields else "source='unknown'"
+
+
+def build_http_ingress_origin(*, platform: str, chat_id: str, context: HttpIngressRequestContext) -> dict[str, str]:
+    origin = {"platform": platform, "chat_id": chat_id}
+    if context.remote:
+        origin["source_ip"] = context.remote
+    if context.peer_ip:
+        origin["peer_ip"] = context.peer_ip
+    if context.forwarded_for:
+        origin["forwarded_for"] = context.forwarded_for
+    if context.real_ip:
+        origin["real_ip"] = context.real_ip
+    if context.user_agent:
+        origin["user_agent"] = context.user_agent
+    return origin
+
+
+def build_ingress_message_event(adapter: IngressAdapter, envelope: IngressEnvelope) -> MessageEvent:
+    source = adapter.build_source(
+        chat_id=envelope.chat_id,
+        chat_name=envelope.chat_name,
+        chat_type=envelope.chat_type,
+        user_id=envelope.user_id,
+        user_name=envelope.user_name,
+        message_id=envelope.message_id,
+    )
+    return MessageEvent(
+        text=envelope.text,
+        message_type=MessageType.TEXT,
+        source=source,
+        raw_message=envelope.raw_payload,
+        message_id=envelope.message_id,
+        internal=envelope.internal,
+    )
+
+
+def schedule_ingress_event(adapter: IngressAdapter, event: MessageEvent) -> asyncio.Task:
+    task = asyncio.create_task(adapter.handle_message(event))
+    try:
+        adapter._background_tasks.add(task)
+    except Exception:
+        pass
+    if hasattr(task, "add_done_callback"):
+        task.add_done_callback(adapter._background_tasks.discard)
+    return task
+
+
+def schedule_ingress_envelope(adapter: IngressAdapter, envelope: IngressEnvelope) -> asyncio.Task:
+    return schedule_ingress_event(adapter, build_ingress_message_event(adapter, envelope))

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -53,6 +53,12 @@ except ImportError:
     web = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
+from gateway.ingress import (
+    NormalizedIngressRequest,
+    build_http_ingress_origin,
+    extract_http_ingress_request_context,
+    format_http_ingress_request_context,
+)
 from gateway.platforms.base import (
     BasePlatformAdapter,
     SendResult,
@@ -842,47 +848,18 @@ class APIServerAdapter(BasePlatformAdapter):
 
     def _request_audit_context(self, request: "web.Request") -> Dict[str, str]:
         """Return non-secret source metadata for security/audit warnings."""
-        peer_ip = ""
-        try:
-            peer = request.transport.get_extra_info("peername") if request.transport else None
-            if isinstance(peer, (tuple, list)) and peer:
-                peer_ip = str(peer[0])
-        except Exception:
-            peer_ip = ""
-
-        return {
-            "remote": self._clean_log_value(getattr(request, "remote", "") or peer_ip),
-            "peer_ip": self._clean_log_value(peer_ip),
-            "forwarded_for": self._clean_log_value(request.headers.get("X-Forwarded-For", "")),
-            "real_ip": self._clean_log_value(request.headers.get("X-Real-IP", "")),
-            "method": self._clean_log_value(request.method, max_len=16),
-            "path": self._clean_log_value(request.path_qs, max_len=500),
-            "user_agent": self._clean_log_value(request.headers.get("User-Agent", ""), max_len=300),
-        }
+        return extract_http_ingress_request_context(request).to_dict()
 
     def _request_audit_log_suffix(self, request: "web.Request") -> str:
-        ctx = self._request_audit_context(request)
-        fields = [f"{key}={value!r}" for key, value in ctx.items() if value]
-        return " ".join(fields) if fields else "source='unknown'"
+        return format_http_ingress_request_context(extract_http_ingress_request_context(request))
 
     def _cron_origin_from_request(self, request: "web.Request") -> Dict[str, str]:
         """Persist safe API source metadata on cron jobs created over HTTP."""
-        ctx = self._request_audit_context(request)
-        origin = {
-            "platform": "api_server",
-            "chat_id": "api",
-        }
-        if ctx.get("remote"):
-            origin["source_ip"] = ctx["remote"]
-        if ctx.get("peer_ip"):
-            origin["peer_ip"] = ctx["peer_ip"]
-        if ctx.get("forwarded_for"):
-            origin["forwarded_for"] = ctx["forwarded_for"]
-        if ctx.get("real_ip"):
-            origin["real_ip"] = ctx["real_ip"]
-        if ctx.get("user_agent"):
-            origin["user_agent"] = ctx["user_agent"]
-        return origin
+        return build_http_ingress_origin(
+            platform="api_server",
+            chat_id="api",
+            context=extract_http_ingress_request_context(request),
+        )
 
     # ------------------------------------------------------------------
     # Auth helper
@@ -1353,6 +1330,107 @@ class APIServerAdapter(BasePlatformAdapter):
             logger.warning("Failed to load session history for %s: %s", session_id, exc)
             return []
 
+    def _normalize_session_chat_request(
+        self,
+        body: Dict[str, Any],
+        *,
+        session_id: str,
+        gateway_session_key: Optional[str],
+        mode: str = "sync_turn",
+        request_id: Optional[str] = None,
+    ) -> tuple[Optional[NormalizedIngressRequest], Optional["web.Response"]]:
+        user_message, err = _session_chat_user_message(body)
+        if err is not None:
+            return None, err
+        system_prompt = body.get("system_message") or body.get("instructions")
+        if system_prompt is not None and not isinstance(system_prompt, str):
+            return None, web.json_response(_openai_error("system_message must be a string", code="invalid_system_message"), status=400)
+        return NormalizedIngressRequest(
+            mode=mode,
+            request_id=request_id or f"session:{session_id}:{mode}",
+            user_message=user_message,
+            conversation_history=self._conversation_history_for_session(session_id),
+            session_id=session_id,
+            session_key=gateway_session_key,
+            ephemeral_system_prompt=system_prompt,
+            metadata={"endpoint": "session_chat"},
+            reply_target={"session_id": session_id},
+        ), None
+
+    def _normalize_run_request(
+        self,
+        body: Dict[str, Any],
+        *,
+        run_id: str,
+        gateway_session_key: Optional[str],
+        request_context: Optional[Dict[str, Any]] = None,
+    ) -> tuple[Optional[NormalizedIngressRequest], Optional["web.Response"]]:
+        raw_input = body.get("input")
+        if not raw_input:
+            return None, web.json_response(_openai_error("Missing 'input' field"), status=400)
+
+        instructions = body.get("instructions")
+        previous_response_id = body.get("previous_response_id")
+        conversation_history: List[Dict[str, Any]] = []
+        user_message: Any = ""
+
+        if isinstance(raw_input, str):
+            user_message = raw_input
+        elif isinstance(raw_input, list):
+            normalized_messages: List[Dict[str, Any]] = []
+            for idx, item in enumerate(raw_input):
+                if not isinstance(item, dict):
+                    continue
+                role = str(item.get("role") or "user")
+                content = item.get("content", "")
+                if isinstance(content, list):
+                    try:
+                        content = _normalize_multimodal_content(content)
+                    except ValueError as exc:
+                        return None, _multimodal_validation_error(exc, param=f"input[{idx}].content")
+                normalized_messages.append({"role": role, "content": content})
+            if normalized_messages:
+                user_message = normalized_messages[-1]["content"]
+                conversation_history.extend(normalized_messages[:-1])
+
+        if not user_message:
+            return None, web.json_response(_openai_error("No user message found in input"), status=400)
+
+        raw_history = body.get("conversation_history")
+        if raw_history:
+            if not isinstance(raw_history, list):
+                return None, web.json_response(_openai_error("'conversation_history' must be an array of message objects"), status=400)
+            explicit_history: List[Dict[str, Any]] = []
+            for i, entry in enumerate(raw_history):
+                if not isinstance(entry, dict) or "role" not in entry or "content" not in entry:
+                    return None, web.json_response(_openai_error(f"conversation_history[{i}] must have 'role' and 'content' fields"), status=400)
+                explicit_history.append({"role": str(entry["role"]), "content": str(entry["content"])})
+            conversation_history = explicit_history
+            if previous_response_id:
+                logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
+
+        stored_session_id = None
+        if not conversation_history and previous_response_id:
+            stored = self._response_store.get(previous_response_id)
+            if stored:
+                conversation_history = list(stored.get("conversation_history", []))
+                stored_session_id = stored.get("session_id")
+                if instructions is None:
+                    instructions = stored.get("instructions")
+
+        session_id = body.get("session_id") or stored_session_id or run_id
+        return NormalizedIngressRequest(
+            mode="background_run",
+            request_id=run_id,
+            user_message=user_message,
+            conversation_history=conversation_history,
+            session_id=session_id,
+            session_key=gateway_session_key,
+            ephemeral_system_prompt=instructions,
+            metadata={"endpoint": "runs", "request_context": dict(request_context or {}), "previous_response_id": previous_response_id},
+            reply_target={"run_id": run_id},
+        ), None
+
     async def _handle_list_sessions(self, request: "web.Request") -> "web.Response":
         """GET /api/sessions — list persisted Hermes sessions."""
         auth_err = self._check_auth(request)
@@ -1550,19 +1628,20 @@ class APIServerAdapter(BasePlatformAdapter):
         body, err = await self._read_json_body(request)
         if err:
             return err
-        user_message, err = _session_chat_user_message(body)
-        if err is not None:
-            return err
-        system_prompt = body.get("system_message") or body.get("instructions")
-        if system_prompt is not None and not isinstance(system_prompt, str):
-            return web.json_response(_openai_error("system_message must be a string", code="invalid_system_message"), status=400)
-        history = self._conversation_history_for_session(session_id)
-        result, usage = await self._run_agent(
-            user_message=user_message,
-            conversation_history=history,
-            ephemeral_system_prompt=system_prompt,
+        normalized, err = self._normalize_session_chat_request(
+            body,
             session_id=session_id,
             gateway_session_key=gateway_session_key,
+            mode="sync_turn",
+        )
+        if err:
+            return err
+        result, usage = await self._run_agent(
+            user_message=normalized.user_message,
+            conversation_history=normalized.conversation_history,
+            ephemeral_system_prompt=normalized.ephemeral_system_prompt,
+            session_id=normalized.session_id,
+            gateway_session_key=normalized.session_key,
         )
         effective_session_id = result.get("session_id") if isinstance(result, dict) else session_id
         final_response = result.get("final_response", "") if isinstance(result, dict) else ""
@@ -1594,12 +1673,15 @@ class APIServerAdapter(BasePlatformAdapter):
         body, err = await self._read_json_body(request)
         if err:
             return err
-        user_message, err = _session_chat_user_message(body)
-        if err is not None:
+        normalized, err = self._normalize_session_chat_request(
+            body,
+            session_id=session_id,
+            gateway_session_key=gateway_session_key,
+            mode="sync_turn",
+            request_id=f"session:{session_id}:stream",
+        )
+        if err:
             return err
-        system_prompt = body.get("system_message") or body.get("instructions")
-        if system_prompt is not None and not isinstance(system_prompt, str):
-            return web.json_response(_openai_error("system_message must be a string", code="invalid_system_message"), status=400)
 
         loop = asyncio.get_running_loop()
         queue: "asyncio.Queue[Optional[tuple[str, Dict[str, Any]]]]" = asyncio.Queue()
@@ -1643,21 +1725,20 @@ class APIServerAdapter(BasePlatformAdapter):
 
         async def _run_and_signal() -> None:
             try:
-                await queue.put(_event_payload("run.started", {"user_message": {"role": "user", "content": user_message}}))
+                await queue.put(_event_payload("run.started", {"user_message": {"role": "user", "content": normalized.user_message}}))
                 await queue.put(_event_payload("message.started", {"message": {"id": message_id, "role": "assistant"}}))
-                history = self._conversation_history_for_session(session_id)
                 result, usage = await self._run_agent(
-                    user_message=user_message,
-                    conversation_history=history,
-                    ephemeral_system_prompt=system_prompt,
-                    session_id=session_id,
+                    user_message=normalized.user_message,
+                    conversation_history=normalized.conversation_history,
+                    ephemeral_system_prompt=normalized.ephemeral_system_prompt,
+                    session_id=normalized.session_id,
                     stream_delta_callback=_delta,
                     tool_progress_callback=_tool_progress,
-                    gateway_session_key=gateway_session_key,
+                    gateway_session_key=normalized.session_key,
                 )
                 final_response = result.get("final_response", "") if isinstance(result, dict) else ""
                 effective_session_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
-                turn_messages = self._turn_transcript_messages(history, user_message, result) if isinstance(result, dict) else []
+                turn_messages = self._turn_transcript_messages(normalized.conversation_history, normalized.user_message, result) if isinstance(result, dict) else []
                 await queue.put(_event_payload("assistant.completed", {
                     "session_id": effective_session_id,
                     "message_id": message_id,
@@ -3645,65 +3726,20 @@ class APIServerAdapter(BasePlatformAdapter):
         except Exception:
             return web.json_response(_openai_error("Invalid JSON"), status=400)
 
-        raw_input = body.get("input")
-        if not raw_input:
-            return web.json_response(_openai_error("Missing 'input' field"), status=400)
-
-        user_message = raw_input if isinstance(raw_input, str) else (raw_input[-1].get("content", "") if isinstance(raw_input, list) else "")
-        if not user_message:
-            return web.json_response(_openai_error("No user message found in input"), status=400)
-
-        instructions = body.get("instructions")
-        previous_response_id = body.get("previous_response_id")
-
-        # Accept explicit conversation_history from the request body.
-        # Precedence: explicit conversation_history > previous_response_id.
-        conversation_history: List[Dict[str, str]] = []
-        raw_history = body.get("conversation_history")
-        if raw_history:
-            if not isinstance(raw_history, list):
-                return web.json_response(
-                    _openai_error("'conversation_history' must be an array of message objects"),
-                    status=400,
-                )
-            for i, entry in enumerate(raw_history):
-                if not isinstance(entry, dict) or "role" not in entry or "content" not in entry:
-                    return web.json_response(
-                        _openai_error(f"conversation_history[{i}] must have 'role' and 'content' fields"),
-                        status=400,
-                    )
-                conversation_history.append({"role": str(entry["role"]), "content": str(entry["content"])})
-            if previous_response_id:
-                logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
-
-        stored_session_id = None
-        if not conversation_history and previous_response_id:
-            stored = self._response_store.get(previous_response_id)
-            if stored:
-                conversation_history = list(stored.get("conversation_history", []))
-                stored_session_id = stored.get("session_id")
-                if instructions is None:
-                    instructions = stored.get("instructions")
-
-        # When input is a multi-message array, extract all but the last
-        # message as conversation history (the last becomes user_message).
-        # Only fires when no explicit history was provided.
-        if not conversation_history and isinstance(raw_input, list) and len(raw_input) > 1:
-            for msg in raw_input[:-1]:
-                if isinstance(msg, dict) and msg.get("role") and msg.get("content"):
-                    content = msg["content"]
-                    if isinstance(content, list):
-                        # Flatten multi-part content blocks to text
-                        content = " ".join(
-                            part.get("text", "") for part in content
-                            if isinstance(part, dict) and part.get("type") == "text"
-                        )
-                    conversation_history.append({"role": msg["role"], "content": str(content)})
+        if not isinstance(body, dict):
+            return web.json_response(_openai_error("Request body must be a JSON object"), status=400)
 
         run_id = f"run_{uuid.uuid4().hex}"
-        session_id = body.get("session_id") or stored_session_id or run_id
-        approval_session_key = gateway_session_key or session_id or run_id
-        ephemeral_system_prompt = instructions
+        normalized, err = self._normalize_run_request(
+            body,
+            run_id=run_id,
+            gateway_session_key=gateway_session_key,
+            request_context=extract_http_ingress_request_context(request).to_dict(),
+        )
+        if err:
+            return err
+        session_id = normalized.session_id or run_id
+        approval_session_key = normalized.session_key or session_id or run_id
         loop = asyncio.get_running_loop()
         q: "asyncio.Queue[Optional[Dict]]" = asyncio.Queue()
         created_at = time.time()
@@ -3739,7 +3775,7 @@ class APIServerAdapter(BasePlatformAdapter):
             try:
                 self._set_run_status(run_id, "running")
                 agent = self._create_agent(
-                    ephemeral_system_prompt=ephemeral_system_prompt,
+                    ephemeral_system_prompt=normalized.ephemeral_system_prompt,
                     session_id=session_id,
                     stream_delta_callback=_text_cb,
                     tool_progress_callback=event_cb,
@@ -3788,8 +3824,8 @@ class APIServerAdapter(BasePlatformAdapter):
                         )
                         register_gateway_notify(approval_session_key, _approval_notify)
                         r = agent.run_conversation(
-                            user_message=user_message,
-                            conversation_history=conversation_history,
+                            user_message=normalized.user_message,
+                            conversation_history=normalized.conversation_history,
                             task_id=effective_task_id,
                         )
                     finally:

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -168,6 +168,35 @@ class TestCreateJob:
                 assert call_kwargs["origin"]["forwarded_for"] == "203.0.113.11"
                 assert call_kwargs["origin"]["user_agent"] == "cron-client"
 
+    def test_cron_origin_from_request_sanitizes_metadata(self, adapter):
+        from types import SimpleNamespace
+
+        request = SimpleNamespace(
+            remote="198.51.100.9\nspoof",
+            transport=None,
+            headers={
+                "X-Forwarded-For": "203.0.113.11\r\nsecond-hop",
+                "X-Real-IP": "198.51.100.10",
+                "User-Agent": "cron-client\nscanner",
+            },
+            method="POST\n",
+            path_qs="/api/jobs\nignored",
+        )
+
+        origin = adapter._cron_origin_from_request(request)
+        audit = adapter._request_audit_context(request)
+
+        assert origin == {
+            "platform": "api_server",
+            "chat_id": "api",
+            "source_ip": "198.51.100.9 spoof",
+            "forwarded_for": "203.0.113.11  second-hop",
+            "real_ip": "198.51.100.10",
+            "user_agent": "cron-client scanner",
+        }
+        assert audit["method"] == "POST"
+        assert audit["path"] == "/api/jobs ignored"
+
     @pytest.mark.asyncio
     async def test_create_job_missing_name(self, adapter):
         """POST /api/jobs without name returns 400."""

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -124,6 +124,74 @@ class TestStartRun:
                 assert status["status"] in {"queued", "running", "completed"}
                 assert status["object"] == "hermes.run"
 
+    def test_normalize_run_request_builds_shared_model(self, adapter):
+        with patch.object(
+            adapter._response_store,
+            "get",
+            return_value={
+                "conversation_history": [{"role": "assistant", "content": "stored"}],
+                "session_id": "stored-session",
+                "instructions": "stored instructions",
+            },
+        ):
+            normalized, err = adapter._normalize_run_request(
+                {"input": "hello", "previous_response_id": "resp_prev"},
+                run_id="run_test",
+                gateway_session_key="client-42",
+                request_context={"path": "/v1/runs"},
+            )
+
+        assert err is None
+        assert normalized is not None
+        assert normalized.mode == "background_run"
+        assert normalized.request_id == "run_test"
+        assert normalized.user_message == "hello"
+        assert normalized.conversation_history == [{"role": "assistant", "content": "stored"}]
+        assert normalized.session_id == "stored-session"
+        assert normalized.session_key == "client-42"
+        assert normalized.ephemeral_system_prompt == "stored instructions"
+        assert normalized.metadata["endpoint"] == "runs"
+        assert normalized.metadata["request_context"] == {"path": "/v1/runs"}
+        assert normalized.reply_target == {"run_id": "run_test"}
+
+    @pytest.mark.asyncio
+    async def test_start_routes_through_normalized_run_helper(self, adapter):
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create, patch.object(
+                adapter,
+                "_normalize_run_request",
+                wraps=adapter._normalize_run_request,
+            ) as wrapped_normalize:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 0
+                mock_agent.session_completion_tokens = 0
+                mock_agent.session_total_tokens = 0
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": [
+                            {"role": "assistant", "content": "earlier"},
+                            {"role": "user", "content": "hello"},
+                        ]
+                    },
+                )
+                assert resp.status == 202
+
+                for _ in range(20):
+                    if mock_agent.run_conversation.called:
+                        break
+                    await asyncio.sleep(0.05)
+
+                wrapped_normalize.assert_called_once()
+                mock_agent.run_conversation.assert_called_once()
+                kwargs = mock_agent.run_conversation.call_args.kwargs
+                assert kwargs["user_message"] == "hello"
+                assert kwargs["conversation_history"] == [{"role": "assistant", "content": "earlier"}]
+
     @pytest.mark.asyncio
     async def test_start_invalid_json_returns_400(self, adapter):
         app = _create_runs_app(adapter)

--- a/tests/gateway/test_ingress.py
+++ b/tests/gateway/test_ingress.py
@@ -1,0 +1,191 @@
+"""Tests for shared HTTP-ingress helpers."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.ingress import (
+    IngressEnvelope,
+    NormalizedIngressRequest,
+    build_http_ingress_origin,
+    build_ingress_message_event,
+    extract_http_ingress_request_context,
+    format_http_ingress_request_context,
+    schedule_ingress_envelope,
+    schedule_ingress_event,
+)
+from gateway.platforms.webhook import WebhookAdapter
+
+
+def _make_adapter() -> WebhookAdapter:
+    config = PlatformConfig(enabled=True, extra={"host": "127.0.0.1", "port": 0, "routes": {}})
+    return WebhookAdapter(config)
+
+
+class TestBuildIngressMessageEvent:
+    def test_builds_message_event_with_route_identity(self):
+        adapter = _make_adapter()
+        envelope = IngressEnvelope(
+            text="hello from ingress",
+            message_id="evt-1",
+            chat_id="webhook:ci:evt-1",
+            chat_name="webhook/ci",
+            chat_type="webhook",
+            user_id="webhook:ci",
+            user_name="ci",
+            raw_payload={"ref": "main"},
+        )
+
+        event = build_ingress_message_event(adapter, envelope)
+
+        assert event.text == "hello from ingress"
+        assert event.message_id == "evt-1"
+        assert event.raw_message == {"ref": "main"}
+        assert event.source.platform == adapter.platform
+        assert event.source.chat_id == "webhook:ci:evt-1"
+        assert event.source.chat_name == "webhook/ci"
+        assert event.source.chat_type == "webhook"
+        assert event.source.user_id == "webhook:ci"
+        assert event.source.user_name == "ci"
+
+
+class TestScheduleIngressEvent:
+    @pytest.mark.asyncio
+    async def test_tracks_background_task_until_completion(self):
+        adapter = _make_adapter()
+        captured = []
+
+        async def _capture(event):
+            captured.append(event)
+
+        adapter.handle_message = _capture
+        event = build_ingress_message_event(
+            adapter,
+            IngressEnvelope(
+                text="hello",
+                message_id="evt-2",
+                chat_id="webhook:test:evt-2",
+                raw_payload={"ok": True},
+            ),
+        )
+
+        task = schedule_ingress_event(adapter, event)
+        assert task in adapter._background_tasks
+
+        await task
+        await asyncio.sleep(0)
+
+        assert captured == [event]
+        assert task not in adapter._background_tasks
+
+    @pytest.mark.asyncio
+    async def test_schedule_envelope_builds_and_dispatches_event(self):
+        adapter = _make_adapter()
+        adapter.handle_message = AsyncMock()
+        envelope = IngressEnvelope(
+            text="dispatch me",
+            message_id="evt-3",
+            chat_id="webhook:test:evt-3",
+            chat_name="webhook/test",
+            user_id="webhook:test",
+            user_name="test",
+            raw_payload={"value": 3},
+            internal=True,
+        )
+
+        task = schedule_ingress_envelope(adapter, envelope)
+        await task
+
+        adapter.handle_message.assert_awaited_once()
+        dispatched_event = adapter.handle_message.await_args.args[0]
+        assert dispatched_event.text == "dispatch me"
+        assert dispatched_event.message_id == "evt-3"
+        assert dispatched_event.internal is True
+        assert dispatched_event.source.chat_id == "webhook:test:evt-3"
+        assert dispatched_event.raw_message == {"value": 3}
+
+
+class TestHttpIngressRequestContext:
+    def test_extracts_sanitized_request_metadata(self):
+        class _Transport:
+            def get_extra_info(self, name):
+                assert name == "peername"
+                return ("198.51.100.7", 443)
+
+        request = SimpleNamespace(
+            remote="198.51.100.9\nspoof",
+            transport=_Transport(),
+            headers={
+                "X-Forwarded-For": "203.0.113.11\r\nsecond-hop",
+                "X-Real-IP": "198.51.100.10",
+                "User-Agent": "curl/8.0\nmalicious",
+            },
+            method="POST\n",
+            path_qs="/webhooks/demo?x=1\r\nignored",
+        )
+
+        context = extract_http_ingress_request_context(request)
+
+        assert context.remote == "198.51.100.9 spoof"
+        assert context.peer_ip == "198.51.100.7"
+        assert context.forwarded_for == "203.0.113.11  second-hop"
+        assert context.real_ip == "198.51.100.10"
+        assert context.user_agent == "curl/8.0 malicious"
+        assert context.method == "POST"
+        assert context.path == "/webhooks/demo?x=1  ignored"
+
+    def test_formats_request_metadata_for_logs_and_origin(self):
+        request = SimpleNamespace(
+            remote="",
+            transport=None,
+            headers={
+                "X-Forwarded-For": "203.0.113.11",
+                "User-Agent": "cron-client",
+            },
+            method="GET",
+            path_qs="/api/jobs/abc",
+        )
+
+        context = extract_http_ingress_request_context(request)
+        suffix = format_http_ingress_request_context(context)
+        origin = build_http_ingress_origin(platform="api_server", chat_id="api", context=context)
+
+        assert "forwarded_for='203.0.113.11'" in suffix
+        assert "method='GET'" in suffix
+        assert "path='/api/jobs/abc'" in suffix
+        assert origin == {
+            "platform": "api_server",
+            "chat_id": "api",
+            "forwarded_for": "203.0.113.11",
+            "user_agent": "cron-client",
+        }
+
+
+class TestNormalizedIngressRequest:
+    def test_to_dict_preserves_shared_request_fields(self):
+        normalized = NormalizedIngressRequest(
+            mode="background_run",
+            request_id="run_123",
+            user_message="hello",
+            conversation_history=[{"role": "user", "content": "earlier"}],
+            session_id="session-1",
+            session_key="client-42",
+            ephemeral_system_prompt="be concise",
+            metadata={"endpoint": "runs"},
+            reply_target={"run_id": "run_123"},
+        )
+
+        assert normalized.to_dict() == {
+            "mode": "background_run",
+            "request_id": "run_123",
+            "user_message": "hello",
+            "conversation_history": [{"role": "user", "content": "earlier"}],
+            "session_id": "session-1",
+            "session_key": "client-42",
+            "ephemeral_system_prompt": "be concise",
+            "metadata": {"endpoint": "runs"},
+            "reply_target": {"run_id": "run_123"},
+        }

--- a/tests/gateway/test_session_api.py
+++ b/tests/gateway/test_session_api.py
@@ -220,7 +220,11 @@ async def test_session_chat_loads_history_and_preserves_session_headers(auth_ada
 
     mock_run = AsyncMock(return_value=({"final_response": "fresh answer", "session_id": session_id}, {"total_tokens": 3}))
     app = _create_session_app(auth_adapter)
-    with patch.object(auth_adapter, "_run_agent", mock_run):
+    with patch.object(auth_adapter, "_run_agent", mock_run), patch.object(
+        auth_adapter,
+        "_normalize_session_chat_request",
+        wraps=auth_adapter._normalize_session_chat_request,
+    ) as wrapped_normalize:
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.post(
                 f"/api/sessions/{session_id}/chat",
@@ -236,6 +240,7 @@ async def test_session_chat_loads_history_and_preserves_session_headers(auth_ada
     assert payload["session_id"] == session_id
     assert payload["message"]["role"] == "assistant"
     assert payload["message"]["content"] == "fresh answer"
+    wrapped_normalize.assert_called_once()
     mock_run.assert_awaited_once()
     _, kwargs = mock_run.call_args
     assert kwargs["session_id"] == session_id
@@ -245,6 +250,32 @@ async def test_session_chat_loads_history_and_preserves_session_headers(auth_ada
         {"role": "user", "content": "earlier"},
         {"role": "assistant", "content": "prior answer"},
     ]
+
+
+@pytest.mark.asyncio
+async def test_normalize_session_chat_request_builds_shared_model(auth_adapter, session_db):
+    session_id = session_db.create_session("normalized-chat-session", "api_server")
+    session_db.append_message(session_id, "user", "earlier")
+
+    normalized, err = auth_adapter._normalize_session_chat_request(
+        {"message": "next", "system_message": "stay focused"},
+        session_id=session_id,
+        gateway_session_key="client-42",
+        mode="sync_turn",
+        request_id="session-normalized",
+    )
+
+    assert err is None
+    assert normalized is not None
+    assert normalized.mode == "sync_turn"
+    assert normalized.request_id == "session-normalized"
+    assert normalized.session_id == session_id
+    assert normalized.session_key == "client-42"
+    assert normalized.user_message == "next"
+    assert normalized.conversation_history == [{"role": "user", "content": "earlier"}]
+    assert normalized.ephemeral_system_prompt == "stay focused"
+    assert normalized.metadata == {"endpoint": "session_chat"}
+    assert normalized.reply_target == {"session_id": session_id}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a shared ingress normalization seam
- normalize lower-risk API paths through the shared model
- keep higher-risk routes deferred for later slices

## Included in this slice
- add gateway/ingress.py
- refactor gateway/platforms/api_server.py
- add/update focused gateway tests for ingress normalization

## Validation
- focused gateway slice passed
- webhook/msgraph related tests in the slice passed
- syntax sanity checked with py_compile

## Notes
- this is an incremental Phase 3 thin slice
- does not yet migrate /v1/chat/completions or /v1/responses
- local main was behind upstream, so this change was pushed on a dedicated branch from Chris's fork
