### PR TITLE
fix: propagate CLI command failures

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12216,9 +12216,13 @@ def main():
         cmd_chat(args)
         return
 
-    # Execute the command
+    # Execute the command. Most subcommands return None on success, but
+    # argparse-style command handlers may return a shell exit code. Preserve
+    # non-zero codes so automation can reliably detect CLI failures.
     if hasattr(args, "func"):
-        args.func(args)
+        result = args.func(args)
+        if isinstance(result, int) and result != 0:
+            sys.exit(result)
     else:
         parser.print_help()
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "jeevesassistant00@gmail.com": "jeeves-assistant",
     "kenmege@yahoo.com": "Kenmege",
     "peterhao@Peters-MacBook-Air.local": "pinguarmy",
     "adalsteinnhelgason@Aalsteinns-MacBook-Pro-3.local": "AIalliAI",

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -535,10 +535,22 @@ class TestCLI:
     def test_board_flag_rejects_unknown(self, tmp_path):
         env = {"HERMES_HOME": str(tmp_path)}
         r = _cli(["--board", "ghost", "list"], env_extra=env)
-        # main.py's dispatcher doesn't propagate return codes today, so we
-        # assert the user-visible signal: a stderr error message. Whether
-        # the exit code stays 0 is a separate (pre-existing) issue.
+        assert r.returncode == 1
         assert "does not exist" in r.stderr
+
+    def test_board_flag_rejects_invalid_slug_with_nonzero_exit(self, tmp_path):
+        env = {"HERMES_HOME": str(tmp_path)}
+        too_long = "a" * 65
+        r = _cli(["--board", too_long, "list"], env_extra=env)
+        assert r.returncode == 2
+        assert "invalid board slug" in r.stderr
+
+    def test_boards_create_rejects_invalid_slug_with_nonzero_exit(self, tmp_path):
+        env = {"HERMES_HOME": str(tmp_path)}
+        too_long = "a" * 65
+        r = _cli(["boards", "create", too_long], env_extra=env)
+        assert r.returncode == 2
+        assert "invalid board slug" in r.stderr
 
     def test_board_flag_rejects_empty_board_dir(self, tmp_path):
         env = {"HERMES_HOME": str(tmp_path)}


### PR DESCRIPTION
## Summary
- Preserve non-zero exit codes returned by argparse subcommand handlers.
- Add subprocess-level regressions for Kanban invalid/unknown board failures.
- Add the Jeeves contributor email mapping required by upstream CI.

## Why
`hermes_cli.main` was calling command handlers but ignoring integer return values. That made commands such as invalid Kanban board operations print errors while still exiting `0`, which hid failures from automation.

## Test Plan
- `python -m pytest tests/hermes_cli/test_kanban_boards.py -q -o 'addopts='`
- `python -m py_compile scripts/release.py hermes_cli/main.py hermes_cli/kanban.py`
- Manual smoke: `python -m hermes_cli.main kanban boards create <65-char-slug> --name x` returns exit code `2`.
