### PR TITLE
fix(cli): show message when --page exceeds available pages in skills browse

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -400,7 +400,10 @@ def do_browse(page: int = 1, page_size: int = 20, source: str = "all",
     # Paginate
     total = len(deduped)
     total_pages = max(1, (total + page_size - 1) // page_size)
+    requested_page = page
     page = max(1, min(page, total_pages))
+    if requested_page != page:
+        c.print(f'[dim]Page {requested_page} requested; only {total_pages} page(s) available.[/]')
     start = (page - 1) * page_size
     end = min(start + page_size, total)
     page_items = deduped[start:end]

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -691,6 +691,34 @@ def test_do_browse_reports_live_per_source_progress():
     assert "demo" in sink.getvalue()
 
 
+def test_do_browse_page_clamp_message():
+    """When page > total_pages, do_browse should print a helpful message
+    instead of silently clamping (issue #45574)."""
+    from hermes_cli.skills_hub import do_browse
+    from tools.skills_hub import SkillMeta
+
+    meta = SkillMeta(
+        name="demo", description="d", source="official",
+        identifier="official/demo", trust_level="builtin",
+    )
+
+    def fake_parallel(sources, query="", per_source_limits=None,
+                      source_filter="all", overall_timeout=30,
+                      on_source_done=None):
+        return [meta], {"official": 1}, []
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None, width=120)
+
+    with patch("tools.skills_hub.create_source_router", return_value=[]),          patch("tools.skills_hub.GitHubAuth"),          patch("tools.skills_hub.parallel_search_sources", side_effect=fake_parallel):
+        # Request page 2 when only 1 page exists (1 skill, page_size=20)
+        do_browse(page=2, page_size=20, console=console)
+
+    output = sink.getvalue()
+    assert "Page 2 requested" in output, f"Expected page-clamp message, got: {output}"
+    assert "only 1 page" in output
+
+
 # ---------------------------------------------------------------------------
 # Regression: full identifier must be recoverable from `hermes skills search`
 # even when the slug is too long to fit the terminal width (issue #33674).


### PR DESCRIPTION
## What does this PR do?

When `hermes skills browse --page N` requests a page beyond the available range (e.g. `--page 2` when only 1 page exists), the page was silently clamped to `total_pages`. This was confusing for `--source official` where the entire catalog (~96 items) fits on a single page — every `--page` value returned identical output.

Now prints a one-line dim message: `Page 2 requested; only 1 page(s) available.`

## Related Issue

Fixes #45574

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/skills_hub.py`: Save requested page before clamping; print informational message when clamped (3 lines)
- `tests/hermes_cli/test_skills_hub.py`: Add `test_do_browse_page_clamp_message` verifying the message appears when page > total_pages (28 lines)

## How to Test

1. Run `hermes skills browse --source official --page 2` — should show "Page 2 requested; only 1 page(s) available." followed by page 1 content
2. Run `hermes skills browse --source official --page 1` — should work normally with no extra message
3. Run `pytest tests/hermes_cli/test_skills_hub.py::test_do_browse_page_clamp_message -v`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/skills_hub.py::do_browse` (pagination logic)
- Blast radius: LOW — only adds an informational message, no behavior change
- Related patterns: Page clamping at line 387, navigation hints at line 442
