### PR TITLE
feat: add live voice session backend

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -56,6 +56,15 @@ from agent.async_utils import safe_schedule_threadsafe
 from agent.i18n import t
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
+from gateway.voice_sessions import (
+    VoiceSessionConfig,
+    VoiceSessionConflict,
+    VoiceSessionLimitExceeded,
+    VoiceSessionManager,
+    VoiceSessionRequest,
+    VoiceSessionState,
+    VoiceSessionUnauthorized,
+)
 
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
@@ -2115,6 +2124,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Track pending exec approvals per session
         # Key: session_key, Value: {"command": str, "pattern_key": str, ...}
         self._pending_approvals: Dict[str, Dict[str, Any]] = {}
+
+        self._voice_session_manager = VoiceSessionManager(
+            auth_checker=self._is_voice_session_request_authorized,
+            playback_stopper=self._stop_voice_session_playback,
+        )
 
         # Track platforms that failed to connect for background reconnection.
         # Key: Platform enum, Value: {"config": platform_config, "attempts": int, "next_retry": float}
@@ -9590,7 +9604,68 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return None
 
 
-    async def _handle_voice_channel_join(self, event: MessageEvent) -> str:
+    @staticmethod
+    def _voice_session_scope(platform: Platform, guild_id: int | str) -> str:
+        return f"{platform.value if hasattr(platform, 'value') else platform}:{guild_id}"
+
+    @staticmethod
+    def _load_voice_session_config() -> VoiceSessionConfig:
+        try:
+            from hermes_cli.config import load_config as _load_full_config
+            cfg = _load_full_config()
+            voice_cfg = cfg_get(cfg, "voice", "live", default={}) or {}
+            if not isinstance(voice_cfg, dict):
+                voice_cfg = {}
+        except Exception:
+            voice_cfg = {}
+        return VoiceSessionConfig.from_dict(voice_cfg)
+
+    def _is_voice_session_request_authorized(self, request: VoiceSessionRequest) -> bool:
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id=str(request.text_channel_id),
+            user_id=str(request.user_id),
+            user_name=request.user_name or str(request.user_id),
+            chat_type="channel",
+        )
+        return self._is_user_authorized(source)
+
+    async def _stop_voice_session_playback(self, guild_id: str, stream_id: Optional[str] = None) -> None:
+        adapter = self.adapters.get(Platform.DISCORD)
+        stop_playback = getattr(adapter, "stop_voice_playback", None) if adapter else None
+        if stop_playback is not None:
+            await stop_playback(int(guild_id), stream_id=stream_id)
+
+    async def _handle_voice_session_audio(
+        self,
+        guild_id: int,
+        user_id: int,
+        pcm_48k_stereo: bytes,
+        timestamp: Optional[float] = None,
+    ) -> None:
+        manager = getattr(self, "_voice_session_manager", None)
+        if manager is None:
+            return
+        try:
+            await manager.receive_audio(
+                self._voice_session_scope(Platform.DISCORD, guild_id),
+                str(user_id),
+                pcm_48k_stereo,
+                timestamp=timestamp,
+            )
+        except VoiceSessionLimitExceeded as exc:
+            logger.warning("Closing live voice session after guardrail hit: %s", exc)
+            await manager.close_session(
+                self._voice_session_scope(Platform.DISCORD, guild_id),
+                reason=str(exc),
+            )
+            adapter = self.adapters.get(Platform.DISCORD)
+            leave_voice = getattr(adapter, "leave_voice_channel", None) if adapter else None
+            if leave_voice is not None:
+                await leave_voice(guild_id)
+
+
+    async def _handle_voice_channel_join(self, event: MessageEvent, live: bool = False) -> str:
         """Join the user's current Discord voice channel."""
         adapter = self.adapters.get(event.source.platform)
         if not hasattr(adapter, "join_voice_channel"):
@@ -9610,6 +9685,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # after connection is not lost.
         if hasattr(adapter, "_voice_input_callback"):
             adapter._voice_input_callback = self._handle_voice_channel_input
+        if hasattr(adapter, "_voice_frame_callback"):
+            setattr(adapter, "_voice_frame_callback", self._handle_voice_session_audio if live else None)
         if hasattr(adapter, "_on_voice_disconnect"):
             adapter._on_voice_disconnect = self._handle_voice_timeout_cleanup
         # Let the adapter's inactivity timer see the live voice-reply mode so it
@@ -9636,9 +9713,49 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter._voice_text_channels[guild_id] = int(event.source.chat_id)
             if hasattr(adapter, "_voice_sources"):
                 adapter._voice_sources[guild_id] = event.source.to_dict()
+            live_session = None
+            if live:
+                try:
+                    live_session = await self._voice_session_manager.create_session(
+                        VoiceSessionRequest(
+                            platform="discord",
+                            guild_id=str(guild_id),
+                            channel_id=str(getattr(voice_channel, "id", "")),
+                            text_channel_id=str(event.source.chat_id),
+                            user_id=str(event.source.user_id),
+                            user_name=str(event.source.user_name or event.source.user_id),
+                            metadata={"channel_name": getattr(voice_channel, "name", "voice")},
+                        ),
+                        self._load_voice_session_config(),
+                    )
+                except VoiceSessionConflict:
+                    leave_voice = getattr(adapter, "leave_voice_channel", None)
+                    if leave_voice is not None:
+                        await leave_voice(guild_id)
+                    return "A live voice session is already active here. Use /voice status or /voice leave first."
+                except VoiceSessionUnauthorized:
+                    leave_voice = getattr(adapter, "leave_voice_channel", None)
+                    if leave_voice is not None:
+                        await leave_voice(guild_id)
+                    return "You are not authorized to start a live voice session."
+                except Exception as exc:
+                    logger.warning("Failed to start live voice session: %s", exc, exc_info=True)
+                    leave_voice = getattr(adapter, "leave_voice_channel", None)
+                    if leave_voice is not None:
+                        await leave_voice(guild_id)
+                    return f"Joined voice, but live session startup failed: {exc}"
             self._voice_mode[self._voice_key(event.source.platform, event.source.chat_id)] = "all"
             self._save_voice_modes()
             self._set_adapter_auto_tts_enabled(adapter, event.source.chat_id, enabled=True)
+            if live and live_session is not None:
+                degraded = f"\nDegraded: {live_session.degraded_reason}" if live_session.degraded_reason else ""
+                return (
+                    f"Joined live voice in **{voice_channel.name}**.\n"
+                    f"Session: `{live_session.session_id}`. Mode: {live_session.config.mode}. "
+                    f"Transcripts: {live_session.config.transcript_mode}.\n"
+                    f"Use /voice leave to disconnect; interruptions stop current speech."
+                    f"{degraded}"
+                )
             return (
                 f"Joined voice channel **{voice_channel.name}**.\n"
                 f"I'll speak my replies and listen to you. Use /voice leave to disconnect."
@@ -9659,6 +9776,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return "Not in a voice channel."
 
         try:
+            manager = getattr(self, "_voice_session_manager", None)
+            if manager is not None:
+                await manager.close_session(
+                    self._voice_session_scope(event.source.platform, guild_id),
+                    reason="user_leave",
+                )
             await adapter.leave_voice_channel(guild_id)
         except Exception as e:
             logger.warning("Error leaving voice channel: %s", e)
@@ -9679,6 +9802,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._save_voice_modes()
         adapter = self.adapters.get(Platform.DISCORD)
         self._set_adapter_auto_tts_disabled(adapter, chat_id, disabled=True)
+        manager = getattr(self, "_voice_session_manager", None)
+        if manager is not None:
+            try:
+                guild_id = next(
+                    (
+                        gid for gid, text_id in getattr(adapter, "_voice_text_channels", {}).items()
+                        if str(text_id) == str(chat_id)
+                    ),
+                    None,
+                )
+                if guild_id is not None:
+                    asyncio.create_task(
+                        manager.close_session(
+                            self._voice_session_scope(Platform.DISCORD, guild_id),
+                            reason="voice_timeout_or_disconnect",
+                        )
+                    )
+            except Exception:
+                logger.debug("voice session timeout cleanup skipped", exc_info=True)
 
     def _is_duplicate_voice_transcript(self, guild_id: int, user_id: int, transcript: str) -> bool:
         """Suppress repeated STT outputs for the same recent utterance.
@@ -9887,7 +10029,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     and hasattr(adapter, "play_in_voice_channel")
                     and hasattr(adapter, "is_in_voice_channel")
                     and adapter.is_in_voice_channel(guild_id)):
-                await adapter.play_in_voice_channel(guild_id, actual_path)
+                play_voice = getattr(adapter, "play_in_voice_channel", None)
+                manager = getattr(self, "_voice_session_manager", None)
+                live_session = manager.get(self._voice_session_scope(event.source.platform, guild_id)) if manager else None
+                if live_session is not None:
+                    await live_session.begin_assistant_speech()
+                try:
+                    if play_voice is not None:
+                        await play_voice(guild_id, actual_path)
+                finally:
+                    if live_session is not None and live_session.state != VoiceSessionState.ENDED:
+                        live_session.set_state(VoiceSessionState.LISTENING)
             elif adapter and hasattr(adapter, "send_voice"):
                 reply_anchor = self._reply_anchor_for_event(event)
                 thread_meta = self._thread_metadata_for_source(event.source, reply_anchor)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1767,7 +1767,7 @@ class GatewaySlashCommandsMixin:
         return t("gateway.set_home.success", name=chat_name, chat_id=chat_id)
 
     async def _handle_voice_command(self, event: MessageEvent) -> str:
-        """Handle /voice [on|off|tts|channel|leave|status] command."""
+        """Handle /voice [on|off|tts|channel|join|live|leave|status] command."""
         args = event.get_command_args().strip().lower()
         chat_id = event.source.chat_id
         platform = event.source.platform
@@ -1795,6 +1795,8 @@ class GatewaySlashCommandsMixin:
             return t("gateway.voice.tts_enabled")
         elif args in {"channel", "join"}:
             return await self._handle_voice_channel_join(event)
+        elif args == "live":
+            return await self._handle_voice_channel_join(event, live=True)
         elif args == "leave":
             return await self._handle_voice_channel_leave(event)
         elif args == "status":

--- a/gateway/voice_sessions.py
+++ b/gateway/voice_sessions.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+"""Realtime voice session lifecycle primitives for gateway adapters.
+
+This module is intentionally platform-neutral: Discord owns joining voice
+channels and decoding RTP, while this backend owns session state, provider
+selection, cancellation/interruption, and guardrails.  The first production
+consumer is the Discord gateway `/voice live` flow.
+"""
+
+import asyncio
+import os
+import time
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Awaitable, Callable, Dict, Optional, Protocol
+
+
+class VoiceSessionError(RuntimeError):
+    """Base class for user-visible voice session failures."""
+
+
+class VoiceSessionConflict(VoiceSessionError):
+    """A live session already exists for this profile/platform scope."""
+
+
+class VoiceSessionUnauthorized(VoiceSessionError):
+    """The caller is not authorized to create/use a voice session."""
+
+
+class VoiceSessionLimitExceeded(VoiceSessionError):
+    """A safe default budget or rate limit was exceeded."""
+
+
+class VoiceSessionState(str, Enum):
+    JOINING = "joining"
+    LISTENING = "listening"
+    USER_SPEAKING = "user_speaking"
+    THINKING = "thinking"
+    SPEAKING = "speaking"
+    INTERRUPTED = "interrupted"
+    TOOL_WAIT = "tool_wait"
+    DEGRADED = "degraded"
+    ENDING = "ending"
+    ENDED = "ended"
+
+
+@dataclass(frozen=True)
+class VoiceSessionConfig:
+    """Safe defaults for one live voice session."""
+
+    provider: str = "pipeline"
+    mode: str = "open_mic"
+    transcript_mode: str = "visible_summary"
+    max_duration_seconds: int = 600
+    max_input_bytes_per_minute: int = 48_000 * 2 * 2 * 60
+    max_events_per_minute: int = 600
+    allow_raw_audio_persistence: bool = False
+
+    @classmethod
+    def from_dict(cls, data: Optional[dict[str, Any]] = None) -> "VoiceSessionConfig":
+        data = dict(data or {})
+        provider = str(data.get("provider") or "pipeline").strip().lower()
+        mode = str(data.get("mode") or "open_mic").strip().lower()
+        transcript_mode = str(data.get("transcript_mode") or "visible_summary").strip().lower()
+        return cls(
+            provider=provider,
+            mode=mode,
+            transcript_mode=transcript_mode,
+            max_duration_seconds=max(30, int(data.get("max_duration_seconds", 600))),
+            max_input_bytes_per_minute=max(16_000, int(data.get("max_input_bytes_per_minute", 48_000 * 2 * 2 * 60))),
+            max_events_per_minute=max(30, int(data.get("max_events_per_minute", 600))),
+            allow_raw_audio_persistence=bool(data.get("allow_raw_audio_persistence", False)),
+        )
+
+
+@dataclass(frozen=True)
+class VoiceSessionRequest:
+    platform: str
+    guild_id: str
+    channel_id: str
+    text_channel_id: str
+    user_id: str
+    user_name: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def scope_key(self) -> str:
+        # One live session per platform/guild/profile scope for MVP.
+        return f"{self.platform}:{self.guild_id}"
+
+
+@dataclass
+class VoiceSessionSnapshot:
+    session_id: str
+    scope_key: str
+    state: VoiceSessionState
+    provider: str
+    mode: str
+    transcript_mode: str
+    started_at: float
+    last_activity_at: float
+    input_bytes: int = 0
+    events_seen: int = 0
+    interrupted_count: int = 0
+    close_reason: Optional[str] = None
+
+
+class RealtimeVoiceProvider(Protocol):
+    name: str
+
+    async def connect(self, session: "VoiceSession") -> None: ...
+    async def send_audio(self, session: "VoiceSession", user_id: str, pcm_48k_stereo: bytes, *, timestamp: float) -> None: ...
+    async def cancel_response(self, session: "VoiceSession", reason: str) -> None: ...
+    async def close(self, session: "VoiceSession") -> None: ...
+
+
+class PipelineVoiceProvider:
+    """Fallback provider that keeps the existing STT -> text agent -> TTS path.
+
+    The Discord adapter still emits completed utterances to the normal Hermes
+    message pipeline.  This provider receives realtime frames for lifecycle,
+    budgeting, and barge-in detection, but deliberately does not persist raw
+    audio or call batch STT itself.
+    """
+
+    name = "pipeline"
+
+    async def connect(self, session: "VoiceSession") -> None:
+        session.set_state(VoiceSessionState.LISTENING)
+
+    async def send_audio(self, session: "VoiceSession", user_id: str, pcm_48k_stereo: bytes, *, timestamp: float) -> None:
+        session.mark_user_speaking(user_id=user_id, timestamp=timestamp)
+
+    async def cancel_response(self, session: "VoiceSession", reason: str) -> None:
+        return None
+
+    async def close(self, session: "VoiceSession") -> None:
+        return None
+
+
+class OpenAIRealtimeVoiceProvider(PipelineVoiceProvider):
+    """Readiness gate for the selected realtime model path.
+
+    Full websocket event translation lands behind this interface.  Until then,
+    selecting provider="openai_realtime" verifies credentials and then runs in
+    degraded pipeline mode rather than silently pretending raw audio is being
+    streamed to OpenAI.
+    """
+
+    name = "openai_realtime"
+
+    async def connect(self, session: "VoiceSession") -> None:
+        if not (os.getenv("OPENAI_API_KEY") or os.getenv("VOICE_TOOLS_OPENAI_KEY")):
+            session.set_state(VoiceSessionState.DEGRADED)
+            session.degraded_reason = "OpenAI realtime credentials missing; using pipeline voice fallback"
+        else:
+            session.set_state(VoiceSessionState.DEGRADED)
+            session.degraded_reason = "OpenAI realtime websocket adapter not enabled yet; using pipeline voice fallback"
+
+
+ProviderFactory = Callable[[VoiceSessionConfig], RealtimeVoiceProvider]
+AuthChecker = Callable[[VoiceSessionRequest], bool | Awaitable[bool]]
+PlaybackStopper = Callable[[str, Optional[str]], Awaitable[None]]
+
+
+def default_provider_factory(config: VoiceSessionConfig) -> RealtimeVoiceProvider:
+    if config.provider in {"openai", "openai_realtime", "realtime"}:
+        return OpenAIRealtimeVoiceProvider()
+    return PipelineVoiceProvider()
+
+
+class VoiceSession:
+    def __init__(
+        self,
+        request: VoiceSessionRequest,
+        config: VoiceSessionConfig,
+        provider: RealtimeVoiceProvider,
+        *,
+        playback_stopper: Optional[PlaybackStopper] = None,
+        now: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.request = request
+        self.config = config
+        self.provider = provider
+        self.session_id = f"vs_{uuid.uuid4().hex[:12]}"
+        self.scope_key = request.scope_key
+        self._now = now
+        self.started_at = now()
+        self.last_activity_at = self.started_at
+        self.state = VoiceSessionState.JOINING
+        self.input_bytes = 0
+        self.events_seen = 0
+        self.interrupted_count = 0
+        self.close_reason: Optional[str] = None
+        self.degraded_reason: Optional[str] = None
+        self._window_started_at = self.started_at
+        self._window_input_bytes = 0
+        self._window_events = 0
+        self._playback_stopper = playback_stopper
+        self._closed = False
+        self._lock = asyncio.Lock()
+
+    def set_state(self, state: VoiceSessionState) -> None:
+        self.state = state
+        self.last_activity_at = self._now()
+
+    def snapshot(self) -> VoiceSessionSnapshot:
+        return VoiceSessionSnapshot(
+            session_id=self.session_id,
+            scope_key=self.scope_key,
+            state=self.state,
+            provider=self.provider.name,
+            mode=self.config.mode,
+            transcript_mode=self.config.transcript_mode,
+            started_at=self.started_at,
+            last_activity_at=self.last_activity_at,
+            input_bytes=self.input_bytes,
+            events_seen=self.events_seen,
+            interrupted_count=self.interrupted_count,
+            close_reason=self.close_reason,
+        )
+
+    async def start(self) -> None:
+        await self.provider.connect(self)
+        if self.state == VoiceSessionState.JOINING:
+            self.set_state(VoiceSessionState.LISTENING)
+
+    def _check_limits(self, byte_count: int, now: float) -> None:
+        if now - self.started_at > self.config.max_duration_seconds:
+            raise VoiceSessionLimitExceeded("voice session duration limit exceeded")
+        if now - self._window_started_at >= 60:
+            self._window_started_at = now
+            self._window_input_bytes = 0
+            self._window_events = 0
+        if self._window_events + 1 > self.config.max_events_per_minute:
+            raise VoiceSessionLimitExceeded("voice session event rate limit exceeded")
+        if self._window_input_bytes + byte_count > self.config.max_input_bytes_per_minute:
+            raise VoiceSessionLimitExceeded("voice session audio budget exceeded")
+
+    def mark_user_speaking(self, *, user_id: str, timestamp: Optional[float] = None) -> None:
+        if self.state == VoiceSessionState.SPEAKING:
+            # The async cancel is done in receive_audio; this synchronous state
+            # update keeps provider callbacks simple.
+            self.state = VoiceSessionState.INTERRUPTED
+        else:
+            self.state = VoiceSessionState.USER_SPEAKING
+        self.last_activity_at = timestamp or self._now()
+
+    async def receive_audio(self, user_id: str, pcm_48k_stereo: bytes, *, timestamp: Optional[float] = None) -> None:
+        if self._closed:
+            return
+        now = timestamp or self._now()
+        async with self._lock:
+            self._check_limits(len(pcm_48k_stereo), now)
+            self.input_bytes += len(pcm_48k_stereo)
+            self.events_seen += 1
+            self._window_input_bytes += len(pcm_48k_stereo)
+            self._window_events += 1
+            was_speaking = self.state == VoiceSessionState.SPEAKING
+            if was_speaking:
+                await self.interrupt(reason="user_barge_in")
+            await self.provider.send_audio(self, user_id, pcm_48k_stereo, timestamp=now)
+
+    async def begin_assistant_speech(self) -> None:
+        if not self._closed:
+            self.set_state(VoiceSessionState.SPEAKING)
+
+    async def interrupt(self, *, reason: str = "interrupted") -> None:
+        if self._closed:
+            return
+        self.interrupted_count += 1
+        self.set_state(VoiceSessionState.INTERRUPTED)
+        if self._playback_stopper is not None:
+            await self._playback_stopper(self.request.guild_id, None)
+        await self.provider.cancel_response(self, reason)
+
+    async def close(self, *, reason: str = "closed") -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self.close_reason = reason
+        self.set_state(VoiceSessionState.ENDING)
+        try:
+            if self._playback_stopper is not None:
+                await self._playback_stopper(self.request.guild_id, None)
+        finally:
+            await self.provider.close(self)
+            self.set_state(VoiceSessionState.ENDED)
+
+
+class VoiceSessionManager:
+    def __init__(
+        self,
+        *,
+        provider_factory: ProviderFactory = default_provider_factory,
+        auth_checker: Optional[AuthChecker] = None,
+        playback_stopper: Optional[PlaybackStopper] = None,
+    ) -> None:
+        self._provider_factory = provider_factory
+        self._auth_checker = auth_checker
+        self._playback_stopper = playback_stopper
+        self._sessions: Dict[str, VoiceSession] = {}
+        self._lock = asyncio.Lock()
+
+    @property
+    def sessions(self) -> Dict[str, VoiceSession]:
+        return dict(self._sessions)
+
+    async def _authorized(self, request: VoiceSessionRequest) -> bool:
+        if self._auth_checker is None:
+            return True
+        allowed = self._auth_checker(request)
+        if asyncio.iscoroutine(allowed):
+            allowed = await allowed
+        return bool(allowed)
+
+    async def create_session(self, request: VoiceSessionRequest, config: Optional[VoiceSessionConfig] = None) -> VoiceSession:
+        if not await self._authorized(request):
+            raise VoiceSessionUnauthorized("not authorized to start a voice session")
+        config = config or VoiceSessionConfig()
+        async with self._lock:
+            existing = self._sessions.get(request.scope_key)
+            if existing and existing.state is not VoiceSessionState.ENDED:
+                raise VoiceSessionConflict(f"voice session already active for {request.scope_key}")
+            provider = self._provider_factory(config)
+            session = VoiceSession(
+                request,
+                config,
+                provider,
+                playback_stopper=self._playback_stopper,
+            )
+            self._sessions[request.scope_key] = session
+        try:
+            await session.start()
+        except Exception:
+            async with self._lock:
+                self._sessions.pop(request.scope_key, None)
+            raise
+        return session
+
+    def get(self, scope_key: str) -> Optional[VoiceSession]:
+        return self._sessions.get(scope_key)
+
+    async def receive_audio(self, scope_key: str, user_id: str, pcm_48k_stereo: bytes, *, timestamp: Optional[float] = None) -> bool:
+        session = self._sessions.get(scope_key)
+        if not session:
+            return False
+        await session.receive_audio(user_id, pcm_48k_stereo, timestamp=timestamp)
+        return True
+
+    async def close_session(self, scope_key: str, *, reason: str = "closed") -> Optional[VoiceSessionSnapshot]:
+        session = self._sessions.get(scope_key)
+        if not session:
+            return None
+        await session.close(reason=reason)
+        async with self._lock:
+            self._sessions.pop(scope_key, None)
+        return session.snapshot()

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -69,6 +69,20 @@ from gateway.platforms.base import (
 from tools.url_safety import is_safe_url
 
 
+def _log_async_task_exception(task: asyncio.Task) -> None:
+    with suppress(asyncio.CancelledError, Exception):
+        exc = task.exception()
+        if exc:
+            logger.debug("live voice frame callback failed: %s", exc)
+
+
+def _log_future_exception(future: Any) -> None:
+    with suppress(Exception):
+        exc = future.exception()
+        if exc:
+            logger.debug("live voice frame callback failed: %s", exc)
+
+
 async def _wait_for_ready_or_bot_exit(
     ready_event: asyncio.Event,
     bot_task: asyncio.Task,
@@ -222,9 +236,13 @@ class VoiceReceiver:
     SAMPLE_RATE = 48000        # Discord native rate
     CHANNELS = 2               # Discord sends stereo
 
-    def __init__(self, voice_client, allowed_user_ids: set = None):
+    def __init__(self, voice_client, allowed_user_ids: Optional[set] = None,
+                 frame_callback: Optional[Callable] = None,
+                 loop: Optional[asyncio.AbstractEventLoop] = None):
         self._vc = voice_client
         self._allowed_user_ids = allowed_user_ids or set()
+        self._frame_callback = frame_callback
+        self._loop = loop
         self._running = False
 
         # Decryption
@@ -284,6 +302,38 @@ class VoiceReceiver:
 
     def resume(self):
         self._paused = False
+
+    def _emit_pcm_frame(self, ssrc: int, pcm: bytes) -> None:
+        """Forward decoded PCM frames to the live voice-session backend."""
+        callback = self._frame_callback
+        loop = self._loop
+        if callback is None or loop is None or loop.is_closed():
+            return
+        with self._lock:
+            user_id = self._ssrc_to_user.get(ssrc, 0)
+        if not user_id:
+            user_id = self._infer_user_for_ssrc(ssrc)
+        if not user_id:
+            return
+        try:
+            coro = callback(
+                int(getattr(self._vc.guild, "id", 0) or self._vc.channel.guild.id),
+                int(user_id),
+                pcm,
+                time.monotonic(),
+            )
+            try:
+                running_loop = asyncio.get_running_loop()
+            except RuntimeError:
+                running_loop = None
+            if running_loop is loop:
+                task = loop.create_task(coro)
+                task.add_done_callback(_log_async_task_exception)
+            else:
+                fut = asyncio.run_coroutine_threadsafe(coro, loop)
+                fut.add_done_callback(_log_future_exception)
+        except Exception:
+            logger.debug("failed to schedule live voice frame", exc_info=True)
 
     # ------------------------------------------------------------------
     # SSRC -> user_id mapping via SPEAKING opcode hook
@@ -457,6 +507,7 @@ class VoiceReceiver:
             if ssrc not in self._decoders:
                 self._decoders[ssrc] = discord.opus.Decoder()
             pcm = self._decoders[ssrc].decode(decrypted)
+            self._emit_pcm_frame(ssrc, pcm)
             with self._lock:
                 self._buffers[ssrc].extend(pcm)
                 self._last_packet_time[ssrc] = time.monotonic()
@@ -639,6 +690,7 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_receivers: Dict[int, VoiceReceiver] = {}  # guild_id -> VoiceReceiver
         self._voice_listen_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> listen loop
         self._voice_input_callback: Optional[Callable] = None  # set by run.py
+        self._voice_frame_callback: Optional[Callable] = None  # set by run.py for live sessions
         self._on_voice_disconnect: Optional[Callable] = None  # set by run.py
         # Resolves the current voice-reply mode ("off"|"voice_only"|"all") for a
         # linked text-channel id; set by run.py. Lets the inactivity timer leave
@@ -2248,7 +2300,12 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Start voice receiver (Phase 2: listen to users)
             try:
-                receiver = VoiceReceiver(vc, allowed_user_ids=self._allowed_user_ids)
+                receiver = VoiceReceiver(
+                    vc,
+                    allowed_user_ids=self._allowed_user_ids,
+                    frame_callback=self._voice_frame_callback,
+                    loop=asyncio.get_running_loop(),
+                )
                 receiver.start()
                 self._voice_receivers[guild_id] = receiver
                 self._voice_listen_tasks[guild_id] = asyncio.ensure_future(
@@ -2299,6 +2356,20 @@ class DiscordAdapter(BasePlatformAdapter):
 
     # Maximum seconds to wait for voice playback before giving up
     PLAYBACK_TIMEOUT = 120
+
+    async def stop_voice_playback(self, guild_id: int, stream_id: Optional[str] = None) -> None:
+        """Stop current Discord voice playback for interruption/cancel."""
+        mixer = getattr(self, "_voice_mixers", {}).get(guild_id) if getattr(self, "_voice_mixers", None) else None
+        if mixer is not None:
+            mixer.stop_speech()
+        vc = self._voice_clients.get(guild_id)
+        if vc and vc.is_connected():
+            try:
+                if vc.is_playing() and mixer is None:
+                    vc.stop()
+            except Exception:
+                pass
+        self._reset_voice_timeout(guild_id)
 
     async def play_in_voice_channel(self, guild_id: int, audio_path: str) -> bool:
         """Play an audio file in the connected voice channel.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "jeevesassistant00@gmail.com": "jeeves-assistant",
     "kenmege@yahoo.com": "Kenmege",
     "peterhao@Peters-MacBook-Air.local": "pinguarmy",
     "adalsteinnhelgason@Aalsteinns-MacBook-Pro-3.local": "AIalliAI",

--- a/tests/gateway/test_discord_live_voice_frames.py
+++ b/tests/gateway/test_discord_live_voice_frames.py
@@ -1,0 +1,69 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from plugins.platforms.discord.adapter import VoiceReceiver
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_voice_receiver_emits_decoded_frames_to_live_session_callback():
+    seen = []
+
+    async def on_frame(guild_id, user_id, pcm, timestamp):
+        seen.append((guild_id, user_id, pcm, timestamp))
+
+    vc = MagicMock()
+    vc.guild = SimpleNamespace(id=111)
+    vc.channel = SimpleNamespace(guild=SimpleNamespace(id=111), members=[])
+    vc.user = SimpleNamespace(id=999)
+    vc._connection.secret_key = [0] * 32
+    vc._connection.dave_session = None
+    vc._connection.ssrc = 999
+    vc._connection.add_socket_listener = MagicMock()
+    vc._connection.remove_socket_listener = MagicMock()
+    vc._connection.hook = None
+
+    receiver = VoiceReceiver(
+        vc,
+        allowed_user_ids={"444"},
+        frame_callback=on_frame,
+        loop=asyncio.get_running_loop(),
+    )
+    receiver.map_ssrc(123, 444)
+
+    receiver._emit_pcm_frame(123, b"\0" * 3840)
+    await asyncio.sleep(0)
+
+    assert len(seen) == 1
+    assert seen[0][0] == 111
+    assert seen[0][1] == 444
+    assert seen[0][2] == b"\0" * 3840
+    assert isinstance(seen[0][3], float)
+
+
+async def test_voice_receiver_skips_live_frame_when_ssrc_unknown():
+    seen = []
+
+    async def on_frame(guild_id, user_id, pcm, timestamp):
+        seen.append((guild_id, user_id, pcm, timestamp))
+
+    vc = MagicMock()
+    vc.guild = SimpleNamespace(id=111)
+    vc.channel = SimpleNamespace(guild=SimpleNamespace(id=111), members=[])
+    vc.user = SimpleNamespace(id=999)
+    vc._connection.secret_key = [0] * 32
+    vc._connection.dave_session = None
+    vc._connection.ssrc = 999
+    vc._connection.add_socket_listener = MagicMock()
+    vc._connection.remove_socket_listener = MagicMock()
+    vc._connection.hook = None
+
+    receiver = VoiceReceiver(vc, frame_callback=on_frame, loop=asyncio.get_running_loop())
+    receiver._emit_pcm_frame(123, b"\0" * 3840)
+    await asyncio.sleep(0)
+
+    assert seen == []

--- a/tests/gateway/test_voice_sessions.py
+++ b/tests/gateway/test_voice_sessions.py
@@ -1,0 +1,130 @@
+from typing import Any
+
+import pytest
+
+from gateway.voice_sessions import (
+    PipelineVoiceProvider,
+    VoiceSessionConfig,
+    VoiceSessionConflict,
+    VoiceSessionLimitExceeded,
+    VoiceSessionManager,
+    VoiceSessionRequest,
+    VoiceSessionState,
+    VoiceSessionUnauthorized,
+)
+
+
+pytestmark = pytest.mark.asyncio
+
+
+def _request(**overrides: Any):
+    data: dict[str, Any] = {
+        "platform": "discord",
+        "guild_id": "111",
+        "channel_id": "222",
+        "text_channel_id": "333",
+        "user_id": "444",
+        "user_name": "Rob",
+    }
+    data.update(overrides)
+    return VoiceSessionRequest(**data)
+
+
+async def test_create_session_starts_provider_and_prevents_conflict():
+    manager = VoiceSessionManager()
+
+    session = await manager.create_session(_request())
+
+    assert session.state == VoiceSessionState.LISTENING
+    assert session.config.mode == "open_mic"
+    with pytest.raises(VoiceSessionConflict):
+        await manager.create_session(_request(channel_id="999"))
+
+
+async def test_auth_checker_blocks_unauthorized_start():
+    manager = VoiceSessionManager(auth_checker=lambda request: request.user_id == "allowed")
+
+    with pytest.raises(VoiceSessionUnauthorized):
+        await manager.create_session(_request(user_id="blocked"))
+
+    session = await manager.create_session(_request(user_id="allowed"))
+    assert session.state == VoiceSessionState.LISTENING
+
+
+async def test_audio_budget_closes_failure_path_without_persisting_audio():
+    manager = VoiceSessionManager()
+    session = await manager.create_session(
+        _request(),
+        VoiceSessionConfig(max_input_bytes_per_minute=16_000),
+    )
+
+    with pytest.raises(VoiceSessionLimitExceeded, match="audio budget"):
+        await session.receive_audio("444", b"0" * 16_001)
+
+    # The over-budget chunk is rejected before it is counted or stored.
+    assert session.input_bytes == 0
+    assert not session.config.allow_raw_audio_persistence
+
+
+async def test_barge_in_stops_playback_and_cancels_provider_response():
+    stopped = []
+
+    class RecordingProvider(PipelineVoiceProvider):
+        name = "recording"
+
+        def __init__(self):
+            self.cancel_reasons = []
+
+        async def cancel_response(self, session, reason):
+            self.cancel_reasons.append(reason)
+
+    provider = RecordingProvider()
+
+    async def stop_playback(guild_id, stream_id):
+        stopped.append((guild_id, stream_id))
+
+    manager = VoiceSessionManager(
+        provider_factory=lambda config: provider,
+        playback_stopper=stop_playback,
+    )
+    session = await manager.create_session(_request())
+    await session.begin_assistant_speech()
+
+    await session.receive_audio("444", b"\0" * 3840, timestamp=session.last_activity_at + 0.1)
+
+    assert session.state == VoiceSessionState.USER_SPEAKING
+    assert session.interrupted_count == 1
+    assert stopped == [("111", None)]
+    assert provider.cancel_reasons == ["user_barge_in"]
+
+
+async def test_close_session_releases_resources_and_removes_manager_entry():
+    stopped = []
+
+    async def stop_playback(guild_id, stream_id):
+        stopped.append((guild_id, stream_id))
+
+    manager = VoiceSessionManager(playback_stopper=stop_playback)
+    session = await manager.create_session(_request())
+
+    snapshot = await manager.close_session(session.scope_key, reason="user_leave")
+
+    assert snapshot is not None
+    assert snapshot.state == VoiceSessionState.ENDED
+    assert snapshot.close_reason == "user_leave"
+    assert manager.get(session.scope_key) is None
+    assert stopped == [("111", None)]
+
+
+async def test_event_rate_limit_rejects_excessive_stream_events():
+    manager = VoiceSessionManager()
+    session = await manager.create_session(
+        _request(),
+        VoiceSessionConfig(max_events_per_minute=30),
+    )
+
+    for _ in range(30):
+        await session.receive_audio("444", b"\0")
+
+    with pytest.raises(VoiceSessionLimitExceeded, match="event rate"):
+        await session.receive_audio("444", b"\0")

--- a/website/docs/developer-guide/gateway-internals.md
+++ b/website/docs/developer-guide/gateway-internals.md
@@ -15,6 +15,7 @@ The messaging gateway is the long-running process that connects Hermes to 20+ ex
 | `gateway/run.py` | `GatewayRunner` — main loop, slash commands, message dispatch (large file; check git for current LOC) |
 | `gateway/session.py` | `SessionStore` — conversation persistence and session key construction |
 | `gateway/delivery.py` | Outbound message delivery to target platforms/channels |
+| `gateway/voice_sessions.py` | Platform-neutral live voice session lifecycle, provider selection, interruption, and guardrails |
 | `gateway/pairing.py` | DM pairing flow for user authorization |
 | `gateway/channel_directory.py` | Maps chat IDs to human-readable names for cron delivery |
 | `gateway/hooks.py` | Hook discovery, loading, and lifecycle event dispatch |
@@ -175,6 +176,24 @@ Adapters implement a common interface:
 - `connect()` / `disconnect()` — lifecycle management
 - `send_message()` — outbound message delivery
 - `on_message()` — inbound message normalization → `MessageEvent`
+
+## Live Voice Sessions
+
+Discord `/voice live` is wired as a gateway-managed live voice session rather than a separate agent loop. The Discord adapter still owns joining/leaving voice channels, decrypting RTP, decoding Discord-native 48 kHz stereo PCM frames, and playing TTS audio. `GatewayRunner` owns the `VoiceSessionManager`, authorization, config loading from `voice.live`, and cleanup on `/voice leave`, timeout, disconnect, or guardrail failure.
+
+The MVP provider stack is intentionally conservative:
+
+- `pipeline` is the default provider and reuses the existing STT → Hermes text agent → TTS path.
+- `openai_realtime` is a readiness gate: it checks for `OPENAI_API_KEY` or `VOICE_TOOLS_OPENAI_KEY`, marks the session degraded, and falls back to `pipeline` until the websocket event adapter is implemented.
+- Raw audio is not persisted by default; decoded frames are used for state, barge-in, and budget accounting.
+
+Important contracts for future realtime providers:
+
+1. Keep provider-specific websocket/event code behind `RealtimeVoiceProvider`; do not put provider protocol details in the Discord adapter.
+2. Preserve `VoiceSessionManager` as the single owner of session conflict checks, auth checks, duration/input/event guardrails, and session snapshots.
+3. Barge-in must call the runner playback stopper before provider cancellation so Discord audio stops even if a provider call hangs or fails.
+4. Network/provider failures should close or degrade the live session with a user-visible reason rather than leaving the bot connected with a dead audio path.
+5. Do not persist raw audio unless `voice.live.allow_raw_audio_persistence` is explicitly enabled by config and documented for the provider.
 
 ### Token Locks
 

--- a/website/docs/guides/use-voice-mode-with-hermes.md
+++ b/website/docs/guides/use-voice-mode-with-hermes.md
@@ -369,9 +369,12 @@ In a Discord text channel where the bot is present:
 
 ```text
 /voice join
+/voice live
 /voice leave
 /voice status
 ```
+
+Use `/voice join` for the classic Discord VC path. Use `/voice live` for the MVP realtime voice-chat session: Hermes still runs the normal STT → agent → TTS pipeline, but the gateway also tracks live-session state, stops current playback when you barge in, and enforces duration/audio/event budgets.
 
 ### What happens when joined
 
@@ -380,12 +383,33 @@ In a Discord text channel where the bot is present:
 - transcripts are posted in the associated text channel
 - Hermes responds in text and audio
 - the text channel is the one where `/voice join` was issued
+- in `/voice live`, `/voice leave` also closes the live session and releases its server-scoped session slot
 
 ### Best practices for Discord VC use
 
 - keep `DISCORD_ALLOWED_USERS` tight
 - use a dedicated bot/testing channel at first
 - verify STT and TTS work in ordinary text-chat voice mode before trying VC mode
+- start with `voice.live.provider: "pipeline"`; `openai_realtime` intentionally degrades to the pipeline provider until the websocket adapter is enabled
+- leave the default `voice.live.*` limits in place unless logs show a legitimate long session is hitting the MVP guardrails
+
+### Live voice session config
+
+Add only the values you want to change; these are the MVP defaults:
+
+```yaml
+voice:
+  live:
+    provider: "pipeline"
+    mode: "open_mic"
+    transcript_mode: "visible_summary"
+    max_duration_seconds: 600
+    max_input_bytes_per_minute: 11520000
+    max_events_per_minute: 600
+    allow_raw_audio_persistence: false
+```
+
+Required secrets are the same as the regular gateway voice path: `DISCORD_BOT_TOKEN`, an authorization path for your user (`DISCORD_ALLOWED_USERS`, pairing, or allow-all in trusted test environments), and whatever STT/TTS provider credentials you choose. Local STT plus Edge TTS can run with no speech API keys; OpenAI realtime testing needs `OPENAI_API_KEY` or `VOICE_TOOLS_OPENAI_KEY` but still runs degraded in the MVP.
 
 ## Voice quality recommendations
 
@@ -424,6 +448,10 @@ Check:
 - TTS provider config
 - API key / quota for ElevenLabs or OpenAI
 - `ffmpeg` install for Edge conversion paths
+
+### "`/voice live` closes by itself"
+
+Check `~/.hermes/logs/gateway.log`. The MVP closes live sessions when duration, decoded-audio bytes, or audio-frame event rates exceed `voice.live.*` limits. Treat that as a safety signal first; only raise limits after confirming the bot is not hearing itself or receiving a runaway stream.
 
 ### "Whisper outputs garbage"
 

--- a/website/docs/user-guide/features/voice-mode.md
+++ b/website/docs/user-guide/features/voice-mode.md
@@ -33,6 +33,7 @@ A paid [Nous Portal](/user-guide/features/tool-gateway) subscription supplies th
 | **Interactive Voice** | CLI | Press Ctrl+B to record, agent auto-detects silence and responds |
 | **Auto Voice Reply** | Telegram, Discord | Agent sends spoken audio alongside text responses |
 | **Voice Channel** | Discord | Bot joins VC, listens to users speaking, speaks replies back |
+| **Live Voice Session** | Discord | Real-time VC session lifecycle with interruption, guardrails, and provider fallback |
 
 ## Requirements
 
@@ -338,6 +339,7 @@ Use these in the Discord text channel where the bot is present:
 ```
 /voice join      Bot joins your current voice channel
 /voice channel   Alias for /voice join
+/voice live      Bot joins and starts a live, interruptible voice session
 /voice leave     Bot disconnects from voice channel
 /voice status    Show voice mode and connected channel
 ```
@@ -368,6 +370,32 @@ When the bot is in a voice channel:
 
 The bot automatically pauses its audio listener while playing TTS replies, preventing it from hearing and re-processing its own output.
 
+### Live Voice Sessions (MVP)
+
+`/voice live` starts the realtime voice-chat MVP on top of the Discord voice-channel flow. The bot joins the voice channel you are currently in, creates one live session for the Discord server, listens to Discord PCM frames, and keeps the normal Hermes STT → text agent → TTS pipeline active while adding live-session state, interruption, and safety budgets.
+
+Use it when you want a more conversational VC loop than `/voice join`:
+
+```text
+/voice live
+```
+
+Expected behavior:
+
+1. The bot joins your current voice channel and replies with a session id.
+2. Your speech is transcribed and posted in the text channel where you ran `/voice live`.
+3. Hermes responds in text and speaks the answer in the VC.
+4. If you speak while Hermes is speaking, the current playback is stopped and the session records an interruption.
+5. `/voice leave` closes the live session and disconnects the bot.
+
+Live-session guardrails are intentionally conservative for the MVP:
+
+- one live session per Discord server/profile scope
+- only authorized users can start or use the session (`DISCORD_ALLOWED_USERS`, pairing, or the normal gateway allow rules)
+- raw audio is not persisted by default
+- excessive duration, input bytes, or frame/event rates close the session automatically
+- `openai_realtime` is a readiness gate today: it checks credentials, then degrades to the pipeline provider until the websocket event adapter is enabled
+
 ### Access Control
 
 Only users listed in `DISCORD_ALLOWED_USERS` can interact via voice. Other users' audio is silently ignored.
@@ -392,6 +420,14 @@ voice:
   beep_enabled: true               # Play record start/stop beeps
   silence_threshold: 200           # RMS level (0-32767) below which counts as silence
   silence_duration: 3.0            # Seconds of silence before auto-stop
+  live:
+    provider: "pipeline"           # "pipeline" (default) | "openai_realtime" (degraded MVP gate)
+    mode: "open_mic"               # MVP mode; push-to-talk is not implemented yet
+    transcript_mode: "visible_summary"
+    max_duration_seconds: 600       # Hard cap for one live Discord voice session
+    max_input_bytes_per_minute: 11520000  # 48kHz stereo 16-bit PCM for one minute
+    max_events_per_minute: 600      # Rate-limit decoded Discord audio frame events
+    allow_raw_audio_persistence: false
 
 # Speech-to-Text
 stt:
@@ -514,6 +550,28 @@ The bot requires an @mention by default in server channels. Make sure you:
 - TTS provider may be failing — check API key and quota
 - Edge TTS (free, no key) is the default fallback
 - Check logs for TTS errors
+
+### `/voice live` says the session is degraded
+
+This is expected if `voice.live.provider` is `openai_realtime` in the MVP. Hermes verifies that `OPENAI_API_KEY` or `VOICE_TOOLS_OPENAI_KEY` is available, then falls back to the normal STT → agent → TTS pipeline until the OpenAI realtime websocket adapter is enabled.
+
+Use the default provider unless you are testing the realtime adapter seam:
+
+```yaml
+voice:
+  live:
+    provider: "pipeline"
+```
+
+### Live session closes unexpectedly
+
+Check the gateway log for a guardrail reason:
+
+```bash
+tail -f ~/.hermes/logs/gateway.log
+```
+
+Common causes are the session duration cap, excessive decoded audio bytes, or too many audio frame events per minute. Tune the `voice.live.*` limits in `config.yaml` only after confirming the bot is not stuck in an audio loop.
 
 ### Whisper returns garbage text
 


### PR DESCRIPTION
## Summary
- Adds a platform-neutral `gateway.voice_sessions` backend for live voice session lifecycle/state, provider selection, auth checks, cancellation/interruption, and safe duration/rate/audio budgets.
- Wires Discord `/voice live` into that manager, streams decoded Discord PCM frames into the live session backend, and stops current voice playback on barge-in/cancel.
- Keeps the MVP provider path safe: `pipeline` reuses the existing STT → Hermes text agent → TTS flow; `openai_realtime` is gated and degrades to pipeline mode unless/until the websocket adapter is enabled.
- Documents `/voice live` setup, required secrets/config, troubleshooting, known MVP limitations, and developer contracts for future realtime providers.

## Setup notes
- Start live Discord voice with `/voice live`; existing `/voice channel` and `/voice join` behavior is unchanged.
- Optional config in `config.yaml` under `voice.live`:
  - `provider`: `pipeline` (default) or `openai_realtime`
  - `mode`: default `open_mic`
  - `transcript_mode`: default `visible_summary`
  - `max_duration_seconds`: default `600`
  - `max_input_bytes_per_minute`: default one minute of Discord-native 48kHz stereo PCM
  - `max_events_per_minute`: default `600`
  - `allow_raw_audio_persistence`: default `false`
- `openai_realtime` currently requires `OPENAI_API_KEY` or `VOICE_TOOLS_OPENAI_KEY`, but intentionally runs degraded through the pipeline path until the websocket event adapter is added.

## Test plan
- `python -m py_compile gateway/voice_sessions.py gateway/run.py plugins/platforms/discord/adapter.py gateway/slash_commands.py`
- `python -m pytest tests/gateway/test_voice_sessions.py tests/gateway/test_discord_live_voice_frames.py -q -o 'addopts='`
- `python -m pytest tests/gateway/test_voice_command.py tests/gateway/test_discord_voice_mixer.py tests/gateway/test_voice_sessions.py tests/gateway/test_discord_live_voice_frames.py -q -o 'addopts='`
- `npm --prefix website run build` (passes; existing unrelated broken-link/anchor warnings remain)
