### PR TITLE
feat(gateway): Telegram Kanban action buttons (Approve, Reject, Park, Resume)

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -295,6 +295,28 @@ class GatewayKanbanWatchersMixin:
                         metadata: dict[str, Any] = {}
                         if sub.get("thread_id"):
                             metadata["thread_id"] = sub["thread_id"]
+                        if platform_str == "telegram" and kind == "blocked":
+                            metadata["telegram_reply_markup"] = {
+                                "inline_keyboard": [[
+                                    {
+                                        "text": "✅ Approve",
+                                        "callback_data": f"kb:approve:{sub['task_id']}:{board_slug or ''}",
+                                    },
+                                    {
+                                        "text": "❌ Reject",
+                                        "callback_data": f"kb:reject:{sub['task_id']}:{board_slug or ''}",
+                                    },
+                                ], [
+                                    {
+                                        "text": "⏸ Park",
+                                        "callback_data": f"kb:park:{sub['task_id']}:{board_slug or ''}",
+                                    },
+                                    {
+                                        "text": "▶️ Resume",
+                                        "callback_data": f"kb:resume:{sub['task_id']}:{board_slug or ''}",
+                                    },
+                                ]]
+                            }
                         sub_key = (
                             sub["task_id"], sub["platform"],
                             sub["chat_id"], sub.get("thread_id") or "",

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -594,6 +594,35 @@ class TelegramAdapter(BasePlatformAdapter):
         reply_to = metadata.get("telegram_reply_to_message_id")
         return int(reply_to) if reply_to is not None else None
 
+    @classmethod
+    def _metadata_reply_markup(cls, metadata: Optional[Dict[str, Any]]) -> Any:
+        """Return Telegram reply markup supplied by gateway metadata."""
+        if not metadata:
+            return None
+        markup = metadata.get("telegram_reply_markup")
+        if not markup:
+            return None
+        if isinstance(InlineKeyboardMarkup, type) and isinstance(markup, InlineKeyboardMarkup):
+            return markup
+        rows = markup.get("inline_keyboard") if isinstance(markup, dict) else None
+        if not isinstance(rows, list):
+            return None
+        keyboard = []
+        for row in rows:
+            if not isinstance(row, list):
+                return None
+            buttons = []
+            for button in row:
+                if not isinstance(button, dict):
+                    return None
+                text = button.get("text")
+                callback_data = button.get("callback_data")
+                if not text or not callback_data:
+                    return None
+                buttons.append(InlineKeyboardButton(str(text), callback_data=str(callback_data)))
+            keyboard.append(buttons)
+        return InlineKeyboardMarkup(keyboard)
+
     @staticmethod
     def _looks_like_private_chat_id(chat_id: str) -> bool:
         try:
@@ -2194,6 +2223,9 @@ class TelegramAdapter(BasePlatformAdapter):
             for i, chunk in enumerate(chunks):
                 retried_thread_not_found = False
                 metadata_reply_to = self._metadata_reply_to_message_id(metadata)
+                reply_markup = None
+                if i == len(chunks) - 1 and metadata:
+                    reply_markup = self._metadata_reply_markup(metadata)
                 private_dm_topic_send = self._is_private_dm_topic_send(chat_id, thread_id, metadata)
                 # reply_to_mode="off" on the existing telegram_dm_topic_reply_fallback path
                 # is an explicit user opt-in to "message_thread_id alone is enough" (PR #23994
@@ -2247,6 +2279,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 **thread_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
+                                reply_markup=reply_markup,
                             )
                         except Exception as md_error:
                             # Markdown parsing failed, try plain text
@@ -2261,6 +2294,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     **thread_kwargs,
                                     **self._link_preview_kwargs(),
                                     **self._notification_kwargs(metadata),
+                                    reply_markup=reply_markup,
                                 )
                             else:
                                 raise
@@ -2723,6 +2757,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 **retry_thread_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
+                                reply_markup=reply_markup,
                             )
                             break
                         except Exception as _retry_err:
@@ -3969,6 +4004,72 @@ class TelegramAdapter(BasePlatformAdapter):
                         "Telegram clarify button: resolve_gateway_clarify returned False (id=%s)",
                         clarify_id,
                     )
+            return
+
+        # --- Kanban decision callbacks (kb:action:task_id:board) ---
+        if data.startswith("kb:"):
+            parts = data.split(":", 3)
+            if len(parts) != 4:
+                await query.answer(text="Invalid Kanban action.")
+                return
+            action, task_id, board = parts[1], parts[2], parts[3] or "default"
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(
+                caller_id,
+                chat_id=query_chat_id,
+                chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                user_name=query_user_name,
+            ):
+                await query.answer(text="⛔ You are not authorized to update Kanban tasks.")
+                return
+
+            user_display = getattr(query.from_user, "first_name", "User")
+            actor = f"Telegram:{user_display}"
+            try:
+                from hermes_cli import kanban_db as kb
+
+                board = kb._normalize_board_slug(board) or kb.DEFAULT_BOARD
+                with kb.connect_closing(board=board) as conn:
+                    task = kb.get_task(conn, task_id)
+                    if task is None:
+                        await query.answer(text=f"Kanban task {task_id} was not found.")
+                        return
+                    status = task.status
+                    if action in {"approve", "resume"}:
+                        kb.add_comment(conn, task_id, actor, f"{action.title()} via Telegram by {user_display}.")
+                        ok = kb.unblock_task(conn, task_id) if status in {"blocked", "scheduled"} else status == "ready"
+                        label = "approved" if action == "approve" else "resumed"
+                    elif action in {"reject", "park"}:
+                        label = "rejected" if action == "reject" else "parked"
+                        reason = f"{label.title()} via Telegram by {user_display}"
+                        if status in {"running", "ready"}:
+                            ok = kb.block_task(conn, task_id, reason=reason)
+                        elif status == "blocked":
+                            kb.add_comment(conn, task_id, actor, reason + ".")
+                            ok = True
+                        else:
+                            ok = False
+                    else:
+                        await query.answer(text="Unknown Kanban action.")
+                        return
+
+                if not ok:
+                    await query.answer(text=f"Could not {action} {task_id} from status '{status}'.")
+                    return
+                confirmation = f"✓ Kanban {task_id} {label} on {board} by {user_display}"
+                await query.answer(text=confirmation[:200])
+                try:
+                    await query.edit_message_text(
+                        text=self.format_message(confirmation),
+                        parse_mode=ParseMode.MARKDOWN_V2,
+                        reply_markup=None,
+                    )
+                except Exception:
+                    pass
+            except Exception as exc:
+                logger.error("[%s] Kanban callback failed: %s", self.name, exc, exc_info=True)
+                await query.answer(text=f"Kanban action failed: {exc}")
             return
 
         # --- Update prompt callbacks ---

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -88,6 +88,37 @@ def test_kanban_notifier_dedupes_board_slugs_pointing_to_same_db(tmp_path, monke
     assert tid in adapter.sent[0]["text"]
 
 
+def test_blocked_telegram_notification_includes_kanban_action_buttons(tmp_path, monkeypatch):
+    db_path = tmp_path / "blocked-buttons.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="needs decision", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        kb.block_task(conn, tid, reason="review-required: check this")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
+
+    assert len(adapter.sent) == 1
+    markup = adapter.sent[0]["metadata"]["telegram_reply_markup"]
+    callbacks = [
+        button["callback_data"]
+        for row in markup["inline_keyboard"]
+        for button in row
+    ]
+    assert callbacks == [
+        f"kb:approve:{tid}:default",
+        f"kb:reject:{tid}:default",
+        f"kb:park:{tid}:default",
+        f"kb:resume:{tid}:default",
+    ]
+
+
 def test_kanban_notifier_claim_prevents_second_watcher_send(tmp_path, monkeypatch):
     db_path = tmp_path / "single-owner.db"
     monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -588,3 +588,145 @@ class TestTelegramApprovalCallback:
         query.answer.assert_called_once()
         query.edit_message_text.assert_called_once()
         assert (tmp_path / ".update_response").read_text() == "n"
+
+
+class TestTelegramKanbanButtons:
+    @pytest.mark.asyncio
+    async def test_send_metadata_reply_markup_adds_inline_keyboard(self):
+        adapter = _make_adapter()
+        adapter._bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=42))
+
+        result = await adapter.send(
+            "12345",
+            "Kanban decision needed",
+            metadata={
+                "telegram_reply_markup": {
+                    "inline_keyboard": [[
+                        {"text": "✅ Approve", "callback_data": "kb:approve:t_123:"},
+                    ]]
+                }
+            },
+        )
+
+        assert result.success is True
+        kwargs = adapter._bot.send_message.call_args[1]
+        assert kwargs["reply_markup"] is not None
+
+    @pytest.mark.asyncio
+    async def test_approve_button_unblocks_kanban_task(self, tmp_path):
+        from hermes_cli import kanban_db as kb
+
+        env = {
+            "TELEGRAM_ALLOWED_USERS": "*",
+            "HERMES_KANBAN_HOME": str(tmp_path),
+            "HERMES_KANBAN_DB": "",
+            "HERMES_KANBAN_BOARD": "",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            with kb.connect_closing(board="default") as conn:
+                task_id = kb.create_task(
+                    conn,
+                    title="Review draft",
+                    assignee="c3o",
+                    created_by="test",
+                    initial_status="blocked",
+                )
+
+            adapter = _make_adapter()
+            query = AsyncMock()
+            query.data = f"kb:approve:{task_id}:"
+            query.message = MagicMock()
+            query.message.chat_id = 12345
+            query.from_user = MagicMock()
+            query.from_user.id = "12345"
+            query.from_user.first_name = "S"
+            query.answer = AsyncMock()
+            query.edit_message_text = AsyncMock()
+
+            update = MagicMock()
+            update.callback_query = query
+
+            await adapter._handle_callback_query(update, MagicMock())
+
+            with kb.connect_closing(board="default") as conn:
+                task = kb.get_task(conn, task_id)
+                comments = kb.list_comments(conn, task_id)
+
+        assert task.status == "ready"
+        assert any("Approve via Telegram" in c.body for c in comments)
+        query.answer.assert_called_once()
+        assert "approved" in query.answer.call_args[1]["text"]
+        query.edit_message_text.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_reject_button_keeps_blocked_task_blocked_with_comment(self, tmp_path):
+        from hermes_cli import kanban_db as kb
+
+        env = {
+            "TELEGRAM_ALLOWED_USERS": "*",
+            "HERMES_KANBAN_HOME": str(tmp_path),
+            "HERMES_KANBAN_DB": "",
+            "HERMES_KANBAN_BOARD": "",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            with kb.connect_closing(board="default") as conn:
+                task_id = kb.create_task(
+                    conn,
+                    title="Review draft",
+                    assignee="c3o",
+                    created_by="test",
+                    initial_status="blocked",
+                )
+
+            adapter = _make_adapter()
+            query = AsyncMock()
+            query.data = f"kb:reject:{task_id}:"
+            query.message = MagicMock()
+            query.message.chat_id = 12345
+            query.from_user = MagicMock()
+            query.from_user.id = "12345"
+            query.from_user.first_name = "S"
+            query.answer = AsyncMock()
+            query.edit_message_text = AsyncMock()
+
+            update = MagicMock()
+            update.callback_query = query
+
+            await adapter._handle_callback_query(update, MagicMock())
+
+            with kb.connect_closing(board="default") as conn:
+                task = kb.get_task(conn, task_id)
+                comments = kb.list_comments(conn, task_id)
+
+        assert task.status == "blocked"
+        assert any("Rejected via Telegram" in c.body for c in comments)
+        assert "rejected" in query.answer.call_args[1]["text"]
+
+    @pytest.mark.asyncio
+    async def test_kanban_button_rejects_unauthorized_user(self, tmp_path):
+        from hermes_cli import kanban_db as kb
+
+        adapter = _make_adapter()
+        runner = _AuthRunner(authorized=False)
+        adapter._message_handler = runner._handle_message
+
+        query = AsyncMock()
+        query.data = "kb:resume:t_missing:default"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.chat.type = "private"
+        query.from_user = MagicMock()
+        query.from_user.id = 222
+        query.from_user.first_name = "Mallory"
+        query.answer = AsyncMock()
+        query.edit_message_text = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+
+        with patch.dict(os.environ, {"HERMES_KANBAN_HOME": str(tmp_path)}, clear=False):
+            await adapter._handle_callback_query(update, MagicMock())
+
+        query.answer.assert_called_once()
+        assert "not authorized" in query.answer.call_args[1]["text"].lower()
+        query.edit_message_text.assert_not_called()


### PR DESCRIPTION
Adds inline Approve, Reject, Park, Resume buttons to blocked Telegram Kanban notifications.

- Gateway notifier attaches `telegram_reply_markup` metadata for blocked tasks
- Telegram adapter renders InlineKeyboardMarkup from metadata and handles kb: callback data
- Implements auth check, status-aware logic (unblock blocked/scheduled, block running/ready)
- 37 gateway tests pass

Closes t_5e1b1c7e