### PR TITLE
fix(agent): guard unsupported completion claims

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -900,10 +900,16 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 result_preview = _err_text[:200] if len(_err_text) > 200 else _err_text
                 logger.warning("Tool %s returned error (%.2fs): %s", function_name, tool_duration, result_preview)
 
-            # Track file-mutation outcome for the turn-end verifier.
+            # Track tool evidence and file-mutation outcome for turn-end verifiers.
             # `blocked` calls never actually ran — don't let a guardrail
             # block count as either a failure or a success.
             if not blocked:
+                try:
+                    agent._record_turn_tool_evidence(
+                        function_name, is_error=is_error,
+                    )
+                except Exception as _evidence_err:
+                    logging.debug("tool-evidence verifier record failed: %s", _evidence_err)
                 try:
                     agent._record_file_mutation_result(
                         function_name, function_args, function_result, is_error,
@@ -1607,11 +1613,17 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         else:
             logger.info("tool %s completed (%.2fs, %d chars)", function_name, tool_duration, _result_len)
 
-        # Track file-mutation outcome for the turn-end verifier.  See
+        # Track tool evidence and file-mutation outcome for turn-end verifiers.  See
         # the concurrent path for the rationale; both paths must feed
         # the same state so the footer reflects every tool call in the
         # turn, not just the parallel ones.
         if not _execution_blocked:
+            try:
+                agent._record_turn_tool_evidence(
+                    function_name, is_error=_is_error_result,
+                )
+            except Exception as _evidence_err:
+                logging.debug("tool-evidence verifier record failed: %s", _evidence_err)
             try:
                 agent._record_file_mutation_result(
                     function_name, function_args, function_result, _is_error_result,

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -567,11 +567,12 @@ def build_turn_context(
     except Exception as exc:
         logger.warning("pre_llm_call hook failed: %s", exc)
 
-    # Per-turn file-mutation verifier state.
+    # Per-turn verifier state.
     agent._turn_failed_file_mutations = {}
     agent._turn_file_mutation_paths = set()
     agent._verification_stop_nudges = 0
     agent._pre_verify_nudges = 0
+    agent._turn_tool_evidence = []
 
     # Record the execution thread so interrupt()/clear_interrupt() can scope
     # the tool-level interrupt signal to THIS agent's thread only.

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -27,6 +27,27 @@ import os
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 
 
+def _sync_trailing_assistant_message(messages, final_response) -> bool:
+    """Mirror a final-response rewrite into the current turn's assistant text."""
+    if not isinstance(final_response, str):
+        return False
+    for msg in reversed(messages or []):
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        if role == "user":
+            return False
+        if role != "assistant":
+            continue
+        if msg.get("tool_calls"):
+            continue
+        if msg.get("content") == final_response:
+            return False
+        msg["content"] = final_response
+        return True
+    return False
+
+
 def finalize_turn(
     agent,
     *,
@@ -311,6 +332,22 @@ def finalize_turn(
         except Exception as _ver_err:
             logger.debug("file-mutation verifier footer failed: %s", _ver_err)
 
+    # Unsupported completion-claim verifier footer.
+    # When a model only ran housekeeping/context tools (todo, skill_view,
+    # memory, session_search), strong claims such as "STATUS: DONE",
+    # "implemented", "deployed", or "tests passed" are not supported by
+    # the evidence from this turn. Append a conservative note to both the
+    # returned response and the trailing assistant transcript message.
+    if final_response and not interrupted:
+        try:
+            _unsupported_footer = agent._format_unsupported_completion_claim_footer(
+                final_response,
+            )
+            if _unsupported_footer:
+                final_response = final_response.rstrip() + "\n\n" + _unsupported_footer
+        except Exception as _claim_err:
+            logger.debug("unsupported completion-claim verifier failed: %s", _claim_err)
+
     # Turn-completion explainer.
     # When a turn ends abnormally after substantive work — empty content
     # after retries, a partial/truncated stream, a still-pending tool
@@ -391,6 +428,20 @@ def finalize_turn(
                     break  # First non-empty string wins
         except Exception as exc:
             logger.warning("transform_llm_output hook failed: %s", exc)
+
+    # Persist the exact text the caller will receive. Footer/explainer logic
+    # and transform_llm_output all run after the first durable write above;
+    # without this synchronization the transcript can disagree with the
+    # delivered response.
+    if final_response and not interrupted:
+        try:
+            if _sync_trailing_assistant_message(messages, final_response):
+                agent._persist_session(messages, conversation_history)
+        except Exception:
+            logger.warning(
+                "Failed to persist final transformed assistant response",
+                exc_info=True,
+            )
 
     # Plugin hook: post_llm_call
     # Fired once per turn after the tool-calling loop completes.

--- a/run_agent.py
+++ b/run_agent.py
@@ -2919,6 +2919,71 @@ class AIAgent:
             for path in targets:
                 state.pop(path, None)
 
+    _COMPLETION_CLAIM_HOUSEKEEPING_TOOLS = frozenset({
+        "todo",
+        "skill_view",
+        "memory",
+        "session_search",
+    })
+    _UNSUPPORTED_COMPLETION_CLAIM_RE = re.compile(
+        r"(?im)(?:"
+        r"^\s*STATUS\s*:\s*(?:DONE|COMPLETE|VERIFIED|DEPLOYED)\b"
+        r"|\b(?<!not )(?<!not yet )(?:implemented|patched|fixed|deployed)\b"
+        r"|\b(?<!not )(?<!not yet )(?:changed|modified)\s+(?:the\s+)?(?:file|files|code)\b"
+        r"|\b(?:tests?|checks?|verification)\s+(?:passed|complete|succeeded|green)\b"
+        r"|\b(?:verified|tested)\s+(?:the\s+)?"
+        r"(?:fix|change|code|implementation|deployment|build|application|feature)\b"
+        r"|\b(?:fix|change|code|implementation|deployment|build|application|feature)\s+"
+        r"(?:is|was|has been)\s+(?:verified|tested)\b"
+        r")"
+    )
+
+    def _record_turn_tool_evidence(
+        self,
+        tool_name: str,
+        *,
+        is_error: bool = False,
+    ) -> None:
+        """Record each unblocked tool execution for turn-end claim checks."""
+        ledger = getattr(self, "_turn_tool_evidence", None)
+        if ledger is None:
+            return
+        name = str(tool_name or "").strip()
+        if not name:
+            return
+        ledger.append({"tool": name, "is_error": bool(is_error)})
+
+    def _format_unsupported_completion_claim_footer(self, response_text: Any) -> str:
+        """Warn when strong completion claims have only housekeeping evidence."""
+        if not isinstance(response_text, str) or not response_text.strip():
+            return ""
+        if "not supported by this turn's tool evidence" in response_text:
+            return ""
+        if not self._UNSUPPORTED_COMPLETION_CLAIM_RE.search(response_text):
+            return ""
+
+        ledger = getattr(self, "_turn_tool_evidence", None) or []
+        names: list[str] = []
+        for entry in ledger:
+            if isinstance(entry, dict):
+                name = str(entry.get("tool") or "").strip()
+            else:
+                name = str(entry or "").strip()
+            if name:
+                names.append(name)
+        if not names:
+            return ""
+        if any(name not in self._COMPLETION_CLAIM_HOUSEKEEPING_TOOLS for name in names):
+            return ""
+
+        tools = ", ".join(dict.fromkeys(names))
+        return (
+            "Verifier note: This turn only used non-executing context tools "
+            f"({tools}), so any claim above that code was implemented, "
+            "deployed, verified, or tested is not supported by this turn's "
+            "tool evidence."
+        )
+
     def _file_mutation_verifier_enabled(self) -> bool:
         """Check whether the per-turn file-mutation verifier footer is on.
 

--- a/tests/run_agent/test_unsupported_completion_claim_verifier.py
+++ b/tests/run_agent/test_unsupported_completion_claim_verifier.py
@@ -1,0 +1,189 @@
+"""Regression tests for housekeeping-only completion-claim guardrails."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from types import SimpleNamespace
+
+from agent.turn_finalizer import finalize_turn
+from run_agent import AIAgent
+
+
+def _bare_agent(tool_names: list[str]) -> AIAgent:
+    agent = object.__new__(AIAgent)
+    agent._turn_tool_evidence = [
+        {"tool": name, "is_error": False} for name in tool_names
+    ]
+    return agent
+
+
+def test_housekeeping_only_done_claim_gets_footer():
+    agent = _bare_agent(["todo", "skill_view"])
+
+    footer = agent._format_unsupported_completion_claim_footer(
+        "STATUS: DONE\nImplemented and verified."
+    )
+
+    assert "todo, skill_view" in footer
+    assert "not supported by this turn's tool evidence" in footer
+
+
+def test_non_housekeeping_tool_evidence_suppresses_footer():
+    agent = _bare_agent(["todo", "terminal"])
+
+    footer = agent._format_unsupported_completion_claim_footer(
+        "STATUS: DONE\nImplemented and verified."
+    )
+
+    assert footer == ""
+
+
+def test_housekeeping_only_normal_reply_stays_quiet():
+    agent = _bare_agent(["memory", "session_search"])
+
+    footer = agent._format_unsupported_completion_claim_footer(
+        "I found the session notes you asked about."
+    )
+
+    assert footer == ""
+
+
+def test_read_context_verified_language_stays_quiet():
+    agent = _bare_agent(["session_search"])
+
+    footer = agent._format_unsupported_completion_claim_footer(
+        "I verified the prior session history and tested the search query wording."
+    )
+
+    assert footer == ""
+
+
+def test_housekeeping_only_negated_claim_stays_quiet():
+    agent = _bare_agent(["todo"])
+
+    footer = agent._format_unsupported_completion_claim_footer(
+        "This is not implemented and could not be verified from context."
+    )
+
+    assert footer == ""
+
+
+def _finalizer_agent(tool_names: list[str], persisted: list[list[dict]]) -> AIAgent:
+    agent = _bare_agent(tool_names)
+    agent.max_iterations = 5
+    agent.iteration_budget = SimpleNamespace(remaining=4, used=1, max_total=5)
+    agent.quiet_mode = True
+    agent.model = "test-model"
+    agent.provider = "test-provider"
+    agent.base_url = "http://test.invalid/v1"
+    agent.session_id = "session-1"
+    agent.context_compressor = SimpleNamespace(last_prompt_tokens=0)
+    agent._turn_failed_file_mutations = {}
+    agent._tool_guardrail_halt_decision = None
+    agent._response_was_previewed = False
+    agent._interrupt_message = None
+    agent._skill_nudge_interval = 0
+    agent._iters_since_skill = 0
+    agent.valid_tool_names = set()
+
+    for attr in (
+        "session_input_tokens",
+        "session_output_tokens",
+        "session_cache_read_tokens",
+        "session_cache_write_tokens",
+        "session_reasoning_tokens",
+        "session_prompt_tokens",
+        "session_completion_tokens",
+        "session_total_tokens",
+        "session_estimated_cost_usd",
+    ):
+        setattr(agent, attr, 0)
+    agent.session_cost_status = ""
+    agent.session_cost_source = ""
+
+    agent._save_trajectory = lambda *_a, **_k: None
+    agent._cleanup_task_resources = lambda *_a, **_k: None
+    agent._drop_trailing_empty_response_scaffolding = lambda *_a, **_k: None
+    agent._persist_session = lambda messages, _history: persisted.append(
+        deepcopy(messages)
+    )
+    agent._turn_completion_explainer_enabled = lambda: False
+    agent._drain_pending_steer = lambda: None
+    agent.clear_interrupt = lambda: None
+    agent._sync_external_memory_for_turn = lambda **_k: None
+    agent._spawn_background_review = lambda **_k: None
+    return agent
+
+
+def test_finalizer_updates_returned_and_persisted_assistant_message(monkeypatch):
+    try:
+        import hermes_cli.plugins as plugins
+
+        monkeypatch.setattr(plugins, "invoke_hook", lambda *_a, **_k: [])
+    except Exception:
+        pass
+
+    persisted: list[list[dict]] = []
+    agent = _finalizer_agent(["todo"], persisted)
+    messages = [
+        {"role": "user", "content": "fix it"},
+        {"role": "assistant", "content": "STATUS: DONE\nImplemented and verified."},
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response=messages[-1]["content"],
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task-1",
+        turn_id="turn-1",
+        user_message="fix it",
+        original_user_message="fix it",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(finish_reason=stop)",
+    )
+
+    assert "not supported by this turn's tool evidence" in result["final_response"]
+    assert messages[-1]["content"] == result["final_response"]
+    assert persisted[-1][-1]["content"] == result["final_response"]
+
+
+def test_finalizer_persists_transform_hook_output(monkeypatch):
+    import hermes_cli.plugins as plugins
+
+    monkeypatch.setattr(
+        plugins,
+        "invoke_hook",
+        lambda hook, **kwargs: ["transformed delivery"]
+        if hook == "transform_llm_output"
+        else [],
+    )
+    persisted: list[list[dict]] = []
+    agent = _finalizer_agent(["terminal"], persisted)
+    messages = [
+        {"role": "user", "content": "report"},
+        {"role": "assistant", "content": "original response"},
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response="original response",
+        api_call_count=1,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task-1",
+        turn_id="turn-1",
+        user_message="report",
+        original_user_message="report",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(finish_reason=stop)",
+    )
+
+    assert result["final_response"] == "transformed delivery"
+    assert messages[-1]["content"] == "transformed delivery"
+    assert persisted[-1][-1]["content"] == "transformed delivery"


### PR DESCRIPTION
## What does this PR do?

Adds a per-turn tool evidence ledger and a conservative final-response verifier for unsupported completion claims. If a turn only executed non-executing context tools (`todo`, `skill_view`, `memory`, `session_search`) but the final answer claims work was implemented, deployed, verified, tested, or reports `STATUS: DONE`, Hermes now appends a verifier note explaining that the claim is not supported by this turn's tool evidence.

The finalizer also mirrors verifier-updated text back into the trailing assistant transcript message and re-persists it, so session history matches the returned `final_response`.

## Related Issue

Fixes #45577

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `agent/turn_context.py`: reset a per-turn `_turn_tool_evidence` ledger with the existing verifier state.
- `agent/tool_executor.py`: record each completed, unblocked tool call in both sequential and concurrent executor paths.
- `run_agent.py`: add conservative detection/formatting for unsupported strong completion claims after housekeeping-only tool evidence.
- `agent/turn_finalizer.py`: append the unsupported-claim verifier note and sync verifier rewrites into the trailing assistant message before re-persisting.
- `tests/run_agent/test_unsupported_completion_claim_verifier.py`: cover the new formatter and finalizer persistence behavior.

## How to Test

1. `python -m pytest tests/run_agent/test_unsupported_completion_claim_verifier.py tests/run_agent/test_file_mutation_verifier.py`
2. `python -m py_compile run_agent.py agent/turn_context.py agent/tool_executor.py agent/turn_finalizer.py tests/run_agent/test_unsupported_completion_claim_verifier.py`
3. `python -m ruff check run_agent.py agent/turn_context.py agent/tool_executor.py agent/turn_finalizer.py tests/run_agent/test_unsupported_completion_claim_verifier.py`

## Checklist

### Code

- [ ] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows, Python 3.12.10

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] `cli-config.yaml.example` update: N/A
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A
- [x] Cross-platform impact considered: no OS-specific APIs added
- [x] Tool descriptions/schemas update: N/A

## Screenshots / Logs

Focused tests: 40 passed, 1 warning (existing `audioop` deprecation from `discord.player`).
Ruff: passed; emitted an existing warning about `run_agent.py:94` invalid `# noqa` directive.