### PR TITLE
fix(matrix): preserve markdown table structure

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -209,7 +209,7 @@ class _MatrixHtmlSanitizer(HTMLParser):
     _ALLOWED_TAGS = {
         "a", "b", "blockquote", "br", "code", "del", "em", "h1", "h2", "h3",
         "h4", "h5", "h6", "hr", "i", "li", "ol", "p", "pre", "s", "strike",
-        "strong", "ul",
+        "strong", "table", "tbody", "td", "th", "thead", "tr", "ul",
     }
     _VOID_TAGS = {"br", "hr"}
 

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1090,6 +1090,24 @@ class TestMatrixMarkdownToHtml:
         assert "<code" in result
         assert "print" in result
 
+    def test_matrix_markdown_preserves_table_structure(self):
+        table = "\n".join(
+            [
+                "| Item | Quantity |",
+                "| --- | --- |",
+                "| Apples | 4 |",
+                "| Bread | 1 |",
+            ]
+        )
+
+        result = self.adapter._markdown_to_html(table)
+
+        assert "<table>" in result
+        assert "<thead>" in result
+        assert "<tbody>" in result
+        assert "<th>Item</th>" in result
+        assert "<td>Apples</td>" in result
+
 
 # ---------------------------------------------------------------------------
 # Helper: display name extraction


### PR DESCRIPTION
## Summary
Matrix messages now preserve markdown table structure instead of flattening tables into plain text.

Salvages #45431 by @sarvesh1327 with contributor authorship preserved.

## Changes
- `gateway/platforms/matrix.py`: allow Matrix-compatible table tags through the HTML sanitizer.
- `tests/gateway/test_matrix.py`: add a regression test for markdown table rendering.

## Validation
| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/gateway/test_matrix.py` | 230 passed |
| `python3 -m py_compile gateway/platforms/matrix.py scripts/release.py` | passed |
| `git diff --check` | passed |

## Infographic

![matrix-table-structure](https://v3b.fal.media/files/b/0a9e2301/ujnETBoh2kryDSQamU5qw_6zZSE6qI.png)
