### PR TITLE
[codex] Fix desktop resume after compression rotation

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -515,9 +515,10 @@ export function useSessionActions({
     async (storedSessionId: string, replaceRoute = false) => {
       const requestId = resumeRequestRef.current + 1
       resumeRequestRef.current = requestId
+      let expectedStoredSessionId = storedSessionId
 
       const isCurrentResume = () =>
-        resumeRequestRef.current === requestId && selectedStoredSessionIdRef.current === storedSessionId
+        resumeRequestRef.current === requestId && selectedStoredSessionIdRef.current === expectedStoredSessionId
 
       // Swap the single live gateway to this session's profile before any
       // gateway call (no-op when it's already on that profile / single-profile).
@@ -642,6 +643,20 @@ export function useSessionActions({
           return
         }
 
+        const resumedStoredSessionId =
+          (resumed.resumed || resumed.session_key || storedSessionId).trim() || storedSessionId
+        const resumedDifferentStoredSession = resumedStoredSessionId !== storedSessionId
+
+        if (resumedDifferentStoredSession) {
+          expectedStoredSessionId = resumedStoredSessionId
+          runtimeIdByStoredSessionIdRef.current.delete(storedSessionId)
+          setSelectedStoredSessionId(resumedStoredSessionId)
+          selectedStoredSessionIdRef.current = resumedStoredSessionId
+          navigate(sessionRoute(resumedStoredSessionId), { replace: true })
+        } else if (replaceRoute) {
+          navigate(sessionRoute(resumedStoredSessionId), { replace: true })
+        }
+
         const currentMessages = $messages.get()
 
         const resumedMessages = preserveLocalAssistantErrors(
@@ -650,7 +665,7 @@ export function useSessionActions({
         )
         // Keep the local snapshot when resume would only reshuffle runtime projection.
         const preferredMessages =
-          localSnapshot.length > 0
+          !resumedDifferentStoredSession && localSnapshot.length > 0
             ? localSnapshot
             : chatMessageArraysEquivalent(currentMessages, resumedMessages)
               ? currentMessages
@@ -662,9 +677,9 @@ export function useSessionActions({
         activeSessionIdRef.current = resumed.session_id
         const runtimeInfo = applyRuntimeInfo(resumed.info)
 
-        patchSessionWorkspace(storedSessionId, runtimeInfo?.cwd)
+        patchSessionWorkspace(resumedStoredSessionId, runtimeInfo?.cwd)
 
-        resumedRunning = Boolean((resumed as { running?: boolean }).running)
+        resumedRunning = Boolean(resumed.running)
 
         updateSessionState(
           resumed.session_id,
@@ -675,7 +690,7 @@ export function useSessionActions({
             busy: resumedRunning,
             awaitingResponse: resumedRunning
           }),
-          storedSessionId
+          resumedStoredSessionId
         )
       } catch (err) {
         if (!isCurrentResume()) {
@@ -704,6 +719,7 @@ export function useSessionActions({
       copy,
       requestGateway,
       runtimeIdByStoredSessionIdRef,
+      navigate,
       selectedStoredSessionIdRef,
       sessionStateByRuntimeIdRef,
       syncSessionStateToView,

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -338,8 +338,12 @@ export interface SessionResumeResponse {
   info?: SessionRuntimeInfo
   message_count: number
   messages: SessionMessage[]
+  requested?: string
   resumed: string
+  running?: boolean
   session_id: string
+  session_key?: string
+  status?: string
 }
 
 export interface SessionRuntimeInfo {

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -394,6 +394,75 @@ def test_session_resume_handles_multimodal_list_content(server, monkeypatch):
     ]
 
 
+def test_session_resume_projects_compression_root_to_tip(server, monkeypatch):
+    """Desktop may reconnect with an old route after context compression.
+
+    Resuming the compression root must bind the live runtime to the latest
+    continuation so prompt submission and model changes do not keep targeting
+    the ended parent session.
+    """
+
+    root = "20260613_074135_root"
+    tip = "20260613_212635_tip"
+    reopened: list[str] = []
+    made_agents: list[tuple[str, str]] = []
+    initialized: list[str] = []
+
+    class _DB:
+        def get_session(self, sid):
+            if sid in {root, tip}:
+                return {"id": sid}
+            return None
+
+        def get_session_by_title(self, _title):
+            return None
+
+        def get_compression_tip(self, sid):
+            return tip if sid == root else sid
+
+        def reopen_session(self, sid):
+            reopened.append(sid)
+
+        def get_messages_as_conversation(self, sid, include_ancestors=False):
+            assert sid == tip
+            return [
+                {"role": "user", "content": "compressed prompt"},
+                {"role": "assistant", "content": "continued"},
+            ]
+
+    def _make_agent(sid, key, session_id=None, session_db=None):
+        made_agents.append((key, session_id))
+        return types.SimpleNamespace(model="test/model", session_id=session_id or key)
+
+    def _init_session(_sid, key, _agent, _history, cols=80):
+        initialized.append(key)
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+    monkeypatch.setattr(server, "_make_agent", _make_agent)
+    monkeypatch.setattr(server, "_init_session", _init_session)
+    monkeypatch.setattr(server, "_session_info", lambda _agent, _session=None: {"model": "test/model"})
+
+    resp = server.handle_request(
+        {
+            "id": "r1",
+            "method": "session.resume",
+            "params": {"session_id": root, "cols": 100},
+        }
+    )
+
+    assert "error" not in resp
+    assert resp["result"]["requested"] == root
+    assert resp["result"]["resumed"] == tip
+    assert resp["result"]["session_key"] == tip
+    assert resp["result"]["messages"] == [
+        {"role": "user", "text": "compressed prompt"},
+        {"role": "assistant", "text": "continued"},
+    ]
+    assert reopened == [tip]
+    assert made_agents == [(tip, tip)]
+    assert initialized == [tip]
+
+
 def test_session_resume_lazy_registers_watch_session_without_agent(server, monkeypatch):
     """``lazy: true`` (subagent watch windows) must register the live session
     — keyed for the child mirror, on this transport — WITHOUT building an

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3882,6 +3882,7 @@ def _(rid, params: dict) -> dict:
     target = params.get("session_id", "")
     if not target:
         return _err(rid, 4006, "session_id required")
+    requested_target = target
     try:
         cols = int(params.get("cols", 80))
     except (TypeError, ValueError):
@@ -3909,6 +3910,20 @@ def _(rid, params: dict) -> dict:
             target = found["id"]
         else:
             return _err(rid, 4007, "session not found")
+
+    try:
+        compression_tip = db.get_compression_tip(target)
+    except AttributeError:
+        compression_tip = None
+    except Exception:
+        logger.exception("session.resume failed to resolve compression tip for %s", target)
+        compression_tip = None
+    if compression_tip and compression_tip != target:
+        tip_found = db.get_session(compression_tip)
+        if tip_found:
+            target = compression_tip
+            found = tip_found
+
     def _reuse_live_payload(sid: str, session: dict) -> dict:
         payload = _live_session_payload(
             sid,
@@ -3917,6 +3932,7 @@ def _(rid, params: dict) -> dict:
             touch=True,
             transport=current_transport() or _stdio_transport,
         )
+        payload["requested"] = requested_target
         payload["resumed"] = target
         # A lazy watch session never owns a run loop, so its payload's running
         # flag is always False — overlay the child-run registry so a reconnecting
@@ -4007,6 +4023,7 @@ def _(rid, params: dict) -> dict:
             rid,
             {
                 "session_id": sid,
+                "requested": requested_target,
                 "resumed": target,
                 "message_count": len(messages),
                 "messages": messages,
@@ -4096,6 +4113,7 @@ def _(rid, params: dict) -> dict:
                 touch=True,
                 transport=current_transport() or _stdio_transport,
             )
+            payload["requested"] = requested_target
             payload["resumed"] = target
             return _ok(rid, payload)
         try:
@@ -4121,6 +4139,7 @@ def _(rid, params: dict) -> dict:
         rid,
         {
             "session_id": sid,
+            "requested": requested_target,
             "resumed": target,
             "message_count": len(messages),
             "messages": messages,


### PR DESCRIPTION
## Summary
- Resolve `session.resume` requests for compressed parent sessions to their latest continuation tip.
- Return the originally requested id alongside the resumed tip so desktop clients can correct stale routes.
- Update the desktop resume path to replace stale stored-session ids with the returned continuation id for routing, workspace state, and runtime mapping.

## Root cause
When a long desktop conversation triggered context compression, Hermes ended the old stored session and continued in a child session. The sidebar/session list could project the old root to the tip, but the desktop WebSocket resume path still accepted the old route id as the active stored session. That left prompt submission and model switching pointed at an ended/busy parent instead of the live continuation.

## Validation
- `uv run --with pytest --with pytest-timeout pytest tests/tui_gateway/test_protocol.py -q`
- `uv run --with ruff ruff check tui_gateway/server.py tests/tui_gateway/test_protocol.py`
- `npm run typecheck` from `apps/desktop`
- `git diff --check HEAD~1..HEAD`

Also verified the desktop hook regression test against the current local runtime checkout before preparing this fork-base branch.