### PR TITLE
fix(codex): drop extra_headers for chatgpt.com backend

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -218,22 +218,10 @@ class ResponsesApiTransport(ProviderTransport):
             kwargs.pop("timeout", None)
 
         if is_codex_backend:
-            prompt_cache_key = kwargs.get("prompt_cache_key")
-            cache_scope_id = str(prompt_cache_key or session_id or "").strip()
-            if cache_scope_id:
-                existing_extra_headers = kwargs.get("extra_headers")
-                merged_extra_headers: Dict[str, str] = {}
-                if isinstance(existing_extra_headers, dict):
-                    merged_extra_headers.update(
-                        {
-                            str(key): str(value)
-                            for key, value in existing_extra_headers.items()
-                            if key and value is not None
-                        }
-                    )
-                merged_extra_headers["session_id"] = cache_scope_id
-                merged_extra_headers["x-client-request-id"] = cache_scope_id
-                kwargs["extra_headers"] = merged_extra_headers
+            # chatgpt.com/backend-api/codex rejects body-level
+            # ``extra_headers`` with HTTP 400. Correlation/cache routing for
+            # this backend must not be sent through the Responses payload.
+            kwargs.pop("extra_headers", None)
 
         max_tokens = params.get("max_tokens")
         if max_tokens is not None and not is_codex_backend:

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -155,6 +155,46 @@ class TestCodexBuildKwargs:
         )
         assert "max_output_tokens" not in kw
 
+    def test_codex_backend_does_not_set_extra_headers(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            session_id="conv-codex-1",
+            is_codex_backend=True,
+        )
+
+        assert "extra_headers" not in kw
+
+    def test_codex_backend_strips_caller_extra_headers(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            session_id="conv-codex-1",
+            is_codex_backend=True,
+            request_overrides={"extra_headers": {"x-test": "1"}},
+        )
+
+        assert "extra_headers" not in kw
+
+    def test_non_codex_responses_preserves_caller_extra_headers(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            is_codex_backend=False,
+            request_overrides={"extra_headers": {"x-test": "1"}},
+        )
+
+        assert kw["extra_headers"] == {"x-test": "1"}
+
     def test_xai_headers(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(


### PR DESCRIPTION
## Summary
Codex Responses requests to the chatgpt.com backend no longer send unsupported body-level `extra_headers`.

## Changes
- Strip `extra_headers` when `is_codex_backend=True`, including caller-supplied overrides.
- Preserve `extra_headers` for non-Codex Responses endpoints.
- Add regression coverage for injected headers, caller override stripping, and non-Codex preservation.

## Validation
| Check | Result |
|---|---|
| `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/agent/transports/test_codex_transport.py::TestCodexBuildKwargs::test_codex_backend_does_not_set_extra_headers tests/agent/transports/test_codex_transport.py::TestCodexBuildKwargs::test_codex_backend_strips_caller_extra_headers tests/agent/transports/test_codex_transport.py::TestCodexBuildKwargs::test_non_codex_responses_preserves_caller_extra_headers -q` | 3 passed |
| `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/agent/transports/test_codex_transport.py -q` | 54 passed |
| `scripts/run_tests.sh tests/agent/transports/test_codex_transport.py` | 54 passed |
| `python3 -m py_compile agent/transports/codex.py tests/agent/transports/test_codex_transport.py && git diff --check` | passed |

Salvages #26749 by @Tranquil-Flow with authorship preserved.
Closes #26599.

## Infographic

![Codex Header Drop](https://v3b.fal.media/files/b/0a9e230a/pfeBdW_A-fia6hqYfWlXK_ETiya9Yd.png)
