### PR TITLE
fix(types): use typing.Callable instead of lowercase 'callable'

### DIFF
--- a/contributors/emails/dev@coevictionhelp.com
+++ b/contributors/emails/dev@coevictionhelp.com
@@ -1,0 +1,2 @@
+KeyArgo
+# contributor mapping for attribution check (PR #45641)

--- a/run_agent.py
+++ b/run_agent.py
@@ -45,7 +45,7 @@ import tempfile
 import time
 import threading
 import uuid
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Callable, Optional
 # NOTE: `from openai import OpenAI` is deliberately NOT at module top — the
 # SDK pulls ~240 ms of imports. We expose `OpenAI` as a thin proxy object
 # that imports the SDK on first call/isinstance check. This preserves:
@@ -5095,14 +5095,15 @@ class AIAgent:
         system_message: str = None,
         conversation_history: List[Dict[str, Any]] = None,
         task_id: str = None,
-        stream_callback: Optional[callable] = None,
+        stream_callback: Optional[Callable] = None,
         persist_user_message: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         from agent.conversation_loop import run_conversation
         return run_conversation(self, user_message, system_message, conversation_history, task_id, stream_callback, persist_user_message)
 
-    def chat(self, message: str, stream_callback: Optional[callable] = None) -> str:
+
+    def chat(self, message: str, stream_callback: Optional[Callable] = None) -> str:
         """
         Simple chat interface that returns just the final response.
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -8340,7 +8340,7 @@ class AIAgent:
         system_message: str = None,
         conversation_history: List[Dict[str, Any]] = None,
         task_id: str = None,
-        stream_callback: Optional[callable] = None,
+        stream_callback: Optional[Callable] = None,
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
         persist_user_display_kind: Optional[str] = None,
@@ -8805,7 +8805,7 @@ class AIAgent:
                     if token is not None:
                         reset_conversation_context(token)
 
-    def chat(self, message: str, stream_callback: Optional[callable] = None) -> str:
+    def chat(self, message: str, stream_callback: Optional[Callable] = None) -> str:
         """
         Simple chat interface that returns just the final response.
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -28,7 +28,7 @@ from concurrent.futures import (
     ThreadPoolExecutor,
     TimeoutError as FuturesTimeoutError,
 )
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Callable, Optional
 
 from toolsets import TOOLSETS
 
@@ -725,7 +725,7 @@ def _build_child_progress_callback(
     depth: Optional[int] = None,
     model: Optional[str] = None,
     toolsets: Optional[List[str]] = None,
-) -> Optional[callable]:
+) -> Optional[Callable]:
     """Build a callback that relays child agent tool calls to the parent display.
 
     Two display paths:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -31,7 +31,7 @@ import weakref
 from concurrent.futures import (
     TimeoutError as FuturesTimeoutError,
 )
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Callable, Optional
 from urllib.parse import urlsplit, urlunsplit
 
 from toolsets import TOOLSETS
@@ -1235,7 +1235,7 @@ def _build_child_progress_callback(
     model: Optional[str] = None,
     toolsets: Optional[List[str]] = None,
     session_ref: Optional[Dict[str, Any]] = None,
-) -> Optional[callable]:
+) -> Optional[Callable]:
     """Build a callback that relays child agent tool calls to the parent display.
 
     Two display paths:


### PR DESCRIPTION
## Summary

Fix from issue #32848 audit (item 13). The lowercase `callable` is
the builtin `any()`-style predicate function, not a type. The
intended type was `typing.Callable`.

## Changes

- `run_agent.py:48` — added `Callable` to typing import
- `run_agent.py:5098, 5105` — `callable` → `Callable`
- `tools/delegate_tool.py:31` — added `Callable` to typing import
- `tools/delegate_tool.py:728` — `callable` → `Callable`

## Behavior

The Python interpreter doesn't catch this at runtime (callable is
always truthy when used as an annotation under PEP 563 deferred
evaluation). But static type checkers (mypy, pyright) flag it as
invalid, and IDE autocomplete/intellisense is degraded.

## Risk

None. Type-only fix. No runtime behavior change. Test suite should
pass unchanged (and does, locally).

Fixes #32848 (part 13)