### PR TITLE
feat(gateway): preserve incoming vCard contacts

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1134,6 +1134,7 @@ SUPPORTED_DOCUMENT_TYPES = {
     ".ts": "text/plain",
     ".py": "text/plain",
     ".sh": "text/plain",
+    ".vcf": "text/vcard",
 }
 
 

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1895,6 +1895,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 filters.LOCATION | getattr(filters, "VENUE", filters.LOCATION),
                 self._handle_location_message
             ))
+            contact_filter = getattr(filters, "CONTACT", None)
+            if contact_filter is not None:
+                self._app.add_handler(TelegramMessageHandler(
+                    contact_filter,
+                    self._handle_contact_message
+                ))
             self._app.add_handler(TelegramMessageHandler(
                 filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
                 self._handle_media_message
@@ -5714,6 +5720,64 @@ class TelegramAdapter(BasePlatformAdapter):
         event = self._apply_telegram_group_observe_attribution(event)
         await self.handle_message(event)
 
+    async def _handle_contact_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle incoming contact/vCard shares from Telegram."""
+        msg = self._effective_update_message(update)
+        if not msg:
+            return
+        if not self._should_process_message(msg):
+            return
+
+        contact = getattr(msg, "contact", None)
+        if not contact:
+            return
+
+        # Build a VCF string from the Telegram contact object
+        first_name = getattr(contact, "first_name", "") or ""
+        last_name = getattr(contact, "last_name", "") or ""
+        phone = getattr(contact, "phone_number", "") or ""
+        user_id = getattr(contact, "user_id", None)
+        vcard_raw = getattr(contact, "vcard", "") or ""
+
+        # Use the raw vcard if Telegram provided one, otherwise build a minimal one
+        if vcard_raw:
+            vcf_content = vcard_raw if vcard_raw.endswith("\n") else f"{vcard_raw}\n"
+        else:
+            full_name = f"{first_name} {last_name}".strip() or "Unknown Contact"
+            vcf_lines = [
+                "BEGIN:VCARD",
+                "VERSION:3.0",
+                f"FN:{full_name}",
+                f"N:{last_name};{first_name};;;",
+            ]
+            if phone:
+                vcf_lines.append(f"TEL;type=CELL:{phone}")
+            if user_id:
+                vcf_lines.append(f"X-TELEGRAM-ID:{user_id}")
+            vcf_lines.append("END:VCARD")
+            vcf_content = "\r\n".join(vcf_lines) + "\r\n"
+
+        full_name = f"{first_name} {last_name}".strip() or "Unknown Contact"
+        display_name = re.sub(r'[^\w.\- ]', '_', full_name).strip() or "contact"
+        vcf_path = cache_document_from_bytes(
+            vcf_content.encode("utf-8"),
+            f"{display_name}.vcf",
+        )
+
+        parts = [f"[The user shared a contact: {full_name}]"]
+        if phone:
+            parts.append(f"Phone: {phone}")
+        if user_id:
+            parts.append(f"Telegram user ID: {user_id}")
+        parts.append(f"\n[Content of {display_name}.vcf]:\n{vcf_content}")
+
+        event = self._build_message_event(msg, MessageType.DOCUMENT, update_id=update.update_id)
+        event.text = "\n".join(parts)
+        event.media_urls = [vcf_path]
+        event.media_types = ["text/vcard"]
+        event = self._apply_telegram_group_observe_attribution(event)
+        await self.handle_message(event)
+
     # ------------------------------------------------------------------
     # Text message aggregation (handles Telegram client-side splits)
     # ------------------------------------------------------------------
@@ -6095,7 +6159,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
                 # For text files, inject content into event.text (capped at 100 KB)
                 MAX_TEXT_INJECT_BYTES = 100 * 1024
-                if ext in {".md", ".txt"} and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
+                if ext in {".md", ".txt", ".vcf"} and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
                     try:
                         text_content = raw_bytes.decode("utf-8")
                         display_name = original_filename or f"document{ext}"

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -1140,7 +1140,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if msg_type == MessageType.DOCUMENT and cached_urls:
                 for doc_path in cached_urls:
                     ext = Path(doc_path).suffix.lower()
-                    if ext in {".txt", ".md", ".csv", ".json", ".xml", ".yaml", ".yml", ".log", ".py", ".js", ".ts", ".html", ".css"}:
+                    if ext in {".txt", ".md", ".csv", ".json", ".xml", ".yaml", ".yml", ".log", ".py", ".js", ".ts", ".html", ".css", ".vcf"}:
                         try:
                             file_size = Path(doc_path).stat().st_size
                             if file_size > MAX_TEXT_INJECT_BYTES:

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -30,6 +30,12 @@ import { execSync } from 'child_process';
 import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import {
+  buildVCardDocumentContent,
+  safeContactFilename,
+  summarizeContactMessage,
+  summarizeContactsArrayMessage,
+} from './contact-card.js';
 
 // Parse CLI args
 const args = process.argv.slice(2);
@@ -164,6 +170,17 @@ function getContextInfo(messageContent) {
     }
   }
   return {};
+}
+
+function writeVCardDocument(vcards, displayName = 'contacts') {
+  const content = buildVCardDocumentContent(vcards, displayName);
+  mkdirSync(DOCUMENT_CACHE_DIR, { recursive: true });
+  const filePath = path.join(
+    DOCUMENT_CACHE_DIR,
+    `vcards_${randomBytes(6).toString('hex')}_${safeContactFilename(displayName)}.vcf`,
+  );
+  writeFileSync(filePath, content, 'utf8');
+  return filePath;
 }
 
 mkdirSync(SESSION_DIR, { recursive: true });
@@ -397,6 +414,25 @@ async function startSocket() {
           mediaUrls.push(filePath);
         } catch (err) {
           console.error('[bridge] Failed to download audio:', err.message);
+        }
+      } else if (messageContent.contactMessage) {
+        body = summarizeContactMessage(messageContent.contactMessage);
+        hasMedia = true;
+        mediaType = 'document';
+        try {
+          mediaUrls.push(writeVCardDocument(messageContent.contactMessage, messageContent.contactMessage.displayName || 'contact'));
+        } catch (err) {
+          console.error('[bridge] Failed to save contact vCard:', err.message);
+        }
+      } else if (messageContent.contactsArrayMessage) {
+        const contacts = messageContent.contactsArrayMessage.contacts || [];
+        body = summarizeContactsArrayMessage(messageContent.contactsArrayMessage);
+        hasMedia = true;
+        mediaType = 'document';
+        try {
+          mediaUrls.push(writeVCardDocument(contacts, 'contacts'));
+        } catch (err) {
+          console.error('[bridge] Failed to save contacts vCard:', err.message);
         }
       } else if (messageContent.documentMessage) {
         body = messageContent.documentMessage.caption || '';

--- a/scripts/whatsapp-bridge/contact-card.js
+++ b/scripts/whatsapp-bridge/contact-card.js
@@ -1,0 +1,154 @@
+/**
+ * WhatsApp contact card (vCard) helpers.
+ *
+ * The bridge needs two representations for incoming contact cards:
+ * 1. a readable summary for the agent message body
+ * 2. the original vCard payload preserved as a cached .vcf document
+ */
+
+export function decodeVCardValue(value = '') {
+  return String(value)
+    .replace(/\\n/g, '\n')
+    .replace(/\\,/g, ',')
+    .replace(/\\;/g, ';')
+    .trim();
+}
+
+export function unfoldVCardLines(vcard = '') {
+  const rawLines = String(vcard || '').split(/\r?\n/);
+  const lines = [];
+  for (const raw of rawLines) {
+    if (/^[ \t]/.test(raw) && lines.length) {
+      // RFC 6350 line folding: continuation lines start with space/tab.
+      lines[lines.length - 1] += raw.slice(1);
+    } else {
+      lines.push(raw);
+    }
+  }
+  return lines;
+}
+
+function parseVCardParams(key = '') {
+  const parts = String(key || '').split(';');
+  const field = (parts.shift() || '').toUpperCase();
+  const params = [];
+  for (const part of parts) {
+    const [rawName, rawValue] = part.split('=');
+    const name = String(rawName || '').toUpperCase();
+    const values = rawValue ? rawValue.split(',') : [part];
+    for (const value of values) {
+      const cleaned = String(value || '').replace(/^"|"$/g, '').trim();
+      if (cleaned && name !== 'VALUE') params.push(cleaned);
+    }
+  }
+  return { field, params };
+}
+
+function uniqueItems(values) {
+  const unique = [];
+  const seen = new Set();
+  for (const item of values) {
+    const value = item.value || '';
+    if (!value) continue;
+    const key = `${item.type || ''}\u0000${value}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(item);
+  }
+  return unique;
+}
+
+function formatVCardValues(label, values) {
+  const unique = uniqueItems(values);
+  if (!unique.length) return '';
+  if (unique.length === 1) {
+    const item = unique[0];
+    return `${label}: ${item.type ? `${item.type}: ` : ''}${item.value}`;
+  }
+  return `${label}:\n${unique.map((item, i) => `  ${i + 1}. ${item.type ? `${item.type}: ` : ''}${item.value}`).join('\n')}`;
+}
+
+export function summarizeVCard(vcard = '', fallbackName = '') {
+  const lines = unfoldVCardLines(vcard);
+  const names = [];
+  const orgs = [];
+  const phones = [];
+  const emails = [];
+  const addresses = [];
+  const urls = [];
+  const notes = [];
+  const birthdays = [];
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const idx = line.indexOf(':');
+    if (idx === -1) continue;
+    const { field, params } = parseVCardParams(line.slice(0, idx));
+    const value = decodeVCardValue(line.slice(idx + 1));
+    if (!value) continue;
+    const type = params.join('/');
+    if (field === 'FN') names.push(value);
+    else if (field === 'N' && !names.length) names.push(value.split(';').filter(Boolean).join(' '));
+    else if (field === 'ORG') orgs.push(value.split(';').filter(Boolean).join(' / '));
+    else if (field === 'TEL') phones.push({ type, value });
+    else if (field === 'EMAIL') emails.push({ type, value });
+    else if (field === 'ADR') addresses.push({ type, value: value.split(';').filter(Boolean).join(', ') });
+    else if (field === 'URL') urls.push({ type, value });
+    else if (field === 'NOTE') notes.push(value);
+    else if (field === 'BDAY') birthdays.push(value);
+  }
+  const name = names[0] || fallbackName || 'Unbekannter Kontakt';
+  const parts = [`Kontakt: ${name}`];
+  if (orgs.length) parts.push(`Organisation: ${Array.from(new Set(orgs)).join(', ')}`);
+  const phoneText = formatVCardValues('Telefon', phones);
+  const emailText = formatVCardValues('E-Mail', emails);
+  const addressText = formatVCardValues('Adresse', addresses);
+  const urlText = formatVCardValues('URL', urls);
+  if (phoneText) parts.push(phoneText);
+  if (emailText) parts.push(emailText);
+  if (addressText) parts.push(addressText);
+  if (birthdays.length) parts.push(`Geburtstag: ${Array.from(new Set(birthdays)).join(', ')}`);
+  if (urlText) parts.push(urlText);
+  if (notes.length) parts.push(`Notiz: ${Array.from(new Set(notes)).join(' / ')}`);
+  return parts.join('\n');
+}
+
+export function ensureVCardEnvelope(vcard = '', displayName = '') {
+  const text = String(vcard || '').trim();
+  if (text) {
+    if (/BEGIN:VCARD/i.test(text)) return text.endsWith('\n') ? text : `${text}\n`;
+    return `BEGIN:VCARD\nVERSION:3.0\nFN:${displayName || 'Unbekannter Kontakt'}\n${text}\nEND:VCARD\n`;
+  }
+  return `BEGIN:VCARD\nVERSION:3.0\nFN:${displayName || 'Unbekannter Kontakt'}\nEND:VCARD\n`;
+}
+
+export function safeContactFilename(name = 'contact') {
+  return String(name || 'contact')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-zA-Z0-9._-]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 80) || 'contact';
+}
+
+export function buildVCardDocumentContent(vcards, displayName = 'contacts') {
+  return (Array.isArray(vcards) ? vcards : [vcards])
+    .map((entry) => ensureVCardEnvelope(entry?.vcard || entry || '', entry?.displayName || displayName))
+    .filter(Boolean)
+    .join('\n');
+}
+
+export function summarizeContactMessage(contactMessage = {}) {
+  return summarizeVCard(contactMessage.vcard || '', contactMessage.displayName || '');
+}
+
+export function summarizeContactsArrayMessage(contactsArrayMessage = {}) {
+  const contacts = contactsArrayMessage.contacts || [];
+  const summaries = contacts.map((contact, index) => {
+    const summary = summarizeVCard(contact.vcard || '', contact.displayName || '');
+    return `${index + 1}. ${summary}`;
+  });
+  return summaries.length
+    ? `Kontakte empfangen:\n${summaries.join('\n')}`
+    : '[contacts received]';
+}

--- a/scripts/whatsapp-bridge/contact-card.test.mjs
+++ b/scripts/whatsapp-bridge/contact-card.test.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildVCardDocumentContent,
+  ensureVCardEnvelope,
+  safeContactFilename,
+  summarizeContactMessage,
+  summarizeContactsArrayMessage,
+  summarizeVCard,
+  unfoldVCardLines,
+} from './contact-card.js';
+
+test('summarizeVCard extracts rich contact fields', () => {
+  const vcard = [
+    'BEGIN:VCARD',
+    'VERSION:3.0',
+    'FN:Ada Lovelace',
+    'ORG:Analytical Engines;Research',
+    'TEL;TYPE=CELL,VOICE:+4912345',
+    'EMAIL;TYPE=WORK:ada@example.com',
+    'ADR;TYPE=HOME:;;Example Street 1;London;;;UK',
+    'BDAY:1815-12-10',
+    'URL:https://example.com/ada',
+    'NOTE:Friend\\, mathematician',
+    'END:VCARD',
+  ].join('\n');
+
+  const summary = summarizeVCard(vcard);
+
+  assert.match(summary, /Kontakt: Ada Lovelace/);
+  assert.match(summary, /Organisation: Analytical Engines \/ Research/);
+  assert.match(summary, /Telefon: CELL\/VOICE: \+4912345/);
+  assert.match(summary, /E-Mail: WORK: ada@example\.com/);
+  assert.match(summary, /Adresse: HOME: Example Street 1, London, UK/);
+  assert.match(summary, /Geburtstag: 1815-12-10/);
+  assert.match(summary, /URL: https:\/\/example\.com\/ada/);
+  assert.match(summary, /Notiz: Friend, mathematician/);
+});
+
+test('summarizeContactMessage uses displayName fallback', () => {
+  const summary = summarizeContactMessage({ displayName: 'Fallback Name', vcard: 'TEL:+123' });
+
+  assert.match(summary, /Kontakt: Fallback Name/);
+  assert.match(summary, /Telefon: \+123/);
+});
+
+test('summarizeContactsArrayMessage numbers multiple contacts', () => {
+  const summary = summarizeContactsArrayMessage({
+    contacts: [
+      { displayName: 'One', vcard: 'FN:One\nTEL:+1' },
+      { displayName: 'Two', vcard: 'FN:Two\nEMAIL:two@example.com' },
+    ],
+  });
+
+  assert.match(summary, /^Kontakte empfangen:/);
+  assert.match(summary, /1\. Kontakt: One/);
+  assert.match(summary, /2\. Kontakt: Two/);
+  assert.match(summary, /E-Mail: two@example\.com/);
+});
+
+test('buildVCardDocumentContent preserves and envelopes incoming vCards', () => {
+  const content = buildVCardDocumentContent([
+    { displayName: 'Raw', vcard: 'BEGIN:VCARD\nFN:Raw\nEND:VCARD' },
+    { displayName: 'Partial', vcard: 'TEL:+42' },
+  ]);
+
+  assert.match(content, /BEGIN:VCARD\nFN:Raw\nEND:VCARD\n/);
+  assert.match(content, /BEGIN:VCARD\nVERSION:3\.0\nFN:Partial\nTEL:\+42\nEND:VCARD\n/);
+});
+
+test('ensureVCardEnvelope creates an empty card when no payload exists', () => {
+  assert.equal(
+    ensureVCardEnvelope('', 'No Payload'),
+    'BEGIN:VCARD\nVERSION:3.0\nFN:No Payload\nEND:VCARD\n',
+  );
+});
+
+test('safeContactFilename strips unsafe characters', () => {
+  assert.equal(safeContactFilename('Äda / Lovelace:work'), 'Ada_Lovelace_work');
+});
+
+test('unfoldVCardLines joins folded continuation lines', () => {
+  assert.deepEqual(
+    unfoldVCardLines('NOTE:very long\n line\nFN:Name'),
+    ['NOTE:very longline', 'FN:Name'],
+  );
+});

--- a/scripts/whatsapp-bridge/package.json
+++ b/scripts/whatsapp-bridge/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "node bridge.js"
+    "start": "node bridge.js",
+    "test": "node --test contact-card.test.mjs"
   },
   "dependencies": {
     "@whiskeysockets/baileys": "WhiskeySockets/Baileys#01047debd81beb20da7b7779b08edcb06aa03770",

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -113,6 +113,7 @@ def _make_update(msg):
     """Wrap a message in a mock Update."""
     update = MagicMock()
     update.message = msg
+    update.effective_message = msg
     return update
 
 
@@ -231,6 +232,47 @@ class TestDocumentDownloadBlock:
         await adapter._handle_media_message(update, MagicMock())
         event = adapter.handle_message.call_args[0][0]
         assert "# Title" in event.text
+
+    @pytest.mark.asyncio
+    async def test_supported_vcf_document_injects_content(self, adapter):
+        content = b"BEGIN:VCARD\nFN:Test Contact\nTEL:+155****4567\nEND:VCARD"
+        file_obj = _make_file_obj(content)
+        doc = _make_document(
+            file_name="contacts.vcf", mime_type="text/vcard",
+            file_size=len(content), file_obj=file_obj,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.media_types == ["text/vcard"]
+        assert "BEGIN:VCARD" in event.text
+        assert "FN:Test Contact" in event.text
+        assert "[Content of contacts.vcf]" in event.text
+
+    @pytest.mark.asyncio
+    async def test_contact_share_preserves_vcard_as_document(self, adapter):
+        contact = MagicMock()
+        contact.first_name = "Ada"
+        contact.last_name = "Lovelace"
+        contact.phone_number = "+441234"
+        contact.user_id = 12345
+        contact.vcard = "BEGIN:VCARD\nFN:Ada Lovelace\nTEL:+441234\nEND:VCARD"
+        msg = _make_message()
+        msg.contact = contact
+        update = _make_update(msg)
+        update.update_id = 77
+
+        await adapter._handle_contact_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.DOCUMENT
+        assert event.media_types == ["text/vcard"]
+        assert event.media_urls and event.media_urls[0].endswith(".vcf")
+        assert "The user shared a contact: Ada Lovelace" in event.text
+        assert "Phone: +441234" in event.text
+        assert "BEGIN:VCARD" in event.text
+        assert "FN:Ada Lovelace" in event.text
 
     @pytest.mark.asyncio
     async def test_caption_preserved_with_injection(self, adapter):


### PR DESCRIPTION
## Summary
- Preserve **incoming** Telegram contact shares as cached `.vcf` documents with readable message text.
- Accept and inline small incoming Telegram `.vcf` document uploads.
- Preserve incoming WhatsApp `contactMessage` and `contactsArrayMessage` payloads as cached `.vcf` documents while giving the agent a structured summary.
- Move WhatsApp vCard parsing/formatting into `scripts/whatsapp-bridge/contact-card.js` with focused node tests.

## Scope
This PR intentionally focuses on **incoming vCard/contact payloads only**.

Out of scope here:
- outbound `MEDIA:/...vcf` delivery extension handling
- calendar files (`.ics` / `.vcs`)
- WhatsApp location messages
- stickers or other non-contact media

## Relationship to related PRs
- #19614 covers Telegram `.vcf` document uploads. This PR includes that incoming-document behavior, avoids the unrelated docs/lockfile changes, and also handles native Telegram contact shares (`message.contact`).
- #43871 covers outbound media delivery for `.ics`, `.vcf`, and `.vcs`. That is complementary but intentionally not included here because this PR is inbound-only.
- #13264 parses WhatsApp contact cards. This PR keeps the same useful direction, but preserves the original `.vcf` as a cached document and covers richer vCard fields plus multi-contact batches.
- #36993 includes WhatsApp location and contact handling. Location handling is intentionally left out here; this PR only handles incoming contact/vCard payloads.

## Test Plan
- `python -m py_compile gateway/platforms/base.py gateway/platforms/telegram.py gateway/platforms/whatsapp.py`
- `node --check scripts/whatsapp-bridge/bridge.js`
- `node --test scripts/whatsapp-bridge/contact-card.test.mjs` (7 passed)
- `scripts/run_tests.sh tests/gateway/test_telegram_documents.py tests/gateway/test_whatsapp_formatting.py tests/gateway/test_telegram_max_doc_bytes.py tests/gateway/test_telegram_caption_merge.py` (86 passed)
