### PR TITLE
fix(dashboard): prevent hidden ChatPage from clearing shared header toolbar

### DIFF
--- a/web/src/contexts/PageHeaderProvider.tsx
+++ b/web/src/contexts/PageHeaderProvider.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useMemo, useState, type ReactNode } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 import { useLocation } from "react-router-dom";
 import { PageHeaderContext } from "./page-header-context";
 import { resolvePageTitle } from "@/lib/resolve-page-title";
@@ -18,15 +18,21 @@ export function PageHeaderProvider({
   const [afterTitle, setAfterTitle] = useState<ReactNode>(null);
   const [end, setEnd] = useState<ReactNode>(null);
 
-  // Clear any per-page title / toolbar slots when the path changes. Child routes
-  // re-fill these on mount via usePageHeader.
-  /* eslint-disable react-hooks/set-state-in-effect */
-  useLayoutEffect(() => {
+  // Clear any per-page title / toolbar slots when the path changes. Child
+  // routes re-fill these from their own layout effects on mount. This MUST run
+  // during render (not in a layout effect): React fires layout effects
+  // child-first, parent-last, so a parent effect that cleared the slots would
+  // always clobber the buttons the child page just set on the same mount —
+  // making them flash in then vanish. Resetting via the render-phase
+  // "previous value" pattern runs before children commit, so it resets on a
+  // genuine path change yet never wipes a freshly-mounted page's slots.
+  const [prevPathname, setPrevPathname] = useState(pathname);
+  if (pathname !== prevPathname) {
+    setPrevPathname(pathname);
     setTitleOverride(null);
     setAfterTitle(null);
     setEnd(null);
-  }, [pathname]);
-  /* eslint-enable react-hooks/set-state-in-effect */
+  }
 
   const defaultTitle = useMemo(
     () => resolvePageTitle(pathname, t, pluginTabs),

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -242,10 +242,13 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   }, []);
 
   useEffect(() => {
-    // When hidden (non-chat tab) we must not register the header button —
-    // another page owns the header's end slot at that point.
+    // When hidden (non-chat tab) another page owns the header's end slot.
+    // We must NOT write to it at all — not even setEnd(null) — or we stomp
+    // the owning page's toolbar (e.g. Profiles page Build/Create buttons
+    // flash in then vanish). Bail without touching the slot. The owning
+    // page's own effect manages set/clear; when the user navigates to /chat
+    // the PageHeaderProvider path-change reset clears it for us first.
     if (!isActive) {
-      setEnd(null);
       return;
     }
     if (!narrow) {


### PR DESCRIPTION
## Root cause

ChatPage is permanently mounted in App.tsx (hidden via CSS on non-chat routes for instant tab switching). When hidden, its header effect called setEnd(null), overwriting whatever toolbar the active page had set — e.g. the Profiles page Build/Create buttons flashed in then vanished because ChatPage's effect re-ran on dep changes and wiped the shared header slot.

Bug confirmed reproducible on clean main in incognito. Exact call order traced via setEnd instrumentation: ProfilesPage set buttons → ChatPage cleared them (line 177, not line 71).

## Fix

**ChatPage.tsx** — When !isActive, bail before touching setEnd. A hidden page must never write to shared UI.

**PageHeaderProvider.tsx** — Replace useLayoutEffect clear with render-phase previous-value pattern, so parent never clobbers child slots on mount.

## Testing

- Flash reproduced on clean main, incognito
- Fix applied, buttons persist on hard refresh
- Verified clone-from-any-profile feature (PR #45558) works without the flash