### PR TITLE
fix(desktop): reattach sessions after websocket reconnect

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -22,6 +22,7 @@ import {
 } from '../lib/session-source'
 import { latestSessionTodos } from '../lib/todos'
 import { setCronFocusJobId, setCronJobs } from '../store/cron'
+import { ensureGatewayForProfileOpen } from '../store/gateway'
 import {
   $panesFlipped,
   $pinnedSessionIds,
@@ -48,6 +49,7 @@ import {
 } from '../store/profile'
 import {
   $activeSessionId,
+  $attentionSessionIds,
   $currentCwd,
   $freshDraftReady,
   $gatewayState,
@@ -60,6 +62,7 @@ import {
   mergeSessionPage,
   MESSAGING_SECTION_LIMIT,
   sessionPinId,
+  setActiveSessionId,
   setAwaitingResponse,
   setBusy,
   setCronSessions,
@@ -79,6 +82,7 @@ import {
 import { clearSessionTodos, setSessionTodos, todoListActive } from '../store/todos'
 import { openUpdatesWindow, startUpdatePoller, stopUpdatePoller } from '../store/updates'
 import { isSecondaryWindow } from '../store/windows'
+import type { SessionResumeResponse } from '../types/hermes'
 
 import { ChatView } from './chat'
 import { requestComposerFocus, requestComposerInsert } from './chat/composer/focus'
@@ -111,7 +115,7 @@ import { useModelControls } from './session/hooks/use-model-controls'
 import { usePreviewRouting } from './session/hooks/use-preview-routing'
 import { usePromptActions } from './session/hooks/use-prompt-actions'
 import { useRouteResume } from './session/hooks/use-route-resume'
-import { useSessionActions } from './session/hooks/use-session-actions'
+import { applyRuntimeInfo, patchSessionWorkspace, useSessionActions } from './session/hooks/use-session-actions'
 import { useSessionStateCache } from './session/hooks/use-session-state-cache'
 import { AppShell } from './shell/app-shell'
 import { useOverlayRouting } from './shell/hooks/use-overlay-routing'
@@ -191,6 +195,7 @@ export function DesktopController() {
 
   const busyRef = useRef(false)
   const creatingSessionRef = useRef(false)
+  const recoveringDetachedSessionsRef = useRef(false)
   const refreshSessionsRequestRef = useRef(0)
 
   const gatewayState = useStore($gatewayState)
@@ -751,6 +756,108 @@ export function DesktopController() {
     updateSessionState
   })
 
+  const recoverDetachedSessions = useCallback(async () => {
+    if (recoveringDetachedSessionsRef.current) {
+      return
+    }
+
+    const candidates = new Set<string>()
+    const selectedStored = selectedStoredSessionIdRef.current
+
+    if (selectedStored) {
+      candidates.add(selectedStored)
+    }
+
+    for (const id of $workingSessionIds.get()) {
+      candidates.add(id)
+    }
+
+    for (const id of $attentionSessionIds.get()) {
+      candidates.add(id)
+    }
+
+    if (!candidates.size) {
+      return
+    }
+
+    recoveringDetachedSessionsRef.current = true
+
+    try {
+      const visibleSessions = $sessions.get()
+
+      for (const storedSessionId of candidates) {
+        const stored = visibleSessions.find(
+          session => session.id === storedSessionId || session._lineage_root_id === storedSessionId
+        )
+
+        const storedProfile = stored?.profile ? normalizeProfileKey(stored.profile) : undefined
+        const recoveryProfile = storedProfile ?? normalizeProfileKey($activeGatewayProfile.get())
+
+        try {
+          const recoveryGateway = await ensureGatewayForProfileOpen(recoveryProfile)
+
+          if (!recoveryGateway) {
+            throw new Error(`Hermes gateway unavailable for profile ${recoveryProfile}`)
+          }
+
+          const resumed = await recoveryGateway.request<SessionResumeResponse>('session.resume', {
+            session_id: storedSessionId,
+            cols: 96,
+            ...(storedProfile && storedProfile !== 'default' ? { profile: storedProfile } : {})
+          })
+
+          const previousRuntimeId = runtimeIdByStoredSessionIdRef.current.get(storedSessionId)
+
+          const isActive =
+            storedSessionId === selectedStoredSessionIdRef.current || previousRuntimeId === activeSessionIdRef.current
+
+          const previousState = sessionStateByRuntimeIdRef.current.get(previousRuntimeId || resumed.session_id)
+          const messages = preserveLocalAssistantErrors(toChatMessages(resumed.messages), previousState?.messages ?? [])
+          const status = resumed.status
+
+          const resumedRunning = Boolean(
+            resumed.running || status === 'working' || status === 'streaming'
+          )
+
+          const runtimeInfo = isActive ? applyRuntimeInfo(resumed.info) : null
+
+          if (isActive && runtimeInfo?.cwd) {
+            patchSessionWorkspace(storedSessionId, runtimeInfo.cwd)
+          }
+
+          updateSessionState(
+            resumed.session_id,
+            state => ({
+              ...state,
+              ...(runtimeInfo ?? {}),
+              awaitingResponse: resumedRunning,
+              busy: resumedRunning,
+              messages
+            }),
+            storedSessionId
+          )
+
+          if (previousRuntimeId && previousRuntimeId !== resumed.session_id) {
+            sessionStateByRuntimeIdRef.current.delete(previousRuntimeId)
+          }
+
+          if (isActive) {
+            setActiveSessionId(resumed.session_id)
+            activeSessionIdRef.current = resumed.session_id
+            setBusy(resumedRunning)
+            busyRef.current = resumedRunning
+            setAwaitingResponse(resumedRunning)
+          }
+        } catch {
+          // Best-effort: one stale/orphaned row must not prevent other live
+          // sessions from reattaching to the fresh WebSocket.
+        }
+      }
+    } finally {
+      recoveringDetachedSessionsRef.current = false
+    }
+  }, [activeSessionIdRef, busyRef, runtimeIdByStoredSessionIdRef, selectedStoredSessionIdRef, sessionStateByRuntimeIdRef, updateSessionState])
+
   useGatewayBoot({
     handleGatewayEvent: handleDesktopGatewayEvent,
     onConnectionReady: c => {
@@ -759,6 +866,7 @@ export function DesktopController() {
     onGatewayReady: g => {
       gatewayRef.current = g
     },
+    onReconnectReady: recoverDetachedSessions,
     refreshHermesConfig,
     refreshSessions
   })

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -68,7 +68,9 @@ class FakeWebSocket {
   }
 
   private emit(type: string, ev: unknown) {
-    for (const fn of this.listeners[type] ?? []) fn(ev)
+    for (const fn of this.listeners[type] ?? []) {
+      fn(ev)
+    }
   }
 }
 
@@ -102,11 +104,12 @@ function fakeDesktop() {
   }
 }
 
-function Harness() {
+function Harness({ onReconnectReady }: { onReconnectReady?: () => Promise<void> | void }) {
   useGatewayBoot({
     handleGatewayEvent: () => undefined,
     onConnectionReady: () => undefined,
     onGatewayReady: () => undefined,
+    onReconnectReady,
     refreshHermesConfig: async () => undefined,
     refreshSessions: async () => undefined
   })
@@ -250,9 +253,11 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     FakeWebSocket.mode = 'fail'
     act(() => FakeWebSocket.instances[0].drop())
     await flushAsync()
+
     for (let i = 0; i < 8; i += 1) {
       await advanceBackoff()
     }
+
     expect($desktopBoot.get().error).toBeTruthy()
 
     // The remote comes back: next reconnect attempt opens.
@@ -261,5 +266,24 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
 
     expect($gatewayState.get()).toBe('open')
     expect($desktopBoot.get().error).toBeNull()
+  })
+
+  it('FIX: a successful post-boot reconnect notifies the app to reattach live sessions', async () => {
+    const onReconnectReady = vi.fn(async () => undefined)
+
+    render(<Harness onReconnectReady={onReconnectReady} />)
+    await flushAsync()
+
+    expect(onReconnectReady).not.toHaveBeenCalled()
+
+    FakeWebSocket.mode = 'fail'
+    act(() => FakeWebSocket.instances[0].drop())
+    await flushAsync()
+
+    FakeWebSocket.mode = 'open'
+    await advanceBackoff()
+
+    expect($gatewayState.get()).toBe('open')
+    expect(onReconnectReady).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -46,6 +46,7 @@ interface GatewayBootOptions {
     connection: Awaited<ReturnType<NonNullable<typeof window.hermesDesktop>['getConnection']>> | null
   ) => void
   onGatewayReady: (gateway: HermesGateway | null) => void
+  onReconnectReady?: () => Promise<void> | void
   refreshHermesConfig: () => Promise<void>
   refreshSessions: () => Promise<void>
 }
@@ -54,6 +55,7 @@ export function useGatewayBoot({
   handleGatewayEvent,
   onConnectionReady,
   onGatewayReady,
+  onReconnectReady,
   refreshHermesConfig,
   refreshSessions
 }: GatewayBootOptions) {
@@ -61,6 +63,7 @@ export function useGatewayBoot({
     handleGatewayEvent,
     onConnectionReady,
     onGatewayReady,
+    onReconnectReady,
     refreshHermesConfig,
     refreshSessions
   })
@@ -69,6 +72,7 @@ export function useGatewayBoot({
     handleGatewayEvent,
     onConnectionReady,
     onGatewayReady,
+    onReconnectReady,
     refreshHermesConfig,
     refreshSessions
   }
@@ -158,6 +162,12 @@ export function useGatewayBoot({
         // Resync state that may have moved on the backend while we were asleep.
         await callbacksRef.current.refreshHermesConfig().catch(() => undefined)
         await callbacksRef.current.refreshSessions().catch(() => undefined)
+        // A reconnect creates a fresh WebSocket transport. Any turns that were
+        // running when the old socket dropped are still alive server-side but
+        // parked on the detached transport until the renderer explicitly resumes
+        // them. Let the app rebind those stored-session lineages now; otherwise
+        // their final events are written to the drop sink and the UI looks stuck.
+        await Promise.resolve(callbacksRef.current.onReconnectReady?.()).catch(() => undefined)
       } catch (err) {
         // OAuth session expired mid-reconnect: surface the actionable "sign in
         // again" message once instead of silently looping the backoff against a
@@ -184,6 +194,14 @@ export function useGatewayBoot({
       // 1s, 2s, 4s … capped at 15s.
       const delay = Math.min(15_000, 1_000 * 2 ** Math.min(reconnectAttempt, 4))
       reconnectAttempt += 1
+
+      // After a prolonged post-boot outage, stop presenting this as endless
+      // "connecting" and surface the recovery UI. Keep scheduling retries below:
+      // a transient network can still come back without forcing a full restart.
+      if (reconnectAttempt >= 6 && !$desktopBoot.get().error) {
+        failDesktopBoot('Hermes gateway connection could not be restored.')
+      }
+
       reconnectTimer = setTimeout(() => {
         reconnectTimer = null
         void attemptReconnect()
@@ -359,10 +377,12 @@ export function useGatewayBoot({
         })
         await ensureDefaultWorkspaceCwd()
         const remoteDefault = await desktopDefaultCwd().catch(() => null)
+
         if (remoteDefault?.cwd && !$activeSessionId.get() && !$currentCwd.get()) {
           setCurrentCwd(remoteDefault.cwd)
           setCurrentBranch(remoteDefault.branch || '')
         }
+
         await callbacksRef.current.refreshHermesConfig()
 
         if (cancelled) {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -202,7 +202,7 @@ function upsertOptimisticSession(
   setSessions(prev => [session, ...prev.filter(s => s.id !== id)])
 }
 
-function patchSessionWorkspace(sessionId: string, cwd: string | undefined) {
+export function patchSessionWorkspace(sessionId: string, cwd: string | undefined) {
   if (!cwd) {
     return
   }
@@ -289,7 +289,7 @@ type SessionRuntimeStatePatch = Partial<
   >
 >
 
-function applyRuntimeInfo(info: SessionRuntimeInfo | undefined): SessionRuntimeStatePatch | null {
+export function applyRuntimeInfo(info: SessionRuntimeInfo | undefined): SessionRuntimeStatePatch | null {
   if (!info) {
     return null
   }
@@ -678,6 +678,7 @@ export function useSessionActions({
           ...(watchWindow ? { lazy: true } : {}),
           ...(sessionProfile ? { profile: sessionProfile } : {})
         })
+
         // The rejection is consumed by the `await` below; this guard only
         // keeps it from surfacing as unhandled while the prefetch settles.
         resumePromise.catch(() => undefined)

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -54,6 +54,7 @@ interface Secondary {
   reconnectTimer: ReturnType<typeof setTimeout> | null
   reconnectAttempt: number
   reconnecting: boolean
+  reconnectPromise: Promise<void> | null
   // While true the entry auto-reconnects on drop; pruning flips it off so a
   // deliberate close doesn't trigger the backoff loop.
   wantOpen: boolean
@@ -131,24 +132,32 @@ function scheduleReconnect(entry: Secondary): void {
 }
 
 async function reconnectSecondary(entry: Secondary): Promise<void> {
-  if (entry.reconnecting || !entry.wantOpen || isOpen(entry.gateway)) {
+  if (!entry.wantOpen || isOpen(entry.gateway)) {
     return
   }
 
-  entry.reconnecting = true
-
-  try {
-    await openSecondary(entry)
-    entry.reconnectAttempt = 0
-  } catch {
-    // Transport failure → fall through to the backoff below.
-  } finally {
-    entry.reconnecting = false
-
-    if (entry.wantOpen && !isOpen(entry.gateway)) {
-      scheduleReconnect(entry)
-    }
+  if (entry.reconnectPromise) {
+    return entry.reconnectPromise
   }
+
+  entry.reconnecting = true
+  entry.reconnectPromise = (async () => {
+    try {
+      await openSecondary(entry)
+      entry.reconnectAttempt = 0
+    } catch {
+      // Transport failure → fall through to the backoff below.
+    } finally {
+      entry.reconnecting = false
+      entry.reconnectPromise = null
+
+      if (entry.wantOpen && !isOpen(entry.gateway)) {
+        scheduleReconnect(entry)
+      }
+    }
+  })()
+
+  return entry.reconnectPromise
 }
 
 function createSecondary(profile: string): Secondary {
@@ -162,6 +171,7 @@ function createSecondary(profile: string): Secondary {
     reconnectTimer: null,
     reconnectAttempt: 0,
     reconnecting: false,
+    reconnectPromise: null,
     wantOpen: true
   }
 
@@ -180,6 +190,30 @@ function createSecondary(profile: string): Secondary {
   secondaries.set(profile, entry)
 
   return entry
+}
+
+export async function ensureGatewayForProfileOpen(profile: string): Promise<HermesGateway | null> {
+  const key = normKey(profile)
+
+  if (key === primaryProfile) {
+    return primaryGateway
+  }
+
+  let entry = secondaries.get(key)
+
+  if (!entry) {
+    entry = createSecondary(key)
+  }
+
+  entry.wantOpen = true
+
+  if (!isOpen(entry.gateway)) {
+    clearTimer(entry)
+    entry.reconnectAttempt = 0
+    await reconnectSecondary(entry)
+  }
+
+  return isOpen(entry.gateway) ? entry.gateway : null
 }
 
 // Make `profile` the active gateway, lazily opening its socket if needed. The

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -339,7 +339,9 @@ export interface SessionResumeResponse {
   message_count: number
   messages: SessionMessage[]
   resumed: string
+  running?: boolean
   session_id: string
+  status?: 'idle' | 'starting' | 'streaming' | 'waiting' | 'working' | string
 }
 
 export interface SessionRuntimeInfo {

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1583,6 +1583,49 @@ def test_ws_orphan_reap_spares_reattached_session(monkeypatch):
     assert server._ws_session_is_orphaned(done) is False
 
 
+def test_ws_orphan_reap_reschedules_detached_mid_turn_until_it_settles(monkeypatch):
+    timers = []
+    closed = []
+
+    class _Timer:
+        def __init__(self, delay, callback):
+            self.daemon = False
+            self.delay = delay
+            self.callback = callback
+            timers.append(self)
+
+        def start(self):
+            pass
+
+    def _close(sid, *, end_reason):
+        closed.append((sid, end_reason))
+        server._sessions.pop(sid, None)
+
+    monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0.01)
+    monkeypatch.setattr(server.threading, "Timer", _Timer)
+    monkeypatch.setattr(server, "_close_session_by_id", _close)
+
+    server._sessions["mid-turn"] = _session(
+        transport=server._detached_ws_transport,
+        running=True,
+    )
+    try:
+        server._schedule_ws_orphan_reap("mid-turn")
+        assert len(timers) == 1
+
+        timers[0].callback()
+        assert closed == []
+        assert "mid-turn" in server._sessions
+        assert len(timers) == 2
+
+        server._sessions["mid-turn"]["running"] = False
+        timers[1].callback()
+        assert closed == [("mid-turn", "ws_orphan_reap")]
+        assert "mid-turn" not in server._sessions
+    finally:
+        server._sessions.pop("mid-turn", None)
+
+
 def test_ws_orphan_reap_disabled_when_grace_zero(monkeypatch):
     """Grace=0 disables the reaper entirely (pre-fix park-forever behaviour)."""
     fired = {"timer": False}

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -527,9 +527,21 @@ def _schedule_ws_orphan_reap(sid: str) -> None:
         # guard with _sessions_lock). _sessions_lock is an RLock and the global
         # ordering is always resume_lock -> sessions_lock, so nesting is safe.
         with _session_resume_lock:
-            if not _ws_session_is_orphaned(_sessions.get(sid)):
+            session = _sessions.get(sid)
+            if _ws_session_is_orphaned(session):
+                _close_session_by_id(sid, end_reason="ws_orphan_reap")
                 return
-            _close_session_by_id(sid, end_reason="ws_orphan_reap")
+            # A detached session can still be mid-turn when the first grace
+            # timer fires. In that case it is correctly not orphaned yet, but
+            # without another timer it becomes immortal the moment the turn
+            # settles. Keep checking until it either reattaches or becomes safe
+            # to reap.
+            if (
+                session
+                and not session.get("_finalized")
+                and session.get("transport") is _detached_ws_transport
+            ):
+                _schedule_ws_orphan_reap(sid)
 
     timer = threading.Timer(_WS_ORPHAN_REAP_GRACE_S, _reap)
     timer.daemon = True


### PR DESCRIPTION
## Summary

Fixes a Desktop reconnect edge case where sessions that were mid-turn when the WebSocket dropped could remain visually stuck after the renderer reconnected.

This change:
- notifies the app after a successful post-boot reconnect so it can explicitly reattach live stored sessions
- resumes selected, working, and attention sessions after reconnect and remaps their runtime session ids/state
- routes reconnect recovery through the owning profile gateway instead of always using the active gateway
- keeps secondary profile reconnects awaitable so recovery does not race an in-flight reconnect
- keeps WS-detached backend sessions on the orphan reaper until they either reattach or settle and become safe to reap

## Why

A dropped Desktop WebSocket moves backend sessions to the detached/drop transport. Without an explicit `session.resume` after the fresh WebSocket opens, final events can continue to be emitted to the drop transport, leaving Desktop looking like the turn is still stuck.

There was also a backend cleanup gap: if the first orphan-reap timer fired while the detached session was still running, it skipped the session once and never checked again, so the session could become immortal after the turn settled.

## Tests

- `venv/bin/python -m pytest tests/test_tui_gateway_server.py::test_ws_orphan_reap_reschedules_detached_mid_turn_until_it_settles tests/test_tui_gateway_server.py::test_ws_orphan_reap_disabled_when_grace_zero tests/test_tui_gateway_server.py::test_ws_orphan_reap_spares_reattached_session -q -o 'addopts='`
- `npm --workspace apps/desktop run test:ui -- src/app/gateway/hooks/use-gateway-boot.test.tsx`
- `npm --workspace apps/desktop run typecheck`
- `npm --workspace apps/desktop run build`
- `npx eslint src/app/desktop-controller.tsx src/app/gateway/hooks/use-gateway-boot.ts src/app/gateway/hooks/use-gateway-boot.test.tsx src/app/session/hooks/use-session-actions.ts src/types/hermes.ts src/store/gateway.ts`
