### PR TITLE
fix(mattermost): preserve threaded delivery targets

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -107,6 +107,7 @@ class MattermostAdapter(BasePlatformAdapter):
         return {
             "Authorization": f"Bearer {self._token}",
             "Content-Type": "application/json",
+            "User-Agent": "HermesAgent-Mattermost/1.0",
         }
 
     async def _api_get(self, path: str) -> Dict[str, Any]:
@@ -286,11 +287,17 @@ class MattermostAdapter(BasePlatformAdapter):
                 "channel_id": chat_id,
                 "message": chunk,
             }
-            # Thread support: reply_to is the root post ID.
-            if reply_to and self._reply_mode == "thread":
+            # Thread support: reply_to or metadata.thread_id is the root post ID.
+            # Gateway delivery/cron/send_message pass thread context via metadata;
+            # normal user-message replies pass reply_to. Honour both so all
+            # outbound paths preserve Mattermost CRT root_id semantics.
+            effective_reply_to = reply_to
+            if not effective_reply_to and metadata:
+                effective_reply_to = metadata.get("thread_id") or metadata.get("root_id")
+            if effective_reply_to and self._reply_mode == "thread":
                 # Ensure root_id points to the thread root, not a reply.
                 # Mattermost rejects non-root post IDs as root_id.
-                resolved_root = await self._resolve_root_id(reply_to)
+                resolved_root = await self._resolve_root_id(str(effective_reply_to))
                 payload["root_id"] = resolved_root
 
             data = await self._api_post("posts", payload)
@@ -927,8 +934,12 @@ async def _standalone_send(
     headers = {
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
+        "User-Agent": "HermesAgent-Mattermost/1.0",
     }
-    upload_headers = {"Authorization": f"Bearer {token}"}
+    upload_headers = {
+        "Authorization": f"Bearer {token}",
+        "User-Agent": "HermesAgent-Mattermost/1.0",
+    }
 
     media_files = media_files or []
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -379,6 +379,19 @@ class TestResolveDeliveryTarget:
             "thread_id": None,
         }
 
+    def test_mattermost_explicit_thread_target(self):
+        """mattermost:<channel_id>:<root_post_id> preserves thread_id."""
+        job = {
+            "deliver": "mattermost:4crs8iwh4tncpqpephzajymeia:87bfm3xu87n75c4ec4xuc9ejow",
+            "origin": None,
+        }
+
+        assert _resolve_delivery_target(job) == {
+            "platform": "mattermost",
+            "chat_id": "4crs8iwh4tncpqpephzajymeia",
+            "thread_id": "87bfm3xu87n75c4ec4xuc9ejow",
+        }
+
     def test_list_form_multiple_platforms_normalized(self, monkeypatch):
         """deliver=['telegram', 'discord'] resolves to multiple targets."""
         from cron.scheduler import _resolve_delivery_targets

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -218,6 +218,36 @@ class TestMattermostSend:
         assert payload["root_id"] == "root_post"
 
     @pytest.mark.asyncio
+    async def test_send_with_metadata_thread_id(self):
+        """metadata.thread_id should become root_id for cron/gateway delivery."""
+        self.adapter._reply_mode = "thread"
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "post456"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_get_resp = AsyncMock()
+        mock_get_resp.status = 200
+        mock_get_resp.json = AsyncMock(return_value={"id": "root_post", "root_id": ""})
+        mock_get_resp.text = AsyncMock(return_value="")
+        mock_get_resp.__aenter__ = AsyncMock(return_value=mock_get_resp)
+        mock_get_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+        self.adapter._session.get = MagicMock(return_value=mock_get_resp)
+
+        result = await self.adapter.send(
+            "channel_1", "Reply!", metadata={"thread_id": "root_post"}
+        )
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert payload["root_id"] == "root_post"
+
+    @pytest.mark.asyncio
     async def test_send_without_thread_no_root_id(self):
         """When reply_mode is 'off', reply_to should NOT set root_id."""
         self.adapter._reply_mode = "off"

--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -16,5 +16,25 @@ def test_photon_e164_target_is_explicit() -> None:
 
 
 def test_e164_target_still_requires_phone_platform() -> None:
-    assert _parse_target_ref("matrix", "+15551234567")[2] is False
+    assert _parse_target_ref("matrix", "+155****4567")[2] is False
+
+
+def test_mattermost_channel_target_is_explicit() -> None:
+    chat_id, thread_id, is_explicit = _parse_target_ref(
+        "mattermost", "4crs8iwh4tncpqpephzajymeia"
+    )
+
+    assert chat_id == "4crs8iwh4tncpqpephzajymeia"
+    assert thread_id is None
+    assert is_explicit is True
+
+
+def test_mattermost_thread_target_is_explicit() -> None:
+    chat_id, thread_id, is_explicit = _parse_target_ref(
+        "mattermost", "4crs8iwh4tncpqpephzajymeia:87bfm3xu87n75c4ec4xuc9ejow"
+    )
+
+    assert chat_id == "4crs8iwh4tncpqpephzajymeia"
+    assert thread_id == "87bfm3xu87n75c4ec4xuc9ejow"
+    assert is_explicit is True
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -31,6 +31,10 @@ _SLACK_TARGET_RE = re.compile(r"^\s*([CGDU][A-Z0-9]{8,})\s*$")
 _SLACK_THREAD_TARGET_RE = re.compile(r"^\s*([CGD][A-Z0-9]{8,}):([^\s:]+)\s*$")
 _WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Za-z0-9._-]+@chatroom|filehelper)\s*$")
 _YUANBAO_TARGET_RE = re.compile(r"^\s*((?:group|direct):[^:]+)\s*$")
+# Mattermost channel/post IDs are 26-character lowercase base32-ish strings.
+# A thread target is encoded as "<channel_id>:<root_post_id>", matching the
+# cron/send_message platform:chat_id:thread_id convention used by Slack/Discord.
+_MATTERMOST_THREAD_TARGET_RE = re.compile(r"^\s*([a-z0-9]{26})(?::([a-z0-9]{26}))?\s*$")
 # Discord snowflake IDs are numeric, same regex pattern as Telegram topic targets.
 _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
 # Platforms that address recipients by phone number and accept E.164 format
@@ -365,6 +369,10 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         match = _NUMERIC_TOPIC_RE.fullmatch(target_ref)
         if match:
             return match.group(1), match.group(2), True
+    if platform_name == "mattermost":
+        match = _MATTERMOST_THREAD_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), match.group(2), True
     if platform_name == "slack":
         match = _SLACK_THREAD_TARGET_RE.fullmatch(target_ref)
         if match:
@@ -519,7 +527,14 @@ async def _send_via_adapter(
             adapter = runner.adapters.get(platform)
         except Exception:
             adapter = None
-        if adapter is not None:
+        # Mattermost's live adapter owns an aiohttp ClientSession created on
+        # the gateway event loop. send_message can run from an agent/tool loop;
+        # directly awaiting adapter.send() there raises aiohttp's
+        # "Timeout context manager should be used inside a task". Prefer the
+        # plugin's standalone REST sender for Mattermost unless a caller has
+        # scheduled delivery onto the gateway loop itself (cron does that in
+        # cron.scheduler via safe_schedule_threadsafe()).
+        if adapter is not None and platform_name != "mattermost":
             try:
                 metadata = {}
                 if thread_id:


### PR DESCRIPTION
## What does this PR do?

Fixes several Mattermost outbound delivery paths that can lose thread context or fail when a live gateway adapter is present:

- `send_message(target="mattermost:<channel_id>:<root_post_id>")` now parses Mattermost threaded targets instead of treating `<channel_id>:<root_post_id>` as one chat id.
- Mattermost delivery honors `metadata.thread_id` / `metadata.root_id` as the effective Mattermost `root_id` when `reply_to` is absent.
- `send_message` avoids directly awaiting the live Mattermost adapter from a potentially different event loop, which can trigger aiohttp's `Timeout context manager should be used inside a task` error.
- Mattermost REST calls include a stable Hermes User-Agent.

## Related Issue

No issue yet. This PR documents and fixes the reproduced bug directly.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/send_message_tool.py`
  - Add Mattermost `<channel_id>[:<root_post_id>]` explicit target parsing.
  - Route Mattermost `send_message` through standalone delivery instead of the live adapter cross-loop path.
- `plugins/platforms/mattermost/adapter.py`
  - Use `metadata.thread_id` / `metadata.root_id` as the effective threaded reply root when `reply_to` is absent.
  - Add a stable `User-Agent` header for REST and file-upload calls.
- `tests/tools/test_send_message_target_parse.py`
  - Cover Mattermost channel and threaded target parsing.
- `tests/cron/test_scheduler.py`
  - Cover explicit `mattermost:<channel_id>:<root_post_id>` cron delivery target parsing.
- `tests/gateway/test_mattermost.py`
  - Cover `metadata.thread_id` -> Mattermost `root_id` behavior.

## How to Test

Regression tests run locally:

```bash
./venv/bin/python -m pytest \
  tests/tools/test_send_message_target_parse.py \
  tests/gateway/test_mattermost.py::TestMattermostSend \
  tests/cron/test_scheduler.py::TestResolveDeliveryTarget::test_mattermost_explicit_thread_target \
  -q
```

Result:

```text
11 passed in 0.31s
```

I also verified the fix against a live Mattermost gateway after restarting the Hermes gateway process:

- `send_message(target="mattermost:<channel_id>:<root_post_id>")` succeeded and the Mattermost API showed `root_id=<root_post_id>`.
- Cron explicit delivery to `mattermost:<channel_id>:<root_post_id>` succeeded and preserved `root_id`.
- Cron `deliver=origin` back to a Mattermost DM thread succeeded and preserved `root_id`.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation and Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted regression test output:

```text
...........                                                              [100%]
11 passed in 0.31s
```
