### PR TITLE
fix(agent): preserve multimodal user content through early crash-resilience persist

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -236,8 +236,11 @@ def build_turn_context(
     active_system_prompt = agent._cached_system_prompt
 
     # Crash-resilience: persist the inbound user turn as soon as the session row exists.
+    # skip_user_override=True: the multimodal content (image_url parts) must
+    # survive in the in-memory messages list for the API call.  The plain-text
+    # override is applied on the final _persist_session after the API call.
     try:
-        agent._persist_session(messages, conversation_history)
+        agent._persist_session(messages, conversation_history, skip_user_override=True)
     except Exception:
         logger.warning(
             "Early turn-start session persistence failed for session=%s",

--- a/run_agent.py
+++ b/run_agent.py
@@ -1476,13 +1476,21 @@ class AIAgent:
             if isinstance(msg, dict) and msg.get("role") == "user":
                 msg["content"] = override
 
-    def _persist_session(self, messages: List[Dict], conversation_history: List[Dict] = None):
+    def _persist_session(self, messages: List[Dict], conversation_history: List[Dict] = None, *, skip_user_override: bool = False):
         """Save session state to both JSON log and SQLite on any exit path.
 
         Ensures conversations are never lost, even on errors or early returns.
+
+        When *skip_user_override* is True, the persist-user-message text
+        replacement is skipped — used by the early crash-resilience persist
+        in ``build_turn_context`` so that multimodal content (image_url
+        parts) survives in the in-memory messages list for the API call.
+        The override is applied on the final persist after the API call
+        completes.
         """
         self._drop_trailing_empty_response_scaffolding(messages)
-        self._apply_persist_user_message_override(messages)
+        if not skip_user_override:
+            self._apply_persist_user_message_override(messages)
         self._session_messages = messages
         self._save_session_log(messages)
         self._flush_messages_to_session_db(messages, conversation_history)


### PR DESCRIPTION
## Bug

WebUI image uploads silently lose images on vision-capable models (e.g. MiMo V2.5). The user uploads an image, but the API request never contains it — `API cache=100%` confirms images are absent from the request.

## Root Cause

`_apply_persist_user_message_override()` mutates the user message content **in-place**, replacing a multimodal list (`[{type: "text", ...}, {type: "image_url", ...}]`) with a plain-text string. This is called inside `_persist_session()`.

`build_turn_context()` invokes `_persist_session()` **before the API call** for crash-resilience (ensuring the user turn survives a process crash). The sequence:

```
build_turn_context:
  line 220: user_msg = {"role": "user", "content": [text_part, image_url_part]}
  line 240: agent._persist_session(messages, ...)   ← calls _apply_persist_user_message_override
             └─ msg["content"] = "Hello"            ← multimodal list → plain string
  return messages                                   ← user content is now plain text

run_conversation:
  API call  ← sends plain text, no images
```

The override is designed for **final** persistence (post-API), where the multimodal content should be replaced with text for cross-session replay and display. The early crash-resilience persist should NOT apply it — the raw multimodal content is exactly what should be saved for crash recovery.

## Fix

- **`run_agent.py`**: Add `skip_user_override` keyword to `_persist_session()` (default `False`). When `True`, skips `_apply_persist_user_message_override()`.
- **`agent/turn_context.py`**: Pass `skip_user_override=True` in the early crash-resilience persist so the in-memory messages list retains multimodal content for the API call.

All other `_persist_session()` call sites (25+ in `conversation_loop.py`, 1 in `turn_finalizer.py`) keep the default `False` and apply the override as before.

## Tests

- `tests/agent/test_image_routing.py`: 77/77 passed
- `tests/agent/test_turn_context*.py`: 6/6 passed