### PR TITLE
Register Qwen3.7 Plus context window

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -198,6 +198,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     "llama": 131072,
     # Qwen — specific model families before the catch-all.
     # Official docs: https://help.aliyun.com/zh/model-studio/developer-reference/
+    "qwen3.7-plus": 1000000,      # 1M context (DashScope/Alibaba & OpenRouter)
     "qwen3.6-plus": 1048576,      # 1M context (DashScope/Alibaba & OpenRouter)
     "qwen3-coder-plus": 1000000,  # 1M context
     "qwen3-coder": 262144,        # 256K context

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -776,6 +776,14 @@ class TestGetModelContextLength:
         assert get_model_context_length("dashscope/qwen3.6-plus") == 1048576
 
     @patch("agent.model_metadata.fetch_model_metadata")
+    def test_qwen3_7_plus_context_length(self, mock_fetch):
+        """qwen3.7-plus has a 1M context window, not the generic 128K Qwen default."""
+        mock_fetch.return_value = {}
+        assert get_model_context_length("qwen3.7-plus") == 1000000
+        assert get_model_context_length("qwen/qwen3.7-plus") == 1000000
+        assert get_model_context_length("dashscope/qwen3.7-plus") == 1000000
+
+    @patch("agent.model_metadata.fetch_model_metadata")
     def test_qwen_generic_context_length(self, mock_fetch):
         """Generic qwen models still get the 128K default."""
         mock_fetch.return_value = {}


### PR DESCRIPTION
## Summary
- add an explicit `qwen3.7-plus` context-window fallback before the generic Qwen fallback
- cover bare and provider-prefixed Qwen3.7 Plus model IDs in model metadata tests

## Why
Without an explicit entry, `qwen3.7-plus` falls through to the generic `qwen` fallback and is displayed as 131,072 tokens instead of the model's 1M context window.

## Tests
- `uv run --with pytest --with pytest-timeout pytest tests/agent/test_model_metadata.py -q`
- `uv run --with ruff ruff check agent/model_metadata.py tests/agent/test_model_metadata.py`
- `git diff --check HEAD~1..HEAD`
