### PR TITLE
fix: strip reasoning_content for providers that don't support echo-back (#45655)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2158,12 +2158,25 @@ def copy_reasoning_content_for_api(agent, source_msg: dict, api_msg: dict) -> No
     # those with HTTP 400. When the active provider enforces the
     # thinking-mode echo, upgrade "" → " " on replay so stale history
     # doesn't 400 the user on the next turn.
+    #
+    # For providers that do NOT enforce thinking-mode echo-back (e.g.
+    # Cerebras, Groq, SambaNova), strip reasoning_content entirely —
+    # some APIs reject the field in input messages even though they
+    # return reasoning_tokens in responses (refs #45655).
     existing = source_msg.get("reasoning_content")
     if isinstance(existing, str):
         if existing == "" and agent._needs_thinking_reasoning_pad():
             api_msg["reasoning_content"] = " "
-        else:
+        elif existing == "":
+            # Empty string — harmless for most providers, preserve it.
             api_msg["reasoning_content"] = existing
+        elif agent._needs_thinking_reasoning_pad():
+            api_msg["reasoning_content"] = existing
+        else:
+            # Non-empty reasoning_content for a provider that doesn't
+            # enforce thinking-mode echo-back — strip it to avoid
+            # HTTP 400 on replay (e.g. Cerebras, refs #45655).
+            api_msg.pop("reasoning_content", None)
         return
 
     needs_thinking_pad = agent._needs_thinking_reasoning_pad()
@@ -2194,8 +2207,13 @@ def copy_reasoning_content_for_api(agent, source_msg: dict, api_msg: dict) -> No
     # This must happen before the unconditional empty-string fallback so
     # genuine reasoning content is not overwritten (#15812 regression in
     # PR #15478).
+    # Only promote for providers that actually support reasoning_content
+    # echo-back — otherwise strip it to avoid HTTP 400 (refs #45655).
     if isinstance(normalized_reasoning, str) and normalized_reasoning:
-        api_msg["reasoning_content"] = normalized_reasoning
+        if needs_thinking_pad:
+            api_msg["reasoning_content"] = normalized_reasoning
+        else:
+            api_msg.pop("reasoning_content", None)
         return
 
     # 4. DeepSeek / Kimi thinking mode: all assistant messages need

--- a/tests/run_agent/test_cerebras_reasoning_content_strip.py
+++ b/tests/run_agent/test_cerebras_reasoning_content_strip.py
@@ -1,0 +1,148 @@
+"""Regression test: Cerebras reasoning_content stripping.
+
+Cerebras API returns ``reasoning_tokens`` in responses but rejects
+``reasoning_content`` in input messages with HTTP 400::
+
+    messages.2.assistant.reasoning_content: property 'reasoning_content'
+    is unsupported
+
+``copy_reasoning_content_for_api`` must strip ``reasoning_content`` for
+providers that don't enforce thinking-mode echo-back (i.e. when
+``_needs_thinking_reasoning_pad()`` returns ``False``).
+
+Refs #45655.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _make_agent(provider: str = "", model: str = "", base_url: str = "") -> AIAgent:
+    agent = object.__new__(AIAgent)
+    agent.provider = provider
+    agent.model = model
+    agent.base_url = base_url
+    agent.verbose_logging = False
+    agent.reasoning_callback = None
+    agent.stream_delta_callback = None
+    agent._stream_callback = None
+    return agent
+
+
+# ---------------------------------------------------------------------------
+# copy_reasoning_content_for_api — Cerebras stripping
+# ---------------------------------------------------------------------------
+
+
+class TestCerebrasReasoningContentStripping:
+    """copy_reasoning_content_for_api strips reasoning_content for Cerebras."""
+
+    def test_strips_non_empty_reasoning_content_for_cerebras(self):
+        """Non-empty reasoning_content must be stripped for Cerebras."""
+        agent = _make_agent(
+            provider="custom:cerebras",
+            model="gpt-oss-120b",
+            base_url="https://api.cerebras.ai/v1",
+        )
+        source = {
+            "role": "assistant",
+            "reasoning_content": "Some reasoning from Cerebras",
+        }
+        api_msg: dict = {"role": "assistant"}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert "reasoning_content" not in api_msg
+
+    def test_strips_reasoning_promotion_for_cerebras(self):
+        """'reasoning' field must NOT be promoted to reasoning_content for Cerebras."""
+        agent = _make_agent(
+            provider="custom:cerebras",
+            model="gpt-oss-120b",
+            base_url="https://api.cerebras.ai/v1",
+        )
+        source = {
+            "role": "assistant",
+            "reasoning": "Some internal reasoning text",
+        }
+        api_msg: dict = {"role": "assistant"}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert "reasoning_content" not in api_msg
+
+    def test_preserves_empty_reasoning_content_for_cerebras(self):
+        """Empty reasoning_content is harmless — preserve it (matches non-thinking behavior)."""
+        agent = _make_agent(
+            provider="custom:cerebras",
+            model="gpt-oss-120b",
+            base_url="https://api.cerebras.ai/v1",
+        )
+        source = {
+            "role": "assistant",
+            "reasoning_content": "",
+        }
+        api_msg: dict = {"role": "assistant"}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg.get("reasoning_content") == ""
+
+    def test_preserves_reasoning_content_for_deepseek(self):
+        """DeepSeek must still receive reasoning_content (regression guard)."""
+        agent = _make_agent(
+            provider="deepseek",
+            model="deepseek-v4-pro",
+            base_url="https://api.deepseek.com/v1",
+        )
+        source = {
+            "role": "assistant",
+            "reasoning_content": "DeepSeek reasoning",
+        }
+        api_msg: dict = {"role": "assistant"}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg["reasoning_content"] == "DeepSeek reasoning"
+
+    def test_preserves_reasoning_content_for_kimi(self):
+        """Kimi must still receive reasoning_content (regression guard)."""
+        agent = _make_agent(
+            provider="kimi-coding",
+            model="kimi-k2",
+            base_url="https://api.kimi.com/v1",
+        )
+        source = {
+            "role": "assistant",
+            "reasoning_content": "Kimi reasoning",
+        }
+        api_msg: dict = {"role": "assistant"}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg["reasoning_content"] == "Kimi reasoning"
+
+    def test_preserves_reasoning_content_for_mimo(self):
+        """MiMo must still receive reasoning_content (regression guard)."""
+        agent = _make_agent(
+            provider="xiaomi",
+            model="mimo-v2.5-pro",
+            base_url="https://api.xiaomimimo.com/v1",
+        )
+        source = {
+            "role": "assistant",
+            "reasoning_content": "MiMo reasoning",
+        }
+        api_msg: dict = {"role": "assistant"}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert api_msg["reasoning_content"] == "MiMo reasoning"
+
+    def test_strips_for_unknown_custom_provider(self):
+        """Unknown custom providers should also have reasoning_content stripped."""
+        agent = _make_agent(
+            provider="custom:sambanova",
+            model="Llama-4-Maverick-17B-128E-Instruct",
+            base_url="https://api.sambanova.ai/v1",
+        )
+        source = {
+            "role": "assistant",
+            "reasoning_content": "Some reasoning",
+        }
+        api_msg: dict = {"role": "assistant"}
+        agent._copy_reasoning_content_for_api(source, api_msg)
+        assert "reasoning_content" not in api_msg


### PR DESCRIPTION
## Summary

Fixes #45655 — Cerebras API rejects `reasoning_content` in input messages with HTTP 400, causing multi-turn agent sessions with tool calling to fail after rate-limit retries.

## Root Cause

In `copy_reasoning_content_for_api()`, non-empty `reasoning_content` was **always** copied to the API message regardless of provider. Cerebras returns `reasoning_tokens` in responses but doesn't accept `reasoning_content` in input messages.

## Fix

Gated `reasoning_content` echo-back on `_needs_thinking_reasoning_pad()`:

- **Step 1** (existing reasoning_content): non-empty string only copied when provider requires it (DeepSeek, Kimi, MiMo)
- **Step 3** (reasoning → reasoning_content promotion): same gate applied

Empty string preserved for all providers (harmless, matches existing behavior).

## Changes

- `agent/agent_runtime_helpers.py` — Gate reasoning_content echo on `_needs_thinking_reasoning_pad()` in steps 1 and 3
- `tests/run_agent/test_cerebras_reasoning_content_strip.py` — 7 regression tests

## Tests

```
47 passed (7 new + 40 existing DeepSeek tests)
```

All existing DeepSeek reasoning_content echo tests continue to pass.

Closes #45655