### PR TITLE
fix(bedrock): omit sampling params for restricted Claude models

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -935,11 +935,14 @@ def build_converse_kwargs(
     if system_prompt:
         kwargs["system"] = system_prompt
 
-    if temperature is not None:
-        kwargs["inferenceConfig"]["temperature"] = temperature
+    from agent.anthropic_adapter import _forbids_sampling_params
 
-    if top_p is not None:
-        kwargs["inferenceConfig"]["topP"] = top_p
+    if not _forbids_sampling_params(model):
+        if temperature is not None:
+            kwargs["inferenceConfig"]["temperature"] = temperature
+
+        if top_p is not None:
+            kwargs["inferenceConfig"]["topP"] = top_p
 
     if stop_sequences:
         kwargs["inferenceConfig"]["stopSequences"] = stop_sequences

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -605,6 +605,74 @@ class TestBuildConverseKwargs:
         assert kwargs["inferenceConfig"]["temperature"] == 0.7
         assert kwargs["inferenceConfig"]["topP"] == 0.9
 
+    def test_omits_sampling_params_for_bedrock_opus_4_7(self):
+        from agent.bedrock_adapter import build_converse_kwargs
+
+        for model_id in (
+            "anthropic.claude-opus-4-7-20260101-v1:0",
+            "us.anthropic.claude-opus-4-7",
+        ):
+            kwargs = build_converse_kwargs(
+                model=model_id,
+                messages=[{"role": "user", "content": "Hi"}],
+                temperature=0.7,
+                top_p=0.9,
+            )
+
+            assert "temperature" not in kwargs["inferenceConfig"]
+            assert "topP" not in kwargs["inferenceConfig"]
+
+    def test_omits_sampling_params_for_bedrock_opus_4_8_variants(self):
+        from agent.bedrock_adapter import build_converse_kwargs
+
+        for model_id in (
+            "anthropic.claude-opus-4-8-20270101-v1:0",
+            "us.anthropic.claude-opus-4-8",
+            "anthropic.claude-opus-4.8",
+        ):
+            kwargs = build_converse_kwargs(
+                model=model_id,
+                messages=[{"role": "user", "content": "Hi"}],
+                temperature=0.5,
+                top_p=0.95,
+            )
+
+            assert "temperature" not in kwargs["inferenceConfig"]
+            assert "topP" not in kwargs["inferenceConfig"]
+
+    def test_keeps_sampling_params_for_bedrock_non_restricted_models(self):
+        from agent.bedrock_adapter import build_converse_kwargs
+
+        for model_id in (
+            "anthropic.claude-sonnet-4-6-20250514-v1:0",
+            "anthropic.claude-haiku-4-5",
+            "test-model",
+        ):
+            kwargs = build_converse_kwargs(
+                model=model_id,
+                messages=[{"role": "user", "content": "Hi"}],
+                temperature=0.7,
+                top_p=0.9,
+            )
+
+            assert kwargs["inferenceConfig"].get("temperature") == 0.7
+            assert kwargs["inferenceConfig"].get("topP") == 0.9
+
+    def test_bedrock_opus_strips_sampling_params_but_keeps_stop_sequences(self):
+        from agent.bedrock_adapter import build_converse_kwargs
+
+        kwargs = build_converse_kwargs(
+            model="us.anthropic.claude-opus-4-8",
+            messages=[{"role": "user", "content": "Hi"}],
+            temperature=0.7,
+            top_p=0.9,
+            stop_sequences=["END"],
+        )
+
+        assert "temperature" not in kwargs["inferenceConfig"]
+        assert "topP" not in kwargs["inferenceConfig"]
+        assert kwargs["inferenceConfig"]["stopSequences"] == ["END"]
+
     def test_includes_guardrail_config(self):
         from agent.bedrock_adapter import build_converse_kwargs
         guardrail = {


### PR DESCRIPTION
## Summary
Bedrock Converse now omits `temperature` and `topP` for Claude models that reject non-default sampling parameters, while preserving those fields for unrestricted models.

## Changes
- Reuse the Anthropic-native `_forbids_sampling_params()` guard in the Bedrock Converse kwargs builder.
- Omit sampling params for Opus 4.7 / 4.8 Bedrock model IDs and inference profiles.
- Preserve `stopSequences` for restricted Opus models.
- Preserve sampling params for Sonnet 4.6, Haiku 4.5, and non-Claude models.

## Validation
| Check | Result |
|---|---|
| Targeted new Bedrock sampling-param tests | 4 passed |
| `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/agent/test_bedrock_adapter.py::TestBuildConverseKwargs -q` | 10 passed |
| `scripts/run_tests.sh tests/agent/test_bedrock_adapter.py` | 128 passed |
| Bedrock kwargs E2E shape check | passed |
| `python3 -m py_compile agent/bedrock_adapter.py tests/agent/test_bedrock_adapter.py && git diff --check` | passed |

Consolidates #38717 by @ashishpatel26 and #36257 by @Tranquil-Flow. Authorship for #38717 is preserved, with #36257 credited via co-author trailer and its stop-sequence regression included.

Closes #36151.

## Infographic

![Bedrock Sampling Guard](https://v3b.fal.media/files/b/0a9e2408/uOQnvkI90iJ0QyREibUNa_gVRkLu0J.png)
