### PR TITLE
docs: reference ~/.hermes/config.yaml as the shell-hooks config path

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -1,7 +1,7 @@
 """
 Shell-script hooks bridge.
 
-Reads the ``hooks:`` block from ``cli-config.yaml``, prompts the user for
+Reads the ``hooks:`` block from ``~/.hermes/config.yaml``, prompts the user for
 consent on first use of each ``(event, command)`` pair, and registers
 callbacks on the existing plugin hook manager so every existing
 ``invoke_hook()`` site dispatches to the configured shell scripts — with
@@ -758,7 +758,7 @@ def _resolve_effective_accept(
     Precedence (any truthy source flips us on):
       1. ``--accept-hooks`` flag (CLI) / explicit argument
       2. ``HERMES_ACCEPT_HOOKS`` env var
-      3. ``hooks_auto_accept: true`` in ``cli-config.yaml``
+      3. ``hooks_auto_accept: true`` in ``~/.hermes/config.yaml``
     """
     if accept_hooks_arg:
         return True

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -1143,7 +1143,7 @@ The hook is guarded on a non-empty, non-interrupted response — it will not fir
 
 ## Shell Hooks
 
-Declare shell-script hooks in your `cli-config.yaml` and Hermes will run them as subprocesses whenever the corresponding plugin-hook event fires — in both CLI and gateway sessions. No Python plugin authoring required.
+Declare shell-script hooks in your `~/.hermes/config.yaml` and Hermes will run them as subprocesses whenever the corresponding plugin-hook event fires — in both CLI and gateway sessions. No Python plugin authoring required.
 
 Use shell hooks when you want a drop-in, single-file script (Bash, Python, anything with a shebang) to:
 
@@ -1307,7 +1307,7 @@ Three escape hatches bypass the interactive prompt — any one is sufficient:
 
 1. `--accept-hooks` flag on the CLI (e.g. `hermes --accept-hooks chat`)
 2. `HERMES_ACCEPT_HOOKS=1` environment variable
-3. `hooks_auto_accept: true` in `cli-config.yaml`
+3. `hooks_auto_accept: true` in `~/.hermes/config.yaml`
 
 Non-TTY runs (gateway, cron, CI) need one of these three — otherwise any newly-added hook silently stays un-registered and logs a warning.
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/hooks.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/hooks.md
@@ -1139,7 +1139,7 @@ def register(ctx):
 
 ## Shell Hooks
 
-在 `cli-config.yaml` 中声明 shell 脚本 hook，Hermes 会在对应的插件 hook 事件触发时将其作为子进程运行——在 CLI 和 gateway 会话中均适用。无需编写 Python 插件。
+在 `~/.hermes/config.yaml` 中声明 shell 脚本 hook，Hermes 会在对应的插件 hook 事件触发时将其作为子进程运行——在 CLI 和 gateway 会话中均适用。无需编写 Python 插件。
 
 当你希望用一个即插即用的单文件脚本（Bash、Python 或任何带 shebang 的脚本）来实现以下功能时，使用 shell hooks：
 
@@ -1303,7 +1303,7 @@ printf '{}\n'
 
 1. CLI 上的 `--accept-hooks` 标志（如 `hermes --accept-hooks chat`）
 2. `HERMES_ACCEPT_HOOKS=1` 环境变量
-3. `cli-config.yaml` 中的 `hooks_auto_accept: true`
+3. `~/.hermes/config.yaml` 中的 `hooks_auto_accept: true`
 
 非 TTY 运行（gateway、cron、CI）需要这三种方式之一——否则任何新添加的 hook 会静默保持未注册状态并记录警告。
 


### PR DESCRIPTION
## Summary

The shell-hooks docstrings (`agent/shell_hooks.py`) and the user guide (`website/docs/user-guide/features/hooks.md` and its `zh-Hans` translation) declared the `hooks:` block in `cli-config.yaml`. The user-facing, preferred config location is `~/.hermes/config.yaml` — the CLI resolves it first, with the project-local `cli-config.yaml` only as a fallback. This aligns the docs/docstrings with where users actually configure shell hooks (other parts of the same hooks guide already reference `~/.hermes/config.yaml`).

## Changes

- `agent/shell_hooks.py` — module docstring + `_resolve_effective_accept` precedence docstring
- `website/docs/user-guide/features/hooks.md` (en) — Shell Hooks section (2 lines)
- `website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/hooks.md` — same two lines, kept in sync

## Test plan

Docs/docstring-only change; no runtime behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)