### PR TITLE
fix: handle remote image URLs in native routing

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -460,6 +460,9 @@ def build_native_content_parts(
     Local paths are read from disk and embedded as base64 ``data:`` URLs.
     Remote URLs (``http(s)://``) are passed through verbatim — the provider
     fetches them server-side. The model still sees the pixels either way.
+    Some gateway adapters historically pass resolved remote media URLs in
+    ``image_paths``; accept those here too instead of treating them as missing
+    local files.
 
     For each successfully attached image, a hint is appended to the text
     part:
@@ -488,19 +491,29 @@ def build_native_content_parts(
     attached_urls: List[str] = []
 
     for raw_path in image_paths:
-        p = Path(raw_path)
+        raw = (str(raw_path) or "").strip()
+        if not raw:
+            continue
+        if raw.startswith(("http://", "https://")):
+            image_parts.append({
+                "type": "image_url",
+                "image_url": {"url": raw},
+            })
+            attached_urls.append(raw)
+            continue
+        p = Path(raw)
         if not p.exists() or not p.is_file():
-            skipped.append(str(raw_path))
+            skipped.append(raw)
             continue
         data_url = _file_to_data_url(p)
         if not data_url:
-            skipped.append(str(raw_path))
+            skipped.append(raw)
             continue
         image_parts.append({
             "type": "image_url",
             "image_url": {"url": data_url},
         })
-        attached_paths.append(str(raw_path))
+        attached_paths.append(raw)
 
     for url in image_urls or []:
         url = (url or "").strip()

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -596,6 +596,25 @@ class TestBuildNativeContentPartsURLs:
             "image_url": {"url": "https://example.com/diagram.png"},
         }
 
+    def test_url_in_image_paths_is_treated_as_remote_url(self):
+        """Gateway adapters may pass signed remote media URLs via image_paths."""
+        parts, skipped = build_native_content_parts(
+            "describe this",
+            ["https://example.com/signed-dingtalk-image.jpg?token=abc"],
+        )
+        assert skipped == []
+        assert parts[0]["type"] == "text"
+        assert (
+            "[Image attached: https://example.com/signed-dingtalk-image.jpg?token=abc]"
+            in parts[0]["text"]
+        )
+        assert parts[1] == {
+            "type": "image_url",
+            "image_url": {
+                "url": "https://example.com/signed-dingtalk-image.jpg?token=abc"
+            },
+        }
+
     def test_mixed_path_and_url(self, tmp_path: Path):
         img = tmp_path / "local.png"
         img.write_bytes(_png_bytes())


### PR DESCRIPTION
## Summary
- Treat http(s) entries passed through image_paths as remote image URLs instead of missing local files
- Preserve existing local file behavior and URL hint text
- Add regression coverage for signed remote media URLs passed by gateway adapters

## Test Plan
- venv/bin/python -m pytest tests/agent/test_image_routing.py -q -o 'addopts='