### PR TITLE
fix(desktop): apply backend PATH/PYTHONPATH to step 4 (existing CLI on PATH)

### DIFF
--- a/apps/desktop/electron/backend-env.cjs
+++ b/apps/desktop/electron/backend-env.cjs
@@ -81,6 +81,7 @@ function buildDesktopBackendEnv({
 
   return {
     PYTHONPATH: appendUniquePathEntries([...pythonPathEntries, currentPythonPath], { delimiter }),
+    PYTHONUTF8: '1',
     [key]: buildDesktopBackendPath({
       hermesHome,
       venvRoot,

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -2350,7 +2350,16 @@ function resolveHermesBackend(dashboardArgs) {
           command: hermesCommand,
           args: dashboardArgs,
           bootstrap: false,
-          env: {},
+          // Step 4 (existing Hermes CLI on PATH) needs the same PATH and
+          // PYTHONPATH augmentation as the other backend paths. Without it,
+          // pip-generated console_scripts .exe stubs (zipapp launchers) on
+          // Windows resolve the wrong Python interpreter and fail with
+          // `No module named 'fastapi'` when running `hermes dashboard`.
+          env: buildDesktopBackendEnv({
+            hermesHome: HERMES_HOME,
+            pythonPathEntries: [ACTIVE_HERMES_ROOT],
+            venvRoot: VENV_ROOT
+          }),
           kind: 'command',
           shell: shellForProbe
         }


### PR DESCRIPTION
The recent backend-env.cjs refactor (9c5052170) added `buildDesktopBackendEnv` to set proper PATH and PYTHONPATH for backend processes spawned by steps 3 (`createActiveBackend`) and 5 (`createPythonBackend`), but missed **step 4** where an existing `hermes` CLI is found on PATH.

Without PATH augmentation, pip-generated console_scripts .exe stubs (zipapp launchers) on Windows resolve the wrong Python interpreter and fail with `No module named 'fastapi'` when spawning `hermes dashboard`.

Fix: apply the same `buildDesktopBackendEnv` to step 4's return object, so the spawned process inherits the venv Scripts/bin directory on its PATH and the project root on its PYTHONPATH.