### PR TITLE
fix(cli): guard mcp list/test/configure against non-dict server entries

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -55,6 +55,23 @@ def _error(text: str):
     print(color(f"  ✗ {text}", Colors.RED))
 
 
+def _normalize_mcp_cfg(name: str, cfg):
+    """Coerce a raw config value to a dict, or return None if unparseable.
+
+    String shorthand (``"https://example.com/mcp"``) is converted to
+    ``{"url": <str>}``.  Non-dict values that are not strings are skipped
+    with a warning so that one malformed entry doesn't abort the entire
+    listing.
+    """
+    if isinstance(cfg, dict):
+        return cfg
+    if isinstance(cfg, str):
+        _warning(f"Server '{name}': string shorthand coerced to URL")
+        return {"url": cfg}
+    _warning(f"Server '{name}': expected dict, got {type(cfg).__name__} — skipped")
+    return None
+
+
 def _confirm(question: str, default: bool = True) -> bool:
     default_str = "Y/n" if default else "y/N"
     try:
@@ -533,6 +550,10 @@ def cmd_mcp_list(args=None):
     print(f"  {'─' * 16} {'─' * 30} {'─' * 12} {'─' * 10}")
 
     for name, cfg in servers.items():
+        cfg = _normalize_mcp_cfg(name, cfg)
+        if cfg is None:
+            continue
+
         # Transport info
         if "url" in cfg:
             url = cfg["url"]
@@ -592,6 +613,9 @@ def cmd_mcp_test(args):
         return
 
     cfg = servers[name]
+    cfg = _normalize_mcp_cfg(name, cfg)
+    if cfg is None:
+        return
     print()
     print(color(f"  Testing '{name}'...", Colors.CYAN))
 
@@ -747,6 +771,9 @@ def cmd_mcp_configure(args):
         return
 
     cfg = servers[name]
+    cfg = _normalize_mcp_cfg(name, cfg)
+    if cfg is None:
+        return
 
     # Discover all available tools
     print()

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -113,6 +113,46 @@ class TestMcpList:
         assert "myserver" in out
         assert "enabled" in out
 
+    def test_list_string_shorthand_coerced_to_url(self, tmp_path, capsys):
+        """A raw string entry is coerced to {'url': str} instead of crashing."""
+        _seed_config(tmp_path, {
+            "broken": "https://example.com/mcp",
+        })
+        from hermes_cli.mcp_config import cmd_mcp_list
+
+        cmd_mcp_list()
+        out = capsys.readouterr().out
+        assert "broken" in out
+        assert "https://example.com/mcp" in out
+        assert "string shorthand" in out.lower() or "coerced" in out.lower()
+
+    def test_list_mixed_string_and_dict(self, tmp_path, capsys):
+        """String entry doesn't abort listing of subsequent dict entries."""
+        _seed_config(tmp_path, {
+            "good": {"url": "https://good.example.com/mcp"},
+            "broken": "https://broken.example.com/mcp",
+        })
+        from hermes_cli.mcp_config import cmd_mcp_list
+
+        cmd_mcp_list()
+        out = capsys.readouterr().out
+        assert "good" in out
+        assert "broken" in out
+
+    def test_list_non_dict_non_string_skipped(self, tmp_path, capsys):
+        """A non-dict, non-string entry is skipped with a warning."""
+        _seed_config(tmp_path, {
+            "good": {"url": "https://good.example.com/mcp"},
+            "bad": 42,
+        })
+        from hermes_cli.mcp_config import cmd_mcp_list
+
+        cmd_mcp_list()
+        out = capsys.readouterr().out
+        assert "good" in out
+        assert "bad" not in out or "skipped" in out.lower()
+        assert "expected dict" in out.lower()
+
 
 # ---------------------------------------------------------------------------
 # Tests: cmd_mcp_remove


### PR DESCRIPTION
## What does this PR do?

Guards `hermes mcp list`, `hermes mcp test`, and `hermes mcp configure` against non-dict MCP server entries in `config.yaml`. When an entry is a raw string (e.g. from `hermes config set mcp_servers.foo "https://..."`), the commands now coerce it to `{"url": str}` instead of crashing with `AttributeError`.

## Related Issue

Fixes #45674

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/mcp_config.py`: Added `_normalize_mcp_cfg()` helper that coerces string shorthand to `{"url": str}` and skips non-dict/non-string types with a warning. Applied to `cmd_mcp_list`, `cmd_mcp_test`, and `cmd_mcp_configure`.
- `tests/hermes_cli/test_mcp_config.py`: Added 3 tests for string shorthand coercion, mixed entries, and non-dict skipping.

## How to Test

1. Set a string MCP entry: `hermes config set mcp_servers.broken "https://example.com/mcp"`
2. Run `hermes mcp list` — should show "broken" with the URL instead of crashing
3. Run `pytest tests/hermes_cli/test_mcp_config.py -x -q` — all 45 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/mcp_config.py` (`cmd_mcp_list`, `cmd_mcp_test`, `cmd_mcp_configure`)
- Blast radius: LOW — additive guard, no behavior change for well-formed configs
- Related patterns: String shorthand coercion for config values
