### PR TITLE
fix(tui): detach session.close finalization from response path (#23642)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -46,6 +46,12 @@ def test_session_create_rejects_at_active_session_limit(monkeypatch, tmp_path):
 
         closed = server._methods["session.close"]("r3", {"session_id": sid})
         assert closed["result"]["closed"] is True
+        # session.close backgrounds finalization (#23642) and the active-session
+        # lease is released inside _finalize_session, so join the close thread
+        # before asserting the registry has drained.
+        t = server._last_close_thread
+        if t is not None:
+            t.join(timeout=5)
         assert active_session_registry_snapshot() == []
 
         third = server._methods["session.create"]("r4", {"cols": 80})
@@ -1492,10 +1498,61 @@ def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
             {"id": "1", "method": "session.close", "params": {"session_id": "sid"}}
         )
         assert resp["result"]["closed"] is True
+        # session.close backgrounds finalization (#23642); the pop (and thus the
+        # True return) is synchronous, but memory commit + finalize hook run on
+        # a daemon thread. Join it before asserting on those side effects.
+        t = server._last_close_thread
+        assert t is not None
+        t.join(timeout=5)
+        assert not t.is_alive()
         assert calls["history"] == [{"role": "user", "content": "hello"}]
         assert ("on_session_finalize", "session-key") in calls["hooks"]
     finally:
         server._sessions.pop("sid", None)
+
+
+def test_session_close_returns_promptly_despite_slow_finalization(monkeypatch):
+    """session.close must return well before a slow memory commit finishes.
+
+    Regression for #23642: finalization (which can call an LLM + write SQLite
+    via commit_memory_session) used to run synchronously on the RPC path, so
+    the TUI's /clear blocked until it completed. Finalization is now detached
+    onto a daemon thread; the response returns promptly and the commit still
+    completes in the background.
+    """
+    committed = threading.Event()
+
+    def _slow_commit(history):
+        time.sleep(0.3)
+        committed.set()
+
+    agent = types.SimpleNamespace(session_id="session-key")
+    agent.commit_memory_session = _slow_commit
+    server._sessions["slow-sid"] = _session(
+        agent=agent, history=[{"role": "user", "content": "hello"}]
+    )
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    try:
+        start = time.monotonic()
+        resp = server.handle_request(
+            {"id": "1", "method": "session.close", "params": {"session_id": "slow-sid"}}
+        )
+        elapsed = time.monotonic() - start
+        assert resp["result"]["closed"] is True
+        # Returned without waiting on the ~300ms commit.
+        assert elapsed < 0.25, f"session.close blocked for {elapsed:.3f}s"
+        # Commit hadn't finished yet at response time.
+        assert not committed.is_set()
+        # ...but it does complete in the background.
+        t = server._last_close_thread
+        assert t is not None
+        t.join(timeout=5)
+        assert committed.wait(timeout=1)
+        assert not t.is_alive()
+    finally:
+        server._sessions.pop("slow-sid", None)
 
 
 def test_ws_orphan_reap_closes_worker_when_session_stays_detached(monkeypatch):
@@ -7145,13 +7202,19 @@ def test_session_close_rpc_delegates_to_close_session_by_id(monkeypatch):
     seen = []
     monkeypatch.setattr(
         server, "_close_session_by_id",
-        lambda sid, *, end_reason: bool(seen.append((sid, end_reason))) or True,
+        # background defaults so callers other than the RPC (which passes
+        # background=True for #23642) still match; the RPC must delegate with
+        # the right sid + end_reason and request backgrounded finalization.
+        lambda sid, *, end_reason, background=False: bool(
+            seen.append((sid, end_reason, background))
+        )
+        or True,
     )
     resp = server.handle_request(
         {"id": "1", "method": "session.close", "params": {"session_id": "s9"}}
     )
     assert resp["result"] == {"closed": True}
-    assert seen == [("s9", "tui_close")]
+    assert seen == [("s9", "tui_close", True)]
 
 
 def test_close_sessions_for_transport_closes_flagged_repoints_rest(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -132,6 +132,11 @@ _db_error: str | None = None
 _stdout_lock = threading.Lock()
 _cfg_lock = threading.Lock()
 _sessions_lock = threading.RLock()  # reentrant: _close_session_by_id may run under callers that already hold it
+# Most-recent background teardown thread spawned by _close_session_by_id(..., background=True)
+# (the session.close RPC path). Exposed so tests/observers can join it; the
+# session itself is already popped before the thread starts, so finalization
+# runs off the response path without affecting idempotency. See #23642.
+_last_close_thread: threading.Thread | None = None
 _prompt_lock = threading.Lock()
 _cfg_cache: dict | None = None
 _cfg_mtime: float | None = None
@@ -477,17 +482,49 @@ def _attach_worker(sid: str, session: dict, worker) -> None:
     worker.close()
 
 
-def _close_session_by_id(sid: str, *, end_reason: str = "tui_close") -> bool:
+def _close_session_by_id(
+    sid: str, *, end_reason: str = "tui_close", background: bool = False
+) -> bool:
     """Single idempotent teardown for one session: pop it under the sessions
     lock, then finalize, unregister notify, close agent + slash worker via the
     shared ``_teardown_session`` path. Returns True iff it closed a live
     session. The ``_finalized`` / worker ``_closed`` guards make concurrent or
-    repeat calls (e.g. session.close racing the WS-orphan reaper) harmless."""
+    repeat calls (e.g. session.close racing the WS-orphan reaper) harmless.
+
+    When ``background=True`` (used only by the explicit ``session.close`` RPC),
+    the session is still popped synchronously under ``_sessions_lock`` — so the
+    True/False return and idempotency are unchanged and the session is
+    immediately invisible to ``/resume`` and the reaper — but the potentially
+    slow ``_teardown_session`` (memory commit, finalize hook, DB end_session,
+    worker close) runs on a daemon thread. This keeps ``/clear`` /
+    ``session.close`` from blocking the JSON-RPC response on a memory commit
+    that may call an LLM + write SQLite (#23642). The popped session is owned
+    solely by that thread, so there's no double-finalize race (and
+    ``_finalized`` guards it regardless). The reaper, transport-close and
+    shutdown paths keep ``background=False`` (synchronous) so their semantics
+    and tests are unaffected."""
     with _sessions_lock:
         session = _sessions.pop(sid, None)
     if session is None:
         return False
-    _teardown_session(session, end_reason=end_reason)
+    if background:
+        global _last_close_thread
+        # Run teardown under a *copy* of the current context so context-local
+        # state the finalization depends on (e.g. the HERMES_HOME override,
+        # which is a ContextVar and gates the active-session lease store) is
+        # propagated into the daemon thread — plain threads don't inherit it.
+        ctx = contextvars.copy_context()
+        t = threading.Thread(
+            target=lambda: ctx.run(
+                _teardown_session, session, end_reason=end_reason
+            ),
+            name=f"session-close-{sid}",
+            daemon=True,
+        )
+        _last_close_thread = t
+        t.start()
+    else:
+        _teardown_session(session, end_reason=end_reason)
     return True
 
 
@@ -5068,8 +5105,17 @@ def _(rid, params: dict) -> dict:
     # both tear the same session down. _close_session_by_id is the single
     # idempotent teardown path (pop + _teardown_session) and returns False
     # when the session is already gone.
+    #
+    # background=True: the session is popped synchronously (so the return value,
+    # idempotency, and reaper-exclusion are unchanged), but the slow
+    # finalization (memory commit, which may call an LLM + write SQLite) runs on
+    # a daemon thread so the RPC response — and therefore the TUI's /clear —
+    # doesn't block on it. Fix for #23642.
     with _session_resume_lock:
-        return _ok(rid, {"closed": _close_session_by_id(sid, end_reason="tui_close")})
+        return _ok(
+            rid,
+            {"closed": _close_session_by_id(sid, end_reason="tui_close", background=True)},
+        )
 
 
 @method("session.branch")


### PR DESCRIPTION
## Problem (#23642 — still present on current `main`, verified)

The TUI's `/clear` blocks because `session.close` runs finalization **synchronously** before returning the JSON-RPC response. The slow part is `agent.commit_memory_session(history)` inside `_finalize_session()` — it can call an LLM and write SQLite. The TUI awaits `session.close` before `session.create`, so the user sees `/clear` hang and stale context until the commit finishes.

On current `main` the relevant code path is:

`@method("session.close")` → `_close_session_by_id(sid)` → pop under `_sessions_lock` → `_teardown_session(session)` → `_finalize_session(session)` *(the slow `commit_memory_session` lives here)*.

This funnel is shared by the WS-orphan reaper, `_close_sessions_for_transport`, and shutdown — so the fix must not change their (already-async / already-correct) semantics.

## Fix

Background the teardown **only for the explicit RPC close path**, with minimal blast radius:

- Added a scoped `background: bool = False` param to `_close_session_by_id`. The session is still **popped synchronously** under `_sessions_lock`, so the `True/False` return value, idempotency (`_finalized` guard), and reaper-exclusion are all unchanged and the session is immediately invisible to `/resume`. Only the slow `_teardown_session` (memory commit, finalize hook, `db.end_session`, slash-worker close, agent close) runs on a `daemon=True` thread.
- The `session.close` RPC passes `background=True`. The reaper / transport-close / shutdown paths keep the default `background=False` (synchronous), so their behavior and tests are untouched.
- The background thread runs under `contextvars.copy_context()` so context-local state the finalization depends on — notably the `HERMES_HOME` override `ContextVar` that gates the active-session **lease** store — propagates into the daemon thread (plain threads don't inherit it). Without this the lease would be released against the wrong home.
- A module-level `_last_close_thread` handle is exposed so observers/tests can `.join()` the background teardown.

Because the session is already popped before the thread starts, there's no double-finalize race (and `_finalized` guards it regardless).

## Tests

- **Updated** `test_session_close_commits_memory_and_fires_finalize_hook` to join the background close thread before asserting the commit/hook side effects (matches the original PR #23646's strategy).
- **Updated** `test_session_close_rpc_delegates_to_close_session_by_id` to assert the RPC delegates with `background=True` (still delegating to `_close_session_by_id`).
- **Updated** `test_session_create_rejects_at_active_session_limit` to join the close thread before asserting the active-session registry has drained.
- **Added** `test_session_close_returns_promptly_despite_slow_finalization`: a session whose `commit_memory_session` sleeps ~300 ms; asserts `session.close` returns in **< 250 ms**, that the commit hadn't finished at response time, and that it **does** complete in the background.

Results (`tests/test_tui_gateway_server.py`):
- Close-scoped run (`-k "session_close or close_session or teardown or orphan or finalize or transport or active_session"`): **15 passed**.
- Full file: **269 passed, 1 failed**. The single failure — `test_browser_manage_connect_default_local_reports_launch_hint` — is **pre-existing and environment-dependent** (it asserts a "No supported Chromium-family browser executable was found" launch hint); it fails identically on clean `origin/main` in this environment and is unrelated to this change.

`python3 -m py_compile` passes on both files.

Closes #23642
Supersedes #23646 (re-implemented on current `main`; the original diff was 522 commits stale and the code it patched was refactored into the `_close_session_by_id` / `_teardown_session` funnel).
