### PR TITLE
FGD-193: add durable approval resume idempotency

### DIFF
--- a/tests/tools/test_approval_resume_idempotency.py
+++ b/tests/tools/test_approval_resume_idempotency.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tools import approval as A
+
+
+@pytest.fixture
+def isolated_gateway_session(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+    monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+    monkeypatch.setattr(A, "_get_approval_mode", lambda: "manual")
+    monkeypatch.setattr(A, "_approval_ledger_path", lambda: tmp_path / "approval-ledger.json")
+
+    session_key = "fgd-193-session"
+    token = A.set_current_session_key(session_key)
+    with A._lock:
+        A._gateway_queues.pop(session_key, None)
+        A._gateway_notify_cbs.pop(session_key, None)
+        A._session_approved.pop(session_key, None)
+    try:
+        yield session_key, tmp_path / "approval-ledger.json"
+    finally:
+        A.reset_current_session_key(token)
+        with A._lock:
+            A._gateway_queues.pop(session_key, None)
+            A._gateway_notify_cbs.pop(session_key, None)
+            A._session_approved.pop(session_key, None)
+
+
+def _load_ledger(path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_gateway_approval_record_created_before_prompt_and_stores_no_raw_command(isolated_gateway_session):
+    session_key, ledger_path = isolated_gateway_session
+    command = "printf 'super-secret-token-123'"
+    seen = {}
+
+    def notify(_approval_data):
+        seen["record"] = A._get_approval_ledger_record(
+            session_key,
+            command,
+            "terminal",
+            ["dangerous-test"],
+        )
+        with A._lock:
+            entry = A._gateway_queues[session_key][-1]
+            entry.result = "deny"
+            entry.event.set()
+
+    result = A._await_gateway_decision(
+        session_key,
+        notify,
+        {
+            "command": command,
+            "pattern_key": "dangerous-test",
+            "pattern_keys": ["dangerous-test"],
+            "description": "dangerous test",
+            "tool_type": "terminal",
+        },
+        surface="gateway",
+    )
+
+    assert result["resolved"] is True
+    assert result["choice"] == "deny"
+    assert result["approval_record_id"] == seen["record"]["id"]
+    assert seen["record"]["status"] == "pending"
+
+    raw_ledger = ledger_path.read_text(encoding="utf-8")
+    assert "super-secret-token-123" not in raw_ledger
+    assert command not in raw_ledger
+    assert _load_ledger(ledger_path)[seen["record"]["id"]]["status"] == "denied"
+
+
+def test_approve_once_marks_approved_once_before_execution_then_completed(isolated_gateway_session):
+    session_key, ledger_path = isolated_gateway_session
+    command = "rm -rf ./build-cache"
+
+    def notify(_approval_data):
+        with A._lock:
+            entry = A._gateway_queues[session_key][-1]
+        resolved = A.resolve_gateway_approval(session_key, "once")
+        assert resolved == 1
+        record = A._get_approval_ledger_record(
+            session_key,
+            command,
+            "terminal",
+            ["dangerous-test"],
+        )
+        assert record["status"] == "approved_once"
+        assert entry.event.is_set()
+
+    decision = A._await_gateway_decision(
+        session_key,
+        notify,
+        {
+            "command": command,
+            "pattern_key": "dangerous-test",
+            "pattern_keys": ["dangerous-test"],
+            "description": "dangerous test",
+            "tool_type": "terminal",
+        },
+        surface="gateway",
+    )
+
+    assert decision["choice"] == "once"
+    record = A._get_approval_ledger_record(session_key, command, "terminal", ["dangerous-test"])
+    assert record["status"] == "approved_once"
+
+    assert A.mark_gateway_approval_executing(record["id"])
+    assert _load_ledger(ledger_path)[record["id"]]["status"] == "executing"
+
+    assert A.mark_gateway_approval_completed(record["id"], exit_code=0)
+    completed = _load_ledger(ledger_path)[record["id"]]
+    assert completed["status"] == "completed"
+    assert completed["exit_code"] == 0
+
+
+def test_execute_code_same_approved_once_after_resume_returns_stale_without_reprompt(isolated_gateway_session):
+    session_key, _ledger_path = isolated_gateway_session
+    calls = []
+
+    def approve_once(_approval_data):
+        calls.append("first")
+        assert A.resolve_gateway_approval(session_key, "once") == 1
+
+    with A._lock:
+        A._gateway_notify_cbs[session_key] = approve_once
+
+    code = "print('hello from execute_code')"
+    first = A.check_execute_code_guard(code, "local")
+    assert first["approved"] is True
+    assert first.get("approval_record_id")
+
+    def should_not_prompt(_approval_data):  # pragma: no cover - assertion below proves this is unused
+        calls.append("second")
+        raise AssertionError("duplicate approval prompt should be suppressed")
+
+    with A._lock:
+        A._gateway_notify_cbs[session_key] = should_not_prompt
+
+    second = A.check_execute_code_guard(code, "local")
+    assert second["approved"] is False
+    assert second["outcome"] == "stale"
+    assert "approval was interrupted" in second["message"]
+    assert calls == ["first"]
+
+
+def test_repeated_same_fingerprint_returns_approval_loop_detected(isolated_gateway_session):
+    session_key, _ledger_path = isolated_gateway_session
+    command = "rm -rf ./node_modules"
+
+    A._prepare_gateway_approval_record(
+        session_key=session_key,
+        command=command,
+        tool_type="terminal",
+        pattern_keys=["dangerous-test"],
+        description="dangerous test",
+    )
+
+    first_duplicate = A._handle_duplicate_gateway_approval(
+        session_key=session_key,
+        command=command,
+        tool_type="terminal",
+        pattern_keys=["dangerous-test"],
+    )
+
+    assert first_duplicate is not None
+    assert first_duplicate["approved"] is False
+    assert first_duplicate["outcome"] == "stale"
+
+    duplicate = A._handle_duplicate_gateway_approval(
+        session_key=session_key,
+        command=command,
+        tool_type="terminal",
+        pattern_keys=["dangerous-test"],
+    )
+
+    assert duplicate is not None
+    assert duplicate["approved"] is False
+    assert duplicate["outcome"] == "approval_loop_detected"
+    assert "APPROVAL LOOP DETECTED" in duplicate["message"]
+
+
+def test_terminal_and_execute_code_paths_remain_guarded_by_approval_module():
+    terminal_source = (A.__file__)
+    assert terminal_source.endswith("approval.py")
+
+    import inspect
+    from tools import code_execution_tool, terminal_tool
+
+    terminal_text = inspect.getsource(terminal_tool)
+    execute_text = inspect.getsource(code_execution_tool)
+
+    assert "approval_record_id" in terminal_text
+    assert "mark_gateway_approval_executing" in terminal_text
+    assert "mark_gateway_approval_completed" in terminal_text
+    assert "check_execute_code_guard" in execute_text
+    assert "mark_gateway_approval_executing" in execute_text
+    assert "mark_gateway_approval_completed" in execute_text

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -9,6 +9,8 @@ This module is the single source of truth for the dangerous command system:
 """
 
 import contextvars
+import hashlib
+import json
 import logging
 import os
 import re
@@ -16,6 +18,7 @@ import sys
 import threading
 import time
 import unicodedata
+from pathlib import Path
 from typing import Optional
 from hermes_cli.config import cfg_get
 
@@ -615,6 +618,215 @@ _session_approved: dict[str, set] = {}
 _session_yolo: set[str] = set()
 _permanent_approved: set = set()
 
+_LEDGER_STATUSES = {
+    "pending",
+    "approved_once",
+    "executing",
+    "completed",
+    "denied",
+    "expired",
+    "stale",
+}
+
+
+def _approval_ledger_path() -> Path:
+    """Return the non-secret durable gateway approval ledger path."""
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / "approval-ledger.json"
+
+
+def _approval_now() -> float:
+    return time.time()
+
+
+def _approval_command_fingerprint(
+    session_key: str,
+    command: str,
+    tool_type: str,
+    pattern_keys: list[str] | tuple[str, ...] | None,
+) -> str:
+    """Hash the exact approval identity without storing the raw command."""
+    payload = {
+        "session_key": session_key or "",
+        "tool_type": tool_type or "gateway",
+        "pattern_keys": list(pattern_keys or []),
+        "command": command or "",
+    }
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _read_approval_ledger() -> dict:
+    path = _approval_ledger_path()
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else {}
+    except FileNotFoundError:
+        return {}
+    except Exception as exc:
+        logger.debug("Failed to read approval ledger %s: %s", path, exc)
+        return {}
+
+
+def _write_approval_ledger(data: dict) -> None:
+    path = _approval_ledger_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh, sort_keys=True, separators=(",", ":"))
+    tmp.replace(path)
+
+
+def _approval_expiry_seconds() -> int:
+    cfg = _get_approval_config()
+    try:
+        timeout = int(cfg.get("gateway_timeout", 300))
+    except (ValueError, TypeError):
+        timeout = 300
+    return max(timeout, 60)
+
+
+def _get_approval_ledger_record(
+    session_key: str,
+    command: str,
+    tool_type: str,
+    pattern_keys: list[str] | tuple[str, ...] | None,
+) -> dict | None:
+    """Return the durable record for an exact command fingerprint, if present."""
+    record_id = _approval_command_fingerprint(session_key, command, tool_type, pattern_keys)
+    record = _read_approval_ledger().get(record_id)
+    return dict(record) if isinstance(record, dict) else None
+
+
+def _save_approval_record(record: dict) -> dict:
+    status = record.get("status")
+    if status not in _LEDGER_STATUSES:
+        raise ValueError(f"invalid approval ledger status: {status!r}")
+    data = _read_approval_ledger()
+    data[record["id"]] = record
+    _write_approval_ledger(data)
+    return record
+
+
+def _prepare_gateway_approval_record(
+    *,
+    session_key: str,
+    command: str,
+    tool_type: str,
+    pattern_keys: list[str] | tuple[str, ...] | None,
+    description: str = "",
+) -> dict:
+    """Create or reuse a non-secret durable approval record before prompting."""
+    now = _approval_now()
+    keys = list(pattern_keys or [])
+    record_id = _approval_command_fingerprint(session_key, command, tool_type, keys)
+    data = _read_approval_ledger()
+    record = data.get(record_id)
+    if isinstance(record, dict):
+        expires_at = float(record.get("expires_at", 0) or 0)
+        if expires_at and expires_at < now and record.get("status") in {"pending", "approved_once"}:
+            record["status"] = "expired"
+            record["updated_at"] = now
+        record["prompt_count"] = int(record.get("prompt_count", 0) or 0) + 1
+        record["updated_at"] = now
+        record["description_hash"] = hashlib.sha256((description or "").encode("utf-8")).hexdigest()
+        data[record_id] = record
+        _write_approval_ledger(data)
+        return dict(record)
+
+    record = {
+        "id": record_id,
+        "session_key_hash": hashlib.sha256((session_key or "").encode("utf-8")).hexdigest(),
+        "command_hash": hashlib.sha256((command or "").encode("utf-8")).hexdigest(),
+        "fingerprint": record_id,
+        "tool_type": tool_type or "gateway",
+        "pattern_keys": keys,
+        "description_hash": hashlib.sha256((description or "").encode("utf-8")).hexdigest(),
+        "status": "pending",
+        "created_at": now,
+        "updated_at": now,
+        "expires_at": now + _approval_expiry_seconds(),
+        "prompt_count": 1,
+    }
+    data[record_id] = record
+    _write_approval_ledger(data)
+    return dict(record)
+
+
+def _update_gateway_approval_record(record_id: str, status: str, **fields) -> bool:
+    if status not in _LEDGER_STATUSES:
+        raise ValueError(f"invalid approval ledger status: {status!r}")
+    data = _read_approval_ledger()
+    record = data.get(record_id)
+    if not isinstance(record, dict):
+        return False
+    record.update(fields)
+    record["status"] = status
+    record["updated_at"] = _approval_now()
+    data[record_id] = record
+    _write_approval_ledger(data)
+    return True
+
+
+def mark_gateway_approval_executing(record_id: str | None) -> bool:
+    """Mark a one-shot approval as executing immediately before tool spawn."""
+    if not record_id:
+        return False
+    return _update_gateway_approval_record(record_id, "executing")
+
+
+def mark_gateway_approval_completed(record_id: str | None, *, exit_code=None) -> bool:
+    """Mark an approval as completed after tool execution returns."""
+    if not record_id:
+        return False
+    fields = {}
+    if exit_code is not None:
+        fields["exit_code"] = exit_code
+    return _update_gateway_approval_record(record_id, "completed", **fields)
+
+
+def _handle_duplicate_gateway_approval(
+    *,
+    session_key: str,
+    command: str,
+    tool_type: str,
+    pattern_keys: list[str] | tuple[str, ...] | None,
+) -> dict | None:
+    """Return a non-approval result when a resumed turn repeats a prompt."""
+    record = _get_approval_ledger_record(session_key, command, tool_type, pattern_keys)
+    if not record:
+        return None
+    status = record.get("status")
+    if status not in {"pending", "approved_once", "executing", "stale"}:
+        return None
+
+    prompt_count = int(record.get("prompt_count", 0) or 0)
+    outcome = "stale"
+    message = (
+        "BLOCKED: A prior command approval was interrupted before Hermes could "
+        "complete the approved action. The command was not re-run automatically. "
+        "Please review and approve the exact action again if it is still needed."
+    )
+    if prompt_count > 1 or status == "stale":
+        outcome = "approval_loop_detected"
+        message = (
+            "APPROVAL LOOP DETECTED\n\n"
+            "The same command approval fingerprint was encountered again after "
+            "a gateway interruption/resume. Hermes will not keep re-prompting "
+            "or auto-run this action. Manually run the command if safe, then "
+            "provide the output for the next step."
+        )
+    _update_gateway_approval_record(record["id"], "stale")
+    return {
+        "approved": False,
+        "message": message,
+        "outcome": outcome,
+        "user_consent": False,
+        "approval_record_id": record["id"],
+    }
+
 # =========================================================================
 # Blocking gateway approval (mirrors CLI's synchronous input() flow)
 # =========================================================================
@@ -688,6 +900,12 @@ def resolve_gateway_approval(session_key: str, choice: str,
 
     for entry in targets:
         entry.result = choice
+        record_id = entry.data.get("approval_record_id") if isinstance(entry.data, dict) else None
+        if record_id:
+            if choice == "once":
+                _update_gateway_approval_record(record_id, "approved_once")
+            elif choice == "deny":
+                _update_gateway_approval_record(record_id, "denied")
         entry.event.set()
     return len(targets)
 
@@ -1188,6 +1406,26 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     description = approval_data.get("description", "")
     primary_key = approval_data.get("pattern_key", "")
     all_keys = approval_data.get("pattern_keys", [primary_key])
+    tool_type = approval_data.get("tool_type", surface)
+
+    duplicate = _handle_duplicate_gateway_approval(
+        session_key=session_key,
+        command=command,
+        tool_type=tool_type,
+        pattern_keys=list(all_keys),
+    )
+    if duplicate is not None:
+        return {"resolved": False, "choice": None, "duplicate": duplicate}
+
+    approval_record = _prepare_gateway_approval_record(
+        session_key=session_key,
+        command=command,
+        tool_type=tool_type,
+        pattern_keys=list(all_keys),
+        description=description,
+    )
+    approval_data = dict(approval_data)
+    approval_data["approval_record_id"] = approval_record["id"]
 
     entry = _ApprovalEntry(approval_data)
     with _lock:
@@ -1253,6 +1491,15 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     _drop_entry()
 
     choice = entry.result
+    record_id = approval_data.get("approval_record_id")
+    if record_id:
+        if not resolved or choice is None:
+            _update_gateway_approval_record(record_id, "expired")
+        elif choice == "deny":
+            _update_gateway_approval_record(record_id, "denied")
+        elif choice == "once":
+            _update_gateway_approval_record(record_id, "approved_once")
+
     # Normalize outcome for the post hook. Unresolved (timeout) and None both
     # mean the user never responded; report that explicitly so plugins can
     # distinguish timeout from explicit deny.
@@ -1267,7 +1514,7 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
         surface=surface,
         choice=_outcome,
     )
-    return {"resolved": resolved, "choice": choice}
+    return {"resolved": resolved, "choice": choice, "approval_record_id": record_id}
 
 
 def check_all_command_guards(command: str, env_type: str,
@@ -1428,6 +1675,7 @@ def check_all_command_guards(command: str, env_type: str,
                 "pattern_key": primary_key,
                 "pattern_keys": all_keys,
                 "description": combined_desc,
+                "tool_type": "terminal",
                 # Mirror the CLI's allow_permanent gate: a tirith warning downgrades
                 # "always" to session scope below, so the UI must not offer it.
                 "allow_permanent": not has_tirith,
@@ -1435,6 +1683,11 @@ def check_all_command_guards(command: str, env_type: str,
             decision = _await_gateway_decision(
                 session_key, notify_cb, approval_data, surface="gateway"
             )
+            if decision.get("duplicate"):
+                duplicate = dict(decision["duplicate"])
+                duplicate.setdefault("pattern_key", primary_key)
+                duplicate.setdefault("description", combined_desc)
+                return duplicate
             if decision.get("notify_failed"):
                 return {
                     "approved": False,
@@ -1488,7 +1741,8 @@ def check_all_command_guards(command: str, env_type: str,
                 # single time only, matching the CLI's behavior.
 
             return {"approved": True, "message": None,
-                    "user_approved": True, "description": combined_desc}
+                    "user_approved": True, "description": combined_desc,
+                    "approval_record_id": decision.get("approval_record_id")}
 
         # Fallback: no gateway callback registered (e.g. cron, batch).
         # Return approval_required for backward compat.
@@ -1699,10 +1953,16 @@ def check_execute_code_guard(code: str, env_type: str) -> dict:
         "pattern_key": pattern_key,
         "pattern_keys": [pattern_key],
         "description": description,
+        "tool_type": "execute_code",
     }
     decision = _await_gateway_decision(
         session_key, notify_cb, approval_data, surface="gateway"
     )
+    if decision.get("duplicate"):
+        duplicate = dict(decision["duplicate"])
+        duplicate.setdefault("pattern_key", pattern_key)
+        duplicate.setdefault("description", description)
+        return duplicate
     if decision.get("notify_failed"):
         return {
             "approved": False,
@@ -1744,7 +2004,8 @@ def check_execute_code_guard(code: str, env_type: str) -> dict:
     # choice == "once": no persistence — approval lasts this single call only.
 
     return {"approved": True, "message": None,
-            "user_approved": True, "description": description}
+            "user_approved": True, "description": description,
+            "approval_record_id": decision.get("approval_record_id")}
 
 
 # Load permanent allowlist from config on module import

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1111,8 +1111,22 @@ def execute_code(
             "duration_seconds": 0,
         }, ensure_ascii=False)
 
+    from tools.approval import (
+        mark_gateway_approval_completed,
+        mark_gateway_approval_executing,
+    )
+    approval_record_id = _guard.get("approval_record_id")
+
     if env_type != "local":
-        return _execute_remote(code, task_id, enabled_tools)
+        mark_gateway_approval_executing(approval_record_id)
+        _remote_result = _execute_remote(code, task_id, enabled_tools)
+        try:
+            _remote_payload = json.loads(_remote_result)
+            _remote_exit = -1 if _remote_payload.get("status") == "error" else 0
+        except Exception:
+            _remote_exit = 0
+        mark_gateway_approval_completed(approval_record_id, exit_code=_remote_exit)
+        return _remote_result
 
     # --- Local execution path (UDS) --- below this line is unchanged ---
 
@@ -1155,6 +1169,7 @@ def execute_code(
 
     tool_call_log: list = []
     tool_call_counter = [0]  # mutable so the RPC thread can increment
+    mark_gateway_approval_executing(approval_record_id)
     exec_start = time.monotonic()
     server_sock = None
 
@@ -1461,6 +1476,7 @@ def execute_code(
             if stderr_text:
                 result["output"] = stdout_text + "\n--- stderr ---\n" + stderr_text
 
+        mark_gateway_approval_completed(approval_record_id, exit_code=exit_code)
         return json.dumps(result, ensure_ascii=False)
 
     except Exception as exc:
@@ -1473,6 +1489,7 @@ def execute_code(
             exc,
             exc_info=True,
         )
+        mark_gateway_approval_completed(approval_record_id, exit_code=-1)
         return json.dumps({
             "status": "error",
             "error": str(exc),

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2049,6 +2049,7 @@ def terminal_tool(
         # Pre-exec security checks (tirith + dangerous command detection)
         # Skip check if force=True (user has confirmed they want to run it)
         approval_note = None
+        approval_record_id = None
         if not force:
             approval = _check_all_guards(command, env_type)
             if not approval["approved"]:
@@ -2080,6 +2081,7 @@ def terminal_tool(
             if approval.get("user_approved"):
                 desc = approval.get("description", "flagged as dangerous")
                 approval_note = f"Command required approval ({desc}) and was approved by the user."
+                approval_record_id = approval.get("approval_record_id")
             elif approval.get("smart_approved"):
                 desc = approval.get("description", "flagged as dangerous")
                 approval_note = f"Command was flagged ({desc}) and auto-approved by smart approval."
@@ -2113,7 +2115,11 @@ def terminal_tool(
             # Spawn a tracked background process via the process registry.
             # For local backends: uses subprocess.Popen with output buffering.
             # For non-local backends: runs inside the sandbox via env.execute().
-            from tools.approval import get_current_session_key
+            from tools.approval import (
+                get_current_session_key,
+                mark_gateway_approval_completed,
+                mark_gateway_approval_executing,
+            )
             from tools.process_registry import process_registry
 
             session_key = get_current_session_key(default="")
@@ -2123,6 +2129,7 @@ def terminal_tool(
                 default_cwd=cwd,
             )
             try:
+                mark_gateway_approval_executing(approval_record_id)
                 if env_type == "local":
                     proc_session = process_registry.spawn_local(
                         command=command,
@@ -2150,6 +2157,8 @@ def terminal_tool(
                 }
                 if approval_note:
                     result_data["approval"] = approval_note
+                if approval_record_id:
+                    result_data["approval_record_id"] = approval_record_id
                 if pty_disabled_reason:
                     result_data["pty_note"] = pty_disabled_reason
 
@@ -2321,8 +2330,10 @@ def terminal_tool(
                     proc_session.watch_patterns = list(watch_patterns)
                     result_data["watch_patterns"] = proc_session.watch_patterns
 
+                mark_gateway_approval_completed(approval_record_id, exit_code=0)
                 return json.dumps(result_data, ensure_ascii=False)
             except Exception as e:
+                mark_gateway_approval_completed(approval_record_id, exit_code=-1)
                 return json.dumps({
                     "output": "",
                     "exit_code": -1,
@@ -2330,9 +2341,14 @@ def terminal_tool(
                 }, ensure_ascii=False)
         else:
             # Run foreground command with retry logic
+            from tools.approval import (
+                mark_gateway_approval_completed,
+                mark_gateway_approval_executing,
+            )
             max_retries = 3
             retry_count = 0
             result = None
+            mark_gateway_approval_executing(approval_record_id)
             
             while retry_count <= max_retries:
                 try:
@@ -2348,6 +2364,7 @@ def terminal_tool(
                 except Exception as e:
                     error_str = str(e).lower()
                     if "timeout" in error_str:
+                        mark_gateway_approval_completed(approval_record_id, exit_code=124)
                         return json.dumps({
                             "output": "",
                             "exit_code": 124,
@@ -2365,6 +2382,7 @@ def terminal_tool(
                     
                     logger.error("Execution failed after %d retries - Command: %s - Error: %s: %s - Task: %s, Backend: %s",
                                  max_retries, _safe_command_preview(command), type(e).__name__, e, effective_task_id, env_type)
+                    mark_gateway_approval_completed(approval_record_id, exit_code=-1)
                     return json.dumps({
                         "output": "",
                         "exit_code": -1,
@@ -2435,9 +2453,12 @@ def terminal_tool(
             }
             if approval_note:
                 result_dict["approval"] = approval_note
+            if approval_record_id:
+                result_dict["approval_record_id"] = approval_record_id
             if exit_note:
                 result_dict["exit_code_meaning"] = exit_note
 
+            mark_gateway_approval_completed(approval_record_id, exit_code=returncode)
             return json.dumps(result_dict, ensure_ascii=False)
 
     except Exception as e:


### PR DESCRIPTION
issue: FGD-193

scope: durable approval/resume idempotency for terminal and execute_code approvals

commit SHA: c3b72cae79699734fe7593f3276a8f9d7fdc7e78

files changed:
- tools/approval.py
- tools/code_execution_tool.py
- tools/terminal_tool.py
- tests/tools/test_approval_resume_idempotency.py

validation passed:
- focused test: 5 passed
- nearby regression tests: 25 passed
- py_compile validation: exit 0

implementation summary:
- non-secret approval ledger helpers added
- approval records keyed by session hash, command fingerprint/hash, tool type, and pattern keys
- no raw command body stored
- once approval marks approved_once before execution
- execution transitions to executing and then completed
- first duplicate returns stale/interrupted without re-prompt
- repeated duplicate returns APPROVAL LOOP DETECTED
- terminal and execute_code paths carry approval lifecycle hooks

caveats:
- no live gateway restart/runtime validation performed
- ledger persistence location/retention policy should receive maintainer review
- background terminal completed means spawn completed, not eventual background process exit

deferred scope:
- no runtime restart
- no Telegram/webhook mutation
- no broad approval policy redesign
- no REMH Materiality Evaluator issue creation
- no retry of blocked REMH Linear precheck
