### PR TITLE
fix: honor Telegram rich_messages opt-out

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -418,6 +418,11 @@ class TelegramAdapter(BasePlatformAdapter):
         self._disable_link_previews: bool = self._coerce_bool_extra("disable_link_previews", False)
         # Bot API 10.1 Rich Messages: send final replies via sendRichMessage
         # with the raw agent markdown so tables/task lists/etc. render natively.
+        # Telegram Web may render these as "This message is not supported",
+        # so keep the legacy rich_messages toggle as an explicit opt-out.
+        self._rich_messages_enabled: bool = self._coerce_bool_extra(
+            "rich_messages", True
+        )
         # Latched off after a capability failure on sendRichMessage /
         # sendRichMessageDraft (e.g. older python-telegram-bot without the
         # endpoint) so later sends skip the doomed rich attempt entirely.
@@ -948,7 +953,8 @@ class TelegramAdapter(BasePlatformAdapter):
 
     def _should_attempt_rich(self, content: str) -> bool:
         return bool(
-            not getattr(self, "_rich_send_disabled", False)
+            getattr(self, "_rich_messages_enabled", True)
+            and not getattr(self, "_rich_send_disabled", False)
             and content
             and content.strip()
             and self._content_fits_rich_limits(content)
@@ -1126,7 +1132,8 @@ class TelegramAdapter(BasePlatformAdapter):
 
     def _should_attempt_rich_draft(self, content: str) -> bool:
         return bool(
-            not getattr(self, "_rich_send_disabled", False)
+            getattr(self, "_rich_messages_enabled", True)
+            and not getattr(self, "_rich_send_disabled", False)
             and not getattr(self, "_rich_draft_disabled", False)
             and content
             and content.strip()

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -67,16 +67,14 @@ async def test_rich_happy_path_sends_raw_markdown():
 
 
 @pytest.mark.asyncio
-async def test_legacy_rich_messages_config_is_ignored():
+async def test_rich_messages_config_false_uses_legacy_send_message():
     adapter = _make_adapter(extra={"rich_messages": False})
 
     result = await adapter.send("12345", RICH_CONTENT)
 
     assert result.success is True
-    # The legacy toggle was removed; stale config entries must not disable the
-    # rich path.
-    adapter._bot.do_api_request.assert_awaited_once()
-    adapter._bot.send_message.assert_not_called()
+    adapter._bot.do_api_request.assert_not_awaited()
+    adapter._bot.send_message.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- restore `platforms.telegram.extra.rich_messages: false` as an explicit opt-out for Bot API rich messages
- apply the opt-out to both final `sendRichMessage` replies and `sendRichMessageDraft` previews
- update the Telegram rich-message regression test to verify the legacy `send_message` path is used when disabled

## Test plan
- `python -m pytest tests/gateway/test_telegram_rich_messages.py -q -o addopts=`
- `python -m py_compile gateway/platforms/telegram.py tests/gateway/test_telegram_rich_messages.py`
- `git diff --check -- gateway/platforms/telegram.py tests/gateway/test_telegram_rich_messages.py`
- `ruff check gateway/platforms/telegram.py tests/gateway/test_telegram_rich_messages.py`

Note: `ruff format --check` still reports pre-existing formatting drift across these files on current main; the ruff format diff does not require additional formatting changes for the new logic beyond the local line wrap already applied.
