### PR TITLE
fix(hindsight): close aiohttp client on retry to prevent connection leak

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -901,7 +901,6 @@ class HindsightMemoryProvider(MemoryProvider):
                 except Exception as _e:
                     raise ImportError(str(_e))
                 from hindsight import HindsightEmbedded
-                HindsightEmbedded.__del__ = lambda self: None
                 llm_provider = self._config.get("llm_provider", "")
                 if llm_provider in {"openai_compatible", "openrouter"}:
                     llm_provider = "openai"
@@ -938,6 +937,30 @@ class HindsightMemoryProvider(MemoryProvider):
     def _run_sync(self, coro):
         """Schedule *coro* on the shared loop using the configured timeout."""
         return _run_sync(coro, timeout=self._timeout)
+
+    def _close_client(self) -> None:
+        """Safely close the current client and release aiohttp resources."""
+        client = self._client
+        if client is None:
+            return
+        try:
+            if self._mode == "local_embedded":
+                inner = getattr(client, "_client", None)
+                if inner is not None and hasattr(inner, "aclose"):
+                    self._run_sync(inner.aclose())
+                    try:
+                        client._client = None
+                    except Exception:
+                        pass
+                try:
+                    client.close()
+                except RuntimeError:
+                    pass
+            else:
+                self._run_sync(client.aclose())
+        except Exception as exc:
+            logger.debug("Hindsight client close failed (non-fatal): %s", exc)
+        self._client = None
 
     def _is_retriable_embedded_connection_error(self, exc: Exception) -> bool:
         """Return True for stale embedded-daemon connection failures."""
@@ -1033,7 +1056,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 "Hindsight embedded daemon appears unreachable; recreating client and retrying once: %s",
                 exc,
             )
-            self._client = None
+            self._close_client()
             client = self._get_client()
             self._client = client
             return self._run_sync(operation(client))
@@ -1737,6 +1760,13 @@ class HindsightMemoryProvider(MemoryProvider):
             self._session_id, self._parent_session_id, reset, self._document_id,
         )
 
+    def __del__(self) -> None:
+        """Safety-net close when shutdown() was never called."""
+        try:
+            self._close_client()
+        except Exception:
+            pass
+
     def shutdown(self) -> None:
         logger.debug("Hindsight shutdown: stopping writer + waiting for background threads")
         # Stop accepting new retain jobs first so anyone still calling
@@ -1760,31 +1790,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 )
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             self._prefetch_thread.join(timeout=5.0)
-        if self._client is not None:
-            try:
-                if self._mode == "local_embedded":
-                    # HindsightEmbedded.close() delegates to its sync client.close().
-                    # When Hermes created/used that client on the shared async loop,
-                    # closing it from this thread can raise "attached to a different
-                    # loop" before aiohttp releases the session. Close the embedded
-                    # inner async client on the shared loop first, then let the
-                    # wrapper clean up daemon/UI bookkeeping.
-                    inner_client = getattr(self._client, "_client", None)
-                    if inner_client is not None and hasattr(inner_client, "aclose"):
-                        _run_sync(inner_client.aclose())
-                        try:
-                            self._client._client = None
-                        except Exception:
-                            pass
-                    try:
-                        self._client.close()
-                    except RuntimeError:
-                        pass
-                else:
-                    self._run_sync(self._client.aclose())
-            except Exception:
-                pass
-            self._client = None
+        self._close_client()
         # The module-global background event loop (_loop / _loop_thread)
         # is intentionally NOT stopped here. It is shared across every
         # HindsightMemoryProvider instance in the process — the plugin

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1620,6 +1620,96 @@ class TestShutdown:
         assert provider._client is None
 
 
+class TestCloseClient:
+    """Tests for _close_client — the shared helper that releases aiohttp resources."""
+
+    def test_cloud_mode_calls_aclose(self, provider):
+        """Cloud-mode clients are closed via aclose()."""
+        mock_client = provider._client
+        assert mock_client is not None
+
+        provider._close_client()
+
+        mock_client.aclose.assert_called_once()
+        assert provider._client is None
+
+    def test_embedded_mode_closes_inner_and_wrapper(self, provider):
+        """Embedded clients close inner async client then wrapper."""
+        inner_client = _make_mock_client()
+        embedded = MagicMock()
+        embedded._client = inner_client
+        embedded.close = MagicMock()
+
+        provider._mode = "local_embedded"
+        provider._client = embedded
+
+        provider._close_client()
+
+        inner_client.aclose.assert_awaited_once()
+        embedded.close.assert_called_once()
+        assert embedded._client is None
+        assert provider._client is None
+
+    def test_noop_when_client_is_none(self, provider):
+        """No error when client is already None."""
+        provider._client = None
+        provider._close_client()  # should not raise
+        assert provider._client is None
+
+    def test_exception_in_aclose_does_not_raise(self, provider):
+        """Close failures are logged but never propagate."""
+        mock_client = provider._client
+        mock_client.aclose = AsyncMock(side_effect=RuntimeError("loop closed"))
+
+        provider._close_client()  # should not raise
+
+        assert provider._client is None
+
+    def test_run_hindsight_operation_closes_old_client_before_retry(self, provider):
+        """The primary fix: _close_client must be called before recreating client."""
+        close_called = []
+        original_close = provider._close_client
+
+        def _tracking_close():
+            close_called.append(True)
+            original_close()
+
+        provider._close_client = _tracking_close
+        provider._is_retriable_embedded_connection_error = lambda exc: True
+
+        # First call raises retriable error, second succeeds
+        provider._client.arecall = AsyncMock(side_effect=ConnectionError("refused"))
+
+        new_client = _make_mock_client()
+        get_count = [0]
+        orig_get = provider._get_client
+
+        def _mock_get_client():
+            get_count[0] += 1
+            if get_count[0] <= 1:
+                return orig_get()
+            provider._client = new_client
+            return new_client
+
+        provider._get_client = _mock_get_client
+
+        provider._run_hindsight_operation(lambda c: c.arecall(bank_id="test"))
+
+        # _close_client must have been called during the retry path
+        assert len(close_called) == 1, (
+            f"Expected _close_client to be called once during retry, called {len(close_called)} times"
+        )
+
+    def test_del_calls_close_client(self, provider):
+        """__del__ safety-net closes the client."""
+        mock_client = provider._client
+
+        provider.__del__()
+
+        mock_client.aclose.assert_called_once()
+        assert provider._client is None
+
+
 @pytest.mark.skipif(os.name == "nt", reason="POSIX mode bits not enforced on Windows")
 def test_save_config_sets_owner_only_permissions(tmp_path):
     """hindsight/config.json must be written with 0o600 so API key is not world-readable."""


### PR DESCRIPTION
## What does this PR do?

Fixes an aiohttp connection leak in the Hindsight memory plugin where `_run_hindsight_operation` orphaned the old client without closing it on retry, causing `ClientSession` and `TCPConnector` objects to accumulate until the process became unresponsive.

## Related Issue

Fixes #45676

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/hindsight/__init__.py`: Extract `_close_client()` helper; call it in `_run_hindsight_operation` before replacing the client (was bare `self._client = None`); reuse in `shutdown()`; remove `HindsightEmbedded.__del__` monkey-patch that disabled GC cleanup; add `__del__` safety-net on `HindsightMemoryProvider`
- `tests/plugins/memory/test_hindsight_provider.py`: 6 new tests covering `_close_client` for cloud/embedded modes, no-op when None, exception safety, retry-path invocation, and `__del__` fallback

## How to Test

1. `pytest tests/plugins/memory/test_hindsight_provider.py -q` — all 108 tests pass (102 existing + 6 new)
2. The leak reproduces when using `local_embedded` mode with a daemon that intermittently drops connections. Each retry now closes the old session before creating a new one.
3. Verify no "Unclosed client session" warnings in logs after extended use with embedded Hindsight.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable — grep-based fallback used.
- Checked symbols: `_run_hindsight_operation`, `_close_client`, `shutdown`, `__del__`
- Callers: `_run_hindsight_operation` is called from 6 tool handlers (retain, recall, reflect); `shutdown` called from atexit + plugin lifecycle
- Blast radius: LOW — changes are isolated to the Hindsight plugin's client lifecycle; no cross-module dependencies
- Related patterns: `shutdown()` already had the correct close pattern; this PR extracts it into a reusable helper
