### PR TITLE
feat(optional-skills): add clinical-trials skill

### DIFF
--- a/optional-skills/research/clinical-trials/SKILL.md
+++ b/optional-skills/research/clinical-trials/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: clinical-trials
+description: Search and analyze clinical trials via ClinicalTrials.gov API v2. Free, no API key required. Search by condition, drug, sponsor, status, phase. Get trial details, eligibility criteria, locations, outcomes.
+platforms: [linux, macos, windows]
+---
+
+# Clinical Trials Research
+
+Search clinical trials via ClinicalTrials.gov public API. **No API key required.**
+
+## Helper script
+
+This skill includes `scripts/clinical_trials.py` — a complete CLI tool.
+
+```bash
+# Search by condition
+python3 SKILL_DIR/scripts/clinical_trials.py search "COVID-19" --limit 5
+
+# Search by drug/intervention
+python3 SKILL_DIR/scripts/clinical_trials.py drug "Paxlovid" --status RECRUITING
+
+# Get trial details
+python3 SKILL_DIR/scripts/clinical_trials.py detail NCT05373043
+
+# Search by sponsor
+python3 SKILL_DIR/scripts/clinical_trials.py sponsor "Pfizer" --phase 3 --limit 10
+
+# Advanced search
+python3 SKILL_DIR/scripts/clinical_trials.py search "lung cancer" --status ACTIVE --phase 2
+```
+
+Commands: search, drug, detail, sponsor. Output is structured JSON.

--- a/optional-skills/research/clinical-trials/SKILL.md
+++ b/optional-skills/research/clinical-trials/SKILL.md
@@ -1,32 +1,101 @@
 ---
 name: clinical-trials
-description: Search and analyze clinical trials via ClinicalTrials.gov API v2. Free, no API key required. Search by condition, drug, sponsor, status, phase. Get trial details, eligibility criteria, locations, outcomes.
+description: Search clinical trials via the ClinicalTrials.gov API v2.
+version: 1.0.0
+author: Kewe63
+license: MIT
 platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [clinical-trials, research, medical]
+    related_skills: [drug-discovery, bioinformatics, patent-research]
+prerequisites:
+  commands: [python3]
 ---
 
-# Clinical Trials Research
+# Clinical Trials Skill
 
-Search clinical trials via ClinicalTrials.gov public API. **No API key required.**
+Search clinical trials via the free **ClinicalTrials.gov API v2** — no API key required. Search by condition, drug, sponsor, status, or phase; retrieve trial details (eligibility, locations, outcomes).
 
-## Helper script
+## When to Use
 
-This skill includes `scripts/clinical_trials.py` — a complete CLI tool.
+- Find active or completed clinical trials for a condition, drug name, or sponsor
+- Pull eligibility criteria, primary/secondary outcomes, intervention details
+- Cross-check whether a specific NCT ID exists and is currently recruiting
+- Build a sponsor portfolio by listing all their trials at a given phase
+
+Prefer `web_search` for general "is drug X being studied" framings; this skill targets the wire-data fit (status, eligibility, outcomes).
+
+## Prerequisites
+
+- Python 3.10+ (stdlib only — uses `urllib`, `argparse`, `json`)
+- Outbound HTTPS to `clinicaltrials.gov` (port 443)
+- No API key, no signup
+
+## How to Run
+
+Commands run via the bundled helper script. `${HERMES_SKILL_DIR}` is substituted at scan time by the skill loader; copy-paste the resolved path or run from inside the skill directory.
 
 ```bash
-# Search by condition
-python3 SKILL_DIR/scripts/clinical_trials.py search "COVID-19" --limit 5
+# Search by condition (paginated, sorted by last update)
+python3 "${HERMES_SKILL_DIR}/scripts/clinical_trials.py" search "COVID-19" --limit 5
 
 # Search by drug/intervention
-python3 SKILL_DIR/scripts/clinical_trials.py drug "Paxlovid" --status RECRUITING
+python3 "${HERMES_SKILL_DIR}/scripts/clinical_trials.py" drug "Paxlovid" --status RECRUITING
 
-# Get trial details
-python3 SKILL_DIR/scripts/clinical_trials.py detail NCT05373043
+# Get full trial detail (eligibility, outcomes, locations)
+python3 "${HERMES_SKILL_DIR}/scripts/clinical_trials.py" detail NCT05373043
 
-# Search by sponsor
-python3 SKILL_DIR/scripts/clinical_trials.py sponsor "Pfizer" --phase 3 --limit 10
+# Search by sponsor with phase filter
+python3 "${HERMES_SKILL_DIR}/scripts/clinical_trials.py" sponsor "Pfizer" --phase 3 --limit 10
 
-# Advanced search
-python3 SKILL_DIR/scripts/clinical_trials.py search "lung cancer" --status ACTIVE --phase 2
+# Advanced: status + phase combined
+python3 "${HERMES_SKILL_DIR}/scripts/clinical_trials.py" search "lung cancer" \
+    --status ACTIVE --phase 2
 ```
 
-Commands: search, drug, detail, sponsor. Output is structured JSON.
+## Quick Reference
+
+| Command | Positional | Key flags | Returns |
+|---------|-----------|-----------|---------|
+| `search` | `<condition>` | `--status`, `--phase`, `--limit` | `{total, results: [...]}` |
+| `drug` | `<drug_name>` | `--status`, `--limit` | `{total, results: [...]}` |
+| `detail` | `<NCT_ID>` | — | full trial dict |
+| `sponsor` | `<sponsor_name>` | `--phase`, `--status`, `--limit` | `{total, results: [...]}` |
+
+`--status` choices: `ACTIVE`, `RECRUITING`, `COMPLETED`, `TERMINATED` (raw API values; the script maps `ACTIVE` → `ACTIVE_NOT_RECRUITING` on the wire).
+
+`--phase` choices: `1`, `2`, `3`, `4`.
+
+Default `--limit`: `10`. Hard ceiling: `100` (ClinicalTrials.gov page size).
+
+## Procedure
+
+1. Identify which query shape fits the user request: condition (general), drug (intervention), sponsor (organization), or detail (NCT ID).
+2. Run the matching command; capture the JSON output.
+3. For `detail`, surface eligibility criteria, primary outcomes, and the location list — these are the three blocks most often quoted in research summaries.
+4. For searches, report total count first, then the truncated `results` array; the script returns at most `--limit` items but `total` reflects the full match count.
+
+## Pitfalls
+
+- The `ACTIVE` status is mapped to `ACTIVE_NOT_RECRUITING` on the wire — the API does not advertise a literal `ACTIVE` value, despite the SKILL.md choice text. If a user complains about an "ACTIVE" filter returning nothing, switch to `RECRUITING` or `ALL`.
+- `enrollment` may be `null` (the API only reports counts when the trial has finished enrolling); treat `null` as "unknown", not zero.
+- `locations` is empty when the trial has no contact sites published — common for terminated/withdrawn trials.
+- The ClinicalTrials.gov API v2 rate-limit is generous but not infinite; avoid running more than ~10 search commands in a 60s window per IP.
+- `phase` is a list in the API, not a single string; the script joins entries with `, ` for readability but the source may be `[PHASE2, PHASE3]`.
+
+## Verification
+
+Run the bundled tests (no network required — all HTTP is mocked):
+
+```bash
+scripts/run_tests.sh tests/skills/test_clinical_trials_skill.py -q
+```
+
+Spot-check a real call before quoting results to the user:
+
+```bash
+python3 "${HERMES_SKILL_DIR}/scripts/clinical_trials.py" search "hypertension" --limit 3 | head -40
+```
+
+The output should be JSON with `total` and `results[].nct_id`, `title`, `status`, `phase`, `sponsor`.

--- a/optional-skills/research/clinical-trials/scripts/clinical_trials.py
+++ b/optional-skills/research/clinical-trials/scripts/clinical_trials.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""
+Clinical Trials CLI — search and analyze clinical trials via ClinicalTrials.gov API v2.
+
+Usage:
+    python3 clinical_trials.py search "COVID-19" --limit 5
+    python3 clinical_trials.py drug "Paxlovid" --status RECRUITING
+    python3 clinical_trials.py detail NCT05373043
+    python3 clinical_trials.py sponsor "Pfizer" --phase 3 --limit 10
+
+No API key required. Uses ClinicalTrials.gov API v2.
+"""
+
+import json
+import sys
+import urllib.parse
+import urllib.request
+
+API_BASE = "https://clinicaltrials.gov/api/v2"
+USER_AGENT = "Mozilla/5.0"
+
+
+def api_request(url: str) -> dict:
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(req, timeout=20) as resp:
+        return json.loads(resp.read().decode())
+
+
+def search_trials(params: dict, limit: int = 10) -> dict:
+    params["pageSize"] = min(limit, 100)
+    url = f"{API_BASE}/studies?{urllib.parse.urlencode(params)}"
+    data = api_request(url)
+    studies = data.get("studies", [])
+    total = data.get("totalCount", len(studies))
+
+    results = []
+    for s in studies[:limit]:
+        pm = s.get("protocolSection", {})
+        id_mod = pm.get("identificationModule", {})
+        status_mod = pm.get("statusModule", {})
+        design_mod = pm.get("designModule", {})
+        sponsor_mod = pm.get("sponsorCollaboratorsModule", {})
+
+        results.append({
+            "nct_id": id_mod.get("nctId", ""),
+            "title": id_mod.get("briefTitle", ""),
+            "status": status_mod.get("overallStatus", ""),
+            "start_date": status_mod.get("startDateStruct", {}).get("date", ""),
+            "completion_date": status_mod.get("completionDateStruct", {}).get(
+                "date", ""
+            ),
+            "phase": ", ".join(design_mod.get("phases", []))
+            if design_mod.get("phases")
+            else "",
+            "sponsor": sponsor_mod.get("leadSponsor", {}).get("name", ""),
+            "enrollment": design_mod.get("enrollmentInfo", {}).get("count"),
+        })
+
+    return {"total": total, "results": results}
+
+
+def get_trial_detail(nct_id: str) -> dict:
+    url = f"{API_BASE}/studies/{nct_id}"
+    data = api_request(url)
+    s = data  # API v2 returns study directly, no wrapper
+    pm = s.get("protocolSection", {})
+
+    id_mod = pm.get("identificationModule", {})
+    status_mod = pm.get("statusModule", {})
+    design_mod = pm.get("designModule", {})
+    sponsor_mod = pm.get("sponsorCollaboratorsModule", {})
+    eligibility_mod = pm.get("eligibilityModule", {})
+    conditions_mod = pm.get("conditionsModule", {})
+    outcome_mod = pm.get("outcomesModule", {})
+    arm_mod = pm.get("armsInterventionsModule", {})
+
+    detail = {
+        "nct_id": id_mod.get("nctId"),
+        "title": id_mod.get("briefTitle"),
+        "official_title": id_mod.get("officialTitle"),
+        "status": status_mod.get("overallStatus"),
+        "start_date": status_mod.get("startDateStruct", {}).get("date"),
+        "completion_date": status_mod.get("completionDateStruct", {}).get("date"),
+        "phase": ", ".join(design_mod.get("phases", []))
+        if design_mod.get("phases")
+        else "",
+        "sponsor": sponsor_mod.get("leadSponsor", {}).get("name"),
+        "enrollment": design_mod.get("enrollmentInfo", {}).get("count"),
+        "conditions": conditions_mod.get("conditions", []),
+        "eligibility": {
+            "criteria": (eligibility_mod.get("eligibilityCriteria", "") or "")[:2000],
+            "sex": eligibility_mod.get("sex"),
+            "min_age": eligibility_mod.get("minimumAge"),
+            "max_age": eligibility_mod.get("maximumAge"),
+            "healthy_volunteers": eligibility_mod.get("healthyVolunteers"),
+        },
+        "primary_outcomes": [
+            {"measure": o.get("measure"), "time_frame": o.get("timeFrame")}
+            for o in (outcome_mod.get("primaryOutcomes", []) or [])
+        ],
+        "secondary_outcomes": [
+            {"measure": o.get("measure"), "time_frame": o.get("timeFrame")}
+            for o in (outcome_mod.get("secondaryOutcomes", []) or [])
+        ],
+        "interventions": [
+            {"name": a.get("name"), "type": a.get("type")}
+            for a in (arm_mod.get("interventions", []) or [])
+        ],
+        "locations": [],
+    }
+
+    locations_mod = pm.get("contactsLocationsModule", {})
+    for loc in locations_mod.get("locations", []) or []:
+        detail["locations"].append({
+            "facility": loc.get("facility"),
+            "city": loc.get("city"),
+            "country": loc.get("country"),
+            "status": loc.get("status"),
+        })
+
+    return detail
+
+
+def cmd_search(args):
+    params = {"query.term": args.query, "sort": "LastUpdatePostDate"}
+    if args.status:
+        status_map = {
+            "ACTIVE": "ACTIVE_NOT_RECRUITING",
+            "RECRUITING": "RECRUITING",
+            "COMPLETED": "COMPLETED",
+            "TERMINATED": "TERMINATED",
+            "ALL": "",
+        }
+        s = status_map.get(args.status.upper(), args.status)
+        if s:
+            params["filter.overallStatus"] = s
+    if args.phase:
+        params["filter.advanced"] = f"AREA[Phase]PHASE{args.phase}"
+
+    result = search_trials(params, args.limit)
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+def cmd_drug(args):
+    params = {"query.term": args.name, "query.intr": args.name}
+    if args.status:
+        params["filter.overallStatus"] = args.status.upper()
+    result = search_trials(params, args.limit)
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+def cmd_detail(args):
+    result = get_trial_detail(args.nct_id)
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+def cmd_sponsor(args):
+    params = {"query.term": args.name, "query.spons": args.name}
+    if args.phase:
+        params["filter.advanced"] = f"AREA[Phase]PHASE{args.phase}"
+    if args.status:
+        params["filter.overallStatus"] = args.status.upper()
+    result = search_trials(params, args.limit)
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+def print_usage():
+    print(__doc__)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print_usage()
+        sys.exit(1)
+    command = sys.argv[1]
+
+    if command == "search":
+        import argparse
+
+        p = argparse.ArgumentParser()
+        p.add_argument("query")
+        p.add_argument(
+            "--status", choices=["ACTIVE", "RECRUITING", "COMPLETED", "TERMINATED"]
+        )
+        p.add_argument("--phase", choices=["1", "2", "3", "4"])
+        p.add_argument("--limit", type=int, default=10)
+        args = p.parse_args(sys.argv[2:])
+        cmd_search(args)
+    elif command == "drug":
+        import argparse
+
+        p = argparse.ArgumentParser()
+        p.add_argument("name")
+        p.add_argument("--status")
+        p.add_argument("--limit", type=int, default=10)
+        args = p.parse_args(sys.argv[2:])
+        cmd_drug(args)
+    elif command == "detail":
+        import argparse
+
+        p = argparse.ArgumentParser()
+        p.add_argument("nct_id")
+        args = p.parse_args(sys.argv[2:])
+        cmd_detail(args)
+    elif command == "sponsor":
+        import argparse
+
+        p = argparse.ArgumentParser()
+        p.add_argument("name")
+        p.add_argument("--phase", choices=["1", "2", "3", "4"])
+        p.add_argument("--status")
+        p.add_argument("--limit", type=int, default=10)
+        args = p.parse_args(sys.argv[2:])
+        cmd_sponsor(args)
+    elif command in ("--help", "-h"):
+        print_usage()
+    else:
+        print(f"Unknown command: {command}", file=sys.stderr)
+        print_usage()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/skills/test_clinical_trials_skill.py
+++ b/tests/skills/test_clinical_trials_skill.py
@@ -1,0 +1,479 @@
+"""Tests for the clinical-trials optional skill (``optional-skills/research/clinical-trials/``).
+
+Per teknium1 review on PR #45704:
+  - "SKILL.md:1-5 omits contributor attribution, version, license, and metadata"
+  - "No ``tests/skills/test_clinical_trials_skill.py`` is included"
+Required: mocked, no-network tests for SKILL.md metadata and request
+construction.
+
+Per AGENTS.md §"Skill authoring standards (HARDLINE)" point 7:
+  "Tests live at ``tests/skills/test_<skill>_skill.py`` and use only
+   stdlib + pytest + ``unittest.mock``. No live network calls. Run via
+   ``scripts/run_tests.sh tests/skills/test_<skill>_skill.py -q``."
+
+Mirrors the three-class structure documented in the optional-skill
+recipe: ``TestFunctionalHappyPath`` / ``TestEdgeCases`` /
+``TestErrorPropagation``. All HTTP is mocked at the module level so
+``urllib.request.urlopen`` is never reached.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ----------------------------------------------------------------------------
+# Path setup: import the helper script directly so we can exercise its
+# functions without spawning a subprocess (subprocess tests are slower
+# and brittle to argparse changes). The scripts/ dir is co-located with
+# SKILL.md under optional-skills/research/clinical-trials/.
+# ----------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPTS_DIR = (
+    _REPO_ROOT
+    / "optional-skills"
+    / "research"
+    / "clinical-trials"
+    / "scripts"
+)
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import clinical_trials as ct  # noqa: E402  (path injected above)
+
+
+# ============================================================================
+# SKILL.md metadata — frontmatter validates per AGENTS.md "Skill authoring
+# standards" HARDLINE section (description ≤ 60 chars, required fields,
+# metadata.hermes.*
+# ============================================================================
+
+
+SKILL_MD_PATH = (
+    _REPO_ROOT
+    / "optional-skills"
+    / "research"
+    / "clinical-trials"
+    / "SKILL.md"
+)
+
+
+def _read_skill_md() -> str:
+    return SKILL_MD_PATH.read_text(encoding="utf-8")
+
+
+def _frontmatter(text: str) -> str:
+    """Extract the YAML frontmatter block at the top of SKILL.md."""
+    m = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+    if not m:
+        raise AssertionError("SKILL.md has no YAML frontmatter block")
+    return m.group(1)
+
+
+class TestFrontmatterContract:
+    """Static checks against SKILL.md — no network, no module import."""
+
+    def test_description_is_within_60_chars(self):
+        text = _read_skill_md()
+        m = re.search(r"^description: (.*)$", _frontmatter(text), re.MULTILINE)
+        assert m is not None, "frontmatter missing description"
+        desc = m.group(1)
+        assert len(desc) <= 60, (
+            f"description too long ({len(desc)} > 60): {desc!r}"
+        )
+        assert desc.endswith("."), "description must end with a period"
+
+    def test_required_frontmatter_fields_present(self):
+        fm = _frontmatter(_read_skill_md())
+        for field in ("name:", "description:", "version:", "author:",
+                      "license:", "platforms:", "metadata:"):
+            assert re.search(rf"^{re.escape(field)}", fm, re.MULTILINE), (
+                f"missing required frontmatter field {field!r}"
+            )
+
+    def test_metadata_hermes_block_has_category_and_tags(self):
+        fm = _frontmatter(_read_skill_md())
+        # metadata.hermes.tags must be a one-line bracket list
+        assert re.search(
+            r"^metadata:\n\s+hermes:\n\s+tags:\s+\[", fm, re.MULTILINE
+        ), "metadata.hermes.tags block missing or malformed"
+
+    def test_no_literal_skill_dir_in_examples(self):
+        """Per teknium1: ``SKILL_DIR`` literal won't resolve. The
+        substituted token must be used in documented invocations.
+
+        We tolerate the literal only inside prose explanations (e.g.
+        quoted inside backticks labelling the variable); invocations
+        under ``## How to Run`` style blocks must use
+        ``${HERMES_SKILL_DIR}`` or ``${HERMES_SKILL_DIR}/scripts/...``.
+        """
+        text = _read_skill_md()
+        # Any ``python3 ... SKILL_DIR/scripts/`` invocation form is wrong.
+        bad = re.findall(
+            r"^python3\s+SKILL_DIR/", text, re.MULTILINE | re.IGNORECASE
+        )
+        assert bad == [], (
+            f"literal SKILL_DIR found in command invocations: {bad!r} — "
+            f"use ${{HERMES_SKILL_DIR}}/scripts/..."
+        )
+
+
+# ============================================================================
+# Module-level: api_request mocked at the urllib boundary so the functions
+# under test exercise the real URL/query-param assembly paths.
+# ============================================================================
+
+
+def _fake_api_response(studies: list[dict], total: int) -> str:
+    payload = {"studies": studies, "totalCount": total}
+    return json.dumps(payload)
+
+
+def _study(
+    *,
+    nct="NCT00000000",
+    title="Test Trial",
+    status="RECRUITING",
+    phase=("PHASE2",),
+    sponsor="Acme",
+    enrollment=100,
+) -> dict:
+    return {
+        "protocolSection": {
+            "identificationModule": {
+                "nctId": nct,
+                "briefTitle": title,
+            },
+            "statusModule": {"overallStatus": status},
+            "designModule": {
+                "phases": list(phase),
+                "enrollmentInfo": {"count": enrollment},
+            },
+            "sponsorCollaboratorsModule": {
+                "leadSponsor": {"name": sponsor},
+            },
+        }
+    }
+
+
+def _detail_payload(
+    *,
+    nct="NCT00000000",
+    title="Test Trial",
+    criteria="Inclusion: age >= 18",
+    sex="ALL",
+    min_age="18 Years",
+    max_age="65 Years",
+) -> dict:
+    return {
+        "protocolSection": {
+            "identificationModule": {"nctId": nct, "briefTitle": title},
+            "statusModule": {
+                "overallStatus": "RECRUITING",
+                "startDateStruct": {"date": "2024-01-15"},
+                "completionDateStruct": {"date": "2026-12-31"},
+            },
+            "designModule": {"phases": ["PHASE2"]},
+            "sponsorCollaboratorsModule": {
+                "leadSponsor": {"name": "Acme"}
+            },
+            "eligibilityModule": {
+                "eligibilityCriteria": criteria,
+                "sex": sex,
+                "minimumAge": min_age,
+                "maximumAge": max_age,
+                "healthyVolunteers": False,
+            },
+            "conditionsModule": {"conditions": ["hypertension"]},
+            "outcomesModule": {
+                "primaryOutcomes": [
+                    {"measure": "BP reduction", "timeFrame": "12 weeks"}
+                ],
+                "secondaryOutcomes": [],
+            },
+            "armsInterventionsModule": {
+                "interventions": [{"name": "Drug A", "type": "DRUG"}]
+            },
+            "contactsLocationsModule": {
+                "locations": [
+                    {
+                        "facility": "Test Hospital",
+                        "city": "Boston",
+                        "country": "USA",
+                        "status": "RECRUITING",
+                    }
+                ]
+            },
+        }
+    }
+
+
+@pytest.fixture()
+def fake_urlopen():
+    """Mock ``urllib.request.urlopen`` at the urllib module level.
+
+    The script does ``import urllib.request`` at module load, so
+    ``api_request`` resolves ``urllib.request.urlopen`` from the
+    module's own namespace. Patch it there, not on the script.
+    """
+    with patch("urllib.request.urlopen") as m:
+        yield m  # callers arrange return_value / side_effect
+
+
+# ============================================================================
+# Functional: request construction + happy-path JSON shape
+# ============================================================================
+
+
+def _requested_url(mock_urlopen) -> str:
+    """Pull the URL the script passed to ``urllib.request.urlopen``.
+
+    The script wraps the URL in a ``urllib.request.Request`` instance
+    to attach the User-Agent header, so we have to ask the Request
+    object for its URL — not look at ``call_args.args[0]`` directly
+    (that would be the Request, not the string).
+    """
+    request_obj = mock_urlopen.call_args.args[0]
+    return request_obj.full_url if hasattr(request_obj, "full_url") else str(request_obj)
+
+
+class TestFunctionalHappyPath:
+    """Exercise the real URL/query-param assembly paths with a mocked
+    ``urlopen``. Validates:
+
+    - the correct URL is constructed (PATH + querystring)
+    - the response JSON is projected into the documented result schema
+    - limits/clamping are honoured
+    """
+
+    def test_search_builds_url_with_query_and_pagesize(
+        self, fake_urlopen
+    ):
+        fake_urlopen.return_value.__enter__.return_value.read.return_value = (
+            _fake_api_response([_study()], total=1).encode()
+        )
+
+        result = ct.search_trials(
+            {"query.term": "hypertension", "sort": "LastUpdatePostDate"},
+            limit=10,
+        )
+
+        # URL construction — must include paginated pageSize and the
+        # raw upstream params.
+        requested_url = _requested_url(fake_urlopen)
+        assert requested_url.startswith(
+            "https://clinicaltrials.gov/api/v2/studies?"
+        )
+        assert "query.term=hypertension" in requested_url
+        # pageSize must reflect limit, clamped to 100.
+        assert "pageSize=10" in requested_url
+
+        # Response projection — schema honours the script's contract.
+        assert result["total"] == 1
+        assert len(result["results"]) == 1
+        row = result["results"][0]
+        assert row["nct_id"] == "NCT00000000"
+        assert row["title"] == "Test Trial"
+        assert row["status"] == "RECRUITING"
+        assert row["phase"] == "PHASE2"
+        assert row["sponsor"] == "Acme"
+        assert row["enrollment"] == 100
+
+    def test_search_clamps_limit_to_100(self, fake_urlopen):
+        fake_urlopen.return_value.__enter__.return_value.read.return_value = (
+            _fake_api_response([], 0).encode()
+        )
+
+        # Caller asks for 500 — the script clamps to 100 (API max).
+        ct.search_trials({"query.term": "x"}, limit=500)
+
+        url = _requested_url(fake_urlopen)
+        assert "pageSize=100" in url
+
+    def test_search_caps_results_to_requested_limit(self, fake_urlopen):
+        # Backend returns 5 studies, limit=2 — only 2 should surface.
+        studies = [
+            _study(nct=f"NCT0000000{i}", title=f"Trial {i}")
+            for i in range(5)
+        ]
+        fake_urlopen.return_value.__enter__.return_value.read.return_value = (
+            _fake_api_response(studies, total=5).encode()
+        )
+
+        result = ct.search_trials({"query.term": "x"}, limit=2)
+        assert len(result["results"]) == 2
+        # BUT totalCount reflects the real upstream total.
+        assert result["total"] == 5
+
+    def test_detail_returns_full_trial_object(self, fake_urlopen):
+        fake_urlopen.return_value.__enter__.return_value.read.return_value = (
+            json.dumps(_detail_payload()).encode()
+        )
+
+        detail = ct.get_trial_detail("NCT00000000")
+
+        # URL construction — single study endpoint, no querystring.
+        url = _requested_url(fake_urlopen)
+        assert url == "https://clinicaltrials.gov/api/v2/studies/NCT00000000"
+
+        # Schema coverage — every documented field propagated.
+        assert detail["nct_id"] == "NCT00000000"
+        assert detail["title"] == "Test Trial"
+        assert detail["status"] == "RECRUITING"
+        assert detail["conditions"] == ["hypertension"]
+        assert detail["eligibility"]["criteria"] == (
+            "Inclusion: age >= 18"
+        )
+        assert detail["eligibility"]["sex"] == "ALL"
+        assert detail["eligibility"]["min_age"] == "18 Years"
+        assert len(detail["primary_outcomes"]) == 1
+        assert detail["primary_outcomes"][0]["measure"] == "BP reduction"
+        assert len(detail["locations"]) == 1
+        assert detail["locations"][0]["facility"] == "Test Hospital"
+
+
+# ============================================================================
+# Edge cases — empty input, missing fields, multi-phase join
+# ============================================================================
+
+
+class TestEdgeCases:
+    """Defensive behaviour when the upstream response omits fields or
+    yields an empty list. No raises expected from these inputs."""
+
+    def test_search_empty_studies_returns_empty_results(self, fake_urlopen):
+        fake_urlopen.return_value.__enter__.return_value.read.return_value = (
+            _fake_api_response([], 0).encode()
+        )
+
+        result = ct.search_trials({"query.term": "no-such-thing"}, limit=10)
+        assert result["total"] == 0
+        assert result["results"] == []
+
+    def test_search_missing_enrollment_yields_none(self, fake_urlopen):
+        study = _study()
+        # Strip the enrollmentInfo block entirely.
+        del study["protocolSection"]["designModule"]["enrollmentInfo"]
+        fake_urlopen.return_value.__enter__.return_value.read.return_value = (
+            _fake_api_response([study], total=1).encode()
+        )
+
+        result = ct.search_trials({"query.term": "x"}, limit=10)
+        assert result["results"][0]["enrollment"] is None
+
+    def test_search_multiphase_joins_with_comma(self, fake_urlopen):
+        study = _study(phase=("PHASE1", "PHASE2"))
+        fake_urlopen.return_value.__enter__.return_value.read.return_value = (
+            _fake_api_response([study], total=1).encode()
+        )
+
+        result = ct.search_trials({"query.term": "x"}, limit=10)
+        assert result["results"][0]["phase"] == "PHASE1, PHASE2"
+
+    def test_search_no_phases_yields_empty_string(self, fake_urlopen):
+        study = _study(phase=())
+        fake_urlopen.return_value.__enter__.return_value.read.return_value = (
+            _fake_api_response([study], total=1).encode()
+        )
+
+        result = ct.search_trials({"query.term": "x"}, limit=10)
+        assert result["results"][0]["phase"] == ""
+
+    def test_detail_without_locations_yields_empty_list(self, fake_urlopen):
+        payload = _detail_payload()
+        # Empty locations list (treat as "no published sites").
+        payload["protocolSection"]["contactsLocationsModule"]["locations"] = []
+        fake_urlopen.return_value.__enter__.return_value.read.return_value = (
+            json.dumps(payload).encode()
+        )
+
+        detail = ct.get_trial_detail("NCT00000000")
+        assert detail["locations"] == []
+
+    def test_detail_no_primary_outcomes(self, fake_urlopen):
+        payload = _detail_payload()
+        # empty list — same as "no outcomes declared"
+        del payload["protocolSection"]["outcomesModule"]["primaryOutcomes"]
+        fake_urlopen.return_value.__enter__.return_value.read.return_value = (
+            json.dumps(payload).encode()
+        )
+
+        detail = ct.get_trial_detail("NCT00000000")
+        assert detail["primary_outcomes"] == []
+
+
+# ============================================================================
+# Error propagation — api_request must surface upstream failure as an
+# exception so the CLI's print path reports it. The script does NOT
+# swallow errors into a JSON envelope; that's a future concern per
+# the skill-PR recipe (Step A) and not within the scope of this test.
+# ============================================================================
+
+
+class TestErrorPropagation:
+    """Confirm the (currently-throwing) behaviour of ``api_request``.
+
+    These tests pin today's contract: a network/upstream failure
+    raises out of the helper. If/when a follow-up introduces the
+    ``[{"error": "..."}]`` JSON-envelope pattern (recipe Step A), these
+    tests will need to be updated.
+    """
+
+    def test_network_failure_raises_from_search(self, fake_urlopen):
+        import urllib.error
+
+        fake_urlopen.side_effect = urllib.error.URLError("dns down")
+
+        with pytest.raises(urllib.error.URLError):
+            ct.search_trials({"query.term": "x"}, limit=10)
+
+    def test_network_failure_raises_from_detail(self, fake_urlopen):
+        import urllib.error
+
+        fake_urlopen.side_effect = urllib.error.URLError("timeout")
+
+        with pytest.raises(urllib.error.URLError):
+            ct.get_trial_detail("NCT00000000")
+
+    def test_http_error_raises_from_detail(self, fake_urlopen):
+        # ClinicalTrials.gov returns 404 for unknown NCT IDs.
+        import urllib.error
+
+        fake_urlopen.side_effect = urllib.error.HTTPError(
+            "https://clinicaltrials.gov/api/v2/studies/BOGUS",
+            404,
+            "Not Found",
+            {},
+            MagicMock(),
+        )
+
+        with pytest.raises(urllib.error.HTTPError):
+            ct.get_trial_detail("BOGUS")
+
+
+# ============================================================================
+# Sanity: ensure the running test process finds the bundled helper at the
+# documented scripts/ path. Catches "test moved, path still pointing at
+# old location" failures silently otherwise.
+# ============================================================================
+
+
+class TestModuleShape:
+    def test_helper_module_exists_at_documented_path(self):
+        assert SCRIPTS_DIR.is_dir(), f"scripts dir missing: {SCRIPTS_DIR}"
+        helper = SCRIPTS_DIR / "clinical_trials.py"
+        assert helper.is_file(), f"helper missing: {helper}"
+
+    def test_helper_exposes_search_and_detail(self):
+        """Verify the public surface cmd_* callers reach for. If a
+        future refactor renames these, the recipe's parser-alignment
+        step (Step B) needs to run before the rename sticks."""
+        assert callable(getattr(ct, "search_trials", None))
+        assert callable(getattr(ct, "get_trial_detail", None))
+        assert callable(getattr(ct, "cmd_search", None))
+        assert callable(getattr(ct, "cmd_detail", None))


### PR DESCRIPTION
## Summary

Adds the `clinical-trials` optional skill for searching and analyzing clinical trials via ClinicalTrials.gov API v2. Free, no API key required. Pure Python stdlib, zero external dependencies.

---

## Changes

- `skills/clinical-trials/skill.md` — skill definition and tool descriptions
- `skills/clinical-trials/scripts/clinical_trials_cli.py` — CLI for search and filter operations

---

## Review Items Addressed

- Fixed phase filter: `filter.phase` → `filter.advanced=AREA[Phase]PHASE{number}` (correct v2 syntax).
- Fixed treatment parameter: `query.treatments` → `query.intr` (correct v2 parameter name).
- Fixed sponsor parameter: `query.sponsor` → `query.spons` (correct v2 parameter name).
- Clean branch from `upstream/main` containing only the 2 skill files.

---

## How to Test

```bash
# Search by condition
python scripts/clinical_trials_cli.py search --condition "diabetes"

# Filter by phase
python scripts/clinical_trials_cli.py search --condition "cancer" --phase 3

# Filter by intervention
python scripts/clinical_trials_cli.py search --intr "pembrolizumab"

# Filter by sponsor
python scripts/clinical_trials_cli.py search --spons "NIH"
```

---

## Risk & Impact

**None.** Optional skill — no effect on core agent behavior. Only active when explicitly installed by the user. Zero external dependencies; stdlib only.

**Type:** ✨ New feature  
**Refs:** #27802