### PR TITLE
feat(web): make web_search default result limit configurable

### DIFF
--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -267,6 +267,10 @@ class TestBackendSelection:
         self._managed_patchers = [
             patch("tools.web_tools.managed_nous_tools_enabled", return_value=True),
             patch("tools.managed_tool_gateway.managed_nous_tools_enabled", return_value=True),
+            # Mock Hermes config layer so CI runner's real keys don't
+            # contaminate tests. _env_value() calls get_env_value first;
+            # returning None falls through to os.getenv / os.environ.
+            patch("hermes_cli.config.get_env_value", return_value=None),
         ]
         for p in self._managed_patchers:
             p.start()
@@ -591,6 +595,10 @@ class TestCheckWebApiKey:
         self._managed_patchers = [
             patch("tools.web_tools.managed_nous_tools_enabled", return_value=True),
             patch("tools.managed_tool_gateway.managed_nous_tools_enabled", return_value=True),
+            # Mock Hermes config layer so CI runner's real keys don't
+            # contaminate tests. _env_value() calls get_env_value first;
+            # returning None falls through to os.getenv / os.environ.
+            patch("hermes_cli.config.get_env_value", return_value=None),
         ]
         for p in self._managed_patchers:
             p.start()


### PR DESCRIPTION
Adds a `web.search_default_limit` config option so users can change the default result count for `web_search` without the model having to pass `limit` explicitly. The model's explicit `limit` still takes priority when provided.

Changes:
- `hermes_cli/config.py` -- added `search_default_limit: 5` to the `web` section of DEFAULT_CONFIG
- `tools/web_tools.py` -- `web_search_tool()` reads the config value when no explicit `limit` is passed; the schema description notes the config option

Follows the same pattern as `tool_search.search_default_limit` in `tools/tool_search.py`.

Closes #45701
