### PR TITLE
fix(api_server): truncate oversized tool outputs in /v1/responses SSE stream

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -102,6 +102,15 @@ def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
         return default
 
 
+# Maximum chars of a tool result to embed in a single SSE event for the
+# Responses streaming endpoint.  aiohttp (used by OpenWebUI and other
+# Python clients) reads at most 131072 bytes per line; a 32K-char cap
+# leaves ample headroom for JSON framing, multi-byte UTF-8, and other
+# fields in the same event.  Tool outputs larger than this are truncated
+# with a visible marker so the client receives a well-formed event
+# instead of a connection reset.  See issue #45647.
+_MAX_SSE_TOOL_OUTPUT_CHARS = 32768
+
 _TRUE_REQUEST_BOOL_STRINGS = frozenset({"1", "true", "yes", "on"})
 _FALSE_REQUEST_BOOL_STRINGS = frozenset({"0", "false", "no", "off"})
 
@@ -2480,6 +2489,14 @@ class APIServerAdapter(BasePlatformAdapter):
 
                 # function_call_output added (result)
                 result_str = result if isinstance(result, str) else json.dumps(result)
+                # Truncate oversized tool outputs to prevent SSE events that
+                # exceed common client line-read limits (e.g. aiohttp's 128 KiB).
+                # See issue #45647.
+                if len(result_str) > _MAX_SSE_TOOL_OUTPUT_CHARS:
+                    result_str = (
+                        result_str[:_MAX_SSE_TOOL_OUTPUT_CHARS]
+                        + "\n...[truncated: tool output exceeded SSE safe limit]"
+                    )
                 output_parts = [{"type": "input_text", "text": result_str}]
                 output_item = {
                     "id": f"fco_{uuid.uuid4().hex[:24]}",

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2144,6 +2144,63 @@ class TestResponsesStreaming:
                 assert '"output": [{"type": "input_text", "text": "{\\"content\\":\\"hello\\"}"}]' in body
 
     @pytest.mark.asyncio
+    async def test_stream_truncates_oversized_tool_output(self, adapter):
+        """Tool outputs exceeding _MAX_SSE_TOOL_OUTPUT_CHARS are truncated to
+        prevent SSE events that break clients with line-read limits (#45647)."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            big_output = "x" * 40000  # exceeds _MAX_SSE_TOOL_OUTPUT_CHARS (32768)
+
+            async def _mock_run_agent(**kwargs):
+                start_cb = kwargs.get("tool_start_callback")
+                complete_cb = kwargs.get("tool_complete_callback")
+                text_cb = kwargs.get("stream_delta_callback")
+                if start_cb:
+                    start_cb("call_big", "read_file", {"path": "/big.txt"})
+                if complete_cb:
+                    complete_cb("call_big", "read_file", {"path": "/big.txt"}, big_output)
+                if text_cb:
+                    text_cb("Done.")
+                return (
+                    {
+                        "final_response": "Done.",
+                        "messages": [
+                            {
+                                "role": "assistant",
+                                "tool_calls": [
+                                    {
+                                        "id": "call_big",
+                                        "function": {
+                                            "name": "read_file",
+                                            "arguments": '{"path":"/big.txt"}',
+                                        },
+                                    }
+                                ],
+                            },
+                            {
+                                "role": "tool",
+                                "tool_call_id": "call_big",
+                                "content": big_output,
+                            },
+                        ],
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "read big", "stream": True},
+                )
+                assert resp.status == 200
+                body = await resp.text()
+                # Truncation marker present
+                assert "[truncated: tool output exceeded SSE safe limit]" in body
+                # Full output not present (40000 x's would make the body > 40KB)
+                assert "x" * 35000 not in body
+
+    @pytest.mark.asyncio
     async def test_streamed_response_is_stored_for_get(self, adapter):
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:


### PR DESCRIPTION
## What does this PR do?

Truncates oversized tool outputs in the `/v1/responses` SSE streaming endpoint to prevent events that exceed common client line-read limits (e.g., aiohttp's 128 KiB default).

## Related Issue

Fixes #45647

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py`: Added `_MAX_SSE_TOOL_OUTPUT_CHARS = 32768` constant and truncation logic in `_emit_tool_completed()`. Tool outputs exceeding the cap are truncated with a visible `[truncated]` marker so clients receive well-formed SSE events instead of connection resets.
- `tests/gateway/test_api_server.py`: Added `test_stream_truncates_oversized_tool_output` — verifies a 40K-char tool output is truncated in the SSE stream and the truncation marker is present.

## How to Test

1. Start the Hermes API server gateway
2. Send a streaming request to `/v1/responses` that triggers a tool producing a large output (>32K chars), e.g., `browser_vision` on a complex page
3. Verify the SSE stream completes without `400 Got more than 131072 bytes` errors
4. Verify the truncated event contains `[truncated: tool output exceeded SSE safe limit]`
5. Run `pytest tests/gateway/test_api_server.py::TestResponsesStreaming -xvs`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_emit_tool_completed()` in `gateway/platforms/api_server.py` (1 call site in `_dispatch()`, same streaming function)
- Blast radius: LOW — only affects `/v1/responses` SSE streaming path; no change to non-streaming responses, Chat Completions, or other endpoints
- Related patterns: The truncation applies consistently to both incremental `response.output_item.added`/`done` events and the terminal `response.completed` payload since they share the same `output_parts` reference
