### PR TITLE
fix(gateway): serialize startup auto-resume before accepting inbound messages (#45682)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2058,6 +2058,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._running_agents: Dict[str, Any] = {}
         self._running_agents_ts: Dict[str, float] = {}  # start timestamp per session
         self._active_session_leases: Dict[str, Any] = {}
+        # Gate set during startup auto-resume.  While True, inbound
+        # (non-internal) messages are queued in the adapter's pending
+        # queue so they don't race with the auto-resume tasks that are
+        # restoring restart-interrupted sessions.  Cleared once all
+        # startup auto-resume tasks have completed (#45682).
+        self._startup_auto_resuming: bool = False
         self._pending_messages: Dict[str, str] = {}  # Queued messages during interrupt
         # Last successfully-resolved (non-empty) model, keyed by session. Used
         # as a fallback when a fresh config read transiently returns an empty
@@ -4495,7 +4501,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         {"restart_timeout", "shutdown_timeout", "restart_interrupted"}
     )
 
-    def _schedule_resume_pending_sessions(self, platform=None) -> int:
+    def _schedule_resume_pending_sessions(self, platform=None) -> tuple:
         """Auto-continue fresh restart-interrupted sessions after startup.
 
         ``resume_pending`` already preserves the transcript AND the existing
@@ -4532,10 +4538,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 ]
         except Exception as exc:
             logger.warning("Failed to enumerate resume-pending sessions: %s", exc)
-            return 0
+            return 0, []
 
+        tasks: list = []
         now = datetime.now()
-        scheduled = 0
+        scheduled: int = 0
         for entry in candidates:
             marker = entry.last_resume_marked_at or entry.updated_at
             if marker is not None and (now - marker).total_seconds() > window:
@@ -4568,6 +4575,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             task = asyncio.create_task(adapter.handle_message(event))
             self._background_tasks.add(task)
             task.add_done_callback(self._background_tasks.discard)
+            tasks.append(task)
             scheduled += 1
 
         if scheduled:
@@ -4575,7 +4583,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "Scheduled auto-resume for %d restart-interrupted session(s)",
                 scheduled,
             )
-        return scheduled
+        return scheduled, tasks
 
     async def start(self) -> bool:
         """
@@ -5073,7 +5081,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # previous gateway restart/shutdown.  The resume_pending flag is cleared
         # by the normal successful-turn path, so a failed auto-resume remains
         # visible for manual recovery on the next user message.
-        self._schedule_resume_pending_sessions()
+        self._startup_auto_resuming = True
+        _ar_scheduled, _ar_tasks = self._schedule_resume_pending_sessions()
+        if _ar_tasks:
+            try:
+                await asyncio.gather(*_ar_tasks, return_exceptions=True)
+            except Exception as _ar_exc:
+                logger.debug("startup auto-resume gather failed: %s", _ar_exc)
+        self._startup_auto_resuming = False
 
         # Drain any recovered process watchers (from crash recovery checkpoint)
         try:
@@ -5628,7 +5643,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         # auto-resume scoped to this platform so recovery
                         # doesn't silently wait for a manual user message.
                         try:
-                            self._schedule_resume_pending_sessions(platform=platform)
+                            self._schedule_resume_pending_sessions(platform=platform)  # noqa: returns (count, tasks), reconnect fire-and-forget
                         except Exception:
                             logger.debug(
                                 "resume-pending reschedule after %s reconnect failed",
@@ -6379,6 +6394,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Internal events (e.g. background-process completion notifications)
         # are system-generated and must skip user authorization.
         is_internal = bool(getattr(event, "internal", False))
+
+        # During startup auto-resume, queue inbound user messages so they
+        # don't race with the auto-resume tasks restoring interrupted
+        # sessions (#45682).  Internal events (the auto-resume triggers
+        # themselves) bypass this gate.
+        if self._startup_auto_resuming and not is_internal:
+            adapter = self.adapters.get(source.platform)
+            if adapter:
+                _gate_key = self._session_key_for_source(source)
+                merge_pending_message_event(
+                    adapter._pending_messages,
+                    _gate_key,
+                    event,
+                    merge_text=True,
+                )
+                logger.debug(
+                    "Startup auto-resume gate: queued inbound message for %s",
+                    _gate_key,
+                )
+            return None
 
         # Fire pre_gateway_dispatch plugin hook for user-originated messages.
         # Plugins receive the MessageEvent and may return a dict influencing flow:

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -883,7 +883,7 @@ async def test_startup_auto_resume_schedules_fresh_pending_sessions():
     runner.session_store._entries = {pending_entry.session_key: pending_entry}
     adapter.handle_message = AsyncMock()
 
-    scheduled = runner._schedule_resume_pending_sessions()
+    scheduled, _tasks = runner._schedule_resume_pending_sessions()
     await asyncio.sleep(0)
 
     assert scheduled == 1
@@ -925,7 +925,7 @@ async def test_startup_auto_resume_includes_crash_recovery():
     runner.session_store._entries = {pending_entry.session_key: pending_entry}
     adapter.handle_message = AsyncMock()
 
-    scheduled = runner._schedule_resume_pending_sessions()
+    scheduled, _tasks = runner._schedule_resume_pending_sessions()
     await asyncio.sleep(0)
 
     assert scheduled == 1
@@ -955,7 +955,7 @@ async def test_startup_auto_resume_skips_stale_entries():
     runner.session_store._entries = {stale_entry.session_key: stale_entry}
     adapter.handle_message = AsyncMock()
 
-    scheduled = runner._schedule_resume_pending_sessions()
+    scheduled, _tasks = runner._schedule_resume_pending_sessions()
 
     assert scheduled == 0
     adapter.handle_message.assert_not_called()
@@ -997,7 +997,7 @@ async def test_startup_auto_resume_skips_suspended_and_originless():
     }
     adapter.handle_message = AsyncMock()
 
-    scheduled = runner._schedule_resume_pending_sessions()
+    scheduled, _tasks = runner._schedule_resume_pending_sessions()
 
     assert scheduled == 0
     adapter.handle_message.assert_not_called()
@@ -1028,7 +1028,7 @@ async def test_startup_auto_resume_skips_disallowed_reasons():
     runner.session_store._entries = {other_entry.session_key: other_entry}
     adapter.handle_message = AsyncMock()
 
-    scheduled = runner._schedule_resume_pending_sessions()
+    scheduled, _tasks = runner._schedule_resume_pending_sessions()
 
     assert scheduled == 0
     adapter.handle_message.assert_not_called()
@@ -1054,7 +1054,7 @@ async def test_startup_auto_resume_skips_when_adapter_unavailable():
     runner.adapters = {}
     adapter.handle_message = AsyncMock()
 
-    scheduled = runner._schedule_resume_pending_sessions()
+    scheduled, _tasks = runner._schedule_resume_pending_sessions()
 
     assert scheduled == 0
     adapter.handle_message.assert_not_called()
@@ -1090,12 +1090,12 @@ async def test_reconnect_reschedules_pending_after_late_platform_connect():
 
     # Platform was not connected at gateway startup → session skipped.
     runner.adapters = {}
-    assert runner._schedule_resume_pending_sessions() == 0
+    assert runner._schedule_resume_pending_sessions() == (0, [])
     adapter.handle_message.assert_not_called()
 
     # Platform reconnects → its pending session is retried.
     runner.adapters = {Platform.TELEGRAM: adapter}
-    scheduled = runner._schedule_resume_pending_sessions(platform=Platform.TELEGRAM)
+    scheduled, _tasks = runner._schedule_resume_pending_sessions(platform=Platform.TELEGRAM)
     await asyncio.sleep(0)
 
     assert scheduled == 1
@@ -1148,7 +1148,7 @@ async def test_reconnect_reschedule_is_platform_scoped():
     adapter.handle_message = AsyncMock()
     runner.adapters = {Platform.TELEGRAM: adapter}
 
-    scheduled = runner._schedule_resume_pending_sessions(platform=Platform.TELEGRAM)
+    scheduled, _tasks = runner._schedule_resume_pending_sessions(platform=Platform.TELEGRAM)
     await asyncio.sleep(0)
 
     # Only the telegram session is resumed; the discord session waits for its
@@ -1182,7 +1182,7 @@ async def test_auto_resume_skips_sessions_with_running_agent():
     runner._running_agents = {pending_entry.session_key: object()}
     adapter.handle_message = AsyncMock()
 
-    scheduled = runner._schedule_resume_pending_sessions(platform=Platform.TELEGRAM)
+    scheduled, _tasks = runner._schedule_resume_pending_sessions(platform=Platform.TELEGRAM)
 
     assert scheduled == 0
     adapter.handle_message.assert_not_called()


### PR DESCRIPTION
Fixes #45682. When the gateway restarts, auto-resume creates background tasks for each interrupted session. Inbound user messages can race with these tasks because both check _running_agents before either places the sentinel, leading to duplicate AIAgent instances for the same session. This fix adds a startup gate that queues inbound user messages while auto-resume tasks are running, then drains them after all tasks complete.