### PR TITLE
fix(tts): extend opus conversion to Feishu for voice bubbles (#45557)

### DIFF
--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2059,12 +2059,12 @@ def text_to_speech_tool(
         text = text[:max_len]
 
     # Detect platform from gateway env var to choose the best output format.
-    # Telegram voice bubbles require Opus (.ogg); OpenAI and ElevenLabs can
-    # produce Opus natively (no ffmpeg needed).  Edge TTS always outputs MP3
-    # and needs ffmpeg for conversion.
+    # Telegram and Feishu voice bubbles require Opus (.ogg); OpenAI and
+    # ElevenLabs can produce Opus natively (no ffmpeg needed).  Edge TTS
+    # always outputs MP3 and needs ffmpeg for conversion.
     from gateway.session_context import get_session_env
     platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
-    want_opus = (platform == "telegram")
+    want_opus = (platform in {"telegram", "feishu"})
 
     # Determine output path
     if output_path:


### PR DESCRIPTION
Fixes #45557. Feishu voice bubbles require Opus (.ogg) format, same as Telegram. The want_opus guard was only set for Telegram, causing Feishu to receive mp3 as file attachments instead of voice bubbles. This fix adds feishu to the want_opus condition so minimax TTS output is properly converted to voice-bubble-compatible format on Feishu.