### PR TITLE
fix(desktop): add restart button when terminal shell exits

### DIFF
--- a/apps/desktop/src/app/right-sidebar/terminal/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/index.tsx
@@ -20,7 +20,7 @@ interface TerminalTabProps {
 export function TerminalTab({ cwd, onAddSelectionToChat }: TerminalTabProps) {
   const { t } = useI18n()
 
-  const { addSelectionToChat, hostRef, selection, selectionStyle, shellName, status } = useTerminalSession({
+  const { addSelectionToChat, hostRef, restartSession, selection, selectionStyle, shellName, status } = useTerminalSession({
     cwd,
     onAddSelectionToChat
   })
@@ -53,6 +53,23 @@ export function TerminalTab({ cwd, onAddSelectionToChat }: TerminalTabProps) {
               strokeScale={0.68}
               type="spiral-search"
             />
+          </div>
+        )}
+        {status === 'closed' && (
+          <div className="absolute inset-0 z-10 grid place-items-center">
+            <div className="flex flex-col items-center gap-2">
+              <span className="text-sm text-(--ui-text-tertiary)">{t.rightSidebar.terminalExited}</span>
+              <Button
+                className="gap-1.5"
+                onClick={restartSession}
+                size="sm"
+                type="button"
+                variant="secondary"
+              >
+                <Codicon name="refresh" size="0.875rem" />
+                {t.rightSidebar.terminalRestart}
+              </Button>
+            </div>
           </div>
         )}
         {selection.trim() && (

--- a/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
@@ -257,6 +257,7 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
   const [selection, setSelection] = useState('')
   const [selectionStyle, setSelectionStyle] = useState<CSSProperties | null>(null)
   const [shellName, setShellName] = useState('shell')
+  const restartRef = useRef<() => void>(() => {})
 
   useEffect(() => {
     onAddSelectionToChatRef.current = onAddSelectionToChat
@@ -326,6 +327,7 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
 
     let disposed = false
     const cleanup: Array<() => void> = []
+    let sessionCleanup: Array<() => void> = []
     let lastSentSize: { cols: number; rows: number } | null = null
 
     const term = new Terminal({
@@ -576,13 +578,41 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
 
           setStatus('open')
 
-          cleanup.push(
+          sessionCleanup.push(
             terminalApi.onData(session.id, armedWrite),
             terminalApi.onExit(session.id, ({ code, signal }) => {
               setStatus('closed')
               term.write(`\r\n[terminal exited${signal ? `: ${signal}` : code !== null ? `: ${code}` : ''}]\r\n`)
             })
           )
+
+          restartRef.current = () => {
+            // Tear down the old session's listeners and PTY
+            sessionCleanup.forEach(run => run())
+            sessionCleanup = []
+
+            const oldId = sessionIdRef.current
+
+            if (oldId) {
+              void terminalApi.dispose(oldId)
+              sessionIdRef.current = null
+            }
+
+            // Clear the xterm buffer and reset visual state
+            term.clear()
+            term.reset()
+            setSelection('')
+            setSelectionStyle(null)
+            selectionRef.current = ''
+            selectionLabelRef.current = ''
+            promptPristine = true
+            stripLeading = true
+            lastSentSize = null
+            setStatus('starting')
+
+            // Start a fresh session
+            startSession()
+          }
 
           window.requestAnimationFrame(() => {
             fitAndResize()
@@ -638,6 +668,7 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
     return () => {
       disposed = true
       cleanup.forEach(run => run())
+      sessionCleanup.forEach(run => run())
       setActiveTerminalReader(null)
 
       const id = sessionIdRef.current
@@ -699,9 +730,14 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
     })
   }, [status])
 
+  const restartSession = useCallback(() => {
+    restartRef.current()
+  }, [])
+
   return {
     addSelectionToChat,
     hostRef,
+    restartSession,
     selection,
     selectionStyle,
     shellName,

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1640,6 +1640,8 @@ export const en: Translations = {
     loadingTree: 'Loading file tree',
     loadingFiles: 'Loading files',
     terminalHide: 'Hide terminal',
+    terminalExited: 'Terminal exited',
+    terminalRestart: 'Restart terminal',
     addToChat: 'Add to chat'
   },
 

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1770,6 +1770,8 @@ export const ja = defineLocale({
     loadingTree: 'ファイルツリーを読み込み中',
     loadingFiles: 'ファイルを読み込み中',
     terminalHide: 'ターミナルを非表示',
+    terminalExited: 'ターミナルが終了しました',
+    terminalRestart: 'ターミナルを再起動',
     addToChat: 'チャットに追加'
   },
 

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1282,6 +1282,8 @@ export interface Translations {
     loadingTree: string
     loadingFiles: string
     terminalHide: string
+    terminalExited: string
+    terminalRestart: string
     addToChat: string
   }
 

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1714,6 +1714,8 @@ export const zhHant = defineLocale({
     loadingTree: '正在載入檔案樹',
     loadingFiles: '正在載入檔案',
     terminalHide: '隱藏終端機',
+    terminalExited: '終端機已結束',
+    terminalRestart: '重新啟動終端機',
     addToChat: '新增至聊天'
   },
 

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1820,6 +1820,8 @@ export const zh: Translations = {
     loadingTree: '正在加载文件树',
     loadingFiles: '正在加载文件',
     terminalHide: '隐藏终端',
+    terminalExited: '终端已退出',
+    terminalRestart: '重启终端',
     addToChat: '添加到对话'
   },
 


### PR DESCRIPTION
## Problem

When a user types `exit` in the built-in terminal pane, the PTY process terminates but there is no UI to close or restart the dead terminal. The pane becomes permanently locked, requiring a full app restart to recover. (Fixes #45649)

## Solution

Add a **"Terminal exited"** overlay with a **"Restart terminal"** button that appears when the PTY session status transitions to `closed`.

### What happens when you click Restart:
1. The old session's `onData` and `onExit` listeners are torn down
2. The old PTY is disposed via `terminalApi.dispose()`
3. The xterm buffer is cleared and reset
4. A fresh PTY session is spawned with `terminalApi.start()`
5. Status transitions `closed` → `starting` → `open`

### Changes

| File | Change |
|------|--------|
| `use-terminal-session.ts` | Add `sessionCleanup` array (separate from component-lifecycle `cleanup`) to track per-session listeners; add `restartRef` + stable `restartSession` callback; on restart, tear down session listeners, dispose PTY, reset xterm, and start fresh |
| `index.tsx` (TerminalTab) | Destructure `restartSession` from hook; add `status === 'closed'` overlay with exit message + restart button (using `Codicon "refresh"` + `Button variant="secondary"`) |
| `en.ts`, `ja.ts`, `zh.ts`, `zh-hant.ts` | Add `terminalExited` / `terminalRestart` i18n strings |
| `types.ts` | Add type declarations for the new i18n keys |

## Testing

- [x] TypeScript compiles cleanly (`tsc --noEmit` passes)
- [ ] Type `exit` in terminal → overlay appears with "Terminal exited" message and "Restart terminal" button
- [ ] Click "Restart terminal" → new shell session starts, overlay disappears, terminal is interactive again
- [ ] Restart works on both Windows and macOS
- [ ] Restart while `starting` is a no-op (button not visible)

## Safety

- The restart function is a no-op when the component is disposed (`disposed` flag guards `startSession`)
- `sessionCleanup` is drained both on restart (to tear down old listeners) and on unmount (to prevent leaks)
- The existing `onExit` handler still writes `[terminal exited: ...]` to the xterm buffer, which remains visible behind the overlay — this preserves context about *why* the terminal exited