### PR TITLE
fix(cli): coerce string MCP server entries to dict in `mcp list`

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -533,6 +533,17 @@ def cmd_mcp_list(args=None):
     print(f"  {'─' * 16} {'─' * 30} {'─' * 12} {'─' * 10}")
 
     for name, cfg in servers.items():
+        # Coerce string shorthand (e.g. from `hermes config set mcp_servers.x URL`)
+        # to the canonical dict form so the listing can proceed.
+        if isinstance(cfg, str):
+            cfg = {"url": cfg}
+        elif not isinstance(cfg, dict):
+            _warning(
+                f"Skipping malformed MCP entry '{name}': "
+                f"expected dict, got {type(cfg).__name__}"
+            )
+            continue
+
         # Transport info
         if "url" in cfg:
             url = cfg["url"]

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -113,6 +113,37 @@ class TestMcpList:
         assert "myserver" in out
         assert "enabled" in out
 
+    def test_list_string_entry_coerced(self, tmp_path, capsys):
+        """A raw string entry (e.g. from `hermes config set mcp_servers.x URL`)
+        is coerced to {'url': str} instead of crashing with AttributeError."""
+        _seed_config(tmp_path, {
+            "good": {"url": "https://good.example.com/mcp"},
+            "broken": "https://example.com/mcp",  # string instead of dict
+        })
+        from hermes_cli.mcp_config import cmd_mcp_list
+
+        cmd_mcp_list()  # should not raise
+        out = capsys.readouterr().out
+        assert "good" in out
+        assert "broken" in out  # string entry still shows up as a URL transport
+        assert "example.com" in out  # URL from string shorthand is visible
+
+    def test_list_non_dict_entry_skipped_with_warning(self, tmp_path, capsys):
+        """Non-dict, non-string entries are skipped with a warning instead of
+        crashing the entire listing."""
+        _seed_config(tmp_path, {
+            "good": {"url": "https://good.example.com/mcp"},
+            "bad": 42,  # int — not coercible
+        })
+        from hermes_cli.mcp_config import cmd_mcp_list
+
+        cmd_mcp_list()  # should not raise
+        out = capsys.readouterr().out
+        assert "good" in out
+        # "bad" appears only in the warning, not as a server table row
+        assert "Skipping" in out
+        assert "expected dict, got int" in out
+
 
 # ---------------------------------------------------------------------------
 # Tests: cmd_mcp_remove


### PR DESCRIPTION
## What does this PR do?

Fixes a crash in `hermes mcp list` where a raw string entry under `mcp_servers` (e.g. from `hermes config set mcp_servers.foo "https://example.com/mcp"`) causes `AttributeError: 'str' object has no attribute 'get'`, aborting the entire listing and hiding any well-configured servers that come after the malformed entry.

## Related Issue

Fixes #45674

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/mcp_config.py`: In `cmd_mcp_list`, coerce string entries to `{"url": str}` (matching the common URL-as-string shorthand) before accessing dict methods. Skip other non-dict types with a warning instead of crashing.
- `tests/hermes_cli/test_mcp_config.py`: Added `test_list_string_entry_coerced` (string entry is shown as a URL transport) and `test_list_non_dict_entry_skipped_with_warning` (int entry is skipped with a diagnostic warning).

## How to Test

1. Set a string MCP entry: `hermes config set mcp_servers.broken "https://example.com/mcp"`
2. Add a valid server: `hermes mcp add good --url https://good.example.com/mcp`
3. Run `hermes mcp list` — both servers should appear without crashing
4. Run `pytest tests/hermes_cli/test_mcp_config.py::TestMcpList -v` — all 5 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `cmd_mcp_list` in `hermes_cli/mcp_config.py` (callers: CLI `mcp` subcommand dispatcher)
- Blast radius: LOW — change is isolated to the listing iteration loop; no impact on server connection, config persistence, or other subcommands
- Related patterns: matches the string-shorthand coercion convention used by many MCP loaders (URL-as-string is widely accepted)
