### PR TITLE
feat(terminal): add tmux backend

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -614,6 +614,12 @@ def load_cli_config() -> Dict[str, Any]:
         "sandbox_dir": "TERMINAL_SANDBOX_DIR",
         # Persistent shell (non-local backends)
         "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
+        # tmux backend config (profile-scoped session, agent-scoped window)
+        "tmux_session_template": "TERMINAL_TMUX_SESSION_TEMPLATE",
+        "tmux_window_template": "TERMINAL_TMUX_WINDOW_TEMPLATE",
+        "tmux_shell": "TERMINAL_TMUX_SHELL",
+        "tmux_preserve_session": "TERMINAL_TMUX_PRESERVE_SESSION",
+        "tmux_history_limit": "TERMINAL_TMUX_HISTORY_LIMIT",
         # Sudo support (works with all backends)
         "sudo_password": "SUDO_PASSWORD",
     }

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1043,6 +1043,11 @@ if _config_path.exists():
                 "docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",
                 "sandbox_dir": "TERMINAL_SANDBOX_DIR",
                 "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
+                "tmux_session_template": "TERMINAL_TMUX_SESSION_TEMPLATE",
+                "tmux_window_template": "TERMINAL_TMUX_WINDOW_TEMPLATE",
+                "tmux_shell": "TERMINAL_TMUX_SHELL",
+                "tmux_preserve_session": "TERMINAL_TMUX_PRESERVE_SESSION",
+                "tmux_history_limit": "TERMINAL_TMUX_HISTORY_LIMIT",
             }
             for _cfg_key, _env_var in _terminal_env_map.items():
                 if _cfg_key in _terminal_cfg:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1011,6 +1011,14 @@ DEFAULT_CONFIG = {
         # Enabled by default for non-local backends (SSH); local is always opt-in
         # via TERMINAL_LOCAL_PERSISTENT env var.
         "persistent_shell": True,
+        # tmux backend: local-host execution with attachable, persistent tmux
+        # sessions. Defaults create one tmux session per Hermes profile and one
+        # window per agent/task id inside that profile session.
+        "tmux_session_template": "hermes-{profile}",
+        "tmux_window_template": "{agent}",
+        "tmux_shell": "",  # empty = Hermes' bash discovery/default shell
+        "tmux_preserve_session": True,
+        "tmux_history_limit": 200000,
     },
 
     "web": {
@@ -5289,6 +5297,11 @@ TERMINAL_CONFIG_ENV_MAP = {
     "docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",
     "sandbox_dir": "TERMINAL_SANDBOX_DIR",
     "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
+    "tmux_session_template": "TERMINAL_TMUX_SESSION_TEMPLATE",
+    "tmux_window_template": "TERMINAL_TMUX_WINDOW_TEMPLATE",
+    "tmux_shell": "TERMINAL_TMUX_SHELL",
+    "tmux_preserve_session": "TERMINAL_TMUX_PRESERVE_SESSION",
+    "tmux_history_limit": "TERMINAL_TMUX_HISTORY_LIMIT",
 }
 
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1340,6 +1340,32 @@ def run_doctor(args):
             )
             # Skip to next section; Docker isn't relevant here.
             terminal_env = "local"
+
+    # tmux (if using tmux backend)
+    if terminal_env == "tmux":
+        tmux = _safe_which("tmux")
+        if tmux:
+            try:
+                result = subprocess.run([tmux, "-V"], capture_output=True, text=True, timeout=5)
+            except subprocess.TimeoutExpired:
+                result = None
+            if result is not None and result.returncode == 0:
+                check_ok("tmux", f"({result.stdout.strip()})")
+            else:
+                _fail_and_issue(
+                    "tmux probe failed",
+                    "(required for TERMINAL_ENV=tmux)",
+                    "Run tmux -V or reinstall tmux",
+                    issues,
+                )
+        else:
+            _fail_and_issue(
+                "tmux not found",
+                "(required for TERMINAL_ENV=tmux)",
+                "Install tmux or change TERMINAL_ENV",
+                issues,
+            )
+
     if terminal_env == "docker":
         if _safe_which("docker"):
             # Check if docker daemon is running

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -147,7 +147,7 @@ TIPS = [
     "mixture_of_agents routes hard problems through 4 frontier LLMs collaboratively.",
     "Terminal commands support background mode with notify_on_complete for long-running tasks.",
     "Terminal background processes support watch_patterns to alert on specific output lines.",
-    "The terminal tool supports 6 backends: local, Docker, SSH, Modal, Daytona, and Singularity.",
+    "The terminal tool supports 7 backends: local, tmux, Docker, SSH, Modal, Daytona, and Singularity.",
 
     # --- Profiles ---
     "Each profile gets its own config, API keys, memory, sessions, skills, and cron jobs.",

--- a/run_agent.py
+++ b/run_agent.py
@@ -74,13 +74,14 @@ def _launch_cwd_for_session(source: str) -> Optional[str]:
     host cwd to restore, so they record nothing.
 
     ``TERMINAL_ENV`` is set by the CLI's config bridge (``load_cli_config``);
-    a non-"local" backend (docker/ssh/modal/...) means the host cwd is
-    irrelevant to the agent's tools, so we skip it there too.
+    remote/container backends (docker/ssh/modal/...) mean the host cwd is
+    irrelevant to the agent's tools, so we skip it there too. ``tmux`` still
+    executes on the local host, so it should preserve the launch cwd.
     """
     if source != "cli":
         return None
     backend = (os.environ.get("TERMINAL_ENV") or "local").strip().lower()
-    if backend and backend != "local":
+    if backend and backend not in {"local", "tmux"}:
         return None
     try:
         return os.getcwd()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -54,6 +54,13 @@ def test_is_destructive_command_treats_install_as_mutating():
     assert run_agent._is_destructive_command("install template.env .env") is True
 
 
+def test_launch_cwd_for_session_treats_tmux_as_local(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("TERMINAL_ENV", "tmux")
+
+    assert run_agent._launch_cwd_for_session("cli") == str(tmp_path)
+
+
 @pytest.fixture()
 def agent():
     """Minimal AIAgent with mocked OpenAI client and tool loading."""

--- a/tests/tools/test_tmux_environment.py
+++ b/tests/tools/test_tmux_environment.py
@@ -1,0 +1,180 @@
+"""Tests for the tmux terminal backend.
+
+The tmux backend keeps execution on the local host while routing each Hermes
+profile into a profile-scoped tmux session and each agent/task into its own
+window. These tests cover config plumbing, isolation-key selection, and the
+real tmux command protocol when tmux is installed.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import threading
+import uuid
+
+import pytest
+
+
+def test_get_env_config_tmux_uses_host_cwd_and_templates(monkeypatch, tmp_path):
+    from tools import terminal_tool
+
+    monkeypatch.setenv("TERMINAL_ENV", "tmux")
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+    monkeypatch.setenv("TERMINAL_TMUX_SESSION_TEMPLATE", "jarvis-{profile}")
+    monkeypatch.setenv("TERMINAL_TMUX_WINDOW_TEMPLATE", "agent-{agent}")
+    monkeypatch.setenv("TERMINAL_TMUX_PRESERVE_SESSION", "false")
+    monkeypatch.setenv("TERMINAL_TMUX_HISTORY_LIMIT", "12345")
+
+    config = terminal_tool._get_env_config()
+
+    assert config["env_type"] == "tmux"
+    assert config["cwd"] == str(tmp_path)
+    assert config["tmux_session_template"] == "jarvis-{profile}"
+    assert config["tmux_window_template"] == "agent-{agent}"
+    assert config["tmux_preserve_session"] is False
+    assert config["tmux_history_limit"] == 12345
+
+
+def test_tmux_backend_preserves_raw_task_id_for_agent_window_isolation(monkeypatch):
+    from tools import terminal_tool
+
+    monkeypatch.setenv("TERMINAL_ENV", "tmux")
+
+    assert terminal_tool._resolve_environment_task_id("agent-child-1", "tmux") == "agent-child-1"
+    assert terminal_tool._resolve_environment_task_id(None, "tmux") == "default"
+
+
+def test_create_environment_constructs_tmux_backend(monkeypatch, tmp_path):
+    from tools import terminal_tool
+
+    captured = {}
+
+    class DummyTmuxEnvironment:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(terminal_tool, "_TmuxEnvironment", DummyTmuxEnvironment, raising=False)
+
+    config = {
+        "tmux_session_template": "jarvis-{profile}",
+        "tmux_window_template": "agent-{agent}",
+        "tmux_shell": "/bin/bash",
+        "tmux_preserve_session": False,
+        "tmux_history_limit": 50000,
+    }
+
+    env = terminal_tool._create_environment(
+        env_type="tmux",
+        image="",
+        cwd=str(tmp_path),
+        timeout=7,
+        local_config=config,
+        task_id="agent-123",
+    )
+
+    assert isinstance(env, DummyTmuxEnvironment)
+    assert captured == {
+        "cwd": str(tmp_path),
+        "timeout": 7,
+        "task_id": "agent-123",
+        "session_template": "jarvis-{profile}",
+        "window_template": "agent-{agent}",
+        "shell": "/bin/bash",
+        "preserve_session": False,
+        "history_limit": 50000,
+    }
+
+
+def test_file_tools_use_tmux_agent_window_key(monkeypatch, tmp_path):
+    from tools import file_tools, terminal_tool
+
+    class DummyEnv:
+        cwd = str(tmp_path)
+
+        def execute(self, *args, **kwargs):  # pragma: no cover - not used here
+            return {"output": "", "returncode": 0}
+
+    captured = {}
+
+    def fake_create_environment(**kwargs):
+        captured.update(kwargs)
+        return DummyEnv()
+
+    monkeypatch.setattr(
+        terminal_tool,
+        "_get_env_config",
+        lambda: {
+            "env_type": "tmux",
+            "cwd": str(tmp_path),
+            "timeout": 180,
+            "tmux_session_template": "hermes-{profile}",
+            "tmux_window_template": "{agent}",
+            "tmux_shell": "",
+            "tmux_preserve_session": True,
+            "tmux_history_limit": 200000,
+        },
+    )
+    monkeypatch.setattr(terminal_tool, "_task_env_overrides", {})
+    monkeypatch.setattr(terminal_tool, "_active_environments", {})
+    monkeypatch.setattr(terminal_tool, "_last_activity", {})
+    monkeypatch.setattr(terminal_tool, "_creation_locks", {})
+    monkeypatch.setattr(terminal_tool, "_creation_locks_lock", threading.Lock())
+    monkeypatch.setattr(terminal_tool, "_create_environment", fake_create_environment)
+    monkeypatch.setattr(terminal_tool, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(file_tools, "_file_ops_cache", {})
+    monkeypatch.setattr(file_tools, "_file_ops_lock", threading.Lock())
+
+    file_tools._get_file_ops("agent-file")
+
+    assert captured["env_type"] == "tmux"
+    assert captured["task_id"] == "agent-file"
+    assert captured["local_config"] == {
+        "tmux_session_template": "hermes-{profile}",
+        "tmux_window_template": "{agent}",
+        "tmux_shell": "",
+        "tmux_preserve_session": True,
+        "tmux_history_limit": 200000,
+    }
+
+
+@pytest.mark.skipif(shutil.which("tmux") is None, reason="tmux is not installed")
+def test_tmux_environment_executes_in_agent_window_and_preserves_state(tmp_path):
+    from tools.environments.tmux import TmuxEnvironment
+
+    session = f"hermes-test-{uuid.uuid4().hex[:10]}"
+    env = TmuxEnvironment(
+        cwd=str(tmp_path),
+        timeout=10,
+        task_id="agent-A",
+        session_template=session,
+        window_template="{agent}",
+        preserve_session=False,
+    )
+
+    try:
+        first = env.execute(
+            "export HERMES_TMUX_TEST=works; mkdir -p subdir; cd subdir; printf 'first'",
+            timeout=10,
+        )
+        assert first["returncode"] == 0
+        assert first["output"].strip() == "first"
+
+        second = env.execute(
+            "printf '%s:%s' \"$HERMES_TMUX_TEST\" \"$(basename \"$PWD\")\"",
+            timeout=10,
+        )
+        assert second["returncode"] == 0
+        assert second["output"].strip() == "works:subdir"
+
+        listed = subprocess.run(
+            ["tmux", "list-windows", "-t", session, "-F", "#{window_name}"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        assert "agent-A" in listed.stdout.splitlines()
+    finally:
+        env.cleanup()
+        subprocess.run(["tmux", "kill-session", "-t", session], check=False)

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -600,10 +600,11 @@ def _get_or_create_env(task_id: str):
         _active_environments, _env_lock, _create_environment,
         _get_env_config, _last_activity, _start_cleanup_thread,
         _creation_locks, _creation_locks_lock, _task_env_overrides,
-        _resolve_container_task_id,
+        _resolve_environment_task_id,
     )
 
-    effective_task_id = _resolve_container_task_id(task_id)
+    env_type_for_key = _get_env_config()["env_type"]
+    effective_task_id = _resolve_environment_task_id(task_id, env_type_for_key)
 
     # Fast path: environment already exists
     with _env_lock:
@@ -665,6 +666,14 @@ def _get_or_create_env(task_id: str):
         if env_type == "local":
             local_config = {
                 "persistent": config.get("local_persistent", False),
+            }
+        elif env_type == "tmux":
+            local_config = {
+                "tmux_session_template": config.get("tmux_session_template", "hermes-{profile}"),
+                "tmux_window_template": config.get("tmux_window_template", "{agent}"),
+                "tmux_shell": config.get("tmux_shell", ""),
+                "tmux_preserve_session": config.get("tmux_preserve_session", True),
+                "tmux_history_limit": config.get("tmux_history_limit", 200000),
             }
 
         logger.info("Creating new %s environment for execute_code task %s...",

--- a/tools/environments/tmux.py
+++ b/tools/environments/tmux.py
@@ -1,0 +1,397 @@
+"""tmux-backed local execution environment.
+
+This backend keeps commands on the local host like ``LocalEnvironment`` but
+routes execution through a profile-scoped tmux session and an agent/task-scoped
+window. Hermes still receives deterministic stdout/exit-code results through a
+small driver protocol while humans can attach to the tmux session to watch the
+live terminal context.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import tempfile
+import threading
+import time
+import uuid
+from pathlib import Path
+
+from tools.environments.base import BaseEnvironment, _ThreadedProcessHandle
+from tools.environments.local import (
+    _find_bash,
+    _make_run_env,
+    _prepend_shell_init,
+    _resolve_safe_cwd,
+    _resolve_shell_init_files,
+)
+
+logger = logging.getLogger(__name__)
+
+_NAME_RE = re.compile(r"[^A-Za-z0-9_-]+")
+_DONE_RE_TEMPLATE = r"\n{marker}(-?\d+){marker}\n"
+
+
+def _slug(value: object, *, default: str, max_len: int = 64) -> str:
+    """Return a tmux-safe session/window name component."""
+    text = str(value or "").strip()
+    text = _NAME_RE.sub("-", text).strip("-_")
+    if not text:
+        text = default
+    if len(text) > max_len:
+        digest = uuid.uuid5(uuid.NAMESPACE_URL, text).hex[:8]
+        text = f"{text[: max_len - 9]}-{digest}"
+    return text
+
+
+def _active_profile_name() -> str:
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        return get_active_profile_name() or "default"
+    except Exception:
+        return "default"
+
+
+def _session_env(name: str) -> str:
+    try:
+        from gateway.session_context import get_session_env
+
+        return get_session_env(name, "") or ""
+    except Exception:
+        return os.getenv(name, "") or ""
+
+
+def _format_template(template: str, values: dict[str, str], fallback: str) -> str:
+    template = template or fallback
+    try:
+        rendered = template.format(**values)
+    except Exception:
+        logger.warning("Invalid tmux name template %r; falling back to %r", template, fallback)
+        rendered = fallback.format(**values)
+    return rendered
+
+
+class TmuxEnvironment(BaseEnvironment):
+    """Execute commands through a local tmux session/window.
+
+    Session naming defaults to one tmux session per Hermes profile and one
+    window per Hermes task/agent inside that session:
+
+    * session: ``hermes-{profile}``
+    * window: ``{agent}``
+
+    ``preserve_session=True`` leaves the tmux session/window alive when Hermes
+    reaps the Python environment object, which is the point of this backend for
+    Desktop/app survivability. Tests can pass ``preserve_session=False`` to clean
+    their windows up deterministically.
+    """
+
+    _snapshot_timeout = 30
+
+    def __init__(
+        self,
+        cwd: str = "",
+        timeout: int = 60,
+        env: dict | None = None,
+        *,
+        task_id: str = "default",
+        session_template: str = "hermes-{profile}",
+        window_template: str = "{agent}",
+        shell: str = "",
+        preserve_session: bool = True,
+        history_limit: int = 200_000,
+    ):
+        if os.name == "nt":
+            raise RuntimeError("tmux terminal backend is only supported on POSIX hosts")
+        if cwd:
+            cwd = os.path.expanduser(cwd)
+        super().__init__(cwd=cwd or os.getcwd(), timeout=timeout, env=env or {})
+
+        self.task_id = str(task_id or "default")
+        self.profile = _slug(_active_profile_name(), default="default")
+        self.session_id = _slug(_session_env("HERMES_SESSION_ID"), default="session")
+        self.session_key = _slug(_session_env("HERMES_SESSION_KEY"), default="session")
+        self.agent = _slug(self.task_id, default="default")
+        self.shell = shell or _find_bash()
+        self.preserve_session = bool(preserve_session)
+        self.history_limit = int(history_limit or 0)
+        self._tmux_bin = shutil.which("tmux")
+        self._pane_lock = threading.Lock()
+        self._target_ready = False
+        self._pane_target = ""
+        self._temp_paths: set[Path] = set()
+
+        values = {
+            "profile": self.profile,
+            "task_id": self.agent,
+            "agent": self.agent,
+            "session_id": self.session_id,
+            "session_key": self.session_key,
+        }
+        self.session_name = _slug(
+            _format_template(session_template, values, "hermes-{profile}"),
+            default=f"hermes-{self.profile}",
+        )
+        self.window_name = _slug(
+            _format_template(window_template, values, "{agent}"),
+            default=self.agent,
+        )
+
+        self.init_session()
+
+    # ------------------------------------------------------------------
+    # tmux control helpers
+    # ------------------------------------------------------------------
+
+    def _tmux_env(self) -> dict[str, str]:
+        env = _make_run_env(self.env)
+        # If Hermes itself is running inside tmux, control commands should talk
+        # to the server by socket/defaults instead of trying to nest clients.
+        env.pop("TMUX", None)
+        return env
+
+    def _tmux(self, args: list[str], *, input_text: str | None = None, check: bool = True) -> subprocess.CompletedProcess:
+        if not self._tmux_bin:
+            raise RuntimeError("tmux executable not found; install tmux or set terminal.backend back to local")
+        result = subprocess.run(
+            [self._tmux_bin, *args],
+            input=input_text,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=self._tmux_env(),
+            check=False,
+        )
+        if check and result.returncode != 0:
+            raise RuntimeError(
+                f"tmux {' '.join(args)} failed with rc={result.returncode}: {result.stderr.strip()}"
+            )
+        return result
+
+    def _target(self) -> str:
+        return f"{self.session_name}:{self.window_name}"
+
+    def _ensure_target(self) -> None:
+        safe_cwd = _resolve_safe_cwd(self.cwd)
+        if safe_cwd != self.cwd:
+            logger.warning(
+                "TmuxEnvironment cwd %r is missing on disk; falling back to %r.",
+                self.cwd,
+                safe_cwd,
+            )
+            self.cwd = safe_cwd
+
+        has_session = self._tmux(["has-session", "-t", self.session_name], check=False)
+        if has_session.returncode != 0:
+            args = [
+                "new-session",
+                "-d",
+                "-s",
+                self.session_name,
+                "-n",
+                self.window_name,
+                "-c",
+                self.cwd,
+            ]
+            if self.shell:
+                args.append(self.shell)
+            self._tmux(args)
+        else:
+            windows = self._tmux(
+                ["list-windows", "-t", self.session_name, "-F", "#{window_name}"],
+            ).stdout.splitlines()
+            if self.window_name not in windows:
+                args = [
+                    "new-window",
+                    "-d",
+                    "-t",
+                    self.session_name,
+                    "-n",
+                    self.window_name,
+                    "-c",
+                    self.cwd,
+                ]
+                if self.shell:
+                    args.append(self.shell)
+                self._tmux(args)
+
+        if self.history_limit > 0:
+            self._tmux(
+                ["set-option", "-t", self.session_name, "-g", "history-limit", str(self.history_limit)],
+                check=False,
+            )
+
+        pane = self._tmux(["display-message", "-p", "-t", self._target(), "#{pane_id}"]).stdout.strip()
+        self._pane_target = pane or self._target()
+        self._target_ready = True
+
+    def _tmp_path(self, suffix: str) -> Path:
+        root = Path(tempfile.gettempdir()) / "hermes-tmux"
+        root.mkdir(parents=True, exist_ok=True)
+        path = root / f"{self.session_name}-{self.window_name}-{uuid.uuid4().hex[:12]}{suffix}"
+        self._temp_paths.add(path)
+        return path
+
+    def _close_pipe(self) -> None:
+        if self._pane_target:
+            self._tmux(["pipe-pane", "-t", self._pane_target], check=False)
+
+    def _send_ctrl_c(self) -> None:
+        if self._pane_target:
+            self._tmux(["send-keys", "-t", self._pane_target, "C-c"], check=False)
+
+    # ------------------------------------------------------------------
+    # BaseEnvironment hooks
+    # ------------------------------------------------------------------
+
+    def _run_bash(
+        self,
+        cmd_string: str,
+        *,
+        login: bool = False,
+        timeout: int = 120,
+        stdin_data: str | None = None,
+    ):
+        if login:
+            init_files = _resolve_shell_init_files()
+            if init_files:
+                cmd_string = _prepend_shell_init(cmd_string, init_files)
+
+        if stdin_data:
+            cmd_string = self._embed_stdin_heredoc(cmd_string, stdin_data)
+
+        cancel_event = threading.Event()
+
+        def _cancel() -> None:
+            cancel_event.set()
+            self._send_ctrl_c()
+
+        return _ThreadedProcessHandle(
+            lambda: self._execute_script_in_tmux(cmd_string, login=login, timeout=timeout, cancel_event=cancel_event),
+            cancel_fn=_cancel,
+        )
+
+    def _execute_script_in_tmux(
+        self,
+        cmd_string: str,
+        *,
+        login: bool,
+        timeout: int,
+        cancel_event: threading.Event,
+    ) -> tuple[str, int]:
+        with self._pane_lock:
+            self._ensure_target()
+            run_id = uuid.uuid4().hex
+            start_marker = f"__HERMES_TMUX_START_{run_id}__"
+            done_marker = f"__HERMES_TMUX_DONE_{run_id}__"
+            script_path = self._tmp_path(".sh")
+            output_path = self._tmp_path(".out")
+            script_path.write_text(cmd_string, encoding="utf-8")
+            try:
+                os.chmod(script_path, 0o600)
+            except OSError:
+                pass
+
+            # Reset any stale pipe on this pane, then capture only this run to a
+            # fresh file. The command line sent to tmux references only the script
+            # path, so the user's command body is not echoed into the model output.
+            self._close_pipe()
+            pipe_cmd = f"cat > {shlex.quote(str(output_path))}"
+            self._tmux(["pipe-pane", "-t", self._pane_target, pipe_cmd])
+
+            bash = shlex.quote(self.shell or _find_bash())
+            login_flag = " -l" if login else ""
+            command_line = (
+                f"printf '\\n{start_marker}\\n'; "
+                f"{bash}{login_flag} {shlex.quote(str(script_path))}; "
+                f"__hermes_tmux_ec=$?; "
+                f"printf '\\n{done_marker}%s{done_marker}\\n' \"$__hermes_tmux_ec\""
+            )
+            self._tmux(["send-keys", "-t", self._pane_target, "-l", command_line])
+            self._tmux(["send-keys", "-t", self._pane_target, "Enter"])
+
+            deadline = time.monotonic() + max(1, int(timeout or self.timeout))
+            last_raw = ""
+            try:
+                while time.monotonic() < deadline:
+                    if cancel_event.is_set():
+                        self._send_ctrl_c()
+                        return self._parse_output(last_raw, start_marker, done_marker, fallback_code=130)
+                    if output_path.exists():
+                        last_raw = output_path.read_text(encoding="utf-8", errors="replace")
+                        parsed = self._try_parse_output(last_raw, start_marker, done_marker)
+                        if parsed is not None:
+                            return parsed
+                    time.sleep(0.05)
+
+                self._send_ctrl_c()
+                output, _ = self._parse_output(last_raw, start_marker, done_marker, fallback_code=124)
+                suffix = f"\n[Command timed out after {timeout}s]"
+                return (output + suffix if output else suffix.lstrip(), 124)
+            finally:
+                self._close_pipe()
+                for path in (script_path, output_path):
+                    try:
+                        path.unlink()
+                        self._temp_paths.discard(path)
+                    except OSError:
+                        pass
+
+    def _normalise_pane_output(self, raw: str) -> str:
+        return raw.replace("\r\n", "\n").replace("\r", "\n")
+
+    def _try_parse_output(self, raw: str, start_marker: str, done_marker: str) -> tuple[str, int] | None:
+        text = self._normalise_pane_output(raw)
+        start_token = f"\n{start_marker}\n"
+        start_idx = text.find(start_token)
+        if start_idx == -1:
+            return None
+        body_start = start_idx + len(start_token)
+        done_re = re.compile(_DONE_RE_TEMPLATE.format(marker=re.escape(done_marker)))
+        match = done_re.search(text, body_start)
+        if not match:
+            return None
+        output = text[body_start : match.start()]
+        try:
+            code = int(match.group(1))
+        except (TypeError, ValueError):
+            code = 1
+        return output, code
+
+    def _parse_output(
+        self,
+        raw: str,
+        start_marker: str,
+        done_marker: str,
+        *,
+        fallback_code: int,
+    ) -> tuple[str, int]:
+        parsed = self._try_parse_output(raw, start_marker, done_marker)
+        if parsed is not None:
+            return parsed
+        text = self._normalise_pane_output(raw)
+        start_token = f"\n{start_marker}\n"
+        start_idx = text.find(start_token)
+        if start_idx != -1:
+            return text[start_idx + len(start_token) :], fallback_code
+        return text, fallback_code
+
+    def cleanup(self):
+        for path in list(self._temp_paths):
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            self._temp_paths.discard(path)
+
+        if self.preserve_session or not self._target_ready:
+            return
+        try:
+            self._tmux(["kill-window", "-t", self._target()], check=False)
+        except Exception:
+            pass

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -3,7 +3,7 @@
 File Operations Module
 
 Provides file manipulation capabilities (read, write, patch, search) that work
-across all terminal backends (local, docker, ssh, singularity, modal, daytona).
+across all terminal backends (local, tmux, docker, ssh, singularity, modal, daytona).
 
 The key insight is that all file operations can be expressed as shell commands,
 so we wrap the terminal backend's execute() interface to provide a unified file API.
@@ -668,7 +668,7 @@ class ShellFileOperations(FileOperations):
     File operations implemented via shell commands.
     
     Works with ANY terminal backend that has execute(command, cwd) method.
-    This includes local, docker, singularity, ssh, modal, and daytona environments.
+    This includes local, tmux, docker, singularity, ssh, modal, and daytona environments.
     """
     
     def __init__(self, terminal_env, cwd: str = None):

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -611,21 +611,22 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
     Thread-safe: uses the same per-task creation locks as terminal_tool to
     prevent duplicate sandbox creation from concurrent tool calls.
 
-    Note: subagent task_ids are collapsed to "default" via
-    ``_resolve_container_task_id`` so delegate_task children share the
-    parent's container and its cached file_ops. RL/benchmark task_ids with
-    a registered env override keep their isolation.
+    Note: subagent task_ids are collapsed to "default" for container/cloud
+    backends so delegate_task children share the parent's container and its
+    cached file_ops. The tmux backend preserves task ids because its contract
+    is one visible tmux window per agent/task.
     """
     from tools.terminal_tool import (
         _active_environments, _env_lock, _create_environment,
         _get_env_config, _last_activity, _start_cleanup_thread,
         _creation_locks,
         _creation_locks_lock,
-        _resolve_container_task_id,
+        _resolve_environment_task_id,
     )
     import time
 
-    task_id = _resolve_container_task_id(task_id)
+    env_type_for_key = _get_env_config()["env_type"]
+    task_id = _resolve_environment_task_id(task_id, env_type_for_key)
 
     # Fast path: check cache -- but also verify the underlying environment
     # is still alive (it may have been killed by the cleanup thread).
@@ -705,6 +706,14 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
             if env_type == "local":
                 local_config = {
                     "persistent": config.get("local_persistent", False),
+                }
+            elif env_type == "tmux":
+                local_config = {
+                    "tmux_session_template": config.get("tmux_session_template", "hermes-{profile}"),
+                    "tmux_window_template": config.get("tmux_window_template", "{agent}"),
+                    "tmux_shell": config.get("tmux_shell", ""),
+                    "tmux_preserve_session": config.get("tmux_preserve_session", True),
+                    "tmux_history_limit": config.get("tmux_history_limit", 200000),
                 }
 
             terminal_env = _create_environment(

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2,17 +2,19 @@
 """
 Terminal Tool Module
 
-A terminal tool that executes commands in local, Docker, Modal, SSH,
+A terminal tool that executes commands in local, tmux, Docker, Modal, SSH,
 Singularity, and Daytona environments. Supports local execution,
-containerized backends, and cloud sandboxes, including managed Modal mode.
+attachable tmux sessions, containerized backends, and cloud sandboxes,
+including managed Modal mode.
 
 Supported environments:
 - "local": Execute directly on the host machine (default, fastest)
+- "tmux": Execute on the host through profile-scoped tmux sessions
 - "docker": Execute in Docker containers (isolated, requires Docker)
 - "modal": Execute in Modal cloud sandboxes (direct Modal or managed gateway)
 
 Features:
-- Multiple execution backends (local, docker, modal)
+- Multiple execution backends (local, tmux, docker, modal)
 - Background task support
 - VM/container lifecycle management
 - Automatic cleanup after inactivity
@@ -832,6 +834,8 @@ from tools.environments.managed_modal import ManagedModalEnvironment as _Managed
 from tools.managed_tool_gateway import is_managed_tool_gateway_ready
 import sys
 
+_TmuxEnvironment = None  # lazy import: tests may install a minimal fake tools package
+
 
 # Tool description for LLM
 TERMINAL_TOOL_DESCRIPTION = """Execute shell commands on a Linux environment. Filesystem, current working directory, and exported environment variables persist between calls.
@@ -1034,6 +1038,20 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
     return "default"
 
 
+def _resolve_environment_task_id(task_id: Optional[str], env_type: str) -> str:
+    """Return the environment-cache key for the selected terminal backend.
+
+    Container/cloud backends intentionally collapse ordinary subagent IDs to a
+    shared ``default`` sandbox so parent and child agents see the same filesystem
+    and installed packages. tmux is different: the requested isolation unit is a
+    visible agent/task window inside the profile-scoped tmux session, so
+    preserving the raw task id is the feature, not a resource leak.
+    """
+    if (env_type or "").strip().lower() == "tmux":
+        return task_id or "default"
+    return _resolve_container_task_id(task_id)
+
+
 # Configuration from environment variables
 
 def _parse_env_var(name: str, default: str, converter: Any = int, type_label: str = "integer"):
@@ -1103,7 +1121,7 @@ def _get_env_config() -> Dict[str, Any]:
     # Default cwd: local uses the host's current directory, ssh uses the
     # remote home, and everything else starts in the backend's default
     # root-like cwd.
-    if env_type == "local":
+    if env_type in {"local", "tmux"}:
         default_cwd = _safe_getcwd()
     elif env_type == "ssh":
         default_cwd = "~"
@@ -1190,6 +1208,15 @@ def _get_env_config() -> Dict[str, Any]:
         "docker_orphan_reaper": os.getenv(
             "TERMINAL_DOCKER_ORPHAN_REAPER", "true"
         ).lower() in {"true", "1", "yes"},
+        # tmux-specific local backend config. One tmux session is created per
+        # profile by default, with one window per agent/task id inside it.
+        "tmux_session_template": os.getenv("TERMINAL_TMUX_SESSION_TEMPLATE", "hermes-{profile}"),
+        "tmux_window_template": os.getenv("TERMINAL_TMUX_WINDOW_TEMPLATE", "{agent}"),
+        "tmux_shell": os.getenv("TERMINAL_TMUX_SHELL", ""),
+        "tmux_preserve_session": os.getenv(
+            "TERMINAL_TMUX_PRESERVE_SESSION", "true"
+        ).lower() in {"true", "1", "yes"},
+        "tmux_history_limit": _parse_env_var("TERMINAL_TMUX_HISTORY_LIMIT", "200000"),
     }
 
 
@@ -1236,6 +1263,22 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
 
     if env_type == "local":
         return _LocalEnvironment(cwd=cwd, timeout=timeout)
+
+    elif env_type == "tmux":
+        tc = local_config or {}
+        tmux_environment_cls = _TmuxEnvironment
+        if tmux_environment_cls is None:
+            from tools.environments.tmux import TmuxEnvironment as tmux_environment_cls
+        return tmux_environment_cls(
+            cwd=cwd,
+            timeout=timeout,
+            task_id=task_id,
+            session_template=tc.get("tmux_session_template", "hermes-{profile}"),
+            window_template=tc.get("tmux_window_template", "{agent}"),
+            shell=tc.get("tmux_shell", ""),
+            preserve_session=tc.get("tmux_preserve_session", True),
+            history_limit=tc.get("tmux_history_limit", 200000),
+        )
     
     elif env_type == "docker":
         # One-shot orphan reaper: clean up labeled containers left behind by
@@ -1348,7 +1391,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     else:
         raise ValueError(
             f"Unknown environment type: {env_type}. Use 'local', 'docker', "
-            f"'singularity', 'modal', 'daytona', or 'ssh'"
+            f"'singularity', 'modal', 'daytona', 'ssh', or 'tmux'"
         )
 
 
@@ -1882,7 +1925,7 @@ def terminal_tool(
         # task_ids collapse back to "default" so the top-level agent and
         # every delegate_task child share one container; only task_ids with
         # a registered env override (RL benchmarks) get isolated sandboxes.
-        effective_task_id = _resolve_container_task_id(task_id)
+        effective_task_id = _resolve_environment_task_id(task_id, env_type)
 
         # Check per-task overrides (set by environments like TerminalBench2Env)
         # before falling back to global env var config.
@@ -2019,6 +2062,14 @@ def terminal_tool(
                         if env_type == "local":
                             local_config = {
                                 "persistent": config.get("local_persistent", False),
+                            }
+                        elif env_type == "tmux":
+                            local_config = {
+                                "tmux_session_template": config.get("tmux_session_template", "hermes-{profile}"),
+                                "tmux_window_template": config.get("tmux_window_template", "{agent}"),
+                                "tmux_shell": config.get("tmux_shell", ""),
+                                "tmux_preserve_session": config.get("tmux_preserve_session", True),
+                                "tmux_history_limit": config.get("tmux_history_limit", 200000),
                             }
 
                         new_env = _create_environment(
@@ -2462,6 +2513,14 @@ def check_terminal_requirements() -> bool:
         if env_type == "local":
             return True
 
+        elif env_type == "tmux":
+            tmux = shutil.which("tmux")
+            if not tmux:
+                logger.error("tmux executable not found; install tmux or switch TERMINAL_ENV to 'local'")
+                return False
+            result = subprocess.run([tmux, "-V"], capture_output=True, timeout=5, stdin=subprocess.DEVNULL)
+            return result.returncode == 0
+
         elif env_type == "docker":
             from tools.environments.docker import find_docker
             docker = find_docker()
@@ -2554,7 +2613,7 @@ def check_terminal_requirements() -> bool:
         else:
             logger.error(
                 "Unknown TERMINAL_ENV '%s'. Use one of: local, docker, singularity, "
-                "modal, daytona, ssh.",
+                "modal, daytona, ssh, tmux.",
                 env_type,
             )
             return False

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -102,11 +102,11 @@ Before that stash step, Hermes also restores tracked `package-lock.json` diffs l
 
 ## Terminal Backend Configuration
 
-Hermes supports six terminal backends. Each determines where the agent's shell commands actually execute — your local machine, a Docker container, a remote server via SSH, a Modal cloud sandbox (direct or via the Nous-managed gateway), a Daytona workspace, or a Singularity/Apptainer container.
+Hermes supports seven terminal backends. Each determines where the agent's shell commands actually execute — your local machine, a local tmux session, a Docker container, a remote server via SSH, a Modal cloud sandbox (direct or via the Nous-managed gateway), a Daytona workspace, or a Singularity/Apptainer container.
 
 ```yaml
 terminal:
-  backend: local    # local | docker | ssh | modal | daytona | singularity
+  backend: local    # local | tmux | docker | ssh | modal | daytona | singularity
   cwd: "."          # Gateway/cron working directory (CLI always uses launch dir)
   timeout: 180      # Per-command timeout in seconds
   env_passthrough: []  # Env var names to forward to sandboxed execution (terminal + execute_code)
@@ -122,6 +122,7 @@ For cloud sandboxes such as Modal and Daytona, `container_persistent: true` mean
 | Backend | Where commands run | Isolation | Best for |
 |---------|-------------------|-----------|----------|
 | **local** | Your machine directly | None | Development, personal use |
+| **tmux** | Your machine, through profile-scoped tmux sessions | None; process/window persistence | Desktop sessions, attachable long-lived terminals |
 | **docker** | Single persistent Docker container (shared across session, `/new`, subagents) | Full (namespaces, cap-drop) | Safe sandboxing, CI/CD |
 | **ssh** | Remote server via SSH | Network boundary | Remote dev, powerful hardware |
 | **modal** | Modal cloud sandbox | Full (cloud VM) | Ephemeral cloud compute, evals |
@@ -140,6 +141,41 @@ terminal:
 :::warning
 The agent has the same filesystem access as your user account. Use `hermes tools` to disable tools you don't want, or switch to Docker for sandboxing.
 :::
+
+### tmux Backend
+
+Runs commands on the local host like the local backend, but sends them through tmux so the live terminal context survives Desktop/App interruptions and can be attached to manually.
+
+```yaml
+terminal:
+  backend: tmux
+  tmux_session_template: "hermes-{profile}"  # one tmux session per Hermes profile
+  tmux_window_template: "{agent}"            # one window per agent/task id
+  tmux_preserve_session: true                 # leave tmux alive after Hermes cleanup
+  tmux_history_limit: 200000                  # scrollback lines per tmux session
+  tmux_shell: ""                              # empty = Hermes' bash discovery
+```
+
+**Requirements:** `tmux` must be installed and available on `$PATH` (`brew install tmux` on macOS).
+
+**How it works:** Hermes creates/reuses the tmux session named by `tmux_session_template` and a window named by `tmux_window_template`. The default templates create one session per Hermes profile (for example, `hermes-architect`) and one window per agent/task. Commands still return deterministic stdout and exit codes to the model, while the tmux window keeps the live terminal scrollback for human inspection.
+
+**Attach manually:**
+
+```bash
+tmux attach -t hermes-architect
+```
+
+Template fields available in the two tmux name templates:
+
+| Field | Meaning |
+|---|---|
+| `{profile}` | Active Hermes profile name (`default`, `architect`, etc.) |
+| `{agent}` / `{task_id}` | Hermes task/agent id used for terminal environment isolation |
+| `{session_id}` | Gateway/Desktop/CLI session id when available |
+| `{session_key}` | Gateway session key when available |
+
+The tmux backend is not a security boundary: it has the same filesystem and account access as the local backend. Use Docker/Singularity/Modal/Daytona when isolation is required.
 
 ### Docker Backend
 
@@ -337,6 +373,7 @@ terminal:
 If terminal commands fail immediately or the terminal tool is reported as disabled:
 
 - **Local** — No special requirements. The safest default when getting started.
+- **tmux** — Run `tmux -V` to verify tmux is installed. If it fails, install tmux or `hermes config set terminal.backend local`.
 - **Docker** — Run `docker version` to verify Docker is working. If it fails, fix Docker or `hermes config set terminal.backend local`.
 - **SSH** — Both `TERMINAL_SSH_HOST` and `TERMINAL_SSH_USER` must be set. Hermes logs a clear error if either is missing.
 - **Modal** — Needs `MODAL_TOKEN_ID` env var or `~/.modal.toml`. Run `hermes doctor` to check.


### PR DESCRIPTION
## Summary
- Add a first-class `tmux` terminal backend that executes on the local host via profile-scoped tmux sessions and agent/task-scoped windows.
- Wire tmux backend config through CLI, gateway/Desktop config bridge, canonical terminal config env map, doctor, execute_code, file tools, defaults, tips, and docs.
- Add regression/integration tests for config parsing, backend factory dispatch, task/window isolation, file-tool environment keys, CLI cwd preservation, and real tmux command/output/state behavior.

## Test Plan
- `python -m pytest tests/tools/test_tmux_environment.py tests/tools/test_terminal_tool.py tests/tools/test_file_tools_container_config.py tests/tools/test_terminal_config_env_sync.py tests/tools/test_code_execution.py tests/tools/test_code_execution_modes.py tests/hermes_cli/test_doctor.py tests/run_agent/test_run_agent.py::test_launch_cwd_for_session_treats_tmux_as_local -q` — 206 passed, 1 warning
- `python -m ruff check tools/environments/tmux.py tools/terminal_tool.py tools/code_execution_tool.py tools/file_tools.py tools/file_operations.py hermes_cli/doctor.py run_agent.py cli.py gateway/run.py hermes_cli/config.py hermes_cli/tips.py tests/tools/test_tmux_environment.py tests/run_agent/test_run_agent.py` — passed, existing run_agent.py noqa warning
- tmux smoke via `terminal_tool(..., TERMINAL_ENV=tmux)` returned `{'output': 'smoke', 'exit_code': 0, 'error': None}`

## Notes
- Broad `tests/tools/test_file_tools.py tests/tools/test_file_operations.py -q` on this macOS host still has unrelated `/tmp` vs `/private/tmp` expectation failures; this change did not touch that path-normalization logic.
- Default tmux naming: `terminal.tmux_session_template: "hermes-{profile}"`, `terminal.tmux_window_template: "{agent}"`.
