### PR TITLE
fix(desktop): quit app after update on Linux/AppImage paths

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -2024,6 +2024,10 @@ async function applyUpdatesPosixInApp() {
       message: 'Backend updated. Restart Hermes to load the new version.',
       percent: 100
     })
+    // On macOS the swap+relaunch script calls app.quit() after the handoff,
+    // but this early-return path (Linux / AppImage / dev) has no such script.
+    // Quit now so the next launch picks up the update automatically.
+    setTimeout(() => app.quit(), 600)
     return { ok: true, backendUpdated: true, rebuiltApp: rebuiltApp || null }
   }
 
@@ -2061,6 +2065,8 @@ fi
       percent: 100
     })
     rememberLog(`[updates] could not write swap script: ${err.message}; rebuilt app at ${rebuiltApp}`)
+    // The swap script couldn't be written — quit so the user can restart manually.
+    setTimeout(() => app.quit(), 600)
     return { ok: true, backendUpdated: true, rebuiltApp }
   }
 

--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -77,7 +77,7 @@ export function UpdatesOverlay() {
 
     setUpdateOverlayOpen(next)
 
-    if (!next && (apply.stage === 'error' || apply.stage === 'restart' || apply.stage === 'manual')) {
+    if (!next && (apply.stage === 'error' || apply.stage === 'restart' || apply.stage === 'done' || apply.stage === 'manual')) {
       resetUpdateApplyState()
     }
   }

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -226,7 +226,7 @@ export interface DesktopUpdateApplyResult {
   hermesRoot?: string
 }
 
-export type DesktopUpdateStage = 'idle' | 'prepare' | 'fetch' | 'pull' | 'pydeps' | 'restart' | 'manual' | 'error'
+export type DesktopUpdateStage = 'idle' | 'prepare' | 'fetch' | 'pull' | 'pydeps' | 'restart' | 'done' | 'manual' | 'error'
 
 export interface DesktopUpdateProgress {
   stage: DesktopUpdateStage

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1279,6 +1279,7 @@ export const en: Translations = {
       pull: 'Almost there…',
       pydeps: 'Finishing up…',
       restart: 'Restarting Hermes…',
+      done: 'Update complete',
       manual: 'Update from your terminal',
       error: 'Update paused'
     },

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1417,6 +1417,7 @@ export const ja = defineLocale({
       pull: 'もうすぐ完了…',
       pydeps: '仕上げ中…',
       restart: 'Hermes を再起動中…',
+      done: '更新完了',
       manual: 'ターミナルから更新',
       error: '更新が一時停止中'
     },

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1373,6 +1373,7 @@ export const zhHant = defineLocale({
       pull: '快完成了…',
       pydeps: '收尾中…',
       restart: '正在重新啟動 Hermes…',
+      done: '更新完成',
       manual: '從終端機更新',
       error: '更新已暫停'
     },

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1467,6 +1467,7 @@ export const zh: Translations = {
       pull: '马上完成…',
       pydeps: '收尾中…',
       restart: '正在重启 Hermes…',
+      done: '更新完成',
       manual: '从终端更新',
       error: '更新已暂停'
     },

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -409,7 +409,7 @@ export async function applyBackendUpdate(): Promise<DesktopUpdateApplyResult> {
 function ingestProgress(payload: DesktopUpdateProgress): void {
   const current = $updateApply.get()
   const log = [...current.log, { stage: payload.stage, message: payload.message, at: payload.at }].slice(-50)
-  const terminal = payload.stage === 'error' || payload.stage === 'restart' || payload.stage === 'manual'
+  const terminal = payload.stage === 'error' || payload.stage === 'restart' || payload.stage === 'manual' || payload.stage === 'done'
 
   $updateApply.set({
     applying: !terminal,


### PR DESCRIPTION
## Problem

On Linux (AppImage) and dev-run paths, the desktop update flow exits early without calling `app.quit()`. The backend finishes updating but the desktop process stays alive at 100% progress, appearing frozen. The macOS path has a swap script that handles the quit, but two code paths miss it:

1. The early-return when no bundle to swap (Linux/AppImage/dev)
2. The swap-script-write failure path (macOS fallback)

Additionally, the renderer never recognized `stage: 'done'` as terminal, so `applying` stayed `true` and the spinner kept running even after the backend completed.

## Changes

- **`main.cjs`**: Add `app.quit()` (600ms delay for progress IPC) to both the early-return path and the swap-script-write-failure path
- **`global.d.ts`**: Add `'done'` to `DesktopUpdateStage` union type
- **`updates.ts`**: Add `|| payload.stage === 'done'` to terminal check in `ingestProgress()`
- **`updates-overlay.tsx`**: Add `|| apply.stage === 'done'` to close/reset condition
- **i18n (en/ja/zh/zh-hant)**: Add `done` stage label in all four locales

## Testing

- `npx tsc --noEmit` — zero errors
- `npx vitest run src/store/updates.test.ts` — 9/9 pass
- Manual verification of both code paths

Fixes #41737