### PR TITLE
[codex] Add opt-in Telegram rich message sends

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -976,7 +976,7 @@ class TelegramAdapter(BasePlatformAdapter):
         rejections (BadRequest from a parser/limit issue) are NOT capability
         errors: the next message may be fine.
         """
-        if isinstance(exc, (AttributeError, TypeError, NotImplementedError)):
+        if isinstance(exc, (AttributeError, NotImplementedError)):
             return True
         if getattr(exc, "error_code", None) == 404:
             return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,7 @@ modal = ["modal==1.3.4"]
 daytona = ["daytona==0.155.0"]
 hindsight = ["hindsight-client==0.6.1"]
 dev = ["debugpy==1.8.20", "pytest==9.0.2", "pytest-asyncio==1.3.0", "mcp==1.26.0", "starlette==1.0.1", "ty==0.0.21", "ruff==0.15.10", "setuptools==82.0.1"]  # starlette: CVE-2026-48710
-messaging = ["python-telegram-bot[webhooks]==22.6", "discord.py[voice]==2.7.1", "aiohttp==3.13.4", "brotlicffi==1.2.0.1", "slack-bolt==1.27.0", "slack-sdk==3.40.1", "qrcode==7.4.2"]  # aiohttp: CVE-2026-34513/34518/34519/34520/34525
+messaging = ["python-telegram-bot[webhooks]==22.8", "discord.py[voice]==2.7.1", "aiohttp==3.13.4", "brotlicffi==1.2.0.1", "slack-bolt==1.27.0", "slack-sdk==3.40.1", "qrcode==7.4.2"]  # aiohttp: CVE-2026-34513/34518/34519/34520/34525
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt==1.27.0", "slack-sdk==3.40.1", "aiohttp==3.13.4"]
 matrix = ["mautrix[encryption]==0.21.0", "aiosqlite==0.22.1", "asyncpg==0.31.0", "aiohttp-socks==0.11.0"]
@@ -194,7 +194,7 @@ bedrock = ["boto3==1.42.89"]
 azure-identity = ["azure-identity==1.25.3"]
 termux = [
   # Baseline Android / Termux path for reliable fresh installs.
-  "python-telegram-bot[webhooks]==22.6",
+  "python-telegram-bot[webhooks]==22.8",
   "hermes-agent[cron]",
   "hermes-agent[cli]",
   "hermes-agent[pty]",

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -178,6 +178,19 @@ async def test_transient_rich_error_does_not_legacy_resend(exc):
 
 
 @pytest.mark.asyncio
+async def test_programmer_type_error_does_not_legacy_resend():
+    adapter = _make_adapter()
+    adapter._bot.do_api_request = AsyncMock(side_effect=TypeError("bad payload shape"))
+
+    result = await adapter.send("12345", RICH_CONTENT)
+
+    assert result.success is False
+    assert "bad payload shape" in (result.error or "")
+    adapter._bot.do_api_request.assert_awaited_once()
+    adapter._bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_transient_timeout_is_not_retryable():
     adapter = _make_adapter()
     adapter._bot.do_api_request = AsyncMock(side_effect=TimedOut("timed out"))

--- a/uv.lock
+++ b/uv.lock
@@ -1663,8 +1663,8 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = "==9.0.2" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==1.3.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
-    { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'messaging'", specifier = "==22.6" },
-    { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'termux'", specifier = "==22.6" },
+    { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'messaging'", specifier = "==22.8" },
+    { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'termux'", specifier = "==22.8" },
     { name = "pywinpty", marker = "sys_platform == 'win32'", specifier = ">=2.0.0,<3" },
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "qrcode", marker = "extra == 'dingtalk'", specifier = "==7.4.2" },
@@ -3231,14 +3231,14 @@ wheels = [
 
 [[package]]
 name = "python-telegram-bot"
-version = "22.6"
+version = "22.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/9b/8df90c85404166a6631e857027866263adb27440d8af1dbeffbdc4f0166c/python_telegram_bot-22.6.tar.gz", hash = "sha256:50ae8cc10f8dff01445628687951020721f37956966b92a91df4c1bf2d113742", size = 1503761, upload-time = "2026-01-24T13:57:00.269Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/77/153517bb1ac1bba670c6fb1dbf09e1fd0730494b1705934e715391413a0d/python_telegram_bot-22.8.tar.gz", hash = "sha256:f9d3847fcb23ee603477e442800b33bb4adf851a73e0619d2050be879decf1ef", size = 1551700, upload-time = "2026-06-12T08:10:29.1Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/97/7298f0e1afe3a1ae52ff4c5af5087ed4de319ea73eb3b5c8c4dd4e76e708/python_telegram_bot-22.6-py3-none-any.whl", hash = "sha256:e598fe171c3dde2dfd0f001619ee9110eece66761a677b34719fb18934935ce0", size = 737267, upload-time = "2026-01-24T13:56:58.06Z" },
+    { url = "https://files.pythonhosted.org/packages/60/7c/ed7d4dd94280bd434173cae9f7a7aedaaab9af128ae4f494423a5687c820/python_telegram_bot-22.8-py3-none-any.whl", hash = "sha256:42373918097f1b837cc4e717d588c19ea79651497ec712bb5b0c76e5e63c50e1", size = 769397, upload-time = "2026-06-12T08:10:27.066Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Hardens Hermes' Telegram Bot API 10.1 rich-message readiness on top of current `main`.

Current `main` already contains the Telegram rich-message implementation and docs. This PR now keeps the follow-up scope narrow:

- bump `python-telegram-bot[webhooks]` from 22.6 to 22.8 in `pyproject.toml` and `uv.lock`
- add regression coverage for programmer `TypeError` handling in the existing rich-message test module
- prevent `TypeError` from being classified as a rich endpoint capability error, so malformed rich-send calls do not silently fall back into legacy `sendMessage`

## Why

Telegram's June 11, 2026 update added rich text for bots and `sendRichMessage` / `InputRichMessage` to Bot API 10.1:

- https://telegram.org/blog/watch-apps-and-more
- https://core.telegram.org/bots/api

`python-telegram-bot` 22.8 is the current stable SDK release available for the Telegram gateway dependency pin. The locked environment exposes `Bot.do_api_request(...)`, which the existing Hermes rich-message path uses for raw Bot API methods such as `sendRichMessage`.

## Changes

- Bumps `python-telegram-bot[webhooks]` pins to 22.8 for messaging and Termux extras.
- Keeps `aiohttp==3.13.4` from current `main`.
- Adds focused async coverage for TypeError no-legacy-fallback behavior in `tests/gateway/test_telegram_rich_messages.py`.
- Removes `TypeError` from the rich capability-error bucket so malformed rich-send calls use the existing no-legacy-resend failure path.

## Validation

```text
/opt/homebrew/bin/uv run --locked --extra messaging --extra dev python -m pytest tests/gateway/test_telegram_rich_messages.py tests/gateway/test_telegram_format.py
123 passed
```

```text
/opt/homebrew/bin/uv run --locked --extra dev python -m ruff check gateway/platforms/telegram.py tests/gateway/test_telegram_rich_messages.py tests/gateway/test_telegram_format.py
All checks passed!
```

```text
/opt/homebrew/bin/uv run --locked --extra messaging python -c 'import inspect, telegram; from telegram import Bot; print(telegram.__version__); print(hasattr(Bot, "do_api_request")); print(inspect.signature(Bot.do_api_request))'

22.8
True
(self, endpoint: str, api_kwargs: dict[str, typing.Any] | None = None, return_type: type[telegram._telegramobject.TelegramObject] | None = None, *, read_timeout: Union[telegram._utils.defaultvalue.DefaultValue[float], float, telegram._utils.defaultvalue.DefaultValue[NoneType], NoneType] = None, write_timeout: Union[telegram._utils.defaultvalue.DefaultValue[float], float, telegram._utils.defaultvalue.DefaultValue[NoneType], NoneType] = None, connect_timeout: Union[telegram._utils.defaultvalue.DefaultValue[float], float, telegram._utils.defaultvalue.DefaultValue[NoneType], NoneType] = None, pool_timeout: Union[telegram._utils.defaultvalue.DefaultValue[float], float, telegram._utils.defaultvalue.DefaultValue[NoneType], NoneType] = None) -> Any
```

```text
git diff --check
```
