### PR TITLE
fix: target_model drives Bedrock api_mode routing — salvage of #27829 by @roadhero, adds regression test

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1677,7 +1677,7 @@ def resolve_runtime_provider(
         # Dual-path routing: Claude models use AnthropicBedrock SDK for full
         # feature parity (prompt caching, thinking budgets, adaptive thinking).
         # Non-Claude models use the Converse API for multi-model support.
-        _current_model = str(model_cfg.get("default") or "").strip()
+        _current_model = target_model or str(model_cfg.get("default") or "").strip()
         if is_anthropic_bedrock_model(_current_model):
             # Claude on Bedrock → AnthropicBedrock SDK → anthropic_messages path
             runtime = {

--- a/tests/agent/test_bedrock_integration.py
+++ b/tests/agent/test_bedrock_integration.py
@@ -201,6 +201,84 @@ class TestRuntimeProvider:
         assert result["provider"] == "bedrock"
         assert result["api_mode"] == "bedrock_converse"
 
+    def test_bedrock_target_model_nova_overrides_claude_default(self, monkeypatch):
+        """Regression for #27829: per-request target_model must drive the
+        Bedrock dual-path api_mode decision, not the config default.
+
+        With a Claude Bedrock model configured as the default, a per-request
+        target_model of a Nova (non-Anthropic) model must route through the
+        Converse API (bedrock_converse), NOT the AnthropicBedrock
+        (anthropic_messages) path.
+        """
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+
+        # Config default is a Claude Bedrock model (would normally route to
+        # the anthropic_messages path).
+        claude_default = {
+            "provider": "bedrock",
+            "default": "us.anthropic.claude-sonnet-4-6",
+        }
+        with patch("hermes_cli.runtime_provider.resolve_provider", return_value="bedrock"), \
+             patch("hermes_cli.runtime_provider._get_model_config", return_value=claude_default):
+            result = resolve_runtime_provider(
+                requested="bedrock",
+                target_model="us.amazon.nova-pro-v1:0",
+            )
+        assert result["provider"] == "bedrock"
+        # target_model (Nova) wins over the Claude default → Converse API.
+        assert result["api_mode"] == "bedrock_converse"
+        assert result.get("bedrock_anthropic") is not True
+
+    def test_bedrock_target_model_claude_overrides_nova_default(self, monkeypatch):
+        """Inverse guard for #27829: a Claude target_model must drive the
+        api_mode to anthropic_messages even when the config default is a
+        Nova (non-Anthropic) model — proving target_model controls routing
+        in both directions.
+        """
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+
+        nova_default = {
+            "provider": "bedrock",
+            "default": "us.amazon.nova-pro-v1:0",
+        }
+        with patch("hermes_cli.runtime_provider.resolve_provider", return_value="bedrock"), \
+             patch("hermes_cli.runtime_provider._get_model_config", return_value=nova_default):
+            result = resolve_runtime_provider(
+                requested="bedrock",
+                target_model="us.anthropic.claude-sonnet-4-6",
+            )
+        assert result["provider"] == "bedrock"
+        # target_model (Claude) wins over the Nova default → AnthropicBedrock.
+        assert result["api_mode"] == "anthropic_messages"
+        assert result.get("bedrock_anthropic") is True
+
+    def test_bedrock_no_target_model_falls_back_to_default(self, monkeypatch):
+        """When no target_model is supplied, api_mode must continue to derive
+        from the config default (preserves pre-#27829 behavior).
+        """
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+
+        claude_default = {
+            "provider": "bedrock",
+            "default": "us.anthropic.claude-sonnet-4-6",
+        }
+        with patch("hermes_cli.runtime_provider.resolve_provider", return_value="bedrock"), \
+             patch("hermes_cli.runtime_provider._get_model_config", return_value=claude_default):
+            result = resolve_runtime_provider(requested="bedrock")
+        assert result["provider"] == "bedrock"
+        # No override → Claude default drives routing → anthropic_messages.
+        assert result["api_mode"] == "anthropic_messages"
+        assert result.get("bedrock_anthropic") is True
+
 
 # ---------------------------------------------------------------------------
 # providers.py integration


### PR DESCRIPTION
**Salvage of #27829 by @roadhero — the fix is theirs; this adds the regression test the hermes-sweeper review requested.**

## The bug
In the Bedrock dual-path routing inside `resolve_runtime_provider` (`hermes_cli/runtime_provider.py`), the `api_mode` decision (`anthropic_messages` via the AnthropicBedrock SDK vs `bedrock_converse` via the Converse API) was classified off the **config default** model, ignoring a per-request `target_model` override. A per-request Nova model could therefore be misrouted to the Anthropic path (and vice-versa).

## The fix (authored by @roadhero, from #27829)
One line:

```python
# before
_current_model = str(model_cfg.get("default") or "").strip()
# after
_current_model = target_model or str(model_cfg.get("default") or "").strip()
```

Now the per-request `target_model` drives the dual-path classification, falling back to the config default when no override is supplied. Verified mergeable on current `main`.

## Tests added
Added to `tests/agent/test_bedrock_integration.py::TestRuntimeProvider` (mirrors existing fixtures + the Nova/Claude id patterns from `tests/agent/test_bedrock_adapter.py`):

- `test_bedrock_target_model_nova_overrides_claude_default` — the exact case the sweeper asked for: Claude Bedrock default configured + `target_model="us.amazon.nova-pro-v1:0"` → asserts `api_mode == "bedrock_converse"`.
- `test_bedrock_target_model_claude_overrides_nova_default` — inverse guard: Nova default + Claude `target_model` → asserts `api_mode == "anthropic_messages"` (proves `target_model` drives routing both directions).
- `test_bedrock_no_target_model_falls_back_to_default` — no `target_model` → falls back to config default (preserves pre-fix behavior).

## Test results
```
$ python3 -m pytest tests/agent/test_bedrock_integration.py -k "bedrock or runtime_provider or target_model" -x -q
58 passed in 2.00s
```
(3 new tests included; `py_compile` clean on both files.)

## Note
Supersedes #27829 only if maintainers prefer the test bundled; otherwise happy to have @roadhero cherry-pick the test into their branch and close this — whatever lands their fix fastest.

cc @roadhero
