### PR TITLE
fix(desktop): prevent stuck 'running' state when loading historical session

### DIFF
--- a/.pr-body.md
+++ b/.pr-body.md
@@ -1,0 +1,37 @@
+## Problem
+
+When a user types `exit` in the built-in terminal pane, the PTY process terminates but there is no UI to close or restart the dead terminal. The pane becomes permanently locked, requiring a full app restart to recover. (Fixes #45649)
+
+## Solution
+
+Add a **"Terminal exited"** overlay with a **"Restart terminal"** button that appears when the PTY session status transitions to `closed`.
+
+### What happens when you click Restart:
+1. The old session's `onData` and `onExit` listeners are torn down
+2. The old PTY is disposed via `terminalApi.dispose()`
+3. The xterm buffer is cleared and reset
+4. A fresh PTY session is spawned with `terminalApi.start()`
+5. Status transitions `closed` → `starting` → `open`
+
+### Changes
+
+| File | Change |
+|------|--------|
+| `use-terminal-session.ts` | Add `sessionCleanup` array (separate from component-lifecycle `cleanup`) to track per-session listeners; add `restartRef` + stable `restartSession` callback; on restart, tear down session listeners, dispose PTY, reset xterm, and start fresh |
+| `index.tsx` (TerminalTab) | Destructure `restartSession` from hook; add `status === 'closed'` overlay with exit message + restart button (using `Codicon "refresh"` + `Button variant="secondary"`) |
+| `en.ts`, `ja.ts`, `zh.ts`, `zh-hant.ts` | Add `terminalExited` / `terminalRestart` i18n strings |
+| `types.ts` | Add type declarations for the new i18n keys |
+
+## Testing
+
+- [x] TypeScript compiles cleanly (`tsc --noEmit` passes)
+- [ ] Type `exit` in terminal → overlay appears with "Terminal exited" message and "Restart terminal" button
+- [ ] Click "Restart terminal" → new shell session starts, overlay disappears, terminal is interactive again
+- [ ] Restart works on both Windows and macOS
+- [ ] Restart while `starting` is a no-op (button not visible)
+
+## Safety
+
+- The restart function is a no-op when the component is disposed (`disposed` flag guards `startSession`)
+- `sessionCleanup` is drained both on restart (to tear down old listeners) and on unmount (to prevent leaks)
+- The existing `onExit` handler still writes `[terminal exited: ...]` to the xterm buffer, which remains visible behind the overlay — this preserves context about *why* the terminal exited

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -640,9 +640,11 @@ export function useSessionActions({
       setFreshDraftReady(false)
       setActiveSessionId(null)
       activeSessionIdRef.current = null
-      busyRef.current = true
-      setBusy(true)
-      setAwaitingResponse(false)
+      // Don't set busy=true optimistically — the gateway session.resume
+      // response tells us whether the session is actually running.
+      // Setting busy=true here causes a stuck "running" state if the
+      // finally block's isCurrentResume() guard fails (race condition)
+      // or if flushPendingViewState restores stale cached busy=true.
       clearNotifications()
       setSelectedStoredSessionId(storedSessionId)
       selectedStoredSessionIdRef.current = storedSessionId
@@ -762,6 +764,12 @@ export function useSessionActions({
           busyRef.current = resumedRunning
           setBusy(resumedRunning)
           setAwaitingResponse(resumedRunning)
+        } else {
+          // User navigated away — ensure busy is never left stuck true.
+          // The next resume will set the correct state from the gateway.
+          busyRef.current = false
+          setBusy(false)
+          setAwaitingResponse(false)
         }
       }
     },


### PR DESCRIPTION
## Problem

When clicking a previous/historical session in the sidebar, the composer send button displays a stuck "running" state (spinning/stop icon) even though no agent turn is actually running. The button stays stuck until the user sends a new message.

## Root Cause

`resumeSession()` in `use-session-actions.ts` sets `busy = true` optimistically before the gateway `session.resume` call (line 643-644). The `finally` block only resets `busy` when `isCurrentResume()` returns `true` — if the user navigates away quickly or another resume starts before the current one completes, the guard fails and `busy` stays `true` permanently.

Additionally, `flushPendingViewState()` in `use-session-state-cache.ts` can restore stale `busy: true` from cached state, overriding the `finally` block's reset.

## Changes

- **Remove optimistic `setBusy(true)`** at resume entry — the gateway `session.resume` response provides the actual running state (`resumed.running`). Setting `busy=true` before that creates a race window that leaves the UI stuck.
- **Add else branch to finally block** — when `isCurrentResume()` is false (user navigated away), reset `busy` and `awaitingResponse` to `false` instead of leaving them in whatever stale state they had.

## Testing

- `npx tsc --noEmit` — zero errors
- Unit tests pass (pre-existing environment failures unrelated to this change)

Fixes #41901