### PR TITLE
fix: guard against malformed custom_providers in get_compatible_custom_providers()

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3983,9 +3983,19 @@ def get_compatible_custom_providers(
     custom_providers = config.get("custom_providers")
     if custom_providers is not None:
         if not isinstance(custom_providers, list):
-            return []
-        for entry in custom_providers:
-            _append_if_new(_normalize_custom_provider_entry(entry))
+            # Malformed custom_providers (e.g. a JSON string instead of a YAML
+            # list) — warn and fall through so providers dict entries are still
+            # processed.  Returning early here silently drops all custom
+            # providers configured under the v12+ ``providers:`` key.
+            logger.warning(
+                "custom_providers is a %s, expected a list — "
+                "skipping legacy entries; providers dict entries will still be used. "
+                "Move your provider configs to the 'providers:' section.",
+                type(custom_providers).__name__,
+            )
+        else:
+            for entry in custom_providers:
+                _append_if_new(_normalize_custom_provider_entry(entry))
 
     for entry in providers_dict_to_custom_providers(config.get("providers")):
         _append_if_new(entry)
@@ -4152,10 +4162,26 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
 
     issues: List[ConfigIssue] = []
 
-    # ── custom_providers must be a list, not a dict ──────────────────────
+    # ── custom_providers must be a list, not a dict or string ──────────
     cp = config.get("custom_providers")
     if cp is not None:
-        if isinstance(cp, dict):
+        if isinstance(cp, str):
+            issues.append(ConfigIssue(
+                "error",
+                f"custom_providers is a string (got {repr(cp[:80])}...) — "
+                "it must be a YAML list (items prefixed with '-')",
+                "Change to:\n"
+                "  custom_providers:\n"
+                "    - name: my-provider\n"
+                "      base_url: https://...\n"
+                "      api_key: ...\n\n"
+                "Or better, move your provider to the 'providers:' section:\n"
+                "  providers:\n"
+                "    my-provider:\n"
+                "      api: https://...\n"
+                "      api_key: ...",
+            ))
+        elif isinstance(cp, dict):
             issues.append(ConfigIssue(
                 "error",
                 "custom_providers is a dict — it must be a YAML list (items prefixed with '-')",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1739,9 +1739,19 @@ def get_compatible_custom_providers(
     custom_providers = config.get("custom_providers")
     if custom_providers is not None:
         if not isinstance(custom_providers, list):
-            return []
-        for entry in custom_providers:
-            _append_if_new(_normalize_custom_provider_entry(entry))
+            # Malformed custom_providers (e.g. a JSON string instead of a YAML
+            # list) — warn and fall through so providers dict entries are still
+            # processed.  Returning early here silently drops all custom
+            # providers configured under the v12+ ``providers:`` key.
+            logger.warning(
+                "custom_providers is a %s, expected a list — "
+                "skipping legacy entries; providers dict entries will still be used. "
+                "Move your provider configs to the 'providers:' section.",
+                type(custom_providers).__name__,
+            )
+        else:
+            for entry in custom_providers:
+                _append_if_new(_normalize_custom_provider_entry(entry))
 
     for entry in providers_dict_to_custom_providers(config.get("providers")):
         _append_if_new(entry)
@@ -2156,10 +2166,26 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
                 "Set voice.submit_mode to direct (submit immediately) or draft (edit before sending)",
             ))
 
-    # ── custom_providers must be a list, not a dict ──────────────────────
+    # ── custom_providers must be a list, not a dict or string ──────────
     cp = config.get("custom_providers")
     if cp is not None:
-        if isinstance(cp, dict):
+        if isinstance(cp, str):
+            issues.append(ConfigIssue(
+                "error",
+                f"custom_providers is a string (got {repr(cp[:80])}...) — "
+                "it must be a YAML list (items prefixed with '-')",
+                "Change to:\n"
+                "  custom_providers:\n"
+                "    - name: my-provider\n"
+                "      base_url: https://...\n"
+                "      api_key: ...\n\n"
+                "Or better, move your provider to the 'providers:' section:\n"
+                "  providers:\n"
+                "    my-provider:\n"
+                "      api: https://...\n"
+                "      api_key: ...",
+            ))
+        elif isinstance(cp, dict):
             issues.append(ConfigIssue(
                 "error",
                 "custom_providers is a dict — it must be a YAML list (items prefixed with '-')",

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -931,6 +931,39 @@ class TestCustomProviderCompatibility:
         models = [e.get("model") for e in compatible]
         assert models == ["qwen3-coder", "glm-5.1", "kimi-k2.5"]
 
+    def test_string_custom_providers_does_not_suppress_providers_dict(
+        self, tmp_path
+    ):
+        """String-form custom_providers (e.g. from `hermes config set` JSON
+        serialisation) must not suppress valid ``providers:`` dict entries."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 17,
+                    "custom_providers": '[{"name":"broken","base_url":"https://x.com"}]',
+                    "providers": {
+                        "my-provider": {
+                            "api": "https://api.example.com/v1",
+                            "api_key": "test-key",
+                            "name": "My Provider",
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            compatible = get_compatible_custom_providers()
+
+        # The malformed custom_providers string is skipped (logged warning),
+        # but the providers dict entry is still resolved.
+        assert len(compatible) == 1
+        assert compatible[0]["name"] == "My Provider"
+        assert compatible[0]["base_url"] == "https://api.example.com/v1"
+        assert compatible[0]["provider_key"] == "my-provider"
+
 
 class TestInterimAssistantMessageConfig:
     """Test the explicit gateway interim-message config gate."""

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1063,6 +1063,95 @@ class TestCustomProviderCompatibility:
             }
         ]
 
+    def test_dedup_across_legacy_and_providers(self, tmp_path):
+        """Same name+url in both schemas should not produce duplicates."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 17,
+                    "custom_providers": [
+                        {
+                            "name": "OpenAI Direct",
+                            "base_url": "https://api.openai.com/v1",
+                            "api_key": "legacy-key",
+                        }
+                    ],
+                    "providers": {
+                        "openai-direct": {
+                            "api": "https://api.openai.com/v1",
+                            "api_key": "new-key",
+                            "name": "OpenAI Direct",
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            compatible = get_compatible_custom_providers()
+
+        assert len(compatible) == 1
+        # Legacy entry wins (read first)
+        assert compatible[0]["api_key"] == "legacy-key"
+
+    def test_dedup_preserves_entries_with_different_models(self, tmp_path):
+        """Entries with same name+URL but different models must not be collapsed."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 17,
+                    "custom_providers": [
+                        {"name": "Ollama Cloud", "base_url": "https://ollama.com/v1", "model": "qwen3-coder"},
+                        {"name": "Ollama Cloud", "base_url": "https://ollama.com/v1", "model": "glm-5.1"},
+                        {"name": "Ollama Cloud", "base_url": "https://ollama.com/v1", "model": "kimi-k2.5"},
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            compatible = get_compatible_custom_providers()
+
+        assert len(compatible) == 3
+        models = [e.get("model") for e in compatible]
+        assert models == ["qwen3-coder", "glm-5.1", "kimi-k2.5"]
+
+    def test_string_custom_providers_does_not_suppress_providers_dict(
+        self, tmp_path
+    ):
+        """String-form custom_providers (e.g. from `hermes config set` JSON
+        serialisation) must not suppress valid ``providers:`` dict entries."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 17,
+                    "custom_providers": '[{"name":"broken","base_url":"https://x.com"}]',
+                    "providers": {
+                        "my-provider": {
+                            "api": "https://api.example.com/v1",
+                            "api_key": "test-key",
+                            "name": "My Provider",
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            compatible = get_compatible_custom_providers()
+
+        # The malformed custom_providers string is skipped (logged warning),
+        # but the providers dict entry is still resolved.
+        assert len(compatible) == 1
+        assert compatible[0]["name"] == "My Provider"
+        assert compatible[0]["base_url"] == "https://api.example.com/v1"
+        assert compatible[0]["provider_key"] == "my-provider"
 
 class TestInterimAssistantMessageConfig:
     """Test the explicit gateway interim-message config gate."""

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -94,6 +94,19 @@ class TestCustomProvidersValidation:
         })
         assert len(issues) == 0
 
+    def test_string_instead_of_list(self):
+        """String-typed custom_providers (JSON-serialised by `hermes config set`)
+        should produce a clear error directing users to YAML list syntax."""
+        issues = validate_config_structure({
+            "custom_providers": '[{"name":"my-provider","base_url":"https://example.com/v1"}]',
+            "model": {"provider": "custom"},
+        })
+        errors = [i for i in issues if i.severity == "error"]
+        assert any(
+            "string" in i.message and "YAML list" in i.message
+            for i in errors
+        ), "Should detect custom_providers as string and suggest YAML list format"
+
 
 class TestFallbackModelValidation:
     """fallback_model should be a top-level dict with provider + model."""

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -58,6 +58,19 @@ class TestCustomProvidersValidation:
         assert any("not a dict" in i.message for i in issues)
 
 
+    def test_string_instead_of_list(self):
+        """String-typed custom_providers (JSON-serialised by `hermes config set`)
+        should produce a clear error directing users to YAML list syntax."""
+        issues = validate_config_structure({
+            "custom_providers": '[{"name":"my-provider","base_url":"https://example.com/v1"}]',
+            "model": {"provider": "custom"},
+        })
+        errors = [i for i in issues if i.severity == "error"]
+        assert any(
+            "string" in i.message and "YAML list" in i.message
+            for i in errors
+        ), "Should detect custom_providers as string and suggest YAML list format"
+
 
 
 class TestMissingModelSection:


### PR DESCRIPTION
## Problem

When `custom_providers` in config.yaml is stored as a string (JSON literal, `'null'`, `'[]'`, etc.) instead of a proper YAML list, `get_compatible_custom_providers()` hits this code path:

```python
custom_providers = config.get("custom_providers")
if custom_providers is not None:
    if not isinstance(custom_providers, list):
        return []  # ← returns immediately
```

The early `return []` means the `providers` dict processing below is **never reached**, silently dropping all custom providers configured under the v12+ `providers:` key. Users get the cryptic "Unknown provider" warning at startup with no clue that their config is being ignored.

This is common because:
- Users hand-edit config.yaml and paste JSON into `custom_providers`
- `hermes config set custom_providers '[...]'` serialises the value as a YAML string

Reported in #13849.

## Fix

### 1. `get_compatible_custom_providers()` — replace early return with fall-through (line 3986)

Instead of `return []`, log a warning and fall through so `providers` dict entries are still processed:

```python
if not isinstance(custom_providers, list):
    logger.warning(
        "custom_providers is a %s, expected a list — "
        "skipping legacy entries; providers dict entries will still be used. "
        "Move your provider configs to the 'providers:' section.",
        type(custom_providers).__name__,
    )
else:
    for entry in custom_providers:
        _append_if_new(_normalize_custom_provider_entry(entry))
```

### 2. `validate_config_structure()` — catch string-typed custom_providers (line 4162)

Added a new `isinstance(cp, str)` branch before the existing dict/list checks, producing a clear error message with migration guidance:

```
custom_providers is a string (got '[{"name":"9router",...}]'...) — it must be a YAML list
```

## Testing

Reproduced on Hermes v0.16.0 (Windows):
1. Set `custom_providers: '[{"name":"9router",...}]'` in config.yaml
2. Added a valid provider in the `providers:` section
3. Confirmed "Unknown provider" warning + provider invisible
4. Applied fix → provider visible, warning logged