### PR TITLE
fix: React error #301 from unstable useSyncExternalStore usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19651,6 +19651,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@testing-library/dom": "^10.4.0",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^22.20.0",
         "@types/qrcode": "^1.5.6",
         "@types/react": "^19.2.14",
@@ -19660,6 +19662,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
+        "jsdom": "^29.1.1",
         "three": "^0.180.0",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.56.1",

--- a/ui-tui/src/hooks/useVirtualHistory.ts
+++ b/ui-tui/src/hooks/useVirtualHistory.ts
@@ -189,14 +189,29 @@ export function useVirtualHistory(
   // key → React.Object.is short-circuits the commit entirely. The key includes
   // sticky state, target scroll position, and viewport height so resize-only
   // changes still recompute the mounted transcript window.
+  //
+  // snapshotKeyRef caches the last snapshot so getSnapshot() returns a stable
+  // value between React's two consecutive calls during tearing detection. Without
+  // this, getSnapshot() reads live scroll state that can change at any moment
+  // (streaming TUI) → false tearing detected → flushSyncWorkAcrossRoots loop
+  // → React error #301.
+  const snapshotKeyRef = useRef('none')
+
   const subscribe = useCallback(
-    (cb: () => void) => (hasScrollRef ? scrollRef.current?.subscribe(cb) : null) ?? NOOP,
+    (cb: () => void) => {
+      if (!hasScrollRef || !scrollRef.current) return NOOP
+      snapshotKeyRef.current = virtualHistorySnapshotKey(scrollRef.current)
+      return scrollRef.current.subscribe(() => {
+        snapshotKeyRef.current = virtualHistorySnapshotKey(scrollRef.current)
+        cb()
+      })
+    },
     [hasScrollRef, scrollRef]
   )
 
   useSyncExternalStore(
     subscribe,
-    () => virtualHistorySnapshotKey(scrollRef.current),
+    () => snapshotKeyRef.current,
     () => 'none'
   )
 

--- a/ui-tui/src/lib/viewportStore.ts
+++ b/ui-tui/src/lib/viewportStore.ts
@@ -1,6 +1,6 @@
 import type { ScrollBoxHandle } from '@hermes/ink'
 import type { RefObject } from 'react'
-import { useCallback, useMemo, useSyncExternalStore } from 'react'
+import { useCallback, useMemo, useRef, useSyncExternalStore } from 'react'
 
 export interface ViewportSnapshot {
   atBottom: boolean
@@ -85,9 +85,23 @@ export function scrollbarSnapshotKey(v: ScrollbarSnapshot) {
 }
 
 export function useViewportSnapshot(scrollRef: RefObject<ScrollBoxHandle | null>): ViewportSnapshot {
+  const cachedKey = useRef(viewportSnapshotKey(getViewportSnapshot(scrollRef.current)))
+
+  const subscribe = useCallback((cb: () => void) => {
+    if (!scrollRef.current) return () => {}
+    // Sync cache on subscribe so getSnapshot() is stable across React's tearing check.
+    // Without this, getSnapshot() reads live state that can change between two consecutive
+    // calls → React detects spurious tearing → flushSyncWorkAcrossRoots loop → #301.
+    cachedKey.current = viewportSnapshotKey(getViewportSnapshot(scrollRef.current))
+    return scrollRef.current.subscribe(() => {
+      cachedKey.current = viewportSnapshotKey(getViewportSnapshot(scrollRef.current))
+      cb()
+    })
+  }, [scrollRef])
+
   const key = useSyncExternalStore(
-    useCallback((cb: () => void) => scrollRef.current?.subscribe(cb) ?? (() => {}), [scrollRef]),
-    () => viewportSnapshotKey(getViewportSnapshot(scrollRef.current)),
+    subscribe,
+    () => cachedKey.current,
     () => viewportSnapshotKey(EMPTY)
   )
 
@@ -106,9 +120,20 @@ export function useViewportSnapshot(scrollRef: RefObject<ScrollBoxHandle | null>
 }
 
 export function useScrollbarSnapshot(scrollRef: RefObject<ScrollBoxHandle | null>): ScrollbarSnapshot {
+  const cachedKey = useRef(scrollbarSnapshotKey(getScrollbarSnapshot(scrollRef.current)))
+
+  const subscribe = useCallback((cb: () => void) => {
+    if (!scrollRef.current) return () => {}
+    cachedKey.current = scrollbarSnapshotKey(getScrollbarSnapshot(scrollRef.current))
+    return scrollRef.current.subscribe(() => {
+      cachedKey.current = scrollbarSnapshotKey(getScrollbarSnapshot(scrollRef.current))
+      cb()
+    })
+  }, [scrollRef])
+
   const key = useSyncExternalStore(
-    useCallback((cb: () => void) => scrollRef.current?.subscribe(cb) ?? (() => {}), [scrollRef]),
-    () => scrollbarSnapshotKey(getScrollbarSnapshot(scrollRef.current)),
+    subscribe,
+    () => cachedKey.current,
     () => scrollbarSnapshotKey(EMPTY_SCROLLBAR)
   )
 

--- a/web/package.json
+++ b/web/package.json
@@ -39,6 +39,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^22.20.0",
     "@types/qrcode": "^1.5.6",
     "@types/react": "^19.2.14",
@@ -48,6 +50,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "jsdom": "^29.1.1",
     "three": "^0.180.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.56.1",

--- a/web/src/plugins/PluginPage.test.tsx
+++ b/web/src/plugins/PluginPage.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { useLayoutEffect } from "react";
+import type { ComponentType } from "react";
+import { PluginPage } from "./PluginPage";
+import { exposePluginSDK } from "./registry";
+
+(
+  globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const Demo: ComponentType = () => <div>plugin-loaded</div>;
+
+type Register = (name: string, component: ComponentType) => void;
+
+function registerPlugin(name: string, component: ComponentType) {
+  exposePluginSDK();
+  (
+    window as unknown as { __HERMES_PLUGINS__: { register: Register } }
+  ).__HERMES_PLUGINS__.register(name, component);
+}
+
+function GapInjector({ name }: { name: string }) {
+  useLayoutEffect(() => {
+    registerPlugin(name, Demo);
+  }, [name]);
+  return null;
+}
+
+describe("PluginPage", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("surfaces a plugin registered in the render->subscribe gap", () => {
+    render(
+      <>
+        <GapInjector name="regtest-gap" />
+        <PluginPage name="regtest-gap" />
+      </>,
+    );
+
+    expect(screen.getByText("plugin-loaded")).toBeTruthy();
+    expect(screen.queryByText("Loading...")).toBeNull();
+  });
+});

--- a/web/src/plugins/PluginPage.tsx
+++ b/web/src/plugins/PluginPage.tsx
@@ -12,15 +12,13 @@ import type { Translations } from "@/i18n/types";
 /** Renders a plugin tab once its bundle has called `register()`. */
 export function PluginPage({ name }: { name: string }) {
   const { t } = useI18n();
-  // Subscribe in render (via useSyncExternalStore) so we never miss
-  // `register()` if the script loads before a useEffect would run.
   const Component = useSyncExternalStore(
-    (onChange) => onPluginRegistered(onChange),
+    onPluginRegistered,
     () => getPluginComponent(name) ?? null,
     () => null,
   );
   const loadError = useSyncExternalStore(
-    (onChange) => onPluginRegistered(onChange),
+    onPluginRegistered,
     () => getPluginLoadError(name) ?? null,
     () => null,
   );


### PR DESCRIPTION
## What changed and why

Two `useSyncExternalStore` call sites were driving React's tearing-detection loop and throwing error #301: the default dashboard (plugins) and active TUI streaming sessions.

### web/src/plugins/PluginPage.tsx

The `subscribe` argument was an inline arrow, `(onChange) => onPluginRegistered(onChange)`, so a fresh function was created on every render. `useSyncExternalStore` re-subscribes whenever the `subscribe` reference changes, so it re-subscribed each render, and every re-subscribe runs a tearing check (React calls `getSnapshot` twice and compares). During plugin registration the registry can differ between those two calls, sending React into a sync re-render loop until it hits the cap and throws #301.

Fixed by passing the module-level `onPluginRegistered` straight in as `subscribe`. It is a stable reference, so React subscribes once. `getSnapshot` still reads the component off the registry `Map` (stable between calls) and `getServerSnapshot` returns `null`. This restores the pre-regression `useSyncExternalStore` behavior, with the stable subscribe as the only change.

### ui-tui/src/lib/viewportStore.ts and ui-tui/src/hooks/useVirtualHistory.ts

`getSnapshot` read the live scroll handle directly (`getViewportSnapshot(scrollRef.current)` / `virtualHistorySnapshotKey(scrollRef.current)`). Under active streaming the scroll position changes continuously, so React's two consecutive `getSnapshot` calls during tearing detection returned different values every time, keeping `flushSyncWorkAcrossRoots` in a loop until it hit the render cap and threw #301.

Fixed by caching the snapshot in a `useRef` that is updated only inside the `subscribe` callback. `getSnapshot` now reads the ref, so it returns a stable value between calls unless the store actually notified React of a change.

## Reproduction

Open the default Hermes dashboard with the achievements plugin active: the browser console shows Minified React error #301 from `flushSyncWorkAcrossRoots` on every load. In the TUI, the same error shows up in the process output during streaming.

## How to test

- `web/`: `npm run check` (typecheck + tests) passes. `npm run build` produces the bundle with no #301 in the console.
- Regression test: `web/src/plugins/PluginPage.test.tsx` renders `<PluginPage>` and registers a plugin from a `useLayoutEffect`, so it lands in the gap between the initial snapshot read and the passive-effect subscription. It fails on the old `useState`/`useEffect` version and passes on this fix. It uses `@testing-library/react` (like `apps/desktop`); `@testing-library/react`, `@testing-library/dom` and `jsdom` were added to `web` devDependencies with the lockfile updated so `npm ci` validates.
- TUI: the viewport and virtualHistory `vitest` suites pass.

## Platform

Linux (Ubuntu 24.04).
