### PR TITLE
feat: add GLM-5.2 to model catalogs

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -253,6 +253,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     "mimo-v2.5": 1048576,
     "mimo-v2-omni": 262144,
     "mimo-v2-flash": 262144,
+    "glm-5.2": 1_000_000,
     "zai-org/GLM-5": 202752,
 }
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -609,15 +609,14 @@ def _resolve_api_key_provider_secret(
 # endpoints.  A key that works on one may return "Insufficient balance" on
 # another.  We probe at setup time and store the working endpoint.
 # Each entry lists candidate models to try in order — newer coding plan accounts
-# may only have access to recent models (glm-5.1, glm-5v-turbo) while older
-# ones still use glm-4.7.
+# may only have access to recent models while older ones still use glm-4.7.
 
 ZAI_ENDPOINTS = [
     # (id, base_url, probe_models, label)
     ("global",        "https://api.z.ai/api/paas/v4",        ["glm-5"],   "Global"),
     ("cn",            "https://open.bigmodel.cn/api/paas/v4", ["glm-5"],   "China"),
-    ("coding-global", "https://api.z.ai/api/coding/paas/v4",  ["glm-5.1", "glm-5v-turbo", "glm-4.7"], "Global (Coding Plan)"),
-    ("coding-cn",     "https://open.bigmodel.cn/api/coding/paas/v4", ["glm-5.1", "glm-5v-turbo", "glm-4.7"], "China (Coding Plan)"),
+    ("coding-global", "https://api.z.ai/api/coding/paas/v4",  ["glm-5.2", "glm-5.1", "glm-5v-turbo", "glm-4.7"], "Global (Coding Plan)"),
+    ("coding-cn",     "https://open.bigmodel.cn/api/coding/paas/v4", ["glm-5.2", "glm-5.1", "glm-5v-turbo", "glm-4.7"], "China (Coding Plan)"),
 ]
 
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -60,6 +60,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     # MiniMax
     ("minimax/minimax-m3",                     ""),
     # Z-AI
+    ("z-ai/glm-5.2",                           "1M context"),
     ("z-ai/glm-5.1",                           ""),
     # Xiaomi
     ("xiaomi/mimo-v2.5-pro",                   ""),
@@ -181,6 +182,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         # MiniMax
         "minimax/minimax-m3",
         # Z-AI
+        "z-ai/glm-5.2",
         "z-ai/glm-5.1",
         # Xiaomi
         "xiaomi/mimo-v2.5-pro",
@@ -256,6 +258,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gemini-3.5-flash",
     ],
     "zai": [
+        "glm-5.2",
         "glm-5.1",
         "glm-5",
         "glm-5v-turbo",

--- a/plugins/model-providers/zai/__init__.py
+++ b/plugins/model-providers/zai/__init__.py
@@ -11,8 +11,11 @@ zai = ProviderProfile(
     description="Z.AI / GLM — Zhipu AI models",
     signup_url="https://z.ai/",
     fallback_models=(
+        "glm-5.2",
+        "glm-5.1",
         "glm-5",
-        "glm-4-9b",
+        "glm-5v-turbo",
+        "glm-4.7",
     ),
     base_url="https://api.z.ai/api/paas/v4",
     default_aux_model="glm-4.5-flash",

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-06-13T08:41:46Z",
+  "updated_at": "2026-06-13T15:09:41Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -87,6 +87,10 @@
         {
           "id": "minimax/minimax-m3",
           "description": ""
+        },
+        {
+          "id": "z-ai/glm-5.2",
+          "description": "1M context"
         },
         {
           "id": "z-ai/glm-5.1",
@@ -201,6 +205,9 @@
         },
         {
           "id": "minimax/minimax-m3"
+        },
+        {
+          "id": "z-ai/glm-5.2"
         },
         {
           "id": "z-ai/glm-5.1"


### PR DESCRIPTION
Adds GLM-5.2 to OpenRouter, Nous, and Z.AI native catalogs. 1M context verified on the Coding Plan endpoint.

- `hermes_cli/models.py` — catalog entries (OpenRouter, Nous, Z.AI native)
- `agent/model_metadata.py` — `"glm-5.2": 1_000_000`
- `hermes_cli/auth.py` — `glm-5.2` first in coding plan probes
- `plugins/model-providers/zai/__init__.py` — updated fallback models
- `website/static/api/model-catalog.json` — regenerated