### PR TITLE
fix(goal): stop loop on explicit completion

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9510,9 +9510,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 active = getattr(adapter, "_active_sessions", {}).get(session_key)
                 if active is not None:
                     generation = getattr(active, "_hermes_run_generation", None)
+                def _schedule_deliver() -> None:
+                    try:
+                        safe_schedule_threadsafe(
+                            _deliver(),
+                            self.loop if getattr(self, "loop", None) is not None else asyncio.get_running_loop(),
+                            logger=logger,
+                            log_message="goal continuation: status scheduling failed",
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            "goal continuation: status scheduling failed: %s",
+                            exc,
+                            exc_info=True,
+                        )
+
                 adapter.register_post_delivery_callback(
                     session_key,
-                    _deliver,
+                    _schedule_deliver,
                     generation=generation,
                 )
                 return

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -319,6 +319,28 @@ def _goal_judge_max_tokens() -> int:
     return DEFAULT_JUDGE_MAX_TOKENS
 
 
+_COMPLETION_NEGATION_RE = re.compile(
+    r"\b(?:not\s+(?:done|complete|completed|finished)|not\s+yet|incomplete|still\s+(?:needs?|need|missing|blocked)|remaining\s+work|to\s+do)\b",
+    re.IGNORECASE,
+)
+_EXPLICIT_COMPLETION_RE = re.compile(
+    r"\b(?:goal|task|work|request|it)\s+(?:is\s+)?(?:done|complete|completed|finished)\b"
+    r"|\b(?:i(?:'ve|\s+have)?|we(?:'ve|\s+have)?)\s+(?:completed|finished|done)\b"
+    r"|^\s*(?:done|complete|completed|finished)\s*[.!]*\s*$",
+    re.IGNORECASE,
+)
+
+
+def response_explicitly_completes_goal(response: str) -> bool:
+    """Return True when the assistant itself clearly says the goal is done."""
+    text = (response or "").strip()
+    if not text:
+        return False
+    if _COMPLETION_NEGATION_RE.search(text):
+        return False
+    return bool(_EXPLICIT_COMPLETION_RE.search(text))
+
+
 def _parse_judge_response(raw: str) -> Tuple[bool, str, bool]:
     """Parse the judge's reply. Fail-open to ``(False, "<reason>", parse_failed)``.
 
@@ -651,6 +673,22 @@ class GoalManager:
         # Count the turn that just finished.
         state.turns_used += 1
         state.last_turn_at = time.time()
+
+        if response_explicitly_completes_goal(last_response):
+            reason = "agent explicitly reported the goal is complete"
+            state.status = "done"
+            state.last_verdict = "done"
+            state.last_reason = reason
+            state.consecutive_parse_failures = 0
+            save_goal(self.session_id, state)
+            return {
+                "status": "done",
+                "should_continue": False,
+                "continuation_prompt": None,
+                "verdict": "done",
+                "reason": reason,
+                "message": f"✓ Goal achieved: {reason}",
+            }
 
         verdict, reason, parse_failed = judge_goal(
             state.goal, last_response, subgoals=state.subgoals or None

--- a/tests/gateway/test_goal_verdict_send.py
+++ b/tests/gateway/test_goal_verdict_send.py
@@ -49,7 +49,11 @@ class _RecordingAdapter:
 
     def __init__(self) -> None:
         self._pending_messages: dict = {}
+        self._post_delivery_callbacks: dict = {}
         self.sends: list[dict] = []
+
+    def register_post_delivery_callback(self, session_key, callback, *, generation=None):
+        self._post_delivery_callbacks[session_key] = callback
 
     async def send(self, chat_id: str, content: str, reply_to=None, metadata=None):
         self.sends.append({"chat_id": chat_id, "content": content, "metadata": metadata})
@@ -70,6 +74,7 @@ def _make_runner_with_adapter(session_id: str = None):
         platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")},
     )
     runner.adapters = {}
+    runner.loop = None
     runner._running_agents = {}
     runner._running_agents_ts = {}
     runner._queued_events = {}
@@ -96,6 +101,15 @@ def _make_runner_with_adapter(session_id: str = None):
     return runner, adapter, session_entry, src
 
 
+async def _fire_deferred_goal_notice(adapter: _RecordingAdapter, session_key: str) -> None:
+    cb = adapter._post_delivery_callbacks.pop(session_key, None)
+    if callable(cb):
+        result = cb()
+        if asyncio.iscoroutine(result):
+            await result
+    await asyncio.sleep(0.05)
+
+
 @pytest.mark.asyncio
 async def test_goal_verdict_done_sent_via_adapter_send(hermes_home):
     """When the judge says done, the '✓ Goal achieved' message must reach
@@ -113,8 +127,7 @@ async def test_goal_verdict_done_sent_via_adapter_send(hermes_home):
             source=src,
             final_response="I shipped the feature.",
         )
-        # fire-and-forget create_task — give the loop a tick
-        await asyncio.sleep(0.05)
+        await _fire_deferred_goal_notice(adapter, session_entry.session_key)
 
     assert len(adapter.sends) == 1, f"expected 1 send, got {len(adapter.sends)}: {adapter.sends}"
     msg = adapter.sends[0]
@@ -142,7 +155,7 @@ async def test_goal_verdict_continue_enqueues_continuation(hermes_home):
             source=src,
             final_response="here's a partial edit",
         )
-        await asyncio.sleep(0.05)
+        await _fire_deferred_goal_notice(adapter, session_entry.session_key)
 
     # Status line sent back
     assert len(adapter.sends) == 1
@@ -170,7 +183,7 @@ async def test_goal_verdict_budget_exhausted_sends_pause(hermes_home):
             source=src,
             final_response="still partial",
         )
-        await asyncio.sleep(0.05)
+        await _fire_deferred_goal_notice(adapter, session_entry.session_key)
 
     assert len(adapter.sends) == 1
     content = adapter.sends[0]["content"]
@@ -219,3 +232,21 @@ async def test_goal_verdict_survives_adapter_without_send(hermes_home):
             final_response="whatever",
         )
         await asyncio.sleep(0.05)
+
+
+@pytest.mark.asyncio
+async def test_goal_status_post_delivery_callback_schedules_coroutine_without_warning(hermes_home):
+    """Post-delivery goal notices register a sync callback, not a raw coroutine."""
+    runner, adapter, session_entry, src = _make_runner_with_adapter()
+    runner.loop = asyncio.get_running_loop()
+
+    await runner._defer_goal_status_notice_after_delivery(src, "✓ Goal achieved: done")
+
+    cb = adapter._post_delivery_callbacks.pop(session_entry.session_key)
+    assert callable(cb)
+    result = cb()
+    assert result is None
+    await asyncio.sleep(0.05)
+
+    assert len(adapter.sends) == 1
+    assert "Goal achieved" in adapter.sends[0]["content"]

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -269,6 +269,38 @@ class TestGoalManager:
         assert mgr.state.status == "done"
         assert mgr.state.turns_used == 1
 
+    def test_evaluate_after_turn_explicit_completion_skips_broken_judge(self, hermes_home):
+        """If the agent says the goal is complete, stop without consulting a broken judge."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="eval-sid-explicit-complete")
+        mgr.set("ship it")
+
+        with patch.object(goals, "judge_goal", side_effect=AssertionError("judge should not run")):
+            decision = mgr.evaluate_after_turn("Goal is complete.")
+
+        assert decision["verdict"] == "done"
+        assert decision["should_continue"] is False
+        assert decision["continuation_prompt"] is None
+        assert mgr.state.status == "done"
+        assert mgr.state.turns_used == 1
+
+    def test_evaluate_after_turn_negated_completion_still_uses_judge(self, hermes_home):
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="eval-sid-negated-complete", default_max_turns=5)
+        mgr.set("ship it")
+
+        with patch.object(goals, "judge_goal", return_value=("continue", "not done", False)) as judge:
+            decision = mgr.evaluate_after_turn("The goal is not complete yet.")
+
+        judge.assert_called_once()
+        assert decision["verdict"] == "continue"
+        assert decision["should_continue"] is True
+        assert mgr.state.status == "active"
+
     def test_evaluate_after_turn_continue_under_budget(self, hermes_home):
         from hermes_cli import goals
         from hermes_cli.goals import GoalManager


### PR DESCRIPTION
Fixes a /goal loop failure where the assistant explicitly reports completion (for example, “Goal is complete.”), but the auxiliary goal judge fails and returns a continue verdict path. In that case Hermes can keep enqueueing the same continuation prompt until the turn budget is exhausted.

Changes:
- Add a deterministic completion guard before calling the auxiliary judge when the assistant response explicitly says the goal/task/work is complete.
- Keep negated statements such as “not complete yet” on the normal judge path.
- Register goal status post-delivery notices as a sync scheduler callback instead of storing a raw coroutine callback, avoiding “coroutine was never awaited” warnings.
- Update gateway goal verdict tests to fire deferred post-delivery callbacks explicitly.

Validation:
- `~/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_goals.py tests/gateway/test_goal_verdict_send.py -o 'addopts=' -q` → 58 passed
- `~/.hermes/hermes-agent/venv/bin/ruff check hermes_cli/goals.py gateway/run.py tests/hermes_cli/test_goals.py tests/gateway/test_goal_verdict_send.py` → passed
- `~/.hermes/hermes-agent/venv/bin/ruff format --check hermes_cli/goals.py gateway/run.py tests/hermes_cli/test_goals.py tests/gateway/test_goal_verdict_send.py` → reports pre-existing formatting drift in the touched large files; not applied to avoid a massive unrelated formatting diff.