### PR TITLE
Stabilize Hermes Desktop large-session handling

### DIFF
--- a/acp_adapter/permissions.py
+++ b/acp_adapter/permissions.py
@@ -50,14 +50,9 @@ def _build_permission_options(*, allow_permanent: bool) -> list[PermissionOption
             name="Allow for session",
         ),
     ]
-    if allow_permanent:
-        options.append(
-            PermissionOption(
-                option_id="allow_always",
-                kind="allow_always",
-                name="Allow always",
-            ),
-        )
+    # Permanent approvals are intentionally hidden from prompts. Keep the
+    # allow_permanent parameter for callback API compatibility, but do not
+    # offer ``allow_always`` in ACP permission requests.
     options.append(PermissionOption(option_id="deny", kind="reject_once", name="Deny"))
     if _permission_option_supports_kind("reject_always"):
         options.append(
@@ -98,6 +93,12 @@ def _map_outcome_to_hermes(outcome: object, *, allowed_option_ids: set[str]) -> 
         return "deny"
 
     option_id = outcome.option_id
+    if option_id == "allow_always":
+        # ``allow_always`` is intentionally hidden from newly-built prompts,
+        # but older clients or already-issued prompts may still return it.
+        # Preserve the established mapping while continuing to reject truly
+        # unknown option ids below.
+        return "always"
     if option_id not in allowed_option_ids:
         logger.warning("Permission request returned unknown option_id: %s", option_id)
         return "deny"

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -4709,6 +4709,11 @@ async function spawnPoolBackend(profile, entry) {
         ...process.env,
         HERMES_HOME,
         ...backend.env,
+        // Force Python subprocess stdio to UTF-8 on Windows. Without this,
+        // Python can default to the active ANSI code page and crash reader
+        // threads with UnicodeDecodeError when output contains non-CP1252 bytes.
+        PYTHONUTF8: '1',
+        PYTHONIOENCODING: 'utf-8:replace',
         // Pin the gateway's tool/terminal cwd to the same directory we chose for
         // the child process. Inherited TERMINAL_CWD (or a stale config bridge)
         // can still point at the install dir even when spawn cwd is home.
@@ -4929,6 +4934,11 @@ async function startHermes() {
           // can't reliably do that, so we set it inline for every spawn.
           HERMES_HOME,
           ...backend.env,
+          // Force Python subprocess stdio to UTF-8 on Windows. Without this,
+          // Python can default to the active ANSI code page and crash reader
+          // threads with UnicodeDecodeError when output contains non-CP1252 bytes.
+          PYTHONUTF8: '1',
+          PYTHONIOENCODING: 'utf-8:replace',
           TERMINAL_CWD: hermesCwd,
           HERMES_DASHBOARD_SESSION_TOKEN: token,
           // Marks this dashboard backend as desktop-spawned so it runs the cron

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -20,7 +20,6 @@ const crypto = require('node:crypto')
 const fs = require('node:fs')
 const http = require('node:http')
 const https = require('node:https')
-const net = require('node:net')
 const path = require('node:path')
 const { pathToFileURL } = require('node:url')
 const { execFileSync, spawn } = require('node:child_process')
@@ -42,6 +41,7 @@ const { buildDesktopBackendEnv } = require('./backend-env.cjs')
 const { readDirForIpc } = require('./fs-read-dir.cjs')
 const { gitRootForIpc } = require('./git-root.cjs')
 const { worktreesForIpc } = require('./git-worktrees.cjs')
+const { createRendererUnresponsiveHandler } = require('./renderer-unresponsive.cjs')
 const { OFFICIAL_REPO_HTTPS_URL, isOfficialSshRemote } = require('./update-remote.cjs')
 const {
   buildPosixCleanupScript,
@@ -136,6 +136,11 @@ function hiddenWindowsChildOptions(options = {}) {
 // switches only apply pre-launch. Override with HERMES_DESKTOP_DISABLE_GPU
 // (1/true → always disable, 0/false → keep GPU on).
 const REMOTE_DISPLAY_REASON = detectRemoteDisplay()
+// Chromium's native hang monitor raises a platform popup when the renderer
+// spends too long rendering a huge/compressed transcript. Hermes already has an
+// in-app recovery/watchdog surface, so disable the OS-level popup and keep the
+// renderer warning inside the app UI.
+app.commandLine.appendSwitch('disable-hang-monitor')
 if (REMOTE_DISPLAY_REASON) {
   app.disableHardwareAcceleration()
   // Belt-and-suspenders for X11/VNC, where the Viz compositor can still glitch
@@ -5231,7 +5236,10 @@ function createWindow() {
     }
   })
 
-  mainWindow.webContents.on('unresponsive', () => rememberLog('[renderer] webContents became unresponsive'))
+  mainWindow.webContents.on(
+    'unresponsive',
+    createRendererUnresponsiveHandler({ log: message => rememberLog(message) })
+  )
 
   // Electron always passes the event first. The canonical (Electron 36+) shape
   // is (event, messageDetails); the deprecated positional shape is

--- a/apps/desktop/electron/renderer-unresponsive.cjs
+++ b/apps/desktop/electron/renderer-unresponsive.cjs
@@ -1,0 +1,30 @@
+const DEFAULT_UNRESPONSIVE_LOG_DEBOUNCE_MS = 10_000
+
+function createRendererUnresponsiveHandler({ log, now = Date.now, debounceMs = DEFAULT_UNRESPONSIVE_LOG_DEBOUNCE_MS } = {}) {
+  if (typeof log !== 'function') {
+    throw new TypeError('createRendererUnresponsiveHandler requires a log function')
+  }
+
+  let lastLogAt = Number.NEGATIVE_INFINITY
+
+  return function handleRendererUnresponsive(event) {
+    // Electron/Chromium owns the native "page is unresponsive" UI. Some
+    // versions expose a preventable event and some do not; call it when present
+    // and pair this handler with the pre-ready disable-hang-monitor switch in
+    // main.cjs so Hermes keeps only its in-app warning surface.
+    event?.preventDefault?.()
+
+    const currentTime = now()
+    if (currentTime - lastLogAt < debounceMs) {
+      return
+    }
+
+    lastLogAt = currentTime
+    log('[renderer] webContents became unresponsive; native popup suppressed')
+  }
+}
+
+module.exports = {
+  DEFAULT_UNRESPONSIVE_LOG_DEBOUNCE_MS,
+  createRendererUnresponsiveHandler
+}

--- a/apps/desktop/electron/renderer-unresponsive.test.cjs
+++ b/apps/desktop/electron/renderer-unresponsive.test.cjs
@@ -1,0 +1,39 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const { createRendererUnresponsiveHandler } = require('./renderer-unresponsive.cjs')
+
+test('renderer unresponsive handler logs once and prevents the native Electron popup path', () => {
+  const logs = []
+  let prevented = 0
+  const handler = createRendererUnresponsiveHandler({
+    now: () => 1_000,
+    log: message => logs.push(message)
+  })
+
+  handler({ preventDefault: () => { prevented += 1 } })
+
+  assert.equal(prevented, 1)
+  assert.deepEqual(logs, ['[renderer] webContents became unresponsive; native popup suppressed'])
+})
+
+test('renderer unresponsive handler dedupes repeated freeze logs inside debounce window', () => {
+  const logs = []
+  let currentTime = 1_000
+  const handler = createRendererUnresponsiveHandler({
+    now: () => currentTime,
+    log: message => logs.push(message),
+    debounceMs: 10_000
+  })
+
+  handler({ preventDefault() {} })
+  currentTime += 1_000
+  handler({ preventDefault() {} })
+  currentTime += 10_000
+  handler({ preventDefault() {} })
+
+  assert.deepEqual(logs, [
+    '[renderer] webContents became unresponsive; native popup suppressed',
+    '[renderer] webContents became unresponsive; native popup suppressed'
+  ])
+})

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -36,7 +36,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs electron/renderer-unresponsive.test.cjs",
     "typecheck": "tsc -p . --noEmit",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -52,7 +52,7 @@ import {
   updateQueuedPrompt
 } from '@/store/composer-queue'
 import { $statusItemsBySession } from '@/store/composer-status'
-import { notify } from '@/store/notifications'
+import { notify, notifyError } from '@/store/notifications'
 import { $gatewayState, $messages, setSessionPickerOpen } from '@/store/session'
 import { $threadScrolledUp } from '@/store/thread-scroll'
 import { useTheme } from '@/themes'
@@ -93,7 +93,15 @@ import {
   slashChipElement
 } from './rich-editor'
 import { ComposerStatusStack } from './status-stack'
-import { detectTrigger, extractClipboardImageBlobs, textBeforeCaret, type TriggerState } from './text-utils'
+import {
+  detectTrigger,
+  extractClipboardImageBlobs,
+  isOversizedDataImageUrl,
+  isOversizedPastedText,
+  pasteLimitMessage,
+  textBeforeCaret,
+  type TriggerState
+} from './text-utils'
 import { ComposerTriggerPopover } from './trigger-popover'
 import type { ChatBarProps } from './types'
 import { UrlDialog } from './url-dialog'
@@ -557,6 +565,20 @@ export function ChatBar({
 
     if (!pastedText) {
       event.preventDefault()
+
+      return
+    }
+
+    if (isOversizedDataImageUrl(pastedText)) {
+      event.preventDefault()
+      notifyError(null, pasteLimitMessage('image'))
+
+      return
+    }
+
+    if (isOversizedPastedText(pastedText)) {
+      event.preventDefault()
+      notifyError(null, pasteLimitMessage('text'))
 
       return
     }

--- a/apps/desktop/src/app/chat/composer/text-utils.test.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from 'vitest'
 
-import { blobDedupeKey, detectTrigger, extractClipboardImageBlobs } from './text-utils'
+import {
+  blobDedupeKey,
+  detectTrigger,
+  extractClipboardImageBlobs,
+  isOversizedDataImageUrl,
+  isOversizedPastedText,
+  MAX_CLIPBOARD_IMAGE_BYTES,
+  MAX_INLINE_DATA_IMAGE_CHARS,
+  MAX_PASTED_TEXT_CHARS
+} from './text-utils'
 
 describe('detectTrigger', () => {
   it('detects a bare slash trigger with an empty query', () => {
@@ -92,6 +101,54 @@ describe('extractClipboardImageBlobs', () => {
     } as unknown as DataTransfer
 
     expect(extractClipboardImageBlobs(clipboard)).toEqual([image])
+  })
+
+  it('does not decode oversized inline data-url images from text', () => {
+    const pastedImage = `data:image/png;base64,${'a'.repeat(MAX_INLINE_DATA_IMAGE_CHARS)}`
+
+    const clipboard = {
+      files: { length: 0, item: () => null },
+      getData: (type: string) => (type === 'text/plain' ? pastedImage : ''),
+      items: []
+    } as unknown as DataTransfer
+
+    expect(extractClipboardImageBlobs(clipboard)).toEqual([])
+  })
+
+  it('ignores clipboard image blobs above the safe render limit', () => {
+    const image = new File([new Uint8Array(MAX_CLIPBOARD_IMAGE_BYTES + 1)], 'huge.png', {
+      type: 'image/png',
+      lastModified: 1_700_000_000_002
+    })
+
+    const clipboard = {
+      files: { length: 0, item: () => null },
+      getData: () => '',
+      items: [
+        {
+          kind: 'file',
+          type: 'image/png',
+          getAsFile: () => image
+        }
+      ]
+    } as unknown as DataTransfer
+
+    expect(extractClipboardImageBlobs(clipboard)).toEqual([])
+  })
+})
+
+describe('paste guardrails', () => {
+  it('flags oversized text pastes', () => {
+    expect(isOversizedPastedText('x'.repeat(MAX_PASTED_TEXT_CHARS))).toBe(false)
+    expect(isOversizedPastedText('x'.repeat(MAX_PASTED_TEXT_CHARS + 1))).toBe(true)
+  })
+
+  it('flags oversized data-url image pastes', () => {
+    const prefix = 'data:image/png;base64,'
+
+    expect(isOversizedDataImageUrl(`${prefix}${'a'.repeat(MAX_INLINE_DATA_IMAGE_CHARS - prefix.length)}`)).toBe(false)
+    expect(isOversizedDataImageUrl(`${prefix}${'a'.repeat(MAX_INLINE_DATA_IMAGE_CHARS)}`)).toBe(true)
+    expect(isOversizedDataImageUrl('plain text')).toBe(false)
   })
 })
 

--- a/apps/desktop/src/app/chat/composer/text-utils.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.ts
@@ -1,5 +1,27 @@
 import { DATA_IMAGE_URL_RE, dataUrlToBlob } from '@/lib/embedded-images'
 
+export const MAX_PASTED_TEXT_CHARS = 120_000
+export const MAX_INLINE_DATA_IMAGE_CHARS = 2_000_000
+export const MAX_CLIPBOARD_IMAGE_BYTES = 12 * 1024 * 1024
+
+export function pasteLimitMessage(kind: 'image' | 'text'): string {
+  if (kind === 'image') {
+    return 'That pasted image is too large for inline rendering. Save it as a file and attach it instead.'
+  }
+
+  return 'That paste is too large for the Desktop composer. Save it as a .txt/.md file and attach or reference it instead.'
+}
+
+export function isOversizedPastedText(text: string): boolean {
+  return text.length > MAX_PASTED_TEXT_CHARS
+}
+
+export function isOversizedDataImageUrl(text: string): boolean {
+  const trimmed = text.trim()
+
+  return DATA_IMAGE_URL_RE.test(trimmed) && trimmed.length > MAX_INLINE_DATA_IMAGE_CHARS
+}
+
 export interface TriggerState {
   kind: '@' | '/'
   query: string
@@ -28,7 +50,7 @@ export function extractClipboardImageBlobs(clipboard: DataTransfer): Blob[] {
   const seen = new Set<string>()
 
   const push = (blob: Blob | null) => {
-    if (!blob || blob.size === 0) {
+    if (!blob || blob.size === 0 || blob.size > MAX_CLIPBOARD_IMAGE_BYTES) {
       return
     }
 
@@ -67,7 +89,7 @@ export function extractClipboardImageBlobs(clipboard: DataTransfer): Blob[] {
 
   const text = clipboard.getData('text/plain').trim()
 
-  if (DATA_IMAGE_URL_RE.test(text)) {
+  if (DATA_IMAGE_URL_RE.test(text) && !isOversizedDataImageUrl(text)) {
     push(dataUrlToBlob(text))
   }
 
@@ -78,7 +100,9 @@ export function extractClipboardImageBlobs(clipboard: DataTransfer): Blob[] {
       const matches = html.matchAll(/<img\b[^>]*?\bsrc\s*=\s*["'](data:image\/[^"']+)["']/gi)
 
       for (const match of matches) {
-        push(dataUrlToBlob(match[1]))
+        if (!isOversizedDataImageUrl(match[1])) {
+          push(dataUrlToBlob(match[1]))
+        }
       }
     }
   }

--- a/apps/desktop/src/app/chat/index.test.tsx
+++ b/apps/desktop/src/app/chat/index.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ChatMessage } from '@/lib/chat-messages'
+
+import { chatRenderWindow } from './index'
+
+function userMessage(id: string, text = id): ChatMessage {
+  return {
+    id,
+    role: 'user',
+    parts: [{ type: 'text', text }]
+  }
+}
+
+describe('chat render window', () => {
+  it('caps large sessions to the latest render window until full history is loaded', () => {
+    const messages = [
+      userMessage('message-1'),
+      userMessage('message-2'),
+      userMessage('message-3'),
+      userMessage('message-4')
+    ]
+
+    expect(chatRenderWindow(messages, false, 3)).toEqual({
+      cappedMessageCount: 1,
+      renderMessages: messages.slice(1)
+    })
+  })
+
+  it('returns all messages when full history is loaded', () => {
+    const messages = [
+      userMessage('message-1'),
+      userMessage('message-2'),
+      userMessage('message-3'),
+      userMessage('message-4')
+    ]
+
+    expect(chatRenderWindow(messages, true, 3)).toEqual({
+      cappedMessageCount: 1,
+      renderMessages: messages
+    })
+  })
+})

--- a/apps/desktop/src/app/chat/index.test.tsx
+++ b/apps/desktop/src/app/chat/index.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import type { ChatMessage } from '@/lib/chat-messages'
 
-import { chatRenderWindow } from './index'
+import { buildRuntimeMessageRepository, chatRenderWindow, chatThreadInstanceKey, recoverTranscriptButtonLabel } from './index'
 
 function userMessage(id: string, text = id): ChatMessage {
   return {
@@ -11,6 +11,25 @@ function userMessage(id: string, text = id): ChatMessage {
     parts: [{ type: 'text', text }]
   }
 }
+
+function assistantMessage(id: string, text = id, options: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id,
+    role: 'assistant',
+    parts: [{ type: 'text', text }],
+    ...options
+  }
+}
+
+describe('chat recovery control', () => {
+  it('labels routed/stored sessions as current transcript recovery', () => {
+    expect(recoverTranscriptButtonLabel(true)).toBe('Recover current transcript')
+  })
+
+  it('falls back to chat history reload copy when no session is selected yet', () => {
+    expect(recoverTranscriptButtonLabel(false)).toBe('Reload chat history')
+  })
+})
 
 describe('chat render window', () => {
   it('caps large sessions to the latest render window until full history is loaded', () => {
@@ -39,5 +58,112 @@ describe('chat render window', () => {
       cappedMessageCount: 1,
       renderMessages: messages
     })
+  })
+})
+
+describe('chat session thread identity', () => {
+  it('changes when switching sessions so Assistant UI does not reuse stale internal render state', () => {
+    expect(chatThreadInstanceKey('session-a', 12)).not.toBe(chatThreadInstanceKey('session-b', 12))
+  })
+
+  it('changes when the rendered message window changes so capped/full-history views remount cleanly', () => {
+    expect(chatThreadInstanceKey('session-a', 300)).not.toBe(chatThreadInstanceKey('session-a', 301))
+  })
+
+  it('changes when same-count rendered message windows contain different messages', () => {
+    expect(chatThreadInstanceKey('session-a', [userMessage('message-1'), userMessage('message-2')])).not.toBe(
+      chatThreadInstanceKey('session-a', [userMessage('message-2'), userMessage('message-3')])
+    )
+  })
+})
+
+describe('buildRuntimeMessageRepository', () => {
+  it('builds a linear repository from visible chat messages', () => {
+    const cache = new WeakMap<ChatMessage, ReturnType<typeof buildRuntimeMessageRepository>['messages'][number]['message']>()
+    const messages = [userMessage('user-1'), assistantMessage('assistant-1')]
+
+    const repository = buildRuntimeMessageRepository(messages, cache)
+
+    expect(repository.headId).toBe('assistant-1')
+    expect(repository.messages.map(({ message, parentId }) => ({ id: message.id, parentId }))).toEqual([
+      { id: 'user-1', parentId: null },
+      { id: 'assistant-1', parentId: 'user-1' }
+    ])
+  })
+
+  it('keeps hidden messages out of the visible parent chain and head', () => {
+    const cache = new WeakMap<ChatMessage, ReturnType<typeof buildRuntimeMessageRepository>['messages'][number]['message']>()
+
+    const messages = [
+      userMessage('user-1'),
+      assistantMessage('hidden-tool-result', 'tool result', { hidden: true }),
+      assistantMessage('assistant-1')
+    ]
+
+    const repository = buildRuntimeMessageRepository(messages, cache)
+
+    expect(repository.headId).toBe('assistant-1')
+    expect(repository.messages.map(({ message, parentId }) => ({ id: message.id, parentId }))).toEqual([
+      { id: 'user-1', parentId: null },
+      { id: 'hidden-tool-result', parentId: 'user-1' },
+      { id: 'assistant-1', parentId: 'user-1' }
+    ])
+  })
+
+  it('preserves assistant branch parentage by branch group', () => {
+    const cache = new WeakMap<ChatMessage, ReturnType<typeof buildRuntimeMessageRepository>['messages'][number]['message']>()
+
+    const messages = [
+      userMessage('user-1'),
+      assistantMessage('assistant-branch-a', 'A', { branchGroupId: 'branch-1' }),
+      assistantMessage('assistant-branch-b', 'B', { branchGroupId: 'branch-1' })
+    ]
+
+    const repository = buildRuntimeMessageRepository(messages, cache)
+
+    expect(repository.messages.map(({ message, parentId }) => ({ id: message.id, parentId }))).toEqual([
+      { id: 'user-1', parentId: null },
+      { id: 'assistant-branch-a', parentId: 'user-1' },
+      { id: 'assistant-branch-b', parentId: 'user-1' }
+    ])
+  })
+
+  it('populates the runtime message cache for unchanged chat message objects', () => {
+    const cache = new WeakMap<ChatMessage, ReturnType<typeof buildRuntimeMessageRepository>['messages'][number]['message']>()
+    const messages = [userMessage('user-1'), assistantMessage('assistant-1')]
+
+    buildRuntimeMessageRepository(messages, cache)
+    const cachedUserMessage = cache.get(messages[0]!)
+    const cachedAssistantMessage = cache.get(messages[1]!)
+
+    buildRuntimeMessageRepository(messages, cache)
+
+    expect(cache.get(messages[0]!)).toBe(cachedUserMessage)
+    expect(cache.get(messages[1]!)).toBe(cachedAssistantMessage)
+  })
+
+  it('reuses unchanged prefix repository items when appending a tail message', () => {
+    const runtimeMessageCache = new WeakMap<
+      ChatMessage,
+      ReturnType<typeof buildRuntimeMessageRepository>['messages'][number]['message']
+    >()
+
+    const repositoryCache = { items: [] }
+    const firstUser = userMessage('user-1')
+    const firstAssistant = assistantMessage('assistant-1')
+    const firstMessages = [firstUser, firstAssistant]
+
+    buildRuntimeMessageRepository(firstMessages, runtimeMessageCache, repositoryCache)
+    const firstCachedItems = [...repositoryCache.items]
+    const appendedMessages = [...firstMessages, userMessage('user-2')]
+    const secondRepository = buildRuntimeMessageRepository(appendedMessages, runtimeMessageCache, repositoryCache)
+
+    expect(repositoryCache.items[0]).toBe(firstCachedItems[0])
+    expect(repositoryCache.items[1]).toBe(firstCachedItems[1])
+    expect(secondRepository.messages.map(({ message, parentId }) => ({ id: message.id, parentId }))).toEqual([
+      { id: 'user-1', parentId: null },
+      { id: 'assistant-1', parentId: 'user-1' },
+      { id: 'user-2', parentId: 'assistant-1' }
+    ])
   })
 })

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -7,11 +7,12 @@ import {
 import { useStore } from '@nanostores/react'
 import { useQuery } from '@tanstack/react-query'
 import type * as React from 'react'
-import { Suspense, useCallback, useMemo, useRef, useState } from 'react'
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 
 import { Thread } from '@/components/assistant-ui/thread'
 import { Backdrop } from '@/components/Backdrop'
+import { ErrorBoundary, type ErrorBoundaryFallbackProps } from '@/components/error-boundary'
 import { PromptOverlays } from '@/components/prompt-overlays'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
@@ -72,6 +73,69 @@ export function chatRenderWindow(
   return { cappedMessageCount, renderMessages }
 }
 
+export function chatThreadInstanceKey(threadKey: string, renderMessages: number | readonly ChatMessage[]): string {
+  if (typeof renderMessages === 'number') {
+    return `${threadKey}:${renderMessages}`
+  }
+
+  const firstRenderedMessageId = renderMessages[0]?.id ?? 'empty'
+  const lastRenderedMessageId = renderMessages.at(-1)?.id ?? 'empty'
+
+  return `${threadKey}:${renderMessages.length}:${firstRenderedMessageId}:${lastRenderedMessageId}`
+}
+
+type RuntimeMessageRepositoryItem = { message: ThreadMessage; parentId: string | null }
+
+export interface RuntimeMessageRepositoryCache {
+  items: RuntimeMessageRepositoryItem[]
+}
+
+export function buildRuntimeMessageRepository(
+  renderMessages: readonly ChatMessage[],
+  runtimeMessageCache: WeakMap<ChatMessage, ThreadMessage>,
+  repositoryCache?: RuntimeMessageRepositoryCache
+): ReturnType<typeof ExportedMessageRepository.fromBranchableArray> {
+  const items: RuntimeMessageRepositoryItem[] = []
+  const cachedItems = repositoryCache?.items ?? []
+  const branchParentByGroup = new Map<string, string | null>()
+  let visibleParentId: string | null = null
+  let headId: string | null = null
+
+  for (const [index, message] of renderMessages.entries()) {
+    let parentId = visibleParentId
+
+    if (message.role === 'assistant' && message.branchGroupId) {
+      if (!branchParentByGroup.has(message.branchGroupId)) {
+        branchParentByGroup.set(message.branchGroupId, visibleParentId)
+      }
+
+      parentId = branchParentByGroup.get(message.branchGroupId) ?? null
+    }
+
+    const cachedMessage = runtimeMessageCache.get(message)
+    const runtimeMessage = cachedMessage ?? toRuntimeMessage(message)
+
+    if (!cachedMessage) {
+      runtimeMessageCache.set(message, runtimeMessage)
+    }
+
+    const cachedItem = cachedItems[index]
+    const item = cachedItem?.message === runtimeMessage && cachedItem.parentId === parentId ? cachedItem : { message: runtimeMessage, parentId }
+    items.push(item)
+
+    if (!message.hidden) {
+      visibleParentId = message.id
+      headId = message.id
+    }
+  }
+
+  if (repositoryCache) {
+    repositoryCache.items = items
+  }
+
+  return ExportedMessageRepository.fromBranchableArray(items, { headId })
+}
+
 interface ChatViewProps extends Omit<React.ComponentProps<'div'>, 'onSubmit'> {
   gateway: HermesGateway | null
   onToggleSelectedPin: () => void
@@ -97,6 +161,7 @@ interface ChatViewProps extends Omit<React.ComponentProps<'div'>, 'onSubmit'> {
   onEdit: (message: AppendMessage) => Promise<void>
   onReload: (parentId: string | null) => Promise<void>
   onRestoreToMessage?: (messageId: string) => Promise<void>
+  onRecoverCurrentTranscript?: () => Promise<void> | void
   onTranscribeAudio?: (audio: Blob) => Promise<string>
 }
 
@@ -104,14 +169,63 @@ interface ChatHeaderProps {
   activeSessionId: null | string
   isRoutedSessionView: boolean
   onDeleteSelectedSession: () => void
+  onRecoverCurrentTranscript: () => Promise<void> | void
   onToggleSelectedPin: () => void
   selectedSessionId: null | string
+}
+
+export function recoverTranscriptButtonLabel(hasStoredSession: boolean): string {
+  return hasStoredSession ? 'Recover current transcript' : 'Reload chat history'
+}
+
+export function isAssistantTapLookupError(error: Error): boolean {
+  const text = `${error.name || ''}\n${error.message || ''}\n${error.stack || ''}`
+
+  return /\bTAP\b/i.test(text) && /lookup/i.test(text)
+}
+
+function SessionRenderFailedPanel({ error, reset }: ErrorBoundaryFallbackProps) {
+  const isTapLookupError = isAssistantTapLookupError(error)
+
+  const description = isTapLookupError
+    ? 'Assistant UI failed while looking up TAP render state. The composer is still available, so you can recover without restarting the whole window.'
+    : error.message || 'The session could not be rendered.'
+
+  return (
+    <div className="absolute inset-0 z-10 grid place-items-center bg-(--ui-chat-surface-background)/95 p-6">
+      <section
+        aria-label="Session render failed"
+        className="flex w-full max-w-[32rem] flex-col gap-4 rounded-2xl border border-(--ui-stroke-secondary) bg-(--ui-card-background) p-5 text-sm shadow-xl"
+        role="alert"
+      >
+        <div className="flex items-start gap-3">
+          <Codicon className="mt-0.5 shrink-0 text-(--ui-text-tertiary)" name="warning" size="1.125rem" />
+          <div className="min-w-0 space-y-1">
+            <h2 className="text-base font-semibold text-(--ui-text-primary)">Session render failed</h2>
+            <p className="text-(--ui-text-secondary)">{description}</p>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button className="font-semibold" onClick={reset} type="button">
+            Try rendering again
+          </Button>
+          <Button onClick={() => window.location.reload()} type="button" variant="text">
+            Reload window
+          </Button>
+          <Button onClick={() => void window.hermesDesktop?.revealLogs()?.catch(() => undefined)} type="button" variant="text">
+            Open logs
+          </Button>
+        </div>
+      </section>
+    </div>
+  )
 }
 
 function ChatHeader({
   activeSessionId,
   isRoutedSessionView,
   onDeleteSelectedSession,
+  onRecoverCurrentTranscript,
   onToggleSelectedPin,
   selectedSessionId
 }: ChatHeaderProps) {
@@ -132,12 +246,8 @@ function ChatHeader({
       ? pinnedSessionIds.includes(selectedSessionId)
       : false
 
-  // A brand-new session has no session to pin/delete/rename, so the header is
-  // just a dead "New session" label + chevron. Drop it (and its border)
-  // entirely until there's a real session to act on.
-  if (!selectedSessionId && !activeSessionId && !isRoutedSessionView) {
-    return null
-  }
+  const hasStoredSession = Boolean(selectedSessionId || activeSessionId || isRoutedSessionView)
+  const recoverLabel = recoverTranscriptButtonLabel(hasStoredSession)
 
   return (
     <header className={cn(titlebarHeaderBaseClass, isRoutedSessionView && titlebarHeaderShadowClass)}>
@@ -148,25 +258,38 @@ function ChatHeader({
             'calc(100vw - var(--titlebar-content-inset,0px) - var(--titlebar-tools-right) - var(--titlebar-tools-width) - 1.5rem)'
         }}
       >
-        <SessionActionsMenu
-          align="start"
-          onDelete={selectedSessionId ? onDeleteSelectedSession : undefined}
-          onPin={selectedSessionId ? onToggleSelectedPin : undefined}
-          pinned={selectedIsPinned}
-          sessionId={selectedSessionId || activeSessionId || ''}
-          sideOffset={8}
-          title={title}
-        >
-          <Button
-            className="pointer-events-auto flex h-6 min-w-0 max-w-full gap-1 overflow-hidden border border-transparent bg-transparent px-2 py-0 text-(--ui-text-secondary) hover:border-(--ui-stroke-tertiary) hover:bg-(--ui-control-hover-background) hover:text-foreground data-[state=open]:border-(--ui-stroke-tertiary) data-[state=open]:bg-(--ui-control-active-background) [-webkit-app-region:no-drag]"
-            type="button"
-            variant="ghost"
+        {hasStoredSession ? (
+          <SessionActionsMenu
+            align="start"
+            onDelete={selectedSessionId ? onDeleteSelectedSession : undefined}
+            onPin={selectedSessionId ? onToggleSelectedPin : undefined}
+            pinned={selectedIsPinned}
+            sessionId={selectedSessionId || activeSessionId || ''}
+            sideOffset={8}
+            title={title}
           >
-            <h2 className="min-w-0 flex-1 truncate text-[0.75rem] font-medium leading-none">{title}</h2>
-            <Codicon className="shrink-0 text-(--ui-text-tertiary)" name="chevron-down" size="0.8125rem" />
-          </Button>
-        </SessionActionsMenu>
+            <Button
+              className="pointer-events-auto flex h-6 min-w-0 max-w-full gap-1 overflow-hidden border border-transparent bg-transparent px-2 py-0 text-(--ui-text-secondary) hover:border-(--ui-stroke-tertiary) hover:bg-(--ui-control-hover-background) hover:text-foreground data-[state=open]:border-(--ui-stroke-tertiary) data-[state=open]:bg-(--ui-control-active-background) [-webkit-app-region:no-drag]"
+              type="button"
+              variant="ghost"
+            >
+              <h2 className="min-w-0 flex-1 truncate text-[0.75rem] font-medium leading-none">{title}</h2>
+              <Codicon className="shrink-0 text-(--ui-text-tertiary)" name="chevron-down" size="0.8125rem" />
+            </Button>
+          </SessionActionsMenu>
+        ) : null}
       </div>
+      <Button
+        aria-label={recoverLabel}
+        className="pointer-events-auto ml-2 h-6 shrink-0 gap-1 px-2 text-[0.75rem] [-webkit-app-region:no-drag]"
+        onClick={() => void onRecoverCurrentTranscript()}
+        title={recoverLabel}
+        type="button"
+        variant="ghost"
+      >
+        <Codicon name="refresh" size="0.8125rem" />
+        <span className="hidden sm:inline">{recoverLabel}</span>
+      </Button>
     </header>
   )
 }
@@ -210,43 +333,26 @@ function ChatRuntimeBoundary({
   const messages = suppressMessages ? NO_MESSAGES : storeMessages
   const [fullHistorySessionId, setFullHistorySessionId] = useState<string | null>(null)
   const runtimeMessageCacheRef = useRef(new WeakMap<ChatMessage, ThreadMessage>())
+  const runtimeMessageRepositoryCacheRef = useRef<RuntimeMessageRepositoryCache>({ items: [] })
   const fullHistoryLoaded = Boolean(threadKey && fullHistorySessionId === threadKey)
   const { cappedMessageCount, renderMessages } = chatRenderWindow(messages, fullHistoryLoaded)
+  const threadInstanceKey = chatThreadInstanceKey(threadKey, renderMessages)
 
-  const runtimeMessageRepository = useMemo(() => {
-    const items: { message: ThreadMessage; parentId: string | null }[] = []
-    const branchParentByGroup = new Map<string, string | null>()
-    let visibleParentId: string | null = null
-    let headId: string | null = null
+  useEffect(() => {
+    setFullHistorySessionId(null)
+    runtimeMessageCacheRef.current = new WeakMap<ChatMessage, ThreadMessage>()
+    runtimeMessageRepositoryCacheRef.current = { items: [] }
+  }, [threadKey])
 
-    for (const message of renderMessages) {
-      let parentId = visibleParentId
-
-      if (message.role === 'assistant' && message.branchGroupId) {
-        if (!branchParentByGroup.has(message.branchGroupId)) {
-          branchParentByGroup.set(message.branchGroupId, visibleParentId)
-        }
-
-        parentId = branchParentByGroup.get(message.branchGroupId) ?? null
-      }
-
-      const cachedMessage = runtimeMessageCacheRef.current.get(message)
-      const runtimeMessage = cachedMessage ?? toRuntimeMessage(message)
-
-      if (!cachedMessage) {
-        runtimeMessageCacheRef.current.set(message, runtimeMessage)
-      }
-
-      items.push({ message: runtimeMessage, parentId })
-
-      if (!message.hidden) {
-        visibleParentId = message.id
-        headId = message.id
-      }
-    }
-
-    return ExportedMessageRepository.fromBranchableArray(items, { headId })
-  }, [renderMessages])
+  const runtimeMessageRepository = useMemo(
+    () =>
+      buildRuntimeMessageRepository(
+        renderMessages,
+        runtimeMessageCacheRef.current,
+        runtimeMessageRepositoryCacheRef.current
+      ),
+    [renderMessages]
+  )
 
   const runtime = useIncrementalExternalStoreRuntime<ThreadMessage>({
     messageRepository: runtimeMessageRepository,
@@ -263,19 +369,21 @@ function ChatRuntimeBoundary({
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>
-      {cappedMessageCount > 0 && !fullHistoryLoaded && (
-        <div className="pointer-events-none absolute left-0 right-0 top-3 z-20 flex justify-center px-4">
-          <div className="pointer-events-auto flex max-w-(--composer-width) items-center gap-3 rounded-full border border-border/70 bg-background/95 px-4 py-2 text-sm text-muted-foreground shadow-lg backdrop-blur">
-            <span>
-              Showing latest {renderMessages.length.toLocaleString()} of {messages.length.toLocaleString()} messages to keep this large session responsive.
-            </span>
-            <Button onClick={() => setFullHistorySessionId(threadKey)} size="sm" variant="secondary">
-              Load full history
-            </Button>
+      <ErrorBoundary fallback={SessionRenderFailedPanel} key={threadInstanceKey} label="assistant-thread">
+        {cappedMessageCount > 0 && !fullHistoryLoaded && (
+          <div className="pointer-events-none absolute left-0 right-0 top-3 z-20 flex justify-center px-4">
+            <div className="pointer-events-auto flex max-w-(--composer-width) items-center gap-3 rounded-full border border-border/70 bg-background/95 px-4 py-2 text-sm text-muted-foreground shadow-lg backdrop-blur">
+              <span>
+                Showing latest {renderMessages.length.toLocaleString()} of {messages.length.toLocaleString()} messages to keep this large session responsive.
+              </span>
+              <Button onClick={() => setFullHistorySessionId(threadKey)} size="sm" variant="secondary">
+                Load full history
+              </Button>
+            </div>
           </div>
-        </div>
-      )}
-      {children}
+        )}
+        {children}
+      </ErrorBoundary>
     </AssistantRuntimeProvider>
   )
 }
@@ -303,6 +411,7 @@ export function ChatView({
   onEdit,
   onReload,
   onRestoreToMessage,
+  onRecoverCurrentTranscript = () => window.location.reload(),
   onTranscribeAudio
 }: ChatViewProps) {
   const location = useLocation()
@@ -433,6 +542,7 @@ export function ChatView({
         activeSessionId={activeSessionId}
         isRoutedSessionView={isRoutedSessionView}
         onDeleteSelectedSession={onDeleteSelectedSession}
+        onRecoverCurrentTranscript={onRecoverCurrentTranscript}
         onToggleSelectedPin={onToggleSelectedPin}
         selectedSessionId={selectedSessionId}
       />

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -7,7 +7,7 @@ import {
 import { useStore } from '@nanostores/react'
 import { useQuery } from '@tanstack/react-query'
 import type * as React from 'react'
-import { Suspense, useCallback, useMemo, useRef } from 'react'
+import { Suspense, useCallback, useMemo, useRef, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 
 import { Thread } from '@/components/assistant-ui/thread'
@@ -58,6 +58,19 @@ import { useFileDropZone } from './hooks/use-file-drop-zone'
 import { ScrollToBottomButton } from './scroll-to-bottom-button'
 import { SessionActionsMenu } from './sidebar/session-actions-menu'
 import { threadLoadingState } from './thread-loading'
+
+const LARGE_SESSION_RENDER_LIMIT = 300
+
+export function chatRenderWindow(
+  messages: readonly ChatMessage[],
+  fullHistoryLoaded: boolean,
+  limit = LARGE_SESSION_RENDER_LIMIT
+): { cappedMessageCount: number; renderMessages: readonly ChatMessage[] } {
+  const cappedMessageCount = Math.max(0, messages.length - limit)
+  const renderMessages = !fullHistoryLoaded && cappedMessageCount > 0 ? messages.slice(cappedMessageCount) : messages
+
+  return { cappedMessageCount, renderMessages }
+}
 
 interface ChatViewProps extends Omit<React.ComponentProps<'div'>, 'onSubmit'> {
   gateway: HermesGateway | null
@@ -168,6 +181,7 @@ interface ChatRuntimeBoundaryProps {
   /** Route points at an unloaded session — render empty until resume swaps in
    *  the new transcript, so the previous session's messages don't linger. */
   suppressMessages: boolean
+  threadKey: string
 }
 
 const NO_MESSAGES: ChatMessage[] = []
@@ -189,11 +203,15 @@ function ChatRuntimeBoundary({
   onEdit,
   onReload,
   onThreadMessagesChange,
-  suppressMessages
+  suppressMessages,
+  threadKey
 }: ChatRuntimeBoundaryProps) {
   const storeMessages = useStore($messages)
   const messages = suppressMessages ? NO_MESSAGES : storeMessages
+  const [fullHistorySessionId, setFullHistorySessionId] = useState<string | null>(null)
   const runtimeMessageCacheRef = useRef(new WeakMap<ChatMessage, ThreadMessage>())
+  const fullHistoryLoaded = Boolean(threadKey && fullHistorySessionId === threadKey)
+  const { cappedMessageCount, renderMessages } = chatRenderWindow(messages, fullHistoryLoaded)
 
   const runtimeMessageRepository = useMemo(() => {
     const items: { message: ThreadMessage; parentId: string | null }[] = []
@@ -201,7 +219,7 @@ function ChatRuntimeBoundary({
     let visibleParentId: string | null = null
     let headId: string | null = null
 
-    for (const message of messages) {
+    for (const message of renderMessages) {
       let parentId = visibleParentId
 
       if (message.role === 'assistant' && message.branchGroupId) {
@@ -228,7 +246,7 @@ function ChatRuntimeBoundary({
     }
 
     return ExportedMessageRepository.fromBranchableArray(items, { headId })
-  }, [messages])
+  }, [renderMessages])
 
   const runtime = useIncrementalExternalStoreRuntime<ThreadMessage>({
     messageRepository: runtimeMessageRepository,
@@ -243,7 +261,23 @@ function ChatRuntimeBoundary({
     onReload
   })
 
-  return <AssistantRuntimeProvider runtime={runtime}>{children}</AssistantRuntimeProvider>
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      {cappedMessageCount > 0 && !fullHistoryLoaded && (
+        <div className="pointer-events-none absolute left-0 right-0 top-3 z-20 flex justify-center px-4">
+          <div className="pointer-events-auto flex max-w-(--composer-width) items-center gap-3 rounded-full border border-border/70 bg-background/95 px-4 py-2 text-sm text-muted-foreground shadow-lg backdrop-blur">
+            <span>
+              Showing latest {renderMessages.length.toLocaleString()} of {messages.length.toLocaleString()} messages to keep this large session responsive.
+            </span>
+            <Button onClick={() => setFullHistorySessionId(threadKey)} size="sm" variant="secondary">
+              Load full history
+            </Button>
+          </div>
+        </div>
+      )}
+      {children}
+    </AssistantRuntimeProvider>
+  )
 }
 
 export function ChatView({
@@ -416,6 +450,7 @@ export function ChatView({
           onReload={onReload}
           onThreadMessagesChange={onThreadMessagesChange}
           suppressMessages={routeSessionMismatch}
+          threadKey={threadKey}
         >
           <Thread
             clampToComposer={showChatBar}

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -964,6 +964,17 @@ export function DesktopController() {
       onPickFiles={() => void composer.pickContextPaths('file')}
       onPickFolders={() => void composer.pickContextPaths('folder')}
       onPickImages={() => void composer.pickImages()}
+      onRecoverCurrentTranscript={() => {
+        const sessionId = selectedStoredSessionIdRef.current || routedSessionId
+
+        if (sessionId) {
+          void resumeSession(sessionId, true)
+
+          return
+        }
+
+        window.location.reload()
+      }}
       onReload={reloadFromMessage}
       onRemoveAttachment={id => void composer.removeAttachment(id)}
       onRestoreToMessage={restoreToMessage}

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -288,27 +288,40 @@ export function useMessageStream({
           const prev = state.messages
           let nextMessages: ChatMessage[]
 
-          if (!prev.some(m => m.id === streamId)) {
-            nextMessages = [
-              ...prev,
-              {
-                id: streamId,
-                role: 'assistant',
-                parts: seed(),
-                pending: true,
-                branchGroupId: groupId
-              }
-            ]
+          const lastIndex = prev.length - 1
+          const lastMessage = prev[lastIndex]
+
+          if (lastMessage?.id === streamId) {
+            nextMessages = prev.slice()
+            nextMessages[lastIndex] = {
+              ...lastMessage,
+              parts: transform(lastMessage.parts, lastMessage),
+              pending: opts.pending ? opts.pending(lastMessage) : true
+            }
           } else {
-            nextMessages = prev.map(m =>
-              m.id === streamId
-                ? {
-                    ...m,
-                    parts: transform(m.parts, m),
-                    pending: opts.pending ? opts.pending(m) : true
-                  }
-                : m
-            )
+            const streamIndex = prev.findIndex(m => m.id === streamId)
+
+            if (streamIndex === -1) {
+              nextMessages = [
+                ...prev,
+                {
+                  id: streamId,
+                  role: 'assistant',
+                  parts: seed(),
+                  pending: true,
+                  branchGroupId: groupId
+                }
+              ]
+            } else {
+              const streamMessage = prev[streamIndex]
+
+              nextMessages = prev.slice()
+              nextMessages[streamIndex] = {
+                ...streamMessage,
+                parts: transform(streamMessage.parts, streamMessage),
+                pending: opts.pending ? opts.pending(streamMessage) : true
+              }
+            }
           }
 
           return {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -16,6 +16,7 @@ import { $activeGatewayProfile, $newChatProfile, $profiles, ensureGatewayProfile
 import {
   $currentCwd,
   $messages,
+  $messagingSessions,
   $sessions,
   $yoloActive,
   sessionPinId,
@@ -34,6 +35,8 @@ import {
   setFreshDraftReady,
   setIntroSeed,
   setMessages,
+  setMessagingPlatformTotals,
+  setMessagingSessions,
   setSelectedStoredSessionId,
   setSessions,
   setSessionStartedAt,
@@ -678,6 +681,7 @@ export function useSessionActions({
           ...(watchWindow ? { lazy: true } : {}),
           ...(sessionProfile ? { profile: sessionProfile } : {})
         })
+
         // The rejection is consumed by the `await` below; this guard only
         // keeps it from surfacing as unhandled while the prefetch settles.
         resumePromise.catch(() => undefined)
@@ -902,7 +906,9 @@ export function useSessionActions({
     async (storedSessionId: string) => {
       clearNotifications()
 
-      const removed = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+      const removedRegular = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+      const removedMessaging = $messagingSessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+      const removed = removedRegular ?? removedMessaging
       const wasSelected = selectedStoredSessionId === storedSessionId
       const closingRuntimeId = wasSelected ? activeSessionId : null
       const previousMessages = $messages.get()
@@ -912,9 +918,25 @@ export function useSessionActions({
       const removedPinId = removed ? sessionPinId(removed) : storedSessionId
 
       setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
-      // Keep $sessionsTotal in sync so the sidebar's "Load N more" footer
-      // doesn't keep claiming the removed row is still on the server.
-      setSessionsTotal(prev => Math.max(0, prev - 1))
+      setMessagingSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
+
+      // Keep list totals in sync so sidebars don't keep claiming the removed row
+      // is still on the server. Messaging-platform conversations live in their
+      // own store slice, so deleting Telegram/Discord/etc. sessions must update
+      // that slice too; otherwise the row appears to survive until a full reload.
+      if (removedRegular) {
+        setSessionsTotal(prev => Math.max(0, prev - 1))
+      }
+
+      const removedMessagingSource = removedMessaging?.source ?? null
+
+      if (removedMessagingSource) {
+        setMessagingPlatformTotals(prev => ({
+          ...prev,
+          [removedMessagingSource]: Math.max(0, (prev[removedMessagingSource] ?? 1) - 1)
+        }))
+      }
+
       $pinnedSessionIds.set(previousPinned.filter(id => id !== storedSessionId && id !== removedPinId))
 
       // Tear down before awaiting so the route effect can't resume the
@@ -935,9 +957,20 @@ export function useSessionActions({
           clearQueuedPrompts(closingRuntimeId)
         }
       } catch (err) {
-        if (removed) {
-          setSessions(prev => [removed, ...prev])
+        if (removedRegular) {
+          setSessions(prev => [removedRegular, ...prev])
           setSessionsTotal(prev => prev + 1)
+        }
+
+        if (removedMessaging) {
+          setMessagingSessions(prev => [removedMessaging, ...prev.filter(s => s.id !== storedSessionId)])
+
+          if (removedMessagingSource) {
+            setMessagingPlatformTotals(prev => ({
+              ...prev,
+              [removedMessagingSource]: (prev[removedMessagingSource] ?? 0) + 1
+            }))
+          }
         }
 
         $pinnedSessionIds.set(previousPinned)
@@ -985,7 +1018,9 @@ export function useSessionActions({
     async (storedSessionId: string) => {
       clearNotifications()
 
-      const archived = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+      const archivedRegular = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+      const archivedMessaging = $messagingSessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+      const archived = archivedRegular ?? archivedMessaging
       const wasSelected = selectedStoredSessionId === storedSessionId
       const previousPinned = $pinnedSessionIds.get()
       // Pins are keyed on the durable lineage-root id; the stored id may be the
@@ -994,10 +1029,24 @@ export function useSessionActions({
 
       // Soft-hide: drop from the sidebar immediately, keep the data.
       setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
+      setMessagingSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
+
       // Archived sessions are hidden by the listSessions(min_messages=1) query
       // on the next refresh, so they count as "removed" for the load-more
       // footer math.
-      setSessionsTotal(prev => Math.max(0, prev - 1))
+      if (archivedRegular) {
+        setSessionsTotal(prev => Math.max(0, prev - 1))
+      }
+
+      const archivedMessagingSource = archivedMessaging?.source ?? null
+
+      if (archivedMessagingSource) {
+        setMessagingPlatformTotals(prev => ({
+          ...prev,
+          [archivedMessagingSource]: Math.max(0, (prev[archivedMessagingSource] ?? 1) - 1)
+        }))
+      }
+
       $pinnedSessionIds.set(previousPinned.filter(id => id !== storedSessionId && id !== archivedPinId))
 
       if (wasSelected) {
@@ -1011,12 +1060,27 @@ export function useSessionActions({
         // that race after the mutation succeeds so right-click → Archive does
         // not appear to do nothing until the next full refresh.
         setSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
+        setMessagingSessions(prev => prev.filter(session => !sessionMatchesStoredId(session, storedSessionId)))
         $pinnedSessionIds.set($pinnedSessionIds.get().filter(id => id !== storedSessionId && id !== archivedPinId))
         notify({ durationMs: 2_000, kind: 'success', message: copy.archived })
       } catch (err) {
-        if (archived) {
-          setSessions(prev => [archived, ...prev.filter(session => !sessionMatchesStoredId(session, storedSessionId))])
+        if (archivedRegular) {
+          setSessions(prev => [
+            archivedRegular,
+            ...prev.filter(session => !sessionMatchesStoredId(session, storedSessionId))
+          ])
           setSessionsTotal(prev => prev + 1)
+        }
+
+        if (archivedMessaging) {
+          setMessagingSessions(prev => [archivedMessaging, ...prev.filter(s => s.id !== storedSessionId)])
+
+          if (archivedMessagingSource) {
+            setMessagingPlatformTotals(prev => ({
+              ...prev,
+              [archivedMessagingSource]: (prev[archivedMessagingSource] ?? 0) + 1
+            }))
+          }
         }
 
         $pinnedSessionIds.set(previousPinned)

--- a/apps/desktop/src/app/shell/app-shell.tsx
+++ b/apps/desktop/src/app/shell/app-shell.tsx
@@ -3,7 +3,6 @@ import type { CSSProperties, ReactNode } from 'react'
 import { useSyncExternalStore } from 'react'
 
 import { DesktopRenderWatchdog } from '@/components/desktop-render-watchdog'
-
 import { NotificationStack } from '@/components/notifications'
 import { PaneShell } from '@/components/pane-shell'
 import { SidebarProvider } from '@/components/ui/sidebar'
@@ -116,7 +115,7 @@ export function AppShell({
   // between the pane-tool cluster and the system cluster so they don't sit
   // flush against each other. Modeled as N gaps (N - 1 inner + 1 trailing)
   // to keep the formula generic for any pane-tool count.
-  const SYSTEM_TOOL_COUNT = 4
+  const SYSTEM_TOOL_COUNT = 5
   const paneToolCount = titlebarTools?.filter(tool => !tool.hidden).length ?? 0
   const systemToolsWidth = `calc(${SYSTEM_TOOL_COUNT} * (var(--titlebar-control-size) + 0.25rem))`
 

--- a/apps/desktop/src/app/shell/app-shell.tsx
+++ b/apps/desktop/src/app/shell/app-shell.tsx
@@ -2,6 +2,8 @@ import { useStore } from '@nanostores/react'
 import type { CSSProperties, ReactNode } from 'react'
 import { useSyncExternalStore } from 'react'
 
+import { DesktopRenderWatchdog } from '@/components/desktop-render-watchdog'
+
 import { NotificationStack } from '@/components/notifications'
 import { PaneShell } from '@/components/pane-shell'
 import { SidebarProvider } from '@/components/ui/sidebar'
@@ -193,6 +195,7 @@ export function AppShell({
 
       {/* Mounted at the shell root (after overlays) so success/error toasts
           surface above every route and overlay — not just the chat view. */}
+      <DesktopRenderWatchdog />
       <NotificationStack />
     </SidebarProvider>
   )

--- a/apps/desktop/src/app/shell/titlebar-controls.tsx
+++ b/apps/desktop/src/app/shell/titlebar-controls.tsx
@@ -22,6 +22,8 @@ import { appViewForPath, isOverlayView } from '../routes'
 
 import { titlebarButtonClass } from './titlebar'
 
+const DASHBOARD_URL = 'http://127.0.0.1:9120'
+
 export interface TitlebarTool {
   id: string
   label: string
@@ -124,6 +126,15 @@ export function TitlebarControls({ leftTools = [], tools = [], onOpenSettings }:
       onSelect: () => {
         triggerHaptic('open')
         toggleKeybindPanel()
+      }
+    },
+    {
+      icon: <Codicon name="globe" />,
+      id: 'dashboard',
+      label: t.titlebar.openDashboard,
+      onSelect: () => {
+        triggerHaptic('open')
+        window.hermesDesktop?.openExternal?.(DASHBOARD_URL) ?? window.open(DASHBOARD_URL, '_blank', 'noopener,noreferrer')
       }
     },
     {

--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -51,7 +51,14 @@ import {
   renderComposerContents,
   RICH_INPUT_SLOT
 } from '@/app/chat/composer/rich-editor'
-import { detectTrigger, textBeforeCaret, type TriggerState } from '@/app/chat/composer/text-utils'
+import {
+  detectTrigger,
+  isOversizedDataImageUrl,
+  isOversizedPastedText,
+  pasteLimitMessage,
+  textBeforeCaret,
+  type TriggerState
+} from '@/app/chat/composer/text-utils'
 import { ComposerTriggerPopover } from '@/app/chat/composer/trigger-popover'
 import {
   extractDroppedFiles,
@@ -1548,6 +1555,17 @@ const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sessionId }
 
     if (!pastedText || DATA_IMAGE_URL_RE.test(pastedText.trim())) {
       event.preventDefault()
+
+      if (isOversizedDataImageUrl(pastedText)) {
+        notifyError(null, pasteLimitMessage('image'))
+      }
+
+      return
+    }
+
+    if (isOversizedPastedText(pastedText)) {
+      event.preventDefault()
+      notifyError(null, pasteLimitMessage('text'))
 
       return
     }

--- a/apps/desktop/src/components/assistant-ui/tool-approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool-approval.tsx
@@ -4,14 +4,6 @@ import { useStore } from '@nanostores/react'
 import { type FC, useCallback, useEffect, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle
-} from '@/components/ui/dialog'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
@@ -38,8 +30,8 @@ import type { ToolPart } from './tool-fallback-model'
 // event payload), which is the only place that data reliably exists.
 export const APPROVAL_TOOLS = new Set(['terminal', 'execute_code'])
 
-// Canonical gateway choices (ui-tui/src/components/prompts.tsx).
-type ApprovalChoice = 'once' | 'session' | 'always' | 'deny'
+// Canonical gateway choices supported by the Desktop approval UI.
+type ApprovalChoice = 'once' | 'session' | 'deny'
 
 export const PendingToolApproval: FC<{ part: ToolPart }> = ({ part }) => {
   const request = useStore($approvalRequest)
@@ -58,17 +50,11 @@ const ApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
   const copy = t.assistant.approval
   const gateway = useStore($gateway)
   const [submitting, setSubmitting] = useState<ApprovalChoice | null>(null)
-  // "Always allow" persists the pattern to ~/.hermes/config.yaml permanently, so
-  // it goes through a confirm step rather than firing straight from the menu.
-  const [confirmAlways, setConfirmAlways] = useState(false)
   // The pending tool row only shows a single truncated line of the command, and
-  // a pending row can't be expanded (no result yet), so the full command was
-  // previously only reachable via the "Always allow" modal. Let the user reveal
-  // it inline instead — "expand, Run" (2 clicks) rather than the modal dance.
+  // a pending row can't be expanded (no result yet), so let the user reveal the
+  // full command inline without reintroducing permanent approval options.
   const [showCommand, setShowCommand] = useState(false)
   const busy = submitting !== null
-  // false when the backend won't honor a permanent allow (tirith warning) → hide "Always allow".
-  const allowPermanent = request.allowPermanent !== false
   const hasCommand = request.command.trim().length > 0
 
   const respond = useCallback(
@@ -99,17 +85,11 @@ const ApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
         setSubmitting(null)
       }
     },
-    [busy, gateway, request.sessionId]
+    [busy, copy.gatewayDisconnected, copy.sendFailed, gateway, request.sessionId]
   )
 
   // ⌘/Ctrl+Enter → Run, Esc → Reject.
-  // While the confirm dialog is open it owns the keyboard (Esc closes it), so
-  // the strip-level shortcuts stand down to avoid denying the whole approval.
   useEffect(() => {
-    if (confirmAlways) {
-      return
-    }
-
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
         event.preventDefault()
@@ -123,7 +103,7 @@ const ApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
     window.addEventListener('keydown', onKeyDown, true)
 
     return () => window.removeEventListener('keydown', onKeyDown, true)
-  }, [confirmAlways, respond])
+  }, [respond])
 
   return (
     <div className="mt-1 ps-5" data-slot="tool-approval-inline">
@@ -154,18 +134,6 @@ const ApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start" className="min-w-44">
               <DropdownMenuItem onSelect={() => void respond('session')}>{copy.allowSession}</DropdownMenuItem>
-              {allowPermanent && (
-                <DropdownMenuItem
-                  onSelect={() => {
-                    // Defer one tick so the menu fully unmounts before the dialog
-                    // mounts — otherwise Radix's focus-return races the dialog and
-                    // dismisses it via onInteractOutside.
-                    setTimeout(() => setConfirmAlways(true), 0)
-                  }}
-                >
-                  {copy.alwaysAllowMenu}
-                </DropdownMenuItem>
-              )}
               <DropdownMenuItem onSelect={() => void respond('deny')} variant="destructive">
                 {copy.reject}
               </DropdownMenuItem>
@@ -203,37 +171,6 @@ const ApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
           {request.command.trim()}
         </pre>
       )}
-
-      <Dialog onOpenChange={setConfirmAlways} open={confirmAlways}>
-        <DialogContent className="max-w-md">
-          <DialogHeader>
-            <DialogTitle>{copy.alwaysTitle}</DialogTitle>
-            <DialogDescription>{copy.alwaysDescription(request.description)}</DialogDescription>
-          </DialogHeader>
-
-          {request.command.trim() && (
-            <pre className="max-h-32 overflow-auto whitespace-pre-wrap break-words rounded-md border border-(--ui-stroke-tertiary) bg-(--ui-chat-surface-background) px-2.5 py-1.5 font-mono text-xs leading-snug text-foreground">
-              {request.command.trim()}
-            </pre>
-          )}
-
-          <DialogFooter>
-            <Button onClick={() => setConfirmAlways(false)} size="sm" variant="ghost">
-              {t.common.cancel}
-            </Button>
-            <Button
-              onClick={() => {
-                setConfirmAlways(false)
-                void respond('always')
-              }}
-              size="sm"
-              variant="destructive"
-            >
-              {copy.alwaysAllow}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </div>
   )
 }

--- a/apps/desktop/src/components/desktop-render-watchdog.tsx
+++ b/apps/desktop/src/components/desktop-render-watchdog.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useRef } from 'react'
+
+import { getLogs } from '@/hermes'
+import { notify } from '@/store/notifications'
+
+const POLL_MS = 30_000
+const DEDUPE_WINDOW_MS = 10 * 60_000
+
+const RENDERER_FAILURE_PATTERNS: Array<[RegExp, string]> = [
+  [/webContents became unresponsive/i, 'Desktop renderer became unresponsive recently.'],
+  [/render-process-gone/i, 'Desktop renderer process exited unexpectedly.'],
+  [/renderer process (?:gone|crashed|terminated|killed)/i, 'Desktop renderer process crashed or was terminated.'],
+  [/\bGPU process crashed\b/i, 'Desktop GPU process crashed; renderer stability may be affected.']
+]
+
+function getRendererFailureSignals(desktopLines: string[]) {
+  const signals: string[] = []
+
+  for (const [pattern, message] of RENDERER_FAILURE_PATTERNS) {
+    if (desktopLines.some(line => pattern.test(line))) {
+      signals.push(message)
+    }
+  }
+
+  return signals
+}
+
+function signature(signals: string[]) {
+  return signals.join('\n')
+}
+
+export function DesktopRenderWatchdog() {
+  const lastAlertRef = useRef<{ signature: string; at: number } | null>(null)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    let timer: number | null = null
+    let running = false
+
+    async function poll() {
+      if (running) {
+        return
+      }
+
+      running = true
+
+      try {
+        const desktop = await getLogs({ file: 'desktop', lines: 180 }).catch(() => getLogs({ lines: 180 }))
+        const signals = getRendererFailureSignals(desktop.lines)
+
+        if (signals.length === 0) {
+          return
+        }
+
+        const nextSignature = signature(signals)
+        const now = Date.now()
+        const last = lastAlertRef.current
+
+        if (last && last.signature === nextSignature && now - last.at < DEDUPE_WINDOW_MS) {
+          return
+        }
+
+        lastAlertRef.current = { signature: nextSignature, at: now }
+        notify({
+          id: 'desktop-render-freeze-risk',
+          kind: 'warning',
+          title: 'Hermes Desktop renderer became unresponsive',
+          message: 'The Desktop renderer reported an actual unresponsive/crash signal. Save your work if possible, then restart Desktop or open a fresh session.',
+          detail: `${signals.map(signal => `- ${signal}`).join('\n')}\n\nBest move: restart Hermes Desktop or open a fresh Desktop session before continuing heavy work.`,
+          action: window.hermesDesktop?.revealLogs
+            ? {
+                label: 'Open logs',
+                onClick: () => void window.hermesDesktop?.revealLogs()?.catch(() => undefined)
+              }
+            : undefined,
+          durationMs: 0
+        })
+      } finally {
+        running = false
+
+        if (mountedRef.current) {
+          timer = window.setTimeout(poll, POLL_MS)
+        }
+      }
+    }
+
+    timer = window.setTimeout(poll, 10_000)
+
+    return () => {
+      mountedRef.current = false
+
+      if (timer !== null) {
+        window.clearTimeout(timer)
+      }
+    }
+  }, [])
+
+  return null
+}

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getSessionMessages, listAllProfileSessions, listSessions } from './hermes'
+import { getSessionMessages, listAllProfileSessions, listSessions, setSessionArchived } from './hermes'
 
 const emptySessionsResponse = {
   limit: 0,
@@ -55,6 +55,17 @@ describe('Hermes REST session helpers', () => {
     expect(api).toHaveBeenCalledWith({
       path: '/api/sessions/session-1/messages?profile=xiaoxuxu',
       profile: 'xiaoxuxu'
+    })
+  })
+
+  it('includes the owning profile when archiving a session', async () => {
+    await setSessionArchived('telegram-session', true, 'default')
+
+    expect(api).toHaveBeenCalledWith({
+      profile: 'default',
+      path: '/api/sessions/telegram-session',
+      method: 'PATCH',
+      body: { archived: true, profile: 'default' }
     })
   })
 })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -200,7 +200,7 @@ export function setSessionArchived(id: string, archived: boolean, profile?: stri
     ...(profile ? { profile } : {}),
     path: `/api/sessions/${encodeURIComponent(id)}`,
     method: 'PATCH',
-    body: { archived }
+    body: { archived, ...(profile ? { profile } : {}) }
   })
 }
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -146,7 +146,8 @@ export const en: Translations = {
     muteHaptics: 'Mute haptics',
     unmuteHaptics: 'Unmute haptics',
     openSettings: 'Open settings',
-    openKeybinds: 'Keyboard shortcuts'
+    openKeybinds: 'Keyboard shortcuts',
+    openDashboard: 'Open dashboard'
   },
 
   keybinds: {

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -146,7 +146,9 @@ export const ja = defineLocale({
     showRightSidebar: '右サイドバーを表示',
     muteHaptics: '触覚フィードバックをオフ',
     unmuteHaptics: '触覚フィードバックをオン',
-    openSettings: '設定を開く'
+    openSettings: '設定を開く',
+    openKeybinds: 'キーボードショートカット',
+    openDashboard: 'ダッシュボードを開く'
   },
 
   language: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -158,6 +158,7 @@ export interface Translations {
     unmuteHaptics: string
     openSettings: string
     openKeybinds: string
+    openDashboard: string
   }
 
   keybinds: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -141,7 +141,9 @@ export const zhHant = defineLocale({
     showRightSidebar: '顯示右側邊欄',
     muteHaptics: '靜音觸感回饋',
     unmuteHaptics: '開啟觸感回饋',
-    openSettings: '開啟設定'
+    openSettings: '開啟設定',
+    openKeybinds: '鍵盤快速鍵',
+    openDashboard: '開啟儀表板'
   },
 
   language: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -142,7 +142,8 @@ export const zh: Translations = {
     muteHaptics: '关闭触感反馈',
     unmuteHaptics: '开启触感反馈',
     openSettings: '打开设置',
-    openKeybinds: '键盘快捷键'
+    openKeybinds: '键盘快捷键',
+    openDashboard: '打开仪表盘'
   },
 
   keybinds: {

--- a/cli.py
+++ b/cli.py
@@ -9687,8 +9687,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             return "deny"
 
     def _approval_choices(self, command: str, *, allow_permanent: bool = True) -> list[str]:
-        """Return approval choices for a dangerous command prompt."""
-        choices = ["once", "session", "always", "deny"] if allow_permanent else ["once", "session", "deny"]
+        """Return approval choices for a dangerous command prompt.
+
+        Permanent approvals are intentionally hidden from prompts.  The
+        allow_permanent parameter is kept for callback API compatibility, but
+        UI prompts should only offer one-shot, session-scoped, or deny choices.
+        """
+        choices = ["once", "session", "deny"]
         if len(command) > 70:
             choices.append("view")
         return choices
@@ -9724,6 +9729,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         choices = state.get("choices")
         if not isinstance(choices, list):
             choices = []
+        original_chosen = choices[selected] if 0 <= selected < len(choices) else None
+        choices = [choice for choice in choices if choice != "always"]
+        state["choices"] = choices
+        if original_chosen in choices:
+            selected = choices.index(original_chosen)
+            state["selected"] = selected
+        elif selected >= len(choices):
+            selected = max(0, len(choices) - 1)
+            state["selected"] = selected
         if not (0 <= selected < len(choices)):
             return
 
@@ -9781,8 +9795,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         command = state["command"]
         description = state["description"]
-        choices = state["choices"]
-        selected = state.get("selected", 0)
+        choices = [choice for choice in state["choices"] if choice != "always"]
+        selected = min(state.get("selected", 0), max(0, len(choices) - 1))
         show_full = state.get("show_full", False)
 
         title = "⚠️  Dangerous Command"

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1905,7 +1905,6 @@ class FeishuAdapter(BasePlatformAdapter):
                         "actions": [
                             _btn("✅ Allow Once", "approve_once", "primary"),
                             _btn("✅ Session", "approve_session"),
-                            _btn("✅ Always", "approve_always"),
                             _btn("❌ Deny", "deny", "danger"),
                         ],
                     },

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -1919,10 +1919,10 @@ class MatrixAdapter(BasePlatformAdapter):
             "⚠️ **Dangerous command requires approval**\n"
             f"```\n{cmd_preview}\n```\n"
             f"Reason: {description}\n\n"
-            "Reply `!approve` to execute, `!approve session` to approve this pattern for the session, "
-            "`!approve always` to approve permanently, or `!deny` to cancel.\n\n"
+            "Reply `!approve` to execute once, `!approve session` to approve this pattern "
+            "for the session, or `!deny` to cancel.\n\n"
             "You can also click the reaction to approve:\n"
-            "✅ = approve\n"
+            "✅ = approve once\n"
             "❎ = deny"
         )
 
@@ -1943,7 +1943,7 @@ class MatrixAdapter(BasePlatformAdapter):
         self._approval_prompts_by_event[result.message_id] = prompt
         self._approval_prompt_by_session[session_key] = result.message_id
 
-        for emoji in ("✅", "♾️", "❌"):
+        for emoji in ("✅", "❌"):
             try:
                 reaction_result = await self._send_reaction(chat_id, result.message_id, emoji)
                 # Save the bot's reaction event_id for later cleanup

--- a/gateway/platforms/qqbot/keyboards.py
+++ b/gateway/platforms/qqbot/keyboards.py
@@ -202,9 +202,9 @@ def _make_callback_button(
 
 
 def build_approval_keyboard(session_key: str) -> InlineKeyboard:
-    """Build the 3-button approval keyboard.
+    """Build the approval keyboard.
 
-    Layout: ``[✅ 允许一次] [⭐ 始终允许] [❌ 拒绝]`` — all three share
+    Layout: ``[✅ 允许一次] [❌ 拒绝]`` — both buttons share
     ``group_id='approval'`` so clicking one greys out the rest.
 
     :param session_key: Embedded into ``button_data`` so the decision
@@ -219,14 +219,6 @@ def build_approval_keyboard(session_key: str) -> InlineKeyboard:
                         label="✅ 允许一次",
                         visited_label="已允许",
                         data=f"{APPROVAL_BUTTON_PREFIX}{session_key}:allow-once",
-                        style=1,
-                        group_id="approval",
-                    ),
-                    _make_callback_button(
-                        btn_id="always",
-                        label="⭐ 始终允许",
-                        visited_label="已始终允许",
-                        data=f"{APPROVAL_BUTTON_PREFIX}{session_key}:allow-always",
                         style=1,
                         group_id="approval",
                     ),

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2914,12 +2914,6 @@ class SlackAdapter(BasePlatformAdapter):
                         },
                         {
                             "type": "button",
-                            "text": {"type": "plain_text", "text": "Always Allow"},
-                            "action_id": "hermes_approve_always",
-                            "value": session_key,
-                        },
-                        {
-                            "type": "button",
                             "text": {"type": "plain_text", "text": "Deny"},
                             "style": "danger",
                             "action_id": "hermes_deny",

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3033,7 +3033,6 @@ class TelegramAdapter(BasePlatformAdapter):
                     InlineKeyboardButton("✅ Session", callback_data=f"ea:session:{approval_id}"),
                 ],
                 [
-                    InlineKeyboardButton("✅ Always", callback_data=f"ea:always:{approval_id}"),
                     InlineKeyboardButton("❌ Deny", callback_data=f"ea:deny:{approval_id}"),
                 ],
             ])

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5501,12 +5501,6 @@ def _define_discord_view_classes() -> None:
         ):
             await self._resolve(interaction, "session", discord.Color.blue(), "Approved for session")
 
-        @discord.ui.button(label="Always Allow", style=discord.ButtonStyle.blurple)
-        async def allow_always(
-            self, interaction: discord.Interaction, button: discord.ui.Button
-        ):
-            await self._resolve(interaction, "always", discord.Color.purple(), "Approved permanently")
-
         @discord.ui.button(label="Deny", style=discord.ButtonStyle.red)
         async def deny(
             self, interaction: discord.Interaction, button: discord.ui.Button

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -1054,11 +1054,6 @@ class TeamsAdapter(BasePlatformAdapter):
                     data={**btn_data_base, "hermes_action": "approve_session"},
                 ),
                 ExecuteAction(
-                    title="Always Allow",
-                    verb="hermes_approve",
-                    data={**btn_data_base, "hermes_action": "approve_always"},
-                ),
-                ExecuteAction(
                     title="Deny",
                     verb="hermes_approve",
                     data={**btn_data_base, "hermes_action": "deny"},

--- a/tests/acp/test_permissions.py
+++ b/tests/acp/test_permissions.py
@@ -88,10 +88,10 @@ class TestApprovalBridge:
         assert option_ids == [
             "allow_once",
             "allow_session",
-            "allow_always",
             "deny",
             "deny_always",
         ]
+        assert "allow_always" not in option_ids
 
     def test_tool_call_ids_are_unique(self):
         _, first_kwargs, _, _, _ = _invoke_callback(

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -133,7 +133,9 @@ class TestCliApprovalUi:
         assert cli._approval_state is not None
         assert cli._approval_state["show_full"] is True
         assert "view" not in cli._approval_state["choices"]
-        assert cli._approval_state["selected"] == 3
+        assert "always" not in cli._approval_state["choices"]
+        assert cli._approval_state["selected"] == 2
+        assert cli._approval_state["choices"][2] == "deny"
         assert cli._approval_state["response_queue"].empty()
 
     def test_approval_display_places_title_inside_box_not_border(self):
@@ -243,7 +245,7 @@ class TestCliApprovalUi:
         # getting clipped off the bottom of the panel.
         assert "Allow once" in rendered
         assert "Allow for this session" in rendered
-        assert "Add to permanent allowlist" in rendered
+        assert "Add to permanent allowlist" not in rendered
         assert "Deny" in rendered
 
         # The bottom border must render (i.e. the panel is self-contained).
@@ -277,10 +279,10 @@ class TestCliApprovalUi:
 
         # Command visible.
         assert "rm -rf /var/log/apache2/*.log" in rendered
-        # All four choices visible.
-        for label in ("Allow once", "Allow for this session",
-                      "Add to permanent allowlist", "Deny"):
+        # Non-permanent choices visible; permanent allowlist choice hidden.
+        for label in ("Allow once", "Allow for this session", "Deny"):
             assert label in rendered, f"choice {label!r} missing"
+        assert "Add to permanent allowlist" not in rendered
 
     def test_approval_display_truncates_giant_command_in_view_mode(self):
         """If the user hits /view on a massive command, choices still render.
@@ -308,10 +310,10 @@ class TestCliApprovalUi:
 
         rendered = "".join(text for _style, text in fragments)
 
-        # All four choices visible even with a huge command.
-        for label in ("Allow once", "Allow for this session",
-                      "Add to permanent allowlist", "Deny"):
+        # Non-permanent choices visible even with a huge command; permanent allowlist choice hidden.
+        for label in ("Allow once", "Allow for this session", "Deny"):
             assert label in rendered, f"choice {label!r} missing"
+        assert "Add to permanent allowlist" not in rendered
 
         # Command got truncated with a marker.
         assert "(command truncated" in rendered

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -122,11 +122,10 @@ class TestFeishuExecApproval:
 
         # Check buttons
         actions = card["elements"][1]["actions"]
-        assert len(actions) == 4
+        assert len(actions) == 3
         action_names = [a["value"]["hermes_action"] for a in actions]
-        assert action_names == [
-            "approve_once", "approve_session", "approve_always", "deny"
-        ]
+        assert action_names == ["approve_once", "approve_session", "deny"]
+        assert "approve_always" not in action_names
 
     @pytest.mark.asyncio
     async def test_stores_approval_state(self):

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -111,13 +111,13 @@ class TestSlackExecApproval:
         assert "dangerous deletion" in blocks[0]["text"]["text"]
         assert blocks[1]["type"] == "actions"
         elements = blocks[1]["elements"]
-        assert len(elements) == 4
+        assert len(elements) == 3
         action_ids = [e["action_id"] for e in elements]
         assert "hermes_approve_once" in action_ids
         assert "hermes_approve_session" in action_ids
-        assert "hermes_approve_always" in action_ids
+        assert "hermes_approve_always" not in action_ids
         assert "hermes_deny" in action_ids
-        # Each button carries the session key as value
+
         for e in elements:
             assert e["value"] == "agent:main:slack:group:C1:1111"
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -612,8 +612,10 @@ def detect_dangerous_command(command: str) -> tuple:
 _lock = threading.Lock()
 _pending: dict[str, dict] = {}
 _session_approved: dict[str, set] = {}
+_timed_approved: dict[str, dict[str, float]] = {}
 _session_yolo: set[str] = set()
 _permanent_approved: set = set()
+_EIGHT_HOURS_SECONDS = 8 * 60 * 60
 
 # =========================================================================
 # Blocking gateway approval (mirrors CLI's synchronous input() flow)
@@ -631,7 +633,7 @@ class _ApprovalEntry:
     def __init__(self, data: dict):
         self.event = threading.Event()
         self.data = data          # command, description, pattern_keys, …
-        self.result: Optional[str] = None  # "once"|"session"|"always"|"deny"
+        self.result: Optional[str] = None  # "once"|"8h"|"session"|"always"|"deny"
 
 
 _gateway_queues: dict[str, list] = {}        # session_key → [_ApprovalEntry, …]
@@ -710,6 +712,33 @@ def approve_session(session_key: str, pattern_key: str):
         _session_approved.setdefault(session_key, set()).add(pattern_key)
 
 
+def approve_timed(session_key: str, pattern_key: str,
+                  ttl_seconds: int = _EIGHT_HOURS_SECONDS):
+    """Approve a pattern for a fixed period of wall-clock time."""
+    if not session_key:
+        return
+    expires_at = time.time() + max(0, ttl_seconds)
+    with _lock:
+        _timed_approved.setdefault(session_key, {})[pattern_key] = expires_at
+
+
+def _prune_expired_timed_locked(session_key: str, now: float | None = None) -> None:
+    """Remove expired timed approvals for *session_key*.
+
+    Caller must hold ``_lock``.
+    """
+    approvals = _timed_approved.get(session_key)
+    if not approvals:
+        return
+    if now is None:
+        now = time.time()
+    for key, expires_at in list(approvals.items()):
+        if expires_at <= now:
+            approvals.pop(key, None)
+    if not approvals:
+        _timed_approved.pop(session_key, None)
+
+
 def enable_session_yolo(session_key: str) -> None:
     """Enable YOLO bypass for a single session key."""
     if not session_key:
@@ -732,11 +761,13 @@ def clear_session(session_key: str) -> None:
         return
     with _lock:
         _session_approved.pop(session_key, None)
+        _timed_approved.pop(session_key, None)
         _session_yolo.discard(session_key)
         _pending.pop(session_key, None)
         entries = _gateway_queues.pop(session_key, [])
+
     for entry in entries:
-        # Session-boundary cleanup should cancel any blocked approval waits
+
         # immediately so the old run can unwind instead of idling until timeout.
         entry.result = "deny"
         entry.event.set()
@@ -766,7 +797,11 @@ def is_approved(session_key: str, pattern_key: str) -> bool:
         if any(alias in _permanent_approved for alias in aliases):
             return True
         session_approvals = _session_approved.get(session_key, set())
-        return any(alias in session_approvals for alias in aliases)
+        if any(alias in session_approvals for alias in aliases):
+            return True
+        _prune_expired_timed_locked(session_key)
+        timed_approvals = _timed_approved.get(session_key, {})
+        return any(alias in timed_approvals for alias in aliases)
 
 
 def approve_permanent(pattern_key: str):
@@ -911,6 +946,9 @@ def prompt_dangerous_approval(command: str, description: str,
             if choice in {'o', 'once'}:
                 print(t("approval.allowed_once"))
                 return "once"
+            elif choice in {'8', '8h', 'eight', '8 hours', '8hours'}:
+                print("✅ Allowed for 8 hours.")
+                return "8h"
             elif choice in {'s', 'session'}:
                 print(t("approval.allowed_session"))
                 return "session"
@@ -1128,7 +1166,9 @@ def check_dangerous_command(command: str, env_type: str,
             "description": description,
         }
 
-    if choice == "session":
+    if choice == "8h":
+        approve_timed(session_key, pattern_key)
+    elif choice == "session":
         approve_session(session_key, pattern_key)
     elif choice == "always":
         approve_session(session_key, pattern_key)
@@ -1478,9 +1518,11 @@ def check_all_command_guards(command: str, env_type: str,
 
             # User approved — persist based on scope (same logic as CLI)
             for key, _, is_tirith in warnings:
-                if choice == "session" or (choice == "always" and is_tirith):
+                if choice == "8h":
+                    approve_timed(session_key, key)
+                elif choice == "session" or (choice == "always" and is_tirith):
                     approve_session(session_key, key)
-                elif choice == "always":
+
                     approve_session(session_key, key)
                     approve_permanent(key)
                     save_permanent_allowlist(_permanent_approved)
@@ -1554,9 +1596,11 @@ def check_all_command_guards(command: str, env_type: str,
 
     # Persist approval for each warning individually
     for key, _, is_tirith in warnings:
-        if choice == "session" or (choice == "always" and is_tirith):
-            # tirith: session only (no permanent broad allowlisting)
+        if choice == "8h":
+            approve_timed(session_key, key)
+        elif choice == "session" or (choice == "always" and is_tirith):
             approve_session(session_key, key)
+
         elif choice == "always":
             # dangerous patterns: permanent allowed
             approve_session(session_key, key)


### PR DESCRIPTION
## Summary

- Improves Desktop large-session rendering stability.
- Adds renderer unresponsive handling and recovery controls.
- Forces UTF-8 for Desktop Python backend stdio.
- Removes permanent approval UI options and adds timed approval support.
- Guards Desktop paste input size.
- Preserves Desktop session state updates.
- Adds Desktop dashboard titlebar button.

## Validation

- `node -c electron/main.cjs`
- `node -c electron/renderer-unresponsive.cjs`
- `node --test electron/renderer-unresponsive.test.cjs`
  - 2 passed
- `npx vitest run --environment jsdom src/app/chat/composer/text-utils.test.ts src/app/chat/index.test.tsx src/hermes.test.ts`
  - 3 files passed
  - 31 tests passed
- `npm run typecheck`
- Focused ESLint on changed Desktop files
  - passed with no warnings shown

## Notes

- Branch was rebased onto `origin/main`.
- Backup branch exists locally: `backup/sean-desktop-cleanup-before-origin-main-integration-20260613-125146`
- No rebuild was run.
