### PR TITLE
feat(memory): govern automatic memory context injection

### DIFF
--- a/agent/memory_governance.py
+++ b/agent/memory_governance.py
@@ -1,0 +1,229 @@
+"""Governance helpers for automatic memory context injection.
+
+This module sits above memory providers. Providers may return legacy formatted
+text via ``prefetch()`` or richer dictionaries via ``prefetch_candidates()``;
+Hermes core owns final filtering, reranking, and redaction before context is
+injected into the model.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+import re
+from typing import Any, Iterable, Mapping
+
+from agent.redact import redact_sensitive_text
+
+_TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9_-]{1,}", re.IGNORECASE)
+
+_STOPWORDS = {
+    "about",
+    "again",
+    "also",
+    "could",
+    "current",
+    "does",
+    "give",
+    "have",
+    "into",
+    "know",
+    "like",
+    "mean",
+    "please",
+    "remind",
+    "should",
+    "that",
+    "the",
+    "their",
+    "there",
+    "this",
+    "what",
+    "when",
+    "where",
+    "which",
+    "with",
+    "would",
+    "you",
+    "your",
+}
+
+_STALE_MARKERS = {
+    "stale",
+    "superseded",
+    "deprecated",
+    "obsolete",
+    "replaced",
+    "inactive",
+    "old",
+}
+
+_SECRET_MARKERS = {
+    "secret",
+    "credential",
+    "credentials",
+    "api-key",
+    "api_key",
+    "token",
+    "password",
+}
+
+_GLOBAL_SCOPES = {"", "all", "any", "global", "shared"}
+
+
+@dataclass(frozen=True)
+class GovernedMemoryCandidate:
+    """A memory item after normalization and before/after governance."""
+
+    content: str
+    provider: str = ""
+    trust: float = 0.0
+    metadata: Mapping[str, Any] | None = None
+
+
+def active_profile_scope() -> str:
+    """Return the active profile identity used for scope filtering."""
+    for key in ("HERMES_PROFILE", "HERMES_AGENT_IDENTITY", "HERMES_PROFILE_NAME"):
+        value = os.getenv(key, "").strip()
+        if value:
+            return value
+    return "default"
+
+
+def query_tokens(query: str) -> set[str]:
+    """Normalize a natural-language user message into recall tokens."""
+    tokens = {m.group(0).lower().strip("_-") for m in _TOKEN_RE.finditer(query or "")}
+    return {t for t in tokens if t and t not in _STOPWORDS and len(t) > 2}
+
+
+def normalize_candidates(raw: Iterable[Any], *, provider: str = "") -> list[GovernedMemoryCandidate]:
+    """Convert provider-returned candidate dicts/strings into candidates."""
+    candidates: list[GovernedMemoryCandidate] = []
+    for item in raw or []:
+        if isinstance(item, str):
+            content = item.strip()
+            if content:
+                candidates.append(GovernedMemoryCandidate(content=content, provider=provider))
+            continue
+        if not isinstance(item, Mapping):
+            continue
+        content = str(item.get("content") or item.get("text") or item.get("memory") or "").strip()
+        if not content:
+            continue
+        trust = item.get("trust_score", item.get("trust", item.get("score", 0.0)))
+        try:
+            trust_f = float(trust or 0.0)
+        except (TypeError, ValueError):
+            trust_f = 0.0
+        candidates.append(
+            GovernedMemoryCandidate(
+                content=content,
+                provider=str(item.get("provider") or provider or ""),
+                trust=trust_f,
+                metadata=dict(item),
+            )
+        )
+    return candidates
+
+
+def govern_candidates(
+    candidates: Iterable[GovernedMemoryCandidate],
+    query: str,
+    *,
+    profile: str | None = None,
+    limit: int = 5,
+) -> list[GovernedMemoryCandidate]:
+    """Filter, redact, and rerank memory candidates for context injection."""
+    q_tokens = query_tokens(query)
+    profile = (profile or active_profile_scope() or "default").strip().lower()
+    governed: list[tuple[float, GovernedMemoryCandidate]] = []
+
+    for cand in candidates:
+        meta = dict(cand.metadata or {})
+        if _is_wrong_scope(meta, profile):
+            continue
+        if _is_stale(meta):
+            continue
+        if _has_secret_marker(meta):
+            continue
+
+        redacted = redact_sensitive_text(cand.content, force=True)
+        if redacted != cand.content:
+            # Automatic memory injection is not the right place to surface even
+            # redacted credentials; omit the whole candidate to avoid teaching
+            # the model that a secret exists.
+            continue
+
+        overlap = len(q_tokens & query_tokens(cand.content))
+        if q_tokens and overlap == 0:
+            continue
+        score = float(overlap) * 10.0 + max(cand.trust, 0.0)
+        governed.append((score, cand))
+
+    governed.sort(key=lambda pair: pair[0], reverse=True)
+    return [cand for _, cand in governed[: max(0, int(limit))]]
+
+
+def render_governed_context(provider_name: str, candidates: Iterable[GovernedMemoryCandidate]) -> str:
+    """Render governed candidates in the legacy text context format."""
+    lines = []
+    for cand in candidates:
+        if cand.trust:
+            lines.append(f"- [{cand.trust:.1f}] {cand.content}")
+        else:
+            lines.append(f"- {cand.content}")
+    if not lines:
+        return ""
+    label = provider_name.replace("_", " ").replace("-", " ").title() if provider_name else "Memory"
+    return f"## {label} Memory\n" + "\n".join(lines)
+
+
+def sanitize_legacy_context(text: str) -> str:
+    """Best-effort governance for legacy provider text."""
+    text = redact_sensitive_text(text or "", force=True)
+    kept = []
+    for line in text.splitlines():
+        if not line.strip():
+            kept.append(line)
+            continue
+        lowered = line.lower()
+        if any(marker in lowered for marker in _SECRET_MARKERS):
+            continue
+        kept.append(line)
+    return "\n".join(kept).strip()
+
+
+def _metadata_words(meta: Mapping[str, Any], keys: tuple[str, ...]) -> set[str]:
+    words: set[str] = set()
+    for key in keys:
+        value = meta.get(key)
+        if value is None:
+            continue
+        if isinstance(value, (list, tuple, set)):
+            parts = value
+        else:
+            parts = re.split(r"[,\s]+", str(value))
+        words.update(str(part).strip().lower() for part in parts if str(part).strip())
+    return words
+
+
+def _is_wrong_scope(meta: Mapping[str, Any], profile: str) -> bool:
+    scopes = _metadata_words(meta, ("profile", "profile_scope", "scope", "agent_identity"))
+    if not scopes:
+        return False
+    return not any(scope in _GLOBAL_SCOPES or scope == profile for scope in scopes)
+
+
+def _is_stale(meta: Mapping[str, Any]) -> bool:
+    words = _metadata_words(meta, ("status", "state", "tags", "tag"))
+    if words & _STALE_MARKERS:
+        return True
+    for key in ("stale", "superseded", "deprecated", "obsolete"):
+        value = meta.get(key)
+        if isinstance(value, bool) and value:
+            return True
+    return False
+
+
+def _has_secret_marker(meta: Mapping[str, Any]) -> bool:
+    return bool(_metadata_words(meta, ("tags", "tag", "category", "kind")) & _SECRET_MARKERS)

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -32,6 +32,12 @@ import threading
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, List, Optional
 
+from agent.memory_governance import (
+    govern_candidates,
+    normalize_candidates,
+    render_governed_context,
+    sanitize_legacy_context,
+)
 from agent.memory_provider import MemoryProvider
 from tools.registry import tool_error
 
@@ -430,16 +436,70 @@ class MemoryManager:
 
     # -- Prefetch / recall ---------------------------------------------------
 
-    def prefetch_all(self, query: str, *, session_id: str = "") -> str:
-        """Collect prefetch context from all providers.
+    @staticmethod
+    def _provider_prefetch_candidates(provider: MemoryProvider, query: str, *, session_id: str = "") -> Optional[List[Any]]:
+        """Return optional structured recall candidates from a provider.
 
-        Returns merged context text labeled by provider. Empty providers
-        are skipped. Failures in one provider don't block others.
+        ``prefetch_candidates`` is deliberately optional so existing providers
+        remain compatible.  Returning ``None`` means the provider does not
+        support structured candidates; raising is handled by the caller so it
+        can fall back to legacy ``prefetch``.
+        """
+        method = getattr(provider, "prefetch_candidates", None)
+        if method is None or not callable(method):
+            return None
+        # The base-class no-op exists for documentation/type checking. Treat it
+        # as "capability not implemented" so legacy providers still use prefetch().
+        if getattr(provider.__class__, "prefetch_candidates", None) is MemoryProvider.prefetch_candidates:
+            return None
+        result = method(query, session_id=session_id)
+        if result is None:
+            return []
+        if isinstance(result, list):
+            return result
+        if isinstance(result, tuple):
+            return list(result)
+        return [result]
+
+    def prefetch_all(self, query: str, *, session_id: str = "") -> str:
+        """Collect governed prefetch context from all providers.
+
+        Providers that expose optional structured candidates are filtered,
+        reranked, and redacted before rendering. Legacy text-only providers
+        remain supported with best-effort redaction/sanitization. Failures in
+        one provider don't block others.
         """
         parts = []
         for provider in self._providers:
             try:
+                raw_candidates = self._provider_prefetch_candidates(
+                    provider, query, session_id=session_id
+                )
+            except Exception as e:
+                logger.debug(
+                    "Memory provider '%s' prefetch_candidates failed; falling back to legacy prefetch: %s",
+                    provider.name, e,
+                )
+                raw_candidates = None
+
+            if raw_candidates is not None:
+                try:
+                    candidates = normalize_candidates(raw_candidates, provider=provider.name)
+                    governed = govern_candidates(candidates, query)
+                    result = render_governed_context(provider.name, governed)
+                    if result and result.strip():
+                        parts.append(result)
+                    continue
+                except Exception as e:
+                    logger.debug(
+                        "Memory provider '%s' governed prefetch failed (non-fatal): %s",
+                        provider.name, e,
+                    )
+                    continue
+
+            try:
                 result = provider.prefetch(query, session_id=session_id)
+                result = sanitize_legacy_context(result)
                 if result and result.strip():
                     parts.append(result)
             except Exception as e:

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -15,7 +15,8 @@ Registration:
 Lifecycle (called by MemoryManager, wired in run_agent.py):
   initialize()          — connect, create resources, warm up
   system_prompt_block()  — static text for the system prompt
-  prefetch(query)        — background recall before each turn
+  prefetch(query)        — legacy formatted recall before each turn
+  prefetch_candidates(query) — optional structured recall candidates for governed injection
   sync_turn(user, asst)  — async write after each turn
   get_tool_schemas()     — tool schemas to expose to the model
   handle_tool_call()     — dispatch a tool call
@@ -91,7 +92,7 @@ class MemoryProvider(ABC):
         return ""
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
-        """Recall relevant context for the upcoming turn.
+        """Recall relevant legacy formatted context for the upcoming turn.
 
         Called before each API call. Return formatted text to inject as
         context, or empty string if nothing relevant. Implementations
@@ -103,6 +104,18 @@ class MemoryProvider(ABC):
         per-session scoping can ignore it.
         """
         return ""
+
+    def prefetch_candidates(self, query: str, *, session_id: str = "") -> List[Dict[str, Any]]:
+        """Optionally return structured recall candidates for governed injection.
+
+        Providers may override this to give Hermes core metadata for scope,
+        supersession/staleness, trust, and redaction decisions. Each candidate
+        should be a dict with at least ``content`` or ``text``; optional keys
+        include ``trust_score``, ``profile``, ``scope``, ``status``, ``tags``.
+        The default returns an empty list and preserves legacy ``prefetch``
+        compatibility.
+        """
+        return []
 
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
         """Queue a background recall for the NEXT turn.

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -369,7 +369,9 @@ def build_turn_context(
     if agent._memory_manager:
         try:
             _query = original_user_message if isinstance(original_user_message, str) else ""
-            ext_prefetch_cache = agent._memory_manager.prefetch_all(_query) or ""
+            ext_prefetch_cache = (
+                agent._memory_manager.prefetch_all(_query, session_id=agent.session_id) or ""
+            )
         except Exception:
             pass
 

--- a/docs/goals/2026-05-29-governed-memory-context-injection-goal.md
+++ b/docs/goals/2026-05-29-governed-memory-context-injection-goal.md
@@ -1,0 +1,85 @@
+# 2026-05-29 Goal: Hermes-Core Governed Memory Context Injection
+
+## Goal Statement
+
+Implement and verify Hermes-core governed memory context injection so automatic pre-turn memory recall applies explicit query normalization, scope filtering, stale/supersession suppression, secret redaction/exclusion, and relevance/reranking before memory context is injected into the model.
+
+This goal turns the clean-holographic production-recall benchmark result into production-path Hermes behavior. The implementation target is Hermes core, especially `agent/memory_manager.py` and adjacent provider contracts/tests, not the clean-holographic storage backend alone.
+
+## Source PRD / Plan
+
+Read first:
+
+- `docs/prds/2026-05-29-governed-memory-context-injection-prd.md`
+- `agent/memory_manager.py`
+- `agent/memory_provider.py`
+- `run_agent.py` memory pre-turn call sites
+- `~/.hermes/skills/devops/clean-holographic-live-repair/references/production-recall-benchmarking.md`
+- `~/.hermes/plugins/clean-holographic/scripts/evaluate_production_recall.py`
+- `~/.hermes/plugins/clean-holographic/tests/fixtures/production_recall_fixture.json`
+
+## Implementation Boundary
+
+### In scope
+
+- Add Hermes-core tests that exercise the actual automatic memory context injection seam, not only raw backend search.
+- Add query normalization for natural-language memory prefetch.
+- Add governed filtering/reranking/redaction before `build_memory_context_block(...)` receives context.
+- Preserve provider compatibility and failure isolation.
+- Add bounded observability for governance decisions without logging sensitive content.
+- Update docs/skills if implementation discovers reusable pitfalls.
+
+### Out of scope
+
+- Live default-profile memory DB writes, repairs, migrations, or synthetic fixture insertion.
+- Broad model/provider/fallback config changes.
+- Clean-holographic storage schema changes unless a strict provider-contract gap blocks the Hermes-core goal.
+- Gateway restart or production rollout without explicit Zev approval.
+- PHI-specific clinical memory behavior.
+
+## Safety Guardrails
+
+- Use synthetic fixtures and temporary `HERMES_HOME` only.
+- If running clean-holographic harnesses, set `HERMES_FORBID_LIVE_DB=1` and use `~/.hermes/hermes-agent/venv/bin/python` on Calliope.
+- Do not touch `~/.hermes/memory_store.db`, `memory_store.db-wal`, or `memory_store.db-shm` except for read-only fingerprinting if needed.
+- Do not expose API keys, tokens, or secrets. Synthetic secrets may be used only as leak sentinels.
+- Keep implementation update-friendly: prefer small core modules/helpers and tests over broad rewrites.
+- Do not restart the live gateway from inside a Telegram turn.
+
+## Required Deliverables
+
+1. **Discovery note in final report:** precise injection seam and provider contract decision.
+2. **Failing-then-passing Hermes-core tests:** cover current-vs-stale, profile/scope isolation, secret exclusion, query normalization, provider compatibility, and provider failure isolation.
+3. **Governance implementation:** pure/testable helper or module integrated at the memory-manager prefetch seam.
+4. **Verification evidence:** focused test commands and outputs, plus `git diff --check`.
+5. **Documentation/skill updates:** patch relevant skill/reference docs if new pitfalls or commands are discovered.
+6. **No-live-DB proof:** state how tests were isolated from the live memory DB.
+
+## Quantitative Gates
+
+- Governed injection strict pass rate: **100%** on the Hermes-core sandbox fixture.
+- Secret leak count: **0** synthetic secret strings in injected context.
+- Profile/scope isolation: **true** for all fixture cases.
+- Supersession/stale suppression: **true** for all fixture cases with current replacements.
+- Existing provider compatibility: focused existing memory-manager/provider tests pass.
+- Workspace hygiene: `git diff --check` passes for changed files.
+
+## Suggested Task Breakdown
+
+1. Verify branch, working tree, and current memory-manager/provider code.
+2. Inspect existing tests and choose the smallest injection-path test seam.
+3. Write failing tests with synthetic provider/candidates.
+4. Implement pure governance helpers: tokenize/query variants, stale/scope checks, secret redaction/exclusion, relevance scoring.
+5. Integrate helpers into `MemoryManager.prefetch_all(...)` or a narrower adjacent method without breaking legacy providers.
+6. Run focused tests; fix regressions.
+7. Run `git diff --check`; optionally run clean-holographic sandbox benchmark if provider contracts changed.
+8. Update docs/skills if needed.
+9. Report evidence and remaining limitations.
+
+## Acceptance Definition
+
+The goal is complete when Hermes core has a tested governed memory context injection path with 100% strict pass on the sandbox governed fixture, 0 synthetic secret leaks, verified profile/scope isolation and stale suppression, no live DB mutation, and a concise final report with exact files changed and test evidence.
+
+## Pause / Approval Condition
+
+This goal is documented and ready, but implementation should remain paused until Zev explicitly says to proceed with coding. Once Zev approves, resume this goal and execute the task breakdown above.

--- a/docs/prds/2026-05-29-governed-memory-context-injection-prd.md
+++ b/docs/prds/2026-05-29-governed-memory-context-injection-prd.md
@@ -1,0 +1,235 @@
+# Governed Memory Context Injection PRD
+
+## 1. Product Overview
+
+**Summary:** Add a Hermes-core governance layer for automatic memory context injection so production recall uses the same safety and relevance rules proven in the clean-holographic production-recall benchmark.
+
+**Problem:** The clean-holographic backend now has a sandbox benchmark showing raw/native recall and governed recall separately. Governed recall passes the production-style fixture, but Hermes core still calls `MemoryProvider.prefetch(...)` through `agent/memory_manager.py` and injects provider text directly after basic fencing/scrubbing. That means production context injection can still depend on backend-specific raw behavior instead of explicit Hermes-level governance.
+
+**Proposed solution:** Implement a provider-agnostic governance layer in Hermes core, centered around `agent/memory_manager.py`, that normalizes prefetch queries and filters/reranks/redacts candidate memory context before it is wrapped by `build_memory_context_block(...)` and added to the model context.
+
+**Primary user:** Zev using Hermes over Telegram/CLI with persistent memory enabled.
+
+**MVP boundary:** Govern automatic pre-turn memory context injection. Do not redesign memory storage, live DB schema, memory write/extraction, or the `fact_store` interactive tool API in this pass.
+
+## 2. Goals and Non-Goals
+
+### Goals
+
+- **G1:** Automatic memory context injection should prefer current, profile-appropriate, non-secret, relevant memories.
+  - Success metric: A Hermes-core sandbox test modeled on `clean-holographic/scripts/evaluate_production_recall.py` passes all governed context-injection cases.
+- **G2:** Keep governance provider-agnostic and backward-compatible.
+  - Success metric: built-in memory and one external provider can still register, prefetch, and sync without API breakage.
+- **G3:** Preserve live-memory safety.
+  - Success metric: tests run under temporary `HERMES_HOME` or `HERMES_FORBID_LIVE_DB=1`; no test touches `~/.hermes/memory_store.db`.
+- **G4:** Make production behavior auditable.
+  - Success metric: debug/report data can distinguish raw provider output from governed injected context without exposing secrets.
+
+### Non-goals
+
+- **NG1:** No live default-profile memory repair or migration.
+- **NG2:** No changes to clean-holographic storage schema unless a test exposes a strict provider-contract gap.
+- **NG3:** No broad provider/model/config changes.
+- **NG4:** No claim of end-to-end memory quality without a Hermes-core injection-path test.
+- **NG5:** No PHI-specific clinical memory logic in this pass.
+
+## 3. Personas and Permissions
+
+- **Zev / Hermes user:** Wants remembered preferences and environment facts to appear reliably without stale or unsafe context. Can approve production-impacting behavior.
+- **Hermes core implementer:** Can modify source and tests in `~/.hermes/hermes-agent`; must keep changes isolated, tested, and update-friendly.
+- **Memory provider/plugin:** Supplies raw context candidates or legacy prefetch text. Should not need live DB changes for MVP.
+
+## 4. User Stories
+
+- **US-1:** As Zev, I want Hermes to recall the current relevant fact instead of a stale superseded fact, so that answers do not regress to old preferences.
+  - Maps to: FR-1, FR-3, FR-5.
+- **US-2:** As Zev, I want topic/profile-specific memories isolated, so that one profile or context does not leak into another.
+  - Maps to: FR-2, FR-5.
+- **US-3:** As Zev, I want secrets and credential-like text excluded from injected memory context, so that recall cannot surface sensitive data.
+  - Maps to: FR-4, FR-6.
+- **US-4:** As a Hermes maintainer, I want governance tested at the actual memory-manager injection seam, so that benchmark wins are not confused with production behavior.
+  - Maps to: FR-5, FR-7.
+
+## 5. Functional Requirements
+
+- **FR-1: Query normalization.** Hermes core must derive safe lexical query variants from the incoming user message for memory prefetch, including stopword/filler stripping similar to the clean-holographic benchmark/backend fix.
+  - Priority: Must.
+  - Acceptance: natural-language benchmark queries retrieve the intended current facts in a sandbox injection-path test.
+
+- **FR-2: Scope filtering.** Governed injection must support profile/session scope metadata where available and must not inject candidate memory explicitly marked for a different profile/scope.
+  - Priority: Must.
+  - Acceptance: cross-profile distractor facts are absent from injected context in tests.
+
+- **FR-3: Stale/supersession suppression.** Governed injection must suppress candidate facts marked stale/superseded/deprecated where metadata or structured text makes that state available.
+  - Priority: Must.
+  - Acceptance: stale facts are absent from top injected context when current replacements exist.
+
+- **FR-4: Secret redaction/exclusion.** Governed injection must exclude or redact credential-like text before context wrapping.
+  - Priority: Must.
+  - Acceptance: injected context contains no synthetic API keys/tokens/secrets from fixtures.
+
+- **FR-5: Injection-path test harness.** Add Hermes-core tests that exercise `MemoryManager.prefetch_all(...)` or the nearest real pre-turn seam, not only raw provider calls.
+  - Priority: Must.
+  - Acceptance: focused tests fail before governance and pass after implementation.
+
+- **FR-6: Provider compatibility.** Existing provider interfaces must keep working. If richer candidate metadata is needed, add it as optional capability detection rather than a required breaking method.
+  - Priority: Must.
+  - Acceptance: existing memory-manager tests and provider registration tests pass.
+
+- **FR-7: Observability.** Add bounded diagnostics for governed injection decisions without logging sensitive content.
+  - Priority: Should.
+  - Acceptance: tests or log assertions prove counts/reasons can be emitted without raw secrets.
+
+## 6. User Experience
+
+**Entry points:** normal Telegram/CLI messages that trigger memory prefetch.
+
+**Core flow:**
+1. User sends a message.
+2. Hermes core normalizes the query and asks providers for candidate memory context.
+3. Governance layer filters/reranks/redacts candidates.
+4. `build_memory_context_block(...)` wraps only governed context.
+5. Model receives current, scoped, non-secret background memory.
+
+**Edge cases:**
+- Provider returns only legacy text with no metadata: preserve backward compatibility and apply best-effort redaction/fence scrubbing.
+- Provider returns pre-wrapped `<memory-context>`: existing sanitizer strips it.
+- All candidates are filtered: inject no memory block rather than injecting unsafe/stale context.
+- Governance errors: log non-fatal warning/debug and fall back safely, preferably to no injected external memory rather than unsafe raw text.
+
+## 7. Narrative Scenario
+
+Zev asks in Telegram about a current Hermes configuration preference. The memory backend has both an old stale fact and a current replacement, plus a distractor from another profile and a synthetic secret fixture. Hermes core receives raw candidates, suppresses the stale and cross-profile entries, redacts/excludes the secret-bearing entry, and injects only the current relevant fact into the fenced memory block.
+
+## 8. Success Metrics
+
+- **Hermes-core governed injection strict pass rate:** Baseline TBD; target 100% on the sandbox fixture adapted from clean-holographic governed cases.
+- **Secret leakage:** Target 0 leaked synthetic secrets in injected context.
+- **Profile isolation:** Target true for all scope-isolation cases.
+- **Supersession suppression:** Target true for all stale/current replacement cases.
+- **Regression suite:** Focused memory-manager/provider tests pass; `git diff --check` clean.
+
+## 9. Technical Considerations
+
+**Likely files to inspect first:**
+- `agent/memory_manager.py`
+- `agent/memory_provider.py`
+- `run_agent.py` memory pre-turn call sites
+- existing `tests/agent/*memory*` tests
+- clean-holographic benchmark files for fixture shape and scoring semantics
+
+**Architecture options:**
+- MVP-compatible option: add a small `agent/memory_governance.py` module with pure functions/classes and call it from `MemoryManager.prefetch_all(...)`.
+- Optional richer option: add a provider capability such as `prefetch_candidates(...)` returning structured candidates while keeping legacy `prefetch(...)` as fallback.
+
+**Data/privacy/security:**
+- Use synthetic fixtures only.
+- Do not mutate live default memory DB.
+- Do not print or log secrets; use synthetic secret sentinels for tests.
+
+**Risks:**
+- Legacy provider text may not expose enough metadata for perfect stale/profile filtering.
+  - Mitigation: support optional structured candidates, document fallback limitations, and test both paths.
+- Over-filtering could hide useful memories.
+  - Mitigation: keep filtering rules explicit, tested, and conservative.
+- Adding governance inside provider plugins would fragment behavior.
+  - Mitigation: keep governance in Hermes core and provider-agnostic.
+
+## 10. Short Implementation Plan
+
+### Phase 0 — Discovery and contract
+
+- Inspect `agent/memory_manager.py`, `agent/memory_provider.py`, `run_agent.py`, and existing memory tests.
+- Identify the narrowest injection seam for governance.
+- Decide whether MVP can parse legacy text or needs an optional structured-candidate provider capability.
+- Document the final contract in code comments or a short developer doc if the contract differs from this PRD.
+
+### Phase 1 — Failing Hermes-core tests
+
+- Add a synthetic provider/test fixture that returns current, stale, cross-profile, distractor, and secret-bearing memory candidates.
+- Add tests around `MemoryManager.prefetch_all(...)` or the closest real pre-turn injection path.
+- Require strict checks for current recall, stale suppression, profile isolation, and secret exclusion.
+
+### Phase 2 — Governance implementation
+
+- Add a pure governance module or helper functions.
+- Implement query normalization, scope checks, stale/supersession checks, redaction/exclusion, and simple relevance/reranking.
+- Integrate at the memory-manager seam while preserving provider failure isolation.
+
+### Phase 3 — Compatibility and regression
+
+- Run focused memory tests and adjacent provider/agent tests.
+- Run `git diff --check`.
+- If clean-holographic plugin tests are relevant, run its production recall harness separately under `HERMES_FORBID_LIVE_DB=1`.
+
+### Phase 4 — Report and compounding
+
+- Report raw-vs-governed behavior precisely.
+- Update the `hermes-agent` skill or clean-holographic reference if implementation reveals reusable pitfalls.
+- Do not claim production memory is fixed until the actual injection-path test passes.
+
+## 11. QA / Acceptance Plan
+
+### Acceptance tests
+
+- **AT-1:** Given current and stale facts for the same entity, when `MemoryManager.prefetch_all(...)` runs on a natural-language query, then injected context contains the current fact and excludes the stale one.
+- **AT-2:** Given a cross-profile distractor, when governed injection runs for the default profile, then the cross-profile fact is absent.
+- **AT-3:** Given a secret-bearing candidate, when governed injection runs, then no synthetic secret string appears in returned context.
+- **AT-4:** Given a legacy provider that only returns plain text, when governed injection runs, then existing provider compatibility is preserved and fence/secret scrubbing still applies.
+- **AT-5:** Given provider prefetch failure, when governed injection runs, then the failure remains non-fatal.
+
+### Regression risks
+
+- Provider API breakage.
+- Memory block formatting changes that leak context to the visible UI.
+- Excess context bloat from expanded query variants or diagnostics.
+
+## 12. Implementation Gate
+
+Coding should not start until:
+
+- [ ] Zev explicitly says to proceed with implementation after reviewing this PRD/plan.
+- [ ] The implementation agent verifies the current working tree and branch.
+- [ ] The implementation agent confirms tests use temporary `HERMES_HOME`/sandbox fixtures only.
+- [ ] The implementation agent verifies no live DB mutation is part of the plan.
+
+## 13. Agent Handoff Contract
+
+**Next agent should read:**
+- This PRD: `docs/prds/2026-05-29-governed-memory-context-injection-prd.md`
+- Goal doc: `docs/goals/2026-05-29-governed-memory-context-injection-goal.md`
+- `agent/memory_manager.py`
+- `agent/memory_provider.py`
+- clean-holographic reference: `~/.hermes/skills/devops/clean-holographic-live-repair/references/production-recall-benchmarking.md`
+- clean-holographic benchmark: `~/.hermes/plugins/clean-holographic/scripts/evaluate_production_recall.py`
+
+**Next agent should build:**
+- Hermes-core governed pre-turn memory context injection at the memory-manager seam.
+
+**Next agent should avoid:**
+- Live memory DB writes.
+- Provider/model/config changes.
+- Claiming end-to-end recall quality without injection-path evidence.
+
+**Next agent should verify:**
+- Focused Hermes-core memory tests.
+- `git diff --check`.
+- Optional clean-holographic sandbox benchmark if the implementation touches provider contracts.
+
+**Next agent should report back:**
+- Files changed.
+- Raw-vs-governed behavior evidence.
+- Test outputs.
+- Any provider-contract limitations or follow-up skill/docs updates.
+
+## 14. Assumptions and Open Questions
+
+**Assumptions:**
+- MVP can start with a pure Hermes-core governance layer and a synthetic provider fixture.
+- Structured provider candidates are preferable but should remain optional unless discovery proves text-only governance is too weak.
+- The first implementation should be local/source-tree only and not immediately restarted into the live Telegram gateway.
+
+**Open questions:**
+- Should the MVP add a formal optional `prefetch_candidates(...)` provider capability, or parse/score legacy provider text first?
+- What exact profile/scope metadata fields are available from built-in memory and clean-holographic today?
+- Should governance diagnostics be exposed through a debug command later, or remain logs/tests only for MVP?

--- a/docs/reports/2026-05-29-governed-memory-context-injection-report.md
+++ b/docs/reports/2026-05-29-governed-memory-context-injection-report.md
@@ -1,0 +1,127 @@
+# Governed Memory Context Injection Report — 2026-05-29
+
+## Summary
+
+Implemented a Hermes-core governed memory prefetch path at `MemoryManager.prefetch_all(...)`.
+
+The new implementation supports an optional structured provider capability, `prefetch_candidates(...)`, and applies provider-agnostic governance before automatic memory context is rendered for injection:
+
+- query-token normalization for natural-language relevance;
+- profile/scope filtering;
+- stale/supersession suppression;
+- secret-bearing candidate exclusion;
+- trust/relevance reranking;
+- best-effort redaction/sanitization for legacy text-only `prefetch(...)` providers.
+
+## Injection Seam
+
+The production pre-turn seam is:
+
+1. `agent/conversation_loop.py` calls `agent._memory_manager.prefetch_all(original_user_message)` once before the tool loop.
+2. The returned text is cached in `_ext_prefetch_cache`.
+3. On each API call, `build_memory_context_block(_ext_prefetch_cache)` wraps that returned text and appends it to the current user message as ephemeral, non-persisted context.
+
+Governance therefore belongs inside `MemoryManager.prefetch_all(...)`, before `build_memory_context_block(...)` receives memory text.
+
+## Files Changed
+
+- `agent/memory_governance.py` — new pure governance helper module.
+- `agent/memory_manager.py` — integrates optional structured candidates and legacy fallback governance at prefetch seam.
+- `agent/memory_provider.py` — documents optional `prefetch_candidates(...)` provider capability.
+- `tests/agent/test_memory_provider.py` — adds governed injection tests and a synthetic candidate provider.
+- `docs/reports/2026-05-29-governed-memory-context-injection-report.md` — this report.
+
+## Behavior Contract
+
+### Structured providers
+
+Providers may optionally implement:
+
+```python
+def prefetch_candidates(self, query: str, *, session_id: str = "") -> list[dict]: ...
+```
+
+Candidate dicts should include `content` or `text`; useful optional metadata includes `trust_score`, `profile`, `scope`, `status`, and `tags`.
+
+If a provider does not override the base no-op `prefetch_candidates(...)`, Hermes treats the capability as absent and falls back to legacy `prefetch(...)`.
+
+### Legacy providers
+
+Legacy formatted text from `prefetch(...)` remains supported. Hermes applies forced redaction and drops obvious secret-bearing lines, but legacy text lacks enough structure for full profile/stale governance. Full governance requires structured candidates.
+
+## Verification Evidence
+
+### RED failures observed before implementation
+
+New tests initially failed because `MemoryManager.prefetch_all(...)` returned no structured candidate output:
+
+- `test_governed_prefetch_filters_scope_stale_and_secrets` failed: expected governed current fact in result, got `''`.
+- `test_governed_prefetch_uses_query_normalization_for_relevance` failed: expected governance fact in result, got `''`.
+
+A follow-up scope test also failed before the profile-scope correction because `default` had been incorrectly treated as a global scope.
+
+### GREEN / regression checks
+
+Focused governed tests:
+
+```bash
+venv/bin/python -m pytest \
+  tests/agent/test_memory_provider.py::TestMemoryManager::test_governed_prefetch_filters_scope_stale_and_secrets \
+  tests/agent/test_memory_provider.py::TestMemoryManager::test_governed_prefetch_uses_query_normalization_for_relevance \
+  tests/agent/test_memory_provider.py::TestMemoryManager::test_governed_prefetch_preserves_legacy_text_provider_compatibility \
+  tests/agent/test_memory_provider.py::TestMemoryManager::test_governed_candidate_failure_falls_back_to_legacy_prefetch -q
+```
+
+Result: `4 passed in 0.07s`.
+
+Scope correction test:
+
+```bash
+venv/bin/python -m pytest tests/agent/test_memory_provider.py::TestMemoryManager::test_governed_prefetch_filters_scope_for_non_default_profile -q
+```
+
+Result: `1 passed in 0.04s`.
+
+Adjacent memory/run-agent regression suite:
+
+```bash
+scripts/run_tests.sh \
+  tests/agent/test_memory_provider.py \
+  tests/run_agent/test_run_agent.py \
+  tests/agent/test_memory_session_switch.py \
+  tests/agent/test_memory_user_id.py
+```
+
+Result: `452 tests passed, 0 failed`.
+
+Whitespace hygiene:
+
+```bash
+git diff --check -- \
+  agent/memory_governance.py \
+  agent/memory_manager.py \
+  agent/memory_provider.py \
+  tests/agent/test_memory_provider.py \
+  docs/prds/2026-05-29-governed-memory-context-injection-prd.md \
+  docs/goals/2026-05-29-governed-memory-context-injection-goal.md
+```
+
+Result: passed.
+
+## Safety / Isolation
+
+- No live default Hermes memory DB was used or mutated.
+- Tests use synthetic in-memory providers/candidates only.
+- No provider/model/config changes were made.
+- The live Telegram gateway was not restarted.
+
+## Remaining Limitations
+
+- Full stale/profile governance requires structured provider candidates. Legacy text-only `prefetch(...)` providers only receive best-effort redaction/secret-line filtering.
+- The active clean-holographic plugin has not yet been updated to expose `prefetch_candidates(...)`; until then, it continues through the legacy text path.
+- No production rollout/restart has been performed in this turn.
+
+## Recommended Follow-Up
+
+- Add `prefetch_candidates(...)` to clean-holographic so Hermes core can apply full governed injection to live clean-holographic recall.
+- Consider a small developer doc for provider authors once the structured candidate shape stabilizes across one real provider.

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -92,6 +92,19 @@ class MessagesMemoryProvider(FakeMemoryProvider):
         self.synced_turns.append((user_content, assistant_content, session_id, messages))
 
 
+class CandidateMemoryProvider(FakeMemoryProvider):
+    """Provider exposing optional structured recall candidates."""
+
+    def __init__(self, name="external", candidates=None):
+        super().__init__(name)
+        self.candidates = candidates or []
+        self.candidate_queries = []
+
+    def prefetch_candidates(self, query, *, session_id=""):
+        self.candidate_queries.append((query, session_id))
+        return list(self.candidates)
+
+
 # ---------------------------------------------------------------------------
 # MemoryProvider ABC tests
 # ---------------------------------------------------------------------------
@@ -398,6 +411,118 @@ class TestMemoryManager:
 
         result = mgr.prefetch_all("query")
         assert "external memory" in result
+
+    # -- Governed memory context injection ----------------------------------
+
+    def test_governed_prefetch_filters_scope_stale_and_secrets(self, monkeypatch):
+        monkeypatch.setenv("HERMES_PROFILE", "default")
+        mgr = MemoryManager()
+        provider = CandidateMemoryProvider(candidates=[
+            {
+                "content": "Current Hermes default profile uses governed memory injection.",
+                "profile": "default",
+                "trust_score": 0.9,
+                "tags": "current,hermes-memory",
+            },
+            {
+                "content": "Stale Hermes default profile uses raw injection.",
+                "profile": "default",
+                "trust_score": 0.95,
+                "status": "superseded",
+                "tags": "stale,hermes-memory",
+            },
+            {
+                "content": "Researcher profile uses a different memory contract.",
+                "profile": "researcher",
+                "trust_score": 0.99,
+                "tags": "current,hermes-memory",
+            },
+            {
+                "content": "Synthetic credential OPENAI_API_KEY=sk-testsecret1234567890 must not leak.",
+                "profile": "default",
+                "trust_score": 0.8,
+                "tags": "current,secret",
+            },
+        ])
+        mgr.add_provider(provider)
+
+        result = mgr.prefetch_all("what is the current Hermes memory injection contract?")
+
+        assert "governed memory injection" in result
+        assert "raw injection" not in result
+        assert "Researcher profile" not in result
+        assert "sk-testsecret" not in result
+        assert "OPENAI_API_KEY" not in result
+        assert provider.candidate_queries == [(
+            "what is the current Hermes memory injection contract?",
+            "",
+        )]
+
+    def test_governed_prefetch_uses_query_normalization_for_relevance(self, monkeypatch):
+        monkeypatch.setenv("HERMES_PROFILE", "default")
+        mgr = MemoryManager()
+        provider = CandidateMemoryProvider(candidates=[
+            {
+                "content": "Hermes memory governance suppresses stale facts before injection.",
+                "profile": "default",
+                "trust_score": 0.4,
+            },
+            {
+                "content": "Unrelated lunch preference: falafel with tahini.",
+                "profile": "default",
+                "trust_score": 0.99,
+            },
+        ])
+        mgr.add_provider(provider)
+
+        result = mgr.prefetch_all("Could you remind me what the memory governance injection rule is?")
+
+        assert "memory governance suppresses stale facts" in result
+        assert "falafel" not in result
+
+    def test_governed_prefetch_filters_scope_for_non_default_profile(self, monkeypatch):
+        monkeypatch.setenv("HERMES_PROFILE", "researcher")
+        mgr = MemoryManager()
+        provider = CandidateMemoryProvider(candidates=[
+            {
+                "content": "Default profile memory must not appear in researcher scope.",
+                "profile": "default",
+                "trust_score": 0.9,
+            },
+            {
+                "content": "Researcher profile memory contract is isolated.",
+                "profile": "researcher",
+                "trust_score": 0.7,
+            },
+        ])
+        mgr.add_provider(provider)
+
+        result = mgr.prefetch_all("what is the researcher memory contract?")
+
+        assert "Researcher profile memory contract" in result
+        assert "Default profile memory" not in result
+
+    def test_governed_prefetch_preserves_legacy_text_provider_compatibility(self):
+        mgr = MemoryManager()
+        provider = FakeMemoryProvider("external")
+        provider._prefetch_result = "## Legacy Memory\n- Existing legacy text still works."
+        mgr.add_provider(provider)
+
+        result = mgr.prefetch_all("query")
+
+        assert "Existing legacy text still works" in result
+        assert provider.prefetch_queries == ["query"]
+
+    def test_governed_candidate_failure_falls_back_to_legacy_prefetch(self):
+        mgr = MemoryManager()
+        provider = CandidateMemoryProvider()
+        provider.prefetch_candidates = MagicMock(side_effect=RuntimeError("candidate failure"))
+        provider._prefetch_result = "legacy fallback memory"
+        mgr.add_provider(provider)
+
+        result = mgr.prefetch_all("query")
+
+        assert "legacy fallback memory" in result
 
     def test_system_prompt_failure_doesnt_block(self):
         mgr = MemoryManager()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3386,6 +3386,70 @@ class TestRunConversation:
         assert result["final_response"] == "Final answer"
         assert result["completed"] is True
 
+    def test_governed_memory_candidates_are_injected_with_session_scope(self, agent, monkeypatch):
+        """Conversation loop should inject governed structured memory into the API request.
+
+        This is the integration seam above MemoryManager unit tests: a provider
+        gets the live session_id, returns structured candidates, core governance
+        filters them, and only the governed context is appended to the current
+        API-call user message without mutating the persisted conversation.
+        """
+        from agent.memory_manager import MemoryManager
+        from tests.agent.test_memory_provider import CandidateMemoryProvider
+
+        self._setup_agent(agent)
+        monkeypatch.setenv("HERMES_PROFILE", "default")
+        provider = CandidateMemoryProvider(candidates=[
+            {
+                "content": "Hermes memory governance injects current session scoped context.",
+                "profile": "default",
+                "trust_score": 0.9,
+                "tags": "current,hermes-memory",
+            },
+            {
+                "content": "Researcher profile memory must not enter default session context.",
+                "profile": "researcher",
+                "trust_score": 1.0,
+            },
+            {
+                "content": "Hermes memory governance old raw injection contract.",
+                "profile": "default",
+                "status": "superseded",
+                "trust_score": 1.0,
+            },
+        ])
+        mgr = MemoryManager()
+        mgr.add_provider(provider)
+        agent._memory_manager = mgr
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Final answer",
+            finish_reason="stop",
+        )
+
+        with (
+            patch.object(agent, "_persist_session") as persist_mock,
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("what is the current Hermes memory governance contract?")
+
+        assert result["final_response"] == "Final answer"
+        assert provider.candidate_queries == [(
+            "what is the current Hermes memory governance contract?",
+            agent.session_id,
+        )]
+        sent_messages = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        user_messages = [m for m in sent_messages if m.get("role") == "user"]
+        assert len(user_messages) == 1
+        sent_user_content = user_messages[0]["content"]
+        assert "<memory-context>" in sent_user_content
+        assert "current session scoped context" in sent_user_content
+        assert "Researcher profile memory" not in sent_user_content
+        assert "old raw injection contract" not in sent_user_content
+        persisted_messages = persist_mock.call_args.args[0]
+        assert persisted_messages[0]["content"] == "what is the current Hermes memory governance contract?"
+        assert "memory-context" not in persisted_messages[0]["content"]
+
     def test_ollama_small_runtime_context_fails_before_api_call(self, agent, caplog):
         self._setup_agent(agent)
         agent.model = "qwen3.5:9b"


### PR DESCRIPTION
## Summary

Adds a provider-agnostic governance layer for automatic memory context injection.

- introduces optional `MemoryProvider.prefetch_candidates(query, session_id=...)` structured recall capability
- filters/reranks structured candidates before injection for profile scope, stale/superseded status, secret-bearing metadata/content, trust, and relevance
- keeps legacy `prefetch()` providers compatible with best-effort redaction/sanitization fallback
- documents the behavior contract and implementation notes

## Verification

- `git diff --check origin/main..HEAD`
- `/Users/calliope/.hermes/hermes-agent/venv/bin/python -m py_compile agent/memory_governance.py agent/memory_manager.py agent/memory_provider.py tests/agent/test_memory_provider.py tests/run_agent/test_run_agent.py`
- `/Users/calliope/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_memory_provider.py::TestMemoryManager::test_governed_prefetch_filters_scope_stale_and_secrets tests/agent/test_memory_provider.py::TestMemoryManager::test_governed_prefetch_uses_query_normalization_for_relevance tests/agent/test_memory_provider.py::TestMemoryManager::test_governed_prefetch_preserves_legacy_text_provider_compatibility tests/agent/test_memory_provider.py::TestMemoryManager::test_governed_candidate_failure_falls_back_to_legacy_prefetch tests/agent/test_memory_provider.py::TestMemoryManager::test_governed_prefetch_filters_scope_for_non_default_profile tests/run_agent/test_run_agent.py::TestMemoryProviderTurnStart -q` → 7 passed, 1 warning
- `scripts/run_tests.sh tests/agent/test_memory_provider.py tests/run_agent/test_run_agent.py` → 474 passed, 0 failed

## Notes

This is intentionally core/provider-agnostic. Providers can continue using legacy formatted `prefetch()`, while providers with richer metadata can opt into `prefetch_candidates()` so Hermes core can own final governance before injected memory reaches the model.
