### PR TITLE
fix(tui): strip --tui-session flag from model name parsing

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -300,9 +300,13 @@ class ModelSwitchResult:
 # ---------------------------------------------------------------------------
 
 def parse_model_flags(raw_args: str) -> tuple[str, str, bool, bool]:
-    """Parse --provider, --global, and --refresh flags from /model command args.
+    """Parse --provider, --global, --tui-session, and --refresh flags from /model command args.
 
     Returns (model_input, explicit_provider, is_global, force_refresh).
+
+    ``--tui-session`` is a no-op marker sent by the TUI model picker for
+    session-scoped switches. It is stripped so it doesn't pollute the model
+    name, and leaves ``is_global=False`` (the default).
 
     Examples::
 
@@ -312,6 +316,7 @@ def parse_model_flags(raw_args: str) -> tuple[str, str, bool, bool]:
         "--provider my-ollama"           -> ("", "my-ollama", False, False)
         "--refresh"                      -> ("", "", False, True)
         "sonnet --provider anthropic --global" -> ("sonnet", "anthropic", True, False)
+        "sonnet --provider custom --tui-session" -> ("sonnet", "custom", False, False)
     """
     is_global = False
     explicit_provider = ""
@@ -320,7 +325,14 @@ def parse_model_flags(raw_args: str) -> tuple[str, str, bool, bool]:
     # Normalize Unicode dashes (Telegram/iOS auto-converts -- to em/en dash)
     # A single Unicode dash before a flag keyword becomes "--"
     import re as _re
-    raw_args = _re.sub(r'[\u2012\u2013\u2014\u2015](provider|global|refresh)', r'--\1', raw_args)
+    raw_args = _re.sub(r'[\u2012\u2013\u2014\u2015](provider|global|refresh|tui-session)', r'--\1', raw_args)
+
+    # Extract --tui-session (TUI model picker session-scoped switch marker).
+    # This flag must be stripped before model name parsing so it doesn't
+    # leak into the model input and cause "Model names cannot contain spaces".
+    # It explicitly means is_global=False (session-only override).
+    if "--tui-session" in raw_args:
+        raw_args = raw_args.replace("--tui-session", "").strip()
 
     # Extract --global
     if "--global" in raw_args:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -98,6 +98,7 @@ AUTHOR_MAP = {
     "rod.boev@gmail.com": "rodboev",
     "70290504+dangelo352@users.noreply.github.com": "dangelo352",
     "zhaolei.vc@bytedance.com": "zhaoleibd",
+    "bradhallett@users.noreply.github.com": "bradhallett",
     "jeffrobodie@gmail.com": "jeffrobodie-glitch",
     "kyssta-exe@users.noreply.github.com": "kyssta-exe",
     "ali.zakaee.1997@gmail.com": "ITheEqualizer",

--- a/tests/hermes_cli/test_parse_model_flags.py
+++ b/tests/hermes_cli/test_parse_model_flags.py
@@ -1,0 +1,80 @@
+"""Unit tests for parse_model_flags flag stripping.
+
+The TUI model picker appends ``--tui-session`` to session-scoped switch
+commands (the default when the user does not toggle ``--global``).
+``parse_model_flags`` must strip this marker before model-name parsing
+so it doesn't leak into ``model_input`` and trigger the "Model names
+cannot contain spaces" validation error.
+"""
+
+import pytest
+
+from hermes_cli.model_switch import parse_model_flags
+
+
+class TestParseModelFlagsTuiSession:
+    """--tui-session flag handling."""
+
+    def test_tui_session_stripped_from_model_name(self):
+        """The flag must not appear in the returned model_input."""
+        model, provider, is_global, _ = parse_model_flags(
+            "glm/glm-5.2 --provider 9router --tui-session"
+        )
+        assert "--tui-session" not in model
+        assert model == "glm/glm-5.2"
+
+    def test_tui_session_preserves_provider(self):
+        """Provider flag must still be extracted alongside --tui-session."""
+        _, provider, _, _ = parse_model_flags(
+            "glm/glm-5.2 --provider custom --tui-session"
+        )
+        assert provider == "custom"
+
+    def test_tui_session_is_not_global(self):
+        """--tui-session explicitly means session-only (is_global=False)."""
+        _, _, is_global, _ = parse_model_flags(
+            "glm/glm-5.2 --provider 9router --tui-session"
+        )
+        assert is_global is False
+
+    def test_tui_session_with_unicode_dash(self):
+        """Unicode dash variants of --tui-session must be normalized."""
+        model, _, _, _ = parse_model_flags(
+            "glm/glm-5.2 \u2014tui-session"
+        )
+        assert "--tui-session" not in model
+        assert model == "glm/glm-5.2"
+
+    def test_bare_model_without_flags(self):
+        """Baseline: bare model name with no flags."""
+        model, provider, is_global, refresh = parse_model_flags("sonnet")
+        assert model == "sonnet"
+        assert provider == ""
+        assert is_global is False
+        assert refresh is False
+
+    def test_global_flag_still_works(self):
+        """--global must still set is_global=True."""
+        _, _, is_global, _ = parse_model_flags("sonnet --global")
+        assert is_global is True
+
+    def test_both_tui_session_and_global(self):
+        """If both flags appear, --global wins for is_global."""
+        _, _, is_global, _ = parse_model_flags(
+            "sonnet --global --tui-session"
+        )
+        assert is_global is True
+
+    def test_refresh_flag_still_works(self):
+        """--refresh must still set force_refresh=True."""
+        _, _, _, refresh = parse_model_flags("--refresh")
+        assert refresh is True
+
+    def test_multi_word_model_after_stripping(self):
+        """After stripping --tui-session, a clean model name must remain."""
+        model, provider, is_global, _ = parse_model_flags(
+            "meta-llama/Llama-3.3-70B-Instruct --provider openrouter --tui-session"
+        )
+        assert model == "meta-llama/Llama-3.3-70B-Instruct"
+        assert provider == "openrouter"
+        assert is_global is False


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where the TUI model picker's `--tui-session` flag leaks into the model name string, triggering `"✗ Model names cannot contain spaces"` and silently breaking every session-scoped model switch.

## Root Cause

The TUI model picker sends commands like `glm/glm-5.2 --provider 9router --tui-session` for session-scoped switches (the default — no Ctrl+G toggle). `parse_model_flags` did not recognize `--tui-session`, so it stayed in the model input string. The validator then rejected `"glm/glm-5.2 --tui-session"` because it contains spaces.

This affects **every** session-only model pick from the TUI picker — the most common interaction.

## Related Issue

Related to #43140 — that issue reports the same error message but for a different cause (models with literal spaces in their names, e.g. vLLM). This PR fixes the `--tui-session` leak path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_switch.py` — `parse_model_flags`: strip `--tui-session` before model name parsing; add it to the Unicode dash normalization regex
- `tests/hermes_cli/test_parse_model_flags.py` — new unit tests covering `--tui-session` stripping, provider preservation, Unicode dash normalization, and interaction with `--global`/`--refresh`
- `scripts/release.py` — add `bradhallett@users.noreply.github.com` to `AUTHOR_MAP` for the `check-attribution` CI gate

## How to Test

```bash
python -m pytest tests/hermes_cli/test_parse_model_flags.py -v -o "addopts="
```

```
9 passed in 0.20s
```

Manual reproduction:
1. Before fix: `parse_model_flags("sonnet --provider custom --tui-session")` returns `model_input="sonnet --tui-session"` → validation fails
2. After fix: returns `model_input="sonnet"`, `provider="custom"`, `is_global=False` → switch succeeds

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`fix(tui): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/hermes_cli/test_parse_model_flags.py tests/hermes_cli/test_model_switch_custom_providers.py -q` — all 34 tests pass
- [x] I've added tests for my changes
- [x] Tested on: macOS 15.2 (Sequoia)