### PR TITLE
fix(tui): suppress redundant Custom endpoint row when named provider covers same URL

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -222,6 +222,29 @@ def _append_unconfigured_rows(rows: list[dict], ctx: ConfigContext) -> list[dict
 
     seen = {r["slug"].lower() for r in rows}
     cur = (ctx.current_provider or "").lower()
+
+    # Suppress the bare "custom" skeleton row when a named user provider
+    # already covers the current endpoint. Without this, the picker shows
+    # both a "Custom endpoint" row and the named provider (e.g. "9Router")
+    # for the same URL, and picking from the wrong one can produce a
+    # provider value that doesn't resolve at runtime.
+    _cur_base_norm = str(ctx.current_base_url or "").strip().rstrip("/").lower()
+    if (
+        "custom" not in seen
+        and _cur_base_norm
+        and any(
+            isinstance(_uc, dict)
+            and str(
+                _uc.get("base_url", "")
+                or _uc.get("url", "")
+                or _uc.get("api", "")
+            ).strip().rstrip("/").lower()
+            == _cur_base_norm
+            for _uc in (ctx.user_providers or {}).values()
+        )
+    ):
+        seen.add("custom")
+
     extras: list[dict] = []
     for entry in CANONICAL_PROVIDERS:
         if entry.slug.lower() in seen:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -98,6 +98,7 @@ AUTHOR_MAP = {
     "rod.boev@gmail.com": "rodboev",
     "70290504+dangelo352@users.noreply.github.com": "dangelo352",
     "zhaolei.vc@bytedance.com": "zhaoleibd",
+    "bradhallett@users.noreply.github.com": "bradhallett",
     "jeffrobodie@gmail.com": "jeffrobodie-glitch",
     "kyssta-exe@users.noreply.github.com": "kyssta-exe",
     "ali.zakaee.1997@gmail.com": "ITheEqualizer",

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -319,6 +319,59 @@ def test_include_unconfigured_skips_already_present_slugs():
     assert or_rows[0]["models"] == ["m1"]  # the authenticated row, not skeleton
 
 
+def test_include_unconfigured_suppresses_custom_when_named_provider_covers_url():
+    """When model.provider='custom' and a named user provider (from the
+    ``providers:`` config section) already covers the same endpoint URL,
+    the bare 'Custom endpoint' skeleton row must NOT appear in the picker.
+
+    Without this suppression, the picker shows both the named provider
+    (e.g. '9Router') and a redundant 'Custom endpoint' row marked as
+    current — picking from the wrong one can persist a provider value
+    that doesn't resolve correctly at runtime.
+    """
+    named_url = "http://127.0.0.1:20128/v1"
+    rows = [
+        {"slug": "9router", "name": "9Router", "models": ["glm/glm-5.2"],
+         "total_models": 1, "is_current": True, "is_user_defined": True,
+         "source": "user-config", "api_url": named_url},
+    ]
+    ctx = ConfigContext(
+        current_provider="custom",
+        current_model="glm/glm-5.2",
+        current_base_url=named_url,
+        user_providers={"9router": {"base_url": named_url, "api_key": "sk-test", "name": "9Router"}},
+        custom_providers=[],
+    )
+    with _list_auth_returning(rows):
+        payload = build_models_payload(ctx, include_unconfigured=True)
+    custom_rows = [r for r in payload["providers"] if r["slug"] == "custom"]
+    assert len(custom_rows) == 0, "Custom endpoint skeleton should be suppressed"
+
+
+def test_include_unconfigured_keeps_custom_when_no_named_provider_matches():
+    """The bare 'Custom endpoint' skeleton must still appear when
+    provider='custom' but NO named user provider covers the same URL —
+    e.g. the user has a named provider for a different endpoint."""
+    custom_url = "http://localhost:8080/v1"
+    other_url = "http://127.0.0.1:20128/v1"
+    rows = [
+        {"slug": "9router", "name": "9Router", "models": ["glm/glm-5.2"],
+         "total_models": 1, "is_current": False, "is_user_defined": True,
+         "source": "user-config", "api_url": other_url},
+    ]
+    ctx = ConfigContext(
+        current_provider="custom",
+        current_model="local-model",
+        current_base_url=custom_url,
+        user_providers={"9router": {"base_url": other_url, "api_key": "sk-test", "name": "9Router"}},
+        custom_providers=[],
+    )
+    with _list_auth_returning(rows):
+        payload = build_models_payload(ctx, include_unconfigured=True)
+    custom_rows = [r for r in payload["providers"] if r["slug"] == "custom"]
+    assert len(custom_rows) == 1, "Custom endpoint skeleton should be present (no URL match)"
+
+
 # ─── picker_hints ──────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes a UI confusion bug in the TUI model picker where both a named custom provider (e.g. "9Router") and a redundant "Custom endpoint" skeleton row appear simultaneously for the same endpoint URL.

## Root Cause

When a user configures a named provider under `providers:` (e.g. `providers.9router`) that covers the same `base_url` as `model.provider: custom`, `_append_unconfigured_rows` in `inventory.py` still adds a bare "Custom endpoint" canonical skeleton row. The picker then shows:

1. **9Router** — the named provider row (from `list_authenticated_providers`)
2. **Custom endpoint** — the skeleton row (from `_append_unconfigured_rows`), marked `is_current=True` because `current_provider == "custom"`

Picking from the skeleton row can persist a `provider: custom` value that may not resolve correctly at runtime if the named provider uses a different resolution path.

`list_authenticated_providers` section 3b already correctly suppresses its own bare-custom row when `custom_providers` covers the URL — but `_append_unconfigured_rows` was not performing the same check against `user_providers`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/inventory.py` — `_append_unconfigured_rows`: suppress the `custom` canonical skeleton when a user-defined provider already covers `ctx.current_base_url`
- `tests/hermes_cli/test_inventory.py` — two new tests: suppression when URLs match, non-suppression when URLs differ
- `scripts/release.py` — add `bradhallett@users.noreply.github.com` to `AUTHOR_MAP` for the `check-attribution` CI gate

## How to Test

```bash
python -m pytest tests/hermes_cli/test_inventory.py -v -o "addopts="
```

```
23 passed in 1.82s
```

Both new tests verify the fix:
- `test_include_unconfigured_suppresses_custom_when_named_provider_covers_url` — skeleton suppressed when URLs match
- `test_include_unconfigured_keeps_custom_when_no_named_provider_matches` — skeleton preserved when URLs differ

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] All 23 inventory tests pass + 25 model_switch_custom_providers tests pass
- [x] I've added tests for my changes
- [x] Tested on: macOS 15.2 (Sequoia)