### PR TITLE
fix(desktop): stop clarify textarea scroll-jitter during steady-state needsInput

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
@@ -80,18 +80,12 @@ describe('useSessionStateCache — per-session turn timer', () => {
   it("keeps a background session's running turn clock and never mirrors it to the view", () => {
     let cache!: Cache
     // Active session is "fg-runtime"; the turn starts on the BACKGROUND session.
-    render(
-      <Harness activeSessionId="fg-runtime" onReady={c => (cache = c)} selectedStoredSessionId="fg-stored" />
-    )
+    render(<Harness activeSessionId="fg-runtime" onReady={c => (cache = c)} selectedStoredSessionId="fg-stored" />)
 
     const startedAt = 1_700_000_000_000
 
     act(() => {
-      cache.updateSessionState(
-        'bg-runtime',
-        state => ({ ...state, busy: true, turnStartedAt: startedAt }),
-        'bg-stored'
-      )
+      cache.updateSessionState('bg-runtime', state => ({ ...state, busy: true, turnStartedAt: startedAt }), 'bg-stored')
     })
 
     // The background session's own cache entry holds the clock...
@@ -110,11 +104,7 @@ describe('useSessionStateCache — per-session turn timer', () => {
     // A turn on the ACTIVE session stages into the view; the flush mirrors its
     // turnStartedAt into the global atom the statusbar reads.
     act(() => {
-      cache.updateSessionState(
-        'fg-runtime',
-        state => ({ ...state, busy: true, turnStartedAt: startedAt }),
-        'fg-stored'
-      )
+      cache.updateSessionState('fg-runtime', state => ({ ...state, busy: true, turnStartedAt: startedAt }), 'fg-stored')
     })
 
     expect($turnStartedAt.get()).toBe(startedAt)
@@ -211,5 +201,41 @@ describe('useSessionStateCache — per-session turn timer', () => {
     expect($currentReasoningEffort.get()).toBe('')
     expect($currentServiceTier.get()).toBe('')
     expect($currentFastMode.get()).toBe(false)
+  })
+
+  it('does not synchronously flush steady-state needsInput heartbeats (clarify scroll-jitter fix)', () => {
+    // The first needsInput=true update is a critical *edge* — it must flush
+    // synchronously so the clarify UI appears immediately. But a second
+    // heartbeat that arrives with the same busy/needsInput flags is
+    // steady-state, not an edge. It must defer to the RAF batch path so
+    // it doesn't re-render the thread and jerk the scroll / reset the
+    // textarea the user is typing into.
+    let cache!: Cache
+
+    // Don't fire rAF synchronously — we want to observe whether it's called.
+    const rafSpy = vi.fn().mockReturnValue(42)
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(rafSpy)
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined)
+
+    render(<Harness activeSessionId="fg-runtime" onReady={c => (cache = c)} selectedStoredSessionId="fg-stored" />)
+
+    rafSpy.mockClear()
+
+    // First update: needsInput flips to true → critical edge → synchronous flush.
+    act(() => {
+      cache.updateSessionState('fg-runtime', state => ({ ...state, busy: true, needsInput: true }), 'fg-stored')
+    })
+
+    // Critical edge flushes synchronously — rAF must NOT have been called
+    // (the sync path cancels any pending rAF and flushes directly).
+    expect(rafSpy).not.toHaveBeenCalled()
+
+    // Second update: same busy=true, needsInput=true → steady-state, not an edge.
+    act(() => {
+      cache.updateSessionState('fg-runtime', state => ({ ...state, busy: true, needsInput: true }), 'fg-stored')
+    })
+
+    // Non-critical flush defers to the RAF batch path.
+    expect(rafSpy).toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -79,9 +79,22 @@ export function useSessionStateCache({
   const runtimeIdByStoredSessionIdRef = useRef(new Map<string, string>())
   const pendingViewStateRef = useRef<{ sessionId: string; state: ClientSessionState } | null>(null)
   const viewSyncRafRef = useRef<number | null>(null)
+  // Track the last `busy`/`needsInput` values we saw at flush time so
+  // `isCriticalTransition` fires only on the *edge* (the flag flipping),
+  // not on every periodic `session.info` heartbeat that arrives while the
+  // session is in steady-state `needsInput` (e.g. blocked on a clarify
+  // prompt). Without this, every heartbeat bypasses RAF coalescing and
+  // re-renders the thread — jerking scroll and resetting the textarea
+  // the user is typing into.
+  const lastFlushedBusyRef = useRef<boolean | undefined>(undefined)
+  const lastFlushedNeedsInputRef = useRef<boolean | undefined>(undefined)
 
   useEffect(() => {
     activeSessionIdRef.current = activeSessionId
+    // Reset edge tracking on session switch so the first flush on the new
+    // session is treated as critical.
+    lastFlushedBusyRef.current = undefined
+    lastFlushedNeedsInputRef.current = undefined
   }, [activeSessionId])
 
   useEffect(() => {
@@ -156,6 +169,12 @@ export function useSessionStateCache({
     // atom the statusbar timer reads. Keeps a backgrounded turn's elapsed
     // time intact on focus instead of zeroing it (the "timer restarts" bug).
     setTurnStartedAt(pending.state.turnStartedAt)
+
+    // Record what we just flushed so the next `isCriticalTransition` check
+    // can distinguish edges (busy/needsInput flipping) from steady-state
+    // heartbeats that carry the same flags.
+    lastFlushedBusyRef.current = pending.state.busy
+    lastFlushedNeedsInputRef.current = pending.state.needsInput
   }, [busyRef, setAwaitingResponse, setBusy, setMessages])
 
   const syncSessionStateToView = useCallback(
@@ -186,7 +205,16 @@ export function useSessionStateCache({
       // state anyway). The plain busy heartbeat stays RAF-batched: that
       // coalescing exists only to keep periodic `session.info` updates from
       // churning `$messages` and jerking the scroll position while reading.
-      const isCriticalTransition = !state.busy || state.needsInput
+      //
+      // But only the *edge* is critical — the first flush where `busy`
+      // flipped to false or `needsInput` flipped to true. Once the session
+      // is in steady-state `needsInput` (e.g. blocked on a clarify prompt),
+      // periodic heartbeats would otherwise bypass the RAF coalescing and
+      // re-render the thread on every tick — jerking the scroll position
+      // and resetting the clarify textarea while the user is typing.
+      const isCriticalTransition =
+        (!state.busy || state.needsInput) &&
+        (lastFlushedBusyRef.current !== state.busy || lastFlushedNeedsInputRef.current !== state.needsInput)
 
       if (isCriticalTransition) {
         if (viewSyncRafRef.current !== null && typeof window !== 'undefined') {


### PR DESCRIPTION
## What does this PR do?

When the agent calls `clarify` and the user is typing a custom response into the textarea, the input field periodically resets and the view scrolls upwards — every few seconds, coinciding with `session.info` heartbeats.

**Root cause:** Commit `d04616964` (#42537) added `needsInput` to the `isCriticalTransition` condition so that clarify prompts would appear immediately even when the window was backgrounded. But the condition `!state.busy || state.needsInput` fires on **every** flush while `needsInput` is `true` — not just the first one. This means every periodic `session.info` heartbeat (usage stats, config refreshes) bypasses the RAF coalescing and triggers a synchronous `flushPendingViewState()` → thread re-render → `use-stick-to-bottom` re-evaluates scroll → **scroll jumps + textarea loses focus**.

**Fix:** Narrow `isCriticalTransition` to fire only on the **edge** — when `busy` or `needsInput` actually changes value (tracked via two refs), not on every heartbeat while those flags are steady-state. The first flush that flips `needsInput` still flushes synchronously (clarify UI appears immediately, the original #42537 bug stays fixed), but subsequent heartbeats with the same flags correctly defer to the RAF batch path.

`@nanostores/react` already guards against same-value `.set()` re-renders via `useSyncExternalStore` snapshot equality (`emit` in `index.js` line 5), so no additional guard is needed on the store setters — the synchronous flush bypass was the sole root cause.

## Related Issue

No existing issue. Related PRs:
- #42537 — the commit that introduced `isCriticalTransition` (this PR narrows its condition, keeping the original fix intact)
- #36717 — alternative approach (1003 lines) that persists clarify textarea state across remounts. This PR (~20 lines) fixes the root cause of the re-renders rather than armoring the component against them. The approaches are complementary but this should be sufficient on its own.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/session/hooks/use-session-state-cache.ts` — Added `lastFlushedBusyRef` / `lastFlushedNeedsInputRef` to track edge transitions. Narrowed `isCriticalTransition` to fire only when `busy` or `needsInput` actually changes value, not on every steady-state heartbeat.
- `apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx` — Added test verifying that the first `needsInput=true` flushes synchronously (critical edge) but the second identical heartbeat defers to RAF (steady-state).

## How to Test

1. Start the desktop app, trigger a clarify prompt with multiple choices
2. Select an option and start typing a custom response
3. Wait 10+ seconds for periodic `session.info` heartbeats to fire
4. **Before fix:** textarea periodically resets, view scrolls upwards
5. **After fix:** textarea and scroll position remain stable while typing

```
cd apps/desktop
npm run typecheck          # ✓ clean
npx eslint src/app/session/hooks/use-session-state-cache.ts  # ✓ 0 errors
npx vitest run --environment jsdom src/app/session/hooks/use-session-state-cache.test.tsx  # ✓ 6/6 pass
```

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: macOS 27.0

### Documentation & Housekeeping

- [x] N/A — I've updated relevant documentation
- [x] N/A — I've updated `cli-config.yaml.example`
- [x] N/A — I've updated `CONTRIBUTING.md` or `AGENTS.md`
- [x] N/A — I've considered cross-platform impact (this is a desktop-only React hook change)
- [x] N/A — I've updated tool descriptions/schemas