### PR TITLE
feat(approval): block sed/perl -i on all .yaml/.yml files

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -458,6 +458,12 @@ DANGEROUS_PATTERNS = [
     # anywhere in the args, not just the first token — `perl -e '...'` (code
     # eval, no -i) does not trip because it has no `-...i` flag token.
     (rf'\b(?:perl|ruby)\b.*(?:^|\s)-[^\s]*i\b.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env (perl/ruby)"),
+    # In-place edit of ANY .yaml/.yml file — sed/perl on YAML files can break
+    # indentation, quoting, or flow sequences silently. Use yaml.safe_load +
+    # atomic_yaml_write instead.  Covers all paths, not just config.yaml.
+    (r'\bsed\s+-[^\s]*i\b.*\.ya?ml\b', "in-place edit of YAML file (sed -i)"),
+    (r'\bsed\s+--in-place\b.*\.ya?ml\b', "in-place edit of YAML file (sed --in-place)"),
+    (r'\b(?:perl|ruby)\b.*(?:^|\s)-[^\s]*i\b.*\.ya?ml\b', "in-place edit of YAML file (perl/ruby -i)"),
     # Script execution via heredoc — bypasses the -e/-c flag patterns above.
     # `python3 << 'EOF'` feeds arbitrary code via stdin without -c/-e flags.
     (r'\b(python[23]?|perl|ruby|node)\s+<<', "script execution via heredoc"),


### PR DESCRIPTION
Closes #45749

## What

Extends the existing `DANGEROUS_PATTERNS` regex table in `tools/approval.py` to block in-place edits (`sed -i`, `sed --in-place`, `perl -i`, `ruby -i`) on **all** `.yaml`/`.yml` files, not just the hardcoded `config.yaml` paths.

## Why

Hermes already blocks these dangerous operations on `config.yaml`. But the agent's YAML-managed surface is much broader — skill SKILL.md files, profile configs, gateway policies — and in-place text substitution on any of them causes silent corruption that wastes troubleshooting time and creates repair work.

## Scope

- **1 file**: `tools/approval.py`
- **+6 lines**: three regex patterns appended to the existing `DANGEROUS_PATTERNS` list
- **No new files, no dependencies, no config changes**
- **Complements** existing `write_approval` gate and `yaml.safe_load` hardening

## Patterns added

```python
(r'\\bsed\\s+-[^\\s]*i\\b.*\\.ya?ml\\b', "in-place edit of YAML file (sed -i)"),
(r'\\bsed\\s+--in-place\\b.*\\.ya?ml\\b', "in-place edit of YAML file (sed --in-place)"),
(r'\\b(?:perl|ruby)\\b.*(?:^|\\s)-[^\\s]*i\\b.*\\.ya?ml\\b', "in-place edit of YAML file (perl/ruby -i)"),
```

## Testing

Verified on live Hermes Desktop:
- `sed -i` on non-YAML files → **allowed** ✓
- `sed -i` on `.yaml`/`.yml` → **blocked** ✓
- `sed --in-place` on `.yaml` → **blocked** ✓
- `perl -i` on `.yaml` → **blocked** ✓
- Existing `config.yaml` guards still work ✓