### PR TITLE
fix(models): support glm-5.2, kimi-k2.7-code + merge live/curated mod…

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -209,7 +209,10 @@ DEFAULT_CONTEXT_LENGTHS = {
     # https://platform.minimax.io/docs/api-reference/text-chat-openai
     "minimax-m3": 1000000,
     "minimax": 204800,
-    # GLM
+    # GLM — GLM-5.2 ships with 1M context; GLM-5 and GLM-5.1 are 200K.
+    # Substring matching is longest-first, so "glm-5.2" wins over the
+    # generic "glm" catch-all for that slug.
+    "glm-5.2": 1_000_000,
     "glm": 202752,
     # xAI Grok — xAI /v1/models does not return context_length metadata,
     # so these hardcoded fallbacks prevent Hermes from probing-down to

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -256,6 +256,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gemini-3.5-flash",
     ],
     "zai": [
+        "glm-5.2",
         "glm-5.1",
         "glm-5",
         "glm-5v-turbo",
@@ -280,6 +281,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "openai/gpt-oss-120b",
     ],
     "kimi-coding": [
+        "kimi-k2.7-code",
         "kimi-k2.6",
         "kimi-k2.5",
         "kimi-for-coding",
@@ -2330,7 +2332,19 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             if api_key:
                 live = _p.fetch_models(api_key=api_key)
                 if live:
-                    return live
+                    # Merge curated entries with live results so models that
+                    # are reachable for inference before they appear in
+                    # /v1/models survive the live fetch (same pattern as the
+                    # Anthropic path above). Curated go first to preserve the
+                    # recommended ordering in the /model picker.
+                    curated = list(_PROVIDER_MODELS.get(normalized, []))
+                    merged = list(curated)
+                    merged_lower = {m.lower() for m in curated}
+                    for m in live:
+                        if m.lower() not in merged_lower:
+                            merged.append(m)
+                            merged_lower.add(m.lower())
+                    return merged
             # Use profile's fallback_models if defined
             if _p.fallback_models:
                 return list(_p.fallback_models)


### PR DESCRIPTION
…el lists

Three changes to fix newly-released models not appearing in the picker or being capped at wrong context lengths:

1. Add glm-5.2 to zai provider's static model list
2. Add kimi-k2.7-code to kimi-coding provider's static model list
3. Fix generic live-fetch path in provider_model_ids() to MERGE curated entries with live /v1/models results instead of replacing them — same pattern already used by the Anthropic path. Providers like Z.AI and Kimi don't list new models in /v1/models immediately even though inference works, causing curated entries to silently disappear.
4. Add glm-5.2 context length (1M tokens) to DEFAULT_CONTEXT_LENGTHS, before the generic 'glm' catch-all (202752) that was capping it at ~200K via substring matching.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

