### PR TITLE
fix(profiles): skip large files in find_alias_for_profile

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -483,6 +483,15 @@ def find_alias_for_profile(profile_name: str) -> Optional[str]:
             continue
         if not is_windows and entry.suffix:
             continue
+        # Skip large files (binaries, AppImages) — wrapper scripts are tiny
+        # shell scripts (< 4 KB).  Without this guard ``list_profiles()``
+        # reads every file in ~/.local/bin/ which can include 200+ MB
+        # binaries, adding 10-15 s of I/O per profile lookup.
+        try:
+            if entry.stat().st_size > 32_768:
+                continue
+        except OSError:
+            continue
         try:
             content = entry.read_text()
         except (OSError, UnicodeDecodeError):


### PR DESCRIPTION
## What does this PR do?

`find_alias_for_profile()` scans `~/.local/bin/` to reverse-lookup profile alias names. It reads the full text of every file in the directory — including large binaries (AppImages, compiled tools). With 9 profiles and 110 files, this means 990 file reads totaling 15+ seconds of I/O.

Since `/api/profiles` runs this synchronously on the async event loop, it blocks all other dashboard API requests too — visiting the cron page (which loads profiles) makes the entire dashboard unresponsive.

This PR adds a 32 KB size guard before `read_text()`. Wrapper scripts are tiny shell scripts (< 4 KB); anything larger is a binary that can't match.

## Related Issue

Fixes #45752

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/profiles.py` — add `entry.stat().st_size > 32_768` guard in `find_alias_for_profile()` before reading file contents

## How to Test

Automated checks:

```bash
cd ~/.hermes/hermes-agent
HOME=/tmp/test-home PYTHONPATH=. python -m pytest tests/hermes_cli/test_profiles.py -q -o 'addopts='
```

Result: 131 passed in 2.75s (including 15 alias-specific tests)

Manual verification:

```bash
# Before: list_profiles() takes 10+ seconds with large binaries in ~/.local/bin/
# After: 0.33 seconds
time python3 -c "from hermes_cli.profiles import list_profiles; list_profiles()"

# Confirm alias resolution still works
hermes profile create test_alias_target
hermes profile alias test_alias_target --name my_alias
python3 -c "from hermes_cli.profiles import find_alias_for_profile; print(find_alias_for_profile('test_alias_target'))"
# Expected: 'my_alias'
```

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/hermes_cli/test_profiles.py` — 131 passed
- [x] Existing alias tests cover the changed code path (15 tests in `TestFindAlias`)
- [x] Platform: Linux, Python 3.10
