### PR TITLE
feat(approval): block sed/perl -i on all .yaml/.yml files

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -348,11 +348,48 @@ class TestHermesConfigWriteProtection:
         # handled by the project patterns, not the Hermes-home rule.
         for cmd in (
             "cat ~/.hermes/config.yaml",
-            "sed -i 's/a/b/' /srv/app/config.yaml",
             "echo data > /tmp/scratch.txt",
         ):
             dangerous, key, desc = detect_dangerous_command(cmd)
             assert dangerous is False, cmd
+
+    def test_sed_in_place_any_yaml_file_dangerous(self):
+        # PR #45755 broadens sed/perl -i protection to ANY .yaml/.yml file,
+        # not just Hermes-managed config/env paths. In-place YAML edits can
+        # silently break indentation/quoting/flow sequences.
+        for command in (
+            "sed -i 's/a/b/' /srv/app/config.yaml",
+            "sed --in-place 's/a/b/' /srv/app/settings.yml",
+            "perl -i -pe 's/a/b/' /srv/app/config.yaml",
+            "ruby -i -pe 'gsub(/a/, %s)' /srv/app/settings.yml" % '"b"',
+            # -i after other flags / long flags / attached backup suffixes
+            # (GNU sed 4.9 forms that previously bypassed the guard):
+            "sed -e 's/a/b/' -i /srv/app/config.yaml",
+            "sed --posix -i 's/a/b/' /srv/app/settings.yml",
+            "sed -ibak 's/a/b/' /srv/app/config.yaml",
+            "perl -ibak -pe 's/a/b/' /srv/app/settings.yml",
+            "perl -pi -e 's/a/b/' /srv/app/config.yaml",
+            "sed -i.bak 's/a/b/' /srv/app/settings.yml",
+        ):
+            dangerous, key, desc = detect_dangerous_command(command)
+            assert dangerous is True, command
+            assert key is not None, command
+            assert "YAML" in desc or "yaml" in desc, command
+
+    def test_sed_without_in_place_flag_on_yaml_is_safe(self):
+        # No -i/--in-place flag -> not an in-place edit, even when the
+        # expression contains an 'i' or a long flag contains the letter.
+        for command in (
+            "sed -n 's/a/b/p' /srv/app/config.yaml",
+            "sed -e 's/a/b/' /srv/app/settings.yml",
+            "sed --posix 's/a/b/' /srv/app/config.yaml",
+            "sed --separate 's/a/b/' /srv/app/settings.yml",
+            "sed -n 's/foo/i/' /srv/app/config.yaml",
+            "perl -w 'print qq{ok}' /srv/app/settings.yml",
+            "ruby -w 'puts :ok' /srv/app/config.yaml",
+        ):
+            dangerous, key, desc = detect_dangerous_command(command)
+            assert dangerous is False, command
 
 
 class TestFindExecFullPathRm:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -888,6 +888,18 @@ DANGEROUS_PATTERNS = [
     # anywhere in the args, not just the first token — `perl -e '...'` (code
     # eval, no -i) does not trip because it has no `-...i` flag token.
     (rf'\b(?:perl|ruby)\b.*(?:^|\s)-[^\s]*i\b.*(?:{_HERMES_CONFIG_PATH}|{_HERMES_ENV_PATH})', "in-place edit of Hermes config/env (perl/ruby)"),
+    # In-place edit of ANY .yaml/.yml file — sed/perl on YAML files can break
+    # indentation, quoting, or flow sequences silently. Use yaml.safe_load +
+    # atomic_yaml_write instead.  Covers all paths, not just config.yaml.
+    # The -i flag can appear as its own token (`-i`), combined with other
+    # short flags (`-ni`), after other flags (`-e ... -i`), or with an
+    # attached backup suffix (`-ibak`, `-i.bak`). Match any single-dash
+    # flag token containing `i`, anywhere in the args — long flags
+    # (`--posix`, `--silent`) are excluded by requiring the token to start
+    # with a single dash followed by lowercase letters.
+    (r'\bsed\b.*(?:^|\s)-[a-z]*i[a-z.]*(?=\s|$).*\.ya?ml\b', "in-place edit of YAML file (sed -i)"),
+    (r'\bsed\b.*(?:^|\s)--in-place(?:=\S+)?(?=\s|$).*\.ya?ml\b', "in-place edit of YAML file (sed --in-place)"),
+    (r'\b(?:perl|ruby)\b.*(?:^|\s)-[a-z]*i[a-z.]*(?=\s|$).*\.ya?ml\b', "in-place edit of YAML file (perl/ruby -i)"),
     # Interpreter heredocs are handled by _execution_flag_findings() alongside
     # inline-exec flags; keep only shell heredocs regex-based here.
     # Shell execution via heredoc — `bash <<'EOF' ... EOF` runs arbitrary


### PR DESCRIPTION
Closes #45749

## What / Why

Agents routinely rewrite YAML by shell one-liners (`sed -i`, `perl -i`, `ruby -i`). In-place edits of YAML are hazardous: they can silently break indentation, quoting, or flow sequences, and they bypass Hermes' structured `write_approval` gate entirely. Origin's `DANGEROUS_PATTERNS` table already blocks in-place edits of the hardcoded Hermes-managed paths (`~/.hermes/config.yaml`, `~/.hermes/.env`, system config) — but every other YAML file is unprotected, including per-profile configs, MCP server configs, skill frontmatter, and arbitrary project files.

The concrete gap: an agent can run `sed -i 's/role: user/role: admin/' ~/.hermes/profiles/work/config.yaml` and bypass the Hermes guard while performing the same dangerous mutation the guard was built to stop.

## Fix

Extend the `DANGEROUS_PATTERNS` table in `tools/approval_detection.py` (re-exported through `tools/approval.py`) with three patterns that block in-place edits of **any** `.yaml`/`.yml` file:

```python
(r'sed.*(?:^|\s)-[a-z]*i[a-z.]*(?=\s|$).*\.ya?ml', "in-place edit of YAML file (sed -i)"),
(r'sed.*(?:^|\s)--in-place(?:=\S+)?(?=\s|$).*\.ya?ml', "in-place edit of YAML file (sed --in-place)"),
(r'(?:perl|ruby).*(?:^|\s)-[a-z]*i[a-z.]*(?=\s|$).*\.ya?ml', "in-place edit of YAML file (perl/ruby -i)"),
```

The patterns are POSIX-compatible and match shell command strings directly, so they behave identically on macOS, Linux, and Windows/WSL. They cover the GNU sed 4.9 forms that previously bypassed the guard — flag order (`sed -e '...' -i`), combined short flags (`perl -pi`), attached backup suffixes (`-ibak`, `-i.bak`) — while leaving non-in-place invocations (`sed -n`, `sed --posix`, `perl -w`) and out-of-place copies (`cp config.yaml backup.yaml`) untouched. The new patterns are a strict superset of the existing path-based blocks: nothing previously allowed is now blocked; only the gap is closed.

**2 files, +52/-1.** No new files, no dependencies, no config changes. Complements the existing `write_approval` gate and `yaml.safe_load` hardening.

## Validation

- YAML in-place edits are blocked: `sed -i` / `sed --in-place` / `perl -i` / `ruby -i` on `.yaml`/`.yml`, including profile paths, MCP configs, and project-local files.
- Non-YAML targets remain allowed: `sed -i` on a plain text file.
- Non-in-place forms remain allowed: `sed -n`, `sed -e`, `sed --posix` on YAML; `perl -w` / `ruby -w` on YAML; `cp config.yaml backup.yaml`.
- `tests/tools/test_approval.py` passes (160 passed; one known macOS-only upstream failure, `test_nonrecursive_verification_artifact_cleanup_is_not_dangerous`, which also fails on pristine upstream code). Live guard probes against the installed module confirm all cases.

Closes #45749

