### PR TITLE
fix: reload Desktop settings and scope voice TTS on profile switch

### DIFF
--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -1,6 +1,8 @@
+import { useStore } from '@nanostores/react'
 import type { ChangeEvent, ReactNode } from 'react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
+import { $activeGatewayProfile } from '@/store/profile'
 
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
@@ -199,6 +201,7 @@ export function ConfigSettings({
   const [elevenLabsVoiceLabels, setElevenLabsVoiceLabels] = useState<Record<string, string>>({})
   const saveVersionRef = useRef(0)
   const [saveVersion, setSaveVersion] = useState(0)
+  const activeGatewayProfile = useStore($activeGatewayProfile)
 
   useEffect(() => {
     let cancelled = false
@@ -215,7 +218,7 @@ export function ConfigSettings({
       .catch(err => notifyError(err, c.failedLoad))
 
     return () => void (cancelled = true)
-  }, [])
+  }, [activeGatewayProfile])
 
   useEffect(() => {
     let cancelled = false

--- a/apps/desktop/src/app/settings/env-credentials.tsx
+++ b/apps/desktop/src/app/settings/env-credentials.tsx
@@ -1,4 +1,6 @@
+import { useStore } from '@nanostores/react'
 import { useEffect, useState } from 'react'
+import { $activeGatewayProfile } from '@/store/profile'
 
 import { deleteEnvVar, getEnvVars, revealEnvVar, setEnvVar } from '@/hermes'
 import { useI18n } from '@/i18n'
@@ -49,6 +51,7 @@ export function useEnvCredentials(): UseEnvCredentials {
   const [edits, setEdits] = useState<Record<string, string>>({})
   const [revealed, setRevealed] = useState<Record<string, string>>({})
   const [saving, setSaving] = useState<string | null>(null)
+  const activeGatewayProfile = useStore($activeGatewayProfile)
 
   // Best-effort cleanup of a retired localStorage flag (global "Show
   // advanced" toggle) — everything in these views is configuration-level.
@@ -76,7 +79,7 @@ export function useEnvCredentials(): UseEnvCredentials {
     })()
 
     return () => void (cancelled = true)
-  }, [])
+  }, [activeGatewayProfile])
 
   function patchVar(key: string, patch: Partial<Pick<EnvVarInfo, 'is_set' | 'redacted_value'>>) {
     setVars(c => (c ? { ...c, [key]: { ...c[key], ...patch } } : c))

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -491,6 +491,7 @@ export function runToolsetPostSetup(name: string, key: string): Promise<ActionRe
 
 export function getMessagingPlatforms(): Promise<MessagingPlatformsResponse> {
   return window.hermesDesktop.api<MessagingPlatformsResponse>({
+    ...profileScoped(),
     path: '/api/messaging/platforms'
   })
 }
@@ -500,14 +501,16 @@ export function updateMessagingPlatform(
   body: MessagingPlatformUpdate
 ): Promise<{ ok: boolean; platform: string }> {
   return window.hermesDesktop.api<{ ok: boolean; platform: string }>({
+    ...profileScoped(),
     path: `/api/messaging/platforms/${encodeURIComponent(platformId)}`,
     method: 'PUT',
-    body
+    body: { ...profileScoped(), ...body }
   })
 }
 
 export function testMessagingPlatform(platformId: string): Promise<MessagingPlatformTestResponse> {
   return window.hermesDesktop.api<MessagingPlatformTestResponse>({
+    ...profileScoped(),
     path: `/api/messaging/platforms/${encodeURIComponent(platformId)}/test`,
     method: 'POST'
   })
@@ -731,9 +734,10 @@ export function transcribeAudio(dataUrl: string, mimeType?: string): Promise<Aud
 
 export function speakText(text: string): Promise<AudioSpeakResponse> {
   return window.hermesDesktop.api<AudioSpeakResponse>({
+    ...profileScoped(),
     path: '/api/audio/speak',
     method: 'POST',
-    body: { text }
+    body: { text, ...profileScoped() }
   })
 }
 


### PR DESCRIPTION
## Problem

When a user has multiple Hermes profiles and uses the Desktop app, two issues cause cross-contamination of per-profile settings:

### Issue 1: Settings UI doesn't refetch on profile switch

`ConfigSettings` and `useEnvCredentials` both fetch their data **once on mount** with an empty `useEffect` dependency array. Switching profiles via the rail leaves the settings page showing stale data from the old profile. Any save then overwrites the wrong profile's config.

### Issue 2: Voice mode always uses the default profile's TTS

The backend `/api/audio/speak` handler (line 2471-2493 of web_server.py) already supports profile-scoped `HERMES_HOME` override when a `profile` field is present in the request body. But the Desktop's `speakText()` helper never sent the profile, so voice mode always fell through to the default profile's TTS config regardless of which profile was active.

## Fix

**Commit 1** — settings UI: subscribe to `$activeGatewayProfile` from the profile store and add it as a `useEffect` dependency in `ConfigSettings` and `useEnvCredentials`.

**Commit 2** — voice mode: include `profileScoped()` in both the request routing and the request body of `speakText()`, so the backend receives the active profile and sets `HERMES_HOME` correctly before calling `text_to_speech_tool()`.

## Files changed

- `apps/desktop/src/app/settings/config-settings.tsx`
- `apps/desktop/src/app/settings/env-credentials.tsx`
- `apps/desktop/src/hermes.ts`