### PR TITLE
fix(desktop): polish slash command completion (space/tab/click + typed args)

### DIFF
--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -135,6 +135,12 @@ function slashChipKindForItem(item: Unstable_TriggerItem): SlashChipKind {
   return 'command'
 }
 
+/** A `/` query is at its arg stage once it's past the command name. */
+const slashArgStage = (query: string) => query.includes(' ')
+
+/** The `/command` token of a slash query (`personality x` → `/personality`). */
+const slashCommandToken = (query: string) => `/${query.split(/\s+/, 1)[0]?.toLowerCase() ?? ''}`
+
 interface QueueEditState {
   attachments: ComposerAttachment[]
   draft: string
@@ -610,19 +616,15 @@ export function ChatBar({
     }
 
     const before = textBeforeCaret(editor)
-    let detected = detectTrigger(before ?? composerPlainText(editor))
+    const found = detectTrigger(before ?? composerPlainText(editor))
 
-    // The arg-stage popover (command name + space + args) is only useful for
-    // commands with an inline options screen. For a no-arg command it would
-    // dead-end on "No matches", so drop the trigger — the directive is already
-    // complete. (Mirrors the menu only opening at this stage when args exist.)
-    if (detected?.kind === '/' && detected.query.includes(' ')) {
-      const command = detected.query.split(/\s+/, 1)[0] ?? ''
-
-      if (!desktopSlashCommandTakesArgs(command)) {
-        detected = null
-      }
-    }
+    // The arg-stage popover is only useful for commands with an options screen.
+    // For a no-arg command it would dead-end on "No matches", so drop it — the
+    // directive is already complete.
+    const detected =
+      found?.kind === '/' && slashArgStage(found.query) && !desktopSlashCommandTakesArgs(slashCommandToken(found.query))
+        ? null
+        : found
 
     setTrigger(detected)
 
@@ -677,11 +679,11 @@ export function ChatBar({
 
   const triggerLoading = trigger?.kind === '@' ? at.loading : trigger?.kind === '/' ? slash.loading : false
 
-  // Suppress the "No matches" empty state once a slash command is past its name
-  // (arg stage): a no-arg command has nothing to offer, and a fully-typed arg
-  // is committed on Space/Tab — neither should dead-end on a popover.
+  // Suppress the "No matches" empty state once a slash command is past its name:
+  // a no-arg command has nothing to offer, and a fully-typed arg commits on
+  // Space/Tab — neither should dead-end on a popover.
   const argStageEmpty =
-    trigger?.kind === '/' && trigger.query.includes(' ') && !triggerLoading && triggerItems.length === 0
+    trigger?.kind === '/' && slashArgStage(trigger.query) && !triggerLoading && !triggerItems.length
 
   const closeTrigger = () => {
     setTrigger(null)
@@ -703,13 +705,12 @@ export function ChatBar({
     }
 
     const text = `/${trigger.query.trimEnd()}`
-    const command = `/${(trigger.query.split(/\s+/, 1)[0] ?? '').toLowerCase()}`
 
     replaceTriggerWithChip({
       id: text,
       type: 'slash',
       label: text.slice(1),
-      metadata: { command, display: text, meta: '', group: '', action: '', rawText: text }
+      metadata: { command: slashCommandToken(trigger.query), display: text, meta: '', group: '', action: '', rawText: text }
     })
   }
 
@@ -865,7 +866,7 @@ export function ChatBar({
       // options step, and an arg option commits the full `/cmd arg` chip. Space
       // is slash-only (an `@` mention takes a literal space) and gated to a
       // non-empty query so a bare `/ ` still types a space.
-      const acceptOnSpace = event.key === ' ' && trigger.kind === '/' && trigger.query.trim().length > 0
+      const acceptOnSpace = event.key === ' ' && trigger.kind === '/' && Boolean(trigger.query.trim())
       const accept = event.key === 'Enter' || event.key === 'Tab' || acceptOnSpace
 
       if (accept) {
@@ -895,10 +896,10 @@ export function ChatBar({
     // directive chip; Enter falls through to submit (send it as-is).
     if (
       trigger?.kind === '/' &&
-      triggerItems.length === 0 &&
+      !triggerItems.length &&
       (event.key === ' ' || event.key === 'Tab') &&
-      trigger.query.includes(' ') &&
-      trigger.query.trim().length > 0
+      slashArgStage(trigger.query) &&
+      trigger.query.trim()
     ) {
       event.preventDefault()
       triggerKeyConsumedRef.current = true

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -610,7 +610,19 @@ export function ChatBar({
     }
 
     const before = textBeforeCaret(editor)
-    const detected = detectTrigger(before ?? composerPlainText(editor))
+    let detected = detectTrigger(before ?? composerPlainText(editor))
+
+    // The arg-stage popover (command name + space + args) is only useful for
+    // commands with an inline options screen. For a no-arg command it would
+    // dead-end on "No matches", so drop the trigger — the directive is already
+    // complete. (Mirrors the menu only opening at this stage when args exist.)
+    if (detected?.kind === '/' && detected.query.includes(' ')) {
+      const command = detected.query.split(/\s+/, 1)[0] ?? ''
+
+      if (!desktopSlashCommandTakesArgs(command)) {
+        detected = null
+      }
+    }
 
     setTrigger(detected)
 

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -677,6 +677,12 @@ export function ChatBar({
 
   const triggerLoading = trigger?.kind === '@' ? at.loading : trigger?.kind === '/' ? slash.loading : false
 
+  // Suppress the "No matches" empty state once a slash command is past its name
+  // (arg stage): a no-arg command has nothing to offer, and a fully-typed arg
+  // is committed on Space/Tab — neither should dead-end on a popover.
+  const argStageEmpty =
+    trigger?.kind === '/' && trigger.query.includes(' ') && !triggerLoading && triggerItems.length === 0
+
   const closeTrigger = () => {
     setTrigger(null)
     setTriggerItems([])
@@ -686,6 +692,26 @@ export function ChatBar({
   useEffect(() => {
     setTriggerActive(idx => Math.min(idx, Math.max(0, triggerItems.length - 1)))
   }, [triggerItems.length])
+
+  // Commit the literally-typed `/command arg` as a directive chip — used when
+  // the completion list is empty because the arg is already fully typed (the
+  // backend completer drops exact matches). Reuses the chip path via a
+  // synthetic item whose serialized form is the verbatim text.
+  const commitTypedSlashDirective = () => {
+    if (trigger?.kind !== '/') {
+      return
+    }
+
+    const text = `/${trigger.query.trimEnd()}`
+    const command = `/${(trigger.query.split(/\s+/, 1)[0] ?? '').toLowerCase()}`
+
+    replaceTriggerWithChip({
+      id: text,
+      type: 'slash',
+      label: text.slice(1),
+      metadata: { command, display: text, meta: '', group: '', action: '', rawText: text }
+    })
+  }
 
   const replaceTriggerWithChip = (item: Unstable_TriggerItem) => {
     const editor = editorRef.current
@@ -834,7 +860,15 @@ export function ChatBar({
         return
       }
 
-      if (event.key === 'Enter' || event.key === 'Tab') {
+      // Enter / Tab / Space all accept the highlighted item: a no-arg command
+      // commits its directive chip, an arg-taking command expands to its
+      // options step, and an arg option commits the full `/cmd arg` chip. Space
+      // is slash-only (an `@` mention takes a literal space) and gated to a
+      // non-empty query so a bare `/ ` still types a space.
+      const acceptOnSpace = event.key === ' ' && trigger.kind === '/' && trigger.query.trim().length > 0
+      const accept = event.key === 'Enter' || event.key === 'Tab' || acceptOnSpace
+
+      if (accept) {
         event.preventDefault()
         triggerKeyConsumedRef.current = true
         const item = triggerItems[triggerActive]
@@ -844,24 +878,6 @@ export function ChatBar({
         }
 
         return
-      }
-
-      // Space accepts the highlighted command while its name is still being
-      // typed (no arg yet). Without this, space on a no-arg command
-      // (`/hermes-agent `) falls through to text insertion, re-detects the
-      // trigger as an arg query, and dead-ends on "No matches" since there are
-      // no args to complete. Mirrors Tab/Enter: arg-taking commands expand to
-      // their options step, no-arg commands commit the directive chip.
-      if (event.key === ' ' && trigger.kind === '/' && trigger.query.length > 0 && !trigger.query.includes(' ')) {
-        const item = triggerItems[triggerActive]
-
-        if (item) {
-          event.preventDefault()
-          triggerKeyConsumedRef.current = true
-          replaceTriggerWithChip(item)
-
-          return
-        }
       }
 
       if (event.key === 'Escape') {
@@ -871,6 +887,24 @@ export function ChatBar({
 
         return
       }
+    }
+
+    // Arg stage with nothing left to suggest — a fully-typed arg the backend
+    // completer no longer echoes (it drops the exact match), e.g.
+    // `/personality creative`. Space/Tab still commit what's typed as a single
+    // directive chip; Enter falls through to submit (send it as-is).
+    if (
+      trigger?.kind === '/' &&
+      triggerItems.length === 0 &&
+      (event.key === ' ' || event.key === 'Tab') &&
+      trigger.query.includes(' ') &&
+      trigger.query.trim().length > 0
+    ) {
+      event.preventDefault()
+      triggerKeyConsumedRef.current = true
+      commitTypedSlashDirective()
+
+      return
     }
 
     // ArrowUp/ArrowDown navigate, in priority order: the queue (edit entries in
@@ -1795,7 +1829,7 @@ export function ChatBar({
           ref={composerRef}
         >
           {showHelpHint && <HelpHint />}
-          {trigger && (
+          {trigger && !argStageEmpty && (
             <ComposerTriggerPopover
               activeIndex={triggerActive}
               items={triggerItems}

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -834,6 +834,24 @@ export function ChatBar({
         return
       }
 
+      // Space accepts the highlighted command while its name is still being
+      // typed (no arg yet). Without this, space on a no-arg command
+      // (`/hermes-agent `) falls through to text insertion, re-detects the
+      // trigger as an arg query, and dead-ends on "No matches" since there are
+      // no args to complete. Mirrors Tab/Enter: arg-taking commands expand to
+      // their options step, no-arg commands commit the directive chip.
+      if (event.key === ' ' && trigger.kind === '/' && trigger.query.length > 0 && !trigger.query.includes(' ')) {
+        const item = triggerItems[triggerActive]
+
+        if (item) {
+          event.preventDefault()
+          triggerKeyConsumedRef.current = true
+          replaceTriggerWithChip(item)
+
+          return
+        }
+      }
+
       if (event.key === 'Escape') {
         event.preventDefault()
         triggerKeyConsumedRef.current = true


### PR DESCRIPTION
## Summary

Makes the desktop composer's slash-command completion behave consistently across every way you can pick a command/arg. Previously, pressing **space** on a complete command dead-ended on a "No matches" popover, and typing an arg out in full (e.g. `/personality creative`) also showed "No matches" because the gateway completer drops the exact match from its suggestions.

### Behavior now

- **Accept = Enter / Tab / Space / click**, at both the command stage and the arg stage:
  - no-arg command (`/hermes-agent`) → commits the directive chip
  - arg-taking command (`/personality`, `/skin`, `/handoff`) → expands to its options step
  - an arg option → commits the full `/cmd arg` chip
- **Typed-out args match.** A fully-typed arg the backend no longer suggests still commits on Space/Tab (via the verbatim text); Enter falls through to submit, so "type it out + Enter" still sends.
- **No more dead-end "No matches"** past a command's name — the arg-stage popover only appears when the command actually takes args, and the empty state is hidden once you're past the command name.
- **Space stays slash-only** so `@` mentions keep a literal space; a bare `/ ` also still types a space.

### Implementation

- Two pure helpers — `slashArgStage(query)` and `slashCommandToken(query)` — drive all three sites (trigger suppression in `refreshTrigger`, the `argStageEmpty` render gate, and the typed-arg commit).
- Enter/Tab/Space unified into one accept branch in the keydown handler.
- `commitTypedSlashDirective` reuses the chip-insertion path via a synthetic item whose serialized form is the verbatim typed text.

## Test plan
- [x] `/hermes-agent` + space/tab/click → commits the chip, no popover after
- [x] `/personality` + space → expands to personality options
- [x] `/personality cr` → `creative` highlighted; space/tab/enter/click commits `/personality creative`
- [x] `/personality creative` (typed in full) → no "No matches"; space/tab commits the chip; **Enter sends**
- [x] `/skin` + space → theme options; pick commits `/skin <theme>`
- [x] `/` + space → types a literal space
- [x] `@file` + space → unchanged (literal space)
- [x] `tsc --noEmit` clean; slash-nav + desktop-slash-commands vitest green