### PR TITLE
docs(messaging): document the '!' prefix workaround for Slack thread commands

### DIFF
--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -192,6 +192,9 @@ Commands support prefix matching: typing `/h` resolves to `/help`, `/mod` resolv
 
 ## Messaging slash commands
 
+> **Slack Thread Workaround:**
+> Slack does not allow standard slash commands inside message threads. If you are communicating with Hermes inside a Slack thread, you must use the `!` prefix instead of `/` (for example: `!stop`, `!new`, `!status`). The gateway will automatically translate it for you.
+
 The messaging gateway supports the following built-in commands inside Telegram, Discord, Slack, WhatsApp, Signal, Email, Home Assistant, and Teams chats:
 
 | Command | Description |


### PR DESCRIPTION
### Summary
Documents the existing `!` command prefix fallback for Slack threads in the global slash commands reference, preventing users from assuming the agent cannot be controlled while in a thread.

### Background
Slack natively restricts standard `/` slash commands from executing inside message threads. The Hermes gateway handles this beautifully by intercepting a `!` prefix (e.g., `!stop`, `!new`) and translating it under the hood. However, while this was mentioned in the platform-specific Slack setup guide, it was missing from the global `slash-commands.md` reference table. This led to friction when users (like myself) tried to interrupt a busy agent in a thread, found `/stop` blocked by Slack, and didn't know the fallback existed.

### Fix
Added a standard Markdown blockquote callout directly under the `## Messaging slash commands` heading in `website/docs/reference/slash-commands.md`.

### Impact
No code changes. Pure documentation addition. Users who hit this Slack limitation will immediately know how to bypass it before they even reach the commands table, saving debugging time and preventing unnecessary issue reports.