### PR TITLE
fix(supermemory): forget document ids returned by store

### DIFF
--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -11,6 +11,7 @@ import logging
 import os
 import re
 import threading
+import time
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone
@@ -261,6 +262,36 @@ def _is_trivial_message(text: str) -> bool:
     return bool(_TRIVIAL_RE.match((text or "").strip()))
 
 
+def _error_status(exc: Exception) -> Optional[int]:
+    for attr in ("status_code", "status"):
+        status = getattr(exc, attr, None)
+        if isinstance(status, int):
+            return status
+    response = getattr(exc, "response", None)
+    if response is not None:
+        for attr in ("status_code", "status"):
+            status = getattr(response, attr, None)
+            if isinstance(status, int):
+                return status
+    return None
+
+
+def _is_not_found_error(exc: Exception) -> bool:
+    """Return True for SDK exceptions that represent HTTP 404/not-found."""
+    if _error_status(exc) == 404:
+        return True
+    text = str(exc).lower()
+    return "404" in text and "not found" in text
+
+
+def _is_document_processing_error(exc: Exception) -> bool:
+    """Return True when Supermemory rejects document deletion while indexing."""
+    if _error_status(exc) != 409:
+        return False
+    text = str(exc).lower()
+    return "processing" in text
+
+
 class _SupermemoryClient:
     def __init__(self, api_key: str, timeout: float, container_tag: str, search_mode: str = "hybrid"):
         from supermemory import Supermemory
@@ -348,9 +379,35 @@ class _SupermemoryClient:
                     })
         return {"static": static, "dynamic": dynamic, "search_results": search_results}
 
-    def forget_memory(self, memory_id: str, *, container_tag: Optional[str] = None) -> None:
+    def _delete_document_with_retry(self, document_id: str) -> None:
+        delays = (2.0, 5.0, 10.0, 15.0)
+        last_error: Exception | None = None
+        for attempt in range(len(delays) + 1):
+            try:
+                self._client.documents.delete(document_id)
+                return
+            except Exception as exc:
+                last_error = exc
+                if attempt >= len(delays) or not _is_document_processing_error(exc):
+                    raise
+                time.sleep(delays[attempt])
+        if last_error is not None:
+            raise last_error
+
+    def forget_memory(self, memory_id: str, *, container_tag: Optional[str] = None,
+                      allow_document_fallback: bool = True) -> None:
         tag = container_tag or self._container_tag
-        self._client.memories.forget(container_tag=tag, id=memory_id)
+        try:
+            self._client.memories.forget(container_tag=tag, id=memory_id)
+            return
+        except Exception as exc:
+            if not allow_document_fallback or not _is_not_found_error(exc):
+                raise
+            logger.debug(
+                "Supermemory memory-id forget returned not-found; trying document delete fallback",
+                exc_info=True,
+            )
+        self._delete_document_with_retry(memory_id)
 
     def forget_by_query(self, query: str, *, container_tag: Optional[str] = None) -> dict:
         results = self.search_memories(query, limit=5, container_tag=container_tag)
@@ -360,7 +417,7 @@ class _SupermemoryClient:
         memory_id = target.get("id", "")
         if not memory_id:
             return {"success": False, "message": "Best matching memory has no id."}
-        self.forget_memory(memory_id, container_tag=container_tag)
+        self.forget_memory(memory_id, container_tag=container_tag, allow_document_fallback=False)
         preview = (target.get("memory") or "")[:100]
         return {"success": True, "message": f'Forgot: "{preview}"', "id": memory_id}
 

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -1,12 +1,15 @@
 import json
 import os
 import stat
+import sys
 import threading
+from types import SimpleNamespace
 
 import pytest
 
 from plugins.memory.supermemory import (
     SupermemoryMemoryProvider,
+    _SupermemoryClient,
     _clean_text_for_capture,
     _format_prefetch_context,
     _load_supermemory_config,
@@ -280,6 +283,108 @@ def test_forget_tool_by_query(provider):
     result = json.loads(provider.handle_tool_call("supermemory_forget", {"query": "that thing"}))
     assert result["success"] is True
     assert result["id"] == "m7"
+
+
+class FakeSupermemoryNotFound(Exception):
+    status_code = 404
+
+
+class FakeSupermemoryMemories:
+    def __init__(self, *, raise_not_found=False):
+        self.raise_not_found = raise_not_found
+        self.forget_calls = []
+
+    def forget(self, **kwargs):
+        self.forget_calls.append(kwargs)
+        if self.raise_not_found:
+            raise FakeSupermemoryNotFound("Error code: 404 - {'error': 'Memory not found'}")
+
+
+class FakeSupermemoryProcessing(Exception):
+    status_code = 409
+
+
+class FakeSupermemoryDocuments:
+    def __init__(self, *, processing_failures=0):
+        self.delete_calls = []
+        self.processing_failures = processing_failures
+
+    def delete(self, document_id):
+        self.delete_calls.append(document_id)
+        if self.processing_failures > 0:
+            self.processing_failures -= 1
+            raise FakeSupermemoryProcessing("Error code: 409 - {'error': 'Document is still processing'}")
+
+
+class FakeSupermemorySearch:
+    def __init__(self, results):
+        self._results = results
+
+    def memories(self, **kwargs):
+        return SimpleNamespace(results=self._results)
+
+
+class FakeSupermemorySDK:
+    def __init__(self, *, raise_not_found=False, search_results=None, processing_failures=0):
+        self.memories = FakeSupermemoryMemories(raise_not_found=raise_not_found)
+        self.documents = FakeSupermemoryDocuments(processing_failures=processing_failures)
+        self.search = FakeSupermemorySearch(search_results or [])
+
+
+class FakeSupermemoryFactory:
+    def __init__(self, sdk):
+        self.sdk = sdk
+
+    def __call__(self, **kwargs):
+        return self.sdk
+
+
+def test_raw_client_forget_falls_back_to_document_delete_for_document_ids(monkeypatch):
+    sdk = FakeSupermemorySDK(raise_not_found=True)
+    monkeypatch.setitem(sys.modules, "supermemory", SimpleNamespace(Supermemory=FakeSupermemoryFactory(sdk)))
+    client = _SupermemoryClient("test-key", 1.0, "hermes")
+
+    client.forget_memory("doc_123")
+
+    assert sdk.memories.forget_calls == [{"container_tag": "hermes", "id": "doc_123"}]
+    assert sdk.documents.delete_calls == ["doc_123"]
+
+
+def test_raw_client_forget_keeps_memory_id_path_when_it_exists(monkeypatch):
+    sdk = FakeSupermemorySDK(raise_not_found=False)
+    monkeypatch.setitem(sys.modules, "supermemory", SimpleNamespace(Supermemory=FakeSupermemoryFactory(sdk)))
+    client = _SupermemoryClient("test-key", 1.0, "hermes")
+
+    client.forget_memory("memory_123")
+
+    assert sdk.memories.forget_calls == [{"container_tag": "hermes", "id": "memory_123"}]
+    assert sdk.documents.delete_calls == []
+
+
+def test_raw_client_forget_retries_document_delete_while_processing(monkeypatch):
+    sdk = FakeSupermemorySDK(raise_not_found=True, processing_failures=2)
+    monkeypatch.setitem(sys.modules, "supermemory", SimpleNamespace(Supermemory=FakeSupermemoryFactory(sdk)))
+    monkeypatch.setattr("plugins.memory.supermemory.time.sleep", lambda delay: None)
+    client = _SupermemoryClient("test-key", 1.0, "hermes")
+
+    client.forget_memory("doc_processing")
+
+    assert sdk.documents.delete_calls == ["doc_processing", "doc_processing", "doc_processing"]
+
+
+def test_forget_by_query_does_not_document_delete_memory_search_ids(monkeypatch):
+    sdk = FakeSupermemorySDK(
+        raise_not_found=True,
+        search_results=[SimpleNamespace(id="memory_missing", memory="fact", similarity=0.91)],
+    )
+    monkeypatch.setitem(sys.modules, "supermemory", SimpleNamespace(Supermemory=FakeSupermemoryFactory(sdk)))
+    client = _SupermemoryClient("test-key", 1.0, "hermes")
+
+    with pytest.raises(FakeSupermemoryNotFound):
+        client.forget_by_query("fact")
+
+    assert sdk.memories.forget_calls == [{"container_tag": "hermes", "id": "memory_missing"}]
+    assert sdk.documents.delete_calls == []
 
 
 def test_profile_tool_formats_sections(provider):


### PR DESCRIPTION
## Summary
- fix `supermemory_forget(id=...)` for IDs returned by `supermemory_store`
- keep the existing memory-ID delete path for IDs returned by memory search / `forget_by_query`
- add a document-delete fallback only when `memories.forget(...)` returns not found
- retry document deletion while Supermemory reports that a freshly-added document is still processing

## Context
This addresses the same root cause described in #12341, but avoids routing all forget calls through `documents.delete(...)`. `supermemory_store` returns document IDs, while `supermemory_search`/`forget_by_query` operate on memory IDs, so the provider needs to support both ID spaces.

## Test plan
- `PYTHONPATH=$WT $REPO/venv/bin/python -m pytest tests/plugins/memory/test_supermemory_provider.py -q`
- `PYTHONPATH=$WT $REPO/venv/bin/python -m py_compile plugins/memory/supermemory/__init__.py tests/plugins/memory/test_supermemory_provider.py`
- live Supermemory smoke: store a temporary document, call patched `supermemory_forget` with the returned ID, confirmed `forget_forgotten=True` and cleanup reported already deleted
