### PR TITLE
fix(telegram): surface rich-send rejections as warnings

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1087,7 +1087,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     # Endpoint missing (old PTB/server) — latch rich off so
                     # every later send doesn't pay a doomed extra roundtrip.
                     self._rich_send_disabled = True
-                logger.debug(
+                logger.warning(
                     "[%s] sendRichMessage rejected (%s) — falling back to MarkdownV2",
                     self.name, exc,
                 )


### PR DESCRIPTION
## Problem

**Symptom:** Markdown tables render briefly (streaming), then collapse into flat lists on the final message. Only in DMs; groups/channels work fine.

**Root cause chain:**

1. `sendRichMessage` (Bot API `sendRichMessage`) delivers raw Markdown — **tables, headers, task-lists all supported**. This is the only path that preserves table formatting in Telegram.
2. When *any* rich send fails, `_rich_send_disabled` is set to `True` — and stays that way **permanently** until gateway restart. Every subsequent message falls back to `MarkdownV2`, which escapes `|` and can't render tables.
3. The rejection is logged at `logger.debug` — invisible in production. Operator sees broken tables and has **zero signal** that rich send is disabled.

**Why DMs specifically?** In `_compute_single_send_routing`, DM chats with certain routing configurations return `None`, causing `sendRichMessage` to be skipped entirely. The first such skip (or any transient API error) latches the flag, and all rich formatting is lost until restart.

## Fix

**This PR:** Promoted `logger.debug` → `logger.warning` for the `sendRichMessage` rejection path (line 1090).

**Why one line matters:** The operator now sees `[WARNING] sendRichMessage rejected (BadRequest: ...)` in logs, immediately knows rich send is down, and can restart the gateway — instead of debugging table rendering for hours.

## For developers implementing rich-send in their own code

If you're building on the same pattern, here's what to do:

### 1. Make the disabled latch visible
```python
# DON'T — invisible failure
logger.debug("rich send rejected — falling back")

# DO — operator sees it
logger.warning("rich send rejected (%s) — falling back to plain text", exc)
```

### 2. Don't latch permanently without a recovery path
```python
# Current (problematic): permanent disable
self._rich_send_disabled = True  # never recovers until restart

# Better: retry with backoff, or reset after N minutes
self._rich_send_disabled_until = time.time() + 300  # 5 min cooldown
```

### 3. Fall back to plain text, not MarkdownV2
When rich send fails, sending the same content as `MarkdownV2` silently corrupts formatting (tables break, `|` becomes literal). Better to strip markup and send **plain text** — at least it's readable:
```python
# DON'T — silently corrupts tables
await bot.send_message(chat_id, text, parse_mode="MarkdownV2")

# DO — readable fallback
await bot.send_message(chat_id, strip_markdown(text))
```

### 4. DM routing must not skip rich send
If your routing layer returns `None` for DM chats, `sendRichMessage` is never called. Ensure DM routing always attempts rich send before falling back:

```python
def _route_send(self, chat_id):
    result = self._compute_routing(chat_id)
    if result is None and is_dm(chat_id):
        return self._send_rich  # always try rich for DMs
    return result
```

---

**TL;DR:** One-line change. Debug → Warning. Saves hours of head-scratching when tables mysteriously break.