### PR TITLE
fix(cron): enable memory reads by default, guard writes at dispatch sites (complements #34098)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -98,6 +98,24 @@ def _ra():
     return run_agent
 
 
+def memory_call_is_write(action, operations) -> bool:
+    """True when a ``memory()`` call performs any write.
+
+    Covers both documented call shapes: the single-op ``action`` form and
+    the batch ``operations`` form (whose entries carry their own action
+    field). Shared by the sequential and concurrent dispatch sites so the
+    cron write guard cannot be bypassed by switching shapes.
+    """
+    if action in ("add", "replace", "remove"):
+        return True
+    if isinstance(operations, list):
+        return any(
+            isinstance(op, dict) and op.get("action") in ("add", "replace", "remove")
+            for op in operations
+        )
+    return False
+
+
 AGENT_RUNTIME_POST_HOOK_TOOL_NAMES = frozenset(
     {"todo", "session_search", "memory", "clarify", "read_terminal", "read_preview", "read_window_below", "setup_mcp", "tour", "delegate_task"}
 )
@@ -3172,11 +3190,22 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             )
     elif function_name == "memory":
         def _execute(next_args: dict) -> Any:
-            target = next_args.get("target", "memory")
+            action = next_args.get("action")
             operations = next_args.get("operations")
+            # Write-protect MEMORY.md/USER.md in cron context.
+            # Cron jobs inherit user context (system-prompt injection) but
+            # must not write automation artifacts into curated memory stores.
+            # memory_call_is_write covers both the single-op `action` form and
+            # the batch `operations` form, so a batch write cannot bypass it.
+            if agent.session_id.startswith("cron_") and agent.platform == "cron" and memory_call_is_write(action, operations):
+                return json.dumps({"success": False, "error": (
+                    "Cron jobs have read-only access to MEMORY.md and USER.md. "
+                    "Write operations are not available in scheduled tasks."
+                )})
+            target = next_args.get("target", "memory")
             from tools.memory_tool import memory_tool as _memory_tool
             result = _memory_tool(
-                action=next_args.get("action"),
+                action=action,
                 target=target,
                 content=next_args.get("content"),
                 old_text=next_args.get("old_text"),

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -97,6 +97,24 @@ def _ra():
     return run_agent
 
 
+def memory_call_is_write(action, operations) -> bool:
+    """True when a ``memory()`` call performs any write.
+
+    Covers both documented call shapes: the single-op ``action`` form and
+    the batch ``operations`` form (whose entries carry their own action
+    field). Shared by the sequential and concurrent dispatch sites so the
+    cron write guard cannot be bypassed by switching shapes.
+    """
+    if action in ("add", "replace", "remove"):
+        return True
+    if isinstance(operations, list):
+        return any(
+            isinstance(op, dict) and op.get("action") in ("add", "replace", "remove")
+            for op in operations
+        )
+    return False
+
+
 AGENT_RUNTIME_POST_HOOK_TOOL_NAMES = frozenset(
     {"todo", "session_search", "memory", "clarify", "read_terminal", "read_preview", "delegate_task"}
 )
@@ -2929,11 +2947,22 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             )
     elif function_name == "memory":
         def _execute(next_args: dict) -> Any:
-            target = next_args.get("target", "memory")
+            action = next_args.get("action")
             operations = next_args.get("operations")
+            # Write-protect MEMORY.md/USER.md in cron context.
+            # Cron jobs inherit user context (system-prompt injection) but
+            # must not write automation artifacts into curated memory stores.
+            # memory_call_is_write covers both the single-op `action` form and
+            # the batch `operations` form, so a batch write cannot bypass it.
+            if agent.session_id.startswith("cron_") and agent.platform == "cron" and memory_call_is_write(action, operations):
+                return json.dumps({"success": False, "error": (
+                    "Cron jobs have read-only access to MEMORY.md and USER.md. "
+                    "Write operations are not available in scheduled tasks."
+                )})
+            target = next_args.get("target", "memory")
             from tools.memory_tool import memory_tool as _memory_tool
             result = _memory_tool(
-                action=next_args.get("action"),
+                action=action,
                 target=target,
                 content=next_args.get("content"),
                 old_text=next_args.get("old_text"),

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -2076,11 +2076,24 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 agent._vprint(f"  {_get_cute_tool_message_impl('session_search', function_args, tool_duration, result=function_result)}")
         elif function_name == "memory":
             def _execute(next_args: dict) -> Any:
-                target = next_args.get("target", "memory")
+                action = next_args.get("action")
                 operations = next_args.get("operations")
+                # Write-protect MEMORY.md/USER.md in cron context.
+                # Cron jobs inherit user context (system-prompt injection) but
+                # must not write automation artifacts into curated memory stores.
+                # memory_call_is_write covers both the single-op `action` form
+                # and the batch `operations` form, so a batch write cannot
+                # bypass it.
+                from agent.agent_runtime_helpers import memory_call_is_write
+                if agent.session_id.startswith("cron_") and agent.platform == "cron" and memory_call_is_write(action, operations):
+                    return json.dumps({"success": False, "error": (
+                        "Cron jobs have read-only access to MEMORY.md and USER.md. "
+                        "Write operations are not available in scheduled tasks."
+                    )})
+                target = next_args.get("target", "memory")
                 from tools.memory_tool import memory_tool as _memory_tool
                 result = _memory_tool(
-                    action=next_args.get("action"),
+                    action=action,
                     target=target,
                     content=next_args.get("content"),
                     old_text=next_args.get("old_text"),

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1597,11 +1597,24 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 agent._vprint(f"  {_get_cute_tool_message_impl('session_search', function_args, tool_duration, result=function_result)}")
         elif function_name == "memory":
             def _execute(next_args: dict) -> Any:
-                target = next_args.get("target", "memory")
+                action = next_args.get("action")
                 operations = next_args.get("operations")
+                # Write-protect MEMORY.md/USER.md in cron context.
+                # Cron jobs inherit user context (system-prompt injection) but
+                # must not write automation artifacts into curated memory stores.
+                # memory_call_is_write covers both the single-op `action` form
+                # and the batch `operations` form, so a batch write cannot
+                # bypass it.
+                from agent.agent_runtime_helpers import memory_call_is_write
+                if agent.session_id.startswith("cron_") and agent.platform == "cron" and memory_call_is_write(action, operations):
+                    return json.dumps({"success": False, "error": (
+                        "Cron jobs have read-only access to MEMORY.md and USER.md. "
+                        "Write operations are not available in scheduled tasks."
+                    )})
+                target = next_args.get("target", "memory")
                 from tools.memory_tool import memory_tool as _memory_tool
                 result = _memory_tool(
-                    action=next_args.get("action"),
+                    action=action,
                     target=target,
                     content=next_args.get("content"),
                     old_text=next_args.get("old_text"),

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -5577,7 +5577,10 @@ def run_job(
             # Without a workdir, keep cwd context discovery disabled.
             skip_context_files=not bool(_job_workdir),
             load_soul_identity=True,
-            skip_memory=True,  # Cron system prompts would corrupt user representations
+            skip_memory=False,  # Cron agents READ memory context (MEMORY.md/USER.md
+                                # injected into the system prompt); writes are
+                                # blocked at the memory() dispatch sites and the
+                                # external-provider sync path for platform="cron".
             skip_background_review=True,  # Cron has no human-in-the-loop need for skill/memory review forks (~30K tok/event)
             platform="cron",
             session_id=_cron_session_id,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3514,7 +3514,10 @@ def run_job(
             # Without a workdir, keep cwd context discovery disabled.
             skip_context_files=not bool(_job_workdir),
             load_soul_identity=True,
-            skip_memory=True,  # Cron system prompts would corrupt user representations
+            skip_memory=False,  # Cron agents READ memory context (MEMORY.md/USER.md
+                                # injected into the system prompt); writes are
+                                # blocked at the memory() dispatch sites and the
+                                # external-provider sync path for platform="cron".
             platform="cron",
             session_id=_cron_session_id,
             session_db=_session_db,

--- a/run_agent.py
+++ b/run_agent.py
@@ -4369,6 +4369,13 @@ class AIAgent:
         """
         if interrupted:
             return
+        # Automated cron runs are read-only for external memory providers too:
+        # the scheduler now passes skip_memory=False so cron agents can READ
+        # memory context, but a completed cron turn must not be mirrored into
+        # provider stores (same policy as the memory() dispatch guards).
+        # Human follow-ups in a cron session (platform="tui") still sync.
+        if str(getattr(self, "session_id", "") or "").startswith("cron_") and getattr(self, "platform", "") == "cron":
+            return
         if not (self._memory_manager and final_response and original_user_message):
             return
         # Multimodal turns carry content as a list of typed parts; providers

--- a/run_agent.py
+++ b/run_agent.py
@@ -4110,6 +4110,13 @@ class AIAgent:
         """
         if interrupted:
             return
+        # Automated cron runs are read-only for external memory providers too:
+        # the scheduler now passes skip_memory=False so cron agents can READ
+        # memory context, but a completed cron turn must not be mirrored into
+        # provider stores (same policy as the memory() dispatch guards).
+        # Human follow-ups in a cron session (platform="tui") still sync.
+        if str(getattr(self, "session_id", "") or "").startswith("cron_") and getattr(self, "platform", "") == "cron":
+            return
         if not (self._memory_manager and final_response and original_user_message):
             return
         # Multimodal turns carry content as a list of typed parts; providers

--- a/tests/agent/test_memory_write_guard.py
+++ b/tests/agent/test_memory_write_guard.py
@@ -1,0 +1,67 @@
+"""Contract tests for the cron memory write guard (#45769).
+
+The guard must treat BOTH documented ``memory()`` call shapes as writes:
+the single-op ``action`` form and the batch ``operations`` form (whose
+entries carry their own action field). Before this fix the dispatch-site
+guard only checked top-level ``action``, so a batch write bypassed it.
+
+``memory_call_is_write`` is a pure predicate shared by the sequential
+(``agent/tool_executor.py``) and concurrent (``agent/agent_runtime_helpers.py``)
+dispatch sites — testing the predicate directly covers both.
+"""
+import pytest
+
+from agent.agent_runtime_helpers import memory_call_is_write
+
+
+class TestMemoryCallIsWrite:
+    def test_single_op_add_is_write(self):
+        assert memory_call_is_write("add", None) is True
+
+    def test_single_op_replace_is_write(self):
+        assert memory_call_is_write("replace", None) is True
+
+    def test_single_op_remove_is_write(self):
+        assert memory_call_is_write("remove", None) is True
+
+    def test_single_op_read_is_not_write(self):
+        assert memory_call_is_write("recall", None) is False
+
+    def test_none_action_without_operations_is_not_write(self):
+        # The batch shape omits top-level action entirely.
+        assert memory_call_is_write(None, None) is False
+
+    def test_batch_add_op_is_write(self):
+        ops = [{"action": "add", "content": "x"}]
+        assert memory_call_is_write(None, ops) is True
+
+    def test_batch_replace_op_is_write(self):
+        ops = [{"action": "replace", "old_text": "x", "content": "y"}]
+        assert memory_call_is_write(None, ops) is True
+
+    def test_batch_remove_op_is_write(self):
+        ops = [{"action": "remove", "old_text": "x"}]
+        assert memory_call_is_write(None, ops) is True
+
+    def test_batch_read_ops_are_not_write(self):
+        ops = [{"action": "recall", "query": "x"}, {"action": "list"}]
+        assert memory_call_is_write(None, ops) is False
+
+    def test_mixed_batch_with_any_write_op_is_write(self):
+        ops = [{"action": "recall", "query": "x"}, {"action": "add", "content": "y"}]
+        assert memory_call_is_write(None, ops) is True
+
+    def test_empty_operations_is_not_write(self):
+        assert memory_call_is_write(None, []) is False
+
+    def test_non_list_operations_is_not_write(self):
+        assert memory_call_is_write(None, {"action": "add"}) is False
+
+    def test_malformed_entries_are_ignored(self):
+        ops = ["not-a-dict", {"action": "recall"}, None]
+        assert memory_call_is_write(None, ops) is False
+
+    def test_top_level_action_beats_empty_operations(self):
+        # Even with an empty operations list, an explicit top-level write
+        # action must still be caught.
+        assert memory_call_is_write("add", []) is True

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -318,6 +318,7 @@ class TestRoutingIntents:
         assert "matrix" not in platforms
 
 
+
 class TestDeliverResultWrapping:
     """Verify that cron deliveries are wrapped with header/footer and no longer mirrored."""
 
@@ -554,6 +555,7 @@ class TestRunJobSessionPersistence:
         kwargs = mock_agent_cls.call_args.kwargs
         assert kwargs["session_db"] is fake_db
         assert kwargs["platform"] == "cron"
+        assert kwargs["skip_memory"] is False
         assert kwargs["session_id"].startswith("cron_test-job_")
         original_session_id = kwargs["session_id"]
         fake_db.get_compression_tip.assert_called_once_with(original_session_id)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -244,6 +244,7 @@ class TestRoutingIntents:
         assert "matrix" not in platforms
 
 
+
 class TestDeliverResultWrapping:
     """Verify that cron deliveries are wrapped with header/footer and no longer mirrored."""
 
@@ -480,6 +481,7 @@ class TestRunJobSessionPersistence:
         kwargs = mock_agent_cls.call_args.kwargs
         assert kwargs["session_db"] is fake_db
         assert kwargs["platform"] == "cron"
+        assert kwargs["skip_memory"] is False
         assert kwargs["session_id"].startswith("cron_test-job_")
         original_session_id = kwargs["session_id"]
         fake_db.get_compression_tip.assert_called_once_with(original_session_id)

--- a/tests/run_agent/test_memory_sync_interrupted.py
+++ b/tests/run_agent/test_memory_sync_interrupted.py
@@ -38,6 +38,17 @@ def _bare_agent():
     return agent
 
 
+def _cron_bare_agent():
+    """Bare agent shaped like an automated cron run (platform="cron")."""
+    from run_agent import AIAgent
+
+    agent = AIAgent.__new__(AIAgent)
+    agent._memory_manager = MagicMock()
+    agent.session_id = "cron_test-job_20260805T120000Z"
+    agent.platform = "cron"
+    return agent
+
+
 class TestSyncExternalMemoryForTurn:
     # --- Interrupt guard (the #15218 fix) -------------------------------
 
@@ -53,6 +64,37 @@ class TestSyncExternalMemoryForTurn:
         )
         agent._memory_manager.sync_all.assert_not_called()
         agent._memory_manager.queue_prefetch_all.assert_not_called()
+
+
+    # --- Automated cron runs are read-only (#45769) ---------------------
+
+    def test_cron_automated_turn_does_not_sync(self):
+        """A completed turn from an automated cron run (platform="cron")
+        must not be mirrored into external memory providers. The scheduler
+        passes skip_memory=False so cron agents can READ context, but the
+        sync path is a write — same policy as the memory() dispatch guards.
+        """
+        agent = _cron_bare_agent()
+        agent._sync_external_memory_for_turn(
+            original_user_message="Summarize the logs",
+            final_response="Done.",
+            interrupted=False,
+        )
+        agent._memory_manager.sync_all.assert_not_called()
+        agent._memory_manager.queue_prefetch_all.assert_not_called()
+
+    def test_cron_human_followup_still_syncs(self):
+        """A human resuming a cron session (platform="tui") is a real
+        conversation — the sync path must NOT be suppressed for it."""
+        agent = _cron_bare_agent()
+        agent.platform = "tui"
+        agent._sync_external_memory_for_turn(
+            original_user_message="What did the job find?",
+            final_response="Here is the summary.",
+            interrupted=False,
+        )
+        agent._memory_manager.sync_all.assert_called_once()
+        agent._memory_manager.queue_prefetch_all.assert_called_once()
 
 
     # --- Normal completed turn still syncs ------------------------------


### PR DESCRIPTION
Closes #45768

## What

Cron agents now read memory context (`skip_memory=False` — MEMORY.md/USER.md injected into the system prompt), but cannot write into curated memory stores. Writes are blocked across all three paths:

1. **`memory()` dispatch (sequential)** — `agent/tool_executor.py` guard
2. **`memory()` dispatch (concurrent)** — `agent/agent_runtime_helpers.py` guard
3. **External-provider sync** — `_sync_external_memory_for_turn` returns early for automated cron runs

Both dispatch guards use a shared `memory_call_is_write()` predicate that inspects the single-op `action` **and** the documented batch `operations` shape (where top-level `action` is omitted), so batch writes cannot bypass the guard.

## Read vs write boundary

- `platform == "cron"` (automated run) → reads allowed, writes blocked everywhere
- `platform == "tui"` (human resumed the cron session in TUI/desktop) → reads + writes + provider sync all work

The `platform` check is reliable: the scheduler sets `platform="cron"`, and `_make_agent` in `tui_gateway/server.py` sets `platform="tui"` for all TUI/desktop sessions — including when a human resumes a cron session.

## How it interacts with #34098

| | This PR | #34098 |
|---|---|---|
| Memory reads | Always on | Per-job opt-in |
| Memory writes (auto) | Blocked by default | Per-job `memory_enabled: true` |
| Memory writes (human follow-up) | Allowed (platform=tui) | Allowed |
| Config needed | None | One bool per job |

Complementary, not competing. This PR provides the default safe behavior + the human follow-up escape hatch; #34098 provides per-job opt-in for trusted maintenance jobs during automated runs.

## Verification

- `tests/agent/test_memory_write_guard.py` — 13 contract cases for `memory_call_is_write()` (single-op + batch shapes, read-only actions pass)
- `tests/run_agent/test_memory_sync_interrupted.py` — cron sync-path guard tests
- `tests/cron/test_scheduler.py` — `skip_memory=False` on the scheduler path
- 80/80 pass

## Related

- Closes #9763 — "Cron jobs hardcode skip_memory=True, making external memory providers unusable"
- Closes #34094 — "cron: skip_memory=True blocks fact_storage in cron sessions"
