### PR TITLE
fix(gateway): deliver MEDIA: tags wrapped in Markdown emphasis

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1222,11 +1222,20 @@ _MEDIA_EXT_ALTERNATION = "|".join(
 # consumer so both behave identically.
 # Path anchors: ``~/`` (Unix home-relative), ``/`` (Unix absolute),
 # ``X:\\`` or ``X:/`` (Windows drive-letter absolute — #34632).
+# Emphasis tolerance: models routinely wrap the tag in Markdown emphasis
+# (``**MEDIA:/x.pdf**``, ``*MEDIA:/x.pdf*``, ``_MEDIA:/x.pdf_``) when they
+# present a file to the user. The old single-quote anchor (``[`"']?``) and the
+# closing lookahead (which lacked ``*``/``_``) failed to match such tags, so the
+# file was silently never delivered and the literal ``MEDIA:`` text leaked into
+# the chat. Allow a short run of emphasis/quote markers on both sides so the tag
+# is recognised regardless of cosmetic Markdown. Code-block / inline-code /
+# blockquote contexts are still neutralised earlier by ``_mask_protected_spans``
+# (#35695), so example tags remain non-deliverable.
 MEDIA_TAG_CLEANUP_RE = re.compile(
-    r'''[`"']?MEDIA:\s*'''
+    r'''[`"'*_]{0,3}MEDIA:\s*'''
     r'''(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|'''
     r'''(?:~/|/|[A-Za-z]:[/\\])\S+(?:[^\S\n]+\S+)*?\.(?:''' + _MEDIA_EXT_ALTERNATION + r'''))'''
-    r'''(?=[\s`"',;:)\]}]|$)[`"']?''',
+    r'''(?=[\s`"'*_,;:)\]}]|$)[`"'*_]{0,3}''',
     re.IGNORECASE,
 )
 

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -458,6 +458,51 @@ class TestExtractMedia:
         assert [p for p, _ in media] == ["/r/a.png"]
         assert "`MEDIA:/ex/b.png`" in cleaned
 
+    # --- Markdown emphasis wrapping tolerance ---
+    # Models routinely present a file as **MEDIA:/path** / *MEDIA:/path* /
+    # _MEDIA:/path_. The old pattern only tolerated a single quote/backtick, so
+    # the emphasis prevented the match and the file was silently never
+    # delivered (the literal MEDIA: text leaked into the chat instead).
+
+    def test_media_bold_wrapped_extracted(self):
+        media, cleaned = BasePlatformAdapter.extract_media(
+            "**MEDIA:/home/u/report.pptx**"
+        )
+        assert media == [("/home/u/report.pptx", False)]
+        assert "MEDIA:" not in cleaned
+
+    def test_media_italic_asterisk_extracted(self):
+        media, _ = BasePlatformAdapter.extract_media("*MEDIA:/home/u/report.pdf*")
+        assert media == [("/home/u/report.pdf", False)]
+
+    def test_media_italic_underscore_extracted(self):
+        media, _ = BasePlatformAdapter.extract_media("_MEDIA:/home/u/report.pdf_")
+        assert media == [("/home/u/report.pdf", False)]
+
+    def test_media_bold_mid_prose_extracted_and_stripped(self):
+        media, cleaned = BasePlatformAdapter.extract_media(
+            "Voici votre fichier **MEDIA:/tmp/r.pdf** bonne lecture"
+        )
+        assert media == [("/tmp/r.pdf", False)]
+        assert "MEDIA:" not in cleaned
+        assert "bonne lecture" in cleaned
+
+    def test_media_bold_wrapped_html_extracted(self):
+        # .html is a recognised extension; emphasis was the only blocker.
+        media, _ = BasePlatformAdapter.extract_media("**MEDIA:/srv/page.html**")
+        assert media == [("/srv/page.html", False)]
+
+    def test_media_underscore_in_filename_unaffected(self):
+        # Emphasis tolerance must not eat a legitimate '_' inside the path.
+        media, _ = BasePlatformAdapter.extract_media("MEDIA:/tmp/my_report_v2.pptx")
+        assert media == [("/tmp/my_report_v2.pptx", False)]
+
+    def test_media_bold_relative_path_still_ignored(self):
+        # The absolute-path anchor must still reject relative paths even when
+        # wrapped in emphasis.
+        media, _ = BasePlatformAdapter.extract_media("**MEDIA:report.html**")
+        assert media == []
+
 
 class TestMediaInsideSerializedJson:
     """Regression coverage for #34375 — MEDIA: embedded in serialized JSON


### PR DESCRIPTION
## What does this PR do?

`extract_media()` fails to deliver a file when the model wraps the delivery tag
in Markdown **emphasis** — `**MEDIA:/path.pptx**`, `*MEDIA:/path*`,
`_MEDIA:/path_`. The file is then silently never attached and the literal
`MEDIA:/path` text is shown to the user instead (the reported symptom: "the bot
sends a path instead of the file").

Root cause is purely in `MEDIA_TAG_CLEANUP_RE` (`gateway/platforms/base.py`):

- the leading anchor only tolerated a single quote/backtick (`` [`"']? ``), so
  a leading `**`/`*`/`_` prevented the match;
- the closing lookahead set `(?=[\s`"',;:)\]}]|$)` excluded `*` and `_`, so a
  trailing `**`/`*`/`_` also prevented the match.

This change lets a short run of emphasis/quote markers (`` [`"'*_]{0,3} ``)
appear on either side of the tag and adds `*`/`_` to the closing lookahead. It
keeps the existing **strict** behavior (a recognized extension is still
required — no loose `\S+` fallback) and does **not** touch the
`_mask_protected_spans` / `_mask_json_string_media` layer, so the deliberate
suppression of example tags inside code blocks, inline code, blockquotes and
serialized JSON (#35695, #34375) is preserved. The absolute-path anchor
(incl. the Windows drive support from #34632) is unchanged, so relative paths
are still rejected and `_` inside a filename is unaffected.

Observed in production across multiple Telegram instances: on instances where
the model emitted emphasis-wrapped tags, those file deliveries were lost 1:1;
instances that never wrapped the tag had zero loss. Some Grok/GPT variants bold
file names by default, so the collision is frequent.

## Related Issue

Fixes #23759.

Supersedes #23765 (open since 2026-05-11, no reviews): that patch predates the
refactor that moved the inline regex into the module-level
`MEDIA_TAG_CLEANUP_RE`, switched the hardcoded extension list to
`_MEDIA_EXT_ALTERNATION`, added the Windows anchor (#34632) and the masking
layer (#35695). It also reintroduced the loose `|\S+` path fallback that the
refactor had removed. This PR applies cleanly on current `main`, is more
general (handles mixed quote+emphasis and `__`/`***`), preserves strict
extension matching, and adds masking-invariant regression coverage. Credit to
@LeonSGP43 for the original report and fix.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py` — `MEDIA_TAG_CLEANUP_RE`: tolerate
  `` [`"'*_]{0,3} `` on both sides of the tag and add `*`/`_` to the closing
  lookahead. Both the non-streaming dispatch path and the streaming consumer
  reference this constant, so extraction and visible-text stripping are fixed
  on both paths at once.
- `tests/gateway/test_platform_base.py` — added `TestExtractMedia` cases for
  bold/italic(`*`)/italic(`_`) wrapping, mid-prose bold, emphasis-wrapped
  `.html`, underscore-in-filename (must be unaffected), and
  emphasis-wrapped relative path (must stay rejected).

## How to Test

1. Before: `BasePlatformAdapter.extract_media("**MEDIA:/tmp/r.pptx**")` → `([], ...)` (file dropped, literal text leaks).
2. After: same input → `([("/tmp/r.pptx", False)], "")` (delivered, text stripped).
3. `pytest tests/gateway/test_platform_base.py -q` → all pass (incl. the
   pre-existing code-block / inline-code / blockquote / JSON suppression tests,
   confirming no regression of #35695 / #34375).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway):`)
- [x] I searched for existing PRs (found #23765 — see Related Issue; this supersedes it)
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the relevant file `tests/gateway/test_platform_base.py` (165 passed, 2 skipped); change is an isolated regex edit
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian 13 (and the regex is platform-agnostic)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstring above the regex) — code comment added
- [x] N/A — no config keys changed
- [x] N/A — no architecture/workflow change
- [x] I've considered cross-platform impact — the Windows drive anchor (#34632) is preserved; emphasis markers are ASCII
- [x] N/A — no tool behavior/schema change
