### PR TITLE
feat: add delete_message to Discord adapter

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1801,6 +1801,32 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.error("[%s] Failed to edit Discord message %s: %s", self.name, message_id, e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
+    async def delete_message(self, chat_id: str, message_id: str) -> bool:
+        """Delete a previously sent Discord message.
+
+        Used by cleanup_progress to remove tool-progress bubbles after
+        the final response lands.  Discord's API allows bots to delete
+        their own messages.  Failures are non-fatal — the caller leaves
+        the message in place and logs at debug level.
+        """
+        if not self._client:
+            return False
+        try:
+            channel = self._client.get_channel(int(chat_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(chat_id))
+            if not channel:
+                return False
+            msg = await channel.fetch_message(int(message_id))
+            await msg.delete()
+            return True
+        except Exception as e:
+            logger.debug(
+                "[%s] Failed to delete Discord message %s: %s",
+                self.name, message_id, e,
+            )
+            return False
+
     async def _send_file_attachment(
         self,
         chat_id: str,


### PR DESCRIPTION
## What

Implements  for the Discord platform adapter, enabling  to remove tool-progress bubbles after the final response lands.

## Why

The  feature (config: ) deletes ephemeral progress messages after the agent's final response completes. This feature requires the platform adapter to implement . Discord's adapter currently inherits the base class no-op, so cleanup is silently disabled even when the config is set.

## How

Follows the same pattern as Telegram's  implementation (line 2797 in ):
1. Fetch channel via  or 
2. Fetch message via 
3. Delete via 
4. Return  on success,  on failure (logged at debug level)

## Testing

- Verified locally on a live Discord gateway with 
- Tool progress messages now auto-delete after the final response lands
- Failures are non-fatal — messages remain if deletion fails

## Checklist

- [x] Follows existing pattern (Telegram adapter)
- [x] Non-breaking addition (overrides base class no-op)
- [x] Error handling with debug logging
- [x] Works with existing  config