### PR TITLE
fix(fallback): self-heal from primary 429s — honor api_key_env in fallback chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes are logged here — for humans **and** agents.
+Format follows [Keep a Changelog](https://keepachangelog.com/). Newest first.
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Newest first.
 ### Changed
 
 ### Fixed
+
+- Fallback chain activation now honors `api_key_env`/`key_env` on fallback
+  provider entries in `run_agent.py`'s inline `_try_activate_fallback`, matching
+  the documented behavior (`fallback-providers.md`) and the refactored runtime
+  helper. Without it, a custom free-tier fallback (e.g. Gemini) that referenced
+  its key by env-var name resolved to no key and was silently skipped, so a
+  primary 429 could exhaust the chain and surface a raw `API call failed after 3
+  retries: HTTP 429` instead of self-healing onto a live provider.

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -636,6 +636,15 @@ def resolve_anthropic_token() -> Optional[str]:
     if resolved_claude_token:
         return resolved_claude_token
 
+    # 3.5 Hermes credential pool (~/.hermes/auth.json:credential_pool.anthropic).
+    # This is where `hermes auth add anthropic --type oauth` stores tokens.
+    # Without this branch, the OAuth flow registered the credential but no
+    # callsite of resolve_anthropic_token() could find it, breaking the
+    # standard 401-retry-with-refresh path in run_agent.
+    pool_token = resolve_anthropic_pool_token()
+    if pool_token:
+        return pool_token
+
     # 4. Regular API key, or a legacy OAuth token saved in ANTHROPIC_API_KEY.
     # This remains as a compatibility fallback for pre-migration Hermes configs.
     api_key = os.getenv("ANTHROPIC_API_KEY", "").strip()
@@ -643,6 +652,118 @@ def resolve_anthropic_token() -> Optional[str]:
         return api_key
 
     return None
+
+
+# ---------------------------------------------------------------------------
+# Hermes credential pool — anthropic OAuth entries
+# ---------------------------------------------------------------------------
+
+_REFRESH_MARGIN_MS = 5 * 60 * 1000  # refresh if expires within 5 min
+
+
+def _hermes_auth_file() -> Path:
+    """Return the path to the Hermes credential store."""
+    return get_hermes_home() / "auth.json"
+
+
+def _read_hermes_pool_anthropic_entry() -> Optional[Dict[str, Any]]:
+    """Return the first anthropic OAuth credential pool entry, or None.
+
+    The dict has access_token / refresh_token / expires_at_ms / source / auth_type
+    as written by `hermes auth add anthropic`.
+    """
+    path = _hermes_auth_file()
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    pool = data.get("credential_pool") or {}
+    entries = pool.get("anthropic") or []
+    if not isinstance(entries, list) or not entries:
+        return None
+    return entries[0]
+
+
+def _write_hermes_pool_anthropic_entry(updated: Dict[str, Any]) -> None:
+    """Persist an updated anthropic OAuth entry back to ~/.hermes/auth.json.
+
+    Replaces the first anthropic entry in the credential_pool — the same
+    one returned by _read_hermes_pool_anthropic_entry.  Silent on I/O errors.
+    """
+    path = _hermes_auth_file()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return
+    pool = data.setdefault("credential_pool", {})
+    entries = pool.get("anthropic")
+    if not isinstance(entries, list) or not entries:
+        return
+    entries[0] = updated
+    data["credential_pool"]["anthropic"] = entries
+    try:
+        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    except (OSError, IOError) as e:
+        logger.debug("Failed to write hermes anthropic pool entry: %s", e)
+
+
+def refresh_hermes_pool_anthropic_token(force: bool = False) -> Optional[str]:
+    """Refresh the first anthropic OAuth entry in the Hermes credential pool.
+
+    Args:
+        force: If True, refresh unconditionally (used on 401 — the access
+            token's claimed expires_at_ms is unreliable since Anthropic may
+            revoke server-side before that timestamp).  If False, refresh
+            only when expires_at_ms is within _REFRESH_MARGIN_MS.
+
+    Returns the new access_token on success, or None when there is no entry,
+    no refresh_token, or the refresh call failed.  The pool entry is
+    written back to disk on success.
+    """
+    entry = _read_hermes_pool_anthropic_entry()
+    if entry is None or entry.get("auth_type") != "oauth":
+        return None
+    refresh_token = entry.get("refresh_token")
+    if not refresh_token:
+        return None
+
+    import time
+
+    if not force:
+        expires_at_ms = entry.get("expires_at_ms")
+        if isinstance(expires_at_ms, (int, float)):
+            now_ms = time.time() * 1000
+            if expires_at_ms - now_ms > _REFRESH_MARGIN_MS:
+                # Token claims to be still valid — just return what we have.
+                return entry.get("access_token") or None
+
+    try:
+        use_json = str(entry.get("source", "")).endswith("hermes_pkce")
+        refreshed = refresh_anthropic_oauth_pure(refresh_token, use_json=use_json)
+    except Exception as exc:
+        logger.debug("Hermes anthropic pool refresh failed: %s", exc)
+        return None
+
+    entry["access_token"] = refreshed["access_token"]
+    entry["refresh_token"] = refreshed.get("refresh_token", refresh_token)
+    if "expires_at_ms" in refreshed:
+        entry["expires_at_ms"] = refreshed["expires_at_ms"]
+    elif "expires_in" in refreshed:
+        entry["expires_at_ms"] = int((time.time() + refreshed["expires_in"]) * 1000)
+    _write_hermes_pool_anthropic_entry(entry)
+    logger.info("Refreshed anthropic OAuth token in hermes credential pool")
+    return entry["access_token"]
+
+
+def resolve_anthropic_pool_token() -> Optional[str]:
+    """Return a usable access_token from the Hermes credential pool.
+
+    Prefers the stored access_token, but transparently refreshes when the
+    token's expires_at_ms is within _REFRESH_MARGIN_MS.
+    """
+    return refresh_hermes_pool_anthropic_token(force=False)
 
 
 def run_oauth_setup_token() -> Optional[str]:

--- a/hermes_cli/chat_session.py
+++ b/hermes_cli/chat_session.py
@@ -1,0 +1,430 @@
+"""In-process chat session that drives AIAgent and streams events to the browser.
+
+A ChatSession owns:
+  - a long-lived AIAgent (constructed once, reused across turns, so the
+    prompt cache survives — see AGENTS.md "Important Policies")
+  - an asyncio.Queue of SSE-formatted strings (the SSE generator drains it)
+  - pending approval/clarify futures (threading.Event + result box per call)
+  - a worker thread that runs the sync run_conversation() per turn
+  - a cancel event the agent loop can poll between iterations
+
+Why threads + asyncio?  AIAgent.run_conversation is sync and blocking.  It
+calls tool/stream callbacks from its own thread.  We bridge those into the
+FastAPI event loop via loop.call_soon_threadsafe, then the SSE generator
+yields them.
+
+The browser only sees structured events; correlating call_id is the
+contract between approval-request events and the POST /approve endpoint.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# How long an idle approval/clarify waits before defaulting to "deny" / "".
+_APPROVAL_TIMEOUT_SECONDS = 300
+_CLARIFY_TIMEOUT_SECONDS = 300
+
+# How long an idle ChatSession lives before the registry evicts it.
+_SESSION_IDLE_TIMEOUT_SECONDS = 60 * 60  # 1 hour
+
+
+def _sse_format(event: str, data: Dict[str, Any]) -> str:
+    """Format a structured event as an SSE frame."""
+    return f"event: {event}\ndata: {json.dumps(data, ensure_ascii=False)}\n\n"
+
+
+@dataclass
+class PendingResponse:
+    """A blocked agent-thread call awaiting a browser response."""
+    event: threading.Event = field(default_factory=threading.Event)
+    result: List[Any] = field(default_factory=lambda: [None])
+
+
+class ChatSession:
+    """One browser tab = one ChatSession.  Owns its AIAgent across turns."""
+
+    def __init__(self, session_id: str, loop: asyncio.AbstractEventLoop):
+        self.session_id = session_id
+        self.loop = loop
+        self.queue: "asyncio.Queue[str]" = asyncio.Queue()
+        self.history: List[Dict[str, Any]] = []
+        self.agent = None  # lazy — built on first turn
+        self.pending_approvals: Dict[str, PendingResponse] = {}
+        self.pending_clarifies: Dict[str, PendingResponse] = {}
+        self.cancel_event = threading.Event()  # set by /cancel, polled by Step 6
+        self.last_activity = time.time()
+        self.lock = threading.Lock()
+        self._worker: Optional[threading.Thread] = None
+        self._closed = False
+
+    # ------------------------------------------------------------------ #
+    # Event emission                                                      #
+    # ------------------------------------------------------------------ #
+
+    def _emit(self, event_name: str, data: Dict[str, Any]) -> None:
+        """Push an SSE-formatted event onto the queue from any thread."""
+        if self._closed:
+            return
+        frame = _sse_format(event_name, data)
+        try:
+            self.loop.call_soon_threadsafe(self.queue.put_nowait, frame)
+        except RuntimeError:
+            # Event loop is closed (server shutdown) — drop the event.
+            logger.debug("ChatSession %s: event loop closed, dropping %s", self.session_id, event_name)
+
+    # ------------------------------------------------------------------ #
+    # Approval / clarify bridges                                          #
+    # ------------------------------------------------------------------ #
+
+    def _approval_callback(self, command: str, description: str, *, allow_permanent: bool = True) -> str:
+        """Bridges tools/approval.prompt_dangerous_approval → browser modal.
+
+        Called from the agent thread.  Blocks until POST /approve resolves
+        the matching call_id or the timeout fires.
+        """
+        call_id = uuid.uuid4().hex
+        pending = PendingResponse()
+        self.pending_approvals[call_id] = pending
+        self._emit("approval-request", {
+            "call_id": call_id,
+            "command": command,
+            "description": description,
+            "allow_permanent": allow_permanent,
+        })
+        if not pending.event.wait(timeout=_APPROVAL_TIMEOUT_SECONDS):
+            # Timed out — clean up and default-deny.
+            self.pending_approvals.pop(call_id, None)
+            logger.warning("Approval timed out for session %s call %s", self.session_id, call_id)
+            return "deny"
+        return pending.result[0] or "deny"
+
+    def resolve_approval(self, call_id: str, decision: str) -> bool:
+        pending = self.pending_approvals.pop(call_id, None)
+        if pending is None:
+            return False
+        pending.result[0] = decision
+        pending.event.set()
+        return True
+
+    def _clarify_callback(self, question: str, choices: Optional[List[str]] = None) -> str:
+        """Bridges agent's clarify hook → browser modal.
+
+        Returns the chosen option or freeform text.  Empty string on timeout.
+        """
+        call_id = uuid.uuid4().hex
+        pending = PendingResponse()
+        self.pending_clarifies[call_id] = pending
+        self._emit("clarify-request", {
+            "call_id": call_id,
+            "question": question,
+            "choices": list(choices or []),
+        })
+        if not pending.event.wait(timeout=_CLARIFY_TIMEOUT_SECONDS):
+            self.pending_clarifies.pop(call_id, None)
+            logger.warning("Clarify timed out for session %s call %s", self.session_id, call_id)
+            return ""
+        return pending.result[0] or ""
+
+    def resolve_clarify(self, call_id: str, answer: str) -> bool:
+        pending = self.pending_clarifies.pop(call_id, None)
+        if pending is None:
+            return False
+        pending.result[0] = answer
+        pending.event.set()
+        return True
+
+    # ------------------------------------------------------------------ #
+    # Turn execution                                                      #
+    # ------------------------------------------------------------------ #
+
+    def _build_agent(self):
+        """Lazy-construct AIAgent on first turn.  Reused across turns."""
+        if self.agent is not None:
+            return self.agent
+
+        # Import inside the method — AIAgent's import chain is heavy.
+        from run_agent import AIAgent
+        from hermes_cli.config import load_config
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        from hermes_state import SessionDB
+
+        cfg = load_config()
+        model_cfg = cfg.get("model") if isinstance(cfg.get("model"), dict) else {}
+        model = model_cfg.get("default") or model_cfg.get("model") or cfg.get("model") or ""
+        if not isinstance(model, str) or not model.strip():
+            raise RuntimeError("No model configured. Set `model.default` in ~/.hermes/config.yaml.")
+
+        runtime = resolve_runtime_provider()
+        # resolve_runtime_provider returns extra keys AIAgent doesn't accept;
+        # filter to the kwargs the constructor actually takes.
+        runtime_keys = {"api_key", "base_url", "provider", "api_mode",
+                        "command", "args", "acp_command", "acp_args",
+                        "credential_pool"}
+        runtime_kwargs = {k: v for k, v in runtime.items() if k in runtime_keys}
+
+        # Persist messages to the same SessionDB used by /api/sessions, so the
+        # Sessions page sees this chat.
+        session_db = SessionDB()
+        session_db.create_session(session_id=self.session_id, source="web")
+
+        self.agent = AIAgent(
+            model=model,
+            **runtime_kwargs,
+            quiet_mode=True,
+            verbose_logging=False,
+            session_id=self.session_id,
+            platform="web",
+            session_db=session_db,
+            clarify_callback=self._clarify_callback,
+        )
+        return self.agent
+
+    def send(self, user_text: str) -> None:
+        """Start a turn in a background worker thread.  Returns immediately.
+
+        Raises if a previous turn is still running.
+        """
+        with self.lock:
+            if self._worker is not None and self._worker.is_alive():
+                raise RuntimeError("A turn is already in progress")
+            self.cancel_event.clear()
+            self.last_activity = time.time()
+            t = threading.Thread(target=self._run_turn, args=(user_text,), daemon=True,
+                                 name=f"chat-{self.session_id[:8]}")
+            self._worker = t
+            t.start()
+
+    def _run_turn(self, user_text: str) -> None:
+        """Worker-thread entry point.  Runs one agent turn end-to-end."""
+        call_id = uuid.uuid4().hex
+        self._emit("turn-start", {"call_id": call_id})
+        try:
+            agent = self._build_agent()
+            # Per-turn callbacks — match the gateway pattern (gateway/run.py:8887).
+            agent.stream_delta_callback = self._on_stream_delta
+            agent.tool_start_callback = self._on_tool_start
+            agent.tool_complete_callback = self._on_tool_complete
+            # Clear any pending interrupt from a previous turn before starting.
+            try:
+                agent.clear_interrupt()
+            except Exception:
+                pass
+
+            # Install web approval handler (module-global in terminal_tool).
+            import tools.terminal_tool as _term
+            previous = _term._approval_callback  # current value, may be None
+            _term.set_approval_callback(self._approval_callback)
+            try:
+                result = agent.run_conversation(
+                    user_text,
+                    conversation_history=self.history,
+                )
+            finally:
+                _term.set_approval_callback(previous)
+
+            self.history = result.get("messages", self.history) or self.history
+            final_text = result.get("final_response", "") or ""
+            self._emit("turn-end", {"call_id": call_id, "final_text": final_text})
+        except Exception as e:  # noqa: BLE001
+            logger.exception("ChatSession %s turn failed", self.session_id)
+            self._emit("error", {"call_id": call_id, "detail": str(e)})
+        finally:
+            self.last_activity = time.time()
+
+    # ------------------------------------------------------------------ #
+    # Per-turn agent callbacks                                            #
+    # ------------------------------------------------------------------ #
+
+    def _on_stream_delta(self, delta: str) -> None:
+        if delta:
+            self._emit("text-delta", {"delta": delta})
+
+    def _on_tool_start(self, call_id: str, name: str, args: Any) -> None:
+        # args may be a dict or a JSON string; render a short summary
+        summary = ""
+        try:
+            if isinstance(args, dict):
+                summary = json.dumps(args, ensure_ascii=False)[:200]
+            else:
+                summary = str(args)[:200]
+        except Exception:
+            summary = ""
+        self._emit("tool-call-start", {
+            "call_id": call_id,
+            "tool": name,
+            "args_summary": summary,
+        })
+
+    def _on_tool_complete(self, call_id: str, name: str, args: Any, result: Any) -> None:
+        ok = True
+        summary = ""
+        try:
+            if isinstance(result, str):
+                parsed = json.loads(result) if result.lstrip().startswith("{") else None
+                if isinstance(parsed, dict):
+                    ok = bool(parsed.get("success", True))
+                    summary = parsed.get("error") or parsed.get("message") or ""
+                else:
+                    summary = result[:200]
+            elif isinstance(result, dict):
+                ok = bool(result.get("success", True))
+                summary = result.get("error") or result.get("message") or ""
+        except Exception:
+            summary = ""
+        self._emit("tool-call-result", {
+            "call_id": call_id,
+            "tool": name,
+            "ok": ok,
+            "summary": str(summary)[:200],
+        })
+
+    # ------------------------------------------------------------------ #
+    # SSE stream + lifecycle                                              #
+    # ------------------------------------------------------------------ #
+
+    async def stream(self):
+        """Async generator yielding SSE frames for the entire session.
+
+        Stays open until the caller disconnects or .close() is called.
+        Multiple turns share the same stream.
+        """
+        # Initial hello so the client knows the connection is live.
+        yield _sse_format("status", {"kind": "connected", "session_id": self.session_id})
+        while not self._closed:
+            try:
+                frame = await asyncio.wait_for(self.queue.get(), timeout=15.0)
+                yield frame
+            except asyncio.TimeoutError:
+                # Heartbeat keeps proxies from idle-killing the connection.
+                yield ": keepalive\n\n"
+            except asyncio.CancelledError:
+                # Client disconnected.
+                logger.debug("ChatSession %s stream cancelled", self.session_id)
+                break
+
+    def cancel_turn(self) -> bool:
+        """Interrupt the agent mid-turn via AIAgent.interrupt().
+
+        AIAgent's interrupt() flips an internal flag the tool loop polls,
+        and propagates to any subagents and in-flight tool executions.
+        Returns True if there was a turn in progress to cancel.
+        """
+        self.cancel_event.set()
+        running = self._worker is not None and self._worker.is_alive()
+        agent = self.agent
+        if agent is not None and running:
+            try:
+                agent.interrupt(message=None)
+            except Exception:
+                logger.exception("ChatSession %s: agent.interrupt() raised", self.session_id)
+        return running
+
+    def close(self) -> None:
+        """Tear down the session and unblock any pending waits."""
+        self._closed = True
+        for p in list(self.pending_approvals.values()):
+            p.event.set()
+        for p in list(self.pending_clarifies.values()):
+            p.event.set()
+
+    # ------------------------------------------------------------------ #
+    # History (for reattach)                                              #
+    # ------------------------------------------------------------------ #
+
+    def load_history_from_db(self) -> None:
+        """Replay messages from SessionDB into self.history.
+
+        Used by the registry when reattaching to a session_id that the
+        in-process registry has evicted but the DB still has.
+        """
+        try:
+            from hermes_state import SessionDB
+            db = SessionDB()
+            self.history = db.get_messages_as_conversation(self.session_id) or []
+        except Exception:
+            logger.exception("Failed to load history for %s", self.session_id)
+            self.history = []
+
+
+# ====================================================================== #
+# Registry                                                                #
+# ====================================================================== #
+
+_registry: Dict[str, ChatSession] = {}
+_registry_lock = threading.Lock()
+
+
+def create_session(loop: asyncio.AbstractEventLoop) -> ChatSession:
+    """Create a fresh ChatSession with a new UUID session_id."""
+    session_id = uuid.uuid4().hex
+    sess = ChatSession(session_id, loop)
+    with _registry_lock:
+        _registry[session_id] = sess
+        _evict_idle_locked()
+    return sess
+
+
+def get_or_reattach(session_id: str, loop: asyncio.AbstractEventLoop) -> Optional[ChatSession]:
+    """Return an existing session, or rebuild one from SessionDB history.
+
+    Returns None if no record exists anywhere.
+    """
+    with _registry_lock:
+        sess = _registry.get(session_id)
+        if sess is not None:
+            sess.last_activity = time.time()
+            return sess
+
+    # Not in-process — try to reattach from DB.
+    try:
+        from hermes_state import SessionDB
+        db = SessionDB()
+        record = db.get_session(session_id)
+    except Exception:
+        record = None
+    if record is None:
+        return None
+
+    sess = ChatSession(session_id, loop)
+    sess.load_history_from_db()
+    with _registry_lock:
+        _registry[session_id] = sess
+    return sess
+
+
+def get(session_id: str) -> Optional[ChatSession]:
+    with _registry_lock:
+        return _registry.get(session_id)
+
+
+def remove(session_id: str) -> bool:
+    with _registry_lock:
+        sess = _registry.pop(session_id, None)
+    if sess is None:
+        return False
+    sess.close()
+    return True
+
+
+def _evict_idle_locked() -> None:
+    """Drop sessions idle for too long.  Caller holds _registry_lock."""
+    now = time.time()
+    stale = [
+        sid for sid, sess in _registry.items()
+        if now - sess.last_activity > _SESSION_IDLE_TIMEOUT_SECONDS
+    ]
+    for sid in stale:
+        sess = _registry.pop(sid)
+        sess.close()
+        logger.info("Evicted idle chat session %s", sid)

--- a/hermes_cli/chat_session.py
+++ b/hermes_cli/chat_session.py
@@ -198,10 +198,16 @@ class ChatSession:
         return self.agent
 
     def send(self, user_text: str) -> None:
-        """Start a turn in a background worker thread.  Returns immediately.
+        """Start a turn, or dispatch a slash command.
 
-        Raises if a previous turn is still running.
+        If the input starts with "/", treat it as a slash command and
+        process it inline (no agent turn).  Otherwise spawn a worker
+        thread to drive AIAgent.run_conversation.
         """
+        stripped = user_text.strip()
+        if stripped.startswith("/"):
+            self._handle_slash_command(stripped)
+            return
         with self.lock:
             if self._worker is not None and self._worker.is_alive():
                 raise RuntimeError("A turn is already in progress")
@@ -211,6 +217,138 @@ class ChatSession:
                                  name=f"chat-{self.session_id[:8]}")
             self._worker = t
             t.start()
+
+    # ------------------------------------------------------------------ #
+    # Slash commands                                                      #
+    # ------------------------------------------------------------------ #
+
+    def _handle_slash_command(self, raw: str) -> None:
+        """Route /foo args to a specific handler.  Emits system-message events."""
+        parts = raw.lstrip("/").split(None, 1)
+        name = parts[0].lower() if parts else ""
+        args = parts[1] if len(parts) > 1 else ""
+        if name == "model":
+            self._handle_model_command(args)
+        elif name in ("help", "?"):
+            self._emit("system-message", {"detail": (
+                "Slash commands available in the dashboard chat:\n"
+                "  /model                              — show usage\n"
+                "  /model <name>                       — switch model for this session\n"
+                "  /model <name> --global              — switch + persist to config.yaml\n"
+                "  /model <name> --provider <p>        — switch model + provider\n"
+                "Aliases: haiku, sonnet, opus, gpt, gpt5, gemini, grok, deepseek, llama, claude\n"
+                "  /help                               — this list"
+            )})
+        else:
+            self._emit("system-message", {"detail": (
+                f"Unknown slash command: /{name}\n"
+                "Try /help for the list."
+            )})
+
+    def _handle_model_command(self, raw_args: str) -> None:
+        """Mirror gateway/run.py:_handle_model_command for the dashboard chat.
+
+        Uses the shared switch_model() pipeline so behavior matches the CLI:
+        same aliases (haiku, sonnet, opus, ...), same --provider / --global
+        flags, same error messages.
+        """
+        try:
+            import yaml
+            from hermes_cli.model_switch import (
+                switch_model as _switch_model,
+                parse_model_flags,
+                MODEL_ALIASES,
+            )
+            from hermes_cli.config import load_config, save_config
+        except Exception as e:  # noqa: BLE001
+            self._emit("system-message", {"detail": f"⚠ /model unavailable: {e}"})
+            return
+
+        model_input, explicit_provider, persist_global = parse_model_flags(raw_args.strip())
+
+        if not model_input and not explicit_provider:
+            # No args — show the current model and a hint.
+            cfg_now = load_config() or {}
+            model_cfg = cfg_now.get("model") if isinstance(cfg_now.get("model"), dict) else {}
+            cur_model = (model_cfg or {}).get("default", "") or cfg_now.get("model", "")
+            cur_provider = (model_cfg or {}).get("provider", "") if isinstance(model_cfg, dict) else ""
+            aliases = ", ".join(sorted(MODEL_ALIASES.keys()))
+            self._emit("system-message", {"detail": (
+                f"Current model: {cur_model or '(unset)'}   provider: {cur_provider or '(auto)'}\n\n"
+                f"Usage:  /model <name> [--provider <p>] [--global]\n"
+                f"Aliases: {aliases}\n"
+                f"Example: /model haiku --global"
+            )})
+            return
+
+        cfg = load_config() or {}
+        model_cfg = cfg.get("model") if isinstance(cfg.get("model"), dict) else {}
+        current_model = (model_cfg or {}).get("default", "") if isinstance(model_cfg, dict) else ""
+        current_provider = (model_cfg or {}).get("provider", "openrouter") if isinstance(model_cfg, dict) else "openrouter"
+        current_base_url = (model_cfg or {}).get("base_url", "") if isinstance(model_cfg, dict) else ""
+
+        try:
+            result = _switch_model(
+                raw_input=model_input,
+                current_provider=current_provider,
+                current_model=current_model,
+                current_base_url=current_base_url,
+                current_api_key="",
+                is_global=persist_global,
+                explicit_provider=explicit_provider,
+                user_providers=cfg.get("providers"),
+                custom_providers=cfg.get("custom_providers"),
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.exception("ChatSession %s: switch_model raised", self.session_id)
+            self._emit("system-message", {"detail": f"⚠ Model switch failed: {e}"})
+            return
+
+        if not result.success:
+            self._emit("system-message", {"detail": f"⚠ {result.error_message or 'Unknown error'}"})
+            return
+
+        # Update the cached agent in-place if it exists and supports switch_model.
+        agent = self.agent
+        if agent is not None:
+            try:
+                agent.switch_model(
+                    new_model=result.new_model,
+                    new_provider=result.target_provider,
+                    api_key=result.api_key,
+                    base_url=result.base_url,
+                    api_mode=result.api_mode,
+                )
+            except Exception:
+                # Fall back to rebuilding on next turn.
+                logger.exception("In-place agent.switch_model failed; will rebuild on next turn")
+                self.agent = None
+
+        # Persist if --global.
+        persisted_note = ""
+        if persist_global:
+            try:
+                model_cfg_w = cfg.setdefault("model", {}) if isinstance(cfg.get("model"), dict) else {}
+                if not isinstance(cfg.get("model"), dict):
+                    cfg["model"] = {"default": result.new_model, "provider": result.target_provider}
+                else:
+                    cfg["model"]["default"] = result.new_model
+                    cfg["model"]["provider"] = result.target_provider
+                    if result.base_url:
+                        cfg["model"]["base_url"] = result.base_url
+                    else:
+                        cfg["model"].pop("base_url", None)
+                save_config(cfg)
+                persisted_note = "  (saved to ~/.hermes/config.yaml)"
+            except Exception as e:  # noqa: BLE001
+                logger.exception("Persisting /model --global failed")
+                persisted_note = f"  (⚠ persist failed: {e})"
+
+        alias_note = f" (alias '{result.resolved_via_alias}')" if result.resolved_via_alias else ""
+        prov_label = result.provider_label or result.target_provider
+        self._emit("system-message", {"detail": (
+            f"Switched to {result.new_model}{alias_note} on {prov_label}{persisted_note}"
+        )})
 
     def _run_turn(self, user_text: str) -> None:
         """Worker-thread entry point.  Runs one agent turn end-to-end."""

--- a/hermes_cli/chat_session.py
+++ b/hermes_cli/chat_session.py
@@ -178,6 +178,12 @@ class ChatSession:
         session_db = SessionDB()
         session_db.create_session(session_id=self.session_id, source="web")
 
+        # Optional per-provider max_tokens cap.  Useful when OpenRouter's
+        # preemptive credit check rejects the default 64k ceiling: setting
+        # max_tokens to e.g. 512 lets small chats run on tiny balances.
+        max_tokens_cfg = cfg.get("max_tokens")
+        max_tokens = int(max_tokens_cfg) if isinstance(max_tokens_cfg, (int, float)) else None
+
         self.agent = AIAgent(
             model=model,
             **runtime_kwargs,
@@ -187,6 +193,7 @@ class ChatSession:
             platform="web",
             session_db=session_db,
             clarify_callback=self._clarify_callback,
+            max_tokens=max_tokens,
         )
         return self.agent
 
@@ -235,12 +242,51 @@ class ChatSession:
 
             self.history = result.get("messages", self.history) or self.history
             final_text = result.get("final_response", "") or ""
-            self._emit("turn-end", {"call_id": call_id, "final_text": final_text})
+            # If the agent swallowed an API error and returned nothing, surface
+            # it as an error event so the user sees something concrete instead
+            # of an empty bubble.  Look in errors.log for the most recent line
+            # mentioning this session_id; failing that, fall back to a generic.
+            if not final_text.strip():
+                err_detail = self._tail_recent_error() or (
+                    "Agent returned no response. "
+                    "Check ~/.hermes/logs/agent.log for details."
+                )
+                self._emit("error", {"call_id": call_id, "detail": err_detail})
+            else:
+                self._emit("turn-end", {"call_id": call_id, "final_text": final_text})
         except Exception as e:  # noqa: BLE001
             logger.exception("ChatSession %s turn failed", self.session_id)
             self._emit("error", {"call_id": call_id, "detail": str(e)})
         finally:
             self.last_activity = time.time()
+
+    def _tail_recent_error(self) -> Optional[str]:
+        """Best-effort: return the most recent ERROR line that mentions our session.
+
+        Used only when the agent returns an empty response so we can show the
+        user *why*.  Reads ~/.hermes/logs/agent.log; silent on any failure.
+        """
+        try:
+            from hermes_constants import get_hermes_home
+            log_path = get_hermes_home() / "logs" / "agent.log"
+            if not log_path.is_file():
+                return None
+            # Tail roughly the last 8 KB — enough to find a recent error line
+            # without loading the whole log.
+            with open(log_path, "rb") as f:
+                f.seek(0, 2)
+                size = f.tell()
+                f.seek(max(0, size - 8192))
+                tail = f.read().decode("utf-8", errors="replace")
+            sid_short = self.session_id
+            for line in reversed(tail.splitlines()):
+                if "ERROR" in line and sid_short in line:
+                    # Strip the timestamp/level prefix for a tidier display.
+                    parts = line.split("] ", 1)
+                    return (parts[1] if len(parts) == 2 else line).strip()
+            return None
+        except Exception:
+            return None
 
     # ------------------------------------------------------------------ #
     # Per-turn agent callbacks                                            #

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -569,7 +569,7 @@ DEFAULT_CONFIG = {
     
     # Text-to-speech configuration
     "tts": {
-        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "neutts" (local)
+        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "gemini" | "neutts" (local) | "supertonic" (local)
         "edge": {
             "voice": "en-US-AriaNeural",
             # Popular: AriaNeural, JennyNeural, AndrewNeural, BrianNeural, SoniaNeural
@@ -598,6 +598,13 @@ DEFAULT_CONFIG = {
             "ref_text": "",   # Path to reference voice transcript (empty = bundled default)
             "model": "neuphonic/neutts-air-q4-gguf",  # HuggingFace model repo
             "device": "cpu",  # cpu, cuda, or mps
+        },
+        "supertonic": {
+            "model": "supertonic-3",  # supertonic, supertonic-2, supertonic-3
+            "voice": "M1",            # M1, M3, M4, M5, F3, F4, F5
+            "language": "",           # "" = auto-detect; or one of 32 codes (en, ko, ja, es, fr, de, ...)
+            "speed": 1.05,            # synthesis speed multiplier
+            "total_steps": 8,         # diffusion steps; higher = better quality, slower
         },
     },
     

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -158,12 +158,12 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "tts.provider": {
         "type": "select",
         "description": "Text-to-speech provider",
-        "options": ["edge", "elevenlabs", "openai", "neutts"],
+        "options": ["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "supertonic"],
     },
     "stt.provider": {
         "type": "select",
         "description": "Speech-to-text provider",
-        "options": ["local", "openai", "mistral"],
+        "options": ["local", "groq", "openai", "mistral"],
     },
     "display.skin": {
         "type": "select",
@@ -173,7 +173,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "dashboard.theme": {
         "type": "select",
         "description": "Web dashboard visual theme",
-        "options": ["default", "midnight", "ember", "mono", "cyberpunk", "rose"],
+        "options": ["default", "midnight", "ember", "mono", "cyberpunk", "rose", "paper"],
     },
     "display.resume_display": {
         "type": "select",
@@ -2092,6 +2092,7 @@ _BUILTIN_DASHBOARD_THEMES = [
     {"name": "mono",      "label": "Mono",           "description": "Clean grayscale — minimal and focused"},
     {"name": "cyberpunk", "label": "Cyberpunk",      "description": "Neon green on black — matrix terminal"},
     {"name": "rose",      "label": "Rosé",           "description": "Soft pink and warm ivory — easy on the eyes"},
+    {"name": "paper",     "label": "Paper",          "description": "White background, black text — bright and minimal"},
 ]
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -50,7 +50,7 @@ from gateway.status import get_running_pid, read_runtime_status
 try:
     from fastapi import FastAPI, File, HTTPException, Request, UploadFile
     from fastapi.middleware.cors import CORSMiddleware
-    from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
+    from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, StreamingResponse
     from fastapi.staticfiles import StaticFiles
     from pydantic import BaseModel
 except ImportError:
@@ -2292,6 +2292,133 @@ async def voice_transcribe(audio: UploadFile = File(...)):
         "transcript": result.get("transcript", ""),
         "provider": result.get("provider", ""),
     }
+
+
+# ---------------------------------------------------------------------------
+# Chat: agent-run streaming API  (Phase 4 — see plans/voice-and-chat.md)
+# ---------------------------------------------------------------------------
+
+class ChatSendBody(BaseModel):
+    text: str
+
+
+class ChatApprovalBody(BaseModel):
+    call_id: str
+    decision: str  # "once" | "session" | "always" | "deny"
+
+
+class ChatClarifyBody(BaseModel):
+    call_id: str
+    answer: str
+
+
+@app.post("/api/chat/sessions")
+async def chat_create_session():
+    """Create a new in-process chat session.  Returns its session_id."""
+    from hermes_cli import chat_session
+    sess = chat_session.create_session(asyncio.get_running_loop())
+    return {"session_id": sess.session_id}
+
+
+@app.get("/api/chat/sessions/{session_id}/stream")
+async def chat_stream(session_id: str, request: Request):
+    """SSE stream for a chat session.  Stays open for the session lifetime."""
+    from hermes_cli import chat_session
+    sess = chat_session.get_or_reattach(session_id, asyncio.get_running_loop())
+    if sess is None:
+        raise HTTPException(status_code=404, detail="session not found")
+
+    async def gen():
+        try:
+            async for frame in sess.stream():
+                if await request.is_disconnected():
+                    break
+                yield frame
+        except asyncio.CancelledError:
+            pass
+
+    return StreamingResponse(
+        gen(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache, no-transform",
+            "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
+        },
+    )
+
+
+@app.post("/api/chat/sessions/{session_id}/send")
+async def chat_send(session_id: str, body: ChatSendBody):
+    """Enqueue a user message and start a turn.  Returns 202 immediately."""
+    from hermes_cli import chat_session
+    sess = chat_session.get(session_id)
+    if sess is None:
+        raise HTTPException(status_code=404, detail="session not found")
+    text = (body.text or "").strip()
+    if not text:
+        raise HTTPException(status_code=400, detail="text is required")
+    try:
+        sess.send(text)
+    except RuntimeError as e:
+        # A previous turn is still running.
+        raise HTTPException(status_code=409, detail=str(e))
+    return JSONResponse(status_code=202, content={"ok": True})
+
+
+@app.post("/api/chat/sessions/{session_id}/approve")
+async def chat_approve(session_id: str, body: ChatApprovalBody):
+    """Resolve a pending approval-request from the browser."""
+    from hermes_cli import chat_session
+    sess = chat_session.get(session_id)
+    if sess is None:
+        raise HTTPException(status_code=404, detail="session not found")
+    if body.decision not in ("once", "session", "always", "deny"):
+        raise HTTPException(status_code=400, detail="invalid decision")
+    if not sess.resolve_approval(body.call_id, body.decision):
+        raise HTTPException(status_code=404, detail="call_id not pending")
+    return {"ok": True}
+
+
+@app.post("/api/chat/sessions/{session_id}/clarify")
+async def chat_clarify(session_id: str, body: ChatClarifyBody):
+    """Resolve a pending clarify-request from the browser."""
+    from hermes_cli import chat_session
+    sess = chat_session.get(session_id)
+    if sess is None:
+        raise HTTPException(status_code=404, detail="session not found")
+    if not sess.resolve_clarify(body.call_id, body.answer):
+        raise HTTPException(status_code=404, detail="call_id not pending")
+    return {"ok": True}
+
+
+@app.post("/api/chat/sessions/{session_id}/cancel")
+async def chat_cancel(session_id: str):
+    """Signal cooperative cancellation of the current turn (Step 6 wires this)."""
+    from hermes_cli import chat_session
+    sess = chat_session.get(session_id)
+    if sess is None:
+        raise HTTPException(status_code=404, detail="session not found")
+    was_running = sess.cancel_turn()
+    return {"ok": True, "was_running": was_running}
+
+
+@app.get("/api/chat/sessions/{session_id}/messages")
+async def chat_messages(session_id: str):
+    """Return the full message history for a chat session (for reattach)."""
+    from hermes_cli import chat_session
+    sess = chat_session.get_or_reattach(session_id, asyncio.get_running_loop())
+    if sess is None:
+        raise HTTPException(status_code=404, detail="session not found")
+    return {"session_id": session_id, "messages": sess.history}
+
+
+@app.delete("/api/chat/sessions/{session_id}")
+async def chat_delete(session_id: str):
+    """Tear down a chat session (in-process only; SessionDB history survives)."""
+    from hermes_cli import chat_session
+    removed = chat_session.remove(session_id)
+    return {"ok": removed}
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -48,7 +48,7 @@ from hermes_cli.config import (
 from gateway.status import get_running_pid, read_runtime_status
 
 try:
-    from fastapi import FastAPI, HTTPException, Request
+    from fastapi import FastAPI, File, HTTPException, Request, UploadFile
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
     from fastapi.staticfiles import StaticFiles
@@ -2148,6 +2148,150 @@ async def set_dashboard_theme(body: ThemeSetBody):
     config["dashboard"]["theme"] = body.name
     save_config(config)
     return {"ok": True, "theme": body.name}
+
+
+# ---------------------------------------------------------------------------
+# Voice: TTS playback + STT transcription
+# ---------------------------------------------------------------------------
+
+class TTSSpeakBody(BaseModel):
+    text: str
+    provider: Optional[str] = None  # override the configured provider for this call
+    voice: Optional[str] = None      # override the configured voice for this call
+
+
+_TTS_MEDIA_TYPES = {".wav": "audio/wav", ".mp3": "audio/mpeg", ".ogg": "audio/ogg"}
+
+
+@app.post("/api/tts/speak")
+async def tts_speak(body: TTSSpeakBody):
+    """Synthesize text to audio and stream the file back.
+
+    Uses the provider configured in ~/.hermes/config.yaml unless `provider`
+    is passed in the body, in which case that provider (and optional voice)
+    are used for this single call without persisting to config.
+    """
+    text = (body.text or "").strip()
+    if not text:
+        raise HTTPException(status_code=400, detail="text is required")
+
+    try:
+        from tools.tts_tool import text_to_speech_tool, _load_tts_config
+        import tools.tts_tool as _tts_mod
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"tts module unavailable: {e}")
+
+    import tempfile
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+        out_path = f.name
+
+    # If the caller supplied an override, swap the loader for this call only.
+    original_loader = _tts_mod._load_tts_config
+    try:
+        if body.provider:
+            base_cfg = original_loader() or {}
+            base_cfg = dict(base_cfg)
+            base_cfg["provider"] = body.provider
+            if body.voice:
+                # Per-provider voice keys vary — set the common ones we know.
+                pc = dict(base_cfg.get(body.provider, {}))
+                for k in ("voice", "voice_id"):
+                    if k in pc or body.provider in ("edge", "openai", "supertonic"):
+                        pc[k] = body.voice
+                        break
+                base_cfg[body.provider] = pc
+            _tts_mod._load_tts_config = lambda: base_cfg
+        result_json = text_to_speech_tool(text, output_path=out_path)
+    finally:
+        _tts_mod._load_tts_config = original_loader
+
+    try:
+        result = json.loads(result_json)
+    except Exception:
+        raise HTTPException(status_code=500, detail="tts returned invalid response")
+
+    if not result.get("success"):
+        try:
+            os.remove(out_path)
+        except Exception:
+            pass
+        raise HTTPException(status_code=500, detail=result.get("error", "tts failed"))
+
+    served_path = result.get("file_path", out_path)
+    ext = Path(served_path).suffix.lower()
+    media_type = _TTS_MEDIA_TYPES.get(ext, "application/octet-stream")
+    return FileResponse(served_path, media_type=media_type, filename=f"speak{ext}")
+
+
+# Browser MediaRecorder typically produces audio/webm; we also accept common
+# audio types. The transcribe pipeline (faster-whisper / cloud STT) handles
+# format internally, but the filename suffix matters for _validate_audio_file().
+_STT_MIME_TO_EXT = {
+    "audio/webm": ".webm",
+    "audio/ogg": ".ogg",
+    "audio/mp4": ".m4a",
+    "audio/x-m4a": ".m4a",
+    "audio/wav": ".wav",
+    "audio/x-wav": ".wav",
+    "audio/wave": ".wav",
+    "audio/mpeg": ".mp3",
+    "audio/mp3": ".mp3",
+    "audio/flac": ".flac",
+}
+
+
+@app.post("/api/voice/transcribe")
+async def voice_transcribe(audio: UploadFile = File(...)):
+    """Transcribe an uploaded audio blob via the configured STT provider.
+
+    Accepts a multipart upload. Saves the bytes to a tempfile with an
+    extension inferred from the content type (browser MediaRecorder
+    defaults to audio/webm), then calls transcribe_audio() which
+    dispatches to faster-whisper / Groq / OpenAI / Mistral depending
+    on stt.provider in config.yaml.
+    """
+    content_type = (audio.content_type or "").split(";")[0].strip().lower()
+    ext = _STT_MIME_TO_EXT.get(content_type)
+    if not ext:
+        # Fall back to the filename extension if the browser sent one.
+        fn_ext = Path(audio.filename or "").suffix.lower()
+        ext = fn_ext if fn_ext in {".webm", ".ogg", ".wav", ".mp3", ".m4a", ".flac"} else ".webm"
+
+    import tempfile
+    data = await audio.read()
+    if not data:
+        raise HTTPException(status_code=400, detail="empty audio upload")
+    if len(data) > 25 * 1024 * 1024:
+        raise HTTPException(status_code=413, detail="audio exceeds 25 MB limit")
+
+    with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as f:
+        f.write(data)
+        tmp_path = f.name
+
+    try:
+        from tools.transcription_tools import transcribe_audio
+    except Exception as e:
+        try:
+            os.remove(tmp_path)
+        except Exception:
+            pass
+        raise HTTPException(status_code=500, detail=f"stt module unavailable: {e}")
+
+    try:
+        result = transcribe_audio(tmp_path)
+    finally:
+        try:
+            os.remove(tmp_path)
+        except Exception:
+            pass
+
+    if not result.get("success"):
+        raise HTTPException(status_code=500, detail=result.get("error", "transcription failed"))
+
+    return {
+        "transcript": result.get("transcript", ""),
+        "provider": result.get("provider", ""),
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/plans/voice-and-chat.md
+++ b/plans/voice-and-chat.md
@@ -1,0 +1,232 @@
+# Voice + Chat Panel for the Web Dashboard
+
+> Phase 4 of the voice-and-chat work. Phases 1–3 (Supertonic provider,
+> `/api/tts/speak`, `/api/voice/transcribe`, dashboard speak/mic buttons)
+> are already shipped. This doc covers the agent-run streaming endpoint
+> and the in-dashboard `ChatPage`.
+
+## Goal
+
+A first-class chat surface inside the web dashboard that drives the
+existing `AIAgent` (`run_agent.py`) and streams responses back to the
+browser. Voice in (via `<MicButton>`) and voice out (via `<SpeakButton>`
+per message) are wired into the same surface.
+
+## Constraints we cannot violate
+
+1. **Prompt caching must not break** — `AGENTS.md` §"Important Policies".
+   Toolsets cannot change mid-conversation. Memories cannot be reloaded
+   mid-conversation. Only context compression may alter past context.
+2. **Session token auth** — `/api/*` (except a small public allowlist)
+   requires the bearer token injected into `index.html`. Streaming endpoint
+   must accept the same header.
+3. **No background polling tax** — the chat panel must close its
+   connection when the user navigates away or the agent finishes; no
+   long-lived sockets per tab.
+4. **Tool approval semantics must survive the boundary** — the agent
+   can request approval for shell commands; the browser must be able to
+   accept/reject and the agent loop must block on that answer.
+
+## Backend: streaming endpoint
+
+### Transport choice — SSE
+
+Use **Server-Sent Events** over WebSocket. Justification:
+
+- Agent → browser is the dominant direction (text deltas, tool events).
+- The few browser → agent messages we need (approval responses,
+  cancellation) can be plain POSTs against a session-scoped endpoint.
+- SSE is one-way HTTP, plays well with FastAPI's `StreamingResponse`,
+  doesn't need a separate protocol upgrade, and survives the existing
+  bearer-token auth middleware unchanged.
+- Reconnect-by-`Last-Event-ID` and per-event types are native to SSE.
+
+### Endpoint shapes
+
+```
+POST  /api/chat/sessions               → { session_id }
+GET   /api/chat/sessions/{id}/stream   → SSE event stream (one per turn)
+POST  /api/chat/sessions/{id}/send     { text } → 202 (kicks off a turn)
+POST  /api/chat/sessions/{id}/approve  { call_id, decision } → 202
+POST  /api/chat/sessions/{id}/cancel   → 202
+GET   /api/chat/sessions/{id}/messages → full history (for resume)
+```
+
+A turn is the unit: `send` enqueues a user message; `stream` delivers
+the agent's response as events until `done` or `error`.
+
+### SSE event types
+
+```
+event: turn-start         data: { call_id }
+event: text-delta         data: { delta: "..." }
+event: tool-call-start    data: { call_id, tool, args_summary }
+event: tool-call-result   data: { call_id, ok, summary }
+event: approval-request   data: { call_id, command, description }
+event: clarify-request    data: { call_id, question, choices }
+event: status             data: { kind: "thinking" | "compressing" | ... }
+event: turn-end           data: { final_text }
+event: error              data: { detail }
+```
+
+Each event is small and structured. `text-delta` is the hot path; everything
+else is rare and informational.
+
+### Reusing AIAgent
+
+`AIAgent.run_conversation(stream_callback=...)` already exists
+(`run_agent.py:8290`) and emits text deltas. We feed it a callback that
+pushes `text-delta` events onto an `asyncio.Queue` consumed by the SSE
+generator. For tool events we need either:
+
+- **(a)** A new optional callback on `AIAgent` (`tool_event_callback`)
+  invoked from `handle_function_call`, OR
+- **(b)** Reading from the session DB after-the-fact and emitting
+  events at known points.
+
+(a) is clean but touches the agent. (b) is messier and lossy. We'll
+add `tool_event_callback` as a no-op default — non-breaking everywhere.
+
+For **approval** and **clarify**, we pass web-bound callback functions
+into the `AIAgent` constructor (the same hooks the CLI uses — see
+`hermes_cli/callbacks.py:18,186`). The web versions:
+
+```python
+def web_approval_callback(call_id, command, description):
+    queue.put({"event":"approval-request","call_id":call_id, ...})
+    return wait_for_response(call_id, timeout=300)  # blocks
+```
+
+The agent loop already blocks on these, so the SSE generator simply
+keeps pumping until the browser POSTs to `/approve` and the wait
+resolves.
+
+### Session lifecycle
+
+- `POST /api/chat/sessions` creates a `ChatSession` in-process that
+  owns: an `AIAgent` instance, a conversation history list, an
+  `asyncio.Queue` for outbound events, and pending-approval futures.
+- `AIAgent` is constructed **once** and reused across turns (preserves
+  prompt cache; see Constraint #1). Toolsets are frozen at creation.
+- Conversation messages are persisted to the existing `SessionDB` so
+  `SessionsPage` continues to show them and `--resume` works from CLI.
+- A `ChatSession` evicts itself from the in-process registry after
+  N minutes of inactivity (or on explicit DELETE). The persisted
+  history survives in `SessionDB` and can be reloaded into a new
+  in-process session via "resume".
+- Multi-tab safety: each browser tab gets its own `session_id`; no
+  sharing. (Future: a "join existing session" mode.)
+
+### Cancellation
+
+`/cancel` sets a flag the agent loop checks at every iteration
+boundary (we already have `_should_cancel()` in `AIAgent`? — TBD,
+see Open Questions). If not present, we add a `cancel_event:
+threading.Event` and check it where `iteration_budget` is checked.
+
+## Frontend: `ChatPage`
+
+### New files
+
+```
+web/src/pages/ChatPage.tsx              # main page
+web/src/components/chat/
+  ChatComposer.tsx                      # input box + send + mic
+  MessageList.tsx                       # virtualized message list
+  Message.tsx                           # bubble + speak button per assistant turn
+  ToolCallEvent.tsx                     # collapsible tool-call card
+  ApprovalDialog.tsx                    # blocking approval modal
+web/src/lib/chat.ts                     # SSE client + chat API wrappers
+```
+
+### `lib/chat.ts` sketch
+
+```ts
+export class ChatClient {
+  constructor(sessionId: string, token: string) { ... }
+  async send(text: string): Promise<void> { ... }      // POST /send
+  async approve(callId, ok): Promise<void> { ... }     // POST /approve
+  async cancel(): Promise<void> { ... }                // POST /cancel
+  onEvent(cb: (e: ChatEvent) => void): () => void {
+    // Opens EventSource to /stream and dispatches typed events.
+  }
+}
+```
+
+`EventSource` doesn't support custom auth headers, so the bearer token
+goes on the URL as a query param (`?token=...`) — backend accepts it on
+this endpoint only. Alternatively use `fetch()` with
+`response.body.getReader()` and parse SSE manually; that's strictly
+better and lets us keep header-based auth. **Recommended: fetch+reader,
+not EventSource.**
+
+### Composer
+
+- Textarea + send button + `<MicButton>` (already exists).
+- Mic transcript replaces the composer's text (or appends, configurable).
+- Enter sends; Shift+Enter newline.
+
+### Message rendering
+
+- User messages: simple bubbles.
+- Assistant messages: Markdown via existing `Markdown` component +
+  `<SpeakButton text={message.text}>` so any reply can be played.
+- Tool-call events: collapsible card. Status shown live (`...`,
+  `✓ done`, `✗ error`).
+- Approval requests: modal blocking the composer; "Allow once / Always
+  allow / Deny" → POST `/approve`.
+
+### Navigation
+
+Add a "Chat" entry to `App.tsx` nav, before Sessions. Default landing
+page becomes Chat.
+
+## Decisions (locked in)
+
+1. **Single persistent thread**. One conversation per browser. Sessions
+   page continues to show full history; no separate thread sidebar in
+   the ChatPage itself.
+2. **Reattach on reload**. Store `session_id` in `localStorage` and try
+   to resume on page load. If the backend has evicted the session,
+   fall back to creating a fresh one; replay persisted history from
+   `SessionDB` so the user doesn't lose conversational context.
+3. **TTS-by-default = off**. Manual click on a per-message
+   `<SpeakButton>`. Header may grow a "voice mode" toggle later.
+4. **Always require approval modal** for any tool call that the
+   existing approval machinery flags as dangerous. Browser must not
+   reuse the CLI's yolo flag — too easy to forget the dashboard is
+   open while doing something else.
+5. **Toolset scope** = CLI parity, gated by approval modal. No new
+   web-safe subset.
+6. **Long-running background tool calls** = out of scope for v1.
+   `terminal(background=true)` should be either disallowed in the web
+   chat (return an error) or treated as foreground for v1. Revisit
+   when the chat panel has matured.
+
+## Order of operations (proposed)
+
+1. Add `tool_event_callback` optional hook to `AIAgent`. No-op default.
+   Verify zero existing tests break.
+2. Build `ChatSession` registry + the six endpoints. Unit-test the
+   SSE generator with a stubbed agent.
+3. Build `web/src/lib/chat.ts` (SSE consumer over fetch+reader).
+4. Build `ChatPage` + composer + message list. Smoke-test against a
+   live local agent. Wire mic + speak buttons.
+5. Add approval modal. Verify a `terminal` call that triggers approval
+   round-trips cleanly.
+6. Add cancellation. Verify Ctrl-C-equivalent stops the agent mid-tool.
+7. Add navigation entry, polish, ship.
+
+**Estimated effort**: 1–2 days for steps 1–4, another day for 5–7
+(approval + cancellation tend to surface edge cases). Total ~3 days
+end-to-end, assuming no surprises in the agent-loop reentrance.
+
+## Things explicitly out of scope for v1
+
+- Multi-user / multi-device sync of the same chat.
+- Always-on listening (push-to-talk only).
+- Streaming TTS (synthesize as deltas arrive) — start with
+  per-message playback.
+- Voice activity detection / barge-in.
+- Persisting partial assistant turns on disconnect (we'll discard and
+  let the user retry).

--- a/run_agent.py
+++ b/run_agent.py
@@ -4959,7 +4959,18 @@ class AIAgent:
             return False
 
         try:
-            from agent.anthropic_adapter import resolve_anthropic_token, build_anthropic_client
+            from agent.anthropic_adapter import (
+                resolve_anthropic_token,
+                build_anthropic_client,
+                refresh_hermes_pool_anthropic_token,
+            )
+
+            # Force-refresh the Hermes credential-pool OAuth entry first.
+            # Anthropic may revoke access tokens before the stored
+            # expires_at_ms suggests; without this nudge, resolve_anthropic_token()
+            # would return the same (still-rejected) token and the 401 retry
+            # would no-op. Safe to call when no pool entry exists.
+            refresh_hermes_pool_anthropic_token(force=True)
 
             new_token = resolve_anthropic_token()
         except Exception as exc:

--- a/run_agent.py
+++ b/run_agent.py
@@ -6063,6 +6063,15 @@ class AIAgent:
             # falling through to OpenRouter defaults.
             fb_base_url_hint = (fb.get("base_url") or "").strip() or None
             fb_api_key_hint = (fb.get("api_key") or "").strip() or None
+            # Honor ``api_key_env`` so fallback entries can reference a key by
+            # env-var name instead of inlining the secret in config.yaml.  This
+            # lets strong free providers (e.g. Gemini, Groq) sit in the chain
+            # via GEMINI_API_KEY/GROQ_API_KEY without storing the raw key.
+            if not fb_api_key_hint:
+                # key_env and api_key_env are both accepted aliases.
+                _fb_key_env = (fb.get("key_env") or fb.get("api_key_env") or "").strip()
+                if _fb_key_env:
+                    fb_api_key_hint = (os.getenv(_fb_key_env) or "").strip() or None
             # For Ollama Cloud endpoints, pull OLLAMA_API_KEY from env
             # when no explicit key is in the fallback config.
             if fb_base_url_hint and "ollama.com" in fb_base_url_hint.lower() and not fb_api_key_hint:

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# changelog.sh — add a line to CHANGELOG.md under ## [Unreleased].
+#   scripts/changelog.sh "<line>"
+#   scripts/changelog.sh --changed "<line>"   # --added(default)|--changed|--fixed|--removed|--rejected
+set -e
+section="Added"
+case "$1" in
+  --added) section="Added"; shift ;; --changed) section="Changed"; shift ;;
+  --fixed) section="Fixed"; shift ;; --removed) section="Removed"; shift ;;
+  --rejected) section="Investigated / Rejected"; shift ;;
+esac
+line="$*"
+[ -n "$line" ] || { echo "usage: scripts/changelog.sh [--added|--changed|--fixed|--removed|--rejected] \"<line>\"" >&2; exit 2; }
+root=$(git rev-parse --show-toplevel); cl="$root/CHANGELOG.md"
+[ -f "$cl" ] || { echo "no CHANGELOG.md at repo root" >&2; exit 1; }
+grep -Fq -- "- $line" "$cl" && { echo "changelog: already present, skipping"; exit 0; }
+awk -v sec="### $section" -v entry="- $line" '
+  BEGIN{u=0;d=0}
+  /^## \[Unreleased\]/{print;u=1;next}
+  u&&!d&&$0==sec{print;print entry;d=1;next}
+  u&&!d&&/^## /{print sec;print entry;print "";print;u=0;d=1;next}
+  {print}
+  END{if(u&&!d){print sec;print entry}}' "$cl" > "$cl.tmp" && mv "$cl.tmp" "$cl"
+git add "$cl"; echo "changelog: + [$section] $line"

--- a/scripts/refresh-oauth
+++ b/scripts/refresh-oauth
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""
+Refresh Hermes' Anthropic OAuth credential.
+
+Recovery flow for when Anthropic invalidates BOTH the access AND refresh
+tokens server-side (the third-party-app OAuth policy in 2026-05 does this
+every few days).  The auto-refresh-on-401 fix in agent/anthropic_adapter.py
+handles "access expired, refresh still valid" — this script handles the
+case where the refresh also failed.
+
+Usage:
+    scripts/refresh-oauth                 # interactive: opens browser, prompts
+    scripts/refresh-oauth CODE#STATE      # non-interactive: paste the code
+                                           # from the OAuth redirect directly
+    scripts/refresh-oauth --skip-verify   # skip the live api.anthropic.com check
+
+What it does:
+    1. Generates PKCE verifier+challenge and opens the Claude.ai OAuth URL
+       (or accepts CODE#STATE from a previous flow that already redirected).
+    2. Stops launchd-managed dashboard + gateway BEFORE writing auth.json,
+       so the credential pool's _mark_exhausted persist cannot clobber the
+       new tokens (this race ate our first re-OAuth attempt today).
+    3. POSTs to console.anthropic.com/v1/oauth/token for the token pair.
+    4. Writes credential_pool.anthropic[0] in ~/.hermes/auth.json with
+       last_status='ok'.
+    5. Live-verifies the new access_token against api.anthropic.com/v1/messages.
+    6. Reloads the daemons.
+
+Stdlib only — works even when the venv is being rebuilt by the watchdog.
+"""
+
+import argparse
+import base64
+import hashlib
+import json
+import secrets
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import webbrowser
+from pathlib import Path
+
+HOME = Path.home()
+AUTH_FILE = HOME / ".hermes" / "auth.json"
+LAUNCH_DASHBOARD = HOME / "Library" / "LaunchAgents" / "sh.hermes.dashboard.plist"
+LAUNCH_GATEWAY = HOME / "Library" / "LaunchAgents" / "sh.hermes.gateway.plist"
+
+# OAuth client identity — same as `hermes auth add anthropic --type oauth`.
+CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+AUTH_URL_BASE = "https://claude.ai/oauth/authorize"
+TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
+REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
+SCOPES = "org:create_api_key user:profile user:inference"
+MESSAGES_URL = "https://api.anthropic.com/v1/messages"
+
+# Verification probe — small, cheap call.
+PROBE_MODEL = "claude-haiku-4-5-20251001"
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def _gen_pkce() -> tuple[str, str]:
+    """Return (verifier, challenge) using S256."""
+    verifier = _b64url(secrets.token_bytes(32))
+    challenge = _b64url(hashlib.sha256(verifier.encode()).digest())
+    return verifier, challenge
+
+
+def _build_authorize_url(verifier: str, challenge: str) -> str:
+    # Anthropic's flow embeds the PKCE verifier into `state` so the redirect
+    # delivers it back to the client.  See agent/anthropic_adapter.py:727.
+    return f"{AUTH_URL_BASE}?" + urllib.parse.urlencode({
+        "code": "true",
+        "client_id": CLIENT_ID,
+        "response_type": "code",
+        "redirect_uri": REDIRECT_URI,
+        "scope": SCOPES,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "state": verifier,
+    })
+
+
+def _open_browser(url: str) -> None:
+    print()
+    print("Open this URL in your browser to authorize:")
+    print(f"  {url}")
+    print()
+    try:
+        webbrowser.open(url)
+        print("  (browser opened automatically)")
+    except Exception:
+        pass
+
+
+def _read_code_interactive(default_verifier: str) -> tuple[str, str, str]:
+    """Prompt for the authorization code.  Returns (code, state, verifier)."""
+    print()
+    print("After authorizing, paste the code below.  Format: CODE#STATE")
+    try:
+        raw = input("Authorization code: ").strip()
+    except (KeyboardInterrupt, EOFError):
+        sys.exit("\nCancelled.")
+    if not raw:
+        sys.exit("No code entered.")
+    if "#" in raw:
+        code, state = raw.split("#", 1)
+        # State in the redirect IS the original verifier (Anthropic's flow).
+        return code, state, state
+    return raw, "", default_verifier
+
+
+def _exchange_code(code: str, state: str, verifier: str) -> dict:
+    body = json.dumps({
+        "grant_type": "authorization_code",
+        "client_id": CLIENT_ID,
+        "code": code,
+        "state": state,
+        "redirect_uri": REDIRECT_URI,
+        "code_verifier": verifier,
+    }).encode()
+    req = urllib.request.Request(
+        TOKEN_URL,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": "claude-cli/2.1 (external, cli)",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=20) as r:
+            return json.loads(r.read().decode())
+    except urllib.error.HTTPError as e:
+        body_txt = e.read().decode(errors="replace")
+        sys.exit(f"Token exchange failed: HTTP {e.code}: {body_txt[:400]}")
+    except urllib.error.URLError as e:
+        sys.exit(f"Token exchange failed: {e}")
+
+
+def _save_to_auth_json(result: dict) -> None:
+    AUTH_FILE.parent.mkdir(parents=True, exist_ok=True)
+    if AUTH_FILE.exists():
+        data = json.loads(AUTH_FILE.read_text())
+    else:
+        data = {
+            "version": 1,
+            "providers": {},
+            "credential_pool": {},
+            "active_provider": "anthropic",
+        }
+    pool = data.setdefault("credential_pool", {})
+    entries = pool.get("anthropic") or []
+    new_expires_at_ms = int((time.time() + result["expires_in"]) * 1000)
+
+    base = entries[0] if entries else {
+        "id": secrets.token_hex(3),
+        "label": "anthropic-oauth-1",
+        "auth_type": "oauth",
+        "priority": 0,
+        "source": "manual:hermes_pkce",
+        "base_url": "https://api.anthropic.com",
+        "request_count": 0,
+    }
+    base.update({
+        "access_token": result["access_token"],
+        "refresh_token": result["refresh_token"],
+        "expires_at_ms": new_expires_at_ms,
+        "last_status": "ok",
+        "last_status_at": None,
+        "last_error_code": None,
+        "last_error_reason": None,
+        "last_error_message": None,
+        "last_error_reset_at": None,
+    })
+    if entries:
+        entries[0] = base
+    else:
+        entries.append(base)
+    pool["anthropic"] = entries
+    AUTH_FILE.write_text(json.dumps(data, indent=2))
+
+
+def _verify_token(access_token: str) -> tuple[int, str]:
+    body = json.dumps({
+        "model": PROBE_MODEL,
+        "max_tokens": 8,
+        "messages": [{"role": "user", "content": "Say OK"}],
+        "system": "You are Claude Code, Anthropic's CLI.",
+    }).encode()
+    req = urllib.request.Request(
+        MESSAGES_URL,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "anthropic-version": "2023-06-01",
+            "anthropic-beta": "oauth-2025-04-20",
+            "content-type": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            return r.status, r.read().decode()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode(errors="replace")
+    except urllib.error.URLError as e:
+        return 0, str(e)
+
+
+def _launchctl(action: str, plist: Path) -> None:
+    if not plist.exists():
+        return
+    subprocess.run(["launchctl", action, str(plist)], capture_output=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Refresh Hermes' Anthropic OAuth credential.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "code",
+        nargs="?",
+        help="CODE#STATE from the OAuth redirect.  Skips the interactive flow.",
+    )
+    parser.add_argument(
+        "--skip-verify",
+        action="store_true",
+        help="Skip the live api.anthropic.com check after exchange.",
+    )
+    parser.add_argument(
+        "--skip-daemon-cycle",
+        action="store_true",
+        help="Don't unload/reload the launchd dashboard + gateway plists.",
+    )
+    args = parser.parse_args()
+
+    # 1. Get code + verifier
+    if args.code:
+        if "#" not in args.code:
+            sys.exit("Code must be in CODE#STATE format (Anthropic's redirect appends #state).")
+        code, state = args.code.split("#", 1)
+        verifier = state  # Anthropic's PKCE: state == verifier
+        print(f"Using provided code (state/verifier extracted from #fragment).")
+    else:
+        verifier, challenge = _gen_pkce()
+        _open_browser(_build_authorize_url(verifier, challenge))
+        code, state, verifier = _read_code_interactive(verifier)
+
+    # 2. Stop daemons (prevents credential_pool clobber race)
+    if not args.skip_daemon_cycle:
+        print("Stopping launchd-managed dashboard + gateway...")
+        _launchctl("unload", LAUNCH_DASHBOARD)
+        _launchctl("unload", LAUNCH_GATEWAY)
+        time.sleep(2)
+
+    # 3. Exchange
+    print("Exchanging code for tokens...")
+    result = _exchange_code(code, state, verifier)
+    print(f"  OK  expires_in={result.get('expires_in')}s  scope={result.get('scope', '?')}")
+
+    # 4. Save
+    _save_to_auth_json(result)
+    print(f"  Saved to {AUTH_FILE}")
+
+    # 5. Verify
+    if not args.skip_verify:
+        print("Verifying against api.anthropic.com...")
+        status, body = _verify_token(result["access_token"])
+        if status == 200:
+            print("  HTTP 200  - token accepted.")
+        else:
+            print(f"  HTTP {status}  body: {body[:200]}")
+            print("  (tokens were still saved; daemons will see them on next attempt)")
+
+    # 6. Reload daemons
+    if not args.skip_daemon_cycle:
+        print("Reloading daemons...")
+        _launchctl("load", LAUNCH_DASHBOARD)
+        _launchctl("load", LAUNCH_GATEWAY)
+
+    print()
+    print("Done.  Try chatting from any surface:")
+    print("  - dashboard: http://127.0.0.1:9119/chat")
+    print("  - telegram:  DM @openheavenhermes_bot")
+    print("  - cli:       hermes chat")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/repair-venv.sh
+++ b/scripts/repair-venv.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Detect a missing or broken Hermes venv and rebuild it.
+#
+# Idempotent: a no-op if the venv is healthy.  Heals it if not.
+# Intended to run from launchd or cron.  Logs to ~/.hermes/logs/venv-watchdog.log.
+#
+# Health = `<venv>/bin/python -c "import hermes_cli"` exits 0.
+
+set -eu
+
+VENV="$HOME/.hermes/hermes-agent/venv"
+INSTALL_DIR="$HOME/.hermes/hermes-agent"
+LOG_DIR="$HOME/.hermes/logs"
+LOG="$LOG_DIR/venv-watchdog.log"
+UV="$HOME/.local/bin/uv"
+
+mkdir -p "$LOG_DIR"
+ts() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+log() { echo "$(ts) $*" >> "$LOG"; }
+
+# Health probe — if both pass, exit silently (no-op).
+if [ -x "$VENV/bin/python" ] && "$VENV/bin/python" -c "import hermes_cli" >/dev/null 2>&1; then
+    exit 0
+fi
+
+log "venv unhealthy or missing — starting rebuild"
+
+if [ ! -x "$UV" ]; then
+    log "ERROR: uv not found at $UV — cannot rebuild.  Install uv first."
+    exit 1
+fi
+
+if [ ! -f "$INSTALL_DIR/pyproject.toml" ]; then
+    log "ERROR: $INSTALL_DIR/pyproject.toml missing — install dir corrupted, manual recovery needed."
+    exit 1
+fi
+
+# If a broken venv directory exists, blow it away before recreating.
+if [ -d "$VENV" ]; then
+    log "removing broken $VENV"
+    rm -rf "$VENV"
+fi
+
+cd "$INSTALL_DIR"
+
+log "creating fresh venv with Python 3.11"
+if ! "$UV" venv venv --python 3.11 >> "$LOG" 2>&1; then
+    log "ERROR: uv venv failed (see above)"
+    exit 1
+fi
+
+log "installing hermes editable + all extras (may take ~1 minute)"
+if ! VIRTUAL_ENV="$VENV" "$UV" pip install -e ".[all]" >> "$LOG" 2>&1; then
+    log "ERROR: editable install failed"
+    exit 1
+fi
+
+# Optional: supertonic (local TTS provider) — best effort, won't fail rebuild.
+if ! VIRTUAL_ENV="$VENV" "$UV" pip install supertonic >> "$LOG" 2>&1; then
+    log "WARN: supertonic install failed (TTS will fall back to other providers)"
+fi
+
+# Final health check
+if "$VENV/bin/python" -c "import hermes_cli" >/dev/null 2>&1; then
+    log "rebuild OK — hermes_cli importable"
+    exit 0
+else
+    log "ERROR: rebuild completed but hermes_cli still not importable"
+    exit 1
+fi

--- a/scripts/run-dashboard.sh
+++ b/scripts/run-dashboard.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# launchd wrapper for `hermes dashboard --no-open`.
+#
+# Why a wrapper instead of invoking hermes directly:
+# the dashboard subcommand runs `npm run build` on every startup with
+# fatal=True, and Vite 7 needs Node 20.19+.  Launchd's restricted PATH
+# resolves /usr/local/bin/node (Node 18) before any fnm-managed Node,
+# so the build fails and the dashboard exits 1.  This wrapper prepends
+# the user's fnm-managed Node directory to PATH before exec'ing hermes.
+
+set -eu
+
+# Pick the newest fnm-installed Node version (alphanumerically sort
+# descending so v22 beats v20, v22.22 beats v22.10, etc.).
+FNM_NODE_DIR="$HOME/.local/share/fnm/node-versions"
+if [ -d "$FNM_NODE_DIR" ]; then
+    NEWEST_NODE=$(ls -1 "$FNM_NODE_DIR" 2>/dev/null | sort -rV | head -n1)
+    if [ -n "$NEWEST_NODE" ] && [ -x "$FNM_NODE_DIR/$NEWEST_NODE/installation/bin/node" ]; then
+        export PATH="$FNM_NODE_DIR/$NEWEST_NODE/installation/bin:$PATH"
+    fi
+fi
+
+exec "$HOME/.hermes/hermes-agent/venv/bin/hermes" dashboard --no-open

--- a/scripts/use-claude
+++ b/scripts/use-claude
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Switch Hermes from any provider (e.g. OpenRouter) to direct Anthropic with
+# a chosen Claude model.
+#
+# Usage:
+#   scripts/use-claude              # interactive picker (default: Haiku 4.5)
+#   scripts/use-claude haiku        # Haiku 4.5  (cheapest, fastest)
+#   scripts/use-claude sonnet       # Sonnet 4.6 (balanced)
+#   scripts/use-claude opus         # Opus 4.7   (premium)
+#   scripts/use-claude --list       # show what each alias resolves to
+#
+# Edits ~/.hermes/config.yaml in place: sets model.default to the chosen
+# Claude model, provider to "anthropic", and removes the OpenRouter base_url
+# and any max_tokens cap left over from credit-limit workarounds.
+#
+# Auth: requires an Anthropic credential in the Hermes credential pool.
+# If missing, the script prints how to set one up and exits non-zero.
+#
+# Targets bash 3.2 so it runs on macOS out of the box (no associative arrays).
+
+set -eo pipefail
+
+CONFIG="${HERMES_HOME:-$HOME/.hermes}/config.yaml"
+
+model_id_for() {
+  case "$1" in
+    haiku)  echo "claude-haiku-4-5-20251001" ;;
+    sonnet) echo "claude-sonnet-4-6" ;;
+    opus)   echo "claude-opus-4-7" ;;
+    *)      return 1 ;;
+  esac
+}
+
+label_for() {
+  case "$1" in
+    haiku)  echo "Haiku 4.5  — fastest, cheapest" ;;
+    sonnet) echo "Sonnet 4.6 — balanced cost/quality" ;;
+    opus)   echo "Opus 4.7   — strongest model" ;;
+    *)      return 1 ;;
+  esac
+}
+
+usage() {
+  sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+list_models() {
+  printf "Available tiers:\n"
+  for tier in haiku sonnet opus; do
+    printf "  %-7s -> %-30s  (%s)\n" "$tier" "$(model_id_for "$tier")" "$(label_for "$tier")"
+  done
+}
+
+resolve_tier() {
+  case "$1" in
+    haiku|h)  echo haiku ;;
+    sonnet|s) echo sonnet ;;
+    opus|o)   echo opus ;;
+    *) echo "Unknown tier '$1'. Try: haiku | sonnet | opus" >&2; exit 2 ;;
+  esac
+}
+
+pick_interactive() {
+  echo "Pick a Claude model (Enter for default = haiku):" >&2
+  echo "  1) haiku   — $(label_for haiku)"  >&2
+  echo "  2) sonnet  — $(label_for sonnet)" >&2
+  echo "  3) opus    — $(label_for opus)"   >&2
+  read -r -p "> " choice
+  case "${choice:-1}" in
+    ""|1|h|haiku)  echo haiku ;;
+    2|s|sonnet)    echo sonnet ;;
+    3|o|opus)      echo opus ;;
+    *) echo "Unknown choice: $choice" >&2; exit 2 ;;
+  esac
+}
+
+check_anthropic_credential() {
+  if ! command -v hermes >/dev/null 2>&1; then
+    echo "ERROR: 'hermes' not found in PATH." >&2
+    exit 3
+  fi
+  if ! hermes auth list 2>&1 | grep -q "^anthropic "; then
+    cat <<'EOF' >&2
+
+ERROR: No Anthropic credential is registered with hermes.
+
+To fix:
+    hermes auth add anthropic --type oauth      # uses your Claude.ai login
+    # ... or, for an API key from console.anthropic.com:
+    hermes auth add anthropic --type api-key
+
+After that's done, re-run this script.
+EOF
+    exit 4
+  fi
+}
+
+# Use the same Python hermes itself runs under, so PyYAML is available without
+# forcing the user to install it in their system Python.
+find_python() {
+  if [ -x "$HOME/.hermes/hermes-agent/venv/bin/python" ]; then
+    echo "$HOME/.hermes/hermes-agent/venv/bin/python"
+  else
+    command -v python3 || command -v python
+  fi
+}
+
+apply_config() {
+  local model_id="$1"
+  local py
+  py="$(find_python)"
+  if [ -z "$py" ]; then
+    echo "ERROR: no python interpreter found." >&2
+    exit 5
+  fi
+  CONFIG_PATH="$CONFIG" MODEL_ID="$model_id" "$py" - <<'PY'
+import os, sys
+import yaml
+path = os.environ["CONFIG_PATH"]
+model_id = os.environ["MODEL_ID"]
+if not os.path.isfile(path):
+    sys.exit(f"config not found: {path}")
+with open(path) as f:
+    cfg = yaml.safe_load(f) or {}
+model = cfg.get("model") or {}
+if not isinstance(model, dict):
+    model = {"default": str(model)}
+model["default"] = model_id
+model["provider"] = "anthropic"
+model.pop("base_url", None)
+cfg["model"] = model
+cfg.pop("max_tokens", None)
+with open(path, "w") as f:
+    yaml.safe_dump(cfg, f, sort_keys=False, default_flow_style=False)
+print(f"  default: {model_id}")
+print(f"  provider: anthropic")
+PY
+}
+
+restart_hint() {
+  if lsof -nP -iTCP:9119 -sTCP:LISTEN >/dev/null 2>&1; then
+    cat <<'EOF'
+
+The dashboard is running at http://127.0.0.1:9119/.
+New chat sessions will use the new model automatically (each session
+builds its own AIAgent on first turn).  Existing in-process sessions
+still use the previous model until they idle out.  Click "New" in the
+Chat tab to start fresh, or restart the dashboard for a clean slate:
+
+    pkill -f 'hermes dashboard' && hermes dashboard --no-open &
+EOF
+  fi
+}
+
+# ---------- main ----------
+
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+  --list)    list_models; exit 0 ;;
+esac
+
+check_anthropic_credential
+
+if [ "$#" -ge 1 ]; then
+  tier="$(resolve_tier "$1")"
+else
+  tier="$(pick_interactive </dev/tty)"
+fi
+
+model_id="$(model_id_for "$tier")"
+echo "Switching Hermes to direct Anthropic — $(label_for "$tier")"
+echo "  config: $CONFIG"
+apply_config "$model_id"
+echo
+echo "Done.  Verify with:   hermes config show model"
+restart_hint

--- a/skills/research/skill-seekers-to-inbox/SKILL.md
+++ b/skills/research/skill-seekers-to-inbox/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: skill-seekers-to-inbox
+description: >
+  Bridge between the skill-seekers CLI (docs-site / GitHub repo / PDF / video
+  bulk crawler) and the neuro-os research inbox. Run skill-seekers to flatten a
+  source into one Markdown file per page, then this skill loops the
+  references/*.md files into ~/.neuro_os_research/inbox.jsonl as
+  one InboxRecord per page. Use when the user wants to ingest a whole
+  documentation site, a GitHub repo, or a PDF (rather than a single URL —
+  for one URL, use the url-to-inbox skill).
+version: 0.1.0
+author: Hermes Agent + Neuro-OS
+license: MIT
+metadata:
+  hermes:
+    tags: [Research, Inbox, Neuro-OS, Bulk-Ingest, Skill-Seekers]
+    related_skills: [url-to-inbox, youtube-content, ocr-and-documents]
+    homepage: https://github.com/wjlgatech/neuro-os/blob/main/docs/url-to-living-knowledge.md
+prerequisites:
+  pip: [skill-seekers]
+---
+
+# Skill-Seekers → Neuro-OS Inbox
+
+Convert a documentation site / GitHub repo / PDF / video / Jupyter notebook into
+one neuro-os `InboxRecord` per page, so the **research vertical's** review +
+compression pipeline takes over from there. This skill is the **bulk** sibling
+of `url-to-inbox` (which handles a single URL at a time).
+
+## Why both `url-to-inbox` and this skill exist
+
+| Use case | Pick |
+|---|---|
+| Paul forwards one YouTube link or one blog post | `url-to-inbox` (one record, one append) |
+| Paul wants to ingest a whole docs site, a GitHub repo, a PDF book | `skill-seekers-to-inbox` (N records, one batch) |
+| Paul wants ongoing monitoring of a blog | `blogwatcher` skill — different pipeline (RSS polling), no neuro-os bridge |
+
+This skill **composes** `url-to-inbox`'s `append_inbox.py` rather than
+duplicating the InboxRecord schema. There is exactly one producer in the
+codebase. If neuro-os evolves the schema, both skills inherit the change.
+
+## Pipeline
+
+```
+SOURCE (URL/repo/PDF/video)
+        │
+        │  skill-seekers create
+        ▼
+<output_dir>/
+  SKILL.md             ← skill-seekers' wrapper (we ignore)
+  references/
+    index.md           ← we skip (navigation file)
+    section_01.md      ← one InboxRecord
+    section_02.md      ← one InboxRecord
+    ...
+        │
+        │  flush_references.py
+        ▼
+~/.neuro_os_research/inbox.jsonl
+        │
+        │  neuro-os research inbox ingest
+        ▼
+MechanismCardProposals → research review → goal-link → living knowledge
+```
+
+`flush_references.py` does NOT call skill-seekers itself — that's a deliberate
+separation so the user runs skill-seekers with whatever flags suit their source
+(`--repo`, `--pdf`, `--video-url`, `--max-pages`, etc.) and then hands the
+output directory to this skill.
+
+## Quick reference
+
+```bash
+# 1. Crawl with skill-seekers (no API key needed for default 'scrape-only').
+skill-seekers create \
+  --url https://docs.something.com \
+  --output /tmp/something-docs \
+  --max-pages 50 \
+  --skip-scrape false \
+  --non-interactive
+
+# 2. Flush the references/ folder into the neuro-os inbox.
+SKILL_DIR=~/.hermes/skills/skill-seekers-to-inbox
+python "$SKILL_DIR/scripts/flush_references.py" \
+  --references-dir /tmp/something-docs/references \
+  --base-url https://docs.something.com \
+  --sender paul@example.com \
+  --source-type blog
+
+# 3. neuro-os does the rest.
+neuro-os research inbox ingest
+```
+
+## Source-type-by-skill-seekers-mode
+
+skill-seekers can ingest 10+ source types; map each to a sensible `--source-type`
+when flushing:
+
+| skill-seekers invocation | Recommended `--source-type` |
+|---|---|
+| `--url <docs site>` | `blog` |
+| `--repo owner/repo` | `other` (treat README + key .md files as blog-equivalent) |
+| `--pdf <path>` | `pdf` |
+| `--video-url <YouTube playlist>` | `youtube` |
+| `--video-file <file>` | `youtube` (closest match; "video" is not in the neuro-os enum) |
+| Notebook / wiki / EPUB | `other` |
+
+If the right answer is genuinely "other," set `--source-type other` — that's a
+first-class value in the neuro-os InboxRecord schema and ingest treats it the
+same as `blog` downstream.
+
+## Front-matter handling
+
+`flush_references.py` parses YAML-ish front-matter at the top of each `.md`:
+
+```yaml
+---
+source_url: https://docs.example.com/page-3
+title: Page Three
+author: Some Person
+---
+# Page Three
+
+Body content...
+```
+
+Resolution order for each field:
+
+| Field | Lookup |
+|---|---|
+| `url` | `source_url` → `url` → `permalink` → `canonical` → `base_url + slug` → `skill-seekers://<filename>` |
+| `title` | `title` → first `# H1` line → filename humanized |
+| `author` | `author` → "skill-seekers" |
+
+If you ran `skill-seekers create` with a `--base-url` known and the per-page
+files lack `source_url`, pass `--base-url` to `flush_references.py` so URLs
+resolve to something useful (`<base>/<slug>`) instead of synthetic
+`skill-seekers://...` ones.
+
+## Idempotency
+
+Same rules as the upstream `url-to-inbox` skill:
+
+- Re-running `flush_references.py` against the same directory appends every
+  file again. neuro-os's sha256 dedup at ingest time catches re-extracted
+  identical bodies, counting them in `records_skipped_duplicate`.
+- If the source changed, both versions get distinct proposals (different sha).
+
+If you want producer-side idempotency, run with `--dry-run` first to see
+what WOULD be appended, then with `--max-records` to stage in batches.
+
+## Why this is a bridge skill, not a tool
+
+Same reasoning as `url-to-inbox` — composing two CLIs (skill-seekers and the
+sibling skill's `append_inbox.py`) is a workflow, not a function call. Keeping
+it as a skill means:
+
+- No prompt-cache cost for users who never use skill-seekers.
+- `flush_references.py` works equally well from cron, the Telegram gateway,
+  or a one-shot `bash` invocation — no agent loop needed.
+- The bridge has its OWN tests; the schema lives only in
+  `url-to-inbox/scripts/append_inbox.py`.
+
+## Failure modes (real ones)
+
+| Symptom | Diagnosis | Fix |
+|---|---|---|
+| `flush_references.py` exits 1: "references dir not found" | skill-seekers's output dir is at `<out>/SKILL.md` + `<out>/references/`, not just `<out>/`. | Point `--references-dir` at the `references/` subfolder explicitly. |
+| All records skipped with `schema: title must be at least 1 char` | The .md files have empty H1 lines and no front-matter `title`. | Pass `--base-url` and rely on filename-derived titles, or fix the upstream skill-seekers run with `--enhance-level metadata`. |
+| URLs in inbox come out as `skill-seekers://<filename>` | The .md files lacked front-matter URLs and no `--base-url` was passed. | Re-run with `--base-url <root>`; neuro-os accepts the synthetic URLs but they're noisy in the dashboard. |
+| neuro-os shows `records_skipped_duplicate=N` after a re-flush | Same source content, sha256 matches existing proposals. | That's working as intended — neuro-os dedup is body-based, not URL-based. |
+
+## Related
+
+- **`url-to-inbox`** — single-URL producer. Use that for one link at a time.
+- **`skill-seekers`** (PyPI) — the upstream crawler. `pip install skill-seekers`.
+  See https://skillseekersweb.com/ for preset configs.
+- **neuro-os research vertical** — the consumer side:
+  https://github.com/wjlgatech/neuro-os/blob/main/docs/url-to-living-knowledge.md
+- **`agentskills-integration-eval.md`** (in neuro-os/docs/plans/) — design
+  notes on why this skill exists as a bridge instead of as a Claude-Code skill
+  that competes with neuro-os's extraction layer.

--- a/skills/research/skill-seekers-to-inbox/scripts/flush_references.py
+++ b/skills/research/skill-seekers-to-inbox/scripts/flush_references.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""
+Convert a ``skill-seekers create`` output directory's ``references/*.md``
+files into one ``InboxRecord`` JSON line each, appended to the neuro-os
+research inbox at ``~/.neuro_os_research/inbox.jsonl``.
+
+Composes with the ``url-to-inbox`` skill — this script does NOT
+re-implement the InboxRecord schema or the append logic; it imports
+``append_inbox`` from the sibling skill so there's exactly one
+producer in the codebase.
+
+Skill-seekers writes:
+
+    <output_dir>/
+      SKILL.md
+      references/
+        index.md
+        section_01.md
+        section_02.md
+        ...
+
+Each section file usually has YAML front-matter with at least
+``source_url`` and ``title``; if it doesn't (legacy versions of
+skill-seekers), we fall back to filename-derived defaults.
+
+Usage:
+    python flush_references.py \\
+      --references-dir <PATH> \\
+      --base-url https://docs.example.com \\
+      [--sender paul@example.com] \\
+      [--urge-tag novelty] \\
+      [--inbox-path ~/.neuro_os_research/inbox.jsonl] \\
+      [--source-type blog]    # default 'blog'; passed to InboxRecord
+      [--dry-run]             # parse + validate but do not append
+      [--max-records N]       # cap (useful for first-time tests)
+
+Output: a JSON summary {records_attempted, records_appended, records_skipped, errors}.
+Exit codes: 0 success (even with some per-file skips), 1 IO/parse error, 2 bad args.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+# Import the producer's schema + append logic from the sibling skill —
+# both single-source-of-truth and zero-duplication. The sibling lives at
+# ../../url-to-inbox/scripts/append_inbox.py.
+SIBLING = Path(__file__).resolve().parents[2] / "url-to-inbox" / "scripts"
+sys.path.insert(0, str(SIBLING))
+try:
+    import append_inbox  # type: ignore
+except ImportError as e:  # pragma: no cover — defensive
+    print(
+        f"error: url-to-inbox sibling skill not found at {SIBLING}: {e}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+_FRONT_MATTER_RE = re.compile(
+    r"^---\s*\n(?P<body>.*?)\n---\s*\n",
+    re.DOTALL,
+)
+
+
+def _parse_front_matter(text: str) -> tuple[dict, str]:
+    """Lightweight YAML-ish front-matter parser (no pyyaml dep). Same
+    shape as the neuro-os ingest pipeline's parser so behaviour matches
+    end-to-end."""
+    m = _FRONT_MATTER_RE.match(text)
+    if not m:
+        return ({}, text)
+    block = m.group("body")
+    body = text[m.end():]
+    meta: dict = {}
+    for line in block.splitlines():
+        if ":" not in line:
+            continue
+        k, _, v = line.partition(":")
+        meta[k.strip()] = v.strip().strip('"').strip("'")
+    return (meta, body)
+
+
+def _derive_url(meta: dict, base_url: Optional[str], filename: str) -> str:
+    """Pick a URL for the InboxRecord — front-matter wins; fall back to
+    ``base_url + path`` shape; final fallback is a synthetic one so the
+    record still passes neuro-os's Pydantic validation."""
+    for key in ("source_url", "url", "permalink", "canonical"):
+        v = meta.get(key)
+        if v:
+            return str(v)
+    if base_url:
+        slug = Path(filename).stem
+        return base_url.rstrip("/") + "/" + slug
+    return f"skill-seekers://{filename}"
+
+
+def _derive_title(meta: dict, filename: str, body: str) -> str:
+    """Title resolution: front-matter > first markdown heading > filename."""
+    for key in ("title", "name"):
+        v = meta.get(key)
+        if v:
+            return str(v)[:400]
+    # First Markdown H1 (`# Title`) line:
+    for line in body.splitlines()[:20]:
+        line = line.strip()
+        if line.startswith("# "):
+            return line[2:].strip()[:400] or filename
+    return Path(filename).stem.replace("-", " ").replace("_", " ").strip().title()[:400] or filename
+
+
+def flush(
+    *,
+    references_dir: Path,
+    base_url: Optional[str],
+    inbox_path: Path,
+    source_type: str = "blog",
+    sender: Optional[str] = None,
+    urge_tag: Optional[str] = None,
+    topic_tags: Optional[list[str]] = None,
+    dry_run: bool = False,
+    max_records: Optional[int] = None,
+    now: Optional[datetime] = None,
+) -> dict:
+    """Walk ``references_dir`` for .md files, build InboxRecords, append.
+
+    Returns a summary dict (machine-readable). ``index.md`` is always
+    skipped — it's a navigation file, not source content.
+    """
+    if not references_dir.exists():
+        raise FileNotFoundError(f"references dir not found: {references_dir}")
+    if not references_dir.is_dir():
+        raise NotADirectoryError(f"not a directory: {references_dir}")
+
+    when = now or datetime.now(timezone.utc)
+
+    files = sorted(p for p in references_dir.iterdir()
+                   if p.is_file() and p.suffix.lower() == ".md"
+                   and p.name.lower() != "index.md")
+    if max_records is not None:
+        files = files[:max_records]
+
+    records_appended = 0
+    records_skipped: list[dict] = []
+    errors: list[dict] = []
+
+    for path in files:
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError as e:
+            errors.append({"file": path.name, "error": f"read: {e}"})
+            continue
+        meta, body = _parse_front_matter(text)
+        body_stripped = body.strip()
+        if not body_stripped:
+            records_skipped.append({"file": path.name, "reason": "empty body"})
+            continue
+
+        url = _derive_url(meta, base_url, path.name)
+        title = _derive_title(meta, path.name, body_stripped)
+        author = (meta.get("author") or "skill-seekers")[:200]
+
+        try:
+            record = append_inbox.build_record(
+                url=url,
+                source_type=source_type,
+                title=title,
+                extracted_text=body_stripped,
+                author=author,
+                sender=sender,
+                urge_tag=urge_tag,
+                topic_tags=list(topic_tags or []),
+                extracted_at=when,
+            )
+        except ValueError as e:
+            records_skipped.append({"file": path.name, "reason": f"schema: {e}"})
+            continue
+
+        if dry_run:
+            records_appended += 1  # count what WOULD have been appended
+            continue
+
+        try:
+            append_inbox.append(record, inbox_path)
+            records_appended += 1
+        except OSError as e:
+            errors.append({"file": path.name, "error": f"write: {e}"})
+
+    return {
+        "references_dir": str(references_dir),
+        "inbox_path": str(inbox_path),
+        "records_attempted": len(files),
+        "records_appended": records_appended,
+        "records_skipped": records_skipped,
+        "errors": errors,
+        "dry_run": dry_run,
+    }
+
+
+def _main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Flush skill-seekers references/*.md into the neuro-os inbox. "
+            "Composes with the url-to-inbox sibling skill."
+        ),
+    )
+    parser.add_argument(
+        "--references-dir", required=True,
+        help="Path to <skill-seekers-output>/references/ (contains *.md files)",
+    )
+    parser.add_argument(
+        "--base-url", default=None,
+        help="Base URL used when individual files lack front-matter URLs",
+    )
+    parser.add_argument(
+        "--inbox-path", default="~/.neuro_os_research/inbox.jsonl",
+        help="Inbox JSONL path (default: ~/.neuro_os_research/inbox.jsonl)",
+    )
+    parser.add_argument(
+        "--source-type", default="blog",
+        choices=["youtube", "blog", "twitter", "pdf", "email-body", "other"],
+        help="source_type to set on every record (default 'blog')",
+    )
+    parser.add_argument(
+        "--sender", default=None,
+        help="Optional sender identity (checked against inbox_allowlist.json)",
+    )
+    parser.add_argument(
+        "--urge-tag", default=None,
+        help="Optional founder-loop drift mode tag",
+    )
+    parser.add_argument(
+        "--topic-tag", action="append", default=[], dest="topic_tags",
+        help="Optional topic tag (may be repeated)",
+    )
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Parse + validate but do not append")
+    parser.add_argument("--max-records", type=int, default=None,
+                        help="Cap on records processed (useful for first-time tests)")
+    args = parser.parse_args(argv)
+
+    try:
+        summary = flush(
+            references_dir=Path(args.references_dir).expanduser(),
+            base_url=args.base_url,
+            inbox_path=Path(args.inbox_path).expanduser(),
+            source_type=args.source_type,
+            sender=args.sender,
+            urge_tag=args.urge_tag,
+            topic_tags=args.topic_tags,
+            dry_run=args.dry_run,
+            max_records=args.max_records,
+        )
+    except (FileNotFoundError, NotADirectoryError) as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/skills/research/url-to-inbox/SKILL.md
+++ b/skills/research/url-to-inbox/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: url-to-inbox
+description: >
+  Convert any URL (YouTube video, blog post, X/Twitter thread, PDF, raw email body)
+  into a structured InboxRecord and append it to neuro-os's research inbox at
+  ~/.neuro_os_research/inbox.jsonl. Pairs with the neuro-os research vertical
+  (URL-to-Living-Knowledge loop). Use when the user forwards a link, asks to
+  "capture" or "save" content for later review, or wants research material to
+  land as a MechanismCardProposal instead of a flat note.
+version: 0.1.0
+author: Hermes Agent + Neuro-OS
+license: MIT
+metadata:
+  hermes:
+    tags: [Research, Knowledge, Inbox, Neuro-OS, Capture, URL]
+    related_skills: [youtube-content, blogwatcher, ocr-and-documents, google-workspace]
+    homepage: https://github.com/wjlgatech/neuro-os/blob/main/docs/url-to-living-knowledge.md
+---
+
+# URL → Neuro-OS Research Inbox
+
+Take a URL → extract text → append a pre-validated `InboxRecord` JSON line to
+`~/.neuro_os_research/inbox.jsonl`. On the next `neuro-os research inbox ingest`,
+the record becomes a `MechanismCardProposal` in the user's review queue and
+eventually a `MechanismCard` linked (via `research goal`) to a startup-vertical
+revenue goal.
+
+This skill is the **producer** half of the URL-to-Living-Knowledge loop. The
+**consumer** half is neuro-os; nothing in this skill talks to neuro-os over the
+network — the contract is a JSONL file both sides can read and write.
+
+## Quick reference
+
+| Action | Command |
+|---|---|
+| Extract a URL → JSON payload | `python SKILL_DIR/scripts/extract_url.py --url <URL>` |
+| Append a payload to the inbox | `python SKILL_DIR/scripts/append_inbox.py --url <URL> --source-type <T> --title <S> --text-file <PATH>` |
+| One-shot (extract + append) | `python SKILL_DIR/scripts/extract_url.py --url <URL> --out-json /tmp/p.json && python SKILL_DIR/scripts/append_inbox.py --url <URL> --source-type "$(jq -r .source_type /tmp/p.json)" --title "$(jq -r .title /tmp/p.json)" --text-file <(jq -r .extracted_text /tmp/p.json)` |
+| Show the InboxRecord schema (consumer side) | See [neuro-os/agent/research/inbox.py](https://github.com/wjlgatech/neuro-os/blob/main/agent/research/inbox.py) |
+
+`SKILL_DIR` is the directory containing this `SKILL.md`.
+
+## The contract (InboxRecord)
+
+One JSON object per line in `~/.neuro_os_research/inbox.jsonl`. The schema is
+defined by `agent.research.inbox.InboxRecord` on the neuro-os side; this skill's
+`append_inbox.py` mirrors the constraints so you fail fast if a producer writes
+something invalid.
+
+```json
+{
+  "url":            "https://...",            // required, 1..2000
+  "source_type":    "youtube",                // required: youtube|blog|twitter|pdf|email-body|other
+  "title":          "Distribution is the moat", // required, 1..400
+  "author":         "Speaker Name",           // default "unknown", 1..200
+  "extracted_text": "...transcript or body...", // required, 1..400_000
+  "extracted_at":   "2026-05-23T12:00:00+00:00", // ISO-8601, set automatically
+  "sender":         "paul@example.com",       // optional, checked against neuro-os inbox_allowlist.json
+  "urge_tag":       "novelty",                // optional founder-loop drift mode
+  "topic_tags":     ["mlops","agents"]        // optional, max 20
+}
+```
+
+`urge_tag` is one of `novelty | social | frustration | fatigue | decision_fatigue | embodied`
+(matches neuro-os's founder-loop drift modes). When present, neuro-os prefixes
+the resulting proposal's `reasoning` with `[urge:<tag>]` so the human reviewer
+sees provenance — "this came in during a novelty urge, not a focused capture."
+
+## Dispatch table (source_type by URL)
+
+| Host / pattern | `source_type` | Extractor |
+|---|---|---|
+| `youtube.com`, `youtu.be`, `*.youtube.com` | `youtube` | `youtube_transcript_api` (with HTML fallback) |
+| `twitter.com`, `x.com` | `twitter` | static HTML scrape (best-effort; client-rendered threads need the `xitter` skill upstream) |
+| URL ends with `.pdf` | `pdf` | NOT handled here — pipe through `ocr-and-documents` skill first |
+| anything else | `blog` / `other` | urllib + stdlib HTML reducer (script/style stripped, paragraphs preserved) |
+
+Use `--source-type auto` (default) to let the script detect. Override with a
+specific value when you know better (e.g. a Substack post on a non-`.blog` host).
+
+## Typical flows
+
+### Manual (one URL, from a terminal)
+
+```bash
+SKILL_DIR=~/.hermes/skills/url-to-inbox
+
+# 1. Extract.
+python "$SKILL_DIR/scripts/extract_url.py" \
+  --url "https://youtube.com/watch?v=abc123" \
+  --out-json /tmp/yt.json
+
+# 2. Append.
+python "$SKILL_DIR/scripts/append_inbox.py" \
+  --url "$(jq -r .url /tmp/yt.json)" \
+  --source-type "$(jq -r .source_type /tmp/yt.json)" \
+  --title "$(jq -r .title /tmp/yt.json)" \
+  --author "$(jq -r .author /tmp/yt.json)" \
+  --text-file <(jq -r .extracted_text /tmp/yt.json) \
+  --sender paul@example.com \
+  --urge-tag novelty
+
+# 3. Hand off to neuro-os (different repo, separate command).
+neuro-os research inbox ingest
+```
+
+### Gmail watcher (Hermes cron)
+
+Run this skill from a Hermes cron job that watches your Gmail inbox via the
+`google-workspace` skill. For each new email with a URL, dispatch to
+`extract_url.py` then `append_inbox.py`, using the email's `From:` header as
+`--sender`. neuro-os's `inbox_allowlist.json` decides whether the sender is
+authorised; you don't need to filter at this layer.
+
+### Telegram forward
+
+Receive a message in your Hermes Telegram gateway → extract URLs from the
+message body → for each URL, run `extract_url.py` → `append_inbox.py`. Pass
+`--urge-tag` if the user attached a `#novelty` / `#social` / `#frustration`
+hashtag.
+
+### Browser share-target / macOS Share Sheet
+
+Wire a POST endpoint that receives `{url, title?, sender?}`, then runs the same
+two scripts. Append-only writes are safe under concurrent producers (each is
+one `f.write(line + "\n")` call holding the file open in append mode).
+
+## Idempotency + dedup
+
+This skill DOES NOT dedup — every `append_inbox.py` call writes one new line.
+neuro-os deduplicates on the **sha256 of the body text** at consume time, so:
+
+- Re-extracting the same URL while the page is unchanged → second proposal
+  collapsed into `records_skipped_duplicate` in the run summary.
+- Re-extracting the same URL after the page changed → both proposals emitted
+  (different sha → different proposals).
+
+If you want producer-side dedup (e.g. cron polling Gmail), keep your own URL
+log; this skill stays simple by leaving dedup to neuro-os.
+
+## Allowlist behaviour (sender field)
+
+`--sender` is forwarded verbatim to the InboxRecord. neuro-os checks the value
+against `~/.neuro_os_research/inbox_allowlist.json` at ingest time:
+
+- File missing or empty → every record passes (solo / local-only).
+- File populated → only records whose `sender` is listed pass; others are
+  counted in `records_skipped_disallowed` and skipped without proposals.
+
+The skill itself never reads the allowlist — that's a deliberate separation so
+producers can run as untrusted code while neuro-os enforces auth.
+
+## Failure modes
+
+| Symptom | Diagnosis | Fix |
+|---|---|---|
+| `append_inbox.py` exits 2 with "X must be at least Y chars" | A required field is missing or empty in your producer call. | Check the schema in the "Contract" section above. |
+| `extract_url.py` returns "(youtube-transcript-api not installed)" | `youtube_transcript_api` Python package isn't installed. | `pip install youtube-transcript-api` |
+| Twitter extraction returns mostly metadata | X/Twitter renders threads client-side; static HTML has only og:tags. | Use Hermes's `xitter` skill upstream to fetch full thread text, then call `append_inbox.py` directly. |
+| neuro-os shows `records_skipped_disallowed=N` after a batch | The sender isn't on the allowlist. | Add it to `~/.neuro_os_research/inbox_allowlist.json`, OR drop the allowlist file entirely. |
+| Inbox grows but `neuro-os research inbox status` shows `cursor=<old>` | You haven't run `neuro-os research inbox ingest` yet. | Run it. |
+
+## Related skills
+
+- **youtube-content** — alternative front-end if you want the transcript as
+  Markdown/chapters/threads instead of into the neuro-os inbox.
+- **google-workspace** — the Gmail polling side of the cron flow above.
+- **ocr-and-documents** — preprocess PDFs before piping the text into
+  `append_inbox.py --source-type pdf`.
+- **xitter** — fetch full X/Twitter threads when this skill's static HTML
+  scraper isn't enough.
+- **neuro-os research vertical** — the consumer side. See
+  https://github.com/wjlgatech/neuro-os/blob/main/docs/url-to-living-knowledge.md
+  for the end-to-end walkthrough.
+
+## Why a skill, not a tool?
+
+This is a workflow that composes other tools (HTTP fetch, transcript API,
+JSONL append). Putting it in `tools/` would require a registry entry, schema,
+and toolset wiring. As a skill, the LLM reads SKILL.md, dispatches the scripts,
+and the user can run the same scripts from a shell. No prompt-cache cost for
+users who don't enable it.

--- a/skills/research/url-to-inbox/scripts/append_inbox.py
+++ b/skills/research/url-to-inbox/scripts/append_inbox.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""
+Append one ``InboxRecord`` JSON line to the neuro-os research inbox.
+
+The neuro-os repo lives in a separate codebase; this helper writes the
+JSONL contract documented in
+``neuro-os/agent/research/inbox.py::InboxRecord``. We deliberately keep
+this script dependency-free (stdlib only) so the skill works on any
+machine where Hermes is installed regardless of whether neuro-os is
+also installed there.
+
+Schema (mirrors the Pydantic model verbatim — keep in sync if the
+neuro-os schema evolves):
+
+  {
+    "url": str (1..2000),
+    "source_type": "youtube"|"blog"|"twitter"|"pdf"|"email-body"|"other",
+    "title": str (1..400),
+    "author": str (1..200, default "unknown"),
+    "extracted_text": str (1..400_000),
+    "extracted_at": ISO-8601 datetime with tz,
+    "sender": str|null (max 200),
+    "urge_tag": str|null (max 64),
+    "topic_tags": list[str] (max 20)
+  }
+
+Usage:
+    python append_inbox.py \\
+      --url https://youtube.com/... \\
+      --source-type youtube \\
+      --title "Distribution is the moat" \\
+      --text-file /tmp/transcript.txt \\
+      [--author "Speaker Name"] \\
+      [--sender paul@example.com] \\
+      [--urge-tag novelty] \\
+      [--topic-tag mlops] [--topic-tag agents] \\
+      [--inbox-path ~/.neuro_os_research/inbox.jsonl]
+
+Output: a JSON object on stdout summarising what was appended.
+Exit codes: 0 success, 1 file/IO error, 2 bad arguments.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+
+VALID_SOURCE_TYPES = (
+    "youtube", "blog", "twitter", "pdf", "email-body", "other",
+)
+DEFAULT_INBOX_PATH = "~/.neuro_os_research/inbox.jsonl"
+
+# Limits that mirror the Pydantic constraints in
+# neuro-os/agent/research/inbox.py. If neuro-os tightens these, update
+# here too — the downstream Pydantic validator will reject overflows
+# anyway, but failing loud at the producer is friendlier.
+_LIMITS = {
+    "url":            (1, 2000),
+    "source_type":    None,  # validated against VALID_SOURCE_TYPES
+    "title":          (1, 400),
+    "author":         (1, 200),
+    "extracted_text": (1, 400_000),
+    "sender":         (0, 200),
+    "urge_tag":       (0, 64),
+}
+
+
+def _ensure_len(name: str, value: Optional[str]) -> Optional[str]:
+    """Validate string length against the schema limits. Empty/None
+    permissible for optional fields; required fields raise."""
+    bounds = _LIMITS.get(name)
+    if bounds is None:
+        return value
+    lo, hi = bounds
+    if value is None:
+        if lo == 0:
+            return None
+        raise ValueError(f"{name!r} is required")
+    if not isinstance(value, str):
+        raise ValueError(f"{name!r} must be a string")
+    n = len(value)
+    if n < lo:
+        raise ValueError(f"{name!r} must be at least {lo} char(s)")
+    if n > hi:
+        raise ValueError(f"{name!r} must be at most {hi} chars (got {n})")
+    return value
+
+
+def build_record(
+    *,
+    url: str,
+    source_type: str,
+    title: str,
+    extracted_text: str,
+    author: str = "unknown",
+    sender: Optional[str] = None,
+    urge_tag: Optional[str] = None,
+    topic_tags: Optional[list[str]] = None,
+    extracted_at: Optional[datetime] = None,
+) -> dict:
+    """Build the InboxRecord dict. Raises ValueError on schema violation
+    so producers see the bug at the boundary, not after writing a bad
+    line to the queue."""
+    if source_type not in VALID_SOURCE_TYPES:
+        raise ValueError(
+            f"source_type must be one of {VALID_SOURCE_TYPES!r}, got {source_type!r}"
+        )
+    _ensure_len("url", url)
+    _ensure_len("title", title)
+    _ensure_len("author", author)
+    _ensure_len("extracted_text", extracted_text)
+    _ensure_len("sender", sender)
+    _ensure_len("urge_tag", urge_tag)
+    tags = list(topic_tags or [])
+    if len(tags) > 20:
+        raise ValueError(f"topic_tags must have ≤20 entries (got {len(tags)})")
+    when = extracted_at or datetime.now(timezone.utc)
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=timezone.utc)
+    return {
+        "url": url,
+        "source_type": source_type,
+        "title": title,
+        "author": author,
+        "extracted_text": extracted_text,
+        "extracted_at": when.isoformat(),
+        "sender": sender,
+        "urge_tag": urge_tag,
+        "topic_tags": tags,
+    }
+
+
+def append(record: dict, inbox_path: Path) -> int:
+    """Append the record as one JSON line. Returns the new 0-indexed
+    line offset. Creates the parent directory as needed."""
+    inbox_path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(record, ensure_ascii=False, default=str)
+    with inbox_path.open("a", encoding="utf-8") as f:
+        f.write(line + "\n")
+    with inbox_path.open("r", encoding="utf-8") as f:
+        return sum(1 for _ in f) - 1
+
+
+def _read_text_file(path: Path) -> str:
+    if not path.exists():
+        raise FileNotFoundError(f"text file not found: {path}")
+    body = path.read_text(encoding="utf-8", errors="replace")
+    if not body.strip():
+        raise ValueError(f"text file is empty: {path}")
+    return body
+
+
+def _main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Append one InboxRecord JSON line to the neuro-os research inbox.",
+    )
+    parser.add_argument("--url", required=True, help="Original source URL")
+    parser.add_argument(
+        "--source-type", required=True, choices=VALID_SOURCE_TYPES,
+        help="Producer-attested source type",
+    )
+    parser.add_argument("--title", required=True, help="Source title (1..400 chars)")
+    parser.add_argument(
+        "--text-file", required=True,
+        help="Path to a file containing the pre-extracted body text",
+    )
+    parser.add_argument("--author", default="unknown", help="Source author")
+    parser.add_argument(
+        "--sender", default=None,
+        help="Optional sender identity (checked against inbox_allowlist.json by neuro-os)",
+    )
+    parser.add_argument(
+        "--urge-tag", default=None,
+        help="Optional active drift mode (novelty/social/frustration/fatigue/decision_fatigue/embodied)",
+    )
+    parser.add_argument(
+        "--topic-tag", action="append", default=[], dest="topic_tags",
+        help="Optional topic tag (may be repeated, max 20 total)",
+    )
+    parser.add_argument(
+        "--inbox-path", default=DEFAULT_INBOX_PATH,
+        help=f"Inbox JSONL path (default: {DEFAULT_INBOX_PATH})",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        body = _read_text_file(Path(args.text_file).expanduser())
+    except (FileNotFoundError, ValueError) as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+    try:
+        record = build_record(
+            url=args.url,
+            source_type=args.source_type,
+            title=args.title,
+            author=args.author,
+            extracted_text=body,
+            sender=args.sender,
+            urge_tag=args.urge_tag,
+            topic_tags=args.topic_tags,
+        )
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+    try:
+        offset = append(record, Path(args.inbox_path).expanduser())
+    except OSError as e:
+        print(f"error: failed to write inbox: {e}", file=sys.stderr)
+        return 1
+
+    print(json.dumps({
+        "appended_offset": offset,
+        "inbox_path": str(Path(args.inbox_path).expanduser()),
+        "source_type": record["source_type"],
+        "url": record["url"],
+        "byte_count": len(body.encode("utf-8")),
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/skills/research/url-to-inbox/scripts/extract_url.py
+++ b/skills/research/url-to-inbox/scripts/extract_url.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""
+Extract a URL into plain text + best-effort metadata, ready for
+``append_inbox.py``.
+
+Dispatch by source type:
+
+  youtube     → reuse the youtube-content skill's transcript fetcher
+                (youtube_transcript_api). Falls back to urllib HTML if the
+                package isn't installed.
+  twitter / x → fetch the HTML and extract <meta name="description">
+                + visible text. (X/Twitter renders threads client-side
+                so this is best-effort; for full threads, run this
+                through Hermes's xitter skill upstream and pipe the
+                resulting text into ``append_inbox.py --text-file -``.)
+  blog/other  → urllib + a small HTML→text reducer (stdlib only, no
+                BeautifulSoup dep). Strips <script>/<style>, collapses
+                whitespace, keeps reasonable line breaks.
+  pdf         → not extracted here — feed the text to ``append_inbox.py``
+                via the ocr-and-documents skill. This script will print
+                a hint and exit 2 if asked.
+  email-body  → already-extracted text; pass via ``append_inbox.py
+                --text-file <body.txt>`` directly.
+
+Usage:
+    python extract_url.py --url <URL> [--source-type auto|...]
+                          [--out-json /tmp/x.json]
+
+Output JSON:
+    {
+      "url": "...",
+      "source_type": "youtube"|"blog"|"twitter"|"pdf"|"other",
+      "title": "...",
+      "author": "...",
+      "extracted_text": "..."
+    }
+
+Exit codes: 0 success, 1 network/parse error, 2 unsupported source type.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Optional
+
+
+USER_AGENT = (
+    "Mozilla/5.0 (Hermes url-to-inbox skill; +https://github.com/wjlgatech/neuro-os)"
+)
+HTTP_TIMEOUT = 20
+
+
+# --------------------------------------------------------------------------
+# Source-type detection
+# --------------------------------------------------------------------------
+
+
+_YOUTUBE_HOSTS = ("youtube.com", "youtu.be", "m.youtube.com", "www.youtube.com")
+_TWITTER_HOSTS = ("twitter.com", "x.com", "mobile.twitter.com")
+
+
+def detect_source_type(url: str) -> str:
+    host = ""
+    m = re.match(r"https?://([^/]+)", url)
+    if m:
+        host = m.group(1).lower()
+    if any(host == h or host.endswith("." + h) for h in _YOUTUBE_HOSTS):
+        return "youtube"
+    if any(host == h or host.endswith("." + h) for h in _TWITTER_HOSTS):
+        return "twitter"
+    if url.lower().split("?", 1)[0].endswith(".pdf"):
+        return "pdf"
+    return "blog"
+
+
+# --------------------------------------------------------------------------
+# HTML reducer (stdlib only)
+# --------------------------------------------------------------------------
+
+
+_SCRIPT_RE = re.compile(r"<script\b[^>]*>.*?</script>", re.IGNORECASE | re.DOTALL)
+_STYLE_RE = re.compile(r"<style\b[^>]*>.*?</style>", re.IGNORECASE | re.DOTALL)
+_TAG_RE = re.compile(r"<[^>]+>")
+_TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+_META_AUTHOR_RE = re.compile(
+    r"<meta[^>]+(?:name|property)=[\"'](?:author|article:author)[\"'][^>]*content=[\"']([^\"']+)[\"']",
+    re.IGNORECASE,
+)
+_META_DESC_RE = re.compile(
+    r"<meta[^>]+(?:name|property)=[\"'](?:description|og:description|twitter:description)[\"'][^>]*content=[\"']([^\"']+)[\"']",
+    re.IGNORECASE,
+)
+_OG_TITLE_RE = re.compile(
+    r"<meta[^>]+property=[\"']og:title[\"'][^>]*content=[\"']([^\"']+)[\"']",
+    re.IGNORECASE,
+)
+_HTML_ENTITIES = {
+    "&amp;": "&", "&lt;": "<", "&gt;": ">", "&quot;": '"',
+    "&#39;": "'", "&nbsp;": " ", "&apos;": "'",
+}
+
+
+def _decode_entities(s: str) -> str:
+    for k, v in _HTML_ENTITIES.items():
+        s = s.replace(k, v)
+    # Numeric entities like &#1234; or &#xABCD;
+    def _num(match: re.Match) -> str:
+        code = match.group(1)
+        try:
+            if code.lower().startswith("x"):
+                return chr(int(code[1:], 16))
+            return chr(int(code))
+        except ValueError:
+            return match.group(0)
+    return re.sub(r"&#(x?[0-9a-fA-F]+);", _num, s)
+
+
+def html_to_text(html: str) -> str:
+    cleaned = _SCRIPT_RE.sub(" ", html)
+    cleaned = _STYLE_RE.sub(" ", cleaned)
+    # Keep paragraph + line breaks visible:
+    cleaned = re.sub(r"</(p|div|li|h[1-6]|br)\s*>", "\n\n", cleaned, flags=re.IGNORECASE)
+    cleaned = re.sub(r"<br\s*/?>", "\n", cleaned, flags=re.IGNORECASE)
+    cleaned = _TAG_RE.sub("", cleaned)
+    cleaned = _decode_entities(cleaned)
+    # Collapse 3+ blank lines → 2, trim trailing space per line.
+    cleaned = re.sub(r"[ \t]+\n", "\n", cleaned)
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    return cleaned.strip()
+
+
+def html_title(html: str) -> Optional[str]:
+    m = _OG_TITLE_RE.search(html)
+    if m:
+        return _decode_entities(m.group(1)).strip()
+    m = _TITLE_RE.search(html)
+    if m:
+        return _decode_entities(m.group(1)).strip()
+    return None
+
+
+def html_author(html: str) -> Optional[str]:
+    m = _META_AUTHOR_RE.search(html)
+    if m:
+        return _decode_entities(m.group(1)).strip()
+    return None
+
+
+def html_description(html: str) -> Optional[str]:
+    m = _META_DESC_RE.search(html)
+    if m:
+        return _decode_entities(m.group(1)).strip()
+    return None
+
+
+# --------------------------------------------------------------------------
+# Fetchers
+# --------------------------------------------------------------------------
+
+
+def fetch_html(url: str) -> str:
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
+        charset = resp.headers.get_content_charset() or "utf-8"
+        raw = resp.read()
+    return raw.decode(charset, errors="replace")
+
+
+def extract_youtube(url: str) -> dict:
+    """Fetch a YouTube transcript using youtube_transcript_api when
+    available; fall back to the page's <title> + description when not."""
+    try:
+        # Lazy import — only required for the YouTube branch.
+        from youtube_transcript_api import YouTubeTranscriptApi  # type: ignore
+    except ImportError:
+        YouTubeTranscriptApi = None  # type: ignore[assignment]
+
+    video_id = _youtube_video_id(url) or url
+    title: Optional[str] = None
+    author: Optional[str] = None
+
+    # Page metadata first — title/author are useful even when transcript fetch fails.
+    try:
+        html = fetch_html(f"https://www.youtube.com/watch?v={video_id}")
+        title = html_title(html)
+        # YouTube exposes channel name via various og: tags; cheap heuristic:
+        m = re.search(r'"author":"([^"]+)"', html)
+        if m:
+            author = m.group(1)
+    except Exception:
+        pass
+
+    if YouTubeTranscriptApi is None:
+        # No transcript library — best we can do is description + title.
+        try:
+            desc = html_description(html or "") if html else None  # type: ignore[has-type]
+        except Exception:
+            desc = None
+        return {
+            "title": title or f"YouTube video {video_id}",
+            "author": author or "unknown",
+            "extracted_text": (desc or "")
+                + "\n\n(youtube-transcript-api not installed; install via "
+                  "`pip install youtube-transcript-api` for full transcript)",
+        }
+
+    try:
+        # Try a small set of common languages; first hit wins.
+        for lang in ("en", "en-US", "en-GB"):
+            try:
+                segs = YouTubeTranscriptApi.get_transcript(video_id, languages=[lang])
+                text = "\n".join(s["text"] for s in segs if s.get("text"))
+                return {
+                    "title": title or f"YouTube video {video_id}",
+                    "author": author or "unknown",
+                    "extracted_text": text or "(empty transcript)",
+                }
+            except Exception:
+                continue
+        # Last resort: any available language.
+        segs = YouTubeTranscriptApi.get_transcript(video_id)
+        text = "\n".join(s["text"] for s in segs if s.get("text"))
+        return {
+            "title": title or f"YouTube video {video_id}",
+            "author": author or "unknown",
+            "extracted_text": text or "(empty transcript)",
+        }
+    except Exception as e:
+        return {
+            "title": title or f"YouTube video {video_id}",
+            "author": author or "unknown",
+            "extracted_text": (
+                f"(transcript fetch failed: {e}; description fallback follows)\n\n"
+                + (html_description(html) if html else "")  # type: ignore[has-type]
+            ),
+        }
+
+
+def _youtube_video_id(url_or_id: str) -> Optional[str]:
+    s = url_or_id.strip()
+    for pat in (
+        r"(?:v=|youtu\.be/|shorts/|embed/|live/)([a-zA-Z0-9_-]{11})",
+        r"^([a-zA-Z0-9_-]{11})$",
+    ):
+        m = re.search(pat, s)
+        if m:
+            return m.group(1)
+    return None
+
+
+def extract_blog(url: str) -> dict:
+    html = fetch_html(url)
+    return {
+        "title": html_title(html) or url,
+        "author": html_author(html) or "unknown",
+        "extracted_text": html_to_text(html),
+    }
+
+
+def extract_twitter(url: str) -> dict:
+    """X/Twitter is client-rendered, so this scraper is best-effort.
+    Returns whatever the static HTML contains plus a hint to the user."""
+    try:
+        html = fetch_html(url)
+    except urllib.error.URLError as e:
+        return {
+            "title": url,
+            "author": "unknown",
+            "extracted_text": (
+                f"(twitter fetch failed: {e}; the X/Twitter HTML is "
+                "client-rendered. For full threads, run the xitter "
+                "skill upstream and pipe its output to append_inbox.py.)"
+            ),
+        }
+    desc = html_description(html) or ""
+    title = html_title(html) or url
+    return {
+        "title": title,
+        "author": "unknown",
+        "extracted_text": desc + (
+            "\n\n(X/Twitter renders threads client-side; for full thread "
+            "text, prefer Hermes's xitter skill upstream.)"
+        ),
+    }
+
+
+# --------------------------------------------------------------------------
+# Driver
+# --------------------------------------------------------------------------
+
+
+def extract(url: str, *, source_type: str = "auto") -> dict:
+    if source_type == "auto":
+        source_type = detect_source_type(url)
+
+    if source_type == "youtube":
+        payload = extract_youtube(url)
+    elif source_type == "twitter":
+        payload = extract_twitter(url)
+    elif source_type == "blog" or source_type == "other":
+        payload = extract_blog(url)
+    elif source_type == "pdf":
+        raise ValueError(
+            "PDF extraction is out of scope for this skill — feed the "
+            "text through the ocr-and-documents skill, then pipe the "
+            "output to append_inbox.py with --source-type pdf."
+        )
+    elif source_type == "email-body":
+        raise ValueError(
+            "email-body inputs are already-extracted text — call "
+            "append_inbox.py directly with --source-type email-body."
+        )
+    else:
+        raise ValueError(f"unsupported source_type {source_type!r}")
+
+    payload["url"] = url
+    payload["source_type"] = source_type
+    return payload
+
+
+def _main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Extract a URL into plain text + metadata for the neuro-os inbox.",
+    )
+    parser.add_argument("--url", required=True, help="URL to extract")
+    parser.add_argument(
+        "--source-type", default="auto",
+        choices=["auto", "youtube", "blog", "twitter", "pdf", "email-body", "other"],
+        help="Source type; 'auto' (default) detects from URL host",
+    )
+    parser.add_argument(
+        "--out-json", default=None,
+        help="If set, write the JSON to this file instead of stdout",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        payload = extract(args.url, source_type=args.source_type)
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+    except urllib.error.URLError as e:
+        print(f"error: fetch failed: {e}", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+    out = json.dumps(payload, ensure_ascii=False, indent=2)
+    if args.out_json:
+        Path(args.out_json).expanduser().write_text(out, encoding="utf-8")
+        print(args.out_json)
+    else:
+        print(out)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/tests/skills/test_skill_seekers_to_inbox.py
+++ b/tests/skills/test_skill_seekers_to_inbox.py
@@ -1,0 +1,255 @@
+"""Tests for skills/research/skill-seekers-to-inbox/scripts/flush_references.py.
+
+Strategy: build a fake ``references/`` directory mimicking skill-seekers'
+output (a mix of front-matter + plain markdown), then drive the
+``flush`` function against it and assert on the inbox JSONL.
+
+We don't shell out to skill-seekers itself — it's a heavy dependency
+(network, optional API key) — and that boundary is already covered by
+skill-seekers's own 3194+ tests.
+"""
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+
+SKILL_ROOT = Path(__file__).resolve().parents[2] / "skills" / "research" / "skill-seekers-to-inbox"
+SCRIPTS_DIR = SKILL_ROOT / "scripts"
+
+# Add the SIBLING url-to-inbox scripts to sys.path FIRST so the
+# bridge's `import append_inbox` resolves.
+SIBLING = SKILL_ROOT.parent / "url-to-inbox" / "scripts"
+sys.path.insert(0, str(SIBLING))
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+# Now import the module under test. We use importlib so that re-running
+# the test file in the same session picks up edits.
+flush_module = importlib.import_module("flush_references")
+
+
+NOW = datetime(2026, 5, 23, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _make_fake_seeker_output(root: Path) -> Path:
+    """Build a directory that mimics ``skill-seekers create --output ...``:
+
+        root/
+          SKILL.md                  ← wrapper, ignored
+          references/
+            index.md                ← skipped (navigation file)
+            section_01.md           ← full front-matter + body
+            section_02.md           ← no front-matter, has H1
+            section_03.md           ← no front-matter, no H1
+            empty.md                ← empty body → skipped
+    """
+    refs = root / "references"
+    refs.mkdir(parents=True)
+    (root / "SKILL.md").write_text("# wrapper\n", encoding="utf-8")
+    (refs / "index.md").write_text("# Index\n- section_01\n", encoding="utf-8")
+    (refs / "section_01.md").write_text(
+        "---\n"
+        "source_url: https://docs.example.com/getting-started\n"
+        "title: Getting Started\n"
+        "author: Docs Team\n"
+        "---\n"
+        "# Getting Started\n\n"
+        "Install with pip. Then run it.\n",
+        encoding="utf-8",
+    )
+    (refs / "section_02.md").write_text(
+        "# Advanced Configuration\n\n"
+        "Configure foo. Then bar.\n",
+        encoding="utf-8",
+    )
+    (refs / "section_03.md").write_text(
+        "Plain prose with no heading at all. Just some body text.\n",
+        encoding="utf-8",
+    )
+    (refs / "empty.md").write_text("\n   \n", encoding="utf-8")
+    return refs
+
+
+# --------------------------------------------------------------------------
+# Front-matter parsing
+# --------------------------------------------------------------------------
+
+
+class TestFrontMatter:
+    def test_parses_clean_front_matter(self):
+        text = (
+            "---\n"
+            "title: Hello\n"
+            "source_url: https://x.com/a\n"
+            "---\n"
+            "body content"
+        )
+        meta, body = flush_module._parse_front_matter(text)
+        assert meta == {"title": "Hello", "source_url": "https://x.com/a"}
+        assert body == "body content"
+
+    def test_no_front_matter_passes_through(self):
+        text = "just body"
+        meta, body = flush_module._parse_front_matter(text)
+        assert meta == {}
+        assert body == "just body"
+
+    def test_strips_quotes_in_values(self):
+        text = '---\ntitle: "Quoted Title"\n---\nbody'
+        meta, _ = flush_module._parse_front_matter(text)
+        assert meta["title"] == "Quoted Title"
+
+
+class TestDeriveUrl:
+    def test_front_matter_source_url_wins(self):
+        url = flush_module._derive_url(
+            {"source_url": "https://x.com/page", "url": "https://y.com/other"},
+            "https://base.example.com",
+            "section_01.md",
+        )
+        assert url == "https://x.com/page"
+
+    def test_fallback_to_base_url_plus_slug(self):
+        url = flush_module._derive_url({}, "https://docs.example.com", "getting-started.md")
+        assert url == "https://docs.example.com/getting-started"
+
+    def test_final_fallback_is_synthetic_scheme(self):
+        url = flush_module._derive_url({}, None, "loose-file.md")
+        assert url == "skill-seekers://loose-file.md"
+
+
+class TestDeriveTitle:
+    def test_front_matter_title_wins(self):
+        t = flush_module._derive_title({"title": "FM Title"}, "foo.md", "# Body Heading")
+        assert t == "FM Title"
+
+    def test_fallback_to_first_h1(self):
+        t = flush_module._derive_title({}, "foo.md", "intro\n# Real Title\n\nbody")
+        assert t == "Real Title"
+
+    def test_fallback_to_humanized_filename(self):
+        t = flush_module._derive_title({}, "advanced-configuration.md", "no heading")
+        assert t == "Advanced Configuration"
+
+
+# --------------------------------------------------------------------------
+# End-to-end flush against a faked skill-seekers output
+# --------------------------------------------------------------------------
+
+
+class TestFlushEndToEnd:
+    def test_appends_one_record_per_md_skipping_index_and_empty(self, tmp_path):
+        refs = _make_fake_seeker_output(tmp_path / "seeker-out")
+        inbox = tmp_path / "inbox.jsonl"
+
+        summary = flush_module.flush(
+            references_dir=refs,
+            base_url="https://docs.example.com",
+            inbox_path=inbox,
+            source_type="blog",
+            sender="paul@example.com",
+            urge_tag="novelty",
+            topic_tags=["docs", "import"],
+            now=NOW,
+        )
+
+        # index.md skipped, empty.md skipped (empty body), 3 content files attempted.
+        assert summary["records_attempted"] == 4  # section_01, _02, _03, empty
+        # empty.md gets caught as "schema" skip OR "empty body" skip (we check both).
+        assert summary["records_appended"] == 3
+        assert any(
+            s["file"] == "empty.md" for s in summary["records_skipped"]
+        )
+        assert summary["errors"] == []
+
+        # Inbox file has exactly 3 lines.
+        lines = inbox.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 3
+        records = [json.loads(line) for line in lines]
+        urls = {r["url"] for r in records}
+        titles = {r["title"] for r in records}
+
+        # section_01 had explicit front-matter url + title:
+        assert "https://docs.example.com/getting-started" in urls
+        assert "Getting Started" in titles
+        # section_02 had no front-matter — title from H1, url from base_url + slug:
+        assert "Advanced Configuration" in titles
+        assert "https://docs.example.com/section_02" in urls
+        # section_03 had no front-matter and no H1 — title humanized from filename:
+        assert "Section 03" in titles or "Section_03" in titles
+
+        # Every record carries the bridge's metadata.
+        for r in records:
+            assert r["sender"] == "paul@example.com"
+            assert r["urge_tag"] == "novelty"
+            assert r["topic_tags"] == ["docs", "import"]
+            assert r["source_type"] == "blog"
+
+    def test_dry_run_does_not_write_inbox(self, tmp_path):
+        refs = _make_fake_seeker_output(tmp_path / "seeker-out")
+        inbox = tmp_path / "inbox.jsonl"
+
+        summary = flush_module.flush(
+            references_dir=refs,
+            base_url="https://docs.example.com",
+            inbox_path=inbox,
+            dry_run=True,
+            now=NOW,
+        )
+
+        assert summary["dry_run"] is True
+        assert summary["records_appended"] == 3   # WOULD have been
+        assert not inbox.exists()  # NO writes happened
+
+    def test_max_records_caps_processing(self, tmp_path):
+        refs = _make_fake_seeker_output(tmp_path / "seeker-out")
+        inbox = tmp_path / "inbox.jsonl"
+
+        summary = flush_module.flush(
+            references_dir=refs,
+            base_url=None,
+            inbox_path=inbox,
+            max_records=2,
+            now=NOW,
+        )
+
+        assert summary["records_attempted"] == 2  # cap honored
+        # And at most 2 records appear in inbox.
+        if inbox.exists():
+            lines = inbox.read_text(encoding="utf-8").splitlines()
+            assert len(lines) <= 2
+
+    def test_missing_directory_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            flush_module.flush(
+                references_dir=tmp_path / "does-not-exist",
+                base_url=None,
+                inbox_path=tmp_path / "inbox.jsonl",
+            )
+
+    def test_uses_sibling_append_inbox_schema(self, tmp_path):
+        """Sanity check that our records match what the url-to-inbox
+        sibling validates against. If neuro-os ever evolves the
+        InboxRecord schema, this test will fail at the bridge layer
+        too."""
+        refs = _make_fake_seeker_output(tmp_path / "seeker-out")
+        inbox = tmp_path / "inbox.jsonl"
+        summary = flush_module.flush(
+            references_dir=refs,
+            base_url="https://docs.example.com",
+            inbox_path=inbox,
+            now=NOW,
+        )
+        assert summary["records_appended"] >= 1
+        line = inbox.read_text(encoding="utf-8").splitlines()[0]
+        rec = json.loads(line)
+        expected_keys = {
+            "url", "source_type", "title", "author", "extracted_text",
+            "extracted_at", "sender", "urge_tag", "topic_tags",
+        }
+        assert set(rec.keys()) == expected_keys

--- a/tests/skills/test_url_to_inbox.py
+++ b/tests/skills/test_url_to_inbox.py
@@ -1,0 +1,404 @@
+"""Tests for skills/research/url-to-inbox/scripts/.
+
+Strategy: hermetic tests against the helper functions. The script
+shells out cleanly (no Hermes / neuro-os import dependencies) so we
+exercise it via importable functions AND via subprocess for the CLI
+entry point — that catches argument parsing regressions.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "skills" / "research" / "url-to-inbox" / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import append_inbox  # noqa: E402
+import extract_url   # noqa: E402
+
+
+NOW = datetime(2026, 5, 23, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# --------------------------------------------------------------------------
+# append_inbox.build_record — schema mirror tests
+# --------------------------------------------------------------------------
+
+
+class TestBuildRecord:
+    def test_minimal_required_fields_pass(self):
+        rec = append_inbox.build_record(
+            url="https://x/1",
+            source_type="blog",
+            title="T",
+            extracted_text="hello world",
+            extracted_at=NOW,
+        )
+        assert rec["url"] == "https://x/1"
+        assert rec["source_type"] == "blog"
+        assert rec["title"] == "T"
+        assert rec["extracted_text"] == "hello world"
+        assert rec["author"] == "unknown"
+        assert rec["sender"] is None
+        assert rec["urge_tag"] is None
+        assert rec["topic_tags"] == []
+        # ISO-8601 with tz, parseable round-trip:
+        assert rec["extracted_at"].endswith("+00:00")
+        datetime.fromisoformat(rec["extracted_at"])
+
+    def test_unknown_source_type_raises(self):
+        with pytest.raises(ValueError, match="source_type must be one of"):
+            append_inbox.build_record(
+                url="https://x", source_type="podcast",
+                title="T", extracted_text="body",
+            )
+
+    def test_url_length_validated(self):
+        with pytest.raises(ValueError, match="url"):
+            append_inbox.build_record(
+                url="https://" + "x" * 2001,
+                source_type="blog", title="T", extracted_text="body",
+            )
+
+    def test_title_required(self):
+        with pytest.raises(ValueError, match="title"):
+            append_inbox.build_record(
+                url="https://x", source_type="blog",
+                title="", extracted_text="body",
+            )
+
+    def test_extracted_text_required(self):
+        with pytest.raises(ValueError, match="extracted_text"):
+            append_inbox.build_record(
+                url="https://x", source_type="blog",
+                title="T", extracted_text="",
+            )
+
+    def test_topic_tags_capped_at_20(self):
+        with pytest.raises(ValueError, match="topic_tags"):
+            append_inbox.build_record(
+                url="https://x", source_type="blog", title="T",
+                extracted_text="body",
+                topic_tags=[f"tag-{i}" for i in range(21)],
+            )
+
+    def test_urge_tag_passes_through(self):
+        rec = append_inbox.build_record(
+            url="https://x", source_type="blog", title="T",
+            extracted_text="body",
+            urge_tag="novelty",
+        )
+        assert rec["urge_tag"] == "novelty"
+
+    def test_naive_datetime_coerced_to_utc(self):
+        naive = datetime(2026, 5, 23, 12, 0, 0)
+        rec = append_inbox.build_record(
+            url="https://x", source_type="blog", title="T",
+            extracted_text="body", extracted_at=naive,
+        )
+        assert rec["extracted_at"].endswith("+00:00")
+
+
+# --------------------------------------------------------------------------
+# append_inbox.append — JSONL roundtrip + concurrent-write safety
+# --------------------------------------------------------------------------
+
+
+class TestAppendJsonl:
+    def test_append_then_read_roundtrip(self, tmp_path):
+        inbox = tmp_path / "inbox.jsonl"
+        rec = append_inbox.build_record(
+            url="https://x", source_type="blog", title="T",
+            extracted_text="body",
+        )
+        offset = append_inbox.append(rec, inbox)
+        assert offset == 0
+        # File contains exactly one JSON line that parses back to our record.
+        lines = inbox.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+        parsed = json.loads(lines[0])
+        assert parsed["url"] == rec["url"]
+        assert parsed["title"] == rec["title"]
+        assert parsed["topic_tags"] == []
+
+    def test_two_appends_produce_two_lines_with_correct_offsets(self, tmp_path):
+        inbox = tmp_path / "inbox.jsonl"
+        r1 = append_inbox.build_record(
+            url="https://x/1", source_type="blog", title="T1",
+            extracted_text="first",
+        )
+        r2 = append_inbox.build_record(
+            url="https://x/2", source_type="blog", title="T2",
+            extracted_text="second",
+        )
+        assert append_inbox.append(r1, inbox) == 0
+        assert append_inbox.append(r2, inbox) == 1
+        lines = inbox.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 2
+
+    def test_parent_dir_created_on_demand(self, tmp_path):
+        inbox = tmp_path / "deeply" / "nested" / "inbox.jsonl"
+        rec = append_inbox.build_record(
+            url="https://x", source_type="blog", title="T",
+            extracted_text="body",
+        )
+        append_inbox.append(rec, inbox)
+        assert inbox.exists()
+
+
+# --------------------------------------------------------------------------
+# extract_url.detect_source_type — dispatch table
+# --------------------------------------------------------------------------
+
+
+class TestSourceTypeDetection:
+    @pytest.mark.parametrize("url,expected", [
+        ("https://youtube.com/watch?v=abc", "youtube"),
+        ("https://www.youtube.com/watch?v=abc", "youtube"),
+        ("https://youtu.be/abc", "youtube"),
+        ("https://m.youtube.com/watch?v=abc", "youtube"),
+        ("https://twitter.com/foo/status/1", "twitter"),
+        ("https://x.com/foo/status/1", "twitter"),
+        ("https://example.com/paper.pdf", "pdf"),
+        ("https://example.com/paper.pdf?dl=1", "pdf"),
+        ("https://blog.example.com/post-1", "blog"),
+        ("https://substack.com/p/post", "blog"),
+    ])
+    def test_dispatch(self, url, expected):
+        assert extract_url.detect_source_type(url) == expected
+
+
+# --------------------------------------------------------------------------
+# extract_url.html_to_text — stdlib HTML reducer
+# --------------------------------------------------------------------------
+
+
+class TestHtmlToText:
+    def test_strips_script_and_style(self):
+        html = """
+        <html><head><style>body { color: red }</style>
+        <script>alert(1)</script></head>
+        <body><p>Hello world</p></body></html>
+        """
+        text = extract_url.html_to_text(html)
+        assert "alert" not in text
+        assert "color: red" not in text
+        assert "Hello world" in text
+
+    def test_keeps_paragraph_breaks(self):
+        html = "<p>First</p><p>Second</p>"
+        text = extract_url.html_to_text(html)
+        # The reducer inserts double newlines between block elements.
+        assert "First" in text and "Second" in text
+        assert "\n\n" in text
+
+    def test_decodes_entities(self):
+        html = "<p>Tom &amp; Jerry &lt;3 &#39;tea&#39;</p>"
+        text = extract_url.html_to_text(html)
+        assert "Tom & Jerry <3 'tea'" in text
+
+    def test_extracts_title(self):
+        html = "<html><head><title>My Page</title></head><body></body></html>"
+        assert extract_url.html_title(html) == "My Page"
+
+    def test_og_title_wins_over_html_title(self):
+        html = """
+        <html><head>
+          <meta property="og:title" content="OG Title">
+          <title>Plain Title</title>
+        </head></html>
+        """
+        assert extract_url.html_title(html) == "OG Title"
+
+    def test_extracts_meta_author(self):
+        html = '<meta name="author" content="Jane Doe">'
+        assert extract_url.html_author(html) == "Jane Doe"
+
+
+# --------------------------------------------------------------------------
+# extract_url.extract — dispatch + error surfaces
+# --------------------------------------------------------------------------
+
+
+class TestExtractDispatch:
+    def test_pdf_raises_with_clear_hint(self):
+        with pytest.raises(ValueError, match="ocr-and-documents"):
+            extract_url.extract("https://x/paper.pdf", source_type="pdf")
+
+    def test_email_body_raises_with_clear_hint(self):
+        with pytest.raises(ValueError, match="email-body"):
+            extract_url.extract("note://something", source_type="email-body")
+
+    def test_blog_branch_uses_fetch_html(self, monkeypatch):
+        canned = """
+        <html><head><title>Distribution is the moat</title>
+        <meta name="author" content="Speaker">
+        </head><body><p>Distribution beats product quality.</p></body></html>
+        """
+        monkeypatch.setattr(extract_url, "fetch_html", lambda url: canned)
+        result = extract_url.extract("https://blog.example.com/p1", source_type="blog")
+        assert result["title"] == "Distribution is the moat"
+        assert result["author"] == "Speaker"
+        assert "Distribution beats product quality" in result["extracted_text"]
+        assert result["source_type"] == "blog"
+        assert result["url"] == "https://blog.example.com/p1"
+
+    def test_auto_dispatches_by_host(self, monkeypatch):
+        canned = "<html><head><title>Post</title></head><body>Body</body></html>"
+        monkeypatch.setattr(extract_url, "fetch_html", lambda url: canned)
+        # blog dispatch
+        r1 = extract_url.extract("https://substack.com/p/post", source_type="auto")
+        assert r1["source_type"] == "blog"
+        # pdf dispatch raises (not fetched)
+        with pytest.raises(ValueError):
+            extract_url.extract("https://x/paper.pdf", source_type="auto")
+
+    def test_youtube_branch_falls_back_when_lib_missing(self, monkeypatch):
+        # Force the ImportError branch by hiding youtube_transcript_api.
+        monkeypatch.setitem(sys.modules, "youtube_transcript_api", None)
+        # And make HTML fetch return a minimal page so the function returns metadata.
+        monkeypatch.setattr(
+            extract_url, "fetch_html",
+            lambda url: '<html><head><title>YT Video</title>'
+                        '<meta name="description" content="some desc">'
+                        '</head></html>'
+        )
+        result = extract_url.extract(
+            "https://youtube.com/watch?v=abcdefghijk",
+            source_type="youtube",
+        )
+        assert result["source_type"] == "youtube"
+        assert "youtube-transcript-api" in result["extracted_text"]
+
+
+# --------------------------------------------------------------------------
+# CLI subprocess smoke (catches argparse regressions)
+# --------------------------------------------------------------------------
+
+
+class TestAppendInboxCli:
+    def test_help_prints(self):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPTS_DIR / "append_inbox.py"), "--help"],
+            capture_output=True, text=True, timeout=10,
+        )
+        assert result.returncode == 0
+        assert "--url" in result.stdout
+        assert "--source-type" in result.stdout
+        assert "--text-file" in result.stdout
+
+    def test_end_to_end_appends_one_line(self, tmp_path):
+        text_file = tmp_path / "body.txt"
+        text_file.write_text("body text for the test", encoding="utf-8")
+        inbox = tmp_path / "inbox.jsonl"
+        result = subprocess.run(
+            [
+                sys.executable, str(SCRIPTS_DIR / "append_inbox.py"),
+                "--url", "https://blog.example.com/test",
+                "--source-type", "blog",
+                "--title", "Test title",
+                "--text-file", str(text_file),
+                "--inbox-path", str(inbox),
+                "--sender", "paul@example.com",
+                "--urge-tag", "novelty",
+                "--topic-tag", "mlops",
+                "--topic-tag", "agents",
+            ],
+            capture_output=True, text=True, timeout=10,
+        )
+        assert result.returncode == 0, result.stderr
+        out = json.loads(result.stdout)
+        assert out["appended_offset"] == 0
+        assert out["source_type"] == "blog"
+        # JSONL line landed.
+        line = inbox.read_text(encoding="utf-8").splitlines()[0]
+        payload = json.loads(line)
+        assert payload["url"] == "https://blog.example.com/test"
+        assert payload["sender"] == "paul@example.com"
+        assert payload["urge_tag"] == "novelty"
+        assert payload["topic_tags"] == ["mlops", "agents"]
+
+    def test_missing_text_file_returns_nonzero(self, tmp_path):
+        result = subprocess.run(
+            [
+                sys.executable, str(SCRIPTS_DIR / "append_inbox.py"),
+                "--url", "https://x",
+                "--source-type", "blog",
+                "--title", "T",
+                "--text-file", str(tmp_path / "does-not-exist.txt"),
+                "--inbox-path", str(tmp_path / "inbox.jsonl"),
+            ],
+            capture_output=True, text=True, timeout=10,
+        )
+        assert result.returncode != 0
+        assert "not found" in result.stderr or "no such" in result.stderr.lower()
+
+    def test_invalid_source_type_rejected_by_argparse(self, tmp_path):
+        text_file = tmp_path / "body.txt"
+        text_file.write_text("body", encoding="utf-8")
+        result = subprocess.run(
+            [
+                sys.executable, str(SCRIPTS_DIR / "append_inbox.py"),
+                "--url", "https://x",
+                "--source-type", "podcast",  # not a valid choice
+                "--title", "T",
+                "--text-file", str(text_file),
+                "--inbox-path", str(tmp_path / "inbox.jsonl"),
+            ],
+            capture_output=True, text=True, timeout=10,
+        )
+        assert result.returncode != 0
+        # argparse prints to stderr.
+        assert "podcast" in result.stderr or "invalid choice" in result.stderr
+
+
+class TestExtractUrlCli:
+    def test_help_prints(self):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPTS_DIR / "extract_url.py"), "--help"],
+            capture_output=True, text=True, timeout=10,
+        )
+        assert result.returncode == 0
+        assert "--url" in result.stdout
+        assert "--source-type" in result.stdout
+
+    def test_pdf_exit_code_is_2(self):
+        result = subprocess.run(
+            [
+                sys.executable, str(SCRIPTS_DIR / "extract_url.py"),
+                "--url", "https://x/paper.pdf",
+                "--source-type", "pdf",
+            ],
+            capture_output=True, text=True, timeout=10,
+        )
+        assert result.returncode == 2
+        assert "ocr-and-documents" in result.stderr
+
+
+# --------------------------------------------------------------------------
+# End-to-end producer→consumer contract: the JSON line a producer writes
+# is exactly the JSON line the neuro-os Pydantic schema expects.
+# --------------------------------------------------------------------------
+
+
+def test_producer_output_matches_documented_schema():
+    """Pin: the keys our producer emits are exactly the keys neuro-os's
+    InboxRecord expects. If neuro-os evolves the schema, this test
+    surfaces the drift at the Hermes side immediately."""
+    rec = append_inbox.build_record(
+        url="https://x", source_type="blog", title="T",
+        extracted_text="body", sender="a@b.com", urge_tag="novelty",
+        topic_tags=["t1"],
+    )
+    expected_keys = {
+        "url", "source_type", "title", "author", "extracted_text",
+        "extracted_at", "sender", "urge_tag", "topic_tags",
+    }
+    assert set(rec.keys()) == expected_keys

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2,7 +2,7 @@
 """
 Text-to-Speech Tool Module
 
-Supports seven TTS providers:
+Supports eight TTS providers:
 - Edge TTS (default, free, no API key): Microsoft Edge neural voices
 - ElevenLabs (premium): High-quality voices, needs ELEVENLABS_API_KEY
 - OpenAI TTS: Good quality, needs OPENAI_API_KEY
@@ -10,6 +10,7 @@ Supports seven TTS providers:
 - Mistral (Voxtral TTS): Multilingual, native Opus, needs MISTRAL_API_KEY
 - Google Gemini TTS: Controllable, 30 prebuilt voices, needs GEMINI_API_KEY
 - NeuTTS (local, free, no API key): On-device TTS via neutts_cli, needs neutts installed
+- Supertonic (local, free, no API key): On-device ONNX TTS, 32 languages, needs supertonic installed
 
 Output formats:
 - Opus (.ogg) for Telegram voice bubbles (requires ffmpeg for Edge TTS)
@@ -759,6 +760,78 @@ def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) ->
 
 
 # ===========================================================================
+# Supertonic (local, ONNX-based TTS — 32 languages, auto-downloads on first run)
+# ===========================================================================
+
+_supertonic_tts_instance = None  # (model_name, TTS) — cached across calls
+_supertonic_tts_lock = threading.Lock()
+
+
+def _check_supertonic_available() -> bool:
+    """Check if the supertonic package is importable (installed locally)."""
+    try:
+        import importlib.util
+        return importlib.util.find_spec("supertonic") is not None
+    except Exception:
+        return False
+
+
+def _get_supertonic_tts(model: str):
+    """Return a cached supertonic TTS instance, loading on first use.
+
+    The TTS object holds ONNX sessions and is expensive to construct,
+    so we cache it module-wide and rebuild only if the model changes.
+    """
+    global _supertonic_tts_instance
+    with _supertonic_tts_lock:
+        if _supertonic_tts_instance is None or _supertonic_tts_instance[0] != model:
+            from supertonic import TTS
+            _supertonic_tts_instance = (model, TTS(model=model, auto_download=True))
+        return _supertonic_tts_instance[1]
+
+
+def _generate_supertonic(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate speech using the local Supertonic ONNX TTS engine.
+
+    Supertonic outputs WAV (numpy array → soundfile-saved). If the caller
+    requested a non-WAV extension we synthesize to a temp .wav and ffmpeg-
+    convert to the target format — same pattern as _generate_neutts.
+    """
+    sup_config = tts_config.get("supertonic", {})
+    model = sup_config.get("model", "supertonic-3")
+    voice = sup_config.get("voice", "M1")
+    lang = sup_config.get("language") or None  # None → auto-detect
+    speed = float(sup_config.get("speed", 1.05))
+    total_steps = int(sup_config.get("total_steps", 8))
+
+    tts = _get_supertonic_tts(model)
+    style = tts.get_voice_style(voice_name=voice)
+    wav, _duration = tts.synthesize(
+        text,
+        voice_style=style,
+        lang=lang,
+        speed=speed,
+        total_steps=total_steps,
+    )
+
+    wav_path = output_path
+    if not output_path.endswith(".wav"):
+        wav_path = output_path.rsplit(".", 1)[0] + ".wav"
+    tts.save_audio(wav, wav_path)
+
+    if wav_path != output_path:
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg:
+            conv_cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path]
+            subprocess.run(conv_cmd, check=True, timeout=30)
+            os.remove(wav_path)
+        else:
+            os.rename(wav_path, output_path)
+
+    return output_path
+
+
+# ===========================================================================
 # Main tool function
 # ===========================================================================
 def text_to_speech_tool(
@@ -877,6 +950,16 @@ def text_to_speech_tool(
             logger.info("Generating speech with NeuTTS (local)...")
             _generate_neutts(text, file_str, tts_config)
 
+        elif provider == "supertonic":
+            if not _check_supertonic_available():
+                return json.dumps({
+                    "success": False,
+                    "error": "Supertonic provider selected but the 'supertonic' package is not installed. "
+                             "Install with: pip install supertonic"
+                }, ensure_ascii=False)
+            logger.info("Generating speech with Supertonic (local)...")
+            _generate_supertonic(text, file_str, tts_config)
+
         else:
             # Default: Edge TTS (free), with NeuTTS as local fallback
             edge_available = True
@@ -916,7 +999,7 @@ def text_to_speech_tool(
         # Try Opus conversion for Telegram compatibility
         # Edge TTS outputs MP3, NeuTTS outputs WAV — both need ffmpeg conversion
         voice_compatible = False
-        if provider in ("edge", "neutts", "minimax", "xai") and not file_str.endswith(".ogg"):
+        if provider in ("edge", "neutts", "supertonic", "minimax", "xai") and not file_str.endswith(".ogg"):
             opus_path = _convert_to_opus(file_str)
             if opus_path:
                 file_str = opus_path
@@ -1000,6 +1083,8 @@ def check_tts_requirements() -> bool:
     except ImportError:
         pass
     if _check_neutts_available():
+        return True
+    if _check_supertonic_available():
         return True
     return False
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import {
   Wrench, Zap, Heart, Star, Code, Eye,
 } from "lucide-react";
 import StatusPage from "@/pages/StatusPage";
+import ChatPage from "@/pages/ChatPage";
 import ConfigPage from "@/pages/ConfigPage";
 import EnvPage from "@/pages/EnvPage";
 import SessionsPage from "@/pages/SessionsPage";
@@ -33,6 +34,7 @@ interface NavItem {
 
 const BUILTIN_NAV: NavItem[] = [
   { path: "/", labelKey: "status", label: "Status", icon: Activity },
+  { path: "/chat", labelKey: "chat", label: "Chat", icon: MessageSquare },
   { path: "/sessions", labelKey: "sessions", label: "Sessions", icon: MessageSquare },
   { path: "/analytics", labelKey: "analytics", label: "Analytics", icon: BarChart3 },
   { path: "/logs", labelKey: "logs", label: "Logs", icon: FileText },
@@ -158,6 +160,7 @@ export default function App() {
       <main className="relative z-2 mx-auto w-full max-w-[1400px] flex-1 px-3 sm:px-6 pt-16 sm:pt-20 pb-4 sm:pb-8">
         <Routes>
           <Route path="/" element={<StatusPage />} />
+          <Route path="/chat" element={<ChatPage />} />
           <Route path="/sessions" element={<SessionsPage />} />
           <Route path="/analytics" element={<AnalyticsPage />} />
           <Route path="/logs" element={<LogsPage />} />

--- a/web/src/components/MicButton.tsx
+++ b/web/src/components/MicButton.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useRef, useState } from "react";
+import { Mic, MicOff, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+type MicState = "idle" | "recording" | "transcribing";
+
+interface Props {
+  onTranscript: (text: string) => void;
+  onError?: (msg: string) => void;
+  size?: "sm" | "default" | "lg" | "icon";
+  variant?: "default" | "ghost" | "outline" | "secondary";
+  label?: string;
+}
+
+export function MicButton({
+  onTranscript,
+  onError,
+  size = "sm",
+  variant = "ghost",
+  label,
+}: Props) {
+  const [state, setState] = useState<MicState>("idle");
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const streamRef = useRef<MediaStream | null>(null);
+
+  const cleanupStream = () => {
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+    }
+    recorderRef.current = null;
+    chunksRef.current = [];
+  };
+
+  useEffect(() => cleanupStream, []);
+
+  const start = async () => {
+    if (state !== "idle") return;
+    if (!navigator.mediaDevices?.getUserMedia) {
+      onError?.("Microphone API not available in this browser");
+      return;
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+
+      const mimeType =
+        MediaRecorder.isTypeSupported("audio/webm;codecs=opus")
+          ? "audio/webm;codecs=opus"
+          : MediaRecorder.isTypeSupported("audio/webm")
+          ? "audio/webm"
+          : "";
+      const recorder = mimeType
+        ? new MediaRecorder(stream, { mimeType })
+        : new MediaRecorder(stream);
+      recorderRef.current = recorder;
+      chunksRef.current = [];
+
+      recorder.ondataavailable = (e) => {
+        if (e.data && e.data.size > 0) chunksRef.current.push(e.data);
+      };
+      recorder.onstop = async () => {
+        const blob = new Blob(chunksRef.current, {
+          type: recorder.mimeType || "audio/webm",
+        });
+        cleanupStream();
+        if (blob.size === 0) {
+          setState("idle");
+          onError?.("No audio captured");
+          return;
+        }
+        setState("transcribing");
+        try {
+          const token = window.__HERMES_SESSION_TOKEN__;
+          const fd = new FormData();
+          // Filename matters for the backend's extension fallback.
+          const ext = blob.type.includes("webm") ? "webm" : "wav";
+          fd.append("audio", blob, `recording.${ext}`);
+          const headers: Record<string, string> = {};
+          if (token) headers["Authorization"] = `Bearer ${token}`;
+          const res = await fetch("/api/voice/transcribe", {
+            method: "POST",
+            headers,
+            body: fd,
+          });
+          if (!res.ok) {
+            const txt = await res.text().catch(() => res.statusText);
+            throw new Error(`${res.status}: ${txt}`);
+          }
+          const data: { transcript: string } = await res.json();
+          onTranscript(data.transcript || "");
+        } catch (err) {
+          onError?.(err instanceof Error ? err.message : String(err));
+        } finally {
+          setState("idle");
+        }
+      };
+      recorder.start();
+      setState("recording");
+    } catch (err) {
+      cleanupStream();
+      const msg = err instanceof Error ? err.message : String(err);
+      onError?.(`Mic permission denied or unavailable: ${msg}`);
+      setState("idle");
+    }
+  };
+
+  const stop = () => {
+    if (recorderRef.current && state === "recording") {
+      recorderRef.current.stop();
+    }
+  };
+
+  const handleClick = () => {
+    if (state === "idle") start();
+    else if (state === "recording") stop();
+  };
+
+  const Icon =
+    state === "transcribing" ? Loader2 : state === "recording" ? MicOff : Mic;
+  const title =
+    state === "recording"
+      ? "Stop recording"
+      : state === "transcribing"
+      ? "Transcribing…"
+      : "Record voice";
+
+  return (
+    <Button
+      type="button"
+      variant={variant}
+      size={size}
+      onClick={handleClick}
+      disabled={state === "transcribing"}
+      title={title}
+      aria-label={title}
+      className={state === "recording" ? "text-destructive" : undefined}
+    >
+      <Icon
+        className={`h-3.5 w-3.5 ${state === "transcribing" ? "animate-spin" : ""} ${
+          state === "recording" ? "animate-pulse" : ""
+        }`}
+      />
+      {label && <span className="ml-1.5">{label}</span>}
+    </Button>
+  );
+}

--- a/web/src/components/SpeakButton.tsx
+++ b/web/src/components/SpeakButton.tsx
@@ -1,0 +1,89 @@
+import { useRef, useState } from "react";
+import { Volume2, Square, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { api } from "@/lib/api";
+
+interface Props {
+  text: string;
+  provider?: string;  // override the configured TTS provider for this call
+  voice?: string;     // override the configured voice for this call
+  label?: string;     // button label; if omitted, just shows the icon
+  size?: "sm" | "default" | "lg" | "icon";
+  variant?: "default" | "ghost" | "outline" | "secondary";
+  onError?: (err: string) => void;
+}
+
+export function SpeakButton({
+  text,
+  provider,
+  voice,
+  label,
+  size = "sm",
+  variant = "ghost",
+  onError,
+}: Props) {
+  const [state, setState] = useState<"idle" | "loading" | "playing">("idle");
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const urlRef = useRef<string | null>(null);
+
+  const cleanup = () => {
+    if (urlRef.current) {
+      URL.revokeObjectURL(urlRef.current);
+      urlRef.current = null;
+    }
+    audioRef.current = null;
+    setState("idle");
+  };
+
+  const stop = () => {
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current.currentTime = 0;
+    }
+    cleanup();
+  };
+
+  const play = async () => {
+    if (state !== "idle") {
+      stop();
+      return;
+    }
+    if (!text.trim()) return;
+    setState("loading");
+    try {
+      const blob = await api.speak({ text, provider, voice });
+      const url = URL.createObjectURL(blob);
+      urlRef.current = url;
+      const audio = new Audio(url);
+      audioRef.current = audio;
+      audio.onended = cleanup;
+      audio.onerror = () => {
+        onError?.("Audio playback failed");
+        cleanup();
+      };
+      await audio.play();
+      setState("playing");
+    } catch (err) {
+      onError?.(err instanceof Error ? err.message : String(err));
+      cleanup();
+    }
+  };
+
+  const Icon =
+    state === "loading" ? Loader2 : state === "playing" ? Square : Volume2;
+
+  return (
+    <Button
+      type="button"
+      variant={variant}
+      size={size}
+      onClick={play}
+      disabled={state === "loading"}
+      title={state === "playing" ? "Stop" : "Test voice"}
+      aria-label={state === "playing" ? "Stop" : "Test voice"}
+    >
+      <Icon className={`h-3.5 w-3.5 ${state === "loading" ? "animate-spin" : ""}`} />
+      {label && <span className="ml-1.5">{label}</span>}
+    </Button>
+  );
+}

--- a/web/src/components/chat/ApprovalDialog.tsx
+++ b/web/src/components/chat/ApprovalDialog.tsx
@@ -1,0 +1,80 @@
+import { useEffect } from "react";
+import { ShieldAlert, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  callId: string;
+  command: string;
+  description: string;
+  allowPermanent?: boolean;
+  onDecide: (decision: "once" | "session" | "always" | "deny") => void;
+}
+
+export function ApprovalDialog({
+  command,
+  description,
+  allowPermanent = true,
+  onDecide,
+}: Props) {
+  // Escape = deny (consistent with the CLI prompt's default).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onDecide("deny");
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onDecide]);
+
+  return (
+    <div className="fixed inset-0 z-50 bg-background/70 backdrop-blur-sm flex items-center justify-center p-4">
+      <div className="w-full max-w-xl rounded-lg border border-destructive/40 bg-card shadow-xl">
+        <div className="flex items-start gap-3 p-4 border-b border-border">
+          <ShieldAlert className="h-5 w-5 text-destructive shrink-0 mt-0.5" />
+          <div className="flex-1">
+            <div className="text-sm font-semibold text-foreground">
+              Dangerous command — approve before running?
+            </div>
+            <div className="text-xs text-muted-foreground mt-0.5">
+              {description}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => onDecide("deny")}
+            className="text-muted-foreground hover:text-foreground"
+            title="Deny (Esc)"
+            aria-label="Deny"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="p-4">
+          <div className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">
+            Command
+          </div>
+          <pre className="font-mono text-xs whitespace-pre-wrap break-all rounded-md bg-muted/40 border border-border px-2 py-2 text-foreground">
+            {command}
+          </pre>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-end gap-2 px-4 pb-4">
+          <Button variant="ghost" size="sm" onClick={() => onDecide("deny")}>
+            Deny
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => onDecide("once")}>
+            Allow once
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => onDecide("session")}>
+            Allow this session
+          </Button>
+          {allowPermanent && (
+            <Button variant="default" size="sm" onClick={() => onDecide("always")}>
+              Always allow
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/chat/ChatComposer.tsx
+++ b/web/src/components/chat/ChatComposer.tsx
@@ -1,0 +1,79 @@
+import { useRef, useEffect } from "react";
+import { Send, Square } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { MicButton } from "@/components/MicButton";
+
+interface Props {
+  value: string;
+  onChange: (text: string) => void;
+  onSend: () => void;
+  onCancel?: () => void;
+  busy?: boolean;          // a turn is in progress
+  disabled?: boolean;
+}
+
+export function ChatComposer({
+  value,
+  onChange,
+  onSend,
+  onCancel,
+  busy = false,
+  disabled = false,
+}: Props) {
+  const taRef = useRef<HTMLTextAreaElement>(null);
+
+  // Auto-grow textarea up to ~6 lines.
+  useEffect(() => {
+    const ta = taRef.current;
+    if (!ta) return;
+    ta.style.height = "auto";
+    ta.style.height = Math.min(ta.scrollHeight, 140) + "px";
+  }, [value]);
+
+  const handleKey = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      if (!busy && value.trim()) onSend();
+    }
+  };
+
+  const handleSendClick = () => {
+    if (busy && onCancel) onCancel();
+    else if (value.trim()) onSend();
+  };
+
+  return (
+    <div className="flex items-end gap-1.5 rounded-lg border border-border bg-card p-1.5">
+      <MicButton
+        onTranscript={(text) => {
+          if (!text) return;
+          const newVal = value ? value + " " + text : text;
+          onChange(newVal);
+          taRef.current?.focus();
+        }}
+        onError={(msg) => console.error("[mic]", msg)}
+      />
+      <textarea
+        ref={taRef}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={handleKey}
+        placeholder={busy ? "agent is responding…" : "Ask Hermes anything (Enter to send, Shift+Enter for newline)"}
+        disabled={disabled}
+        rows={1}
+        className="flex-1 resize-none bg-transparent outline-none px-1.5 py-1 text-sm text-foreground placeholder:text-muted-foreground disabled:opacity-50 min-h-[24px] max-h-[140px]"
+      />
+      <Button
+        type="button"
+        size="sm"
+        variant={busy ? "outline" : "default"}
+        onClick={handleSendClick}
+        disabled={disabled || (!busy && !value.trim())}
+        title={busy ? "Cancel turn" : "Send"}
+        aria-label={busy ? "Cancel turn" : "Send"}
+      >
+        {busy ? <Square className="h-3.5 w-3.5" /> : <Send className="h-3.5 w-3.5" />}
+      </Button>
+    </div>
+  );
+}

--- a/web/src/components/chat/Message.tsx
+++ b/web/src/components/chat/Message.tsx
@@ -1,6 +1,6 @@
 import { Markdown } from "@/components/Markdown";
 import { SpeakButton } from "@/components/SpeakButton";
-import { CheckCircle2, XCircle, Loader2, AlertCircle, ChevronDown, ChevronRight } from "lucide-react";
+import { CheckCircle2, XCircle, Loader2, AlertCircle, ChevronDown, ChevronRight, Info } from "lucide-react";
 import { useState } from "react";
 
 /* ------------------------------------------------------------------ */
@@ -19,6 +19,7 @@ export type ChatItem =
       status: "running" | "ok" | "failed";
       summary?: string;
     }
+  | { id: string; kind: "system"; detail: string }
   | { id: string; kind: "error"; detail: string };
 
 /* ------------------------------------------------------------------ */
@@ -131,6 +132,17 @@ export function ToolCallCard({
   );
 }
 
+export function SystemBubble({ detail }: { detail: string }) {
+  return (
+    <div className="flex justify-center">
+      <div className="max-w-[90%] rounded-md border border-border bg-muted/40 px-3 py-2 text-xs flex items-start gap-2">
+        <Info className="h-3.5 w-3.5 text-muted-foreground mt-0.5 shrink-0" />
+        <pre className="whitespace-pre-wrap font-mono text-foreground/80 leading-snug">{detail}</pre>
+      </div>
+    </div>
+  );
+}
+
 export function ErrorBanner({ detail }: { detail: string }) {
   return (
     <div className="flex justify-start">
@@ -157,6 +169,8 @@ export function MessageItem({ item }: { item: ChatItem }) {
           summary={item.summary}
         />
       );
+    case "system":
+      return <SystemBubble detail={item.detail} />;
     case "error":
       return <ErrorBanner detail={item.detail} />;
   }

--- a/web/src/components/chat/Message.tsx
+++ b/web/src/components/chat/Message.tsx
@@ -1,0 +1,163 @@
+import { Markdown } from "@/components/Markdown";
+import { SpeakButton } from "@/components/SpeakButton";
+import { CheckCircle2, XCircle, Loader2, AlertCircle, ChevronDown, ChevronRight } from "lucide-react";
+import { useState } from "react";
+
+/* ------------------------------------------------------------------ */
+/*  Item types — flat list state for ChatPage                          */
+/* ------------------------------------------------------------------ */
+
+export type ChatItem =
+  | { id: string; kind: "user"; text: string }
+  | { id: string; kind: "assistant"; text: string; pending?: boolean }
+  | {
+      id: string;
+      kind: "tool";
+      callId: string;
+      tool: string;
+      args: string;
+      status: "running" | "ok" | "failed";
+      summary?: string;
+    }
+  | { id: string; kind: "error"; detail: string };
+
+/* ------------------------------------------------------------------ */
+/*  Renderers                                                          */
+/* ------------------------------------------------------------------ */
+
+export function UserMessage({ text }: { text: string }) {
+  return (
+    <div className="flex justify-end">
+      <div className="max-w-[80%] rounded-lg bg-primary px-3 py-1.5 text-primary-foreground text-sm whitespace-pre-wrap">
+        {text}
+      </div>
+    </div>
+  );
+}
+
+export function AssistantMessage({
+  text,
+  pending,
+}: {
+  text: string;
+  pending?: boolean;
+}) {
+  return (
+    <div className="flex justify-start">
+      <div className="max-w-[85%] flex flex-col gap-1">
+        <div className="rounded-lg bg-card border border-border px-3 py-2">
+          {text ? (
+            <div className="text-sm">
+              <Markdown content={text} />
+            </div>
+          ) : pending ? (
+            <div className="text-sm text-muted-foreground flex items-center gap-1.5">
+              <Loader2 className="h-3 w-3 animate-spin" />
+              <span>thinking…</span>
+            </div>
+          ) : null}
+        </div>
+        {text && !pending && (
+          <div className="flex items-center gap-1 px-1">
+            <SpeakButton text={text} variant="ghost" size="sm" />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function ToolCallCard({
+  tool,
+  args,
+  status,
+  summary,
+}: {
+  tool: string;
+  args: string;
+  status: "running" | "ok" | "failed";
+  summary?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const Icon = status === "running" ? Loader2 : status === "ok" ? CheckCircle2 : XCircle;
+  const color =
+    status === "running"
+      ? "text-muted-foreground"
+      : status === "ok"
+      ? "text-success"
+      : "text-destructive";
+
+  return (
+    <div className="flex justify-start">
+      <div className="max-w-[85%] w-full rounded-md border border-border bg-muted/30 text-xs overflow-hidden">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="flex items-center gap-1.5 w-full px-2 py-1 hover:bg-muted/50"
+        >
+          {open ? (
+            <ChevronDown className="h-3 w-3 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="h-3 w-3 text-muted-foreground" />
+          )}
+          <Icon className={`h-3.5 w-3.5 ${color} ${status === "running" ? "animate-spin" : ""}`} />
+          <code className="font-mono text-foreground">{tool}</code>
+          {summary && status !== "running" && (
+            <span className="text-muted-foreground truncate ml-1">— {summary}</span>
+          )}
+        </button>
+        {open && (
+          <div className="border-t border-border bg-background/50 p-2">
+            <div className="text-muted-foreground text-[10px] uppercase tracking-wider mb-1">
+              args
+            </div>
+            <pre className="font-mono text-[11px] whitespace-pre-wrap break-all text-foreground">
+              {args || "(empty)"}
+            </pre>
+            {summary && (
+              <>
+                <div className="text-muted-foreground text-[10px] uppercase tracking-wider mb-1 mt-2">
+                  result
+                </div>
+                <pre className="font-mono text-[11px] whitespace-pre-wrap break-all text-foreground">
+                  {summary}
+                </pre>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function ErrorBanner({ detail }: { detail: string }) {
+  return (
+    <div className="flex justify-start">
+      <div className="max-w-[85%] rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm flex items-start gap-2">
+        <AlertCircle className="h-4 w-4 text-destructive mt-0.5 shrink-0" />
+        <div className="text-destructive whitespace-pre-wrap">{detail}</div>
+      </div>
+    </div>
+  );
+}
+
+export function MessageItem({ item }: { item: ChatItem }) {
+  switch (item.kind) {
+    case "user":
+      return <UserMessage text={item.text} />;
+    case "assistant":
+      return <AssistantMessage text={item.text} pending={item.pending} />;
+    case "tool":
+      return (
+        <ToolCallCard
+          tool={item.tool}
+          args={item.args}
+          status={item.status}
+          summary={item.summary}
+        />
+      );
+    case "error":
+      return <ErrorBanner detail={item.detail} />;
+  }
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -198,6 +198,23 @@ export const api = {
     fetchJSON<PluginManifestResponse[]>("/api/dashboard/plugins"),
   rescanPlugins: () =>
     fetchJSON<{ ok: boolean; count: number }>("/api/dashboard/plugins/rescan"),
+
+  // Voice — TTS
+  speak: async (opts: { text: string; provider?: string; voice?: string }): Promise<Blob> => {
+    const token = window.__HERMES_SESSION_TOKEN__;
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (token) headers["Authorization"] = `Bearer ${token}`;
+    const res = await fetch("/api/tts/speak", {
+      method: "POST",
+      headers,
+      body: JSON.stringify(opts),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => res.statusText);
+      throw new Error(`${res.status}: ${text}`);
+    }
+    return res.blob();
+  },
 };
 
 export interface PlatformStatus {

--- a/web/src/lib/chat.ts
+++ b/web/src/lib/chat.ts
@@ -1,0 +1,226 @@
+// SSE client for the Hermes chat API.
+// We use fetch + ReadableStream (not EventSource) so we can send the
+// bearer Authorization header.  The wire format is plain SSE:
+//   event: <name>\ndata: <json>\n\n
+
+const STORAGE_KEY = "hermes.chat.session_id";
+
+export interface BaseEvent { call_id?: string }
+
+export interface StatusEvent extends BaseEvent {
+  type: "status";
+  kind: string;
+  session_id?: string;
+}
+export interface TextDeltaEvent extends BaseEvent {
+  type: "text-delta";
+  delta: string;
+}
+export interface TurnStartEvent extends BaseEvent { type: "turn-start" }
+export interface TurnEndEvent extends BaseEvent {
+  type: "turn-end";
+  final_text: string;
+}
+export interface ToolCallStartEvent extends BaseEvent {
+  type: "tool-call-start";
+  tool: string;
+  args_summary: string;
+}
+export interface ToolCallResultEvent extends BaseEvent {
+  type: "tool-call-result";
+  tool: string;
+  ok: boolean;
+  summary: string;
+}
+export interface ApprovalRequestEvent extends BaseEvent {
+  type: "approval-request";
+  command: string;
+  description: string;
+  allow_permanent?: boolean;
+}
+export interface ClarifyRequestEvent extends BaseEvent {
+  type: "clarify-request";
+  question: string;
+  choices: string[];
+}
+export interface ErrorEvent extends BaseEvent {
+  type: "error";
+  detail: string;
+}
+
+export type ChatEvent =
+  | StatusEvent
+  | TextDeltaEvent
+  | TurnStartEvent
+  | TurnEndEvent
+  | ToolCallStartEvent
+  | ToolCallResultEvent
+  | ApprovalRequestEvent
+  | ClarifyRequestEvent
+  | ErrorEvent;
+
+type Listener = (e: ChatEvent) => void;
+
+function authHeaders(): Record<string, string> {
+  const token = window.__HERMES_SESSION_TOKEN__;
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+/** Create a new session and store its id in localStorage. */
+export async function createSession(): Promise<string> {
+  const res = await fetch("/api/chat/sessions", {
+    method: "POST",
+    headers: authHeaders(),
+  });
+  if (!res.ok) throw new Error(`createSession: ${res.status}`);
+  const { session_id } = (await res.json()) as { session_id: string };
+  localStorage.setItem(STORAGE_KEY, session_id);
+  return session_id;
+}
+
+/** Return the persisted session id, or null. */
+export function loadStoredSession(): string | null {
+  return localStorage.getItem(STORAGE_KEY);
+}
+
+export function clearStoredSession(): void {
+  localStorage.removeItem(STORAGE_KEY);
+}
+
+/** Fetch persisted messages for resume (history replay). */
+export async function getMessages(sessionId: string): Promise<unknown[]> {
+  const res = await fetch(`/api/chat/sessions/${encodeURIComponent(sessionId)}/messages`, {
+    headers: authHeaders(),
+  });
+  if (res.status === 404) return [];
+  if (!res.ok) throw new Error(`getMessages: ${res.status}`);
+  const data = (await res.json()) as { messages?: unknown[] };
+  return data.messages ?? [];
+}
+
+export class ChatClient {
+  readonly sessionId: string;
+  private listeners = new Set<Listener>();
+  private abort: AbortController | null = null;
+  private closed = false;
+
+  constructor(sessionId: string) {
+    this.sessionId = sessionId;
+  }
+
+  on(listener: Listener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private emit(e: ChatEvent) {
+    for (const cb of this.listeners) {
+      try { cb(e); } catch (err) { console.error("[chat] listener", err); }
+    }
+  }
+
+  /** Start streaming events.  Runs until close() or the connection drops. */
+  async connect(): Promise<void> {
+    if (this.abort) throw new Error("already connected");
+    this.abort = new AbortController();
+    try {
+      const res = await fetch(
+        `/api/chat/sessions/${encodeURIComponent(this.sessionId)}/stream`,
+        { headers: { ...authHeaders(), Accept: "text/event-stream" }, signal: this.abort.signal },
+      );
+      if (res.status === 404) {
+        this.emit({ type: "error", detail: "Session not found" });
+        return;
+      }
+      if (!res.ok || !res.body) {
+        throw new Error(`stream: ${res.status}`);
+      }
+      const reader = res.body.getReader();
+      const dec = new TextDecoder();
+      let buf = "";
+      while (!this.closed) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buf += dec.decode(value, { stream: true });
+        // SSE frames are separated by a blank line.
+        let idx: number;
+        while ((idx = buf.indexOf("\n\n")) !== -1) {
+          const frame = buf.slice(0, idx);
+          buf = buf.slice(idx + 2);
+          const ev = parseFrame(frame);
+          if (ev) this.emit(ev);
+        }
+      }
+    } catch (err) {
+      if (!this.closed) {
+        this.emit({ type: "error", detail: err instanceof Error ? err.message : String(err) });
+      }
+    } finally {
+      this.abort = null;
+    }
+  }
+
+  close(): void {
+    this.closed = true;
+    if (this.abort) {
+      this.abort.abort();
+      this.abort = null;
+    }
+  }
+
+  async send(text: string): Promise<void> {
+    const res = await fetch(`/api/chat/sessions/${encodeURIComponent(this.sessionId)}/send`, {
+      method: "POST",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ text }),
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => res.statusText);
+      throw new Error(`send: ${res.status} ${detail}`);
+    }
+  }
+
+  async approve(callId: string, decision: "once" | "session" | "always" | "deny"): Promise<void> {
+    const res = await fetch(`/api/chat/sessions/${encodeURIComponent(this.sessionId)}/approve`, {
+      method: "POST",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ call_id: callId, decision }),
+    });
+    if (!res.ok) throw new Error(`approve: ${res.status}`);
+  }
+
+  async clarify(callId: string, answer: string): Promise<void> {
+    const res = await fetch(`/api/chat/sessions/${encodeURIComponent(this.sessionId)}/clarify`, {
+      method: "POST",
+      headers: { ...authHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ call_id: callId, answer }),
+    });
+    if (!res.ok) throw new Error(`clarify: ${res.status}`);
+  }
+
+  async cancel(): Promise<void> {
+    const res = await fetch(`/api/chat/sessions/${encodeURIComponent(this.sessionId)}/cancel`, {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    if (!res.ok) throw new Error(`cancel: ${res.status}`);
+  }
+}
+
+function parseFrame(frame: string): ChatEvent | null {
+  let event = "message";
+  let data = "";
+  for (const line of frame.split("\n")) {
+    if (line.startsWith(":")) continue; // comment / keepalive
+    const colon = line.indexOf(":");
+    if (colon < 0) continue;
+    const field = line.slice(0, colon);
+    const val = line.slice(colon + 1).replace(/^ /, "");
+    if (field === "event") event = val;
+    else if (field === "data") data = data ? data + "\n" + val : val;
+  }
+  if (!data) return null;
+  let payload: Record<string, unknown> = {};
+  try { payload = JSON.parse(data); } catch { return null; }
+  return { type: event, ...payload } as unknown as ChatEvent;
+}

--- a/web/src/lib/chat.ts
+++ b/web/src/lib/chat.ts
@@ -47,6 +47,10 @@ export interface ErrorEvent extends BaseEvent {
   type: "error";
   detail: string;
 }
+export interface SystemMessageEvent extends BaseEvent {
+  type: "system-message";
+  detail: string;
+}
 
 export type ChatEvent =
   | StatusEvent
@@ -57,6 +61,7 @@ export type ChatEvent =
   | ToolCallResultEvent
   | ApprovalRequestEvent
   | ClarifyRequestEvent
+  | SystemMessageEvent
   | ErrorEvent;
 
 type Listener = (e: ChatEvent) => void;

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1,0 +1,325 @@
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
+import { MessageSquare, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  ChatClient,
+  createSession,
+  loadStoredSession,
+  clearStoredSession,
+  getMessages,
+  type ChatEvent,
+} from "@/lib/chat";
+import { MessageItem, type ChatItem } from "@/components/chat/Message";
+import { ChatComposer } from "@/components/chat/ChatComposer";
+import { ApprovalDialog } from "@/components/chat/ApprovalDialog";
+
+/* ------------------------------------------------------------------ */
+/*  Reducer: SSE events → ChatItem[] state                              */
+/* ------------------------------------------------------------------ */
+
+type Action =
+  | { type: "push-user"; text: string }
+  | { type: "event"; e: ChatEvent }
+  | { type: "reset" }
+  | { type: "set"; items: ChatItem[] };
+
+function itemsReducer(items: ChatItem[], action: Action): ChatItem[] {
+  switch (action.type) {
+    case "reset":
+      return [];
+    case "set":
+      return action.items;
+    case "push-user":
+      // Push a pending assistant placeholder right after the user message
+      // so the user sees "thinking…" immediately.
+      return [
+        ...items,
+        { id: id(), kind: "user", text: action.text },
+        { id: id(), kind: "assistant", text: "", pending: true },
+      ];
+    case "event": {
+      const e = action.e;
+      switch (e.type) {
+        case "turn-start":
+          return items;  // already pushed a placeholder
+        case "text-delta": {
+          // Append delta to the most recent pending assistant message,
+          // OR start a new assistant message if the last item is a tool.
+          const last = items[items.length - 1];
+          if (last && last.kind === "assistant") {
+            const updated = { ...last, text: last.text + e.delta, pending: false };
+            return [...items.slice(0, -1), updated];
+          }
+          return [...items, { id: id(), kind: "assistant", text: e.delta }];
+        }
+        case "tool-call-start": {
+          // End any pending assistant placeholder.
+          const next = items.map((it) =>
+            it.kind === "assistant" && it.pending ? { ...it, pending: false } : it,
+          );
+          return [
+            ...next,
+            {
+              id: id(),
+              kind: "tool",
+              callId: e.call_id || id(),
+              tool: e.tool,
+              args: e.args_summary || "",
+              status: "running",
+            },
+          ];
+        }
+        case "tool-call-result": {
+          return items.map((it) => {
+            if (it.kind === "tool" && it.callId === e.call_id) {
+              return { ...it, status: e.ok ? "ok" : "failed", summary: e.summary } as ChatItem;
+            }
+            return it;
+          });
+        }
+        case "turn-end": {
+          // If no text-delta fired (non-streaming providers / errors), the
+          // assistant message might still be empty — fill it from final_text.
+          const out: ChatItem[] = [];
+          let filled = false;
+          for (let i = items.length - 1; i >= 0; i--) {
+            const it = items[i];
+            if (!filled && it.kind === "assistant" && (it.pending || !it.text)) {
+              out.unshift({ ...it, text: e.final_text || it.text, pending: false });
+              filled = true;
+            } else {
+              out.unshift(it);
+            }
+          }
+          if (!filled && e.final_text) {
+            out.push({ id: id(), kind: "assistant", text: e.final_text });
+          }
+          return out;
+        }
+        case "error":
+          return [
+            ...items.map((it) =>
+              it.kind === "assistant" && it.pending ? { ...it, pending: false } : it,
+            ),
+            { id: id(), kind: "error", detail: e.detail },
+          ];
+        default:
+          return items;
+      }
+    }
+  }
+}
+
+let _idc = 0;
+function id() { return `it-${Date.now()}-${_idc++}`; }
+
+/* ------------------------------------------------------------------ */
+/*  Page                                                                */
+/* ------------------------------------------------------------------ */
+
+interface PendingApproval {
+  callId: string;
+  command: string;
+  description: string;
+  allowPermanent: boolean;
+}
+
+export default function ChatPage() {
+  const [items, dispatch] = useReducer(itemsReducer, []);
+  const [draft, setDraft] = useState("");
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [connError, setConnError] = useState<string | null>(null);
+  const [approval, setApproval] = useState<PendingApproval | null>(null);
+  const clientRef = useRef<ChatClient | null>(null);
+  const scrollerRef = useRef<HTMLDivElement>(null);
+
+  // Auto-scroll on new items.
+  useEffect(() => {
+    const el = scrollerRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [items]);
+
+  // Bootstrap: reattach or create a session.
+  useEffect(() => {
+    let cancelled = false;
+    async function init() {
+      let sid = loadStoredSession();
+      if (sid) {
+        // Reattach — try to load persisted history first.
+        try {
+          await getMessages(sid);  // 404 → fall through to fresh
+        } catch {
+          sid = null;
+        }
+      }
+      if (!sid) {
+        try {
+          sid = await createSession();
+        } catch (err) {
+          if (!cancelled) setConnError(err instanceof Error ? err.message : String(err));
+          return;
+        }
+      }
+      if (cancelled) return;
+      setSessionId(sid);
+      const client = new ChatClient(sid);
+      clientRef.current = client;
+      const off = client.on(handleEvent);
+      client.connect().catch((e) => {
+        if (!cancelled) setConnError(e instanceof Error ? e.message : String(e));
+      });
+      return () => off();
+    }
+    init();
+    return () => {
+      cancelled = true;
+      clientRef.current?.close();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleEvent = useCallback((e: ChatEvent) => {
+    if (e.type === "status" && e.kind === "connected") {
+      setConnError(null);
+      return;
+    }
+    if (e.type === "turn-start") {
+      setBusy(true);
+    }
+    if (e.type === "turn-end" || e.type === "error") {
+      setBusy(false);
+    }
+    if (e.type === "approval-request") {
+      setApproval({
+        callId: e.call_id || "",
+        command: e.command,
+        description: e.description,
+        allowPermanent: e.allow_permanent !== false,
+      });
+      // Don't dispatch this as a chat item — it shows as a modal instead.
+      return;
+    }
+    dispatch({ type: "event", e });
+  }, []);
+
+  const handleApprovalDecision = useCallback(
+    async (decision: "once" | "session" | "always" | "deny") => {
+      const pending = approval;
+      setApproval(null);
+      if (!pending || !clientRef.current) return;
+      try {
+        await clientRef.current.approve(pending.callId, decision);
+      } catch (err) {
+        dispatch({
+          type: "event",
+          e: { type: "error", detail: err instanceof Error ? err.message : String(err) },
+        });
+      }
+    },
+    [approval],
+  );
+
+  const handleSend = async () => {
+    const text = draft.trim();
+    if (!text || !clientRef.current || busy) return;
+    setDraft("");
+    dispatch({ type: "push-user", text });
+    setBusy(true);
+    try {
+      await clientRef.current.send(text);
+    } catch (err) {
+      setBusy(false);
+      dispatch({
+        type: "event",
+        e: { type: "error", detail: err instanceof Error ? err.message : String(err) },
+      });
+    }
+  };
+
+  const handleCancel = async () => {
+    try {
+      await clientRef.current?.cancel();
+    } catch (err) {
+      console.warn("[chat] cancel failed", err);
+    }
+  };
+
+  const handleNew = async () => {
+    clientRef.current?.close();
+    clientRef.current = null;
+    clearStoredSession();
+    dispatch({ type: "reset" });
+    setSessionId(null);
+    setBusy(false);
+    try {
+      const sid = await createSession();
+      setSessionId(sid);
+      const client = new ChatClient(sid);
+      clientRef.current = client;
+      client.on(handleEvent);
+      client.connect().catch((e) => setConnError(e instanceof Error ? e.message : String(e)));
+    } catch (err) {
+      setConnError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const sessionLabel = useMemo(
+    () => (sessionId ? sessionId.slice(0, 8) : "—"),
+    [sessionId],
+  );
+
+  return (
+    <div className="flex flex-col h-full min-h-[calc(100vh-9rem)] max-h-[calc(100vh-7rem)]">
+      <div className="flex items-center justify-between gap-2 pb-2 border-b border-border mb-3">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <MessageSquare className="h-4 w-4" />
+          <span>Chat</span>
+          <code className="text-xs bg-muted/50 px-1.5 py-0.5 rounded">{sessionLabel}</code>
+        </div>
+        <Button variant="ghost" size="sm" onClick={handleNew} title="New chat" aria-label="New chat">
+          <Plus className="h-3.5 w-3.5 mr-1.5" />
+          New
+        </Button>
+      </div>
+
+      {connError && (
+        <div className="mb-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          Connection error: {connError}
+        </div>
+      )}
+
+      <div ref={scrollerRef} className="flex-1 overflow-y-auto flex flex-col gap-3 py-2 pr-1">
+        {items.length === 0 ? (
+          <div className="flex-1 flex flex-col items-center justify-center text-muted-foreground gap-2">
+            <MessageSquare className="h-8 w-8 opacity-40" />
+            <span className="text-sm">Send a message to start chatting with Hermes.</span>
+          </div>
+        ) : (
+          items.map((it) => <MessageItem key={it.id} item={it} />)
+        )}
+      </div>
+
+      <div className="pt-3 mt-auto">
+        <ChatComposer
+          value={draft}
+          onChange={setDraft}
+          onSend={handleSend}
+          onCancel={handleCancel}
+          busy={busy}
+          disabled={!sessionId || approval !== null}
+        />
+      </div>
+
+      {approval && (
+        <ApprovalDialog
+          callId={approval.callId}
+          command={approval.command}
+          description={approval.description}
+          allowPermanent={approval.allowPermanent}
+          onDecide={handleApprovalDecision}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -19,6 +19,7 @@ import { ApprovalDialog } from "@/components/chat/ApprovalDialog";
 
 type Action =
   | { type: "push-user"; text: string }
+  | { type: "push-user-slash"; text: string }  // user typed /something; no assistant placeholder
   | { type: "event"; e: ChatEvent }
   | { type: "reset" }
   | { type: "set"; items: ChatItem[] };
@@ -36,6 +37,12 @@ function itemsReducer(items: ChatItem[], action: Action): ChatItem[] {
         ...items,
         { id: id(), kind: "user", text: action.text },
         { id: id(), kind: "assistant", text: "", pending: true },
+      ];
+    case "push-user-slash":
+      // Slash commands don't trigger an agent turn — no assistant placeholder.
+      return [
+        ...items,
+        { id: id(), kind: "user", text: action.text },
       ];
     case "event": {
       const e = action.e;
@@ -103,6 +110,8 @@ function itemsReducer(items: ChatItem[], action: Action): ChatItem[] {
             ),
             { id: id(), kind: "error", detail: e.detail },
           ];
+        case "system-message":
+          return [...items, { id: id(), kind: "system", detail: e.detail }];
         default:
           return items;
       }
@@ -223,13 +232,20 @@ export default function ChatPage() {
   const handleSend = async () => {
     const text = draft.trim();
     if (!text || !clientRef.current || busy) return;
+    const isSlash = text.startsWith("/");
     setDraft("");
-    dispatch({ type: "push-user", text });
-    setBusy(true);
+    if (isSlash) {
+      // Slash commands are handled server-side without an agent turn,
+      // so we don't enter busy mode and we don't push an assistant placeholder.
+      dispatch({ type: "push-user-slash", text });
+    } else {
+      dispatch({ type: "push-user", text });
+      setBusy(true);
+    }
     try {
       await clientRef.current.send(text);
     } catch (err) {
-      setBusy(false);
+      if (!isSlash) setBusy(false);
       dispatch({
         type: "event",
         e: { type: "error", detail: err instanceof Error ? err.message : String(err) },

--- a/web/src/pages/ConfigPage.tsx
+++ b/web/src/pages/ConfigPage.tsx
@@ -33,6 +33,7 @@ import { getNestedValue, setNestedValue } from "@/lib/nested";
 import { useToast } from "@/hooks/useToast";
 import { Toast } from "@/components/Toast";
 import { AutoField } from "@/components/AutoField";
+import { SpeakButton } from "@/components/SpeakButton";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -266,6 +267,21 @@ export default function ConfigPage() {
                 {section.replace(/_/g, " ")}
               </span>
               <div className="flex-1 border-t border-border" />
+              {section === "tts" && (() => {
+                const cfg = config as Record<string, unknown> | null;
+                const tts = (cfg?.tts as Record<string, unknown> | undefined) ?? {};
+                const provider = (tts.provider as string | undefined) ?? undefined;
+                const pCfg = (provider ? (tts[provider] as Record<string, unknown> | undefined) : undefined) ?? {};
+                const voice = (pCfg.voice ?? pCfg.voice_id) as string | undefined;
+                return (
+                  <SpeakButton
+                    text="Hello from Hermes. This is a quick test of your text to speech settings."
+                    provider={provider}
+                    voice={voice}
+                    onError={(msg) => showToast(`TTS error: ${msg}`, "error")}
+                  />
+                );
+              })()}
             </div>
           )}
           <div className="py-1">

--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -20,6 +20,7 @@ import { Markdown } from "@/components/Markdown";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { MicButton } from "@/components/MicButton";
 import { useI18n } from "@/i18n";
 
 const SOURCE_CONFIG: Record<string, { icon: typeof Terminal; color: string }> = {
@@ -388,27 +389,33 @@ export default function SessionsPage() {
             {total}
           </Badge>
         </div>
-        <div className="relative w-full sm:w-64">
-          {searching ? (
-            <div className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 animate-spin rounded-full border-[1.5px] border-primary border-t-transparent" />
-          ) : (
-            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
-          )}
-          <Input
-            placeholder={t.sessions.searchPlaceholder}
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="pl-8 pr-7 h-8 text-xs"
+        <div className="flex items-center gap-1 w-full sm:w-auto">
+          <div className="relative w-full sm:w-64">
+            {searching ? (
+              <div className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 animate-spin rounded-full border-[1.5px] border-primary border-t-transparent" />
+            ) : (
+              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+            )}
+            <Input
+              placeholder={t.sessions.searchPlaceholder}
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="pl-8 pr-7 h-8 text-xs"
+            />
+            {search && (
+              <button
+                type="button"
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground cursor-pointer"
+                onClick={() => setSearch("")}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            )}
+          </div>
+          <MicButton
+            onTranscript={(text) => setSearch(text.trim())}
+            onError={(msg) => console.error("[mic]", msg)}
           />
-          {search && (
-            <button
-              type="button"
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground cursor-pointer"
-              onClick={() => setSearch("")}
-            >
-              <X className="h-3 w-3" />
-            </button>
-          )}
         </div>
       </div>
 

--- a/web/src/themes/presets.ts
+++ b/web/src/themes/presets.ts
@@ -218,6 +218,41 @@ export const roseTheme: DashboardTheme = {
   },
 };
 
+export const paperTheme: DashboardTheme = {
+  name: "paper",
+  label: "Paper",
+  description: "White background, black text — bright and minimal",
+  colors: {
+    background: "#ffffff",
+    foreground: "#000000",
+    card: "#ffffff",
+    "card-foreground": "#000000",
+    primary: "#111111",
+    "primary-foreground": "#ffffff",
+    secondary: "#f4f4f5",
+    "secondary-foreground": "#000000",
+    muted: "#f4f4f5",
+    "muted-foreground": "#52525b",
+    accent: "#e4e4e7",
+    "accent-foreground": "#000000",
+    destructive: "#dc2626",
+    "destructive-foreground": "#ffffff",
+    success: "#16a34a",
+    warning: "#d97706",
+    border: "color-mix(in srgb, #000000 14%, transparent)",
+    input: "color-mix(in srgb, #000000 14%, transparent)",
+    ring: "#000000",
+    popover: "#ffffff",
+    "popover-foreground": "#000000",
+  },
+  overlay: {
+    noiseOpacity: 0.0,
+    noiseBlendMode: "normal",
+    warmGlowOpacity: 0.0,
+    warmGlowColor: "rgba(0,0,0,0)",
+  },
+};
+
 /** All built-in themes, keyed by name. */
 export const BUILTIN_THEMES: Record<string, DashboardTheme> = {
   default: defaultTheme,
@@ -226,4 +261,5 @@ export const BUILTIN_THEMES: Record<string, DashboardTheme> = {
   mono: monoTheme,
   cyberpunk: cyberpunkTheme,
   rose: roseTheme,
+  paper: paperTheme,
 };


### PR DESCRIPTION
## Headline change (this session)

**Make the provider fallback chain actually self-heal from a primary 429.**

`run_agent.py`'s inline `_try_activate_fallback` only read a literal `api_key`
from each fallback entry — it ignored `api_key_env`, even though
`fallback-providers.md` documents it and the refactored runtime helper
(`chat_completion_helpers.try_activate_fallback`) already honors it.

**Symptom:** a free-tier fallback (e.g. Gemini) that referenced its key by
env-var name resolved to *no key* and was silently skipped. A primary 429 could
then walk the chain into dead/unauthenticated links and surface a raw
`API call failed after 3 retries: HTTP 429` instead of failing over.

**Fix:** honor `api_key_env`/`key_env` in the inline path, matching the docs and
the runtime helper.

### Verified live
Forced a 429 from a mock primary; the eager rate-limit fallback switched
`mock-model → gemini-2.5-flash` (key resolved from `GEMINI_API_KEY`) on **attempt
1** and answered correctly in ~1.7s:

```
Error classified: reason=rate_limit status=429 ... fallback=True
Fallback activated: mock-model → gemini-2.5-flash (custom)
API call #1: model=gemini-2.5-flash ... latency=1.7s → PONG
```

Changelog updated; docs already documented the behavior (source had drifted).

---

## ⚠️ Scope note

This PR is the existing `chore/doc-sync-automation` branch, which bundles **15
commits**. Only the top one (`db3a626c`) is the fallback fix above. The rest are
prior in-flight work (doc-sync automation, dashboard chat/voice panel, TTS,
skills, ops scripts). Maintainers may prefer to cherry-pick `db3a626c` alone —
happy to split it into a focused PR on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)