### PR TITLE
fix(gateway): auto-deliver video_generate output without a model-emitted MEDIA tag

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -747,14 +747,23 @@ _AUTO_APPEND_MEDIA_TOOL_NAMES = {
     "text_to_speech",
     "text_to_speech_tool",
     "image_generate",
+    "video_generate",
 }
 
-# Tools in this set return their deliverable artifact as a JSON payload with a
-# local-file path field rather than a literal ``MEDIA:`` tag (e.g. image_generate
-# returns ``{"success": true, "image": "/abs/path.png"}``). The auto-append path
-# extracts the path from these fields so delivery is deterministic and does not
-# depend on the model restating the path in its final reply.
-_JSON_MEDIA_TOOL_PATH_FIELDS = ("host_image", "image", "agent_visible_image")
+# Producer tools that return their deliverable artifact as a JSON payload with a
+# local-file path field rather than a literal ``MEDIA:`` tag. Each tool maps to
+# the result field(s) to probe, in priority order (e.g. image_generate returns
+# ``{"success": true, "image": "/abs/path.png"}``; video_generate returns
+# ``{"success": true, "video": "/abs/path.mp4"}``). The auto-append path reads
+# the path from these fields so delivery is deterministic and does NOT depend on
+# the model restating a correctly-formatted ``MEDIA:`` tag in its final reply.
+# Safety: only the success-gated result of an allowlisted producer tool is read,
+# and remote URLs / non-deliverable extensions are rejected by ``_TOOL_MEDIA_RE``
+# — so an internal/temp file a generic tool happened to write is never delivered.
+_JSON_MEDIA_TOOL_PATH_FIELDS: Dict[str, tuple[str, ...]] = {
+    "image_generate": ("host_image", "image", "agent_visible_image"),
+    "video_generate": ("video",),
+}
 
 
 # Extension-anchored MEDIA: matcher for tool results. Mirrors the dispatch-site
@@ -780,9 +789,12 @@ def _collect_auto_append_media_tags(
     Two layered guards keep stale/example MEDIA: strings out of the reply:
 
     1. Producer-tool allowlist: only tools that intentionally emit deliverable
-       artifacts (TTS) are eligible. Documentation, logs, and search results can
-       contain example strings such as MEDIA:/absolute/path/to/file, which must
-       never be delivered as attachments. (Fixes the original report behind #16721.)
+       artifacts (image_generate, video_generate, TTS) are eligible. Generic
+       file-producing tools (write_file, terminal, ...) are deliberately NOT in
+       the allowlist, so an internal/temp file they write is never auto-delivered.
+       Documentation, logs, and search results can also contain example strings
+       such as MEDIA:/absolute/path/to/file, which must never be delivered as
+       attachments. (Fixes the original report behind #16721.)
     2. Current-turn isolation: only messages produced this turn are scanned, so a
        tool result from an earlier turn (still present in the full message list)
        cannot leak onto a later text-only reply (#34608).
@@ -822,16 +834,19 @@ def _collect_auto_append_media_tags(
             continue
         content = str(msg.get("content") or "")
         tool_name = tool_name_by_call_id.get(call_id)
-        # JSON-payload tools (image_generate) return a local-file path in a
-        # known field rather than a MEDIA: tag. Extract it so delivery is
-        # deterministic even when the model omits the path from its reply.
-        if tool_name == "image_generate" and "MEDIA:" not in content:
+        # Producer tools that return their artifact path in a structured JSON
+        # field (image_generate, video_generate) deliver deterministically: read
+        # the path from the result rather than relying on the model to restate a
+        # correctly-formatted MEDIA: tag in its reply. TTS keeps the MEDIA:-scan
+        # path below, which also carries the [[audio_as_voice]] directive.
+        json_fields = _JSON_MEDIA_TOOL_PATH_FIELDS.get(tool_name)
+        if json_fields and "MEDIA:" not in content:
             try:
                 payload = json.loads(content)
             except Exception:
                 payload = None
             if isinstance(payload, dict) and payload.get("success"):
-                for field in _JSON_MEDIA_TOOL_PATH_FIELDS:
+                for field in json_fields:
                     path = payload.get(field)
                     if (isinstance(path, str)
                             and _TOOL_MEDIA_RE.fullmatch(f"MEDIA:{path}")

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -259,6 +259,112 @@ caption
         )
         assert tags == []
 
+    # --- video_generate: structured (model-agnostic) auto-append ---
+    # video_generate returns {"success": true, "video": "<url-or-abs-path>"} but
+    # was historically absent from the auto-append allowlist + field map, so a
+    # generated video was only delivered if the model restated a MEDIA: tag in
+    # prose. Reading the structured "video" field makes delivery deterministic.
+
+    def test_gateway_auto_append_video_generate_json_path(self):
+        """video_generate returns a local path in JSON (no MEDIA: tag); it is
+        auto-appended so delivery doesn't depend on the model restating it."""
+        from gateway.run import _collect_auto_append_media_tags
+
+        messages = [
+            {"role": "user", "content": "Make me a clip"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "call_vid", "function": {"name": "video_generate"}}
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_vid",
+                "content": '{"success": true, "video": "/tmp/gen/clip.mp4", "modality": "text"}',
+            },
+            {"role": "assistant", "content": "Here's your clip."},
+        ]
+
+        tags, voice = _collect_auto_append_media_tags(messages, history_offset=0)
+        assert tags == ["MEDIA:/tmp/gen/clip.mp4"]
+        assert voice is False
+
+    def test_gateway_auto_append_video_generate_failure_and_url_ignored(self):
+        """Failed generations and remote URLs are not auto-delivered."""
+        from gateway.run import _collect_auto_append_media_tags
+
+        def _vid_msgs(content):
+            return [
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {"id": "c", "function": {"name": "video_generate"}}
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "c", "content": content},
+            ]
+
+        # Failed generation
+        tags, _ = _collect_auto_append_media_tags(
+            _vid_msgs('{"success": false, "video": null, "error": "boom"}'),
+            history_offset=0,
+        )
+        assert tags == []
+
+        # Remote URL is not a local file path (provider returned a URL)
+        tags, _ = _collect_auto_append_media_tags(
+            _vid_msgs('{"success": true, "video": "https://provider/clip.mp4"}'),
+            history_offset=0,
+        )
+        assert tags == []
+
+    def test_gateway_auto_append_video_generate_dedupes_history(self):
+        """A generated video path already in history is not re-sent."""
+        from gateway.run import _collect_auto_append_media_tags
+
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "c", "function": {"name": "video_generate"}}
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "c",
+                "content": '{"success": true, "video": "/tmp/gen/clip.mp4"}',
+            },
+        ]
+
+        tags, _ = _collect_auto_append_media_tags(
+            messages, history_offset=0, history_media_paths={"/tmp/gen/clip.mp4"}
+        )
+        assert tags == []
+
+    def test_gateway_auto_append_video_field_only_read_from_allowlisted_tool(self):
+        """The structured 'video' field is only harvested from an allowlisted
+        producer tool — a non-producer tool returning a look-alike field must
+        not trigger delivery (allowlist is the primary false-positive guard)."""
+        from gateway.run import _collect_auto_append_media_tags
+
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"id": "c", "function": {"name": "execute_code"}}
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "c",
+                "content": '{"success": true, "video": "/tmp/internal/clip.mp4"}',
+            },
+        ]
+
+        tags, _ = _collect_auto_append_media_tags(messages, history_offset=0)
+        assert tags == []
+
     def test_media_tags_not_extracted_from_history(self):
         """MEDIA tags from previous turns should NOT be extracted again."""
         # Simulate conversation history with a TTS call from a previous turn


### PR DESCRIPTION
## What does this PR do?

Makes generated-**video** delivery model-agnostic, and generalizes the existing
deterministic media auto-append so it covers the whole producer-tool family
instead of just `image_generate`.

**The bug.** `video_generate` returns a structured result —
`{"success": true, "video": "<url-or-abs-path>"}` (see
`agent/video_gen_provider.py` `success_response`) — but it was **absent** from
both `_AUTO_APPEND_MEDIA_TOOL_NAMES` and `_JSON_MEDIA_TOOL_PATH_FIELDS` in
`gateway/run.py`. So a generated video is delivered **only if the model restates
a correctly-formatted `MEDIA:` tag in its prose reply**. When the model omits the
tag, or wraps/mis-formats it (e.g. Markdown emphasis), the file is silently never
attached and the user gets nothing. `image_generate` already avoids this by
reading its path from the tool's JSON result; videos had no such path.

**The fix.** Generalize the proven `image_generate` JSON branch into a small
per-tool field map and add `video_generate` to the allowlist:

```python
_JSON_MEDIA_TOOL_PATH_FIELDS = {
    "image_generate": ("host_image", "image", "agent_visible_image"),
    "video_generate": ("video",),
}
```

The path is now read from the tool's **structured result**, so delivery no longer
depends on how (or whether) the model restates it in free text. This is the
model-agnostic counterpart to the prose-parsing path.

## Related Issue

Companion to #45773 (`fix(gateway): deliver MEDIA: tags wrapped in Markdown
emphasis`) — **different layer, disjoint files**. #45773 hardens the *prose-parse*
path (`extract_media` regex in `base.py`) for hand-authored / pre-existing paths;
this PR fixes the *structured-harvest* path (auto-append in `run.py`) for
tool-produced media. They are independent and can land in either order. No
separate issue filed — the gap is fully described above.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` — add `"video_generate"` to `_AUTO_APPEND_MEDIA_TOOL_NAMES`;
  turn `_JSON_MEDIA_TOOL_PATH_FIELDS` into a per-tool field map; generalize the
  `tool_name == "image_generate"` branch to `json_fields = MAP.get(tool_name)`.
  Docstring/comments updated. No interface, schema, or config change.
- `tests/gateway/test_media_extraction.py` — `video_generate` coverage:
  structured path delivered, remote URL ignored, failed generation ignored,
  history dedup, and a guard that the `"video"` field is only harvested from the
  allowlisted producer tool (a `execute_code` look-alike result is **not**
  delivered).

## How to Test

1. Before: a `video_generate` result `{"success": true, "video": "/tmp/clip.mp4"}`
   with a text-only assistant reply → video **not** delivered.
2. After: same input → `_collect_auto_append_media_tags(...)` returns
   `["MEDIA:/tmp/clip.mp4"]` → delivered, independent of the model's prose.
3. `pytest tests/gateway/test_media_extraction.py -q` → all pass (incl. the
   existing `image_generate` / TTS / stale-leak / compression-fallback cases).

## False-positive safety

All four existing guards are reused unchanged:
1. **Producer-tool allowlist** — only `image_generate`, `video_generate`, TTS are
   harvested; generic file producers (`write_file`, `terminal`, …) are excluded,
   so an internal/temp file they write is never auto-delivered.
2. **Success-gate** — `payload.get("success")` must be truthy.
3. **`_TOOL_MEDIA_RE`** — requires a deliverable extension + a real local-path
   anchor, so remote URLs (a provider may return a URL in `video`) and
   non-media artifacts are rejected (delivery then falls back to the gateway's
   existing URL-download path — unchanged, out of scope here).
4. **Current-turn isolation + history dedup** — unchanged.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit messages follow Conventional Commits (`fix(gateway):`)
- [x] I searched for existing PRs (this complements #45773; not a duplicate)
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` — ran the media zone: `tests/gateway/test_media_extraction.py`, `test_platform_base.py`, `test_run_tool_media_re.py` (196 passed, 2 skipped); change is localized to the auto-append path
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian 13

### Documentation & Housekeeping

- [x] Updated docstring/comments in `gateway/run.py`
- [x] N/A — no config keys changed
- [x] N/A — no architecture/workflow change
- [x] Cross-platform: path anchor + extension guard unchanged; no platform-specific assumptions
- [x] N/A — no tool behavior/schema change
