### PR TITLE
fix: read fallback_providers/fallback_model from under model: key

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4253,6 +4253,22 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
             "Move fallback_model to the top level of config.yaml (no indentation)",
         ))
 
+    # ── Check for fallback keys mistakenly nested under model: ──────────
+    model_cfg = config.get("model")
+    if isinstance(model_cfg, dict):
+        for nested_key in ("fallback_providers", "fallback_model"):
+            if nested_key in model_cfg:
+                issues.append(ConfigIssue(
+                    "warning",
+                    f"'{nested_key}' is nested under 'model:' — "
+                    "it should be a top-level key",
+                    f"Move '{nested_key}' to the top level of config.yaml:\n"
+                    f"  {nested_key}:\n"
+                    f"    - provider: ...\n"
+                    f"      model: ...\n"
+                    f"(not indented under 'model:')",
+                ))
+
     # ── model section: should exist when custom_providers is configured ──
     model_cfg = config.get("model")
     if cp and not model_cfg:

--- a/hermes_cli/fallback_config.py
+++ b/hermes_cli/fallback_config.py
@@ -61,8 +61,18 @@ def get_fallback_chain(config: dict[str, Any] | None) -> list[dict[str, Any]]:
     chain: list[dict[str, Any]] = []
     seen: set[tuple[str, str, str]] = set()
 
+    model_cfg = config.get("model")
+    if not isinstance(model_cfg, dict):
+        model_cfg = {}
+
     for key in ("fallback_providers", "fallback_model"):
-        for entry in _iter_fallback_entries(config.get(key)):
+        # Top-level key takes priority (documented location).
+        entries = config.get(key)
+        # Also check under model: — a natural but unsupported placement
+        # that users sometimes choose, mirroring default/provider.
+        if entries is None:
+            entries = model_cfg.get(key)
+        for entry in _iter_fallback_entries(entries):
             identity = _entry_identity(entry)
             if identity in seen:
                 continue


### PR DESCRIPTION
## Problem

When users nest `fallback_providers` or `fallback_model` under the `model:` section — a natural placement mirroring `default`/`provider` — the keys are **silently ignored**. `get_fallback_chain()` only reads them from config top-level, so the fallback chain comes back empty and failover never engages, with no warning.

Reported in #45309.

```yaml
# ❌ SILENTLY IGNORED (nested under model:)
model:
  default: gpt-5.5
  provider: openai-codex
  fallback_providers:        # ← never read
    - provider: openrouter
      model: some-model

# ✅ WORKS (top-level)
fallback_providers:           # ← honored
  - provider: openrouter
    model: some-model
```

## Fix

### 1. `hermes_cli/fallback_config.py` — `get_fallback_chain()`

Also check `config.model.*` when the top-level key is absent. Top-level still takes priority.

```python
model_cfg = config.get("model")
...
entries = config.get(key)
if entries is None:
    entries = model_cfg.get(key)  # ← fallback read
```

### 2. `hermes_cli/config.py` — `validate_config_structure()`

New check that warns when `fallback_providers` or `fallback_model` are found nested under `model:`, with migration hint pointing to the correct top-level placement.

## Files changed
- `hermes_cli/fallback_config.py` — +11/-1
- `hermes_cli/config.py` — +16