### PR TITLE
fix: preserve gateway env and custom provider aliases

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2407,6 +2407,7 @@ StartLimitIntervalSec=0
 
 [Service]
 Type=simple
+EnvironmentFile=-{hermes_home}/gateway.env
 User={username}
 Group={group_name}
 ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run
@@ -2445,6 +2446,7 @@ StartLimitIntervalSec=0
 
 [Service]
 Type=simple
+EnvironmentFile=-{hermes_home}/gateway.env
 ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run
 WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -538,8 +538,10 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                 continue
             # Match exact name or normalized name
             name_norm = _normalize_custom_provider_name(ep_name)
-            # Resolve the API key from the env var name stored in key_env
-            key_env = str(entry.get("key_env", "") or "").strip()
+            # Resolve the API key from the env var name stored in key_env.
+            # Accept api_key_env too: setup/import flows and docs have used
+            # both spellings for providers: dict entries.
+            key_env = str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
             resolved_api_key = os.getenv(key_env, "").strip() if key_env else ""
             # Fall back to inline api_key when key_env is absent or unresolvable
             if not resolved_api_key:
@@ -553,8 +555,10 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                         "name": entry.get("name", ep_name),
                         "base_url": base_url.strip(),
                         "api_key": resolved_api_key,
-                        "model": entry.get("default_model", ""),
+                        "model": entry.get("default_model") or entry.get("model", ""),
                     }
+                    if key_env:
+                        result["key_env"] = key_env
                     extra_body = entry.get("extra_body")
                     if isinstance(extra_body, dict):
                         result["extra_body"] = dict(extra_body)
@@ -582,8 +586,10 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                             "name": display_name,
                             "base_url": base_url.strip(),
                             "api_key": resolved_api_key,
-                            "model": entry.get("default_model", ""),
+                            "model": entry.get("default_model") or entry.get("model", ""),
                         }
+                        if key_env:
+                            result["key_env"] = key_env
                         extra_body = entry.get("extra_body")
                         if isinstance(extra_body, dict):
                             result["extra_body"] = dict(extra_body)

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -415,6 +415,28 @@ class TestGeneratedSystemdUnits:
         timeout = int(max(60, DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT) + 30)
         return f"TimeoutStopSec={timeout}"
 
+    def test_user_unit_loads_gateway_env_file(self):
+        unit = gateway_cli.generate_systemd_unit(system=False)
+
+        assert "EnvironmentFile=-" in unit
+        assert "/gateway.env" in unit
+
+    def test_system_unit_loads_target_users_gateway_env_file(self, monkeypatch):
+        monkeypatch.setattr(
+            gateway_cli,
+            "_system_service_identity",
+            lambda run_as_user=None: ("alice", "alice", "/home/alice"),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_hermes_home_for_target_user",
+            lambda home: "/home/alice/.hermes",
+        )
+
+        unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
+
+        assert "EnvironmentFile=-/home/alice/.hermes/gateway.env" in unit
+
     def test_user_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self, monkeypatch):
         monkeypatch.setattr(
             gateway_cli,

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -863,6 +863,52 @@ def test_named_custom_provider_uses_key_env_from_providers_dict(monkeypatch):
     assert resolved["model"] == "acme-large"
 
 
+def test_named_custom_provider_accepts_api_key_env_and_model_fields(monkeypatch):
+    """providers dict accepts documented api_key_env/model aliases.
+
+    Some importers and examples write ``api_key_env`` + ``model`` instead of
+    the older ``key_env`` + ``default_model`` spelling. Runtime resolution
+    must accept both forms so gateway services can load credentials from their
+    generated environment file without duplicating config fields.
+    """
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("MYCORP_API_KEY", "env-secret")
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "mycorp-proxy": {
+                    "base_url": "https://proxy.example.com/v1",
+                    "model": "acme-large",
+                    "api_key_env": "MYCORP_API_KEY",
+                    "name": "MyCorp Proxy",
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="mycorp-proxy")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "https://proxy.example.com/v1"
+    assert resolved["api_key"] == "env-secret"
+    assert resolved["requested_provider"] == "mycorp-proxy"
+    assert resolved["source"] == "custom_provider:MyCorp Proxy"
+    assert resolved["model"] == "acme-large"
+
+
 def test_named_custom_provider_same_url_uses_matching_key_env_and_api_mode(monkeypatch):
     """Named custom providers on one gateway must keep their own credentials and protocol."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)


### PR DESCRIPTION
# fix: preserve gateway env and custom provider aliases

## Summary
- Load `$HERMES_HOME/gateway.env` from generated Linux systemd gateway units so gateway-only credentials and routing env vars survive service restarts.
- Accept `api_key_env` as an alias for `key_env` in `providers:` custom provider entries.
- Accept `model` as an alias for `default_model` in `providers:` custom provider entries.
- Add regression tests for generated unit env-file loading and provider alias resolution.

## Why
Some setups keep gateway runtime secrets/policy in `gateway.env` and define custom providers with the documented/imported `api_key_env` + `model` spelling. Without these compatibility paths, a service reinstall/restart can drop gateway env vars, and custom provider resolution may silently fall back to `no-key-required` or lose the intended model name.

## Test Plan
- [x] `uv run --extra dev python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py::test_named_custom_provider_accepts_api_key_env_and_model_fields -v --tb=short -o addopts=''`
- [x] `uv run --extra dev python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py::test_named_custom_provider_uses_providers_dict_when_list_missing tests/hermes_cli/test_runtime_provider_resolution.py::test_named_custom_provider_uses_key_env_from_providers_dict tests/hermes_cli/test_runtime_provider_resolution.py::test_named_custom_provider_accepts_api_key_env_and_model_fields tests/hermes_cli/test_runtime_provider_resolution.py::test_bare_custom_resolves_providers_dict_entry_named_custom -v --tb=short -o addopts=''`
- [x] `uv run --extra dev python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -q --tb=short -o addopts=''` — 130 passed
- [x] `uv run --extra dev ruff check hermes_cli/gateway.py hermes_cli/runtime_provider.py tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_runtime_provider_resolution.py`
- [x] `uv run --extra dev python -m py_compile hermes_cli/gateway.py hermes_cli/runtime_provider.py`
- [x] `uv run --extra dev python - <<'PY' ... generate_systemd_unit(system=False) assertion ... PY`

## Notes
- On Windows, `tests/hermes_cli/test_gateway_service.py` is skipped at module import because it requires POSIX `pwd`/`grp`. The generated-unit assertion was still exercised directly via `hermes_cli.gateway.generate_systemd_unit(system=False)`.
- Independent delegate review could not run in this local session because delegation provider resolution failed (`Unknown provider 'openai codex'`). Static scan found only documented env-key/test fixture strings and no shell/eval/pickle hits.
