### PR TITLE
feat: add local muncho runtime hooks

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -34,6 +34,7 @@ from typing import Any, Dict, List, Optional
 from hermes_cli.timeouts import get_provider_request_timeout
 from agent.prompt_builder import format_steer_marker
 from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
+from agent.local_muncho_fallback import local_muncho_tool_block_for_agent_guard_error
 from agent.trajectory import convert_scratchpad_to_think
 from agent.credential_pool import STATUS_EXHAUSTED
 from agent.error_classifier import FailoverReason
@@ -1757,6 +1758,77 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 status="blocked",
                 error_type="plugin_block",
                 error_message=block_message,
+                middleware_trace=list(_tool_middleware_trace),
+            )
+        except Exception:
+            pass
+        return result
+
+    try:
+        from agent.local_muncho.runtime import (
+            guard_internal_error_decision_for_agent,
+            guard_tool_action_for_agent,
+            tool_block_result,
+        )
+
+        _muncho_decision = guard_tool_action_for_agent(
+            agent,
+            function_name,
+            function_args,
+        )
+    except Exception as _muncho_guard_err:
+        logger.debug("local muncho tool guard error: %s", _muncho_guard_err)
+        try:
+            _muncho_decision = guard_internal_error_decision_for_agent(
+                agent,
+                _muncho_guard_err,
+                guard_name="tool_action",
+            )
+        except Exception:
+            _muncho_decision = None
+            _muncho_fallback_result, _muncho_fallback_reason = (
+                local_muncho_tool_block_for_agent_guard_error(
+                    agent,
+                    _muncho_guard_err,
+                    guard_name="tool_action",
+                )
+            )
+            if _muncho_fallback_result is not None:
+                try:
+                    from model_tools import _emit_post_tool_call_hook
+                    _emit_post_tool_call_hook(
+                        function_name=function_name,
+                        function_args=function_args,
+                        result=_muncho_fallback_result,
+                        task_id=effective_task_id or "",
+                        session_id=getattr(agent, "session_id", "") or "",
+                        tool_call_id=tool_call_id or "",
+                        turn_id=getattr(agent, "_current_turn_id", "") or "",
+                        api_request_id=getattr(agent, "_current_api_request_id", "") or "",
+                        status="blocked",
+                        error_type="local_muncho_runtime",
+                        error_message=_muncho_fallback_reason,
+                        middleware_trace=list(_tool_middleware_trace),
+                    )
+                except Exception:
+                    pass
+                return _muncho_fallback_result
+    if _muncho_decision is not None and not _muncho_decision.allowed:
+        result = tool_block_result(_muncho_decision)
+        try:
+            from model_tools import _emit_post_tool_call_hook
+            _emit_post_tool_call_hook(
+                function_name=function_name,
+                function_args=function_args,
+                result=result,
+                task_id=effective_task_id or "",
+                session_id=getattr(agent, "session_id", "") or "",
+                tool_call_id=tool_call_id or "",
+                turn_id=getattr(agent, "_current_turn_id", "") or "",
+                api_request_id=getattr(agent, "_current_api_request_id", "") or "",
+                status="blocked",
+                error_type="local_muncho_runtime",
+                error_message=_muncho_decision.message or _muncho_decision.reason,
                 middleware_trace=list(_tool_middleware_trace),
             )
         except Exception:

--- a/agent/local_muncho/__init__.py
+++ b/agent/local_muncho/__init__.py
@@ -1,0 +1,37 @@
+"""Local Muncho primary runtime guard package."""
+
+from agent.local_muncho.runtime import (
+    LocalMunchoRuntime,
+    get_current_runtime,
+    get_runtime_for_agent,
+    guard_internal_error_decision_for_agent,
+    guard_internal_error_decision_for_current_context,
+    guard_approval_mutation_for_current_context,
+    guard_tool_action_for_agent,
+    guard_tool_action_for_current_context,
+    guard_worker_spawn_for_agent,
+    reset_current_canonical_brain,
+    reset_current_runtime_context,
+    set_current_canonical_brain,
+    set_current_runtime_context,
+    validate_final_response_for_agent,
+)
+from agent.local_muncho.types import RuntimeContext
+
+__all__ = [
+    "LocalMunchoRuntime",
+    "RuntimeContext",
+    "get_current_runtime",
+    "get_runtime_for_agent",
+    "guard_internal_error_decision_for_agent",
+    "guard_internal_error_decision_for_current_context",
+    "guard_approval_mutation_for_current_context",
+    "guard_tool_action_for_agent",
+    "guard_tool_action_for_current_context",
+    "guard_worker_spawn_for_agent",
+    "reset_current_canonical_brain",
+    "reset_current_runtime_context",
+    "set_current_canonical_brain",
+    "set_current_runtime_context",
+    "validate_final_response_for_agent",
+]

--- a/agent/local_muncho/backends.py
+++ b/agent/local_muncho/backends.py
@@ -1,0 +1,177 @@
+"""No-network backend boundary for the Local Muncho runtime.
+
+Phase 2 intentionally stops at the adapter contract.  This module names the
+Redis/Postgres boundary without importing client libraries or opening sockets.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from agent.local_muncho.brain import CanonicalBrainUnavailable
+from agent.local_muncho.types import (
+    ApprovalRecord,
+    AuditEvent,
+    CodexTaskCreate,
+    CodexTaskPatch,
+    HeartbeatPayload,
+    KnowledgeContext,
+    LeaseState,
+    LockHandle,
+    RuntimeEvent,
+    SupportCasePatch,
+)
+
+
+@dataclass(frozen=True)
+class BackendDescriptor:
+    """Configuration-only description of a future Canonical Brain backend."""
+
+    kind: str
+    configured: bool
+    reason: str
+    env_var: str = ""
+    schema: str = ""
+
+
+class UnavailableCanonicalBrain:
+    """CanonicalBrain-shaped placeholder that never performs I/O."""
+
+    def __init__(
+        self,
+        reason: str = "Local Muncho backend is not implemented",
+    ) -> None:
+        self.reason = reason
+
+    def _unavailable(self) -> None:
+        raise CanonicalBrainUnavailable(self.reason)
+
+    def load_knowledge_context(self, scope: str, *, max_chars: int) -> KnowledgeContext:
+        self._unavailable()
+
+    def read_active_lease(self) -> LeaseState | None:
+        self._unavailable()
+
+    def refresh_active_lease(
+        self,
+        payload: HeartbeatPayload,
+        ttl_seconds: int,
+    ) -> LeaseState:
+        self._unavailable()
+
+    def acquire_lock(
+        self,
+        key: str,
+        value: Mapping[str, Any],
+        ttl_seconds: int,
+    ) -> LockHandle:
+        self._unavailable()
+
+    def release_lock(self, handle: LockHandle) -> None:
+        self._unavailable()
+
+    def write_runtime_event(self, event: RuntimeEvent) -> None:
+        self._unavailable()
+
+    def write_audit_log(self, event: AuditEvent) -> None:
+        self._unavailable()
+
+    def write_discord_event(self, event: Mapping[str, Any]) -> None:
+        self._unavailable()
+
+    def upsert_support_case(self, case: SupportCasePatch) -> None:
+        self._unavailable()
+
+    def record_approval(self, approval: ApprovalRecord) -> None:
+        self._unavailable()
+
+    def create_codex_task(self, task: CodexTaskCreate) -> str:
+        self._unavailable()
+
+    def update_codex_task(self, task_id: str, patch: CodexTaskPatch) -> None:
+        self._unavailable()
+
+
+def _brain_config(config: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    if not isinstance(config, Mapping):
+        return {}
+    runtime_cfg = config.get("muncho_runtime")
+    if isinstance(runtime_cfg, Mapping):
+        config = runtime_cfg
+    brain_cfg = config.get("brain")
+    return brain_cfg if isinstance(brain_cfg, Mapping) else {}
+
+
+def describe_configured_backends(
+    config: Mapping[str, Any] | None = None,
+) -> tuple[BackendDescriptor, ...]:
+    """Return backend readiness from config/env presence without connecting."""
+
+    brain_cfg = _brain_config(config)
+    schema = str(brain_cfg.get("schema") or "muncho_internal_support")
+    postgres_env = str(brain_cfg.get("postgres_dsn_env") or "MUNCHO_POSTGRES_DSN")
+    redis_env = str(brain_cfg.get("redis_url_env") or "MUNCHO_REDIS_URL")
+
+    postgres_present = bool(os.getenv(postgres_env, "").strip())
+    redis_present = bool(os.getenv(redis_env, "").strip())
+    return (
+        BackendDescriptor(
+            kind="postgres",
+            configured=postgres_present,
+            reason=(
+                "dsn env var is present; adapter intentionally not connected in phase 2"
+                if postgres_present
+                else "dsn env var is not set"
+            ),
+            env_var=postgres_env,
+            schema=schema,
+        ),
+        BackendDescriptor(
+            kind="redis",
+            configured=redis_present,
+            reason=(
+                "url env var is present; adapter intentionally not connected in phase 2"
+                if redis_present
+                else "url env var is not set"
+            ),
+            env_var=redis_env,
+            schema=schema,
+        ),
+    )
+
+
+def build_canonical_brain_backend(
+    config: Mapping[str, Any] | None = None,
+) -> UnavailableCanonicalBrain | None:
+    """Return the no-network placeholder when backend config is present.
+
+    The real Redis lease / Postgres audit and knowledge adapters belong here in
+    a later phase.  Returning ``None`` for an unconfigured backend preserves the
+    runtime's existing fail-closed "canonical brain unavailable" behavior.
+    """
+
+    descriptors = describe_configured_backends(config)
+    configured = [item.kind for item in descriptors if item.configured]
+    if not configured:
+        return None
+    return UnavailableCanonicalBrain(
+        "Local Muncho backend adapter is configured but not implemented "
+        f"in this phase: {', '.join(configured)}"
+    )
+
+
+# TODO(local-muncho): Implement Redis lease and Postgres audit/knowledge
+# adapters here once live backend work is in scope.
+# TODO(local-muncho): Route-back, approval mutation, kanban dashboard writes,
+# and Codex task persistence should be wired through this boundary once their
+# stable write seams are isolated.
+
+
+__all__ = [
+    "BackendDescriptor",
+    "UnavailableCanonicalBrain",
+    "build_canonical_brain_backend",
+    "describe_configured_backends",
+]

--- a/agent/local_muncho/brain.py
+++ b/agent/local_muncho/brain.py
@@ -1,0 +1,69 @@
+"""Canonical Brain protocol boundary for Local Muncho runtime hooks."""
+
+from __future__ import annotations
+
+from typing import Protocol, Mapping, Any
+
+from agent.local_muncho.types import (
+    ApprovalRecord,
+    AuditEvent,
+    CodexTaskCreate,
+    CodexTaskPatch,
+    HeartbeatPayload,
+    KnowledgeContext,
+    LeaseState,
+    LockHandle,
+    RuntimeEvent,
+    SupportCasePatch,
+)
+
+
+class CanonicalBrainUnavailable(RuntimeError):
+    """Raised when an enabled runtime has no Canonical Brain backend."""
+
+
+class CanonicalBrain(Protocol):
+    def load_knowledge_context(self, scope: str, *, max_chars: int) -> KnowledgeContext:
+        ...
+
+    def read_active_lease(self) -> LeaseState | None:
+        ...
+
+    def refresh_active_lease(
+        self,
+        payload: HeartbeatPayload,
+        ttl_seconds: int,
+    ) -> LeaseState:
+        ...
+
+    def acquire_lock(
+        self,
+        key: str,
+        value: Mapping[str, Any],
+        ttl_seconds: int,
+    ) -> LockHandle:
+        ...
+
+    def release_lock(self, handle: LockHandle) -> None:
+        ...
+
+    def write_runtime_event(self, event: RuntimeEvent) -> None:
+        ...
+
+    def write_audit_log(self, event: AuditEvent) -> None:
+        ...
+
+    def write_discord_event(self, event: Mapping[str, Any]) -> None:
+        ...
+
+    def upsert_support_case(self, case: SupportCasePatch) -> None:
+        ...
+
+    def record_approval(self, approval: ApprovalRecord) -> None:
+        ...
+
+    def create_codex_task(self, task: CodexTaskCreate) -> str:
+        ...
+
+    def update_codex_task(self, task_id: str, patch: CodexTaskPatch) -> None:
+        ...

--- a/agent/local_muncho/evidence.py
+++ b/agent/local_muncho/evidence.py
@@ -1,0 +1,103 @@
+"""Deterministic evidence-first validation for Local Muncho responses."""
+
+from __future__ import annotations
+
+import re
+from typing import Sequence
+
+from agent.local_muncho.types import (
+    EvidenceValidationResult,
+    RuntimeContext,
+    ToolEvidence,
+)
+
+
+REQUIRED_FRAME_FIELDS = (
+    "VERDICT",
+    "TL;DR",
+    "CATEGORY",
+    "EVIDENCE_CHECKED",
+    "EVIDENCE_GAP",
+    "STATUS",
+    "NEXT_ACTION",
+    "APPROVAL_NEEDED",
+    "RISK",
+)
+
+_CLAIM_RE = re.compile(
+    r"\b(sent|routed|tracked|fixed|approved|completed)\b",
+    re.IGNORECASE,
+)
+_SECRET_RE = re.compile(
+    r"("
+    r"\b(?:access[_-]?token|auth[_-]?token|api[_-]?key|secret|password)\s*[:=]\s*['\"]?[^'\"\s]{8,}"
+    r"|\bBearer\s+[A-Za-z0-9._~+/=-]{12,}"
+    r"|\bsk-[A-Za-z0-9]{16,}"
+    r")",
+    re.IGNORECASE,
+)
+_CARDISH_RE = re.compile(r"\b(?:\d[ -]*?){13,19}\b")
+
+
+def _has_required_field(text: str, field: str) -> bool:
+    return bool(re.search(rf"(?m)^\s*{re.escape(field)}\s*:", text))
+
+
+def _blocked_frame(reason: str, gaps: Sequence[str]) -> str:
+    gap_text = "; ".join(gaps) if gaps else reason
+    return "\n".join(
+        [
+            "VERDICT: BLOCKED",
+            "TL;DR: Local Muncho runtime blocked the model text before delivery.",
+            "CATEGORY: runtime_guard",
+            "EVIDENCE_CHECKED: deterministic-validator",
+            f"EVIDENCE_GAP: {gap_text}",
+            "STATUS: blocked",
+            "NEXT_ACTION: collect durable evidence or request operator approval",
+            "APPROVAL_NEEDED: yes",
+            "RISK: unverified-visible-claim",
+        ]
+    )
+
+
+def validate_final_output(
+    text: str,
+    *,
+    context: RuntimeContext,
+    evidence: Sequence[ToolEvidence],
+    required_frame: bool = True,
+) -> EvidenceValidationResult:
+    text = text or ""
+    gaps: list[str] = []
+    missing: list[str] = []
+
+    if required_frame:
+        missing = [field for field in REQUIRED_FRAME_FIELDS if not _has_required_field(text, field)]
+        if missing:
+            gaps.append("missing required frame fields: " + ", ".join(missing))
+
+    if _SECRET_RE.search(text) or _CARDISH_RE.search(text):
+        gaps.append("protected data pattern present in visible text")
+
+    if context.lane == "internal-support":
+        lowered = text.lower()
+        if "customer hermes" in lowered and "internal support" in lowered:
+            gaps.append("Customer Hermes and internal-support lanes are conflated")
+
+    if _CLAIM_RE.search(text):
+        durable_evidence = [
+            item for item in evidence
+            if item.success or item.durable_ref or item.tool_name in {"send_message", "approval"}
+        ]
+        if not durable_evidence:
+            gaps.append("visible completion/send/fix claim has no durable evidence")
+
+    if gaps:
+        return EvidenceValidationResult(
+            allowed=False,
+            reason="; ".join(gaps),
+            missing_fields=tuple(missing),
+            evidence_gaps=tuple(gaps),
+            replacement_text=_blocked_frame("validation failed", gaps),
+        )
+    return EvidenceValidationResult(allowed=True, reason="validated")

--- a/agent/local_muncho/policy.py
+++ b/agent/local_muncho/policy.py
@@ -1,0 +1,52 @@
+"""Policy classification for Local Muncho guard hooks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+READ_ONLY_TOOLS = frozenset(
+    {
+        "browser_snapshot",
+        "read_file",
+        "read_terminal",
+        "session_search",
+        "tool_describe",
+        "tool_search",
+        "web_search",
+    }
+)
+
+
+@dataclass(frozen=True)
+class ToolPolicy:
+    action: str
+    requires_lease: bool
+    approval_class: str | None = None
+
+
+def classify_tool_action(tool_name: str, args: Mapping[str, Any] | None) -> ToolPolicy:
+    args = args or {}
+    if tool_name == "send_message":
+        action = str(args.get("action") or "send").lower().strip()
+        if action == "list":
+            return ToolPolicy("tool:send_message:list", requires_lease=False)
+        return ToolPolicy(
+            f"tool:send_message:{action}",
+            requires_lease=True,
+            approval_class="visible_send",
+        )
+    if tool_name == "delegate_task":
+        return ToolPolicy("tool:delegate_task", requires_lease=True, approval_class="worker_spawn")
+    if tool_name.startswith("kanban_"):
+        return ToolPolicy(f"tool:{tool_name}", requires_lease=True, approval_class="kanban")
+    if tool_name in {"approval", "slash_confirm"}:
+        return ToolPolicy(f"tool:{tool_name}", requires_lease=True, approval_class="approval")
+    if tool_name in READ_ONLY_TOOLS:
+        return ToolPolicy(f"tool:{tool_name}", requires_lease=False)
+    return ToolPolicy(f"tool:{tool_name}", requires_lease=True)
+
+
+def visible_send_action(kind: str) -> str:
+    return f"visible_send:{str(kind or 'final').lower()}"

--- a/agent/local_muncho/runtime.py
+++ b/agent/local_muncho/runtime.py
@@ -1,0 +1,610 @@
+"""Local Muncho runtime coordinator and hook helpers."""
+
+from __future__ import annotations
+
+import contextvars
+import json
+import os
+import re
+import uuid
+from typing import Any, Mapping, Sequence
+
+from agent.local_muncho.brain import CanonicalBrain
+from agent.local_muncho.evidence import validate_final_output as _validate_final_output
+from agent.local_muncho.policy import classify_tool_action
+from agent.local_muncho.types import (
+    ApprovalRecord,
+    AuditEvent,
+    CodexTaskCreate,
+    CodexTaskPatch,
+    EvidenceValidationResult,
+    GuardDecision,
+    HeartbeatPayload,
+    HeartbeatResult,
+    KnowledgeContext,
+    LeaseAssertion,
+    LockRequest,
+    RuntimeContext,
+    RuntimeEvent,
+    ToolEvidence,
+    WorkerContract,
+    utc_ts,
+)
+
+
+_current_context: contextvars.ContextVar[RuntimeContext | None] = contextvars.ContextVar(
+    "local_muncho_runtime_context",
+    default=None,
+)
+_current_brain: contextvars.ContextVar[CanonicalBrain | None] = contextvars.ContextVar(
+    "local_muncho_canonical_brain",
+    default=None,
+)
+
+_SENSITIVE_KEY_RE = re.compile(r"(token|secret|password|api[_-]?key|dsn|credential)", re.IGNORECASE)
+_SENSITIVE_VALUE_RE = re.compile(
+    r"(\bBearer\s+[A-Za-z0-9._~+/=-]{12,}|\bsk-[A-Za-z0-9]{16,})",
+    re.IGNORECASE,
+)
+
+
+def set_current_runtime_context(context: RuntimeContext | None):
+    return _current_context.set(context)
+
+
+def reset_current_runtime_context(token) -> None:
+    _current_context.reset(token)
+
+
+def set_current_canonical_brain(brain: CanonicalBrain | None):
+    return _current_brain.set(brain)
+
+
+def reset_current_canonical_brain(token) -> None:
+    _current_brain.reset(token)
+
+
+def _runtime_cfg(config: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    if not isinstance(config, Mapping):
+        return {}
+    block = config.get("muncho_runtime")
+    return block if isinstance(block, Mapping) else config
+
+
+def _load_runtime_config() -> Mapping[str, Any]:
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        return load_config_readonly().get("muncho_runtime", {}) or {}
+    except Exception:
+        return {}
+
+
+def _redact_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return _SENSITIVE_VALUE_RE.sub("***", value)
+    if isinstance(value, Mapping):
+        return redact_mapping(value)
+    if isinstance(value, list):
+        return [_redact_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_redact_value(item) for item in value)
+    return value
+
+
+def redact_mapping(metadata: Mapping[str, Any] | None) -> dict[str, Any]:
+    redacted: dict[str, Any] = {}
+    for key, value in (metadata or {}).items():
+        if _SENSITIVE_KEY_RE.search(str(key)):
+            redacted[str(key)] = "***"
+        else:
+            redacted[str(key)] = _redact_value(value)
+    return redacted
+
+
+def context_from_env() -> RuntimeContext:
+    return RuntimeContext(
+        lane=os.getenv("HERMES_MUNCHO_RUNTIME_LANE") or None,
+        session_id=os.getenv("HERMES_SESSION_ID", ""),
+        platform=os.getenv("HERMES_SESSION_PLATFORM", ""),
+        user_id=os.getenv("HERMES_SESSION_USER_ID", ""),
+        chat_id=os.getenv("HERMES_SESSION_CHAT_ID", ""),
+        thread_id=os.getenv("HERMES_SESSION_THREAD_ID", ""),
+        message_id=os.getenv("HERMES_SESSION_MESSAGE_ID", ""),
+        profile=os.getenv("HERMES_PROFILE", ""),
+    )
+
+
+def context_from_agent(agent: Any) -> RuntimeContext:
+    explicit = getattr(agent, "_local_muncho_context", None)
+    if isinstance(explicit, RuntimeContext):
+        return explicit
+    env_context = context_from_env()
+    return RuntimeContext(
+        lane=getattr(agent, "local_muncho_lane", None) or env_context.lane,
+        session_id=getattr(agent, "session_id", "") or env_context.session_id,
+        platform=getattr(agent, "platform", "") or env_context.platform,
+        user_id=getattr(agent, "user_id", "") or env_context.user_id,
+        chat_id=getattr(agent, "chat_id", "") or env_context.chat_id,
+        thread_id=str(getattr(agent, "thread_id", "") or env_context.thread_id),
+        message_id=env_context.message_id,
+        profile=env_context.profile,
+    )
+
+
+def evidence_from_messages(messages: Sequence[Mapping[str, Any]] | None) -> list[ToolEvidence]:
+    call_names: dict[str, str] = {}
+    evidence: list[ToolEvidence] = []
+    for message in messages or []:
+        if message.get("role") == "assistant":
+            for tool_call in message.get("tool_calls") or []:
+                if not isinstance(tool_call, Mapping):
+                    continue
+                call_id = str(tool_call.get("id") or "")
+                function = tool_call.get("function") or {}
+                name = function.get("name") if isinstance(function, Mapping) else None
+                if call_id and name:
+                    call_names[call_id] = str(name)
+        if message.get("role") != "tool":
+            continue
+        content = message.get("content")
+        parsed: Any = content
+        success = False
+        if isinstance(content, str):
+            try:
+                parsed = json.loads(content)
+            except Exception:
+                parsed = content
+        if isinstance(parsed, Mapping):
+            success = bool(parsed.get("success") or parsed.get("ok") or parsed.get("approved"))
+            if "error" in parsed:
+                success = False
+        call_id = str(message.get("tool_call_id") or "")
+        evidence.append(
+            ToolEvidence(
+                tool_name=str(message.get("name") or call_names.get(call_id) or "tool"),
+                tool_call_id=call_id,
+                result=parsed,
+                success=success,
+                durable_ref=str(parsed.get("id") or parsed.get("message_id") or "")
+                if isinstance(parsed, Mapping)
+                else "",
+            )
+        )
+    return evidence
+
+
+class LocalMunchoRuntime:
+    def __init__(
+        self,
+        config: Mapping[str, Any] | None,
+        context: RuntimeContext,
+        brain: CanonicalBrain | None = None,
+    ) -> None:
+        self.config = dict(_runtime_cfg(config))
+        self.context = context
+        self.brain = brain
+
+    @classmethod
+    def from_config(
+        cls,
+        config: Mapping[str, Any],
+        context: RuntimeContext,
+        brain: CanonicalBrain | None = None,
+    ) -> "LocalMunchoRuntime":
+        cfg = _runtime_cfg(config)
+        if brain is None:
+            brain_cfg = cfg.get("brain", {}) if isinstance(cfg.get("brain"), Mapping) else {}
+            if cfg.get("allow_stub") and brain_cfg.get("mode") == "stub":
+                from agent.local_muncho.testing import InMemoryCanonicalBrain
+
+                brain = InMemoryCanonicalBrain()
+        return cls(cfg, context, brain)
+
+    def enabled(self) -> bool:
+        if not bool(self.config.get("enabled", False)):
+            return False
+        lane = str(self.config.get("lane") or "internal-support")
+        return self.context.lane == lane
+
+    def _allow_or_fail_open(self, reason: str) -> GuardDecision:
+        if bool(self.config.get("fail_open", False)):
+            return GuardDecision.allow(f"fail_open:{reason}")
+        return GuardDecision.block(reason, code="local_muncho_block")
+
+    def _lease_failure(self, reason: str) -> LeaseAssertion:
+        return LeaseAssertion(False, reason=reason)
+
+    def load_context(self, scope: str = "internal-support") -> KnowledgeContext:
+        if not self.enabled():
+            return KnowledgeContext(scope=scope, text="", version="")
+        if self.brain is None:
+            return KnowledgeContext(scope=scope, text="", version="")
+        max_chars = int(self.config.get("knowledge_max_chars") or 24000)
+        return self.brain.load_knowledge_context(scope, max_chars=max_chars)
+
+    def emit_heartbeat(
+        self,
+        *,
+        status: str,
+        event_type: str,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> HeartbeatResult:
+        if not self.enabled():
+            return HeartbeatResult(True, reason="runtime disabled")
+        if self.brain is None:
+            return HeartbeatResult(False, reason="canonical brain unavailable")
+        payload = HeartbeatPayload(
+            runtime_id=str(self.config.get("runtime_id") or "local-muncho"),
+            runtime_kind=str(self.config.get("runtime_kind") or "local-primary"),
+            status=status,
+            event_type=event_type,
+            metadata=redact_mapping(metadata),
+        )
+        try:
+            lease = self.brain.refresh_active_lease(
+                payload,
+                ttl_seconds=int(self.config.get("lease_ttl_seconds") or 90),
+            )
+            self.brain.write_runtime_event(
+                RuntimeEvent(
+                    event_type=event_type,
+                    status=status,
+                    context=self.context,
+                    metadata=payload.metadata,
+                )
+            )
+            return HeartbeatResult(True, reason="heartbeat emitted", lease=lease)
+        except Exception as exc:
+            return HeartbeatResult(False, reason=f"heartbeat failed: {exc}")
+
+    def assert_active_lease(
+        self,
+        *,
+        action: str,
+        lock_key: str | None = None,
+        case_id: str | None = None,
+        approval_class: str | None = None,
+    ) -> LeaseAssertion:
+        if not self.enabled():
+            return LeaseAssertion(True, reason="runtime disabled")
+        if self.brain is None:
+            return self._lease_failure("canonical brain unavailable")
+        try:
+            lease = self.brain.read_active_lease()
+        except Exception as exc:
+            return self._lease_failure(f"lease read failed: {exc}")
+        if lease is None:
+            return self._lease_failure("active lease missing")
+        expected_owner = str(self.config.get("runtime_id") or "local-muncho")
+        if lease.lease_owner != expected_owner:
+            return self._lease_failure("active lease owner mismatch")
+        active_runtime = str(lease.active_runtime or "")
+        allowed_runtime = {
+            "local",
+            "local-primary",
+            str(self.config.get("runtime_kind") or "local-primary"),
+        }
+        if active_runtime not in allowed_runtime:
+            return self._lease_failure("active lease runtime mismatch")
+        if lease.is_expired():
+            return self._lease_failure("active lease expired")
+        flags = {str(flag).lower() for flag in (lease.flags or ())}
+        if "force-cloud" in flags:
+            return self._lease_failure("force-cloud flag active")
+        if "pause-all" in flags:
+            return self._lease_failure("pause-all flag active")
+        if approval_class and lease.approval_classes:
+            if approval_class not in set(lease.approval_classes):
+                return self._lease_failure("approval class not covered by active lease")
+        if lock_key:
+            try:
+                handle = self.brain.acquire_lock(
+                    lock_key,
+                    {"token": str(uuid.uuid4()), "action": action, "case_id": case_id or ""},
+                    ttl_seconds=int(self.config.get("lease_ttl_seconds") or 90),
+                )
+            except Exception as exc:
+                return self._lease_failure(f"lock acquire failed: {exc}")
+            if not handle.acquired:
+                return self._lease_failure("scoped lock unavailable")
+        return LeaseAssertion(True, reason="active lease ok", lease=lease)
+
+    def guard_tool_action(
+        self,
+        tool_name: str,
+        args: Mapping[str, Any],
+    ) -> GuardDecision:
+        if not self.enabled():
+            return GuardDecision.allow("runtime disabled")
+        policy = classify_tool_action(tool_name, args)
+        if not policy.requires_lease:
+            return GuardDecision.allow("read-only action")
+        assertion = self.assert_active_lease(
+            action=policy.action,
+            approval_class=policy.approval_class,
+        )
+        if not assertion.allowed:
+            return self._allow_or_fail_open(assertion.reason)
+        return GuardDecision.allow(assertion.reason)
+
+    def validate_final_output(
+        self,
+        text: str,
+        *,
+        evidence: Sequence[ToolEvidence],
+    ) -> EvidenceValidationResult:
+        if not self.enabled():
+            return EvidenceValidationResult(True, reason="runtime disabled")
+        assertion = self.assert_active_lease(action="final_output")
+        if not assertion.allowed:
+            replacement = _blocked_text(assertion.reason)
+            return EvidenceValidationResult(
+                False,
+                reason=assertion.reason,
+                evidence_gaps=(assertion.reason,),
+                replacement_text=replacement,
+            )
+        result = _validate_final_output(text, context=self.context, evidence=evidence)
+        if not result.allowed:
+            self._audit("final_output_validation", "blocked", result.reason)
+            return result
+        final_assertion = self.assert_active_lease(action="final_output_recheck")
+        if not final_assertion.allowed:
+            replacement = _blocked_text(final_assertion.reason)
+            return EvidenceValidationResult(
+                False,
+                reason=final_assertion.reason,
+                evidence_gaps=(final_assertion.reason,),
+                replacement_text=replacement,
+            )
+        return result
+
+    def guard_worker_spawn(
+        self,
+        contract: WorkerContract,
+        *,
+        source: str,
+    ) -> GuardDecision:
+        if not self.enabled():
+            return GuardDecision.allow("runtime disabled")
+        assertion = self.assert_active_lease(
+            action=f"worker_spawn:{source}",
+            approval_class="worker_spawn",
+        )
+        if not assertion.allowed:
+            return self._allow_or_fail_open(assertion.reason)
+        if self.brain is not None:
+            try:
+                self.brain.write_runtime_event(
+                    RuntimeEvent(
+                        event_type="worker_spawn_guard",
+                        status="allowed",
+                        context=self.context,
+                        metadata={
+                            "source": source,
+                            "task_count": contract.task_count,
+                        },
+                    )
+                )
+            except Exception:
+                pass
+        return GuardDecision.allow(assertion.reason)
+
+    def guard_approval_mutation(
+        self,
+        *,
+        action: str,
+        session_key: str,
+        choice: str = "",
+    ) -> GuardDecision:
+        if not self.enabled():
+            return GuardDecision.allow("runtime disabled")
+        assertion = self.assert_active_lease(action=f"approval:{action}", approval_class="approval")
+        if not assertion.allowed:
+            return self._allow_or_fail_open(assertion.reason)
+        if self.brain is not None:
+            try:
+                self.brain.record_approval(
+                    ApprovalRecord(
+                        approval_id=f"{action}:{session_key}:{int(utc_ts())}",
+                        session_key=session_key,
+                        choice=choice,
+                        context=self.context,
+                        metadata={"action": action},
+                    )
+                )
+            except Exception:
+                pass
+        return GuardDecision.allow(assertion.reason)
+
+    def create_codex_task(self, title: str, metadata: Mapping[str, Any] | None = None) -> str | None:
+        if not self.enabled() or self.brain is None:
+            return None
+        try:
+            return self.brain.create_codex_task(
+                CodexTaskCreate(title=title, context=self.context, metadata=redact_mapping(metadata))
+            )
+        except Exception:
+            return None
+
+    def update_codex_task(self, task_id: str | None, patch: CodexTaskPatch) -> None:
+        if not task_id or not self.enabled() or self.brain is None:
+            return
+        try:
+            self.brain.update_codex_task(task_id, patch)
+        except Exception:
+            pass
+
+    def _audit(self, action: str, outcome: str, reason: str, metadata: Mapping[str, Any] | None = None) -> None:
+        if self.brain is None:
+            return
+        try:
+            self.brain.write_audit_log(
+                AuditEvent(
+                    action=action,
+                    outcome=outcome,
+                    context=self.context,
+                    reason=reason,
+                    metadata=redact_mapping(metadata),
+                )
+            )
+        except Exception:
+            pass
+
+
+def guard_internal_error_decision(
+    runtime: LocalMunchoRuntime,
+    exc: BaseException,
+    *,
+    guard_name: str,
+) -> GuardDecision | None:
+    """Fail closed for guard wrapper errors only when this runtime is active."""
+
+    try:
+        enabled = runtime.enabled()
+    except Exception:
+        enabled = False
+    if not enabled:
+        return None
+
+    detail = str(exc) or exc.__class__.__name__
+    reason = f"Local Muncho runtime {guard_name} guard internal error: {detail}"
+    return GuardDecision.block(
+        reason,
+        code="local_muncho_guard_error",
+        replacement_text=_blocked_text(reason),
+    )
+
+
+def guard_internal_error_decision_for_agent(
+    agent: Any,
+    exc: BaseException,
+    *,
+    guard_name: str,
+) -> GuardDecision | None:
+    return guard_internal_error_decision(
+        get_runtime_for_agent(agent),
+        exc,
+        guard_name=guard_name,
+    )
+
+
+def guard_internal_error_decision_for_current_context(
+    exc: BaseException,
+    *,
+    guard_name: str,
+) -> GuardDecision | None:
+    return guard_internal_error_decision(
+        get_current_runtime(),
+        exc,
+        guard_name=guard_name,
+    )
+
+
+def _blocked_text(reason: str) -> str:
+    return "\n".join(
+        [
+            "VERDICT: BLOCKED",
+            "TL;DR: Local Muncho runtime blocked the response before delivery.",
+            "CATEGORY: runtime_guard",
+            "EVIDENCE_CHECKED: active-lease",
+            f"EVIDENCE_GAP: {reason}",
+            "STATUS: blocked",
+            "NEXT_ACTION: restore local lease or hand off to cloud runtime",
+            "APPROVAL_NEEDED: yes",
+            "RISK: unsafe-runtime-transition",
+        ]
+    )
+
+
+def get_current_runtime(
+    *,
+    context: RuntimeContext | None = None,
+    brain: CanonicalBrain | None = None,
+    config: Mapping[str, Any] | None = None,
+) -> LocalMunchoRuntime:
+    return LocalMunchoRuntime.from_config(
+        config if config is not None else _load_runtime_config(),
+        context or _current_context.get() or context_from_env(),
+        brain if brain is not None else _current_brain.get(),
+    )
+
+
+def get_runtime_for_agent(agent: Any) -> LocalMunchoRuntime:
+    brain = getattr(agent, "_local_muncho_brain", None) or _current_brain.get()
+    config = getattr(agent, "_local_muncho_config", None)
+    return LocalMunchoRuntime.from_config(
+        config if isinstance(config, Mapping) else _load_runtime_config(),
+        context_from_agent(agent),
+        brain,
+    )
+
+
+def guard_tool_action_for_agent(
+    agent: Any,
+    tool_name: str,
+    args: Mapping[str, Any],
+) -> GuardDecision:
+    return get_runtime_for_agent(agent).guard_tool_action(tool_name, args)
+
+
+def guard_tool_action_for_current_context(
+    tool_name: str,
+    args: Mapping[str, Any],
+) -> GuardDecision:
+    return get_current_runtime().guard_tool_action(tool_name, args)
+
+
+def validate_final_response_for_agent(
+    agent: Any,
+    text: str,
+    messages: Sequence[Mapping[str, Any]] | None,
+) -> str:
+    runtime = get_runtime_for_agent(agent)
+    try:
+        result = runtime.validate_final_output(text, evidence=evidence_from_messages(messages))
+    except Exception as exc:
+        decision = guard_internal_error_decision(
+            runtime,
+            exc,
+            guard_name="final_output",
+        )
+        if decision is not None and not decision.allowed:
+            return decision.replacement_text or decision.message or text
+        return text
+    return result.replacement_text or text
+
+
+def guard_worker_spawn_for_agent(
+    agent: Any,
+    contract: WorkerContract,
+    *,
+    source: str,
+) -> GuardDecision:
+    return get_runtime_for_agent(agent).guard_worker_spawn(contract, source=source)
+
+
+def guard_approval_mutation_for_current_context(
+    *,
+    action: str,
+    session_key: str,
+    choice: str = "",
+) -> GuardDecision:
+    return get_current_runtime().guard_approval_mutation(
+        action=action,
+        session_key=session_key,
+        choice=choice,
+    )
+
+
+def tool_block_result(decision: GuardDecision) -> str:
+    return json.dumps(
+        {
+            "error": decision.message or decision.reason or "Local Muncho runtime blocked this action",
+            "status": "blocked",
+            "blocked_by": "local_muncho_runtime",
+            "code": decision.code or "local_muncho_block",
+        },
+        ensure_ascii=False,
+    )

--- a/agent/local_muncho/testing.py
+++ b/agent/local_muncho/testing.py
@@ -1,0 +1,134 @@
+"""In-memory Canonical Brain implementation for Local Muncho unit tests."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Mapping, Sequence
+
+from agent.local_muncho.types import (
+    ApprovalRecord,
+    AuditEvent,
+    CodexTaskCreate,
+    CodexTaskPatch,
+    HeartbeatPayload,
+    KnowledgeContext,
+    LeaseState,
+    LockHandle,
+    RuntimeEvent,
+    SupportCasePatch,
+    utc_ts,
+)
+
+
+class InMemoryCanonicalBrain:
+    def __init__(
+        self,
+        *,
+        lease: LeaseState | None = None,
+        lease_sequence: Sequence[LeaseState | None] | None = None,
+        knowledge_records: Mapping[str, str] | None = None,
+        knowledge_version: str = "in-memory",
+    ) -> None:
+        self.lease = lease
+        self._lease_sequence = list(lease_sequence or [])
+        self.knowledge_records = dict(knowledge_records or {})
+        self.knowledge_version = knowledge_version
+        self.runtime_events: list[RuntimeEvent] = []
+        self.audit_events: list[AuditEvent] = []
+        self.discord_events: list[Mapping[str, Any]] = []
+        self.support_cases: list[SupportCasePatch] = []
+        self.approvals: list[ApprovalRecord] = []
+        self.codex_tasks: dict[str, dict[str, Any]] = {}
+        self.locks: dict[str, LockHandle] = {}
+
+    def load_knowledge_context(self, scope: str, *, max_chars: int) -> KnowledgeContext:
+        selected: list[Mapping[str, Any]] = []
+        chunks: list[str] = []
+        for path, content in self.knowledge_records.items():
+            if "FORBIDDEN_TO_LLM" in content or "PROTECTED_LIVE" in content:
+                continue
+            if "INTERNAL_ONLY" not in content and "CUSTOMER_SAFE_SHARED" not in content:
+                continue
+            selected.append({"path": path, "version": self.knowledge_version})
+            chunks.append(f"# {path}\n{content}")
+        text = "\n\n".join(chunks)[:max_chars]
+        self.write_runtime_event(
+            RuntimeEvent(
+                event_type="knowledge_context_loaded",
+                status="ok",
+                context=None,  # type: ignore[arg-type]
+                metadata={"scope": scope, "version": self.knowledge_version},
+            )
+        )
+        return KnowledgeContext(
+            scope=scope,
+            text=text,
+            version=self.knowledge_version,
+            records=tuple(selected),
+        )
+
+    def read_active_lease(self) -> LeaseState | None:
+        if self._lease_sequence:
+            return self._lease_sequence.pop(0)
+        return self.lease
+
+    def refresh_active_lease(
+        self,
+        payload: HeartbeatPayload,
+        ttl_seconds: int,
+    ) -> LeaseState:
+        expires_at = utc_ts() + max(1, int(ttl_seconds))
+        self.lease = LeaseState(
+            lease_owner=payload.runtime_id,
+            active_runtime=payload.runtime_kind,
+            expires_at=expires_at,
+            metadata=dict(payload.metadata),
+        )
+        return self.lease
+
+    def acquire_lock(
+        self,
+        key: str,
+        value: Mapping[str, Any],
+        ttl_seconds: int,
+    ) -> LockHandle:
+        existing = self.locks.get(key)
+        now = utc_ts()
+        if existing and existing.expires_at and existing.expires_at > now:
+            return LockHandle(key=key, token="", acquired=False, expires_at=existing.expires_at)
+        handle = LockHandle(
+            key=key,
+            token=str(value.get("token") or uuid.uuid4()),
+            acquired=True,
+            expires_at=now + max(1, int(ttl_seconds)),
+        )
+        self.locks[key] = handle
+        return handle
+
+    def release_lock(self, handle: LockHandle) -> None:
+        existing = self.locks.get(handle.key)
+        if existing and existing.token == handle.token:
+            self.locks.pop(handle.key, None)
+
+    def write_runtime_event(self, event: RuntimeEvent) -> None:
+        self.runtime_events.append(event)
+
+    def write_audit_log(self, event: AuditEvent) -> None:
+        self.audit_events.append(event)
+
+    def write_discord_event(self, event: Mapping[str, Any]) -> None:
+        self.discord_events.append(dict(event))
+
+    def upsert_support_case(self, case: SupportCasePatch) -> None:
+        self.support_cases.append(case)
+
+    def record_approval(self, approval: ApprovalRecord) -> None:
+        self.approvals.append(approval)
+
+    def create_codex_task(self, task: CodexTaskCreate) -> str:
+        task_id = f"codex-{len(self.codex_tasks) + 1}"
+        self.codex_tasks[task_id] = {"create": task, "patches": []}
+        return task_id
+
+    def update_codex_task(self, task_id: str, patch: CodexTaskPatch) -> None:
+        self.codex_tasks.setdefault(task_id, {"patches": []})["patches"].append(patch)

--- a/agent/local_muncho/types.py
+++ b/agent/local_muncho/types.py
@@ -1,0 +1,211 @@
+"""Types for the disabled-by-default Local Muncho runtime guard."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+
+def utc_ts() -> float:
+    return datetime.now(timezone.utc).timestamp()
+
+
+@dataclass(frozen=True)
+class RuntimeContext:
+    lane: str | None = None
+    session_id: str = ""
+    platform: str = ""
+    user_id: str = ""
+    chat_id: str = ""
+    thread_id: str = ""
+    message_id: str = ""
+    profile: str = ""
+    case_id: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class KnowledgeContext:
+    scope: str
+    text: str
+    version: str = ""
+    records: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class LeaseState:
+    lease_owner: str
+    active_runtime: str
+    expires_at: float | datetime | None
+    flags: Sequence[str] = field(default_factory=tuple)
+    approval_classes: Sequence[str] = field(default_factory=tuple)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def is_expired(self, now: float | None = None) -> bool:
+        if self.expires_at is None:
+            return True
+        expiry = self.expires_at
+        if isinstance(expiry, datetime):
+            expiry = expiry.timestamp()
+        return float(expiry) <= (utc_ts() if now is None else now)
+
+
+@dataclass(frozen=True)
+class LeaseAssertion:
+    allowed: bool
+    reason: str = ""
+    lease: LeaseState | None = None
+
+
+@dataclass(frozen=True)
+class HeartbeatPayload:
+    runtime_id: str
+    runtime_kind: str
+    status: str
+    event_type: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    emitted_at: float = field(default_factory=utc_ts)
+
+
+@dataclass(frozen=True)
+class HeartbeatResult:
+    allowed: bool
+    reason: str = ""
+    lease: LeaseState | None = None
+
+
+@dataclass(frozen=True)
+class GuardDecision:
+    allowed: bool
+    reason: str = ""
+    message: str = ""
+    code: str = ""
+    replacement_text: str | None = None
+
+    @classmethod
+    def allow(cls, reason: str = "allowed") -> "GuardDecision":
+        return cls(True, reason=reason, code="allowed")
+
+    @classmethod
+    def block(
+        cls,
+        reason: str,
+        *,
+        message: str | None = None,
+        code: str = "blocked",
+        replacement_text: str | None = None,
+    ) -> "GuardDecision":
+        return cls(
+            False,
+            reason=reason,
+            message=message or reason,
+            code=code,
+            replacement_text=replacement_text,
+        )
+
+
+@dataclass(frozen=True)
+class EvidenceValidationResult:
+    allowed: bool
+    reason: str = ""
+    missing_fields: Sequence[str] = field(default_factory=tuple)
+    evidence_gaps: Sequence[str] = field(default_factory=tuple)
+    replacement_text: str | None = None
+
+
+@dataclass(frozen=True)
+class ToolEvidence:
+    tool_name: str
+    result: Any
+    tool_call_id: str = ""
+    success: bool = False
+    durable_ref: str = ""
+
+
+@dataclass(frozen=True)
+class VisibleSendIntent:
+    kind: str
+    platform: str = ""
+    chat_id: str = ""
+    thread_id: str = ""
+    text: str = ""
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class VisibleSendDecision:
+    allowed: bool
+    reason: str = ""
+    replacement_text: str | None = None
+
+
+@dataclass(frozen=True)
+class WorkerContract:
+    goals: Sequence[str] = field(default_factory=tuple)
+    task_count: int = 0
+    source_task_id: str = ""
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class LockRequest:
+    key: str
+    action: str = ""
+
+
+@dataclass(frozen=True)
+class LockHandle:
+    key: str
+    token: str
+    acquired: bool
+    expires_at: float | None = None
+
+
+@dataclass(frozen=True)
+class RuntimeEvent:
+    event_type: str
+    status: str
+    context: RuntimeContext
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    created_at: float = field(default_factory=utc_ts)
+
+
+@dataclass(frozen=True)
+class AuditEvent:
+    action: str
+    outcome: str
+    context: RuntimeContext
+    reason: str = ""
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    created_at: float = field(default_factory=utc_ts)
+
+
+@dataclass(frozen=True)
+class SupportCasePatch:
+    case_id: str
+    fields: Mapping[str, Any]
+    context: RuntimeContext
+
+
+@dataclass(frozen=True)
+class ApprovalRecord:
+    approval_id: str
+    session_key: str
+    choice: str
+    context: RuntimeContext
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class CodexTaskCreate:
+    title: str
+    context: RuntimeContext
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class CodexTaskPatch:
+    status: str | None = None
+    final_text: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)

--- a/agent/local_muncho_fallback.py
+++ b/agent/local_muncho_fallback.py
@@ -1,0 +1,161 @@
+"""Import-independent Local Muncho guard fallback helpers.
+
+These helpers intentionally avoid importing ``agent.local_muncho``.  They are
+used only when the real runtime guard import or helper resolution failed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from typing import Any
+
+
+def _runtime_cfg(config: Any) -> Mapping[str, Any]:
+    if not isinstance(config, Mapping):
+        return {}
+    block = config.get("muncho_runtime")
+    return block if isinstance(block, Mapping) else config
+
+
+def _load_runtime_cfg_readonly() -> tuple[Mapping[str, Any], bool]:
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        return _runtime_cfg(load_config_readonly()), True
+    except Exception:
+        return {}, False
+
+
+def _get_value(obj: Any, key: str) -> Any:
+    if isinstance(obj, Mapping):
+        return obj.get(key)
+    return getattr(obj, key, None)
+
+
+def _agent_runtime_cfg(agent: Any) -> tuple[Mapping[str, Any], bool]:
+    config = getattr(agent, "_local_muncho_config", None)
+    if isinstance(config, Mapping):
+        return _runtime_cfg(config), True
+    return _load_runtime_cfg_readonly()
+
+
+def _agent_lane(agent: Any) -> str:
+    context = getattr(agent, "_local_muncho_context", None)
+    lane = _get_value(context, "lane")
+    return str(
+        lane
+        or getattr(agent, "local_muncho_lane", None)
+        or os.getenv("HERMES_MUNCHO_RUNTIME_LANE")
+        or ""
+    )
+
+
+def _current_lane() -> str:
+    return str(os.getenv("HERMES_MUNCHO_RUNTIME_LANE") or "")
+
+
+def _plausibly_enabled_from_cfg(
+    cfg: Mapping[str, Any],
+    *,
+    cfg_known: bool,
+    lane: str,
+) -> bool:
+    if bool(cfg.get("enabled", False)):
+        expected_lane = str(cfg.get("lane") or "internal-support")
+        return not lane or lane == expected_lane
+    if cfg_known:
+        return False
+    return bool(lane)
+
+
+def local_muncho_plausibly_enabled_for_agent(agent: Any) -> bool:
+    cfg, cfg_known = _agent_runtime_cfg(agent)
+    return _plausibly_enabled_from_cfg(
+        cfg,
+        cfg_known=cfg_known,
+        lane=_agent_lane(agent),
+    )
+
+
+def local_muncho_plausibly_enabled_for_current_context() -> bool:
+    cfg, cfg_known = _load_runtime_cfg_readonly()
+    return _plausibly_enabled_from_cfg(
+        cfg,
+        cfg_known=cfg_known,
+        lane=_current_lane(),
+    )
+
+
+def local_muncho_guard_error_reason(exc: BaseException, *, guard_name: str) -> str:
+    detail = str(exc) or exc.__class__.__name__
+    return f"Local Muncho runtime {guard_name} guard internal error: {detail}"
+
+
+def local_muncho_tool_block_result(
+    reason: str,
+    *,
+    code: str = "local_muncho_guard_error",
+) -> str:
+    return json.dumps(
+        {
+            "error": reason,
+            "status": "blocked",
+            "blocked_by": "local_muncho_runtime",
+            "code": code,
+        },
+        ensure_ascii=False,
+    )
+
+
+def local_muncho_tool_block_for_agent_guard_error(
+    agent: Any,
+    exc: BaseException,
+    *,
+    guard_name: str,
+) -> tuple[str | None, str | None]:
+    if not local_muncho_plausibly_enabled_for_agent(agent):
+        return None, None
+    reason = local_muncho_guard_error_reason(exc, guard_name=guard_name)
+    return local_muncho_tool_block_result(reason), reason
+
+
+def local_muncho_tool_block_for_current_guard_error(
+    exc: BaseException,
+    *,
+    guard_name: str,
+) -> tuple[str | None, str | None]:
+    if not local_muncho_plausibly_enabled_for_current_context():
+        return None, None
+    reason = local_muncho_guard_error_reason(exc, guard_name=guard_name)
+    return local_muncho_tool_block_result(reason), reason
+
+
+def local_muncho_blocked_text(reason: str) -> str:
+    return "\n".join(
+        [
+            "VERDICT: BLOCKED",
+            "TL;DR: Local Muncho runtime blocked the response before delivery.",
+            "CATEGORY: runtime_guard",
+            "EVIDENCE_CHECKED: active-lease",
+            f"EVIDENCE_GAP: {reason}",
+            "STATUS: blocked",
+            "NEXT_ACTION: restore local lease or hand off to cloud runtime",
+            "APPROVAL_NEEDED: yes",
+            "RISK: unsafe-runtime-transition",
+        ]
+    )
+
+
+def local_muncho_final_text_for_agent_guard_error(
+    agent: Any,
+    exc: BaseException,
+    *,
+    guard_name: str,
+) -> str | None:
+    if not local_muncho_plausibly_enabled_for_agent(agent):
+        return None
+    return local_muncho_blocked_text(
+        local_muncho_guard_error_reason(exc, guard_name=guard_name)
+    )

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -36,6 +36,9 @@ from agent.tool_dispatch_helpers import (
     _append_subdir_hint_to_multimodal,
     make_tool_result_message,
 )
+from agent.local_muncho_fallback import (
+    local_muncho_tool_block_for_agent_guard_error,
+)
 from tools.terminal_tool import (
     get_active_env,
 )
@@ -101,6 +104,41 @@ def _cancelled_tool_result(reason: str = "user interrupt") -> str:
         },
         ensure_ascii=False,
     )
+
+
+def _local_muncho_tool_block(
+    agent,
+    function_name: str,
+    function_args: dict,
+) -> tuple[str | None, str | None]:
+    try:
+        from agent.local_muncho.runtime import (
+            guard_internal_error_decision_for_agent,
+            guard_tool_action_for_agent,
+            tool_block_result,
+        )
+
+        decision = guard_tool_action_for_agent(agent, function_name, function_args)
+        if decision.allowed:
+            return None, None
+        return tool_block_result(decision), decision.message or decision.reason
+    except Exception as exc:
+        logger.debug("local muncho tool guard error: %s", exc)
+        try:
+            decision = guard_internal_error_decision_for_agent(
+                agent,
+                exc,
+                guard_name="tool_action",
+            )
+            if decision is not None and not decision.allowed:
+                return tool_block_result(decision), decision.message or decision.reason
+        except Exception:
+            pass
+        return local_muncho_tool_block_for_agent_guard_error(
+            agent,
+            exc,
+            guard_name="tool_action",
+        )
 
 
 def _emit_cancelled_terminal_post_tool_call(
@@ -372,10 +410,13 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     middleware_trace=list(middleware_trace),
                 )
             else:
-                guardrail_decision = agent._tool_guardrails.before_call(function_name, function_args)
-                if not guardrail_decision.allows_execution:
-                    block_result = agent._guardrail_block_result(guardrail_decision)
-                    blocked_by_guardrail = True
+                muncho_block, muncho_reason = _local_muncho_tool_block(
+                    agent,
+                    function_name,
+                    function_args,
+                )
+                if muncho_block is not None:
+                    block_result = muncho_block
                     _emit_terminal_post_tool_call(
                         agent,
                         function_name=function_name,
@@ -384,10 +425,27 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                         effective_task_id=effective_task_id,
                         tool_call_id=getattr(tool_call, "id", "") or "",
                         status="blocked",
-                        error_type="guardrail_block",
-                        error_message=getattr(guardrail_decision, "message", None) or "Tool blocked by guardrail policy",
+                        error_type="local_muncho_runtime",
+                        error_message=muncho_reason,
                         middleware_trace=list(middleware_trace),
                     )
+                else:
+                    guardrail_decision = agent._tool_guardrails.before_call(function_name, function_args)
+                    if not guardrail_decision.allows_execution:
+                        block_result = agent._guardrail_block_result(guardrail_decision)
+                        blocked_by_guardrail = True
+                        _emit_terminal_post_tool_call(
+                            agent,
+                            function_name=function_name,
+                            function_args=function_args,
+                            result=block_result,
+                            effective_task_id=effective_task_id,
+                            tool_call_id=getattr(tool_call, "id", "") or "",
+                            status="blocked",
+                            error_type="guardrail_block",
+                            error_message=getattr(guardrail_decision, "message", None) or "Tool blocked by guardrail policy",
+                            middleware_trace=list(middleware_trace),
+                        )
 
         # ── Checkpoint preflight (only for tools that will execute) ──
         if block_result is None:
@@ -829,6 +887,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # Check plugin hooks for a block directive before executing.
         _block_msg: Optional[str] = None
         _block_error_type = "plugin_block"
+        _structured_block_result: str | None = None
         if _ts_scope_block is not None:
             _block_msg = _ts_scope_block
             _block_error_type = "tool_scope_block"
@@ -850,9 +909,19 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
 
         _guardrail_block_decision: ToolGuardrailDecision | None = None
         if _block_msg is None:
-            guardrail_decision = agent._tool_guardrails.before_call(function_name, function_args)
-            if not guardrail_decision.allows_execution:
-                _guardrail_block_decision = guardrail_decision
+            _muncho_block, _muncho_reason = _local_muncho_tool_block(
+                agent,
+                function_name,
+                function_args,
+            )
+            if _muncho_block is not None:
+                _block_msg = _muncho_reason or "Local Muncho runtime blocked this action"
+                _block_error_type = "local_muncho_runtime"
+                _structured_block_result = _muncho_block
+            else:
+                guardrail_decision = agent._tool_guardrails.before_call(function_name, function_args)
+                if not guardrail_decision.allows_execution:
+                    _guardrail_block_decision = guardrail_decision
 
         _execution_blocked = _block_msg is not None or _guardrail_block_decision is not None
 
@@ -930,7 +999,10 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
 
         if _block_msg is not None:
             # Tool blocked by plugin policy — return error without executing.
-            function_result = json.dumps({"error": _block_msg}, ensure_ascii=False)
+            function_result = _structured_block_result or json.dumps(
+                {"error": _block_msg},
+                ensure_ascii=False,
+            )
             tool_duration = 0.0
             _emit_terminal_post_tool_call(
                 agent,

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import os
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
+from agent.local_muncho_fallback import local_muncho_final_text_for_agent_guard_error
 
 
 def finalize_turn(
@@ -259,6 +260,45 @@ def finalize_turn(
                             )
         except Exception as _exp_err:
             logger.debug("turn-completion explainer failed: %s", _exp_err)
+
+    # Local Muncho evidence-first validation. This is intentionally before
+    # transform_llm_output/post_llm_call so model text is replaced before any
+    # downstream visible-output hook observes it. No-op unless the runtime is
+    # explicitly enabled for the current context.
+    if final_response and not interrupted:
+        try:
+            from agent.local_muncho.runtime import (
+                guard_internal_error_decision_for_agent,
+                validate_final_response_for_agent,
+            )
+
+            final_response = validate_final_response_for_agent(
+                agent,
+                final_response,
+                messages,
+            )
+        except Exception as _muncho_err:
+            logger.debug("local muncho final-output guard failed: %s", _muncho_err)
+            try:
+                _muncho_decision = guard_internal_error_decision_for_agent(
+                    agent,
+                    _muncho_err,
+                    guard_name="final_output",
+                )
+                if _muncho_decision is not None and not _muncho_decision.allowed:
+                    final_response = (
+                        _muncho_decision.replacement_text
+                        or _muncho_decision.message
+                        or final_response
+                    )
+            except Exception:
+                _fallback_text = local_muncho_final_text_for_agent_guard_error(
+                    agent,
+                    _muncho_err,
+                    guard_name="final_output",
+                )
+                if _fallback_text is not None:
+                    final_response = _fallback_text
 
     _response_transformed = False
 

--- a/gateway/local_muncho_guard.py
+++ b/gateway/local_muncho_guard.py
@@ -1,0 +1,104 @@
+"""Visible-send guard helpers for the Local Muncho runtime."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from copy import copy
+from dataclasses import is_dataclass, replace
+from typing import Any, Mapping
+
+from agent.local_muncho.policy import visible_send_action
+from agent.local_muncho.runtime import get_current_runtime
+from agent.local_muncho.types import VisibleSendDecision, VisibleSendIntent
+
+
+class LocalMunchoVisibleSendBlocked(RuntimeError):
+    pass
+
+
+async def guard_visible_send(
+    intent: VisibleSendIntent,
+    *,
+    runtime: Any = None,
+) -> VisibleSendDecision:
+    runtime = runtime or get_current_runtime()
+    if not runtime.enabled():
+        return VisibleSendDecision(True, reason="runtime disabled")
+
+    assertion = runtime.assert_active_lease(
+        action=visible_send_action(intent.kind),
+        approval_class="visible_send",
+    )
+    if not assertion.allowed:
+        return VisibleSendDecision(False, reason=assertion.reason)
+
+    validated_kinds = {"final", "error", "degraded_status", "send_message"}
+    if intent.text and intent.kind in validated_kinds:
+        validation = runtime.validate_final_output(intent.text, evidence=())
+        if not validation.allowed:
+            recheck = runtime.assert_active_lease(action="visible_send:replacement")
+            if recheck.allowed:
+                return VisibleSendDecision(
+                    True,
+                    reason=validation.reason,
+                    replacement_text=validation.replacement_text,
+                )
+            return VisibleSendDecision(False, reason=recheck.reason)
+
+    return VisibleSendDecision(True, reason=assertion.reason)
+
+
+async def send_with_muncho_guard(
+    send_coro_factory: Callable[[], Awaitable[Any]],
+    *,
+    intent: VisibleSendIntent,
+    runtime: Any = None,
+) -> Any:
+    decision = await guard_visible_send(intent, runtime=runtime)
+    if not decision.allowed:
+        raise LocalMunchoVisibleSendBlocked(decision.reason)
+    return await send_coro_factory()
+
+
+def _runtime_streaming_config(runtime: Any) -> Mapping[str, Any]:
+    config = getattr(runtime, "config", {})
+    if not isinstance(config, Mapping):
+        return {}
+    streaming = config.get("streaming")
+    return streaming if isinstance(streaming, Mapping) else {}
+
+
+def guard_stream_consumer_config(config: Any, *, runtime: Any = None) -> Any:
+    """Return a guarded stream config copy without touching the consumer core.
+
+    Disabled runtime returns the original object by identity.  Enabled runtime
+    can clamp callers to buffer-only/edit delivery using muncho_runtime.streaming.
+    """
+
+    runtime = runtime or get_current_runtime()
+    if not runtime.enabled():
+        return config
+
+    streaming = _runtime_streaming_config(runtime)
+    if not streaming.get("buffer_only", False) and streaming.get(
+        "drafts_enabled",
+        True,
+    ):
+        return config
+
+    updates: dict[str, Any] = {}
+    if streaming.get("buffer_only", False):
+        updates["buffer_only"] = True
+    if not streaming.get("drafts_enabled", True):
+        updates["transport"] = "edit"
+    if not updates:
+        return config
+
+    if is_dataclass(config) and not isinstance(config, type):
+        return replace(config, **updates)
+
+    guarded = copy(config)
+    for key, value in updates.items():
+        if hasattr(guarded, key):
+            setattr(guarded, key, value)
+    return guarded

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2049,6 +2049,33 @@ DEFAULT_CONFIG = {
     # Gateway / cron / non-interactive runs need this (or one of the other
     # channels) to pick up newly-added hooks.
     "hooks_auto_accept": False,
+
+    # Local Muncho primary runtime guard. Disabled by default and inert unless
+    # a caller supplies an explicit internal-support runtime context.
+    "muncho_runtime": {
+        "enabled": False,
+        "lane": "internal-support",
+        "runtime_id": "local-muncho",
+        "runtime_kind": "local-primary",
+        "heartbeat_interval_seconds": 30,
+        "lease_ttl_seconds": 90,
+        "local_unhealthy_after_seconds": 120,
+        "quiet_period_before_switch_back_seconds": 180,
+        "fail_open": False,
+        "allow_stub": False,
+        "owner_visible_degraded_status": True,
+        "streaming": {
+            "buffer_only": True,
+            "drafts_enabled": False,
+        },
+        "brain": {
+            "schema": "muncho_internal_support",
+            "postgres_dsn_env": "MUNCHO_POSTGRES_DSN",
+            "redis_url_env": "MUNCHO_REDIS_URL",
+            "knowledge_pack_path": None,
+        },
+    },
+
     # Custom personalities — add your own entries here
     # Supports string format: {"name": "system prompt"}
     # Or dict format: {"name": {"description": "...", "system_prompt": "...", "tone": "...", "style": "..."}}

--- a/model_tools.py
+++ b/model_tools.py
@@ -29,6 +29,7 @@ import threading
 import time
 from typing import Dict, Any, List, Optional, Tuple
 
+from agent.local_muncho_fallback import local_muncho_tool_block_for_current_guard_error
 from tools.registry import discover_builtin_tools, registry
 from toolsets import resolve_toolset, validate_toolset
 
@@ -1017,6 +1018,69 @@ def handle_function_call(
     try:
         if function_name in _AGENT_LOOP_TOOLS:
             return json.dumps({"error": f"{function_name} must be handled by the agent loop"})
+
+        # Local Muncho runtime guard. This is a defense-in-depth registry seam
+        # for tools that reach model_tools directly; agent-loop-owned tools are
+        # guarded in agent/tool_executor.py and agent_runtime_helpers.py.
+        try:
+            from agent.local_muncho.runtime import (
+                guard_internal_error_decision_for_current_context,
+                guard_tool_action_for_current_context,
+                tool_block_result,
+            )
+
+            _muncho_decision = guard_tool_action_for_current_context(
+                function_name,
+                function_args,
+            )
+        except Exception as _muncho_guard_err:
+            logger.debug("local muncho tool guard error: %s", _muncho_guard_err)
+            try:
+                _muncho_decision = guard_internal_error_decision_for_current_context(
+                    _muncho_guard_err,
+                    guard_name="tool_action",
+                )
+            except Exception:
+                _muncho_decision = None
+                _muncho_fallback_result, _muncho_fallback_reason = (
+                    local_muncho_tool_block_for_current_guard_error(
+                        _muncho_guard_err,
+                        guard_name="tool_action",
+                    )
+                )
+                if _muncho_fallback_result is not None:
+                    _emit_post_tool_call_hook(
+                        function_name=function_name,
+                        function_args=function_args,
+                        result=_muncho_fallback_result,
+                        task_id=task_id,
+                        session_id=session_id,
+                        tool_call_id=tool_call_id,
+                        turn_id=turn_id,
+                        api_request_id=api_request_id,
+                        status="blocked",
+                        error_type="local_muncho_runtime",
+                        error_message=_muncho_fallback_reason,
+                        middleware_trace=list(_tool_middleware_trace),
+                    )
+                    return _muncho_fallback_result
+        if _muncho_decision is not None and not _muncho_decision.allowed:
+            result = tool_block_result(_muncho_decision)
+            _emit_post_tool_call_hook(
+                function_name=function_name,
+                function_args=function_args,
+                result=result,
+                task_id=task_id,
+                session_id=session_id,
+                tool_call_id=tool_call_id,
+                turn_id=turn_id,
+                api_request_id=api_request_id,
+                status="blocked",
+                error_type="local_muncho_runtime",
+                error_message=_muncho_decision.message or _muncho_decision.reason,
+                middleware_trace=list(_tool_middleware_trace),
+            )
+            return result
 
         # Check plugin hooks for a block directive (unless caller already
         # checked — e.g. run_agent._invoke_tool passes skip=True to

--- a/tests/test_local_muncho_runtime.py
+++ b/tests/test_local_muncho_runtime.py
@@ -1,0 +1,666 @@
+from __future__ import annotations
+
+import builtins
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from agent.local_muncho.backends import (
+    UnavailableCanonicalBrain,
+    build_canonical_brain_backend,
+    describe_configured_backends,
+)
+from agent.local_muncho.brain import CanonicalBrainUnavailable
+from agent.local_muncho.evidence import validate_final_output
+from agent.local_muncho.runtime import (
+    LocalMunchoRuntime,
+    reset_current_canonical_brain,
+    reset_current_runtime_context,
+    set_current_canonical_brain,
+    set_current_runtime_context,
+    validate_final_response_for_agent,
+)
+from agent.local_muncho.testing import InMemoryCanonicalBrain
+from agent.local_muncho.types import (
+    LeaseState,
+    RuntimeContext,
+    ToolEvidence,
+    VisibleSendIntent,
+    WorkerContract,
+    utc_ts,
+)
+from gateway.local_muncho_guard import guard_stream_consumer_config, guard_visible_send
+from gateway.stream_consumer import StreamConsumerConfig
+
+
+def _cfg(**overrides):
+    cfg = {
+        "enabled": True,
+        "lane": "internal-support",
+        "runtime_id": "local-muncho",
+        "runtime_kind": "local-primary",
+        "lease_ttl_seconds": 90,
+        "fail_open": False,
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def _ctx(lane: str | None = "internal-support") -> RuntimeContext:
+    return RuntimeContext(
+        lane=lane,
+        platform="discord",
+        chat_id="chat",
+        thread_id="thread",
+    )
+
+
+def _lease(**overrides) -> LeaseState:
+    data = {
+        "lease_owner": "local-muncho",
+        "active_runtime": "local-primary",
+        "expires_at": utc_ts() + 90,
+    }
+    data.update(overrides)
+    return LeaseState(**data)
+
+
+def _valid_frame() -> str:
+    return "\n".join(
+        [
+            "VERDICT: PASS",
+            "TL;DR: ok",
+            "CATEGORY: runtime_guard",
+            "EVIDENCE_CHECKED: unit-test",
+            "EVIDENCE_GAP: none",
+            "STATUS: done",
+            "NEXT_ACTION: none",
+            "APPROVAL_NEEDED: no",
+            "RISK: low",
+        ]
+    )
+
+
+def test_disabled_runtime_is_noop_for_final_validation() -> None:
+    class Agent:
+        _local_muncho_config = {"enabled": False}
+        _local_muncho_context = _ctx()
+        _local_muncho_brain = None
+
+    text = "ordinary Hermes response without Muncho frame"
+    assert validate_final_response_for_agent(Agent(), text, messages=[]) == text
+
+
+def test_backend_boundary_is_no_network_placeholder(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MUNCHO_POSTGRES_DSN", "postgres://placeholder")
+    monkeypatch.delenv("MUNCHO_REDIS_URL", raising=False)
+
+    descriptors = describe_configured_backends(_cfg())
+    assert descriptors[0].kind == "postgres"
+    assert descriptors[0].configured is True
+    assert descriptors[1].kind == "redis"
+    assert descriptors[1].configured is False
+
+    backend = build_canonical_brain_backend(_cfg())
+    assert isinstance(backend, UnavailableCanonicalBrain)
+    with pytest.raises(CanonicalBrainUnavailable):
+        backend.read_active_lease()
+
+
+def test_enabled_runtime_without_brain_fails_closed_for_mutating_tool() -> None:
+    runtime = LocalMunchoRuntime(_cfg(), _ctx(), brain=None)
+    decision = runtime.guard_tool_action("send_message", {"action": "send"})
+    assert not decision.allowed
+    assert "canonical brain unavailable" in decision.reason
+
+
+def test_tool_guard_internal_error_blocks_when_runtime_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agent.tool_executor import _local_muncho_tool_block
+
+    class Agent:
+        _local_muncho_config = _cfg()
+        _local_muncho_context = _ctx()
+        _local_muncho_brain = InMemoryCanonicalBrain(lease=_lease())
+
+    def raise_guard_error(self, tool_name, args):
+        raise RuntimeError("guard exploded")
+
+    monkeypatch.setattr(
+        LocalMunchoRuntime,
+        "guard_tool_action",
+        raise_guard_error,
+    )
+
+    result, reason = _local_muncho_tool_block(
+        Agent(),
+        "send_message",
+        {"target": "discord:123", "message": "hello"},
+    )
+    assert result is not None
+    parsed = json.loads(result)
+    assert parsed["status"] == "blocked"
+    assert parsed["blocked_by"] == "local_muncho_runtime"
+    assert parsed["code"] == "local_muncho_guard_error"
+    assert "tool_action guard internal error" in parsed["error"]
+    assert "guard exploded" in reason
+
+
+def test_tool_guard_internal_error_noops_when_runtime_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agent.tool_executor import _local_muncho_tool_block
+
+    class Agent:
+        _local_muncho_config = {"enabled": False}
+        _local_muncho_context = _ctx()
+        _local_muncho_brain = None
+
+    def raise_guard_error(self, tool_name, args):
+        raise RuntimeError("guard exploded")
+
+    monkeypatch.setattr(
+        LocalMunchoRuntime,
+        "guard_tool_action",
+        raise_guard_error,
+    )
+
+    result, reason = _local_muncho_tool_block(
+        Agent(),
+        "send_message",
+        {"target": "discord:123", "message": "hello"},
+    )
+    assert result is None
+    assert reason is None
+
+
+def test_tool_guard_import_failure_blocks_when_runtime_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agent.tool_executor import _local_muncho_tool_block
+
+    class Agent:
+        _local_muncho_config = _cfg()
+        _local_muncho_context = _ctx()
+        _local_muncho_brain = None
+
+    real_import = builtins.__import__
+
+    def fail_runtime_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "agent.local_muncho.runtime":
+            raise ImportError("runtime helper unavailable")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fail_runtime_import)
+
+    result, reason = _local_muncho_tool_block(
+        Agent(),
+        "send_message",
+        {"target": "discord:123", "message": "hello"},
+    )
+    assert result is not None
+    parsed = json.loads(result)
+    assert parsed["status"] == "blocked"
+    assert parsed["blocked_by"] == "local_muncho_runtime"
+    assert parsed["code"] == "local_muncho_guard_error"
+    assert "tool_action guard internal error" in parsed["error"]
+    assert "runtime helper unavailable" in reason
+
+
+def test_tool_guard_import_failure_noops_when_runtime_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agent.tool_executor import _local_muncho_tool_block
+
+    class Agent:
+        _local_muncho_config = {"enabled": False}
+        _local_muncho_context = _ctx()
+        _local_muncho_brain = None
+
+    real_import = builtins.__import__
+
+    def fail_runtime_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "agent.local_muncho.runtime":
+            raise ImportError("runtime helper unavailable")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fail_runtime_import)
+
+    result, reason = _local_muncho_tool_block(
+        Agent(),
+        "send_message",
+        {"target": "discord:123", "message": "hello"},
+    )
+    assert result is None
+    assert reason is None
+
+
+def test_sequential_tool_block_preserves_local_muncho_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import agent.tool_executor as tool_executor
+
+    class Hints:
+        def check_tool_call(self, function_name, function_args):
+            return ""
+
+    class Agent:
+        _interrupt_requested = False
+        _local_muncho_config = _cfg()
+        _local_muncho_context = _ctx()
+        _local_muncho_brain = None
+        _subdirectory_hints = Hints()
+        quiet_mode = True
+        verbose_logging = False
+        tool_progress_mode = "off"
+        tool_progress_callback = None
+        tool_start_callback = None
+        tool_complete_callback = None
+        tool_delay = 0
+        session_id = "session"
+
+        def _tool_result_content_for_active_model(self, function_name, result):
+            return result
+
+        def _apply_pending_steer_to_tool_results(self, messages, count):
+            return None
+
+        def _touch_activity(self, message):
+            return None
+
+    monkeypatch.setattr(tool_executor, "_emit_terminal_post_tool_call", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        tool_executor,
+        "maybe_persist_tool_result",
+        lambda content, **kwargs: content,
+    )
+    monkeypatch.setattr(tool_executor, "enforce_turn_budget", lambda *a, **kw: None)
+
+    tool_call = SimpleNamespace(
+        id="call-1",
+        function=SimpleNamespace(
+            name="send_message",
+            arguments=json.dumps({"target": "discord:123", "message": "hello"}),
+        ),
+    )
+    messages: list[dict] = []
+
+    tool_executor.execute_tool_calls_sequential(
+        Agent(),
+        SimpleNamespace(tool_calls=[tool_call]),
+        messages,
+        "task-1",
+    )
+
+    parsed = json.loads(messages[-1]["content"])
+    assert parsed["status"] == "blocked"
+    assert parsed["blocked_by"] == "local_muncho_runtime"
+    assert parsed["code"] == "local_muncho_block"
+    assert "canonical brain unavailable" in parsed["error"]
+
+
+def test_active_local_lease_allows_tool_and_force_cloud_blocks() -> None:
+    runtime = LocalMunchoRuntime(
+        _cfg(),
+        _ctx(),
+        brain=InMemoryCanonicalBrain(lease=_lease()),
+    )
+    assert runtime.guard_tool_action("send_message", {"action": "send"}).allowed
+
+    blocked = LocalMunchoRuntime(
+        _cfg(),
+        _ctx(),
+        brain=InMemoryCanonicalBrain(lease=_lease(flags=("force-cloud",))),
+    )
+    decision = blocked.guard_tool_action("send_message", {"action": "send"})
+    assert not decision.allowed
+    assert "force-cloud" in decision.reason
+
+
+def test_final_output_requires_structured_evidence_frame() -> None:
+    result = validate_final_output(
+        "Completed the task successfully.",
+        context=_ctx(),
+        evidence=(),
+    )
+    assert not result.allowed
+    assert result.replacement_text is not None
+    assert "VERDICT: BLOCKED" in result.replacement_text
+    assert "missing required frame fields" in result.reason
+
+
+def test_completion_claim_requires_durable_evidence() -> None:
+    result = validate_final_output(
+        _valid_frame() + "\ncompleted",
+        context=_ctx(),
+        evidence=(),
+    )
+    assert not result.allowed
+    assert "no durable evidence" in result.reason
+
+    ok = validate_final_output(
+        _valid_frame() + "\ncompleted",
+        context=_ctx(),
+        evidence=(
+            ToolEvidence(
+                tool_name="send_message",
+                result={"success": True},
+                success=True,
+            ),
+        ),
+    )
+    assert ok.allowed
+
+
+def test_final_response_rechecks_lease_before_return() -> None:
+    brain = InMemoryCanonicalBrain(
+        lease_sequence=(_lease(), _lease(flags=("pause-all",))),
+    )
+    runtime = LocalMunchoRuntime(_cfg(), _ctx(), brain=brain)
+    result = runtime.validate_final_output(_valid_frame(), evidence=())
+    assert not result.allowed
+    assert result.replacement_text is not None
+    assert "pause-all" in result.replacement_text
+
+
+def test_final_output_guard_internal_error_replaces_when_runtime_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Agent:
+        _local_muncho_config = _cfg()
+        _local_muncho_context = _ctx()
+        _local_muncho_brain = InMemoryCanonicalBrain(lease=_lease())
+
+    def raise_validation_error(self, text, *, evidence):
+        raise RuntimeError("validator exploded")
+
+    monkeypatch.setattr(
+        LocalMunchoRuntime,
+        "validate_final_output",
+        raise_validation_error,
+    )
+
+    result = validate_final_response_for_agent(Agent(), "original response", messages=[])
+    assert result.startswith("VERDICT: BLOCKED")
+    assert "final_output guard internal error" in result
+    assert "validator exploded" in result
+    assert result != "original response"
+
+
+def test_final_output_guard_internal_error_noops_when_runtime_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Agent:
+        _local_muncho_config = {"enabled": False}
+        _local_muncho_context = _ctx()
+        _local_muncho_brain = None
+
+    def raise_validation_error(self, text, *, evidence):
+        raise RuntimeError("validator exploded")
+
+    monkeypatch.setattr(
+        LocalMunchoRuntime,
+        "validate_final_output",
+        raise_validation_error,
+    )
+
+    assert (
+        validate_final_response_for_agent(Agent(), "original response", messages=[])
+        == "original response"
+    )
+
+
+@pytest.mark.asyncio
+async def test_visible_send_guard_replaces_unverified_text_before_send() -> None:
+    runtime = LocalMunchoRuntime(
+        _cfg(),
+        _ctx(),
+        brain=InMemoryCanonicalBrain(lease=_lease()),
+    )
+    decision = await guard_visible_send(
+        VisibleSendIntent(
+            kind="send_message",
+            platform="discord",
+            chat_id="chat",
+            thread_id="thread",
+            text="done",
+        ),
+        runtime=runtime,
+    )
+    assert decision.allowed
+    assert decision.replacement_text is not None
+    assert "VERDICT: BLOCKED" in decision.replacement_text
+
+
+def test_stream_config_guard_is_disabled_by_default_noop() -> None:
+    runtime = LocalMunchoRuntime({"enabled": False}, _ctx(), brain=None)
+    config = StreamConsumerConfig(buffer_only=False, transport="auto")
+    assert guard_stream_consumer_config(config, runtime=runtime) is config
+
+
+def test_stream_config_guard_can_force_buffer_only_copy() -> None:
+    runtime = LocalMunchoRuntime(
+        _cfg(streaming={"buffer_only": True, "drafts_enabled": False}),
+        _ctx(),
+        brain=InMemoryCanonicalBrain(lease=_lease()),
+    )
+    config = StreamConsumerConfig(buffer_only=False, transport="auto")
+    guarded = guard_stream_consumer_config(config, runtime=runtime)
+    assert guarded is not config
+    assert guarded.buffer_only is True
+    assert guarded.transport == "edit"
+    assert config.buffer_only is False
+    assert config.transport == "auto"
+
+
+def test_send_message_tool_guard_noops_when_runtime_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import gateway.config as gateway_config
+    import tools.send_message_tool as send_message_tool
+    from gateway.config import Platform, PlatformConfig
+
+    class FakeGatewayConfig:
+        platforms = {Platform.DISCORD: PlatformConfig(enabled=True, token="token")}
+
+        def get_home_channel(self, platform):
+            return None
+
+    sent: dict[str, str] = {}
+
+    async def fake_send_to_platform(platform, pconfig, chat_id, message, **kwargs):
+        sent["message"] = message
+        return {
+            "success": True,
+            "platform": platform.value,
+            "chat_id": chat_id,
+            "message_id": "m1",
+        }
+
+    monkeypatch.setattr(
+        gateway_config,
+        "load_gateway_config",
+        lambda: FakeGatewayConfig(),
+    )
+    monkeypatch.setattr(send_message_tool, "_send_to_platform", fake_send_to_platform)
+    monkeypatch.setattr(
+        "agent.local_muncho.runtime._load_runtime_config",
+        lambda: {"enabled": False},
+    )
+
+    parsed = json.loads(
+        send_message_tool._handle_send({"target": "discord:123", "message": "hello"})
+    )
+    assert parsed["success"] is True
+    assert sent["message"] == "hello"
+
+
+def test_send_message_tool_guard_error_noops_when_runtime_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import gateway.config as gateway_config
+    import gateway.local_muncho_guard as local_muncho_guard
+    import tools.send_message_tool as send_message_tool
+    from gateway.config import Platform, PlatformConfig
+
+    class FakeGatewayConfig:
+        platforms = {Platform.DISCORD: PlatformConfig(enabled=True, token="token")}
+
+        def get_home_channel(self, platform):
+            return None
+
+    sent: dict[str, str] = {}
+
+    async def fake_send_to_platform(platform, pconfig, chat_id, message, **kwargs):
+        sent["message"] = message
+        return {
+            "success": True,
+            "platform": platform.value,
+            "chat_id": chat_id,
+            "message_id": "m1",
+        }
+
+    async def raise_visible_guard(*args, **kwargs):
+        raise RuntimeError("visible guard exploded")
+
+    monkeypatch.setattr(
+        gateway_config,
+        "load_gateway_config",
+        lambda: FakeGatewayConfig(),
+    )
+    monkeypatch.setattr(send_message_tool, "_send_to_platform", fake_send_to_platform)
+    monkeypatch.setattr(local_muncho_guard, "guard_visible_send", raise_visible_guard)
+    monkeypatch.setattr(
+        "agent.local_muncho.runtime._load_runtime_config",
+        lambda: {"enabled": False},
+    )
+
+    parsed = json.loads(
+        send_message_tool._handle_send({"target": "discord:123", "message": "hello"})
+    )
+    assert parsed["success"] is True
+    assert sent["message"] == "hello"
+
+
+def test_send_message_tool_replaces_visible_text_before_delivery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import gateway.config as gateway_config
+    import tools.send_message_tool as send_message_tool
+    from gateway.config import Platform, PlatformConfig
+
+    class FakeGatewayConfig:
+        platforms = {Platform.DISCORD: PlatformConfig(enabled=True, token="token")}
+
+        def get_home_channel(self, platform):
+            return None
+
+    sent: dict[str, str] = {}
+
+    async def fake_send_to_platform(platform, pconfig, chat_id, message, **kwargs):
+        sent["message"] = message
+        return {
+            "success": True,
+            "platform": platform.value,
+            "chat_id": chat_id,
+            "message_id": "m1",
+        }
+
+    monkeypatch.setattr(
+        gateway_config,
+        "load_gateway_config",
+        lambda: FakeGatewayConfig(),
+    )
+    monkeypatch.setattr(send_message_tool, "_send_to_platform", fake_send_to_platform)
+    monkeypatch.setattr("agent.local_muncho.runtime._load_runtime_config", lambda: _cfg())
+    ctx_token = set_current_runtime_context(_ctx())
+    brain_token = set_current_canonical_brain(InMemoryCanonicalBrain(lease=_lease()))
+    try:
+        parsed = json.loads(
+            send_message_tool._handle_send({"target": "discord:123", "message": "done"})
+        )
+    finally:
+        reset_current_canonical_brain(brain_token)
+        reset_current_runtime_context(ctx_token)
+
+    assert parsed["success"] is True
+    assert sent["message"].startswith("VERDICT: BLOCKED")
+
+
+def test_send_message_tool_guard_error_blocks_when_runtime_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import gateway.config as gateway_config
+    import gateway.local_muncho_guard as local_muncho_guard
+    import tools.send_message_tool as send_message_tool
+    from gateway.config import Platform, PlatformConfig
+
+    class FakeGatewayConfig:
+        platforms = {Platform.DISCORD: PlatformConfig(enabled=True, token="token")}
+
+        def get_home_channel(self, platform):
+            return None
+
+    sent: dict[str, str] = {}
+
+    async def fake_send_to_platform(platform, pconfig, chat_id, message, **kwargs):
+        sent["message"] = message
+        return {
+            "success": True,
+            "platform": platform.value,
+            "chat_id": chat_id,
+            "message_id": "m1",
+        }
+
+    async def raise_visible_guard(*args, **kwargs):
+        raise RuntimeError("visible guard exploded")
+
+    monkeypatch.setattr(
+        gateway_config,
+        "load_gateway_config",
+        lambda: FakeGatewayConfig(),
+    )
+    monkeypatch.setattr(send_message_tool, "_send_to_platform", fake_send_to_platform)
+    monkeypatch.setattr(local_muncho_guard, "guard_visible_send", raise_visible_guard)
+    monkeypatch.setattr("agent.local_muncho.runtime._load_runtime_config", lambda: _cfg())
+    ctx_token = set_current_runtime_context(_ctx())
+    brain_token = set_current_canonical_brain(InMemoryCanonicalBrain(lease=_lease()))
+    try:
+        parsed = json.loads(
+            send_message_tool._handle_send({"target": "discord:123", "message": "done"})
+        )
+    finally:
+        reset_current_canonical_brain(brain_token)
+        reset_current_runtime_context(ctx_token)
+
+    assert parsed["status"] == "blocked"
+    assert parsed["blocked_by"] == "local_muncho_runtime"
+    assert parsed["code"] == "local_muncho_guard_error"
+    assert "visible_send guard internal error" in parsed["error"]
+    assert sent == {}
+
+
+def test_worker_spawn_requires_active_lease() -> None:
+    runtime = LocalMunchoRuntime(
+        _cfg(),
+        _ctx(),
+        brain=InMemoryCanonicalBrain(lease=None),
+    )
+    decision = runtime.guard_worker_spawn(
+        WorkerContract(goals=("x",), task_count=1),
+        source="delegate_task",
+    )
+    assert not decision.allowed
+    assert "active lease missing" in decision.reason
+
+
+def test_tool_block_result_is_json() -> None:
+    runtime = LocalMunchoRuntime(_cfg(), _ctx(), brain=InMemoryCanonicalBrain(lease=None))
+    decision = runtime.guard_tool_action("send_message", {"action": "send"})
+    from agent.local_muncho.runtime import tool_block_result
+
+    parsed = json.loads(tool_block_result(decision))
+    assert parsed["blocked_by"] == "local_muncho_runtime"
+    assert parsed["status"] == "blocked"

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -30,6 +30,7 @@ from concurrent.futures import (
 )
 from typing import Any, Dict, List, Optional
 
+from agent.local_muncho_fallback import local_muncho_tool_block_for_agent_guard_error
 from toolsets import TOOLSETS
 
 # Sentinel value used by the runtime provider system for providers that are
@@ -2128,6 +2129,49 @@ def delegate_task(
             )
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
+
+    try:
+        from agent.local_muncho.runtime import (
+            guard_internal_error_decision_for_agent,
+            guard_worker_spawn_for_agent,
+        )
+        from agent.local_muncho.types import WorkerContract
+
+        _muncho_decision = guard_worker_spawn_for_agent(
+            parent_agent,
+            WorkerContract(
+                goals=tuple(str(task.get("goal") or "") for task in task_list),
+                task_count=len(task_list),
+                source_task_id=str(getattr(parent_agent, "task_id", "") or ""),
+                metadata={"role": top_role},
+            ),
+            source="delegate_task",
+        )
+    except Exception as _muncho_err:
+        logger.debug("delegate_task local muncho guard error: %s", _muncho_err)
+        try:
+            _muncho_decision = guard_internal_error_decision_for_agent(
+                parent_agent,
+                _muncho_err,
+                guard_name="worker_spawn",
+            )
+        except Exception:
+            _muncho_decision = None
+            _muncho_fallback_result, _ = (
+                local_muncho_tool_block_for_agent_guard_error(
+                    parent_agent,
+                    _muncho_err,
+                    guard_name="worker_spawn",
+                )
+            )
+            if _muncho_fallback_result is not None:
+                return _muncho_fallback_result
+    if _muncho_decision is not None and not _muncho_decision.allowed:
+        return tool_error(
+            _muncho_decision.message
+            or _muncho_decision.reason
+            or "Local Muncho runtime blocked delegate_task spawn."
+        )
 
     overall_start = time.monotonic()
     results = []

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -14,6 +14,7 @@ import ssl
 import time
 from email.utils import formatdate
 
+from agent.local_muncho_fallback import local_muncho_tool_block_for_current_guard_error
 from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
@@ -393,6 +394,23 @@ def _handle_send(args):
     if duplicate_skip:
         return json.dumps(duplicate_skip)
 
+    guard_result, replacement_message = _guard_visible_send_before_delivery(
+        platform_name=platform_name,
+        chat_id=chat_id,
+        thread_id=thread_id,
+        message=cleaned_message,
+        metadata={
+            "target": target,
+            "used_home_channel": used_home_channel,
+            "media_count": len(media_files),
+        },
+    )
+    if guard_result is not None:
+        return guard_result
+    if replacement_message is not None and replacement_message != cleaned_message:
+        cleaned_message = replacement_message
+        mirror_text = replacement_message
+
     # Slack: resolve user IDs (U...) to DM channel IDs via conversations.open
     if platform_name == "slack" and chat_id and chat_id.startswith("U"):
         try:
@@ -455,6 +473,74 @@ def _handle_send(args):
         return json.dumps(result)
     except Exception as e:
         return json.dumps(_error(f"Send failed: {e}"))
+
+
+def _guard_visible_send_before_delivery(
+    *,
+    platform_name: str,
+    chat_id: str,
+    thread_id: str | None,
+    message: str,
+    metadata: dict | None = None,
+):
+    """Apply the Local Muncho visible-send guard before platform delivery."""
+
+    try:
+        from agent.local_muncho.runtime import (
+            guard_internal_error_decision_for_current_context,
+            tool_block_result,
+        )
+        from agent.local_muncho.types import VisibleSendIntent
+        from gateway.local_muncho_guard import guard_visible_send
+        from model_tools import _run_async
+
+        decision = _run_async(
+            guard_visible_send(
+                VisibleSendIntent(
+                    kind="send_message",
+                    platform=platform_name,
+                    chat_id=str(chat_id or ""),
+                    thread_id=str(thread_id or ""),
+                    text=message or "",
+                    metadata=metadata or {},
+                )
+            )
+        )
+    except Exception as exc:
+        logger.debug("send_message local muncho visible-send guard error: %s", exc)
+        try:
+            decision = guard_internal_error_decision_for_current_context(
+                exc,
+                guard_name="visible_send",
+            )
+            if decision is not None and not decision.allowed:
+                return tool_block_result(decision), message
+        except Exception:
+            pass
+        result, _reason = local_muncho_tool_block_for_current_guard_error(
+            exc,
+            guard_name="visible_send",
+        )
+        return result, message
+
+    if decision.allowed:
+        return None, decision.replacement_text or message
+
+    return (
+        json.dumps(
+            {
+                "error": (
+                    decision.reason
+                    or "Local Muncho runtime blocked send_message delivery"
+                ),
+                "status": "blocked",
+                "blocked_by": "local_muncho_runtime",
+                "code": "local_muncho_block",
+            },
+            ensure_ascii=False,
+        ),
+        message,
+    )
 
 
 def _parse_target_ref(platform_name: str, target_ref: str):


### PR DESCRIPTION
## Summary
- Add disabled-by-default Local Muncho runtime guard scaffolding.
- Add Canonical Brain protocol, no-network backend boundary, evidence-first validation, visible send/delegate/tool/final guard seams, and import-independent fail-closed fallback behavior.
- Add focused in-memory tests for disabled no-op, fail-closed lease/guard behavior, evidence validation, visible-send replacement, stream config clamp, import-resolution fallback, and sequential structured block metadata.

## Validation
- `pytest tests/test_local_muncho_runtime.py -q` → 23 passed, 1 existing `discord.player audioop` deprecation warning.
- `pytest tests/test_transform_tool_result_hook.py tests/test_local_muncho_runtime.py -q` → 32 passed, 1 existing warning.
- `py_compile` touched Python files → pass.
- `ruff check` touched files → pass.
- `git diff --check` → pass.
- Secret/dangerous added-line scans → no findings.
- Independent final re-review → PASS.

## Safety / Non-goals
- Disabled by default.
- No live gateway change required to activate.
- No network/cloud/OAuth/schema migration/package install/deploy.
- Backend adapters are no-network placeholders only.
- No merge requested from this task.