### PR TITLE
fix(config): resolve desktop profile config reset and .env deletion on Windows

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -240,17 +240,34 @@ if (INSTALL_STAMP) {
 // HERMES_HOME beneath the throwaway userData dir so a fresh-install run never
 // touches the user's real ~/.hermes / %LOCALAPPDATA%\hermes.
 function resolveHermesHome() {
-  if (process.env.HERMES_HOME) return path.resolve(process.env.HERMES_HOME)
-  if (USER_DATA_OVERRIDE) return path.join(path.resolve(USER_DATA_OVERRIDE), 'hermes-home')
-  if (IS_WINDOWS && process.env.LOCALAPPDATA) {
+  let home = null
+  if (process.env.HERMES_HOME) {
+    home = path.resolve(process.env.HERMES_HOME)
+  } else if (USER_DATA_OVERRIDE) {
+    home = path.join(path.resolve(USER_DATA_OVERRIDE), 'hermes-home')
+  } else if (IS_WINDOWS && process.env.LOCALAPPDATA) {
     const localappdata = path.join(process.env.LOCALAPPDATA, 'hermes')
     const legacy = path.join(app.getPath('home'), '.hermes')
     // Migrate transparently to LOCALAPPDATA, but honour an existing legacy
     // ~/.hermes setup (no LOCALAPPDATA install yet) so users don't lose state.
-    if (!directoryExists(localappdata) && directoryExists(legacy)) return legacy
-    return localappdata
+    if (!directoryExists(localappdata) && directoryExists(legacy)) {
+      home = legacy
+    } else {
+      home = localappdata
+    }
+  } else {
+    home = path.join(app.getPath('home'), '.hermes')
   }
-  return path.join(app.getPath('home'), '.hermes')
+
+  // Normalize back to global root if resolved home is a profile directory
+  if (home) {
+    const parentDir = path.dirname(home)
+    if (path.basename(parentDir) === 'profiles') {
+      home = path.dirname(parentDir)
+    }
+  }
+
+  return home
 }
 
 const HERMES_HOME = resolveHermesHome()

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1655,9 +1655,10 @@ def _setup_telegram_auto_result():
 
     profile_name: str | None = None
     try:
-        hermes_home = str(get_hermes_home())
-        if "/profiles/" in hermes_home:
-            profile_name = hermes_home.rstrip("/").rsplit("/", 1)[-1]
+        from pathlib import Path
+        hermes_home_path = Path(get_hermes_home())
+        if hermes_home_path.parent.name == "profiles":
+            profile_name = hermes_home_path.name
     except Exception:
         pass
 


### PR DESCRIPTION
Fixes #45758 


### Description
This PR fixes a critical data loss bug on Windows where restarting or crashing the desktop app resets custom profile configs (`profiles/<name>/config.yaml`) to the minimal onboarding stub and deletes `.env` files.

### Root Causes
1. **Desktop App Relaunch Home Override**: When a custom profile gateway is active (via `hermes -p <profile>`), the desktop app inherits `process.env.HERMES_HOME` set to the profile directory. Electron's `resolveHermesHome` accepted this value directly, pointing `ACTIVE_HERMES_ROOT` inside the profile folder. Because the profile folder lacks the `.hermes-bootstrap-complete` marker and a python venv, `isBootstrapComplete()` returned `false` on startup/restart, triggering `install.ps1` against the profile directory. This wiped `.env` files and rewrote `config.yaml` with the onboarding consent stub.
2. **Windows Path Separators in Setup**: In `hermes_cli/setup.py` (line 1659), a hardcoded check `if "/profiles/" in hermes_home:` failed on Windows due to the backslash separator, breaking profile name extraction.

### Changes
- **Electron (`main.cjs`)**: Updated `resolveHermesHome()` to detect if the resolved directory is a profile subdirectory (parent named `profiles`) and normalize it back to the global home root. This ensures that even when environment variables point to a profile, the desktop runtime resolves to the correct root installation where the agent files and bootstrap markers reside.
- **Python CLI (`setup.py`)**: Updated `_setup_telegram_auto_result` to use `pathlib.Path` for a platform-independent check (`hermes_home_path.parent.name == "profiles"`).

### Verification
- Verified that `pytest tests/agent/test_onboarding.py` passes successfully (42/42 tests).
- Confirmed paths resolve correctly on Windows machines without triggering false bootstrap routines.