### PR TITLE
fix(tui-gateway): redact secrets from exec RPC output and guard command.dispatch

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "drmani215@gmail.com": "bionicbutterfly13",
     "peterhao@Peters-MacBook-Air.local": "pinguarmy",
     "barronlroth@gmail.com": "barronlroth",
     "ondrej.drapalik@gmail.com": "OndrejDrapalik",

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -7052,3 +7052,133 @@ def test_reap_idle_sessions_closes_only_evictable(monkeypatch):
         assert closed == [("stale", "idle_timeout")]
     finally:
         server._sessions.clear()
+
+
+# ---------------------------------------------------------------------------
+# Exec-output redaction — secrets must never leave the TUI gateway raw.
+#
+# cli.exec, command.dispatch (quick-command exec), and shell.exec each run a
+# subprocess and return its stdout/stderr to the RPC caller. The TUI gateway
+# is reachable over the network via the dashboard WebSocket (/api/ws), so any
+# unredacted output is a secret-exfiltration path. These tests pin that every
+# exec-output payload passes through the secret redactor, fails closed, and
+# leaves non-secret output untouched.
+# ---------------------------------------------------------------------------
+
+# A secret-shaped value (sk-ant- prefix → masked) carried alongside a plain
+# control token. After redaction the sentinel disappears; the control remains.
+_EXEC_LEAK_NEEDLE = "LEAKSENTINEL"
+_EXEC_SECRET_LINE = "PUBLIC_OK OPENAI_API_KEY=sk-ant-LEAKSENTINEL0123456789abcdefghij"
+
+
+def _quick_exec_cfg(command):
+    return {"quick_commands": {"leak": {"type": "exec", "command": command}}}
+
+
+def test_command_dispatch_exec_redacts_secret_output(monkeypatch):
+    monkeypatch.setattr(server, "_resolve_name", lambda n: n)
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: _quick_exec_cfg(f"printf '%s' '{_EXEC_SECRET_LINE}'")
+    )
+    resp = server._methods["command.dispatch"]("r1", {"name": "leak", "session_id": ""})
+    out = resp["result"]["output"]
+    assert "PUBLIC_OK" in out  # non-secret output preserved
+    assert _EXEC_LEAK_NEEDLE not in out  # secret redacted
+
+
+def test_shell_exec_redacts_secret_output():
+    resp = server._methods["shell.exec"]("r1", {"command": f"printf '%s' '{_EXEC_SECRET_LINE}'"})
+    combined = resp["result"]["stdout"] + resp["result"]["stderr"]
+    assert "PUBLIC_OK" in combined
+    assert _EXEC_LEAK_NEEDLE not in combined
+
+
+def test_cli_exec_redacts_secret_output(monkeypatch):
+    fake = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout=_EXEC_SECRET_LINE, stderr=""
+    )
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: fake)
+    resp = server._methods["cli.exec"]("r1", {"argv": ["version"]})
+    out = resp["result"]["output"]
+    assert "PUBLIC_OK" in out
+    assert _EXEC_LEAK_NEEDLE not in out
+
+
+def test_exec_paths_fail_closed_when_redaction_unavailable(monkeypatch):
+    redact_module = types.ModuleType("agent.redact")
+
+    def fail_redaction(*_args, **_kwargs):
+        raise RuntimeError("redaction unavailable")
+
+    setattr(redact_module, "redact_sensitive_text", fail_redaction)
+    monkeypatch.setitem(sys.modules, "agent.redact", redact_module)
+
+    shell_resp = server._methods["shell.exec"](
+        "r1", {"command": f"printf '%s' '{_EXEC_SECRET_LINE}'"}
+    )
+    assert _EXEC_LEAK_NEEDLE not in shell_resp["result"]["stdout"]
+
+    monkeypatch.setattr(server, "_resolve_name", lambda n: n)
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: _quick_exec_cfg(f"printf '%s' '{_EXEC_SECRET_LINE}'")
+    )
+    disp_resp = server._methods["command.dispatch"]("r2", {"name": "leak", "session_id": ""})
+    payload = disp_resp.get("result", {}).get("output", "") or disp_resp.get("error", {}).get(
+        "message", ""
+    )
+    assert _EXEC_LEAK_NEEDLE not in payload
+
+    # cli.exec returns its subprocess output too; mock run() so it surfaces the
+    # secret, then confirm the redactor-failure path still fails closed.
+    fake = subprocess.CompletedProcess(args=[], returncode=0, stdout=_EXEC_SECRET_LINE, stderr="")
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: fake)
+    cli_resp = server._methods["cli.exec"]("r3", {"argv": ["version"]})
+    assert _EXEC_LEAK_NEEDLE not in cli_resp["result"]["output"]
+
+
+def test_command_dispatch_exec_passes_through_non_secret_output(monkeypatch):
+    monkeypatch.setattr(server, "_resolve_name", lambda n: n)
+    monkeypatch.setattr(server, "_load_cfg", lambda: _quick_exec_cfg("printf '%s' hello"))
+    resp = server._methods["command.dispatch"]("r1", {"name": "leak", "session_id": ""})
+    assert resp["result"]["output"] == "hello"
+
+
+def test_command_dispatch_exec_blocks_dangerous_command(monkeypatch):
+    def _boom(*_a, **_k):
+        raise AssertionError("subprocess.run must not execute a blocked quick command")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+    monkeypatch.setattr(server, "_resolve_name", lambda n: n)
+    monkeypatch.setattr(server, "_load_cfg", lambda: _quick_exec_cfg("rm -rf /"))
+    resp = server._methods["command.dispatch"]("r1", {"name": "leak", "session_id": ""})
+    assert "error" in resp
+    assert "block" in resp["error"]["message"].lower()
+
+
+def test_command_dispatch_exec_blocks_dangerous_nonhardline_command(monkeypatch):
+    # Covers the non-hardline detect_dangerous_command branch ("rm -rf /" above
+    # is hardline; a git force-push is dangerous-but-not-hardline).
+    def _boom(*_a, **_k):
+        raise AssertionError("subprocess.run must not execute a blocked quick command")
+
+    monkeypatch.setattr(subprocess, "run", _boom)
+    monkeypatch.setattr(server, "_resolve_name", lambda n: n)
+    monkeypatch.setattr(server, "_load_cfg", lambda: _quick_exec_cfg("git push --force"))
+    resp = server._methods["command.dispatch"]("r1", {"name": "leak", "session_id": ""})
+    assert "error" in resp
+    assert "block" in resp["error"]["message"].lower()
+
+
+def test_command_dispatch_exec_redacts_secret_in_error_envelope(monkeypatch):
+    # A nonzero exit returns _err(...) carrying the combined output; that path
+    # must be redacted too, not just the success return.
+    monkeypatch.setattr(server, "_resolve_name", lambda n: n)
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: _quick_exec_cfg(f"printf '%s' '{_EXEC_SECRET_LINE}' >&2; exit 3"),
+    )
+    resp = server._methods["command.dispatch"]("r1", {"name": "leak", "session_id": ""})
+    assert "error" in resp
+    assert _EXEC_LEAK_NEEDLE not in resp["error"]["message"]
+    assert "PUBLIC_OK" in resp["error"]["message"]

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2418,6 +2418,26 @@ def _redact_tui_verbose_text(text: str) -> str:
     return _cap_tui_verbose_text(redacted)
 
 
+def _redact_exec_output(text: str) -> str:
+    """Scrub secrets from subprocess output before it leaves the gateway.
+
+    cli.exec / command.dispatch (quick-command exec) / shell.exec return raw
+    stdout/stderr to RPC callers, and the gateway is reachable over the network
+    via the dashboard WebSocket (/api/ws). ``force=True`` scrubs regardless of
+    the user's global redaction preference; on any redactor failure we fail
+    closed with a marker rather than leaking raw output. Callers slice first,
+    so the existing payload caps still bound size. Unlike
+    ``_redact_tui_verbose_text`` this does NOT add the verbose-tail label, which
+    is meant for tool-detail display, not command output.
+    """
+    try:
+        from agent.redact import redact_sensitive_text
+
+        return redact_sensitive_text(str(text), force=True)
+    except Exception:
+        return "[output withheld: redaction unavailable]"
+
+
 def _tool_args_text(args: dict) -> str:
     try:
         raw = json.dumps(args or {}, indent=2, ensure_ascii=False, default=str)
@@ -7821,7 +7841,8 @@ def _(rid, params: dict) -> dict:
         parts = [r.stdout or "", r.stderr or ""]
         out = "\n".join(p for p in parts if p).strip() or "(no output)"
         return _ok(
-            rid, {"blocked": False, "code": r.returncode, "output": out[:48_000]}
+            rid,
+            {"blocked": False, "code": r.returncode, "output": _redact_exec_output(out[:48_000])},
         )
     except subprocess.TimeoutExpired:
         return _err(rid, 5016, "cli.exec: timeout")
@@ -7871,19 +7892,49 @@ def _(rid, params: dict) -> dict:
     if name in qcmds:
         qc = qcmds[name]
         if qc.get("type") == "exec":
+            command_str = qc.get("command", "")
+            # Same safety gate shell.exec applies (see shell.exec below): quick
+            # commands are reachable over the dashboard WebSocket, so block
+            # destructive commands here too. Intentionally-dangerous commands
+            # belong on the agent path, not a one-shot quick command.
+            try:
+                from tools.approval import detect_dangerous_command, detect_hardline_command
+
+                is_hardline, hardline_desc = detect_hardline_command(command_str)
+                if is_hardline:
+                    return _err(
+                        rid,
+                        4005,
+                        f"blocked (hardline): {hardline_desc}. Use the agent for dangerous commands.",
+                    )
+                is_dangerous, _, desc = detect_dangerous_command(command_str)
+                if is_dangerous:
+                    return _err(
+                        rid,
+                        4005,
+                        f"blocked: {desc}. Use the agent for dangerous commands.",
+                    )
+            except ImportError:
+                return _err(
+                    rid, 5001, "quick command unavailable: approval safety module not importable"
+                )
             r = subprocess.run(
-                qc.get("command", ""),
+                command_str,
                 shell=True,
                 capture_output=True,
                 text=True,
                 timeout=30,
                 stdin=subprocess.DEVNULL,
             )
-            output = (
-                (r.stdout or "")
-                + ("\n" if r.stdout and r.stderr else "")
-                + (r.stderr or "")
-            ).strip()[:4000]
+            # Redact before returning — the gateway is network-reachable and
+            # must not ship raw secrets from the subprocess environment/output.
+            output = _redact_exec_output(
+                (
+                    (r.stdout or "")
+                    + ("\n" if r.stdout and r.stderr else "")
+                    + (r.stderr or "")
+                ).strip()[:4000]
+            )
             if r.returncode != 0:
                 return _err(
                     rid,
@@ -10102,8 +10153,8 @@ def _(rid, params: dict) -> dict:
         return _ok(
             rid,
             {
-                "stdout": r.stdout[-4000:],
-                "stderr": r.stderr[-2000:],
+                "stdout": _redact_exec_output(r.stdout[-4000:]),
+                "stderr": _redact_exec_output(r.stderr[-2000:]),
                 "code": r.returncode,
             },
         )


### PR DESCRIPTION
## What does this PR do?

The TUI gateway's three subprocess-executing JSON-RPC methods — `cli.exec`,
`command.dispatch` (quick-command `type: exec`), and `shell.exec` — returned raw
subprocess `stdout`/`stderr` to the caller with **no secret redaction**, even
though the messaging gateway already scrubs user-facing text before it leaves the
process (`gateway/run.py` `_redact_gateway_user_facing_secrets`). This PR makes
the TUI gateway consistent with that contract and also gives `command.dispatch`
the same approval-gate guard `shell.exec` already has.

**Framing per `SECURITY.md`:** output redaction and the approval gate are
in-process heuristics (§2.4), not boundaries — so this is **not** a
boundary-bypass report and is intentionally filed as a regular PR per §3.2
("redaction can always get smarter … welcome as regular issues or pull
requests"), not through the private security channel.

## Related Issue

No existing issue. Hardening contribution under CONTRIBUTING priority #3
("Security hardening"). Searched open PRs for duplicates before filing.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue) — redaction
      inconsistency vs. the gateway's documented behavior. (Not a §3.1 advisory;
      see framing above.)

## Changes Made

- `tui_gateway/server.py`
  - Add `_redact_exec_output()` — runs `redact_sensitive_text(text, force=True)`
    and **fails closed** to a marker if the redactor raises (mirrors the existing
    `_redact_tui_verbose_text`, minus the verbose-tail label meant for tool-detail
    display).
  - Apply it to all three exec-output payloads **after** the existing length
    slicing, so payload caps still bound size: `cli.exec`, `command.dispatch`
    exec (both success and error returns), `shell.exec`.
  - Apply the same `detect_hardline_command` / `detect_dangerous_command` guard
    `shell.exec` uses to `command.dispatch`'s exec path, which previously had no
    safety check at all.
- `tests/test_tui_gateway_server.py` — new tests: per-method redaction
  (`cli.exec` / `command.dispatch` / `shell.exec`), fail-closed under redactor
  failure on all three, non-secret passthrough, redaction of the
  `command.dispatch` error envelope, and dangerous-command blocking for both the
  hardline and non-hardline branches (asserts `subprocess.run` is never reached).
- `scripts/release.py` — add the contributor's email to `AUTHOR_MAP` so the
  attribution check passes (separate `chore` commit).

## How to Test

```bash
# Targeted (matches CI hermetic env)
scripts/run_tests.sh tests/test_tui_gateway_server.py
# or
pytest tests/test_tui_gateway_server.py -q
```

Manual sentinel (no real creds needed):

```bash
env -i PATH="$PATH" HOME="$HOME" OPENAI_API_KEY="sk-test-DUMMYLEAK0123456789abcdef" \
  venv/bin/python - <<'PY'
import tui_gateway.server as s
s._resolve_name = lambda n: n
s._load_cfg = lambda: {"quick_commands": {"leak": {"type": "exec",
    "command": 'printf "%s" "$OPENAI_API_KEY"'}}}
r = s._methods["command.dispatch"]("1", {"name": "leak", "session_id": ""})
print(r)  # output is masked (sk-...), not the raw value
PY
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(tui-gateway): …`, `chore(release): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (plus the required AUTHOR_MAP attribution line)
- [x] I've run the tests (`tests/test_tui_gateway_server.py`: 265 passed). The 8 new tests pass. The single local failure, `test_browser_manage_connect_default_local_reports_launch_hint`, is pre-existing and unrelated: it asserts the "no Chromium-family browser found" message, which only appears when no browser is installed — it fails on dev machines that have a Chromium-family browser and passes in CI (which has none). Confirmed by reproducing on a clean `upstream/main` checkout.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Darwin 24.6)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on the new helper) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure Python, no platform-specific calls)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (RPC method behavior only; `command.dispatch` exec now rejects destructive commands, consistent with `shell.exec`)

## Note on behavior change

`command.dispatch` quick commands of `type: exec` now reject genuinely
destructive commands (root deletes, fork bombs) the same way `shell.exec` does.
Ordinary quick commands — including relative-path `rm -rf ./build` — are
unaffected; only root-level/destructive patterns are blocked, and the agent path
remains available for those. Happy to drop this second change into a follow-up
PR if you'd prefer the redaction fix in isolation.
