### PR TITLE
feat: emit native CSE provenance metadata

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -741,7 +741,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         # registered providers with profiles were bypassing the strip.
         api_messages = agent._prepare_messages_for_non_vision_model(api_messages)
 
-        return _ct.build_kwargs(
+        api_kwargs = _ct.build_kwargs(
             model=agent.model,
             messages=api_messages,
             tools=tools_for_api,
@@ -762,6 +762,9 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             supports_reasoning=agent._supports_reasoning_extra_body(),
             qwen_session_metadata=_qwen_meta,
         )
+        from agent.cse_hermes_provenance import attach_cse_hermes_provenance_metadata
+
+        return attach_cse_hermes_provenance_metadata(agent, api_kwargs, api_messages)
 
     # ── Legacy flag path ────────────────────────────────────────────
     # Reached only when get_provider_profile() returns None — i.e. a
@@ -773,7 +776,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
     # Strip image parts for non-vision models (no-op when vision-capable).
     _msgs_for_chat = agent._prepare_messages_for_non_vision_model(api_messages)
 
-    return _ct.build_kwargs(
+    api_kwargs = _ct.build_kwargs(
         model=agent.model,
         messages=_msgs_for_chat,
         tools=tools_for_api,
@@ -809,6 +812,9 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
         anthropic_max_output=_ant_max,
         provider_name=agent.provider,
     )
+    from agent.cse_hermes_provenance import attach_cse_hermes_provenance_metadata
+
+    return attach_cse_hermes_provenance_metadata(agent, api_kwargs, _msgs_for_chat)
 
 
 

--- a/agent/cse_hermes_provenance.py
+++ b/agent/cse_hermes_provenance.py
@@ -1,0 +1,298 @@
+"""Native CSE/Hermes body-signal provenance envelope helpers.
+
+This module is deliberately sideband-only: it builds redaction-safe metadata for
+CSE-facing provider calls and never mutates model-visible messages.  The first
+consumer is the local ``cse-live`` OpenAI-compatible provider façade, which
+expects the envelope under ``metadata.cse_hermes_provenance``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import re
+import secrets
+import uuid
+from typing import Any
+
+PROVENANCE_METADATA_KEY = "cse_hermes_provenance"
+EXPECTED_SCHEMA_VERSION = "cse.hermes.provenance.v1"
+CSE_PROVIDER_MODEL_IDS = {"cse-live"}
+_ALLOWED_ATOM_RE = re.compile(r"[^A-Za-z0-9_.:-]+")
+
+_SOURCE_KINDS = {"cli", "gateway", "telegram", "cron", "heartbeat", "test_harness", "unknown"}
+_SURFACE_KINDS = {"direct_chat", "group_chat", "topic_thread", "cli", "local_daemon", "unknown"}
+_PLATFORM_REF_PLATFORMS = {"telegram", "gateway", "cli", "cron", "test_harness", "unknown"}
+_PROCESS_LOCAL_REF_SALT = secrets.token_hex(32)
+
+
+def should_emit_cse_hermes_provenance(agent: Any) -> bool:
+    """Return true when this provider call should carry CSE provenance.
+
+    The default is intentionally narrow so ordinary providers are untouched.
+    Falsey ``HERMES_CSE_HERMES_PROVENANCE`` values disable emission for
+    troubleshooting; truthy values do not broaden emission beyond CSE routes.
+    """
+
+    override = os.getenv("HERMES_CSE_HERMES_PROVENANCE")
+    if override is not None and override.strip().lower() in {"0", "false", "no", "off"}:
+        return False
+
+    model = str(getattr(agent, "model", "") or "").strip().lower()
+    if model in CSE_PROVIDER_MODEL_IDS:
+        return True
+    return any(model.endswith(f"/{model_id}") for model_id in CSE_PROVIDER_MODEL_IDS)
+
+
+def attach_cse_hermes_provenance_metadata(
+    agent: Any,
+    api_kwargs: dict[str, Any],
+    api_messages: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Attach native CSE provenance to OpenAI-compatible chat kwargs.
+
+    The returned dict is the same request object with a redaction-safe
+    ``metadata.cse_hermes_provenance`` entry.  Existing caller-provided
+    metadata keys are preserved, but the CSE provenance key itself is
+    overwritten so request overrides cannot spoof a native body signal.
+    """
+
+    if not should_emit_cse_hermes_provenance(agent):
+        return api_kwargs
+
+    metadata = api_kwargs.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+
+    metadata[PROVENANCE_METADATA_KEY] = build_cse_hermes_provenance(
+        agent,
+        api_messages,
+        tools_present=bool(api_kwargs.get("tools")),
+    )
+    api_kwargs["metadata"] = metadata
+    return api_kwargs
+
+
+def build_cse_hermes_provenance(
+    agent: Any,
+    api_messages: list[dict[str, Any]],
+    *,
+    tools_present: bool = False,
+) -> dict[str, Any]:
+    """Build a redaction-safe native body-signal provenance envelope."""
+
+    profile_id = _safe_profile_id(_active_profile_name())
+    raw_session_id = _safe_str(getattr(agent, "session_id", None)) or "anonymous"
+    session_ref = _prefixed_hash("session", raw_session_id)
+    trace_ref = _prefixed_hash("trace", profile_id, raw_session_id)
+    conversation_ref = _prefixed_hash("conversation", profile_id, raw_session_id)
+    request_ref = f"req_{uuid.uuid4().hex[:24]}"
+    api_call_count = getattr(agent, "_api_call_count", None)
+    turn_seed = f"{raw_session_id}:{api_call_count}:{request_ref}"
+    turn_ref = _prefixed_hash("turn", turn_seed)
+
+    source_kind = _source_kind(agent)
+    surface_kind = _surface_kind(agent, source_kind)
+    message_kind = _message_kind(api_messages)
+    capability_mode = (
+        "tool_round_trip"
+        if tools_present or message_kind in {"tool_request", "tool_result", "tool_denial"} or _messages_contain_tool_semantics(api_messages)
+        else "text_only_pr2"
+    )
+    complete = source_kind != "unknown" and surface_kind != "unknown"
+
+    provenance: dict[str, Any] = {
+        "schema_version": EXPECTED_SCHEMA_VERSION,
+        "request_id": request_ref,
+        "trace_id": trace_ref,
+        "turn_id": turn_ref,
+        "hermes_profile_id": profile_id,
+        "hermes_session_id": session_ref,
+        "source_kind": source_kind,
+        "surface_kind": surface_kind,
+        "message_kind": message_kind,
+        "entity_id": "cse-live",
+        "conversation_id": conversation_ref,
+        "capability_mode": capability_mode,
+        "provenance_policy": "required_for_v1" if complete else "optional_transient",
+        "provenance_completeness": "complete" if complete else "partial",
+        "payload_redaction_state": "redacted",
+        "raw_identifier_values_included": False,
+        "producer": {
+            "system": "hermes-agent",
+            "kind": "native_body_signal_producer",
+            "authority": "hermes",
+        },
+        "delivery_context": {
+            "body_route_ref": _ref("body_route", profile_id, source_kind, surface_kind, raw_session_id),
+            "delivery_state": "provider_request_pre_delivery",
+            "delivery_authority": "hermes",
+        },
+        "audit_context": {
+            "audit_ref": _ref("audit", trace_ref, request_ref, turn_ref),
+            "raw_payloads_included": False,
+        },
+        "memory_context": {
+            "transfer_policy": "none",
+            "host_context_kinds": [],
+            "host_context_ref_count": 0,
+            "cse_memory_ref_count": 0,
+        },
+    }
+
+    platform_refs = _platform_refs(agent, source_kind, surface_kind)
+    if platform_refs:
+        provenance["platform_refs"] = platform_refs
+
+    return provenance
+
+
+def _active_profile_name() -> str:
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        return get_active_profile_name() or "default"
+    except Exception:
+        return os.getenv("HERMES_PROFILE") or "default"
+
+
+def _source_kind(agent: Any) -> str:
+    platform = _safe_str(getattr(agent, "platform", None)).lower()
+    if platform in _SOURCE_KINDS:
+        return platform
+    if platform in {"discord", "slack", "signal", "whatsapp", "matrix", "sms"}:
+        return "gateway"
+    return "unknown"
+
+
+def _surface_kind(agent: Any, source_kind: str) -> str:
+    if source_kind == "cli":
+        return "cli"
+    if source_kind in {"cron", "heartbeat", "test_harness"}:
+        return "local_daemon"
+
+    thread_id = _safe_str(getattr(agent, "thread_id", None))
+    if thread_id:
+        return "topic_thread"
+
+    chat_type = _safe_str(getattr(agent, "chat_type", None)).lower()
+    if chat_type in {"group", "supergroup", "channel"}:
+        return "group_chat"
+    if chat_type in {"dm", "private", "direct"}:
+        return "direct_chat"
+
+    chat_id = _safe_str(getattr(agent, "chat_id", None))
+    if chat_id:
+        return "direct_chat"
+    return "unknown"
+
+
+def _message_kind(messages: list[dict[str, Any]]) -> str:
+    for message in reversed(messages or []):
+        if not isinstance(message, dict):
+            continue
+        role = message.get("role")
+        if role == "tool":
+            return "tool_result"
+        if role == "function":
+            return "tool_result"
+        if role == "assistant" and message.get("tool_calls"):
+            return "tool_request"
+        if role == "user":
+            return "user_message"
+    return "user_message"
+
+
+def _messages_contain_tool_semantics(messages: list[dict[str, Any]]) -> bool:
+    for message in messages or []:
+        if not isinstance(message, dict):
+            continue
+        if message.get("role") in {"tool", "function"}:
+            return True
+        if any(field in message for field in ("tool_call_id", "tool_calls", "function_call")):
+            return True
+    return False
+
+
+def _platform_refs(agent: Any, source_kind: str, surface_kind: str) -> dict[str, str] | None:
+    platform = source_kind if source_kind in _PLATFORM_REF_PLATFORMS else "unknown"
+    refs: dict[str, str] = {"platform": platform}
+
+    chat_id = _safe_str(getattr(agent, "chat_id", None))
+    user_id = _safe_str(getattr(agent, "user_id", None)) or _safe_str(getattr(agent, "user_id_alt", None))
+    thread_id = _safe_str(getattr(agent, "thread_id", None))
+
+    if chat_id:
+        refs["chat_ref"] = _ref("chat", platform, chat_id)
+    if user_id:
+        refs["user_ref"] = _ref("user", platform, user_id)
+    if thread_id:
+        key = "topic_ref" if platform == "telegram" or surface_kind == "topic_thread" else "thread_ref"
+        refs[key] = _ref("topic" if key == "topic_ref" else "thread", platform, thread_id)
+
+    return refs if len(refs) > 1 or platform in {"cli", "cron", "test_harness"} else None
+
+
+def _safe_profile_id(value: str) -> str:
+    cleaned = _safe_atom(value or "default")
+    return cleaned or "default"
+
+
+def _safe_str(value: Any) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    return text
+
+
+def _safe_atom(value: str) -> str:
+    cleaned = _ALLOWED_ATOM_RE.sub("_", _safe_str(value))
+    cleaned = cleaned.strip("._:-")
+    return cleaned or "unknown"
+
+
+def _ref(kind: str, *parts: Any) -> str:
+    return f"ref:{kind}:{_digest(*parts)}"
+
+
+def _prefixed_hash(prefix: str, *parts: Any) -> str:
+    return f"{prefix}_{_digest(*parts)}"
+
+
+def _digest(*parts: Any) -> str:
+    payload = json.dumps([str(part) for part in parts], separators=(",", ":"), sort_keys=True)
+    return hmac.new(_ref_salt().encode("utf-8"), payload.encode("utf-8"), hashlib.sha256).hexdigest()[:24]
+
+
+def _ref_salt() -> str:
+    env_salt = os.getenv("HERMES_CSE_PROVENANCE_REF_SALT")
+    if env_salt:
+        return env_salt
+    try:
+        from hermes_constants import get_hermes_home
+
+        salt_path = get_hermes_home() / "cse_hermes_provenance_salt"
+        if salt_path.exists():
+            value = salt_path.read_text(encoding="utf-8").strip()
+            if value:
+                return value
+        salt_path.parent.mkdir(parents=True, exist_ok=True)
+        value = secrets.token_hex(32)
+        try:
+            fd = os.open(str(salt_path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        except FileExistsError:
+            value = salt_path.read_text(encoding="utf-8").strip()
+            if value:
+                return value
+            raise
+        try:
+            os.write(fd, (value + "\n").encode("utf-8"))
+        finally:
+            os.close(fd)
+        return value
+    except Exception:
+        # Last-resort process-local salt: still avoids a public static salt,
+        # though refs may not be stable if the local profile cannot store the salt.
+        return _PROCESS_LOCAL_REF_SALT

--- a/tests/agent/test_cse_hermes_provenance.py
+++ b/tests/agent/test_cse_hermes_provenance.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+
+RAW_CHAT_ID = "123456789"
+RAW_USER_ID = "987654321"
+RAW_THREAD_ID = "555777"
+RAW_PROMPT_SENTINEL = "RAW-HERMES-CSE-PROVENANCE-SHOULD-NOT-LEAK"
+
+
+@pytest.fixture(autouse=True)
+def _fixed_ref_salt(monkeypatch):
+    monkeypatch.setenv("HERMES_CSE_PROVENANCE_REF_SALT", "test-cse-hermes-provenance-salt")
+
+
+def _agent(**overrides):
+    values = {
+        "model": "cse-live",
+        "provider": "custom",
+        "base_url": "http://127.0.0.1:18080/v1",
+        "session_id": "raw-session-id-for-test",
+        "platform": "cli",
+        "chat_type": None,
+        "chat_id": None,
+        "thread_id": None,
+        "user_id": None,
+        "user_id_alt": None,
+        "gateway_session_key": None,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_cse_live_chat_kwargs_receive_native_sideband_metadata_without_prompt_smuggling():
+    from agent.cse_hermes_provenance import (
+        PROVENANCE_METADATA_KEY,
+        attach_cse_hermes_provenance_metadata,
+    )
+
+    messages = [{"role": "user", "content": f"hello {RAW_PROMPT_SENTINEL}"}]
+    kwargs = {"model": "cse-live", "messages": [message.copy() for message in messages]}
+
+    attached = attach_cse_hermes_provenance_metadata(_agent(), kwargs, messages)
+
+    provenance = attached["metadata"][PROVENANCE_METADATA_KEY]
+    assert provenance["schema_version"] == "cse.hermes.provenance.v1"
+    assert provenance["source_kind"] == "cli"
+    assert provenance["surface_kind"] == "cli"
+    assert provenance["message_kind"] == "user_message"
+    assert provenance["entity_id"] == "cse-live"
+    assert provenance["capability_mode"] == "text_only_pr2"
+    assert provenance["provenance_policy"] == "required_for_v1"
+    assert provenance["provenance_completeness"] == "complete"
+    assert provenance["payload_redaction_state"] == "redacted"
+    assert provenance["producer"] == {
+        "system": "hermes-agent",
+        "kind": "native_body_signal_producer",
+        "authority": "hermes",
+    }
+    assert provenance["delivery_context"]["delivery_authority"] == "hermes"
+    assert provenance["audit_context"]["audit_ref"].startswith("ref:audit:")
+    assert provenance["hermes_session_id"].startswith("session_")
+    assert provenance["conversation_id"].startswith("conversation_")
+    assert RAW_PROMPT_SENTINEL not in json.dumps(provenance)
+    assert attached["messages"] == kwargs["messages"]
+    assert "metadata" not in attached["messages"][0]
+
+
+def test_gateway_provenance_redacts_raw_chat_user_thread_and_gateway_session_values():
+    from agent.cse_hermes_provenance import build_cse_hermes_provenance
+
+    agent = _agent(
+        platform="telegram",
+        chat_type="group",
+        chat_id=RAW_CHAT_ID,
+        user_id=RAW_USER_ID,
+        user_id_alt="raw-alt-user-id",
+        thread_id=RAW_THREAD_ID,
+        gateway_session_key="telegram:123456789:555777",
+    )
+
+    provenance = build_cse_hermes_provenance(agent, [{"role": "user", "content": "hi"}])
+    serialized = json.dumps(provenance, sort_keys=True)
+
+    assert provenance["source_kind"] == "telegram"
+    assert provenance["surface_kind"] == "topic_thread"
+    refs = provenance["platform_refs"]
+    assert refs["platform"] == "telegram"
+    assert refs["chat_ref"].startswith("ref:chat:")
+    assert refs["user_ref"].startswith("ref:user:")
+    assert refs["topic_ref"].startswith("ref:topic:")
+    for raw in (RAW_CHAT_ID, RAW_USER_ID, RAW_THREAD_ID, "telegram:123456789:555777"):
+        assert raw not in serialized
+    assert provenance["raw_identifier_values_included"] is False
+
+
+def test_tool_result_request_sets_tool_round_trip_kind_without_copying_tool_result_text():
+    from agent.cse_hermes_provenance import build_cse_hermes_provenance
+
+    messages = [
+        {"role": "user", "content": "use a tool"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "call_safe_123", "type": "function", "function": {"name": "skills_list", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_safe_123", "content": RAW_PROMPT_SENTINEL},
+    ]
+
+    provenance = build_cse_hermes_provenance(_agent(), messages)
+
+    assert provenance["message_kind"] == "tool_result"
+    assert provenance["capability_mode"] == "tool_round_trip"
+    assert RAW_PROMPT_SENTINEL not in json.dumps(provenance)
+
+
+def test_non_cse_models_are_not_given_cse_body_signal_metadata_by_default():
+    from agent.cse_hermes_provenance import attach_cse_hermes_provenance_metadata
+
+    kwargs = {"model": "openai/gpt-5.1", "messages": [{"role": "user", "content": "hi"}]}
+
+    attached = attach_cse_hermes_provenance_metadata(
+        _agent(model="openai/gpt-5.1", provider="openrouter"),
+        kwargs,
+        kwargs["messages"],
+    )
+
+    assert "metadata" not in attached
+
+
+def test_cse_live_route_overwrites_preexisting_spoofable_provenance_metadata():
+    from agent.cse_hermes_provenance import (
+        PROVENANCE_METADATA_KEY,
+        attach_cse_hermes_provenance_metadata,
+    )
+
+    kwargs = {
+        "model": "cse-live",
+        "messages": [{"role": "user", "content": "hi"}],
+        "metadata": {PROVENANCE_METADATA_KEY: {"request_id": "req_fake_spoof"}, "keep": "me"},
+    }
+
+    attached = attach_cse_hermes_provenance_metadata(_agent(), kwargs, kwargs["messages"])
+
+    assert attached["metadata"]["keep"] == "me"
+    provenance = attached["metadata"][PROVENANCE_METADATA_KEY]
+    assert provenance["request_id"] != "req_fake_spoof"
+    assert provenance["producer"]["kind"] == "native_body_signal_producer"
+
+
+def test_disable_env_override_does_not_enable_cse_metadata_for_non_cse_models(monkeypatch):
+    from agent.cse_hermes_provenance import attach_cse_hermes_provenance_metadata
+
+    monkeypatch.setenv("HERMES_CSE_HERMES_PROVENANCE", "1")
+    kwargs = {"model": "openai/gpt-5.1", "messages": [{"role": "user", "content": "hi"}]}
+
+    attached = attach_cse_hermes_provenance_metadata(
+        _agent(model="openai/gpt-5.1", provider="openrouter"),
+        kwargs,
+        kwargs["messages"],
+    )
+
+    assert "metadata" not in attached
+
+
+def test_unknown_origin_does_not_claim_complete_required_v1_provenance():
+    from agent.cse_hermes_provenance import build_cse_hermes_provenance
+
+    provenance = build_cse_hermes_provenance(
+        _agent(platform="mystery", chat_id=None, user_id=None, thread_id=None),
+        [{"role": "user", "content": "hi"}],
+    )
+
+    assert provenance["source_kind"] == "unknown"
+    assert provenance["surface_kind"] == "unknown"
+    assert provenance["provenance_policy"] == "optional_transient"
+    assert provenance["provenance_completeness"] == "partial"
+
+
+def test_build_api_kwargs_attaches_native_metadata_for_cse_live_custom_provider():
+    from agent.transports.chat_completions import ChatCompletionsTransport
+    from run_agent import AIAgent
+
+    agent = object.__new__(AIAgent)
+    agent.api_mode = "chat_completions"
+    agent.model = "cse-live"
+    agent.provider = "custom"
+    agent.base_url = "http://127.0.0.1:18080/v1"
+    agent._base_url_lower = agent.base_url.lower()
+    agent._base_url_hostname = "127.0.0.1"
+    agent.tools = []
+    agent.max_tokens = None
+    agent.reasoning_config = None
+    agent.request_overrides = {}
+    agent.session_id = "integration-session-id"
+    agent.platform = "cli"
+    agent.chat_type = None
+    agent.chat_id = None
+    agent.thread_id = None
+    agent.user_id = None
+    agent.user_id_alt = None
+    agent.gateway_session_key = None
+    agent._api_call_count = 1
+    agent._ephemeral_max_output_tokens = None
+    agent._ollama_num_ctx = None
+    agent.providers_allowed = None
+    agent.providers_ignored = None
+    agent.providers_order = None
+    agent.provider_sort = None
+    agent.provider_require_parameters = False
+    agent.provider_data_collection = None
+    agent.openrouter_min_coding_score = None
+    agent._get_transport = lambda: ChatCompletionsTransport()
+    agent._is_qwen_portal = lambda: False
+    agent._is_openrouter_url = lambda: False
+    agent._resolved_api_call_timeout = lambda: None
+    agent._max_tokens_param = lambda value: {"max_tokens": value}
+    agent._supports_reasoning_extra_body = lambda: False
+    agent._github_models_reasoning_extra_body = lambda: None
+    agent._lmstudio_reasoning_options_cached = lambda: None
+    agent._prepare_messages_for_non_vision_model = lambda messages: messages
+    agent._qwen_prepare_chat_messages = lambda messages: messages
+    agent._qwen_prepare_chat_messages_inplace = lambda messages: None
+
+    kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+
+    assert kwargs["metadata"]["cse_hermes_provenance"]["entity_id"] == "cse-live"
+    assert kwargs["metadata"]["cse_hermes_provenance"]["source_kind"] == "cli"


### PR DESCRIPTION
## Summary
- add a narrow native CSE/Hermes provenance producer for the `cse-live` model route
- attach `metadata.cse_hermes_provenance` at the OpenAI-compatible request boundary without mutating prompt-visible messages
- HMAC-hash raw session/channel/user/thread inputs with a profile-local secret salt before emitting refs
- overwrite pre-existing CSE provenance on the CSE route so request overrides cannot spoof a native body signal
- keep ordinary non-CSE providers unaffected; falsey `HERMES_CSE_HERMES_PROVENANCE` only disables emission for troubleshooting

## Verification
- `venv/bin/ruff check agent/cse_hermes_provenance.py agent/chat_completion_helpers.py tests/agent/test_cse_hermes_provenance.py` — pass
- `PYTHONPATH=. pytest -q tests/agent/test_cse_hermes_provenance.py tests/test_ctx_halving_fix.py tests/agent/transports` — 360 passed, 1 warning
- static added-line scan for secrets/injection/eval/pickle/SQL formatting — clean
- `git diff --cached --check` — clean
- Issoy read-only peer review — APPROVE after fixing spoofing/salt/env/completeness concerns

Part of dotanga/cse-live#467 and dotanga/cse-live#462.
