### PR TITLE
Send WhatsApp voice notes as Opus when possible

### DIFF
--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -118,6 +118,7 @@ _DEFAULT_MIME = {
     "document": "application/octet-stream",
     "sticker": "image/webp",
 }
+_WHATSAPP_OPUS_MIME = "audio/ogg; codecs=opus"
 
 # ffmpeg location at import time. ``shutil.which`` honours PATHEXT on
 # Windows so a user's ``ffmpeg.exe`` is picked up. None means MP3 voice
@@ -1099,14 +1100,12 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
         WhatsApp renders ``audio/ogg; codecs=opus`` as the green
         voice-note bubble; other audio types (MP3, WAV, AAC, etc.) appear as
-        a generic audio attachment. Hermes TTS providers may produce any
-        supported audio container, so we try ffmpeg conversion to Opus first
-        for local non-Opus files and fall back to sending the original audio
-        when ffmpeg is unavailable.
+        a generic audio attachment. Native Ogg/Opus is uploaded as-is. For
+        local non-Opus files, we try ffmpeg conversion to Opus first and
+        fall back to sending the original audio when ffmpeg is unavailable.
         """
         source = audio_path
         mime_type: Optional[str] = None
-
         is_local_file = (
             not audio_path.startswith(("http://", "https://"))
             and os.path.exists(audio_path)
@@ -1114,18 +1113,20 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         suffix = Path(audio_path).suffix.lower()
         is_opus_voice = suffix in {".ogg", ".opus"}
 
-        if is_local_file and not is_opus_voice:
+        if is_local_file and is_opus_voice:
+            mime_type = _WHATSAPP_OPUS_MIME
+        elif is_local_file:
             opus_path = await self._convert_to_opus(audio_path)
             if opus_path:
                 try:
                     result = await self._send_media_from_path_or_link(
                         chat_id, opus_path, "audio",
                         caption=caption, reply_to=reply_to,
-                        mime_type="audio/ogg; codecs=opus",
+                        mime_type=_WHATSAPP_OPUS_MIME,
                     )
                 finally:
                     # The .ogg is a transient conversion artifact next to
-                    # the source MP3 — clean it up after upload so voice
+                    # the source audio, so clean it up after upload to keep
                     # sends don't leak a file per message.
                     try:
                         os.unlink(opus_path)
@@ -1136,8 +1137,6 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # Warn-once is logged inside _convert_to_opus.
             if suffix == ".mp3":
                 mime_type = "audio/mpeg"
-        elif is_local_file and is_opus_voice:
-            mime_type = "audio/ogg; codecs=opus"
 
         return await self._send_media_from_path_or_link(
             chat_id, source, "audio",

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -1098,20 +1098,23 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         """Send an audio file as a WhatsApp voice message.
 
         WhatsApp renders ``audio/ogg; codecs=opus`` as the green
-        voice-note bubble; other audio types (MP3, AAC, etc.) appear as
-        a generic audio attachment. Hermes TTS produces MP3, so we try
-        ffmpeg conversion to opus first and fall back to sending the
-        MP3 as-is when ffmpeg is unavailable.
+        voice-note bubble; other audio types (MP3, WAV, AAC, etc.) appear as
+        a generic audio attachment. Hermes TTS providers may produce any
+        supported audio container, so we try ffmpeg conversion to Opus first
+        for local non-Opus files and fall back to sending the original audio
+        when ffmpeg is unavailable.
         """
         source = audio_path
         mime_type: Optional[str] = None
 
-        is_local_mp3 = (
+        is_local_file = (
             not audio_path.startswith(("http://", "https://"))
-            and audio_path.lower().endswith(".mp3")
             and os.path.exists(audio_path)
         )
-        if is_local_mp3:
+        suffix = Path(audio_path).suffix.lower()
+        is_opus_voice = suffix in {".ogg", ".opus"}
+
+        if is_local_file and not is_opus_voice:
             opus_path = await self._convert_to_opus(audio_path)
             if opus_path:
                 try:
@@ -1129,9 +1132,12 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     except OSError:
                         pass
                 return result
-            # Will deliver as MP3 attachment, not voice bubble.
+            # Will deliver as a plain audio attachment, not a voice bubble.
             # Warn-once is logged inside _convert_to_opus.
-            mime_type = "audio/mpeg"
+            if suffix == ".mp3":
+                mime_type = "audio/mpeg"
+        elif is_local_file and is_opus_voice:
+            mime_type = "audio/ogg; codecs=opus"
 
         return await self._send_media_from_path_or_link(
             chat_id, source, "audio",
@@ -1156,12 +1162,12 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         )
 
     # ------------------------------------------------------------------ opus conversion
-    async def _convert_to_opus(self, mp3_path: str) -> Optional[str]:
-        """Convert an MP3 to ``audio/ogg; codecs=opus`` for voice bubbles.
+    async def _convert_to_opus(self, audio_path: str) -> Optional[str]:
+        """Convert an audio file to ``audio/ogg; codecs=opus`` for voice bubbles.
 
         Returns the path to the converted file, or None if ffmpeg is
         missing / conversion fails (caller falls back to sending the
-        original MP3 as an audio file).
+        original audio file).
 
         ``-application voip`` tunes the opus encoder for speech.
         ``-b:a 32k -vbr on`` matches the bitrate WhatsApp produces for
@@ -1171,10 +1177,10 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             self._warn_once_no_ffmpeg()
             return None
 
-        out_path = mp3_path.rsplit(".", 1)[0] + ".ogg"
+        out_path = audio_path.rsplit(".", 1)[0] + ".ogg"
         try:
             proc = await asyncio.create_subprocess_exec(
-                _FFMPEG_PATH, "-y", "-i", mp3_path,
+                _FFMPEG_PATH, "-y", "-i", audio_path,
                 "-c:a", "libopus", "-b:a", "32k", "-vbr", "on",
                 "-application", "voip", out_path,
                 stdout=asyncio.subprocess.DEVNULL,
@@ -1200,7 +1206,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._warned_no_ffmpeg = True
         logger.warning(
             "[whatsapp_cloud] ffmpeg not found on PATH — voice messages will "
-            "be delivered as MP3 audio attachments instead of native voice "
+            "be delivered as audio attachments instead of native voice "
             "notes (green waveform bubble). Install ffmpeg to enable: "
             "Windows `winget install Gyan.FFmpeg`, macOS `brew install ffmpeg`, "
             "Linux package manager."

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -1180,6 +1180,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         try:
             proc = await asyncio.create_subprocess_exec(
                 _FFMPEG_PATH, "-y", "-i", audio_path,
+                "-ac", "1", "-ar", "48000",
                 "-c:a", "libopus", "-b:a", "32k", "-vbr", "on",
                 "-application", "voip", out_path,
                 stdout=asyncio.subprocess.DEVNULL,

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -23,13 +23,12 @@ import express from 'express';
 import { Boom } from '@hapi/boom';
 import pino from 'pino';
 import path from 'path';
-import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync, unlinkSync } from 'fs';
+import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { randomBytes, createHash } from 'crypto';
-import { execSync } from 'child_process';
-import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import { buildMediaPayload } from './media-payload.js';
 
 // Parse CLI args
 const args = process.argv.slice(2);
@@ -576,25 +575,6 @@ app.post('/edit', async (req, res) => {
   }
 });
 
-// MIME type map and media type inference for /send-media
-const MIME_MAP = {
-  jpg: 'image/jpeg', jpeg: 'image/jpeg', png: 'image/png',
-  webp: 'image/webp', gif: 'image/gif',
-  mp4: 'video/mp4', mov: 'video/quicktime', avi: 'video/x-msvideo',
-  mkv: 'video/x-matroska', '3gp': 'video/3gpp',
-  pdf: 'application/pdf',
-  doc: 'application/msword',
-  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-};
-
-function inferMediaType(ext) {
-  if (['jpg', 'jpeg', 'png', 'webp', 'gif'].includes(ext)) return 'image';
-  if (['mp4', 'mov', 'avi', 'mkv', '3gp'].includes(ext)) return 'video';
-  if (['ogg', 'opus', 'mp3', 'wav', 'm4a'].includes(ext)) return 'audio';
-  return 'document';
-}
-
 // Send media (image, video, document) natively
 app.post('/send-media', async (req, res) => {
   if (!sock || connectionState !== 'connected') {
@@ -611,55 +591,9 @@ app.post('/send-media', async (req, res) => {
       return res.status(404).json({ error: `File not found: ${filePath}` });
     }
 
-    const buffer = readFileSync(filePath);
-    const ext = filePath.toLowerCase().split('.').pop();
-    const type = mediaType || inferMediaType(ext);
-    let msgPayload;
-
-    switch (type) {
-      case 'image':
-        msgPayload = { image: buffer, caption: caption || undefined, mimetype: MIME_MAP[ext] || 'image/jpeg' };
-        break;
-      case 'video':
-        msgPayload = { video: buffer, caption: caption || undefined, mimetype: MIME_MAP[ext] || 'video/mp4' };
-        break;
-      case 'audio': {
-        // WhatsApp only renders a native voice bubble (ptt) when the file is ogg/opus.
-        // If the caller passes mp3, wav, m4a etc. (e.g. from Edge TTS / NeuTTS),
-        // silently convert to ogg/opus via ffmpeg so ptt is always honoured.
-        let audioBuffer = buffer;
-        let audioExt = ext;
-        const needsConversion = !['ogg', 'opus'].includes(ext);
-        let tmpPath = null;
-        if (needsConversion) {
-          tmpPath = path.join(tmpdir(), `hermes_voice_${randomBytes(6).toString('hex')}.ogg`);
-          try {
-            execSync(
-              `ffmpeg -y -i ${JSON.stringify(filePath)} -ar 48000 -ac 1 -c:a libopus ${JSON.stringify(tmpPath)}`,
-              { timeout: 30000, stdio: 'pipe' }
-            );
-            audioBuffer = readFileSync(tmpPath);
-            audioExt = 'ogg';
-          } catch (convErr) {
-            // ffmpeg not available or conversion failed — fall back to original format
-            console.warn('[bridge] ffmpeg conversion failed, sending as file attachment:', convErr.message);
-          } finally {
-            try { if (tmpPath && existsSync(tmpPath)) unlinkSync(tmpPath); } catch (_) {}
-          }
-        }
-        const audioMime = (audioExt === 'ogg' || audioExt === 'opus') ? 'audio/ogg; codecs=opus' : 'audio/mpeg';
-        msgPayload = { audio: audioBuffer, mimetype: audioMime, ptt: audioExt === 'ogg' || audioExt === 'opus' };
-        break;
-      }
-      case 'document':
-      default:
-        msgPayload = {
-          document: buffer,
-          fileName: fileName || path.basename(filePath),
-          caption: caption || undefined,
-          mimetype: MIME_MAP[ext] || 'application/octet-stream',
-        };
-        break;
+    const { payload: msgPayload, warning } = buildMediaPayload({ filePath, mediaType, caption, fileName });
+    if (warning) {
+      console.warn('[bridge] ffmpeg conversion failed, sending as file attachment:', warning);
     }
 
     const sent = await sendWithTimeout(chatId, msgPayload);

--- a/scripts/whatsapp-bridge/media-payload.js
+++ b/scripts/whatsapp-bridge/media-payload.js
@@ -67,7 +67,7 @@ export function buildMediaPayload({
         tmpPath = makeTempPath(filePath);
         try {
           exec(
-            `ffmpeg -y -i ${JSON.stringify(filePath)} -ar 48000 -ac 1 -c:a libopus ${JSON.stringify(tmpPath)}`,
+            `ffmpeg -y -i ${JSON.stringify(filePath)} -ar 48000 -ac 1 -c:a libopus -b:a 32k -vbr on -application voip ${JSON.stringify(tmpPath)}`,
             { timeout: 30000, stdio: 'pipe' },
           );
           audioBuffer = readFile(tmpPath);

--- a/scripts/whatsapp-bridge/media-payload.js
+++ b/scripts/whatsapp-bridge/media-payload.js
@@ -1,0 +1,105 @@
+import path from 'path';
+import { execSync } from 'child_process';
+import { randomBytes } from 'crypto';
+import { existsSync, readFileSync, unlinkSync } from 'fs';
+import { tmpdir } from 'os';
+
+export const MIME_MAP = {
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  webp: 'image/webp',
+  gif: 'image/gif',
+  mp4: 'video/mp4',
+  mov: 'video/quicktime',
+  avi: 'video/x-msvideo',
+  mkv: 'video/x-matroska',
+  '3gp': 'video/3gpp',
+  pdf: 'application/pdf',
+  doc: 'application/msword',
+  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+};
+
+export function inferMediaType(ext) {
+  if (['jpg', 'jpeg', 'png', 'webp', 'gif'].includes(ext)) return 'image';
+  if (['mp4', 'mov', 'avi', 'mkv', '3gp'].includes(ext)) return 'video';
+  if (['ogg', 'opus', 'mp3', 'wav', 'm4a'].includes(ext)) return 'audio';
+  return 'document';
+}
+
+function defaultTempPath() {
+  return path.join(tmpdir(), `hermes_voice_${randomBytes(6).toString('hex')}.ogg`);
+}
+
+export function buildMediaPayload({
+  filePath,
+  mediaType,
+  caption,
+  fileName,
+  readFile = readFileSync,
+  exists = existsSync,
+  remove = unlinkSync,
+  exec = execSync,
+  makeTempPath = defaultTempPath,
+} = {}) {
+  const buffer = readFile(filePath);
+  const ext = filePath.toLowerCase().split('.').pop();
+  const type = mediaType || inferMediaType(ext);
+
+  switch (type) {
+    case 'image':
+      return {
+        payload: { image: buffer, caption: caption || undefined, mimetype: MIME_MAP[ext] || 'image/jpeg' },
+      };
+    case 'video':
+      return {
+        payload: { video: buffer, caption: caption || undefined, mimetype: MIME_MAP[ext] || 'video/mp4' },
+      };
+    case 'audio': {
+      let audioBuffer = buffer;
+      let audioExt = ext;
+      const needsConversion = !['ogg', 'opus'].includes(ext);
+      let tmpPath = null;
+      let warning = null;
+
+      if (needsConversion) {
+        tmpPath = makeTempPath(filePath);
+        try {
+          exec(
+            `ffmpeg -y -i ${JSON.stringify(filePath)} -ar 48000 -ac 1 -c:a libopus ${JSON.stringify(tmpPath)}`,
+            { timeout: 30000, stdio: 'pipe' },
+          );
+          audioBuffer = readFile(tmpPath);
+          audioExt = 'ogg';
+        } catch (convErr) {
+          warning = convErr?.message || String(convErr);
+        } finally {
+          try {
+            if (tmpPath && exists(tmpPath)) remove(tmpPath);
+          } catch (_) {}
+        }
+      }
+
+      const isVoiceNote = audioExt === 'ogg' || audioExt === 'opus';
+      return {
+        payload: {
+          audio: audioBuffer,
+          mimetype: isVoiceNote ? 'audio/ogg; codecs=opus' : 'audio/mpeg',
+          ptt: isVoiceNote,
+        },
+        warning,
+      };
+    }
+    case 'document':
+    default:
+      return {
+        payload: {
+          document: buffer,
+          fileName: fileName || path.basename(filePath),
+          caption: caption || undefined,
+          mimetype: MIME_MAP[ext] || 'application/octet-stream',
+        },
+      };
+  }
+}

--- a/scripts/whatsapp-bridge/media-payload.test.mjs
+++ b/scripts/whatsapp-bridge/media-payload.test.mjs
@@ -62,6 +62,12 @@ test('buildMediaPayload converts non-Opus audio to a native voice note when ffmp
 
     assert.equal(warning, null);
     assert.match(execCommand, /^ffmpeg -y -i /);
+    assert.match(execCommand, / -ar 48000 /);
+    assert.match(execCommand, / -ac 1 /);
+    assert.match(execCommand, / -c:a libopus /);
+    assert.match(execCommand, / -b:a 32k /);
+    assert.match(execCommand, / -vbr on /);
+    assert.match(execCommand, / -application voip /);
     assert.deepEqual(payload.audio, converted);
     assert.equal(payload.mimetype, 'audio/ogg; codecs=opus');
     assert.equal(payload.ptt, true);

--- a/scripts/whatsapp-bridge/media-payload.test.mjs
+++ b/scripts/whatsapp-bridge/media-payload.test.mjs
@@ -1,0 +1,96 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+
+import { buildMediaPayload, inferMediaType } from './media-payload.js';
+
+function withTempDir(fn) {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'hermes-wa-media-'));
+  try {
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+for (const ext of ['ogg', 'opus']) {
+  test(`buildMediaPayload sends .${ext} audio as a native voice note without ffmpeg`, () => {
+    withTempDir((dir) => {
+      const filePath = path.join(dir, `reply.${ext}`);
+      const original = Buffer.from(`voice-${ext}`);
+      writeFileSync(filePath, original);
+
+      const { payload, warning } = buildMediaPayload({
+        filePath,
+        exec: () => {
+          throw new Error('ffmpeg should not run');
+        },
+      });
+
+      assert.equal(warning, null);
+      assert.deepEqual(payload.audio, original);
+      assert.equal(payload.mimetype, 'audio/ogg; codecs=opus');
+      assert.equal(payload.ptt, true);
+    });
+  });
+}
+
+test('buildMediaPayload converts non-Opus audio to a native voice note when ffmpeg succeeds', () => {
+  withTempDir((dir) => {
+    const filePath = path.join(dir, 'reply.mp3');
+    const tmpPath = path.join(dir, 'reply-converted.ogg');
+    const converted = Buffer.from('converted-opus');
+    writeFileSync(filePath, Buffer.from('original-mp3'));
+    let execCommand = '';
+    let cleaned = false;
+
+    const { payload, warning } = buildMediaPayload({
+      filePath,
+      makeTempPath: () => tmpPath,
+      exec: (command, options) => {
+        execCommand = command;
+        assert.deepEqual(options, { timeout: 30000, stdio: 'pipe' });
+        writeFileSync(tmpPath, converted);
+      },
+      remove: (target) => {
+        assert.equal(target, tmpPath);
+        cleaned = true;
+      },
+    });
+
+    assert.equal(warning, null);
+    assert.match(execCommand, /^ffmpeg -y -i /);
+    assert.deepEqual(payload.audio, converted);
+    assert.equal(payload.mimetype, 'audio/ogg; codecs=opus');
+    assert.equal(payload.ptt, true);
+    assert.equal(cleaned, true);
+  });
+});
+
+test('buildMediaPayload falls back to original audio when ffmpeg conversion fails', () => {
+  withTempDir((dir) => {
+    const filePath = path.join(dir, 'reply.mp3');
+    const original = Buffer.from('original-mp3');
+    writeFileSync(filePath, original);
+
+    const { payload, warning } = buildMediaPayload({
+      filePath,
+      makeTempPath: () => path.join(dir, 'reply-converted.ogg'),
+      exec: () => {
+        throw new Error('missing ffmpeg');
+      },
+    });
+
+    assert.equal(warning, 'missing ffmpeg');
+    assert.deepEqual(payload.audio, original);
+    assert.equal(payload.mimetype, 'audio/mpeg');
+    assert.equal(payload.ptt, false);
+  });
+});
+
+test('inferMediaType classifies WhatsApp voice-note formats as audio', () => {
+  assert.equal(inferMediaType('ogg'), 'audio');
+  assert.equal(inferMediaType('opus'), 'audio');
+});

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -1131,6 +1131,33 @@ class TestSendDocument:
 class TestSendVoice:
     """Local non-Opus audio converts to Opus; fallback sends the original."""
 
+    @pytest.mark.parametrize("suffix", [".ogg", ".opus"])
+    @pytest.mark.asyncio
+    async def test_send_voice_native_opus_uploads_without_conversion(self, suffix):
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(side_effect=[
+            _mock_upload_response("voice_id"),
+            _mock_message_response(),
+        ])
+        adapter._convert_to_opus = AsyncMock()
+
+        path = _tmpfile(suffix, content=b"OggS")
+        try:
+            result = await adapter.send_voice("15551234567", path)
+            assert result.success is True
+            adapter._convert_to_opus.assert_not_awaited()
+
+            upload_files = adapter._http_client.post.call_args_list[0].kwargs["files"]
+            assert upload_files["file"][2] == "audio/ogg; codecs=opus"
+            assert upload_files["type"] == (None, "audio/ogg; codecs=opus")
+
+            send_payload = adapter._http_client.post.call_args_list[1].kwargs["json"]
+            assert send_payload["type"] == "audio"
+            assert send_payload["audio"]["id"] == "voice_id"
+        finally:
+            _os.unlink(path)
+
     @pytest.mark.asyncio
     async def test_send_voice_no_ffmpeg_falls_back_to_mp3(self):
         adapter = _make_adapter()

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -1129,7 +1129,7 @@ class TestSendDocument:
 
 
 class TestSendVoice:
-    """MP3 voice with ffmpeg present -> opus; without ffmpeg -> MP3 fallback."""
+    """Local non-Opus audio converts to Opus; fallback sends the original."""
 
     @pytest.mark.asyncio
     async def test_send_voice_no_ffmpeg_falls_back_to_mp3(self):
@@ -1179,6 +1179,54 @@ class TestSendVoice:
             _os.unlink(mp3_path)
             if _os.path.exists(opus_path):
                 _os.unlink(opus_path)
+
+    @pytest.mark.asyncio
+    async def test_send_voice_wav_uses_opus_conversion(self):
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(side_effect=[
+            _mock_upload_response("voice_id"),
+            _mock_message_response(),
+        ])
+        # Pretend ffmpeg conversion succeeded by returning a fake Opus path.
+        opus_path = _tmpfile(".ogg", content=b"OggS")
+        adapter._convert_to_opus = AsyncMock(return_value=opus_path)
+
+        wav_path = _tmpfile(".wav", content=b"RIFF\x24\x00\x00\x00WAVE")
+        try:
+            result = await adapter.send_voice("15551234567", wav_path)
+            assert result.success is True
+            adapter._convert_to_opus.assert_awaited_once_with(wav_path)
+            upload_files = adapter._http_client.post.call_args_list[0].kwargs["files"]
+            assert upload_files["file"][0] == _os.path.basename(opus_path)
+            assert upload_files["file"][2] == "audio/ogg; codecs=opus"
+            send_payload = adapter._http_client.post.call_args_list[1].kwargs["json"]
+            assert send_payload["type"] == "audio"
+        finally:
+            _os.unlink(wav_path)
+            if _os.path.exists(opus_path):
+                _os.unlink(opus_path)
+
+    @pytest.mark.asyncio
+    async def test_send_voice_existing_ogg_uploads_as_opus_without_conversion(self):
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(side_effect=[
+            _mock_upload_response("voice_id"),
+            _mock_message_response(),
+        ])
+        adapter._convert_to_opus = AsyncMock()
+
+        ogg_path = _tmpfile(".ogg", content=b"OggS")
+        try:
+            result = await adapter.send_voice("15551234567", ogg_path)
+            assert result.success is True
+            adapter._convert_to_opus.assert_not_awaited()
+            upload_files = adapter._http_client.post.call_args_list[0].kwargs["files"]
+            assert upload_files["file"][0] == _os.path.basename(ogg_path)
+            assert upload_files["file"][2] == "audio/ogg; codecs=opus"
+        finally:
+            _os.unlink(ogg_path)
 
     @pytest.mark.asyncio
     async def test_warn_once_no_ffmpeg_actually_only_warns_once(self):

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -1265,6 +1265,52 @@ class TestSendVoice:
         adapter._warn_once_no_ffmpeg()
         assert adapter._warned_no_ffmpeg is True
 
+    @pytest.mark.asyncio
+    async def test_convert_to_opus_forces_whatsapp_voice_note_shape(self):
+        from pathlib import Path
+
+        from gateway.platforms import whatsapp_cloud as wac
+
+        class _Proc:
+            returncode = 0
+
+            async def communicate(self):
+                return b"", b""
+
+        adapter = _make_adapter()
+        source_path = _tmpfile(".wav", content=b"RIFF....WAVE")
+        captured_args = None
+
+        async def fake_create_subprocess_exec(*args, **_kwargs):
+            nonlocal captured_args
+            captured_args = args
+            Path(str(args[-1])).write_bytes(b"OggS")
+            return _Proc()
+
+        try:
+            with _patch.object(wac, "_FFMPEG_PATH", "ffmpeg"), _patch(
+                "gateway.platforms.whatsapp_cloud.asyncio.create_subprocess_exec",
+                new=fake_create_subprocess_exec,
+            ):
+                opus_path = await adapter._convert_to_opus(source_path)
+
+            assert opus_path is not None
+            args = captured_args
+            assert args is not None
+            assert args[0] == "ffmpeg"
+            assert args[3] == source_path
+            assert args[args.index("-ac") + 1] == "1"
+            assert args[args.index("-ar") + 1] == "48000"
+            assert args[args.index("-c:a") + 1] == "libopus"
+            assert args[args.index("-b:a") + 1] == "32k"
+            assert args[args.index("-vbr") + 1] == "on"
+            assert args[args.index("-application") + 1] == "voip"
+            assert args[-1] == opus_path
+        finally:
+            _os.unlink(source_path)
+            if "opus_path" in locals() and opus_path and _os.path.exists(opus_path):
+                _os.unlink(opus_path)
+
 
 # ---------------------------------------------------------------------------
 # Inbound media — Graph two-step download (Phase 4)

--- a/tests/tools/test_tts_command_providers.py
+++ b/tests/tools/test_tts_command_providers.py
@@ -33,6 +33,7 @@ from tools.tts_tool import (
     _has_any_command_tts_provider,
     _is_command_provider_config,
     _is_command_tts_voice_compatible,
+    _is_native_ogg_opus,
     _iter_command_providers,
     _render_command_tts_template,
     _resolve_command_provider_config,
@@ -47,6 +48,9 @@ from tools.tts_tool import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+OPUS_OGG_BYTES = b"OggS\x00\x02" + (b"\x00" * 20) + b"OpusHead" + (b"\x00" * 16)
+
+
 def _python_copy_command(output_placeholder: str = "{output_path}") -> str:
     """Return a cross-platform shell command that copies {input_path} -> output."""
     interpreter = sys.executable
@@ -54,6 +58,19 @@ def _python_copy_command(output_placeholder: str = "{output_path}") -> str:
         f'"{interpreter}" -c "import shutil, sys; '
         f'shutil.copyfile(sys.argv[1], sys.argv[2])" '
         f'{{input_path}} {output_placeholder}'
+    )
+
+
+def _python_write_bytes_command(
+    payload: bytes,
+    output_placeholder: str = "{output_path}",
+) -> str:
+    """Return a command that writes fixed bytes to {output_path}."""
+    interpreter = sys.executable
+    return (
+        f'"{interpreter}" -c "from pathlib import Path; import sys; '
+        f'Path(sys.argv[1]).write_bytes(bytes.fromhex(sys.argv[2]))" '
+        f'{output_placeholder} {payload.hex()}'
     )
 
 
@@ -197,14 +214,20 @@ class TestConfigGetters:
     def test_output_format_path_override(self):
         assert _get_command_tts_output_format({}, "/tmp/clip.wav") == "wav"
 
+    def test_output_format_path_override_opus(self):
+        assert _get_command_tts_output_format({}, "/tmp/clip.opus") == "opus"
+
     def test_output_format_unknown_path_falls_back_to_config(self):
         assert _get_command_tts_output_format({"format": "ogg"}, "/tmp/clip.xyz") == "ogg"
+
+    def test_output_format_accepts_opus(self):
+        assert _get_command_tts_output_format({"format": "opus"}) == "opus"
 
     def test_output_format_rejects_unknown(self):
         assert _get_command_tts_output_format({"format": "m4a"}) == DEFAULT_COMMAND_TTS_OUTPUT_FORMAT
 
     def test_output_format_supported_set(self):
-        assert COMMAND_TTS_OUTPUT_FORMATS == frozenset({"mp3", "wav", "ogg", "flac"})
+        assert COMMAND_TTS_OUTPUT_FORMATS == frozenset({"mp3", "wav", "ogg", "opus", "flac"})
 
     def test_voice_compatible_boolean(self):
         assert _is_command_tts_voice_compatible({"voice_compatible": True}) is True
@@ -452,13 +475,13 @@ class TestTextToSpeechToolWithCommandProvider:
 
     def test_voice_compatible_opt_in_toggles_flag(self, tmp_path):
         """voice_compatible=true is reflected in the response when the
-        file is already .ogg (no ffmpeg needed)."""
+        file is already Ogg/Opus (no ffmpeg needed)."""
         cfg = {
             "provider": "py-copy-ogg",
             "providers": {
                 "py-copy-ogg": {
                     "type": "command",
-                    "command": _python_copy_command(),
+                    "command": _python_write_bytes_command(OPUS_OGG_BYTES),
                     "output_format": "ogg",
                     "voice_compatible": True,
                 },
@@ -471,7 +494,55 @@ class TestTextToSpeechToolWithCommandProvider:
         data = json.loads(result)
         assert data["success"] is True
         assert data["voice_compatible"] is True
+        assert _is_native_ogg_opus(data["file_path"]) is True
         assert data["media_tag"].startswith("[[audio_as_voice]]")
+
+    def test_voice_compatible_opt_in_accepts_opus_extension(self, tmp_path):
+        cfg = {
+            "provider": "py-opus",
+            "providers": {
+                "py-opus": {
+                    "type": "command",
+                    "command": _python_write_bytes_command(OPUS_OGG_BYTES),
+                    "output_format": "opus",
+                    "voice_compatible": True,
+                },
+            },
+        }
+        out = tmp_path / "clip"
+
+        with patch("tools.tts_tool._load_tts_config", return_value=cfg):
+            result = text_to_speech_tool(text="hi", output_path=str(out))
+        data = json.loads(result)
+        opus_path = tmp_path / "clip.opus"
+        assert data["success"] is True
+        assert data["file_path"] == str(opus_path)
+        assert data["voice_compatible"] is True
+        assert data["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{opus_path}"
+
+    def test_voice_compatible_opt_in_rejects_fake_ogg(self, tmp_path):
+        cfg = {
+            "provider": "py-fake-ogg",
+            "providers": {
+                "py-fake-ogg": {
+                    "type": "command",
+                    "command": _python_write_bytes_command(b"not opus"),
+                    "output_format": "ogg",
+                    "voice_compatible": True,
+                },
+            },
+        }
+        out = tmp_path / "clip.ogg"
+
+        with patch("tools.tts_tool._load_tts_config", return_value=cfg), \
+             patch("tools.tts_tool._convert_to_opus", return_value=None) as convert:
+            result = text_to_speech_tool(text="hi", output_path=str(out))
+        data = json.loads(result)
+        assert data["success"] is True
+        assert data["file_path"] == str(out)
+        assert data["voice_compatible"] is False
+        assert data["media_tag"] == f"MEDIA:{out}"
+        convert.assert_called_once_with(str(out))
 
     def test_missing_command_falls_through_to_builtin(self, tmp_path):
         """A provider entry with an empty command is not a command

--- a/tests/tools/test_tts_dotenv_fallback.py
+++ b/tests/tools/test_tts_dotenv_fallback.py
@@ -56,6 +56,20 @@ class TestDotenvFallbackPerProvider:
 
             mock_import.return_value.assert_called_once_with(api_key="el-dotenv-key")
 
+    def test_elevenlabs_opus_extension_requests_opus_format(self, tmp_path):
+        from tools import tts_tool
+
+        with patch.object(tts_tool, "get_env_value", return_value="el-dotenv-key"), \
+             patch.object(tts_tool, "_import_elevenlabs") as mock_import:
+            mock_client = MagicMock()
+            mock_client.text_to_speech.convert.return_value = iter([b"audio"])
+            mock_import.return_value = MagicMock(return_value=mock_client)
+
+            tts_tool._generate_elevenlabs("hi", str(tmp_path / "out.opus"), {})
+
+        kwargs = mock_client.text_to_speech.convert.call_args[1]
+        assert kwargs["output_format"] == "opus_48000_64"
+
     def test_xai_reads_dotenv_key(self, tmp_path):
         """xAI TTS now resolves credentials through ``tools.xai_http``; the
         dotenv fallback contract from #17140 is preserved by patching the

--- a/tests/tools/test_tts_gemini.py
+++ b/tests/tools/test_tts_gemini.py
@@ -1,6 +1,7 @@
 """Tests for the Google Gemini TTS provider in tools/tts_tool.py."""
 
 import base64
+import subprocess
 import struct
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -114,6 +115,29 @@ class TestGenerateGeminiTts:
         assert data[8:12] == b"WAVE"
         # Audio payload should match the PCM we put in
         assert data[44:] == fake_pcm_bytes
+
+    def test_opus_output_uses_libopus_ffmpeg(
+        self, tmp_path, monkeypatch, mock_gemini_response
+    ):
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        output_path = str(tmp_path / "test.opus")
+        seen_cmd: list[str] = []
+
+        def fake_run(cmd, **_kwargs):
+            seen_cmd[:] = cmd
+            (tmp_path / "test.opus").write_bytes(b"OggS\x00\x02OpusHead")
+            return subprocess.CompletedProcess(cmd, 0, b"", b"")
+
+        with patch("requests.post", return_value=mock_gemini_response), \
+             patch("tools.tts_tool.shutil.which", return_value="/usr/bin/ffmpeg"), \
+             patch("tools.tts_tool.subprocess.run", side_effect=fake_run):
+            result = _generate_gemini_tts("Hi", output_path, {})
+
+        assert result == output_path
+        assert "-acodec" in seen_cmd
+        assert "libopus" in seen_cmd
 
     def test_default_voice_and_model(self, tmp_path, monkeypatch, mock_gemini_response):
         from tools.tts_tool import (

--- a/tests/tools/test_tts_mistral.py
+++ b/tests/tools/test_tts_mistral.py
@@ -54,7 +54,13 @@ class TestGenerateMistralTts:
 
     @pytest.mark.parametrize(
         "extension, expected_format",
-        [(".ogg", "opus"), (".wav", "wav"), (".flac", "flac"), (".mp3", "mp3")],
+        [
+            (".ogg", "opus"),
+            (".opus", "opus"),
+            (".wav", "wav"),
+            (".flac", "flac"),
+            (".mp3", "mp3"),
+        ],
     )
     def test_response_format_from_extension(
         self, tmp_path, mock_mistral_module, monkeypatch, extension, expected_format

--- a/tests/tools/test_tts_opus_routing.py
+++ b/tests/tools/test_tts_opus_routing.py
@@ -44,7 +44,8 @@ def test_edge_cli_preserves_native_mp3(tmp_path, monkeypatch):
     convert.assert_not_called()
 
 
-def test_edge_telegram_converts_to_opus_voice(tmp_path, monkeypatch):
+@pytest.mark.parametrize("platform", ["telegram", "whatsapp", "whatsapp_cloud"])
+def test_edge_voice_platforms_convert_to_opus_voice(tmp_path, monkeypatch, platform):
     out = tmp_path / "speech.mp3"
     opus = tmp_path / "speech.ogg"
 
@@ -55,7 +56,7 @@ def test_edge_telegram_converts_to_opus_voice(tmp_path, monkeypatch):
 
     convert = Mock(side_effect=fake_convert)
 
-    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", platform)
     monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "edge"})
     monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
     monkeypatch.setattr(tts_tool, "_generate_edge_tts", _write_edge_output)

--- a/tests/tools/test_tts_opus_routing.py
+++ b/tests/tools/test_tts_opus_routing.py
@@ -8,6 +8,9 @@ from gateway.session_context import _UNSET, _VAR_MAP
 from tools import tts_tool
 
 
+OPUS_OGG_BYTES = b"OggS\x00\x02" + (b"\x00" * 20) + b"OpusHead" + (b"\x00" * 16)
+
+
 def _reset_session_context() -> None:
     for var in _VAR_MAP.values():
         var.set(_UNSET)
@@ -51,7 +54,7 @@ def test_edge_voice_platforms_convert_to_opus_voice(tmp_path, monkeypatch, platf
 
     def fake_convert(path: str) -> str:
         assert path == str(out)
-        opus.write_bytes(b"ogg")
+        opus.write_bytes(OPUS_OGG_BYTES)
         return str(opus)
 
     convert = Mock(side_effect=fake_convert)
@@ -69,3 +72,26 @@ def test_edge_voice_platforms_convert_to_opus_voice(tmp_path, monkeypatch, platf
     assert result["voice_compatible"] is True
     assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{opus}"
     convert.assert_called_once_with(str(out))
+
+
+def test_voice_platform_rejects_invalid_opus_conversion(tmp_path, monkeypatch):
+    out = tmp_path / "speech.mp3"
+    opus = tmp_path / "speech.ogg"
+
+    def fake_convert(path: str) -> str:
+        assert path == str(out)
+        opus.write_bytes(b"not opus")
+        return str(opus)
+
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "whatsapp_cloud")
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "edge"})
+    monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
+    monkeypatch.setattr(tts_tool, "_generate_edge_tts", _write_edge_output)
+    monkeypatch.setattr(tts_tool, "_convert_to_opus", Mock(side_effect=fake_convert))
+
+    result = json.loads(tts_tool.text_to_speech_tool("hello", output_path=str(out)))
+
+    assert result["success"] is True
+    assert result["file_path"] == str(out)
+    assert result["voice_compatible"] is False
+    assert result["media_tag"] == f"MEDIA:{out}"

--- a/tests/tools/test_tts_opus_routing.py
+++ b/tests/tools/test_tts_opus_routing.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -95,3 +96,31 @@ def test_voice_platform_rejects_invalid_opus_conversion(tmp_path, monkeypatch):
     assert result["file_path"] == str(out)
     assert result["voice_compatible"] is False
     assert result["media_tag"] == f"MEDIA:{out}"
+
+
+def test_tts_opus_conversion_forces_whatsapp_ready_shape(tmp_path, monkeypatch):
+    source = tmp_path / "speech.mp3"
+    source.write_bytes(b"mp3")
+    output = tmp_path / "speech.ogg"
+    commands = []
+
+    def fake_run(command, **kwargs):
+        commands.append((command, kwargs))
+        output.write_bytes(OPUS_OGG_BYTES)
+        return subprocess.CompletedProcess(command, 0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(tts_tool, "_has_ffmpeg", lambda: True)
+    monkeypatch.setattr(tts_tool.subprocess, "run", fake_run)
+
+    result = tts_tool._convert_to_opus(str(source))
+
+    assert result == str(output)
+    assert commands
+    command, kwargs = commands[0]
+    assert command[:4] == ["ffmpeg", "-i", str(source), "-acodec"]
+    assert "libopus" in command
+    assert command[command.index("-ac") + 1] == "1"
+    assert command[command.index("-ar") + 1] == "48000"
+    assert command[command.index("-application") + 1] == "voip"
+    assert command[-2:] == [str(output), "-y"]
+    assert kwargs["stdin"] is subprocess.DEVNULL

--- a/tests/tools/test_tts_speed.py
+++ b/tests/tools/test_tts_speed.py
@@ -69,7 +69,7 @@ class TestEdgeTtsSpeed:
 # ---------------------------------------------------------------------------
 
 class TestOpenaiTtsSpeed:
-    def _run(self, tts_config, tmp_path, monkeypatch):
+    def _run(self, tts_config, tmp_path, monkeypatch, output_name="out.mp3"):
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")
         mock_response = MagicMock()
         mock_client = MagicMock()
@@ -80,7 +80,7 @@ class TestOpenaiTtsSpeed:
              patch("tools.tts_tool._resolve_openai_audio_client_config",
                    return_value=("test-key", None)):
             from tools.tts_tool import _generate_openai_tts
-            _generate_openai_tts("Hello", str(tmp_path / "out.mp3"), tts_config)
+            _generate_openai_tts("Hello", str(tmp_path / output_name), tts_config)
         return mock_client.audio.speech.create
 
     def test_default_no_speed_kwarg(self, tmp_path, monkeypatch):
@@ -112,6 +112,11 @@ class TestOpenaiTtsSpeed:
         create = self._run({"speed": 10.0}, tmp_path, monkeypatch)
         kwargs = create.call_args[1]
         assert kwargs["speed"] == 4.0
+
+    def test_opus_extension_requests_opus_response_format(self, tmp_path, monkeypatch):
+        create = self._run({}, tmp_path, monkeypatch, output_name="out.opus")
+        kwargs = create.call_args[1]
+        assert kwargs["response_format"] == "opus"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -22,8 +22,9 @@ Custom command providers:
   See the Local Command section of ``website/docs/user-guide/features/tts.md``.
 
 Output formats:
-- Opus (.ogg) for Telegram voice bubbles (requires ffmpeg for Edge TTS)
-- MP3 (.mp3) for everything else (CLI, Discord, WhatsApp)
+- Opus (.ogg) for native voice bubbles/notes on Telegram and WhatsApp
+  surfaces (requires ffmpeg for providers that only emit MP3/WAV)
+- MP3 (.mp3) for everything else (CLI, Discord)
 
 Configuration is loaded from ~/.hermes/config.yaml under the 'tts:' key.
 The user chooses the provider and voice; the model just sends text.
@@ -390,6 +391,7 @@ DEFAULT_COMMAND_TTS_TIMEOUT_SECONDS = 120
 DEFAULT_COMMAND_TTS_OUTPUT_FORMAT = "mp3"
 COMMAND_TTS_OUTPUT_FORMATS = frozenset({"mp3", "wav", "ogg", "flac"})
 DEFAULT_COMMAND_TTS_MAX_TEXT_LENGTH = 5000
+OPUS_VOICE_PLATFORMS = frozenset({"telegram", "whatsapp", "whatsapp_cloud"})
 
 
 def _get_provider_section(tts_config: Dict[str, Any], name: str) -> Dict[str, Any]:
@@ -2059,12 +2061,13 @@ def text_to_speech_tool(
         text = text[:max_len]
 
     # Detect platform from gateway env var to choose the best output format.
-    # Telegram voice bubbles require Opus (.ogg); OpenAI and ElevenLabs can
-    # produce Opus natively (no ffmpeg needed).  Edge TTS always outputs MP3
-    # and needs ffmpeg for conversion.
+    # Telegram voice bubbles and WhatsApp voice notes require Opus (.ogg).
+    # OpenAI, ElevenLabs, Mistral, and Gemini can produce Opus natively
+    # (no ffmpeg needed). Edge TTS always outputs MP3 and needs ffmpeg
+    # for conversion.
     from gateway.session_context import get_session_env
     platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
-    want_opus = (platform == "telegram")
+    want_opus = platform in OPUS_VOICE_PLATFORMS
 
     # Determine output path
     if output_path:
@@ -2702,7 +2705,7 @@ from tools.registry import registry, tool_error
 
 TTS_SCHEMA = {
     "name": "text_to_speech",
-    "description": "Convert text to speech audio. Returns a MEDIA: path that the platform delivers as native audio. Compatible providers render as a voice bubble on Telegram; otherwise audio is sent as a regular attachment. In CLI mode, saves to ~/voice-memos/. Voice and provider are user-configured (built-in providers like edge/openai or custom command providers under tts.providers.<name>), not model-selected.",
+    "description": "Convert text to speech audio. Returns a MEDIA: path that the platform delivers as native audio. Compatible providers render as a voice bubble/note on Telegram and WhatsApp; otherwise audio is sent as a regular attachment. In CLI mode, saves to ~/voice-memos/. Voice and provider are user-configured (built-in providers like edge/openai or custom command providers under tts.providers.<name>), not model-selected.",
     "parameters": {
         "type": "object",
         "properties": {

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -22,7 +22,7 @@ Custom command providers:
   See the Local Command section of ``website/docs/user-guide/features/tts.md``.
 
 Output formats:
-- Opus (.ogg) for native voice bubbles/notes on Telegram and WhatsApp
+- Opus (.ogg/.opus) for native voice bubbles/notes on Telegram and WhatsApp
   surfaces (requires ffmpeg for providers that only emit MP3/WAV)
 - MP3 (.mp3) for everything else (CLI, Discord)
 
@@ -389,9 +389,11 @@ BUILTIN_TTS_PROVIDERS = frozenset({
 
 DEFAULT_COMMAND_TTS_TIMEOUT_SECONDS = 120
 DEFAULT_COMMAND_TTS_OUTPUT_FORMAT = "mp3"
-COMMAND_TTS_OUTPUT_FORMATS = frozenset({"mp3", "wav", "ogg", "flac"})
+COMMAND_TTS_OUTPUT_FORMATS = frozenset({"mp3", "wav", "ogg", "opus", "flac"})
 DEFAULT_COMMAND_TTS_MAX_TEXT_LENGTH = 5000
 OPUS_VOICE_PLATFORMS = frozenset({"telegram", "whatsapp", "whatsapp_cloud"})
+OGG_OPUS_EXTENSIONS = frozenset({".ogg", ".opus"})
+OGG_OPUS_SIGNATURE_SCAN_BYTES = 64 * 1024
 
 
 def _get_provider_section(tts_config: Dict[str, Any], name: str) -> Dict[str, Any]:
@@ -602,7 +604,7 @@ def _get_command_tts_output_format(
     config: Dict[str, Any],
     output_path: Optional[str] = None,
 ) -> str:
-    """Return the validated output format (mp3/wav/ogg/flac)."""
+    """Return the validated output format (mp3/wav/ogg/opus/flac)."""
     if output_path:
         suffix = Path(output_path).suffix.lower().strip().lstrip(".")
         if suffix in COMMAND_TTS_OUTPUT_FORMATS:
@@ -622,6 +624,26 @@ def _is_command_tts_voice_compatible(config: Dict[str, Any]) -> bool:
     if isinstance(value, str):
         return value.strip().lower() in {"1", "true", "yes", "on"}
     return bool(value)
+
+
+def _wants_ogg_opus_output(path: str) -> bool:
+    """Return True when *path* asks for an Ogg/Opus container extension."""
+    return Path(path).suffix.lower() in OGG_OPUS_EXTENSIONS
+
+
+def _is_native_ogg_opus(path: str) -> bool:
+    """Return True when *path* is a non-empty Ogg container with Opus audio."""
+    file_path = Path(path)
+    if file_path.suffix.lower() not in OGG_OPUS_EXTENSIONS:
+        return False
+    try:
+        if file_path.stat().st_size <= 0:
+            return False
+        with file_path.open("rb") as f:
+            header = f.read(OGG_OPUS_SIGNATURE_SCAN_BYTES)
+    except OSError:
+        return False
+    return header.startswith(b"OggS") and b"OpusHead" in header
 
 
 def _shell_quote_context(command_template: str, position: int) -> Optional[str]:
@@ -878,19 +900,19 @@ def _has_any_command_tts_provider(tts_config: Optional[Dict[str, Any]] = None) -
 
 
 # ===========================================================================
-# ffmpeg Opus conversion (Edge TTS MP3 -> OGG Opus for Telegram)
+# ffmpeg Opus conversion for voice-note platforms
 # ===========================================================================
 def _has_ffmpeg() -> bool:
     """Check if ffmpeg is available on the system."""
     return shutil.which("ffmpeg") is not None
 
 
-def _convert_to_opus(mp3_path: str) -> Optional[str]:
+def _convert_to_opus(audio_path: str) -> Optional[str]:
     """
-    Convert an MP3 file to OGG Opus format for Telegram voice bubbles.
+    Convert an audio file to OGG Opus format for voice bubbles.
 
     Args:
-        mp3_path: Path to the input MP3 file.
+        audio_path: Path to the input audio file.
 
     Returns:
         Path to the .ogg file, or None if conversion fails.
@@ -898,10 +920,13 @@ def _convert_to_opus(mp3_path: str) -> Optional[str]:
     if not _has_ffmpeg():
         return None
 
-    ogg_path = mp3_path.rsplit(".", 1)[0] + ".ogg"
+    source = Path(audio_path)
+    ogg_path = str(source.with_suffix(".ogg"))
+    if os.path.abspath(ogg_path) == os.path.abspath(audio_path):
+        ogg_path = str(source.with_name(f"{source.stem}.opus.ogg"))
     try:
         result = subprocess.run(
-            ["ffmpeg", "-i", mp3_path, "-acodec", "libopus",
+            ["ffmpeg", "-i", audio_path, "-acodec", "libopus",
              "-ac", "1", "-b:a", "64k", "-vbr", "off", ogg_path, "-y"],
             capture_output=True, timeout=30,
             stdin=subprocess.DEVNULL,
@@ -910,7 +935,7 @@ def _convert_to_opus(mp3_path: str) -> Optional[str]:
             logger.warning("ffmpeg conversion failed with return code %d: %s", 
                           result.returncode, result.stderr.decode('utf-8', errors='ignore')[:200])
             return None
-        if os.path.exists(ogg_path) and os.path.getsize(ogg_path) > 0:
+        if _is_native_ogg_opus(ogg_path):
             return ogg_path
     except subprocess.TimeoutExpired:
         logger.warning("ffmpeg OGG conversion timed out after 30s")
@@ -918,6 +943,16 @@ def _convert_to_opus(mp3_path: str) -> Optional[str]:
         logger.warning("ffmpeg not found in PATH")
     except Exception as e:
         logger.warning("ffmpeg OGG conversion failed: %s", e, exc_info=True)
+    return None
+
+
+def _ensure_ogg_opus_voice_file(audio_path: str) -> Optional[str]:
+    """Return a verified Ogg/Opus file path, converting when needed."""
+    if _is_native_ogg_opus(audio_path):
+        return audio_path
+    opus_path = _convert_to_opus(audio_path)
+    if opus_path and _is_native_ogg_opus(opus_path):
+        return opus_path
     return None
 
 
@@ -975,7 +1010,7 @@ def _generate_elevenlabs(text: str, output_path: str, tts_config: Dict[str, Any]
     model_id = el_config.get("model_id", DEFAULT_ELEVENLABS_MODEL_ID)
 
     # Determine output format based on file extension
-    if output_path.endswith(".ogg"):
+    if _wants_ogg_opus_output(output_path):
         output_format = "opus_48000_64"
     else:
         output_format = "mp3_44100_128"
@@ -1021,7 +1056,7 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     speed = float(oai_config.get("speed", tts_config.get("speed", 1.0)))
 
     # Determine response format from extension
-    if output_path.endswith(".ogg"):
+    if _wants_ogg_opus_output(output_path):
         response_format = "opus"
     else:
         response_format = "mp3"
@@ -1334,7 +1369,7 @@ def _generate_mistral_tts(text: str, output_path: str, tts_config: Dict[str, Any
     model = mi_config.get("model", DEFAULT_MISTRAL_TTS_MODEL)
     voice_id = mi_config.get("voice_id") or DEFAULT_MISTRAL_TTS_VOICE_ID
 
-    if output_path.endswith(".ogg"):
+    if _wants_ogg_opus_output(output_path):
         response_format = "opus"
     elif output_path.endswith(".wav"):
         response_format = "wav"
@@ -1567,7 +1602,7 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     Args:
         text: Text to convert (prompt-style; supports inline direction like
               "Say cheerfully:" and audio tags like [whispers]).
-        output_path: Where to save the audio file (.wav, .mp3, or .ogg).
+        output_path: Where to save the audio file (.wav, .mp3, .ogg, or .opus).
         tts_config: TTS config dict.
 
     Returns:
@@ -1662,7 +1697,7 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         return output_path
 
     # Otherwise write WAV to a temp file and ffmpeg-convert to the target
-    # format (.mp3 or .ogg). If ffmpeg is missing, fall back to renaming the
+    # format (.mp3, .ogg, or .opus). If ffmpeg is missing, fall back to renaming the
     # WAV -- this matches the NeuTTS behavior and keeps the tool usable on
     # systems without ffmpeg (audio still plays, just with a misleading
     # extension).
@@ -1675,7 +1710,7 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         if ffmpeg:
             # For .ogg output, force libopus encoding (Telegram voice bubbles
             # require Opus specifically; ffmpeg's default for .ogg is Vorbis).
-            if output_path.lower().endswith(".ogg"):
+            if _wants_ogg_opus_output(output_path):
                 cmd = [
                     ffmpeg, "-i", wav_path,
                     "-acodec", "libopus", "-ac", "1",
@@ -2061,7 +2096,7 @@ def text_to_speech_tool(
         text = text[:max_len]
 
     # Detect platform from gateway env var to choose the best output format.
-    # Telegram voice bubbles and WhatsApp voice notes require Opus (.ogg).
+    # Telegram voice bubbles and WhatsApp voice notes require Opus (.ogg/.opus).
     # OpenAI, ElevenLabs, Mistral, and Gemini can produce Opus natively
     # (no ffmpeg needed). Edge TTS always outputs MP3 and needs ffmpeg
     # for conversion.
@@ -2268,11 +2303,10 @@ def text_to_speech_tool(
             # delivery only kicks in when the user explicitly opts in
             # via ``voice_compatible: true`` in their provider config.
             if _is_command_tts_voice_compatible(command_provider_config):
-                if not file_str.endswith(".ogg"):
-                    opus_path = _convert_to_opus(file_str)
-                    if opus_path:
-                        file_str = opus_path
-                voice_compatible = file_str.endswith(".ogg")
+                opus_path = _ensure_ogg_opus_voice_file(file_str)
+                if opus_path:
+                    file_str = opus_path
+                    voice_compatible = True
         elif provider not in BUILTIN_TTS_PROVIDERS:
             # Plugin-registered provider (issue #30398). Voice-bubble
             # delivery opts in via ``TTSProvider.voice_compatible``
@@ -2280,22 +2314,20 @@ def text_to_speech_tool(
             # already write Opus skip the ffmpeg conversion.
             plugin_voice_compatible = _plugin_provider_is_voice_compatible(provider)
             if plugin_voice_compatible:
-                if not file_str.endswith(".ogg"):
-                    opus_path = _convert_to_opus(file_str)
-                    if opus_path:
-                        file_str = opus_path
-                voice_compatible = file_str.endswith(".ogg")
+                opus_path = _ensure_ogg_opus_voice_file(file_str)
+                if opus_path:
+                    file_str = opus_path
+                    voice_compatible = True
         elif (
             want_opus
             and provider in {"edge", "neutts", "minimax", "xai", "kittentts", "piper"}
-            and not file_str.endswith(".ogg")
         ):
-            opus_path = _convert_to_opus(file_str)
+            opus_path = _ensure_ogg_opus_voice_file(file_str)
             if opus_path:
                 file_str = opus_path
                 voice_compatible = True
         elif provider in {"elevenlabs", "openai", "mistral", "gemini"}:
-            voice_compatible = want_opus and file_str.endswith(".ogg")
+            voice_compatible = want_opus and _is_native_ogg_opus(file_str)
 
         file_size = os.path.getsize(file_str)
         logger.info("TTS audio saved: %s (%s bytes, provider: %s)", file_str, f"{file_size:,}", provider)

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -926,8 +926,14 @@ def _convert_to_opus(audio_path: str) -> Optional[str]:
         ogg_path = str(source.with_name(f"{source.stem}.opus.ogg"))
     try:
         result = subprocess.run(
-            ["ffmpeg", "-i", audio_path, "-acodec", "libopus",
-             "-ac", "1", "-b:a", "64k", "-vbr", "off", ogg_path, "-y"],
+            [
+                "ffmpeg", "-i", audio_path,
+                "-acodec", "libopus",
+                "-ac", "1", "-ar", "48000",
+                "-b:a", "64k", "-vbr", "off",
+                "-application", "voip",
+                ogg_path, "-y",
+            ],
             capture_output=True, timeout=30,
             stdin=subprocess.DEVNULL,
         )


### PR DESCRIPTION
## Summary
- convert local non-Opus WhatsApp Cloud voice files such as WAV/MP3 to Ogg/Opus before upload
- pass through existing `.ogg`/`.opus` files with `audio/ogg; codecs=opus` without conversion
- treat WhatsApp and WhatsApp Cloud sessions like Telegram for TTS Opus voice-note routing

## Why
`voice` can now write WhatsApp-ready Ogg/Opus directly. Hermes should preserve that output when available, and only use ffmpeg conversion as a fallback for providers that still emit WAV/MP3. This makes both Baileys-style WhatsApp voice notes and the WhatsApp Cloud adapter line up with the same speech format contract.

## Verification
- `./.venv/bin/python -m pytest -q tests/tools/test_tts_opus_routing.py tests/tools/test_tts_command_providers.py tests/gateway/test_whatsapp_cloud.py` (163 passed)
- `./.venv/bin/python -m ruff check tools/tts_tool.py tests/tools/test_tts_opus_routing.py gateway/platforms/whatsapp_cloud.py tests/gateway/test_whatsapp_cloud.py`
- `git diff --check`

## Local voice integration smoke
- installed merged `voice`/`voiced` from rgbkrk/voice main
- set local Kokoro command provider to `output_format: ogg`
- verified Hermes returns `voice_compatible: true` with `MEDIA:/home/ubuntu/.hermes/audio_cache/...ogg`
- verified output via ffprobe: Opus, mono, 48000 Hz
