### PR TITLE
fix(agent): scope Nous tags to Nous auxiliary calls

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5004,7 +5004,7 @@ def _build_call_kwargs(
 
     # Provider-specific extra_body
     merged_extra = dict(extra_body or {})
-    if provider == "nous" or auxiliary_is_nous:
+    if provider == "nous":
         merged_extra.setdefault("tags", []).extend(_nous_portal_tags())
     if merged_extra:
         kwargs["extra_body"] = merged_extra

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -81,6 +81,7 @@ AUTHOR_MAP = {
     "290859878+synapsesx@users.noreply.github.com": "synapsesx",
     "157689911+itsflownium@users.noreply.github.com": "itsflownium",
     "dirtyren@users.noreply.github.com": "dirtyren",
+    "achaljhawar03@gmail.com": "achaljhawar",
     "claytonchew@ClaytonMacMiniM4.local": "claytonchew",
     "hbentel@gmail.com": "hbentel",
     "JustinBao@outlook.com": "justinbao19",

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -146,6 +146,47 @@ class TestBuildCallKwargsMaxTokens:
         assert "max_completion_tokens" not in kwargs
 
 
+class TestNousTagsScoping:
+    def test_tags_injected_when_provider_is_nous(self, monkeypatch):
+        import agent.auxiliary_client as aux
+
+        monkeypatch.setattr(aux, "auxiliary_is_nous", False)
+
+        kwargs = aux._build_call_kwargs(
+            provider="nous",
+            model="hermes-4",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        assert kwargs["extra_body"]["tags"] == aux._nous_portal_tags()
+
+    def test_tags_not_injected_for_gemini_when_main_is_nous(self, monkeypatch):
+        import agent.auxiliary_client as aux
+
+        monkeypatch.setattr(aux, "auxiliary_is_nous", True)
+
+        kwargs = aux._build_call_kwargs(
+            provider="gemini",
+            model="gemini-2.5-flash",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        assert "extra_body" not in kwargs
+
+    def test_tags_not_injected_for_openrouter_when_main_is_nous(self, monkeypatch):
+        import agent.auxiliary_client as aux
+
+        monkeypatch.setattr(aux, "auxiliary_is_nous", True)
+
+        kwargs = aux._build_call_kwargs(
+            provider="openrouter",
+            model="openai/gpt-5.4",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        assert "extra_body" not in kwargs
+
+
 class TestNormalizeAuxProvider:
     def test_maps_github_copilot_aliases(self):
         assert _normalize_aux_provider("github") == "copilot"


### PR DESCRIPTION
## Summary
Auxiliary calls now add Nous Portal tags only when that specific call is routed to Nous, preventing Nous main-provider state from leaking Nous-only `tags` into Gemini/OpenRouter/custom auxiliary requests.

## Changes
- Scope auxiliary `tags` injection to `provider == "nous"` in `_build_call_kwargs()`.
- Add regression coverage for the positive Nous case and the non-Nous override cases while `auxiliary_is_nous` is true.
- Add release author mapping for @achaljhawar.

## Validation
| Check | Result |
|---|---|
| `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/agent/test_auxiliary_client.py::TestNousTagsScoping -q` | 3 passed |
| `scripts/run_tests.sh tests/agent/test_auxiliary_client.py` | 221 passed |
| auxiliary kwargs E2E shape check | passed |
| `python3 -m py_compile agent/auxiliary_client.py tests/agent/test_auxiliary_client.py && git diff --check` | passed |

Salvages #12477 by @achaljhawar with authorship preserved.
Closes #12408.

## Infographic

![Aux Tag Scope](https://v3b.fal.media/files/b/0a9e2c03/5ZQTv2nxo0R8t01wOsCyS_9iM9j45M.png)
