### PR TITLE
fix(agent): advance fallback chain on 500/502 server errors

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -879,7 +879,10 @@ def _classify_by_status(
                 retryable=False,
                 should_fallback=True,
             )
-        return result_fn(FailoverReason.server_error, retryable=True)
+        # Bare 500/502 server-error path: also route to the fallback
+        # chain (#32961). The provider is down or returning generic 5xx;
+        # the next provider in fallback_providers is a reasonable next try.
+        return result_fn(FailoverReason.server_error, retryable=True, should_fallback=True)
 
     if status_code in {503, 529}:
         return result_fn(FailoverReason.overloaded, retryable=True)
@@ -892,9 +895,13 @@ def _classify_by_status(
             should_fallback=True,
         )
 
-    # Other 5xx — retryable
+    # Other 5xx — retryable, and route to fallback_providers (#32961):
+    # a 501/504/505 from the primary means the next provider in the
+    # chain should get a turn rather than burning the retry budget on
+    # the same host. 503/529 are explicitly handled above as `overloaded`
+    # and are intentionally out of scope.
     if 500 <= status_code < 600:
-        return result_fn(FailoverReason.server_error, retryable=True)
+        return result_fn(FailoverReason.server_error, retryable=True, should_fallback=True)
 
     return None
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -405,6 +405,51 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.server_error
         assert result.retryable is True
 
+    # ── Server errors should trigger fallback chain (#32961) ──
+    # Bare 500/502 (no request-validation signal) currently returns
+    # `should_fallback=False` (the dataclass default), so the
+    # `fallback_providers` chain never advances and Hermes retries the
+    # same provider. This is the same recovery contract the connection-
+    # error path already follows.
+
+    def test_500_plain_server_error_should_fallback(self):
+        e = MockAPIError("Internal Server Error", status_code=500)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.server_error
+        assert result.retryable is True
+        assert result.should_fallback is True
+
+    def test_502_plain_server_error_should_fallback(self):
+        e = MockAPIError("Bad Gateway", status_code=502)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.server_error
+        assert result.retryable is True
+        assert result.should_fallback is True
+
+    def test_504_other_5xx_should_fallback(self):
+        """The 'other 5xx' catch-all (e.g. 504 Gateway Timeout) at the
+        bottom of classify_api_error must also propagate should_fallback.
+        503/529 are handled earlier as `overloaded` and are out of scope."""
+        e = MockAPIError("Gateway Timeout", status_code=504)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.server_error
+        assert result.retryable is True
+        assert result.should_fallback is True
+
+    def test_503_overloaded_unchanged_no_fallback(self):
+        """Regression guard (#32961): 503/529 is intentionally classified as
+        `overloaded` and does NOT trigger the fallback chain. overloaded ==
+        transient retry signal; server_error == provider-down. Future diffs
+        touching the 500/502 path must NOT silently widen to 503/529."""
+        e = MockAPIError("Service Unavailable", status_code=503)
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.overloaded
+        assert result.should_fallback is False
+        e2 = MockAPIError("Overloaded", status_code=529)
+        result2 = classify_api_error(e2)
+        assert result2.reason == FailoverReason.overloaded
+        assert result2.should_fallback is False
+
     # ── Model not found ──
 
     def test_404_model_not_found(self):


### PR DESCRIPTION
## Summary

`classify_api_error` returned `should_fallback=False` for bare HTTP 500/502 responses, so the `fallback_providers` chain never advanced and Hermes retried the same provider until the retry budget was exhausted. Connection errors already followed the correct contract — this aligns server errors with the same recovery behavior.

---

## Solution

Two return statements in `agent/error_classifier.py:_classify_by_status` now pass `should_fallback=True`:

- **Line 882** — bare 500/502 server-error path
- **Line 897** — "other 5xx" catch-all (501/504/505)

The 503/529 path remains classified as `overloaded` and intentionally does **not** trigger the fallback chain (`overloaded` = transient retry signal; `server_error` = provider-down). A regression-guard test pins that boundary so future diffs don't silently widen the fix.

---

## Changes

| File | Change |
|---|---|
| `agent/error_classifier.py` | 2 return statements updated + inline comments explaining the 503/529 boundary |
| `tests/agent/test_error_classifier.py` | 4 new tests: 500 fallback, 502 fallback, 504 fallback, 503/529 unchanged |

---

## How to Test

```bash
# Error classifier tests
pytest tests/agent/test_error_classifier.py
# ✅ 165/165 passed

# Regression checks
pytest tests/agent/test_credential_pool.py
# ✅ 85/85 passed

pytest tests/run_agent/test_run_agent.py
# ✅ 15/15 passed (5xx/fallback filtered cases)

# Lint
ruff check  # ✅ All checks passed
```

---

## Behavior Change

For users with `fallback_providers` configured, HTTP 500/502 (and 501/504/505) responses from the primary provider now advance to the next provider in the chain instead of retrying the same provider — matching the existing behavior for connection errors. Users **without** a fallback chain are unaffected (the flag is a hint, not a hard switch).

---

## Checklist

- [x] Tests pass — 165/165 error classifier, 85/85 credential pool
- [x] 4 new regression tests added including 503/529 boundary guard
- [x] `ruff check` clean
- [x] Follows Conventional Commits

---

## Risk & Impact

**Low.** Scoped to the fallback hint flag only — no retry logic or error classification semantics changed. The 503/529 boundary is explicitly pinned by a regression test to prevent unintended widening.

**Type:** 🐛 Bug fix  
**Closes:** #32961