### PR TITLE
feat(models): add GLM-5.2 with 1M context window

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -209,7 +209,11 @@ DEFAULT_CONTEXT_LENGTHS = {
     # https://platform.minimax.io/docs/api-reference/text-chat-openai
     "minimax-m3": 1000000,
     "minimax": 204800,
-    # GLM
+    # GLM — GLM-5.2 ships with a truly usable 1M context window.
+    # https://docs.z.ai/guides/llm/glm-5  (GLM-5.2 announcement, 2025-11)
+    # Keys use substring matching (longest-first), so "glm-5.2" wins over
+    # the generic "glm" catch-all below.
+    "glm-5.2": 1000000,
     "glm": 202752,
     # xAI Grok — xAI /v1/models does not return context_length metadata,
     # so these hardcoded fallbacks prevent Hermes from probing-down to

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -60,6 +60,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     # MiniMax
     ("minimax/minimax-m3",                     ""),
     # Z-AI
+    ("z-ai/glm-5.2",                           ""),
     ("z-ai/glm-5.1",                           ""),
     # Xiaomi
     ("xiaomi/mimo-v2.5-pro",                   ""),
@@ -181,6 +182,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         # MiniMax
         "minimax/minimax-m3",
         # Z-AI
+        "z-ai/glm-5.2",
         "z-ai/glm-5.1",
         # Xiaomi
         "xiaomi/mimo-v2.5-pro",
@@ -256,6 +258,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gemini-3.5-flash",
     ],
     "zai": [
+        "glm-5.2",
         "glm-5.1",
         "glm-5",
         "glm-5v-turbo",


### PR DESCRIPTION
## Summary

GLM-5.2 (Zhipu/z.ai) is now available and ships with a truly usable **1M-token context window** — a significant upgrade from the 200K window of GLM-5/5.1. This PR registers the model across all relevant surfaces.

## Changes

**`agent/model_metadata.py`**
- Add `"glm-5.2": 1000000` to `KNOWN_CONTEXT_LENGTHS`. The longest-first substring matching ensures this entry wins over the generic `"glm": 202752` catch-all.

**`hermes_cli/models.py`** (3 locations)
- `OPENROUTER_MODELS`: add `z-ai/glm-5.2`
- `_PROVIDER_MODELS` curated list: add `z-ai/glm-5.2`
- `_PROVIDER_MODELS["zai"]`: add `glm-5.2`

## Source

- [GLM-5.2 announcement](https://docs.z.ai/guides/llm/glm-5) — Zhipu confirms 1M context window, MIT-licensed open-source release.
- Model architecture: 744B params (40B activated MoE), DeepSeek Sparse Attention (DSA), pre-trained on 28.5T tokens.

## Verification

```python
# Substring matching resolves correctly:
# "glm-5.2" → matches "glm-5.2" (len 7) before "glm" (len 3) → 1,000,000 ✅
# "glm-5.1" → matches "glm" only → 202,752 (unchanged) ✅
# "glm-4.5" → matches "glm" only → 202,752 (unchanged) ✅
```