### PR TITLE
feat(auxiliary): first-class auxiliary.<task>.enabled config knob

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -5921,6 +5921,29 @@ def _get_auxiliary_task_config(task: str) -> Dict[str, Any]:
     return task_config
 
 
+class AuxiliaryTaskDisabled(RuntimeError):
+    """Raised when an auxiliary task is disabled via ``auxiliary.<task>.enabled: false``.
+
+    Subclasses RuntimeError so existing broad except handlers around
+    auxiliary calls (title generation, compression, ...) degrade cleanly.
+    """
+
+
+def _ensure_task_enabled(task: str) -> None:
+    """Raise :class:`AuxiliaryTaskDisabled` when config disables the task.
+
+    Only a literal ``False`` disables — absent or non-bool values mean
+    enabled, so a typo never silently turns a task off.
+    """
+    if not task:
+        return
+    if _get_auxiliary_task_config(task).get("enabled") is False:
+        raise AuxiliaryTaskDisabled(
+            f"Auxiliary task '{task}' is disabled via config "
+            f"(auxiliary.{task}.enabled: false)."
+        )
+
+
 def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float:
     """Read timeout from auxiliary.{task}.timeout in config, falling back to *default*."""
     if not task:
@@ -6311,7 +6334,9 @@ def call_llm(
 
     Raises:
         RuntimeError: If no provider is configured.
+        AuxiliaryTaskDisabled: If config sets auxiliary.<task>.enabled: false.
     """
+    _ensure_task_enabled(task)
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
     if api_mode:
@@ -6931,6 +6956,7 @@ async def async_call_llm(
 
     Same as call_llm() but async. See call_llm() for full documentation.
     """
+    _ensure_task_enabled(task)
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
     effective_extra_body = _get_task_extra_body(task)

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -530,6 +530,15 @@ prompt_caching:
 #                           # extra_body:
 #                           #   chat_template_kwargs:
 #                           #     enable_thinking: false
+#
+#   # Session title generation. Set enabled: false to turn the task off
+#   # entirely — no auxiliary LLM call is made. Any auxiliary.<task> block
+#   # honours `enabled`; only a literal false disables (absent / non-bool =
+#   # enabled, so a typo never silently turns a task off).
+#   title_generation:
+#     enabled: true          # false = disable this task (skip the LLM call)
+#     provider: "auto"
+#     model: ""
 
 # =============================================================================
 # Persistent Memory

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1553,6 +1553,9 @@ DEFAULT_CONFIG = {
             "extra_body": {},
         },
         "title_generation": {
+            # Set enabled: false to turn off session-title generation entirely
+            # (no auxiliary LLM call). Any auxiliary.<task> block honours this.
+            "enabled": True,
             "provider": "auto",
             "model": "",
             "base_url": "",

--- a/tests/agent/test_auxiliary_task_enabled.py
+++ b/tests/agent/test_auxiliary_task_enabled.py
@@ -1,0 +1,66 @@
+"""Tests for the first-class ``auxiliary.<task>.enabled`` config knob.
+
+Setting ``auxiliary.<task>.enabled: false`` in config.yaml must disable the
+task cleanly — no provider resolution, no network call — instead of relying
+on workarounds like ``provider: none`` (which only works by accident of the
+resolution error path).
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from agent.auxiliary_client import (
+    AuxiliaryTaskDisabled,
+    async_call_llm,
+    call_llm,
+)
+
+_MESSAGES = [{"role": "user", "content": "hi"}]
+
+
+def test_call_llm_disabled_task_raises_without_resolving_provider():
+    with patch(
+        "agent.auxiliary_client._get_auxiliary_task_config",
+        return_value={"enabled": False},
+    ), patch(
+        "agent.auxiliary_client._resolve_task_provider_model",
+        side_effect=AssertionError("provider resolution must not run for a disabled task"),
+    ):
+        with pytest.raises(AuxiliaryTaskDisabled, match="title_generation"):
+            call_llm(task="title_generation", messages=_MESSAGES)
+
+
+@pytest.mark.asyncio
+async def test_async_call_llm_disabled_task_raises_without_resolving_provider():
+    with patch(
+        "agent.auxiliary_client._get_auxiliary_task_config",
+        return_value={"enabled": False},
+    ), patch(
+        "agent.auxiliary_client._resolve_task_provider_model",
+        side_effect=AssertionError("provider resolution must not run for a disabled task"),
+    ):
+        with pytest.raises(AuxiliaryTaskDisabled, match="title_generation"):
+            await async_call_llm(task="title_generation", messages=_MESSAGES)
+
+
+@pytest.mark.parametrize("cfg", [{}, {"enabled": True}, {"enabled": "false"}])
+def test_call_llm_enabled_or_absent_proceeds_to_resolution(cfg):
+    """Anything other than a literal False proceeds (absent = enabled;
+    non-bool values are ignored rather than guessed)."""
+    sentinel = RuntimeError("resolution reached")
+    with patch(
+        "agent.auxiliary_client._get_auxiliary_task_config",
+        return_value=cfg,
+    ), patch(
+        "agent.auxiliary_client._resolve_task_provider_model",
+        side_effect=sentinel,
+    ):
+        with pytest.raises(RuntimeError, match="resolution reached"):
+            call_llm(task="title_generation", messages=_MESSAGES)
+
+
+def test_disabled_task_error_is_runtimeerror_subclass():
+    """Existing callers catch broad Exception/RuntimeError — the new type
+    must stay inside that hierarchy so disabling a task degrades cleanly."""
+    assert issubclass(AuxiliaryTaskDisabled, RuntimeError)


### PR DESCRIPTION
## What does this PR do?

Adds a first-class `auxiliary.<task>.enabled` config knob so an auxiliary task (e.g. `title_generation`) can be turned off cleanly.

Today the only way to disable an auxiliary task is the `provider: none` workaround, which works only by accident of the provider-resolution error path and is fragile to refactors. This makes disabling a side task (title generation, compression, vision, ...) explicit and robust.

## Related Issue

No existing issue — small config robustness improvement. Happy to open one first if preferred.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ♻️ Refactor (replaces a fragile workaround with explicit behavior)

## Changes Made

- `agent/auxiliary_client.py`: add `AuxiliaryTaskDisabled(RuntimeError)` and `_ensure_task_enabled()`, called at the top of `call_llm` / `async_call_llm` **before** any provider resolution. Only a literal `False` disables; absent or non-bool means enabled, so a typo never silently turns a task off. Subclassing `RuntimeError` lets existing broad handlers around auxiliary calls degrade cleanly.
- `hermes_cli/config.py`: document the knob on `title_generation` in `DEFAULT_CONFIG`.
- `cli-config.yaml.example`: document `enabled` in the auxiliary section.
- `tests/agent/test_auxiliary_task_enabled.py`: coverage.

## How to Test

1. Set `auxiliary.title_generation.enabled: false` in config.
2. Trigger a flow that would generate a session title — no auxiliary LLM call is made (raises `AuxiliaryTaskDisabled`, handled cleanly by existing handlers).
3. Run: `pytest tests/agent/test_auxiliary_task_enabled.py -q` → 6 passed.

## Checklist

- [x] Conventional Commits
- [x] PR contains only changes related to this feature
- [x] `pytest tests/agent/test_auxiliary_task_enabled.py -q` passes (6 passed)
- [x] Added tests
- [x] Updated `cli-config.yaml.example` for the new config key
