### PR TITLE
feat(cron): per-job max_turns and wall-clock timeout caps for cron jobs

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1775,6 +1775,23 @@ def _validate_job_mode_invariants(
             "no_agent=True requires a script — with no agent and no script "
             "there is nothing for the job to run."
         )
+def _normalize_max_turns(value: Any) -> Optional[int]:
+    """Normalize a per-job ``max_turns`` cap: positive int, else None.
+
+    bool is rejected explicitly (bool is an int subclass) and other types are
+    ignored rather than coerced — a malformed cap must fall back to the global
+    config, never silently cap the job at a bogus value.
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value if value > 0 else None
+
+
+def _normalize_job_timeout(value: Any) -> Optional[float]:
+    """Normalize a per-job wall-clock ``timeout`` (seconds): positive number → float, else None."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value) if value > 0 else None
 
 
 def create_job(
@@ -1797,6 +1814,8 @@ def create_job(
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    max_turns: Optional[int] = None,
+    timeout: Optional[Union[int, float]] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1989,6 +2008,9 @@ def create_job(
         "origin": origin,  # Tracks where job was created for "origin" delivery
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
+        # Per-job execution caps (None = fall back to global config/env).
+        "max_turns": _normalize_max_turns(max_turns),
+        "timeout": _normalize_job_timeout(timeout),
     }
     # Only persist attach_to_session when explicitly set, so existing jobs and
     # the common case stay byte-identical (absent key => fall back to the
@@ -2100,6 +2122,12 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     _mv = updates[_mon_field]
                     _mv = str(_mv).strip() if isinstance(_mv, str) else None
                     updates[_mon_field] = _mv or None
+            # Normalize per-job caps if present in updates.  0 / None / invalid
+            # all mean "clear the cap" (fall back to global config/env).
+            if "max_turns" in updates:
+                updates["max_turns"] = _normalize_max_turns(updates["max_turns"])
+            if "timeout" in updates:
+                updates["timeout"] = _normalize_job_timeout(updates["timeout"])
 
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1195,6 +1195,25 @@ def _normalized_inference_axes(job: Dict[str, Any]) -> Tuple[Optional[str], Opti
     )
 
 
+def _normalize_max_turns(value: Any) -> Optional[int]:
+    """Normalize a per-job ``max_turns`` cap: positive int, else None.
+
+    bool is rejected explicitly (bool is an int subclass) and other types are
+    ignored rather than coerced — a malformed cap must fall back to the global
+    config, never silently cap the job at a bogus value.
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value if value > 0 else None
+
+
+def _normalize_job_timeout(value: Any) -> Optional[float]:
+    """Normalize a per-job wall-clock ``timeout`` (seconds): positive number → float, else None."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value) if value > 0 else None
+
+
 def create_job(
     prompt: Optional[str],
     schedule: str,
@@ -1213,6 +1232,8 @@ def create_job(
     workdir: Optional[str] = None,
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
+    max_turns: Optional[int] = None,
+    timeout: Optional[Union[int, float]] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -1378,6 +1399,9 @@ def create_job(
         "origin": origin,  # Tracks where job was created for "origin" delivery
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
+        # Per-job execution caps (None = fall back to global config/env).
+        "max_turns": _normalize_max_turns(max_turns),
+        "timeout": _normalize_job_timeout(timeout),
     }
     # Only persist attach_to_session when explicitly set, so existing jobs and
     # the common case stay byte-identical (absent key => fall back to the
@@ -1481,6 +1505,13 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates["workdir"] = None
                 else:
                     updates["workdir"] = _normalize_workdir(_wd)
+
+            # Normalize per-job caps if present in updates.  0 / None / invalid
+            # all mean "clear the cap" (fall back to global config/env).
+            if "max_turns" in updates:
+                updates["max_turns"] = _normalize_max_turns(updates["max_turns"])
+            if "timeout" in updates:
+                updates["timeout"] = _normalize_job_timeout(updates["timeout"])
 
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1300,6 +1300,47 @@ def _cwd_lock_timeout_seconds() -> float:
     )
 
 
+def _resolve_job_max_iterations(job: dict, cfg: dict) -> int:
+    """Resolve the turn ceiling for a cron run.
+
+    Precedence: per-job ``max_turns`` > config.yaml ``agent.max_turns`` >
+    top-level ``max_turns``.  Both levels are normalized by
+    :func:`hermes_cli.config.resolve_turn_limit`, the single turn-limit
+    normalization point, so ``none`` / ``unlimited`` / an explicit ``0``
+    keep their "no ceiling" meaning instead of being swallowed by an ``or``
+    chain — and an absent global stays unlimited rather than picking up a
+    cron-only default.
+
+    A per-job value that does not normalize to a real cap (non-int, <= 0,
+    ``none``) is not treated as a ceiling: it falls through to the global
+    config rather than capping the job at a bogus value or silently
+    uncapping it.
+    """
+    from hermes_cli.config import TURN_LIMIT_UNLIMITED, resolve_turn_limit
+
+    job_cap = resolve_turn_limit(job.get("max_turns"))
+    if job_cap != TURN_LIMIT_UNLIMITED:
+        return job_cap
+    global_cap = cfg.get("agent", {}).get("max_turns")
+    if global_cap is None:
+        global_cap = cfg.get("max_turns")
+    return resolve_turn_limit(global_cap)
+
+
+def _resolve_job_wall_clock_limit(job: dict) -> Optional[float]:
+    """Resolve the per-job wall-clock ceiling (seconds), or None when unset.
+
+    Unlike the inactivity limit (HERMES_CRON_TIMEOUT), this caps *total*
+    runtime — retry storms touch the activity tracker on every attempt, so an
+    agent stuck retrying never trips the inactivity watcher.  The wall-clock
+    cap interrupts it regardless of activity.
+    """
+    raw = job.get("timeout")
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        return None
+    return float(raw) if raw > 0 else None
+
+
 def _get_parallel_pool(max_workers: Optional[int]) -> concurrent.futures.ThreadPoolExecutor:
     """Return (or create) the persistent parallel pool."""
     global _parallel_pool, _parallel_pool_max_workers
@@ -5411,14 +5452,11 @@ def run_job(
                     logger.warning("Job '%s': failed to parse prefill messages file '%s': %s", job_id, pfpath, e)
                     prefill_messages = None
 
-        # Max iterations — resolved through resolve_turn_limit() so that
-        # agent.max_turns: none / unlimited → sys.maxsize sentinel, and
-        # explicit 0 / null / "none" are honored instead of skipped by `or`.
-        from hermes_cli.config import resolve_turn_limit as _resolve_turn_limit
-        _mt = _cfg.get("agent", {}).get("max_turns")
-        if _mt is None:
-            _mt = _cfg.get("max_turns")
-        max_iterations = _resolve_turn_limit(_mt)
+        # Max iterations — per-job cap wins over global config (cron sessions
+        # previously had no per-job ceiling). Both levels normalize through
+        # resolve_turn_limit(), so agent.max_turns: none / unlimited and an
+        # explicit 0 keep meaning "no ceiling".
+        max_iterations = _resolve_job_max_iterations(job, _cfg)
 
         # Provider routing
         pr = _cfg.get("provider_routing") or {}
@@ -5787,6 +5825,10 @@ def run_job(
         # _touch_activity() on every tool call, API call, and stream delta).
         _cron_timeout = _cron_inactivity_seconds()
         _cron_inactivity_limit = _cron_timeout if _cron_timeout > 0 else None
+        # Per-job wall-clock ceiling — caps total runtime regardless of
+        # activity (retry storms touch the activity tracker on every attempt,
+        # so the inactivity watcher alone never catches a stuck retry loop).
+        _wall_clock_limit = _resolve_job_wall_clock_limit(job)
         _POLL_INTERVAL = 5.0
         # Keep the one-shot run_claim fresh while the run is alive (#62002):
         # the claim TTL is a dead-owner detector, but without a heartbeat a
@@ -5837,10 +5879,12 @@ def run_job(
         # Tag this fire and time the run_conversation call for the usage_audit.jsonl entry.
         _audit_fire_id = uuid.uuid4().hex
         _audit_t_start = time.monotonic()
+        _run_started_at = time.monotonic()
         _cron_future = _cron_pool.submit(_cron_context.run, agent.run_conversation, prompt)
         _inactivity_timeout = False
+        _wall_clock_timeout = False
         try:
-            if _cron_inactivity_limit is None:
+            if _cron_inactivity_limit is None and _wall_clock_limit is None:
                 # Unlimited — no inactivity watchdog, but a one-shot still
                 # needs its run_claim heartbeat, so poll instead of blocking.
                 if _is_oneshot or cancel_event is not None:
@@ -5869,7 +5913,17 @@ def run_job(
                         break
                     _abort_if_fire_claim_lost()
                     _heartbeat_run_claim_if_due()
-                    # Agent still running — check inactivity.
+                    # Agent still running — check the wall-clock cap first
+                    # (activity must not keep a job alive past it).
+                    if (
+                        _wall_clock_limit is not None
+                        and time.monotonic() - _run_started_at >= _wall_clock_limit
+                    ):
+                        _wall_clock_timeout = True
+                        break
+                    # Check inactivity.
+                    if _cron_inactivity_limit is None:
+                        continue
                     _idle_secs = 0.0
                     if hasattr(agent, "get_activity_summary"):
                         try:
@@ -5885,6 +5939,31 @@ def run_job(
             raise
         finally:
             _cron_pool.shutdown(wait=False, cancel_futures=True)
+
+        if _wall_clock_timeout:
+            _elapsed = time.monotonic() - _run_started_at
+            _activity = {}
+            if hasattr(agent, "get_activity_summary"):
+                try:
+                    _activity = agent.get_activity_summary()
+                except Exception:
+                    pass
+            logger.error(
+                "Job '%s' exceeded wall-clock limit (%.0fs >= %.0fs) "
+                "| last_activity=%s | iteration=%s/%s | tool=%s",
+                job_name, _elapsed, _wall_clock_limit,
+                _activity.get("last_activity_desc", "unknown"),
+                _activity.get("api_call_count", 0),
+                _activity.get("max_iterations", 0),
+                _activity.get("current_tool") or "none",
+            )
+            if hasattr(agent, "interrupt"):
+                agent.interrupt("Cron job timed out (wall-clock)")
+            raise TimeoutError(
+                f"Cron job '{job_name}' exceeded its wall-clock limit "
+                f"({int(_elapsed)}s >= {int(_wall_clock_limit)}s) "
+                f"— last activity: {_activity.get('last_activity_desc', 'unknown')}"
+            )
 
         if _inactivity_timeout:
             # Build diagnostic summary from the agent's activity tracker.

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -21,6 +21,7 @@ import subprocess
 import sys
 import threading
 import time
+from contextlib import contextmanager
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -480,6 +481,34 @@ class _ReadWriteLock:
 # Serializes the per-job TERMINAL_CWD override against every other concurrently
 # running cron job.  See _ReadWriteLock and run_job for the usage contract.
 _terminal_cwd_lock = _ReadWriteLock()
+
+
+def _resolve_job_max_iterations(job: dict, cfg: dict) -> int:
+    """Resolve the turn ceiling for a cron run.
+
+    Precedence: per-job ``max_turns`` > config.yaml ``agent.max_turns`` >
+    top-level ``max_turns`` > 500.  Invalid per-job values (non-int, <= 0)
+    fall through to the global config rather than capping the job at a
+    bogus value.
+    """
+    job_cap = job.get("max_turns")
+    if not isinstance(job_cap, bool) and isinstance(job_cap, int) and job_cap > 0:
+        return job_cap
+    return cfg.get("agent", {}).get("max_turns") or cfg.get("max_turns") or 500
+
+
+def _resolve_job_wall_clock_limit(job: dict) -> Optional[float]:
+    """Resolve the per-job wall-clock ceiling (seconds), or None when unset.
+
+    Unlike the inactivity limit (HERMES_CRON_TIMEOUT), this caps *total*
+    runtime — retry storms touch the activity tracker on every attempt, so an
+    agent stuck retrying never trips the inactivity watcher.  The wall-clock
+    cap interrupts it regardless of activity.
+    """
+    raw = job.get("timeout")
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        return None
+    return float(raw) if raw > 0 else None
 
 
 def _get_parallel_pool(max_workers: Optional[int]) -> concurrent.futures.ThreadPoolExecutor:
@@ -3237,8 +3266,9 @@ def run_job(
                     logger.warning("Job '%s': failed to parse prefill messages file '%s': %s", job_id, pfpath, e)
                     prefill_messages = None
 
-        # Max iterations
-        max_iterations = _cfg.get("agent", {}).get("max_turns") or _cfg.get("max_turns") or 500
+        # Max iterations — per-job cap wins over global config (issue: cron
+        # sessions previously had no per-job ceiling).
+        max_iterations = _resolve_job_max_iterations(job, _cfg)
 
         # Provider routing
         pr = _cfg.get("provider_routing") or {}
@@ -3490,6 +3520,10 @@ def run_job(
         else:
             _cron_timeout = 600.0
         _cron_inactivity_limit = _cron_timeout if _cron_timeout > 0 else None
+        # Per-job wall-clock ceiling — caps total runtime regardless of
+        # activity (retry storms touch the activity tracker on every attempt,
+        # so the inactivity watcher alone never catches a stuck retry loop).
+        _wall_clock_limit = _resolve_job_wall_clock_limit(job)
         _POLL_INTERVAL = 5.0
         # Keep the one-shot run_claim fresh while the run is alive (#62002):
         # the claim TTL is a dead-owner detector, but without a heartbeat a
@@ -3528,10 +3562,12 @@ def run_job(
         # env passthrough registrations) when the cron run hops into the worker
         # thread used for inactivity timeout monitoring.
         _cron_context = contextvars.copy_context()
+        _run_started_at = time.monotonic()
         _cron_future = _cron_pool.submit(_cron_context.run, agent.run_conversation, prompt)
         _inactivity_timeout = False
+        _wall_clock_timeout = False
         try:
-            if _cron_inactivity_limit is None:
+            if _cron_inactivity_limit is None and _wall_clock_limit is None:
                 # Unlimited — no inactivity watchdog, but a one-shot still
                 # needs its run_claim heartbeat, so poll instead of blocking.
                 if _is_oneshot:
@@ -3556,7 +3592,17 @@ def run_job(
                         result = _cron_future.result()
                         break
                     _heartbeat_run_claim_if_due()
-                    # Agent still running — check inactivity.
+                    # Agent still running — check the wall-clock cap first
+                    # (activity must not keep a job alive past it).
+                    if (
+                        _wall_clock_limit is not None
+                        and time.monotonic() - _run_started_at >= _wall_clock_limit
+                    ):
+                        _wall_clock_timeout = True
+                        break
+                    # Check inactivity.
+                    if _cron_inactivity_limit is None:
+                        continue
                     _idle_secs = 0.0
                     if hasattr(agent, "get_activity_summary"):
                         try:
@@ -3572,6 +3618,31 @@ def run_job(
             raise
         finally:
             _cron_pool.shutdown(wait=False, cancel_futures=True)
+
+        if _wall_clock_timeout:
+            _elapsed = time.monotonic() - _run_started_at
+            _activity = {}
+            if hasattr(agent, "get_activity_summary"):
+                try:
+                    _activity = agent.get_activity_summary()
+                except Exception:
+                    pass
+            logger.error(
+                "Job '%s' exceeded wall-clock limit (%.0fs >= %.0fs) "
+                "| last_activity=%s | iteration=%s/%s | tool=%s",
+                job_name, _elapsed, _wall_clock_limit,
+                _activity.get("last_activity_desc", "unknown"),
+                _activity.get("api_call_count", 0),
+                _activity.get("max_iterations", 0),
+                _activity.get("current_tool") or "none",
+            )
+            if hasattr(agent, "interrupt"):
+                agent.interrupt("Cron job timed out (wall-clock)")
+            raise TimeoutError(
+                f"Cron job '{job_name}' exceeded its wall-clock limit "
+                f"({int(_elapsed)}s >= {int(_wall_clock_limit)}s) "
+                f"— last activity: {_activity.get('last_activity_desc', 'unknown')}"
+            )
 
         if _inactivity_timeout:
             # Build diagnostic summary from the agent's activity tracker.

--- a/tests/cron/test_cron_job_caps.py
+++ b/tests/cron/test_cron_job_caps.py
@@ -1,0 +1,274 @@
+"""Tests for per-job execution caps: ``max_turns`` and ``timeout``.
+
+Covers:
+
+* ``create_job`` storing/normalizing ``max_turns`` (turn ceiling) and
+  ``timeout`` (wall-clock seconds ceiling).
+* ``update_job`` setting and clearing both fields.
+* ``cronjob(action='create'/'update')`` tool-level plumbing.
+* ``scheduler._resolve_job_max_iterations`` precedence: job field >
+  config.yaml ``agent.max_turns`` > top-level ``max_turns`` > 500.
+* ``scheduler._resolve_job_wall_clock_limit`` validation.
+* Wall-clock watcher: an agent that stays *active* (retry storms touch the
+  activity tracker, so the inactivity watcher never fires) is still
+  interrupted once the job's wall-clock cap elapses.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import json
+import time
+
+import pytest
+
+
+@pytest.fixture
+def hermes_env(tmp_path, monkeypatch):
+    """Isolate HERMES_HOME for each test so jobs/scripts don't leak."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "scripts").mkdir()
+    (home / "cron").mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    # Reload modules that cache get_hermes_home() at import time.
+    import importlib
+    import hermes_constants
+    importlib.reload(hermes_constants)
+    import cron.jobs
+    importlib.reload(cron.jobs)
+    import cron.scheduler
+    importlib.reload(cron.scheduler)
+
+    return home
+
+
+# ---------------------------------------------------------------------------
+# create_job / update_job: data-layer semantics
+# ---------------------------------------------------------------------------
+
+def test_create_job_stores_max_turns_and_timeout(hermes_env):
+    from cron.jobs import create_job
+
+    job = create_job(
+        prompt="say hi",
+        schedule="every 5m",
+        deliver="local",
+        max_turns=30,
+        timeout=900,
+    )
+    assert job["max_turns"] == 30
+    assert job["timeout"] == 900.0
+
+
+def test_create_job_defaults_have_no_caps(hermes_env):
+    from cron.jobs import create_job
+
+    job = create_job(prompt="say hi", schedule="every 5m", deliver="local")
+    assert job["max_turns"] is None
+    assert job["timeout"] is None
+
+
+@pytest.mark.parametrize("bad", [0, -5, "abc", 2.5, False])
+def test_create_job_invalid_max_turns_normalizes_to_none(hermes_env, bad):
+    from cron.jobs import create_job
+
+    job = create_job(
+        prompt="say hi", schedule="every 5m", deliver="local", max_turns=bad
+    )
+    assert job["max_turns"] is None
+
+
+@pytest.mark.parametrize("bad", [0, -1, "abc", False])
+def test_create_job_invalid_timeout_normalizes_to_none(hermes_env, bad):
+    from cron.jobs import create_job
+
+    job = create_job(
+        prompt="say hi", schedule="every 5m", deliver="local", timeout=bad
+    )
+    assert job["timeout"] is None
+
+
+def test_update_job_sets_and_clears_caps(hermes_env):
+    from cron.jobs import create_job, get_job, update_job
+
+    job = create_job(prompt="say hi", schedule="every 5m", deliver="local")
+
+    update_job(job["id"], {"max_turns": 25, "timeout": 600})
+    updated = get_job(job["id"])
+    assert updated["max_turns"] == 25
+    assert updated["timeout"] == 600.0
+
+    # 0 clears the cap (back to global defaults).
+    update_job(job["id"], {"max_turns": 0, "timeout": 0})
+    cleared = get_job(job["id"])
+    assert cleared["max_turns"] is None
+    assert cleared["timeout"] is None
+
+
+# ---------------------------------------------------------------------------
+# cronjob tool plumbing
+# ---------------------------------------------------------------------------
+
+def test_cronjob_create_and_update_plumb_caps(hermes_env):
+    from tools.cronjob_tools import cronjob
+    from cron.jobs import get_job
+
+    out = json.loads(
+        cronjob(
+            action="create",
+            prompt="say hi",
+            schedule="every 5m",
+            deliver="local",
+            max_turns=30,
+            timeout=900,
+        )
+    )
+    assert out["success"] is True
+    job = get_job(out["job_id"])
+    assert job["max_turns"] == 30
+    assert job["timeout"] == 900.0
+
+    cronjob(action="update", job_id=out["job_id"], max_turns=25, timeout=600)
+    job = get_job(out["job_id"])
+    assert job["max_turns"] == 25
+    assert job["timeout"] == 600.0
+
+
+def test_cronjob_schema_exposes_caps():
+    from tools.cronjob_tools import CRONJOB_SCHEMA
+
+    props = CRONJOB_SCHEMA["parameters"]["properties"]
+    assert props["max_turns"]["type"] == "integer"
+    assert props["timeout"]["type"] == "number"
+
+
+# ---------------------------------------------------------------------------
+# scheduler: per-job max_iterations resolution
+# ---------------------------------------------------------------------------
+
+def test_resolve_job_max_iterations_prefers_job_field(hermes_env):
+    from cron.scheduler import _resolve_job_max_iterations
+
+    cfg = {"agent": {"max_turns": 60}, "max_turns": 50}
+    assert _resolve_job_max_iterations({"max_turns": 30}, cfg) == 30
+
+
+def test_resolve_job_max_iterations_falls_back_to_config(hermes_env):
+    from cron.scheduler import _resolve_job_max_iterations
+    from hermes_cli.config import TURN_LIMIT_UNLIMITED
+
+    assert _resolve_job_max_iterations({}, {"agent": {"max_turns": 60}}) == 60
+    assert _resolve_job_max_iterations({}, {"max_turns": 50}) == 50
+    # No job cap and no global cap — max_turns is unlimited by default, so the
+    # per-job knob must not introduce a cron-only ceiling of its own.
+    assert _resolve_job_max_iterations({}, {}) == TURN_LIMIT_UNLIMITED
+
+
+@pytest.mark.parametrize("bad", [0, -5, "abc", None, True, "none", "unlimited"])
+def test_resolve_job_max_iterations_ignores_invalid_job_value(hermes_env, bad):
+    from cron.scheduler import _resolve_job_max_iterations
+    from hermes_cli.config import TURN_LIMIT_UNLIMITED
+
+    # A per-job value that is not a real ceiling falls through to the global
+    # config instead of capping the job at a bogus value.
+    assert _resolve_job_max_iterations({"max_turns": bad}, {}) == TURN_LIMIT_UNLIMITED
+    assert _resolve_job_max_iterations({"max_turns": bad}, {"agent": {"max_turns": 60}}) == 60
+
+
+# ---------------------------------------------------------------------------
+# scheduler: per-job wall-clock limit resolution
+# ---------------------------------------------------------------------------
+
+def test_resolve_job_wall_clock_limit(hermes_env):
+    from cron.scheduler import _resolve_job_wall_clock_limit
+
+    assert _resolve_job_wall_clock_limit({"timeout": 900}) == 900.0
+    assert _resolve_job_wall_clock_limit({"timeout": 0}) is None
+    assert _resolve_job_wall_clock_limit({"timeout": "abc"}) is None
+    assert _resolve_job_wall_clock_limit({}) is None
+
+
+# ---------------------------------------------------------------------------
+# Wall-clock watcher: active agent past the cap is interrupted
+# ---------------------------------------------------------------------------
+
+class ActiveFakeAgent:
+    """Agent that never goes idle (simulates a retry storm: every retry
+    touches the activity tracker) but runs longer than the wall-clock cap."""
+
+    def __init__(self, run_duration=5.0):
+        self._run_duration = run_duration
+        self._interrupted = False
+        self._interrupt_msg = None
+
+    def get_activity_summary(self):
+        return {
+            "last_activity_ts": time.time(),
+            "last_activity_desc": "API error recovery (attempt 2/3)",
+            "seconds_since_activity": 0.0,
+            "current_tool": None,
+            "api_call_count": 5,
+            "max_iterations": 90,
+        }
+
+    def interrupt(self, msg):
+        self._interrupted = True
+        self._interrupt_msg = msg
+
+    def run_conversation(self, prompt):
+        time.sleep(self._run_duration)
+        return {"final_response": "Done", "messages": []}
+
+
+def test_active_agent_past_wall_clock_cap_is_interrupted():
+    """Mirrors the scheduler watcher loop with a per-job wall-clock limit:
+    activity alone must not keep a job alive past its wall-clock cap."""
+    agent = ActiveFakeAgent(run_duration=5.0)
+    _cron_inactivity_limit = 10.0   # never reached — agent is always active
+    _wall_clock_limit = 0.3          # job-level cap
+    _POLL_INTERVAL = 0.05
+
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    _run_started_at = time.monotonic()
+    future = pool.submit(agent.run_conversation, "test prompt")
+    _inactivity_timeout = False
+    _wall_clock_timeout = False
+
+    result = None
+    while True:
+        done, _ = concurrent.futures.wait({future}, timeout=_POLL_INTERVAL)
+        if done:
+            result = future.result()
+            break
+        if (
+            _wall_clock_limit is not None
+            and time.monotonic() - _run_started_at >= _wall_clock_limit
+        ):
+            _wall_clock_timeout = True
+            break
+        _idle_secs = 0.0
+        if hasattr(agent, "get_activity_summary"):
+            _act = agent.get_activity_summary()
+            _idle_secs = _act.get("seconds_since_activity", 0.0)
+        if _idle_secs >= _cron_inactivity_limit:
+            _inactivity_timeout = True
+            break
+
+    pool.shutdown(wait=False, cancel_futures=True)
+    assert result is None
+    assert _wall_clock_timeout
+    assert not _inactivity_timeout
+
+
+def test_scheduler_watcher_source_has_wall_clock_branch():
+    """The real scheduler watcher must consult the per-job wall-clock limit —
+    guards against the cap living only in tests."""
+    import inspect
+    import cron.scheduler as scheduler
+
+    src = inspect.getsource(scheduler)
+    assert "_resolve_job_wall_clock_limit" in src
+    assert "_wall_clock_timeout" in src

--- a/tests/cron/test_cron_job_caps.py
+++ b/tests/cron/test_cron_job_caps.py
@@ -1,0 +1,267 @@
+"""Tests for per-job execution caps: ``max_turns`` and ``timeout``.
+
+Covers:
+
+* ``create_job`` storing/normalizing ``max_turns`` (turn ceiling) and
+  ``timeout`` (wall-clock seconds ceiling).
+* ``update_job`` setting and clearing both fields.
+* ``cronjob(action='create'/'update')`` tool-level plumbing.
+* ``scheduler._resolve_job_max_iterations`` precedence: job field >
+  config.yaml ``agent.max_turns`` > top-level ``max_turns`` > 500.
+* ``scheduler._resolve_job_wall_clock_limit`` validation.
+* Wall-clock watcher: an agent that stays *active* (retry storms touch the
+  activity tracker, so the inactivity watcher never fires) is still
+  interrupted once the job's wall-clock cap elapses.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import json
+import time
+
+import pytest
+
+
+@pytest.fixture
+def hermes_env(tmp_path, monkeypatch):
+    """Isolate HERMES_HOME for each test so jobs/scripts don't leak."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "scripts").mkdir()
+    (home / "cron").mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    # Reload modules that cache get_hermes_home() at import time.
+    import importlib
+    import hermes_constants
+    importlib.reload(hermes_constants)
+    import cron.jobs
+    importlib.reload(cron.jobs)
+    import cron.scheduler
+    importlib.reload(cron.scheduler)
+
+    return home
+
+
+# ---------------------------------------------------------------------------
+# create_job / update_job: data-layer semantics
+# ---------------------------------------------------------------------------
+
+def test_create_job_stores_max_turns_and_timeout(hermes_env):
+    from cron.jobs import create_job
+
+    job = create_job(
+        prompt="say hi",
+        schedule="every 5m",
+        deliver="local",
+        max_turns=30,
+        timeout=900,
+    )
+    assert job["max_turns"] == 30
+    assert job["timeout"] == 900.0
+
+
+def test_create_job_defaults_have_no_caps(hermes_env):
+    from cron.jobs import create_job
+
+    job = create_job(prompt="say hi", schedule="every 5m", deliver="local")
+    assert job["max_turns"] is None
+    assert job["timeout"] is None
+
+
+@pytest.mark.parametrize("bad", [0, -5, "abc", 2.5, False])
+def test_create_job_invalid_max_turns_normalizes_to_none(hermes_env, bad):
+    from cron.jobs import create_job
+
+    job = create_job(
+        prompt="say hi", schedule="every 5m", deliver="local", max_turns=bad
+    )
+    assert job["max_turns"] is None
+
+
+@pytest.mark.parametrize("bad", [0, -1, "abc", False])
+def test_create_job_invalid_timeout_normalizes_to_none(hermes_env, bad):
+    from cron.jobs import create_job
+
+    job = create_job(
+        prompt="say hi", schedule="every 5m", deliver="local", timeout=bad
+    )
+    assert job["timeout"] is None
+
+
+def test_update_job_sets_and_clears_caps(hermes_env):
+    from cron.jobs import create_job, get_job, update_job
+
+    job = create_job(prompt="say hi", schedule="every 5m", deliver="local")
+
+    update_job(job["id"], {"max_turns": 25, "timeout": 600})
+    updated = get_job(job["id"])
+    assert updated["max_turns"] == 25
+    assert updated["timeout"] == 600.0
+
+    # 0 clears the cap (back to global defaults).
+    update_job(job["id"], {"max_turns": 0, "timeout": 0})
+    cleared = get_job(job["id"])
+    assert cleared["max_turns"] is None
+    assert cleared["timeout"] is None
+
+
+# ---------------------------------------------------------------------------
+# cronjob tool plumbing
+# ---------------------------------------------------------------------------
+
+def test_cronjob_create_and_update_plumb_caps(hermes_env):
+    from tools.cronjob_tools import cronjob
+    from cron.jobs import get_job
+
+    out = json.loads(
+        cronjob(
+            action="create",
+            prompt="say hi",
+            schedule="every 5m",
+            deliver="local",
+            max_turns=30,
+            timeout=900,
+        )
+    )
+    assert out["success"] is True
+    job = get_job(out["job_id"])
+    assert job["max_turns"] == 30
+    assert job["timeout"] == 900.0
+
+    cronjob(action="update", job_id=out["job_id"], max_turns=25, timeout=600)
+    job = get_job(out["job_id"])
+    assert job["max_turns"] == 25
+    assert job["timeout"] == 600.0
+
+
+def test_cronjob_schema_exposes_caps():
+    from tools.cronjob_tools import CRONJOB_SCHEMA
+
+    props = CRONJOB_SCHEMA["parameters"]["properties"]
+    assert props["max_turns"]["type"] == "integer"
+    assert props["timeout"]["type"] == "number"
+
+
+# ---------------------------------------------------------------------------
+# scheduler: per-job max_iterations resolution
+# ---------------------------------------------------------------------------
+
+def test_resolve_job_max_iterations_prefers_job_field(hermes_env):
+    from cron.scheduler import _resolve_job_max_iterations
+
+    cfg = {"agent": {"max_turns": 60}, "max_turns": 50}
+    assert _resolve_job_max_iterations({"max_turns": 30}, cfg) == 30
+
+
+def test_resolve_job_max_iterations_falls_back_to_config(hermes_env):
+    from cron.scheduler import _resolve_job_max_iterations
+
+    assert _resolve_job_max_iterations({}, {"agent": {"max_turns": 60}}) == 60
+    assert _resolve_job_max_iterations({}, {"max_turns": 50}) == 50
+    assert _resolve_job_max_iterations({}, {}) == 500
+
+
+@pytest.mark.parametrize("bad", [0, -5, "abc", None])
+def test_resolve_job_max_iterations_ignores_invalid_job_value(hermes_env, bad):
+    from cron.scheduler import _resolve_job_max_iterations
+
+    assert _resolve_job_max_iterations({"max_turns": bad}, {}) == 500
+
+
+# ---------------------------------------------------------------------------
+# scheduler: per-job wall-clock limit resolution
+# ---------------------------------------------------------------------------
+
+def test_resolve_job_wall_clock_limit(hermes_env):
+    from cron.scheduler import _resolve_job_wall_clock_limit
+
+    assert _resolve_job_wall_clock_limit({"timeout": 900}) == 900.0
+    assert _resolve_job_wall_clock_limit({"timeout": 0}) is None
+    assert _resolve_job_wall_clock_limit({"timeout": "abc"}) is None
+    assert _resolve_job_wall_clock_limit({}) is None
+
+
+# ---------------------------------------------------------------------------
+# Wall-clock watcher: active agent past the cap is interrupted
+# ---------------------------------------------------------------------------
+
+class ActiveFakeAgent:
+    """Agent that never goes idle (simulates a retry storm: every retry
+    touches the activity tracker) but runs longer than the wall-clock cap."""
+
+    def __init__(self, run_duration=5.0):
+        self._run_duration = run_duration
+        self._interrupted = False
+        self._interrupt_msg = None
+
+    def get_activity_summary(self):
+        return {
+            "last_activity_ts": time.time(),
+            "last_activity_desc": "API error recovery (attempt 2/3)",
+            "seconds_since_activity": 0.0,
+            "current_tool": None,
+            "api_call_count": 5,
+            "max_iterations": 90,
+        }
+
+    def interrupt(self, msg):
+        self._interrupted = True
+        self._interrupt_msg = msg
+
+    def run_conversation(self, prompt):
+        time.sleep(self._run_duration)
+        return {"final_response": "Done", "messages": []}
+
+
+def test_active_agent_past_wall_clock_cap_is_interrupted():
+    """Mirrors the scheduler watcher loop with a per-job wall-clock limit:
+    activity alone must not keep a job alive past its wall-clock cap."""
+    agent = ActiveFakeAgent(run_duration=5.0)
+    _cron_inactivity_limit = 10.0   # never reached — agent is always active
+    _wall_clock_limit = 0.3          # job-level cap
+    _POLL_INTERVAL = 0.05
+
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    _run_started_at = time.monotonic()
+    future = pool.submit(agent.run_conversation, "test prompt")
+    _inactivity_timeout = False
+    _wall_clock_timeout = False
+
+    result = None
+    while True:
+        done, _ = concurrent.futures.wait({future}, timeout=_POLL_INTERVAL)
+        if done:
+            result = future.result()
+            break
+        if (
+            _wall_clock_limit is not None
+            and time.monotonic() - _run_started_at >= _wall_clock_limit
+        ):
+            _wall_clock_timeout = True
+            break
+        _idle_secs = 0.0
+        if hasattr(agent, "get_activity_summary"):
+            _act = agent.get_activity_summary()
+            _idle_secs = _act.get("seconds_since_activity", 0.0)
+        if _idle_secs >= _cron_inactivity_limit:
+            _inactivity_timeout = True
+            break
+
+    pool.shutdown(wait=False, cancel_futures=True)
+    assert result is None
+    assert _wall_clock_timeout
+    assert not _inactivity_timeout
+
+
+def test_scheduler_watcher_source_has_wall_clock_branch():
+    """The real scheduler watcher must consult the per-job wall-clock limit —
+    guards against the cap living only in tests."""
+    import inspect
+    import cron.scheduler as scheduler
+
+    src = inspect.getsource(scheduler)
+    assert "_resolve_job_wall_clock_limit" in src
+    assert "_wall_clock_timeout" in src

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1211,6 +1211,8 @@ def cronjob(
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    max_turns: Optional[int] = None,
+    timeout: Optional[Union[int, float]] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
 ) -> str:
@@ -1311,6 +1313,8 @@ def cronjob(
                     attach_to_session=attach_to_session,
                     monitor_script=_normalize_optional_job_value(monitor_script),
                     monitor_url=_normalize_optional_job_value(monitor_url),
+                    max_turns=max_turns,
+                    timeout=timeout,
                 )
             except CronSchedulerRegistrationError as exc:
                 _partial = exc.to_dict()
@@ -1595,6 +1599,12 @@ def cronjob(
                             success=False,
                         )
                 updates["no_agent"] = target_no_agent
+            if max_turns is not None:
+                # 0 clears the cap — update_job() normalizes (invalid → None).
+                updates["max_turns"] = max_turns
+            if timeout is not None:
+                # 0 clears the cap — update_job() normalizes (invalid → None).
+                updates["timeout"] = timeout
             if repeat is not None:
                 # Normalize: treat 0 or negative as None (infinite)
                 normalized_repeat = None if repeat <= 0 else repeat
@@ -1747,6 +1757,14 @@ Scheduling from cron-run sessions is disabled by default and enabled via cron.al
                 "type": "boolean",
                 "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
             },
+            "max_turns": {
+                "type": "integer",
+                "description": "Optional per-job ceiling on agent turns (API call iterations) for LLM-driven jobs. Overrides the global config.yaml agent.max_turns for this job only. Use a low value (e.g. 25-30) for well-delimited recurring jobs so a stuck session cannot burn quota. On update, pass 0 to clear (fall back to global config). Ignored when no_agent=True."
+            },
+            "timeout": {
+                "type": "number",
+                "description": "Optional per-job wall-clock ceiling in seconds for the whole agent run. Unlike the global HERMES_CRON_TIMEOUT (inactivity-based — retry storms count as activity and never trip it), this caps total runtime: when it elapses the job is interrupted regardless of activity. On update, pass 0 to clear. Ignored when no_agent=True (script jobs have their own timeout)."
+            },
         },
         "required": ["action"]
     }
@@ -1807,6 +1825,8 @@ registry.register(
         no_agent=args.get("no_agent"),
         monitor_script=args.get("monitor_script"),
         monitor_url=args.get("monitor_url"),
+        max_turns=args.get("max_turns"),
+        timeout=args.get("timeout"),
         task_id=kw.get("task_id"),
         session_id=kw.get("session_id"),
     ),

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -677,6 +677,8 @@ def cronjob(
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
+    max_turns: Optional[int] = None,
+    timeout: Optional[Union[int, float]] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -750,6 +752,8 @@ def cronjob(
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
                 attach_to_session=attach_to_session,
+                max_turns=max_turns,
+                timeout=timeout,
             )
             _notify_provider_jobs_changed_safe()
             _create_message = f"Cron job '{job['name']}' created."
@@ -947,6 +951,12 @@ def cronjob(
                             success=False,
                         )
                 updates["no_agent"] = target_no_agent
+            if max_turns is not None:
+                # 0 clears the cap — update_job() normalizes (invalid → None).
+                updates["max_turns"] = max_turns
+            if timeout is not None:
+                # 0 clears the cap — update_job() normalizes (invalid → None).
+                updates["timeout"] = timeout
             if repeat is not None:
                 # Normalize: treat 0 or negative as None (infinite)
                 normalized_repeat = None if repeat <= 0 else repeat
@@ -1091,6 +1101,14 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "boolean",
                 "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
             },
+            "max_turns": {
+                "type": "integer",
+                "description": "Optional per-job ceiling on agent turns (API call iterations) for LLM-driven jobs. Overrides the global config.yaml agent.max_turns for this job only. Use a low value (e.g. 25-30) for well-delimited recurring jobs so a stuck session cannot burn quota. On update, pass 0 to clear (fall back to global config). Ignored when no_agent=True."
+            },
+            "timeout": {
+                "type": "number",
+                "description": "Optional per-job wall-clock ceiling in seconds for the whole agent run. Unlike the global HERMES_CRON_TIMEOUT (inactivity-based — retry storms count as activity and never trip it), this caps total runtime: when it elapses the job is interrupted regardless of activity. On update, pass 0 to clear. Ignored when no_agent=True (script jobs have their own timeout)."
+            },
         },
         "required": ["action"]
     }
@@ -1146,6 +1164,8 @@ registry.register(
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
         no_agent=args.get("no_agent"),
+        max_turns=args.get("max_turns"),
+        timeout=args.get("timeout"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,


### PR DESCRIPTION
## What does this PR do?

Adds optional per-job `max_turns` and wall-clock `timeout` ceilings to cron jobs.

Today a cron session has no per-job ceiling: `max_turns` is global-only (`config.yaml agent.max_turns`) and the only runtime guard — the `HERMES_CRON_TIMEOUT` inactivity watcher — never fires during retry storms, because every retry touches the activity tracker ("API error recovery"). An unattended agentic cron job stuck retrying can therefore keep calling the API for hours with no ceiling. These caps give each job an independent, opt-in budget.

## Related Issue

Implements #63267 (*feat: per-job max_turns for cron jobs*).

Also relevant to #82813 / #82815: the turn ceiling here now resolves through `hermes_cli.config.resolve_turn_limit()` at both the per-job and the global level, so `max_turns: none` / `unlimited` / an explicit `0` are honored in the cron path too rather than being swallowed by an `or` chain.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ♻️ Robustness (retry-storm / runaway-session guard)

## Changes Made

- `tools/cronjob_tools.py` + `cron/jobs.py`: optional `max_turns` (int) and `timeout` (seconds) per job in the schema/tool and `create_job` / `update_job`; `0` clears the cap on update; bool/invalid values are rejected (fall back to global config rather than capping at a bogus value).
- `cron/scheduler.py`: `_resolve_job_max_iterations` (precedence: per-job > `agent.max_turns` > `max_turns`, each normalized by `resolve_turn_limit()`, so an absent global stays unlimited and the per-job knob never introduces a cron-only default) and `_resolve_job_wall_clock_limit`; the inactivity watcher gains a wall-clock branch that interrupts the run when total elapsed exceeds the job cap, **regardless of activity** (so a retry loop that keeps the inactivity watcher alive is still bounded).
- Opt-in: behaviour is unchanged when both fields are unset.
- `tests/cron/test_cron_job_caps.py`: coverage.

## How to Test

1. Create a cron job with `max_turns: 5` and `timeout: 30`.
2. Verify a long / stuck agentic run is interrupted at the wall-clock cap regardless of activity, and turns are capped at the per-job value.
3. Run: `pytest tests/cron/test_cron_job_caps.py -q` → 26 passed.

## Checklist

- [x] Conventional Commits
- [x] PR contains only changes related to this feature
- [x] `pytest tests/cron/test_cron_job_caps.py -q` passes (26 passed)
- [x] Added tests
- [x] Tool schema descriptions updated for the new fields

