### PR TITLE
fix(model-switch): exhausted credential pool should not count as authenticated

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1693,6 +1693,20 @@ def list_authenticated_providers(
                 store = _load_auth_store()
                 if store and store.get("credential_pool", {}).get(hermes_id):
                     has_creds = True
+                    # ...but if it parses into a full pool whose every entry is
+                    # exhausted/dead, it has no usable credential right now, so
+                    # don't treat it as authenticated -- otherwise an aggregator
+                    # whose quota is spent hijacks no-provider model resolution
+                    # and sticks as the session provider (#45759). Simple
+                    # token-style entries (no exhaustion-tracked entries) keep
+                    # the prior behaviour.
+                    try:
+                        from agent.credential_pool import load_pool as _load_pool
+                        _pool = _load_pool(hermes_id)
+                        if _pool.has_credentials() and not _pool.has_available():
+                            has_creds = False
+                    except Exception:
+                        pass
             except Exception:
                 pass
         if not has_creds:
@@ -1783,7 +1797,10 @@ def list_authenticated_providers(
             try:
                 from agent.credential_pool import load_pool
                 pool = load_pool(hermes_slug)
-                if pool.has_credentials():
+                # has_available(), not has_credentials(): an all-exhausted pool
+                # holds entries but no usable credential, so it must not count
+                # as authenticated (#45759).
+                if pool.has_available():
                     has_creds = True
             except Exception as exc:
                 logger.debug("Credential pool check failed for %s: %s", hermes_slug, exc)
@@ -1924,7 +1941,9 @@ def list_authenticated_providers(
             try:
                 from agent.credential_pool import load_pool
                 _cp_pool = load_pool(_cp.slug)
-                if _cp_pool.has_credentials():
+                # has_available(): exclude pools whose every entry is exhausted
+                # (#45759).
+                if _cp_pool.has_available():
                     _cp_has_creds = True
             except Exception:
                 pass

--- a/tests/hermes_cli/test_authenticated_providers_exhausted_pool.py
+++ b/tests/hermes_cli/test_authenticated_providers_exhausted_pool.py
@@ -1,0 +1,78 @@
+"""Regression test for #45759.
+
+An all-exhausted credential pool holds entries but no *usable* credential.
+``list_authenticated_providers`` must not treat such a provider as
+authenticated -- otherwise an aggregator whose quota is spent gets matched
+during no-provider ``/model`` resolution, wins the model name, and sticks as
+the session provider (the "sticky provider fallback pollution" bug).
+"""
+
+import pytest
+
+
+class _FakePool:
+    def __init__(self, available: bool):
+        self._available = available
+
+    def has_credentials(self) -> bool:
+        # The pool still holds entries...
+        return True
+
+    def has_available(self) -> bool:
+        # ...but none of them are usable when exhausted/dead.
+        return self._available
+
+
+def _patch_opencode_pool(monkeypatch, *, available: bool):
+    """Make the opencode-go aggregator look configured but with a pool whose
+    only credential is (un)available, depending on ``available``."""
+    import hermes_cli.auth as auth
+    import agent.credential_pool as cp
+
+    monkeypatch.setattr(
+        auth,
+        "_load_auth_store",
+        lambda: {
+            "version": 1,
+            "providers": {},
+            "active_provider": None,
+            "credential_pool": {"opencode-go": {"entries": [{"id": "x"}]}},
+        },
+    )
+    monkeypatch.setattr(
+        cp,
+        "load_pool",
+        lambda provider: _FakePool(available if provider == "opencode-go" else True),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _strip_provider_env(monkeypatch):
+    """Don't let real provider keys in the environment authenticate providers
+    through a different code path than the pool gate under test."""
+    import os
+
+    for key in list(os.environ):
+        if "OPENCODE" in key or key.endswith("_API_KEY"):
+            monkeypatch.delenv(key, raising=False)
+
+
+def test_exhausted_pool_provider_is_not_authenticated(monkeypatch):
+    """The fix: an exhausted pool is NOT authenticated. Fails on main, where
+    the gate accepted any stored pool entry regardless of usability."""
+    from hermes_cli.model_switch import get_authenticated_provider_slugs
+
+    _patch_opencode_pool(monkeypatch, available=False)
+    slugs = get_authenticated_provider_slugs(current_provider="alibaba")
+    assert "opencode-go" not in slugs
+
+
+def test_pool_provider_with_available_credential_is_authenticated(monkeypatch):
+    """Control: with a usable credential the provider IS authenticated, proving
+    the test drives the credential gate rather than excluding it for some other
+    reason."""
+    from hermes_cli.model_switch import get_authenticated_provider_slugs
+
+    _patch_opencode_pool(monkeypatch, available=True)
+    slugs = get_authenticated_provider_slugs(current_provider="alibaba")
+    assert "opencode-go" in slugs


### PR DESCRIPTION
Fixes #45759

## Problem
After an unrelated provider returns 401, the next `/model` switch can get hijacked by an aggregator (e.g. `opencode-go`) whose credentials are already spent, and it then sticks as the session provider — every later switch fails with "Provider resolver returned an empty API key" while still routing through the dead aggregator.

## Root cause
`list_authenticated_providers` decides a provider is authenticated if a credential pool merely *exists* for it, without checking that the pool still holds a usable credential:

- the auth-store gate accepted any stored `credential_pool[<provider>]` entry (bare key presence);
- two further gates used `pool.has_credentials()`, which is just `bool(entries)` — true even when every entry is exhausted/dead.

So a spent aggregator pool reported as authenticated, won the model-name match during no-provider resolution, and was set as the sticky session provider. Because `resolved_in_current_catalog` then gates out re-detection, the poisoned route persists across subsequent switches.

## Fix
Require at least one *available* entry (`has_available()` — an entry not in exhaustion cooldown) at all three credential-pool gates in `list_authenticated_providers`. The auth-store gate keeps its prior behaviour for simple token-style entries (creds that do not parse into exhaustion-tracked entries) and only demotes a pool that has entries but none available, so providers whose credentials live only in the auth-store `credential_pool` (e.g. mapped providers) still appear.

## Test
`tests/hermes_cli/test_authenticated_providers_exhausted_pool.py`:
- an aggregator whose only pooled credential is exhausted is **not** listed as authenticated (fails on `main`, passes with the fix);
- control: with a usable credential the same provider **is** listed (confirms the test drives the credential gate).

Verified the existing provider-listing/auth-gate suites still pass, including `test_mapped_provider_credential_pool_visibility` (simple token-style pool creds remain visible).

## Out of scope
The reporter also asked for a fail-closed revert when a switched-to provider 401s at turn time; that touches the runtime turn loop and credential rotation and is best handled separately.