### PR TITLE
fix(prompt): surface the Hermes config/state directory in environment hints

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1086,6 +1086,11 @@ def build_environment_hints() -> str:
             host_lines.append(f"Current working directory: {resolve_agent_cwd()}")
         except OSError:
             pass
+        host_lines.append(
+            f"Hermes config/state directory: {get_hermes_home()} "
+            "(your own config.yaml, .env, sessions, and skills live here "
+            "— NOT under the current working directory)"
+        )
 
         if sys.platform == "win32" and not is_wsl():
             host_lines.append(

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1169,6 +1169,23 @@ class TestEnvironmentHints:
         assert "hostname" not in result
         assert "WSL" not in result
 
+    def test_build_environment_hints_includes_hermes_home(self, monkeypatch):
+        import agent.prompt_builder as _pb
+        import sys, platform
+        from pathlib import Path
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(sys, "platform", "linux")
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        monkeypatch.setattr(platform, "release", lambda: "6.8.0-generic")
+        monkeypatch.setattr(_pb, "get_hermes_home", lambda: Path("/opt/data"))
+        monkeypatch.delenv("TERMINAL_ENV", raising=False)
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        # The agent must be told where its own config/state lives, not left to
+        # guess a cwd-relative path (#45792).
+        assert "Hermes config/state directory:" in result
+        assert "/opt/data" in result
+
     def test_build_environment_hints_on_windows_local(self, monkeypatch):
         import agent.prompt_builder as _pb
         import sys


### PR DESCRIPTION
Fixes #45792

## Problem
When the agent is asked where its own configuration lives, it guesses a working-directory-relative path (e.g. `/opt/hermes/.hermes`) instead of the real Hermes home — `/opt/data` inside Docker, `~/.hermes` otherwise. The local-backend environment hints already tell the model the host, user home, and current working directory, but never the Hermes home, so it has nothing accurate to anchor on.

## Fix
Add one line to the local-backend host block in `build_environment_hints()`:

```
Hermes config/state directory: <get_hermes_home()> (your own config.yaml, .env, sessions, and skills live here — NOT under the current working directory)
```

`get_hermes_home()` is already imported and resolves the correct location per environment. The line is only emitted on the local backend; the remote-backend branch still suppresses host info.

## Test
`tests/agent/test_prompt_builder.py::TestEnvironmentHints::test_build_environment_hints_includes_hermes_home` monkeypatches `get_hermes_home` to a known path and asserts it appears, labelled as the config/state directory. Fails on `main` (line absent), passes with the fix. The existing docker-suppression test still passes, confirming the line stays out of the remote-backend hints.