### PR TITLE
feat(web): make the web_search default result limit configurable

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1105,6 +1105,7 @@ DEFAULT_CONFIG = {
         "backend": "",           # shared fallback — applies to both search and extract
         "search_backend": "",    # per-capability override for web_search (e.g. "searxng")
         "extract_backend": "",   # per-capability override for web_extract (e.g. "native")
+        "search_default_limit": 5,  # default web_search result count when the caller omits `limit`
     },
 
     "browser": {

--- a/tests/tools/test_web_search_default_limit.py
+++ b/tests/tools/test_web_search_default_limit.py
@@ -1,0 +1,61 @@
+"""Regression test for #45701.
+
+web_search's default result count must be configurable via
+``web.search_default_limit`` instead of a hardcoded 5, while an explicit
+``limit`` argument still wins.
+"""
+
+import tools.web_tools as wt
+import agent.web_search_registry as wsr
+
+
+def _mock_provider(captured):
+    class _P:
+        name = "mock"
+
+        def supports_search(self):
+            return True
+
+        def search(self, query, limit):
+            captured["limit"] = limit
+            return {"success": True, "data": {"web": []}}
+
+    return _P()
+
+
+def _patch_search(monkeypatch, captured, *, config_limit=None):
+    monkeypatch.setattr(wt, "_ensure_web_plugins_loaded", lambda: None)
+    monkeypatch.setattr(wt, "_get_search_backend", lambda: "")
+    monkeypatch.setattr(wsr, "get_active_search_provider", lambda: _mock_provider(captured))
+    cfg = {} if config_limit is None else {"search_default_limit": config_limit}
+    monkeypatch.setattr(wt, "_load_web_config", lambda: cfg)
+
+
+def test_omitted_limit_uses_configured_default(monkeypatch):
+    """The fix: when the caller omits limit, the configured default is used.
+    Fails on main, where the limit is a hardcoded 5."""
+    captured = {}
+    _patch_search(monkeypatch, captured, config_limit=20)
+    wt.web_search_tool("hello")
+    assert captured["limit"] == 20
+
+
+def test_explicit_limit_overrides_config(monkeypatch):
+    captured = {}
+    _patch_search(monkeypatch, captured, config_limit=20)
+    wt.web_search_tool("hello", limit=7)
+    assert captured["limit"] == 7
+
+
+def test_default_falls_back_to_5_when_unset(monkeypatch):
+    captured = {}
+    _patch_search(monkeypatch, captured, config_limit=None)
+    wt.web_search_tool("hello")
+    assert captured["limit"] == 5
+
+
+def test_helper_clamps_out_of_range(monkeypatch):
+    monkeypatch.setattr(wt, "_load_web_config", lambda: {"search_default_limit": 500})
+    assert wt._get_web_search_default_limit() == 100
+    monkeypatch.setattr(wt, "_load_web_config", lambda: {"search_default_limit": 0})
+    assert wt._get_web_search_default_limit() == 1

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -495,7 +495,10 @@ class TestWebSearchSchema:
         assert result == '{"success": true}'
         mock_search.assert_called_once_with("site:example.com docs", limit=12)
 
-    def test_registered_handler_defaults_limit_to_five(self):
+    def test_registered_handler_defers_limit_to_config_when_omitted(self):
+        # When the caller omits ``limit`` the handler passes None, so
+        # web_search_tool resolves the configured web.search_default_limit
+        # rather than a hardcoded value (#45701).
         import tools.web_tools
 
         entry = tools.web_tools.registry.get_entry("web_search")
@@ -503,7 +506,7 @@ class TestWebSearchSchema:
             result = entry.handler({"query": "docs"})
 
         assert result == '{"success": true}'
-        mock_search.assert_called_once_with("docs", limit=5)
+        mock_search.assert_called_once_with("docs", limit=None)
 
     def test_web_search_clamps_limit_before_backend_call(self):
         import tools.web_tools

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -784,7 +784,17 @@ def _ensure_web_plugins_loaded() -> None:
         logger.warning("Web plugin discovery failed (non-fatal): %s", exc)
 
 
-def web_search_tool(query: str, limit: int = 5) -> str:
+def _get_web_search_default_limit() -> int:
+    """Default web_search result count from config ``web.search_default_limit``
+    (clamped to [1, 100]); falls back to 5 when unset or unreadable."""
+    try:
+        value = int(_load_web_config().get("search_default_limit", 5))
+    except (TypeError, ValueError):
+        return 5
+    return min(max(value, 1), 100)
+
+
+def web_search_tool(query: str, limit: int | None = None) -> str:
     """
     Search the web for information using available search API backend.
 
@@ -818,10 +828,12 @@ def web_search_tool(query: str, limit: int = 5) -> str:
     Raises:
         Exception: If search fails or API key is not set
     """
+    if limit is None:
+        limit = _get_web_search_default_limit()
     try:
         limit = int(limit)
     except (TypeError, ValueError):
-        limit = 5
+        limit = _get_web_search_default_limit()
     limit = min(max(limit, 1), 100)
 
     debug_call_data = {
@@ -1326,7 +1338,7 @@ WEB_SEARCH_SCHEMA = {
             },
             "limit": {
                 "type": "integer",
-                "description": "Maximum number of results to return. Defaults to 5.",
+                "description": "Maximum number of results to return. Defaults to the configured web.search_default_limit (5 unless changed).",
                 "minimum": 1,
                 "maximum": 100,
                 "default": 5
@@ -1357,7 +1369,7 @@ registry.register(
     name="web_search",
     toolset="web",
     schema=WEB_SEARCH_SCHEMA,
-    handler=lambda args, **kw: web_search_tool(args.get("query", ""), limit=args.get("limit", 5)),
+    handler=lambda args, **kw: web_search_tool(args.get("query", ""), limit=args.get("limit")),
     check_fn=check_web_api_key,
     requires_env=_web_requires_env(),
     emoji="🔍",


### PR DESCRIPTION
Fixes #45701

## Problem
`web_search` always defaults to 5 results when the caller omits `limit`. There is no way for an operator to change that default — the value is hardcoded in `web_search_tool` and in the registered tool handler.

## Fix
Add a `web.search_default_limit` config key (default 5), alongside the existing `web.backend` / `web.search_backend` / `web.extract_backend` keys:

- `hermes_cli/config.py`: new key in the `web` defaults.
- `tools/web_tools.py`: a small `_get_web_search_default_limit()` helper (reads the key via the existing `_load_web_config()`, clamped to `[1, 100]`, falls back to 5). `web_search_tool(query, limit=None)` resolves the configured default when `limit is None`; an explicit `limit` still wins and the final value is clamped. The registered handler passes `None` when the model omits `limit`, so config takes effect rather than a hardcoded 5.

The change is scoped to the search limit only — backend selection is untouched.

## Test
`tests/tools/test_web_search_default_limit.py` (network-free, mock provider captures the resolved limit):
- omitted `limit` uses the configured default (fails on `main`, where it is hardcoded 5);
- explicit `limit` overrides config;
- falls back to 5 when the key is unset;
- helper clamps out-of-range values.

`test_web_tools_config.py`'s handler-default test is updated to the new contract (handler passes `None` so config resolves the default); the rest of that suite passes unchanged.
