### PR TITLE
fix(compaction): make Codex gpt-5.5 autoraise notice actually one-time

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -86,6 +86,34 @@ def _build_codex_gpt55_autoraise_notice(autoraise: Dict[str, float]) -> str:
     )
 
 
+def _codex_gpt55_autoraise_ack_path() -> str:
+    """Path to the marker file that records acknowledgement of the notice.
+
+    Stored under ``~/.hermes/`` so it survives reinstalls but is per-user.
+    Delete the file to see the notice again (useful after a settings change).
+    """
+    return os.path.join(get_hermes_home(), ".codex_gpt55_autoraise_acked")
+
+
+def _codex_gpt55_autoraise_acked() -> bool:
+    """Return True when the user has already seen the autoraise notice."""
+    try:
+        return os.path.exists(_codex_gpt55_autoraise_ack_path())
+    except OSError:
+        return False
+
+
+def _record_codex_gpt55_autoraise_acked() -> None:
+    """Best-effort marker write. Silent on failure — the worst case is the
+    notice fires again next session, which is no worse than today's behavior.
+    """
+    try:
+        with open(_codex_gpt55_autoraise_ack_path(), "w") as fh:
+            fh.write("")
+    except OSError:
+        pass
+
+
 def _normalized_custom_base_url(value: Any) -> str:
     if not isinstance(value, str):
         return ""
@@ -1685,9 +1713,12 @@ def init_agent(
         # exact opt-back-out command. Printed inline at startup for CLI users;
         # gateway users get the same text replayed via _compression_warning on
         # turn 1 (set below, after the warning slot is initialized).
+        # Acknowledgement is persisted to ~/.hermes/.codex_gpt55_autoraise_acked
+        # so the notice fires once per install, not once per agent init.
         _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-        if _autoraise and compression_enabled:
+        if _autoraise and compression_enabled and not _codex_gpt55_autoraise_acked():
             print(_build_codex_gpt55_autoraise_notice(_autoraise))
+            _record_codex_gpt55_autoraise_acked()
 
     # Check immediately so CLI users see the warning at startup.
     # Gateway status_callback is not yet wired, so any warning is stored
@@ -1696,9 +1727,13 @@ def init_agent(
     # Gateway parity for the Codex gpt-5.5 autoraise notice: the startup print
     # above only reaches the CLI, so stash the same text here to be replayed
     # through status_callback on the first turn (Telegram/Discord/Slack/etc.).
+    # Same per-install ack file as the CLI branch — without it, the gateway
+    # would replay the notice on every conversation turn-1, which is what
+    # users were reporting.
     _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-    if _autoraise and compression_enabled:
+    if _autoraise and compression_enabled and not _codex_gpt55_autoraise_acked():
         agent._compression_warning = _build_codex_gpt55_autoraise_notice(_autoraise)
+        _record_codex_gpt55_autoraise_acked()
     # Lazy feasibility check: deferred to the first turn that approaches the
     # compression threshold. Running it eagerly here costs ~400ms cold (network
     # probe of the auxiliary provider chain + /models lookup) on every agent

--- a/tests/agent/test_codex_gpt55_autoraise_notice.py
+++ b/tests/agent/test_codex_gpt55_autoraise_notice.py
@@ -1,0 +1,86 @@
+"""Tests for one-time gating of the Codex gpt-5.5 autoraise notice.
+
+The notice was previously re-emitted on every agent init (i.e. every Discord
+turn-1 / new conversation / CLI invocation), even though its docstring called
+it a "one-time notice." This module covers the per-install ack file that
+silences subsequent emissions.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from agent.agent_init import (
+    _build_codex_gpt55_autoraise_notice,
+    _codex_gpt55_autoraise_ack_path,
+    _codex_gpt55_autoraise_acked,
+    _record_codex_gpt55_autoraise_acked,
+)
+
+
+@pytest.fixture
+def isolated_hermes_home(tmp_path, monkeypatch):
+    """Point ``get_hermes_home()`` at a clean tmp dir for the test.
+
+    The module imports ``get_hermes_home`` from ``hermes_constants`` at
+    load time — patch the symbol where it's actually looked up (inside
+    ``agent.agent_init``) so our helpers see the redirected path.
+    """
+    monkeypatch.setattr(
+        "agent.agent_init.get_hermes_home",
+        lambda: str(tmp_path),
+    )
+    return tmp_path
+
+
+def test_ack_path_is_under_hermes_home(isolated_hermes_home):
+    assert _codex_gpt55_autoraise_ack_path() == os.path.join(
+        str(isolated_hermes_home), ".codex_gpt55_autoraise_acked"
+    )
+
+
+def test_acked_false_when_marker_absent(isolated_hermes_home):
+    assert _codex_gpt55_autoraise_acked() is False
+
+
+def test_acked_true_after_record(isolated_hermes_home):
+    _record_codex_gpt55_autoraise_acked()
+    assert _codex_gpt55_autoraise_acked() is True
+    # And persists across re-checks (file-backed, not just in-memory).
+    assert os.path.exists(_codex_gpt55_autoraise_ack_path())
+
+
+def test_record_is_idempotent(isolated_hermes_home):
+    _record_codex_gpt55_autoraise_acked()
+    _record_codex_gpt55_autoraise_acked()  # second call must not raise
+    assert _codex_gpt55_autoraise_acked() is True
+
+
+def test_record_silent_on_oserror(isolated_hermes_home):
+    """Filesystem errors must not crash agent init — falling back to
+    "notice re-emits next session" is no worse than the pre-patch baseline.
+    """
+    with patch("builtins.open", side_effect=OSError("disk full")):
+        _record_codex_gpt55_autoraise_acked()  # must not raise
+
+    assert _codex_gpt55_autoraise_acked() is False
+
+
+def test_acked_silent_on_oserror(isolated_hermes_home, monkeypatch):
+    """A racy unreadable home dir must degrade to "not acked" cleanly."""
+    monkeypatch.setattr(os.path, "exists", lambda _: (_ for _ in ()).throw(OSError("eperm")))
+    assert _codex_gpt55_autoraise_acked() is False
+
+
+def test_notice_text_includes_opt_out_command():
+    """The notice MUST include the exact command the user needs to opt out.
+
+    A user staring at the notice should never have to grep for it — this
+    is the assertion that protects against accidental message rewording
+    in a refactor.
+    """
+    text = _build_codex_gpt55_autoraise_notice({"from": 0.50, "to": 0.85})
+    assert "hermes config set compression.codex_gpt55_autoraise false" in text
+    assert "85%" in text
+    assert "50%" in text


### PR DESCRIPTION
## Summary

Fixes #45817 — the `_build_codex_gpt55_autoraise_notice` docstring says "one-time notice" but the implementation has no persistence, so it re-fires on every agent init: every Discord/Slack/Telegram turn-1, every CLI startup, every new conversation.

This patch adds a per-install marker at `~/.hermes/.codex_gpt55_autoraise_acked` and gates both emission sites (CLI print + gateway status_callback) on its absence. The notice fires once for both surfaces, records the ack, then both branches stay silent.

Deleting the marker re-arms the notice — useful when the user changes a compression-related setting and you want to inform them again.

## Implementation notes

- Three helpers added next to `_build_codex_gpt55_autoraise_notice`: `_codex_gpt55_autoraise_ack_path()`, `_codex_gpt55_autoraise_acked()`, `_record_codex_gpt55_autoraise_acked()`
- OSError on either read or write degrades cleanly to today's behavior (notice re-fires next session) — never crashes agent init
- Marker file lives under `get_hermes_home()` so it survives reinstalls but is per-user

## Real-world failure this fixes

A user with the Discord gateway sees the notice repeated on every new thread / conversation start, with no path to silence it short of `compression.codex_gpt55_autoraise: false` (which also disables the cache-friendly behavior they want).

## Test plan

- [x] 7 new tests in `tests/agent/test_codex_gpt55_autoraise_notice.py` covering: ack path location, acked-false default, acked-true after record, idempotent record, silent OSError on record, silent OSError on read, notice text invariants (still contains opt-out command + before/after percentages)
- [x] Existing 16 tests in `tests/run_agent/test_compression_feasibility.py` still pass
- [x] Patched gateway live-verified — notice fired once, marker file created, subsequent restarts silent

Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)