### PR TITLE
fix(cli): validate keys in 'hermes config set'

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -8151,23 +8151,25 @@ def _default_value_for_key(dotted_key: str):
     return node if not isinstance(node, dict) else None
 
 
+_ENV_REDIRECT_KEYS = frozenset({
+    'OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'VOICE_TOOLS_OPENAI_KEY',
+    'EXA_API_KEY', 'PARALLEL_API_KEY', 'FIRECRAWL_API_KEY', 'FIRECRAWL_API_URL',
+    'FIRECRAWL_GATEWAY_URL', 'TOOL_GATEWAY_DOMAIN', 'TOOL_GATEWAY_SCHEME',
+    'TOOL_GATEWAY_USER_TOKEN', 'TAVILY_API_KEY',
+    'BROWSERBASE_API_KEY', 'BROWSERBASE_PROJECT_ID', 'BROWSER_USE_API_KEY',
+    'FAL_KEY', 'TELEGRAM_BOT_TOKEN', 'DISCORD_BOT_TOKEN',
+    'TERMINAL_SSH_HOST', 'TERMINAL_SSH_USER', 'TERMINAL_SSH_KEY',
+    'SUDO_PASSWORD', 'SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN',
+    'GITHUB_TOKEN', 'HONCHO_API_KEY',
+})
+
+
 def _is_valid_config_key(dotted_key: str, current_user_config: Dict[str, Any]) -> bool:
     """Return True if dotted_key is a recognized configuration or environment variable key."""
     # 1. Check environment variables
     # (Matches set_config_value's logic for redirecting to .env)
     upper_key = dotted_key.upper()
-    api_keys = {
-        'OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'VOICE_TOOLS_OPENAI_KEY',
-        'EXA_API_KEY', 'PARALLEL_API_KEY', 'FIRECRAWL_API_KEY', 'FIRECRAWL_API_URL',
-        'FIRECRAWL_GATEWAY_URL', 'TOOL_GATEWAY_DOMAIN', 'TOOL_GATEWAY_SCHEME',
-        'TOOL_GATEWAY_USER_TOKEN', 'TAVILY_API_KEY',
-        'BROWSERBASE_API_KEY', 'BROWSERBASE_PROJECT_ID', 'BROWSER_USE_API_KEY',
-        'FAL_KEY', 'TELEGRAM_BOT_TOKEN', 'DISCORD_BOT_TOKEN',
-        'TERMINAL_SSH_HOST', 'TERMINAL_SSH_USER', 'TERMINAL_SSH_KEY',
-        'SUDO_PASSWORD', 'SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN',
-        'GITHUB_TOKEN', 'HONCHO_API_KEY',
-    }
-    if (upper_key in api_keys or
+    if (upper_key in _ENV_REDIRECT_KEYS or
         upper_key in REQUIRED_ENV_VARS or
         upper_key in OPTIONAL_ENV_VARS or
         upper_key in _EXTRA_ENV_KEYS or
@@ -8269,20 +8271,9 @@ def set_config_value(key: str, value: str):
         sys.exit(1)
 
     # Check if it's an API key (goes to .env)
-    api_keys = [
-        'OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'VOICE_TOOLS_OPENAI_KEY',
-        'EXA_API_KEY', 'PARALLEL_API_KEY', 'FIRECRAWL_API_KEY', 'FIRECRAWL_API_URL',
-        'FIRECRAWL_GATEWAY_URL', 'TOOL_GATEWAY_DOMAIN', 'TOOL_GATEWAY_SCHEME',
-        'TOOL_GATEWAY_USER_TOKEN', 'TAVILY_API_KEY',
-        'BROWSERBASE_API_KEY', 'BROWSERBASE_PROJECT_ID', 'BROWSER_USE_API_KEY',
-        'FAL_KEY', 'TELEGRAM_BOT_TOKEN', 'DISCORD_BOT_TOKEN',
-        'TERMINAL_SSH_HOST', 'TERMINAL_SSH_USER', 'TERMINAL_SSH_KEY',
-        'SUDO_PASSWORD', 'SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN',
-        'GITHUB_TOKEN', 'HONCHO_API_KEY',
-    ]
-    
-    if key.upper() in api_keys or key.upper().endswith(('_API_KEY', '_TOKEN')) or key.upper().startswith('TERMINAL_SSH'):
-        save_env_value(key.upper(), value)
+    upper_key = key.upper()
+    if upper_key in _ENV_REDIRECT_KEYS or upper_key.endswith(('_API_KEY', '_TOKEN')) or upper_key.startswith('TERMINAL_SSH'):
+        save_env_value(upper_key, value)
         print(f"✓ Set {key} in {get_env_path()}")
         return
     

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4736,19 +4736,6 @@ def _normalize_custom_provider_entry(
     # rest of the normalizer treats it as the canonical field.
     if "api_key_env" in entry and "key_env" not in entry:
         entry["key_env"] = entry["api_key_env"]
-    _KNOWN_KEYS = {
-        # ``provider`` duplicates the ``providers.<name>`` mapping key and is
-        # unused here, but Hermes' own config writer has historically emitted it
-        # into provider entries. Accept it silently so those (self-written)
-        # configs don't warn on every load.
-        "provider",
-        "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
-        "api_mode", "transport", "model", "default_model", "models",
-        "context_length", "rate_limit_delay",
-        "request_timeout_seconds", "stale_timeout_seconds",
-        "discover_models", "extra_body", "extra_headers",
-        "ssl_ca_cert", "ssl_verify",
-    }
     for camel, snake in _CAMEL_ALIASES.items():
         if camel in entry and snake not in entry:
             _warn_once_per_provider(
@@ -4758,7 +4745,7 @@ def _normalize_custom_provider_entry(
                 provider_key or "?", camel, snake,
             )
             entry[snake] = entry[camel]
-    unknown = set(entry.keys()) - _KNOWN_KEYS - set(_CAMEL_ALIASES.keys())
+    unknown = set(entry.keys()) - _KNOWN_PROVIDER_KEYS - set(_CAMEL_ALIASES.keys())
     if unknown:
         _warn_once_per_provider(
             provider_key, "unknown:" + ",".join(sorted(unknown)),
@@ -4890,6 +4877,21 @@ def _normalize_custom_provider_entry(
         normalized["ssl_verify"] = ssl_verify.strip()
 
     return normalized
+
+
+_KNOWN_PROVIDER_KEYS = {
+    # ``provider`` duplicates the ``providers.<name>`` mapping key and is
+    # unused here, but Hermes' own config writer has historically emitted it
+    # into provider entries. Accept it silently so those (self-written)
+    # configs don't warn on every load.
+    "provider",
+    "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
+    "api_mode", "transport", "model", "default_model", "models",
+    "context_length", "rate_limit_delay",
+    "request_timeout_seconds", "stale_timeout_seconds",
+    "discover_models", "extra_body", "extra_headers",
+    "ssl_ca_cert", "ssl_verify",
+}
 
 
 def _custom_provider_entry_to_provider_config(
@@ -8149,6 +8151,83 @@ def _default_value_for_key(dotted_key: str):
     return node if not isinstance(node, dict) else None
 
 
+def _is_valid_config_key(dotted_key: str, current_user_config: Dict[str, Any]) -> bool:
+    """Return True if dotted_key is a recognized configuration or environment variable key."""
+    # 1. Check environment variables
+    # (Matches set_config_value's logic for redirecting to .env)
+    upper_key = dotted_key.upper()
+    api_keys = {
+        'OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'VOICE_TOOLS_OPENAI_KEY',
+        'EXA_API_KEY', 'PARALLEL_API_KEY', 'FIRECRAWL_API_KEY', 'FIRECRAWL_API_URL',
+        'FIRECRAWL_GATEWAY_URL', 'TOOL_GATEWAY_DOMAIN', 'TOOL_GATEWAY_SCHEME',
+        'TOOL_GATEWAY_USER_TOKEN', 'TAVILY_API_KEY',
+        'BROWSERBASE_API_KEY', 'BROWSERBASE_PROJECT_ID', 'BROWSER_USE_API_KEY',
+        'FAL_KEY', 'TELEGRAM_BOT_TOKEN', 'DISCORD_BOT_TOKEN',
+        'TERMINAL_SSH_HOST', 'TERMINAL_SSH_USER', 'TERMINAL_SSH_KEY',
+        'SUDO_PASSWORD', 'SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN',
+        'GITHUB_TOKEN', 'HONCHO_API_KEY',
+    }
+    if (upper_key in api_keys or
+        upper_key in REQUIRED_ENV_VARS or
+        upper_key in OPTIONAL_ENV_VARS or
+        upper_key in _EXTRA_ENV_KEYS or
+        upper_key.endswith(('_API_KEY', '_TOKEN')) or
+        upper_key.startswith('TERMINAL_SSH')):
+        return True
+
+    # 2. Check if it's already in the user's config (allow updates to custom keys)
+    try:
+        parts = dotted_key.split('.')
+        curr = current_user_config
+        found = True
+        for part in parts:
+            if isinstance(curr, dict) and part in curr:
+                curr = curr[part]
+            else:
+                found = False
+                break
+        if found:
+            return True
+    except Exception:
+        pass
+
+    # 3. Check DEFAULT_CONFIG tree
+    parts = dotted_key.split('.')
+
+    # Special case: providers.<name>.<field>
+    if parts[0] == "providers" and len(parts) >= 2:
+        if len(parts) == 2:
+            return True
+        return parts[-1] in _KNOWN_PROVIDER_KEYS
+
+    # Special case: skills.config.<name>
+    if dotted_key.startswith("skills.config."):
+        return True
+
+    # Special case: Legacy or Test keys
+    if parts[0] in {"custom_providers", "platforms", "verbose"}:
+        return True
+
+    # Recursive check in DEFAULT_CONFIG
+    current = DEFAULT_CONFIG
+    for part in parts:
+        if isinstance(current, dict):
+            if part in current:
+                current = current[part]
+            else:
+                return False
+        elif isinstance(current, list):
+            try:
+                int(part)
+                return True
+            except ValueError:
+                return False
+        else:
+            return False
+
+    return True
+
+
 def set_config_value(key: str, value: str):
     """Set a configuration value."""
     if is_managed():
@@ -8170,6 +8249,25 @@ def set_config_value(key: str, value: str):
             file=sys.stderr,
         )
         sys.exit(1)
+
+    # Otherwise it goes to config.yaml
+    # Read the raw user config (not merged with defaults) to avoid
+    # dumping all default values back to the file
+    config_path = get_config_path()
+    require_readable_config_before_write(config_path)
+    user_config = {}
+    if config_path.exists():
+        try:
+            with open(config_path, encoding="utf-8") as f:
+                user_config = fast_safe_load(f) or {}
+        except Exception:
+            user_config = {}
+
+    if not _is_valid_config_key(key, user_config):
+        print(color(f"⚠ Unknown configuration key: {key}", Colors.YELLOW))
+        print(f"  Check '{get_config_path()}' for valid structure.")
+        sys.exit(1)
+
     # Check if it's an API key (goes to .env)
     api_keys = [
         'OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'VOICE_TOOLS_OPENAI_KEY',
@@ -8187,19 +8285,6 @@ def set_config_value(key: str, value: str):
         save_env_value(key.upper(), value)
         print(f"✓ Set {key} in {get_env_path()}")
         return
-    
-    # Otherwise it goes to config.yaml
-    # Read the raw user config (not merged with defaults) to avoid
-    # dumping all default values back to the file
-    config_path = get_config_path()
-    require_readable_config_before_write(config_path)
-    user_config = {}
-    if config_path.exists():
-        try:
-            with open(config_path, encoding="utf-8") as f:
-                user_config = fast_safe_load(f) or {}
-        except Exception:
-            user_config = {}
     
     # Handle nested keys (e.g., "tts.provider") including numeric list
     # indices (e.g., "custom_providers.0.api_key").  Delegates to

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -8164,6 +8164,127 @@ _ENV_REDIRECT_KEYS = frozenset({
 })
 
 
+_KNOWN_MODEL_CONFIG_KEYS = frozenset({
+    "default",
+    "model",
+    "name",
+    "provider",
+    "fallback",
+    "base_url",
+    "api_base",
+    "api_key",
+    "api",
+    "api_mode",
+    "auth_mode",
+    "key_env",
+    "api_key_env",
+    "context_length",
+    "max_tokens",
+    "reasoning_effort",
+    "supports_vision",
+    "ollama_num_ctx",
+    "persist_switch_by_default",
+    "openai_runtime",
+    "default_headers",
+    "aliases",
+    "entra",
+})
+
+_KNOWN_PROVIDER_MODEL_KEYS = frozenset({
+    "context_length",
+    "timeout_seconds",
+    "stale_timeout_seconds",
+    "supports_vision",
+})
+
+_KNOWN_QUICK_COMMAND_KEYS = frozenset({"type", "command", "target"})
+
+_KNOWN_TTS_COMMAND_PROVIDER_KEYS = frozenset({
+    "type",
+    "command",
+    "format",
+    "output_format",
+    "timeout",
+    "timeout_seconds",
+    "voice_compatible",
+    "max_text_length",
+    "voice",
+    "model",
+})
+
+_KNOWN_STT_COMMAND_PROVIDER_KEYS = frozenset({
+    "type",
+    "command",
+    "format",
+    "output_format",
+    "language",
+    "timeout",
+    "timeout_seconds",
+    "model",
+})
+
+
+def _is_valid_dynamic_config_key(parts: List[str]) -> bool:
+    """Validate config namespaces whose user-defined names are absent from defaults."""
+    if not parts or any(not part for part in parts):
+        return False
+
+    root = parts[0]
+
+    # DEFAULT_CONFIG keeps ``model`` as a legacy scalar, while the runtime also
+    # supports a structured model block. Keep the structured surface explicit so
+    # typos under model do not become inert config entries.
+    if root == "model":
+        if len(parts) == 1:
+            return True
+        field = parts[1]
+        if field not in _KNOWN_MODEL_CONFIG_KEYS:
+            return False
+        if field == "aliases":
+            return len(parts) in {2, 3}
+        if field == "default_headers":
+            return len(parts) >= 2
+        if field == "entra":
+            return len(parts) == 2 or (len(parts) == 3 and parts[2] == "scope")
+        return len(parts) == 2
+
+    # providers.<name> has both provider-wide fields and per-model overrides.
+    if root == "providers":
+        if len(parts) == 2:
+            return True
+        if len(parts) < 3:
+            return False
+        field = parts[2]
+        if field not in _KNOWN_PROVIDER_KEYS:
+            return False
+        if len(parts) == 3:
+            return True
+        if field in {"extra_body", "extra_headers"}:
+            return True
+        if field == "models":
+            return len(parts) == 4 or (
+                len(parts) == 5 and parts[4] in _KNOWN_PROVIDER_MODEL_KEYS
+            )
+        return False
+
+    if root == "quick_commands":
+        return len(parts) == 2 or (
+            len(parts) == 3 and parts[2] in _KNOWN_QUICK_COMMAND_KEYS
+        )
+
+    if len(parts) >= 2 and root in {"tts", "stt"} and parts[1] == "providers":
+        if len(parts) in {2, 3}:
+            return True
+        known_fields = (
+            _KNOWN_TTS_COMMAND_PROVIDER_KEYS
+            if root == "tts"
+            else _KNOWN_STT_COMMAND_PROVIDER_KEYS
+        )
+        return len(parts) == 4 and parts[3] in known_fields
+
+    return False
+
+
 def _is_valid_config_key(dotted_key: str, current_user_config: Dict[str, Any]) -> bool:
     """Return True if dotted_key is a recognized configuration or environment variable key."""
     # 1. Check environment variables
@@ -8193,16 +8314,12 @@ def _is_valid_config_key(dotted_key: str, current_user_config: Dict[str, Any]) -
     except Exception:
         pass
 
-    # 3. Check DEFAULT_CONFIG tree
+    # 3. Check namespaces containing user-defined names.
     parts = dotted_key.split('.')
+    if _is_valid_dynamic_config_key(parts):
+        return True
 
-    # Special case: providers.<name>.<field>
-    if parts[0] == "providers" and len(parts) >= 2:
-        if len(parts) == 2:
-            return True
-        return parts[-1] in _KNOWN_PROVIDER_KEYS
-
-    # Special case: skills.config.<name>
+    # Skill manifests define their own non-secret config keys.
     if dotted_key.startswith("skills.config."):
         return True
 
@@ -8210,7 +8327,7 @@ def _is_valid_config_key(dotted_key: str, current_user_config: Dict[str, Any]) -
     if parts[0] in {"custom_providers", "platforms", "verbose"}:
         return True
 
-    # Recursive check in DEFAULT_CONFIG
+    # 4. Check the static DEFAULT_CONFIG tree.
     current = DEFAULT_CONFIG
     for part in parts:
         if isinstance(current, dict):
@@ -8252,6 +8369,18 @@ def set_config_value(key: str, value: str):
         )
         sys.exit(1)
 
+    # Environment-shaped keys do not depend on config.yaml. Route them before
+    # reading the YAML so a malformed config file cannot block secret rotation.
+    upper_key = key.upper()
+    if (
+        upper_key in _ENV_REDIRECT_KEYS
+        or upper_key.endswith(("_API_KEY", "_TOKEN"))
+        or upper_key.startswith("TERMINAL_SSH")
+    ):
+        save_env_value(upper_key, value)
+        print(f"✓ Set {key} in {get_env_path()}")
+        return
+
     # Otherwise it goes to config.yaml
     # Read the raw user config (not merged with defaults) to avoid
     # dumping all default values back to the file
@@ -8270,13 +8399,6 @@ def set_config_value(key: str, value: str):
         print(f"  Check '{get_config_path()}' for valid structure.")
         sys.exit(1)
 
-    # Check if it's an API key (goes to .env)
-    upper_key = key.upper()
-    if upper_key in _ENV_REDIRECT_KEYS or upper_key.endswith(('_API_KEY', '_TOKEN')) or upper_key.startswith('TERMINAL_SSH'):
-        save_env_value(upper_key, value)
-        print(f"✓ Set {key} in {get_env_path()}")
-        return
-    
     # Handle nested keys (e.g., "tts.provider") including numeric list
     # indices (e.g., "custom_providers.0.api_key").  Delegates to
     # _set_nested which preserves list-typed nodes; before #17876 the

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -126,6 +126,83 @@ class TestConfigYamlRouting:
 
 
 # ---------------------------------------------------------------------------
+# Config key validation — regression tests for PR #45820 review
+# ---------------------------------------------------------------------------
+
+class TestConfigKeyValidation:
+    """Fresh dynamic entries stay writable while unknown paths are rejected."""
+
+    def test_fresh_model_alias_is_accepted(self, _isolated_hermes_home):
+        set_config_value(
+            "model.aliases.fav",
+            "anthropic/claude-opus-4.6",
+        )
+
+        import yaml
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert saved["model"]["aliases"]["fav"] == "anthropic/claude-opus-4.6"
+
+    def test_fresh_quick_command_is_accepted(self, _isolated_hermes_home):
+        set_config_value("quick_commands.status.type", "exec")
+        set_config_value(
+            "quick_commands.status.command",
+            "systemctl status hermes-agent",
+        )
+
+        import yaml
+        saved = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert saved["quick_commands"]["status"] == {
+            "type": "exec",
+            "command": "systemctl status hermes-agent",
+        }
+
+    @pytest.mark.parametrize(("key", "value", "expected"), [
+        ("providers.example.models.model-v1.timeout_seconds", "30", 30),
+        ("providers.example.extra_headers.X-Tenant", "acme", "acme"),
+        ("tts.providers.local-piper.type", "command", "command"),
+        ("tts.providers.local-piper.timeout_seconds", "45", 45),
+        ("stt.providers.local-whisper.command", "whisper-cli", "whisper-cli"),
+        ("stt.providers.local-whisper.output_format", "txt", "txt"),
+    ])
+    def test_documented_dynamic_registries_are_accepted(
+        self, _isolated_hermes_home, key, value, expected
+    ):
+        set_config_value(key, value)
+
+        import yaml
+        node = yaml.safe_load(_read_config(_isolated_hermes_home))
+        for part in key.split("."):
+            node = node[part]
+        assert node == expected
+
+    @pytest.mark.parametrize("key", [
+        "model.typo",
+        "providers.example.typo",
+        "quick_commands.status.typo",
+        "tts.providers.local.typo",
+    ])
+    def test_unknown_dynamic_fields_are_rejected(
+        self, _isolated_hermes_home, key
+    ):
+        with pytest.raises(SystemExit) as exc:
+            set_config_value(key, "value")
+
+        assert exc.value.code == 1
+        assert _read_config(_isolated_hermes_home) == ""
+
+    def test_unknown_root_path_is_rejected(
+        self, _isolated_hermes_home, capsys
+    ):
+        with pytest.raises(SystemExit) as exc:
+            set_config_value("foo.bar", "baz")
+
+        assert exc.value.code == 1
+        assert "Unknown configuration key: foo.bar" in capsys.readouterr().out
+        assert _read_config(_isolated_hermes_home) == ""
+        assert _read_env(_isolated_hermes_home) == ""
+
+
+# ---------------------------------------------------------------------------
 # Empty / falsy values — regression tests for #4277
 # ---------------------------------------------------------------------------
 
@@ -281,12 +358,14 @@ class TestStringTypedConfigValues:
         assert node == expected
         assert type(node) is type(expected)
 
-    def test_unknown_keys_keep_existing_coercion(self, _isolated_hermes_home):
-        set_config_value("custom.enabled", "off")
+    def test_dynamic_keys_without_defaults_keep_existing_coercion(
+        self, _isolated_hermes_home
+    ):
+        set_config_value("providers.custom.discover_models", "off")
 
         import yaml
         saved = yaml.safe_load(_read_config(_isolated_hermes_home))
-        assert saved["custom"]["enabled"] is False
+        assert saved["providers"]["custom"]["discover_models"] is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Description**

Previously, `hermes config set` silently accepted arbitrary configuration paths. Typos were persisted to `config.yaml` even though Hermes never consumed them.

This PR adds key validation to `set_config_value` while preserving supported dynamic configuration namespaces.

**Changes**

1. `_is_valid_config_key` accepts known environment variables, existing user-defined paths, keys from `DEFAULT_CONFIG`, and explicitly modeled dynamic namespaces.
2. Unknown paths such as `foo.bar` are rejected with a helpful warning and exit status 1.
3. Fresh dynamic entries remain supported, including:
   - `model.aliases.<name>` and the structured `model.*` fields consumed by Hermes
   - `quick_commands.<name>.{type,command,target}`
   - `providers.<id>` fields, per-model overrides, extra bodies, and extra headers
   - command-backed `tts.providers.<name>` and `stt.providers.<name>` entries
4. `_KNOWN_PROVIDER_KEYS` and `_ENV_REDIRECT_KEYS` are shared constants, avoiding duplicated validation and routing lists.
5. Environment-shaped keys are still routed before reading `config.yaml`, so a malformed YAML file cannot block secret rotation.

**Testing**

- Added end-to-end regression tests for fresh `model.aliases.fav` and `quick_commands.status` entries.
- Added acceptance coverage for provider overrides and command-backed TTS/STT providers.
- Added rejection coverage for `foo.bar` and unknown fields inside dynamic namespaces.
- Ran the relevant config, validation, managed-scope, and environment-reference suites: **271 passed**.
- `ruff check hermes_cli/config.py tests/hermes_cli/test_set_config_value.py`: passed.
