### PR TITLE
fix(agent): treat Codex reasoning items as thinking-only

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -881,6 +881,8 @@ def try_recover_primary_transport(
 
 def drop_thinking_only_and_merge_users(
     messages: List[Dict[str, Any]],
+    *,
+    drop_codex_reasoning_items: bool = True,
 ) -> List[Dict[str, Any]]:
     """Drop thinking-only assistant turns; merge any adjacent user messages left behind.
 
@@ -902,7 +904,13 @@ def drop_thinking_only_and_merge_users(
         return messages
 
     # Pass 1: drop thinking-only assistant turns.
-    kept = [m for m in messages if not _ra().AIAgent._is_thinking_only_assistant(m)]
+    kept = [
+        m for m in messages
+        if not _ra().AIAgent._is_thinking_only_assistant(
+            m,
+            drop_codex_reasoning_items=drop_codex_reasoning_items,
+        )
+    ]
     dropped = len(messages) - len(kept)
     if dropped == 0:
         return messages

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -707,7 +707,10 @@ def run_conversation(
         # a thinking-only turn. Runs on the per-call copy only — the
         # stored conversation history keeps the reasoning block for the
         # UI transcript and session persistence.
-        api_messages = agent._drop_thinking_only_and_merge_users(api_messages)
+        api_messages = agent._drop_thinking_only_and_merge_users(
+            api_messages,
+            drop_codex_reasoning_items=agent.api_mode != "codex_responses",
+        )
 
         # Normalize message whitespace and tool-call JSON for consistent
         # prefix matching.  Ensures bit-perfect prefixes across turns,

--- a/run_agent.py
+++ b/run_agent.py
@@ -3297,6 +3297,16 @@ class AIAgent:
         rd = msg.get("reasoning_details")
         if isinstance(rd, list) and rd:
             return True
+        # Codex Responses stores encrypted reasoning state under a separate
+        # assistant-message key. Treat only real reasoning items as
+        # thinking-only; empty/junk lists should fall through to the generic
+        # empty-turn handling instead of being dropped here.
+        codex_items = msg.get("codex_reasoning_items")
+        if isinstance(codex_items, list):
+            return any(
+                isinstance(item, dict) and item.get("type") == "reasoning"
+                for item in codex_items
+            )
         return False
 
     @staticmethod

--- a/run_agent.py
+++ b/run_agent.py
@@ -3246,7 +3246,11 @@ class AIAgent:
         return sanitize_api_messages(messages)
 
     @staticmethod
-    def _is_thinking_only_assistant(msg: Dict[str, Any]) -> bool:
+    def _is_thinking_only_assistant(
+        msg: Dict[str, Any],
+        *,
+        drop_codex_reasoning_items: bool = True,
+    ) -> bool:
         """Return True if ``msg`` is an assistant turn whose only payload is reasoning.
 
         "Thinking-only" means the model emitted reasoning (``reasoning`` or
@@ -3302,7 +3306,7 @@ class AIAgent:
         # thinking-only; empty/junk lists should fall through to the generic
         # empty-turn handling instead of being dropped here.
         codex_items = msg.get("codex_reasoning_items")
-        if isinstance(codex_items, list):
+        if drop_codex_reasoning_items and isinstance(codex_items, list):
             return any(
                 isinstance(item, dict) and item.get("type") == "reasoning"
                 for item in codex_items
@@ -3312,10 +3316,15 @@ class AIAgent:
     @staticmethod
     def _drop_thinking_only_and_merge_users(
         messages: List[Dict[str, Any]],
+        *,
+        drop_codex_reasoning_items: bool = True,
     ) -> List[Dict[str, Any]]:
         """Forwarder — see ``agent.agent_runtime_helpers.drop_thinking_only_and_merge_users``."""
         from agent.agent_runtime_helpers import drop_thinking_only_and_merge_users
-        return drop_thinking_only_and_merge_users(messages)
+        return drop_thinking_only_and_merge_users(
+            messages,
+            drop_codex_reasoning_items=drop_codex_reasoning_items,
+        )
 
     @staticmethod
     def _cap_delegate_task_calls(tool_calls: list) -> list:

--- a/tests/run_agent/test_thinking_only_sanitizer.py
+++ b/tests/run_agent/test_thinking_only_sanitizer.py
@@ -104,6 +104,38 @@ class TestIsThinkingOnlyAssistant:
         }
         assert AIAgent._is_thinking_only_assistant(msg)
 
+    def test_codex_reasoning_items_list_form_detected(self):
+        msg = {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "id": "rs_123", "encrypted_content": "enc_blob"}
+            ],
+        }
+        assert AIAgent._is_thinking_only_assistant(msg)
+
+    def test_codex_reasoning_items_with_visible_text_is_not_thinking_only(self):
+        msg = {
+            "role": "assistant",
+            "content": "Visible answer",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "id": "rs_123", "encrypted_content": "enc_blob"}
+            ],
+        }
+        assert not AIAgent._is_thinking_only_assistant(msg)
+
+    def test_empty_codex_reasoning_items_list_is_not_thinking_only(self):
+        msg = {"role": "assistant", "content": "", "codex_reasoning_items": []}
+        assert not AIAgent._is_thinking_only_assistant(msg)
+
+    def test_non_reasoning_codex_items_are_not_thinking_only(self):
+        msg = {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [None, "x", {"type": "other"}],
+        }
+        assert not AIAgent._is_thinking_only_assistant(msg)
+
     def test_user_message_never_thinking_only(self):
         assert not AIAgent._is_thinking_only_assistant({"role": "user", "content": ""})
 


### PR DESCRIPTION
## Summary
Codex reasoning-only assistant turns are now recognized by the thinking-only sanitizer for non-Codex handoffs, while native Codex Responses turns still preserve encrypted reasoning replay.

## Changes
- Treat non-empty `codex_reasoning_items` lists containing reasoning items as thinking-only when visible content and tool calls are absent.
- Keep visible assistant text intact even when `codex_reasoning_items` are present.
- Ignore empty or non-reasoning `codex_reasoning_items` lists so generic empty-turn handling owns those cases.
- Preserve Codex reasoning replay on the `codex_responses` path so invalid-encrypted-content recovery still sees and disables replay correctly.

## Validation
| Check | Result |
|---|---|
| Targeted Codex reasoning-item sanitizer tests | 4 passed |
| `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/run_agent/test_thinking_only_sanitizer.py -q` | 29 passed |
| `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/run_agent/test_thinking_only_sanitizer.py tests/run_agent/test_run_agent_codex_responses.py::test_run_conversation_codex_disables_reasoning_replay_after_invalid_encrypted_content -q` | 30 passed |
| `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/run_agent/test_run_agent_codex_responses.py::test_run_conversation_codex_disables_reasoning_replay_after_invalid_encrypted_content tests/run_agent/test_run_agent_codex_responses.py::test_run_conversation_codex_continues_after_reasoning_only_response -q` | 2 passed |
| `scripts/run_tests.sh tests/run_agent/test_thinking_only_sanitizer.py tests/run_agent/test_run_agent_codex_responses.py` | 105 passed |
| Codex thinking-only sanitizer E2E | passed |
| `python3 -m py_compile run_agent.py agent/agent_runtime_helpers.py agent/conversation_loop.py tests/run_agent/test_thinking_only_sanitizer.py tests/run_agent/test_run_agent_codex_responses.py && git diff --check` | passed |

Salvages #29225 by @briandevans with authorship preserved.
Closes #29205.

## Infographic

![Reasoning Item Clear](https://v3b.fal.media/files/b/0a9e2d25/Qfr6TNW_rVFJNKmoeySGF_40KJBgcn.png)
