### PR TITLE
fix(desktop): trim wrapper parens from raw URL autolinks

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
@@ -134,6 +134,24 @@ describe('preprocessMarkdown', () => {
     expect(output).toContain('<https://example.com/wiki/Foo_(bar)>')
   })
 
+  it('preserves a trailing balanced pair after an earlier stray closing paren', () => {
+    const output = preprocessMarkdown('See https://example.com/a)(b)')
+
+    expect(output).toContain('<https://example.com/a)(b)>')
+  })
+
+  it('strips three wrapper closing parens from raw-url autolinks', () => {
+    const output = preprocessMarkdown('(((https://example.com/page)))')
+
+    expect(output).toBe('(((<https://example.com/page>)))')
+  })
+
+  it('preserves an unmatched opening paren at the end of a raw URL', () => {
+    const output = preprocessMarkdown('https://example.com/foo(')
+
+    expect(output).toContain('<https://example.com/foo(>')
+  })
+
   it('strips only the wrapper closing paren around balanced-paren URLs', () => {
     const output = preprocessMarkdown('(https://example.com/wiki/Foo_(bar))')
 

--- a/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.test.ts
@@ -94,6 +94,60 @@ describe('preprocessMarkdown', () => {
     expect(output).toContain('<https://www.getyourguide.com/culebra-island-l145468/from-fajardo-tour-t19894/>')
   })
 
+  it('does not include wrapper closing parens in raw-url autolinks', () => {
+    const output = preprocessMarkdown('Check (https://example.com/page)')
+
+    expect(output).toContain('(<https://example.com/page>)')
+    expect(output).not.toContain('<https://example.com/page)>')
+  })
+
+  it('strips wrapper closing parens from bare raw-url autolinks', () => {
+    const output = preprocessMarkdown('(https://example.com/page)')
+
+    expect(output).toBe('(<https://example.com/page>)')
+    expect(output).not.toContain('<https://example.com/page)>')
+  })
+
+  it('strips multiple wrapper closing parens from raw-url autolinks', () => {
+    const output = preprocessMarkdown('((https://example.com/page))')
+
+    expect(output).toBe('((<https://example.com/page>))')
+    expect(output).not.toContain('<https://example.com/page)>')
+    expect(output).not.toContain('<https://example.com/page))>')
+  })
+
+  it('leaves raw URLs inside inline code spans unchanged', () => {
+    const input = 'Keep `https://example.com/page)` literal.'
+    const output = preprocessMarkdown(input)
+
+    expect(output).toBe(input)
+  })
+
+  it('keeps trailing punctuation outside wrapper-paren raw-url autolinks', () => {
+    expect(preprocessMarkdown('(https://example.com/page).')).toBe('(<https://example.com/page>).')
+    expect(preprocessMarkdown('(https://example.com/page),')).toBe('(<https://example.com/page>),')
+  })
+
+  it('preserves balanced parens inside raw-url autolinks', () => {
+    const output = preprocessMarkdown('See https://example.com/wiki/Foo_(bar)')
+
+    expect(output).toContain('<https://example.com/wiki/Foo_(bar)>')
+  })
+
+  it('strips only the wrapper closing paren around balanced-paren URLs', () => {
+    const output = preprocessMarkdown('(https://example.com/wiki/Foo_(bar))')
+
+    expect(output).toBe('(<https://example.com/wiki/Foo_(bar)>)')
+    expect(output).not.toContain('<https://example.com/wiki/Foo_(bar))>')
+  })
+
+  it('does not autolink canonical markdown links', () => {
+    const input = '[link](https://github.com/NousResearch/hermes-agent/issues)'
+    const output = preprocessMarkdown(input)
+
+    expect(output).toBe(input)
+  })
+
   it('strips orphan numeric citation markers outside code spans', () => {
     const output = preprocessMarkdown('This is the source[0], but keep `items[0]` untouched.')
 

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -125,6 +125,31 @@ function isUrlOnlyBlock(lines: string[]): boolean {
   return nonEmpty.length > 0 && nonEmpty.every(line => URL_ONLY_LINE_RE.test(line))
 }
 
+function trimUnbalancedTrailingParens(url: string): string {
+  let result = url
+
+  while (result.endsWith(')')) {
+    let opens = 0
+    let closes = 0
+
+    for (const char of result) {
+      if (char === '(') {
+        opens += 1
+      } else if (char === ')') {
+        closes += 1
+      }
+    }
+
+    if (closes <= opens) {
+      break
+    }
+
+    result = result.slice(0, -1)
+  }
+
+  return result
+}
+
 function autoLinkRawUrls(text: string): string {
   return text.replace(RAW_URL_RE, (url: string, index: number) => {
     const previous = text[index - 1] || ''
@@ -134,7 +159,9 @@ function autoLinkRawUrls(text: string): string {
       return url
     }
 
-    return `<${url}>`
+    const trimmed = trimUnbalancedTrailingParens(url)
+
+    return `<${trimmed}>${url.slice(trimmed.length)}`
   })
 }
 

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -128,29 +128,32 @@ function isUrlOnlyBlock(lines: string[]): boolean {
 // Strip only the *unbalanced* trailing `)` — the closing paren of a prose
 // wrapper like `(https://example.com/page)`, which the bare-URL matcher
 // greedily captures into the href. Parens that belong to the URL itself
-// (`…/wiki/Foo_(bar)`) stay intact: a trailing `)` is peeled only while the
-// URL holds more `)` than `(`. Count once, then trim from the end — the loop
-// only ever removes trailing closers, so `opens` never changes.
+// (`…/wiki/Foo_(bar)`) stay intact. Track normal left-to-right pairing and
+// peel only a suffix made entirely of unmatched closing parens; this avoids
+// sacrificing a valid trailing pair when an earlier stray `)` exists.
 function trimUnbalancedTrailingParens(url: string): string {
-  let opens = 0
-  let closes = 0
+  let depth = 0
+  let unmatchedSuffixStart: number | null = null
 
-  for (const char of url) {
+  for (let index = 0; index < url.length; index += 1) {
+    const char = url[index]
+
     if (char === '(') {
-      opens += 1
+      depth += 1
+      unmatchedSuffixStart = null
     } else if (char === ')') {
-      closes += 1
+      if (depth > 0) {
+        depth -= 1
+        unmatchedSuffixStart = null
+      } else if (unmatchedSuffixStart === null) {
+        unmatchedSuffixStart = index
+      }
+    } else {
+      unmatchedSuffixStart = null
     }
   }
 
-  let end = url.length
-
-  while (closes > opens && url[end - 1] === ')') {
-    closes -= 1
-    end -= 1
-  }
-
-  return url.slice(0, end)
+  return unmatchedSuffixStart === null ? url : url.slice(0, unmatchedSuffixStart)
 }
 
 function autoLinkRawUrls(text: string): string {

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -125,29 +125,32 @@ function isUrlOnlyBlock(lines: string[]): boolean {
   return nonEmpty.length > 0 && nonEmpty.every(line => URL_ONLY_LINE_RE.test(line))
 }
 
+// Strip only the *unbalanced* trailing `)` — the closing paren of a prose
+// wrapper like `(https://example.com/page)`, which the bare-URL matcher
+// greedily captures into the href. Parens that belong to the URL itself
+// (`…/wiki/Foo_(bar)`) stay intact: a trailing `)` is peeled only while the
+// URL holds more `)` than `(`. Count once, then trim from the end — the loop
+// only ever removes trailing closers, so `opens` never changes.
 function trimUnbalancedTrailingParens(url: string): string {
-  let result = url
+  let opens = 0
+  let closes = 0
 
-  while (result.endsWith(')')) {
-    let opens = 0
-    let closes = 0
-
-    for (const char of result) {
-      if (char === '(') {
-        opens += 1
-      } else if (char === ')') {
-        closes += 1
-      }
+  for (const char of url) {
+    if (char === '(') {
+      opens += 1
+    } else if (char === ')') {
+      closes += 1
     }
-
-    if (closes <= opens) {
-      break
-    }
-
-    result = result.slice(0, -1)
   }
 
-  return result
+  let end = url.length
+
+  while (closes > opens && url[end - 1] === ')') {
+    closes -= 1
+    end -= 1
+  }
+
+  return url.slice(0, end)
 }
 
 function autoLinkRawUrls(text: string): string {


### PR DESCRIPTION
## What does this PR do?

Fixes desktop raw-URL autolinking when a URL is wrapped in prose parentheses.

The malformed href is produced before the click handler: `autoLinkRawUrls()` includes a trailing unmatched `)` in the generated autolink, so text like `(https://example.com/page)` becomes an href ending in `page)`. This patch trims only unbalanced trailing closing parens from raw URL matches, then re-appends the stripped parens as plain text outside the `<...>` autolink.

Balanced URL parens, such as `https://example.com/wiki/Foo_(bar)`, are preserved.

## Root cause & issue-fit (empirical before/after)

Verified by running `preprocessMarkdown()` against `main` vs. this branch. The reported GitHub 404 comes from the **raw URL wrapped in prose parens** path: `autoLinkRawUrls()` captured the wrapper `)` into the `<...>` autolink, so the generated href ended in `)`. Canonical `[text](url)` links (the form quoted in the issue) are never autolinked — the skip guard in `autoLinkRawUrls()` has been present since the desktop app landed — so they already render with a clean href on `main` and are intentionally unchanged here.

| Input | `main` (before) | this PR (after) |
|---|---|---|
| `[link](https://github.com/NousResearch/hermes-agent/issues)` | `[link](.../issues)` — clean | `[link](.../issues)` — unchanged |
| `See the issue (https://github.com/NousResearch/hermes-agent/issues)` | `(<.../issues)>` — href ends in `)` -> **404** | `(<.../issues>)` — fixed |
| `(https://example.com/page)` | `(<.../page)>` — broken | `(<.../page>)` — fixed |
| `https://en.wikipedia.org/wiki/Foo_(bar)` | `<.../Foo_(bar)>` | `<.../Foo_(bar)>` — balanced parens preserved |

> The issue's literal `[text](url)` repro is unchanged by this PR (it already renders correctly on `main`); the reproducible adjacent defect is a trailing `)` from prose-paren wrapping, fixed above.

## Related Issue

Related to #45650

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/lib/markdown-preprocess.ts`
  - Add balance-aware trimming for unmatched trailing `)` in raw URL autolinks.
  - Keep existing skip behavior for explicit angle autolinks and canonical Markdown links.
- `apps/desktop/src/components/assistant-ui/markdown-text.test.ts`
  - Add regression coverage for wrapper parens, multiple wrapper parens, balanced URL parens, inline code spans, trailing punctuation, and canonical Markdown links.

## How to Test

1. Render or preprocess `Check (https://example.com/page)`.
2. Confirm the generated markdown contains `(<https://example.com/page>)`, not `<https://example.com/page)>`.
3. Confirm balanced URL parens remain intact, e.g. `https://example.com/wiki/Foo_(bar)` stays inside the autolink.

```bash
cd apps/desktop
vitest run --environment jsdom src/components/assistant-ui/markdown-text.test.ts
```

Result: 1 test file passed, 27 tests passed.

## Duplicate-work check

Checked live before opening:

- No open or closed PR references `45650 in:body`.
- No PR found for `markdown-preprocess autoLinkRawUrls`.
- No PR found for `desktop markdown malformed URL`.
- No PR found for `trailing parens markdown link`.
- Related but not duplicate:
  - #42955 hardens dangerous URL schemes in `markdown-text.tsx`; it does not change `autoLinkRawUrls()` or `markdown-preprocess.ts`.
  - #41093 fixed trailing emphasis asterisks in the same raw autolinker family; it does not address unmatched trailing `)`.
  - #45648 was closed only to split the original combined report into focused issues.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) -- N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys -- N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows -- N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) -- renderer-only string preprocessing
- [x] I've updated tool descriptions/schemas if I changed tool behavior -- N/A

## Screenshots / Logs

Focused UI regression test:

```text
Test Files  1 passed (1)
Tests       23 passed (23)
```


## 2026-07-10 shepherding refresh

Rebased onto current `main` at `4c80b4e5d` while preserving both original commits and the focused two-file scope. Revalidated against the current desktop renderer hardening added since the original base.

Fresh proof:

- `vitest run --environment jsdom src/components/assistant-ui/markdown-text.test.ts` — 27/27 passed
- renderer TypeScript (`tsc -p . --noEmit`) — passed
- Electron TypeScript (`tsc -p tsconfig.electron.json --noEmit`) — passed
- ESLint on both touched files — passed
- `git diff --check origin/main...HEAD` — passed

Live duplicate search for issue #45650 and the raw-URL/trailing-parenthesis terms found no competing PR.

Private review follow-up: replaced global parenthesis counts with left-to-right match tracking so an earlier stray `)` cannot cause a later valid pair to be trimmed. Added regressions for `a)(b)`, triple wrappers, and an unmatched trailing opener; all 27 focused tests pass.

### Overlap / rebase-risk check

Open PR #49857 touches the same two files and `autoLinkRawUrls()` for a different bug (URLs inside Markdown link text). It is not a duplicate and the fixes are logically compatible, but whichever PR lands second may need a small manual rebase.
