### PR TITLE
fix(desktop): surface approval fallback prompt

### DIFF
--- a/apps/desktop/src/components/assistant-ui/tool-approval.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool-approval.test.tsx
@@ -6,7 +6,7 @@ import { $gateway } from '@/store/gateway'
 import { $approvalRequest, clearAllPrompts, setApprovalRequest } from '@/store/prompts'
 import { $activeSessionId } from '@/store/session'
 
-import { PendingToolApproval } from './tool-approval'
+import { ApprovalPromptFallback, PendingToolApproval } from './tool-approval'
 import type { ToolPart } from './tool-fallback-model'
 
 // Radix's DropdownMenu touches pointer-capture + scrollIntoView, which jsdom
@@ -129,5 +129,43 @@ describe('PendingToolApproval', () => {
     // The session + reject options still render, but never the permanent allow.
     expect(await screen.findByRole('menuitem', { name: /Allow this session/ })).toBeTruthy()
     expect(screen.queryByRole('menuitem', { name: /Always allow/ })).toBeNull()
+  })
+})
+
+describe('ApprovalPromptFallback', () => {
+  it('renders a dialog when an approval request has no mounted inline row', async () => {
+    setRequest('echo blocked')
+    render(<ApprovalPromptFallback />)
+
+    expect(await screen.findByRole('dialog')).toBeTruthy()
+    expect(screen.getByText('Approval required')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Run/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Reject/ })).toBeTruthy()
+  })
+
+  it('does not render the dialog when the inline approval row is mounted', async () => {
+    setRequest('echo blocked')
+    render(
+      <>
+        <PendingToolApproval part={part('terminal')} />
+        <ApprovalPromptFallback />
+      </>
+    )
+
+    expect(await screen.findByRole('button', { name: /Run/ })).toBeTruthy()
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('sends approval.respond from the fallback dialog', async () => {
+    const request = mockGateway()
+    setRequest('echo blocked')
+    render(<ApprovalPromptFallback />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /Run/ }))
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('approval.respond', { choice: 'once', session_id: 'sess-1' })
+    })
+    expect($approvalRequest.get()).toBeNull()
   })
 })

--- a/apps/desktop/src/components/assistant-ui/tool-approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool-approval.tsx
@@ -15,7 +15,7 @@ import {
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
-import { ChevronDown, Loader2 } from '@/lib/icons'
+import { AlertTriangle, ChevronDown, Loader2 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { $gateway } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
@@ -53,7 +53,80 @@ export const PendingToolApproval: FC<{ part: ToolPart }> = ({ part }) => {
 
 const isMac = typeof navigator !== 'undefined' && /Mac|iP(hone|ad|od)/.test(navigator.platform)
 
-const ApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
+function inlineApprovalVisible(): boolean {
+  if (typeof document === 'undefined') {
+    return false
+  }
+
+  const inline = document.querySelector('[data-slot="tool-approval-inline"]')
+
+  if (!(inline instanceof HTMLElement) || inline.closest('[hidden]')) {
+    return false
+  }
+
+  const style = window.getComputedStyle(inline)
+
+  if (style.display === 'none' || style.visibility === 'hidden') {
+    return false
+  }
+
+  const rect = inline.getBoundingClientRect()
+
+  if (rect.width === 0 && rect.height === 0) {
+    return true
+  }
+
+  return rect.bottom > 0 && rect.right > 0 && rect.top < window.innerHeight && rect.left < window.innerWidth
+}
+
+export const ApprovalPromptFallback: FC = () => {
+  const { t } = useI18n()
+  const copy = t.assistant.approval
+  const request = useStore($approvalRequest)
+  const [showFallback, setShowFallback] = useState(false)
+
+  useEffect(() => {
+    if (!request || typeof document === 'undefined') {
+      setShowFallback(false)
+
+      return
+    }
+
+    const update = () => setShowFallback(!inlineApprovalVisible())
+    const timer = window.setTimeout(update, 0)
+
+    const observer = new MutationObserver(update)
+    observer.observe(document.body, { childList: true, subtree: true })
+
+    return () => {
+      window.clearTimeout(timer)
+      observer.disconnect()
+    }
+  }, [request])
+
+  if (!request || !showFallback) {
+    return null
+  }
+
+  return (
+    <Dialog open>
+      <DialogContent className="max-w-xl" showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle icon={AlertTriangle}>{copy.promptTitle}</DialogTitle>
+          <DialogDescription>{request.description || copy.promptDescription}</DialogDescription>
+        </DialogHeader>
+
+        <ApprovalBar className="mt-0 ps-0" request={request} surface="fallback" />
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+const ApprovalBar: FC<{ className?: string; request: ApprovalRequest; surface?: 'fallback' | 'inline' }> = ({
+  className,
+  request,
+  surface = 'inline'
+}) => {
   const { t } = useI18n()
   const copy = t.assistant.approval
   const gateway = useStore($gateway)
@@ -126,7 +199,10 @@ const ApprovalBar: FC<{ request: ApprovalRequest }> = ({ request }) => {
   }, [confirmAlways, respond])
 
   return (
-    <div className="mt-1 ps-5" data-slot="tool-approval-inline">
+    <div
+      className={cn('mt-1 ps-5', className)}
+      data-slot={surface === 'inline' ? 'tool-approval-inline' : 'tool-approval-fallback'}
+    >
       <div className="flex items-center gap-2.5">
         <div className="inline-flex h-6 items-stretch overflow-hidden rounded-md border border-primary/25 bg-primary/10 text-primary">
           <Button

--- a/apps/desktop/src/components/prompt-overlays.tsx
+++ b/apps/desktop/src/components/prompt-overlays.tsx
@@ -3,6 +3,7 @@
 import { useStore } from '@nanostores/react'
 import { type FormEvent, useCallback, useEffect, useState } from 'react'
 
+import { ApprovalPromptFallback } from '@/components/assistant-ui/tool-approval'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -227,6 +228,7 @@ function SecretDialog() {
 export function PromptOverlays() {
   return (
     <>
+      <ApprovalPromptFallback />
       <SudoDialog />
       <SecretDialog />
     </>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1689,6 +1689,8 @@ export const en: Translations = {
     approval: {
       gatewayDisconnected: 'Hermes gateway is not connected',
       sendFailed: 'Could not send approval response',
+      promptTitle: 'Approval required',
+      promptDescription: 'Hermes needs approval before it can continue.',
       run: 'Run',
       command: 'Command',
       moreOptions: 'More approval options',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1829,6 +1829,8 @@ export const ja = defineLocale({
     approval: {
       gatewayDisconnected: 'Hermes ゲートウェイが接続されていません',
       sendFailed: '承認応答を送信できませんでした',
+      promptTitle: '承認が必要です',
+      promptDescription: '続行するには Hermes の承認が必要です。',
       run: '実行',
       command: 'コマンド',
       moreOptions: 'その他の承認オプション',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1348,6 +1348,8 @@ export interface Translations {
     approval: {
       gatewayDisconnected: string
       sendFailed: string
+      promptTitle: string
+      promptDescription: string
       run: string
       command: string
       moreOptions: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1773,6 +1773,8 @@ export const zhHant = defineLocale({
     approval: {
       gatewayDisconnected: 'Hermes 閘道未連線',
       sendFailed: '無法傳送核准回應',
+      promptTitle: '需要核准',
+      promptDescription: 'Hermes 需要核准才能繼續。',
       run: '執行',
       command: '指令',
       moreOptions: '更多核准選項',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1869,6 +1869,8 @@ export const zh: Translations = {
     approval: {
       gatewayDisconnected: 'Hermes 网关未连接',
       sendFailed: '无法发送审批响应',
+      promptTitle: '需要审批',
+      promptDescription: 'Hermes 需要审批才能继续。',
       run: '运行',
       command: '命令',
       moreOptions: '更多审批选项',


### PR DESCRIPTION
## What does this PR do?

Desktop already parks `approval.request` events per session and renders approval controls inline under pending `terminal` / `execute_code` tool rows. That leaves a failure mode where the backend is waiting for `approval.respond`, but the active Desktop view has no actionable approval UI because the inline row is missing, hidden, or outside the visible viewport.

This PR adds a Desktop fallback approval dialog mounted with the existing prompt overlays. It reuses the same approval action component as the inline row, and it only appears when a live approval request exists and the inline approval bar is not visibly available.

Root cause: approval state was durable, but the only renderer was tied to one transcript row. If that row was not mounted or visible, the user could only see the session needing input while the agent kept waiting.

## Related Issue

Related support thread: https://discord.com/channels/1053877538025386074/1515049553194389564

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `ApprovalPromptFallback` in `apps/desktop/src/components/assistant-ui/tool-approval.tsx`.
- Mounted the approval fallback from `apps/desktop/src/components/prompt-overlays.tsx` next to sudo/secret prompts.
- Reused the existing `ApprovalBar` response path so fallback approvals still call `approval.respond` with the same choices.
- Added visibility checks so the fallback only appears when the inline approval bar is absent, hidden, or outside the visible viewport.
- Added localized copy for the fallback dialog title/description.
- Added focused UI tests covering fallback render, inline suppression, and fallback response submission.

## How to Test

1. Trigger a Desktop `approval.request` while no visible inline approval bar is mounted.
2. Confirm Desktop shows an approval dialog with Run/Reject controls.
3. Confirm choosing Run sends `approval.respond` and clears the request.

Focused test run:

`npm run test:ui -- src/components/assistant-ui/tool-approval.test.tsx`

Result: 1 file passed, 11 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL/Linux local checkout, Desktop UI jsdom test

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Focused test output:

```text
Test Files  1 passed (1)
Tests       11 passed (11)
Duration    2.67s
```

Full Python test suite was not run; this is a Desktop UI-only change and the focused Desktop UI test above covers the changed approval surface.
