### PR TITLE
perf(process): wake waiters on background completion

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -5,6 +5,7 @@ import os
 import signal
 import subprocess
 import sys
+import threading
 import time
 import pytest
 from unittest.mock import MagicMock, patch
@@ -265,6 +266,31 @@ class TestOrphanedPipeReconciliation:
             os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
         except (ProcessLookupError, PermissionError):
             pass
+
+    def test_wait_wakes_when_session_moves_to_finished(self, registry):
+        """wait() should not sleep for the old 1s polling tick after exit."""
+        s = _make_session(sid="proc_wait_event", output="done")
+        registry._running[s.id] = s
+
+        def finish_later():
+            time.sleep(0.05)
+            s.exited = True
+            s.exit_code = 0
+            with patch.object(registry, "_write_checkpoint"):
+                registry._move_to_finished(s)
+
+        t = threading.Thread(target=finish_later)
+        t.start()
+        start = time.monotonic()
+        try:
+            result = registry.wait(s.id, timeout=5)
+        finally:
+            t.join(timeout=1)
+        elapsed = time.monotonic() - start
+
+        assert result["status"] == "exited", result
+        assert result["exit_code"] == 0
+        assert elapsed < 0.3, f"wait() should wake on completion; took {elapsed:.3f}s"
 
 
 # =========================================================================

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -129,6 +129,7 @@ class ProcessSession:
     _watch_cooldown_until: float = field(default=0.0, repr=False)
     _watch_strike_candidate: bool = field(default=False, repr=False)
     _watch_consecutive_strikes: int = field(default=0, repr=False)
+    _completion_event: threading.Event = field(default_factory=threading.Event, repr=False)
     _lock: threading.Lock = field(default_factory=threading.Lock)
     _reader_thread: Optional[threading.Thread] = field(default=None, repr=False)
     _pty: Any = field(default=None, repr=False)  # ptyprocess handle (when use_pty=True)
@@ -870,6 +871,7 @@ class ProcessRegistry:
         with self._lock:
             was_running = self._running.pop(session.id, None) is not None
             self._finished[session.id] = session
+        session._completion_event.set()
         self._write_checkpoint()
 
         # Only enqueue completion notification on the FIRST move.  Without
@@ -1093,6 +1095,8 @@ class ProcessRegistry:
 
         while time.monotonic() < deadline:
             session = self._refresh_detached_session(session)
+            if session is None:
+                return {"status": "not_found", "error": f"No process with ID {session_id}"}
             # Reconcile against real child state — guards against orphaned-
             # pipe reader hangs where the reader is blocked but the direct
             # child has already exited (issue #17327).
@@ -1118,7 +1122,10 @@ class ProcessRegistry:
                     result["timeout_note"] = timeout_note
                 return result
 
-            time.sleep(1)
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            session._completion_event.wait(timeout=min(1.0, remaining))
 
         result = {
             "status": "timeout",


### PR DESCRIPTION
## Summary
`process(action="wait")` now wakes as soon as a background process is moved to finished instead of waiting for the next 1-second polling tick.

## Changes
- `tools/process_registry.py`: add a per-session completion event, signal it from `_move_to_finished()`, and have `wait()` block on the event with the existing timeout cap.
- `tests/tools/test_process_registry.py`: add a regression test proving `wait()` returns promptly when completion happens from another thread.

## Validation
| Check | Result |
|---|---|
| RED test before implementation | failed: `wait()` took 1.001s |
| Targeted regression | passed: `1 passed in 0.17s` |
| Process wait smoke | passed: exited successfully in ~238ms including shell startup |
| Targeted suite | `99 passed in 2.2s` |

## Notes
- Preserves timeout, interrupt, detached-session refresh, local-exit reconciliation, and completion-consumed behavior.
- The untracked `.plans/speed-optimization-audit.md` is intentionally not included in this PR.

## Infographic

![Wake on Completion](https://v3b.fal.media/files/b/0a9e2e36/3D3djHb9B5P0qbM2fD2QA_bzmg5iKy.png)
