### PR TITLE
feat(desktop): highlight terminal shell input

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -20,7 +20,6 @@ const crypto = require('node:crypto')
 const fs = require('node:fs')
 const http = require('node:http')
 const https = require('node:https')
-const net = require('node:net')
 const path = require('node:path')
 const { pathToFileURL } = require('node:url')
 const { execFileSync, spawn } = require('node:child_process')
@@ -5979,6 +5978,27 @@ function terminalChannel(id, suffix) {
   return `hermes:terminal:${id}:${suffix}`
 }
 
+function disposeTerminalSessionListeners(sessionInfo) {
+  for (const disposable of sessionInfo.disposables || []) {
+    try {
+      disposable.dispose()
+    } catch {
+      // Listener may already be detached.
+    }
+  }
+
+  sessionInfo.disposables = []
+
+  if (sessionInfo.removeSenderDestroyedListener) {
+    try {
+      sessionInfo.removeSenderDestroyedListener()
+    } catch {
+      // Sender may already be destroyed.
+    }
+    sessionInfo.removeSenderDestroyedListener = null
+  }
+}
+
 function disposeTerminalSession(id) {
   const sessionInfo = terminalSessions.get(id)
 
@@ -5987,6 +6007,7 @@ function disposeTerminalSession(id) {
   }
 
   terminalSessions.delete(id)
+  disposeTerminalSessionListeners(sessionInfo)
 
   try {
     sessionInfo.pty.kill()
@@ -5995,6 +6016,12 @@ function disposeTerminalSession(id) {
   }
 
   return true
+}
+
+function disposeAllTerminalSessions() {
+  for (const id of [...terminalSessions.keys()]) {
+    disposeTerminalSession(id)
+  }
 }
 
 ipcMain.handle('hermes:fs:readDir', async (_event, dirPath) => readDirForIpc(dirPath))
@@ -6023,22 +6050,27 @@ ipcMain.handle('hermes:terminal:start', async (event, payload = {}) => {
     rows
   })
 
-  terminalSessions.set(id, { pty: ptyProcess, webContentsId: event.sender.id })
+  const sessionInfo = { disposables: [], removeSenderDestroyedListener: null, pty: ptyProcess, webContentsId: event.sender.id }
+  terminalSessions.set(id, sessionInfo)
 
   const send = (suffix, payload) => {
-    if (event.sender.isDestroyed()) {
+    if (!terminalSessions.has(id) || event.sender.isDestroyed()) {
       return
     }
 
     event.sender.send(terminalChannel(id, suffix), payload)
   }
 
-  ptyProcess.onData(data => send('data', data))
-  ptyProcess.onExit(({ exitCode, signal }) => {
-    terminalSessions.delete(id)
+  const dataDisposable = ptyProcess.onData(data => send('data', data))
+  const exitDisposable = ptyProcess.onExit(({ exitCode, signal }) => {
+    disposeTerminalSessionListeners(sessionInfo)
     send('exit', { code: exitCode, signal: signal || null })
+    terminalSessions.delete(id)
   })
-  event.sender.once('destroyed', () => disposeTerminalSession(id))
+  sessionInfo.disposables.push(dataDisposable, exitDisposable)
+  const senderDestroyedListener = () => disposeTerminalSession(id)
+  sessionInfo.removeSenderDestroyedListener = () => event.sender.off('destroyed', senderDestroyedListener)
+  event.sender.once('destroyed', senderDestroyedListener)
 
   return { cwd, id, shell: name }
 })
@@ -6512,6 +6544,7 @@ app.on('before-quit', () => {
   }
   flushDesktopLogBufferSync()
   closePreviewWatchers()
+  disposeAllTerminalSessions()
 
   if (hermesProcess && !hermesProcess.killed) {
     hermesProcess.kill('SIGTERM')

--- a/apps/desktop/electron/terminal-session-lifecycle.test.cjs
+++ b/apps/desktop/electron/terminal-session-lifecycle.test.cjs
@@ -1,0 +1,28 @@
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const ELECTRON_DIR = __dirname
+
+function readElectronFile(name) {
+  return fs.readFileSync(path.join(ELECTRON_DIR, name), 'utf8').replace(/\r\n/g, '\n')
+}
+
+test('embedded terminal sessions dispose node-pty listeners before app quit', () => {
+  const source = readElectronFile('main.cjs')
+
+  assert.match(source, /function disposeAllTerminalSessions\(\)/)
+  assert.match(source, /function disposeTerminalSessionListeners\(sessionInfo\)/)
+  assert.match(source, /const dataDisposable = ptyProcess\.onData/)
+  assert.match(source, /const exitDisposable = ptyProcess\.onExit/)
+  assert.match(source, /disposables: \[\], removeSenderDestroyedListener: null/)
+  assert.match(source, /sessionInfo\.disposables\.push\(dataDisposable, exitDisposable\)/)
+  assert.match(source, /removeSenderDestroyedListener/)
+  assert.match(source, /event\.sender\.off\('destroyed', senderDestroyedListener\)/)
+
+  const beforeQuit = source.slice(source.indexOf("app.on('before-quit'"), source.indexOf("app.on('window-all-closed'"))
+  assert.match(beforeQuit, /disposeAllTerminalSessions\(\)/)
+})

--- a/apps/desktop/electron/windows-child-process.test.cjs
+++ b/apps/desktop/electron/windows-child-process.test.cjs
@@ -28,14 +28,14 @@ test('desktop background child processes opt into hidden Windows consoles', () =
   assert.match(source, /function hiddenWindowsChildOptions\(options = \{\}\)/)
 
   requireHiddenChildOptions(source, "execFileSync(\n          'reg'")
-  requireHiddenChildOptions(source, 'execFileSync(pyExe')
-  requireHiddenChildOptions(source, 'spawn(resolveGitBinary()')
+  requireHiddenChildOptions(source, "execFileSync(\n          pyExe")
+  requireHiddenChildOptions(source, "spawn(\n      resolveGitBinary()")
   requireHiddenChildOptions(source, "execFileSync('taskkill'")
-  requireHiddenChildOptions(source, 'spawn(command, args')
+  requireHiddenChildOptions(source, "spawn(\n        command,\n        args")
   requireHiddenChildOptions(source, "spawn('curl'")
-  requireHiddenChildOptions(source, 'spawn(backend.command, backend.args')
-  requireHiddenChildOptions(source, 'hermesProcess = spawn(backend.command, backend.args')
-  requireHiddenChildOptions(source, "spawn(py, ['-m', 'hermes_cli.main', 'uninstall', '--gui-summary']")
+  requireHiddenChildOptions(source, "spawn(\n    backend.command,\n    backend.args")
+  requireHiddenChildOptions(source, "hermesProcess = spawn(\n      backend.command,\n      backend.args")
+  requireHiddenChildOptions(source, "spawn(\n        py,\n        ['-m', 'hermes_cli.main', 'uninstall', '--gui-summary']")
 })
 
 test('intentional or interactive desktop child processes stay documented', () => {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -36,7 +36,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/terminal-session-lifecycle.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs",
     "typecheck": "tsc -p . --noEmit",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",

--- a/apps/desktop/src/app/right-sidebar/terminal/syntax-highlighting.test.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/syntax-highlighting.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  isDraftTextVisible,
+  layoutSyntaxDecorationSegments,
+  TerminalCommandDraft,
+  tokenizeShellCommand
+} from './syntax-highlighting'
+
+describe('tokenizeShellCommand', () => {
+  it('highlights commands, options, strings, operators, variables, paths, and comments', () => {
+    const tokens = tokenizeShellCommand('FOO=bar python ./script.py --flag=$HOME | grep "ok" # done')
+
+    expect(tokens.map(token => [token.kind, token.text])).toEqual([
+      ['assignment', 'FOO=bar'],
+      ['command', 'python'],
+      ['path', './script.py'],
+      ['option', '--flag'],
+      ['variable', '$HOME'],
+      ['operator', '|'],
+      ['command', 'grep'],
+      ['string', '"ok"'],
+      ['comment', '# done']
+    ])
+  })
+
+  it('marks a command after a control operator as a new command', () => {
+    const tokens = tokenizeShellCommand('git status && npm run build')
+
+    expect(tokens.filter(token => token.kind === 'command').map(token => token.text)).toEqual(['git', 'npm'])
+    expect(tokens.some(token => token.kind === 'operator' && token.text === '&&')).toBe(true)
+  })
+})
+
+describe('TerminalCommandDraft', () => {
+  it('tracks printable input, cursor movement, insertion, and deletion', () => {
+    const draft = new TerminalCommandDraft()
+
+    draft.applyUserInput('git')
+    draft.applyUserInput('\x1b[D')
+    draft.applyUserInput('u')
+    draft.applyUserInput('\x7f')
+    draft.applyUserInput('s')
+
+    expect(draft.text).toBe('gist')
+    expect(draft.cursor).toBe(3)
+  })
+
+  it('clears the draft on submit and shell-history navigation', () => {
+    const draft = new TerminalCommandDraft()
+
+    draft.applyUserInput('npm test')
+    draft.applyUserInput('\r')
+    expect(draft.text).toBe('')
+
+    draft.applyUserInput('npm test')
+    draft.applyUserInput('\x1b[A')
+    expect(draft.text).toBe('')
+  })
+
+  it('ignores terminal escape wrappers without inserting protocol bytes', () => {
+    const draft = new TerminalCommandDraft()
+
+    draft.applyUserInput('\x1b[200~printf "ok"\x1b[201~')
+    expect(draft.text).toBe('printf "ok"')
+
+    draft.applyUserInput('\x1b[1;5D')
+    expect(draft.text).toBe('printf "ok"')
+
+    draft.applyUserInput('\x1bOA')
+    draft.applyUserInput('\x1bOP')
+    draft.applyUserInput('\x1bPignored\x1b\\')
+    expect(draft.text).toBe('printf "ok"')
+  })
+})
+
+describe('isDraftTextVisible', () => {
+  it('confirms echoed draft text at the current cursor, including wrapped rows', () => {
+    const lines = ['pytho', 'n    ']
+
+    expect(
+      isDraftTextVisible({
+        cols: 5,
+        cursor: 6,
+        cursorX: 1,
+        cursorY: 1,
+        lineAt: row => lines[row] ?? null,
+        text: 'python'
+      })
+    ).toBe(true)
+  })
+
+  it('rejects hidden input that is not echoed in the terminal buffer', () => {
+    expect(
+      isDraftTextVisible({
+        cols: 20,
+        cursor: 6,
+        cursorX: 10,
+        cursorY: 0,
+        lineAt: () => 'Password: '.padEnd(20, ' '),
+        text: 'secret'
+      })
+    ).toBe(false)
+  })
+})
+
+describe('layoutSyntaxDecorationSegments', () => {
+  it('splits highlighted tokens across wrapped terminal rows', () => {
+    const segments = layoutSyntaxDecorationSegments({
+      cols: 5,
+      cursor: 6,
+      cursorX: 1,
+      cursorY: 2,
+      tokens: [{ end: 6, kind: 'command', start: 0, text: 'python' }]
+    })
+
+    expect(segments).toEqual([
+      { kind: 'command', rowOffset: -1, width: 5, x: 0 },
+      { kind: 'command', rowOffset: 0, width: 1, x: 0 }
+    ])
+  })
+}
+)

--- a/apps/desktop/src/app/right-sidebar/terminal/syntax-highlighting.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/syntax-highlighting.ts
@@ -1,0 +1,746 @@
+import type { IDecoration, IMarker, ITheme, Terminal } from '@xterm/xterm'
+
+export type SyntaxTokenKind = 'assignment' | 'command' | 'comment' | 'keyword' | 'operator' | 'option' | 'path' | 'string' | 'variable'
+
+export interface SyntaxToken {
+  end: number
+  kind: SyntaxTokenKind
+  start: number
+  text: string
+}
+
+export interface SyntaxDecorationSegment {
+  kind: SyntaxTokenKind
+  rowOffset: number
+  width: number
+  x: number
+}
+
+const COMMAND_PREFIX_KEYWORDS = new Set(['arch', 'builtin', 'command', 'env', 'exec', 'noglob', 'nohup', 'sudo', 'time'])
+
+const SHELL_KEYWORDS = new Set([
+  'case',
+  'do',
+  'done',
+  'elif',
+  'else',
+  'esac',
+  'fi',
+  'for',
+  'function',
+  'if',
+  'in',
+  'select',
+  'then',
+  'until',
+  'while'
+])
+
+const OPERATORS = ['&&', '||', ';;', '|&', '>>', '<<', '2>', '1>', ';', '|', '&', '(', ')', '<', '>'] as const
+
+const CONTROL_SEQUENCES = {
+  arrowDown: '\x1b[B',
+  arrowLeft: '\x1b[D',
+  arrowRight: '\x1b[C',
+  arrowUp: '\x1b[A',
+  delete: '\x1b[3~',
+  end: '\x1b[F',
+  endTilde: '\x1b[4~',
+  home: '\x1b[H',
+  homeTilde: '\x1b[1~'
+} as const
+
+function isWhitespace(ch: string | undefined) {
+  return ch === ' ' || ch === '\t' || ch === '\r' || ch === '\n'
+}
+
+function operatorAt(input: string, index: number): string | null {
+  return OPERATORS.find(op => input.startsWith(op, index)) ?? null
+}
+
+function isCommentStart(input: string, index: number) {
+  return input[index] === '#' && (index === 0 || isWhitespace(input[index - 1]))
+}
+
+function readQuoted(input: string, index: number) {
+  const quote = input[index]
+  let i = index + 1
+
+  while (i < input.length) {
+    if (input[i] === '\\') {
+      i += 2
+
+      continue
+    }
+
+    if (input[i] === quote) {
+      return i + 1
+    }
+
+    i += 1
+  }
+
+  return input.length
+}
+
+function readWord(input: string, index: number) {
+  let i = index
+
+  while (i < input.length) {
+    if (isWhitespace(input[i]) || isCommentStart(input, i) || operatorAt(input, i)) {
+      break
+    }
+
+    if (input[i] === '"' || input[i] === "'") {
+      i = readQuoted(input, i)
+    } else {
+      i += 1
+    }
+  }
+
+  return i
+}
+
+function pushToken(tokens: SyntaxToken[], kind: SyntaxTokenKind, input: string, start: number, end: number) {
+  if (end <= start) {
+    return
+  }
+
+  tokens.push({ end, kind, start, text: input.slice(start, end) })
+}
+
+function pushVariableTokens(tokens: SyntaxToken[], input: string, word: string, wordStart: number) {
+  const variablePattern = /\$(?:[A-Za-z_][A-Za-z0-9_]*|\{[^}\n]*\})/g
+  let match: RegExpExecArray | null = null
+
+  while ((match = variablePattern.exec(word))) {
+    pushToken(tokens, 'variable', input, wordStart + match.index, wordStart + match.index + match[0].length)
+  }
+}
+
+function pushEmbeddedStringTokens(tokens: SyntaxToken[], input: string, word: string, wordStart: number) {
+  let i = 0
+
+  while (i < word.length) {
+    if (word[i] === '"' || word[i] === "'") {
+      const end = readQuoted(word, i)
+      pushToken(tokens, 'string', input, wordStart + i, wordStart + end)
+      i = end
+    } else {
+      i += 1
+    }
+  }
+}
+
+function isPathWord(word: string) {
+  return word.startsWith('./') || word.startsWith('../') || word.startsWith('~/') || word.startsWith('/') || word.includes('/')
+}
+
+function isAssignmentWord(word: string) {
+  return /^[A-Za-z_][A-Za-z0-9_]*=/.test(word)
+}
+
+function optionEnd(word: string) {
+  const equals = word.indexOf('=')
+
+  return equals === -1 ? word.length : equals
+}
+
+export function tokenizeShellCommand(input: string): SyntaxToken[] {
+  const tokens: SyntaxToken[] = []
+  let expectingCommand = true
+  let index = 0
+
+  while (index < input.length) {
+    if (isWhitespace(input[index])) {
+      index += 1
+
+      continue
+    }
+
+    if (isCommentStart(input, index)) {
+      pushToken(tokens, 'comment', input, index, input.length)
+
+      break
+    }
+
+    const op = operatorAt(input, index)
+
+    if (op) {
+      pushToken(tokens, 'operator', input, index, index + op.length)
+      index += op.length
+      expectingCommand = true
+
+      continue
+    }
+
+    if (input[index] === '"' || input[index] === "'") {
+      const end = readQuoted(input, index)
+      pushToken(tokens, 'string', input, index, end)
+      pushVariableTokens(tokens, input, input.slice(index, end), index)
+      index = end
+      expectingCommand = false
+
+      continue
+    }
+
+    const start = index
+    const end = readWord(input, start)
+    const word = input.slice(start, end)
+
+    if (!word) {
+      index += 1
+
+      continue
+    }
+
+    if (expectingCommand && isAssignmentWord(word)) {
+      pushToken(tokens, 'assignment', input, start, end)
+      pushVariableTokens(tokens, input, word, start)
+      index = end
+
+      continue
+    }
+
+    if (expectingCommand) {
+      if (COMMAND_PREFIX_KEYWORDS.has(word) || SHELL_KEYWORDS.has(word)) {
+        pushToken(tokens, 'keyword', input, start, end)
+        expectingCommand = COMMAND_PREFIX_KEYWORDS.has(word)
+      } else {
+        pushToken(tokens, 'command', input, start, end)
+        expectingCommand = false
+      }
+    } else if (word.startsWith('-') && word !== '-') {
+      pushToken(tokens, 'option', input, start, start + optionEnd(word))
+    } else if (isPathWord(word)) {
+      pushToken(tokens, 'path', input, start, end)
+    }
+
+    pushEmbeddedStringTokens(tokens, input, word, start)
+    pushVariableTokens(tokens, input, word, start)
+    index = end
+  }
+
+  return tokens.sort((a, b) => a.start - b.start || b.end - a.end)
+}
+
+function insertAt(value: string, index: number, text: string) {
+  return `${value.slice(0, index)}${text}${value.slice(index)}`
+}
+
+function removeBefore(value: string, index: number) {
+  return `${value.slice(0, Math.max(0, index - 1))}${value.slice(index)}`
+}
+
+function removeAt(value: string, index: number) {
+  return `${value.slice(0, index)}${value.slice(index + 1)}`
+}
+
+function previousWordBoundary(value: string, index: number) {
+  let cursor = index
+
+  while (cursor > 0 && /\s/.test(value[cursor - 1] ?? '')) {
+    cursor -= 1
+  }
+
+  while (cursor > 0 && !/\s/.test(value[cursor - 1] ?? '')) {
+    cursor -= 1
+  }
+
+  return cursor
+}
+
+function escapeStringSequenceLength(data: string, index: number) {
+  const bell = data.indexOf('\x07', index + 2)
+  const stringTerminator = data.indexOf('\x1b\\', index + 2)
+  const terminator = [bell, stringTerminator].filter(candidate => candidate !== -1).sort((a, b) => a - b)[0]
+
+  if (terminator === undefined) {
+    return data.length - index
+  }
+
+  return terminator - index + (terminator === stringTerminator ? 2 : 1)
+}
+
+function escapeSequenceLength(data: string, index: number) {
+  if (data[index] !== '\x1b') {
+    return 0
+  }
+
+  const next = data[index + 1]
+
+  if (!next) {
+    return 1
+  }
+
+  if (next === '[') {
+    let cursor = index + 2
+
+    while (cursor < data.length) {
+      const code = data.charCodeAt(cursor)
+
+      if (code >= 0x40 && code <= 0x7e) {
+        return cursor - index + 1
+      }
+
+      cursor += 1
+    }
+
+    return data.length - index
+  }
+
+  if (next === ']') {
+    return escapeStringSequenceLength(data, index)
+  }
+
+  if (next === 'O') {
+    return Math.min(3, data.length - index)
+  }
+
+  if (next === 'P' || next === 'X' || next === '^' || next === '_') {
+    return escapeStringSequenceLength(data, index)
+  }
+
+  return Math.min(2, data.length - index)
+}
+
+export class TerminalCommandDraft {
+  cursor = 0
+  text = ''
+
+  applyUserInput(data: string) {
+    let changed = false
+    let index = 0
+
+    while (index < data.length) {
+      const rest = data.slice(index)
+
+      if (rest.startsWith(CONTROL_SEQUENCES.arrowLeft)) {
+        this.cursor = Math.max(0, this.cursor - 1)
+        index += CONTROL_SEQUENCES.arrowLeft.length
+        changed = true
+
+        continue
+      }
+
+      if (rest.startsWith(CONTROL_SEQUENCES.arrowRight)) {
+        this.cursor = Math.min(this.text.length, this.cursor + 1)
+        index += CONTROL_SEQUENCES.arrowRight.length
+        changed = true
+
+        continue
+      }
+
+      if (rest.startsWith(CONTROL_SEQUENCES.home) || rest.startsWith(CONTROL_SEQUENCES.homeTilde)) {
+        this.cursor = 0
+        index += rest.startsWith(CONTROL_SEQUENCES.home) ? CONTROL_SEQUENCES.home.length : CONTROL_SEQUENCES.homeTilde.length
+        changed = true
+
+        continue
+      }
+
+      if (rest.startsWith(CONTROL_SEQUENCES.end) || rest.startsWith(CONTROL_SEQUENCES.endTilde)) {
+        this.cursor = this.text.length
+        index += rest.startsWith(CONTROL_SEQUENCES.end) ? CONTROL_SEQUENCES.end.length : CONTROL_SEQUENCES.endTilde.length
+        changed = true
+
+        continue
+      }
+
+      if (rest.startsWith(CONTROL_SEQUENCES.delete)) {
+        if (this.cursor < this.text.length) {
+          this.text = removeAt(this.text, this.cursor)
+        }
+
+        index += CONTROL_SEQUENCES.delete.length
+        changed = true
+
+        continue
+      }
+
+      if (rest.startsWith(CONTROL_SEQUENCES.arrowUp) || rest.startsWith(CONTROL_SEQUENCES.arrowDown)) {
+        this.clear()
+        index += rest.startsWith(CONTROL_SEQUENCES.arrowUp) ? CONTROL_SEQUENCES.arrowUp.length : CONTROL_SEQUENCES.arrowDown.length
+        changed = true
+
+        continue
+      }
+
+      const escapeLength = escapeSequenceLength(data, index)
+
+      if (escapeLength > 0) {
+        index += escapeLength
+        changed = true
+
+        continue
+      }
+
+      const ch = data[index]
+
+      if (ch === '\r' || ch === '\n' || ch === '\x03') {
+        this.clear()
+        index += 1
+        changed = true
+
+        continue
+      }
+
+      if (ch === '\x01') {
+        this.cursor = 0
+        index += 1
+        changed = true
+
+        continue
+      }
+
+      if (ch === '\x05') {
+        this.cursor = this.text.length
+        index += 1
+        changed = true
+
+        continue
+      }
+
+      if (ch === '\x0b') {
+        this.text = this.text.slice(0, this.cursor)
+        index += 1
+        changed = true
+
+        continue
+      }
+
+      if (ch === '\x15') {
+        this.text = this.text.slice(this.cursor)
+        this.cursor = 0
+        index += 1
+        changed = true
+
+        continue
+      }
+
+      if (ch === '\x17') {
+        const start = previousWordBoundary(this.text, this.cursor)
+        this.text = `${this.text.slice(0, start)}${this.text.slice(this.cursor)}`
+        this.cursor = start
+        index += 1
+        changed = true
+
+        continue
+      }
+
+      if (ch === '\b' || ch === '\x7f') {
+        if (this.cursor > 0) {
+          this.text = removeBefore(this.text, this.cursor)
+          this.cursor -= 1
+        }
+
+        index += 1
+        changed = true
+
+        continue
+      }
+
+      if (ch === '\t') {
+        this.clear()
+        index += 1
+        changed = true
+
+        continue
+      }
+
+      if (ch >= ' ' && ch !== '\x7f') {
+        this.text = insertAt(this.text, this.cursor, ch)
+        this.cursor += 1
+        index += 1
+        changed = true
+
+        continue
+      }
+
+      index += 1
+    }
+
+    return changed
+  }
+
+  clear() {
+    this.text = ''
+    this.cursor = 0
+  }
+}
+
+export function layoutSyntaxDecorationSegments({
+  cols,
+  cursor,
+  cursorX,
+  cursorY,
+  tokens
+}: {
+  cols: number
+  cursor: number
+  cursorX: number
+  cursorY: number
+  tokens: SyntaxToken[]
+}): SyntaxDecorationSegment[] {
+  if (cols <= 0) {
+    return []
+  }
+
+  const commandStartCell = cursorY * cols + cursorX - cursor
+  const segments: SyntaxDecorationSegment[] = []
+
+  for (const token of tokens) {
+    let start = commandStartCell + token.start
+    const end = commandStartCell + token.end
+
+    while (start < end) {
+      const row = Math.floor(start / cols)
+      const x = ((start % cols) + cols) % cols
+      const rowEnd = (row + 1) * cols
+      const width = Math.max(0, Math.min(end, rowEnd) - start)
+
+      if (width > 0) {
+        segments.push({ kind: token.kind, rowOffset: row - cursorY, width, x })
+      }
+
+      start = rowEnd
+    }
+  }
+
+  return segments
+}
+
+export function readVisibleDraftText({
+  cols,
+  cursor,
+  cursorX,
+  cursorY,
+  lineAt,
+  textLength
+}: {
+  cols: number
+  cursor: number
+  cursorX: number
+  cursorY: number
+  lineAt: (row: number) => string | null
+  textLength: number
+}): string | null {
+  if (cols <= 0 || textLength < 0) {
+    return null
+  }
+
+  const startCell = cursorY * cols + cursorX - cursor
+
+  if (startCell < 0) {
+    return null
+  }
+
+  const endCell = startCell + textLength
+  let out = ''
+  let current = startCell
+
+  while (current < endCell) {
+    const row = Math.floor(current / cols)
+    const startCol = ((current % cols) + cols) % cols
+    const endCol = Math.min(cols, endCell - row * cols)
+    const line = lineAt(row)
+
+    if (line === null) {
+      return null
+    }
+
+    out += line.padEnd(cols, ' ').slice(startCol, endCol)
+    current = row * cols + endCol
+  }
+
+  return out
+}
+
+export function isDraftTextVisible({
+  cols,
+  cursor,
+  cursorX,
+  cursorY,
+  lineAt,
+  text
+}: {
+  cols: number
+  cursor: number
+  cursorX: number
+  cursorY: number
+  lineAt: (row: number) => string | null
+  text: string
+}) {
+  return readVisibleDraftText({ cols, cursor, cursorX, cursorY, lineAt, textLength: text.length }) === text
+}
+
+const FALLBACK_COLORS: Record<SyntaxTokenKind, string> = {
+  assignment: '#4ec9b0',
+  command: '#23d18b',
+  comment: '#6a9955',
+  keyword: '#c586c0',
+  operator: '#569cd6',
+  option: '#dcdcaa',
+  path: '#9cdcfe',
+  string: '#ce9178',
+  variable: '#4ec9b0'
+}
+
+const THEME_COLOR_SLOT: Partial<Record<SyntaxTokenKind, keyof ITheme>> = {
+  assignment: 'cyan',
+  command: 'green',
+  comment: 'brightBlack',
+  keyword: 'magenta',
+  operator: 'blue',
+  option: 'yellow',
+  path: 'brightCyan',
+  string: 'magenta',
+  variable: 'cyan'
+}
+
+function decorationColor(kind: SyntaxTokenKind, theme: ITheme) {
+  const slot = THEME_COLOR_SLOT[kind]
+  const color = slot ? theme[slot] : undefined
+
+  return typeof color === 'string' && /^#[0-9a-f]{6}$/i.test(color) ? color : FALLBACK_COLORS[kind]
+}
+
+export class TerminalSyntaxHighlighter {
+  private readonly draft = new TerminalCommandDraft()
+  private readonly getTheme: () => ITheme
+  private readonly term: Terminal
+  private decorations: IDecoration[] = []
+  private frame = 0
+  private markers: IMarker[] = []
+
+  constructor(term: Terminal, getTheme: () => ITheme) {
+    this.term = term
+    this.getTheme = getTheme
+  }
+
+  handleUserInput(data: string) {
+    if (this.term.buffer.active.type === 'alternate') {
+      this.draft.clear()
+      this.clear()
+
+      return
+    }
+
+    if (!this.draft.applyUserInput(data)) {
+      return
+    }
+
+    if (!this.draft.text.trim()) {
+      this.clear()
+
+      return
+    }
+
+    // Do not render from raw keyboard input. The PTY may have echo disabled
+    // (password prompts), so decorations only refresh after visible terminal
+    // output confirms the draft is actually present in the xterm buffer.
+    this.clear()
+  }
+
+  refresh() {
+    if (!this.draft.text.trim()) {
+      this.clear()
+
+      return
+    }
+
+    this.schedule()
+  }
+
+  dispose() {
+    if (this.frame) {
+      window.cancelAnimationFrame(this.frame)
+      this.frame = 0
+    }
+
+    this.clear()
+    this.draft.clear()
+  }
+
+  private clear() {
+    for (const decoration of this.decorations) {
+      decoration.dispose()
+    }
+
+    for (const marker of this.markers) {
+      marker.dispose()
+    }
+
+    this.decorations = []
+    this.markers = []
+  }
+
+  private schedule() {
+    if (this.frame) {
+      window.cancelAnimationFrame(this.frame)
+    }
+
+    this.frame = window.requestAnimationFrame(() => {
+      this.frame = 0
+      this.render()
+    })
+  }
+
+  private render() {
+    this.clear()
+
+    const buffer = this.term.buffer.active
+
+    if (buffer.type === 'alternate' || !this.draft.text.trim()) {
+      return
+    }
+
+    if (
+      !isDraftTextVisible({
+        cols: this.term.cols,
+        cursor: this.draft.cursor,
+        cursorX: buffer.cursorX,
+        cursorY: buffer.cursorY,
+        lineAt: row => buffer.getLine(buffer.baseY + row)?.translateToString(false) ?? null,
+        text: this.draft.text
+      })
+    ) {
+      return
+    }
+
+    const tokens = tokenizeShellCommand(this.draft.text)
+
+    const segments = layoutSyntaxDecorationSegments({
+      cols: this.term.cols,
+      cursor: this.draft.cursor,
+      cursorX: buffer.cursorX,
+      cursorY: buffer.cursorY,
+      tokens
+    })
+
+    const theme = this.getTheme()
+
+    for (const segment of segments) {
+      const marker = this.term.registerMarker(segment.rowOffset)
+
+      if (!marker) {
+        continue
+      }
+
+      const decoration = this.term.registerDecoration({
+        foregroundColor: decorationColor(segment.kind, theme),
+        layer: 'top',
+        marker,
+        width: segment.width,
+        x: segment.x
+      })
+
+      if (decoration) {
+        this.markers.push(marker)
+        this.decorations.push(decoration)
+      } else {
+        marker.dispose()
+      }
+    }
+  }
+}

--- a/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
@@ -18,6 +18,7 @@ import {
   terminalSelectionLabel,
   terminalTheme
 } from './selection'
+import { TerminalSyntaxHighlighter } from './syntax-highlighting'
 
 type TerminalStatus = 'closed' | 'open' | 'starting'
 
@@ -242,10 +243,13 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
   // never touches transparency.
   const ansiPalette = renderedMode === 'dark' ? (theme.darkTerminal ?? theme.terminal) : theme.terminal
   const activeTheme = useMemo(() => terminalTheme(renderedMode, ansiPalette), [renderedMode, ansiPalette])
+  const activeThemeRef = useRef(activeTheme)
+  activeThemeRef.current = activeTheme
   const initialThemeRef = useRef(activeTheme)
   const hostRef = useRef<HTMLDivElement | null>(null)
   const termRef = useRef<Terminal | null>(null)
   const webglRef = useRef<WebglAddon | null>(null)
+  const syntaxHighlighterRef = useRef<TerminalSyntaxHighlighter | null>(null)
   const sessionIdRef = useRef<string | null>(null)
   const shellNameRef = useRef('shell')
   const selectionLabelRef = useRef('')
@@ -359,8 +363,17 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
     })
 
     const fit = new FitAddon()
+    const syntaxHighlighter = new TerminalSyntaxHighlighter(term, () => activeThemeRef.current)
 
     termRef.current = term
+    syntaxHighlighterRef.current = syntaxHighlighter
+    cleanup.push(() => {
+      syntaxHighlighter.dispose()
+
+      if (syntaxHighlighterRef.current === syntaxHighlighter) {
+        syntaxHighlighterRef.current = null
+      }
+    })
     term.loadAddon(fit)
     term.loadAddon(new Unicode11Addon())
     term.loadAddon(new WebLinksAddon())
@@ -423,9 +436,17 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
     // resize cleanup doesn't reintroduce the blank line.
     let stripLeading = true
 
+    const writeTerminalData = (data: string) => {
+      term.write(data)
+      // The user's keystrokes reach xterm through the PTY echo, not local echo.
+      // Refresh after terminal output so decorations line up with the actual
+      // rendered cursor position instead of the pre-echo input event.
+      syntaxHighlighter.refresh()
+    }
+
     const armedWrite = (data: string) => {
       if (!stripLeading) {
-        term.write(data)
+        writeTerminalData(data)
 
         return
       }
@@ -439,14 +460,14 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
         const controls = keepEscapeSequences(next)
 
         if (controls) {
-          term.write(controls)
+          writeTerminalData(controls)
         }
 
         return
       }
 
       stripLeading = false
-      term.write(next)
+      writeTerminalData(next)
     }
 
     const scheduleGapCleanup = () => {
@@ -531,6 +552,8 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
       const id = sessionIdRef.current
 
       if (id) {
+        syntaxHighlighter.handleUserInput(data)
+
         // Once the user submits a line, real output may follow — stop the
         // pristine-prompt gap cleanup so we never clear command scrollback.
         if (promptPristine && data.includes('\r')) {
@@ -670,6 +693,7 @@ export function useTerminalSession({ cwd, onAddSelectionToChat }: UseTerminalSes
       // light/dark switch leaves already-drawn cells stale until the atlas is
       // cleared. No-op for the DOM fallback.
       webglRef.current?.clearTextureAtlas()
+      syntaxHighlighterRef.current?.refresh()
     })
 
     return () => cancelAnimationFrame(raf)


### PR DESCRIPTION
## Summary
- Adds xterm-decoration shell-input syntax highlighting for the Desktop embedded terminal.
- Gates rendering on visible PTY echo so no-echo prompts (for example password prompts) do not expose hidden input length.
- Handles terminal control/protocol sequences before tokenization, including CSI, OSC, SS3, bracketed paste wrappers, and DCS/SOS/PM/APC string controls.
- Disposes node-pty terminal session listeners on renderer destruction and app quit to avoid native cleanup crashes.

Note: Catppuccin Mocha theme availability is covered separately by #45798. This PR keeps the terminal highlighter theme-aware so it uses whatever active terminal palette is present.

## Test plan
- `npm run test:ui -- src/app/right-sidebar/terminal/syntax-highlighting.test.ts` — 8 passed
- `npm run test:desktop:platforms` — 165 passed, 1 skipped
- `npx eslint src/app/right-sidebar/terminal/syntax-highlighting.ts src/app/right-sidebar/terminal/syntax-highlighting.test.ts src/app/right-sidebar/terminal/use-terminal-session.ts electron/main.cjs electron/terminal-session-lifecycle.test.cjs electron/windows-child-process.test.cjs`
- `npm run typecheck`
- `npm --workspace apps/desktop run build`

## Review
- Static security scan clean: no hardcoded secrets, shell injection, dangerous eval/exec, unsafe deserialization, or SQL string formatting.
- Independent final review passed with no blocking security or logic issues.
