### PR TITLE
fix(codex): bound leaked tool-call scan to prefix window

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -70,6 +70,21 @@ _TOOL_CALL_LEAK_PATTERN = re.compile(
     r"(?:^|[\s>|])to=functions\.[A-Za-z_][\w.]*",
     re.IGNORECASE,
 )
+_TOOL_CALL_LEAK_SCAN_LIMIT = 8192
+
+
+def _scan_for_leaked_tool_call(text: str) -> bool:
+    """Return True if Codex leaked a Harmony tool-call marker near the start.
+
+    Real leaked tool-call serializations begin with the Harmony marker.  Bound
+    the regex to a prefix window so multi-megabyte successful assistant output
+    never spends unbounded GIL time proving it does not contain a leak.
+    """
+    return bool(
+        _TOOL_CALL_LEAK_PATTERN.search(
+            text[:_TOOL_CALL_LEAK_SCAN_LIMIT + 64]
+        )
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1227,7 +1242,7 @@ def _normalize_codex_response(
     # ``function_call`` item. The existing loop already handles message
     # append, dedup, and retry budget.
     leaked_tool_call_text = False
-    if final_text and not tool_calls and _TOOL_CALL_LEAK_PATTERN.search(final_text):
+    if final_text and not tool_calls and _scan_for_leaked_tool_call(final_text):
         leaked_tool_call_text = True
         logger.warning(
             "Codex response contains leaked tool-call text in assistant content "

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -992,6 +992,7 @@ AUTHOR_MAP = {
     "tuancanhnguyen706@gmail.com": "xxxigm",
     "larcombe.n@gmail.com": "NickLarcombe",
     "54813621+xxxigm@users.noreply.github.com": "xxxigm",
+    "xxxigm@users.noreply.github.com": "xxxigm",
     "asurla@nvidia.com": "anniesurla",
     "kchantharuan@nvidia.com": "nv-kasikritc",
     "bbednarski@nvidia.com": "bbednarski9",

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1520,6 +1520,42 @@ def test_normalize_codex_response_detects_leaked_tool_call_text(monkeypatch):
     assert assistant_message.tool_calls == []
 
 
+def test_scan_for_leaked_tool_call_checks_prefix_window_only(monkeypatch):
+    from agent.codex_responses_adapter import (
+        _TOOL_CALL_LEAK_SCAN_LIMIT,
+        _scan_for_leaked_tool_call,
+    )
+
+    marker = "to=functions.terminal {\"command\": \"pwd\"}"
+
+    assert _scan_for_leaked_tool_call(marker) is True
+    assert _scan_for_leaked_tool_call("x" * (_TOOL_CALL_LEAK_SCAN_LIMIT - 10) + " " + marker) is True
+    assert _scan_for_leaked_tool_call("x" * (_TOOL_CALL_LEAK_SCAN_LIMIT + 10) + marker) is False
+
+
+def test_normalize_codex_response_ignores_late_tool_call_marker_past_scan_window(monkeypatch):
+    from agent.codex_responses_adapter import _TOOL_CALL_LEAK_SCAN_LIMIT, _normalize_codex_response
+
+    late_marker = "x" * (_TOOL_CALL_LEAK_SCAN_LIMIT + 100) + " to=functions.terminal {\"command\": \"pwd\"}"
+    response = SimpleNamespace(
+        output=[
+            SimpleNamespace(
+                type="message",
+                status="completed",
+                content=[SimpleNamespace(type="output_text", text=late_marker)],
+            )
+        ],
+        usage=SimpleNamespace(input_tokens=4, output_tokens=2, total_tokens=6),
+        status="completed",
+        model="gpt-5.4",
+    )
+
+    assistant_message, finish_reason = _normalize_codex_response(response)
+
+    assert finish_reason == "stop"
+    assert assistant_message.content == late_marker
+
+
 def test_normalize_codex_response_ignores_tool_call_text_when_real_tool_call_present(monkeypatch):
     """If the model emitted BOTH a structured function_call AND some text that
     happens to contain `to=functions.*` (unlikely but possible), trust the


### PR DESCRIPTION
## Summary
Codex leaked-tool-call detection now scans only a bounded assistant-text prefix instead of running the Harmony marker regex over arbitrarily large successful responses.

## Changes
- Add `_TOOL_CALL_LEAK_SCAN_LIMIT` and `_scan_for_leaked_tool_call()` in `agent/codex_responses_adapter.py`.
- Route `_normalize_codex_response()` through the bounded helper.
- Preserve existing behavior for early `to=functions.*` leaks.
- Ignore markers beyond the prefix window so huge normal answers do not pay an unbounded regex scan cost or trip late false positives.

## Validation
| Check | Result |
|---|---|
| Targeted bounded leak-scan tests | 3 passed |
| `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/run_agent/test_run_agent_codex_responses.py -q` | 78 passed |
| `scripts/run_tests.sh tests/run_agent/test_run_agent_codex_responses.py` | 78 passed |
| Bounded leak-scan E2E helper check | passed |
| `python3 -m py_compile agent/codex_responses_adapter.py tests/run_agent/test_run_agent_codex_responses.py && git diff --check` | passed |

Partially salvages #32098 by @xxxigm with authorship preserved. This intentionally takes only the bounded Codex leak-scan piece; the watchdog and gateway MEDIA-regex changes from #32098 remain separate design work.

Refs #32079.

## Infographic

![Bounded Leak Scan](https://v3b.fal.media/files/b/0a9e2e53/-IMV3BA32S2CAneYbr0tU_h3TJur2W.png)
