### PR TITLE
feat(telegram): add disable_rich_messages config option

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -424,8 +424,8 @@ class TelegramAdapter(BasePlatformAdapter):
         # Latched off after a capability failure on sendRichMessage /
         # sendRichMessageDraft (e.g. older python-telegram-bot without the
         # endpoint) so later sends skip the doomed rich attempt entirely.
-        self._rich_send_disabled: bool = False
-        self._rich_draft_disabled: bool = False
+        self._rich_send_disabled: bool = self._coerce_bool_extra("disable_rich_messages", False)
+        self._rich_draft_disabled: bool = self._coerce_bool_extra("disable_rich_messages", False)
         # Buffer rapid/album photo updates so Telegram image bursts are handled
         # as a single MessageEvent instead of self-interrupting multiple turns.
         self._media_batch_delay_seconds = float(os.getenv("HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS", "0.8"))

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -465,3 +465,25 @@ def test_streaming_overflow_limit_none_when_rich_latched_off():
     adapter = _make_adapter()
     adapter._rich_send_disabled = True
     assert adapter.streaming_overflow_limit() is None
+
+
+# ----------------------------------------------------------------------
+# Config-driven disable_rich_messages
+# ----------------------------------------------------------------------
+def test_disable_rich_messages_extra_disables_send():
+    """Setting telegram.extra.disable_rich_messages=true disables rich sends."""
+    adapter = _make_adapter(extra={"disable_rich_messages": True})
+    assert adapter._rich_send_disabled is True
+
+
+def test_disable_rich_messages_extra_disables_draft():
+    """Setting telegram.extra.disable_rich_messages=true disables rich drafts."""
+    adapter = _make_adapter(extra={"disable_rich_messages": True})
+    assert adapter._rich_draft_disabled is True
+
+
+def test_disable_rich_messages_default_is_enabled():
+    """Without the extra key, rich messages remain enabled."""
+    adapter = _make_adapter()
+    assert adapter._rich_send_disabled is False
+    assert adapter._rich_draft_disabled is False

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -911,6 +911,18 @@ The rich path is skipped automatically when content exceeds the 32,768-byte rich
 
 There's nothing to configure for the fallback — the adapter picks the right rendering per message. If you want the legacy "always code-block" behavior, disable table normalization by setting `telegram.pretty_tables: false` in `config.yaml` (default: `true`).
 
+**Disable rich messages.** If you prefer plain MarkdownV2 rendering (no native tables, headings, task lists, etc.) — for example, on a smartwatch client where rich messages render as media blocks — set `disable_rich_messages: true` in the `extra` section:
+
+```yaml
+gateway:
+  platforms:
+    telegram:
+      extra:
+        disable_rich_messages: true
+```
+
+Both the final reply and the streaming draft will use the legacy MarkdownV2 `sendMessage` path. Rich messages are enabled by default and this setting has no effect if the Bot API server doesn't support `sendRichMessage` (the adapter already falls back automatically).
+
 **Link previews.** Telegram auto-generates link previews for URLs in bot messages. If you'd rather suppress those (long `/tools` output, agent reply that mentions ten links, etc.):
 
 ```yaml


### PR DESCRIPTION
## Problem

Telegram Bot API 10.1 rich messages (`sendRichMessage`) render native tables, headings, task lists, etc. — but some clients (e.g. smartwatch apps) display rich messages as opaque media blocks instead of readable text. There was no way for users to opt out of rich messages.

## Solution

Add `gateway.platforms.telegram.extra.disable_rich_messages` config option (default: `false`). When set to `true`, both `_rich_send_disabled` and `_rich_draft_disabled` are initialized from this setting, causing the adapter to skip the rich path and use the legacy MarkdownV2 `sendMessage` path for all outgoing messages.

This follows the existing `_coerce_bool_extra` pattern used by `disable_link_previews` — same mechanism, same config location.

### Config example

```yaml
gateway:
  platforms:
    telegram:
      extra:
        disable_rich_messages: true
```

## Changes

- **`gateway/platforms/telegram.py`**: Initialize `_rich_send_disabled` and `_rich_draft_disabled` from `self._coerce_bool_extra("disable_rich_messages", False)` instead of hardcoded `False`.
- **`tests/gateway/test_telegram_rich_messages.py`**: 3 new tests — config disables send, config disables draft, default is enabled.
- **`website/docs/user-guide/messaging/telegram.md`**: Document the new option in the Rendering section.

## Testing

All 38 tests in `test_telegram_rich_messages.py` pass, including the 3 new ones:

```
test_disable_rich_messages_extra_disables_send PASSED
test_disable_rich_messages_extra_disables_draft PASSED
test_disable_rich_messages_default_is_enabled PASSED
```

## Design notes

- Uses the existing `_coerce_bool_extra` pattern — no new config schema, no new env var (per project convention that behavioral settings go in `config.yaml`).
- Rich messages remain enabled by default, so existing behaviour is unchanged.
- If the Bot API server doesn't support `sendRichMessage`, the adapter already falls back automatically — this setting just lets users force the fallback path.