### PR TITLE
fix(desktop): flip the foreground view to the warm session synchronously on resume

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.resume-warm.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.resume-warm.test.tsx
@@ -4,8 +4,9 @@ import { useEffect } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { $sessions, setSessions } from '@/store/session'
+import type { SessionInfo } from '@/types/hermes'
 
-import type { ClientSessionState, SessionInfo } from '../../types'
+import type { ClientSessionState } from '../../types'
 
 import { useSessionActions } from './use-session-actions'
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions.resume-warm.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.resume-warm.test.tsx
@@ -1,0 +1,118 @@
+import { cleanup, render, waitFor } from '@testing-library/react'
+import type { MutableRefObject } from 'react'
+import { useEffect } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { $sessions, setSessions } from '@/store/session'
+
+import type { ClientSessionState, SessionInfo } from '../../types'
+
+import { useSessionActions } from './use-session-actions'
+
+// Keep the gateway-profile swap a no-op so resumeSession's awaits settle
+// without a real backend.
+vi.mock('@/store/profile', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  ensureGatewayProfile: vi.fn(async () => {})
+}))
+
+const ref = <T,>(value: T): MutableRefObject<T> => ({ current: value })
+
+function state(storedSessionId: string): ClientSessionState {
+  return {
+    storedSessionId,
+    messages: [],
+    branch: '',
+    cwd: '',
+    model: '',
+    provider: '',
+    reasoningEffort: '',
+    serviceTier: '',
+    fast: false,
+    yolo: false,
+    personality: '',
+    busy: false,
+    awaitingResponse: false,
+    streamId: null,
+    sawAssistantPayload: false,
+    pendingBranchGroup: null,
+    interrupted: false,
+    needsInput: false,
+    turnStartedAt: null
+  }
+}
+
+function Harness({
+  deps,
+  onReady
+}: {
+  deps: Parameters<typeof useSessionActions>[0]
+  onReady: (resume: (storedSessionId: string, replaceRoute?: boolean) => Promise<void>) => void
+}) {
+  const actions = useSessionActions(deps)
+
+  useEffect(() => {
+    onReady(actions.resumeSession)
+  }, [actions.resumeSession, onReady])
+
+  return null
+}
+
+describe('resumeSession warm-cached switch (#45738)', () => {
+  afterEach(() => {
+    cleanup()
+    setSessions(() => [])
+    vi.restoreAllMocks()
+  })
+
+  it('flips the foreground view to the warm session synchronously, before the resolve/gateway awaits', async () => {
+    const storedA = 'stored-A'
+    const storedB = 'stored-B'
+    const rtA = 'rt-A'
+    const rtB = 'rt-B'
+
+    const activeSessionIdRef = ref<string | null>(rtA)
+    const selectedStoredSessionIdRef = ref<string | null>(storedA)
+    const runtimeIdByStoredSessionIdRef = ref(new Map<string, string>([[storedA, rtA], [storedB, rtB]]))
+    const sessionStateByRuntimeIdRef = ref(new Map<string, ClientSessionState>([[rtA, state(storedA)], [rtB, state(storedB)]]))
+    const syncSessionStateToView = vi.fn()
+
+    // Both sessions cached so resolveStoredSession is a pure store hit (no
+    // gateway round-trip).
+    setSessions(() => [{ id: storedA } as SessionInfo, { id: storedB } as SessionInfo])
+
+    const requestGateway = vi.fn(async () => ({}) as never)
+
+    const deps: Parameters<typeof useSessionActions>[0] = {
+      activeSessionId: rtA,
+      activeSessionIdRef,
+      busyRef: ref(false),
+      creatingSessionRef: ref(false),
+      ensureSessionState: () => state(storedB),
+      getRouteToken: () => 'token',
+      navigate: vi.fn() as never,
+      requestGateway,
+      runtimeIdByStoredSessionIdRef,
+      selectedStoredSessionId: storedA,
+      selectedStoredSessionIdRef,
+      sessionStateByRuntimeIdRef,
+      syncSessionStateToView,
+      updateSessionState: () => state(storedB)
+    }
+
+    let resume: ((s: string, r?: boolean) => Promise<void>) | null = null
+    render(<Harness deps={deps} onReady={r => (resume = r)} />)
+    await waitFor(() => expect(resume).not.toBeNull())
+
+    // Call without awaiting: the async body runs synchronously up to its first
+    // await (resolveStoredSession). The fix repaints the foreground view here;
+    // on main the warm repaint only happens AFTER the awaits, so the previous
+    // session would still be active at this point.
+    const pending = resume!(storedB)
+
+    expect(activeSessionIdRef.current).toBe(rtB)
+    expect(syncSessionStateToView).toHaveBeenCalledWith(rtB, sessionStateByRuntimeIdRef.current.get(rtB))
+
+    await pending.catch(() => {})
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -337,6 +337,17 @@ export function useSessionActions({
         setActiveSessionId(null)
         activeSessionIdRef.current = null
         setMessages([])
+      } else {
+        // Warm-cached target: flip the foreground view to the new session
+        // SYNCHRONOUSLY here, before the profile-resolve / gateway-swap awaits
+        // below. activeSessionId is what the status stack and transcript key on,
+        // so if we wait until the post-await fast-path to repaint, the previous
+        // session's transcript and status linger above the composer during the
+        // await window (#45738). The fast-path below re-applies this idempotently
+        // (with the model merge) and adds the usage refresh.
+        setActiveSessionId(warmRuntimeId)
+        activeSessionIdRef.current = warmRuntimeId
+        syncSessionStateToView(warmRuntimeId, warmState)
       }
 
       // Swap the single live gateway to this session's profile before any


### PR DESCRIPTION
Fixes #45738

## Problem
Resuming a session that is already warm-cached briefly shows the **previous** session's transcript and status stack above the composer. In `resumeSession`, the entry block only clears/repaints for a *cold* target; for a warm-cached target the repaint happens in the post-await fast path (after `resolveStoredSession` and `ensureGatewayProfile`). `activeSessionId` — which the status stack and transcript key on — therefore stays pointed at the old session for the whole await window, so the old thread lingers until resume lands.

## Fix
Repaint the warm-cached target **synchronously at resume entry**, before those awaits: set `activeSessionId`/`activeSessionIdRef` to the warm runtime id and sync its cached view state. The existing post-await fast path re-applies this idempotently (with the model merge) and adds the usage refresh, so behaviour once resume completes is unchanged — this only removes the dead-air window where the wrong session was foregrounded.

## Test
`use-session-actions.resume-warm.test.tsx`: seeds two warm-cached sessions, sets A active, calls `resumeSession(B)`, and asserts the **synchronous** state (immediately after the call, before any await resolves) — `activeSessionIdRef.current` is B's runtime id and the cached view state was synced for B. Fails on `main` (the view is still A until the awaits resolve), passes with the fix. The existing `use-session-actions` tests are unaffected.
