### PR TITLE
fix(gateway): preserve Telegram rich formatting during streaming edits

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1134,6 +1134,57 @@ class TelegramAdapter(BasePlatformAdapter):
             and self._bot_supports_rich()
         )
 
+    async def _try_edit_rich(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+    ) -> Optional[SendResult]:
+        """Attempt a single ``editMessageText`` rich edit.
+
+        Bot API 10.1 extends ``editMessageText`` with a ``rich_message``
+        parameter. Use that raw endpoint for Telegram streaming edits so tables,
+        task lists, details blocks, formulas, etc. persist instead of being
+        flattened through the legacy ``text`` + MarkdownV2 path.
+
+        Returns a :class:`SendResult`, or ``None`` to signal "fall back to the
+        legacy edit path" for per-message parser failures or missing endpoint
+        capability.
+        """
+        payload: Dict[str, Any] = {
+            "chat_id": int(chat_id),
+            "message_id": int(message_id),
+            "rich_message": self._rich_message_payload(content),
+        }
+        try:
+            await self._bot.do_api_request(
+                "editMessageText", api_kwargs=payload, return_type=Message
+            )
+        except Exception as exc:
+            err_str = str(exc).lower()
+            if "not modified" in err_str:
+                return SendResult(success=True, message_id=message_id)
+            if self._is_rich_fallback_error(exc):
+                if self._is_rich_capability_error(exc):
+                    self._rich_send_disabled = True
+                logger.debug(
+                    "[%s] editMessageText.rich_message rejected (%s) — falling back to legacy edit",
+                    self.name, exc,
+                )
+                return None
+            is_timeout = "timed out" in err_str
+            is_connect_timeout = self._looks_like_connect_timeout(exc)
+            logger.warning(
+                "[%s] editMessageText.rich_message transient failure: %s",
+                self.name, exc,
+            )
+            return SendResult(
+                success=False,
+                error=str(exc),
+                retryable=(is_connect_timeout or not is_timeout),
+            )
+        return SendResult(success=True, message_id=message_id)
+
     async def _try_send_rich_draft(
         self,
         chat_id: str,
@@ -2469,6 +2520,14 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         if not self._bot:
             return SendResult(success=False, error="Not connected")
+
+        # Bot API 10.1 rich edits preserve structured streaming output. Try
+        # this before the legacy 4096-char split path because rich messages have
+        # a larger 32768 UTF-8 character budget and understand tables/task lists.
+        if self._should_attempt_rich(content):
+            rich_result = await self._try_edit_rich(chat_id, message_id, content)
+            if rich_result is not None:
+                return rich_result
 
         # Pre-flight: if content already exceeds the limit, split-and-deliver
         # without round-tripping a doomed edit.

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -35,6 +35,7 @@ def _make_adapter(extra=None):
     # so _bot_supports_rich() is satisfied (real Bot.do_api_request is async too).
     bot.do_api_request = AsyncMock(return_value=SimpleNamespace(message_id=123))
     bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
+    bot.edit_message_text = AsyncMock(return_value=MagicMock(message_id=123))
     bot.send_chat_action = AsyncMock()  # keeps the post-send typing re-trigger quiet
     bot.send_message_draft = AsyncMock(return_value=True)  # legacy draft fallback
     adapter._bot = bot
@@ -260,6 +261,54 @@ async def test_rich_gate_tolerates_minimal_bot_without_raw_endpoint():
 
     assert result.success is True
     assert result.message_id == "42"
+
+
+# ── Streaming edits: editMessageText.rich_message ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rich_edit_happy_path_sends_raw_markdown_for_streaming():
+    adapter = _make_adapter()
+
+    result = await adapter.edit_message("12345", "123", RICH_CONTENT)
+
+    assert result.success is True
+    adapter._bot.do_api_request.assert_awaited_once()
+    call = adapter._bot.do_api_request.call_args
+    assert call.args[0] == "editMessageText"
+    api_kwargs = call.kwargs["api_kwargs"]
+    assert api_kwargs["chat_id"] == 12345
+    assert api_kwargs["message_id"] == 123
+    assert api_kwargs["rich_message"]["markdown"] == RICH_CONTENT
+    # Rich edit must preserve tables/task lists instead of flattening through
+    # the legacy text + MarkdownV2 edit path.
+    assert "text" not in api_kwargs
+    adapter._bot.edit_message_text.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rich_edit_final_also_uses_raw_markdown():
+    adapter = _make_adapter()
+
+    result = await adapter.edit_message("12345", "123", RICH_CONTENT, finalize=True)
+
+    assert result.success is True
+    call = adapter._bot.do_api_request.call_args
+    assert call.args[0] == "editMessageText"
+    assert call.kwargs["api_kwargs"]["rich_message"]["markdown"] == RICH_CONTENT
+    adapter._bot.edit_message_text.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rich_edit_bad_request_falls_back_to_legacy_edit():
+    adapter = _make_adapter()
+    adapter._bot.do_api_request = AsyncMock(side_effect=BadRequest("can't parse rich message"))
+
+    result = await adapter.edit_message("12345", "123", RICH_CONTENT)
+
+    assert result.success is True
+    adapter._bot.do_api_request.assert_awaited_once()
+    adapter._bot.edit_message_text.assert_awaited_once()
 
 
 # ── Streaming drafts: sendRichMessageDraft ─────────────────────────────

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -311,6 +311,56 @@ async def test_rich_edit_bad_request_falls_back_to_legacy_edit():
     adapter._bot.edit_message_text.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_rich_edit_capability_failure_falls_back_and_latches_off():
+    adapter = _make_adapter()
+    adapter._bot.do_api_request = AsyncMock(side_effect=RuntimeError("Method not found"))
+
+    result = await adapter.edit_message("12345", "123", RICH_CONTENT)
+
+    assert result.success is True  # legacy edit delivered the frame
+    adapter._bot.edit_message_text.assert_awaited_once()
+    assert adapter._rich_send_disabled is True
+
+    # Subsequent edits skip the doomed rich endpoint entirely.
+    adapter._bot.do_api_request.reset_mock()
+    adapter._bot.edit_message_text.reset_mock()
+    result2 = await adapter.edit_message("12345", "123", RICH_CONTENT)
+    assert result2.success is True
+    adapter._bot.do_api_request.assert_not_called()
+    adapter._bot.edit_message_text.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_rich_edit_transient_failure_does_not_latch_off():
+    adapter = _make_adapter()
+    adapter._bot.do_api_request = AsyncMock(side_effect=TimedOut("timed out"))
+
+    result = await adapter.edit_message("12345", "123", RICH_CONTENT)
+
+    # A timeout may have reached Telegram, so do not immediately legacy-resend;
+    # importantly, transient errors must not disable rich edits for the adapter.
+    assert result.success is False
+    assert result.retryable is False
+    assert adapter._rich_send_disabled is False
+    adapter._bot.edit_message_text.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rich_edit_oversized_skips_rich_and_uses_legacy_split():
+    adapter = _make_adapter()
+    oversized = "a" * 40000
+    assert len(oversized.encode("utf-8")) > TelegramAdapter.RICH_MESSAGE_MAX_BYTES
+
+    result = await adapter.edit_message("12345", "123", oversized)
+
+    assert result.success is True
+    adapter._bot.do_api_request.assert_not_called()
+    # Oversized rich content falls through to the existing legacy split path.
+    assert adapter._bot.edit_message_text.await_count >= 1
+    assert adapter._bot.send_message.await_count >= 1
+
+
 # ── Streaming drafts: sendRichMessageDraft ─────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- route Telegram streaming edits through Bot API 10.1 `editMessageText` with `rich_message.markdown`
- preserve raw rich Markdown for tables/task lists/details instead of flattening through legacy `text` + MarkdownV2 edits
- keep legacy fallback behavior for rich parser/capability failures and transient edit failures

## Why
`sendRichMessageDraft` can show rich tables/checklists while streaming, but the persistent edited message previously went through the legacy edit path. That made rich-only constructs appear briefly during streaming and then disappear/flatten in the final message.

Bot API 10.1 documents rich edits as `editMessageText(..., rich_message=InputRichMessage)`, so the send/draft/edit path can stay rich end-to-end.

## Tests
- `python -m pytest tests/gateway/test_telegram_rich_messages.py tests/gateway/test_stream_consumer_fresh_final.py tests/gateway/test_run_progress_topics.py -q -o 'addopts='`
- local live smoke against Telegram Bot API: `sendRichMessage` followed by `editMessageText` with `rich_message.markdown` preserved a table/checklist/details block
