### PR TITLE
fix(discord): route skill slash fallbacks

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7067,7 +7067,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         command = event.get_command()
 
         from hermes_cli.commands import (
-            GATEWAY_KNOWN_COMMANDS,
             is_gateway_known_command,
             resolve_command as _resolve_cmd,
         )
@@ -7495,7 +7494,40 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     resolve_skill_command_key,
                 )
                 skill_cmds = get_skill_commands()
-                cmd_key = resolve_skill_command_key(command)
+                skill_user_instruction = event.get_command_args().strip()
+                normalized_command = command.replace("_", "-")
+
+                if normalized_command == "skill-list":
+                    if not skill_cmds:
+                        return "No runnable skills are currently available."
+                    names = sorted(info.get("name") or key.lstrip("/")
+                                   for key, info in skill_cmds.items())
+                    preview = ", ".join(names[:25])
+                    suffix = (
+                        f" and {len(names) - 25} more"
+                        if len(names) > 25 else ""
+                    )
+                    return (
+                        f"Available skills: {preview}{suffix}. "
+                        "Run one with `/skill <name> [args]`."
+                    )
+
+                if normalized_command == "skill":
+                    parts = skill_user_instruction.split(maxsplit=1)
+                    if not parts:
+                        return (
+                            "Usage: `/skill <name> [args]`. "
+                            "Use `/skill_list` to list available skills."
+                        )
+                    cmd_key = resolve_skill_command_key(parts[0])
+                    skill_user_instruction = parts[1] if len(parts) > 1 else ""
+                    if cmd_key is None:
+                        return (
+                            f"Unknown skill: `{parts[0]}`. "
+                            "Use `/skill_list` to list available skills."
+                        )
+                else:
+                    cmd_key = resolve_skill_command_key(command)
                 if cmd_key is not None:
                     # Check per-platform disabled status before executing.
                     # get_skill_commands() only applies the *global* disabled
@@ -7510,9 +7542,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 f"The **{_skill_name}** skill is disabled for {_plat}.\n"
                                 f"Enable it with: `hermes skills config`"
                             )
-                    user_instruction = event.get_command_args().strip()
                     msg = build_skill_invocation_message(
-                        cmd_key, user_instruction, task_id=_quick_key
+                        cmd_key, skill_user_instruction, task_id=_quick_key
                     )
                     if msg:
                         event.text = msg
@@ -7531,7 +7562,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # Normalize to hyphenated form before checking known
                     # built-ins (command may be an alias target set by the
                     # quick-command block above, so _cmd_def can be stale).
-                    if command.replace("_", "-") not in GATEWAY_KNOWN_COMMANDS:
+                    if not is_gateway_known_command(command):
                         logger.warning(
                             "Unrecognized slash command /%s from %s — "
                             "replying with unknown-command notice",

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -326,19 +326,28 @@ def is_gateway_known_command(name: str | None) -> bool:
     """Return True if ``name`` resolves to a gateway-dispatchable slash command.
 
     This covers both built-in commands (``GATEWAY_KNOWN_COMMANDS`` derived
-    from ``COMMAND_REGISTRY``) and plugin-registered commands, which are
-    looked up lazily so importing this module never forces plugin
-    discovery. Gateway code uses this to decide whether to emit
-    ``command:<name>`` hooks — plugin commands get the same lifecycle
-    events as built-ins.
+    from ``COMMAND_REGISTRY``), plugin-registered commands, and installed
+    skill commands. Plugin and skill commands are looked up lazily so
+    importing this module never forces plugin or skill discovery. Gateway
+    code uses this to decide whether to emit ``command:<name>`` hooks —
+    dynamic commands get the same lifecycle events as built-ins.
     """
     if not name:
         return False
+    name = name.strip().lstrip("/").lower().replace("_", "-")
     if name in GATEWAY_KNOWN_COMMANDS:
+        return True
+    if name in {"skill", "skill-list"}:
         return True
     for plugin_name, _description, _args_hint in _iter_plugin_command_entries():
         if plugin_name == name:
             return True
+    try:
+        from agent.skill_commands import get_skill_commands
+        if f"/{name}" in get_skill_commands():
+            return True
+    except Exception:
+        pass
     return False
 
 

--- a/tests/gateway/test_unknown_command.py
+++ b/tests/gateway/test_unknown_command.py
@@ -170,6 +170,116 @@ async def test_underscored_alias_for_hyphenated_builtin_not_flagged(monkeypatch)
         assert "Unknown command" not in result
 
 
+@pytest.mark.asyncio
+async def test_plugin_command_without_hook_not_flagged_as_unknown(monkeypatch):
+    """Plugin commands must use the same known-command predicate as hooks.
+
+    The unknown-command guard used to consult only the static
+    GATEWAY_KNOWN_COMMANDS set, so plugin slash commands could be recognized
+    for hooks and then rejected later in the skill fallback block.
+    """
+    import gateway.run as gateway_run
+    from hermes_cli import plugins as plugins_mod
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError("plugin command leaked to the agent")
+    )
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+    monkeypatch.setattr(
+        plugins_mod,
+        "get_plugin_commands",
+        lambda: {"metricas": {"description": "Metrics", "args_hint": "dias:7"}},
+    )
+    monkeypatch.setattr(
+        plugins_mod,
+        "get_plugin_command_handler",
+        lambda name: (lambda args: f"metrics {args}") if name == "metricas" else None,
+    )
+
+    result = await runner._handle_message(_make_event("/metricas dias:7"))
+
+    assert result == "metrics dias:7"
+    runner._run_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_skill_command_wrapper_dispatches_named_skill(monkeypatch):
+    """Discord's native /skill wrapper can reach the text dispatcher on some
+    clients; when it does, route /skill <name> through the skill loader instead
+    of returning the unknown-command notice."""
+    import agent.skill_commands as skill_commands_mod
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(return_value={"final_response": "agent ok"})
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+    monkeypatch.setattr(
+        skill_commands_mod,
+        "get_skill_commands",
+        lambda: {
+            "/alpha": {
+                "name": "alpha",
+                "description": "First skill",
+                "skill_dir": "/tmp/alpha",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        skill_commands_mod,
+        "build_skill_invocation_message",
+        lambda cmd_key, user_instruction="", task_id=None, runtime_note="": (
+            f"loaded {cmd_key}: {user_instruction}"
+        ),
+    )
+
+    result = await runner._handle_message(_make_event("/skill alpha extra args"))
+
+    assert result == "agent ok"
+    runner._run_agent.assert_awaited_once()
+    assert runner._run_agent.await_args.kwargs["message"] == "loaded /alpha: extra args"
+
+
+@pytest.mark.asyncio
+async def test_skill_list_alias_returns_available_skills(monkeypatch):
+    """Discord reports mention /skill_list; keep that alias out of the
+    unknown-command path and return a compact catalog hint."""
+    import agent.skill_commands as skill_commands_mod
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError("skill_list leaked to the agent")
+    )
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+    monkeypatch.setattr(
+        skill_commands_mod,
+        "get_skill_commands",
+        lambda: {
+            "/alpha": {"name": "alpha", "description": "First skill"},
+            "/beta": {"name": "beta", "description": "Second skill"},
+        },
+    )
+
+    result = await runner._handle_message(_make_event("/skill_list"))
+
+    assert result is not None
+    assert "Available skills:" in result
+    assert "alpha" in result
+    assert "beta" in result
+    assert "Unknown command" not in result
+    runner._run_agent.assert_not_called()
+
+
 # ------------------------------------------------------------------
 # command:<name> decision hook — deny / handled / rewrite
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- recognize dynamic skill slash commands in `is_gateway_known_command`
- route gateway-level `/skill <name> [args]` fallbacks through the existing skill loader
- add `/skill_list`/`/skill-list` fallback output instead of the unknown-command notice
- make the unknown-command guard use the dynamic known-command predicate so plugin slashes are not rejected after hook checks

Closes #45839

## Tests
- `uv run --extra dev python -m pytest tests/gateway/test_unknown_command.py -q`
- `uv run --extra dev ruff check hermes_cli/commands.py gateway/run.py tests/gateway/test_unknown_command.py`
- `git diff --check`