### PR TITLE
feat(plugins): opt-in session continuity via pre_llm_call hook

### DIFF
--- a/plugins/session_continuity/__init__.py
+++ b/plugins/session_continuity/__init__.py
@@ -1,0 +1,359 @@
+"""session_continuity plugin.
+
+Injects a small, deterministic continuity block on the first turn of a fresh
+user-facing session. The hook returns ``{"context": ...}``, so Hermes appends
+the block to the current user message at API-call time; the cached system prompt
+is never changed.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_CHARS = 2000
+DEFAULT_MESSAGE_LIMIT = 6
+MIN_MAX_CHARS = 500
+MAX_MAX_CHARS = 8000
+MIN_MESSAGE_LIMIT = 2
+MAX_MESSAGE_LIMIT = 12
+
+EXCLUDED_SOURCES = {"subagent", "tool", "cron", "curator", "catalog"}
+EXCLUDED_PLATFORMS = EXCLUDED_SOURCES | {"background_review"}
+
+
+def _clamp_int(value: Any, default: int, minimum: int, maximum: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(minimum, min(maximum, parsed))
+
+
+def _load_settings() -> Dict[str, int]:
+    """Read optional plugin settings from config.yaml, fail-closed."""
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        cfg = load_config_readonly()
+        section = cfg.get("session_continuity", {})
+        if not isinstance(section, dict):
+            section = {}
+        return {
+            "max_chars": _clamp_int(
+                section.get("max_chars"),
+                DEFAULT_MAX_CHARS,
+                MIN_MAX_CHARS,
+                MAX_MAX_CHARS,
+            ),
+            "message_limit": _clamp_int(
+                section.get("message_limit"),
+                DEFAULT_MESSAGE_LIMIT,
+                MIN_MESSAGE_LIMIT,
+                MAX_MESSAGE_LIMIT,
+            ),
+        }
+    except Exception:
+        return {
+            "max_chars": DEFAULT_MAX_CHARS,
+            "message_limit": DEFAULT_MESSAGE_LIMIT,
+        }
+
+
+def _open_session_db():
+    try:
+        from hermes_state import SessionDB
+
+        return SessionDB()
+    except Exception as exc:
+        logger.debug("session_continuity: SessionDB unavailable: %s", exc)
+        return None
+
+
+def _normalize_text(value: Any) -> str:
+    if isinstance(value, str):
+        text = value
+    else:
+        return ""
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def _clip(text: str, max_chars: int) -> str:
+    if len(text) <= max_chars:
+        return text
+    if max_chars <= 1:
+        return text[:max_chars]
+    return text[: max_chars - 3].rstrip() + "..."
+
+
+def _format_ts(ts: Any) -> str:
+    try:
+        value = float(ts)
+    except (TypeError, ValueError):
+        return ""
+    try:
+        return (
+            datetime.fromtimestamp(value, timezone.utc)
+            .isoformat(timespec="seconds")
+            .replace("+00:00", "Z")
+        )
+    except Exception:
+        return ""
+
+
+def _has_prior_dialog(
+    conversation_history: Optional[Iterable[Dict[str, Any]]],
+    user_message: Any,
+) -> bool:
+    """Return True if the hook payload already contains prior chat turns."""
+    if not conversation_history:
+        return False
+    dialog = [
+        m for m in conversation_history
+        if isinstance(m, dict) and m.get("role") in {"user", "assistant"}
+    ]
+    if not dialog:
+        return False
+    if len(dialog) == 1 and dialog[0].get("role") == "user":
+        current = _normalize_text(user_message)
+        seen = _normalize_text(dialog[0].get("content"))
+        return bool(seen and current and seen != current)
+    return True
+
+
+def _is_user_facing_platform(platform: Any) -> bool:
+    value = str(platform or "").strip().lower()
+    if not value:
+        return True
+    return value not in EXCLUDED_PLATFORMS
+
+
+def _source_filter_for_platform(platform: Any) -> str:
+    """Return the session source to recall from for a hook platform value.
+
+    Continuity is intentionally scoped to the same surface by default. Without
+    this, enabling the plugin in a gateway could leak a private CLI/Desktop
+    session into a group chat's first turn. Empty platform values mirror
+    Hermes' session creation fallback and are treated as ``cli``.
+    """
+    value = str(platform or "").strip().lower()
+    if value in EXCLUDED_PLATFORMS:
+        return ""
+    return value or "cli"
+
+
+def _recent_visible_session(
+    db,
+    current_session_id: str,
+    *,
+    source: str = "",
+    user_id: str = "",
+) -> Optional[Dict[str, Any]]:
+    try:
+        rows = db.list_sessions_rich(
+            source=source or None,
+            exclude_sources=sorted(EXCLUDED_SOURCES),
+            limit=20,
+            include_children=False,
+            min_message_count=1,
+            order_by_last_active=True,
+            include_archived=False,
+        )
+    except Exception as exc:
+        logger.debug("session_continuity: failed to list sessions: %s", exc)
+        return None
+
+    current = str(current_session_id or "")
+    current_user = str(user_id or "")
+    for row in rows:
+        sid = str(row.get("id") or "")
+        if not sid or sid == current:
+            continue
+        row_source = str(row.get("source") or "").lower()
+        if row_source in EXCLUDED_SOURCES:
+            continue
+        row_user = str(row.get("user_id") or "")
+        if current_user and row_user and row_user != current_user:
+            continue
+        if int(row.get("message_count") or 0) <= 0:
+            continue
+        return row
+    return None
+
+
+def _recent_dialog_messages(db, session_id: str, limit: int) -> List[Dict[str, str]]:
+    try:
+        rows = db.get_messages(session_id)
+    except Exception as exc:
+        logger.debug("session_continuity: failed to load messages: %s", exc)
+        return []
+
+    dialog: List[Dict[str, str]] = []
+    for row in rows:
+        role = row.get("role")
+        if role not in {"user", "assistant"}:
+            continue
+        if row.get("tool_call_id") or row.get("tool_name"):
+            continue
+        if row.get("tool_calls") and not row.get("content"):
+            continue
+        content = _normalize_text(row.get("content"))
+        if not content:
+            continue
+        dialog.append({"role": str(role), "content": content})
+    return dialog[-limit:]
+
+
+def _build_block(
+    session: Dict[str, Any],
+    messages: List[Dict[str, str]],
+    *,
+    max_chars: int,
+) -> Optional[str]:
+    sid = str(session.get("id") or "")
+    if not sid or not messages:
+        return None
+
+    title = _normalize_text(session.get("title")) or "(untitled)"
+    source = _normalize_text(session.get("source")) or "unknown"
+    last_active = _format_ts(session.get("last_active") or session.get("started_at"))
+    sid_prefix = sid[:8]
+
+    header = [
+        "[Session continuity: most recent previous visible session]",
+        f"Session: {sid_prefix}",
+        f"Source: {source}",
+        f"Title: {title}",
+    ]
+    if last_active:
+        header.append(f"Last active: {last_active}")
+    header.append("Recent dialog:")
+
+    budget_for_messages = max(120, max_chars - sum(len(line) + 1 for line in header))
+    per_message = max(80, budget_for_messages // max(1, len(messages)))
+    lines = list(header)
+    for msg in messages:
+        label = "User" if msg["role"] == "user" else "Assistant"
+        lines.append(f"- {label}: {_clip(msg['content'], per_message)}")
+
+    block = "\n".join(lines)
+    return _clip(block, max_chars)
+
+
+def build_continuity_context(
+    *,
+    session_db: Any = None,
+    current_session_id: str = "",
+    is_first_turn: bool = True,
+    conversation_history: Optional[Iterable[Dict[str, Any]]] = None,
+    user_message: Any = "",
+    platform: Any = "",
+    sender_id: Any = "",
+    max_chars: Optional[int] = None,
+    message_limit: Optional[int] = None,
+) -> Optional[str]:
+    """Return the continuity block, or ``None`` when nothing should inject."""
+    if not is_first_turn:
+        return None
+    if not _is_user_facing_platform(platform):
+        return None
+    if _has_prior_dialog(conversation_history, user_message):
+        return None
+
+    settings = _load_settings()
+    max_chars = _clamp_int(
+        max_chars if max_chars is not None else settings["max_chars"],
+        DEFAULT_MAX_CHARS,
+        MIN_MAX_CHARS,
+        MAX_MAX_CHARS,
+    )
+    message_limit = _clamp_int(
+        message_limit if message_limit is not None else settings["message_limit"],
+        DEFAULT_MESSAGE_LIMIT,
+        MIN_MESSAGE_LIMIT,
+        MAX_MESSAGE_LIMIT,
+    )
+
+    db = session_db if session_db is not None else _open_session_db()
+    if db is None:
+        return None
+
+    session = _recent_visible_session(
+        db,
+        current_session_id,
+        source=_source_filter_for_platform(platform),
+        user_id=str(sender_id or ""),
+    )
+    if not session:
+        return None
+    messages = _recent_dialog_messages(db, str(session["id"]), message_limit)
+    return _build_block(session, messages, max_chars=max_chars)
+
+
+def pre_llm_call(
+    session_id: str = "",
+    is_first_turn: bool = False,
+    conversation_history: Optional[Iterable[Dict[str, Any]]] = None,
+    user_message: Any = "",
+    platform: Any = "",
+    sender_id: Any = "",
+    session_db: Any = None,
+    **_: Any,
+) -> Optional[Dict[str, str]]:
+    """Hook callback registered with Hermes."""
+    try:
+        context = build_continuity_context(
+            current_session_id=session_id,
+            is_first_turn=is_first_turn,
+            conversation_history=conversation_history,
+            user_message=user_message,
+            platform=platform,
+            sender_id=sender_id,
+            session_db=session_db,
+        )
+        if context:
+            return {"context": context}
+    except Exception as exc:
+        logger.debug("session_continuity: hook failed open: %s", exc)
+    return None
+
+
+def continuity_status(*, session_db: Any = None, current_session_id: str = "") -> str:
+    """Small testable status helper used by the slash command."""
+    db = session_db if session_db is not None else _open_session_db()
+    if db is None:
+        return "Session continuity is enabled, but SessionDB is unavailable."
+    session = _recent_visible_session(db, current_session_id)
+    if not session:
+        return "Session continuity is enabled. No previous visible session is available."
+    sid = str(session.get("id") or "")
+    source = _normalize_text(session.get("source")) or "unknown"
+    title = _normalize_text(session.get("title")) or "(untitled)"
+    return (
+        "Session continuity is enabled. "
+        f"Next fresh session can recall {sid[:8]} ({source}) - {title}."
+    )
+
+
+def _handle_continuity_command(raw_args: str = "") -> str:
+    sub = (raw_args or "").strip().split(maxsplit=1)[0].lower()
+    if sub in {"", "status"}:
+        return continuity_status()
+    if sub == "reset":
+        return "Session continuity has no persistent plugin state to reset."
+    return "Usage: /continuity [status|reset]"
+
+
+def register(ctx) -> None:
+    ctx.register_hook("pre_llm_call", pre_llm_call)
+    ctx.register_command(
+        "continuity",
+        handler=_handle_continuity_command,
+        description="Show session-continuity plugin status.",
+        args_hint="[status|reset]",
+    )

--- a/plugins/session_continuity/plugin.yaml
+++ b/plugins/session_continuity/plugin.yaml
@@ -1,0 +1,7 @@
+name: session_continuity
+version: 0.1.0
+description: "Opt-in first-turn continuity: injects a compact summary of the most recent visible previous session into the current user message via pre_llm_call. No system-prompt mutation and no model calls."
+author: NousResearch
+kind: standalone
+hooks:
+  - pre_llm_call

--- a/tests/plugins/test_session_continuity_plugin.py
+++ b/tests/plugins/test_session_continuity_plugin.py
@@ -1,0 +1,217 @@
+from pathlib import Path
+
+import yaml
+
+from hermes_state import SessionDB
+from plugins.session_continuity import (
+    build_continuity_context,
+    continuity_status,
+    pre_llm_call,
+)
+
+
+def _db(tmp_path: Path) -> SessionDB:
+    return SessionDB(db_path=tmp_path / "state.db")
+
+
+def _seed_session(db: SessionDB, sid: str, source: str = "cli", user_id: str = "") -> None:
+    kwargs = {"user_id": user_id} if user_id else {}
+    db.create_session(session_id=sid, source=source, model="test-model", **kwargs)
+
+
+def test_returns_no_context_when_not_first_turn(tmp_path):
+    db = _db(tmp_path)
+    try:
+        _seed_session(db, "prior")
+        db.append_message("prior", "user", "remember this")
+
+        assert build_continuity_context(
+            session_db=db,
+            current_session_id="current",
+            is_first_turn=False,
+        ) is None
+    finally:
+        db.close()
+
+
+def test_returns_no_context_for_hidden_or_current_only_sessions(tmp_path):
+    db = _db(tmp_path)
+    try:
+        _seed_session(db, "current")
+        db.append_message("current", "user", "new turn")
+
+        _seed_session(db, "archived")
+        db.append_message("archived", "user", "hidden fact")
+        db.set_session_archived("archived", True)
+
+        _seed_session(db, "cron-run", source="cron")
+        db.append_message("cron-run", "user", "cron fact")
+
+        assert build_continuity_context(
+            session_db=db,
+            current_session_id="current",
+            is_first_turn=True,
+            conversation_history=[{"role": "user", "content": "new turn"}],
+            user_message="new turn",
+        ) is None
+    finally:
+        db.close()
+
+
+def test_builds_bounded_block_from_previous_visible_session(tmp_path):
+    db = _db(tmp_path)
+    try:
+        _seed_session(db, "older-session")
+        db.append_message("older-session", "user", "older user detail")
+        db.append_message("older-session", "assistant", "older assistant detail")
+
+        _seed_session(db, "prior-session")
+        db.set_session_title("prior-session", "Project Alpha")
+        db.append_message("prior-session", "user", "first user fact")
+        db.append_message("prior-session", "tool", "tool output secret", tool_name="terminal")
+        db.append_message("prior-session", "assistant", "assistant answer")
+        db.append_message(
+            "prior-session",
+            "assistant",
+            "",
+            tool_calls=[{"id": "call_1", "function": {"name": "terminal", "arguments": "{}"}}],
+        )
+        db.append_message("prior-session", "user", "latest user fact " + ("x" * 500))
+
+        _seed_session(db, "current")
+        db.append_message("current", "user", "hello")
+
+        block = build_continuity_context(
+            session_db=db,
+            current_session_id="current",
+            is_first_turn=True,
+            conversation_history=[{"role": "user", "content": "hello"}],
+            user_message="hello",
+            max_chars=700,
+            message_limit=4,
+        )
+
+        assert block is not None
+        assert len(block) <= 700
+        assert "Session continuity" in block
+        assert "prior-se" in block
+        assert "Project Alpha" in block
+        assert "first user fact" in block
+        assert "assistant answer" in block
+        assert "latest user fact" in block
+        assert "tool output secret" not in block
+        assert "older user detail" not in block
+        assert "current" not in block
+    finally:
+        db.close()
+
+
+def test_skips_when_history_already_has_prior_dialog(tmp_path):
+    db = _db(tmp_path)
+    try:
+        _seed_session(db, "prior")
+        db.append_message("prior", "user", "remember this")
+
+        block = build_continuity_context(
+            session_db=db,
+            current_session_id="current",
+            is_first_turn=True,
+            conversation_history=[
+                {"role": "user", "content": "old"},
+                {"role": "assistant", "content": "reply"},
+                {"role": "user", "content": "new"},
+            ],
+            user_message="new",
+        )
+
+        assert block is None
+    finally:
+        db.close()
+
+
+def test_scopes_recall_to_same_source_and_user_when_available(tmp_path):
+    db = _db(tmp_path)
+    try:
+        _seed_session(db, "cli-session", source="cli", user_id="phil")
+        db.append_message("cli-session", "user", "private cli detail")
+
+        _seed_session(db, "telegram-other-user", source="telegram", user_id="other")
+        db.append_message("telegram-other-user", "user", "other user's telegram detail")
+
+        _seed_session(db, "telegram-same-user", source="telegram", user_id="phil")
+        db.append_message("telegram-same-user", "user", "same user telegram detail")
+
+        block = build_continuity_context(
+            session_db=db,
+            current_session_id="current",
+            is_first_turn=True,
+            conversation_history=[{"role": "user", "content": "hi"}],
+            user_message="hi",
+            platform="telegram",
+            sender_id="phil",
+        )
+
+        assert block is not None
+        assert "same user telegram detail" in block
+        assert "private cli detail" not in block
+        assert "other user's telegram detail" not in block
+    finally:
+        db.close()
+
+
+def test_hook_return_is_user_message_context_only(tmp_path):
+    db = _db(tmp_path)
+    try:
+        _seed_session(db, "prior")
+        db.append_message("prior", "user", "continuity detail")
+
+        result = pre_llm_call(
+            session_id="current",
+            is_first_turn=True,
+            conversation_history=[{"role": "user", "content": "hi"}],
+            user_message="hi",
+            session_db=db,
+        )
+
+        assert result is not None
+        assert set(result) == {"context"}
+        assert "continuity detail" in result["context"]
+    finally:
+        db.close()
+
+
+def test_status_helper_reports_candidate(tmp_path):
+    db = _db(tmp_path)
+    try:
+        _seed_session(db, "prior-status")
+        db.set_session_title("prior-status", "Status Title")
+        db.append_message("prior-status", "user", "hello")
+
+        status = continuity_status(session_db=db)
+
+        assert "enabled" in status
+        assert "prior-st" in status
+        assert "Status Title" in status
+    finally:
+        db.close()
+
+
+def test_plugin_manager_loads_bundled_plugin_when_enabled(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes_home"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"enabled": ["session_continuity"]}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    from hermes_cli.plugins import PluginManager
+
+    mgr = PluginManager()
+    mgr.discover_and_load()
+
+    loaded = mgr._plugins.get("session_continuity")
+    assert loaded is not None
+    assert loaded.enabled
+    assert "pre_llm_call" in loaded.hooks_registered
+    assert "continuity" in loaded.commands_registered

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -56,6 +56,7 @@ The repo ships these bundled plugins under `plugins/`. All are opt-in — enable
 | Plugin | Kind | Purpose |
 |---|---|---|
 | `disk-cleanup` | hooks + slash command | Auto-track ephemeral files and clean them on session end |
+| `session_continuity` | hook + slash command | On the first turn of a fresh session, inject a compact summary of the most recent previous visible session into the current user message |
 | `security-guidance` | hooks | Pattern-match dangerous code on `write_file`/`patch` and append a security warning (or block) — 25 rules (Apache-2.0 fork of Anthropic's `claude-plugins-official` patterns) |
 | `observability/langfuse` | hooks | Trace turns / LLM calls / tools to [Langfuse](https://langfuse.com) |
 | `observability/nemo_relay` | hooks | Relay observability events (turns / LLM calls / tools) to an NVIDIA NeMo endpoint |
@@ -117,6 +118,24 @@ Auto-tracks and removes ephemeral files created during sessions — test scripts
 **Enabling:** `hermes plugins enable disk-cleanup` (or check the box in `hermes plugins`).
 
 **Disabling again:** `hermes plugins disable disk-cleanup`.
+
+### session_continuity
+
+Restores lightweight continuity across fresh sessions without changing the cached system prompt. On the first turn only, the plugin finds the most recent previous visible session, takes its title/source/date/session prefix plus a few recent user/assistant messages, and returns it from `pre_llm_call` as `{"context": "..."}`. Hermes appends that context to the current user message at API-call time.
+
+It skips subagent, tool, cron, curator/catalog, archived, child, current, and empty sessions. By default it recalls from the same surface/source (for example Telegram recalls Telegram sessions, CLI recalls CLI sessions), and when both sessions have a user id it requires that user id to match. Tool messages and tool-call-only assistant messages are not included. No LLM calls are made.
+
+**Enabling:** `hermes plugins enable session_continuity`.
+
+Optional config:
+
+```yaml
+session_continuity:
+  max_chars: 2000
+  message_limit: 6
+```
+
+**Slash command:** `/continuity status` shows the current candidate; `/continuity reset` is a no-op because the plugin keeps no persistent state.
 
 ### security-guidance
 


### PR DESCRIPTION
## Summary

Opt-in plugin that injects a compact continuity block on the first turn of a fresh user-facing session — the agent sees a brief summary of the most recent visible previous session before the first message is sent to the LLM. No system-prompt mutation, no model calls, no cache invalidation.

## Design

- **Plugin hook:** `pre_llm_call` — returns `{"context": "..."}` which Hermes appends to the current user message at API-call time. The cached system prompt is never touched.
- **Deterministic:** zero LLM calls. Pulls raw messages from the SQLite session DB and formats them as a compact text block. Full token budget control via `max_chars` (configurable in `config.yaml`, default 2000, clamped 500–8000).
- **Scope-safe:** Only recalls sessions from the same platform surface (CLI → CLI, Telegram → Telegram, etc.) and same user_id when available. Excludes subagent, tool, cron, curator, and archived sessions.
- **Fail-closed:** If SessionDB is unavailable, config is broken, or any error occurs — the hook returns `None` silently. Logged at debug level.

## What it looks like in action

When you open a fresh CLI session after chatting earlier, the first message the model sees has this appended:

```
[Session continuity: most recent previous visible session]
Session: abc12345
Source: cli
Title: Project Alpha
Last active: 2026-06-13T18:15:26Z
Recent dialog:
- User: first user fact
- Assistant: assistant answer
- User: latest user fact...
```

## Files

| File | Purpose |
|------|---------|
| `plugins/session_continuity/__init__.py` | Core plugin logic: settings loader, session recall, message clipping, hook callback |
| `plugins/session_continuity/plugin.yaml` | Plugin manifest (standalone, pre_llm_call hook) |
| `tests/plugins/test_session_continuity_plugin.py` | 8 tests covering first-turn gating, source/user scoping, content clipping, hook shape, DB unavailability, and integration with PluginManager |

## Testing

```
collected 8 items
tests/plugins/test_session_continuity_plugin.py ........ [100%]
```

## Usage

Enable in `config.yaml`:

```yaml
plugins:
  enabled:
    - session_continuity
```

Optional settings:

```yaml
session_continuity:
  max_chars: 2000      # 500-8000, default 2000
  message_limit: 6     # 2-12 recent dialog messages, default 6
```

Slash command: `/continuity status` shows which session would be recalled next.
