### PR TITLE
fix(mcp): preserve event loop during probes

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -212,7 +212,7 @@ def _probe_single_server(
         _ensure_mcp_loop,
         _run_on_mcp_loop,
         _connect_server,
-        _stop_mcp_loop,
+        _stop_mcp_loop_if_idle,
     )
 
     config = _resolve_mcp_server_config(config)
@@ -240,7 +240,7 @@ def _probe_single_server(
     except BaseException as exc:
         raise _unwrap_exception_group(exc) from None
     finally:
-        _stop_mcp_loop()
+        _stop_mcp_loop_if_idle()
 
     return tools_found
 

--- a/tests/tools/test_mcp_probe.py
+++ b/tests/tools/test_mcp_probe.py
@@ -162,14 +162,14 @@ class TestProbeMcpServerTools:
         assert result["github"][0] == ("my_tool", "")
 
     def test_cleanup_called_even_on_failure(self):
-        """_stop_mcp_loop is called even when probe fails."""
+        """Probe cleanup is attempted even when probe fails."""
         config = {"github": {"command": "npx", "connect_timeout": 5}}
 
         with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
              patch("tools.mcp_tool._load_mcp_config", return_value=config), \
              patch("tools.mcp_tool._ensure_mcp_loop"), \
              patch("tools.mcp_tool._run_on_mcp_loop", side_effect=RuntimeError("boom")), \
-             patch("tools.mcp_tool._stop_mcp_loop") as mock_stop:
+             patch("tools.mcp_tool._stop_mcp_loop_if_idle") as mock_stop:
 
             from tools.mcp_tool import probe_mcp_server_tools
             result = probe_mcp_server_tools()

--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -57,6 +57,32 @@ class TestMCPLoopExceptionHandler:
         finally:
             mcp_mod._stop_mcp_loop()
 
+    def test_probe_cleanup_does_not_stop_loop_with_registered_servers(self):
+        """Probe cleanup must not kill the shared loop used by live MCP tools."""
+        import tools.mcp_tool as mcp_mod
+
+        with mcp_mod._lock:
+            mcp_mod._servers.clear()
+            mcp_mod._server_connecting.clear()
+        try:
+            mcp_mod._ensure_mcp_loop()
+            with mcp_mod._lock:
+                loop = mcp_mod._mcp_loop
+                mcp_mod._servers["live"] = MagicMock(session=object())
+
+            assert mcp_mod._stop_mcp_loop_if_idle() is False
+
+            with mcp_mod._lock:
+                assert mcp_mod._mcp_loop is loop
+                assert mcp_mod._mcp_thread is not None
+            assert loop is not None
+            assert loop.is_running()
+        finally:
+            with mcp_mod._lock:
+                mcp_mod._servers.clear()
+                mcp_mod._server_connecting.clear()
+            mcp_mod._stop_mcp_loop()
+
 
 # ---------------------------------------------------------------------------
 # Fix 2: stdio PID tracking

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3946,7 +3946,7 @@ def probe_mcp_server_tools() -> Dict[str, List[tuple]]:
     except Exception as exc:
         logger.debug("MCP probe failed: %s", exc)
     finally:
-        _stop_mcp_loop()
+        _stop_mcp_loop_if_idle()
 
     return result
 
@@ -4084,10 +4084,25 @@ def _kill_orphaned_mcp_children(include_active: bool = False) -> None:
         )
 
 
-def _stop_mcp_loop():
+def _stop_mcp_loop_if_idle() -> bool:
+    """Stop the MCP loop only when no registered server still owns it.
+
+    Probe paths create temporary MCPServerTask instances that are not placed in
+    ``_servers``.  They should clean up an otherwise-idle loop, but must not
+    tear down the process-global loop when live agent tools are registered on
+    it.  Otherwise a dashboard/CLI probe can make later MCP tool calls fail
+    with ``MCP event loop is not running``.
+    """
+    return _stop_mcp_loop(only_if_idle=True)
+
+
+def _stop_mcp_loop(*, only_if_idle: bool = False) -> bool:
     """Stop the background event loop and join its thread."""
     global _mcp_loop, _mcp_thread
     with _lock:
+        if only_if_idle and (_servers or _server_connecting):
+            logger.debug("Leaving MCP event loop running; active servers are registered or connecting")
+            return False
         loop = _mcp_loop
         thread = _mcp_thread
         _mcp_loop = None
@@ -4104,3 +4119,4 @@ def _stop_mcp_loop():
         # graceful shutdown are now orphaned — include active PIDs too
         # since the loop is gone and no session can still be in flight.
         _kill_orphaned_mcp_children(include_active=True)
+    return True


### PR DESCRIPTION
## What does this PR do?

Prevents MCP probe/test cleanup from stopping the process-global MCP event loop while registered or connecting MCP servers still own it.

A support report showed runtime tool calls failing with `RuntimeError: MCP event loop is not running` even though `hermes mcp test <server>` passed and the HTTP MCP server was reachable. The code path matches a lifecycle race: `hermes_cli.mcp_config._probe_single_server()` and `tools.mcp_tool.probe_mcp_server_tools()` temporarily connect to MCP servers, then unconditionally call `_stop_mcp_loop()` in cleanup. In a dashboard/gateway process that already has registered MCP tools, that stops the shared loop underneath live tool handlers. Later calls to `_run_on_mcp_loop()` then fail before they can schedule the MCP tool call.

This keeps the existing probe cleanup behavior when the loop is idle, but leaves it running when `_servers` or `_server_connecting` show active registered MCP ownership.

Adjacent PR checked before this change: #39163. That fixes shutdown of temporary probed servers, but not stopping the shared MCP loop while registered tools are live.

## Related Issue

None filed from the support thread.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `tools/mcp_tool.py`: add `_stop_mcp_loop_if_idle()` and `only_if_idle` support on `_stop_mcp_loop()`.
- `tools/mcp_tool.py`: make `probe_mcp_server_tools()` use idle-only cleanup.
- `hermes_cli/mcp_config.py`: make `_probe_single_server()` use idle-only cleanup.
- `tests/tools/test_mcp_stability.py`: add regression coverage that probe cleanup leaves the loop running when a registered server exists.
- `tests/tools/test_mcp_probe.py`: update cleanup expectation to the new idle-only helper.

## How to Test

1. Start an agent session with an MCP server registered.
2. Run a dashboard/CLI MCP test/probe in the same process.
3. Call an MCP tool from the agent session again.
4. The tool call should still schedule on the existing MCP event loop instead of failing with `MCP event loop is not running`.
5. Run `scripts/run_tests.sh -j 4 tests/tools/test_mcp_stability.py tests/tools/test_mcp_probe.py tests/hermes_cli/test_mcp_config.py -- -q`.

## Checklist

### Code

- [ ] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: WSL/Linux targeted test runner

### Documentation & Housekeeping

- [x] I have updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I have considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I have updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

Focused test run:

`scripts/run_tests.sh -j 4 tests/tools/test_mcp_stability.py tests/tools/test_mcp_probe.py tests/hermes_cli/test_mcp_config.py -- -q`

Result: 3 files, 71 tests passed, 0 failed.
