### PR TITLE
fix(copilot-acp): detect provider and honor selected model

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -410,6 +410,7 @@ class CopilotACPClient:
         response_text, reasoning_text = self._run_prompt(
             prompt_text,
             timeout_seconds=_effective_timeout,
+            model=model,
         )
 
         tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)
@@ -435,7 +436,15 @@ class CopilotACPClient:
             model=model or "copilot-acp",
         )
 
-    def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
+    def _run_prompt(
+        self,
+        prompt_text: str,
+        *,
+        timeout_seconds: float,
+        model: str | None = None,
+    ) -> tuple[str, str]:
+        selected_model = str(model or "").strip()
+
         try:
             proc = subprocess.Popen(
                 [self._acp_command] + self._acp_args,
@@ -574,6 +583,15 @@ class CopilotACPClient:
             session_id = str(session.get("sessionId") or "").strip()
             if not session_id:
                 raise RuntimeError("Copilot ACP did not return a sessionId.")
+
+            if selected_model and selected_model != "copilot-acp":
+                _request(
+                    "session/set_model",
+                    {
+                        "sessionId": session_id,
+                        "modelId": selected_model,
+                    },
+                )
 
             text_parts: list[str] = []
             reasoning_parts: list[str] = []

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1467,6 +1467,18 @@ def list_authenticated_providers(
         has_creds = False
         if overlay.auth_type == "aws_sdk":
             has_creds = _has_aws_sdk_creds_for_listing(hermes_slug)
+        elif overlay.auth_type == "external_process":
+            try:
+                from hermes_cli.auth import get_external_process_provider_status
+
+                status = get_external_process_provider_status(hermes_slug)
+                has_creds = bool(status.get("configured"))
+            except Exception as exc:
+                logger.debug(
+                    "External-process provider check failed for %s: %s",
+                    hermes_slug,
+                    exc,
+                )
         elif overlay.extra_env_vars:
             has_creds = any(os.environ.get(ev) for ev in overlay.extra_env_vars)
         # Also check api_key_env_vars from PROVIDER_REGISTRY for api_key auth_type

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -205,3 +205,78 @@ def test_run_prompt_passes_home_when_parent_env_is_clean(monkeypatch, tmp_path):
 
     assert "env" in captured["kwargs"]
     assert captured["kwargs"]["env"]["HOME"]
+
+
+
+def test_chat_completion_sets_model_on_created_acp_session(monkeypatch, tmp_path):
+    class FakeACPProcess:
+        def __init__(self):
+            self.stdin = io.StringIO()
+            self.stdout = io.StringIO(
+                "\n".join(
+                    json.dumps(message)
+                    for message in [
+                        {"jsonrpc": "2.0", "id": 1, "result": {}},
+                        {
+                            "jsonrpc": "2.0",
+                            "id": 2,
+                            "result": {"sessionId": "session-1"},
+                        },
+                        {"jsonrpc": "2.0", "id": 3, "result": {}},
+                        {
+                            "jsonrpc": "2.0",
+                            "method": "session/update",
+                            "params": {
+                                "update": {
+                                    "sessionUpdate": "agent_message_chunk",
+                                    "content": {"text": "ok"},
+                                }
+                            },
+                        },
+                        {"jsonrpc": "2.0", "id": 4, "result": {}},
+                    ]
+                )
+                + "\n"
+            )
+            self.stderr = io.StringIO()
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            return None
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            return None
+
+    process = FakeACPProcess()
+    client = _make_home_client(tmp_path)
+    monkeypatch.setattr(
+        "agent.copilot_acp_client.subprocess.Popen",
+        lambda *args, **kwargs: process,
+    )
+
+    response = client.chat.completions.create(
+        model="claude-opus-4.7",
+        messages=[{"role": "user", "content": "hello"}],
+        timeout=1,
+    )
+
+    requests = [
+        json.loads(line)
+        for line in process.stdin.getvalue().splitlines()
+        if line.strip()
+    ]
+    assert requests[2] == {
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "session/set_model",
+        "params": {
+            "sessionId": "session-1",
+            "modelId": "claude-opus-4.7",
+        },
+    }
+    assert response.choices[0].message.content == "ok"

--- a/tests/hermes_cli/test_copilot_in_model_list.py
+++ b/tests/hermes_cli/test_copilot_in_model_list.py
@@ -20,3 +20,22 @@ def test_copilot_picker_uses_live_catalog_when_available():
     assert copilot is not None
     assert copilot["models"] == live_models
     assert copilot["total_models"] == len(live_models)
+
+
+def test_copilot_acp_picker_detects_installed_cli():
+    with patch("agent.models_dev.fetch_models_dev", return_value={}), \
+         patch("hermes_cli.auth.shutil.which", return_value="/usr/local/bin/copilot"), \
+         patch("hermes_cli.models.cached_provider_model_ids", return_value=["copilot-acp"]):
+        providers = list_authenticated_providers(
+            current_provider="openrouter",
+            max_models=50,
+        )
+
+    copilot_acp = next(
+        (p for p in providers if p["slug"] == "copilot-acp"),
+        None,
+    )
+
+    assert copilot_acp is not None
+    assert copilot_acp["models"] == ["copilot-acp"]
+    assert copilot_acp["total_models"] == 1


### PR DESCRIPTION
## What does this PR do?

Fixes two related GitHub Copilot ACP integration bugs:

1. An installed `copilot` CLI was not treated as configured by the model inventory, so `copilot-acp` was hidden or shown as requiring setup in the TUI and Desktop model pickers.
2. Hermes displayed the selected Copilot model but never applied it to the created ACP session. Copilot therefore continued using its persisted default model instead.

The picker now detects configured `external_process` providers through their provider status. After `session/new`, the ACP client applies the Hermes model with the protocol-native `session/set_model` request before prompting.

## Related Issue

Fixes #45858. Reproduced end-to-end with GitHub Copilot CLI 1.0.62 on Linux.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/model_switch.py`: recognize configured external-process providers during picker inventory construction.
- `agent/copilot_acp_client.py`: propagate the requested model and call `session/set_model` after creating the ACP session.
- `tests/hermes_cli/test_copilot_in_model_list.py`: cover installed Copilot CLI discovery.
- `tests/agent/test_copilot_acp_client.py`: verify the model is applied to the created ACP session before the prompt.

## How to Test

1. Authenticate the GitHub Copilot CLI and confirm `copilot --acp` is available.
2. Select `GitHub Copilot ACP` and a non-default model such as `claude-opus-4.7` in Hermes Desktop.
3. Start a new session and verify Copilot's session event contains `session.model_change` with `newModel: claude-opus-4.7`.

Automated checks:

```text
10 passed in 1.08s
All checks passed! (ruff)
```

A full local suite run was attempted, but unrelated ACP adapter tests could not collect because the optional `acp` package was absent from the local test environment. The two changed test files pass completely.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] `cli-config.yaml.example` update: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A
- [x] Cross-platform impact considered: Python subprocess and ACP JSON-RPC paths remain platform-neutral
- [x] Tool descriptions/schemas update: N/A

## Screenshots / Logs

Before the fix, Hermes showed `claude-opus-4.7`, while Copilot's own session events selected `gpt-5.5`.

After the fix, Copilot's persisted session event reports:

```json
{"type":"session.model_change","data":{"newModel":"claude-opus-4.7"}}
```

