### PR TITLE
feat: add generic runtime guard hooks

### DIFF
--- a/agent/runtime_guard.py
+++ b/agent/runtime_guard.py
@@ -1,0 +1,235 @@
+"""Generic disabled-by-default runtime guard primitives."""
+
+from __future__ import annotations
+
+import contextvars
+import json
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from agent.runtime_guard_fallback import (
+    _runtime_guard_cfg,
+    runtime_guard_blocked_text,
+    runtime_guard_guard_error_reason,
+)
+from agent.runtime_guard_types import GuardContext, GuardDecision
+
+logger = logging.getLogger(__name__)
+
+_CURRENT_RUNTIME_GUARD: contextvars.ContextVar[Any] = contextvars.ContextVar(
+    "runtime_guard",
+    default=None,
+)
+
+
+class RuntimeGuardUnavailable(RuntimeError):
+    """Raised when runtime guard is enabled but no guard implementation exists."""
+
+
+def set_current_runtime_guard(guard: Any):
+    """Install a guard object for the current context and return a reset token."""
+    return _CURRENT_RUNTIME_GUARD.set(guard)
+
+
+def reset_current_runtime_guard(token) -> None:
+    """Reset a guard token returned by ``set_current_runtime_guard``."""
+    _CURRENT_RUNTIME_GUARD.reset(token)
+
+
+def _load_runtime_guard_config() -> Mapping[str, Any]:
+    from hermes_cli.config import load_config_readonly
+
+    return _runtime_guard_cfg(load_config_readonly())
+
+
+def _config_for_agent(agent: Any = None) -> Mapping[str, Any]:
+    if agent is not None:
+        for attr in ("_runtime_guard_config", "runtime_guard_config"):
+            config = getattr(agent, attr, None)
+            if isinstance(config, Mapping):
+                return _runtime_guard_cfg(config)
+    return _load_runtime_guard_config()
+
+
+def runtime_guard_enabled(agent: Any = None, *, config: Mapping[str, Any] | None = None) -> bool:
+    cfg = _runtime_guard_cfg(config) if config is not None else _config_for_agent(agent)
+    return bool(cfg.get("enabled", False))
+
+
+def runtime_guard_fail_closed(agent: Any = None, *, config: Mapping[str, Any] | None = None) -> bool:
+    cfg = _runtime_guard_cfg(config) if config is not None else _config_for_agent(agent)
+    return bool(cfg.get("fail_closed", True))
+
+
+def _runtime_guard_for_agent(agent: Any = None) -> Any:
+    guard = _CURRENT_RUNTIME_GUARD.get()
+    if guard is not None:
+        return guard
+    if agent is not None:
+        for attr in ("_runtime_guard", "runtime_guard"):
+            guard = getattr(agent, attr, None)
+            if guard is not None:
+                return guard
+    raise RuntimeGuardUnavailable("no runtime_guard implementation is active")
+
+
+def _coerce_decision(value: Any, context: GuardContext) -> GuardDecision:
+    if isinstance(value, GuardDecision):
+        return value.with_context(context)
+    if value is None or value is True:
+        return GuardDecision.allow(context=context)
+    if value is False:
+        return GuardDecision.block("runtime_guard blocked this action", context=context)
+    if isinstance(value, Mapping):
+        allowed = bool(value.get("allowed", value.get("allow", False)))
+        if allowed:
+            return GuardDecision.allow(str(value.get("reason") or "allowed"), context=context)
+        return GuardDecision.block(
+            str(value.get("reason") or value.get("message") or "runtime_guard blocked this action"),
+            message=str(value.get("message") or value.get("reason") or ""),
+            code=str(value.get("code") or "runtime_guard_block"),
+            replacement_text=value.get("replacement_text"),
+            context=context,
+            metadata=value.get("metadata") if isinstance(value.get("metadata"), Mapping) else None,
+        )
+    return GuardDecision.allow(context=context)
+
+
+def _evaluate_guard(
+    *,
+    agent: Any = None,
+    context: GuardContext,
+    payload: Mapping[str, Any] | None = None,
+) -> GuardDecision:
+    guard = _runtime_guard_for_agent(agent)
+    payload = dict(payload or {})
+    method_names = (
+        f"guard_{context.guard_name}",
+        f"evaluate_{context.guard_name}",
+        "guard",
+        "evaluate",
+    )
+    for method_name in method_names:
+        method = getattr(guard, method_name, None)
+        if callable(method):
+            return _coerce_decision(method(context, **payload), context)
+    if callable(guard):
+        return _coerce_decision(guard(context, **payload), context)
+    raise RuntimeGuardUnavailable("runtime_guard implementation has no callable guard method")
+
+
+def _guard_internal_error_decision(
+    exc: BaseException,
+    *,
+    agent: Any = None,
+    context: GuardContext,
+) -> GuardDecision:
+    if runtime_guard_fail_closed(agent):
+        reason = runtime_guard_guard_error_reason(exc, guard_name=context.guard_name)
+        return GuardDecision.block(reason, code="runtime_guard_error", context=context)
+    logger.debug("runtime_guard failed open for %s: %s", context.guard_name, exc)
+    return GuardDecision.allow("runtime_guard failed open", context=context)
+
+
+def guard_tool_action_for_agent(
+    agent: Any,
+    tool_name: str,
+    tool_args: Mapping[str, Any] | None,
+    *,
+    task_id: str = "",
+    tool_call_id: str = "",
+) -> GuardDecision:
+    context = GuardContext(
+        guard_name="tool_action",
+        action=f"tool:{tool_name}",
+        session_id=getattr(agent, "session_id", "") or "",
+        task_id=task_id or "",
+        tool_call_id=tool_call_id or "",
+        turn_id=getattr(agent, "_current_turn_id", "") or "",
+        api_request_id=getattr(agent, "_current_api_request_id", "") or "",
+        platform=getattr(agent, "platform", "") or "",
+        tool_name=tool_name,
+        tool_args=tool_args or {},
+    )
+    if not runtime_guard_enabled(agent):
+        return GuardDecision.allow("runtime_guard disabled", context=context)
+    try:
+        return _evaluate_guard(agent=agent, context=context, payload={"tool_args": tool_args or {}})
+    except Exception as exc:
+        return _guard_internal_error_decision(exc, agent=agent, context=context)
+
+
+def guard_tool_action_for_current_context(
+    tool_name: str,
+    tool_args: Mapping[str, Any] | None,
+    *,
+    task_id: str = "",
+    session_id: str = "",
+    tool_call_id: str = "",
+    turn_id: str = "",
+    api_request_id: str = "",
+    platform: str = "",
+) -> GuardDecision:
+    context = GuardContext(
+        guard_name="tool_action",
+        action=f"tool:{tool_name}",
+        session_id=session_id or "",
+        task_id=task_id or "",
+        tool_call_id=tool_call_id or "",
+        turn_id=turn_id or "",
+        api_request_id=api_request_id or "",
+        platform=platform or "",
+        tool_name=tool_name,
+        tool_args=tool_args or {},
+    )
+    if not runtime_guard_enabled():
+        return GuardDecision.allow("runtime_guard disabled", context=context)
+    try:
+        return _evaluate_guard(context=context, payload={"tool_args": tool_args or {}})
+    except Exception as exc:
+        return _guard_internal_error_decision(exc, context=context)
+
+
+def guard_final_output_for_agent(agent: Any, text: str) -> GuardDecision:
+    context = GuardContext(
+        guard_name="final_output",
+        action="final_output",
+        session_id=getattr(agent, "session_id", "") or "",
+        platform=getattr(agent, "platform", "") or "",
+    )
+    if not runtime_guard_enabled(agent):
+        return GuardDecision.allow("runtime_guard disabled", context=context)
+    try:
+        return _evaluate_guard(agent=agent, context=context, payload={"text": text})
+    except Exception as exc:
+        return _guard_internal_error_decision(exc, agent=agent, context=context)
+
+
+def guarded_final_output_for_agent(agent: Any, text: str) -> str:
+    decision = guard_final_output_for_agent(agent, text)
+    if decision.allowed:
+        return text
+    return final_output_block_text(decision)
+
+
+def tool_block_result(decision: GuardDecision) -> str:
+    message = decision.message or decision.reason or "runtime_guard blocked this action"
+    code = decision.code or "runtime_guard_block"
+    return json.dumps(
+        {
+            "error": message,
+            "status": "blocked",
+            "blocked_by": "runtime_guard",
+            "code": code,
+            "runtime_guard_block": decision.to_metadata(),
+        },
+        ensure_ascii=False,
+    )
+
+
+def final_output_block_text(decision: GuardDecision) -> str:
+    if decision.replacement_text:
+        return decision.replacement_text
+    reason = decision.message or decision.reason or "runtime_guard blocked the response"
+    return runtime_guard_blocked_text(reason, guard_name="final_output")

--- a/agent/runtime_guard_fallback.py
+++ b/agent/runtime_guard_fallback.py
@@ -1,0 +1,131 @@
+"""Import-independent fallback helpers for the generic runtime guard.
+
+These helpers avoid importing ``agent.runtime_guard`` so callers can still
+fail closed when the main guard module or a configured guard cannot be
+resolved.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+
+def _runtime_guard_cfg(config: Any) -> Mapping[str, Any]:
+    if not isinstance(config, Mapping):
+        return {}
+    block = config.get("runtime_guard")
+    return block if isinstance(block, Mapping) else config
+
+
+def _load_runtime_guard_cfg_readonly() -> tuple[Mapping[str, Any], bool]:
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        return _runtime_guard_cfg(load_config_readonly()), True
+    except Exception:
+        return {}, False
+
+
+def _agent_runtime_guard_cfg(agent: Any) -> tuple[Mapping[str, Any], bool]:
+    for attr in ("_runtime_guard_config", "runtime_guard_config"):
+        config = getattr(agent, attr, None)
+        if isinstance(config, Mapping):
+            return _runtime_guard_cfg(config), True
+    return _load_runtime_guard_cfg_readonly()
+
+
+def _enabled_and_fail_closed(cfg: Mapping[str, Any]) -> bool:
+    return bool(cfg.get("enabled", False)) and bool(cfg.get("fail_closed", True))
+
+
+def runtime_guard_enabled_for_agent(agent: Any) -> bool:
+    cfg, _ = _agent_runtime_guard_cfg(agent)
+    return bool(cfg.get("enabled", False))
+
+
+def runtime_guard_enabled_for_current_context() -> bool:
+    cfg, _ = _load_runtime_guard_cfg_readonly()
+    return bool(cfg.get("enabled", False))
+
+
+def runtime_guard_guard_error_reason(exc: BaseException, *, guard_name: str) -> str:
+    detail = str(exc) or exc.__class__.__name__
+    return f"runtime_guard {guard_name} guard internal error: {detail}"
+
+
+def runtime_guard_block_result(
+    reason: str,
+    *,
+    guard_name: str,
+    code: str = "runtime_guard_error",
+    metadata: Mapping[str, Any] | None = None,
+) -> str:
+    block = {
+        "allowed": False,
+        "reason": reason,
+        "message": reason,
+        "code": code,
+        "context": {"guard_name": guard_name, "action": guard_name},
+    }
+    if metadata:
+        block["metadata"] = dict(metadata)
+    return json.dumps(
+        {
+            "error": reason,
+            "status": "blocked",
+            "blocked_by": "runtime_guard",
+            "code": code,
+            "runtime_guard_block": block,
+        },
+        ensure_ascii=False,
+    )
+
+
+def runtime_guard_tool_block_for_agent_guard_error(
+    agent: Any,
+    exc: BaseException,
+    *,
+    guard_name: str,
+) -> tuple[str | None, str | None]:
+    cfg, _ = _agent_runtime_guard_cfg(agent)
+    if not _enabled_and_fail_closed(cfg):
+        return None, None
+    reason = runtime_guard_guard_error_reason(exc, guard_name=guard_name)
+    return runtime_guard_block_result(reason, guard_name=guard_name), reason
+
+
+def runtime_guard_tool_block_for_current_guard_error(
+    exc: BaseException,
+    *,
+    guard_name: str,
+) -> tuple[str | None, str | None]:
+    cfg, _ = _load_runtime_guard_cfg_readonly()
+    if not _enabled_and_fail_closed(cfg):
+        return None, None
+    reason = runtime_guard_guard_error_reason(exc, guard_name=guard_name)
+    return runtime_guard_block_result(reason, guard_name=guard_name), reason
+
+
+def runtime_guard_blocked_text(reason: str, *, guard_name: str) -> str:
+    return (
+        "Response blocked by runtime_guard.\n\n"
+        f"Guard: {guard_name}\n"
+        f"Reason: {reason}"
+    )
+
+
+def runtime_guard_final_text_for_agent_guard_error(
+    agent: Any,
+    exc: BaseException,
+    *,
+    guard_name: str,
+) -> str | None:
+    cfg, _ = _agent_runtime_guard_cfg(agent)
+    if not _enabled_and_fail_closed(cfg):
+        return None
+    return runtime_guard_blocked_text(
+        runtime_guard_guard_error_reason(exc, guard_name=guard_name),
+        guard_name=guard_name,
+    )

--- a/agent/runtime_guard_types.py
+++ b/agent/runtime_guard_types.py
@@ -1,0 +1,114 @@
+"""Generic runtime guard data types.
+
+These primitives intentionally do not encode any deployment-specific policy.
+They give embedders a stable shape for deciding whether a runtime action may
+continue, while the default runtime guard remains disabled.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class GuardContext:
+    """Context passed to a runtime guard decision point."""
+
+    guard_name: str
+    action: str = ""
+    session_id: str = ""
+    task_id: str = ""
+    tool_call_id: str = ""
+    turn_id: str = ""
+    api_request_id: str = ""
+    platform: str = ""
+    tool_name: str = ""
+    tool_args: Mapping[str, Any] = field(default_factory=dict)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_metadata(self) -> dict[str, Any]:
+        """Return non-sensitive context metadata for blocked tool results."""
+        data: dict[str, Any] = {
+            "guard_name": self.guard_name,
+            "action": self.action,
+        }
+        for key in (
+            "session_id",
+            "task_id",
+            "tool_call_id",
+            "turn_id",
+            "api_request_id",
+            "platform",
+            "tool_name",
+        ):
+            value = getattr(self, key)
+            if value:
+                data[key] = value
+        if self.metadata:
+            data["metadata"] = dict(self.metadata)
+        return data
+
+
+@dataclass(frozen=True)
+class GuardDecision:
+    """Decision returned by a runtime guard."""
+
+    allowed: bool
+    reason: str = ""
+    message: str = ""
+    code: str = ""
+    replacement_text: str | None = None
+    context: GuardContext | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def allow(cls, reason: str = "allowed", *, context: GuardContext | None = None) -> "GuardDecision":
+        return cls(True, reason=reason, code="allowed", context=context)
+
+    @classmethod
+    def block(
+        cls,
+        reason: str,
+        *,
+        message: str | None = None,
+        code: str = "runtime_guard_block",
+        replacement_text: str | None = None,
+        context: GuardContext | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> "GuardDecision":
+        return cls(
+            False,
+            reason=reason,
+            message=message or reason,
+            code=code,
+            replacement_text=replacement_text,
+            context=context,
+            metadata=dict(metadata or {}),
+        )
+
+    def with_context(self, context: GuardContext) -> "GuardDecision":
+        if self.context is context:
+            return self
+        return GuardDecision(
+            allowed=self.allowed,
+            reason=self.reason,
+            message=self.message,
+            code=self.code,
+            replacement_text=self.replacement_text,
+            context=context,
+            metadata=self.metadata,
+        )
+
+    def to_metadata(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "allowed": self.allowed,
+            "reason": self.reason,
+            "message": self.message or self.reason,
+            "code": self.code or ("allowed" if self.allowed else "runtime_guard_block"),
+        }
+        if self.context is not None:
+            data["context"] = self.context.to_metadata()
+        if self.metadata:
+            data["metadata"] = dict(self.metadata)
+        return data

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -103,6 +103,38 @@ def _cancelled_tool_result(reason: str = "user interrupt") -> str:
     )
 
 
+def _runtime_guard_tool_block(
+    agent,
+    *,
+    function_name: str,
+    function_args: dict,
+    effective_task_id: str,
+    tool_call_id: str,
+) -> tuple[str | None, str | None]:
+    try:
+        from agent.runtime_guard import guard_tool_action_for_agent, tool_block_result
+
+        decision = guard_tool_action_for_agent(
+            agent,
+            function_name,
+            function_args,
+            task_id=effective_task_id or "",
+            tool_call_id=tool_call_id or "",
+        )
+        if decision.allowed:
+            return None, None
+        return tool_block_result(decision), decision.message or decision.reason
+    except Exception as exc:
+        logger.debug("runtime_guard tool guard error: %s", exc)
+        from agent.runtime_guard_fallback import runtime_guard_tool_block_for_agent_guard_error
+
+        return runtime_guard_tool_block_for_agent_guard_error(
+            agent,
+            exc,
+            guard_name="tool_action",
+        )
+
+
 def _emit_cancelled_terminal_post_tool_call(
     agent,
     *,
@@ -372,10 +404,15 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     middleware_trace=list(middleware_trace),
                 )
             else:
-                guardrail_decision = agent._tool_guardrails.before_call(function_name, function_args)
-                if not guardrail_decision.allows_execution:
-                    block_result = agent._guardrail_block_result(guardrail_decision)
-                    blocked_by_guardrail = True
+                runtime_guard_block, runtime_guard_reason = _runtime_guard_tool_block(
+                    agent,
+                    function_name=function_name,
+                    function_args=function_args,
+                    effective_task_id=effective_task_id,
+                    tool_call_id=getattr(tool_call, "id", "") or "",
+                )
+                if runtime_guard_block is not None:
+                    block_result = runtime_guard_block
                     _emit_terminal_post_tool_call(
                         agent,
                         function_name=function_name,
@@ -384,10 +421,30 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                         effective_task_id=effective_task_id,
                         tool_call_id=getattr(tool_call, "id", "") or "",
                         status="blocked",
-                        error_type="guardrail_block",
-                        error_message=getattr(guardrail_decision, "message", None) or "Tool blocked by guardrail policy",
+                        error_type="runtime_guard",
+                        error_message=runtime_guard_reason,
                         middleware_trace=list(middleware_trace),
                     )
+                else:
+                    guardrail_decision = agent._tool_guardrails.before_call(function_name, function_args)
+                    if not guardrail_decision.allows_execution:
+                        block_result = agent._guardrail_block_result(guardrail_decision)
+                        blocked_by_guardrail = True
+                        _emit_terminal_post_tool_call(
+                            agent,
+                            function_name=function_name,
+                            function_args=function_args,
+                            result=block_result,
+                            effective_task_id=effective_task_id,
+                            tool_call_id=getattr(tool_call, "id", "") or "",
+                            status="blocked",
+                            error_type="guardrail_block",
+                            error_message=(
+                                getattr(guardrail_decision, "message", None)
+                                or "Tool blocked by guardrail policy"
+                            ),
+                            middleware_trace=list(middleware_trace),
+                        )
 
         # ── Checkpoint preflight (only for tools that will execute) ──
         if block_result is None:
@@ -829,6 +886,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # Check plugin hooks for a block directive before executing.
         _block_msg: Optional[str] = None
         _block_error_type = "plugin_block"
+        _structured_block_result: str | None = None
         if _ts_scope_block is not None:
             _block_msg = _ts_scope_block
             _block_error_type = "tool_scope_block"
@@ -850,9 +908,21 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
 
         _guardrail_block_decision: ToolGuardrailDecision | None = None
         if _block_msg is None:
-            guardrail_decision = agent._tool_guardrails.before_call(function_name, function_args)
-            if not guardrail_decision.allows_execution:
-                _guardrail_block_decision = guardrail_decision
+            _runtime_block_result, _runtime_block_reason = _runtime_guard_tool_block(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                effective_task_id=effective_task_id,
+                tool_call_id=getattr(tool_call, "id", "") or "",
+            )
+            if _runtime_block_result is not None:
+                _block_msg = _runtime_block_reason or "runtime_guard blocked this action"
+                _block_error_type = "runtime_guard"
+                _structured_block_result = _runtime_block_result
+            else:
+                guardrail_decision = agent._tool_guardrails.before_call(function_name, function_args)
+                if not guardrail_decision.allows_execution:
+                    _guardrail_block_decision = guardrail_decision
 
         _execution_blocked = _block_msg is not None or _guardrail_block_decision is not None
 
@@ -930,7 +1000,10 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
 
         if _block_msg is not None:
             # Tool blocked by plugin policy — return error without executing.
-            function_result = json.dumps({"error": _block_msg}, ensure_ascii=False)
+            function_result = _structured_block_result or json.dumps(
+                {"error": _block_msg},
+                ensure_ascii=False,
+            )
             tool_duration = 0.0
             _emit_terminal_post_tool_call(
                 agent,

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -284,6 +284,34 @@ def finalize_turn(
         except Exception as exc:
             logger.warning("transform_llm_output hook failed: %s", exc)
 
+    # Runtime guard: validate final text after existing response transforms and
+    # before downstream observers or delivery code consume it.
+    if final_response and not interrupted:
+        try:
+            from agent.runtime_guard import guarded_final_output_for_agent
+
+            _guarded_response = guarded_final_output_for_agent(agent, final_response)
+            if _guarded_response != final_response:
+                final_response = _guarded_response
+                _response_transformed = True
+        except Exception as exc:
+            logger.debug("runtime_guard final-output guard failed: %s", exc)
+            try:
+                from agent.runtime_guard_fallback import (
+                    runtime_guard_final_text_for_agent_guard_error,
+                )
+
+                _fallback_response = runtime_guard_final_text_for_agent_guard_error(
+                    agent,
+                    exc,
+                    guard_name="final_output",
+                )
+                if _fallback_response is not None:
+                    final_response = _fallback_response
+                    _response_transformed = True
+            except Exception:
+                pass
+
     # Plugin hook: post_llm_call
     # Fired once per turn after the tool-calling loop completes.
     # Plugins can use this to persist conversation data (e.g. sync

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -811,6 +811,10 @@ DEFAULT_CONFIG = {
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
+    "runtime_guard": {
+        "enabled": False,
+        "fail_closed": True,
+    },
     # Global active chat session cap across CLI, TUI/dashboard, and messaging.
     # None/0 = unbounded.
     "max_concurrent_sessions": None,
@@ -4109,7 +4113,7 @@ def check_config_version() -> Tuple[int, int]:
 _KNOWN_ROOT_KEYS = {
     "_config_version", "model", "providers", "fallback_model",
     "fallback_providers", "credential_pool_strategies", "toolsets",
-    "agent", "terminal", "display", "compression", "delegation",
+    "runtime_guard", "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "custom_providers", "context", "memory", "gateway",
     "sessions", "streaming", "updates",
 }

--- a/model_tools.py
+++ b/model_tools.py
@@ -873,6 +873,46 @@ def _emit_post_tool_call_hook(
         logger.debug("post_tool_call hook error: %s", _hook_err)
 
 
+def _runtime_guard_tool_block_for_dispatch(
+    *,
+    function_name: str,
+    function_args: Dict[str, Any],
+    task_id: Optional[str] = None,
+    session_id: Optional[str] = None,
+    tool_call_id: Optional[str] = None,
+    turn_id: Optional[str] = None,
+    api_request_id: Optional[str] = None,
+) -> tuple[Optional[str], Optional[str]]:
+    try:
+        from agent.runtime_guard import (
+            guard_tool_action_for_current_context,
+            tool_block_result,
+        )
+
+        decision = guard_tool_action_for_current_context(
+            function_name,
+            function_args,
+            task_id=task_id or "",
+            session_id=session_id or "",
+            tool_call_id=tool_call_id or "",
+            turn_id=turn_id or "",
+            api_request_id=api_request_id or "",
+        )
+        if decision.allowed:
+            return None, None
+        return tool_block_result(decision), decision.message or decision.reason
+    except Exception as exc:
+        logger.debug("runtime_guard tool guard error: %s", exc)
+        from agent.runtime_guard_fallback import (
+            runtime_guard_tool_block_for_current_guard_error,
+        )
+
+        return runtime_guard_tool_block_for_current_guard_error(
+            exc,
+            guard_name="tool_action",
+        )
+
+
 def handle_function_call(
     function_name: str,
     function_args: Dict[str, Any],
@@ -1017,6 +1057,32 @@ def handle_function_call(
     try:
         if function_name in _AGENT_LOOP_TOOLS:
             return json.dumps({"error": f"{function_name} must be handled by the agent loop"})
+
+        runtime_guard_block, runtime_guard_reason = _runtime_guard_tool_block_for_dispatch(
+            function_name=function_name,
+            function_args=function_args,
+            task_id=task_id,
+            session_id=session_id,
+            tool_call_id=tool_call_id,
+            turn_id=turn_id,
+            api_request_id=api_request_id,
+        )
+        if runtime_guard_block is not None:
+            _emit_post_tool_call_hook(
+                function_name=function_name,
+                function_args=function_args,
+                result=runtime_guard_block,
+                task_id=task_id,
+                session_id=session_id,
+                tool_call_id=tool_call_id,
+                turn_id=turn_id,
+                api_request_id=api_request_id,
+                status="blocked",
+                error_type="runtime_guard",
+                error_message=runtime_guard_reason,
+                middleware_trace=list(_tool_middleware_trace),
+            )
+            return runtime_guard_block
 
         # Check plugin hooks for a block directive (unless caller already
         # checked — e.g. run_agent._invoke_tool passes skip=True to

--- a/tests/test_runtime_guard.py
+++ b/tests/test_runtime_guard.py
@@ -1,0 +1,310 @@
+import json
+from types import SimpleNamespace
+
+import model_tools
+from agent.runtime_guard import reset_current_runtime_guard, set_current_runtime_guard
+from agent.runtime_guard_types import GuardDecision
+from agent.tool_executor import execute_tool_calls_sequential
+from agent.tool_guardrails import ToolCallGuardrailController, toolguard_synthetic_result
+
+
+def _write_runtime_guard_config(hermes_home, *, enabled, fail_closed=True):
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "config.yaml").write_text(
+        "\n".join(
+            [
+                "runtime_guard:",
+                f"  enabled: {str(enabled).lower()}",
+                f"  fail_closed: {str(fail_closed).lower()}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _patch_registry_dispatch(monkeypatch, result='{"ok": true}'):
+    from tools.registry import registry
+
+    calls = []
+
+    def _dispatch(name, args, **kwargs):
+        calls.append((name, args, kwargs))
+        return result
+
+    monkeypatch.setattr(registry, "dispatch", _dispatch)
+    monkeypatch.setattr(model_tools, "_READ_SEARCH_TOOLS", frozenset())
+    return calls
+
+
+def test_runtime_guard_disabled_config_is_noop(tmp_path, monkeypatch):
+    _write_runtime_guard_config(tmp_path / "hermes", enabled=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    calls = _patch_registry_dispatch(monkeypatch, result='{"output": "ran"}')
+
+    out = model_tools.handle_function_call(
+        "dummy_tool",
+        {"value": 1},
+        task_id="task-1",
+        session_id="session-1",
+        tool_call_id="call-1",
+        skip_pre_tool_call_hook=True,
+    )
+
+    assert out == '{"output": "ran"}'
+    assert len(calls) == 1
+
+
+def test_enabled_runtime_guard_block_returns_structured_metadata(tmp_path, monkeypatch):
+    _write_runtime_guard_config(tmp_path / "hermes", enabled=True)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    calls = _patch_registry_dispatch(monkeypatch)
+
+    class BlockingGuard:
+        def guard_tool_action(self, context, **kwargs):
+            return GuardDecision.block(
+                "blocked by test guard",
+                message="blocked message",
+                code="policy_block",
+                context=context,
+                metadata={"rule": "test"},
+            )
+
+    token = set_current_runtime_guard(BlockingGuard())
+    try:
+        out = model_tools.handle_function_call(
+            "dummy_tool",
+            {"value": 1},
+            task_id="task-1",
+            session_id="session-1",
+            tool_call_id="call-1",
+            skip_pre_tool_call_hook=True,
+        )
+    finally:
+        reset_current_runtime_guard(token)
+
+    data = json.loads(out)
+    assert calls == []
+    assert data["status"] == "blocked"
+    assert data["blocked_by"] == "runtime_guard"
+    assert data["runtime_guard_block"]["allowed"] is False
+    assert data["runtime_guard_block"]["code"] == "policy_block"
+    assert data["runtime_guard_block"]["context"]["tool_name"] == "dummy_tool"
+    assert data["runtime_guard_block"]["metadata"] == {"rule": "test"}
+
+
+def test_enabled_runtime_guard_resolution_failure_fails_closed(tmp_path, monkeypatch):
+    _write_runtime_guard_config(tmp_path / "hermes", enabled=True, fail_closed=True)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    calls = _patch_registry_dispatch(monkeypatch)
+
+    out = model_tools.handle_function_call(
+        "dummy_tool",
+        {},
+        task_id="task-1",
+        session_id="session-1",
+        tool_call_id="call-1",
+        skip_pre_tool_call_hook=True,
+    )
+
+    data = json.loads(out)
+    assert calls == []
+    assert data["status"] == "blocked"
+    assert data["blocked_by"] == "runtime_guard"
+    assert data["code"] == "runtime_guard_error"
+    assert data["runtime_guard_block"]["context"]["guard_name"] == "tool_action"
+
+
+def test_enabled_runtime_guard_exception_fails_closed(tmp_path, monkeypatch):
+    _write_runtime_guard_config(tmp_path / "hermes", enabled=True, fail_closed=True)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    calls = _patch_registry_dispatch(monkeypatch)
+
+    class RaisingGuard:
+        def guard_tool_action(self, context, **kwargs):
+            raise RuntimeError("guard failed")
+
+    token = set_current_runtime_guard(RaisingGuard())
+    try:
+        out = model_tools.handle_function_call(
+            "dummy_tool",
+            {},
+            task_id="task-1",
+            session_id="session-1",
+            tool_call_id="call-1",
+            skip_pre_tool_call_hook=True,
+        )
+    finally:
+        reset_current_runtime_guard(token)
+
+    data = json.loads(out)
+    assert calls == []
+    assert data["status"] == "blocked"
+    assert data["blocked_by"] == "runtime_guard"
+    assert data["code"] == "runtime_guard_error"
+
+
+def test_enabled_runtime_guard_exception_can_fail_open_when_configured(tmp_path, monkeypatch):
+    _write_runtime_guard_config(tmp_path / "hermes", enabled=True, fail_closed=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    calls = _patch_registry_dispatch(monkeypatch, result='{"output": "ran"}')
+
+    class RaisingGuard:
+        def guard_tool_action(self, context, **kwargs):
+            raise RuntimeError("guard failed")
+
+    token = set_current_runtime_guard(RaisingGuard())
+    try:
+        out = model_tools.handle_function_call(
+            "dummy_tool",
+            {},
+            task_id="task-1",
+            session_id="session-1",
+            tool_call_id="call-1",
+            skip_pre_tool_call_hook=True,
+        )
+    finally:
+        reset_current_runtime_guard(token)
+
+    assert out == '{"output": "ran"}'
+    assert len(calls) == 1
+
+
+def test_final_output_guard_replaces_response_when_enabled(tmp_path, monkeypatch):
+    from agent.runtime_guard import guarded_final_output_for_agent
+
+    _write_runtime_guard_config(tmp_path / "hermes", enabled=True)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+    class BlockingGuard:
+        def guard_final_output(self, context, **kwargs):
+            return GuardDecision.block(
+                "blocked final output",
+                replacement_text="safe replacement",
+                context=context,
+            )
+
+    token = set_current_runtime_guard(BlockingGuard())
+    try:
+        out = guarded_final_output_for_agent(SimpleNamespace(session_id="s1", platform="cli"), "unsafe")
+    finally:
+        reset_current_runtime_guard(token)
+
+    assert out == "safe replacement"
+
+
+def test_final_output_guard_exception_fails_closed_when_enabled(tmp_path, monkeypatch):
+    from agent.runtime_guard import guarded_final_output_for_agent
+
+    _write_runtime_guard_config(tmp_path / "hermes", enabled=True, fail_closed=True)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+
+    class RaisingGuard:
+        def guard_final_output(self, context, **kwargs):
+            raise RuntimeError("final guard failed")
+
+    token = set_current_runtime_guard(RaisingGuard())
+    try:
+        out = guarded_final_output_for_agent(SimpleNamespace(session_id="s1", platform="cli"), "unsafe")
+    finally:
+        reset_current_runtime_guard(token)
+
+    assert "Response blocked by runtime_guard" in out
+    assert "final guard failed" in out
+
+
+class _SubdirectoryHints:
+    def check_tool_call(self, name, args):
+        return ""
+
+
+class _FakeAgent:
+    def __init__(self):
+        self._interrupt_requested = False
+        self.quiet_mode = True
+        self.verbose_logging = False
+        self.tool_progress_mode = "off"
+        self.log_prefix_chars = 80
+        self.log_prefix = ""
+        self.tool_progress_callback = None
+        self.tool_start_callback = None
+        self.tool_complete_callback = None
+        self.tool_delay = 0
+        self.session_id = "session-1"
+        self.platform = "cli"
+        self.valid_tool_names = set()
+        self._current_turn_id = "turn-1"
+        self._current_api_request_id = "request-1"
+        self._checkpoint_mgr = SimpleNamespace(enabled=False)
+        self._tool_guardrails = ToolCallGuardrailController()
+        self._subdirectory_hints = _SubdirectoryHints()
+        self._context_engine_tool_names = set()
+        self._memory_manager = None
+
+    def _vprint(self, *args, **kwargs):
+        return None
+
+    def _touch_activity(self, *args, **kwargs):
+        return None
+
+    def _should_emit_quiet_tool_messages(self):
+        return False
+
+    def _should_start_quiet_spinner(self):
+        return False
+
+    def _guardrail_block_result(self, decision):
+        return toolguard_synthetic_result(decision)
+
+    def _append_guardrail_observation(self, tool_name, function_args, function_result, *, failed):
+        return function_result
+
+    def _record_file_mutation_result(self, function_name, function_args, function_result, is_error):
+        return None
+
+    def _tool_result_content_for_active_model(self, tool_name, result):
+        return result
+
+    def _apply_pending_steer_to_tool_results(self, messages, num_tool_msgs):
+        return None
+
+
+def test_structured_block_metadata_preserved_in_sequential_tool_result(tmp_path, monkeypatch):
+    _write_runtime_guard_config(tmp_path / "hermes", enabled=True)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    calls = _patch_registry_dispatch(monkeypatch)
+
+    class BlockingGuard:
+        def guard_tool_action(self, context, **kwargs):
+            return GuardDecision.block(
+                "blocked before execution",
+                code="runtime_guard_block",
+                context=context,
+                metadata={"source": "unit-test"},
+            )
+
+    token = set_current_runtime_guard(BlockingGuard())
+    try:
+        tool_call = SimpleNamespace(
+            id="call-1",
+            function=SimpleNamespace(
+                name="terminal",
+                arguments=json.dumps({"command": "echo should-not-run"}),
+            ),
+        )
+        messages = []
+        execute_tool_calls_sequential(
+            _FakeAgent(),
+            SimpleNamespace(tool_calls=[tool_call]),
+            messages,
+            "task-1",
+        )
+    finally:
+        reset_current_runtime_guard(token)
+
+    assert calls == []
+    assert len(messages) == 1
+    data = json.loads(messages[0]["content"])
+    assert data["blocked_by"] == "runtime_guard"
+    assert data["runtime_guard_block"]["context"]["tool_name"] == "terminal"
+    assert data["runtime_guard_block"]["metadata"] == {"source": "unit-test"}


### PR DESCRIPTION
## Summary
- Adds generic runtime guard primitives (`GuardContext`, `GuardDecision`, and disabled-by-default guard helpers).
- Preserves structured runtime guard block metadata through registry dispatch and agent tool execution paths.
- Adds fail-closed fallback helpers for enabled guard failures and a minimal final-output guard seam.

## Configuration
- Adds `runtime_guard.enabled: false` by default.
- Adds `runtime_guard.fail_closed: true` by default.
- Does not add backend DSNs or new user-facing environment variables.

## Test Plan
- `python -m pytest tests/test_runtime_guard.py -q`
- `python -m pytest tests/test_transform_tool_result_hook.py tests/test_runtime_guard.py -q`
- `python -m pytest tests/test_runtime_guard.py tests/test_transform_tool_result_hook.py tests/test_model_tools.py -q`
- `python -m py_compile agent/runtime_guard_types.py agent/runtime_guard.py agent/runtime_guard_fallback.py model_tools.py agent/tool_executor.py agent/turn_finalizer.py hermes_cli/config.py tests/test_runtime_guard.py`
- `ruff check agent/runtime_guard_types.py agent/runtime_guard.py agent/runtime_guard_fallback.py model_tools.py agent/tool_executor.py agent/turn_finalizer.py hermes_cli/config.py tests/test_runtime_guard.py`
- `git diff --check`
- Added-line scans for product-specific wording, secrets, and dangerous patterns.