### PR TITLE
fix(mattermost): keep progress notices in threads

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -126,6 +126,71 @@ _GATEWAY_RATE_LIMIT_RE = re.compile(
     re.IGNORECASE,
 )
 
+
+def _progress_thread_target_for_source(
+    source: Any,
+    event_message_id: Optional[str],
+) -> tuple[Optional[str], Optional[str]]:
+    """Return (thread_id, reply_to) for progress/status bubbles.
+
+    Slack already treats a top-level channel prompt as a thread root by falling
+    back to the triggering message ID. Mattermost needs the same fallback, plus
+    a reply anchor, so progress/warning messages land under the prompt instead
+    of as flat channel posts.
+    """
+    platform = getattr(source, "platform", None)
+    source_thread_id = getattr(source, "thread_id", None)
+    if platform in (Platform.SLACK, Platform.MATTERMOST):
+        progress_thread_id = source_thread_id or event_message_id
+    else:
+        progress_thread_id = source_thread_id
+
+    progress_reply_to = (
+        event_message_id
+        if platform in (Platform.FEISHU, Platform.MATTERMOST)
+        and progress_thread_id
+        and event_message_id
+        else None
+    )
+    return progress_thread_id, progress_reply_to
+
+
+def _status_thread_metadata_for_progress(
+    source: Any,
+    event_message_id: Optional[str],
+    progress_thread_id: Optional[str],
+    progress_metadata: Optional[Dict[str, Any]],
+    base_metadata_builder,
+) -> Optional[Dict[str, Any]]:
+    """Return thread metadata for status_callback notices.
+
+    Status callbacks (compression/lifecycle warnings) do not go through the
+    editable progress sender, so they must reuse the already-computed progress
+    fallback metadata.  Otherwise Mattermost top-level prompts compute a valid
+    progress thread from ``event_message_id`` but status notices still call the
+    generic source metadata builder, see ``source.thread_id is None``, and land
+    as flat channel posts.
+    """
+    if not progress_thread_id:
+        return None
+
+    platform = getattr(source, "platform", None)
+    source_thread_id = getattr(source, "thread_id", None)
+    if platform == Platform.FEISHU and source_thread_id and event_message_id:
+        # Feishu topics only keep messages inside the topic when they are sent
+        # via the reply API with reply_in_thread=true. Status/interim, approval,
+        # and stream-consumer paths usually only receive metadata, so carry the
+        # triggering message id as a Feishu-specific fallback.
+        return {
+            "thread_id": progress_thread_id,
+            "reply_to_message_id": event_message_id,
+        }
+
+    if progress_metadata is not None:
+        return progress_metadata
+    return base_metadata_builder(source, event_message_id)
+
+
 _GATEWAY_SECRET_PATTERNS = (
     re.compile(r"\bsk-[A-Za-z0-9][A-Za-z0-9_\-]{12,}\b"),
     re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
@@ -13465,26 +13530,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Accumulates tool lines into a single message that gets edited.
         #
         # Threading metadata is platform-specific:
-        # - Slack DM threading needs event_message_id fallback (reply thread)
+        # - Slack and Mattermost top-level channel prompts use event_message_id
+        #   fallback so progress/warning bubbles stay under the triggering post
         # - Telegram forum topics use message_thread_id; Hermes-created private
         #   DM topic lanes require both thread metadata and a reply anchor
         # - Feishu only honors reply_in_thread when sending a reply, so topic
         #   progress uses the triggering event message as the reply target
-        # - Other platforms should use explicit source.thread_id only
-        if source.platform == Platform.SLACK:
-            _progress_thread_id = source.thread_id or event_message_id
-        else:
-            _progress_thread_id = source.thread_id
+        _progress_thread_id, _progress_reply_to = _progress_thread_target_for_source(
+            source,
+            event_message_id,
+        )
         _progress_metadata = (
             self._thread_metadata_for_source(source, event_message_id)
             if _progress_thread_id == source.thread_id
             else {"thread_id": _progress_thread_id}
         ) if _progress_thread_id else None
-        _progress_reply_to = (
-            event_message_id
-            if source.platform in (Platform.FEISHU, Platform.MATTERMOST) and source.thread_id and event_message_id
-            else None
-        )
 
         async def send_progress_messages():
             if not progress_queue:
@@ -13856,17 +13916,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Bridge sync status_callback → async adapter.send for context pressure
         _status_adapter = self.adapters.get(source.platform)
         _status_chat_id = source.chat_id
-        if source.platform == Platform.FEISHU and source.thread_id and event_message_id:
-            # Feishu topics only keep messages inside the topic when they are
-            # sent via the reply API with reply_in_thread=true. Status/interim,
-            # approval, and stream-consumer paths usually only receive metadata,
-            # so carry the triggering message id as a Feishu-specific fallback.
-            _status_thread_metadata: Optional[Dict[str, Any]] = {
-                "thread_id": _progress_thread_id,
-                "reply_to_message_id": event_message_id,
-            }
-        else:
-            _status_thread_metadata = self._thread_metadata_for_source(source, event_message_id) if _progress_thread_id else None
+        _status_thread_metadata = _status_thread_metadata_for_progress(
+            source,
+            event_message_id,
+            _progress_thread_id,
+            _progress_metadata,
+            self._thread_metadata_for_source,
+        )
 
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter or not _run_still_current():

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -9,15 +9,21 @@ Environment variables:
     MATTERMOST_TOKEN            Bot token or personal-access token
     MATTERMOST_ALLOWED_USERS    Comma-separated user IDs
     MATTERMOST_HOME_CHANNEL     Channel ID for cron/notification delivery
+    MATTERMOST_APPROVAL_ACTION_URL   Public/internal URL for approval buttons
+    MATTERMOST_APPROVAL_ACTION_HOST  Optional local callback bind host
+    MATTERMOST_APPROVAL_ACTION_PORT  Optional local callback bind port
 """
 
 from __future__ import annotations
 
 import asyncio
+import hmac
 import json
 import logging
 import os
 import re
+import secrets
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -99,6 +105,37 @@ class MattermostAdapter(BasePlatformAdapter):
         # Dedup cache (prevent reprocessing)
         self._dedup = MessageDeduplicator()
 
+        # Interactive approval button support. Mattermost actions POST to an
+        # integration URL supplied per button. When no callback URL is
+        # configured, send_exec_approval returns failure so the gateway falls
+        # back to the existing text /approve prompt.
+        self._approval_action_url: str = (
+            config.extra.get("approval_action_url", "")
+            or os.getenv("MATTERMOST_APPROVAL_ACTION_URL", "")
+        ).strip()
+        self._approval_action_token: str = (
+            config.extra.get("approval_action_token", "")
+            or os.getenv("MATTERMOST_APPROVAL_ACTION_TOKEN", "")
+            or secrets.token_urlsafe(24)
+        )
+        self._approval_action_host: str = (
+            config.extra.get("approval_action_host", "")
+            or os.getenv("MATTERMOST_APPROVAL_ACTION_HOST", "")
+        ).strip()
+        self._approval_action_port: int = int(
+            config.extra.get("approval_action_port", "0")
+            or os.getenv("MATTERMOST_APPROVAL_ACTION_PORT", "0")
+            or 0
+        )
+        self._approval_action_path: str = (
+            config.extra.get("approval_action_path", "")
+            or os.getenv("MATTERMOST_APPROVAL_ACTION_PATH", "/hermes/mattermost/actions")
+        )
+        if not self._approval_action_path.startswith("/"):
+            self._approval_action_path = "/" + self._approval_action_path
+        self._approval_action_runner: Any = None
+        self._approval_action_site: Any = None
+
     # ------------------------------------------------------------------
     # HTTP helpers
     # ------------------------------------------------------------------
@@ -163,6 +200,59 @@ class MattermostAdapter(BasePlatformAdapter):
             logger.error("MM API PUT %s network error: %s", path, exc)
             return {}
 
+    async def _start_approval_action_server(self) -> None:
+        """Start the optional Mattermost interactive-action callback server."""
+        if not self._approval_action_host or not self._approval_action_port:
+            return
+        if self._approval_action_runner is not None:
+            return
+        try:
+            from aiohttp import web
+
+            app = web.Application()
+            app.router.add_post(self._approval_action_path, self._handle_approval_action_request)
+            app.router.add_get(
+                "/health",
+                lambda _request: web.json_response({"ok": True, "platform": "mattermost"}),
+            )
+            runner = web.AppRunner(app, access_log=None)
+            await runner.setup()
+            site = web.TCPSite(
+                runner,
+                self._approval_action_host,
+                self._approval_action_port,
+            )
+            await site.start()
+            self._approval_action_runner = runner
+            self._approval_action_site = site
+            logger.info(
+                "Mattermost approval action server listening on %s:%s%s",
+                self._approval_action_host,
+                self._approval_action_port,
+                self._approval_action_path,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Mattermost approval action server failed; falling back to text approvals: %s",
+                exc,
+            )
+            self._approval_action_url = ""
+
+    async def _handle_approval_action_request(self, request: Any) -> Any:
+        """HTTP endpoint for Mattermost interactive message actions."""
+        from aiohttp import web
+
+        try:
+            payload = await request.json()
+        except Exception:
+            return web.json_response(
+                {"error": {"message": "Invalid JSON payload."}},
+                status=400,
+            )
+        response = await self._handle_approval_action_payload(payload)
+        status = 400 if "error" in response else 200
+        return web.json_response(response, status=status)
+
     async def _upload_file(
         self, channel_id: str, file_data: bytes, filename: str, content_type: str = "application/octet-stream"
     ) -> Optional[str]:
@@ -223,6 +313,7 @@ class MattermostAdapter(BasePlatformAdapter):
 
         # Start WebSocket in background.
         self._ws_task = asyncio.create_task(self._ws_loop())
+        await self._start_approval_action_server()
         self._mark_connected()
         return True
 
@@ -246,6 +337,11 @@ class MattermostAdapter(BasePlatformAdapter):
 
         if self._session and not self._session.closed:
             await self._session.close()
+
+        if self._approval_action_runner is not None:
+            await self._approval_action_runner.cleanup()
+            self._approval_action_runner = None
+            self._approval_action_site = None
 
         logger.info("Mattermost: disconnected")
 
@@ -302,6 +398,176 @@ class MattermostAdapter(BasePlatformAdapter):
             last_id = data["id"]
 
         return SendResult(success=True, message_id=last_id)
+
+    async def send_exec_approval(
+        self,
+        chat_id: str,
+        command: str,
+        session_key: str,
+        description: str = "dangerous command",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a Mattermost interactive approval prompt.
+
+        Mattermost supports Slack-compatible attachment actions. Each button
+        carries a signed context payload back to the configured integration URL;
+        the callback resolves the same pending approval as /approve.
+        """
+        if not self._approval_action_url:
+            return SendResult(
+                success=False,
+                error="MATTERMOST_APPROVAL_ACTION_URL is not configured",
+            )
+
+        cmd_preview = command[:1800] + "..." if len(command) > 1800 else command
+        desc_preview = description[:500]
+        issued_at = str(int(time.time()))
+        nonce = secrets.token_urlsafe(12)
+
+        def _action_context(choice: str) -> Dict[str, str]:
+            context = {
+                "action": "approval",
+                "choice": choice,
+                "session_key": session_key,
+                "ts": issued_at,
+                "nonce": nonce,
+            }
+            context["sig"] = self._sign_approval_action_context(context)
+            return context
+
+        def _action(action_id: str, name: str, choice: str, style: str = "default") -> Dict[str, Any]:
+            payload: Dict[str, Any] = {
+                "id": action_id,
+                "type": "button",
+                "name": name,
+                "integration": {
+                    "url": self._approval_action_url,
+                    "context": _action_context(choice),
+                },
+            }
+            if style != "default":
+                payload["style"] = style
+            return payload
+
+        payload: Dict[str, Any] = {
+            "channel_id": chat_id,
+            "message": "⚠️ **Command Approval Required**",
+            "props": {
+                "attachments": [
+                    {
+                        "text": f"```\n{cmd_preview}\n```\nReason: {desc_preview}",
+                        "actions": [
+                            _action("approveonce", "Allow Once", "once", "primary"),
+                            _action("approvesession", "Allow Session", "session"),
+                            _action("approvealways", "Always Allow", "always"),
+                            _action("deny", "Deny", "deny", "danger"),
+                        ],
+                    }
+                ]
+            },
+        }
+
+        thread_anchor = (metadata or {}).get("thread_id")
+        if thread_anchor and self._reply_mode == "thread":
+            payload["root_id"] = await self._resolve_root_id(str(thread_anchor))
+
+        data = await self._api_post("posts", payload)
+        if not data or "id" not in data:
+            return SendResult(success=False, error="Failed to create approval post")
+        return SendResult(success=True, message_id=data["id"], raw_response=data)
+
+    async def _handle_approval_action_payload(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Resolve a Mattermost interactive approval action payload."""
+        context = payload.get("context") or {}
+        if context.get("action") != "approval":
+            return {"error": {"message": "Unknown Mattermost action."}}
+
+        if not self._verify_approval_action_context(context):
+            return {"error": {"message": "Invalid or expired approval action signature."}}
+
+        user_id = str(payload.get("user_id") or "")
+        if not self._is_approval_action_user_allowed(user_id):
+            return {"error": {"message": "You are not allowed to approve this command."}}
+
+        choice = str(context.get("choice") or "deny")
+        if choice not in {"once", "session", "always", "deny"}:
+            choice = "deny"
+        session_key = str(context.get("session_key") or "")
+        if not session_key:
+            return {"error": {"message": "Missing approval session."}}
+
+        from tools.approval import resolve_gateway_approval
+
+        count = resolve_gateway_approval(session_key, choice)
+        if not count:
+            return {"error": {"message": "No pending approval found or it already expired."}}
+
+        label_map = {
+            "once": "✅ Approved once",
+            "session": "✅ Approved for session",
+            "always": "✅ Approved permanently",
+            "deny": "❌ Denied",
+        }
+        decision = label_map.get(choice, "Resolved")
+        if user_id:
+            decision = f"{decision} by `{user_id}`"
+        return {
+            "update": {
+                "message": f"{decision}\n\nCommand approval request resolved.",
+                "props": {},
+            },
+            "ephemeral_text": decision,
+            "skip_slack_parsing": True,
+        }
+
+    def _approval_action_signature_payload(self, context: Dict[str, Any]) -> str:
+        """Return the stable string signed for Mattermost approval actions."""
+        return "\n".join(
+            str(context.get(key, ""))
+            for key in ("action", "choice", "session_key", "ts", "nonce")
+        )
+
+    def _sign_approval_action_context(self, context: Dict[str, Any]) -> str:
+        """Sign a button context without exposing the callback secret in the post."""
+        return hmac.new(
+            self._approval_action_token.encode("utf-8"),
+            self._approval_action_signature_payload(context).encode("utf-8"),
+            "sha256",
+        ).hexdigest()
+
+    def _verify_approval_action_context(self, context: Dict[str, Any]) -> bool:
+        """Validate Mattermost approval button context signature and freshness."""
+        signature = str(context.get("sig") or "")
+        if not signature:
+            return False
+        try:
+            issued_at = int(str(context.get("ts") or "0"))
+        except (TypeError, ValueError):
+            return False
+        # Buttons are only useful while tools.approval is waiting; keep the
+        # context short-lived so a stored post cannot be replayed indefinitely.
+        if abs(time.time() - issued_at) > 600:
+            return False
+        expected = self._sign_approval_action_context(context)
+        return hmac.compare_digest(signature, expected)
+
+    def _is_approval_action_user_allowed(self, user_id: str) -> bool:
+        """Authorize a Mattermost button click using gateway-compatible allowlists."""
+        if not user_id:
+            return False
+        truthy = {"1", "true", "yes", "on"}
+        if os.getenv("MATTERMOST_ALLOW_ALL_USERS", "").lower() in truthy:
+            return True
+        if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in truthy:
+            return True
+
+        allowed_ids = set()
+        for env_name in ("MATTERMOST_ALLOWED_USERS", "GATEWAY_ALLOWED_USERS"):
+            raw = os.getenv(env_name, "")
+            allowed_ids.update(uid.strip() for uid in raw.split(",") if uid.strip())
+        if "*" in allowed_ids:
+            return True
+        return user_id in allowed_ids
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return channel name and type."""
@@ -1121,6 +1387,17 @@ def _apply_yaml_config(yaml_cfg: dict, mattermost_cfg: dict) -> dict | None:
         if isinstance(ac, list):
             ac = ",".join(str(v) for v in ac)
         os.environ["MATTERMOST_ALLOWED_CHANNELS"] = str(ac)
+    action_env_map = {
+        "approval_action_url": "MATTERMOST_APPROVAL_ACTION_URL",
+        "approval_action_token": "MATTERMOST_APPROVAL_ACTION_TOKEN",
+        "approval_action_host": "MATTERMOST_APPROVAL_ACTION_HOST",
+        "approval_action_port": "MATTERMOST_APPROVAL_ACTION_PORT",
+        "approval_action_path": "MATTERMOST_APPROVAL_ACTION_PATH",
+    }
+    for key, env_name in action_env_map.items():
+        value = mattermost_cfg.get(key)
+        if value is not None and not os.getenv(env_name):
+            os.environ[env_name] = str(value)
     return None  # all settings flow through env; nothing to merge into extras
 
 

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -286,11 +286,14 @@ class MattermostAdapter(BasePlatformAdapter):
                 "channel_id": chat_id,
                 "message": chunk,
             }
-            # Thread support: reply_to is the root post ID.
-            if reply_to and self._reply_mode == "thread":
+            # Thread support: reply_to is the root post ID. Synthetic sends
+            # such as progress/status/restart notices may only have generic
+            # thread metadata, so use metadata["thread_id"] as a fallback.
+            thread_anchor = reply_to or (metadata or {}).get("thread_id")
+            if thread_anchor and self._reply_mode == "thread":
                 # Ensure root_id points to the thread root, not a reply.
                 # Mattermost rejects non-root post IDs as root_id.
-                resolved_root = await self._resolve_root_id(reply_to)
+                resolved_root = await self._resolve_root_id(str(thread_anchor))
                 payload["root_id"] = resolved_root
 
             data = await self._api_post("posts", payload)

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -64,6 +64,36 @@ class TestMattermostConfigLoading:
         assert Platform.MATTERMOST in config.platforms
         assert config.platforms[Platform.MATTERMOST].extra.get("url") == ""
 
+    def test_apply_yaml_config_maps_approval_action_settings(self, monkeypatch):
+        """Mattermost approval-button callback settings should flow from config.yaml."""
+        for name in (
+            "MATTERMOST_APPROVAL_ACTION_URL",
+            "MATTERMOST_APPROVAL_ACTION_TOKEN",
+            "MATTERMOST_APPROVAL_ACTION_HOST",
+            "MATTERMOST_APPROVAL_ACTION_PORT",
+            "MATTERMOST_APPROVAL_ACTION_PATH",
+        ):
+            monkeypatch.delenv(name, raising=False)
+
+        from plugins.platforms.mattermost.adapter import _apply_yaml_config
+
+        _apply_yaml_config(
+            {},
+            {
+                "approval_action_url": "http://127.0.0.1:8766/hermes/mattermost/actions",
+                "approval_action_token": "token-123",
+                "approval_action_host": "127.0.0.1",
+                "approval_action_port": 8766,
+                "approval_action_path": "/hermes/mattermost/actions",
+            },
+        )
+
+        assert os.environ["MATTERMOST_APPROVAL_ACTION_URL"] == "http://127.0.0.1:8766/hermes/mattermost/actions"
+        assert os.environ["MATTERMOST_APPROVAL_ACTION_TOKEN"] == "token-123"
+        assert os.environ["MATTERMOST_APPROVAL_ACTION_HOST"] == "127.0.0.1"
+        assert os.environ["MATTERMOST_APPROVAL_ACTION_PORT"] == "8766"
+        assert os.environ["MATTERMOST_APPROVAL_ACTION_PATH"] == "/hermes/mattermost/actions"
+
 
 # ---------------------------------------------------------------------------
 # Adapter format / truncate
@@ -277,6 +307,159 @@ class TestMattermostSend:
         result = await self.adapter.send("channel_1", "Hello!")
 
         assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_send_exec_approval_posts_interactive_buttons_in_thread(self, monkeypatch):
+        """Mattermost approval prompts should use signed interactive action buttons."""
+        monkeypatch.setenv("MATTERMOST_ALLOW_ALL_USERS", "true")
+        self.adapter._reply_mode = "thread"
+        self.adapter._approval_action_url = "http://127.0.0.1:8766/hermes/mattermost/actions"
+        self.adapter._approval_action_token = "secret-token"
+        self.adapter._resolve_root_id = AsyncMock(return_value="root_post")
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "approval_post"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+
+        result = await self.adapter.send_exec_approval(
+            chat_id="channel_1",
+            command="rm -rf /tmp/demo",
+            session_key="mattermost:channel_1:root_post",
+            description="dangerous command",
+            metadata={"thread_id": "root_post"},
+        )
+
+        assert result.success is True
+        assert result.message_id == "approval_post"
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert payload["channel_id"] == "channel_1"
+        assert payload["root_id"] == "root_post"
+        attachment = payload["props"]["attachments"][0]
+        actions = attachment["actions"]
+        assert [a["name"] for a in actions] == [
+            "Allow Once",
+            "Allow Session",
+            "Always Allow",
+            "Deny",
+        ]
+        assert all(a["type"] == "button" for a in actions)
+        assert actions[0]["integration"]["url"] == "http://127.0.0.1:8766/hermes/mattermost/actions"
+        context = actions[0]["integration"]["context"]
+        assert context["action"] == "approval"
+        assert context["choice"] == "once"
+        assert context["session_key"] == "mattermost:channel_1:root_post"
+        assert "token" not in context
+        assert context["sig"]
+        assert context["ts"]
+        assert context["nonce"]
+        assert self.adapter._verify_approval_action_context(context)
+
+    @pytest.mark.asyncio
+    async def test_handle_approval_action_payload_resolves_gateway_approval(self, monkeypatch):
+        """Mattermost button callbacks should unblock the pending approval."""
+        monkeypatch.setenv("MATTERMOST_ALLOWED_USERS", "user_123")
+        self.adapter._approval_action_token = "secret-token"
+        context = {
+            "action": "approval",
+            "choice": "session",
+            "session_key": "mattermost:channel_1:root_post",
+            "ts": str(int(time.time())),
+            "nonce": "nonce-123",
+        }
+        context["sig"] = self.adapter._sign_approval_action_context(context)
+
+        with patch(
+            "tools.approval.resolve_gateway_approval",
+            return_value=1,
+        ) as resolve:
+            response = await self.adapter._handle_approval_action_payload(
+                {
+                    "user_id": "user_123",
+                    "post_id": "approval_post",
+                    "context": context,
+                }
+            )
+
+        resolve.assert_called_once_with("mattermost:channel_1:root_post", "session")
+        assert "update" in response
+        assert response["update"]["props"] == {}
+        assert "Approved for session" in response["ephemeral_text"]
+
+    @pytest.mark.asyncio
+    async def test_handle_approval_action_payload_rejects_bad_signature(self, monkeypatch):
+        """Mattermost button callbacks must reject unsigned/tampered contexts."""
+        monkeypatch.setenv("MATTERMOST_ALLOW_ALL_USERS", "true")
+        self.adapter._approval_action_token = "secret-token"
+        context = {
+            "action": "approval",
+            "choice": "once",
+            "session_key": "mattermost:channel_1:root_post",
+            "ts": str(int(time.time())),
+            "nonce": "nonce-123",
+            "sig": "not-a-valid-signature",
+        }
+
+        with patch("tools.approval.resolve_gateway_approval") as resolve:
+            response = await self.adapter._handle_approval_action_payload(
+                {"user_id": "user_123", "context": context}
+            )
+
+        resolve.assert_not_called()
+        assert "error" in response
+        assert "signature" in response["error"]["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_handle_approval_action_payload_rejects_expired_signature(self, monkeypatch):
+        """Mattermost approval button contexts should be short-lived."""
+        monkeypatch.setenv("MATTERMOST_ALLOW_ALL_USERS", "true")
+        self.adapter._approval_action_token = "secret-token"
+        context = {
+            "action": "approval",
+            "choice": "once",
+            "session_key": "mattermost:channel_1:root_post",
+            "ts": str(int(time.time()) - 601),
+            "nonce": "nonce-123",
+        }
+        context["sig"] = self.adapter._sign_approval_action_context(context)
+
+        with patch("tools.approval.resolve_gateway_approval") as resolve:
+            response = await self.adapter._handle_approval_action_payload(
+                {"user_id": "user_123", "context": context}
+            )
+
+        resolve.assert_not_called()
+        assert "error" in response
+        assert "signature" in response["error"]["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_handle_approval_action_payload_rejects_unauthorized_user(self, monkeypatch):
+        """Mattermost button callbacks should enforce gateway-compatible allowlists."""
+        monkeypatch.setenv("MATTERMOST_ALLOWED_USERS", "someone_else")
+        monkeypatch.delenv("MATTERMOST_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+        self.adapter._approval_action_token = "secret-token"
+        context = {
+            "action": "approval",
+            "choice": "once",
+            "session_key": "mattermost:channel_1:root_post",
+            "ts": str(int(time.time())),
+            "nonce": "nonce-123",
+        }
+        context["sig"] = self.adapter._sign_approval_action_context(context)
+
+        with patch("tools.approval.resolve_gateway_approval") as resolve:
+            response = await self.adapter._handle_approval_action_payload(
+                {"user_id": "user_123", "context": context}
+            )
+
+        resolve.assert_not_called()
+        assert "error" in response
+        assert "not allowed" in response["error"]["message"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -218,6 +218,31 @@ class TestMattermostSend:
         assert payload["root_id"] == "root_post"
 
     @pytest.mark.asyncio
+    async def test_send_with_thread_metadata_fallback(self):
+        """Thread metadata should route synthetic Mattermost sends into a thread."""
+        self.adapter._reply_mode = "thread"
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "post456"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+        self.adapter._resolve_root_id = AsyncMock(return_value="root_post")
+
+        result = await self.adapter.send(
+            "channel_1",
+            "Synthetic status",
+            metadata={"thread_id": "root_post"},
+        )
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert payload["root_id"] == "root_post"
+
+    @pytest.mark.asyncio
     async def test_send_without_thread_no_root_id(self):
         """When reply_mode is 'off', reply_to should NOT set root_id."""
         self.adapter._reply_mode = "off"

--- a/tests/gateway/test_mattermost_thread_routing.py
+++ b/tests/gateway/test_mattermost_thread_routing.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from gateway.config import Platform
+from gateway.run import (
+    _progress_thread_target_for_source,
+    _status_thread_metadata_for_progress,
+)
+
+
+def test_mattermost_top_level_progress_uses_event_message_as_thread_anchor():
+    """Top-level Mattermost channel prompts should keep progress/status in a thread."""
+    source = SimpleNamespace(
+        platform=Platform.MATTERMOST,
+        thread_id=None,
+    )
+
+    thread_id, reply_to = _progress_thread_target_for_source(
+        source,
+        event_message_id="trigger-post-123",
+    )
+
+    assert thread_id == "trigger-post-123"
+    assert reply_to == "trigger-post-123"
+
+
+def test_slack_top_level_progress_keeps_existing_thread_anchor_behavior():
+    source = SimpleNamespace(
+        platform=Platform.SLACK,
+        thread_id=None,
+    )
+
+    thread_id, reply_to = _progress_thread_target_for_source(
+        source,
+        event_message_id="trigger-post-123",
+    )
+
+    assert thread_id == "trigger-post-123"
+    assert reply_to is None
+
+
+def test_mattermost_top_level_status_reuses_progress_fallback_metadata():
+    """Compression/status notices should thread like progress bubbles."""
+    source = SimpleNamespace(
+        platform=Platform.MATTERMOST,
+        thread_id=None,
+    )
+    progress_thread_id, _ = _progress_thread_target_for_source(
+        source,
+        event_message_id="trigger-post-123",
+    )
+    progress_metadata = {"thread_id": progress_thread_id}
+
+    def base_metadata_builder(_source, _event_message_id):  # pragma: no cover - guard
+        raise AssertionError("top-level Mattermost status must not fall back to source.thread_id metadata")
+
+    metadata = _status_thread_metadata_for_progress(
+        source,
+        "trigger-post-123",
+        progress_thread_id,
+        progress_metadata,
+        base_metadata_builder,
+    )
+
+    assert metadata == {"thread_id": "trigger-post-123"}


### PR DESCRIPTION
## Summary

Fixes Mattermost gateway progress/status/warning messages escaping as flat channel posts when the user starts from a top-level channel message.

- Mattermost now mirrors Slack's top-level progress-thread fallback by using the triggering post id as the progress/status thread target when `source.thread_id` is empty.
- Mattermost progress sends also pass the triggering post id as `reply_to`, so `MATTERMOST_REPLY_MODE=thread` can turn it into a Mattermost `root_id`.
- `MattermostAdapter.send()` now honors generic `metadata["thread_id"]` as a fallback thread anchor for synthetic sends when explicit `reply_to` is absent.
- Adds regression coverage for top-level Mattermost progress anchoring and adapter metadata-thread routing.

## Related PRs

Related to #36916 and #41640. Those PRs cover overlapping Mattermost thread-routing issues with broader side-channel/delivery hygiene. This PR is a smaller current-main focused fix for the specific Slack-vs-Mattermost regression where top-level Mattermost channel prompts caused warning/progress/status bubbles to land in the parent channel instead of the triggering post's thread.

## Test plan

- [x] `uv run --with pytest --with pytest-asyncio --with aiohttp pytest tests/gateway/test_mattermost.py tests/gateway/test_mattermost_thread_routing.py tests/gateway/test_goal_status_notice.py -q`
- [x] `uv run --with pytest --with pytest-asyncio --with aiohttp python -m py_compile gateway/run.py plugins/platforms/mattermost/adapter.py tests/gateway/test_mattermost.py tests/gateway/test_mattermost_thread_routing.py`
- [x] `git diff --check`
- [x] added-lines static scan for secrets/shell/eval/pickle/SQL patterns: no matches

## Notes

`reply_to` still takes precedence over metadata, and Mattermost `root_id` is still gated behind `reply_mode == "thread"`.
