### PR TITLE
Handle WhatsApp Cloud calls with a sidecar

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1495,6 +1495,23 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 ] = float(wa_cloud_calling_sidecar_timeout)
             except ValueError:
                 pass
+        wa_cloud_calling_sidecar_tts_stream_command = os.getenv(
+            "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND"
+        )
+        if wa_cloud_calling_sidecar_tts_stream_command:
+            config.platforms[Platform.WHATSAPP_CLOUD].extra[
+                "calling_sidecar_tts_stream_command"
+            ] = wa_cloud_calling_sidecar_tts_stream_command
+        wa_cloud_calling_sidecar_tts_stream_timeout = os.getenv(
+            "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT"
+        )
+        if wa_cloud_calling_sidecar_tts_stream_timeout:
+            try:
+                config.platforms[Platform.WHATSAPP_CLOUD].extra[
+                    "calling_sidecar_tts_stream_timeout"
+                ] = float(wa_cloud_calling_sidecar_tts_stream_timeout)
+            except ValueError:
+                pass
     whatsapp_cloud_home = os.getenv("WHATSAPP_CLOUD_HOME_CHANNEL")
     if whatsapp_cloud_home and Platform.WHATSAPP_CLOUD in config.platforms:
         config.platforms[Platform.WHATSAPP_CLOUD].home_channel = HomeChannel(

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1479,6 +1479,22 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         wa_cloud_api_version = os.getenv("WHATSAPP_CLOUD_API_VERSION")
         if wa_cloud_api_version:
             config.platforms[Platform.WHATSAPP_CLOUD].extra["api_version"] = wa_cloud_api_version
+        # Optional: local WhatsApp Calling/WebRTC SDP sidecar
+        wa_cloud_calling_sidecar_url = os.getenv("WHATSAPP_CLOUD_CALLING_SIDECAR_URL")
+        if wa_cloud_calling_sidecar_url:
+            config.platforms[Platform.WHATSAPP_CLOUD].extra[
+                "calling_sidecar_url"
+            ] = wa_cloud_calling_sidecar_url
+        wa_cloud_calling_sidecar_timeout = os.getenv(
+            "WHATSAPP_CLOUD_CALLING_SIDECAR_TIMEOUT"
+        )
+        if wa_cloud_calling_sidecar_timeout:
+            try:
+                config.platforms[Platform.WHATSAPP_CLOUD].extra[
+                    "calling_sidecar_timeout"
+                ] = float(wa_cloud_calling_sidecar_timeout)
+            except ValueError:
+                pass
     whatsapp_cloud_home = os.getenv("WHATSAPP_CLOUD_HOME_CHANNEL")
     if whatsapp_cloud_home and Platform.WHATSAPP_CLOUD in config.platforms:
         config.platforms[Platform.WHATSAPP_CLOUD].home_channel = HomeChannel(

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2785,6 +2785,20 @@ class BasePlatformAdapter(ABC):
         """
         return await self.send_voice(chat_id=chat_id, audio_path=audio_path, **kwargs)
 
+    async def play_tts_text(
+        self,
+        chat_id: str,
+        text: str,
+        **kwargs,
+    ) -> SendResult:
+        """
+        Play auto-TTS directly from text when a platform can stream audio.
+
+        The default returns failure so callers fall back to file-based
+        ``text_to_speech_tool`` generation and ``play_tts`` delivery.
+        """
+        return SendResult(success=False, error="Direct TTS playback is not supported")
+
     async def send_video(
         self,
         chat_id: str,
@@ -4278,17 +4292,29 @@ class BasePlatformAdapter(ABC):
                         and text_content
                         and not media_files):
                     try:
-                        from tools.tts_tool import text_to_speech_tool, check_tts_requirements
-                        if check_tts_requirements():
-                            import json as _json
-                            speech_text = self.prepare_tts_text(text_content)
-                            if not speech_text:
-                                raise ValueError("Empty text after markdown cleanup")
-                            tts_result_str = await asyncio.to_thread(
-                                text_to_speech_tool, text=speech_text
+                        speech_text = self.prepare_tts_text(text_content)
+                        if not speech_text:
+                            raise ValueError("Empty text after markdown cleanup")
+
+                        direct_tts = await self.play_tts_text(
+                            chat_id=event.source.chat_id,
+                            text=speech_text,
+                            metadata=_thread_metadata,
+                        )
+                        if not bool(getattr(direct_tts, "success", False)):
+                            from tools.tts_tool import text_to_speech_tool, check_tts_requirements
+                            if check_tts_requirements():
+                                import json as _json
+                                tts_result_str = await asyncio.to_thread(
+                                    text_to_speech_tool, text=speech_text
+                                )
+                                tts_data = _json.loads(tts_result_str)
+                                _tts_path = tts_data.get("file_path")
+                        else:
+                            logger.debug(
+                                "[%s] Auto-TTS delivered directly from text",
+                                self.name,
                             )
-                            tts_data = _json.loads(tts_result_str)
-                            _tts_path = tts_data.get("file_path")
                     except Exception as tts_err:
                         logger.warning("[%s] Auto-TTS failed: %s", self.name, tts_err)
 

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -2234,6 +2234,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 call_id,
                 pre_accept.error,
             )
+            await self._close_calling_sidecar_session(call_id)
             return
 
         accept = await self._send_call_action(call_id, "accept", sdp=answer.sdp)
@@ -2243,6 +2244,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 call_id,
                 accept.error,
             )
+            await self._close_calling_sidecar_session(call_id)
             return
 
         logger.info("[whatsapp_cloud] accepted call %s via calling sidecar", call_id)

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -688,6 +688,118 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
         return SendResult(success=True, raw_response=body)
 
+    def _calling_sidecar_call_id_from_metadata(
+        self,
+        metadata: Optional[Dict[str, Any]],
+    ) -> Optional[str]:
+        """Return an active sidecar call id carried by delivery metadata."""
+        if not isinstance(metadata, dict):
+            return None
+        for key in ("whatsapp_call_id", "call_id", "thread_id"):
+            candidate = str(metadata.get(key) or "").strip()
+            if candidate and candidate in self._calling_sidecar_call_ids:
+                return candidate
+        return None
+
+    async def _decode_call_audio_file_to_pcm(
+        self,
+        audio_path: str,
+    ) -> tuple[Optional[bytes], Optional[str]]:
+        """Decode a local audio file into the sidecar's fixed PCM shape."""
+        if not audio_path or audio_path.startswith(("http://", "https://")):
+            return None, "Calling sidecar audio requires a local file"
+        if not os.path.isfile(audio_path):
+            return None, f"Audio file not found: {audio_path}"
+        if not _FFMPEG_PATH:
+            return None, "ffmpeg is required to decode TTS audio for live calls"
+
+        proc = await asyncio.create_subprocess_exec(
+            _FFMPEG_PATH,
+            "-v",
+            "error",
+            "-i",
+            audio_path,
+            "-f",
+            "s16le",
+            "-acodec",
+            "pcm_s16le",
+            "-ar",
+            str(CALLING_PCM_SAMPLE_RATE),
+            "-ac",
+            str(CALLING_PCM_CHANNELS),
+            "pipe:1",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(),
+                timeout=max(self._calling_sidecar_timeout, 30.0),
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.communicate()
+            return None, "ffmpeg timed out while decoding TTS audio for live call"
+
+        if proc.returncode != 0:
+            detail = (stderr or b"").decode("utf-8", errors="replace").strip()
+            return None, (
+                "ffmpeg failed to decode TTS audio for live call"
+                + (f": {detail[:500]}" if detail else "")
+            )
+        if not stdout:
+            return None, "ffmpeg produced no PCM for live call audio"
+        if len(stdout) % CALLING_PCM_BYTES_PER_SAMPLE:
+            return None, "ffmpeg produced partial s16le samples for live call audio"
+        return stdout, None
+
+    async def _send_calling_sidecar_audio_file(
+        self,
+        call_id: str,
+        audio_path: str,
+    ) -> SendResult:
+        """Decode a TTS file and pace it into the live sidecar call."""
+        pcm, error = await self._decode_call_audio_file_to_pcm(audio_path)
+        if error:
+            return SendResult(success=False, error=error)
+        if not pcm:
+            return SendResult(success=False, error="No PCM decoded from TTS audio")
+
+        sequence = 0
+        for offset in range(0, len(pcm), CALLING_PCM_FRAME_BYTES):
+            frame = pcm[offset : offset + CALLING_PCM_FRAME_BYTES]
+            if len(frame) < CALLING_PCM_FRAME_BYTES:
+                frame += b"\x00" * (CALLING_PCM_FRAME_BYTES - len(frame))
+
+            result = await self._send_calling_sidecar_audio(
+                call_id,
+                frame,
+                sequence=sequence,
+            )
+            if not result.success and result.retryable:
+                await asyncio.sleep(CALLING_PCM_FRAME_MS / 1_000)
+                result = await self._send_calling_sidecar_audio(
+                    call_id,
+                    frame,
+                    sequence=sequence,
+                )
+            if not result.success:
+                return result
+
+            sequence += 1
+            if offset + CALLING_PCM_FRAME_BYTES < len(pcm):
+                await asyncio.sleep(CALLING_PCM_FRAME_MS / 1_000)
+
+        return SendResult(
+            success=True,
+            raw_response={
+                "call_id": call_id,
+                "queued_pcm_bytes": len(pcm),
+                "frames": sequence,
+                "audio": CALLING_AUDIO_CONTRACT,
+            },
+        )
+
     async def _receive_calling_sidecar_audio(
         self,
         call_id: str,
@@ -1723,6 +1835,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         audio_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
         """Send an audio file as a WhatsApp voice message.
@@ -1733,6 +1846,10 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         ffmpeg conversion to opus first and fall back to sending the
         MP3 as-is when ffmpeg is unavailable.
         """
+        call_id = self._calling_sidecar_call_id_from_metadata(metadata)
+        if call_id:
+            return await self._send_calling_sidecar_audio_file(call_id, audio_path)
+
         source = audio_path
         mime_type: Optional[str] = None
 

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -2459,6 +2459,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         try:
             proc = await asyncio.create_subprocess_exec(
                 _FFMPEG_PATH, "-y", "-i", audio_path,
+                "-ac", "1", "-ar", "48000",
                 "-c:a", "libopus", "-b:a", "32k", "-vbr", "on",
                 "-application", "voip", out_path,
                 stdout=asyncio.subprocess.DEVNULL,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -53,6 +53,7 @@ import mimetypes
 import os
 import re
 import shutil
+import struct
 import wave
 import uuid
 from collections import OrderedDict
@@ -120,6 +121,14 @@ CALLING_PCM_MAX_INBOUND_QUEUE_BYTES = (
     CALLING_PCM_SAMPLE_RATE * CALLING_PCM_CHANNELS * CALLING_PCM_BYTES_PER_SAMPLE * 10
 )
 CALLING_PCM_ENCODING = "pcm_s16le"
+CALLING_PCM_SPEECH_PEAK_THRESHOLD = 384
+CALLING_PCM_MAX_SEGMENT_BYTES = (
+    CALLING_PCM_SAMPLE_RATE * CALLING_PCM_CHANNELS * CALLING_PCM_BYTES_PER_SAMPLE * 5
+)
+CALLING_PCM_MIN_DISPATCH_BYTES = (
+    CALLING_PCM_SAMPLE_RATE * CALLING_PCM_CHANNELS * CALLING_PCM_BYTES_PER_SAMPLE // 4
+)
+CALLING_PCM_TRAILING_SILENCE_POLLS = 2
 CALLING_AUDIO_CONTRACT = {
     "sample_rate": CALLING_PCM_SAMPLE_RATE,
     "channels": CALLING_PCM_CHANNELS,
@@ -955,6 +964,26 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             wav.writeframes(pcm_s16le)
         return str(out_path)
 
+    @staticmethod
+    def _calling_sidecar_pcm_peak(pcm_s16le: bytes) -> int:
+        """Return the absolute peak amplitude of signed 16-bit PCM."""
+        if not pcm_s16le or len(pcm_s16le) % CALLING_PCM_BYTES_PER_SAMPLE:
+            return 0
+        peak = 0
+        for (sample,) in struct.iter_unpack("<h", pcm_s16le):
+            magnitude = abs(sample)
+            if magnitude > peak:
+                peak = magnitude
+        return peak
+
+    @staticmethod
+    def _calling_sidecar_pcm_has_speech(pcm_s16le: bytes) -> bool:
+        """Cheap silence gate for decoded call audio before STT dispatch."""
+        return (
+            WhatsAppCloudAdapter._calling_sidecar_pcm_peak(pcm_s16le)
+            >= CALLING_PCM_SPEECH_PEAK_THRESHOLD
+        )
+
     async def _dispatch_calling_sidecar_pcm(
         self,
         call_id: str,
@@ -1064,27 +1093,44 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         """Long-poll sidecar PCM and dispatch speech-ish chunks to Hermes."""
         buffer = bytearray()
         silent_polls = 0
-        segment_limit = CALLING_PCM_SAMPLE_RATE * CALLING_PCM_BYTES_PER_SAMPLE * 5
 
         try:
             while call_id in self._calling_sidecar_call_ids:
                 audio = await self._receive_calling_sidecar_audio(call_id)
                 if audio is not None and audio.pcm_s16le:
-                    buffer.extend(audio.pcm_s16le)
-                    silent_polls = 0
-                    if len(buffer) >= segment_limit:
-                        await self._dispatch_calling_sidecar_pcm(
-                            call_id,
-                            chat_id,
-                            sender_name,
-                            bytes(buffer),
-                        )
-                        buffer.clear()
+                    pcm = audio.pcm_s16le
+                    if self._calling_sidecar_pcm_has_speech(pcm):
+                        buffer.extend(pcm)
+                        silent_polls = 0
+                        if len(buffer) >= CALLING_PCM_MAX_SEGMENT_BYTES:
+                            await self._dispatch_calling_sidecar_pcm(
+                                call_id,
+                                chat_id,
+                                sender_name,
+                                bytes(buffer),
+                            )
+                            buffer.clear()
+                        continue
+
+                    if buffer:
+                        silent_polls += 1
+                        if silent_polls == 1:
+                            buffer.extend(pcm)
+                        if silent_polls >= CALLING_PCM_TRAILING_SILENCE_POLLS:
+                            if len(buffer) >= CALLING_PCM_MIN_DISPATCH_BYTES:
+                                await self._dispatch_calling_sidecar_pcm(
+                                    call_id,
+                                    chat_id,
+                                    sender_name,
+                                    bytes(buffer),
+                                )
+                            buffer.clear()
+                            silent_polls = 0
                     continue
 
                 if buffer:
                     silent_polls += 1
-                    if silent_polls >= 2:
+                    if silent_polls >= CALLING_PCM_TRAILING_SILENCE_POLLS:
                         await self._dispatch_calling_sidecar_pcm(
                             call_id,
                             chat_id,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -106,6 +106,7 @@ CALLING_PCM_FRAME_BYTES = (
     * CALLING_PCM_FRAME_MS
     // 1_000
 )
+CALLING_PCM_DRAIN_WAIT_MS = 500
 CALLING_PCM_ENCODING = "pcm_s16le"
 GRAPH_API_BASE = "https://graph.facebook.com"
 # Meta retries failed webhooks for up to 7 days. We don't need to remember
@@ -533,6 +534,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         call_id: str,
         *,
         max_bytes: int = CALLING_PCM_FRAME_BYTES,
+        wait_ms: int = CALLING_PCM_DRAIN_WAIT_MS,
     ) -> Optional[CallingSidecarAudio]:
         """Drain decoded inbound 48 kHz PCM from a local WebRTC sidecar call."""
         if not self._calling_sidecar_enabled():
@@ -558,13 +560,16 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "[whatsapp_cloud] sidecar audio max_bytes must preserve s16le samples"
             )
             return None
+        if not isinstance(wait_ms, int) or wait_ms < 0:
+            logger.warning("[whatsapp_cloud] invalid sidecar audio wait_ms=%r", wait_ms)
+            return None
 
         encoded_call_id = quote(normalized_call_id, safe="")
         url = f"{self._calling_sidecar_url}/calls/{encoded_call_id}/audio"
         try:
             resp = await self._http_client.get(
                 url,
-                params={"max_bytes": max_bytes},
+                params={"max_bytes": max_bytes, "wait_ms": wait_ms},
                 timeout=self._calling_sidecar_timeout,
             )
         except Exception:

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -2231,6 +2231,14 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "[whatsapp_cloud] sidecar did not produce an SDP answer for %s",
                 call_id,
             )
+            reject = await self._send_call_action(call_id, "reject")
+            if not reject.success:
+                logger.warning(
+                    "[whatsapp_cloud] reject failed for %s after sidecar answer "
+                    "failure: %s",
+                    call_id,
+                    reject.error,
+                )
             return
         self._calling_sidecar_call_ids.add(call_id)
 

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -39,6 +39,10 @@ Optional / Phase-3+:
 - WHATSAPP_CLOUD_API_VERSION      (default v20.0)
 - WHATSAPP_CLOUD_CALLING_SIDECAR_URL      (optional WebRTC SDP bridge)
 - WHATSAPP_CLOUD_CALLING_SIDECAR_TIMEOUT  (default 10.0 seconds)
+- WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND
+                                     (optional raw pcm_s16le TTS command)
+- WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT
+                                     (default 180.0 seconds)
 """
 
 from __future__ import annotations
@@ -54,6 +58,7 @@ import os
 import re
 import shutil
 import struct
+import tempfile
 import wave
 import uuid
 from collections import OrderedDict
@@ -98,6 +103,7 @@ DEFAULT_WEBHOOK_HOST = "0.0.0.0"
 DEFAULT_WEBHOOK_PORT = 8090
 DEFAULT_WEBHOOK_PATH = "/whatsapp/webhook"
 DEFAULT_CALLING_SIDECAR_TIMEOUT = 10.0
+DEFAULT_CALLING_SIDECAR_TTS_STREAM_TIMEOUT = 180.0
 CALLING_PCM_SAMPLE_RATE = 48_000
 CALLING_PCM_CHANNELS = 1
 CALLING_PCM_FRAME_MS = 20
@@ -343,6 +349,18 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             or extra.get("callingSidecarTimeout")
             or os.getenv("WHATSAPP_CLOUD_CALLING_SIDECAR_TIMEOUT"),
             DEFAULT_CALLING_SIDECAR_TIMEOUT,
+        )
+        self._calling_sidecar_tts_stream_command: str = str(
+            extra.get("calling_sidecar_tts_stream_command")
+            or extra.get("callingSidecarTtsStreamCommand")
+            or os.getenv("WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND")
+            or ""
+        ).strip()
+        self._calling_sidecar_tts_stream_timeout: float = self._coerce_positive_float(
+            extra.get("calling_sidecar_tts_stream_timeout")
+            or extra.get("callingSidecarTtsStreamTimeout")
+            or os.getenv("WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT"),
+            DEFAULT_CALLING_SIDECAR_TTS_STREAM_TIMEOUT,
         )
 
         # Behavior-mixin contract: these names are read by the mixin's
@@ -863,6 +881,226 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "audio": audio,
             },
         )
+
+    async def _send_calling_sidecar_tts_stream_command(
+        self,
+        call_id: str,
+        text: str,
+    ) -> SendResult:
+        """Run a raw-PCM TTS stream command and post frames to the sidecar."""
+        command_template = str(
+            getattr(self, "_calling_sidecar_tts_stream_command", "") or ""
+        ).strip()
+        if not command_template:
+            return SendResult(
+                success=False,
+                error="Calling sidecar TTS stream command not configured",
+            )
+
+        normalized_call_id = str(call_id or "").strip()
+        text = str(text or "").strip()
+        if not normalized_call_id or not text:
+            return SendResult(success=False, error="Missing call_id or TTS text")
+
+        audio = self._calling_sidecar_audio_contract()
+        frame_bytes = int(audio["frame_bytes"])
+        frame_ms = int(audio["frame_ms"])
+        timeout = float(
+            getattr(
+                self,
+                "_calling_sidecar_tts_stream_timeout",
+                DEFAULT_CALLING_SIDECAR_TTS_STREAM_TIMEOUT,
+            )
+        )
+
+        async def terminate_process(proc: Any) -> None:
+            if getattr(proc, "returncode", None) is not None:
+                return
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                return
+            except Exception:
+                logger.debug(
+                    "[whatsapp_cloud] failed to kill TTS stream command",
+                    exc_info=True,
+                )
+                return
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=2.0)
+            except Exception:
+                pass
+
+        async def send_frame(frame: bytes, sequence: int) -> SendResult:
+            result = await self._send_calling_sidecar_audio(
+                normalized_call_id,
+                frame,
+                sequence=sequence,
+            )
+            if not result.success and result.retryable:
+                await asyncio.sleep(frame_ms / 1_000)
+                result = await self._send_calling_sidecar_audio(
+                    normalized_call_id,
+                    frame,
+                    sequence=sequence,
+                )
+            return result
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            text_path = Path(tmpdir) / "input.txt"
+            text_path.write_text(text, encoding="utf-8")
+
+            try:
+                from tools.tts_tool import _render_command_tts_template
+
+                command = _render_command_tts_template(
+                    command_template,
+                    {
+                        "input_path": str(text_path),
+                        "text_path": str(text_path),
+                        "text": text,
+                        "sample_rate": str(int(audio["sample_rate"])),
+                        "channels": str(int(audio["channels"])),
+                        "frame_ms": str(frame_ms),
+                        "encoding": str(audio["encoding"]),
+                        "voice": "",
+                        "speed": "",
+                    },
+                )
+            except Exception as exc:
+                return SendResult(
+                    success=False,
+                    error=f"Failed to render TTS stream command: {exc}",
+                )
+
+            try:
+                proc = await asyncio.create_subprocess_shell(
+                    command,
+                    stdin=asyncio.subprocess.DEVNULL,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+            except Exception as exc:
+                logger.exception("[whatsapp_cloud] failed to start TTS stream command")
+                return SendResult(success=False, error=str(exc), retryable=True)
+
+            if proc.stdout is None:
+                await terminate_process(proc)
+                return SendResult(
+                    success=False,
+                    error="TTS stream command did not expose stdout",
+                )
+
+            stderr_task = (
+                asyncio.create_task(proc.stderr.read())
+                if proc.stderr is not None
+                else None
+            )
+
+            async def cancel_stderr_task() -> None:
+                if stderr_task is None or stderr_task.done():
+                    return
+                stderr_task.cancel()
+                try:
+                    await stderr_task
+                except asyncio.CancelledError:
+                    pass
+                except Exception:
+                    pass
+
+            pending = bytearray()
+            sequence = 0
+            accepted_bytes = 0
+
+            try:
+                while True:
+                    chunk = await asyncio.wait_for(
+                        proc.stdout.read(frame_bytes * 8),
+                        timeout=timeout,
+                    )
+                    if not chunk:
+                        break
+                    pending.extend(chunk)
+                    while len(pending) >= frame_bytes:
+                        frame = bytes(pending[:frame_bytes])
+                        del pending[:frame_bytes]
+                        result = await send_frame(frame, sequence)
+                        if not result.success:
+                            await terminate_process(proc)
+                            await cancel_stderr_task()
+                            return result
+                        sequence += 1
+                        accepted_bytes += len(frame)
+
+                if pending:
+                    frame = bytes(pending)
+                    frame += b"\x00" * (frame_bytes - len(frame))
+                    result = await send_frame(frame, sequence)
+                    if not result.success:
+                        await terminate_process(proc)
+                        await cancel_stderr_task()
+                        return result
+                    sequence += 1
+                    accepted_bytes += len(pending)
+
+                returncode = await asyncio.wait_for(proc.wait(), timeout=5.0)
+            except asyncio.TimeoutError:
+                await terminate_process(proc)
+                await cancel_stderr_task()
+                return SendResult(
+                    success=False,
+                    error=f"TTS stream command timed out after {timeout:g}s",
+                    retryable=True,
+                )
+
+            stderr = b""
+            if stderr_task is not None:
+                try:
+                    stderr = await stderr_task
+                except Exception:
+                    stderr = b""
+
+            if returncode != 0:
+                detail = stderr.decode("utf-8", errors="replace").strip()
+                return SendResult(
+                    success=False,
+                    error=(
+                        f"TTS stream command exited with code {returncode}"
+                        + (f": {detail[:500]}" if detail else "")
+                    ),
+                )
+            if sequence == 0:
+                return SendResult(
+                    success=False,
+                    error="TTS stream command produced no PCM frames",
+                )
+
+        return SendResult(
+            success=True,
+            raw_response={
+                "call_id": normalized_call_id,
+                "queued_pcm_bytes": accepted_bytes,
+                "frames": sequence,
+                "audio": audio,
+            },
+        )
+
+    async def play_tts_text(
+        self,
+        chat_id: str,
+        text: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Stream synthesized reply text directly into an active sidecar call."""
+        call_id = self._calling_sidecar_call_id_from_metadata(metadata)
+        if not call_id:
+            return SendResult(
+                success=False,
+                error="No active calling sidecar call for TTS text",
+            )
+        return await self._send_calling_sidecar_tts_stream_command(call_id, text)
 
     async def _receive_calling_sidecar_audio(
         self,
@@ -2352,6 +2590,9 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "calling_sidecar_contract_loaded": isinstance(
                     getattr(self, "_calling_sidecar_contract", None),
                     dict,
+                ),
+                "calling_sidecar_tts_stream_configured": bool(
+                    getattr(self, "_calling_sidecar_tts_stream_command", ""),
                 ),
                 "ffmpeg_present": _FFMPEG_PATH is not None,
                 "accepted": self._accepted_count,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -408,6 +408,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         # Runtime
         self._runner = None
         self._http_client: Optional["httpx.AsyncClient"] = None
+        self._calling_sidecar_call_ids: set[str] = set()
 
     # ------------------------------------------------------------------ helpers
     @staticmethod
@@ -896,6 +897,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "[whatsapp_cloud] sidecar had no session for terminated call %s",
                 normalized_call_id,
             )
+            self._calling_sidecar_call_ids.discard(normalized_call_id)
             return True
         if resp.status_code != 200:
             logger.warning(
@@ -905,7 +907,13 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 str(getattr(resp, "text", ""))[:500],
             )
             return False
+        self._calling_sidecar_call_ids.discard(normalized_call_id)
         return True
+
+    async def _close_all_calling_sidecar_sessions(self) -> None:
+        """Best-effort close for every local sidecar session Hermes created."""
+        for call_id in sorted(self._calling_sidecar_call_ids):
+            await self._close_calling_sidecar_session(call_id)
 
     @staticmethod
     def _bounded_put(cache: "OrderedDict[str, str]", key: str, value: str) -> None:
@@ -1015,6 +1023,8 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             except Exception:
                 logger.exception("[whatsapp_cloud] webhook server cleanup failed")
             self._runner = None
+        if self._calling_sidecar_call_ids:
+            await self._close_all_calling_sidecar_sessions()
         if self._http_client is not None:
             try:
                 await self._http_client.aclose()
@@ -2222,6 +2232,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 call_id,
             )
             return
+        self._calling_sidecar_call_ids.add(call_id)
 
         pre_accept = await self._send_call_action(
             call_id,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import binascii
 import hashlib
 import hmac
 import logging
@@ -97,6 +98,14 @@ DEFAULT_CALLING_SIDECAR_TIMEOUT = 10.0
 CALLING_PCM_SAMPLE_RATE = 48_000
 CALLING_PCM_CHANNELS = 1
 CALLING_PCM_FRAME_MS = 20
+CALLING_PCM_BYTES_PER_SAMPLE = 2
+CALLING_PCM_FRAME_BYTES = (
+    CALLING_PCM_SAMPLE_RATE
+    * CALLING_PCM_CHANNELS
+    * CALLING_PCM_BYTES_PER_SAMPLE
+    * CALLING_PCM_FRAME_MS
+    // 1_000
+)
 CALLING_PCM_ENCODING = "pcm_s16le"
 GRAPH_API_BASE = "https://graph.facebook.com"
 # Meta retries failed webhooks for up to 7 days. We don't need to remember
@@ -181,6 +190,17 @@ class CallingSidecarAnswer:
 
     call_id: str
     sdp: str
+    audio: Dict[str, Any]
+
+
+@dataclass(frozen=True)
+class CallingSidecarAudio:
+    """Decoded inbound PCM drained from the local WhatsApp Calling sidecar."""
+
+    call_id: str
+    pcm_s16le: bytes
+    returned_bytes: int
+    queued_rx_bytes: int
     audio: Dict[str, Any]
 
 
@@ -507,6 +527,117 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             return SendResult(success=False, error=error_msg, raw_response=body)
 
         return SendResult(success=True, raw_response=body)
+
+    async def _receive_calling_sidecar_audio(
+        self,
+        call_id: str,
+        *,
+        max_bytes: int = CALLING_PCM_FRAME_BYTES,
+    ) -> Optional[CallingSidecarAudio]:
+        """Drain decoded inbound 48 kHz PCM from a local WebRTC sidecar call."""
+        if not self._calling_sidecar_enabled():
+            return None
+        if self._http_client is None:
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar configured but HTTP client "
+                "is unavailable"
+            )
+            return None
+
+        normalized_call_id = str(call_id or "").strip()
+        if not normalized_call_id:
+            return None
+        if not isinstance(max_bytes, int) or max_bytes <= 0:
+            logger.warning(
+                "[whatsapp_cloud] invalid sidecar audio max_bytes=%r",
+                max_bytes,
+            )
+            return None
+        if max_bytes % CALLING_PCM_BYTES_PER_SAMPLE:
+            logger.warning(
+                "[whatsapp_cloud] sidecar audio max_bytes must preserve s16le samples"
+            )
+            return None
+
+        encoded_call_id = quote(normalized_call_id, safe="")
+        url = f"{self._calling_sidecar_url}/calls/{encoded_call_id}/audio"
+        try:
+            resp = await self._http_client.get(
+                url,
+                params={"max_bytes": max_bytes},
+                timeout=self._calling_sidecar_timeout,
+            )
+        except Exception:
+            logger.exception(
+                "[whatsapp_cloud] calling sidecar audio drain failed for %s",
+                normalized_call_id,
+            )
+            return None
+
+        if resp.status_code != 200:
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar audio drain rejected "
+                "(status=%d): %s",
+                resp.status_code,
+                str(getattr(resp, "text", ""))[:500],
+            )
+            return None
+
+        try:
+            data = resp.json()
+        except Exception:
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar audio drain returned invalid JSON"
+            )
+            return None
+        if not isinstance(data, dict):
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar audio drain response is not an object"
+            )
+            return None
+
+        try:
+            pcm = base64.b64decode(
+                str(data.get("pcm_s16le_base64") or ""),
+                validate=True,
+            )
+        except (binascii.Error, ValueError):
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar audio drain had invalid base64"
+            )
+            return None
+
+        try:
+            returned_bytes = int(data.get("returned_bytes") or 0)
+            queued_rx_bytes = int(data.get("queued_rx_bytes") or 0)
+        except (TypeError, ValueError):
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar audio drain had invalid byte counts"
+            )
+            return None
+        if returned_bytes != len(pcm):
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar audio drain byte count mismatch "
+                "(reported=%d, decoded=%d)",
+                returned_bytes,
+                len(pcm),
+            )
+            return None
+        if len(pcm) % CALLING_PCM_BYTES_PER_SAMPLE:
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar audio drain returned partial s16le sample"
+            )
+            return None
+
+        audio = data.get("audio")
+        answer_call_id = str(data.get("call_id") or "").strip() or normalized_call_id
+        return CallingSidecarAudio(
+            call_id=answer_call_id,
+            pcm_s16le=pcm,
+            returned_bytes=returned_bytes,
+            queued_rx_bytes=queued_rx_bytes,
+            audio=audio if isinstance(audio, dict) else {},
+        )
 
     async def _send_call_action(
         self,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -428,6 +428,67 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             audio=audio if isinstance(audio, dict) else {},
         )
 
+    async def _send_call_action(
+        self,
+        call_id: str,
+        action: str,
+        *,
+        sdp: Optional[str] = None,
+    ) -> SendResult:
+        """Send a WhatsApp Calling action to Graph API.
+
+        ``pre_accept`` and ``accept`` require an SDP answer session; ``reject``
+        and ``terminate`` do not.
+        """
+        if self._http_client is None:
+            return SendResult(success=False, error="Not connected")
+
+        normalized_call_id = str(call_id or "").strip()
+        normalized_action = str(action or "").strip()
+        if not normalized_call_id or not normalized_action:
+            return SendResult(success=False, error="Missing call_id or action")
+
+        payload: Dict[str, Any] = {
+            "messaging_product": "whatsapp",
+            "call_id": normalized_call_id,
+            "action": normalized_action,
+        }
+        if sdp is not None:
+            sdp_text = str(sdp)
+            if not sdp_text.strip():
+                return SendResult(success=False, error="Missing SDP answer")
+            payload["session"] = {
+                "sdp_type": "answer",
+                "sdp": sdp_text,
+            }
+
+        url = self._graph_url("calls")
+        headers = {
+            "Authorization": f"Bearer {self._access_token}",
+            "Content-Type": "application/json",
+        }
+        try:
+            resp = await self._http_client.post(url, headers=headers, json=payload)
+        except Exception as exc:
+            logger.exception("[whatsapp_cloud] call action %s failed", normalized_action)
+            return SendResult(success=False, error=str(exc))
+
+        if resp.status_code != 200:
+            try:
+                body = resp.json()
+            except Exception:
+                body = {"raw": resp.text[:500]}
+            error_msg = self._format_graph_error(body, resp.status_code)
+            logger.warning(
+                "[whatsapp_cloud] call action %s rejected (status=%d): %s",
+                normalized_action,
+                resp.status_code,
+                error_msg,
+            )
+            return SendResult(success=False, error=error_msg)
+
+        return SendResult(success=True)
+
     @staticmethod
     def _bounded_put(cache: "OrderedDict[str, str]", key: str, value: str) -> None:
         """Insert into a FIFO-capped OrderedDict, evicting oldest entries."""
@@ -1584,16 +1645,19 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         return True
 
     async def _dispatch_payload(self, payload: Dict[str, Any]) -> None:
-        """Walk a verified Meta webhook payload and dispatch each message.
+        """Walk a verified Meta webhook payload and dispatch each message/call.
 
         Payload shape (truncated):
           {object, entry: [{id, changes: [{value: {messages, contacts,
-          statuses, metadata}, field: "messages"}]}]}
+          statuses, metadata}, field: "messages"|"calls"}]}]}
 
         We surface ``messages`` events as MessageEvents; ``statuses``
         events (sent/delivered/read/failed) are logged but not dispatched
         — the agent doesn't currently consume delivery receipts and
         forwarding them would create noisy synthetic events.
+
+        ``calls`` connect events are routed to the optional local WebRTC
+        sidecar when configured.
         """
         if payload.get("object") != "whatsapp_business_account":
             logger.debug(
@@ -1607,12 +1671,16 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             for change in entry.get("changes") or []:
                 if not isinstance(change, dict):
                     continue
-                if change.get("field") != "messages":
+                field = change.get("field")
+                value = change.get("value") or {}
+                if field == "calls":
+                    await self._dispatch_call_events(value)
+                    continue
+                if field != "messages":
                     # Other fields (account_alerts, template_status_update,
                     # etc.) are subscription-dependent and not message
                     # ingress. Silent skip.
                     continue
-                value = change.get("value") or {}
                 contacts = value.get("contacts") or []
                 metadata = value.get("metadata") or {}
                 # Build a wa_id → profile-name index for the messages we're
@@ -1674,6 +1742,90 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                             status.get("status"),
                             status.get("id"),
                         )
+
+    async def _dispatch_call_events(self, value: Dict[str, Any]) -> None:
+        """Handle WhatsApp Calling webhook events from a verified payload."""
+        for raw_call in value.get("calls") or []:
+            if not isinstance(raw_call, dict):
+                continue
+            event = str(raw_call.get("event") or "").strip().lower()
+            call_id = str(raw_call.get("id") or "").strip()
+            if event == "connect":
+                await self._handle_call_connect(raw_call)
+            elif event == "terminate":
+                logger.info(
+                    "[whatsapp_cloud] call terminated (call_id=%s, status=%s)",
+                    call_id,
+                    raw_call.get("status"),
+                )
+            else:
+                logger.debug(
+                    "[whatsapp_cloud] ignoring call event %r for %s",
+                    raw_call.get("event"),
+                    call_id,
+                )
+
+    async def _handle_call_connect(self, raw_call: Dict[str, Any]) -> None:
+        """Handle an inbound WhatsApp Calling connect offer."""
+        call_id = str(raw_call.get("id") or "").strip()
+        session = raw_call.get("session") or {}
+        if not isinstance(session, dict):
+            logger.warning(
+                "[whatsapp_cloud] call connect %s had non-object session",
+                call_id or "<missing>",
+            )
+            return
+
+        sdp_type = str(session.get("sdp_type") or "").strip().lower()
+        remote_sdp = str(session.get("sdp") or "")
+        if not call_id or sdp_type != "offer" or not remote_sdp.strip():
+            logger.warning(
+                "[whatsapp_cloud] ignoring malformed call connect "
+                "(call_id=%s, sdp_type=%s)",
+                call_id or "<missing>",
+                sdp_type or "<missing>",
+            )
+            return
+
+        if not self._calling_sidecar_enabled():
+            logger.info(
+                "[whatsapp_cloud] received call connect %s but no calling "
+                "sidecar is configured",
+                call_id,
+            )
+            return
+
+        answer = await self._request_calling_sidecar_answer(call_id, remote_sdp)
+        if answer is None:
+            logger.warning(
+                "[whatsapp_cloud] sidecar did not produce an SDP answer for %s",
+                call_id,
+            )
+            return
+
+        pre_accept = await self._send_call_action(
+            call_id,
+            "pre_accept",
+            sdp=answer.sdp,
+        )
+        if not pre_accept.success:
+            logger.warning(
+                "[whatsapp_cloud] pre_accept failed for %s: %s",
+                call_id,
+                pre_accept.error,
+            )
+            return
+
+        accept = await self._send_call_action(call_id, "accept", sdp=answer.sdp)
+        if not accept.success:
+            logger.warning(
+                "[whatsapp_cloud] accept failed for %s: %s",
+                call_id,
+                accept.error,
+            )
+            return
+
+        logger.info("[whatsapp_cloud] accepted call %s via calling sidecar", call_id)
 
     async def _dispatch_interactive_reply(
         self,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -37,6 +37,8 @@ Optional / Phase-3+:
 - WHATSAPP_CLOUD_WEBHOOK_PORT     (default 8090)
 - WHATSAPP_CLOUD_WEBHOOK_PATH     (default /whatsapp/webhook)
 - WHATSAPP_CLOUD_API_VERSION      (default v20.0)
+- WHATSAPP_CLOUD_CALLING_SIDECAR_URL      (optional WebRTC SDP bridge)
+- WHATSAPP_CLOUD_CALLING_SIDECAR_TIMEOUT  (default 10.0 seconds)
 """
 
 from __future__ import annotations
@@ -51,6 +53,7 @@ import re
 import shutil
 import uuid
 from collections import OrderedDict
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -88,6 +91,7 @@ DEFAULT_API_VERSION = "v20.0"
 DEFAULT_WEBHOOK_HOST = "0.0.0.0"
 DEFAULT_WEBHOOK_PORT = 8090
 DEFAULT_WEBHOOK_PATH = "/whatsapp/webhook"
+DEFAULT_CALLING_SIDECAR_TIMEOUT = 10.0
 GRAPH_API_BASE = "https://graph.facebook.com"
 # Meta retries failed webhooks for up to 7 days. We don't need to remember
 # every wamid for the full retry window — the practical risk is duplicate
@@ -165,6 +169,15 @@ def _ext_for_mime(mime: str) -> Optional[str]:
 _INBOUND_MEDIA_CACHE = Path(get_hermes_dir("platforms/whatsapp_cloud/media", "whatsapp_cloud/media"))
 
 
+@dataclass(frozen=True)
+class CallingSidecarAnswer:
+    """Validated SDP answer returned by the local WhatsApp Calling sidecar."""
+
+    call_id: str
+    sdp: str
+    audio: Dict[str, Any]
+
+
 def check_whatsapp_cloud_requirements() -> bool:
     """Return whether transport dependencies are available.
 
@@ -214,13 +227,27 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         # Graph API
         self._api_version: str = str(extra.get("api_version", DEFAULT_API_VERSION))
 
+        # Optional WhatsApp Calling/WebRTC sidecar. This is intentionally
+        # separate from Graph API calls: the sidecar owns SDP/media bridging
+        # while the Cloud adapter remains the webhook/session boundary.
+        self._calling_sidecar_url: str = str(
+            extra.get("calling_sidecar_url")
+            or extra.get("callingSidecarUrl")
+            or os.getenv("WHATSAPP_CLOUD_CALLING_SIDECAR_URL")
+            or ""
+        ).strip().rstrip("/")
+        self._calling_sidecar_timeout: float = self._coerce_positive_float(
+            extra.get("calling_sidecar_timeout")
+            or extra.get("callingSidecarTimeout")
+            or os.getenv("WHATSAPP_CLOUD_CALLING_SIDECAR_TIMEOUT"),
+            DEFAULT_CALLING_SIDECAR_TIMEOUT,
+        )
+
         # Behavior-mixin contract: these names are read by the mixin's
         # gating methods. WHATSAPP_CLOUD_* env vars take precedence so the
         # two adapters can run in parallel with independent policies; the
         # shared WHATSAPP_* names remain as fallback for single-adapter
         # setups.
-        import os
-
         self._reply_prefix: Optional[str] = extra.get("reply_prefix")
         self._dm_policy: str = str(
             extra.get("dm_policy")
@@ -302,6 +329,104 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if path.startswith("/"):
             path = path[1:]
         return f"{GRAPH_API_BASE}/{self._api_version}/{self._phone_number_id}/{path}"
+
+    @staticmethod
+    def _coerce_positive_float(value: Any, default: float) -> float:
+        if value is None:
+            return default
+        try:
+            parsed = float(value)
+        except (TypeError, ValueError):
+            return default
+        return parsed if parsed > 0 else default
+
+    def _calling_sidecar_enabled(self) -> bool:
+        return bool(self._calling_sidecar_url)
+
+    async def _request_calling_sidecar_answer(
+        self,
+        call_id: str,
+        remote_sdp: str,
+    ) -> Optional[CallingSidecarAnswer]:
+        """Ask the configured local WebRTC sidecar for an SDP answer.
+
+        The sidecar contract mirrors the voice repo's prototype:
+        POST /offer with {"call_id", "type": "offer", "sdp"} and expect
+        {"type": "answer", "sdp": "...", "audio": {...}}. Full Meta
+        Calling webhook handling can call this once it has extracted the
+        inbound offer.
+        """
+        if not self._calling_sidecar_enabled():
+            return None
+        if self._http_client is None:
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar configured but HTTP client "
+                "is unavailable"
+            )
+            return None
+
+        normalized_call_id = str(call_id or "").strip()
+        remote_sdp_text = str(remote_sdp or "")
+        if not normalized_call_id or not remote_sdp_text.strip():
+            logger.warning(
+                "[whatsapp_cloud] refusing calling sidecar request with empty "
+                "call_id or sdp"
+            )
+            return None
+
+        url = f"{self._calling_sidecar_url}/offer"
+        payload = {
+            "call_id": normalized_call_id,
+            "type": "offer",
+            "sdp": remote_sdp_text,
+        }
+        try:
+            resp = await self._http_client.post(
+                url,
+                json=payload,
+                timeout=self._calling_sidecar_timeout,
+            )
+        except Exception:
+            logger.exception("[whatsapp_cloud] calling sidecar offer request failed")
+            return None
+
+        if resp.status_code != 200:
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar rejected offer "
+                "(status=%d): %s",
+                resp.status_code,
+                str(getattr(resp, "text", ""))[:500],
+            )
+            return None
+
+        try:
+            data = resp.json()
+        except Exception:
+            logger.warning("[whatsapp_cloud] calling sidecar returned invalid JSON")
+            return None
+
+        if not isinstance(data, dict):
+            logger.warning("[whatsapp_cloud] calling sidecar response is not an object")
+            return None
+        if data.get("type") != "answer":
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar response type was %r, not 'answer'",
+                data.get("type"),
+            )
+            return None
+
+        sdp = str(data.get("sdp") or "")
+        if not sdp.strip():
+            logger.warning("[whatsapp_cloud] calling sidecar answer missing sdp")
+            return None
+
+        audio = data.get("audio")
+        answer_call_id = str(data.get("call_id") or "").strip() or normalized_call_id
+        return CallingSidecarAnswer(
+            call_id=answer_call_id,
+            sdp=sdp,
+            audio=audio if isinstance(audio, dict) else {},
+        )
 
     @staticmethod
     def _bounded_put(cache: "OrderedDict[str, str]", key: str, value: str) -> None:
@@ -1312,6 +1437,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "webhook_path": self._webhook_path,
                 "verify_token_configured": bool(self._verify_token),
                 "app_secret_configured": bool(self._app_secret),
+                "calling_sidecar_configured": self._calling_sidecar_enabled(),
                 "ffmpeg_present": _FFMPEG_PATH is not None,
                 "accepted": self._accepted_count,
                 "duplicates": self._duplicate_count,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -56,6 +56,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional
+from urllib.parse import quote
 
 try:
     from aiohttp import web
@@ -488,6 +489,51 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             return SendResult(success=False, error=error_msg)
 
         return SendResult(success=True)
+
+    async def _close_calling_sidecar_session(self, call_id: str) -> bool:
+        """Best-effort close for a local WebRTC sidecar call session."""
+        if not self._calling_sidecar_enabled():
+            return False
+        if self._http_client is None:
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar configured but HTTP client "
+                "is unavailable"
+            )
+            return False
+
+        normalized_call_id = str(call_id or "").strip()
+        if not normalized_call_id:
+            return False
+
+        encoded_call_id = quote(normalized_call_id, safe="")
+        url = f"{self._calling_sidecar_url}/calls/{encoded_call_id}/close"
+        try:
+            resp = await self._http_client.post(
+                url,
+                timeout=self._calling_sidecar_timeout,
+            )
+        except Exception:
+            logger.exception(
+                "[whatsapp_cloud] calling sidecar close request failed for %s",
+                normalized_call_id,
+            )
+            return False
+
+        if resp.status_code == 404:
+            logger.debug(
+                "[whatsapp_cloud] sidecar had no session for terminated call %s",
+                normalized_call_id,
+            )
+            return True
+        if resp.status_code != 200:
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar close rejected "
+                "(status=%d): %s",
+                resp.status_code,
+                str(getattr(resp, "text", ""))[:500],
+            )
+            return False
+        return True
 
     @staticmethod
     def _bounded_put(cache: "OrderedDict[str, str]", key: str, value: str) -> None:
@@ -1753,6 +1799,8 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if event == "connect":
                 await self._handle_call_connect(raw_call)
             elif event == "terminate":
+                if call_id:
+                    await self._close_calling_sidecar_session(call_id)
                 logger.info(
                     "[whatsapp_cloud] call terminated (call_id=%s, status=%s)",
                     call_id,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -589,9 +589,17 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             )
             return None
 
-        answer_call_id = str(data.get("call_id") or "").strip() or normalized_call_id
+        answer_call_id = str(data.get("call_id") or "").strip()
+        if answer_call_id and answer_call_id != normalized_call_id:
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar answer call_id mismatch "
+                "(expected=%s, got=%s)",
+                normalized_call_id,
+                answer_call_id,
+            )
+            return None
         return CallingSidecarAnswer(
-            call_id=answer_call_id,
+            call_id=normalized_call_id,
             sdp=sdp,
             audio=audio,
         )
@@ -793,9 +801,17 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             )
             return None
 
-        answer_call_id = str(data.get("call_id") or "").strip() or normalized_call_id
+        answer_call_id = str(data.get("call_id") or "").strip()
+        if answer_call_id and answer_call_id != normalized_call_id:
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar audio drain call_id mismatch "
+                "(expected=%s, got=%s)",
+                normalized_call_id,
+                answer_call_id,
+            )
+            return None
         return CallingSidecarAudio(
-            call_id=answer_call_id,
+            call_id=normalized_call_id,
             pcm_s16le=pcm,
             returned_bytes=returned_bytes,
             queued_rx_bytes=queued_rx_bytes,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -44,6 +44,7 @@ Optional / Phase-3+:
 from __future__ import annotations
 
 import asyncio
+import base64
 import hashlib
 import hmac
 import logging
@@ -93,6 +94,10 @@ DEFAULT_WEBHOOK_HOST = "0.0.0.0"
 DEFAULT_WEBHOOK_PORT = 8090
 DEFAULT_WEBHOOK_PATH = "/whatsapp/webhook"
 DEFAULT_CALLING_SIDECAR_TIMEOUT = 10.0
+CALLING_PCM_SAMPLE_RATE = 48_000
+CALLING_PCM_CHANNELS = 1
+CALLING_PCM_FRAME_MS = 20
+CALLING_PCM_ENCODING = "pcm_s16le"
 GRAPH_API_BASE = "https://graph.facebook.com"
 # Meta retries failed webhooks for up to 7 days. We don't need to remember
 # every wamid for the full retry window — the practical risk is duplicate
@@ -428,6 +433,80 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             sdp=sdp,
             audio=audio if isinstance(audio, dict) else {},
         )
+
+    async def _send_calling_sidecar_audio(
+        self,
+        call_id: str,
+        pcm_s16le: bytes,
+        *,
+        sequence: Optional[int] = None,
+    ) -> SendResult:
+        """Queue outbound 48 kHz 20 ms PCM for a local WebRTC sidecar call."""
+        if not self._calling_sidecar_enabled():
+            return SendResult(success=False, error="Calling sidecar not configured")
+        if self._http_client is None:
+            return SendResult(success=False, error="Not connected")
+
+        normalized_call_id = str(call_id or "").strip()
+        if not normalized_call_id:
+            return SendResult(success=False, error="Missing call_id")
+        if not isinstance(pcm_s16le, (bytes, bytearray, memoryview)):
+            return SendResult(success=False, error="PCM payload must be bytes")
+
+        pcm_bytes = bytes(pcm_s16le)
+        if not pcm_bytes:
+            return SendResult(success=False, error="PCM payload is empty")
+        if len(pcm_bytes) % 2:
+            return SendResult(
+                success=False,
+                error="PCM payload must contain whole s16le samples",
+            )
+
+        encoded_call_id = quote(normalized_call_id, safe="")
+        url = f"{self._calling_sidecar_url}/calls/{encoded_call_id}/audio"
+        payload: Dict[str, Any] = {
+            "sample_rate": CALLING_PCM_SAMPLE_RATE,
+            "channels": CALLING_PCM_CHANNELS,
+            "frame_ms": CALLING_PCM_FRAME_MS,
+            "encoding": CALLING_PCM_ENCODING,
+            "pcm_s16le_base64": base64.b64encode(pcm_bytes).decode("ascii"),
+        }
+        if sequence is not None:
+            payload["sequence"] = sequence
+
+        try:
+            resp = await self._http_client.post(
+                url,
+                json=payload,
+                timeout=self._calling_sidecar_timeout,
+            )
+        except Exception as exc:
+            logger.exception(
+                "[whatsapp_cloud] calling sidecar audio request failed for %s",
+                normalized_call_id,
+            )
+            return SendResult(success=False, error=str(exc), retryable=True)
+
+        try:
+            body = resp.json()
+        except Exception:
+            body = {"raw": str(getattr(resp, "text", ""))[:500]}
+
+        if resp.status_code != 200:
+            error_msg = ""
+            if isinstance(body, dict):
+                error_msg = str(body.get("error") or "")
+            if not error_msg:
+                error_msg = f"calling sidecar audio failed with HTTP {resp.status_code}"
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar audio rejected "
+                "(status=%d): %s",
+                resp.status_code,
+                error_msg,
+            )
+            return SendResult(success=False, error=error_msg, raw_response=body)
+
+        return SendResult(success=True, raw_response=body)
 
     async def _send_call_action(
         self,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -19,9 +19,9 @@ Phase scope (this file evolves across phases):
             + wamid replay protection + dispatch via handle_message. Phase 3
             adapter is end-to-end usable for text DMs.
 - Phase 4 — media upload + send (image/video/audio/document), inbound
-            media download via the Graph media endpoint, voice-note opus
-            conversion via ffmpeg with graceful MP3 fallback when ffmpeg
-            isn't on PATH. Document text injection for readable types.
+            media download via the Graph media endpoint, voice-note Ogg/Opus
+            pass-through with ffmpeg conversion fallback when needed.
+            Document text injection for readable types.
 - Phase 5 — 24-hour conversation window + template fallback.
 
 Required env vars to enable the adapter:
@@ -179,9 +179,12 @@ _DEFAULT_MIME = {
     "sticker": "image/webp",
 }
 
+_WHATSAPP_OPUS_MIME = "audio/ogg; codecs=opus"
+_WHATSAPP_OPUS_EXTENSIONS = (".ogg", ".opus")
+
 # ffmpeg location at import time. ``shutil.which`` honours PATHEXT on
-# Windows so a user's ``ffmpeg.exe`` is picked up. None means MP3 voice
-# falls back to "audio file attachment" rendering in WhatsApp.
+# Windows so a user's ``ffmpeg.exe`` is picked up. None means non-Opus
+# voice output falls back to "audio file attachment" rendering in WhatsApp.
 _FFMPEG_PATH = shutil.which("ffmpeg")
 
 # Python's mimetypes module returns RFC-correct but real-world-uncommon
@@ -2369,9 +2372,9 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
         WhatsApp renders ``audio/ogg; codecs=opus`` as the green
         voice-note bubble; other audio types (MP3, AAC, etc.) appear as
-        a generic audio attachment. Hermes TTS produces MP3, so we try
-        ffmpeg conversion to opus first and fall back to sending the
-        MP3 as-is when ffmpeg is unavailable.
+        a generic audio attachment. Existing Ogg/Opus files are uploaded
+        directly with the WhatsApp voice MIME; other local audio is
+        converted to Ogg/Opus with ffmpeg when available.
         """
         call_id = self._calling_sidecar_call_id_from_metadata(metadata)
         if call_id:
@@ -2380,32 +2383,33 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         source = audio_path
         mime_type: Optional[str] = None
 
-        is_local_mp3 = (
-            not audio_path.startswith(("http://", "https://"))
-            and audio_path.lower().endswith(".mp3")
-            and os.path.exists(audio_path)
-        )
-        if is_local_mp3:
+        is_remote = audio_path.startswith(("http://", "https://"))
+        is_local_existing = not is_remote and os.path.exists(audio_path)
+        lower_path = audio_path.lower()
+
+        if is_local_existing and lower_path.endswith(_WHATSAPP_OPUS_EXTENSIONS):
+            mime_type = _WHATSAPP_OPUS_MIME
+        elif is_local_existing:
             opus_path = await self._convert_to_opus(audio_path)
             if opus_path:
                 try:
                     result = await self._send_media_from_path_or_link(
                         chat_id, opus_path, "audio",
                         caption=caption, reply_to=reply_to,
-                        mime_type="audio/ogg; codecs=opus",
+                        mime_type=_WHATSAPP_OPUS_MIME,
                     )
                 finally:
-                    # The .ogg is a transient conversion artifact next to
-                    # the source MP3 — clean it up after upload so voice
-                    # sends don't leak a file per message.
+                    # The .ogg is a transient conversion artifact; clean
+                    # it up after upload so voice sends don't leak files.
                     try:
                         os.unlink(opus_path)
                     except OSError:
                         pass
                 return result
-            # Will deliver as MP3 attachment, not voice bubble.
+            # Will deliver as an audio attachment, not a voice bubble.
             # Warn-once is logged inside _convert_to_opus.
-            mime_type = "audio/mpeg"
+            if lower_path.endswith(".mp3"):
+                mime_type = "audio/mpeg"
 
         return await self._send_media_from_path_or_link(
             chat_id, source, "audio",
@@ -2430,12 +2434,12 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         )
 
     # ------------------------------------------------------------------ opus conversion
-    async def _convert_to_opus(self, mp3_path: str) -> Optional[str]:
-        """Convert an MP3 to ``audio/ogg; codecs=opus`` for voice bubbles.
+    async def _convert_to_opus(self, audio_path: str) -> Optional[str]:
+        """Convert audio to ``audio/ogg; codecs=opus`` for voice bubbles.
 
         Returns the path to the converted file, or None if ffmpeg is
         missing / conversion fails (caller falls back to sending the
-        original MP3 as an audio file).
+        original audio as an attachment).
 
         ``-application voip`` tunes the opus encoder for speech.
         ``-b:a 32k -vbr on`` matches the bitrate WhatsApp produces for
@@ -2445,10 +2449,16 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             self._warn_once_no_ffmpeg()
             return None
 
-        out_path = mp3_path.rsplit(".", 1)[0] + ".ogg"
+        out_file = tempfile.NamedTemporaryFile(
+            prefix="hermes_whatsapp_voice_",
+            suffix=".ogg",
+            delete=False,
+        )
+        out_path = out_file.name
+        out_file.close()
         try:
             proc = await asyncio.create_subprocess_exec(
-                _FFMPEG_PATH, "-y", "-i", mp3_path,
+                _FFMPEG_PATH, "-y", "-i", audio_path,
                 "-c:a", "libopus", "-b:a", "32k", "-vbr", "on",
                 "-application", "voip", out_path,
                 stdout=asyncio.subprocess.DEVNULL,
@@ -2462,10 +2472,18 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     proc.returncode,
                     (stderr or b"").decode("utf-8", errors="replace")[:500],
                 )
+                try:
+                    os.unlink(out_path)
+                except OSError:
+                    pass
                 return None
             return out_path
         except Exception:
             logger.exception("[whatsapp_cloud] ffmpeg subprocess raised")
+            try:
+                os.unlink(out_path)
+            except OSError:
+                pass
             return None
 
     def _warn_once_no_ffmpeg(self) -> None:
@@ -2474,7 +2492,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._warned_no_ffmpeg = True
         logger.warning(
             "[whatsapp_cloud] ffmpeg not found on PATH — voice messages will "
-            "be delivered as MP3 audio attachments instead of native voice "
+            "be delivered as audio attachments instead of native voice "
             "notes (green waveform bubble). Install ffmpeg to enable: "
             "Windows `winget install Gyan.FFmpeg`, macOS `brew install ffmpeg`, "
             "Linux package manager."

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -53,6 +53,7 @@ import mimetypes
 import os
 import re
 import shutil
+import wave
 import uuid
 from collections import OrderedDict
 from dataclasses import dataclass
@@ -85,6 +86,7 @@ from gateway.platforms.base import (
     SUPPORTED_DOCUMENT_TYPES,
 )
 from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin
+from gateway.session import SessionSource
 from hermes_constants import get_hermes_dir
 
 logger = logging.getLogger(__name__)
@@ -409,6 +411,8 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._runner = None
         self._http_client: Optional["httpx.AsyncClient"] = None
         self._calling_sidecar_call_ids: set[str] = set()
+        self._calling_sidecar_tasks: Dict[str, asyncio.Task] = {}
+        self._calling_sidecar_auto_tts_chats: Dict[str, str] = {}
 
     # ------------------------------------------------------------------ helpers
     @staticmethod
@@ -930,6 +934,173 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             audio=audio,
         )
 
+    def _write_calling_sidecar_pcm_wav(self, call_id: str, pcm_s16le: bytes) -> str:
+        """Persist decoded sidecar PCM as a WAV file for Hermes STT."""
+        if not pcm_s16le:
+            raise ValueError("pcm_s16le must not be empty")
+        if len(pcm_s16le) % CALLING_PCM_BYTES_PER_SAMPLE:
+            raise ValueError("pcm_s16le must contain whole s16le samples")
+
+        safe_call_id = re.sub(r"[^A-Za-z0-9._-]+", "_", call_id).strip("_")
+        if not safe_call_id:
+            safe_call_id = "call"
+        out_dir = _INBOUND_MEDIA_CACHE / "calls"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = out_dir / f"call_{safe_call_id}_{uuid.uuid4().hex[:12]}.wav"
+
+        with wave.open(str(out_path), "wb") as wav:
+            wav.setnchannels(CALLING_PCM_CHANNELS)
+            wav.setsampwidth(CALLING_PCM_BYTES_PER_SAMPLE)
+            wav.setframerate(CALLING_PCM_SAMPLE_RATE)
+            wav.writeframes(pcm_s16le)
+        return str(out_path)
+
+    async def _dispatch_calling_sidecar_pcm(
+        self,
+        call_id: str,
+        chat_id: str,
+        sender_name: str,
+        pcm_s16le: bytes,
+    ) -> None:
+        """Dispatch one decoded call-audio segment through Hermes STT."""
+        normalized_call_id = str(call_id or "").strip()
+        normalized_chat_id = str(chat_id or "").strip()
+        if not normalized_call_id or not normalized_chat_id or not pcm_s16le:
+            return
+
+        try:
+            wav_path = self._write_calling_sidecar_pcm_wav(
+                normalized_call_id,
+                pcm_s16le,
+            )
+        except Exception:
+            logger.exception(
+                "[whatsapp_cloud] failed to write call audio segment for %s",
+                normalized_call_id,
+            )
+            return
+
+        source = SessionSource(
+            platform=self.platform,
+            chat_id=normalized_chat_id,
+            user_id=normalized_chat_id,
+            user_name=sender_name or normalized_chat_id,
+            chat_type="dm",
+            thread_id=normalized_call_id,
+        )
+        event = MessageEvent(
+            source=source,
+            text="(The user sent a message with no text content)",
+            message_type=MessageType.VOICE,
+            raw_message={
+                "type": "whatsapp_call_audio",
+                "call_id": normalized_call_id,
+            },
+            message_id=f"{normalized_call_id}:{uuid.uuid4().hex[:12]}",
+            media_urls=[wav_path],
+            media_types=["audio/wav"],
+        )
+        await self.handle_message(event)
+
+    def _enable_calling_sidecar_auto_tts(self, call_id: str, chat_id: str) -> None:
+        """Temporarily force voice replies while a live call is active."""
+        if not chat_id:
+            return
+        enabled = getattr(self, "_auto_tts_enabled_chats", None)
+        if not isinstance(enabled, set):
+            return
+        if chat_id not in enabled:
+            enabled.add(chat_id)
+            self._calling_sidecar_auto_tts_chats[call_id] = chat_id
+
+    def _disable_calling_sidecar_auto_tts(self, call_id: str) -> None:
+        chat_id = self._calling_sidecar_auto_tts_chats.pop(call_id, None)
+        if not chat_id:
+            return
+        enabled = getattr(self, "_auto_tts_enabled_chats", None)
+        if isinstance(enabled, set):
+            enabled.discard(chat_id)
+
+    def _start_calling_sidecar_drain(
+        self,
+        call_id: str,
+        chat_id: str,
+        sender_name: str = "",
+    ) -> None:
+        """Start draining decoded inbound sidecar PCM into Hermes turns."""
+        normalized_call_id = str(call_id or "").strip()
+        normalized_chat_id = str(chat_id or "").strip()
+        if not normalized_call_id or not normalized_chat_id:
+            return
+        if self._message_handler is None:
+            return
+
+        self._enable_calling_sidecar_auto_tts(normalized_call_id, normalized_chat_id)
+        existing = self._calling_sidecar_tasks.get(normalized_call_id)
+        if existing is not None and not existing.done():
+            existing.cancel()
+
+        task = asyncio.create_task(
+            self._run_calling_sidecar_audio_loop(
+                normalized_call_id,
+                normalized_chat_id,
+                sender_name,
+            )
+        )
+        self._calling_sidecar_tasks[normalized_call_id] = task
+        task.add_done_callback(
+            lambda _task, _call_id=normalized_call_id: self._calling_sidecar_tasks.pop(
+                _call_id,
+                None,
+            )
+        )
+
+    async def _run_calling_sidecar_audio_loop(
+        self,
+        call_id: str,
+        chat_id: str,
+        sender_name: str,
+    ) -> None:
+        """Long-poll sidecar PCM and dispatch speech-ish chunks to Hermes."""
+        buffer = bytearray()
+        silent_polls = 0
+        segment_limit = CALLING_PCM_SAMPLE_RATE * CALLING_PCM_BYTES_PER_SAMPLE * 5
+
+        try:
+            while call_id in self._calling_sidecar_call_ids:
+                audio = await self._receive_calling_sidecar_audio(call_id)
+                if audio is not None and audio.pcm_s16le:
+                    buffer.extend(audio.pcm_s16le)
+                    silent_polls = 0
+                    if len(buffer) >= segment_limit:
+                        await self._dispatch_calling_sidecar_pcm(
+                            call_id,
+                            chat_id,
+                            sender_name,
+                            bytes(buffer),
+                        )
+                        buffer.clear()
+                    continue
+
+                if buffer:
+                    silent_polls += 1
+                    if silent_polls >= 2:
+                        await self._dispatch_calling_sidecar_pcm(
+                            call_id,
+                            chat_id,
+                            sender_name,
+                            bytes(buffer),
+                        )
+                        buffer.clear()
+                        silent_polls = 0
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception(
+                "[whatsapp_cloud] calling sidecar audio loop failed for %s",
+                call_id,
+            )
+
     async def _send_call_action(
         self,
         call_id: str,
@@ -993,6 +1164,16 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
     async def _close_calling_sidecar_session(self, call_id: str) -> bool:
         """Best-effort close for a local WebRTC sidecar call session."""
+        normalized_call_id = str(call_id or "").strip()
+        if not normalized_call_id:
+            return False
+
+        task = self._calling_sidecar_tasks.pop(normalized_call_id, None)
+        if task is not None and not task.done():
+            task.cancel()
+        self._disable_calling_sidecar_auto_tts(normalized_call_id)
+        self._calling_sidecar_call_ids.discard(normalized_call_id)
+
         if not self._calling_sidecar_enabled():
             return False
         if self._http_client is None:
@@ -1000,10 +1181,6 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "[whatsapp_cloud] calling sidecar configured but HTTP client "
                 "is unavailable"
             )
-            return False
-
-        normalized_call_id = str(call_id or "").strip()
-        if not normalized_call_id:
             return False
 
         encoded_call_id = quote(normalized_call_id, safe="")
@@ -2306,13 +2483,23 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
     async def _dispatch_call_events(self, value: Dict[str, Any]) -> None:
         """Handle WhatsApp Calling webhook events from a verified payload."""
+        contacts_by_waid: Dict[str, str] = {}
+        for contact in value.get("contacts") or []:
+            if not isinstance(contact, dict):
+                continue
+            wa_id = str(contact.get("wa_id") or "").strip()
+            profile = contact.get("profile") or {}
+            name = str(profile.get("name") or "").strip()
+            if wa_id:
+                contacts_by_waid[wa_id] = name
+
         for raw_call in value.get("calls") or []:
             if not isinstance(raw_call, dict):
                 continue
             event = str(raw_call.get("event") or "").strip().lower()
             call_id = str(raw_call.get("id") or "").strip()
             if event == "connect":
-                await self._handle_call_connect(raw_call)
+                await self._handle_call_connect(raw_call, contacts_by_waid)
             elif event == "terminate":
                 if call_id:
                     await self._close_calling_sidecar_session(call_id)
@@ -2328,7 +2515,11 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     call_id,
                 )
 
-    async def _handle_call_connect(self, raw_call: Dict[str, Any]) -> None:
+    async def _handle_call_connect(
+        self,
+        raw_call: Dict[str, Any],
+        contacts_by_waid: Optional[Dict[str, str]] = None,
+    ) -> None:
         """Handle an inbound WhatsApp Calling connect offer."""
         call_id = str(raw_call.get("id") or "").strip()
         session = raw_call.get("session") or {}
@@ -2400,6 +2591,9 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             return
 
         logger.info("[whatsapp_cloud] accepted call %s via calling sidecar", call_id)
+        chat_id = str(raw_call.get("from") or "").strip()
+        sender_name = (contacts_by_waid or {}).get(chat_id, "")
+        self._start_calling_sidecar_drain(call_id, chat_id, sender_name)
 
     async def _dispatch_interactive_reply(
         self,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -111,6 +111,9 @@ CALLING_PCM_DEFAULT_DRAIN_BYTES = (
 )
 CALLING_PCM_DRAIN_WAIT_MS = 500
 CALLING_PCM_MAX_DRAIN_WAIT_MS = 5_000
+CALLING_PCM_MAX_OUTBOUND_QUEUE_BYTES = (
+    CALLING_PCM_SAMPLE_RATE * CALLING_PCM_CHANNELS * CALLING_PCM_BYTES_PER_SAMPLE * 10
+)
 CALLING_PCM_ENCODING = "pcm_s16le"
 CALLING_AUDIO_CONTRACT = {
     "sample_rate": CALLING_PCM_SAMPLE_RATE,
@@ -122,6 +125,7 @@ CALLING_AUDIO_CONTRACT = {
     "frame_bytes": CALLING_PCM_FRAME_BYTES,
     "default_drain_bytes": CALLING_PCM_DEFAULT_DRAIN_BYTES,
     "max_drain_wait_ms": CALLING_PCM_MAX_DRAIN_WAIT_MS,
+    "max_outbound_queue_bytes": CALLING_PCM_MAX_OUTBOUND_QUEUE_BYTES,
 }
 GRAPH_API_BASE = "https://graph.facebook.com"
 # Meta retries failed webhooks for up to 7 days. We don't need to remember
@@ -212,6 +216,24 @@ def _matches_calling_audio_contract(audio: Any) -> bool:
         and frame_ms == CALLING_PCM_FRAME_MS
         and encoding == CALLING_PCM_ENCODING
     )
+
+
+def _normalize_calling_audio_contract(audio: Dict[str, Any]) -> Dict[str, Any]:
+    """Fill optional sidecar contract fields with Hermes' local defaults."""
+    normalized = dict(audio)
+    normalized.setdefault("bytes_per_sample", CALLING_PCM_BYTES_PER_SAMPLE)
+    normalized.setdefault(
+        "samples_per_frame",
+        CALLING_PCM_SAMPLE_RATE * CALLING_PCM_FRAME_MS // 1_000,
+    )
+    normalized.setdefault("frame_bytes", CALLING_PCM_FRAME_BYTES)
+    normalized.setdefault("default_drain_bytes", CALLING_PCM_DEFAULT_DRAIN_BYTES)
+    normalized.setdefault("max_drain_wait_ms", CALLING_PCM_MAX_DRAIN_WAIT_MS)
+    normalized.setdefault(
+        "max_outbound_queue_bytes",
+        CALLING_PCM_MAX_OUTBOUND_QUEUE_BYTES,
+    )
+    return normalized
 
 
 # Inbound media cache lives under the user's hermes dir so it survives
@@ -469,6 +491,8 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "Hermes PCM settings"
             )
             return None
+        data = dict(data)
+        data["audio"] = _normalize_calling_audio_contract(data["audio"])
         return data
 
     async def _request_calling_sidecar_answer(
@@ -626,14 +650,24 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if isinstance(body, dict):
                 error_msg = str(body.get("error") or "")
             if not error_msg:
-                error_msg = f"calling sidecar audio failed with HTTP {resp.status_code}"
+                if resp.status_code == 429:
+                    error_msg = "calling sidecar audio backpressure"
+                else:
+                    error_msg = (
+                        f"calling sidecar audio failed with HTTP {resp.status_code}"
+                    )
             logger.warning(
                 "[whatsapp_cloud] calling sidecar audio rejected "
                 "(status=%d): %s",
                 resp.status_code,
                 error_msg,
             )
-            return SendResult(success=False, error=error_msg, raw_response=body)
+            return SendResult(
+                success=False,
+                error=error_msg,
+                raw_response=body,
+                retryable=resp.status_code == 429,
+            )
 
         return SendResult(success=True, raw_response=body)
 

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -419,6 +419,8 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         # Runtime
         self._runner = None
         self._http_client: Optional["httpx.AsyncClient"] = None
+        self._calling_sidecar_contract: Optional[Dict[str, Any]] = None
+        self._calling_sidecar_contract_checked: bool = False
         self._calling_sidecar_call_ids: set[str] = set()
         self._calling_sidecar_tasks: Dict[str, asyncio.Task] = {}
         self._calling_sidecar_auto_tts_chats: Dict[str, str] = {}
@@ -447,6 +449,47 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
     def _calling_sidecar_enabled(self) -> bool:
         return bool(self._calling_sidecar_url)
+
+    def _calling_sidecar_audio_contract(self) -> Dict[str, Any]:
+        """Return the cached sidecar audio shape or Hermes' legacy default."""
+        contract = getattr(self, "_calling_sidecar_contract", None)
+        if isinstance(contract, dict):
+            audio = contract.get("audio")
+            if isinstance(audio, dict) and _matches_calling_audio_contract(audio):
+                return _normalize_calling_audio_contract(audio)
+        return dict(CALLING_AUDIO_CONTRACT)
+
+    def _calling_sidecar_endpoint_url(
+        self,
+        endpoint: str,
+        default_path: str,
+        *,
+        call_id: Optional[str] = None,
+    ) -> str:
+        """Build a sidecar URL from the cached contract with legacy fallback."""
+        path = default_path
+        contract = getattr(self, "_calling_sidecar_contract", None)
+        endpoints = contract.get("endpoints") if isinstance(contract, dict) else None
+        if isinstance(endpoints, dict):
+            spec = endpoints.get(endpoint)
+            if isinstance(spec, dict):
+                candidate = str(spec.get("path") or "").strip()
+                if candidate:
+                    path = candidate
+
+        if call_id is not None:
+            path = path.replace("{call_id}", quote(call_id, safe=""))
+        if not path.startswith("/"):
+            path = f"/{path}"
+        return f"{self._calling_sidecar_url}{path}"
+
+    async def _ensure_calling_sidecar_contract(self) -> Optional[Dict[str, Any]]:
+        """Fetch the optional sidecar contract once per adapter lifetime."""
+        if getattr(self, "_calling_sidecar_contract_checked", False):
+            return getattr(self, "_calling_sidecar_contract", None)
+        self._calling_sidecar_contract_checked = True
+        self._calling_sidecar_contract = await self._request_calling_sidecar_contract()
+        return self._calling_sidecar_contract
 
     async def _request_calling_sidecar_contract(self) -> Optional[Dict[str, Any]]:
         """Fetch and validate the local sidecar's optional machine contract."""
@@ -548,7 +591,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             )
             return None
 
-        url = f"{self._calling_sidecar_url}/offer"
+        url = self._calling_sidecar_endpoint_url("offer", "/offer")
         payload = {
             "call_id": normalized_call_id,
             "type": "offer",
@@ -645,13 +688,17 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 error="PCM payload must contain whole s16le samples",
             )
 
-        encoded_call_id = quote(normalized_call_id, safe="")
-        url = f"{self._calling_sidecar_url}/calls/{encoded_call_id}/audio"
+        audio = self._calling_sidecar_audio_contract()
+        url = self._calling_sidecar_endpoint_url(
+            "send_audio",
+            "/calls/{call_id}/audio",
+            call_id=normalized_call_id,
+        )
         payload: Dict[str, Any] = {
-            "sample_rate": CALLING_PCM_SAMPLE_RATE,
-            "channels": CALLING_PCM_CHANNELS,
-            "frame_ms": CALLING_PCM_FRAME_MS,
-            "encoding": CALLING_PCM_ENCODING,
+            "sample_rate": int(audio["sample_rate"]),
+            "channels": int(audio["channels"]),
+            "frame_ms": int(audio["frame_ms"]),
+            "encoding": str(audio["encoding"]),
             "pcm_s16le_base64": base64.b64encode(pcm_bytes).decode("ascii"),
         }
         if sequence is not None:
@@ -726,6 +773,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if not _FFMPEG_PATH:
             return None, "ffmpeg is required to decode TTS audio for live calls"
 
+        audio = self._calling_sidecar_audio_contract()
         proc = await asyncio.create_subprocess_exec(
             _FFMPEG_PATH,
             "-v",
@@ -737,9 +785,9 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             "-acodec",
             "pcm_s16le",
             "-ar",
-            str(CALLING_PCM_SAMPLE_RATE),
+            str(int(audio["sample_rate"])),
             "-ac",
-            str(CALLING_PCM_CHANNELS),
+            str(int(audio["channels"])),
             "pipe:1",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
@@ -778,11 +826,14 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if not pcm:
             return SendResult(success=False, error="No PCM decoded from TTS audio")
 
+        audio = self._calling_sidecar_audio_contract()
+        frame_bytes = int(audio["frame_bytes"])
+        frame_ms = int(audio["frame_ms"])
         sequence = 0
-        for offset in range(0, len(pcm), CALLING_PCM_FRAME_BYTES):
-            frame = pcm[offset : offset + CALLING_PCM_FRAME_BYTES]
-            if len(frame) < CALLING_PCM_FRAME_BYTES:
-                frame += b"\x00" * (CALLING_PCM_FRAME_BYTES - len(frame))
+        for offset in range(0, len(pcm), frame_bytes):
+            frame = pcm[offset : offset + frame_bytes]
+            if len(frame) < frame_bytes:
+                frame += b"\x00" * (frame_bytes - len(frame))
 
             result = await self._send_calling_sidecar_audio(
                 call_id,
@@ -790,7 +841,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 sequence=sequence,
             )
             if not result.success and result.retryable:
-                await asyncio.sleep(CALLING_PCM_FRAME_MS / 1_000)
+                await asyncio.sleep(frame_ms / 1_000)
                 result = await self._send_calling_sidecar_audio(
                     call_id,
                     frame,
@@ -800,8 +851,8 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 return result
 
             sequence += 1
-            if offset + CALLING_PCM_FRAME_BYTES < len(pcm):
-                await asyncio.sleep(CALLING_PCM_FRAME_MS / 1_000)
+            if offset + frame_bytes < len(pcm):
+                await asyncio.sleep(frame_ms / 1_000)
 
         return SendResult(
             success=True,
@@ -809,7 +860,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "call_id": call_id,
                 "queued_pcm_bytes": len(pcm),
                 "frames": sequence,
-                "audio": CALLING_AUDIO_CONTRACT,
+                "audio": audio,
             },
         )
 
@@ -817,8 +868,8 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self,
         call_id: str,
         *,
-        max_bytes: int = CALLING_PCM_DEFAULT_DRAIN_BYTES,
-        wait_ms: int = CALLING_PCM_DRAIN_WAIT_MS,
+        max_bytes: Optional[int] = None,
+        wait_ms: Optional[int] = None,
     ) -> Optional[CallingSidecarAudio]:
         """Drain decoded inbound 48 kHz PCM from a local WebRTC sidecar call."""
         if not self._calling_sidecar_enabled():
@@ -833,6 +884,14 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         normalized_call_id = str(call_id or "").strip()
         if not normalized_call_id:
             return None
+        audio_contract = self._calling_sidecar_audio_contract()
+        if max_bytes is None:
+            max_bytes = int(audio_contract["default_drain_bytes"])
+        if wait_ms is None:
+            wait_ms = min(
+                CALLING_PCM_DRAIN_WAIT_MS,
+                int(audio_contract["max_drain_wait_ms"]),
+            )
         if not isinstance(max_bytes, int) or max_bytes <= 0:
             logger.warning(
                 "[whatsapp_cloud] invalid sidecar audio max_bytes=%r",
@@ -848,8 +907,11 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             logger.warning("[whatsapp_cloud] invalid sidecar audio wait_ms=%r", wait_ms)
             return None
 
-        encoded_call_id = quote(normalized_call_id, safe="")
-        url = f"{self._calling_sidecar_url}/calls/{encoded_call_id}/audio"
+        url = self._calling_sidecar_endpoint_url(
+            "receive_audio",
+            "/calls/{call_id}/audio",
+            call_id=normalized_call_id,
+        )
         try:
             resp = await self._http_client.get(
                 url,
@@ -957,10 +1019,11 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         out_dir.mkdir(parents=True, exist_ok=True)
         out_path = out_dir / f"call_{safe_call_id}_{uuid.uuid4().hex[:12]}.wav"
 
+        audio = self._calling_sidecar_audio_contract()
         with wave.open(str(out_path), "wb") as wav:
-            wav.setnchannels(CALLING_PCM_CHANNELS)
-            wav.setsampwidth(CALLING_PCM_BYTES_PER_SAMPLE)
-            wav.setframerate(CALLING_PCM_SAMPLE_RATE)
+            wav.setnchannels(int(audio["channels"]))
+            wav.setsampwidth(int(audio["bytes_per_sample"]))
+            wav.setframerate(int(audio["sample_rate"]))
             wav.writeframes(pcm_s16le)
         return str(out_path)
 
@@ -1229,8 +1292,11 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             )
             return False
 
-        encoded_call_id = quote(normalized_call_id, safe="")
-        url = f"{self._calling_sidecar_url}/calls/{encoded_call_id}/close"
+        url = self._calling_sidecar_endpoint_url(
+            "close_call",
+            "/calls/{call_id}/close",
+            call_id=normalized_call_id,
+        )
         try:
             resp = await self._http_client.post(
                 url,
@@ -2283,6 +2349,10 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "verify_token_configured": bool(self._verify_token),
                 "app_secret_configured": bool(self._app_secret),
                 "calling_sidecar_configured": self._calling_sidecar_enabled(),
+                "calling_sidecar_contract_loaded": isinstance(
+                    getattr(self, "_calling_sidecar_contract", None),
+                    dict,
+                ),
                 "ffmpeg_present": _FFMPEG_PATH is not None,
                 "accepted": self._accepted_count,
                 "duplicates": self._duplicate_count,
@@ -2595,6 +2665,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             )
             return
 
+        await self._ensure_calling_sidecar_contract()
         answer = await self._request_calling_sidecar_answer(call_id, remote_sdp)
         if answer is None:
             logger.warning(

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -114,6 +114,9 @@ CALLING_PCM_MAX_DRAIN_WAIT_MS = 5_000
 CALLING_PCM_MAX_OUTBOUND_QUEUE_BYTES = (
     CALLING_PCM_SAMPLE_RATE * CALLING_PCM_CHANNELS * CALLING_PCM_BYTES_PER_SAMPLE * 10
 )
+CALLING_PCM_MAX_INBOUND_QUEUE_BYTES = (
+    CALLING_PCM_SAMPLE_RATE * CALLING_PCM_CHANNELS * CALLING_PCM_BYTES_PER_SAMPLE * 10
+)
 CALLING_PCM_ENCODING = "pcm_s16le"
 CALLING_AUDIO_CONTRACT = {
     "sample_rate": CALLING_PCM_SAMPLE_RATE,
@@ -126,6 +129,7 @@ CALLING_AUDIO_CONTRACT = {
     "default_drain_bytes": CALLING_PCM_DEFAULT_DRAIN_BYTES,
     "max_drain_wait_ms": CALLING_PCM_MAX_DRAIN_WAIT_MS,
     "max_outbound_queue_bytes": CALLING_PCM_MAX_OUTBOUND_QUEUE_BYTES,
+    "max_inbound_queue_bytes": CALLING_PCM_MAX_INBOUND_QUEUE_BYTES,
 }
 GRAPH_API_BASE = "https://graph.facebook.com"
 # Meta retries failed webhooks for up to 7 days. We don't need to remember
@@ -232,6 +236,10 @@ def _normalize_calling_audio_contract(audio: Dict[str, Any]) -> Dict[str, Any]:
     normalized.setdefault(
         "max_outbound_queue_bytes",
         CALLING_PCM_MAX_OUTBOUND_QUEUE_BYTES,
+    )
+    normalized.setdefault(
+        "max_inbound_queue_bytes",
+        CALLING_PCM_MAX_INBOUND_QUEUE_BYTES,
     )
     return normalized
 

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -108,6 +108,12 @@ CALLING_PCM_FRAME_BYTES = (
 )
 CALLING_PCM_DRAIN_WAIT_MS = 500
 CALLING_PCM_ENCODING = "pcm_s16le"
+CALLING_AUDIO_CONTRACT = {
+    "sample_rate": CALLING_PCM_SAMPLE_RATE,
+    "channels": CALLING_PCM_CHANNELS,
+    "frame_ms": CALLING_PCM_FRAME_MS,
+    "encoding": CALLING_PCM_ENCODING,
+}
 GRAPH_API_BASE = "https://graph.facebook.com"
 # Meta retries failed webhooks for up to 7 days. We don't need to remember
 # every wamid for the full retry window — the practical risk is duplicate
@@ -178,6 +184,25 @@ def _ext_for_mime(mime: str) -> Optional[str]:
     if override:
         return override
     return mimetypes.guess_extension(primary) or None
+
+
+def _matches_calling_audio_contract(audio: Any) -> bool:
+    """Return whether a sidecar audio object matches Hermes' PCM frame shape."""
+    if not isinstance(audio, dict):
+        return False
+    try:
+        sample_rate = int(audio.get("sample_rate"))
+        channels = int(audio.get("channels"))
+        frame_ms = int(audio.get("frame_ms"))
+    except (TypeError, ValueError):
+        return False
+    encoding = str(audio.get("encoding") or "").strip().lower()
+    return (
+        sample_rate == CALLING_PCM_SAMPLE_RATE
+        and channels == CALLING_PCM_CHANNELS
+        and frame_ms == CALLING_PCM_FRAME_MS
+        and encoding == CALLING_PCM_ENCODING
+    )
 
 
 # Inbound media cache lives under the user's hermes dir so it survives
@@ -370,6 +395,73 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     def _calling_sidecar_enabled(self) -> bool:
         return bool(self._calling_sidecar_url)
 
+    async def _request_calling_sidecar_contract(self) -> Optional[Dict[str, Any]]:
+        """Fetch and validate the local sidecar's optional machine contract."""
+        if not self._calling_sidecar_enabled():
+            return None
+        if self._http_client is None:
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar configured but HTTP client "
+                "is unavailable"
+            )
+            return None
+
+        url = f"{self._calling_sidecar_url}/contract"
+        try:
+            resp = await self._http_client.get(
+                url,
+                timeout=self._calling_sidecar_timeout,
+            )
+        except Exception:
+            logger.exception("[whatsapp_cloud] calling sidecar contract request failed")
+            return None
+
+        if resp.status_code == 404:
+            logger.debug(
+                "[whatsapp_cloud] calling sidecar does not expose /contract yet"
+            )
+            return None
+        if resp.status_code != 200:
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar contract request failed "
+                "(status=%d): %s",
+                resp.status_code,
+                str(getattr(resp, "text", ""))[:500],
+            )
+            return None
+
+        try:
+            data = resp.json()
+        except Exception:
+            logger.warning("[whatsapp_cloud] calling sidecar contract returned invalid JSON")
+            return None
+        if not isinstance(data, dict):
+            logger.warning("[whatsapp_cloud] calling sidecar contract is not an object")
+            return None
+        if data.get("contract") != "voice.webrtc_sidecar":
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar contract id was %r",
+                data.get("contract"),
+            )
+            return None
+        try:
+            version = int(data.get("version") or 0)
+        except (TypeError, ValueError):
+            version = 0
+        if version < 1:
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar contract version is invalid: %r",
+                data.get("version"),
+            )
+            return None
+        if not _matches_calling_audio_contract(data.get("audio")):
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar audio contract does not match "
+                "Hermes PCM settings"
+            )
+            return None
+        return data
+
     async def _request_calling_sidecar_answer(
         self,
         call_id: str,
@@ -448,11 +540,18 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             return None
 
         audio = data.get("audio")
+        if not _matches_calling_audio_contract(audio):
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar answer audio contract does not "
+                "match Hermes PCM settings"
+            )
+            return None
+
         answer_call_id = str(data.get("call_id") or "").strip() or normalized_call_id
         return CallingSidecarAnswer(
             call_id=answer_call_id,
             sdp=sdp,
-            audio=audio if isinstance(audio, dict) else {},
+            audio=audio,
         )
 
     async def _send_calling_sidecar_audio(
@@ -635,13 +734,20 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             return None
 
         audio = data.get("audio")
+        if not _matches_calling_audio_contract(audio):
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar audio drain contract does not "
+                "match Hermes PCM settings"
+            )
+            return None
+
         answer_call_id = str(data.get("call_id") or "").strip() or normalized_call_id
         return CallingSidecarAudio(
             call_id=answer_call_id,
             pcm_s16le=pcm,
             returned_bytes=returned_bytes,
             queued_rx_bytes=queued_rx_bytes,
-            audio=audio if isinstance(audio, dict) else {},
+            audio=audio,
         )
 
     async def _send_call_action(

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -106,13 +106,22 @@ CALLING_PCM_FRAME_BYTES = (
     * CALLING_PCM_FRAME_MS
     // 1_000
 )
+CALLING_PCM_DEFAULT_DRAIN_BYTES = (
+    CALLING_PCM_SAMPLE_RATE * CALLING_PCM_CHANNELS * CALLING_PCM_BYTES_PER_SAMPLE
+)
 CALLING_PCM_DRAIN_WAIT_MS = 500
+CALLING_PCM_MAX_DRAIN_WAIT_MS = 5_000
 CALLING_PCM_ENCODING = "pcm_s16le"
 CALLING_AUDIO_CONTRACT = {
     "sample_rate": CALLING_PCM_SAMPLE_RATE,
     "channels": CALLING_PCM_CHANNELS,
     "frame_ms": CALLING_PCM_FRAME_MS,
     "encoding": CALLING_PCM_ENCODING,
+    "bytes_per_sample": CALLING_PCM_BYTES_PER_SAMPLE,
+    "samples_per_frame": CALLING_PCM_SAMPLE_RATE * CALLING_PCM_FRAME_MS // 1_000,
+    "frame_bytes": CALLING_PCM_FRAME_BYTES,
+    "default_drain_bytes": CALLING_PCM_DEFAULT_DRAIN_BYTES,
+    "max_drain_wait_ms": CALLING_PCM_MAX_DRAIN_WAIT_MS,
 }
 GRAPH_API_BASE = "https://graph.facebook.com"
 # Meta retries failed webhooks for up to 7 days. We don't need to remember
@@ -632,7 +641,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self,
         call_id: str,
         *,
-        max_bytes: int = CALLING_PCM_FRAME_BYTES,
+        max_bytes: int = CALLING_PCM_DEFAULT_DRAIN_BYTES,
         wait_ms: int = CALLING_PCM_DRAIN_WAIT_MS,
     ) -> Optional[CallingSidecarAudio]:
         """Drain decoded inbound 48 kHz PCM from a local WebRTC sidecar call."""

--- a/scripts/verify_voice_command_tts.py
+++ b/scripts/verify_voice_command_tts.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
-"""Validate a voice-backed Hermes command TTS provider in an isolated home.
+"""Validate a voice-backed Hermes command TTS provider.
 
-This script writes a temporary Hermes config that points a command provider at
-`voice say --format ogg-opus`, runs Hermes' real text_to_speech_tool entry
-point, and verifies the resulting audio is WhatsApp-ready Ogg/Opus.
+By default this script writes a temporary Hermes config that points a command
+provider at `voice say --format ogg-opus`, runs Hermes' real
+text_to_speech_tool entry point, and verifies the resulting audio is
+WhatsApp-ready Ogg/Opus.
+
+Pass `--use-existing-config` to validate a deployed HERMES_HOME without
+rewriting config.yaml.
 """
 
 from __future__ import annotations
@@ -91,7 +95,26 @@ def write_isolated_config(
     return config_path
 
 
-def run_tts_tool(*, hermes_home: Path, text: str, output_path: str | None, platform: str) -> dict[str, Any]:
+def default_hermes_home() -> Path:
+    return Path(os.environ.get("HERMES_HOME", "~/.hermes")).expanduser()
+
+
+def existing_config_path(hermes_home: Path) -> Path:
+    config_path = hermes_home / "config.yaml"
+    if not config_path.is_file():
+        raise SystemExit(
+            f"{config_path} does not exist; remove --use-existing-config or pass --hermes-home"
+        )
+    return config_path
+
+
+def run_tts_tool(
+    *,
+    hermes_home: Path,
+    text: str,
+    output_path: str | None,
+    platform: str,
+) -> dict[str, Any]:
     os.environ["HERMES_HOME"] = str(hermes_home)
     os.environ["HERMES_SESSION_PLATFORM"] = platform
     sys.path.insert(0, str(repo_root()))
@@ -142,13 +165,20 @@ def probe_audio(path: Path, *, ffprobe_bin: str) -> dict[str, str]:
     return parse_ffprobe(completed.stdout)
 
 
-def validate_result(result: dict[str, Any], probe: dict[str, str]) -> None:
+def validate_result(
+    result: dict[str, Any],
+    probe: dict[str, str],
+    *,
+    expected_provider: str,
+) -> None:
     path = Path(str(result.get("file_path") or ""))
     media_tag = str(result.get("media_tag") or "")
     failures: list[str] = []
 
-    if result.get("provider") != "kokoro":
-        failures.append(f"expected provider kokoro, got {result.get('provider')!r}")
+    if result.get("provider") != expected_provider:
+        failures.append(
+            f"expected provider {expected_provider}, got {result.get('provider')!r}"
+        )
     if result.get("voice_compatible") is not True:
         failures.append("expected voice_compatible=true")
     if not media_tag.startswith("[[audio_as_voice]]\nMEDIA:"):
@@ -171,17 +201,32 @@ def validate_result(result: dict[str, Any], probe: dict[str, str]) -> None:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "Run Hermes TTS against an isolated command provider backed by "
+            "Run Hermes TTS against a command provider backed by "
             "`voice say --format ogg-opus` and verify Ogg/Opus output."
         )
     )
     parser.add_argument("--voice-bin", default=os.environ.get("VOICE_BIN", "voice"))
     parser.add_argument("--ffprobe-bin", default=os.environ.get("FFPROBE_BIN", "ffprobe"))
     parser.add_argument("--hermes-home", type=Path)
+    parser.add_argument(
+        "--use-existing-config",
+        action="store_true",
+        help=(
+            "Use the existing config.yaml under --hermes-home or HERMES_HOME. "
+            "The default mode writes an isolated temporary config."
+        ),
+    )
     parser.add_argument("--keep-home", action="store_true")
     parser.add_argument("--force", action="store_true")
     parser.add_argument("--output-path")
-    parser.add_argument("--provider", default="kokoro")
+    parser.add_argument(
+        "--provider",
+        default="kokoro",
+        help=(
+            "Provider name to write in isolated mode, and expected result "
+            "provider in --use-existing-config mode."
+        ),
+    )
     parser.add_argument("--voice", default="af_heart")
     parser.add_argument("--speed", default="1.0")
     parser.add_argument("--timeout", type=float, default=180.0)
@@ -192,17 +237,25 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    voice_bin = resolve_executable(args.voice_bin, label="voice binary")
     ffprobe_bin = resolve_executable(args.ffprobe_bin, label="ffprobe")
 
-    temporary_home = args.hermes_home is None
-    hermes_home = (
-        Path(tempfile.mkdtemp(prefix="hermes-voice-command-tts."))
-        if temporary_home
-        else args.hermes_home.expanduser().resolve()
-    )
-
-    try:
+    if args.use_existing_config:
+        temporary_home = False
+        hermes_home = (
+            args.hermes_home.expanduser().resolve()
+            if args.hermes_home is not None
+            else default_hermes_home().resolve()
+        )
+        config_path = existing_config_path(hermes_home)
+        mode = "existing"
+    else:
+        voice_bin = resolve_executable(args.voice_bin, label="voice binary")
+        temporary_home = args.hermes_home is None
+        hermes_home = (
+            Path(tempfile.mkdtemp(prefix="hermes-voice-command-tts."))
+            if temporary_home
+            else args.hermes_home.expanduser().resolve()
+        )
         config_path = write_isolated_config(
             hermes_home,
             provider=args.provider,
@@ -212,6 +265,9 @@ def main() -> int:
             timeout=args.timeout,
             force=args.force or temporary_home,
         )
+        mode = "isolated"
+
+    try:
         result = run_tts_tool(
             hermes_home=hermes_home,
             text=args.text,
@@ -220,12 +276,13 @@ def main() -> int:
         )
         audio_path = Path(str(result["file_path"]))
         probe = probe_audio(audio_path, ffprobe_bin=ffprobe_bin)
-        validate_result(result, probe)
-        retained = not (temporary_home and not args.keep_home)
+        validate_result(result, probe, expected_provider=args.provider)
+        retained = bool(args.output_path) or not (temporary_home and not args.keep_home)
         print(
             json.dumps(
                 {
                     "success": True,
+                    "mode": mode,
                     "hermes_home": str(hermes_home),
                     "config_path": str(config_path),
                     "retained": retained,

--- a/scripts/verify_voice_command_tts.py
+++ b/scripts/verify_voice_command_tts.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Validate a voice-backed Hermes command TTS provider in an isolated home.
+
+This script writes a temporary Hermes config that points a command provider at
+`voice say --format ogg-opus`, runs Hermes' real text_to_speech_tool entry
+point, and verifies the resulting audio is WhatsApp-ready Ogg/Opus.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_TEXT = "Hermes voice command provider smoke test."
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def resolve_executable(value: str, *, label: str) -> str:
+    if "/" in value:
+        path = Path(value).expanduser()
+        if not path.is_file() or not os.access(path, os.X_OK):
+            raise SystemExit(f"{label} is not executable: {path}")
+        return str(path.resolve())
+
+    found = shutil.which(value)
+    if not found:
+        raise SystemExit(f"{label} not found on PATH: {value}")
+    return found
+
+
+def build_config(*, provider: str, voice_bin: str, voice: str, speed: str, timeout: float) -> str:
+    command = (
+        f"{shlex.quote(voice_bin)} say --format ogg-opus "
+        "--input-file {input_path} --output {output_path} "
+        "--voice {voice} --speed {speed}"
+    )
+    return (
+        "tts:\n"
+        f"  provider: {provider}\n"
+        "  providers:\n"
+        f"    {provider}:\n"
+        "      type: command\n"
+        f"      command: {json.dumps(command)}\n"
+        "      output_format: ogg\n"
+        "      voice_compatible: true\n"
+        f"      voice: {json.dumps(voice)}\n"
+        f"      speed: {json.dumps(speed)}\n"
+        f"      timeout: {timeout:g}\n"
+        "      max_text_length: 2000\n"
+    )
+
+
+def write_isolated_config(
+    hermes_home: Path,
+    *,
+    provider: str,
+    voice_bin: str,
+    voice: str,
+    speed: str,
+    timeout: float,
+    force: bool,
+) -> Path:
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    config_path = hermes_home / "config.yaml"
+    if config_path.exists() and not force:
+        raise SystemExit(
+            f"{config_path} already exists; pass --force to overwrite it"
+        )
+    config_path.write_text(
+        build_config(
+            provider=provider,
+            voice_bin=voice_bin,
+            voice=voice,
+            speed=speed,
+            timeout=timeout,
+        ),
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def run_tts_tool(*, hermes_home: Path, text: str, output_path: str | None, platform: str) -> dict[str, Any]:
+    os.environ["HERMES_HOME"] = str(hermes_home)
+    os.environ["HERMES_SESSION_PLATFORM"] = platform
+    sys.path.insert(0, str(repo_root()))
+
+    from tools.tts_tool import text_to_speech_tool
+
+    raw = text_to_speech_tool(text, output_path=output_path)
+    try:
+        result = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"text_to_speech_tool returned invalid JSON: {raw}") from exc
+
+    if not result.get("success"):
+        raise SystemExit(
+            "text_to_speech_tool failed: "
+            + json.dumps(result, ensure_ascii=False, indent=2)
+        )
+    return result
+
+
+def parse_ffprobe(output: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in output.splitlines():
+        key, sep, value = line.partition("=")
+        if sep:
+            values[key] = value
+    return values
+
+
+def probe_audio(path: Path, *, ffprobe_bin: str) -> dict[str, str]:
+    completed = subprocess.run(
+        [
+            ffprobe_bin,
+            "-v",
+            "error",
+            "-select_streams",
+            "a:0",
+            "-show_entries",
+            "stream=codec_name,sample_rate,channels",
+            "-of",
+            "default=noprint_wrappers=1",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return parse_ffprobe(completed.stdout)
+
+
+def validate_result(result: dict[str, Any], probe: dict[str, str]) -> None:
+    path = Path(str(result.get("file_path") or ""))
+    media_tag = str(result.get("media_tag") or "")
+    failures: list[str] = []
+
+    if result.get("provider") != "kokoro":
+        failures.append(f"expected provider kokoro, got {result.get('provider')!r}")
+    if result.get("voice_compatible") is not True:
+        failures.append("expected voice_compatible=true")
+    if not media_tag.startswith("[[audio_as_voice]]\nMEDIA:"):
+        failures.append("expected media_tag to start with [[audio_as_voice]] and MEDIA:")
+    if path.suffix.lower() != ".ogg":
+        failures.append(f"expected .ogg output, got {path}")
+    if not path.is_file() or path.stat().st_size == 0:
+        failures.append(f"expected non-empty output file at {path}")
+    if probe.get("codec_name") != "opus":
+        failures.append(f"expected codec_name=opus, got {probe.get('codec_name')!r}")
+    if probe.get("sample_rate") != "48000":
+        failures.append(f"expected sample_rate=48000, got {probe.get('sample_rate')!r}")
+    if probe.get("channels") != "1":
+        failures.append(f"expected channels=1, got {probe.get('channels')!r}")
+
+    if failures:
+        raise SystemExit("validation failed:\n- " + "\n- ".join(failures))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run Hermes TTS against an isolated command provider backed by "
+            "`voice say --format ogg-opus` and verify Ogg/Opus output."
+        )
+    )
+    parser.add_argument("--voice-bin", default=os.environ.get("VOICE_BIN", "voice"))
+    parser.add_argument("--ffprobe-bin", default=os.environ.get("FFPROBE_BIN", "ffprobe"))
+    parser.add_argument("--hermes-home", type=Path)
+    parser.add_argument("--keep-home", action="store_true")
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument("--output-path")
+    parser.add_argument("--provider", default="kokoro")
+    parser.add_argument("--voice", default="af_heart")
+    parser.add_argument("--speed", default="1.0")
+    parser.add_argument("--timeout", type=float, default=180.0)
+    parser.add_argument("--platform", default="whatsapp")
+    parser.add_argument("--text", default=DEFAULT_TEXT)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    voice_bin = resolve_executable(args.voice_bin, label="voice binary")
+    ffprobe_bin = resolve_executable(args.ffprobe_bin, label="ffprobe")
+
+    temporary_home = args.hermes_home is None
+    hermes_home = (
+        Path(tempfile.mkdtemp(prefix="hermes-voice-command-tts."))
+        if temporary_home
+        else args.hermes_home.expanduser().resolve()
+    )
+
+    try:
+        config_path = write_isolated_config(
+            hermes_home,
+            provider=args.provider,
+            voice_bin=voice_bin,
+            voice=args.voice,
+            speed=args.speed,
+            timeout=args.timeout,
+            force=args.force or temporary_home,
+        )
+        result = run_tts_tool(
+            hermes_home=hermes_home,
+            text=args.text,
+            output_path=args.output_path,
+            platform=args.platform,
+        )
+        audio_path = Path(str(result["file_path"]))
+        probe = probe_audio(audio_path, ffprobe_bin=ffprobe_bin)
+        validate_result(result, probe)
+        retained = not (temporary_home and not args.keep_home)
+        print(
+            json.dumps(
+                {
+                    "success": True,
+                    "hermes_home": str(hermes_home),
+                    "config_path": str(config_path),
+                    "retained": retained,
+                    "file_path": (
+                        str(audio_path)
+                        if retained
+                        else "<temporary; pass --keep-home or --output-path to retain>"
+                    ),
+                    "provider": result.get("provider"),
+                    "voice_compatible": result.get("voice_compatible"),
+                    "media_tag_prefix": str(result.get("media_tag", "")).splitlines()[0],
+                    "codec_name": probe.get("codec_name"),
+                    "sample_rate": probe.get("sample_rate"),
+                    "channels": probe.get("channels"),
+                },
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
+        return 0
+    finally:
+        if temporary_home and not args.keep_home:
+            shutil.rmtree(hermes_home, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_voice_full_duplex_sidecar.py
+++ b/scripts/verify_voice_full_duplex_sidecar.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Validate the voice WebRTC sidecar full-duplex preflight from Hermes.
+
+This is a small Hermes-side wrapper around the optional voice repo smoke:
+
+    examples/webrtc-sidecar/full_duplex_loopback_smoke.py
+
+It keeps the heavy WebRTC dependencies in the voice smoke environment, captures
+the machine-readable JSON output, and verifies the fields Hermes cares about
+before an operator attempts a real WhatsApp Calling session.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+
+DEFAULT_INBOUND_TEXT = "hello world"
+DEFAULT_OUTBOUND_TEXT = "Hello from Hermes through the voice WebRTC sidecar."
+DEFAULT_EXPECT_WORDS = ("hello", "world")
+DEFAULT_TIMEOUT = 90.0
+
+
+def resolve_executable(value: str, *, label: str) -> str:
+    if "/" in value:
+        path = Path(value).expanduser()
+        if not path.is_file() or not os.access(path, os.X_OK):
+            raise SystemExit(f"{label} is not executable: {path}")
+        # Preserve virtualenv entrypoint symlinks. Resolving
+        # /tmp/venv/bin/python to the base interpreter bypasses pyvenv.cfg and
+        # drops the sidecar dependencies installed in that venv.
+        return os.path.abspath(os.path.expanduser(value))
+
+    found = shutil.which(value)
+    if not found:
+        raise SystemExit(f"{label} not found on PATH: {value}")
+    return found
+
+
+def default_python_bin() -> str:
+    configured = os.environ.get("VOICE_WEBRTC_PYTHON")
+    if configured:
+        return configured
+    common_venv = Path("/tmp/voice-webrtc-venv/bin/python")
+    if common_venv.is_file() and os.access(common_venv, os.X_OK):
+        return str(common_venv)
+    return sys.executable
+
+
+def full_duplex_smoke_path(voice_repo: Path) -> Path:
+    return (
+        voice_repo
+        / "examples"
+        / "webrtc-sidecar"
+        / "full_duplex_loopback_smoke.py"
+    )
+
+
+def resolve_voice_smoke(voice_repo: Path) -> Path:
+    path = full_duplex_smoke_path(voice_repo.expanduser().resolve())
+    if not path.is_file():
+        raise SystemExit(
+            "voice full-duplex sidecar smoke not found: "
+            f"{path}. Pass --voice-repo pointing at rgbkrk/voice main."
+        )
+    return path
+
+
+def build_smoke_command(
+    *,
+    python_bin: str,
+    smoke_path: Path,
+    voice_bin: str,
+    inbound_text: str,
+    outbound_text: str,
+    voice: str,
+    speed: str,
+    timeout: float,
+    expect_words: list[str],
+) -> list[str]:
+    command = [
+        python_bin,
+        str(smoke_path),
+        "--voice-bin",
+        voice_bin,
+        "--inbound-text",
+        inbound_text,
+        "--outbound-text",
+        outbound_text,
+        "--voice",
+        voice,
+        "--speed",
+        speed,
+        "--timeout",
+        f"{timeout:g}",
+    ]
+    for word in expect_words:
+        command.extend(["--expect-word", word])
+    return command
+
+
+def run_smoke_command(
+    command: list[str],
+    *,
+    timeout: float,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def parse_smoke_json(stdout: str) -> dict[str, Any]:
+    decoder = json.JSONDecoder()
+    text = stdout.strip()
+    for index, char in enumerate(text):
+        if char != "{":
+            continue
+        try:
+            parsed, end = decoder.raw_decode(text[index:])
+        except json.JSONDecodeError:
+            continue
+        if text[index + end :].strip():
+            continue
+        if not isinstance(parsed, dict):
+            raise ValueError("full-duplex smoke JSON root must be an object")
+        return parsed
+    raise ValueError("full-duplex smoke did not print a JSON object")
+
+
+def validate_smoke_result(result: dict[str, Any]) -> None:
+    failures: list[str] = []
+
+    if result.get("success") is not True:
+        failures.append("success must be true")
+
+    audio = result.get("audio")
+    if not isinstance(audio, dict):
+        failures.append("audio must be an object")
+    else:
+        if int(audio.get("sample_rate") or 0) != 48_000:
+            failures.append("audio.sample_rate must be 48000")
+        if int(audio.get("channels") or 0) != 1:
+            failures.append("audio.channels must be 1")
+        if int(audio.get("frame_ms") or 0) != 20:
+            failures.append("audio.frame_ms must be 20")
+        if str(audio.get("encoding") or "") != "pcm_s16le":
+            failures.append("audio.encoding must be pcm_s16le")
+
+    transcript = str(result.get("transcript") or "").strip()
+    if not transcript:
+        failures.append("transcript must be non-empty")
+    if int(result.get("outbound_webrtc_bytes") or 0) <= 0:
+        failures.append("outbound_webrtc_bytes must be positive")
+    if int(result.get("decoded_pcm_bytes") or 0) <= 0:
+        failures.append("decoded_pcm_bytes must be positive")
+
+    stt = result.get("stt")
+    if not isinstance(stt, dict):
+        failures.append("stt must be an object")
+    elif not str(stt.get("text") or "").strip():
+        failures.append("stt.text must be non-empty")
+
+    if failures:
+        raise SystemExit("validation failed:\n- " + "\n- ".join(failures))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--voice-repo",
+        type=Path,
+        default=Path(os.environ.get("VOICE_REPO", ".")),
+        help="Path to an rgbkrk/voice checkout containing examples/webrtc-sidecar",
+    )
+    parser.add_argument("--python-bin", default=default_python_bin())
+    parser.add_argument("--voice-bin", default=os.environ.get("VOICE_BIN", "voice"))
+    parser.add_argument("--voice", default="af_heart")
+    parser.add_argument("--speed", default="1.0")
+    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
+    parser.add_argument("--inbound-text", default=DEFAULT_INBOUND_TEXT)
+    parser.add_argument("--outbound-text", default=DEFAULT_OUTBOUND_TEXT)
+    parser.add_argument(
+        "--expect-word",
+        action="append",
+        default=None,
+        help="word expected in the inbound transcript; repeatable",
+    )
+    args = parser.parse_args()
+    if args.expect_word is None:
+        args.expect_word = list(DEFAULT_EXPECT_WORDS)
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    python_bin = resolve_executable(args.python_bin, label="sidecar Python")
+    voice_bin = resolve_executable(args.voice_bin, label="voice binary")
+    smoke_path = resolve_voice_smoke(args.voice_repo)
+    command = build_smoke_command(
+        python_bin=python_bin,
+        smoke_path=smoke_path,
+        voice_bin=voice_bin,
+        inbound_text=args.inbound_text,
+        outbound_text=args.outbound_text,
+        voice=args.voice,
+        speed=args.speed,
+        timeout=args.timeout,
+        expect_words=args.expect_word,
+    )
+
+    completed = run_smoke_command(command, timeout=args.timeout + 5)
+    if completed.returncode != 0:
+        stderr = completed.stderr.strip()
+        raise SystemExit(
+            f"full-duplex smoke exited with code {completed.returncode}"
+            + (f": {stderr[:1000]}" if stderr else "")
+        )
+
+    try:
+        result = parse_smoke_json(completed.stdout)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    validate_smoke_result(result)
+
+    print(
+        json.dumps(
+            {
+                "success": True,
+                "voice_repo": str(args.voice_repo.expanduser().resolve()),
+                "voice_bin": voice_bin,
+                "python_bin": python_bin,
+                "smoke": result,
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_voice_full_duplex_sidecar.py
+++ b/scripts/verify_voice_full_duplex_sidecar.py
@@ -26,6 +26,7 @@ DEFAULT_INBOUND_TEXT = "hello world"
 DEFAULT_OUTBOUND_TEXT = "Hello from Hermes through the voice WebRTC sidecar."
 DEFAULT_EXPECT_WORDS = ("hello", "world")
 DEFAULT_TIMEOUT = 90.0
+MAX_CHILD_ERROR_CHARS = 4000
 
 
 def resolve_executable(value: str, *, label: str) -> str:
@@ -118,6 +119,14 @@ def run_smoke_command(
         timeout=timeout,
         check=False,
     )
+
+
+def format_child_error(text: str, *, max_chars: int = MAX_CHILD_ERROR_CHARS) -> str:
+    stripped = text.strip()
+    if len(stripped) <= max_chars:
+        return stripped
+    omitted = len(stripped) - max_chars
+    return f"... omitted {omitted} chars from child stderr ...\n{stripped[-max_chars:]}"
 
 
 def parse_smoke_json(stdout: str) -> dict[str, Any]:
@@ -221,10 +230,10 @@ def main() -> int:
 
     completed = run_smoke_command(command, timeout=args.timeout + 5)
     if completed.returncode != 0:
-        stderr = completed.stderr.strip()
+        stderr = format_child_error(completed.stderr)
         raise SystemExit(
             f"full-duplex smoke exited with code {completed.returncode}"
-            + (f": {stderr[:1000]}" if stderr else "")
+            + (f": {stderr}" if stderr else "")
         )
 
     try:

--- a/scripts/verify_voice_live_gateway.py
+++ b/scripts/verify_voice_live_gateway.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""Verify a running local Hermes gateway is using the voice-native stack.
+
+This is the live-service counterpart to ``verify_voice_local_stack.py``. It is
+intentionally read-mostly: it inspects the systemd user service, verifies the
+running process environment points at the expected checkout, confirms imports
+resolve from that checkout, and checks the local WhatsApp bridge health.
+
+Pass ``--run-tts-smoke`` to also generate one live-config TTS reply and verify
+that Hermes returns a WhatsApp-ready Ogg/Opus voice-note file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import sys
+from typing import Any
+from urllib.error import URLError
+from urllib.request import urlopen
+
+from verify_voice_local_stack import audit_live_hermes_root
+
+
+DEFAULT_SERVICE = "hermes-gateway.service"
+DEFAULT_BRIDGE_URL = "http://127.0.0.1:3000"
+DEFAULT_TTS_TEXT = "Hermes live voice gateway smoke."
+IMPORT_MODULES = (
+    "hermes_cli.main",
+    "tools.tts_tool",
+    "tools.tirith_security",
+    "gateway.platforms.whatsapp_cloud",
+    "gateway.platforms.whatsapp",
+)
+
+
+def resolve_executable(value: str, *, label: str) -> str:
+    if "/" in value:
+        path = Path(value).expanduser()
+        if not path.is_file() or not os.access(path, os.X_OK):
+            raise SystemExit(f"{label} is not executable: {path}")
+        return os.path.abspath(os.path.expanduser(value))
+
+    found = shutil.which(value)
+    if not found:
+        raise SystemExit(f"{label} not found on PATH: {value}")
+    return found
+
+
+def run_command(command: list[str], *, timeout: float) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def parse_systemctl_show(output: str) -> dict[str, str]:
+    data: dict[str, str] = {}
+    for line in output.splitlines():
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        data[key] = value
+    return data
+
+
+def get_service_state(service: str, *, timeout: float) -> dict[str, str]:
+    completed = run_command(
+        [
+            "systemctl",
+            "--user",
+            "show",
+            service,
+            "-p",
+            "ActiveState",
+            "-p",
+            "SubState",
+            "-p",
+            "MainPID",
+            "-p",
+            "Environment",
+            "-p",
+            "DropInPaths",
+            "--no-pager",
+        ],
+        timeout=timeout,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise SystemExit(f"systemctl show failed for {service}: {detail}")
+    return parse_systemctl_show(completed.stdout)
+
+
+def parse_systemd_environment(value: str) -> dict[str, str]:
+    env: dict[str, str] = {}
+    for part in shlex.split(value):
+        if "=" not in part:
+            continue
+        key, raw = part.split("=", 1)
+        env[key] = raw
+    return env
+
+
+def parse_proc_environ(data: bytes) -> dict[str, str]:
+    env: dict[str, str] = {}
+    for item in data.split(b"\0"):
+        if not item or b"=" not in item:
+            continue
+        key, value = item.split(b"=", 1)
+        env[key.decode("utf-8", errors="replace")] = value.decode(
+            "utf-8", errors="replace"
+        )
+    return env
+
+
+def read_process_env(pid: int) -> dict[str, str]:
+    path = Path("/proc") / str(pid) / "environ"
+    try:
+        return parse_proc_environ(path.read_bytes())
+    except OSError as exc:
+        raise SystemExit(f"failed to read process environment for PID {pid}: {exc}") from exc
+
+
+def path_is_under(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def validate_service_state(state: dict[str, str]) -> int:
+    if state.get("ActiveState") != "active":
+        raise SystemExit(f"gateway service is not active: {state}")
+    try:
+        pid = int(state.get("MainPID") or "0")
+    except ValueError as exc:
+        raise SystemExit(f"gateway service MainPID is invalid: {state.get('MainPID')!r}") from exc
+    if pid <= 0:
+        raise SystemExit(f"gateway service has no running MainPID: {state}")
+    return pid
+
+
+def validate_env_points_at_root(
+    env: dict[str, str],
+    root: Path,
+    *,
+    label: str,
+    bridge_bin_dir: Path | None = None,
+) -> dict[str, Any]:
+    root_text = str(root.resolve())
+    pythonpath = env.get("PYTHONPATH", "")
+    if root_text not in pythonpath.split(os.pathsep):
+        raise SystemExit(f"{label} PYTHONPATH does not include {root_text}: {pythonpath!r}")
+
+    result: dict[str, Any] = {
+        "PYTHONPATH": pythonpath,
+    }
+    if bridge_bin_dir is not None:
+        path = env.get("PATH", "")
+        bridge_bin_text = str(bridge_bin_dir.resolve())
+        if bridge_bin_text not in path.split(os.pathsep):
+            raise SystemExit(
+                f"{label} PATH does not include bridge bin dir "
+                f"{bridge_bin_text}: {path!r}"
+            )
+        result["bridge_bin_on_path"] = True
+    return result
+
+
+def import_smoke(
+    *,
+    python_bin: str,
+    live_root: Path,
+    hermes_home: Path,
+    timeout: float,
+) -> dict[str, str]:
+    code = """
+import importlib
+import inspect
+import json
+
+modules = {}
+for name in %r:
+    module = importlib.import_module(name)
+    modules[name] = inspect.getfile(module)
+print(json.dumps(modules, sort_keys=True))
+""" % (IMPORT_MODULES,)
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(live_root)
+    env["HERMES_HOME"] = str(hermes_home)
+    completed = subprocess.run(
+        [python_bin, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+        env=env,
+        cwd=str(live_root),
+        stdin=subprocess.DEVNULL,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise SystemExit(f"import smoke failed: {detail}")
+    try:
+        parsed = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"import smoke did not return JSON: {completed.stdout!r}") from exc
+    if not isinstance(parsed, dict):
+        raise SystemExit("import smoke JSON root must be an object")
+
+    for module, file_path in parsed.items():
+        if not path_is_under(Path(str(file_path)), live_root):
+            raise SystemExit(
+                f"module {module} resolved outside live root {live_root}: {file_path}"
+            )
+    return {str(key): str(value) for key, value in parsed.items()}
+
+
+def get_bridge_health(url: str, *, timeout: float) -> dict[str, Any]:
+    target = url.rstrip("/") + "/health"
+    try:
+        with urlopen(target, timeout=timeout) as response:
+            body = response.read().decode("utf-8", errors="replace")
+    except URLError as exc:
+        raise SystemExit(f"bridge health request failed for {target}: {exc}") from exc
+    try:
+        parsed = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"bridge health returned invalid JSON: {body!r}") from exc
+    if not isinstance(parsed, dict):
+        raise SystemExit("bridge health JSON root must be an object")
+    return parsed
+
+
+def validate_bridge_health(health: dict[str, Any], *, require_connected: bool) -> None:
+    if require_connected and health.get("status") != "connected":
+        raise SystemExit(f"bridge is not connected: {health}")
+
+
+def parse_ffprobe_json(output: str) -> dict[str, str]:
+    data = json.loads(output)
+    streams = data.get("streams")
+    if not isinstance(streams, list) or not streams:
+        raise ValueError("ffprobe output has no streams")
+    stream = streams[0]
+    if not isinstance(stream, dict):
+        raise ValueError("ffprobe stream must be an object")
+    return {
+        "codec_name": str(stream.get("codec_name") or ""),
+        "sample_rate": str(stream.get("sample_rate") or ""),
+        "channels": str(stream.get("channels") or ""),
+    }
+
+
+def probe_audio(path: Path, *, ffprobe_bin: str, timeout: float) -> dict[str, str]:
+    completed = run_command(
+        [
+            ffprobe_bin,
+            "-v",
+            "error",
+            "-select_streams",
+            "a:0",
+            "-show_entries",
+            "stream=codec_name,sample_rate,channels",
+            "-of",
+            "json",
+            str(path),
+        ],
+        timeout=timeout,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise SystemExit(f"ffprobe failed for {path}: {detail}")
+    try:
+        return parse_ffprobe_json(completed.stdout)
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"ffprobe output invalid for {path}: {completed.stdout!r}") from exc
+
+
+def run_tts_smoke(
+    *,
+    python_bin: str,
+    live_root: Path,
+    hermes_home: Path,
+    platform: str,
+    text: str,
+    ffprobe_bin: str,
+    timeout: float,
+) -> dict[str, Any]:
+    code = """
+import json
+from tools import tts_tool
+print(json.dumps(json.loads(tts_tool.text_to_speech_tool(%r)), sort_keys=True))
+""" % (text,)
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(live_root)
+    env["HERMES_HOME"] = str(hermes_home)
+    env["HERMES_SESSION_PLATFORM"] = platform
+    completed = subprocess.run(
+        [python_bin, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+        env=env,
+        cwd=str(live_root),
+        stdin=subprocess.DEVNULL,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise SystemExit(f"TTS smoke failed: {detail}")
+    try:
+        result = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"TTS smoke returned invalid JSON: {completed.stdout!r}") from exc
+    if result.get("success") is not True:
+        raise SystemExit(f"TTS smoke reported failure: {result}")
+    if result.get("voice_compatible") is not True:
+        raise SystemExit(f"TTS smoke was not voice-compatible: {result}")
+    media_tag = str(result.get("media_tag") or "")
+    if not media_tag.startswith("[[audio_as_voice]]\nMEDIA:"):
+        raise SystemExit(f"TTS smoke media tag is not a voice note: {media_tag!r}")
+    audio_path = Path(str(result.get("file_path") or ""))
+    if not audio_path.is_file():
+        raise SystemExit(f"TTS smoke file does not exist: {audio_path}")
+    probe = probe_audio(audio_path, ffprobe_bin=ffprobe_bin, timeout=timeout)
+    if probe != {"codec_name": "opus", "sample_rate": "48000", "channels": "1"}:
+        raise SystemExit(f"TTS smoke audio is not mono 48 kHz Opus: {probe}")
+    return {
+        "result": result,
+        "probe": probe,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--service", default=DEFAULT_SERVICE)
+    parser.add_argument("--live-hermes-root", type=Path, required=True)
+    parser.add_argument("--hermes-home", type=Path, default=Path("~/.hermes"))
+    parser.add_argument("--python-bin", default="~/.hermes/hermes-agent/venv/bin/python")
+    parser.add_argument("--bridge-url", default=DEFAULT_BRIDGE_URL)
+    parser.add_argument("--ffprobe-bin", default=os.environ.get("FFPROBE_BIN", "ffprobe"))
+    parser.add_argument("--timeout", type=float, default=15.0)
+    parser.add_argument("--allow-disconnected-bridge", action="store_true")
+    parser.add_argument("--run-tts-smoke", action="store_true")
+    parser.add_argument("--tts-platform", default="whatsapp")
+    parser.add_argument("--tts-text", default=DEFAULT_TTS_TEXT)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    live_root = args.live_hermes_root.expanduser().resolve()
+    hermes_home = args.hermes_home.expanduser().resolve()
+    python_bin = resolve_executable(args.python_bin, label="Hermes Python")
+    ffprobe_bin = (
+        resolve_executable(args.ffprobe_bin, label="ffprobe")
+        if args.run_tts_smoke
+        else ""
+    )
+    bridge_bin_dir = live_root / "scripts" / "whatsapp-bridge" / "node_modules" / ".bin"
+
+    checks: dict[str, Any] = {}
+    live_root_audit = audit_live_hermes_root(live_root)
+    if live_root_audit.get("success") is not True:
+        raise SystemExit(
+            "live root audit failed:\n- "
+            + "\n- ".join(str(item) for item in live_root_audit.get("failures", []))
+        )
+    checks["live_root"] = live_root_audit
+
+    service_state = get_service_state(args.service, timeout=args.timeout)
+    pid = validate_service_state(service_state)
+    unit_env = parse_systemd_environment(service_state.get("Environment", ""))
+    checks["systemd_unit"] = {
+        "service": args.service,
+        "pid": pid,
+        "drop_in_paths": service_state.get("DropInPaths", ""),
+        "env": validate_env_points_at_root(
+            unit_env,
+            live_root,
+            label="systemd unit",
+            bridge_bin_dir=bridge_bin_dir,
+        ),
+    }
+
+    process_env = read_process_env(pid)
+    checks["running_process"] = {
+        "pid": pid,
+        "env": validate_env_points_at_root(
+            process_env,
+            live_root,
+            label="running gateway process",
+            bridge_bin_dir=bridge_bin_dir,
+        ),
+    }
+
+    checks["imports"] = import_smoke(
+        python_bin=python_bin,
+        live_root=live_root,
+        hermes_home=hermes_home,
+        timeout=args.timeout,
+    )
+
+    bridge_health = get_bridge_health(args.bridge_url, timeout=args.timeout)
+    validate_bridge_health(
+        bridge_health,
+        require_connected=not args.allow_disconnected_bridge,
+    )
+    checks["bridge_health"] = bridge_health
+
+    if args.run_tts_smoke:
+        checks["tts_smoke"] = run_tts_smoke(
+            python_bin=python_bin,
+            live_root=live_root,
+            hermes_home=hermes_home,
+            platform=args.tts_platform,
+            text=args.tts_text,
+            ffprobe_bin=ffprobe_bin,
+            timeout=args.timeout,
+        )
+
+    print(
+        json.dumps(
+            {
+                "success": True,
+                "live_hermes_root": str(live_root),
+                "hermes_home": str(hermes_home),
+                "checks": checks,
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_voice_live_gateway.py
+++ b/scripts/verify_voice_live_gateway.py
@@ -352,6 +352,15 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--ffprobe-bin", default=os.environ.get("FFPROBE_BIN", "ffprobe"))
     parser.add_argument("--timeout", type=float, default=15.0)
     parser.add_argument("--allow-disconnected-bridge", action="store_true")
+    parser.add_argument(
+        "--skip-bridge-health",
+        action="store_true",
+        help=(
+            "Skip the local Baileys bridge /health check. Use this for "
+            "Cloud-API-only gateway deployments that do not run the Node "
+            "WhatsApp bridge."
+        ),
+    )
     parser.add_argument("--run-tts-smoke", action="store_true")
     parser.add_argument("--tts-platform", default="whatsapp")
     parser.add_argument("--tts-text", default=DEFAULT_TTS_TEXT)
@@ -412,12 +421,19 @@ def main() -> int:
         timeout=args.timeout,
     )
 
-    bridge_health = get_bridge_health(args.bridge_url, timeout=args.timeout)
-    validate_bridge_health(
-        bridge_health,
-        require_connected=not args.allow_disconnected_bridge,
-    )
-    checks["bridge_health"] = bridge_health
+    if args.skip_bridge_health:
+        checks["bridge_health"] = {
+            "success": True,
+            "skipped": True,
+            "reason": "--skip-bridge-health was provided",
+        }
+    else:
+        bridge_health = get_bridge_health(args.bridge_url, timeout=args.timeout)
+        validate_bridge_health(
+            bridge_health,
+            require_connected=not args.allow_disconnected_bridge,
+        )
+        checks["bridge_health"] = bridge_health
 
     if args.run_tts_smoke:
         checks["tts_smoke"] = run_tts_smoke(

--- a/scripts/verify_voice_local_stack.py
+++ b/scripts/verify_voice_local_stack.py
@@ -10,6 +10,8 @@ This aggregate preflight runs the existing focused verifiers in a safe order:
 
 By default the script creates a temporary Hermes home and removes it after a
 passing or failing run. Pass --keep-home to inspect the generated config.
+Pass --live-hermes-root to also prove the checkout used by a local gateway has
+the voice-native WhatsApp and sidecar surfaces from this branch.
 """
 
 from __future__ import annotations
@@ -30,6 +32,30 @@ DEFAULT_COMMAND_TEXT = "Hermes local voice command preflight."
 DEFAULT_STREAM_TEXT = "Hermes local voice stream preflight."
 DEFAULT_FULL_DUPLEX_INBOUND_TEXT = "hello world"
 DEFAULT_FULL_DUPLEX_OUTBOUND_TEXT = "Hello from Hermes through the local voice sidecar."
+
+LIVE_ROOT_REQUIREMENTS = (
+    {
+        "path": "tools/tts_tool.py",
+        "description": "command-provider voice-compatible Opus routing",
+        "tokens": (
+            "voice_compatible",
+            "libopus",
+            "-application",
+            "voip",
+        ),
+    },
+    {
+        "path": "gateway/platforms/whatsapp_cloud.py",
+        "description": "WhatsApp Cloud voice notes and calling sidecar client",
+        "tokens": (
+            "calling_sidecar_url",
+            "voice.webrtc_sidecar",
+            "_send_calling_sidecar_tts_stream_command",
+            "-application",
+            "voip",
+        ),
+    },
+)
 
 
 def repo_root() -> Path:
@@ -105,6 +131,61 @@ def run_process(
         env=env,
         stdin=subprocess.DEVNULL,
     )
+
+
+def audit_live_hermes_root(root: Path) -> dict[str, Any]:
+    resolved = root.expanduser().resolve()
+    failures: list[str] = []
+    checked: list[dict[str, Any]] = []
+
+    if not resolved.is_dir():
+        failures.append(f"live Hermes root is not a directory: {resolved}")
+        return {
+            "success": False,
+            "root": str(resolved),
+            "checked": checked,
+            "failures": failures,
+        }
+
+    for requirement in LIVE_ROOT_REQUIREMENTS:
+        rel_path = str(requirement["path"])
+        required_tokens = tuple(str(token) for token in requirement["tokens"])
+        path = resolved / rel_path
+        check = {
+            "path": rel_path,
+            "description": requirement["description"],
+            "required_tokens": list(required_tokens),
+        }
+        if not path.is_file():
+            check["present"] = False
+            failures.append(f"{rel_path} is missing")
+            checked.append(check)
+            continue
+
+        text = path.read_text(encoding="utf-8", errors="replace")
+        missing = [token for token in required_tokens if token not in text]
+        check["present"] = True
+        check["missing_tokens"] = missing
+        if missing:
+            failures.append(f"{rel_path} is missing tokens: {', '.join(missing)}")
+        checked.append(check)
+
+    return {
+        "success": not failures,
+        "root": str(resolved),
+        "checked": checked,
+        "failures": failures,
+    }
+
+
+def require_live_hermes_root(root: Path) -> dict[str, Any]:
+    result = audit_live_hermes_root(root)
+    if result["success"] is not True:
+        raise SystemExit(
+            "live Hermes root is missing voice-native integration surfaces:\n- "
+            + "\n- ".join(result["failures"])
+        )
+    return result
 
 
 def run_plain_step(
@@ -277,6 +358,15 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--command-text", default=DEFAULT_COMMAND_TEXT)
     parser.add_argument("--stream-text", default=DEFAULT_STREAM_TEXT)
     parser.add_argument("--stream-command-template")
+    parser.add_argument(
+        "--live-hermes-root",
+        type=Path,
+        help=(
+            "Optional checkout used by a running local gateway. When provided, "
+            "fail unless that checkout contains the voice-native WhatsApp "
+            "and calling sidecar integration surfaces."
+        ),
+    )
     parser.add_argument("--voice-repo", type=Path, default=default_voice_repo())
     parser.add_argument("--webrtc-python-bin", default=os.environ.get("VOICE_WEBRTC_PYTHON"))
     parser.add_argument("--skip-full-duplex", action="store_true")
@@ -319,6 +409,10 @@ def main() -> int:
 
     checks: dict[str, Any] = {}
     try:
+        if args.live_hermes_root is not None:
+            checks["live_hermes_root"] = require_live_hermes_root(
+                args.live_hermes_root
+            )
         checks["hermes_cli"] = run_plain_step(
             "Hermes CLI",
             [hermes_bin, "--help"],

--- a/scripts/verify_voice_local_stack.py
+++ b/scripts/verify_voice_local_stack.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""Validate the local Hermes + voice stack without touching the live gateway.
+
+This aggregate preflight runs the existing focused verifiers in a safe order:
+
+1. The local Hermes CLI entrypoint starts with an isolated HERMES_HOME.
+2. Hermes command-provider TTS returns WhatsApp-ready Ogg/Opus from voice.
+3. Hermes' stream command path returns raw 48 kHz mono 20 ms pcm_s16le frames.
+4. Optionally, the voice WebRTC sidecar full-duplex smoke passes locally.
+
+By default the script creates a temporary Hermes home and removes it after a
+passing or failing run. Pass --keep-home to inspect the generated config.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+
+DEFAULT_COMMAND_TEXT = "Hermes local voice command preflight."
+DEFAULT_STREAM_TEXT = "Hermes local voice stream preflight."
+DEFAULT_FULL_DUPLEX_INBOUND_TEXT = "hello world"
+DEFAULT_FULL_DUPLEX_OUTBOUND_TEXT = "Hello from Hermes through the local voice sidecar."
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def script_path(name: str) -> Path:
+    path = repo_root() / "scripts" / name
+    if not path.is_file():
+        raise SystemExit(f"script not found: {path}")
+    return path
+
+
+def resolve_executable(value: str, *, label: str) -> str:
+    if "/" in value:
+        path = Path(value).expanduser()
+        if not path.is_file() or not os.access(path, os.X_OK):
+            raise SystemExit(f"{label} is not executable: {path}")
+        return os.path.abspath(os.path.expanduser(value))
+
+    found = shutil.which(value)
+    if not found:
+        raise SystemExit(f"{label} not found on PATH: {value}")
+    return found
+
+
+def default_hermes_bin() -> str:
+    local = repo_root() / ".venv" / "bin" / "hermes"
+    if local.is_file() and os.access(local, os.X_OK):
+        return str(local)
+    return "hermes"
+
+
+def default_voice_repo() -> Path | None:
+    configured = os.environ.get("VOICE_REPO")
+    return Path(configured) if configured else None
+
+
+def shell_join(command: list[str]) -> str:
+    return " ".join(shlex.quote(part) for part in command)
+
+
+def parse_json_object(stdout: str) -> dict[str, Any]:
+    decoder = json.JSONDecoder()
+    text = stdout.strip()
+    for index, char in enumerate(text):
+        if char != "{":
+            continue
+        try:
+            parsed, end = decoder.raw_decode(text[index:])
+        except json.JSONDecodeError:
+            continue
+        if text[index + end :].strip():
+            continue
+        if not isinstance(parsed, dict):
+            raise ValueError("JSON root must be an object")
+        return parsed
+    raise ValueError("command did not print a JSON object")
+
+
+def run_process(
+    command: list[str],
+    *,
+    timeout: float,
+    env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+        env=env,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def run_plain_step(
+    name: str,
+    command: list[str],
+    *,
+    timeout: float,
+    env: dict[str, str],
+) -> dict[str, Any]:
+    completed = run_process(command, timeout=timeout, env=env)
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise SystemExit(
+            f"{name} failed with exit code {completed.returncode}"
+            + (f": {detail[:1000]}" if detail else "")
+        )
+    first_line = next(
+        (line for line in completed.stdout.splitlines() if line.strip()),
+        "",
+    )
+    return {
+        "success": True,
+        "command": shell_join(command),
+        "stdout_first_line": first_line,
+    }
+
+
+def run_json_step(
+    name: str,
+    command: list[str],
+    *,
+    timeout: float,
+    env: dict[str, str],
+) -> dict[str, Any]:
+    completed = run_process(command, timeout=timeout, env=env)
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise SystemExit(
+            f"{name} failed with exit code {completed.returncode}"
+            + (f": {detail[:1000]}" if detail else "")
+        )
+    try:
+        result = parse_json_object(completed.stdout)
+    except ValueError as exc:
+        raise SystemExit(f"{name} did not return JSON: {exc}") from exc
+    if result.get("success") is not True:
+        raise SystemExit(
+            f"{name} reported failure: "
+            + json.dumps(result, ensure_ascii=False, indent=2)
+        )
+    return {
+        "success": True,
+        "command": shell_join(command),
+        "result": result,
+    }
+
+
+def command_tts_command(
+    args: argparse.Namespace,
+    *,
+    voice_bin: str,
+    hermes_home: Path,
+) -> list[str]:
+    command = [
+        sys.executable,
+        str(script_path("verify_voice_command_tts.py")),
+        "--voice-bin",
+        voice_bin,
+        "--hermes-home",
+        str(hermes_home),
+        "--force",
+        "--provider",
+        args.provider,
+        "--voice",
+        args.voice,
+        "--speed",
+        args.speed,
+        "--timeout",
+        f"{args.tts_timeout:g}",
+    ]
+    if args.keep_home:
+        command.append("--keep-home")
+    command.extend(["--text", args.command_text])
+    return command
+
+
+def stream_tts_command(
+    args: argparse.Namespace,
+    *,
+    voice_bin: str,
+) -> list[str]:
+    command = [
+        sys.executable,
+        str(script_path("verify_voice_stream_tts.py")),
+        "--voice-bin",
+        voice_bin,
+        "--voice",
+        args.voice,
+        "--speed",
+        args.speed,
+        "--timeout",
+        f"{args.stream_timeout:g}",
+        "--text",
+        args.stream_text,
+    ]
+    if args.stream_command_template:
+        command.extend(["--command-template", args.stream_command_template])
+    return command
+
+
+def resolve_voice_repo_for_full_duplex(args: argparse.Namespace) -> Path | None:
+    if args.skip_full_duplex:
+        return None
+    if args.voice_repo is None:
+        raise SystemExit(
+            "full-duplex validation needs --voice-repo or VOICE_REPO; "
+            "pass --skip-full-duplex to validate only command and stream TTS"
+        )
+    voice_repo = args.voice_repo.expanduser().resolve()
+    smoke = voice_repo / "examples" / "webrtc-sidecar" / "full_duplex_loopback_smoke.py"
+    if not smoke.is_file():
+        raise SystemExit(f"voice full-duplex smoke not found: {smoke}")
+    return voice_repo
+
+
+def full_duplex_command(
+    args: argparse.Namespace,
+    *,
+    voice_bin: str,
+    voice_repo: Path,
+) -> list[str]:
+    command = [
+        sys.executable,
+        str(script_path("verify_voice_full_duplex_sidecar.py")),
+        "--voice-repo",
+        str(voice_repo),
+        "--voice-bin",
+        voice_bin,
+        "--voice",
+        args.voice,
+        "--speed",
+        args.speed,
+        "--timeout",
+        f"{args.full_duplex_timeout:g}",
+        "--inbound-text",
+        args.full_duplex_inbound_text,
+        "--outbound-text",
+        args.full_duplex_outbound_text,
+    ]
+    if args.webrtc_python_bin:
+        command.extend(["--python-bin", args.webrtc_python_bin])
+    for word in args.expect_word:
+        command.extend(["--expect-word", word])
+    return command
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--voice-bin", default=os.environ.get("VOICE_BIN", "voice"))
+    parser.add_argument("--hermes-bin", default=os.environ.get("HERMES_BIN", default_hermes_bin()))
+    parser.add_argument("--hermes-home", type=Path)
+    parser.add_argument("--keep-home", action="store_true")
+    parser.add_argument("--provider", default="kokoro")
+    parser.add_argument("--voice", default="af_heart")
+    parser.add_argument("--speed", default="1.0")
+    parser.add_argument("--tts-timeout", type=float, default=180.0)
+    parser.add_argument("--stream-timeout", type=float, default=180.0)
+    parser.add_argument("--full-duplex-timeout", type=float, default=90.0)
+    parser.add_argument("--cli-timeout", type=float, default=10.0)
+    parser.add_argument("--command-text", default=DEFAULT_COMMAND_TEXT)
+    parser.add_argument("--stream-text", default=DEFAULT_STREAM_TEXT)
+    parser.add_argument("--stream-command-template")
+    parser.add_argument("--voice-repo", type=Path, default=default_voice_repo())
+    parser.add_argument("--webrtc-python-bin", default=os.environ.get("VOICE_WEBRTC_PYTHON"))
+    parser.add_argument("--skip-full-duplex", action="store_true")
+    parser.add_argument(
+        "--full-duplex-inbound-text",
+        default=DEFAULT_FULL_DUPLEX_INBOUND_TEXT,
+    )
+    parser.add_argument(
+        "--full-duplex-outbound-text",
+        default=DEFAULT_FULL_DUPLEX_OUTBOUND_TEXT,
+    )
+    parser.add_argument(
+        "--expect-word",
+        action="append",
+        default=None,
+        help="word expected in the inbound full-duplex transcript; repeatable",
+    )
+    args = parser.parse_args()
+    if args.expect_word is None:
+        args.expect_word = ["hello", "world"]
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    voice_bin = resolve_executable(args.voice_bin, label="voice binary")
+    hermes_bin = resolve_executable(args.hermes_bin, label="Hermes CLI")
+    voice_repo = resolve_voice_repo_for_full_duplex(args)
+
+    temporary_home = args.hermes_home is None
+    hermes_home = (
+        Path(tempfile.mkdtemp(prefix="hermes-voice-local-stack."))
+        if temporary_home
+        else args.hermes_home.expanduser().resolve()
+    )
+    hermes_home.mkdir(parents=True, exist_ok=True)
+
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(hermes_home)
+
+    checks: dict[str, Any] = {}
+    try:
+        checks["hermes_cli"] = run_plain_step(
+            "Hermes CLI",
+            [hermes_bin, "--help"],
+            timeout=args.cli_timeout,
+            env=env,
+        )
+        checks["command_tts"] = run_json_step(
+            "command TTS verifier",
+            command_tts_command(args, voice_bin=voice_bin, hermes_home=hermes_home),
+            timeout=args.tts_timeout + 30,
+            env=env,
+        )
+        checks["stream_tts"] = run_json_step(
+            "stream TTS verifier",
+            stream_tts_command(args, voice_bin=voice_bin),
+            timeout=args.stream_timeout + 30,
+            env=env,
+        )
+        if voice_repo is None:
+            checks["full_duplex_sidecar"] = {
+                "success": True,
+                "skipped": True,
+                "reason": "--skip-full-duplex was provided",
+            }
+        else:
+            checks["full_duplex_sidecar"] = run_json_step(
+                "full-duplex sidecar verifier",
+                full_duplex_command(args, voice_bin=voice_bin, voice_repo=voice_repo),
+                timeout=args.full_duplex_timeout + 15,
+                env=env,
+            )
+
+        print(
+            json.dumps(
+                {
+                    "success": True,
+                    "hermes_home": str(hermes_home),
+                    "retained": bool(args.keep_home or not temporary_home),
+                    "voice_bin": voice_bin,
+                    "hermes_bin": hermes_bin,
+                    "voice_repo": str(voice_repo) if voice_repo is not None else None,
+                    "checks": checks,
+                },
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
+        return 0
+    finally:
+        if temporary_home and not args.keep_home:
+            shutil.rmtree(hermes_home, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_voice_stream_tts.py
+++ b/scripts/verify_voice_stream_tts.py
@@ -40,6 +40,9 @@ class AudioContract:
     frame_ms: int = DEFAULT_FRAME_MS
     encoding: str = DEFAULT_ENCODING
     bytes_per_sample: int = DEFAULT_BYTES_PER_SAMPLE
+    raw_outbound_pcm_command: str = ""
+    raw_inbound_pcm_command: str = ""
+    completed_voice_note_command: str = ""
 
     @property
     def samples_per_frame(self) -> int:
@@ -108,6 +111,137 @@ def build_default_command_template(voice_bin: str) -> str:
         f"--raw-output - --input-file {{input_path}} "
         f"--voice {{voice}} --speed {{speed}}"
     )
+
+
+def load_voice_stream_contract(voice_bin: str, *, timeout: float = 5.0) -> dict[str, Any]:
+    completed = subprocess.run(
+        [voice_bin, "stream-contract"],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=True,
+    )
+    parsed = json.loads(completed.stdout)
+    if not isinstance(parsed, dict):
+        raise ValueError("voice stream-contract root must be an object")
+    return parsed
+
+
+def audio_contract_from_voice(
+    voice_bin: str,
+    *,
+    fallback: AudioContract,
+) -> AudioContract:
+    try:
+        contract = load_voice_stream_contract(voice_bin)
+    except (
+        FileNotFoundError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        json.JSONDecodeError,
+        ValueError,
+    ) as exc:
+        raise SystemExit(f"failed to load `voice stream-contract`: {exc}") from exc
+
+    audio = contract.get("audio")
+    if not isinstance(audio, dict):
+        raise SystemExit("voice stream-contract audio section must be an object")
+
+    surface_commands = validate_voice_surfaces(contract.get("voice_surfaces"), audio)
+    return AudioContract(
+        sample_rate=int(audio.get("sample_rate") or fallback.sample_rate),
+        channels=int(audio.get("channels") or fallback.channels),
+        frame_ms=int(audio.get("frame_ms") or fallback.frame_ms),
+        encoding=str(audio.get("encoding") or fallback.encoding),
+        bytes_per_sample=int(audio.get("bytes_per_sample") or fallback.bytes_per_sample),
+        raw_outbound_pcm_command=surface_commands.get("raw_outbound_pcm", ""),
+        raw_inbound_pcm_command=surface_commands.get("raw_inbound_pcm", ""),
+        completed_voice_note_command=surface_commands.get("completed_voice_note", ""),
+    )
+
+
+def validate_voice_surfaces(
+    surfaces: object,
+    audio: dict[str, object],
+) -> dict[str, str]:
+    if surfaces is None:
+        raise SystemExit("voice stream-contract is missing voice_surfaces")
+    if not isinstance(surfaces, dict):
+        raise SystemExit("voice stream-contract voice_surfaces section must be an object")
+
+    frame_bytes = int(audio.get("frame_bytes") or 0)
+    encoding = str(audio.get("encoding") or "")
+    commands: dict[str, str] = {}
+
+    completed = surface_object(surfaces, "completed_voice_note")
+    if completed.get("output") != "audio/ogg; codecs=opus":
+        raise SystemExit("completed_voice_note output must be audio/ogg; codecs=opus")
+    if completed.get("transport") != "completed_file":
+        raise SystemExit("completed_voice_note transport must be completed_file")
+    completed_command = surface_command(completed, "completed_voice_note")
+    require_command_parts(
+        completed_command,
+        "completed_voice_note",
+        ["voice say", "--format ogg-opus", "--output"],
+    )
+    commands["completed_voice_note"] = completed_command
+
+    outbound = surface_object(surfaces, "raw_outbound_pcm")
+    if outbound.get("output") != encoding:
+        raise SystemExit("raw_outbound_pcm output must match audio.encoding")
+    if outbound.get("transport") != "stdout_pcm_frames":
+        raise SystemExit("raw_outbound_pcm transport must be stdout_pcm_frames")
+    if int(outbound.get("frame_bytes") or 0) != frame_bytes:
+        raise SystemExit("raw_outbound_pcm frame_bytes must match audio.frame_bytes")
+    outbound_command = surface_command(outbound, "raw_outbound_pcm")
+    require_command_parts(
+        outbound_command,
+        "raw_outbound_pcm",
+        ["voice stream", "--raw-output", "--sample-rate", "--frame-ms"],
+    )
+    commands["raw_outbound_pcm"] = outbound_command
+
+    inbound = surface_object(surfaces, "raw_inbound_pcm")
+    if inbound.get("input") != encoding:
+        raise SystemExit("raw_inbound_pcm input must match audio.encoding")
+    if inbound.get("transport") != "stdin_pcm_frames":
+        raise SystemExit("raw_inbound_pcm transport must be stdin_pcm_frames")
+    if int(inbound.get("frame_bytes") or 0) != frame_bytes:
+        raise SystemExit("raw_inbound_pcm frame_bytes must match audio.frame_bytes")
+    inbound_command = surface_command(inbound, "raw_inbound_pcm")
+    require_command_parts(
+        inbound_command,
+        "raw_inbound_pcm",
+        ["voice stream-transcribe", "--raw-input", "--sample-rate", "--frame-ms"],
+    )
+    commands["raw_inbound_pcm"] = inbound_command
+
+    return commands
+
+
+def surface_object(surfaces: dict[str, object], name: str) -> dict[str, object]:
+    surface = surfaces.get(name)
+    if not isinstance(surface, dict):
+        raise SystemExit(f"voice stream-contract voice_surfaces.{name} must be an object")
+    return surface
+
+
+def surface_command(surface: dict[str, object], name: str) -> str:
+    command = str(surface.get("command") or "")
+    if not command:
+        raise SystemExit(
+            f"voice stream-contract voice_surfaces.{name}.command must be non-empty"
+        )
+    return command
+
+
+def require_command_parts(command: str, name: str, parts: list[str]) -> None:
+    missing = [part for part in parts if part not in command]
+    if missing:
+        raise SystemExit(
+            f"voice stream-contract voice_surfaces.{name}.command is missing: "
+            + ", ".join(missing)
+        )
 
 
 def render_stream_command(
@@ -229,11 +363,12 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     voice_bin = resolve_executable(args.voice_bin, label="voice binary")
-    contract = AudioContract(
+    fallback_contract = AudioContract(
         sample_rate=args.sample_rate,
         channels=args.channels,
         frame_ms=args.frame_ms,
     )
+    contract = audio_contract_from_voice(voice_bin, fallback=fallback_contract)
     contract.validate()
     command_template = args.command_template or build_default_command_template(voice_bin)
 
@@ -272,6 +407,11 @@ def main() -> int:
                     "retained": retained,
                     "command_template": command_template,
                     "audio": contract.as_dict(),
+                    "voice_surfaces": {
+                        "raw_outbound_pcm_command": contract.raw_outbound_pcm_command,
+                        "raw_inbound_pcm_command": contract.raw_inbound_pcm_command,
+                        "completed_voice_note_command": contract.completed_voice_note_command,
+                    },
                     "pcm": stats,
                 },
                 indent=2,

--- a/scripts/verify_voice_stream_tts.py
+++ b/scripts/verify_voice_stream_tts.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Validate a voice-backed WhatsApp Calling TTS stream command.
+
+This script renders the same command template Hermes uses for
+``calling_sidecar_tts_stream_command``, runs it against a temporary input file,
+and verifies that stdout is raw 48 kHz mono 20 ms ``pcm_s16le`` frames suitable
+for the voice WebRTC sidecar.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import shlex
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+
+DEFAULT_TEXT = "Hermes voice stream command smoke test."
+DEFAULT_SAMPLE_RATE = 48_000
+DEFAULT_CHANNELS = 1
+DEFAULT_FRAME_MS = 20
+DEFAULT_BYTES_PER_SAMPLE = 2
+DEFAULT_ENCODING = "pcm_s16le"
+DEFAULT_MIN_PEAK = 384
+DEFAULT_MIN_DURATION_MS = 200
+
+
+@dataclass(frozen=True)
+class AudioContract:
+    sample_rate: int = DEFAULT_SAMPLE_RATE
+    channels: int = DEFAULT_CHANNELS
+    frame_ms: int = DEFAULT_FRAME_MS
+    encoding: str = DEFAULT_ENCODING
+    bytes_per_sample: int = DEFAULT_BYTES_PER_SAMPLE
+
+    @property
+    def samples_per_frame(self) -> int:
+        return self.sample_rate * self.frame_ms // 1_000
+
+    @property
+    def frame_bytes(self) -> int:
+        return self.samples_per_frame * self.channels * self.bytes_per_sample
+
+    @property
+    def bytes_per_second(self) -> int:
+        return self.sample_rate * self.channels * self.bytes_per_sample
+
+    def validate(self) -> None:
+        failures: list[str] = []
+        if self.sample_rate <= 0:
+            failures.append("sample_rate must be positive")
+        if self.channels <= 0:
+            failures.append("channels must be positive")
+        if self.frame_ms <= 0:
+            failures.append("frame_ms must be positive")
+        if self.bytes_per_sample <= 0:
+            failures.append("bytes_per_sample must be positive")
+        if self.encoding != DEFAULT_ENCODING:
+            failures.append(f"encoding must be {DEFAULT_ENCODING}")
+        if self.samples_per_frame <= 0:
+            failures.append("samples_per_frame must be positive")
+        if self.frame_bytes <= 0:
+            failures.append("frame_bytes must be positive")
+        if failures:
+            raise SystemExit("invalid audio contract:\n- " + "\n- ".join(failures))
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "sample_rate": self.sample_rate,
+            "channels": self.channels,
+            "frame_ms": self.frame_ms,
+            "encoding": self.encoding,
+            "bytes_per_sample": self.bytes_per_sample,
+            "samples_per_frame": self.samples_per_frame,
+            "frame_bytes": self.frame_bytes,
+        }
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def resolve_executable(value: str, *, label: str) -> str:
+    if "/" in value:
+        path = Path(value).expanduser()
+        if not path.is_file() or not os.access(path, os.X_OK):
+            raise SystemExit(f"{label} is not executable: {path}")
+        return str(path.resolve())
+
+    found = shutil.which(value)
+    if not found:
+        raise SystemExit(f"{label} not found on PATH: {value}")
+    return found
+
+
+def build_default_command_template(voice_bin: str) -> str:
+    return (
+        f"{shlex.quote(voice_bin)} stream --quiet "
+        f"--sample-rate {{sample_rate}} --frame-ms {{frame_ms}} "
+        f"--raw-output - --input-file {{input_path}} "
+        f"--voice {{voice}} --speed {{speed}}"
+    )
+
+
+def render_stream_command(
+    command_template: str,
+    *,
+    input_path: Path,
+    text: str,
+    contract: AudioContract,
+    voice: str,
+    speed: str,
+) -> str:
+    sys.path.insert(0, str(repo_root()))
+    from tools.tts_tool import _render_command_tts_template
+
+    return _render_command_tts_template(
+        command_template,
+        {
+            "input_path": str(input_path),
+            "text_path": str(input_path),
+            "text": text,
+            "sample_rate": str(contract.sample_rate),
+            "channels": str(contract.channels),
+            "frame_ms": str(contract.frame_ms),
+            "encoding": contract.encoding,
+            "voice": voice,
+            "speed": speed,
+        },
+    )
+
+
+def max_abs_pcm_s16le(pcm: bytes) -> int:
+    if len(pcm) % DEFAULT_BYTES_PER_SAMPLE:
+        raise ValueError("pcm_s16le payload must contain whole samples")
+    if not pcm:
+        return 0
+    return max(abs(sample[0]) for sample in struct.iter_unpack("<h", pcm))
+
+
+def validate_pcm(
+    pcm: bytes,
+    *,
+    contract: AudioContract,
+    min_peak: int = DEFAULT_MIN_PEAK,
+    min_duration_ms: int = DEFAULT_MIN_DURATION_MS,
+) -> dict[str, Any]:
+    contract.validate()
+    failures: list[str] = []
+
+    if not pcm:
+        failures.append("stream command produced no PCM")
+    if len(pcm) % contract.bytes_per_sample:
+        failures.append("PCM byte length is not aligned to whole s16le samples")
+    if len(pcm) % contract.frame_bytes:
+        failures.append(
+            f"PCM byte length {len(pcm)} is not aligned to {contract.frame_bytes}-byte frames"
+        )
+
+    duration_ms = (
+        len(pcm) * 1_000 // contract.bytes_per_second
+        if contract.bytes_per_second > 0
+        else 0
+    )
+    if duration_ms < min_duration_ms:
+        failures.append(
+            f"PCM duration {duration_ms}ms is shorter than minimum {min_duration_ms}ms"
+        )
+
+    peak = 0
+    if len(pcm) % contract.bytes_per_sample == 0:
+        peak = max_abs_pcm_s16le(pcm)
+        if peak < min_peak:
+            failures.append(f"PCM peak {peak} is below minimum {min_peak}")
+
+    if failures:
+        raise SystemExit("validation failed:\n- " + "\n- ".join(failures))
+
+    return {
+        "bytes": len(pcm),
+        "frames": len(pcm) // contract.frame_bytes,
+        "duration_ms": duration_ms,
+        "peak": peak,
+    }
+
+
+def run_stream_command(command: str, *, timeout: float) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        command,
+        shell=True,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a Hermes WhatsApp Calling TTS stream command and verify raw "
+            "pcm_s16le frame output."
+        )
+    )
+    parser.add_argument("--voice-bin", default=os.environ.get("VOICE_BIN", "voice"))
+    parser.add_argument("--command-template")
+    parser.add_argument("--voice", default="af_heart")
+    parser.add_argument("--speed", default="1.0")
+    parser.add_argument("--sample-rate", type=int, default=DEFAULT_SAMPLE_RATE)
+    parser.add_argument("--channels", type=int, default=DEFAULT_CHANNELS)
+    parser.add_argument("--frame-ms", type=int, default=DEFAULT_FRAME_MS)
+    parser.add_argument("--timeout", type=float, default=180.0)
+    parser.add_argument("--text", default=DEFAULT_TEXT)
+    parser.add_argument("--min-peak", type=int, default=DEFAULT_MIN_PEAK)
+    parser.add_argument("--min-duration-ms", type=int, default=DEFAULT_MIN_DURATION_MS)
+    parser.add_argument("--keep-input", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    voice_bin = resolve_executable(args.voice_bin, label="voice binary")
+    contract = AudioContract(
+        sample_rate=args.sample_rate,
+        channels=args.channels,
+        frame_ms=args.frame_ms,
+    )
+    contract.validate()
+    command_template = args.command_template or build_default_command_template(voice_bin)
+
+    tmpdir = Path(tempfile.mkdtemp(prefix="hermes-voice-stream-tts."))
+    try:
+        input_path = tmpdir / "input.txt"
+        input_path.write_text(args.text, encoding="utf-8")
+        command = render_stream_command(
+            command_template,
+            input_path=input_path,
+            text=args.text,
+            contract=contract,
+            voice=args.voice,
+            speed=args.speed,
+        )
+        completed = run_stream_command(command, timeout=args.timeout)
+        if completed.returncode != 0:
+            detail = completed.stderr.decode("utf-8", errors="replace").strip()
+            raise SystemExit(
+                f"stream command exited with code {completed.returncode}"
+                + (f": {detail[:1000]}" if detail else "")
+            )
+
+        stats = validate_pcm(
+            completed.stdout,
+            contract=contract,
+            min_peak=args.min_peak,
+            min_duration_ms=args.min_duration_ms,
+        )
+        retained = bool(args.keep_input)
+        print(
+            json.dumps(
+                {
+                    "success": True,
+                    "input_path": str(input_path) if retained else "<temporary>",
+                    "retained": retained,
+                    "command_template": command_template,
+                    "audio": contract.as_dict(),
+                    "pcm": stats,
+                },
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
+        return 0
+    finally:
+        if not args.keep_input:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_voice_stream_tts.py
+++ b/scripts/verify_voice_stream_tts.py
@@ -43,6 +43,7 @@ class AudioContract:
     raw_outbound_pcm_command: str = ""
     raw_inbound_pcm_command: str = ""
     completed_voice_note_command: str = ""
+    streamed_voice_note_command: str = ""
 
     @property
     def samples_per_frame(self) -> int:
@@ -157,6 +158,7 @@ def audio_contract_from_voice(
         raw_outbound_pcm_command=surface_commands.get("raw_outbound_pcm", ""),
         raw_inbound_pcm_command=surface_commands.get("raw_inbound_pcm", ""),
         completed_voice_note_command=surface_commands.get("completed_voice_note", ""),
+        streamed_voice_note_command=surface_commands.get("streamed_voice_note", ""),
     )
 
 
@@ -185,6 +187,19 @@ def validate_voice_surfaces(
         ["voice say", "--format ogg-opus", "--output"],
     )
     commands["completed_voice_note"] = completed_command
+
+    streamed = surface_object(surfaces, "streamed_voice_note")
+    if streamed.get("output") != "audio/ogg; codecs=opus":
+        raise SystemExit("streamed_voice_note output must be audio/ogg; codecs=opus")
+    if streamed.get("transport") != "daemon_stream_encoded_file":
+        raise SystemExit("streamed_voice_note transport must be daemon_stream_encoded_file")
+    streamed_command = surface_command(streamed, "streamed_voice_note")
+    require_command_parts(
+        streamed_command,
+        "streamed_voice_note",
+        ["voice stream", "--output", "--format ogg-opus"],
+    )
+    commands["streamed_voice_note"] = streamed_command
 
     outbound = surface_object(surfaces, "raw_outbound_pcm")
     if outbound.get("output") != encoding:
@@ -338,6 +353,107 @@ def run_stream_command(command: str, *, timeout: float) -> subprocess.CompletedP
     )
 
 
+def build_streamed_ogg_command(
+    *,
+    voice_bin: str,
+    input_path: Path,
+    output_path: Path,
+    contract: AudioContract,
+    voice: str,
+    speed: str,
+) -> list[str]:
+    return [
+        voice_bin,
+        "stream",
+        "--quiet",
+        "--sample-rate",
+        str(contract.sample_rate),
+        "--frame-ms",
+        str(contract.frame_ms),
+        "--output",
+        str(output_path),
+        "--format",
+        "ogg-opus",
+        "--input-file",
+        str(input_path),
+        "--voice",
+        voice,
+        "--speed",
+        speed,
+    ]
+
+
+def run_streamed_ogg_command(
+    command: list[str],
+    *,
+    timeout: float,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def parse_ffprobe(output: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in output.splitlines():
+        key, sep, value = line.partition("=")
+        if sep:
+            values[key] = value
+    return values
+
+
+def probe_audio(path: Path, *, ffprobe_bin: str) -> dict[str, str]:
+    completed = subprocess.run(
+        [
+            ffprobe_bin,
+            "-v",
+            "error",
+            "-select_streams",
+            "a:0",
+            "-show_entries",
+            "stream=codec_name,sample_rate,channels",
+            "-of",
+            "default=noprint_wrappers=1",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return parse_ffprobe(completed.stdout)
+
+
+def validate_streamed_ogg(path: Path, *, probe: dict[str, str]) -> dict[str, Any]:
+    failures: list[str] = []
+
+    if path.suffix.lower() not in {".ogg", ".opus"}:
+        failures.append(f"expected .ogg or .opus output, got {path}")
+    if not path.is_file() or path.stat().st_size == 0:
+        failures.append(f"expected non-empty streamed Ogg/Opus output at {path}")
+    if probe.get("codec_name") != "opus":
+        failures.append(f"expected codec_name=opus, got {probe.get('codec_name')!r}")
+    if probe.get("sample_rate") != "48000":
+        failures.append(f"expected sample_rate=48000, got {probe.get('sample_rate')!r}")
+    if probe.get("channels") != "1":
+        failures.append(f"expected channels=1, got {probe.get('channels')!r}")
+
+    if failures:
+        raise SystemExit("streamed Ogg/Opus validation failed:\n- " + "\n- ".join(failures))
+
+    return {
+        "bytes": path.stat().st_size,
+        "codec_name": probe.get("codec_name"),
+        "sample_rate": probe.get("sample_rate"),
+        "channels": probe.get("channels"),
+    }
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
@@ -346,6 +462,7 @@ def parse_args() -> argparse.Namespace:
         )
     )
     parser.add_argument("--voice-bin", default=os.environ.get("VOICE_BIN", "voice"))
+    parser.add_argument("--ffprobe-bin", default=os.environ.get("FFPROBE_BIN", "ffprobe"))
     parser.add_argument("--command-template")
     parser.add_argument("--voice", default="af_heart")
     parser.add_argument("--speed", default="1.0")
@@ -357,12 +474,22 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--min-peak", type=int, default=DEFAULT_MIN_PEAK)
     parser.add_argument("--min-duration-ms", type=int, default=DEFAULT_MIN_DURATION_MS)
     parser.add_argument("--keep-input", action="store_true")
+    parser.add_argument(
+        "--skip-streamed-ogg",
+        action="store_true",
+        help="validate the advertised streamed_voice_note surface without running it",
+    )
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
     voice_bin = resolve_executable(args.voice_bin, label="voice binary")
+    ffprobe_bin = (
+        None
+        if args.skip_streamed_ogg
+        else resolve_executable(args.ffprobe_bin, label="ffprobe")
+    )
     fallback_contract = AudioContract(
         sample_rate=args.sample_rate,
         channels=args.channels,
@@ -398,6 +525,40 @@ def main() -> int:
             min_peak=args.min_peak,
             min_duration_ms=args.min_duration_ms,
         )
+
+        streamed_ogg: dict[str, Any]
+        if args.skip_streamed_ogg:
+            streamed_ogg = {
+                "success": True,
+                "skipped": True,
+                "reason": "--skip-streamed-ogg was provided",
+            }
+        else:
+            ogg_path = tmpdir / "streamed.ogg"
+            ogg_command = build_streamed_ogg_command(
+                voice_bin=voice_bin,
+                input_path=input_path,
+                output_path=ogg_path,
+                contract=contract,
+                voice=args.voice,
+                speed=args.speed,
+            )
+            ogg_completed = run_streamed_ogg_command(ogg_command, timeout=args.timeout)
+            if ogg_completed.returncode != 0:
+                detail = ogg_completed.stderr.strip() or ogg_completed.stdout.strip()
+                raise SystemExit(
+                    f"streamed Ogg/Opus command exited with code {ogg_completed.returncode}"
+                    + (f": {detail[:1000]}" if detail else "")
+                )
+            probe = probe_audio(ogg_path, ffprobe_bin=ffprobe_bin or "ffprobe")
+            ogg_stats = validate_streamed_ogg(ogg_path, probe=probe)
+            streamed_ogg = {
+                "success": True,
+                "path": str(ogg_path) if args.keep_input else "<temporary>",
+                "command": " ".join(shlex.quote(part) for part in ogg_command),
+                **ogg_stats,
+            }
+
         retained = bool(args.keep_input)
         print(
             json.dumps(
@@ -411,8 +572,10 @@ def main() -> int:
                         "raw_outbound_pcm_command": contract.raw_outbound_pcm_command,
                         "raw_inbound_pcm_command": contract.raw_inbound_pcm_command,
                         "completed_voice_note_command": contract.completed_voice_note_command,
+                        "streamed_voice_note_command": contract.streamed_voice_note_command,
                     },
                     "pcm": stats,
+                    "streamed_ogg": streamed_ogg,
                 },
                 indent=2,
                 ensure_ascii=False,

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -542,6 +542,92 @@ class TestCallingSidecarClient:
         assert result.raw_response == {"error": "sample_rate must be 48000"}
 
     @pytest.mark.asyncio
+    async def test_receive_calling_sidecar_audio_drains_pcm_payload(self):
+        adapter = _make_adapter(
+            calling_sidecar_url="http://127.0.0.1:8787",
+            calling_sidecar_timeout=2.5,
+        )
+        adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(
+                200,
+                {
+                    "call_id": "wacid.call/with/slash",
+                    "returned_bytes": 4,
+                    "queued_rx_bytes": 8,
+                    "pcm_s16le_base64": base64.b64encode(
+                        b"\x01\x00\xff\xff"
+                    ).decode("ascii"),
+                    "audio": {
+                        "sample_rate": 48000,
+                        "channels": 1,
+                        "frame_ms": 20,
+                        "encoding": "pcm_s16le",
+                    },
+                },
+            )
+        )
+
+        audio = await adapter._receive_calling_sidecar_audio(
+            "wacid.call/with/slash",
+            max_bytes=4,
+        )
+
+        assert audio is not None
+        assert audio.call_id == "wacid.call/with/slash"
+        assert audio.pcm_s16le == b"\x01\x00\xff\xff"
+        assert audio.returned_bytes == 4
+        assert audio.queued_rx_bytes == 8
+        assert audio.audio["encoding"] == "pcm_s16le"
+        call = adapter._http_client.get.call_args
+        assert call.args[0] == (
+            "http://127.0.0.1:8787/calls/wacid.call%2Fwith%2Fslash/audio"
+        )
+        assert call.kwargs["params"] == {"max_bytes": 4}
+        assert call.kwargs["timeout"] == 2.5
+
+    @pytest.mark.asyncio
+    async def test_receive_calling_sidecar_audio_requires_sidecar(self):
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock()
+
+        audio = await adapter._receive_calling_sidecar_audio("call-1")
+
+        assert audio is None
+        adapter._http_client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_receive_calling_sidecar_audio_rejects_partial_sample_request(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock()
+
+        audio = await adapter._receive_calling_sidecar_audio("call-1", max_bytes=1)
+
+        assert audio is None
+        adapter._http_client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_receive_calling_sidecar_audio_rejects_bad_sidecar_payload(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(
+                200,
+                {
+                    "returned_bytes": 99,
+                    "queued_rx_bytes": 0,
+                    "pcm_s16le_base64": base64.b64encode(b"\x00\x00").decode("ascii"),
+                },
+            )
+        )
+
+        audio = await adapter._receive_calling_sidecar_audio("call-1")
+
+        assert audio is None
+
+    @pytest.mark.asyncio
     async def test_close_calling_sidecar_session_posts_close(self):
         adapter = _make_adapter(
             calling_sidecar_url="http://127.0.0.1:8787",

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -426,6 +426,55 @@ class TestCallingSidecarClient:
 
         assert answer is None
 
+    @pytest.mark.asyncio
+    async def test_send_call_action_posts_session_answer(self):
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(200, {"success": True})
+        )
+
+        result = await adapter._send_call_action(
+            "wacid.call-1",
+            "pre_accept",
+            sdp="v=0\r\n",
+        )
+
+        assert result.success is True
+        call = adapter._http_client.post.call_args
+        assert call.args[0] == "https://graph.facebook.com/v20.0/1234567890/calls"
+        assert call.kwargs["headers"]["Authorization"] == "Bearer test-token"
+        assert call.kwargs["json"] == {
+            "messaging_product": "whatsapp",
+            "call_id": "wacid.call-1",
+            "action": "pre_accept",
+            "session": {
+                "sdp_type": "answer",
+                "sdp": "v=0\r\n",
+            },
+        }
+
+    @pytest.mark.asyncio
+    async def test_send_call_action_returns_graph_error(self):
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(
+                400,
+                {
+                    "error": {
+                        "code": 100,
+                        "message": "Invalid call id",
+                    }
+                },
+            )
+        )
+
+        result = await adapter._send_call_action("bad-call", "accept", sdp="v=0\r\n")
+
+        assert result.success is False
+        assert "graph error 100" in result.error
+
 
 # ---------------------------------------------------------------------------
 # Inbound webhook verify (GET) handshake
@@ -565,6 +614,51 @@ _SAMPLE_INBOUND_TEXT_PAYLOAD = {
                                 "timestamp": "1758254144",
                                 "text": {"body": "Hi!"},
                                 "type": "text",
+                            }
+                        ],
+                    },
+                }
+            ],
+        }
+    ],
+}
+
+
+_SAMPLE_CALL_CONNECT_PAYLOAD = {
+    "object": "whatsapp_business_account",
+    "entry": [
+        {
+            "id": "215589313241560883",
+            "changes": [
+                {
+                    "field": "calls",
+                    "value": {
+                        "messaging_product": "whatsapp",
+                        "metadata": {
+                            "display_phone_number": "15551797781",
+                            "phone_number_id": "7794189252778687",
+                        },
+                        "contacts": [
+                            {
+                                "profile": {"name": "Jessica Laverdetman"},
+                                "wa_id": "13557825698",
+                            }
+                        ],
+                        "calls": [
+                            {
+                                "id": "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh",
+                                "from": "13557825698",
+                                "to": "15551797781",
+                                "event": "connect",
+                                "timestamp": "1762216151",
+                                "direction": "USER_INITIATED",
+                                "session": {
+                                    "sdp_type": "offer",
+                                    "sdp": (
+                                        "v=0\r\n"
+                                        "m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n"
+                                    ),
+                                },
                             }
                         ],
                     },
@@ -825,6 +919,125 @@ class TestWebhookDispatch:
         )
         assert response.status == 200
         adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_call_connect_without_sidecar_does_not_dispatch_message(self):
+        adapter = _make_adapter(app_secret="key")
+        adapter.handle_message = AsyncMock()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock()
+        body = json.dumps(_SAMPLE_CALL_CONNECT_PAYLOAD).encode("utf-8")
+        sig = _sign("key", body)
+
+        response = await adapter._handle_webhook(
+            _post_request(body, {"X-Hub-Signature-256": sig})
+        )
+
+        assert response.status == 200
+        adapter.handle_message.assert_not_called()
+        adapter._http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_call_connect_routes_offer_to_sidecar_and_accepts(self):
+        adapter = _make_adapter(
+            app_secret="key",
+            calling_sidecar_url="http://127.0.0.1:8787",
+        )
+        adapter.handle_message = AsyncMock()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(side_effect=[
+            _mock_httpx_response(
+                200,
+                {
+                    "call_id": "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh",
+                    "type": "answer",
+                    "sdp": "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
+                    "audio": {
+                        "codec": "opus",
+                        "sample_rate": 48000,
+                        "channels": 1,
+                        "frame_ms": 20,
+                    },
+                },
+            ),
+            _mock_httpx_response(200, {"success": True}),
+            _mock_httpx_response(200, {"success": True}),
+        ])
+        body = json.dumps(_SAMPLE_CALL_CONNECT_PAYLOAD).encode("utf-8")
+        sig = _sign("key", body)
+
+        response = await adapter._handle_webhook(
+            _post_request(body, {"X-Hub-Signature-256": sig})
+        )
+
+        assert response.status == 200
+        adapter.handle_message.assert_not_called()
+        assert adapter._http_client.post.call_count == 3
+
+        sidecar_call = adapter._http_client.post.call_args_list[0]
+        assert sidecar_call.args[0] == "http://127.0.0.1:8787/offer"
+        assert sidecar_call.kwargs["json"] == {
+            "call_id": "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh",
+            "type": "offer",
+            "sdp": "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
+        }
+
+        pre_accept_call = adapter._http_client.post.call_args_list[1]
+        accept_call = adapter._http_client.post.call_args_list[2]
+        assert pre_accept_call.args[0].endswith("/calls")
+        assert accept_call.args[0].endswith("/calls")
+        assert pre_accept_call.kwargs["json"]["action"] == "pre_accept"
+        assert accept_call.kwargs["json"]["action"] == "accept"
+        assert pre_accept_call.kwargs["json"]["session"] == {
+            "sdp_type": "answer",
+            "sdp": "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
+        }
+        assert accept_call.kwargs["json"]["session"] == {
+            "sdp_type": "answer",
+            "sdp": "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
+        }
+
+    @pytest.mark.asyncio
+    async def test_call_connect_sidecar_failure_skips_graph_accept(self):
+        adapter = _make_adapter(
+            app_secret="key",
+            calling_sidecar_url="http://127.0.0.1:8787",
+        )
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(503, {"error": "down"})
+        )
+        body = json.dumps(_SAMPLE_CALL_CONNECT_PAYLOAD).encode("utf-8")
+        sig = _sign("key", body)
+
+        response = await adapter._handle_webhook(
+            _post_request(body, {"X-Hub-Signature-256": sig})
+        )
+
+        assert response.status == 200
+        assert adapter._http_client.post.call_count == 1
+        assert adapter._http_client.post.call_args.args[0].endswith("/offer")
+
+    @pytest.mark.asyncio
+    async def test_call_connect_malformed_offer_skips_sidecar(self):
+        adapter = _make_adapter(
+            app_secret="key",
+            calling_sidecar_url="http://127.0.0.1:8787",
+        )
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock()
+        payload = json.loads(json.dumps(_SAMPLE_CALL_CONNECT_PAYLOAD))
+        session = payload["entry"][0]["changes"][0]["value"]["calls"][0]["session"]
+        session["sdp_type"] = "answer"
+        body = json.dumps(payload).encode("utf-8")
+        sig = _sign("key", body)
+
+        response = await adapter._handle_webhook(
+            _post_request(body, {"X-Hub-Signature-256": sig})
+        )
+
+        assert response.status == 200
+        adapter._http_client.post.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_dispatch_handles_button_reply(self):

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -53,6 +53,7 @@ def _make_adapter(**overrides):
     adapter._calling_sidecar_timeout = overrides.pop("calling_sidecar_timeout", 10.0)
     adapter._runner = None
     adapter._http_client = None
+    adapter._calling_sidecar_call_ids = set()
 
     # Behavior-mixin contract
     adapter._reply_prefix = None
@@ -803,6 +804,7 @@ class TestCallingSidecarClient:
             calling_sidecar_url="http://127.0.0.1:8787",
             calling_sidecar_timeout=2.5,
         )
+        adapter._calling_sidecar_call_ids.add("wacid.call/with/slash")
         adapter._http_client = MagicMock()
         adapter._http_client.post = AsyncMock(
             return_value=_mock_httpx_response(200, {"closed": True})
@@ -816,10 +818,12 @@ class TestCallingSidecarClient:
             "http://127.0.0.1:8787/calls/wacid.call%2Fwith%2Fslash/close"
         )
         assert call.kwargs["timeout"] == 2.5
+        assert adapter._calling_sidecar_call_ids == set()
 
     @pytest.mark.asyncio
     async def test_close_calling_sidecar_session_treats_404_as_closed(self):
         adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._calling_sidecar_call_ids.add("wacid.missing")
         adapter._http_client = MagicMock()
         adapter._http_client.post = AsyncMock(
             return_value=_mock_httpx_response(404, {"error": "unknown call_id"})
@@ -828,6 +832,29 @@ class TestCallingSidecarClient:
         closed = await adapter._close_calling_sidecar_session("wacid.missing")
 
         assert closed is True
+        assert adapter._calling_sidecar_call_ids == set()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_closes_tracked_sidecar_sessions_before_http_close(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._calling_sidecar_call_ids.update({"wacid.two", "wacid.one"})
+        http_client = MagicMock()
+        http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(200, {"closed": True})
+        )
+        http_client.aclose = AsyncMock()
+        adapter._http_client = http_client
+
+        await adapter.disconnect()
+
+        assert adapter._http_client is None
+        posted_urls = [call.args[0] for call in http_client.post.call_args_list]
+        assert posted_urls == [
+            "http://127.0.0.1:8787/calls/wacid.one/close",
+            "http://127.0.0.1:8787/calls/wacid.two/close",
+        ]
+        http_client.aclose.assert_awaited_once()
+        assert adapter._calling_sidecar_call_ids == set()
 
 
 # ---------------------------------------------------------------------------
@@ -1383,6 +1410,9 @@ class TestWebhookDispatch:
             "sdp_type": "answer",
             "sdp": "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
         }
+        assert adapter._calling_sidecar_call_ids == {
+            "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh"
+        }
 
     @pytest.mark.asyncio
     async def test_call_connect_sidecar_failure_skips_graph_accept(self):
@@ -1444,6 +1474,7 @@ class TestWebhookDispatch:
             "http://127.0.0.1:8787/calls/"
             "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh/close"
         )
+        assert adapter._calling_sidecar_call_ids == set()
 
     @pytest.mark.asyncio
     async def test_call_connect_accept_failure_closes_sidecar(self):
@@ -1486,6 +1517,7 @@ class TestWebhookDispatch:
             "http://127.0.0.1:8787/calls/"
             "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh/close"
         )
+        assert adapter._calling_sidecar_call_ids == set()
 
     @pytest.mark.asyncio
     async def test_call_connect_malformed_offer_skips_sidecar(self):
@@ -1515,6 +1547,7 @@ class TestWebhookDispatch:
             calling_sidecar_url="http://127.0.0.1:8787",
         )
         adapter.handle_message = AsyncMock()
+        adapter._calling_sidecar_call_ids.add("wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh")
         adapter._http_client = MagicMock()
         adapter._http_client.post = AsyncMock(
             return_value=_mock_httpx_response(200, {"closed": True})
@@ -1533,6 +1566,7 @@ class TestWebhookDispatch:
             "http://127.0.0.1:8787/calls/"
             "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh/close"
         )
+        assert adapter._calling_sidecar_call_ids == set()
 
     @pytest.mark.asyncio
     async def test_call_terminate_without_sidecar_skips_http(self):

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -475,6 +475,38 @@ class TestCallingSidecarClient:
         assert result.success is False
         assert "graph error 100" in result.error
 
+    @pytest.mark.asyncio
+    async def test_close_calling_sidecar_session_posts_close(self):
+        adapter = _make_adapter(
+            calling_sidecar_url="http://127.0.0.1:8787",
+            calling_sidecar_timeout=2.5,
+        )
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(200, {"closed": True})
+        )
+
+        closed = await adapter._close_calling_sidecar_session("wacid.call/with/slash")
+
+        assert closed is True
+        call = adapter._http_client.post.call_args
+        assert call.args[0] == (
+            "http://127.0.0.1:8787/calls/wacid.call%2Fwith%2Fslash/close"
+        )
+        assert call.kwargs["timeout"] == 2.5
+
+    @pytest.mark.asyncio
+    async def test_close_calling_sidecar_session_treats_404_as_closed(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(404, {"error": "unknown call_id"})
+        )
+
+        closed = await adapter._close_calling_sidecar_session("wacid.missing")
+
+        assert closed is True
+
 
 # ---------------------------------------------------------------------------
 # Inbound webhook verify (GET) handshake
@@ -659,6 +691,39 @@ _SAMPLE_CALL_CONNECT_PAYLOAD = {
                                         "m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n"
                                     ),
                                 },
+                            }
+                        ],
+                    },
+                }
+            ],
+        }
+    ],
+}
+
+
+_SAMPLE_CALL_TERMINATE_PAYLOAD = {
+    "object": "whatsapp_business_account",
+    "entry": [
+        {
+            "id": "215589313241560883",
+            "changes": [
+                {
+                    "field": "calls",
+                    "value": {
+                        "messaging_product": "whatsapp",
+                        "metadata": {
+                            "display_phone_number": "15551797781",
+                            "phone_number_id": "7794189252778687",
+                        },
+                        "calls": [
+                            {
+                                "id": "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh",
+                                "from": "13557825698",
+                                "to": "15551797781",
+                                "event": "terminate",
+                                "timestamp": "1762216199",
+                                "direction": "USER_INITIATED",
+                                "status": "COMPLETED",
                             }
                         ],
                     },
@@ -1030,6 +1095,47 @@ class TestWebhookDispatch:
         session = payload["entry"][0]["changes"][0]["value"]["calls"][0]["session"]
         session["sdp_type"] = "answer"
         body = json.dumps(payload).encode("utf-8")
+        sig = _sign("key", body)
+
+        response = await adapter._handle_webhook(
+            _post_request(body, {"X-Hub-Signature-256": sig})
+        )
+
+        assert response.status == 200
+        adapter._http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_call_terminate_closes_sidecar_session(self):
+        adapter = _make_adapter(
+            app_secret="key",
+            calling_sidecar_url="http://127.0.0.1:8787",
+        )
+        adapter.handle_message = AsyncMock()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(200, {"closed": True})
+        )
+        body = json.dumps(_SAMPLE_CALL_TERMINATE_PAYLOAD).encode("utf-8")
+        sig = _sign("key", body)
+
+        response = await adapter._handle_webhook(
+            _post_request(body, {"X-Hub-Signature-256": sig})
+        )
+
+        assert response.status == 200
+        adapter.handle_message.assert_not_called()
+        adapter._http_client.post.assert_awaited_once()
+        assert adapter._http_client.post.call_args.args[0] == (
+            "http://127.0.0.1:8787/calls/"
+            "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh/close"
+        )
+
+    @pytest.mark.asyncio
+    async def test_call_terminate_without_sidecar_skips_http(self):
+        adapter = _make_adapter(app_secret="key")
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock()
+        body = json.dumps(_SAMPLE_CALL_TERMINATE_PAYLOAD).encode("utf-8")
         sig = _sign("key", body)
 
         response = await adapter._handle_webhook(

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -1406,6 +1406,88 @@ class TestWebhookDispatch:
         assert adapter._http_client.post.call_args.args[0].endswith("/offer")
 
     @pytest.mark.asyncio
+    async def test_call_connect_pre_accept_failure_closes_sidecar(self):
+        adapter = _make_adapter(
+            app_secret="key",
+            calling_sidecar_url="http://127.0.0.1:8787",
+        )
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(side_effect=[
+            _mock_httpx_response(
+                200,
+                {
+                    "call_id": "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh",
+                    "type": "answer",
+                    "sdp": "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
+                    "audio": {
+                        "sample_rate": 48000,
+                        "channels": 1,
+                        "frame_ms": 20,
+                        "encoding": "pcm_s16le",
+                    },
+                },
+            ),
+            _mock_httpx_response(500, {"error": {"message": "pre_accept failed"}}),
+            _mock_httpx_response(200, {"closed": True}),
+        ])
+        body = json.dumps(_SAMPLE_CALL_CONNECT_PAYLOAD).encode("utf-8")
+        sig = _sign("key", body)
+
+        response = await adapter._handle_webhook(
+            _post_request(body, {"X-Hub-Signature-256": sig})
+        )
+
+        assert response.status == 200
+        assert adapter._http_client.post.call_count == 3
+        assert adapter._http_client.post.call_args_list[1].kwargs["json"]["action"] == "pre_accept"
+        assert adapter._http_client.post.call_args_list[2].args[0] == (
+            "http://127.0.0.1:8787/calls/"
+            "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh/close"
+        )
+
+    @pytest.mark.asyncio
+    async def test_call_connect_accept_failure_closes_sidecar(self):
+        adapter = _make_adapter(
+            app_secret="key",
+            calling_sidecar_url="http://127.0.0.1:8787",
+        )
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(side_effect=[
+            _mock_httpx_response(
+                200,
+                {
+                    "call_id": "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh",
+                    "type": "answer",
+                    "sdp": "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
+                    "audio": {
+                        "sample_rate": 48000,
+                        "channels": 1,
+                        "frame_ms": 20,
+                        "encoding": "pcm_s16le",
+                    },
+                },
+            ),
+            _mock_httpx_response(200, {"success": True}),
+            _mock_httpx_response(500, {"error": {"message": "accept failed"}}),
+            _mock_httpx_response(200, {"closed": True}),
+        ])
+        body = json.dumps(_SAMPLE_CALL_CONNECT_PAYLOAD).encode("utf-8")
+        sig = _sign("key", body)
+
+        response = await adapter._handle_webhook(
+            _post_request(body, {"X-Hub-Signature-256": sig})
+        )
+
+        assert response.status == 200
+        assert adapter._http_client.post.call_count == 4
+        assert adapter._http_client.post.call_args_list[1].kwargs["json"]["action"] == "pre_accept"
+        assert adapter._http_client.post.call_args_list[2].kwargs["json"]["action"] == "accept"
+        assert adapter._http_client.post.call_args_list[3].args[0] == (
+            "http://127.0.0.1:8787/calls/"
+            "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh/close"
+        )
+
+    @pytest.mark.asyncio
     async def test_call_connect_malformed_offer_skips_sidecar(self):
         adapter = _make_adapter(
             app_secret="key",

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -908,6 +908,122 @@ class TestCallingSidecarClient:
                 except OSError:
                     pass
 
+    def test_calling_sidecar_pcm_speech_gate_ignores_silence(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        silence = b"\x00\x00" * 960
+        speech = (1000).to_bytes(2, "little", signed=True) * 960
+
+        assert adapter._calling_sidecar_pcm_peak(silence) == 0
+        assert adapter._calling_sidecar_pcm_has_speech(silence) is False
+        assert adapter._calling_sidecar_pcm_peak(speech) == 1000
+        assert adapter._calling_sidecar_pcm_has_speech(speech) is True
+
+    @pytest.mark.asyncio
+    async def test_calling_sidecar_audio_loop_ignores_pure_silence(self):
+        from gateway.platforms.whatsapp_cloud import (
+            CALLING_AUDIO_CONTRACT,
+            CALLING_PCM_DEFAULT_DRAIN_BYTES,
+            CallingSidecarAudio,
+        )
+
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._calling_sidecar_call_ids.add("call-1")
+        adapter._dispatch_calling_sidecar_pcm = AsyncMock()
+        silence = b"\x00" * CALLING_PCM_DEFAULT_DRAIN_BYTES
+        responses = [
+            CallingSidecarAudio(
+                call_id="call-1",
+                pcm_s16le=silence,
+                returned_bytes=len(silence),
+                queued_rx_bytes=0,
+                audio=dict(CALLING_AUDIO_CONTRACT),
+            ),
+            CallingSidecarAudio(
+                call_id="call-1",
+                pcm_s16le=silence,
+                returned_bytes=len(silence),
+                queued_rx_bytes=0,
+                audio=dict(CALLING_AUDIO_CONTRACT),
+            ),
+        ]
+
+        async def receive(_call_id):
+            if responses:
+                return responses.pop(0)
+            adapter._calling_sidecar_call_ids.discard("call-1")
+            return None
+
+        adapter._receive_calling_sidecar_audio = receive
+
+        await adapter._run_calling_sidecar_audio_loop(
+            "call-1",
+            "13557825698",
+            "Jessica Laverdetman",
+        )
+
+        adapter._dispatch_calling_sidecar_pcm.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_calling_sidecar_audio_loop_flushes_speech_after_silence(self):
+        from gateway.platforms.whatsapp_cloud import (
+            CALLING_AUDIO_CONTRACT,
+            CALLING_PCM_DEFAULT_DRAIN_BYTES,
+            CallingSidecarAudio,
+        )
+
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._calling_sidecar_call_ids.add("call-1")
+        adapter._dispatch_calling_sidecar_pcm = AsyncMock()
+        speech = (
+            (1000).to_bytes(2, "little", signed=True)
+            * (CALLING_PCM_DEFAULT_DRAIN_BYTES // 2)
+        )
+        silence = b"\x00" * CALLING_PCM_DEFAULT_DRAIN_BYTES
+        responses = [
+            CallingSidecarAudio(
+                call_id="call-1",
+                pcm_s16le=speech,
+                returned_bytes=len(speech),
+                queued_rx_bytes=0,
+                audio=dict(CALLING_AUDIO_CONTRACT),
+            ),
+            CallingSidecarAudio(
+                call_id="call-1",
+                pcm_s16le=silence,
+                returned_bytes=len(silence),
+                queued_rx_bytes=0,
+                audio=dict(CALLING_AUDIO_CONTRACT),
+            ),
+            CallingSidecarAudio(
+                call_id="call-1",
+                pcm_s16le=silence,
+                returned_bytes=len(silence),
+                queued_rx_bytes=0,
+                audio=dict(CALLING_AUDIO_CONTRACT),
+            ),
+        ]
+
+        async def receive(_call_id):
+            if responses:
+                return responses.pop(0)
+            adapter._calling_sidecar_call_ids.discard("call-1")
+            return None
+
+        adapter._receive_calling_sidecar_audio = receive
+
+        await adapter._run_calling_sidecar_audio_loop(
+            "call-1",
+            "13557825698",
+            "Jessica Laverdetman",
+        )
+
+        adapter._dispatch_calling_sidecar_pcm.assert_awaited_once()
+        call = adapter._dispatch_calling_sidecar_pcm.call_args
+        assert call.args[:3] == ("call-1", "13557825698", "Jessica Laverdetman")
+        dispatched_pcm = call.args[3]
+        assert dispatched_pcm.startswith(speech)
+        assert len(dispatched_pcm) == len(speech) + len(silence)
+
     @pytest.mark.asyncio
     async def test_close_calling_sidecar_session_posts_close(self):
         adapter = _make_adapter(

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -48,6 +48,8 @@ def _make_adapter(**overrides):
     adapter._webhook_path = "/whatsapp/webhook"
     adapter._health_path = "/health"
     adapter._api_version = overrides.pop("api_version", "v20.0")
+    adapter._calling_sidecar_url = overrides.pop("calling_sidecar_url", "")
+    adapter._calling_sidecar_timeout = overrides.pop("calling_sidecar_timeout", 10.0)
     adapter._runner = None
     adapter._http_client = None
 
@@ -288,6 +290,141 @@ class TestSendText:
         result = await adapter.send("15551234567", "hi")
         assert result.success is False
         assert "boom" in result.error
+
+
+# ---------------------------------------------------------------------------
+# WhatsApp Calling sidecar client
+# ---------------------------------------------------------------------------
+
+class TestCallingSidecarClient:
+    def test_init_reads_calling_sidecar_config_from_extra(self, monkeypatch):
+        from gateway.platforms.whatsapp_cloud import WhatsAppCloudAdapter
+
+        monkeypatch.delenv("WHATSAPP_CLOUD_CALLING_SIDECAR_URL", raising=False)
+        monkeypatch.delenv("WHATSAPP_CLOUD_CALLING_SIDECAR_TIMEOUT", raising=False)
+
+        config = MagicMock()
+        config.extra = {
+            "phone_number_id": "123",
+            "access_token": "tok",
+            "calling_sidecar_url": "http://127.0.0.1:8787/",
+            "calling_sidecar_timeout": "2.5",
+        }
+
+        adapter = WhatsAppCloudAdapter(config)
+
+        assert adapter._calling_sidecar_url == "http://127.0.0.1:8787"
+        assert adapter._calling_sidecar_timeout == 2.5
+        assert adapter._calling_sidecar_enabled() is True
+
+    def test_gateway_env_overrides_populate_calling_sidecar(self, monkeypatch):
+        from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+
+        monkeypatch.setenv("WHATSAPP_CLOUD_PHONE_NUMBER_ID", "phone-123")
+        monkeypatch.setenv("WHATSAPP_CLOUD_ACCESS_TOKEN", "token-123")
+        monkeypatch.setenv(
+            "WHATSAPP_CLOUD_CALLING_SIDECAR_URL",
+            "http://127.0.0.1:8787",
+        )
+        monkeypatch.setenv("WHATSAPP_CLOUD_CALLING_SIDECAR_TIMEOUT", "4.25")
+
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+
+        extra = config.platforms[Platform.WHATSAPP_CLOUD].extra
+        assert extra["phone_number_id"] == "phone-123"
+        assert extra["access_token"] == "token-123"
+        assert extra["calling_sidecar_url"] == "http://127.0.0.1:8787"
+        assert extra["calling_sidecar_timeout"] == 4.25
+
+    @pytest.mark.asyncio
+    async def test_disabled_without_url(self):
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock()
+
+        answer = await adapter._request_calling_sidecar_answer("call-1", "v=0\r\n")
+
+        assert answer is None
+        adapter._http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_request_posts_offer_and_returns_answer(self):
+        adapter = _make_adapter(
+            calling_sidecar_url="http://127.0.0.1:8787",
+            calling_sidecar_timeout=2.5,
+        )
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(
+                200,
+                {
+                    "call_id": "call-1",
+                    "type": "answer",
+                    "sdp": "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
+                    "audio": {
+                        "codec": "opus",
+                        "sample_rate": 48000,
+                        "channels": 1,
+                        "frame_ms": 20,
+                    },
+                },
+            )
+        )
+
+        answer = await adapter._request_calling_sidecar_answer("call-1", "v=0\r\n")
+
+        assert answer is not None
+        assert answer.call_id == "call-1"
+        assert answer.sdp.startswith("v=0")
+        assert answer.audio["codec"] == "opus"
+        adapter._http_client.post.assert_awaited_once()
+        call = adapter._http_client.post.call_args
+        assert call.args[0] == "http://127.0.0.1:8787/offer"
+        assert call.kwargs["timeout"] == 2.5
+        assert call.kwargs["json"] == {
+            "call_id": "call-1",
+            "type": "offer",
+            "sdp": "v=0\r\n",
+        }
+
+    @pytest.mark.asyncio
+    async def test_request_requires_connected_http_client(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+
+        answer = await adapter._request_calling_sidecar_answer("call-1", "v=0\r\n")
+
+        assert answer is None
+
+    @pytest.mark.asyncio
+    async def test_request_rejects_non_200(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(503, {"error": "sidecar down"})
+        )
+
+        answer = await adapter._request_calling_sidecar_answer("call-1", "v=0\r\n")
+
+        assert answer is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("body", [
+        {"type": "offer", "sdp": "v=0"},
+        {"type": "answer"},
+        {"type": "answer", "sdp": ""},
+        ["not", "an", "object"],
+    ])
+    async def test_request_rejects_invalid_answer(self, body):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(200, body)
+        )
+
+        answer = await adapter._request_calling_sidecar_answer("call-1", "v=0\r\n")
+
+        assert answer is None
 
 
 # ---------------------------------------------------------------------------
@@ -803,6 +940,7 @@ class TestHealth:
         assert body["phone_number_id"] == "555"
         assert body["verify_token_configured"] is True
         assert body["app_secret_configured"] is True
+        assert body["calling_sidecar_configured"] is False
         assert body["accepted"] == 0
         assert body["duplicates"] == 0
         assert body["rejected_signature"] == 0

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import base64
 import asyncio
 import json
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -52,6 +52,14 @@ def _make_adapter(**overrides):
     adapter._api_version = overrides.pop("api_version", "v20.0")
     adapter._calling_sidecar_url = overrides.pop("calling_sidecar_url", "")
     adapter._calling_sidecar_timeout = overrides.pop("calling_sidecar_timeout", 10.0)
+    adapter._calling_sidecar_tts_stream_command = overrides.pop(
+        "calling_sidecar_tts_stream_command",
+        "",
+    )
+    adapter._calling_sidecar_tts_stream_timeout = overrides.pop(
+        "calling_sidecar_tts_stream_timeout",
+        180.0,
+    )
     adapter._runner = None
     adapter._http_client = None
     adapter._calling_sidecar_contract = overrides.pop("calling_sidecar_contract", None)
@@ -102,6 +110,7 @@ def _make_adapter(**overrides):
     adapter._auto_tts_default = False
     adapter._auto_tts_enabled_chats = set()
     adapter._auto_tts_disabled_chats = set()
+    adapter._typing_paused = set()
 
     # Apply any leftover overrides directly
     for key, value in overrides.items():
@@ -314,6 +323,14 @@ class TestCallingSidecarClient:
 
         monkeypatch.delenv("WHATSAPP_CLOUD_CALLING_SIDECAR_URL", raising=False)
         monkeypatch.delenv("WHATSAPP_CLOUD_CALLING_SIDECAR_TIMEOUT", raising=False)
+        monkeypatch.delenv(
+            "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND",
+            raising=False,
+        )
+        monkeypatch.delenv(
+            "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT",
+            raising=False,
+        )
 
         config = MagicMock()
         config.extra = {
@@ -321,12 +338,18 @@ class TestCallingSidecarClient:
             "access_token": "tok",
             "calling_sidecar_url": "http://127.0.0.1:8787/",
             "calling_sidecar_timeout": "2.5",
+            "calling_sidecar_tts_stream_command": (
+                "voice stream --raw-output - --input-file {input_path}"
+            ),
+            "calling_sidecar_tts_stream_timeout": "30",
         }
 
         adapter = WhatsAppCloudAdapter(config)
 
         assert adapter._calling_sidecar_url == "http://127.0.0.1:8787"
         assert adapter._calling_sidecar_timeout == 2.5
+        assert adapter._calling_sidecar_tts_stream_command.startswith("voice stream")
+        assert adapter._calling_sidecar_tts_stream_timeout == 30.0
         assert adapter._calling_sidecar_enabled() is True
 
     def test_gateway_env_overrides_populate_calling_sidecar(self, monkeypatch):
@@ -339,6 +362,14 @@ class TestCallingSidecarClient:
             "http://127.0.0.1:8787",
         )
         monkeypatch.setenv("WHATSAPP_CLOUD_CALLING_SIDECAR_TIMEOUT", "4.25")
+        monkeypatch.setenv(
+            "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND",
+            "voice stream --raw-output - --input-file {input_path}",
+        )
+        monkeypatch.setenv(
+            "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT",
+            "45.5",
+        )
 
         config = GatewayConfig()
         _apply_env_overrides(config)
@@ -348,6 +379,8 @@ class TestCallingSidecarClient:
         assert extra["access_token"] == "token-123"
         assert extra["calling_sidecar_url"] == "http://127.0.0.1:8787"
         assert extra["calling_sidecar_timeout"] == 4.25
+        assert extra["calling_sidecar_tts_stream_command"].startswith("voice stream")
+        assert extra["calling_sidecar_tts_stream_timeout"] == 45.5
 
     @pytest.mark.asyncio
     async def test_disabled_without_url(self):
@@ -792,6 +825,133 @@ class TestCallingSidecarClient:
         assert result.error == "outbound PCM queue is full"
         assert result.raw_response == {"error": "outbound PCM queue is full"}
         assert result.retryable is True
+
+    @pytest.mark.asyncio
+    async def test_play_tts_text_stream_command_posts_pcm_frames(self, monkeypatch):
+        from gateway.platforms.base import SendResult
+
+        frame = b"\x01\x00" * 960
+        chunks = [frame + frame[:100], frame[100:], b""]
+        commands = []
+
+        class FakeStream:
+            def __init__(self, values):
+                self._values = list(values)
+
+            async def read(self, _n=-1):
+                if self._values:
+                    return self._values.pop(0)
+                return b""
+
+        class FakeProc:
+            def __init__(self):
+                self.stdout = FakeStream(chunks)
+                self.stderr = FakeStream([b""])
+                self.returncode = None
+                self.killed = False
+
+            async def wait(self):
+                self.returncode = 0
+                return 0
+
+            def kill(self):
+                self.killed = True
+                self.returncode = -9
+
+        async def fake_create_subprocess_shell(command, **_kwargs):
+            commands.append(command)
+            return FakeProc()
+
+        monkeypatch.setattr(
+            "gateway.platforms.whatsapp_cloud.asyncio.create_subprocess_shell",
+            fake_create_subprocess_shell,
+        )
+        adapter = _make_adapter(
+            calling_sidecar_url="http://127.0.0.1:8787",
+            calling_sidecar_tts_stream_command=(
+                "voice stream --quiet --sample-rate {sample_rate} "
+                "--frame-ms {frame_ms} --raw-output - --input-file {input_path}"
+            ),
+        )
+        adapter._calling_sidecar_call_ids.add("call-1")
+        adapter._send_calling_sidecar_audio = AsyncMock(
+            return_value=SendResult(success=True)
+        )
+
+        result = await adapter.play_tts_text(
+            "15551234567",
+            "Hello from the call",
+            metadata={"thread_id": "call-1"},
+        )
+
+        assert result.success is True
+        assert result.raw_response["frames"] == 2
+        assert result.raw_response["queued_pcm_bytes"] == len(frame) * 2
+        assert commands
+        assert "--sample-rate 48000" in commands[0]
+        assert "--frame-ms 20" in commands[0]
+        assert adapter._send_calling_sidecar_audio.await_count == 2
+        first = adapter._send_calling_sidecar_audio.await_args_list[0]
+        second = adapter._send_calling_sidecar_audio.await_args_list[1]
+        assert first.args == ("call-1", frame)
+        assert first.kwargs["sequence"] == 0
+        assert second.args == ("call-1", frame)
+        assert second.kwargs["sequence"] == 1
+
+    @pytest.mark.asyncio
+    async def test_play_tts_text_without_stream_command_falls_back(self, monkeypatch):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._calling_sidecar_call_ids.add("call-1")
+
+        result = await adapter.play_tts_text(
+            "15551234567",
+            "Hello from the call",
+            metadata={"thread_id": "call-1"},
+        )
+
+        assert result.success is False
+        assert "not configured" in result.error
+
+    @pytest.mark.asyncio
+    async def test_base_auto_tts_uses_direct_text_stream_before_file_tts(self):
+        from gateway.platforms.base import MessageEvent, MessageType, SendResult
+        from gateway.platforms.whatsapp_cloud import WhatsAppCloudAdapter
+        from gateway.session import SessionSource, build_session_key
+
+        config = MagicMock()
+        config.extra = {
+            "phone_number_id": "123",
+            "access_token": "tok",
+            "calling_sidecar_url": "http://127.0.0.1:8787",
+            "calling_sidecar_tts_stream_command": "voice stream --raw-output -",
+        }
+        adapter = WhatsAppCloudAdapter(config)
+        adapter._message_handler = AsyncMock(return_value="Hello **there**")
+        adapter._auto_tts_enabled_chats.add("15551234567")
+        adapter.play_tts_text = AsyncMock(return_value=SendResult(success=True))
+        adapter.send = AsyncMock(
+            return_value=SendResult(success=True, message_id="text-1")
+        )
+        event = MessageEvent(
+            source=SessionSource(
+                platform=Platform.WHATSAPP_CLOUD,
+                chat_id="15551234567",
+                chat_type="dm",
+            ),
+            text="voice input",
+            message_type=MessageType.VOICE,
+        )
+
+        with patch("tools.tts_tool.text_to_speech_tool") as tts_tool:
+            await adapter._process_message_background(
+                event,
+                build_session_key(event.source),
+            )
+
+        adapter.play_tts_text.assert_awaited_once()
+        assert adapter.play_tts_text.await_args.kwargs["text"] == "Hello there"
+        tts_tool.assert_not_called()
+        adapter.send.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_receive_calling_sidecar_audio_drains_pcm_payload(self):
@@ -2090,6 +2250,7 @@ class TestHealth:
         assert body["app_secret_configured"] is True
         assert body["calling_sidecar_configured"] is False
         assert body["calling_sidecar_contract_loaded"] is False
+        assert body["calling_sidecar_tts_stream_configured"] is False
         assert body["accepted"] == 0
         assert body["duplicates"] == 0
         assert body["rejected_signature"] == 0

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -583,7 +583,7 @@ class TestCallingSidecarClient:
         assert call.args[0] == (
             "http://127.0.0.1:8787/calls/wacid.call%2Fwith%2Fslash/audio"
         )
-        assert call.kwargs["params"] == {"max_bytes": 4}
+        assert call.kwargs["params"] == {"max_bytes": 4, "wait_ms": 500}
         assert call.kwargs["timeout"] == 2.5
 
     @pytest.mark.asyncio
@@ -604,6 +604,17 @@ class TestCallingSidecarClient:
         adapter._http_client.get = AsyncMock()
 
         audio = await adapter._receive_calling_sidecar_audio("call-1", max_bytes=1)
+
+        assert audio is None
+        adapter._http_client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_receive_calling_sidecar_audio_rejects_negative_wait(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock()
+
+        audio = await adapter._receive_calling_sidecar_audio("call-1", wait_ms=-1)
 
         assert audio is None
         adapter._http_client.get.assert_not_called()

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -849,6 +849,21 @@ class TestCallingSidecarClient:
 
         assert audio is None
 
+    def test_calling_sidecar_call_id_from_metadata_requires_active_call(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._calling_sidecar_call_ids.add("wacid.call-1")
+
+        assert adapter._calling_sidecar_call_id_from_metadata({
+            "whatsapp_call_id": "wacid.call-1",
+        }) == "wacid.call-1"
+        assert adapter._calling_sidecar_call_id_from_metadata({
+            "thread_id": "wacid.call-1",
+        }) == "wacid.call-1"
+        assert adapter._calling_sidecar_call_id_from_metadata({
+            "whatsapp_call_id": "wacid.unknown",
+        }) is None
+        assert adapter._calling_sidecar_call_id_from_metadata(None) is None
+
     @pytest.mark.asyncio
     async def test_close_calling_sidecar_session_posts_close(self):
         adapter = _make_adapter(
@@ -2133,6 +2148,55 @@ class TestSendVoice:
             _os.unlink(mp3_path)
             if _os.path.exists(opus_path):
                 _os.unlink(opus_path)
+
+    @pytest.mark.asyncio
+    async def test_send_voice_active_call_metadata_posts_pcm_to_sidecar(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._calling_sidecar_call_ids.add("wacid.call/1")
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(
+                200,
+                {
+                    "call_id": "wacid.call/1",
+                    "accepted_bytes": 1920,
+                    "queued_tx_bytes": 1920,
+                    "audio": {
+                        "sample_rate": 48000,
+                        "channels": 1,
+                        "frame_ms": 20,
+                        "encoding": "pcm_s16le",
+                    },
+                },
+            )
+        )
+        adapter._decode_call_audio_file_to_pcm = AsyncMock(
+            return_value=(b"\x01\x00\xff\xff", None)
+        )
+        audio_path = _tmpfile(".ogg", content=b"OggS")
+        try:
+            result = await adapter.send_voice(
+                "15551234567",
+                audio_path,
+                metadata={"thread_id": "wacid.call/1"},
+            )
+        finally:
+            _os.unlink(audio_path)
+
+        assert result.success is True
+        assert adapter._http_client.post.call_count == 1
+        call = adapter._http_client.post.call_args
+        assert call.args[0] == "http://127.0.0.1:8787/calls/wacid.call%2F1/audio"
+        payload = call.kwargs["json"]
+        assert payload["sample_rate"] == 48000
+        assert payload["channels"] == 1
+        assert payload["frame_ms"] == 20
+        assert payload["encoding"] == "pcm_s16le"
+        assert payload["sequence"] == 0
+        pcm = base64.b64decode(payload["pcm_s16le_base64"])
+        assert pcm.startswith(b"\x01\x00\xff\xff")
+        assert len(pcm) == 1920
+        assert result.raw_response["queued_pcm_bytes"] == 4
 
     @pytest.mark.asyncio
     async def test_warn_once_no_ffmpeg_actually_only_warns_once(self):

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -2709,6 +2709,14 @@ class TestSendVoice:
             args = spawn.await_args.args
             assert args[0] == "ffmpeg"
             assert args[3] == source_path
+            assert "-ac" in args
+            assert args[args.index("-ac") + 1] == "1"
+            assert "-ar" in args
+            assert args[args.index("-ar") + 1] == "48000"
+            assert "-c:a" in args
+            assert args[args.index("-c:a") + 1] == "libopus"
+            assert "-application" in args
+            assert args[args.index("-application") + 1] == "voip"
             assert args[-1] == opus_path
         finally:
             _os.unlink(source_path)

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -1415,14 +1415,17 @@ class TestWebhookDispatch:
         }
 
     @pytest.mark.asyncio
-    async def test_call_connect_sidecar_failure_skips_graph_accept(self):
+    async def test_call_connect_sidecar_failure_rejects_graph_call(self):
         adapter = _make_adapter(
             app_secret="key",
             calling_sidecar_url="http://127.0.0.1:8787",
         )
         adapter._http_client = MagicMock()
         adapter._http_client.post = AsyncMock(
-            return_value=_mock_httpx_response(503, {"error": "down"})
+            side_effect=[
+                _mock_httpx_response(503, {"error": "down"}),
+                _mock_httpx_response(200, {"success": True}),
+            ]
         )
         body = json.dumps(_SAMPLE_CALL_CONNECT_PAYLOAD).encode("utf-8")
         sig = _sign("key", body)
@@ -1432,8 +1435,13 @@ class TestWebhookDispatch:
         )
 
         assert response.status == 200
-        assert adapter._http_client.post.call_count == 1
-        assert adapter._http_client.post.call_args.args[0].endswith("/offer")
+        assert adapter._http_client.post.call_count == 2
+        sidecar_call = adapter._http_client.post.call_args_list[0]
+        reject_call = adapter._http_client.post.call_args_list[1]
+        assert sidecar_call.args[0] == "http://127.0.0.1:8787/offer"
+        assert reject_call.args[0].endswith("/calls")
+        assert reject_call.kwargs["json"]["action"] == "reject"
+        assert "session" not in reject_call.kwargs["json"]
 
     @pytest.mark.asyncio
     async def test_call_connect_pre_accept_failure_closes_sidecar(self):

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -2577,7 +2577,31 @@ class TestSendDocument:
 
 
 class TestSendVoice:
-    """MP3 voice with ffmpeg present -> opus; without ffmpeg -> MP3 fallback."""
+    """WhatsApp voice-note routing: direct Opus, conversion, and fallback."""
+
+    @pytest.mark.asyncio
+    async def test_send_voice_direct_ogg_uploads_with_opus_mime(self):
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(side_effect=[
+            _mock_upload_response("voice_id"),
+            _mock_message_response(),
+        ])
+        adapter._convert_to_opus = AsyncMock()
+
+        path = _tmpfile(".ogg", content=b"OggS")
+        try:
+            result = await adapter.send_voice("15551234567", path)
+            assert result.success is True
+            adapter._convert_to_opus.assert_not_awaited()
+            upload_files = adapter._http_client.post.call_args_list[0].kwargs["files"]
+            assert upload_files["file"][2] == "audio/ogg; codecs=opus"
+            assert upload_files["type"][1] == "audio/ogg; codecs=opus"
+            send_payload = adapter._http_client.post.call_args_list[1].kwargs["json"]
+            assert send_payload["type"] == "audio"
+            assert send_payload["audio"]["id"] == "voice_id"
+        finally:
+            _os.unlink(path)
 
     @pytest.mark.asyncio
     async def test_send_voice_no_ffmpeg_falls_back_to_mp3(self):
@@ -2621,11 +2645,74 @@ class TestSendVoice:
             # Conversion was invoked with the original MP3
             uploaded_path = adapter._convert_to_opus.call_args.args[0]
             assert uploaded_path == mp3_path
+            upload_files = adapter._http_client.post.call_args_list[0].kwargs["files"]
+            assert upload_files["file"][2] == "audio/ogg; codecs=opus"
+            assert upload_files["type"][1] == "audio/ogg; codecs=opus"
             send_payload = adapter._http_client.post.call_args_list[1].kwargs["json"]
             assert send_payload["type"] == "audio"
         finally:
             _os.unlink(mp3_path)
             if _os.path.exists(opus_path):
+                _os.unlink(opus_path)
+
+    @pytest.mark.asyncio
+    async def test_send_voice_wav_uses_ffmpeg_opus_when_available(self):
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(side_effect=[
+            _mock_upload_response("voice_id"),
+            _mock_message_response(),
+        ])
+        opus_path = _tmpfile(".ogg", content=b"OggS")
+        adapter._convert_to_opus = AsyncMock(return_value=opus_path)
+
+        wav_path = _tmpfile(".wav", content=b"RIFF....WAVE")
+        try:
+            result = await adapter.send_voice("15551234567", wav_path)
+            assert result.success is True
+            adapter._convert_to_opus.assert_awaited_once_with(wav_path)
+            upload_files = adapter._http_client.post.call_args_list[0].kwargs["files"]
+            assert upload_files["file"][2] == "audio/ogg; codecs=opus"
+            assert upload_files["type"][1] == "audio/ogg; codecs=opus"
+        finally:
+            _os.unlink(wav_path)
+            if _os.path.exists(opus_path):
+                _os.unlink(opus_path)
+
+    @pytest.mark.asyncio
+    async def test_convert_to_opus_uses_temp_output_path(self):
+        from pathlib import Path
+
+        from gateway.platforms import whatsapp_cloud as wac
+
+        class _Proc:
+            returncode = 0
+
+            async def communicate(self):
+                return b"", b""
+
+        adapter = _make_adapter()
+        source_path = _tmpfile(".wav", content=b"RIFF....WAVE")
+        spawn = AsyncMock(return_value=_Proc())
+
+        try:
+            with _patch.object(wac, "_FFMPEG_PATH", "ffmpeg"), _patch(
+                "gateway.platforms.whatsapp_cloud.asyncio.create_subprocess_exec",
+                new=spawn,
+            ):
+                opus_path = await adapter._convert_to_opus(source_path)
+
+            assert opus_path is not None
+            assert _os.path.exists(opus_path)
+            assert _os.path.basename(opus_path).startswith("hermes_whatsapp_voice_")
+            assert opus_path != str(Path(source_path).with_suffix(".ogg"))
+            args = spawn.await_args.args
+            assert args[0] == "ffmpeg"
+            assert args[3] == source_path
+            assert args[-1] == opus_path
+        finally:
+            _os.unlink(source_path)
+            if "opus_path" in locals() and opus_path and _os.path.exists(opus_path):
                 _os.unlink(opus_path)
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -13,6 +13,7 @@ exercised with synthetic ``Request`` objects.
 from __future__ import annotations
 
 import base64
+import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock
 
@@ -54,6 +55,8 @@ def _make_adapter(**overrides):
     adapter._runner = None
     adapter._http_client = None
     adapter._calling_sidecar_call_ids = set()
+    adapter._calling_sidecar_tasks = {}
+    adapter._calling_sidecar_auto_tts_chats = {}
 
     # Behavior-mixin contract
     adapter._reply_prefix = None
@@ -91,6 +94,8 @@ def _make_adapter(**overrides):
     adapter._active_sessions = {}
     adapter._pending_messages = {}
     adapter._background_tasks = set()
+    adapter._auto_tts_default = False
+    adapter._auto_tts_enabled_chats = set()
     adapter._auto_tts_disabled_chats = set()
 
     # Apply any leftover overrides directly
@@ -865,6 +870,45 @@ class TestCallingSidecarClient:
         assert adapter._calling_sidecar_call_id_from_metadata(None) is None
 
     @pytest.mark.asyncio
+    async def test_dispatch_calling_sidecar_pcm_creates_voice_event(self):
+        from gateway.platforms.base import MessageType
+        import wave as _wave
+
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter.handle_message = AsyncMock()
+        pcm = b"\x01\x00" * 960
+
+        await adapter._dispatch_calling_sidecar_pcm(
+            "wacid.call/1",
+            "13557825698",
+            "Jessica Laverdetman",
+            pcm,
+        )
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.call_args.args[0]
+        try:
+            assert event.message_type == MessageType.VOICE
+            assert event.source.platform == Platform.WHATSAPP_CLOUD
+            assert event.source.chat_id == "13557825698"
+            assert event.source.user_id == "13557825698"
+            assert event.source.user_name == "Jessica Laverdetman"
+            assert event.source.thread_id == "wacid.call/1"
+            assert event.media_types == ["audio/wav"]
+            assert event.media_urls and _os.path.exists(event.media_urls[0])
+            with _wave.open(event.media_urls[0], "rb") as wav:
+                assert wav.getframerate() == 48000
+                assert wav.getnchannels() == 1
+                assert wav.getsampwidth() == 2
+                assert wav.readframes(960) == pcm
+        finally:
+            for path in event.media_urls:
+                try:
+                    _os.unlink(path)
+                except OSError:
+                    pass
+
+    @pytest.mark.asyncio
     async def test_close_calling_sidecar_session_posts_close(self):
         adapter = _make_adapter(
             calling_sidecar_url="http://127.0.0.1:8787",
@@ -899,6 +943,56 @@ class TestCallingSidecarClient:
 
         assert closed is True
         assert adapter._calling_sidecar_call_ids == set()
+
+    @pytest.mark.asyncio
+    async def test_close_calling_sidecar_session_cancels_drain_task(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._calling_sidecar_call_ids.add("wacid.call-1")
+        adapter._auto_tts_enabled_chats.add("13557825698")
+        adapter._calling_sidecar_auto_tts_chats["wacid.call-1"] = "13557825698"
+        task = asyncio.create_task(asyncio.sleep(60))
+        adapter._calling_sidecar_tasks["wacid.call-1"] = task
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(200, {"closed": True})
+        )
+
+        try:
+            closed = await adapter._close_calling_sidecar_session("wacid.call-1")
+            await asyncio.sleep(0)
+        finally:
+            if not task.done():
+                task.cancel()
+
+        assert closed is True
+        assert task.cancelled()
+        assert adapter._calling_sidecar_tasks == {}
+        assert adapter._calling_sidecar_auto_tts_chats == {}
+        assert adapter._auto_tts_enabled_chats == set()
+
+    @pytest.mark.asyncio
+    async def test_close_calling_sidecar_session_cleans_local_state_without_http(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._calling_sidecar_call_ids.add("wacid.call-1")
+        adapter._auto_tts_enabled_chats.add("13557825698")
+        adapter._calling_sidecar_auto_tts_chats["wacid.call-1"] = "13557825698"
+        task = asyncio.create_task(asyncio.sleep(60))
+        adapter._calling_sidecar_tasks["wacid.call-1"] = task
+        adapter._http_client = None
+
+        try:
+            closed = await adapter._close_calling_sidecar_session("wacid.call-1")
+            await asyncio.sleep(0)
+        finally:
+            if not task.done():
+                task.cancel()
+
+        assert closed is False
+        assert task.cancelled()
+        assert adapter._calling_sidecar_call_ids == set()
+        assert adapter._calling_sidecar_tasks == {}
+        assert adapter._calling_sidecar_auto_tts_chats == {}
+        assert adapter._auto_tts_enabled_chats == set()
 
     @pytest.mark.asyncio
     async def test_disconnect_closes_tracked_sidecar_sessions_before_http_close(self):
@@ -1424,6 +1518,7 @@ class TestWebhookDispatch:
             calling_sidecar_url="http://127.0.0.1:8787",
         )
         adapter.handle_message = AsyncMock()
+        adapter._start_calling_sidecar_drain = MagicMock()
         adapter._http_client = MagicMock()
         adapter._http_client.post = AsyncMock(side_effect=[
             _mock_httpx_response(
@@ -1479,6 +1574,11 @@ class TestWebhookDispatch:
         assert adapter._calling_sidecar_call_ids == {
             "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh"
         }
+        adapter._start_calling_sidecar_drain.assert_called_once_with(
+            "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh",
+            "13557825698",
+            "Jessica Laverdetman",
+        )
 
     @pytest.mark.asyncio
     async def test_call_connect_sidecar_failure_rejects_graph_call(self):

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -440,6 +440,7 @@ class TestCallingSidecarClient:
         assert contract["audio"]["frame_bytes"] == 1920
         assert contract["audio"]["default_drain_bytes"] == 96000
         assert contract["audio"]["max_drain_wait_ms"] == 5000
+        assert contract["audio"]["max_outbound_queue_bytes"] == 960000
         call = adapter._http_client.get.call_args
         assert call.args[0] == "http://127.0.0.1:8787/contract"
         assert call.kwargs["timeout"] == 2.5
@@ -636,6 +637,25 @@ class TestCallingSidecarClient:
         assert result.success is False
         assert result.error == "sample_rate must be 48000"
         assert result.raw_response == {"error": "sample_rate must be 48000"}
+        assert result.retryable is False
+
+    @pytest.mark.asyncio
+    async def test_send_calling_sidecar_audio_treats_429_as_backpressure(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(
+                429,
+                {"error": "outbound PCM queue is full"},
+            )
+        )
+
+        result = await adapter._send_calling_sidecar_audio("call-1", b"\x00\x00")
+
+        assert result.success is False
+        assert result.error == "outbound PCM queue is full"
+        assert result.raw_response == {"error": "outbound PCM queue is full"}
+        assert result.retryable is True
 
     @pytest.mark.asyncio
     async def test_receive_calling_sidecar_audio_drains_pcm_payload(self):

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -54,6 +54,11 @@ def _make_adapter(**overrides):
     adapter._calling_sidecar_timeout = overrides.pop("calling_sidecar_timeout", 10.0)
     adapter._runner = None
     adapter._http_client = None
+    adapter._calling_sidecar_contract = overrides.pop("calling_sidecar_contract", None)
+    adapter._calling_sidecar_contract_checked = overrides.pop(
+        "calling_sidecar_contract_checked",
+        False,
+    )
     adapter._calling_sidecar_call_ids = set()
     adapter._calling_sidecar_tasks = {}
     adapter._calling_sidecar_auto_tts_chats = {}
@@ -466,6 +471,90 @@ class TestCallingSidecarClient:
         call = adapter._http_client.get.call_args
         assert call.args[0] == "http://127.0.0.1:8787/contract"
         assert call.kwargs["timeout"] == 2.5
+
+    @pytest.mark.asyncio
+    async def test_cached_contract_drives_sidecar_paths_and_audio_window(self):
+        contract = {
+            "contract": "voice.webrtc_sidecar",
+            "version": 1,
+            "audio": {
+                "sample_rate": 48000,
+                "channels": 1,
+                "frame_ms": 20,
+                "encoding": "pcm_s16le",
+                "bytes_per_sample": 2,
+                "frame_bytes": 1920,
+                "default_drain_bytes": 3840,
+                "max_drain_wait_ms": 200,
+            },
+            "endpoints": {
+                "offer": {"path": "/v1/offer"},
+                "send_audio": {"path": "/v1/calls/{call_id}/tx"},
+                "receive_audio": {"path": "/v1/calls/{call_id}/rx"},
+                "close_call": {"path": "/v1/calls/{call_id}/done"},
+            },
+        }
+        adapter = _make_adapter(
+            calling_sidecar_url="http://127.0.0.1:8787",
+            calling_sidecar_contract=contract,
+            calling_sidecar_contract_checked=True,
+        )
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(side_effect=[
+            _mock_httpx_response(
+                200,
+                {
+                    "call_id": "call/1",
+                    "type": "answer",
+                    "sdp": "v=0\r\n",
+                    "audio": contract["audio"],
+                },
+            ),
+            _mock_httpx_response(
+                200,
+                {"accepted_bytes": 2, "queued_tx_bytes": 2},
+            ),
+            _mock_httpx_response(200, {"closed": True}),
+        ])
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(
+                200,
+                {
+                    "call_id": "call/1",
+                    "returned_bytes": 2,
+                    "queued_rx_bytes": 0,
+                    "pcm_s16le_base64": base64.b64encode(b"\x01\x00").decode("ascii"),
+                    "audio": contract["audio"],
+                },
+            )
+        )
+
+        answer = await adapter._request_calling_sidecar_answer("call/1", "v=0\r\n")
+        sent = await adapter._send_calling_sidecar_audio("call/1", b"\x01\x00")
+        received = await adapter._receive_calling_sidecar_audio("call/1")
+        adapter._calling_sidecar_call_ids.add("call/1")
+        closed = await adapter._close_calling_sidecar_session("call/1")
+
+        assert answer is not None
+        assert sent.success is True
+        assert received is not None
+        assert closed is True
+        assert adapter._http_client.post.call_args_list[0].args[0] == (
+            "http://127.0.0.1:8787/v1/offer"
+        )
+        assert adapter._http_client.post.call_args_list[1].args[0] == (
+            "http://127.0.0.1:8787/v1/calls/call%2F1/tx"
+        )
+        assert adapter._http_client.get.call_args.args[0] == (
+            "http://127.0.0.1:8787/v1/calls/call%2F1/rx"
+        )
+        assert adapter._http_client.get.call_args.kwargs["params"] == {
+            "max_bytes": 3840,
+            "wait_ms": 200,
+        }
+        assert adapter._http_client.post.call_args_list[2].args[0] == (
+            "http://127.0.0.1:8787/v1/calls/call%2F1/done"
+        )
 
     @pytest.mark.asyncio
     async def test_request_contract_tolerates_older_sidecar_404(self):
@@ -1636,6 +1725,9 @@ class TestWebhookDispatch:
         adapter.handle_message = AsyncMock()
         adapter._start_calling_sidecar_drain = MagicMock()
         adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(404, {"error": "not found"})
+        )
         adapter._http_client.post = AsyncMock(side_effect=[
             _mock_httpx_response(
                 200,
@@ -1703,6 +1795,9 @@ class TestWebhookDispatch:
             calling_sidecar_url="http://127.0.0.1:8787",
         )
         adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(404, {"error": "not found"})
+        )
         adapter._http_client.post = AsyncMock(
             side_effect=[
                 _mock_httpx_response(503, {"error": "down"}),
@@ -1732,6 +1827,9 @@ class TestWebhookDispatch:
             calling_sidecar_url="http://127.0.0.1:8787",
         )
         adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(404, {"error": "not found"})
+        )
         adapter._http_client.post = AsyncMock(side_effect=[
             _mock_httpx_response(
                 200,
@@ -1773,6 +1871,9 @@ class TestWebhookDispatch:
             calling_sidecar_url="http://127.0.0.1:8787",
         )
         adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(404, {"error": "not found"})
+        )
         adapter._http_client.post = AsyncMock(side_effect=[
             _mock_httpx_response(
                 200,
@@ -1988,6 +2089,7 @@ class TestHealth:
         assert body["verify_token_configured"] is True
         assert body["app_secret_configured"] is True
         assert body["calling_sidecar_configured"] is False
+        assert body["calling_sidecar_contract_loaded"] is False
         assert body["accepted"] == 0
         assert body["duplicates"] == 0
         assert body["rejected_signature"] == 0

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -542,6 +542,31 @@ class TestCallingSidecarClient:
         assert answer is None
 
     @pytest.mark.asyncio
+    async def test_request_rejects_mismatched_answer_call_id(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(
+                200,
+                {
+                    "call_id": "other-call",
+                    "type": "answer",
+                    "sdp": "v=0\r\n",
+                    "audio": {
+                        "sample_rate": 48000,
+                        "channels": 1,
+                        "frame_ms": 20,
+                        "encoding": "pcm_s16le",
+                    },
+                },
+            )
+        )
+
+        answer = await adapter._request_calling_sidecar_answer("call-1", "v=0\r\n")
+
+        assert answer is None
+
+    @pytest.mark.asyncio
     async def test_send_call_action_posts_session_answer(self):
         adapter = _make_adapter()
         adapter._http_client = MagicMock()
@@ -790,6 +815,32 @@ class TestCallingSidecarClient:
                     "returned_bytes": 99,
                     "queued_rx_bytes": 0,
                     "pcm_s16le_base64": base64.b64encode(b"\x00\x00").decode("ascii"),
+                },
+            )
+        )
+
+        audio = await adapter._receive_calling_sidecar_audio("call-1")
+
+        assert audio is None
+
+    @pytest.mark.asyncio
+    async def test_receive_calling_sidecar_audio_rejects_mismatched_call_id(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(
+                200,
+                {
+                    "call_id": "other-call",
+                    "returned_bytes": 2,
+                    "queued_rx_bytes": 0,
+                    "pcm_s16le_base64": base64.b64encode(b"\x00\x00").decode("ascii"),
+                    "audio": {
+                        "sample_rate": 48000,
+                        "channels": 1,
+                        "frame_ms": 20,
+                        "encoding": "pcm_s16le",
+                    },
                 },
             )
         )

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -12,6 +12,7 @@ exercised with synthetic ``Request`` objects.
 
 from __future__ import annotations
 
+import base64
 import json
 from unittest.mock import AsyncMock, MagicMock
 
@@ -474,6 +475,71 @@ class TestCallingSidecarClient:
 
         assert result.success is False
         assert "graph error 100" in result.error
+
+    @pytest.mark.asyncio
+    async def test_send_calling_sidecar_audio_posts_pcm_payload(self):
+        adapter = _make_adapter(
+            calling_sidecar_url="http://127.0.0.1:8787",
+            calling_sidecar_timeout=2.5,
+        )
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(
+                200,
+                {"accepted_bytes": 4, "queued_tx_bytes": 4},
+            )
+        )
+
+        result = await adapter._send_calling_sidecar_audio(
+            "wacid.call/with/slash",
+            b"\x01\x00\xff\xff",
+            sequence=17,
+        )
+
+        assert result.success is True
+        assert result.raw_response == {"accepted_bytes": 4, "queued_tx_bytes": 4}
+        call = adapter._http_client.post.call_args
+        assert call.args[0] == (
+            "http://127.0.0.1:8787/calls/wacid.call%2Fwith%2Fslash/audio"
+        )
+        assert call.kwargs["timeout"] == 2.5
+        assert call.kwargs["json"] == {
+            "sequence": 17,
+            "sample_rate": 48000,
+            "channels": 1,
+            "frame_ms": 20,
+            "encoding": "pcm_s16le",
+            "pcm_s16le_base64": base64.b64encode(b"\x01\x00\xff\xff").decode("ascii"),
+        }
+
+    @pytest.mark.asyncio
+    async def test_send_calling_sidecar_audio_requires_sidecar(self):
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock()
+
+        result = await adapter._send_calling_sidecar_audio("call-1", b"\x00\x00")
+
+        assert result.success is False
+        assert result.error == "Calling sidecar not configured"
+        adapter._http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_send_calling_sidecar_audio_returns_sidecar_error(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(
+                400,
+                {"error": "sample_rate must be 48000"},
+            )
+        )
+
+        result = await adapter._send_calling_sidecar_audio("call-1", b"\x00\x00")
+
+        assert result.success is False
+        assert result.error == "sample_rate must be 48000"
+        assert result.raw_response == {"error": "sample_rate must be 48000"}
 
     @pytest.mark.asyncio
     async def test_close_calling_sidecar_session_posts_close(self):

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -441,6 +441,7 @@ class TestCallingSidecarClient:
         assert contract["audio"]["default_drain_bytes"] == 96000
         assert contract["audio"]["max_drain_wait_ms"] == 5000
         assert contract["audio"]["max_outbound_queue_bytes"] == 960000
+        assert contract["audio"]["max_inbound_queue_bytes"] == 960000
         call = adapter._http_client.get.call_args
         assert call.args[0] == "http://127.0.0.1:8787/contract"
         assert call.kwargs["timeout"] == 2.5

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -364,10 +364,10 @@ class TestCallingSidecarClient:
                     "type": "answer",
                     "sdp": "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
                     "audio": {
-                        "codec": "opus",
                         "sample_rate": 48000,
                         "channels": 1,
                         "frame_ms": 20,
+                        "encoding": "pcm_s16le",
                     },
                 },
             )
@@ -378,7 +378,7 @@ class TestCallingSidecarClient:
         assert answer is not None
         assert answer.call_id == "call-1"
         assert answer.sdp.startswith("v=0")
-        assert answer.audio["codec"] == "opus"
+        assert answer.audio["encoding"] == "pcm_s16le"
         adapter._http_client.post.assert_awaited_once()
         call = adapter._http_client.post.call_args
         assert call.args[0] == "http://127.0.0.1:8787/offer"
@@ -410,6 +410,75 @@ class TestCallingSidecarClient:
         assert answer is None
 
     @pytest.mark.asyncio
+    async def test_request_fetches_machine_readable_contract(self):
+        adapter = _make_adapter(
+            calling_sidecar_url="http://127.0.0.1:8787",
+            calling_sidecar_timeout=2.5,
+        )
+        adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(
+                200,
+                {
+                    "contract": "voice.webrtc_sidecar",
+                    "version": 1,
+                    "audio": {
+                        "sample_rate": 48000,
+                        "channels": 1,
+                        "frame_ms": 20,
+                        "encoding": "pcm_s16le",
+                        "frame_bytes": 1920,
+                    },
+                },
+            )
+        )
+
+        contract = await adapter._request_calling_sidecar_contract()
+
+        assert contract is not None
+        assert contract["contract"] == "voice.webrtc_sidecar"
+        assert contract["audio"]["frame_bytes"] == 1920
+        call = adapter._http_client.get.call_args
+        assert call.args[0] == "http://127.0.0.1:8787/contract"
+        assert call.kwargs["timeout"] == 2.5
+
+    @pytest.mark.asyncio
+    async def test_request_contract_tolerates_older_sidecar_404(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(404, {"error": "not found"})
+        )
+
+        contract = await adapter._request_calling_sidecar_contract()
+
+        assert contract is None
+
+    @pytest.mark.asyncio
+    async def test_request_contract_rejects_mismatched_audio_shape(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(
+                200,
+                {
+                    "contract": "voice.webrtc_sidecar",
+                    "version": 1,
+                    "audio": {
+                        "sample_rate": 16000,
+                        "channels": 1,
+                        "frame_ms": 20,
+                        "encoding": "pcm_s16le",
+                    },
+                },
+            )
+        )
+
+        contract = await adapter._request_calling_sidecar_contract()
+
+        assert contract is None
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("body", [
         {"type": "offer", "sdp": "v=0"},
         {"type": "answer"},
@@ -421,6 +490,31 @@ class TestCallingSidecarClient:
         adapter._http_client = MagicMock()
         adapter._http_client.post = AsyncMock(
             return_value=_mock_httpx_response(200, body)
+        )
+
+        answer = await adapter._request_calling_sidecar_answer("call-1", "v=0\r\n")
+
+        assert answer is None
+
+    @pytest.mark.asyncio
+    async def test_request_rejects_mismatched_answer_audio_shape(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(
+                200,
+                {
+                    "call_id": "call-1",
+                    "type": "answer",
+                    "sdp": "v=0\r\n",
+                    "audio": {
+                        "sample_rate": 16000,
+                        "channels": 1,
+                        "frame_ms": 20,
+                        "encoding": "pcm_s16le",
+                    },
+                },
+            )
         )
 
         answer = await adapter._request_calling_sidecar_answer("call-1", "v=0\r\n")
@@ -1181,10 +1275,10 @@ class TestWebhookDispatch:
                     "type": "answer",
                     "sdp": "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
                     "audio": {
-                        "codec": "opus",
                         "sample_rate": 48000,
                         "channels": 1,
                         "frame_ms": 20,
+                        "encoding": "pcm_s16le",
                     },
                 },
             ),

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -429,6 +429,18 @@ class TestCallingSidecarClient:
                         "encoding": "pcm_s16le",
                         "frame_bytes": 1920,
                     },
+                    "payloads": {
+                        "offer_request": {
+                            "call_id": "Required call session identifier from the WhatsApp Calling webhook.",
+                            "sdp": "Required remote SDP offer from WhatsApp.",
+                        },
+                        "offer_response": {
+                            "sdp": "Local SDP answer to pass unchanged to WhatsApp pre_accept and accept actions.",
+                        },
+                        "call_state": {
+                            "queued_rx_bytes": "Inbound decoded PCM bytes queued for Hermes to drain.",
+                        },
+                    },
                 },
             )
         )
@@ -442,6 +454,9 @@ class TestCallingSidecarClient:
         assert contract["audio"]["max_drain_wait_ms"] == 5000
         assert contract["audio"]["max_outbound_queue_bytes"] == 960000
         assert contract["audio"]["max_inbound_queue_bytes"] == 960000
+        assert contract["payloads"]["offer_request"]["call_id"].startswith("Required")
+        assert "pre_accept" in contract["payloads"]["offer_response"]["sdp"]
+        assert "queued_rx_bytes" in contract["payloads"]["call_state"]
         call = adapter._http_client.get.call_args
         assert call.args[0] == "http://127.0.0.1:8787/contract"
         assert call.kwargs["timeout"] == 2.5

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -438,6 +438,8 @@ class TestCallingSidecarClient:
         assert contract is not None
         assert contract["contract"] == "voice.webrtc_sidecar"
         assert contract["audio"]["frame_bytes"] == 1920
+        assert contract["audio"]["default_drain_bytes"] == 96000
+        assert contract["audio"]["max_drain_wait_ms"] == 5000
         call = adapter._http_client.get.call_args
         assert call.args[0] == "http://127.0.0.1:8787/contract"
         assert call.kwargs["timeout"] == 2.5
@@ -679,6 +681,33 @@ class TestCallingSidecarClient:
         )
         assert call.kwargs["params"] == {"max_bytes": 4, "wait_ms": 500}
         assert call.kwargs["timeout"] == 2.5
+
+    @pytest.mark.asyncio
+    async def test_receive_calling_sidecar_audio_defaults_to_contract_window(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(
+                200,
+                {
+                    "returned_bytes": 0,
+                    "queued_rx_bytes": 0,
+                    "pcm_s16le_base64": "",
+                    "audio": {
+                        "sample_rate": 48000,
+                        "channels": 1,
+                        "frame_ms": 20,
+                        "encoding": "pcm_s16le",
+                    },
+                },
+            )
+        )
+
+        audio = await adapter._receive_calling_sidecar_audio("call-1")
+
+        assert audio is not None
+        call = adapter._http_client.get.call_args
+        assert call.kwargs["params"] == {"max_bytes": 96000, "wait_ms": 500}
 
     @pytest.mark.asyncio
     async def test_receive_calling_sidecar_audio_requires_sidecar(self):

--- a/tests/tools/test_tts_opus_routing.py
+++ b/tests/tools/test_tts_opus_routing.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -69,3 +70,31 @@ def test_edge_voice_note_platforms_convert_to_opus_voice(tmp_path, monkeypatch, 
     assert result["voice_compatible"] is True
     assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{opus}"
     convert.assert_called_once_with(str(out))
+
+
+def test_tts_opus_conversion_forces_whatsapp_ready_shape(tmp_path, monkeypatch):
+    source = tmp_path / "speech.mp3"
+    source.write_bytes(b"mp3")
+    output = tmp_path / "speech.ogg"
+    commands = []
+
+    def fake_run(command, **kwargs):
+        commands.append((command, kwargs))
+        output.write_bytes(b"OggS")
+        return subprocess.CompletedProcess(command, 0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(tts_tool, "_has_ffmpeg", lambda: True)
+    monkeypatch.setattr(tts_tool.subprocess, "run", fake_run)
+
+    result = tts_tool._convert_to_opus(str(source))
+
+    assert result == str(output)
+    assert commands
+    command, kwargs = commands[0]
+    assert command[:4] == ["ffmpeg", "-i", str(source), "-acodec"]
+    assert "libopus" in command
+    assert command[command.index("-ac") + 1] == "1"
+    assert command[command.index("-ar") + 1] == "48000"
+    assert command[command.index("-application") + 1] == "voip"
+    assert command[-2:] == [str(output), "-y"]
+    assert kwargs["stdin"] is subprocess.DEVNULL

--- a/tests/tools/test_tts_opus_routing.py
+++ b/tests/tools/test_tts_opus_routing.py
@@ -44,7 +44,8 @@ def test_edge_cli_preserves_native_mp3(tmp_path, monkeypatch):
     convert.assert_not_called()
 
 
-def test_edge_telegram_converts_to_opus_voice(tmp_path, monkeypatch):
+@pytest.mark.parametrize("platform", ["telegram", "whatsapp", "whatsapp_cloud"])
+def test_edge_voice_note_platforms_convert_to_opus_voice(tmp_path, monkeypatch, platform):
     out = tmp_path / "speech.mp3"
     opus = tmp_path / "speech.ogg"
 
@@ -55,7 +56,7 @@ def test_edge_telegram_converts_to_opus_voice(tmp_path, monkeypatch):
 
     convert = Mock(side_effect=fake_convert)
 
-    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", platform)
     monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "edge"})
     monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
     monkeypatch.setattr(tts_tool, "_generate_edge_tts", _write_edge_output)

--- a/tests/tools/test_verify_voice_command_tts_script.py
+++ b/tests/tools/test_verify_voice_command_tts_script.py
@@ -2,6 +2,8 @@ import importlib.util
 import shlex
 from pathlib import Path
 
+import pytest
+
 
 SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "verify_voice_command_tts.py"
 
@@ -43,3 +45,41 @@ def test_parse_ffprobe_output_extracts_stream_fields():
         "sample_rate": "48000",
         "channels": "1",
     }
+
+
+def test_existing_config_path_requires_config_yaml(tmp_path: Path):
+    script = _load_script_module()
+
+    with pytest.raises(SystemExit) as excinfo:
+        script.existing_config_path(tmp_path)
+
+    assert "config.yaml does not exist" in str(excinfo.value)
+
+
+def test_existing_config_path_returns_deployed_config(tmp_path: Path):
+    script = _load_script_module()
+    config = tmp_path / "config.yaml"
+    config.write_text("tts:\n  provider: kokoro\n", encoding="utf-8")
+
+    assert script.existing_config_path(tmp_path) == config
+
+
+def test_validate_result_uses_expected_provider(tmp_path: Path):
+    script = _load_script_module()
+    audio = tmp_path / "reply.ogg"
+    audio.write_bytes(b"OggS")
+
+    result = {
+        "provider": "kokoro",
+        "voice_compatible": True,
+        "media_tag": f"[[audio_as_voice]]\nMEDIA:{audio}",
+        "file_path": str(audio),
+    }
+    probe = {"codec_name": "opus", "sample_rate": "48000", "channels": "1"}
+
+    script.validate_result(result, probe, expected_provider="kokoro")
+
+    with pytest.raises(SystemExit) as excinfo:
+        script.validate_result(result, probe, expected_provider="other")
+
+    assert "expected provider other" in str(excinfo.value)

--- a/tests/tools/test_verify_voice_command_tts_script.py
+++ b/tests/tools/test_verify_voice_command_tts_script.py
@@ -1,0 +1,45 @@
+import importlib.util
+import shlex
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "verify_voice_command_tts.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location("verify_voice_command_tts", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_config_uses_explicit_ogg_opus_voice_command():
+    script = _load_script_module()
+
+    config = script.build_config(
+        provider="kokoro",
+        voice_bin="/tmp/bin/voice with spaces",
+        voice="af_heart",
+        speed="1.0",
+        timeout=180.0,
+    )
+
+    assert "provider: kokoro" in config
+    assert "output_format: ogg" in config
+    assert "voice_compatible: true" in config
+    assert "--format ogg-opus" in config
+    assert "--input-file {input_path}" in config
+    assert "--output {output_path}" in config
+    assert shlex.quote("/tmp/bin/voice with spaces") in config
+
+
+def test_parse_ffprobe_output_extracts_stream_fields():
+    script = _load_script_module()
+
+    assert script.parse_ffprobe("codec_name=opus\nsample_rate=48000\nchannels=1\n") == {
+        "codec_name": "opus",
+        "sample_rate": "48000",
+        "channels": "1",
+    }

--- a/tests/tools/test_verify_voice_full_duplex_sidecar_script.py
+++ b/tests/tools/test_verify_voice_full_duplex_sidecar_script.py
@@ -1,0 +1,156 @@
+import importlib.util
+import json
+import os
+from pathlib import Path
+import sys
+
+import pytest
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "verify_voice_full_duplex_sidecar.py"
+)
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "verify_voice_full_duplex_sidecar",
+        SCRIPT_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _valid_result():
+    return {
+        "success": True,
+        "transcript": "Hello World",
+        "outbound_webrtc_bytes": 23_040,
+        "decoded_pcm_bytes": 124_992,
+        "audio": {
+            "sample_rate": 48_000,
+            "channels": 1,
+            "frame_ms": 20,
+            "encoding": "pcm_s16le",
+        },
+        "stt": {"text": "Hello World"},
+    }
+
+
+def test_build_smoke_command_points_at_voice_full_duplex_smoke():
+    script = _load_script_module()
+    smoke_path = Path("/repo/examples/webrtc-sidecar/full_duplex_loopback_smoke.py")
+
+    command = script.build_smoke_command(
+        python_bin="/tmp/venv/bin/python",
+        smoke_path=smoke_path,
+        voice_bin="/usr/local/bin/voice",
+        inbound_text="hello world",
+        outbound_text="hello back",
+        voice="af_heart",
+        speed="1.0",
+        timeout=90.0,
+        expect_words=["hello", "world"],
+    )
+
+    assert command[:4] == [
+        "/tmp/venv/bin/python",
+        str(smoke_path),
+        "--voice-bin",
+        "/usr/local/bin/voice",
+    ]
+    assert "--inbound-text" in command
+    assert "--outbound-text" in command
+    assert command[-4:] == ["--expect-word", "hello", "--expect-word", "world"]
+
+
+def test_full_duplex_smoke_path_uses_voice_repo_layout():
+    script = _load_script_module()
+
+    assert script.full_duplex_smoke_path(Path("/voice")) == Path(
+        "/voice/examples/webrtc-sidecar/full_duplex_loopback_smoke.py"
+    )
+
+
+def test_resolve_executable_preserves_virtualenv_symlink(tmp_path: Path):
+    script = _load_script_module()
+    target = tmp_path / "python3"
+    target.write_text("#!/bin/sh\n", encoding="utf-8")
+    target.chmod(0o755)
+    symlink = tmp_path / "python"
+    symlink.symlink_to(target.name)
+
+    resolved = script.resolve_executable(str(symlink), label="python")
+
+    assert resolved == os.path.abspath(str(symlink))
+    assert Path(resolved).is_symlink()
+
+
+def test_parse_smoke_json_accepts_progress_prefix():
+    script = _load_script_module()
+    result = _valid_result()
+
+    parsed = script.parse_smoke_json("progress line\n" + json.dumps(result))
+
+    assert parsed == result
+
+
+def test_parse_smoke_json_rejects_missing_json():
+    script = _load_script_module()
+
+    with pytest.raises(ValueError, match="did not print"):
+        script.parse_smoke_json("not json")
+
+
+def test_validate_smoke_result_accepts_voice_contract_shape():
+    script = _load_script_module()
+
+    script.validate_smoke_result(_valid_result())
+
+
+def test_validate_smoke_result_rejects_silent_outbound():
+    script = _load_script_module()
+    result = _valid_result()
+    result["outbound_webrtc_bytes"] = 0
+
+    with pytest.raises(SystemExit, match="outbound_webrtc_bytes"):
+        script.validate_smoke_result(result)
+
+
+def test_parse_args_uses_default_expected_words(monkeypatch):
+    script = _load_script_module()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["verify_voice_full_duplex_sidecar.py", "--voice-repo", "/voice"],
+    )
+
+    args = script.parse_args()
+
+    assert args.voice_repo == Path("/voice")
+    assert args.expect_word == ["hello", "world"]
+
+
+def test_parse_args_replaces_default_expected_words(monkeypatch):
+    script = _load_script_module()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "verify_voice_full_duplex_sidecar.py",
+            "--voice-repo",
+            "/voice",
+            "--expect-word",
+            "testing",
+        ],
+    )
+
+    args = script.parse_args()
+
+    assert args.expect_word == ["testing"]

--- a/tests/tools/test_verify_voice_full_duplex_sidecar_script.py
+++ b/tests/tools/test_verify_voice_full_duplex_sidecar_script.py
@@ -108,6 +108,17 @@ def test_parse_smoke_json_rejects_missing_json():
         script.parse_smoke_json("not json")
 
 
+def test_format_child_error_preserves_tail():
+    script = _load_script_module()
+    stderr = "Traceback header\n" + ("x" * 1200) + "\nRuntimeError: useful tail"
+
+    formatted = script.format_child_error(stderr, max_chars=80)
+
+    assert "omitted" in formatted
+    assert "Traceback header" not in formatted
+    assert "RuntimeError: useful tail" in formatted
+
+
 def test_validate_smoke_result_accepts_voice_contract_shape():
     script = _load_script_module()
 

--- a/tests/tools/test_verify_voice_live_gateway_script.py
+++ b/tests/tools/test_verify_voice_live_gateway_script.py
@@ -1,0 +1,316 @@
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "verify_voice_live_gateway.py"
+)
+SCRIPTS_DIR = SCRIPT_PATH.parent
+
+
+def _load_script_module():
+    if str(SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    spec = importlib.util.spec_from_file_location("verify_voice_live_gateway", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_voice_native_root(root: Path) -> None:
+    tools_dir = root / "tools"
+    gateway_dir = root / "gateway" / "platforms"
+    bridge_bin = root / "scripts" / "whatsapp-bridge" / "node_modules" / ".bin"
+    tools_dir.mkdir(parents=True)
+    gateway_dir.mkdir(parents=True)
+    bridge_bin.mkdir(parents=True)
+    (tools_dir / "tts_tool.py").write_text(
+        "\n".join(["voice_compatible", "libopus", "-application", "voip"]),
+        encoding="utf-8",
+    )
+    (gateway_dir / "whatsapp_cloud.py").write_text(
+        "\n".join(
+            [
+                "calling_sidecar_url",
+                "voice.webrtc_sidecar",
+                "_send_calling_sidecar_tts_stream_command",
+                "-application",
+                "voip",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_parse_systemctl_show_keeps_key_values():
+    script = _load_script_module()
+
+    parsed = script.parse_systemctl_show(
+        "ActiveState=active\nMainPID=123\nignored line\nEnvironment=A=B\n"
+    )
+
+    assert parsed == {
+        "ActiveState": "active",
+        "MainPID": "123",
+        "Environment": "A=B",
+    }
+
+
+def test_parse_systemd_environment_handles_quoted_values():
+    script = _load_script_module()
+
+    parsed = script.parse_systemd_environment(
+        'PYTHONPATH=/live PATH=/bin "EXTRA=value with spaces"'
+    )
+
+    assert parsed == {
+        "PYTHONPATH": "/live",
+        "PATH": "/bin",
+        "EXTRA": "value with spaces",
+    }
+
+
+def test_parse_proc_environ_reads_nul_separated_environment():
+    script = _load_script_module()
+
+    parsed = script.parse_proc_environ(b"PYTHONPATH=/live\0PATH=/bin\0bad\0")
+
+    assert parsed == {"PYTHONPATH": "/live", "PATH": "/bin"}
+
+
+def test_path_is_under_accepts_children_and_rejects_siblings(tmp_path: Path):
+    script = _load_script_module()
+    root = tmp_path / "root"
+    child = root / "pkg" / "module.py"
+    sibling = tmp_path / "root-other" / "module.py"
+    child.parent.mkdir(parents=True)
+    sibling.parent.mkdir(parents=True)
+    child.write_text("", encoding="utf-8")
+    sibling.write_text("", encoding="utf-8")
+
+    assert script.path_is_under(child, root) is True
+    assert script.path_is_under(sibling, root) is False
+
+
+def test_validate_service_state_requires_active_service_and_pid():
+    script = _load_script_module()
+
+    assert script.validate_service_state({"ActiveState": "active", "MainPID": "42"}) == 42
+
+    with pytest.raises(SystemExit, match="not active"):
+        script.validate_service_state({"ActiveState": "inactive", "MainPID": "42"})
+    with pytest.raises(SystemExit, match="MainPID is invalid"):
+        script.validate_service_state({"ActiveState": "active", "MainPID": "nope"})
+    with pytest.raises(SystemExit, match="no running MainPID"):
+        script.validate_service_state({"ActiveState": "active", "MainPID": "0"})
+
+
+def test_validate_env_points_at_root_requires_pythonpath_and_bridge_path(tmp_path: Path):
+    script = _load_script_module()
+    root = tmp_path / "hermes"
+    bridge_bin = root / "scripts" / "whatsapp-bridge" / "node_modules" / ".bin"
+    bridge_bin.mkdir(parents=True)
+    env = {
+        "PYTHONPATH": str(root),
+        "PATH": f"/usr/bin:{bridge_bin}",
+    }
+
+    result = script.validate_env_points_at_root(
+        env,
+        root,
+        label="unit",
+        bridge_bin_dir=bridge_bin,
+    )
+
+    assert result["PYTHONPATH"] == str(root)
+    assert result["bridge_bin_on_path"] is True
+
+    with pytest.raises(SystemExit, match="PYTHONPATH"):
+        script.validate_env_points_at_root({}, root, label="unit")
+    with pytest.raises(SystemExit, match="PATH"):
+        script.validate_env_points_at_root(
+            {"PYTHONPATH": str(root), "PATH": "/usr/bin"},
+            root,
+            label="unit",
+            bridge_bin_dir=bridge_bin,
+        )
+
+
+def test_validate_bridge_health_requires_connected_when_requested():
+    script = _load_script_module()
+
+    script.validate_bridge_health({"status": "connected"}, require_connected=True)
+    script.validate_bridge_health({"status": "connecting"}, require_connected=False)
+    with pytest.raises(SystemExit, match="not connected"):
+        script.validate_bridge_health({"status": "connecting"}, require_connected=True)
+
+
+def test_parse_ffprobe_json_extracts_audio_shape():
+    script = _load_script_module()
+
+    parsed = script.parse_ffprobe_json(
+        json.dumps(
+            {
+                "streams": [
+                    {
+                        "codec_name": "opus",
+                        "sample_rate": "48000",
+                        "channels": 1,
+                    }
+                ]
+            }
+        )
+    )
+
+    assert parsed == {"codec_name": "opus", "sample_rate": "48000", "channels": "1"}
+
+    with pytest.raises(ValueError, match="no streams"):
+        script.parse_ffprobe_json(json.dumps({"streams": []}))
+
+
+def test_import_smoke_runs_from_live_root(tmp_path: Path, monkeypatch):
+    script = _load_script_module()
+    live_root = tmp_path / "live"
+    module_path = live_root / "tools" / "tts_tool.py"
+    module_path.parent.mkdir(parents=True)
+    module_path.write_text("", encoding="utf-8")
+
+    def fake_run(_command, **kwargs):
+        assert kwargs["cwd"] == str(live_root)
+        return subprocess.CompletedProcess(
+            _command,
+            0,
+            stdout=json.dumps({"tools.tts_tool": str(module_path)}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(script.subprocess, "run", fake_run)
+
+    result = script.import_smoke(
+        python_bin="/python",
+        live_root=live_root,
+        hermes_home=tmp_path / "home",
+        timeout=1.0,
+    )
+
+    assert result == {"tools.tts_tool": str(module_path)}
+
+
+def test_run_tts_smoke_runs_from_live_root(tmp_path: Path, monkeypatch):
+    script = _load_script_module()
+    live_root = tmp_path / "live"
+    audio_path = tmp_path / "speech.ogg"
+    live_root.mkdir()
+    audio_path.write_bytes(b"OggS")
+
+    def fake_run(_command, **kwargs):
+        assert kwargs["cwd"] == str(live_root)
+        return subprocess.CompletedProcess(
+            _command,
+            0,
+            stdout=json.dumps(
+                {
+                    "success": True,
+                    "voice_compatible": True,
+                    "media_tag": f"[[audio_as_voice]]\nMEDIA:{audio_path}",
+                    "file_path": str(audio_path),
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(script.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        script,
+        "probe_audio",
+        lambda *_args, **_kwargs: {
+            "codec_name": "opus",
+            "sample_rate": "48000",
+            "channels": "1",
+        },
+    )
+
+    result = script.run_tts_smoke(
+        python_bin="/python",
+        live_root=live_root,
+        hermes_home=tmp_path / "home",
+        platform="whatsapp",
+        text="hello",
+        ffprobe_bin="/ffprobe",
+        timeout=1.0,
+    )
+
+    assert result["probe"]["codec_name"] == "opus"
+
+
+def test_main_skips_ffprobe_when_tts_smoke_is_disabled(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    script = _load_script_module()
+    live_root = tmp_path / "hermes"
+    _write_voice_native_root(live_root)
+    bridge_bin = live_root / "scripts" / "whatsapp-bridge" / "node_modules" / ".bin"
+
+    labels = []
+
+    def fake_resolve(value, *, label):
+        labels.append(label)
+        if label == "ffprobe":
+            raise AssertionError("ffprobe should only be needed for TTS smoke")
+        return value
+
+    monkeypatch.setattr(script, "resolve_executable", fake_resolve)
+    monkeypatch.setattr(
+        script,
+        "get_service_state",
+        lambda *_args, **_kwargs: {
+            "ActiveState": "active",
+            "MainPID": "123",
+            "Environment": (
+                f"PYTHONPATH={live_root} PATH=/usr/bin:{bridge_bin}"
+            ),
+            "DropInPaths": "/drop-in.conf",
+        },
+    )
+    monkeypatch.setattr(
+        script,
+        "read_process_env",
+        lambda _pid: {"PYTHONPATH": str(live_root), "PATH": f"/usr/bin:{bridge_bin}"},
+    )
+    monkeypatch.setattr(
+        script,
+        "import_smoke",
+        lambda **_kwargs: {"tools.tts_tool": str(live_root / "tools" / "tts_tool.py")},
+    )
+    monkeypatch.setattr(
+        script,
+        "get_bridge_health",
+        lambda *_args, **_kwargs: {"status": "connected", "queueLength": 0},
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "verify_voice_live_gateway.py",
+            "--live-hermes-root",
+            str(live_root),
+            "--python-bin",
+            "/python",
+        ],
+    )
+
+    assert script.main() == 0
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["success"] is True
+    assert labels == ["Hermes Python"]

--- a/tests/tools/test_verify_voice_live_gateway_script.py
+++ b/tests/tools/test_verify_voice_live_gateway_script.py
@@ -314,3 +314,64 @@ def test_main_skips_ffprobe_when_tts_smoke_is_disabled(
     output = json.loads(capsys.readouterr().out)
     assert output["success"] is True
     assert labels == ["Hermes Python"]
+
+
+def test_main_can_skip_bridge_health_for_cloud_only_gateway(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    script = _load_script_module()
+    live_root = tmp_path / "hermes"
+    _write_voice_native_root(live_root)
+    bridge_bin = live_root / "scripts" / "whatsapp-bridge" / "node_modules" / ".bin"
+
+    monkeypatch.setattr(script, "resolve_executable", lambda value, *, label: value)
+    monkeypatch.setattr(
+        script,
+        "get_service_state",
+        lambda *_args, **_kwargs: {
+            "ActiveState": "active",
+            "MainPID": "123",
+            "Environment": (
+                f"PYTHONPATH={live_root} PATH=/usr/bin:{bridge_bin}"
+            ),
+            "DropInPaths": "/drop-in.conf",
+        },
+    )
+    monkeypatch.setattr(
+        script,
+        "read_process_env",
+        lambda _pid: {"PYTHONPATH": str(live_root), "PATH": f"/usr/bin:{bridge_bin}"},
+    )
+    monkeypatch.setattr(
+        script,
+        "import_smoke",
+        lambda **_kwargs: {"tools.tts_tool": str(live_root / "tools" / "tts_tool.py")},
+    )
+
+    def fail_bridge_health(*_args, **_kwargs):
+        raise AssertionError("bridge health should be skipped")
+
+    monkeypatch.setattr(script, "get_bridge_health", fail_bridge_health)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "verify_voice_live_gateway.py",
+            "--live-hermes-root",
+            str(live_root),
+            "--python-bin",
+            "/python",
+            "--skip-bridge-health",
+        ],
+    )
+
+    assert script.main() == 0
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["checks"]["bridge_health"] == {
+        "success": True,
+        "skipped": True,
+        "reason": "--skip-bridge-health was provided",
+    }

--- a/tests/tools/test_verify_voice_local_stack_script.py
+++ b/tests/tools/test_verify_voice_local_stack_script.py
@@ -137,3 +137,58 @@ def test_run_json_step_rejects_unsuccessful_result(monkeypatch):
 
     with pytest.raises(SystemExit, match="reported failure"):
         script.run_json_step("demo", ["demo"], timeout=1.0, env={})
+
+
+def _write_live_root(root: Path, *, include_cloud: bool = True) -> None:
+    tools_dir = root / "tools"
+    gateway_dir = root / "gateway" / "platforms"
+    tools_dir.mkdir(parents=True)
+    gateway_dir.mkdir(parents=True)
+    (tools_dir / "tts_tool.py").write_text(
+        "\n".join(["voice_compatible", "libopus", "-application", "voip"]),
+        encoding="utf-8",
+    )
+    if include_cloud:
+        (gateway_dir / "whatsapp_cloud.py").write_text(
+            "\n".join(
+                [
+                    "calling_sidecar_url",
+                    "voice.webrtc_sidecar",
+                    "_send_calling_sidecar_tts_stream_command",
+                    "-application",
+                    "voip",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+
+def test_audit_live_hermes_root_accepts_voice_native_checkout(tmp_path: Path):
+    script = _load_script_module()
+    _write_live_root(tmp_path)
+
+    result = script.audit_live_hermes_root(tmp_path)
+
+    assert result["success"] is True
+    assert result["failures"] == []
+    assert [check["path"] for check in result["checked"]] == [
+        "tools/tts_tool.py",
+        "gateway/platforms/whatsapp_cloud.py",
+    ]
+
+
+def test_audit_live_hermes_root_reports_stale_checkout(tmp_path: Path):
+    script = _load_script_module()
+    _write_live_root(tmp_path, include_cloud=False)
+
+    result = script.audit_live_hermes_root(tmp_path)
+
+    assert result["success"] is False
+    assert "gateway/platforms/whatsapp_cloud.py is missing" in result["failures"]
+
+
+def test_require_live_hermes_root_fails_on_missing_surfaces(tmp_path: Path):
+    script = _load_script_module()
+
+    with pytest.raises(SystemExit, match="voice-native integration surfaces"):
+        script.require_live_hermes_root(tmp_path / "missing")

--- a/tests/tools/test_verify_voice_local_stack_script.py
+++ b/tests/tools/test_verify_voice_local_stack_script.py
@@ -1,0 +1,139 @@
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "verify_voice_local_stack.py"
+)
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location("verify_voice_local_stack", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _args(**overrides):
+    values = {
+        "provider": "kokoro",
+        "voice": "af_heart",
+        "speed": "1.0",
+        "tts_timeout": 180.0,
+        "stream_timeout": 180.0,
+        "full_duplex_timeout": 90.0,
+        "command_text": "command smoke",
+        "stream_text": "stream smoke",
+        "stream_command_template": None,
+        "skip_full_duplex": False,
+        "voice_repo": Path("/voice"),
+        "webrtc_python_bin": None,
+        "full_duplex_inbound_text": "hello world",
+        "full_duplex_outbound_text": "hello back",
+        "expect_word": ["hello", "world"],
+        "keep_home": False,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def test_command_tts_command_uses_isolated_hermes_home():
+    script = _load_script_module()
+
+    command = script.command_tts_command(
+        _args(keep_home=True),
+        voice_bin="/tmp/voice",
+        hermes_home=Path("/tmp/hermes-home"),
+    )
+
+    assert command[:2] == [sys.executable, str(script.script_path("verify_voice_command_tts.py"))]
+    assert "--voice-bin" in command
+    assert "/tmp/voice" in command
+    assert "--hermes-home" in command
+    assert "/tmp/hermes-home" in command
+    assert "--force" in command
+    assert "--keep-home" in command
+    assert command[-2:] == ["--text", "command smoke"]
+
+
+def test_stream_tts_command_can_use_custom_template():
+    script = _load_script_module()
+
+    command = script.stream_tts_command(
+        _args(stream_command_template="voice stream --raw-output -"),
+        voice_bin="/tmp/voice",
+    )
+
+    assert command[:2] == [sys.executable, str(script.script_path("verify_voice_stream_tts.py"))]
+    assert "--voice-bin" in command
+    assert "/tmp/voice" in command
+    assert "--command-template" in command
+    assert "voice stream --raw-output -" in command
+
+
+def test_full_duplex_command_passes_voice_repo_and_python():
+    script = _load_script_module()
+
+    command = script.full_duplex_command(
+        _args(webrtc_python_bin="/tmp/venv/bin/python", expect_word=["testing"]),
+        voice_bin="/tmp/voice",
+        voice_repo=Path("/voice"),
+    )
+
+    assert command[:2] == [
+        sys.executable,
+        str(script.script_path("verify_voice_full_duplex_sidecar.py")),
+    ]
+    assert "--voice-repo" in command
+    assert "/voice" in command
+    assert "--python-bin" in command
+    assert "/tmp/venv/bin/python" in command
+    assert command[-2:] == ["--expect-word", "testing"]
+
+
+def test_resolve_voice_repo_requires_full_duplex_checkout(tmp_path: Path):
+    script = _load_script_module()
+
+    with pytest.raises(SystemExit, match="full-duplex validation needs"):
+        script.resolve_voice_repo_for_full_duplex(_args(voice_repo=None))
+
+    assert script.resolve_voice_repo_for_full_duplex(
+        _args(skip_full_duplex=True, voice_repo=None)
+    ) is None
+
+    with pytest.raises(SystemExit, match="voice full-duplex smoke not found"):
+        script.resolve_voice_repo_for_full_duplex(_args(voice_repo=tmp_path))
+
+
+def test_parse_json_object_accepts_progress_prefix():
+    script = _load_script_module()
+
+    parsed = script.parse_json_object('progress\n{"success": true, "value": 1}\n')
+
+    assert parsed == {"success": True, "value": 1}
+
+
+def test_run_json_step_rejects_unsuccessful_result(monkeypatch):
+    script = _load_script_module()
+
+    def fake_run(command, **kwargs):
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps({"success": False, "error": "bad"}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(script, "run_process", fake_run)
+
+    with pytest.raises(SystemExit, match="reported failure"):
+        script.run_json_step("demo", ["demo"], timeout=1.0, env={})

--- a/tests/tools/test_verify_voice_stream_tts_script.py
+++ b/tests/tools/test_verify_voice_stream_tts_script.py
@@ -51,6 +51,72 @@ def test_audio_contract_matches_voice_sidecar_pcm_shape():
     }
 
 
+def stream_contract_json(**surface_overrides):
+    raw_outbound = {
+        "command": 'voice stream --sample-rate 48000 --frame-ms 20 --raw-output - "hello"',
+        "output": "pcm_s16le",
+        "transport": "stdout_pcm_frames",
+        "frame_bytes": 1_920,
+    }
+    raw_outbound.update(surface_overrides)
+    return {
+        "audio": {
+            "sample_rate": 48_000,
+            "channels": 1,
+            "frame_ms": 20,
+            "encoding": "pcm_s16le",
+            "bytes_per_sample": 2,
+            "frame_bytes": 1_920,
+        },
+        "voice_surfaces": {
+            "completed_voice_note": {
+                "command": 'voice say --format ogg-opus --output reply.ogg "hello"',
+                "output": "audio/ogg; codecs=opus",
+                "transport": "completed_file",
+            },
+            "raw_outbound_pcm": raw_outbound,
+            "raw_inbound_pcm": {
+                "command": "voice stream-transcribe --raw-input - --sample-rate 48000 --frame-ms 20",
+                "input": "pcm_s16le",
+                "transport": "stdin_pcm_frames",
+                "frame_bytes": 1_920,
+            },
+        },
+    }
+
+
+def test_audio_contract_from_voice_reads_stream_contract(monkeypatch):
+    script = _load_script_module()
+
+    def fake_load(_voice_bin):
+        return stream_contract_json()
+
+    monkeypatch.setattr(script, "load_voice_stream_contract", fake_load)
+
+    contract = script.audio_contract_from_voice(
+        "/tmp/voice",
+        fallback=script.AudioContract(sample_rate=16_000),
+    )
+
+    assert contract.sample_rate == 48_000
+    assert contract.frame_bytes == 1_920
+    assert "voice stream" in contract.raw_outbound_pcm_command
+    assert "--raw-input" in contract.raw_inbound_pcm_command
+    assert "--format ogg-opus" in contract.completed_voice_note_command
+
+
+def test_audio_contract_from_voice_rejects_surface_frame_drift(monkeypatch):
+    script = _load_script_module()
+
+    def fake_load(_voice_bin):
+        return stream_contract_json(frame_bytes=960)
+
+    monkeypatch.setattr(script, "load_voice_stream_contract", fake_load)
+
+    with pytest.raises(SystemExit, match="raw_outbound_pcm frame_bytes"):
+        script.audio_contract_from_voice("/tmp/voice", fallback=script.AudioContract())
+
+
 def test_validate_pcm_accepts_non_silent_whole_frames():
     script = _load_script_module()
     contract = script.AudioContract()

--- a/tests/tools/test_verify_voice_stream_tts_script.py
+++ b/tests/tools/test_verify_voice_stream_tts_script.py
@@ -1,0 +1,90 @@
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "verify_voice_stream_tts.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location("verify_voice_stream_tts", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_default_command_template_streams_raw_pcm_stdout():
+    script = _load_script_module()
+
+    template = script.build_default_command_template("/tmp/bin/voice with spaces")
+
+    assert template.startswith("'/tmp/bin/voice with spaces' stream --quiet")
+    assert "--sample-rate {sample_rate}" in template
+    assert "--frame-ms {frame_ms}" in template
+    assert "--raw-output -" in template
+    assert "--input-file {input_path}" in template
+    assert "--voice {voice}" in template
+    assert "--speed {speed}" in template
+
+
+def test_audio_contract_matches_voice_sidecar_pcm_shape():
+    script = _load_script_module()
+
+    contract = script.AudioContract()
+
+    assert contract.samples_per_frame == 960
+    assert contract.frame_bytes == 1920
+    assert contract.bytes_per_second == 96_000
+    assert contract.as_dict() == {
+        "sample_rate": 48_000,
+        "channels": 1,
+        "frame_ms": 20,
+        "encoding": "pcm_s16le",
+        "bytes_per_sample": 2,
+        "samples_per_frame": 960,
+        "frame_bytes": 1920,
+    }
+
+
+def test_validate_pcm_accepts_non_silent_whole_frames():
+    script = _load_script_module()
+    contract = script.AudioContract()
+    frame = (12_000).to_bytes(2, byteorder="little", signed=True) * 960
+
+    stats = script.validate_pcm(frame * 10, contract=contract)
+
+    assert stats == {
+        "bytes": 19_200,
+        "frames": 10,
+        "duration_ms": 200,
+        "peak": 12_000,
+    }
+
+
+def test_validate_pcm_rejects_silence():
+    script = _load_script_module()
+    contract = script.AudioContract()
+
+    with pytest.raises(SystemExit, match="PCM peak 0 is below minimum"):
+        script.validate_pcm(b"\x00" * contract.frame_bytes, contract=contract)
+
+
+def test_validate_pcm_rejects_partial_sample():
+    script = _load_script_module()
+    contract = script.AudioContract()
+
+    with pytest.raises(SystemExit, match="whole s16le samples"):
+        script.validate_pcm(b"\x00", contract=contract)
+
+
+def test_validate_pcm_rejects_partial_frame():
+    script = _load_script_module()
+    contract = script.AudioContract()
+
+    with pytest.raises(SystemExit, match="not aligned to 1920-byte frames"):
+        script.validate_pcm(b"\x01\x00" * 100, contract=contract)

--- a/tests/tools/test_verify_voice_stream_tts_script.py
+++ b/tests/tools/test_verify_voice_stream_tts_script.py
@@ -74,6 +74,11 @@ def stream_contract_json(**surface_overrides):
                 "output": "audio/ogg; codecs=opus",
                 "transport": "completed_file",
             },
+            "streamed_voice_note": {
+                "command": 'voice stream --output reply.ogg --format ogg-opus "hello"',
+                "output": "audio/ogg; codecs=opus",
+                "transport": "daemon_stream_encoded_file",
+            },
             "raw_outbound_pcm": raw_outbound,
             "raw_inbound_pcm": {
                 "command": "voice stream-transcribe --raw-input - --sample-rate 48000 --frame-ms 20",
@@ -103,6 +108,7 @@ def test_audio_contract_from_voice_reads_stream_contract(monkeypatch):
     assert "voice stream" in contract.raw_outbound_pcm_command
     assert "--raw-input" in contract.raw_inbound_pcm_command
     assert "--format ogg-opus" in contract.completed_voice_note_command
+    assert "voice stream" in contract.streamed_voice_note_command
 
 
 def test_audio_contract_from_voice_rejects_surface_frame_drift(monkeypatch):
@@ -154,3 +160,45 @@ def test_validate_pcm_rejects_partial_frame():
 
     with pytest.raises(SystemExit, match="not aligned to 1920-byte frames"):
         script.validate_pcm(b"\x01\x00" * 100, contract=contract)
+
+
+def test_build_streamed_ogg_command_uses_daemon_stream_output(tmp_path: Path):
+    script = _load_script_module()
+    contract = script.AudioContract()
+
+    command = script.build_streamed_ogg_command(
+        voice_bin="/tmp/voice",
+        input_path=tmp_path / "input.txt",
+        output_path=tmp_path / "reply.ogg",
+        contract=contract,
+        voice="af_heart",
+        speed="1.0",
+    )
+
+    assert command[:3] == ["/tmp/voice", "stream", "--quiet"]
+    assert "--output" in command
+    assert str(tmp_path / "reply.ogg") in command
+    assert "--format" in command
+    assert "ogg-opus" in command
+    assert "--sample-rate" in command
+    assert "48000" in command
+
+
+def test_validate_streamed_ogg_requires_real_opus_file(tmp_path: Path):
+    script = _load_script_module()
+    output = tmp_path / "reply.ogg"
+    output.write_bytes(b"OggS")
+
+    stats = script.validate_streamed_ogg(
+        output,
+        probe={"codec_name": "opus", "sample_rate": "48000", "channels": "1"},
+    )
+
+    assert stats["bytes"] == 4
+    assert stats["codec_name"] == "opus"
+
+    with pytest.raises(SystemExit, match="codec_name=opus"):
+        script.validate_streamed_ogg(
+            output,
+            probe={"codec_name": "vorbis", "sample_rate": "48000", "channels": "1"},
+        )

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -899,8 +899,14 @@ def _convert_to_opus(mp3_path: str) -> Optional[str]:
     ogg_path = mp3_path.rsplit(".", 1)[0] + ".ogg"
     try:
         result = subprocess.run(
-            ["ffmpeg", "-i", mp3_path, "-acodec", "libopus",
-             "-ac", "1", "-b:a", "64k", "-vbr", "off", ogg_path, "-y"],
+            [
+                "ffmpeg", "-i", mp3_path,
+                "-acodec", "libopus",
+                "-ac", "1", "-ar", "48000",
+                "-b:a", "64k", "-vbr", "off",
+                "-application", "voip",
+                ogg_path, "-y",
+            ],
             capture_output=True, timeout=30,
             stdin=subprocess.DEVNULL,
         )

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2059,12 +2059,12 @@ def text_to_speech_tool(
         text = text[:max_len]
 
     # Detect platform from gateway env var to choose the best output format.
-    # Telegram voice bubbles require Opus (.ogg); OpenAI and ElevenLabs can
-    # produce Opus natively (no ffmpeg needed).  Edge TTS always outputs MP3
-    # and needs ffmpeg for conversion.
+    # Telegram voice bubbles and WhatsApp voice notes require Opus (.ogg).
+    # OpenAI and ElevenLabs can produce Opus natively (no ffmpeg needed).
+    # Edge TTS always outputs MP3 and needs ffmpeg for conversion.
     from gateway.session_context import get_session_env
     platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
-    want_opus = (platform == "telegram")
+    want_opus = platform in {"telegram", "whatsapp", "whatsapp_cloud"}
 
     # Determine output path
     if output_path:
@@ -2101,8 +2101,9 @@ def text_to_speech_tool(
         if command_provider_config is not None:
             fmt = _get_command_tts_output_format(command_provider_config)
             file_path = out_dir / f"tts_{timestamp}.{fmt}"
-        # Use .ogg for Telegram with providers that support native Opus output,
-        # otherwise fall back to .mp3 (Edge TTS will attempt ffmpeg conversion later).
+        # Use .ogg for platforms with native voice-note/bubble delivery when
+        # providers support native Opus output; otherwise fall back to .mp3
+        # (Edge TTS will attempt ffmpeg conversion later).
         elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini"}:
             file_path = out_dir / f"tts_{timestamp}.ogg"
         else:

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -340,6 +340,15 @@ config that calls `voice say --format ogg-opus`, runs Hermes'
 run proves Hermes receives a `voice_compatible` media tag and that the audio is
 real Opus in an Ogg container, mono, at 48 kHz.
 
+To validate an already deployed Hermes home without rewriting its config:
+
+```bash
+scripts/verify_voice_command_tts.py --use-existing-config --hermes-home ~/.hermes
+```
+
+In this mode the script uses the configured `tts.provider` path and only writes
+the generated audio cache entry.
+
 #### Security
 
 Command-type providers run whatever shell command you configure, with your user's permissions. Hermes quotes placeholder values and enforces the configured timeout, but the command template itself is trusted local input — treat it the same way you would a shell script on your PATH.

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -165,18 +165,18 @@ tts:
 
 Only positive integers are honored. Zero, negative, non-numeric, or boolean values fall through to the provider default, so a broken config can't accidentally disable truncation.
 
-### Telegram Voice Bubbles & ffmpeg
+### Voice Bubbles / Notes & ffmpeg
 
-Telegram voice bubbles require Opus/OGG audio format:
+Telegram voice bubbles and WhatsApp voice notes require Opus/OGG audio format:
 
 - **OpenAI, ElevenLabs, and Mistral** produce Opus natively — no extra setup
-- **Edge TTS** (default) outputs MP3 and needs **ffmpeg** to convert:
-- **MiniMax TTS** outputs MP3 and needs **ffmpeg** to convert for Telegram voice bubbles
-- **Google Gemini TTS** outputs raw PCM and uses **ffmpeg** to encode Opus directly for Telegram voice bubbles
-- **xAI TTS** outputs MP3 and needs **ffmpeg** to convert for Telegram voice bubbles
-- **NeuTTS** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
-- **KittenTTS** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
-- **Piper** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
+- **Edge TTS** (default) outputs MP3 and needs **ffmpeg** to convert.
+- **MiniMax TTS** outputs MP3 and needs **ffmpeg** to convert for native voice delivery
+- **Google Gemini TTS** outputs raw PCM and uses **ffmpeg** to encode Opus directly for native voice delivery
+- **xAI TTS** outputs MP3 and needs **ffmpeg** to convert for native voice delivery
+- **NeuTTS** outputs WAV and also needs **ffmpeg** to convert for native voice delivery
+- **KittenTTS** outputs WAV and also needs **ffmpeg** to convert for native voice delivery
+- **Piper** outputs WAV and also needs **ffmpeg** to convert for native voice delivery
 
 ```bash
 # Ubuntu/Debian
@@ -189,10 +189,10 @@ brew install ffmpeg
 sudo dnf install ffmpeg
 ```
 
-Without ffmpeg, Edge TTS, MiniMax TTS, NeuTTS, KittenTTS, and Piper audio are sent as regular audio files (playable, but shown as a rectangular player instead of a voice bubble).
+Without ffmpeg, Edge TTS, MiniMax TTS, NeuTTS, KittenTTS, and Piper audio are sent as regular audio files (playable, but shown as a rectangular player instead of a native voice bubble/note).
 
 :::tip
-If you want voice bubbles without installing ffmpeg, switch to the OpenAI, ElevenLabs, or Mistral provider.
+If you want native voice delivery without installing ffmpeg, switch to the OpenAI, ElevenLabs, Mistral, or an Ogg/Opus command provider such as `voice`.
 :::
 
 ### xAI Custom Voices (voice cloning)

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -35,7 +35,7 @@ Convert text to speech with ten providers:
 |----------|----------|--------|
 | Telegram | Voice bubble (plays inline) | Opus `.ogg` |
 | Discord | Voice bubble (Opus/OGG), falls back to file attachment | Opus/MP3 |
-| WhatsApp | Audio file attachment | MP3 |
+| WhatsApp | Native voice note with `voice_compatible`; regular attachment otherwise | Ogg/Opus preferred; MP3/WAV fallback |
 | CLI | Saved to `~/.hermes/audio_cache/` | MP3 |
 
 ### Configuration
@@ -404,7 +404,7 @@ Override these on your provider class for richer integration:
 - `list_models()` → list of `{id, display, languages, max_text_length}` dicts.
 - `get_setup_schema()` → return `{name, badge, tag, env_vars: [{key, prompt, url}]}` to power the picker row in `hermes tools` / `hermes setup`. Without this, the plugin still works but its row in the picker is minimal.
 - `stream(text, *, voice, model, format, **extra)` → iterator yielding audio bytes for streaming delivery (default raises `NotImplementedError`).
-- `voice_compatible` property → set `True` if your output is Opus-compatible and the gateway should deliver it as a voice bubble (default `False` = regular audio attachment).
+- `voice_compatible` property → set `True` when your output should use native voice-message delivery. Ogg/Opus output is sent directly; MP3/WAV output may be converted by gateways that support conversion (default `False` = regular audio attachment).
 
 See `agent/tts_provider.py` for the full ABC including docstrings.
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -325,6 +325,21 @@ Use `{{` and `}}` for literal braces.
 - **`type: command` is the default when `command:` is set.** Writing `type: command` explicitly is good practice but not required; an entry with a non-empty `command` string is treated as a command provider.
 - **`{input_path}` / `{text_path}` are interchangeable.** Use whichever reads better in your command.
 
+#### Local Ogg/Opus validation
+
+When using [`voice`](https://github.com/rgbkrk/voice) as a command provider,
+validate the integration before restarting a live gateway:
+
+```bash
+VOICE_BIN=/path/to/voice scripts/verify_voice_command_tts.py
+```
+
+The script creates a temporary `HERMES_HOME`, writes a Kokoro command-provider
+config that calls `voice say --format ogg-opus`, runs Hermes'
+`text_to_speech_tool`, and checks the generated file with `ffprobe`. A passing
+run proves Hermes receives a `voice_compatible` media tag and that the audio is
+real Opus in an Ogg container, mono, at 48 kHz.
+
 #### Security
 
 Command-type providers run whatever shell command you configure, with your user's permissions. Hermes quotes placeholder values and enforces the configured timeout, but the command template itself is trusted local input — treat it the same way you would a shell script on your PATH.

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -252,7 +252,7 @@ tts:
       command: "voxcpm --ref ~/voice.wav --text-file {input_path} --out {output_path}"
       output_format: mp3
       timeout: 180
-      voice_compatible: true       # try to deliver as a Telegram voice bubble
+      voice_compatible: true       # try to deliver as a native voice note/bubble
 
     mlx-kokoro:
       type: command
@@ -312,7 +312,7 @@ Use `{{` and `}}` for literal braces.
 |--------------------|---------|------------------------------------------------------------------------------------------------------------|
 | `timeout`          | `120`   | Seconds; the process tree is killed on expiry (Unix `killpg`, Windows `taskkill /T`).                       |
 | `output_format`    | `mp3`   | One of `mp3` / `wav` / `ogg` / `flac`. Auto-inferred from the output extension if Hermes picks a path.      |
-| `voice_compatible` | `false` | When `true`, Hermes converts MP3/WAV output to Opus/OGG via ffmpeg so Telegram renders a voice bubble.      |
+| `voice_compatible` | `false` | When `true`, Hermes routes the output through native voice-message delivery. Existing Ogg/Opus output is sent directly; MP3/WAV output is converted to Ogg/Opus via ffmpeg when the platform requires it. |
 | `max_text_length`  | `5000`  | Input is truncated to this length before rendering the command.                                             |
 | `voice` / `model`  | empty   | Passed to the command as placeholder values only.                                                           |
 
@@ -320,6 +320,7 @@ Use `{{` and `}}` for literal braces.
 
 - **Built-in names always win.** A `tts.providers.openai` entry never shadows the native OpenAI provider, so no user config can silently replace a built-in.
 - **Default delivery is a document.** Command providers deliver as regular audio attachments on every platform. Opt in to voice-bubble delivery per-provider with `voice_compatible: true`.
+- **Prefer native Ogg/Opus when your engine can write it.** For WhatsApp voice notes and Telegram voice bubbles, set `output_format: ogg` and have the command produce real Opus in an Ogg container. Hermes can then skip conversion and hand the file directly to the platform adapter.
 - **Command failures surface to the agent.** Non-zero exit, empty output, or timeout all return an error with the command's stderr/stdout included so you can debug the provider from the conversation.
 - **`type: command` is the default when `command:` is set.** Writing `type: command` explicitly is good practice but not required; an entry with a non-empty `command` string is treated as a command provider.
 - **`{input_path}` / `{text_path}` are interchangeable.** Use whichever reads better in your command.

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -349,15 +349,20 @@ involving Meta's Graph API:
 cd /path/to/voice
 python3 -m venv /tmp/voice-webrtc-venv
 /tmp/voice-webrtc-venv/bin/pip install -r examples/webrtc-sidecar/requirements.txt pytest
-/tmp/voice-webrtc-venv/bin/python examples/webrtc-sidecar/full_duplex_loopback_smoke.py --voice-bin /path/to/voice
+
+cd /path/to/hermes-agent
+VOICE_REPO=/path/to/voice \
+VOICE_WEBRTC_PYTHON=/tmp/voice-webrtc-venv/bin/python \
+  scripts/verify_voice_full_duplex_sidecar.py --voice-bin /path/to/voice
 ```
 
-The full-duplex smoke keeps everything local: it sends one `voice stream`
-utterance through a local WebRTC peer into the sidecar, drains the decoded PCM
-through `voice stream-transcribe`, and simultaneously queues outbound
-`voice stream` PCM back to the same peer. A passing run proves the sidecar,
-PCM contract, inbound STT bridge, and outbound TTS bridge agree before a real
-WhatsApp call is attempted.
+That wrapper runs `examples/webrtc-sidecar/full_duplex_loopback_smoke.py` from
+the `voice` checkout. The full-duplex smoke keeps everything local: it sends
+one `voice stream` utterance through a local WebRTC peer into the sidecar,
+drains the decoded PCM through `voice stream-transcribe`, and simultaneously
+queues outbound `voice stream` PCM back to the same peer. A passing run proves
+the sidecar, PCM contract, inbound STT bridge, and outbound TTS bridge agree
+before a real WhatsApp call is attempted.
 
 Supported stream-command placeholders:
 

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -303,6 +303,16 @@ tts:
       timeout: 180
 ```
 
+Validate a live Hermes home before restarting the gateway:
+
+```bash
+scripts/verify_voice_command_tts.py --use-existing-config --hermes-home ~/.hermes
+```
+
+A passing run proves the configured provider returns a `[[audio_as_voice]]`
+media tag and real mono 48 kHz Ogg/Opus audio suitable for WhatsApp voice-note
+delivery.
+
 You can check whether the gateway found ffmpeg via the health endpoint:
 
 ```bash

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -342,6 +342,23 @@ Validate the installed command shape before a live call:
 scripts/verify_voice_stream_tts.py --voice-bin /path/to/voice
 ```
 
+Then validate the local WebRTC media bridge from a `voice` checkout before
+involving Meta's Graph API:
+
+```bash
+cd /path/to/voice
+python3 -m venv /tmp/voice-webrtc-venv
+/tmp/voice-webrtc-venv/bin/pip install -r examples/webrtc-sidecar/requirements.txt pytest
+/tmp/voice-webrtc-venv/bin/python examples/webrtc-sidecar/full_duplex_loopback_smoke.py --voice-bin /path/to/voice
+```
+
+The full-duplex smoke keeps everything local: it sends one `voice stream`
+utterance through a local WebRTC peer into the sidecar, drains the decoded PCM
+through `voice stream-transcribe`, and simultaneously queues outbound
+`voice stream` PCM back to the same peer. A passing run proves the sidecar,
+PCM contract, inbound STT bridge, and outbound TTS bridge agree before a real
+WhatsApp call is attempted.
+
 Supported stream-command placeholders:
 
 | Placeholder | Meaning |

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -352,6 +352,11 @@ Validate the installed command shape before a live call:
 scripts/verify_voice_stream_tts.py --voice-bin /path/to/voice
 ```
 
+The verifier reads `/path/to/voice stream-contract`, validates the advertised
+`raw_outbound_pcm` / `raw_inbound_pcm` `voice_surfaces`, then runs the rendered
+stream command and checks stdout for non-silent 48 kHz mono 20 ms `pcm_s16le`
+frames.
+
 Then validate the local WebRTC media bridge from a `voice` checkout before
 involving Meta's Graph API:
 

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -230,6 +230,10 @@ All settings live in `~/.hermes/.env`.  Required values are in **bold**.
 | `WHATSAPP_CLOUD_WEBHOOK_PATH` | `/whatsapp/webhook` | URL path Meta posts to. |
 | `WHATSAPP_CLOUD_API_VERSION` | `v20.0` | Meta Graph API version. Only override if a newer version is recommended in Meta's docs. |
 | `WHATSAPP_CLOUD_HOME_CHANNEL` | — | wa_id to use as the bot's home channel (for cron jobs etc). |
+| `WHATSAPP_CLOUD_CALLING_SIDECAR_URL` | — | Optional loopback URL for an experimental WhatsApp Calling / WebRTC sidecar. |
+| `WHATSAPP_CLOUD_CALLING_SIDECAR_TIMEOUT` | `10.0` | HTTP timeout in seconds for sidecar control-plane requests. |
+| `WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND` | — | Optional command that writes raw `pcm_s16le` TTS audio to stdout for live calls. |
+| `WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT` | `180.0` | Timeout in seconds for the live-call TTS stream command. |
 
 You can have **both** the Baileys (`whatsapp`) and Cloud (`whatsapp_cloud`) adapters enabled simultaneously, targeting different phone numbers.
 
@@ -277,13 +281,27 @@ This makes it obvious when the bot has seen your message versus when it's still 
 
 WhatsApp distinguishes between a "voice note" (the green waveform bubble) and a generic audio file attachment. The difference is purely codec: voice notes need to be `audio/ogg` with `opus` encoding.
 
-Hermes TTS produces MP3. Two paths:
+Hermes can use either direct Ogg/Opus output or a conversion fallback:
 
-- **With ffmpeg on PATH** (recommended) — outbound TTS is converted and arrives as a proper voice note. Install:
-  - Windows: `winget install Gyan.FFmpeg`
-  - macOS: `brew install ffmpeg`
-  - Linux: package manager
-- **Without ffmpeg** — outbound TTS arrives as an MP3 audio attachment. Plays fine, just doesn't look like a voice note. A one-time warning fires in the gateway log so you know.
+- **Direct Ogg/Opus** (preferred) — command TTS providers can produce WhatsApp-ready `.ogg` output directly. Set `output_format: ogg` and `voice_compatible: true`; Hermes uploads the file as `audio/ogg; codecs=opus` without ffmpeg conversion.
+- **With ffmpeg on PATH** — MP3/WAV outputs are converted and arrive as proper voice notes.
+- **Without ffmpeg** — MP3/WAV outputs arrive as generic audio attachments. They play fine, but do not render as voice-note bubbles. A one-time warning fires in the gateway log so you know.
+
+For a local `voice` / Kokoro command provider:
+
+```yaml
+tts:
+  provider: kokoro
+  providers:
+    kokoro:
+      type: command
+      command: /home/you/.local/bin/voice say --format ogg-opus --input-file {input_path} --output {output_path} --voice {voice} --speed {speed}
+      output_format: ogg
+      voice_compatible: true
+      voice: af_heart
+      speed: 1.0
+      timeout: 180
+```
 
 You can check whether the gateway found ffmpeg via the health endpoint:
 
@@ -291,6 +309,45 @@ You can check whether the gateway found ffmpeg via the health endpoint:
 curl http://localhost:8090/health
 # look for "ffmpeg_present": true
 ```
+
+### WhatsApp Calling / WebRTC sidecar (experimental)
+
+The Cloud API's live calling surface is a WebRTC media path, not a file-upload path. Hermes keeps that boundary separate from the normal Graph API adapter:
+
+1. Meta sends a `calls` webhook with an SDP offer.
+2. Hermes forwards the offer to a local sidecar at `WHATSAPP_CLOUD_CALLING_SIDECAR_URL`.
+3. The sidecar returns an SDP answer and exposes a fixed PCM contract.
+4. Hermes sends `pre_accept` and `accept` to Graph with that SDP answer.
+5. The sidecar bridges WebRTC RTP audio to local 48 kHz, mono, 20 ms `pcm_s16le` frames.
+6. Hermes drains inbound PCM from the sidecar, writes utterance WAV segments for the existing STT path, and sends outbound TTS frames back to the sidecar.
+
+The sidecar contract is identified as `voice.webrtc_sidecar`. Hermes fetches `GET /contract` when available and uses its endpoint paths and audio fields; older sidecars can omit `/contract` and use the legacy `/offer`, `/calls/{call_id}/audio`, and `/calls/{call_id}/close` paths.
+
+Minimal config:
+
+```bash
+WHATSAPP_CLOUD_CALLING_SIDECAR_URL=http://127.0.0.1:8787
+```
+
+For low-latency outbound speech, add a command that writes headerless `pcm_s16le` to stdout. With the `voice` daemon running, this uses `voice stream` directly instead of generating a file and decoding it with ffmpeg:
+
+```bash
+WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND='voice stream --quiet --sample-rate {sample_rate} --frame-ms {frame_ms} --raw-output - --input-file {input_path}'
+WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT=180
+```
+
+Supported stream-command placeholders:
+
+| Placeholder | Meaning |
+|---|---|
+| `{input_path}` / `{text_path}` | Temp UTF-8 file containing the reply text |
+| `{text}` | Reply text itself, shell-quoted for the command context |
+| `{sample_rate}` | Sidecar PCM sample rate, currently `48000` |
+| `{channels}` | Sidecar PCM channels, currently `1` |
+| `{frame_ms}` | Sidecar frame duration, currently `20` |
+| `{encoding}` | Sidecar PCM encoding, currently `pcm_s16le` |
+
+The health endpoint reports `calling_sidecar_configured`, `calling_sidecar_contract_loaded`, and `calling_sidecar_tts_stream_configured` booleans so you can confirm the live-call path is wired.
 
 ---
 
@@ -401,7 +458,7 @@ This uses your Nous Portal access token instead of needing a separate OpenAI key
 | Outbound | Local bridge → Baileys | HTTPS to graph.facebook.com |
 | Groups | Full support | DMs only (v1) |
 | 24h window | No restriction | Hard rule — templates required after |
-| Voice notes (out) | Native | Native with ffmpeg, MP3 fallback otherwise |
+| Voice notes (out) | Native with Ogg/Opus, ffmpeg fallback for MP3/WAV | Native with Ogg/Opus, ffmpeg fallback for MP3/WAV |
 | Read receipts | No | Yes (blue double-checkmarks) |
 | Typing indicator | No | Yes (auto-dismisses on response) |
 | Interactive buttons | Text fallback only | Native (clarify, approval, slash-confirm) |

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -327,6 +327,25 @@ Ogg/Opus output, verifies the raw `voice stream` PCM contract, and then runs
 the full-duplex sidecar smoke from the `voice` checkout. Pass
 `--skip-full-duplex` when the WebRTC sidecar dependencies are not installed yet.
 
+After installing a local gateway service, verify the running process is using
+the expected voice-native checkout:
+
+```bash
+scripts/verify_voice_live_gateway.py \
+  --live-hermes-root /path/to/hermes-agent \
+  --python-bin ~/.hermes/hermes-agent/venv/bin/python \
+  --hermes-home ~/.hermes \
+  --skip-bridge-health \
+  --run-tts-smoke
+```
+
+That live check inspects the systemd user service, verifies the running process
+environment, confirms imports resolve from the expected checkout, and can run
+one live-config TTS smoke that must produce mono 48 kHz Ogg/Opus. Omit
+`--skip-bridge-health` when the Baileys WhatsApp bridge is also enabled and you
+want the verifier to require the local bridge `/health` endpoint to be
+connected.
+
 You can check whether the gateway found ffmpeg via the health endpoint:
 
 ```bash

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -313,6 +313,20 @@ A passing run proves the configured provider returns a `[[audio_as_voice]]`
 media tag and real mono 48 kHz Ogg/Opus audio suitable for WhatsApp voice-note
 delivery.
 
+For a single local preflight that uses an isolated Hermes home and leaves the
+live gateway untouched, run:
+
+```bash
+scripts/verify_voice_local_stack.py \
+  --voice-bin /path/to/voice \
+  --voice-repo /path/to/voice
+```
+
+That aggregate check starts the local Hermes CLI, verifies command-provider
+Ogg/Opus output, verifies the raw `voice stream` PCM contract, and then runs
+the full-duplex sidecar smoke from the `voice` checkout. Pass
+`--skip-full-duplex` when the WebRTC sidecar dependencies are not installed yet.
+
 You can check whether the gateway found ffmpeg via the health endpoint:
 
 ```bash

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -41,7 +41,7 @@ The rest of this page is the manual reference.
 1. **A Meta Business account**.  Create one at [business.facebook.com](https://business.facebook.com/).
 2. **A Meta app with WhatsApp enabled**.  See "Creating the Meta app" below.
 3. **A way to expose a local port to the public internet** with HTTPS.  Cloudflare Tunnel (`cloudflared`) is recommended — free, no port forwarding, no domain required.  ngrok, your own domain with a reverse proxy + TLS, or a VPS with the gateway directly bound to a public IP all work too.
-4. **Optional but recommended**: ffmpeg on `PATH` so outbound voice messages render as native WhatsApp voice-note bubbles (green waveform) instead of MP3 audio attachments. Hermes degrades gracefully if absent.
+4. **Optional for MP3/WAV providers**: ffmpeg on `PATH` lets Hermes convert non-Opus TTS output into native WhatsApp voice-note bubbles (green waveform). Command providers that emit Ogg/Opus directly do not need ffmpeg for outbound voice messages.
 
 ---
 
@@ -254,7 +254,7 @@ You can have **both** the Baileys (`whatsapp`) and Cloud (`whatsapp_cloud`) adap
 
 - **Text** — markdown is auto-converted to WhatsApp's flavored syntax (`**bold**` → `*bold*`, `~~strike~~` → `~strike~`, headers → bold, `[link](url)` → `link (url)`). Long messages split at 4096 chars per chunk.
 - **Images** — agent-generated images and local image files both supported, delivered as native photo attachments.
-- **Voice messages** — text-to-speech output is converted via ffmpeg into the native WhatsApp voice-note bubble (green waveform). Without ffmpeg installed, falls back to an MP3 audio attachment. See "Voice messages" below.
+- **Voice messages** — text-to-speech output can be sent directly as Ogg/Opus for native WhatsApp voice-note bubbles (green waveform). MP3/WAV output uses ffmpeg conversion when available and otherwise falls back to a regular audio attachment. See "Voice messages" below.
 - **Video / documents** — both supported, sent as native attachments.
 
 ### Interactive UX

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -336,6 +336,12 @@ WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND='voice stream --quiet --sample
 WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT=180
 ```
 
+Validate the installed command shape before a live call:
+
+```bash
+scripts/verify_voice_stream_tts.py --voice-bin /path/to/voice
+```
+
 Supported stream-command placeholders:
 
 | Placeholder | Meaning |

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -367,9 +367,12 @@ scripts/verify_voice_stream_tts.py --voice-bin /path/to/voice
 ```
 
 The verifier reads `/path/to/voice stream-contract`, validates the advertised
-`raw_outbound_pcm` / `raw_inbound_pcm` `voice_surfaces`, then runs the rendered
-stream command and checks stdout for non-silent 48 kHz mono 20 ms `pcm_s16le`
-frames.
+`streamed_voice_note`, `raw_outbound_pcm`, and `raw_inbound_pcm`
+`voice_surfaces`, then runs the rendered stream command and checks stdout for
+non-silent 48 kHz mono 20 ms `pcm_s16le` frames. It also runs
+`voice stream --output ... --format ogg-opus` and verifies the streamed file is
+real mono 48 kHz Ogg/Opus, so the low-latency daemon frame path and completed
+voice-note path are both covered without a WAV intermediate.
 
 Then validate the local WebRTC media bridge from a `voice` checkout before
 involving Meta's Graph API:

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -200,6 +200,41 @@ tts:
 
 With that shape Hermes asks `voice` for `.ogg` output up front, and the bridge sends it as a native voice note without a WAV or MP3 intermediate.
 
+After installing a local gateway service, verify the running process is using
+the expected voice-native checkout before relying on WhatsApp delivery:
+
+```bash
+scripts/verify_voice_live_gateway.py \
+  --live-hermes-root /path/to/hermes-agent \
+  --python-bin ~/.hermes/hermes-agent/venv/bin/python \
+  --hermes-home ~/.hermes \
+  --run-tts-smoke
+```
+
+The live verifier checks the systemd user service, confirms `PYTHONPATH` points
+at the expected checkout, confirms imports resolve from that checkout, checks
+the local bridge `/health` endpoint, and optionally generates one real
+WhatsApp-ready Ogg/Opus TTS file from the live config.
+
+For a temporary checkout-based deployment, add a systemd user-service drop-in
+that points the gateway at that checkout, then restart:
+
+```ini
+# ~/.config/systemd/user/hermes-gateway.service.d/voice-stack.conf
+[Service]
+Environment="PYTHONPATH=/path/to/hermes-agent"
+Environment="PATH=/path/to/hermes-agent/scripts/whatsapp-bridge/node_modules/.bin:/usr/bin:/home/you/.local/bin:/home/you/.cargo/bin:/usr/local/bin:/bin"
+```
+
+```bash
+systemctl --user daemon-reload
+systemctl --user restart hermes-gateway.service
+```
+
+Rollback is removing that drop-in, reloading systemd, and restarting the
+gateway. Run `verify_voice_live_gateway.py` after either deploy or rollback so
+you know which checkout the live process imported.
+
 ---
 
 ## Message Formatting & Delivery

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -172,7 +172,7 @@ with reconnection logic.
 Hermes supports voice on WhatsApp:
 
 - **Incoming:** Voice messages (`.ogg` opus) are automatically transcribed using the configured STT provider: local `faster-whisper`, Groq Whisper (`GROQ_API_KEY`), or OpenAI Whisper (`VOICE_TOOLS_OPENAI_KEY`)
-- **Outgoing:** TTS responses are sent as MP3 audio file attachments
+- **Outgoing:** TTS responses can be sent as native WhatsApp voice notes when the audio is Ogg/Opus. The bridge sends `.ogg` / `.opus` files with `ptt: true`; MP3/WAV outputs are converted with ffmpeg when possible and otherwise fall back to regular audio attachments.
 - Agent responses are prefixed with "⚕ **Hermes Agent**" by default. You can customize or disable this in `config.yaml`:
 
 ```yaml
@@ -181,6 +181,24 @@ whatsapp:
   reply_prefix: ""                          # Empty string disables the header
   # reply_prefix: "🤖 *My Bot*\n──────\n"  # Custom prefix (supports \n for newlines)
 ```
+
+For a local `voice` / Kokoro setup that writes WhatsApp-ready Ogg/Opus directly, configure a command TTS provider like this:
+
+```yaml
+tts:
+  provider: kokoro
+  providers:
+    kokoro:
+      type: command
+      command: /home/you/.local/bin/voice say --format ogg-opus --input-file {input_path} --output {output_path} --voice {voice} --speed {speed}
+      output_format: ogg
+      voice_compatible: true
+      voice: af_heart
+      speed: 1.0
+      timeout: 180
+```
+
+With that shape Hermes asks `voice` for `.ogg` output up front, and the bridge sends it as a native voice note without a WAV or MP3 intermediate.
 
 ---
 


### PR DESCRIPTION
## Summary

- add optional WhatsApp Cloud Calling sidecar config via `extra` and `WHATSAPP_CLOUD_CALLING_SIDECAR_*` env vars
- add a validated `/offer` client seam that posts `{call_id,type:"offer",sdp}` and returns a typed SDP answer
- route verified `field: "calls"` connect webhooks with `session.sdp_type: "offer"` into the sidecar
- send WhatsApp `pre_accept` and `accept` Graph `/calls` actions with the sidecar SDP answer
- close local sidecar sessions on verified WhatsApp call `terminate` webhooks
- expose sidecar configured state in the WhatsApp Cloud health payload without leaking the endpoint URL
- cover disabled, config/env, success, non-200, disconnected, malformed sidecar responses, Graph call actions, verified call connect webhooks, and terminate cleanup

## Verification

- `./.venv/bin/python -m pytest -q tests/gateway/test_whatsapp_cloud.py`
- `./.venv/bin/python -m pytest -q tests/hermes_cli/test_whatsapp_cloud_setup.py`
- `./.venv/bin/python -m ruff check gateway/platforms/whatsapp_cloud.py gateway/config.py tests/gateway/test_whatsapp_cloud.py`
- `git diff --check`

## Notes

This is the Hermes-side bridge for the `voice` WebRTC sidecar spike. It keeps behavior disabled unless `WHATSAPP_CLOUD_CALLING_SIDECAR_URL` or matching platform `extra` config is set. Full production call/session management still needs stronger telemetry, retry policy decisions, and a hardened media sidecar lifecycle.