### PR TITLE
Add OpenRouter Fusion support

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -474,6 +474,16 @@ def init_agent(
     agent.provider_require_parameters = provider_require_parameters
     agent.provider_data_collection = provider_data_collection
     agent.openrouter_min_coding_score = openrouter_min_coding_score
+    agent.openrouter_fusion_config = None
+    try:
+        from hermes_cli.config import load_config as _load_or_cfg
+
+        _or_cfg = (_load_or_cfg().get("openrouter") or {})
+        _fusion_cfg = _or_cfg.get("fusion")
+        if isinstance(_fusion_cfg, dict):
+            agent.openrouter_fusion_config = dict(_fusion_cfg)
+    except Exception:
+        pass
 
     # Store toolset filtering options
     agent.enabled_toolsets = enabled_toolsets

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -758,6 +758,7 @@ def build_api_kwargs(agent, api_messages: list) -> dict:
             # Context forwarded to profile hooks:
             provider_preferences=_prefs or None,
             openrouter_min_coding_score=agent.openrouter_min_coding_score,
+            openrouter_fusion=getattr(agent, "openrouter_fusion_config", None),
             anthropic_max_output=_ant_max,
             supports_reasoning=agent._supports_reasoning_extra_body(),
             qwen_session_metadata=_qwen_meta,

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -498,11 +498,24 @@ class ChatCompletionsTransport(ProviderTransport):
         if timeout is not None:
             api_kwargs["timeout"] = timeout
 
-        # Tools — apply Moonshot/Kimi schema sanitization regardless of path
+        # Tools — local Hermes functions plus optional provider-managed server
+        # tools. Only local function schemas go through Moonshot/Kimi schema
+        # sanitization; server tools are provider declarations, not JSON Schema
+        # functions Hermes will dispatch locally.
+        request_tools: list[dict[str, Any]] = []
         if tools:
+            local_tools = tools
             if is_moonshot_model(model):
-                tools = sanitize_moonshot_tools(tools)
-            api_kwargs["tools"] = tools
+                local_tools = sanitize_moonshot_tools(local_tools)
+            request_tools.extend(local_tools)
+        server_tools = profile.build_server_tools(
+            model=model,
+            openrouter_fusion=params.get("openrouter_fusion"),
+        )
+        if server_tools:
+            request_tools.extend(server_tools)
+        if request_tools:
+            api_kwargs["tools"] = request_tools
 
         # max_tokens resolution — priority: ephemeral > user > profile default
         max_tokens_fn = params.get("max_tokens_param_fn")
@@ -533,6 +546,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 model=model,
                 ollama_num_ctx=params.get("ollama_num_ctx"),
                 session_id=params.get("session_id"),
+                openrouter_fusion=params.get("openrouter_fusion"),
             )
         )
         api_kwargs.update(top_level_from_profile)
@@ -548,6 +562,7 @@ class ChatCompletionsTransport(ProviderTransport):
             base_url=params.get("base_url"),
             reasoning_config=reasoning_config,
             openrouter_min_coding_score=params.get("openrouter_min_coding_score"),
+            openrouter_fusion=params.get("openrouter_fusion"),
         )
         if profile_body:
             extra_body.update(profile_body)

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -503,17 +503,21 @@ class ChatCompletionsTransport(ProviderTransport):
         # sanitization; server tools are provider declarations, not JSON Schema
         # functions Hermes will dispatch locally.
         request_tools: list[dict[str, Any]] = []
-        if tools:
-            local_tools = tools
-            if is_moonshot_model(model):
-                local_tools = sanitize_moonshot_tools(local_tools)
-            request_tools.extend(local_tools)
         server_tools = profile.build_server_tools(
             model=model,
             openrouter_fusion=params.get("openrouter_fusion"),
         )
-        if server_tools:
-            request_tools.extend(server_tools)
+        if isinstance(server_tools, list):
+            from providers.base import ProviderServerTools
+
+            server_tools = ProviderServerTools(tools=server_tools)
+        if tools and not server_tools.replace_local_tools:
+            local_tools = tools
+            if is_moonshot_model(model):
+                local_tools = sanitize_moonshot_tools(local_tools)
+            request_tools.extend(local_tools)
+        if server_tools.tools:
+            request_tools.extend(server_tools.tools)
         if request_tools:
             api_kwargs["tools"] = request_tools
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12210,6 +12210,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ("compression", "protect_last_n"),
         ("agent", "disabled_toolsets"),
         ("memory", "provider"),
+        ("openrouter", "fusion"),
     )
 
     _HONCHO_CACHE_BUSTING_KEYS = (

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1196,10 +1196,28 @@ DEFAULT_CONFIG = {
     #   pick the strongest available coder (router's documented default
     #   when the plugins block is omitted).
     #   See: https://openrouter.ai/docs/guides/routing/routers/pareto-router
+    # fusion: enable OpenRouter Fusion server-side model collaboration.
+    #   When enabled, Hermes appends the `openrouter:fusion` server tool to
+    #   OpenRouter chat-completions requests. `force: true` sets
+    #   `tool_choice: required` so Fusion is used for every eligible request.
+    #   Leave analysis_models empty to let OpenRouter choose the analysis
+    #   panel. The router model `openrouter/fusion` also works through the
+    #   normal model setting.
+    #   See: https://openrouter.ai/docs/features/fusion
     "openrouter": {
         "response_cache": True,
         "response_cache_ttl": 300,
         "min_coding_score": 0.65,
+        "fusion": {
+            "enabled": False,
+            "force": False,
+            "analysis_models": [],
+            "judge_model": "",
+            "max_tool_calls": None,
+            "max_completion_tokens": None,
+            "reasoning": {},
+            "temperature": None,
+        },
     },
 
     # AWS Bedrock provider configuration.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1198,11 +1198,12 @@ DEFAULT_CONFIG = {
     #   See: https://openrouter.ai/docs/guides/routing/routers/pareto-router
     # fusion: enable OpenRouter Fusion server-side model collaboration.
     #   When enabled, Hermes appends the `openrouter:fusion` server tool to
-    #   OpenRouter chat-completions requests. `force: true` sets
-    #   `tool_choice: required` so Fusion is used for every eligible request.
-    #   Leave analysis_models empty to let OpenRouter choose the analysis
-    #   panel. The router model `openrouter/fusion` also works through the
-    #   normal model setting.
+    #   OpenRouter chat-completions requests. `force: true` sends Fusion as
+    #   the only request tool and sets `tool_choice: required`; this guarantees
+    #   Fusion is selected, but local Hermes tools are unavailable for that
+    #   request. Leave analysis_models empty to let OpenRouter choose the
+    #   analysis panel. The router model `openrouter/fusion` also works
+    #   through the normal model setting.
     #   See: https://openrouter.ai/docs/features/fusion
     "openrouter": {
         "response_cache": True,

--- a/plugins/model-providers/openrouter/__init__.py
+++ b/plugins/model-providers/openrouter/__init__.py
@@ -44,6 +44,113 @@ def _anthropic_reasoning_is_mandatory(model: str | None) -> bool:
     return not any(sub in m for sub in _ANTHROPIC_REASONING_OPTIONAL_SUBSTRINGS)
 
 
+def _coerce_bool(value: Any, *, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on", "enabled"}:
+            return True
+        if normalized in {"0", "false", "no", "off", "disabled"}:
+            return False
+    return bool(value)
+
+
+def _positive_int(value: Any, *, max_value: int | None = None) -> int | None:
+    if value in {None, ""}:
+        return None
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError):
+        return None
+    if coerced <= 0:
+        return None
+    if max_value is not None and coerced > max_value:
+        return None
+    return coerced
+
+
+def _coerce_temperature(value: Any) -> float | None:
+    if value in {None, ""}:
+        return None
+    try:
+        coerced = float(value)
+    except (TypeError, ValueError):
+        return None
+    # OpenRouter forwards to many upstreams; keep the common OpenAI-compatible
+    # range so Hermes never sends clearly invalid Fusion judge temperatures.
+    if 0.0 <= coerced <= 2.0:
+        return coerced
+    return None
+
+
+def _coerce_model_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        items = [item.strip() for item in value.split(",")]
+    elif isinstance(value, (list, tuple)):
+        items = [str(item).strip() for item in value]
+    else:
+        return []
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in items:
+        if item and item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result[:8]
+
+
+def normalize_fusion_config(value: Any) -> dict[str, Any] | None:
+    """Validate ``openrouter.fusion`` into OpenRouter's Fusion tool shape.
+
+    The supported config mirrors OpenRouter's ``openrouter:fusion`` server
+    tool parameters: analysis model panel, judge model, tool-call budget,
+    judge completion budget, reasoning config, and judge temperature.
+    Invalid optional values are dropped locally.
+    """
+    if not isinstance(value, dict):
+        return None
+
+    if not _coerce_bool(value.get("enabled"), default=False):
+        return None
+
+    parameters: dict[str, Any] = {}
+    analysis_models = _coerce_model_list(value.get("analysis_models"))
+    if analysis_models:
+        parameters["analysis_models"] = analysis_models
+
+    judge = value.get("judge")
+    if isinstance(judge, dict):
+        judge_model = str(judge.get("model") or "").strip()
+    else:
+        judge_model = str(value.get("judge_model") or value.get("model") or "").strip()
+    if judge_model:
+        parameters["model"] = judge_model
+
+    coerced = _positive_int(value.get("max_tool_calls"), max_value=16)
+    if coerced is not None:
+        parameters["max_tool_calls"] = coerced
+
+    coerced = _positive_int(value.get("max_completion_tokens"))
+    if coerced is not None:
+        parameters["max_completion_tokens"] = coerced
+
+    reasoning = value.get("reasoning")
+    if isinstance(reasoning, dict) and reasoning:
+        parameters["reasoning"] = dict(reasoning)
+
+    temperature = _coerce_temperature(value.get("temperature"))
+    if temperature is not None:
+        parameters["temperature"] = temperature
+
+    return {
+        "tool": {"type": "openrouter:fusion", "parameters": parameters},
+        "tool_choice": "required" if _coerce_bool(value.get("force"), default=False) else None,
+    }
+
+
 class OpenRouterProfile(ProviderProfile):
     """OpenRouter aggregator — provider preferences, reasoning config passthrough."""
 
@@ -98,7 +205,16 @@ class OpenRouterProfile(ProviderProfile):
                     body["plugins"] = [
                         {"id": "pareto-router", "min_coding_score": score_f}
                     ]
+
         return body
+
+    def build_server_tools(
+        self, *, model: str | None = None, **context: Any
+    ) -> list[dict[str, Any]]:
+        fusion = normalize_fusion_config(context.get("openrouter_fusion"))
+        if not fusion:
+            return []
+        return [fusion["tool"]]
 
     def build_api_kwargs_extras(
         self,
@@ -162,6 +278,10 @@ class OpenRouterProfile(ProviderProfile):
             extra_headers["x-grok-conv-id"] = session_id
         if extra_headers:
             top_level["extra_headers"] = extra_headers
+
+        fusion = normalize_fusion_config(context.get("openrouter_fusion"))
+        if fusion and fusion.get("tool_choice"):
+            top_level["tool_choice"] = fusion["tool_choice"]
 
         return extra_body, top_level
 

--- a/plugins/model-providers/openrouter/__init__.py
+++ b/plugins/model-providers/openrouter/__init__.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any
 
 from providers import register_provider
-from providers.base import ProviderProfile
+from providers.base import ProviderProfile, ProviderServerTools
 
 logger = logging.getLogger(__name__)
 
@@ -148,6 +148,7 @@ def normalize_fusion_config(value: Any) -> dict[str, Any] | None:
     return {
         "tool": {"type": "openrouter:fusion", "parameters": parameters},
         "tool_choice": "required" if _coerce_bool(value.get("force"), default=False) else None,
+        "replace_local_tools": _coerce_bool(value.get("force"), default=False),
     }
 
 
@@ -210,11 +211,14 @@ class OpenRouterProfile(ProviderProfile):
 
     def build_server_tools(
         self, *, model: str | None = None, **context: Any
-    ) -> list[dict[str, Any]]:
+    ) -> ProviderServerTools:
         fusion = normalize_fusion_config(context.get("openrouter_fusion"))
         if not fusion:
-            return []
-        return [fusion["tool"]]
+            return ProviderServerTools()
+        return ProviderServerTools(
+            tools=[fusion["tool"]],
+            replace_local_tools=bool(fusion.get("replace_local_tools")),
+        )
 
     def build_api_kwargs_extras(
         self,

--- a/providers/base.py
+++ b/providers/base.py
@@ -145,6 +145,19 @@ class ProviderProfile:
         """
         return {}, {}
 
+    def build_server_tools(
+        self, *, model: str | None = None, **context: Any
+    ) -> list[dict[str, Any]]:
+        """Return provider-managed tools to append to the request.
+
+        OpenAI-compatible providers increasingly expose server-side tools that
+        are declared in the same ``tools`` array as local function tools, but
+        are executed by the provider rather than by Hermes. Provider profiles
+        own those declarations so the agent loop can continue dispatching only
+        local function tool calls.
+        """
+        return []
+
     def get_max_tokens(self, model: str | None) -> int | None:
         """Return the default max_tokens cap for *model*.
 

--- a/providers/base.py
+++ b/providers/base.py
@@ -21,6 +21,14 @@ logger = logging.getLogger(__name__)
 OMIT_TEMPERATURE = object()
 
 
+@dataclass(frozen=True)
+class ProviderServerTools:
+    """Provider-managed tool declarations for Chat Completions requests."""
+
+    tools: list[dict[str, Any]] = field(default_factory=list)
+    replace_local_tools: bool = False
+
+
 def _profile_user_agent() -> str:
     """Return a ``hermes-cli/<version>`` UA string, with a stable fallback.
 
@@ -147,7 +155,7 @@ class ProviderProfile:
 
     def build_server_tools(
         self, *, model: str | None = None, **context: Any
-    ) -> list[dict[str, Any]]:
+    ) -> ProviderServerTools:
         """Return provider-managed tools to append to the request.
 
         OpenAI-compatible providers increasingly expose server-side tools that
@@ -156,7 +164,7 @@ class ProviderProfile:
         own those declarations so the agent loop can continue dispatching only
         local function tool calls.
         """
-        return []
+        return ProviderServerTools()
 
     def get_max_tokens(self, model: str | None) -> int | None:
         """Return the default max_tokens cap for *model*.

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -236,8 +236,8 @@ class TestChatCompletionsBuildKwargs:
             {"id": "pareto-router", "min_coding_score": 0.8}
         ]
 
-    def test_openrouter_fusion_appends_server_tool(self, transport):
-        """Fusion is a provider-managed server tool, not a local function."""
+    def test_openrouter_fusion_force_replaces_local_tools(self, transport):
+        """Forced Fusion must be the selected tool, not just any tool."""
         from providers import get_provider_profile
         profile = get_provider_profile("openrouter")
         msgs = [{"role": "user", "content": "Hi"}]
@@ -258,7 +258,6 @@ class TestChatCompletionsBuildKwargs:
             },
         )
         assert kw["tools"] == [
-            local_tool,
             {
                 "type": "openrouter:fusion",
                 "parameters": {
@@ -273,6 +272,27 @@ class TestChatCompletionsBuildKwargs:
         assert kw["tool_choice"] == "required"
         assert "plugins" not in kw.get("extra_body", {})
 
+    def test_openrouter_fusion_appends_server_tool_without_force(self, transport):
+        """Non-forced Fusion can coexist with local Hermes tools."""
+        from providers import get_provider_profile
+        profile = get_provider_profile("openrouter")
+        local_tool = {
+            "type": "function",
+            "function": {"name": "local_search", "parameters": {}},
+        }
+        kw = transport.build_kwargs(
+            model="anthropic/claude-sonnet-4.6",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[local_tool],
+            provider_profile=profile,
+            openrouter_fusion={"enabled": True},
+        )
+        assert kw["tools"] == [
+            local_tool,
+            {"type": "openrouter:fusion", "parameters": {}},
+        ]
+        assert "tool_choice" not in kw
+
     def test_openrouter_fusion_without_force_omits_tool_choice(self, transport):
         from providers import get_provider_profile
         profile = get_provider_profile("openrouter")
@@ -284,6 +304,20 @@ class TestChatCompletionsBuildKwargs:
         )
         assert kw["tools"] == [{"type": "openrouter:fusion", "parameters": {}}]
         assert "tool_choice" not in kw
+
+    def test_provider_server_tools_accepts_legacy_list_return(self, transport):
+        from providers.base import ProviderProfile
+
+        class LegacyServerToolProfile(ProviderProfile):
+            def build_server_tools(self, **_context):
+                return [{"type": "provider:server-tool", "parameters": {}}]
+
+        kw = transport.build_kwargs(
+            model="test/model",
+            messages=[{"role": "user", "content": "Hi"}],
+            provider_profile=LegacyServerToolProfile(name="legacy"),
+        )
+        assert kw["tools"] == [{"type": "provider:server-tool", "parameters": {}}]
 
     def test_nous_tags(self, transport):
         from agent.portal_tags import nous_portal_tags

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -236,6 +236,55 @@ class TestChatCompletionsBuildKwargs:
             {"id": "pareto-router", "min_coding_score": 0.8}
         ]
 
+    def test_openrouter_fusion_appends_server_tool(self, transport):
+        """Fusion is a provider-managed server tool, not a local function."""
+        from providers import get_provider_profile
+        profile = get_provider_profile("openrouter")
+        msgs = [{"role": "user", "content": "Hi"}]
+        local_tool = {
+            "type": "function",
+            "function": {"name": "local_search", "parameters": {}},
+        }
+        kw = transport.build_kwargs(
+            model="anthropic/claude-sonnet-4.6",
+            messages=msgs,
+            tools=[local_tool],
+            provider_profile=profile,
+            openrouter_fusion={
+                "enabled": True,
+                "analysis_models": "openai/gpt-5-mini, anthropic/claude-sonnet-4.6",
+                "judge": {"model": "openai/gpt-5.4"},
+                "force": True,
+            },
+        )
+        assert kw["tools"] == [
+            local_tool,
+            {
+                "type": "openrouter:fusion",
+                "parameters": {
+                    "analysis_models": [
+                        "openai/gpt-5-mini",
+                        "anthropic/claude-sonnet-4.6",
+                    ],
+                    "model": "openai/gpt-5.4",
+                },
+            },
+        ]
+        assert kw["tool_choice"] == "required"
+        assert "plugins" not in kw.get("extra_body", {})
+
+    def test_openrouter_fusion_without_force_omits_tool_choice(self, transport):
+        from providers import get_provider_profile
+        profile = get_provider_profile("openrouter")
+        kw = transport.build_kwargs(
+            model="anthropic/claude-sonnet-4.6",
+            messages=[{"role": "user", "content": "Hi"}],
+            provider_profile=profile,
+            openrouter_fusion={"enabled": True},
+        )
+        assert kw["tools"] == [{"type": "openrouter:fusion", "parameters": {}}]
+        assert "tool_choice" not in kw
+
     def test_nous_tags(self, transport):
         from agent.portal_tags import nous_portal_tags
         from providers import get_provider_profile

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -152,6 +152,75 @@ class TestOpenRouterProfile:
             )
             assert "plugins" not in body, f"bad={bad!r}"
 
+    def test_fusion_disabled_omits_server_tool(self):
+        p = get_provider_profile("openrouter")
+        cfg = {"enabled": False, "analysis_models": ["openai/gpt-5-mini"]}
+        assert p.build_extra_body(openrouter_fusion=cfg) == {}
+        assert p.build_server_tools(openrouter_fusion=cfg) == []
+
+    def test_fusion_config_emits_server_tool(self):
+        p = get_provider_profile("openrouter")
+        cfg = {
+            "enabled": True,
+            "analysis_models": ["openai/gpt-5-mini", "anthropic/claude-sonnet-4.6"],
+            "judge_model": "openai/gpt-5.4",
+            "max_tool_calls": "3",
+            "max_completion_tokens": 1024,
+            "reasoning": {"effort": "high"},
+            "temperature": "0.2",
+        }
+        assert p.build_extra_body(openrouter_fusion=cfg) == {}
+        assert p.build_server_tools(openrouter_fusion=cfg) == [
+            {
+                "type": "openrouter:fusion",
+                "parameters": {
+                    "analysis_models": [
+                        "openai/gpt-5-mini",
+                        "anthropic/claude-sonnet-4.6",
+                    ],
+                    "model": "openai/gpt-5.4",
+                    "max_tool_calls": 3,
+                    "max_completion_tokens": 1024,
+                    "reasoning": {"effort": "high"},
+                    "temperature": 0.2,
+                },
+            }
+        ]
+
+    def test_fusion_config_drops_invalid_optional_values(self):
+        p = get_provider_profile("openrouter")
+        cfg = {
+            "enabled": "yes",
+            "analysis_models": [f"provider/model-{idx}" for idx in range(10)],
+            "max_tool_calls": 17,
+            "max_completion_tokens": 0,
+            "temperature": 2.5,
+        }
+        assert p.build_server_tools(openrouter_fusion=cfg) == [
+            {
+                "type": "openrouter:fusion",
+                "parameters": {
+                    "analysis_models": [f"provider/model-{idx}" for idx in range(8)]
+                },
+            }
+        ]
+
+    def test_fusion_force_sets_tool_choice_required(self):
+        p = get_provider_profile("openrouter")
+        _extra_body, top_level = p.build_api_kwargs_extras(
+            openrouter_fusion={"enabled": True, "force": True},
+        )
+        assert top_level["tool_choice"] == "required"
+
+    def test_fusion_does_not_append_to_pareto_plugin(self):
+        p = get_provider_profile("openrouter")
+        body = p.build_extra_body(
+            model="openrouter/pareto-code",
+            openrouter_min_coding_score=0.65,
+            openrouter_fusion={"enabled": True},
+        )
+        assert body["plugins"] == [{"id": "pareto-router", "min_coding_score": 0.65}]
+
     def test_reasoning_full_config(self):
         p = get_provider_profile("openrouter")
         eb, _ = p.build_api_kwargs_extras(

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -156,7 +156,9 @@ class TestOpenRouterProfile:
         p = get_provider_profile("openrouter")
         cfg = {"enabled": False, "analysis_models": ["openai/gpt-5-mini"]}
         assert p.build_extra_body(openrouter_fusion=cfg) == {}
-        assert p.build_server_tools(openrouter_fusion=cfg) == []
+        server_tools = p.build_server_tools(openrouter_fusion=cfg)
+        assert server_tools.tools == []
+        assert server_tools.replace_local_tools is False
 
     def test_fusion_config_emits_server_tool(self):
         p = get_provider_profile("openrouter")
@@ -170,7 +172,8 @@ class TestOpenRouterProfile:
             "temperature": "0.2",
         }
         assert p.build_extra_body(openrouter_fusion=cfg) == {}
-        assert p.build_server_tools(openrouter_fusion=cfg) == [
+        server_tools = p.build_server_tools(openrouter_fusion=cfg)
+        assert server_tools.tools == [
             {
                 "type": "openrouter:fusion",
                 "parameters": {
@@ -186,6 +189,7 @@ class TestOpenRouterProfile:
                 },
             }
         ]
+        assert server_tools.replace_local_tools is False
 
     def test_fusion_config_drops_invalid_optional_values(self):
         p = get_provider_profile("openrouter")
@@ -196,7 +200,8 @@ class TestOpenRouterProfile:
             "max_completion_tokens": 0,
             "temperature": 2.5,
         }
-        assert p.build_server_tools(openrouter_fusion=cfg) == [
+        server_tools = p.build_server_tools(openrouter_fusion=cfg)
+        assert server_tools.tools == [
             {
                 "type": "openrouter:fusion",
                 "parameters": {
@@ -204,6 +209,15 @@ class TestOpenRouterProfile:
                 },
             }
         ]
+        assert server_tools.replace_local_tools is False
+
+    def test_fusion_force_replaces_local_tools(self):
+        p = get_provider_profile("openrouter")
+        server_tools = p.build_server_tools(
+            openrouter_fusion={"enabled": True, "force": True},
+        )
+        assert server_tools.tools == [{"type": "openrouter:fusion", "parameters": {}}]
+        assert server_tools.replace_local_tools is True
 
     def test_fusion_force_sets_tool_choice_required(self):
         p = get_provider_profile("openrouter")

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -1087,6 +1087,21 @@ class TestProviderRouting:
         kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
         assert kwargs["extra_body"]["provider"]["only"] == ["anthropic", "google"]
 
+    def test_fusion_config_reaches_openrouter_kwargs(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "openrouter")
+        agent.openrouter_fusion_config = {
+            "enabled": True,
+            "analysis_models": ["openai/gpt-5-mini"],
+            "force": True,
+        }
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+        assert kwargs["tools"][-1] == {
+            "type": "openrouter:fusion",
+            "parameters": {"analysis_models": ["openai/gpt-5-mini"]},
+        }
+        assert "plugins" not in kwargs.get("extra_body", {})
+        assert kwargs["tool_choice"] == "required"
+
     def test_ignore_providers(self, monkeypatch):
         agent = _make_agent(monkeypatch, "openrouter")
         agent.providers_ignored = ["deepinfra"]

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1477,6 +1477,79 @@ provider_routing:
 
 **Shortcuts:** Append `:nitro` to any model name for throughput sorting (e.g., `anthropic/claude-sonnet-4:nitro`), or `:floor` for price sorting.
 
+## OpenRouter Fusion
+
+[OpenRouter Fusion](https://openrouter.ai/docs/features/fusion) lets OpenRouter coordinate multiple analysis models and use a judge model to produce the final answer. Hermes exposes Fusion through the OpenRouter provider; it uses your existing `OPENROUTER_API_KEY` and does not require a separate Hermes tool.
+
+To make Fusion available on normal OpenRouter chat requests, enable it in `~/.hermes/config.yaml`:
+
+```yaml
+model:
+  provider: openrouter
+  model: anthropic/claude-sonnet-4.6
+
+openrouter:
+  fusion:
+    enabled: true
+```
+
+With that setting, Hermes appends OpenRouter's `openrouter:fusion` server tool to the request. OpenRouter and the selected model can decide when to use it, and normal Hermes local tools remain available.
+
+You can also pin the analysis panel and judge settings:
+
+```yaml
+openrouter:
+  fusion:
+    enabled: true
+    analysis_models:
+      - openai/gpt-5-mini
+      - anthropic/claude-sonnet-4.6
+    judge_model: openai/gpt-5.4
+    max_tool_calls: 3
+    max_completion_tokens: 1024
+    reasoning:
+      effort: high
+    temperature: 0.2
+```
+
+Supported keys:
+
+| Key | Meaning |
+|-----|---------|
+| `enabled` | Add the `openrouter:fusion` server tool to OpenRouter chat-completions requests. |
+| `force` | Require Fusion for the request. See the note below. |
+| `analysis_models` | Up to 8 model IDs for Fusion's analysis panel. Leave empty to let OpenRouter choose. |
+| `judge_model` | Judge/final model sent as Fusion's `model` parameter. |
+| `max_tool_calls` | Maximum Fusion tool calls, capped by Hermes at 16. |
+| `max_completion_tokens` | Completion-token budget for the judge model. |
+| `reasoning` | Reasoning object forwarded to the judge model, such as `{effort: high}`. |
+| `temperature` | Judge-model temperature; Hermes forwards values from 0 through 2. |
+
+:::warning Forced Fusion disables local tools for that request
+OpenRouter documents `tool_choice: "required"` as "choose some tool" when more than one tool is present. To guarantee Fusion is the chosen tool, Hermes sends Fusion as the **only** request tool when `openrouter.fusion.force: true` is set. That means local Hermes tools, MCP tools, and built-in function tools are unavailable for that request.
+
+Use forced mode when you want every eligible turn to go through Fusion:
+
+```yaml
+openrouter:
+  fusion:
+    enabled: true
+    force: true
+```
+
+Leave `force` off when you want Fusion to coexist with normal Hermes tool use.
+:::
+
+OpenRouter also exposes a router model named `openrouter/fusion`. You can select it like any other OpenRouter model:
+
+```yaml
+model:
+  provider: openrouter
+  model: openrouter/fusion
+```
+
+Use `openrouter/fusion` when you want Fusion as the model route itself. Use `openrouter.fusion.enabled` when you want to add Fusion as a server-side option while using another OpenRouter model.
+
 ## OpenRouter Pareto Code Router
 
 OpenRouter ships an experimental coding-model router at `openrouter/pareto-code` that auto-routes requests to the cheapest model meeting a coding-quality bar (ranked by [Artificial Analysis](https://artificialanalysis.ai/)). Pick this model and tune the `min_coding_score` knob in `~/.hermes/config.yaml`:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -997,6 +997,54 @@ auxiliary:
 
 The shape mirrors what OpenRouter accepts in the chat completions request body. Hermes forwards the entire `extra_body` verbatim, so any other OpenRouter request-body field documented at [openrouter.ai/docs](https://openrouter.ai/docs) works the same way.
 
+### OpenRouter Fusion for the main agent
+
+When your main model provider is OpenRouter, Hermes can add OpenRouter's Fusion server tool to each chat-completions request. Fusion lets OpenRouter coordinate multiple analysis models and judge the final answer server-side.
+
+Minimal config:
+
+```yaml
+model:
+  provider: openrouter
+  model: anthropic/claude-sonnet-4.6
+
+openrouter:
+  fusion:
+    enabled: true
+```
+
+Optional tuning:
+
+```yaml
+openrouter:
+  fusion:
+    enabled: true
+    analysis_models:
+      - openai/gpt-5-mini
+      - anthropic/claude-sonnet-4.6
+    judge_model: openai/gpt-5.4
+    max_tool_calls: 3
+    max_completion_tokens: 1024
+    reasoning:
+      effort: high
+    temperature: 0.2
+```
+
+Set `force: true` to require Fusion on every eligible request:
+
+```yaml
+openrouter:
+  fusion:
+    enabled: true
+    force: true
+```
+
+Forced Fusion has an important tradeoff: Hermes sends Fusion as the only request tool so OpenRouter must choose it. Local Hermes tools, MCP tools, and built-in function tools are unavailable for that request. Leave `force` off when you want Fusion to coexist with normal tool use.
+
+This top-level `openrouter.fusion` config applies to the main agent. It does not automatically propagate into auxiliary model calls. For auxiliary tasks that use OpenRouter, configure OpenRouter request-body behavior under that task's `extra_body` if needed.
+
+For the full Fusion option reference, see [OpenRouter Fusion](/integrations/providers#openrouter-fusion).
+
 ### Changing the Vision Model
 
 To use GPT-4o instead of Gemini Flash for image analysis:


### PR DESCRIPTION
## Summary
- add OpenRouter Fusion as a provider-managed server tool for chat-completions requests
- wire `openrouter.fusion` config through the agent and OpenRouter provider profile
- make `force: true` send Fusion as the only request tool so OpenRouter must choose Fusion instead of a local Hermes tool
- document Fusion setup, tuning options, forced-mode tradeoff, and the `openrouter/fusion` router model

## Verification
- `HERMES_HOME=/tmp/hermes-fusion-clean-test /Users/kenny.rogers/.hermes/hermes-agent/venv/bin/python -m pytest tests/providers/test_provider_profiles.py tests/agent/transports/test_chat_completions.py tests/run_agent/test_provider_parity.py -q`
- `scripts/run_tests.sh tests/providers/test_provider_profiles.py tests/agent/transports/test_chat_completions.py tests/run_agent/test_provider_parity.py`
- live OpenRouter request with `openrouter:fusion` server tool returned HTTP 200 and `fusion-ok`
- live OpenRouter forced-exclusive request returned HTTP 200 and `fusion-force-ok`
- `git diff --check FETCH_HEAD...HEAD -- website/docs/integrations/providers.md website/docs/user-guide/configuration.md`

## Not run
- Docusaurus build/typecheck; `website/node_modules` was not installed locally.