### PR TITLE
fix(codex): refresh OAuth tokens earlier

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -95,7 +95,13 @@ STEPFUN_STEP_PLAN_INTL_BASE_URL = "https://api.stepfun.ai/step_plan/v1"
 STEPFUN_STEP_PLAN_CN_BASE_URL = "https://api.stepfun.com/step_plan/v1"
 CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
-CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
+# Refresh Codex OAuth access tokens well before expiry.  Two minutes was too
+# close for long gateway/agent turns: a request can begin with a token that is
+# technically valid and then cross expiry while streaming/tool-calling.  Refresh
+# about a day and a half early so desktop/gateway downtime does not leave
+# long-lived setups waiting until the last few minutes before rotating a
+# 10-day ChatGPT token.
+CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 36 * 60 * 60
 XAI_OAUTH_ISSUER = "https://auth.x.ai"
 XAI_OAUTH_DISCOVERY_URL = f"{XAI_OAUTH_ISSUER}/.well-known/openid-configuration"
 XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828"

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -10,6 +10,7 @@ import pytest
 
 from hermes_cli.auth import (
     AuthError,
+    CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
     DEFAULT_CODEX_BASE_URL,
     PROVIDER_REGISTRY,
     _read_codex_tokens,
@@ -20,6 +21,12 @@ from hermes_cli.auth import (
     resolve_codex_runtime_credentials,
     resolve_provider,
 )
+
+
+def test_codex_oauth_refresh_skew_is_large_enough_for_long_agent_turns():
+    """Codex OAuth should refresh long before a token can expire mid-turn."""
+
+    assert CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS == 36 * 60 * 60
 
 
 def _setup_hermes_auth(hermes_home: Path, *, access_token: str = "access", refresh_token: str = "refresh"):


### PR DESCRIPTION
## Summary
- Refresh Codex OAuth access tokens 36 hours before expiry instead of waiting until the last few minutes.
- Add a regression test documenting that the skew is large enough for long-running agent/gateway turns.

## Why
A request can start with a technically-valid access token and cross expiry during long streaming/tool-calling turns. Refreshing earlier keeps unattended gateway and worker sessions from hitting avoidable mid-turn auth failures while still using the normal refresh-token path.

## Tests
- `python -m pytest tests/hermes_cli/test_auth_codex_provider.py -q -o 'addopts='`
- `gitleaks git --log-opts='origin/main..HEAD' --no-banner --redact`
- `git diff --check origin/main..HEAD`

## Safety review
- gpt-worker-2: PASS.
- epistula: PASS; no private-path/secret/customer/family markers in diff-only scan.
