### PR TITLE
fix(gateway): reduce Discord noise and harden recovery

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -43,6 +43,7 @@ Payment / credit exhaustion fallback:
 import json
 import logging
 import os
+import queue
 import threading
 import time
 from pathlib import Path  # noqa: F401 — used by test mocks
@@ -767,14 +768,17 @@ class _CodexCompletionsAdapter:
             if converted:
                 resp_kwargs["tools"] = converted
 
-        # Stream and collect the response
-        text_parts: List[str] = []
-        tool_calls_raw: List[Any] = []
-        usage = None
+        # Stream and collect the response.  The OpenAI SDK's Responses stream
+        # can block before yielding the first event (or while entering the
+        # context manager), so checking a deadline *inside* the iterator is not
+        # enough.  When the caller supplies a timeout, run the blocking stream
+        # in a daemon worker and join it from here.  This preserves the
+        # chat.completions timeout contract for gateway-side auxiliary tasks:
+        # a stuck Codex compression call should raise and let the main turn keep
+        # moving, not hold the Discord worker until systemd/watchdogs intervene.
         total_timeout = timeout if isinstance(timeout, (int, float)) and timeout > 0 else None
         deadline = time.monotonic() + float(total_timeout) if total_timeout else None
         timed_out = threading.Event()
-        timeout_timer: Optional[threading.Timer] = None
 
         def _timeout_message() -> str:
             return f"Codex auxiliary Responses stream exceeded {float(total_timeout):.1f}s total timeout"
@@ -814,11 +818,10 @@ class _CodexCompletionsAdapter:
                 # new failure mode for auxiliary calls.
                 pass
 
-        try:
-            if total_timeout:
-                timeout_timer = threading.Timer(float(total_timeout), _close_client_on_timeout)
-                timeout_timer.daemon = True
-                timeout_timer.start()
+        def _stream_and_collect() -> Tuple[List[str], List[Any], Any]:
+            text_parts: List[str] = []
+            tool_calls_raw: List[Any] = []
+            usage = None
             _check_cancelled()
 
             # Event-driven Responses streaming via the low-level
@@ -895,14 +898,46 @@ class _CodexCompletionsAdapter:
                     total_tokens=getattr(resp_usage, "total_tokens", 0)
                         or (resp_usage.get("total_tokens", 0) if isinstance(resp_usage, dict) else 0),
                 )
+            return text_parts, tool_calls_raw, usage
+
+        try:
+            if total_timeout:
+                result_queue: "queue.Queue[Tuple[str, Any]]" = queue.Queue(maxsize=1)
+
+                def _worker() -> None:
+                    try:
+                        result_queue.put(("ok", _stream_and_collect()))
+                    except BaseException as exc:  # propagate worker failures below
+                        result_queue.put(("err", exc))
+
+                worker = threading.Thread(
+                    target=_worker,
+                    name="codex-auxiliary-stream",
+                    daemon=True,
+                )
+                worker.start()
+                worker.join(float(total_timeout))
+                if worker.is_alive():
+                    _close_client_on_timeout()
+                    raise TimeoutError(_timeout_message())
+                try:
+                    status, payload = result_queue.get_nowait()
+                except queue.Empty:
+                    _close_client_on_timeout()
+                    raise TimeoutError(_timeout_message())
+                if status == "err":
+                    if timed_out.is_set():
+                        raise TimeoutError(_timeout_message()) from payload
+                    logger.debug("Codex auxiliary Responses API call failed: %s", payload)
+                    raise payload
+                text_parts, tool_calls_raw, usage = payload
+            else:
+                text_parts, tool_calls_raw, usage = _stream_and_collect()
         except Exception as exc:
-            if timed_out.is_set():
+            if timed_out.is_set() and not isinstance(exc, TimeoutError):
                 raise TimeoutError(_timeout_message()) from exc
             logger.debug("Codex auxiliary Responses API call failed: %s", exc)
             raise
-        finally:
-            if timeout_timer is not None:
-                timeout_timer.cancel()
 
         content = "".join(text_parts).strip() or None
 
@@ -5431,32 +5466,30 @@ def call_llm(
         # When the provider returns a 429 rate-limit (not billing), fall
         # back to an alternative provider instead of exhausting retries
         # against the same rate-limited endpoint.
-        should_fallback = (
-            _is_payment_error(first_err)
-            or _is_connection_error(first_err)
-            or _is_rate_limit_error(first_err)
-        )
-        # Respect explicit provider choice for transient errors (auth, request
-        # validation, etc.) but allow fallback when the provider clearly cannot
-        # serve the request due to capacity: payment/quota exhaustion and
-        # connection failures are capacity problems, not request constraints.
-        # See #26803: daily token quota (429 + "too many tokens per day") must
-        # fall back just like a 402 credit error.
+        is_payment_error = _is_payment_error(first_err)
+        is_connection_error = _is_connection_error(first_err)
+        is_rate_limit_error = _is_rate_limit_error(first_err)
+        should_fallback = is_payment_error or is_connection_error or is_rate_limit_error
+
+        if is_connection_error:
+            try:
+                _evict_cached_clients(resolved_provider or "auto")
+            except Exception:
+                logger.debug(
+                    "Auxiliary %s: failed to evict cached client after connection error",
+                    task or "call",
+                    exc_info=True,
+                )
+
         is_auto = resolved_provider in {"auto", "", None}
-        # Capacity errors bypass the explicit-provider gate: the provider
-        # literally cannot serve this request regardless of user intent.
-        is_capacity_error = _is_payment_error(first_err) or _is_connection_error(first_err)
+        is_capacity_error = is_payment_error or is_connection_error
         if should_fallback and (is_auto or is_capacity_error):
-            if _is_payment_error(first_err):
+            if is_payment_error:
                 reason = "payment error"
-                # Resolve the actual provider label (resolved_provider may be
-                # "auto"; the client's base_url tells us which backend got the
-                # 402). Mark THAT label unhealthy so subsequent aux calls
-                # skip it instead of paying another doomed RTT.
                 _mark_provider_unhealthy(
                     _recoverable_pool_provider(resolved_provider, client, main_runtime=main_runtime) or resolved_provider
                 )
-            elif _is_rate_limit_error(first_err):
+            elif is_rate_limit_error:
                 reason = "rate limit"
             else:
                 reason = "connection error"
@@ -5878,23 +5911,28 @@ async def async_call_llm(
                         raise
 
         # ── Payment / connection / rate-limit fallback (mirrors sync call_llm) ──
-        should_fallback = (
-            _is_payment_error(first_err)
-            or _is_connection_error(first_err)
-            or _is_rate_limit_error(first_err)
-        )
-        # Capacity errors (payment/quota/connection) bypass the explicit-provider
-        # gate — the provider cannot serve the request regardless of user intent.
-        # See #26803: daily token quota must fall back like a 402 credit error.
+        is_payment_error = _is_payment_error(first_err)
+        is_connection_error = _is_connection_error(first_err)
+        is_rate_limit_error = _is_rate_limit_error(first_err)
+        should_fallback = is_payment_error or is_connection_error or is_rate_limit_error
+        if is_connection_error:
+            try:
+                _evict_cached_clients(resolved_provider or "auto")
+            except Exception:
+                logger.debug(
+                    "Auxiliary %s (async): failed to evict cached client after connection error",
+                    task or "call",
+                    exc_info=True,
+                )
         is_auto = resolved_provider in {"auto", "", None}
-        is_capacity_error = _is_payment_error(first_err) or _is_connection_error(first_err)
+        is_capacity_error = is_payment_error or is_connection_error
         if should_fallback and (is_auto or is_capacity_error):
-            if _is_payment_error(first_err):
+            if is_payment_error:
                 reason = "payment error"
                 _mark_provider_unhealthy(
                     _recoverable_pool_provider(resolved_provider, client) or resolved_provider
                 )
-            elif _is_rate_limit_error(first_err):
+            elif is_rate_limit_error:
                 reason = "rate limit"
             else:
                 reason = "connection error"

--- a/cli.py
+++ b/cli.py
@@ -7744,6 +7744,156 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         
         return True
     
+    def _handle_background_command(self, cmd: str):
+        """Handle /background <prompt> — run a prompt in a separate background session.
+
+        Spawns a new AIAgent in a background thread with its own session.
+        When it completes, prints the result to the CLI without modifying
+        the active session's conversation history.
+        """
+        parts = cmd.strip().split(maxsplit=1)
+        if len(parts) < 2 or not parts[1].strip():
+            _cprint("  Usage: /background <prompt>")
+            _cprint("  Example: /background Summarize the top HN stories today")
+            _cprint("  The task runs in a separate session and results display here when done.")
+            return
+
+        prompt = parts[1].strip()
+        self._background_task_counter += 1
+        task_num = self._background_task_counter
+        task_id = f"bg_{datetime.now().strftime('%H%M%S')}_{uuid.uuid4().hex[:6]}"
+
+        # Make sure we have valid credentials
+        if not self._ensure_runtime_credentials():
+            _cprint("  (>_<) Cannot start background task: no valid credentials.")
+            return
+
+        _cprint(f"  🔄 Background task #{task_num} started: \"{prompt[:60]}{'...' if len(prompt) > 60 else ''}\"")
+        _cprint(f"  Task ID: {task_id}")
+        _cprint("  You can continue chatting — results will appear when done.\n")
+
+        turn_route = self._resolve_turn_agent_config(prompt)
+
+        def run_background():
+            set_sudo_password_callback(self._sudo_password_callback)
+            set_approval_callback(self._approval_callback)
+            try:
+                set_secret_capture_callback(self._secret_capture_callback)
+            except Exception:
+                pass
+            try:
+                bg_agent = AIAgent(
+                    model=turn_route["model"],
+                    api_key=turn_route["runtime"].get("api_key"),
+                    base_url=turn_route["runtime"].get("base_url"),
+                    provider=turn_route["runtime"].get("provider"),
+                    api_mode=turn_route["runtime"].get("api_mode"),
+                    acp_command=turn_route["runtime"].get("command"),
+                    acp_args=turn_route["runtime"].get("args"),
+                    max_iterations=self.max_turns,
+                    enabled_toolsets=self.enabled_toolsets,
+                    quiet_mode=True,
+                    verbose_logging=False,
+                    session_id=task_id,
+                    platform="cli",
+                    session_db=self._session_db,
+                    reasoning_config=self.reasoning_config,
+                    service_tier=self.service_tier,
+                    request_overrides=turn_route.get("request_overrides"),
+                    providers_allowed=self._providers_only,
+                    providers_ignored=self._providers_ignore,
+                    providers_order=self._providers_order,
+                    provider_sort=self._provider_sort,
+                    provider_require_parameters=self._provider_require_params,
+                    provider_data_collection=self._provider_data_collection,
+                    fallback_model=self._fallback_model,
+                )
+                # Silence raw spinner; route thinking through TUI widget when no foreground agent is active.
+                bg_agent._print_fn = lambda *_a, **_kw: None
+
+                def _bg_thinking(text: str) -> None:
+                    # Concurrent bg tasks may race on _spinner_text; acceptable for best-effort UI.
+                    if not self._agent_running:
+                        self._spinner_text = text
+                        if self._app:
+                            self._app.invalidate()
+
+                bg_agent.thinking_callback = _bg_thinking
+
+                result = bg_agent.run_conversation(
+                    user_message=prompt,
+                    task_id=task_id,
+                )
+
+                response = result.get("final_response", "") if result else ""
+                if not response and result and result.get("error"):
+                    response = f"Error: {result['error']}"
+
+                # Display result in the CLI (thread-safe via patch_stdout).
+                # Force a TUI refresh first so spinner/status bar don't overlap
+                # with the output (fixes #2718).
+                if self._app:
+                    self._app.invalidate()
+                    time.sleep(0.05)  # brief pause for refresh
+                print()
+                ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
+                _cprint(f"  ✅ Background task #{task_num} complete")
+                _cprint(f"  Prompt: \"{prompt[:60]}{'...' if len(prompt) > 60 else ''}\"")
+                ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
+                if response:
+                    try:
+                        from hermes_cli.skin_engine import get_active_skin
+                        _skin = get_active_skin()
+                        label = _skin.get_branding("response_label", "⚕ Hermes")
+                        _resp_color = _skin.get_color("response_border", "#CD7F32")
+                        _resp_text = _skin.get_color("banner_text", "#FFF8DC")
+                    except Exception:
+                        label = "⚕ Hermes"
+                        _resp_color = "#CD7F32"
+                        _resp_text = "#FFF8DC"
+
+                    _chat_console = ChatConsole()
+                    _chat_console.print(Panel(
+                        _render_final_assistant_content(response, mode=self.final_response_markdown),
+                        title=f"[{_resp_color} bold]{label} (background #{task_num})[/]",
+                        title_align="left",
+                        border_style=_resp_color,
+                        style=_resp_text,
+                        box=rich_box.HORIZONTALS,
+                        padding=(1, 4),
+                    ))
+                else:
+                    _cprint("  （返信を生成できませんでした）")
+
+                # Play bell if enabled
+                if self.bell_on_complete:
+                    sys.stdout.write("\a")
+                    sys.stdout.flush()
+
+            except Exception as e:
+                # Same TUI refresh pattern as success path (#2718)
+                if self._app:
+                    self._app.invalidate()
+                    time.sleep(0.05)
+                print()
+                _cprint(f"  ❌ Background task #{task_num} failed: {e}")
+            finally:
+                try:
+                    set_sudo_password_callback(None)
+                    set_approval_callback(None)
+                    set_secret_capture_callback(None)
+                except Exception:
+                    pass
+                self._background_tasks.pop(task_id, None)
+                # Clear spinner only if no foreground agent owns it
+                if not self._agent_running:
+                    self._spinner_text = ""
+                if self._app:
+                    self._invalidate(min_interval=0)
+
+        thread = threading.Thread(target=run_background, daemon=True, name=f"bg-task-{task_id}")
+        self._background_tasks[task_id] = thread
+        thread.start()
 
     @staticmethod
     def _try_launch_chrome_debug(port: int, system: str) -> bool:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1867,11 +1867,15 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 
         final_response = result.get("final_response", "") or ""
         # Strip leaked placeholder text that upstream may inject on empty completions.
-        if final_response.strip() == "(No response generated)":
+        no_response_placeholders = {
+            "(No response generated)",
+            "（返信を生成できませんでした）",
+        }
+        if final_response.strip() in no_response_placeholders:
             final_response = ""
         # Use a separate variable for log display; keep final_response clean
         # for delivery logic (empty response = no delivery).
-        logged_response = final_response if final_response else "(No response generated)"
+        logged_response = final_response if final_response else "（返信を生成できませんでした）"
         
         output = f"""# Cron Job: {job_name}
 

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -254,7 +254,12 @@ def _normalise(setting: str, value: Any) -> Any:
             return "off"
         if value is True:
             return "all"
-        return str(value).lower()
+        lowered = str(value).strip().lower()
+        if lowered in {"off", "none", "false", "no", "0"}:
+            return "off"
+        if lowered in {"on", "true", "yes", "1"}:
+            return "all"
+        return lowered
     if setting == "tool_progress_tools":
         return _normalise_tool_progress_tools(value)
     if setting in {

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -32,6 +32,10 @@ from typing import Any
 
 _GLOBAL_DEFAULTS: dict[str, Any] = {
     "tool_progress": "all",
+    # Optional allowlist for progress bubbles.  When set, only these tool names
+    # are shown (e.g. ["memory"] to keep 🧠 memory visible while hiding noisy
+    # terminal/read_file/search progress).  None/empty means no per-tool filter.
+    "tool_progress_tools": None,
     "show_reasoning": False,
     "tool_preview_length": 0,
     "streaming": None,  # None = follow top-level streaming config
@@ -216,6 +220,33 @@ def resolve_display_setting(
 # Helpers
 # ---------------------------------------------------------------------------
 
+_TOOL_PROGRESS_TOOL_SENTINELS = {"all", "*", "none", "off", "false"}
+
+
+def _normalise_tool_progress_tools(value: Any) -> list[str] | None:
+    """Return a lower-case tool allowlist, or None for no per-tool filter."""
+    if value is None or value is False:
+        return None
+    if isinstance(value, str):
+        raw_items = [part.strip() for part in value.split(",")]
+    elif isinstance(value, (list, tuple, set)):
+        raw_items = [str(item).strip() for item in value]
+    else:
+        return None
+
+    tools: list[str] = []
+    for item in raw_items:
+        lowered = item.lower()
+        if not lowered:
+            continue
+        if lowered in _TOOL_PROGRESS_TOOL_SENTINELS:
+            # Explicit all/off sentinels mean "no allowlist" even when they
+            # appear in YAML list form (e.g. tool_progress_tools: [all]).
+            return None
+        tools.append(lowered)
+    return tools or None
+
+
 def _normalise(setting: str, value: Any) -> Any:
     """Normalise YAML quirks (bare ``off`` → False in YAML 1.1)."""
     if setting == "tool_progress":
@@ -224,6 +255,8 @@ def _normalise(setting: str, value: Any) -> Any:
         if value is True:
             return "all"
         return str(value).lower()
+    if setting == "tool_progress_tools":
+        return _normalise_tool_progress_tools(value)
     if setting in {
         "show_reasoning",
         "streaming",

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -92,6 +92,7 @@ MAX_REQUEST_BYTES = 10_000_000  # 10 MB — accommodates long agent conversation
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
+NO_RESPONSE_GENERATED_FALLBACK = "（返信を生成できませんでした）"
 
 
 def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
@@ -1967,6 +1968,8 @@ class APIServerAdapter(BasePlatformAdapter):
         is_failed = bool(result.get("failed"))
         completed = bool(result.get("completed", True))
         err_msg = result.get("error")
+        if not final_response and not (is_failed or is_partial):
+            final_response = err_msg or NO_RESPONSE_GENERATED_FALLBACK
 
         # Decide finish_reason. OpenAI uses "length" for truncation, "stop"
         # for normal completion, and downstream SDKs accept "error" / custom
@@ -3013,7 +3016,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         final_response = result.get("final_response", "")
         if not final_response:
-            final_response = result.get("error", "(No response generated)")
+            final_response = result.get("error", NO_RESPONSE_GENERATED_FALLBACK)
 
         response_id = f"resp_{uuid.uuid4().hex[:28]}"
         created_at = int(time.time())
@@ -3465,7 +3468,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # Final assistant message
         final = result.get("final_response", "")
         if not final:
-            final = result.get("error", "(No response generated)")
+            final = result.get("error", NO_RESPONSE_GENERATED_FALLBACK)
 
         items.append({
             "type": "message",

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3393,6 +3393,9 @@ class BasePlatformAdapter(ABC):
         if result.success:
             return result
 
+        if isinstance(result.raw_response, dict) and result.raw_response.get("unsafe_to_retry"):
+            return result
+
         error_str = result.error or ""
         is_network = result.retryable or self._is_retryable_error(error_str)
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3429,8 +3429,9 @@ class BasePlatformAdapter(ABC):
                 # All retries exhausted (loop completed without break) — notify user
                 logger.error("[%s] Failed to deliver response after %d retries: %s", self.name, max_retries, error_str)
                 notice = (
-                    "\u26a0\ufe0f Message delivery failed after multiple attempts. "
-                    "Please try again \u2014 your request was processed but the response could not be sent."
+                    "⚠️ 返信の送信に複数回失敗しました。"
+                    "依頼の処理自体は完了している可能性がありますが、結果を送れませんでした。"
+                    "少し待ってからもう一度送ってください。"
                 )
                 try:
                     await self.send(chat_id=chat_id, content=notice, reply_to=reply_to, metadata=metadata)
@@ -3442,7 +3443,7 @@ class BasePlatformAdapter(ABC):
         logger.warning("[%s] Send failed: %s — trying plain-text fallback", self.name, error_str)
         fallback_result = await self.send(
             chat_id=chat_id,
-            content=f"(Response formatting failed, plain text:)\n\n{content[:3500]}",
+            content=f"（返信の整形に失敗したため、プレーンテキストで送ります）\n\n{content[:3500]}",
             reply_to=reply_to,
             metadata=metadata,
         )
@@ -4499,14 +4500,13 @@ class BasePlatformAdapter(ABC):
             # Send the error to the user so they aren't left with radio silence
             try:
                 error_type = type(e).__name__
-                error_detail = str(e)[:300] if str(e) else "no details available"
+                error_detail = str(e)[:300] if str(e) else "詳細なし"
                 _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
                 await self.send(
                     chat_id=event.source.chat_id,
                     content=(
-                        f"Sorry, I encountered an error ({error_type}).\n"
-                        f"{error_detail}\n"
-                        "Try again or use /reset to start a fresh session."
+                        f"⚠️ 処理中にエラーが発生しました（{error_type}）。\n"
+                        "もう一度送るか、続く場合は /reset で新しく始めてください。"
                     ),
                     metadata=_thread_metadata,
                 )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1937,23 +1937,30 @@ def _normalize_empty_agent_response(
         ) or ("400" in error_str and history_len > 50)
         if is_context_failure:
             return (
-                "⚠️ Session too large for the model's context window.\n"
-                "Use /compact to compress the conversation, or "
-                "/reset to start fresh."
+                "⚠️ 会話が長くなり、モデルのコンテキスト上限に近づきました。\n"
+                "/compact で圧縮するか、/reset で新しく始めてください。"
             )
+        logger.warning(
+            "Agent failed with empty response; hiding raw error from gateway user: %s",
+            str(error_detail)[:1000],
+        )
         return (
-            f"The request failed: {str(error_detail)[:300]}\n"
-            "Try again or use /reset to start a fresh session."
+            "⚠️ 処理中に一時的なエラーが発生しました。もう一度送ってください。\n"
+            "続く場合は /reset で新しい会話に切り替えてください。"
         )
 
     api_calls = int(agent_result.get("api_calls", 0) or 0)
     if api_calls > 0 and not agent_result.get("interrupted"):
         if agent_result.get("partial"):
             err = agent_result.get("error", "processing incomplete")
-            return f"⚠️ Processing stopped: {str(err)[:200]}. Try again."
+            logger.warning(
+                "Agent stopped with partial response; hiding raw error from gateway user: %s",
+                str(err)[:1000],
+            )
+            return "⚠️ 処理が途中で止まりました。もう一度送ってください。"
         return (
-            "⚠️ Processing completed but no response was generated. "
-            "This may be a transient error — try sending your message again."
+            "⚠️ 処理は完了しましたが、返信文を生成できませんでした。"
+            "一時的な可能性があるので、もう一度送ってください。"
         )
 
     return response
@@ -8724,9 +8731,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # looks like a bug; a short explanation is more helpful.
             if response == "(empty)":
                 response = (
-                    "⚠️ The model returned no response after processing tool "
-                    "results. This can happen with some models — try again or "
-                    "rephrase your question."
+                    "⚠️ モデルが返信文を生成できませんでした。"
+                    "もう一度送るか、少し言い換えて試してください。"
                 )
             agent_messages = agent_result.get("messages", [])
             _response_time = time.time() - _msg_start_time
@@ -8931,9 +8937,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if hasattr(self, "_pending_model_notes"):
                     self._pending_model_notes.pop(session_key, None)
                 response = (response or "") + (
-                    "\n\n🔄 Session auto-reset — the conversation exceeded the "
-                    "maximum context size and could not be compressed further. "
-                    "Your next message will start a fresh session."
+                    "\n\n🔄 会話がコンテキスト上限を超え、圧縮もできなかったため、"
+                    "セッションを自動でリセットしました。次のメッセージから新しい会話になります。"
                 )
 
             ts = datetime.now().isoformat()
@@ -9121,9 +9126,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             status_code = getattr(e, "status_code", None)
             _hist_len = len(history) if 'history' in locals() else 0
             if status_code == 401:
-                status_hint = " Check your API key or run `claude /login` to refresh OAuth credentials."
+                status_hint = " APIキーまたはOAuth認証を確認してください。"
             elif status_code == 402:
-                status_hint = " Your API balance or quota is exhausted. Check your provider dashboard."
+                status_hint = " APIの残高または利用枠が不足しています。プロバイダ側の設定を確認してください。"
             elif status_code == 429:
                 # Check if this is a plan usage limit (resets on a schedule) vs a transient rate limit
                 _err_body = getattr(e, "response", None)
@@ -9140,30 +9145,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if _resets_in and _resets_in > 0:
                         import math
                         _hours = math.ceil(_resets_in / 3600)
-                        status_hint = f" Your plan's usage limit has been reached. It resets in ~{_hours}h."
+                        status_hint = f" 利用上限に達しました。約{_hours}時間後にリセットされます。"
                     else:
-                        status_hint = " Your plan's usage limit has been reached. Please wait until it resets."
+                        status_hint = " 利用上限に達しました。リセットまで少し待ってください。"
                 else:
-                    status_hint = " You are being rate-limited. Please wait a moment and try again."
+                    status_hint = " レート制限中です。少し待ってからもう一度送ってください。"
             elif status_code == 529:
-                status_hint = " The API is temporarily overloaded. Please try again shortly."
+                status_hint = " APIが一時的に混み合っています。少し待ってからもう一度送ってください。"
             elif status_code in {400, 500}:
                 # 400 with a large session is context overflow.
                 # 500 with a large session often means the payload is too large
                 # for the API to process — treat it the same way.
                 if _hist_len > 50:
                     return (
-                        "⚠️ Session too large for the model's context window.\n"
-                        "Use /compact to compress the conversation, or "
-                        "/reset to start fresh."
+                        "⚠️ 会話が長くなり、モデルのコンテキスト上限に近づきました。\n"
+                        "/compact で圧縮するか、/reset で新しく始めてください。"
                     )
                 elif status_code == 400:
-                    status_hint = " The request was rejected by the API."
+                    status_hint = " APIにリクエストが拒否されました。"
+            logger.warning(
+                "Gateway handler error hidden from user response: type=%s detail=%s hint=%s",
+                error_type, str(error_detail)[:1000], status_hint.strip(),
+            )
             return (
-                f"Sorry, I encountered an error ({error_type}).\n"
-                f"{error_detail}\n"
-                f"{status_hint}"
-                "Try again or use /reset to start a fresh session."
+                f"⚠️ 処理中にエラーが発生しました（{error_type}）。\n"
+                f"{status_hint.strip()}\n"
+                "もう一度送るか、続く場合は /reset で新しく始めてください。"
             )
         finally:
             # Restore session context variables to their pre-handler state
@@ -10150,6 +10157,40 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.warning("Post-stream media extraction failed: %s", e)
 
 
+    async def _handle_background_command(self, event: MessageEvent) -> str:
+        """Handle /background <prompt> — run a prompt in a separate background session.
+
+        Spawns a new AIAgent in a background thread with its own session.
+        When it completes, sends the result back to the same chat without
+        modifying the active session's conversation history.
+        """
+        prompt = event.get_command_args().strip()
+        if not prompt:
+            return (
+                "使い方: /background <依頼内容>\n"
+                "例: /background 今日のHNトップ記事を要約して\n\n"
+                "別セッションで実行します。このまま会話でき、完了したらここに結果を送ります。"
+            )
+
+        source = event.source
+        task_id = f"bg_{datetime.now().strftime('%H%M%S')}_{os.urandom(3).hex()}"
+
+        event_message_id = self._reply_anchor_for_event(event)
+
+        # Fire-and-forget the background task
+        _task = asyncio.create_task(
+            self._run_background_task(
+                prompt,
+                source,
+                task_id,
+                event_message_id=event_message_id,
+            )
+        )
+        self._background_tasks.add(_task)
+        _task.add_done_callback(self._background_tasks.discard)
+
+        preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
+        return f'🔄 バックグラウンド作業を開始しました: "{preview}"\nTask ID: {task_id}\nこのまま会話できます。完了したら結果を送ります。'
 
     async def _run_background_task(
         self,
@@ -10182,7 +10223,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not runtime_kwargs.get("api_key"):
                 await adapter.send(
                     source.chat_id,
-                    f"❌ Background task {task_id} failed: no provider credentials configured.",
+                    f"❌ バックグラウンド作業 {task_id} に失敗しました: モデルAPIの認証情報が設定されていません。",
                     metadata=_thread_metadata,
                 )
                 return
@@ -10260,7 +10301,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             response = result.get("final_response", "") if result else ""
             if not response and result and result.get("error"):
-                response = f"Error: {result['error']}"
+                logger.warning(
+                    "Background task %s returned error without response; hiding raw error: %s",
+                    task_id, str(result.get("error"))[:1000],
+                )
+                response = "⚠️ バックグラウンド作業中にエラーが発生しました。もう一度試してください。"
             if result:
                 response = _format_provider_api_failure_for_gateway(result, response)
 
@@ -10272,7 +10317,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 images, text_content = adapter.extract_images(response)
 
                 preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
-                header = f'✅ Background task complete\nPrompt: "{preview}"\n\n'
+                header = f'✅ バックグラウンド作業が完了しました\n依頼: "{preview}"\n\n'
 
                 if text_content:
                     await adapter.send(
@@ -10283,7 +10328,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 elif not images and not media_files:
                     await adapter.send(
                         chat_id=source.chat_id,
-                        content=header + "(No response generated)",
+                        content=header + "(返信なし)",
                         metadata=_thread_metadata,
                     )
 
@@ -10340,7 +10385,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
                 await adapter.send(
                     chat_id=source.chat_id,
-                    content=f'✅ Background task complete\nPrompt: "{preview}"\n\n(No response generated)',
+                    content=f'✅ バックグラウンド作業が完了しました\n依頼: "{preview}"\n\n(返信なし)',
                     metadata=_thread_metadata,
                 )
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3147,6 +3147,36 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             pass
 
+    def _runtime_status_active_state(self) -> str:
+        """Return the runtime state to persist while work is still active."""
+        return "draining" if getattr(self, "_draining", False) else "running"
+
+    async def _runtime_status_heartbeat_loop(self, session_key: str) -> None:
+        """Keep ``gateway_state.json`` fresh while a gateway turn is busy.
+
+        External watchdogs use the runtime status file as the cheap liveness
+        signal for the gateway process. A single agent turn can legitimately
+        run for much longer than the watchdog window, so claiming/releasing
+        ``active_agents`` is not enough: ``updated_at`` must continue moving
+        while the turn is active so a healthy-but-busy gateway is not mistaken
+        for a wedged process and restarted mid-turn.
+        """
+        if not session_key:
+            return
+        interval = _float_env("HERMES_GATEWAY_STATUS_HEARTBEAT_INTERVAL", 30.0)
+        if interval <= 0:
+            return
+        try:
+            while session_key in getattr(self, "_running_agents", {}):
+                await asyncio.sleep(interval)
+                if session_key not in getattr(self, "_running_agents", {}):
+                    return
+                self._update_runtime_status(self._runtime_status_active_state())
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.debug("Runtime status heartbeat stopped for %s: %s", session_key, exc)
+
     def _update_platform_runtime_status(
         self,
         platform: str,
@@ -7546,6 +7576,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._running_agents[_quick_key] = _AGENT_PENDING_SENTINEL
         self._running_agents_ts[_quick_key] = time.time()
         _run_generation = self._begin_session_run_generation(_quick_key)
+        self._update_runtime_status(self._runtime_status_active_state())
+        _runtime_status_heartbeat_task = asyncio.create_task(
+            self._runtime_status_heartbeat_loop(_quick_key)
+        )
 
         try:
             _agent_result = await self._handle_message_with_agent(event, source, _quick_key, _run_generation)
@@ -7580,13 +7614,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return _agent_result
         finally:
             # Unconditional release covers every exit path. _release_running_agent_state
-            # is idempotent (pop-on-absent is harmless) and, called without a
-            # run_generation guard, always clears the slot regardless of which
-            # generation it holds. This evicts the zombie left when session_reset
-            # bumps the generation (N -> N+1) mid-flight: gen-N's guarded release
-            # inside _run_agent returns False, and the old sentinel-only check here
-            # missed the leftover real agent — locking the session out forever (#28686).
+            # is idempotent and clears stale real-agent slots left when session_reset
+            # bumps the generation mid-flight. Always cancel the heartbeat task too.
             self._release_running_agent_state(_quick_key)
+            _runtime_status_heartbeat_task.cancel()
+            try:
+                await _runtime_status_heartbeat_task
+            except asyncio.CancelledError:
+                pass
+            except Exception as exc:
+                logger.debug(
+                    "Runtime status heartbeat cleanup failed for %s: %s",
+                    _quick_key,
+                    exc,
+                )
 
     async def _prepare_inbound_message_text(
         self,
@@ -12348,16 +12389,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             session_key, run_generation
         ):
             return False
+        released = self._running_agents.pop(session_key, None) is not None
         lease = getattr(self, "_active_session_leases", {}).pop(session_key, None)
         if lease is not None:
             try:
                 lease.release()
             except Exception:
                 logger.debug("Failed to release active session slot", exc_info=True)
-        self._running_agents.pop(session_key, None)
         self._running_agents_ts.pop(session_key, None)
         if hasattr(self, "_busy_ack_ts"):
             self._busy_ack_ts.pop(session_key, None)
+        if released:
+            self._update_runtime_status(self._runtime_status_active_state())
         return True
 
     def _clear_session_boundary_security_state(self, session_key: str) -> None:
@@ -13125,10 +13168,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _env_tp and not _tool_progress_configured
             else (_resolved_tp or _env_tp or "all")
         )
+        _progress_tool_filter = resolve_display_setting(
+            user_config, platform_key, "tool_progress_tools"
+        )
+        progress_tool_allowlist = {
+            str(name).strip().lower()
+            for name in (_progress_tool_filter or [])
+            if str(name).strip()
+        }
         # Disable tool progress for webhooks - they don't support message editing,
         # so each progress line would be sent as a separate message.
         from gateway.config import Platform
-        tool_progress_enabled = progress_mode != "off" and source.platform != Platform.WEBHOOK
+        tool_progress_enabled = (
+            source.platform != Platform.WEBHOOK
+            and (progress_mode != "off" or bool(progress_tool_allowlist))
+        )
         # Natural assistant status messages are intentionally independent from
         # tool progress and token streaming. Users can keep tool_progress quiet
         # in chat platforms while opting into concise mid-turn updates.
@@ -13254,6 +13308,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             # Only act on tool.started events (ignore tool.completed, reasoning.available, etc.)
             if event_type not in {"tool.started",}:
+                return
+
+            # Optional per-tool allowlist.  This keeps high-signal progress
+            # (for example 🧠 memory writes) visible while suppressing noisy
+            # operational calls like terminal/read_file/search_files.
+            if (
+                progress_tool_allowlist
+                and str(tool_name or "").strip().lower() not in progress_tool_allowlist
+            ):
                 return
 
             # Suppress tool-progress bubbles once the user has sent `stop`.
@@ -14663,18 +14726,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 try:
                     from agent.title_generator import maybe_auto_title
                     all_msgs = result_holder[0].get("messages", []) if result_holder[0] else []
-                    # In Gateway mode, auto-title failures must NOT be
-                    # surfaced as user-visible messages (fixes #23246).
-                    # Log them at debug level only — they are not actionable
-                    # to the end user. CLI mode keeps the existing behaviour
-                    # via the agent's _emit_auxiliary_failure path.
-                    def _title_failure_cb(task: str, exc: BaseException) -> None:
-                        logger.debug(
-                            "Gateway auto-title failure suppressed (not user-visible): %s: %s",
-                            task, exc,
-                        )
+                    # Title generation is a best-effort background convenience.
+                    # In chat gateways, do not surface failures to the user: a
+                    # transient auxiliary/provider error should not post an
+                    # extra warning message after the main answer was already delivered.
                     maybe_auto_title_kwargs = {
-                        "failure_callback": _title_failure_cb,
+                        "failure_callback": None,
                         "main_runtime": {
                             "model": getattr(agent, "model", None),
                             "provider": getattr(agent, "provider", None),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1822,6 +1822,97 @@ import weakref as _weakref
 _gateway_runner_ref: _weakref.ref = lambda: None
 
 
+_PROVIDER_API_FAILURE_RE = re.compile(
+    r"^API call failed after (?P<retries>\d+) retries:\s*(?P<detail>.*)$",
+    re.IGNORECASE | re.DOTALL,
+)
+_REQUEST_ID_RE = re.compile(
+    r"\brequest[ _-]?id\b\s*(?:[:=]|is|was)?\s*([A-Za-z0-9][A-Za-z0-9._:-]{8,})",
+    re.IGNORECASE,
+)
+
+
+def _looks_like_provider_api_failure(text: str) -> bool:
+    if not text:
+        return False
+    lowered = text.lower()
+    return bool(_PROVIDER_API_FAILURE_RE.match(text.strip())) or any(
+        marker in lowered
+        for marker in (
+            "api call failed after",
+            "rate limited after",
+            "provider's stream connection",
+            "openai.badrequesterror",
+            "openai.authenticationerror",
+            "openai.permissiondeniederror",
+            "openai.ratelimiterror",
+            "openai.internalservererror",
+        )
+    )
+
+
+def _format_provider_api_failure_for_gateway(agent_result: dict, response: str) -> str:
+    """Return a short user-facing fallback for provider/API failures.
+
+    The agent core intentionally keeps the raw provider error in logs and in the
+    result dict for diagnostics.  Gateway chats should not expose long English
+    SDK/provider messages (especially help-center text and request IDs) as the
+    visible bot reply.
+    """
+    if not response:
+        return response
+
+    error_detail = str(agent_result.get("error") or "") if isinstance(agent_result, dict) else ""
+    raw_text = str(response)
+    combined = "\n".join(part for part in (raw_text, error_detail) if part)
+    if not _looks_like_provider_api_failure(raw_text) and not _looks_like_provider_api_failure(error_detail):
+        return response
+
+    request_id_match = _REQUEST_ID_RE.search(combined)
+    request_id = request_id_match.group(1).strip(".,;)") if request_id_match else None
+    logger.warning(
+        "Provider/API failure hidden from gateway user response%s: %s",
+        f" request_id={request_id}" if request_id else "",
+        combined[:2000],
+    )
+
+    lowered = combined.lower()
+    context_markers = (
+        "context length", "context size", "context window", "maximum context",
+        "token limit", "too many tokens", "reduce the length", "exceeds the limit",
+        "request entity too large", "prompt is too long", "payload too large",
+        "input is too long",
+    )
+    if any(marker in lowered for marker in context_markers):
+        return (
+            "⚠️ 会話が長くなり、モデルのコンテキスト上限に近づきました。\n"
+            "/compact で圧縮するか、/reset で新しく始めてください。"
+        )
+
+    if any(marker in lowered for marker in ("429", "rate limit", "rate_limited", "too many requests")):
+        return (
+            "⚠️ モデルAPIが一時的に混み合っています。少し待って再実行してください。\n"
+            "詳細はログに記録しました。"
+        )
+
+    if any(marker in lowered for marker in ("401", "403", "authentication", "permission", "api key", "unauthorized")):
+        return (
+            "⚠️ モデルAPIの認証または権限で失敗しました。設定を確認してください。\n"
+            "詳細はログに記録しました。"
+        )
+
+    if any(marker in lowered for marker in ("connection lost", "connection reset", "connection closed", "network connection", "network error", "stream connection")):
+        return (
+            "⚠️ モデルAPIとの接続が途中で切れました。少し待って再実行してください。\n"
+            "大きな出力中に起きた場合は、作業を小さく分けると通りやすいです。"
+        )
+
+    return (
+        "⚠️ モデル応答が一時的に失敗しました。少し待って再実行してください。\n"
+        "詳細はログに記録しました。"
+    )
+
+
 def _normalize_empty_agent_response(
     agent_result: dict,
     response: str,
@@ -8670,6 +8761,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             response = _normalize_empty_agent_response(
                 agent_result, response, history_len=len(history),
             )
+            response = _format_provider_api_failure_for_gateway(agent_result, response)
             response = _sanitize_gateway_final_response(source.platform, response)
 
             # Ordering contract: the agent thread already updated the contextvar
@@ -10169,6 +10261,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             response = result.get("final_response", "") if result else ""
             if not response and result and result.get("error"):
                 response = f"Error: {result['error']}"
+            if result:
+                response = _format_provider_api_failure_for_gateway(result, response)
 
             # Extract media files from the response
             if response:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1471,6 +1471,7 @@ DEFAULT_CONFIG = {
         "interim_assistant_messages": True,  # Gateway: show natural mid-turn assistant status messages
         "tool_progress_command": False,  # Enable /verbose command in messaging gateway
         "tool_progress_overrides": {},  # DEPRECATED — use display.platforms instead
+        "tool_progress_tools": None,  # Optional gateway progress allowlist, e.g. ["memory"]
         "tool_preview_length": 0,  # Max chars for tool call previews (0 = no limit, show full paths/commands)
         # Auto-delete system-notice replies (e.g. "✨ New session started!",
         # "♻ Restarting gateway…", "⚡ Stopped…") after N seconds on platforms

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3913,10 +3913,10 @@ class DiscordAdapter(BasePlatformAdapter):
         async def slash_queue(interaction: discord.Interaction, prompt: str):
             await self._run_simple_slash(interaction, f"/queue {prompt}", "Queued for the next turn.")
 
-        @tree.command(name="background", description="Run a prompt in the background")
-        @discord.app_commands.describe(prompt="The prompt to run in the background")
+        @tree.command(name="background", description="プロンプトをバックグラウンドで実行します")
+        @discord.app_commands.describe(prompt="バックグラウンドで実行する内容")
         async def slash_background(interaction: discord.Interaction, prompt: str):
-            await self._run_simple_slash(interaction, f"/background {prompt}", "Background task started~")
+            await self._run_simple_slash(interaction, f"/background {prompt}", "バックグラウンド作業を開始しました~")
 
         # ── Auto-register any gateway-available commands not yet on the tree ──
         # This ensures new commands added to COMMAND_REGISTRY in

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -31,6 +31,9 @@ _DISCORD_COMMAND_SYNC_STATE_SUBDIR = "gateway"
 _DISCORD_COMMAND_SYNC_STATE_FILENAME = "discord_command_sync_state.json"
 _DISCORD_COMMAND_SYNC_MUTATION_INTERVAL_SECONDS = 4.5
 _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS = 30.0
+_DISCORD_SEND_MAX_ATTEMPTS = 3
+_DISCORD_SEND_BASE_DELAY_SECONDS = 0.75
+_DISCORD_SEND_MAX_DELAY_SECONDS = 30.0
 
 try:
     import discord
@@ -1869,15 +1872,19 @@ class DiscordAdapter(BasePlatformAdapter):
                 except Exception as e:
                     logger.debug("Could not fetch reply-to message: %s", e)
 
+            warnings: list[str] = []
             for i, chunk in enumerate(chunks):
                 if self._reply_to_mode == "all":
                     chunk_reference = reference
                 else:  # "first" (default) or "off"
                     chunk_reference = reference if i == 0 else None
                 try:
-                    msg = await channel.send(
-                        content=chunk,
-                        reference=chunk_reference,
+                    msg = await self._discord_api_call_with_retry(
+                        lambda: channel.send(
+                            content=chunk,
+                            reference=chunk_reference,
+                        ),
+                        op_name="send message chunk",
                     )
                 except Exception as e:
                     err_text = str(e)
@@ -1897,11 +1904,33 @@ class DiscordAdapter(BasePlatformAdapter):
                             reply_to,
                         )
                         reference = None
-                        msg = await channel.send(
-                            content=chunk,
-                            reference=None,
+                        msg = await self._discord_api_call_with_retry(
+                            lambda: channel.send(
+                                content=chunk,
+                                reference=None,
+                            ),
+                            op_name="send message chunk without reply reference",
                         )
                     else:
+                        # If earlier chunks are acknowledged, do not bubble a
+                        # failure back to BasePlatformAdapter._send_with_retry:
+                        # it would resend the whole response and duplicate the
+                        # delivered chunks. Return partial success with a
+                        # warning instead.
+                        if message_ids:
+                            warning = f"Failed to send Discord chunk {i + 1}/{len(chunks)} after retries: {e}"
+                            logger.error("[%s] %s", self.name, warning, exc_info=True)
+                            warnings.append(warning)
+                            raw_response: Dict[str, Any] = {
+                                "message_ids": message_ids,
+                                "warnings": warnings,
+                                "partial": True,
+                            }
+                            return SendResult(
+                                success=True,
+                                message_id=message_ids[0],
+                                raw_response=raw_response,
+                            )
                         raise
                 message_ids.append(str(msg.id))
 
@@ -1911,15 +1940,142 @@ class DiscordAdapter(BasePlatformAdapter):
                 _target_id = thread_id or chat_id
                 self._last_self_message_id[_target_id] = message_ids[-1]
 
+            raw_response: Dict[str, Any] = {"message_ids": message_ids}
+            if warnings:
+                raw_response["warnings"] = warnings
+
             return SendResult(
                 success=True,
                 message_id=message_ids[0] if message_ids else None,
-                raw_response={"message_ids": message_ids}
+                raw_response=raw_response
             )
 
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error("[%s] Failed to send Discord message: %s", self.name, e, exc_info=True)
-            return SendResult(success=False, error=str(e))
+            return SendResult(
+                success=False,
+                error=str(e),
+                retryable=self._is_transient_discord_send_error(e),
+            )
+
+
+    @staticmethod
+    def _discord_error_status(exc: BaseException) -> Optional[int]:
+        """Extract a Discord/HTTP status code from common exception shapes."""
+        for value in (
+            getattr(exc, "status", None),
+            getattr(exc, "status_code", None),
+            getattr(getattr(exc, "response", None), "status", None),
+            getattr(getattr(exc, "response", None), "status_code", None),
+        ):
+            try:
+                if value is not None:
+                    return int(value)
+            except (TypeError, ValueError):
+                continue
+        return None
+
+    @staticmethod
+    def _discord_retry_after(exc: BaseException) -> Optional[float]:
+        """Extract Retry-After seconds, clamped to a safe local maximum."""
+        candidates: list[Any] = [getattr(exc, "retry_after", None)]
+        response = getattr(exc, "response", None)
+        headers = getattr(response, "headers", None)
+        if headers:
+            try:
+                candidates.append(headers.get("Retry-After"))
+            except Exception:
+                pass
+        for value in candidates:
+            try:
+                if value is not None:
+                    return max(0.0, min(float(value), _DISCORD_SEND_MAX_DELAY_SECONDS))
+            except (TypeError, ValueError):
+                continue
+        return None
+
+    @classmethod
+    def _is_transient_discord_send_error(cls, exc: BaseException) -> bool:
+        """Return True for send failures worth retrying locally.
+
+        Permission, validation, auth, and missing-channel errors fail fast.
+        Transport drops and server/rate-limit responses get a short
+        operation-local retry so the whole response is not replayed by the
+        generic platform retry wrapper after partial delivery.
+        """
+        status = cls._discord_error_status(exc)
+        if status in {429, 500, 502, 503, 504}:
+            return True
+        if status in {400, 401, 403, 404}:
+            return False
+        if isinstance(exc, (BrokenPipeError, ConnectionResetError, ConnectionError)):
+            return True
+        if isinstance(exc, OSError):
+            text = str(exc).lower()
+            return any(pat in text for pat in ("broken pipe", "connection reset", "connection closed"))
+        text = str(exc).lower()
+        return any(
+            pat in text
+            for pat in (
+                "server disconnected",
+                "broken pipe",
+                "connection reset",
+                "connection closed",
+                "connection aborted",
+                "temporarily unavailable",
+            )
+        )
+
+    @classmethod
+    def _is_safe_create_thread_retry(cls, exc: BaseException) -> bool:
+        """Retry forum starter creation only when Discord clearly rejected it.
+
+        A Broken pipe / server-disconnected after create_thread() is ambiguous:
+        the thread may already exist, so replaying can duplicate a forum post.
+        A 429 with Retry-After is safe because Discord refused the mutation.
+        """
+        return cls._discord_error_status(exc) == 429
+
+    def _discord_send_delay(self, exc: BaseException, attempt_index: int) -> float:
+        retry_after = self._discord_retry_after(exc)
+        if retry_after is not None:
+            return retry_after
+        return min(
+            _DISCORD_SEND_BASE_DELAY_SECONDS * (2 ** attempt_index),
+            _DISCORD_SEND_MAX_DELAY_SECONDS,
+        )
+
+    async def _discord_api_call_with_retry(
+        self,
+        operation: Callable[[], Any],
+        *,
+        op_name: str,
+        retry_unknown_delivery: bool = True,
+    ) -> Any:
+        """Run one Discord API operation with bounded local retries."""
+        for attempt_index in range(_DISCORD_SEND_MAX_ATTEMPTS):
+            try:
+                return await operation()
+            except Exception as exc:
+                transient = self._is_transient_discord_send_error(exc)
+                safe_for_operation = retry_unknown_delivery or self._is_safe_create_thread_retry(exc)
+                if (
+                    not transient
+                    or not safe_for_operation
+                    or attempt_index >= _DISCORD_SEND_MAX_ATTEMPTS - 1
+                ):
+                    raise
+                delay = self._discord_send_delay(exc, attempt_index)
+                logger.warning(
+                    "[%s] Discord %s failed transiently (attempt %d/%d, retrying in %.1fs): %s",
+                    self.name,
+                    op_name,
+                    attempt_index + 1,
+                    _DISCORD_SEND_MAX_ATTEMPTS,
+                    delay,
+                    exc,
+                )
+                await asyncio.sleep(delay)
 
     async def _send_to_forum(self, forum_channel: Any, content: str) -> SendResult:
         """Create a thread post in a forum channel with the message as starter content.
@@ -1941,13 +2097,30 @@ class DiscordAdapter(BasePlatformAdapter):
         starter_content = chunks[0] if chunks else thread_name
 
         try:
-            thread = await forum_channel.create_thread(
-                name=thread_name,
-                content=starter_content,
+            thread = await self._discord_api_call_with_retry(
+                lambda: forum_channel.create_thread(
+                    name=thread_name,
+                    content=starter_content,
+                ),
+                op_name="create forum thread",
+                retry_unknown_delivery=False,
             )
         except Exception as e:
             logger.error("[%s] Failed to create forum thread in %s: %s", self.name, forum_channel.id, e)
-            return SendResult(success=False, error=f"Forum thread creation failed: {e}")
+            unsafe_to_retry = (
+                self._is_transient_discord_send_error(e)
+                and not self._is_safe_create_thread_retry(e)
+            )
+            raw_response = {"unsafe_to_retry": True} if unsafe_to_retry else None
+            error = f"Forum thread creation failed: {e}"
+            if unsafe_to_retry:
+                error = f"{error}; not retried to avoid duplicate forum post"
+            return SendResult(
+                success=False,
+                error=error,
+                raw_response=raw_response,
+                retryable=self._is_safe_create_thread_retry(e),
+            )
 
         thread_channel = thread if hasattr(thread, "send") else getattr(thread, "thread", None)
         thread_id = str(getattr(thread_channel, "id", getattr(thread, "id", "")))
@@ -1960,7 +2133,10 @@ class DiscordAdapter(BasePlatformAdapter):
         warnings: list[str] = []
         for chunk in chunks[1:]:
             try:
-                msg = await thread_channel.send(content=chunk)
+                msg = await self._discord_api_call_with_retry(
+                    lambda: thread_channel.send(content=chunk),
+                    op_name="send forum follow-up chunk",
+                )
                 message_ids.append(str(msg.id))
             except Exception as e:
                 warning = f"Failed to send follow-up chunk to forum thread {thread_id}: {e}"

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -21,7 +21,7 @@ import threading
 import time
 from collections import defaultdict
 from contextlib import suppress
-from typing import Callable, Dict, List, Optional, Any, Tuple
+from typing import Callable, Dict, List, Optional, Any, Tuple, Set
 
 logger = logging.getLogger(__name__)
 
@@ -567,6 +567,196 @@ class VoiceReceiver:
                 pass
 
 
+def _env_bool(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    value = raw.strip().lower()
+    if not value:
+        return default
+    if value in {"1", "true", "yes", "on"}:
+        return True
+    if value in {"0", "false", "no", "off"}:
+        return False
+    logger.warning("Invalid boolean for %s=%r; using default %s", name, raw, default)
+    return default
+
+
+def _env_int(name: str, default: int, *, min_value: Optional[int] = None) -> int:
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = int(raw.strip())
+    except ValueError:
+        logger.warning("Invalid integer for %s=%r; using default %s", name, raw, default)
+        return default
+    if min_value is not None and value < min_value:
+        logger.warning("Invalid integer for %s=%r; using default %s", name, raw, default)
+        return default
+    return value
+
+
+def _env_float(name: str, default: float, *, min_value: Optional[float] = None) -> float:
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = float(raw.strip())
+    except ValueError:
+        logger.warning("Invalid float for %s=%r; using default %s", name, raw, default)
+        return default
+    if min_value is not None and value < min_value:
+        logger.warning("Invalid float for %s=%r; using default %s", name, raw, default)
+        return default
+    return value
+
+
+def _discord_allow_bots_mode() -> str:
+    raw = os.getenv("DISCORD_ALLOW_BOTS", "none")
+    mode = raw.strip().lower()
+    if mode in {"none", "mentions", "all"}:
+        return mode
+    if mode:
+        logger.warning(
+            "Invalid DISCORD_ALLOW_BOTS=%r; expected one of none, mentions, all. Using none.",
+            raw,
+        )
+    return "none"
+
+
+def _discord_allowed_bot_ids() -> Set[str]:
+    raw = os.getenv("DISCORD_ALLOWED_BOTS", "")
+    return {part.strip() for part in raw.split(",") if part.strip()}
+
+
+def _normalise_dialogue_text(text: str) -> str:
+    text = re.sub(r"<@!?\d+>", "", text or "")
+    text = re.sub(r"\s+", "", text)
+    return text.strip().lower()
+
+
+_DEFAULT_BOT_DIALOGUE_STOP_PHRASES = (
+    "了解",
+    "承知",
+    "確認しました",
+    "完了として",
+    "ここで止めます",
+    "ここまでにします",
+    "返信はここで止めます",
+    "会話は終了",
+    "終了済み",
+    "未決点なし",
+    "追加なし",
+    "大丈夫です",
+    "👍",
+)
+
+
+def _bot_dialogue_stop_phrases() -> Tuple[str, ...]:
+    raw = os.getenv("DISCORD_BOT_DIALOGUE_STOP_PHRASES", "")
+    phrases = [p.strip() for p in raw.split(",") if p.strip()]
+    if not phrases:
+        phrases = list(_DEFAULT_BOT_DIALOGUE_STOP_PHRASES)
+    return tuple(_normalise_dialogue_text(p) for p in phrases if _normalise_dialogue_text(p))
+
+
+def _is_bot_dialogue_closure_only(text: str) -> bool:
+    """Return True for bot replies that should end a bot-to-bot handoff.
+
+    The guard intentionally catches short acknowledgement / closure-only
+    messages before they reach the LLM.  Short messages may still contain
+    useful next actions (for example, "了解しました。ログを確認します。"), so
+    acknowledgements are treated as closure-only only when the remainder is
+    just polite suffixes, emoji, or punctuation.
+    """
+    norm = _normalise_dialogue_text(text)
+    if not norm:
+        return True
+
+    # Hermes gateway status/busy notices are control-plane messages, not
+    # conversational content.  When one Hermes Discord bot is talking to
+    # another, these notices can otherwise be fed back into the peer LLM and
+    # create noisy "same thing twice" acknowledgement loops.  This predicate is
+    # used only for peer-bot messages, so it is safe to block these aggressively
+    # before the normal substantive-reply heuristics below.
+    status_prefixes = (
+        "⚡interruptingcurrenttask",
+        "operationinterrupted:",
+        "operationinterrupted",
+        "gatewayrestarting",
+        "gatewayshutdown",
+        "gatewayisrestarting",
+        "sessionautomaticallyreset",
+        "◐sessionautomaticallyreset",
+    )
+    if norm.startswith(status_prefixes):
+        return True
+
+    status_contains = (
+        "i'llrespondtoyourmessageshortly",
+        "i’llrespondtoyourmessageshortly",
+        "waitingformodelresponse",
+        "interruptingcurrenttask",
+        "queuedforthenextturn",
+        "currenttaskisstillrunning",
+    )
+    if any(marker in norm for marker in status_contains):
+        return True
+
+    if "?" in norm or "？" in norm:
+        return False
+
+    stripped = norm.strip("。．.!！、,…〜~ー-()（）[]【】{}『』\"'` ")
+    if stripped in {"👍", "+1", "ok", "okay"}:
+        return True
+
+    # Avoid false positives on short substantive handoffs such as
+    # "了解しました。ログを確認します。" while still blocking pure acks.
+    for ack in ("了解", "承知"):
+        if stripped.startswith(ack):
+            rest = stripped[len(ack):]
+            if re.fullmatch(
+                r"(しました|いたしました|です|ですー|です〜|です!|です！|ます|[。．.!！、,…〜~ー\-()（）\[\]【】{}『』\"'`🙏👍🙇])*",
+                rest,
+            ):
+                return True
+            return False
+
+    substantive_markers = (
+        "追加で",
+        "次に",
+        "ただし",
+        "しかし",
+        "一方",
+        "また、",
+        "さらに",
+        "必要",
+        "ログ",
+        "設定",
+        "実装",
+        "調査",
+        "確認します",
+        "送ります",
+        "対応します",
+        "進めます",
+        "提案",
+        "理由",
+        "手順",
+        "todo",
+        "http",
+    )
+    if any(marker in norm for marker in substantive_markers):
+        return False
+
+    for phrase in _bot_dialogue_stop_phrases():
+        if not phrase or phrase in {"了解", "承知"}:
+            continue
+        if norm == phrase or (phrase in norm and len(norm) <= max(24, len(phrase) + 14)):
+            return True
+    return False
+
+
 def _read_dm_role_auth_guild() -> Optional[int]:
     """Return the guild ID opted-in for DM role-based auth, or None.
 
@@ -675,6 +865,75 @@ class DiscordAdapter(BasePlatformAdapter):
         # history backfill to skip the full scan on hot paths.  Falls back to
         # scanning channel.history() on cache miss (cold start / restart).
         self._last_self_message_id: Dict[str, str] = {}
+        # Per-thread peer-bot dialogue guard.  This is intentionally local to
+        # each Discord bot process: it prevents one Hermes bot from continuing
+        # to feed closure/ack-only messages from another bot into the LLM.
+        self._bot_dialogue_counts: Dict[str, Tuple[float, int]] = {}
+
+    def _bot_dialogue_key(self, message: DiscordMessage) -> str:
+        channel = getattr(message, "channel", None)
+        channel_id = getattr(channel, "id", None)
+        if channel_id is not None:
+            return str(channel_id)
+        parent_id = getattr(channel, "parent_id", None)
+        return str(parent_id or "unknown")
+
+    def _accept_peer_bot_message(self, message: DiscordMessage) -> bool:
+        """Gateway-level safety guard for bot-to-bot Discord handoffs."""
+        if not _env_bool("DISCORD_BOT_DIALOGUE_GUARD", True):
+            return True
+
+        content = getattr(message, "content", "") or ""
+        key = self._bot_dialogue_key(message)
+        now = time.time()
+        reset_seconds = _env_float("DISCORD_BOT_DIALOGUE_RESET_SECONDS", 900.0, min_value=0.0)
+        max_messages = _env_int("DISCORD_BOT_DIALOGUE_MAX_MESSAGES", 5, min_value=0)
+
+        last_ts, count = self._bot_dialogue_counts.get(key, (0.0, 0))
+        if now - last_ts > reset_seconds:
+            count = 0
+
+        has_non_text_payload = bool(
+            getattr(message, "attachments", None)
+            or getattr(message, "embeds", None)
+            or getattr(message, "stickers", None)
+        )
+        if _is_bot_dialogue_closure_only(content) and not has_non_text_payload:
+            logger.info(
+                "[Discord] Bot dialogue guard blocked closure-only bot message "
+                "channel=%s author=%s content=%r",
+                key,
+                getattr(getattr(message, "author", None), "id", "unknown"),
+                content[:120],
+            )
+            self._bot_dialogue_counts[key] = (now, count)
+            return False
+
+        allowed_bot_ids = _discord_allowed_bot_ids()
+        author_id = str(getattr(getattr(message, "author", None), "id", ""))
+        if allowed_bot_ids and author_id not in allowed_bot_ids:
+            logger.info(
+                "[Discord] Bot dialogue guard blocked unlisted peer-bot message "
+                "channel=%s author=%s",
+                key,
+                author_id or "unknown",
+            )
+            self._bot_dialogue_counts[key] = (now, count)
+            return False
+
+        if max_messages > 0 and count >= max_messages:
+            logger.info(
+                "[Discord] Bot dialogue guard blocked peer-bot message after limit "
+                "channel=%s count=%s max=%s",
+                key,
+                count,
+                max_messages,
+            )
+            self._bot_dialogue_counts[key] = (now, count)
+            return False
+
+        self._bot_dialogue_counts[key] = (now, count + 1)
+        return True
 
     def _handle_bot_task_done(self, task: asyncio.Task) -> None:
         """Surface post-startup discord.py task exits to the gateway supervisor.
@@ -897,12 +1156,14 @@ class DiscordAdapter(BasePlatformAdapter):
                 # not being in DISCORD_ALLOWED_USERS (fixes #4466).
                 _role_authorized = False
                 if getattr(message.author, "bot", False):
-                    allow_bots = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
+                    allow_bots = _discord_allow_bots_mode()
                     if allow_bots == "none":
                         return
                     elif allow_bots == "mentions":
                         if not self._client.user or self._client.user not in message.mentions:
                             return
+                    if not adapter_self._accept_peer_bot_message(message):
+                        return
                     # "all" falls through; bot is permitted — skip the
                     # human-user allowlist below (bots aren't in it).
                 else:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -973,6 +973,7 @@ class TestAuxiliaryPoolAwareness:
 
         with (
             patch("agent.auxiliary_client.load_pool", return_value=_Pool()),
+            patch("hermes_cli.models.get_nous_recommended_aux_model", return_value=None),
             patch("agent.auxiliary_client.OpenAI") as mock_openai,
             patch("hermes_cli.models.get_nous_recommended_aux_model", return_value=None),
         ):
@@ -1604,8 +1605,66 @@ class TestCallLlmPaymentFallback:
         assert fallback_client.chat.completions.create.called
 
 
+    def test_connection_error_evicts_cached_auto_client_before_fallback(self):
+        """Timeouts close Codex streams; evict the cached auto wrapper before fallback."""
+        primary_client = MagicMock()
+        primary_client.chat.completions.create.side_effect = TimeoutError("Codex auxiliary Responses stream exceeded 30.0s total timeout")
+
+        fallback_client = MagicMock()
+        fallback_client.chat.completions.create.return_value = MagicMock(choices=[
+            MagicMock(message=MagicMock(content="fallback response"))
+        ])
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                    return_value=(primary_client, "gpt-5.5")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("auto", None, None, None, None)), \
+             patch("agent.auxiliary_client._evict_cached_clients") as mock_evict, \
+             patch("agent.auxiliary_client._try_payment_fallback",
+                    return_value=(fallback_client, "fallback-model", "openrouter")):
+            result = call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert result.choices[0].message.content == "fallback response"
+        mock_evict.assert_called_once_with("auto")
+        assert fallback_client.chat.completions.create.called
+
+    @pytest.mark.asyncio
+    async def test_async_connection_error_evicts_cached_auto_client_before_fallback(self):
+        primary_client = MagicMock()
+        primary_client.chat.completions.create = AsyncMock(
+            side_effect=TimeoutError("Codex auxiliary Responses stream exceeded 30.0s total timeout")
+        )
+
+        fallback_client = MagicMock()
+        async_fallback_client = MagicMock()
+        async_fallback_client.chat.completions.create = AsyncMock(return_value=MagicMock(choices=[
+            MagicMock(message=MagicMock(content="async fallback response"))
+        ]))
+
+        with patch("agent.auxiliary_client._get_cached_client",
+                    return_value=(primary_client, "gpt-5.5")), \
+             patch("agent.auxiliary_client._resolve_task_provider_model",
+                    return_value=("auto", None, None, None, None)), \
+             patch("agent.auxiliary_client._evict_cached_clients") as mock_evict, \
+             patch("agent.auxiliary_client._try_payment_fallback",
+                    return_value=(fallback_client, "fallback-model", "openrouter")), \
+             patch("agent.auxiliary_client._to_async_client",
+                    return_value=(async_fallback_client, "fallback-model")):
+            result = await async_call_llm(
+                task="session_search",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert result.choices[0].message.content == "async fallback response"
+        mock_evict.assert_called_once_with("auto")
+        async_fallback_client.chat.completions.create.assert_awaited_once()
+
+
 class TestAuxiliaryFallbackLayering:
-    """Explicit-provider users get layered fallback: configured_chain → main agent → warn."""
+    """Explicit-provider users get layered fallback: configured_chain -> main agent -> warn."""
 
     def _make_payment_err(self):
         exc = Exception("Payment Required: insufficient credits")
@@ -1613,7 +1672,7 @@ class TestAuxiliaryFallbackLayering:
         return exc
 
     def test_explicit_provider_uses_configured_chain_first(self, monkeypatch, caplog):
-        """When a user has fallback_chain configured, it's tried BEFORE the main agent model."""
+        """When a user has fallback_chain configured, it is tried BEFORE the main agent model."""
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
 
         primary_client = MagicMock()
@@ -1640,7 +1699,6 @@ class TestAuxiliaryFallbackLayering:
             )
 
         assert chain_client.chat.completions.create.called
-        # Main agent fallback should NOT have been consulted — chain succeeded first
         main_called.assert_not_called()
 
     def test_explicit_provider_falls_back_to_main_when_chain_exhausted(self, monkeypatch):
@@ -2972,6 +3030,39 @@ class TestCodexAuxiliaryAdapterTimeout:
             )
 
         assert time.monotonic() - started < 0.14
+
+    def test_enforces_total_timeout_when_responses_create_blocks(self):
+        """Timeout must fire even before responses.create(stream=True) yields any events."""
+        close_calls = []
+
+        class BlockingCreateStream:
+            def close(self):
+                pass
+
+            def __iter__(self):
+                return iter(())
+
+        class FakeResponses:
+            def create(self, **kwargs):
+                assert kwargs.get("stream") is True
+                time.sleep(0.3)
+                return BlockingCreateStream()
+
+        fake_client = SimpleNamespace(
+            responses=FakeResponses(),
+            close=lambda: close_calls.append(True),
+        )
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+
+        started = time.monotonic()
+        with pytest.raises(TimeoutError):
+            adapter.create(
+                messages=[{"role": "user", "content": "summarize this"}],
+                timeout=0.05,
+            )
+
+        assert time.monotonic() - started < 0.14
+        assert close_calls
 
 
 class TestCodexAuxiliaryToolMessageConversion:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1154,8 +1154,8 @@ class TestRunJobSessionPersistence:
     def test_run_job_empty_response_returns_empty_not_placeholder(self, tmp_path):
         """Empty final_response should stay empty for delivery logic (issue #2234).
 
-        The placeholder '(No response generated)' should only appear in the
-        output log, not in the returned final_response that's used for delivery.
+        The placeholder should only appear in the output log, not in the
+        returned final_response that's used for delivery.
         """
         job = {
             "id": "silent-job",
@@ -1190,7 +1190,41 @@ class TestRunJobSessionPersistence:
         # final_response should be empty for delivery logic to skip
         assert final_response == ""
         # But the output log should show the placeholder
-        assert "(No response generated)" in output
+        assert "（返信を生成できませんでした）" in output
+
+    def test_run_job_japanese_placeholder_stays_empty_for_delivery(self, tmp_path):
+        """A leaked Japanese empty-response placeholder should not be delivered."""
+        job = {
+            "id": "silent-job-japanese-placeholder",
+            "name": "silent test",
+            "prompt": "do work via tools only",
+        }
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "（返信を生成できませんでした）"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == ""
+        assert "（返信を生成できませんでした）" in output
 
     @pytest.mark.parametrize(
         "agent_result,expected_err_substring",

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -27,6 +27,7 @@ from aiohttp.test_utils import TestClient, TestServer
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
+    NO_RESPONSE_GENERATED_FALLBACK,
     ResponseStore,
     _IdempotencyCache,
     _derive_chat_session_id,
@@ -1351,6 +1352,29 @@ class TestChatCompletionsEndpoint:
             assert "usage" in data
 
     @pytest.mark.asyncio
+    async def test_empty_agent_response_uses_japanese_fallback(self, adapter):
+        """Empty agent results should not expose the old English sentinel."""
+        mock_result = {"final_response": "", "messages": [], "api_calls": 1}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [{"role": "user", "content": "Hello"}],
+                    },
+                )
+                assert resp.status == 200
+                data = await resp.json()
+
+        content = data["choices"][0]["message"]["content"]
+        assert content == NO_RESPONSE_GENERATED_FALLBACK
+        assert "No response generated" not in content
+
+    @pytest.mark.asyncio
     async def test_system_prompt_extracted(self, adapter):
         """System messages from the client are passed as ephemeral_system_prompt."""
         mock_result = {
@@ -1576,6 +1600,26 @@ class TestResponsesEndpoint:
             assert data["output"][0]["type"] == "message"
             assert data["output"][0]["content"][0]["type"] == "output_text"
             assert data["output"][0]["content"][0]["text"] == "Paris is the capital of France."
+
+    @pytest.mark.asyncio
+    async def test_empty_response_uses_japanese_fallback(self, adapter):
+        """Responses API should share the user-facing empty-response fallback."""
+        mock_result = {"final_response": "", "messages": [], "api_calls": 1}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "Hello"},
+                )
+                assert resp.status == 200
+                data = await resp.json()
+
+        text = data["output"][0]["content"][0]["text"]
+        assert text == NO_RESPONSE_GENERATED_FALLBACK
+        assert "No response generated" not in text
 
     @pytest.mark.asyncio
     async def test_successful_response_with_array_input(self, adapter):

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -62,7 +62,7 @@ class TestHandleBackgroundCommand:
         runner = _make_runner()
         event = _make_event(text="/background")
         result = await runner._handle_background_command(event)
-        assert "Usage:" in result
+        assert "使い方:" in result
         assert "/background" in result
 
     @pytest.mark.asyncio
@@ -71,7 +71,7 @@ class TestHandleBackgroundCommand:
         runner = _make_runner()
         event = _make_event(text="/bg")
         result = await runner._handle_background_command(event)
-        assert "Usage:" in result
+        assert "使い方:" in result
 
     @pytest.mark.asyncio
     async def test_empty_prompt_shows_usage(self):
@@ -79,7 +79,7 @@ class TestHandleBackgroundCommand:
         runner = _make_runner()
         event = _make_event(text="/background   ")
         result = await runner._handle_background_command(event)
-        assert "Usage:" in result
+        assert "使い方:" in result
 
     @pytest.mark.asyncio
     async def test_valid_prompt_starts_task(self):
@@ -102,7 +102,7 @@ class TestHandleBackgroundCommand:
             result = await runner._handle_background_command(event)
 
         assert "🔄" in result
-        assert "Background task started" in result
+        assert "バックグラウンド作業を開始しました" in result
         assert "bg_" in result  # task ID starts with bg_
         assert "Summarize the top HN stories" in result
         assert len(created_tasks) == 1  # background task was created
@@ -135,7 +135,7 @@ class TestHandleBackgroundCommand:
         with patch("gateway.run.asyncio.create_task", side_effect=capture_task):
             result = await runner._handle_background_command(event)
 
-        assert "Background task started" in result
+        assert "バックグラウンド作業を開始しました" in result
         runner._run_background_task.assert_called_once()
         assert runner._run_background_task.call_args.kwargs["event_message_id"] == "463"
 
@@ -182,7 +182,7 @@ class TestHandleBackgroundCommand:
                     platform=platform,
                 )
                 result = await runner._handle_background_command(event)
-                assert "Background task started" in result
+                assert "バックグラウンド作業を開始しました" in result
 
 
 # ---------------------------------------------------------------------------
@@ -227,7 +227,7 @@ class TestRunBackgroundTask:
         # Should have sent an error message
         mock_adapter.send.assert_called_once()
         call_args = mock_adapter.send.call_args
-        assert "failed" in call_args[1].get("content", call_args[0][1] if len(call_args[0]) > 1 else "").lower()
+        assert "失敗しました" in call_args[1].get("content", call_args[0][1] if len(call_args[0]) > 1 else "")
 
     @pytest.mark.asyncio
     async def test_successful_task_sends_result(self):
@@ -262,7 +262,7 @@ class TestRunBackgroundTask:
         mock_adapter.send.assert_called_once()
         call_args = mock_adapter.send.call_args
         content = call_args[1].get("content", call_args[0][1] if len(call_args[0]) > 1 else "")
-        assert "Background task complete" in content
+        assert "バックグラウンド作業が完了しました" in content
         assert "Hello from background!" in content
         mock_agent_instance.shutdown_memory_provider.assert_called_once()
         mock_agent_instance.close.assert_called_once()

--- a/tests/gateway/test_discord_bot_dialogue_guard.py
+++ b/tests/gateway/test_discord_bot_dialogue_guard.py
@@ -1,0 +1,181 @@
+from types import SimpleNamespace
+
+from gateway.config import PlatformConfig
+from plugins.platforms.discord.adapter import (
+    DiscordAdapter,
+    _discord_allow_bots_mode,
+    _discord_allowed_bot_ids,
+    _is_bot_dialogue_closure_only,
+)
+
+
+def test_bot_dialogue_closure_only_detects_ack_and_stop_phrases():
+    assert _is_bot_dialogue_closure_only("👍")
+    assert _is_bot_dialogue_closure_only("OK!")
+    assert _is_bot_dialogue_closure_only("了解です〜。")
+    assert _is_bot_dialogue_closure_only("（承知しました。）")
+    assert _is_bot_dialogue_closure_only("（ここで止めます）")
+    assert _is_bot_dialogue_closure_only("この会話は終了済みとして扱います。")
+
+
+def test_bot_dialogue_closure_only_allows_substantive_reply():
+    text = "了解です。追加で確認すると、実装前にログと設定を見たほうが安全です。"
+    assert not _is_bot_dialogue_closure_only(text)
+
+
+def test_bot_dialogue_closure_only_allows_short_substantive_ack():
+    assert not _is_bot_dialogue_closure_only("了解しました。ログを確認します。")
+    assert not _is_bot_dialogue_closure_only("承知しました。対応します。")
+
+
+def test_bot_dialogue_closure_only_blocks_gateway_status_notices():
+    assert _is_bot_dialogue_closure_only(
+        "⚡ Interrupting current task (iteration 1/90). I'll respond to your message shortly."
+    )
+    assert _is_bot_dialogue_closure_only(
+        "Operation interrupted: waiting for model response (16.5s elapsed)."
+    )
+
+
+def test_bot_dialogue_closure_only_does_not_block_questions():
+    assert not _is_bot_dialogue_closure_only("大丈夫ですか？")
+    assert not _is_bot_dialogue_closure_only("確認しましたか?")
+
+
+def test_peer_bot_guard_blocks_after_configured_limit(monkeypatch):
+    monkeypatch.setenv("DISCORD_BOT_DIALOGUE_GUARD", "true")
+    monkeypatch.setenv("DISCORD_BOT_DIALOGUE_MAX_MESSAGES", "2")
+    monkeypatch.setenv("DISCORD_BOT_DIALOGUE_RESET_SECONDS", "900")
+    monkeypatch.delenv("DISCORD_ALLOWED_BOTS", raising=False)
+    adapter = DiscordAdapter(PlatformConfig())
+    channel = SimpleNamespace(id=123, parent_id=None)
+    author = SimpleNamespace(id=456)
+
+    def msg(content):
+        return SimpleNamespace(content=content, channel=channel, author=author)
+
+    assert adapter._accept_peer_bot_message(msg("1つ目の実質的な返答です。"))
+    assert adapter._accept_peer_bot_message(msg("2つ目の実質的な返答です。"))
+    assert not adapter._accept_peer_bot_message(msg("3つ目なので止まるべきです。"))
+
+
+def test_peer_bot_guard_blocks_closure_without_incrementing_limit(monkeypatch):
+    monkeypatch.setenv("DISCORD_BOT_DIALOGUE_GUARD", "true")
+    monkeypatch.setenv("DISCORD_BOT_DIALOGUE_MAX_MESSAGES", "2")
+    monkeypatch.delenv("DISCORD_ALLOWED_BOTS", raising=False)
+    adapter = DiscordAdapter(PlatformConfig())
+    channel = SimpleNamespace(id=123, parent_id=None)
+    author = SimpleNamespace(id=456)
+    message = SimpleNamespace(content="承知しました。", channel=channel, author=author)
+
+    assert not adapter._accept_peer_bot_message(message)
+    assert adapter._bot_dialogue_counts["123"][1] == 0
+
+
+def test_peer_bot_guard_allows_attachment_only_messages(monkeypatch):
+    monkeypatch.setenv("DISCORD_BOT_DIALOGUE_GUARD", "true")
+    monkeypatch.setenv("DISCORD_BOT_DIALOGUE_MAX_MESSAGES", "2")
+    monkeypatch.delenv("DISCORD_ALLOWED_BOTS", raising=False)
+    adapter = DiscordAdapter(PlatformConfig())
+    channel = SimpleNamespace(id=123, parent_id=None)
+    author = SimpleNamespace(id=456)
+    attachment = SimpleNamespace(filename="handoff.png", content_type="image/png")
+    message = SimpleNamespace(
+        content="",
+        channel=channel,
+        author=author,
+        attachments=[attachment],
+    )
+
+    assert adapter._accept_peer_bot_message(message)
+    assert adapter._bot_dialogue_counts["123"][1] == 1
+
+
+def test_peer_bot_guard_allows_closure_text_when_attachment_present(monkeypatch):
+    monkeypatch.setenv("DISCORD_BOT_DIALOGUE_GUARD", "true")
+    monkeypatch.setenv("DISCORD_BOT_DIALOGUE_MAX_MESSAGES", "2")
+    monkeypatch.delenv("DISCORD_ALLOWED_BOTS", raising=False)
+    adapter = DiscordAdapter(PlatformConfig())
+    channel = SimpleNamespace(id=123, parent_id=None)
+    author = SimpleNamespace(id=456)
+    attachment = SimpleNamespace(filename="result.txt", content_type="text/plain")
+    message = SimpleNamespace(
+        content="完了しました。",
+        channel=channel,
+        author=author,
+        attachments=[attachment],
+    )
+
+    assert adapter._accept_peer_bot_message(message)
+    assert adapter._bot_dialogue_counts["123"][1] == 1
+
+
+def test_peer_bot_guard_keys_threads_by_thread_channel_id(monkeypatch):
+    monkeypatch.setenv("DISCORD_BOT_DIALOGUE_GUARD", "true")
+    monkeypatch.setenv("DISCORD_BOT_DIALOGUE_MAX_MESSAGES", "1")
+    monkeypatch.delenv("DISCORD_ALLOWED_BOTS", raising=False)
+    adapter = DiscordAdapter(PlatformConfig())
+    author = SimpleNamespace(id=456)
+    thread_a = SimpleNamespace(id=1001, parent_id=999)
+    thread_b = SimpleNamespace(id=1002, parent_id=999)
+
+    def msg(content, channel):
+        return SimpleNamespace(content=content, channel=channel, author=author)
+
+    assert adapter._accept_peer_bot_message(msg("thread A first substantive reply", thread_a))
+    assert not adapter._accept_peer_bot_message(msg("thread A second substantive reply", thread_a))
+    assert adapter._accept_peer_bot_message(msg("thread B first substantive reply", thread_b))
+
+
+def test_peer_bot_guard_invalid_env_values_fall_back_safely(monkeypatch):
+    monkeypatch.setenv("DISCORD_BOT_DIALOGUE_GUARD", "not-a-bool")
+    monkeypatch.setenv("DISCORD_BOT_DIALOGUE_MAX_MESSAGES", "1")
+    monkeypatch.setenv("DISCORD_BOT_DIALOGUE_RESET_SECONDS", "not-a-number")
+    monkeypatch.delenv("DISCORD_ALLOWED_BOTS", raising=False)
+    adapter = DiscordAdapter(PlatformConfig())
+    channel = SimpleNamespace(id=123, parent_id=None)
+    author = SimpleNamespace(id=456)
+
+    def msg(content):
+        return SimpleNamespace(content=content, channel=channel, author=author)
+
+    assert adapter._accept_peer_bot_message(msg("1つ目の実質的な返答です。"))
+    assert not adapter._accept_peer_bot_message(msg("2つ目なので止まるべきです。"))
+
+
+def test_discord_allow_bots_invalid_value_is_not_treated_as_all(monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "true")
+    assert _discord_allow_bots_mode() == "none"
+
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", " ALL ")
+    assert _discord_allow_bots_mode() == "all"
+
+
+def test_discord_allowed_bot_ids_parse_comma_separated_allowlist(monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOWED_BOTS", " 111,222 ,, 333 ")
+    assert _discord_allowed_bot_ids() == {"111", "222", "333"}
+
+
+def test_peer_bot_guard_blocks_bots_not_in_allowlist(monkeypatch):
+    monkeypatch.setenv("DISCORD_BOT_DIALOGUE_GUARD", "true")
+    monkeypatch.setenv("DISCORD_ALLOWED_BOTS", "111,222")
+    adapter = DiscordAdapter(PlatformConfig())
+    channel = SimpleNamespace(id=123, parent_id=None)
+    unlisted_author = SimpleNamespace(id=999)
+    message = SimpleNamespace(content="実質的な返答です。", channel=channel, author=unlisted_author)
+
+    assert not adapter._accept_peer_bot_message(message)
+    assert adapter._bot_dialogue_counts["123"][1] == 0
+
+
+def test_peer_bot_guard_allows_bots_in_allowlist(monkeypatch):
+    monkeypatch.setenv("DISCORD_BOT_DIALOGUE_GUARD", "true")
+    monkeypatch.setenv("DISCORD_ALLOWED_BOTS", "111,222")
+    monkeypatch.setenv("DISCORD_BOT_DIALOGUE_MAX_MESSAGES", "2")
+    adapter = DiscordAdapter(PlatformConfig())
+    channel = SimpleNamespace(id=123, parent_id=None)
+    listed_author = SimpleNamespace(id=222)
+    message = SimpleNamespace(content="実質的な返答です。", channel=channel, author=listed_author)
+
+    assert adapter._accept_peer_bot_message(message)
+    assert adapter._bot_dialogue_counts["123"][1] == 1

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -45,6 +45,17 @@ _ensure_discord_mock()
 from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
 
 
+class FakeDiscordHTTPError(RuntimeError):
+    def __init__(self, message, *, status=None, retry_after=None):
+        super().__init__(message)
+        self.status = status
+        self.retry_after = retry_after
+
+
+async def _noop_sleep(delay):
+    return None
+
+
 @pytest.mark.asyncio
 async def test_send_retries_without_reference_when_reply_target_is_system_message():
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
@@ -158,6 +169,95 @@ async def test_send_does_not_retry_on_unrelated_errors():
     # Only the first attempt happens — no reference-retry replay.
     assert channel.send.await_count == 1
     assert send_calls[0]["reference"] is reference_obj
+
+
+
+
+@pytest.mark.asyncio
+async def test_send_retries_transient_broken_pipe_once(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    sleep_calls = []
+
+    async def fake_sleep(delay):
+        sleep_calls.append(delay)
+
+    monkeypatch.setattr("gateway.platforms.discord.asyncio.sleep", fake_sleep)
+
+    sent_msg = SimpleNamespace(id=1234)
+    channel = SimpleNamespace(
+        send=AsyncMock(side_effect=[BrokenPipeError("Broken pipe"), sent_msg]),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send("555", "hello")
+
+    assert result.success is True
+    assert result.message_id == "1234"
+    assert channel.send.await_count == 2
+    assert len(sleep_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_send_retries_429_with_retry_after(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    sleep_calls = []
+
+    async def fake_sleep(delay):
+        sleep_calls.append(delay)
+
+    monkeypatch.setattr("gateway.platforms.discord.asyncio.sleep", fake_sleep)
+
+    sent_msg = SimpleNamespace(id=1235)
+    channel = SimpleNamespace(
+        send=AsyncMock(side_effect=[
+            FakeDiscordHTTPError("429 Too Many Requests", status=429, retry_after=2.0),
+            sent_msg,
+        ]),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send("555", "hello")
+
+    assert result.success is True
+    assert result.message_id == "1235"
+    assert channel.send.await_count == 2
+    assert sleep_calls == [2.0]
+
+
+@pytest.mark.asyncio
+async def test_send_returns_partial_success_after_acknowledged_chunk_failure(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter.MAX_MESSAGE_LENGTH = 20
+    monkeypatch.setattr("gateway.platforms.discord.asyncio.sleep", _noop_sleep)
+
+    first_msg = SimpleNamespace(id=2001)
+    channel = SimpleNamespace(
+        send=AsyncMock(side_effect=[
+            first_msg,
+            BrokenPipeError("Broken pipe"),
+            BrokenPipeError("Broken pipe"),
+            BrokenPipeError("Broken pipe"),
+        ]),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send("555", "A" * 50)
+
+    assert result.success is True
+    assert result.message_id == "2001"
+    assert result.raw_response["partial"] is True
+    assert result.raw_response["message_ids"] == ["2001"]
+    assert "Broken pipe" in result.raw_response["warnings"][0]
+    assert channel.send.await_count == 4
 
 
 # ---------------------------------------------------------------------------
@@ -317,6 +417,101 @@ async def test_send_to_forum_follow_up_chunk_failures_collected_as_warnings():
     warnings = (result.raw_response or {}).get("warnings") or []
     assert len(warnings) >= 1
     assert all("rate limited" in w for w in warnings)
+
+
+@pytest.mark.asyncio
+async def test_send_to_forum_retries_follow_up_transient_failure(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter.MAX_MESSAGE_LENGTH = 20
+    monkeypatch.setattr("gateway.platforms.discord.asyncio.sleep", _noop_sleep)
+
+    starter = SimpleNamespace(id=500)
+    follow_up_calls = []
+
+    async def fake_follow_up_send(*, content):
+        follow_up_calls.append(content)
+        if len(follow_up_calls) == 1:
+            raise BrokenPipeError("Broken pipe")
+        return SimpleNamespace(id=500 + len(follow_up_calls))
+
+    thread_ch = SimpleNamespace(
+        id=555,
+        send=AsyncMock(side_effect=fake_follow_up_send),
+    )
+    thread = SimpleNamespace(id=555, message=starter, thread=thread_ch)
+    forum_channel = _discord_mod.ForumChannel()
+    forum_channel.id = 999
+    forum_channel.name = "ideas"
+    forum_channel.create_thread = AsyncMock(return_value=thread)
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: forum_channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send("999", "A" * 25)
+
+    assert result.success is True
+    assert result.raw_response["message_ids"][:2] == ["500", "502"]
+    assert "warnings" not in result.raw_response
+    assert thread_ch.send.await_count == len(result.raw_response["message_ids"])
+
+
+@pytest.mark.asyncio
+async def test_send_to_forum_retries_create_thread_on_429(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    sleep_calls = []
+
+    async def fake_sleep(delay):
+        sleep_calls.append(delay)
+
+    monkeypatch.setattr("gateway.platforms.discord.asyncio.sleep", fake_sleep)
+
+    thread = SimpleNamespace(
+        id=555,
+        message=SimpleNamespace(id=500),
+        thread=SimpleNamespace(id=555, send=AsyncMock()),
+    )
+    forum_channel = _discord_mod.ForumChannel()
+    forum_channel.id = 999
+    forum_channel.name = "ideas"
+    forum_channel.create_thread = AsyncMock(side_effect=[
+        FakeDiscordHTTPError("429 Too Many Requests", status=429, retry_after=1.5),
+        thread,
+    ])
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: forum_channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send("999", "Hello forum!")
+
+    assert result.success is True
+    assert result.message_id == "500"
+    assert forum_channel.create_thread.await_count == 2
+    assert sleep_calls == [1.5]
+
+
+@pytest.mark.asyncio
+async def test_send_to_forum_does_not_retry_ambiguous_create_thread_disconnect(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    monkeypatch.setattr("gateway.platforms.discord.asyncio.sleep", _noop_sleep)
+
+    forum_channel = _discord_mod.ForumChannel()
+    forum_channel.id = 999
+    forum_channel.name = "ideas"
+    forum_channel.create_thread = AsyncMock(side_effect=RuntimeError("Server disconnected"))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: forum_channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send("999", "Hello forum!")
+
+    assert result.success is False
+    assert "not retried to avoid duplicate forum post" in (result.error or "")
+    assert result.raw_response["unsafe_to_retry"] is True
+    assert result.retryable is False
+    assert forum_channel.create_thread.await_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -181,7 +181,7 @@ async def test_send_retries_transient_broken_pipe_once(monkeypatch):
     async def fake_sleep(delay):
         sleep_calls.append(delay)
 
-    monkeypatch.setattr("gateway.platforms.discord.asyncio.sleep", fake_sleep)
+    monkeypatch.setattr("plugins.platforms.discord.adapter.asyncio.sleep", fake_sleep)
 
     sent_msg = SimpleNamespace(id=1234)
     channel = SimpleNamespace(
@@ -208,7 +208,7 @@ async def test_send_retries_429_with_retry_after(monkeypatch):
     async def fake_sleep(delay):
         sleep_calls.append(delay)
 
-    monkeypatch.setattr("gateway.platforms.discord.asyncio.sleep", fake_sleep)
+    monkeypatch.setattr("plugins.platforms.discord.adapter.asyncio.sleep", fake_sleep)
 
     sent_msg = SimpleNamespace(id=1235)
     channel = SimpleNamespace(
@@ -234,7 +234,7 @@ async def test_send_retries_429_with_retry_after(monkeypatch):
 async def test_send_returns_partial_success_after_acknowledged_chunk_failure(monkeypatch):
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
     adapter.MAX_MESSAGE_LENGTH = 20
-    monkeypatch.setattr("gateway.platforms.discord.asyncio.sleep", _noop_sleep)
+    monkeypatch.setattr("plugins.platforms.discord.adapter.asyncio.sleep", _noop_sleep)
 
     first_msg = SimpleNamespace(id=2001)
     channel = SimpleNamespace(
@@ -423,7 +423,7 @@ async def test_send_to_forum_follow_up_chunk_failures_collected_as_warnings():
 async def test_send_to_forum_retries_follow_up_transient_failure(monkeypatch):
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
     adapter.MAX_MESSAGE_LENGTH = 20
-    monkeypatch.setattr("gateway.platforms.discord.asyncio.sleep", _noop_sleep)
+    monkeypatch.setattr("plugins.platforms.discord.adapter.asyncio.sleep", _noop_sleep)
 
     starter = SimpleNamespace(id=500)
     follow_up_calls = []
@@ -464,7 +464,7 @@ async def test_send_to_forum_retries_create_thread_on_429(monkeypatch):
     async def fake_sleep(delay):
         sleep_calls.append(delay)
 
-    monkeypatch.setattr("gateway.platforms.discord.asyncio.sleep", fake_sleep)
+    monkeypatch.setattr("plugins.platforms.discord.adapter.asyncio.sleep", fake_sleep)
 
     thread = SimpleNamespace(
         id=555,
@@ -494,7 +494,7 @@ async def test_send_to_forum_retries_create_thread_on_429(monkeypatch):
 @pytest.mark.asyncio
 async def test_send_to_forum_does_not_retry_ambiguous_create_thread_disconnect(monkeypatch):
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
-    monkeypatch.setattr("gateway.platforms.discord.asyncio.sleep", _noop_sleep)
+    monkeypatch.setattr("plugins.platforms.discord.adapter.asyncio.sleep", _noop_sleep)
 
     forum_channel = _discord_mod.ForumChannel()
     forum_channel.id = 999

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -149,6 +149,14 @@ class TestYAMLNormalisation:
         config = {"display": {"tool_progress": True}}
         assert resolve_display_setting(config, "telegram", "tool_progress") == "all"
 
+    def test_tool_progress_string_sentinels_normalised(self):
+        """String sentinels like 'none' and 'false' really disable gateway progress."""
+        from gateway.display_config import resolve_display_setting
+
+        for value in ("off", "none", "false", "no", "0"):
+            config = {"display": {"tool_progress": value}}
+            assert resolve_display_setting(config, "discord", "tool_progress") == "off"
+
     def test_show_reasoning_string_true(self):
         """String 'true' is normalised to bool True."""
         from gateway.display_config import resolve_display_setting

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -170,6 +170,41 @@ class TestYAMLNormalisation:
         config = {"display": {"platforms": {"slack": {"tool_progress": False}}}}
         assert resolve_display_setting(config, "slack", "tool_progress") == "off"
 
+    def test_tool_progress_tools_string_normalised_to_list(self):
+        """Comma-separated tool allowlist strings become clean lower-case lists."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {"display": {"tool_progress_tools": "Memory, patch,"}}
+        assert resolve_display_setting(config, "discord", "tool_progress_tools") == [
+            "memory",
+            "patch",
+        ]
+
+    def test_tool_progress_tools_platform_override_wins(self):
+        """Per-platform allowlists can override the global allowlist."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "tool_progress_tools": ["memory"],
+                "platforms": {"discord": {"tool_progress_tools": ["patch"]}},
+            }
+        }
+        assert resolve_display_setting(config, "discord", "tool_progress_tools") == [
+            "patch",
+        ]
+        assert resolve_display_setting(config, "telegram", "tool_progress_tools") == [
+            "memory",
+        ]
+
+    def test_tool_progress_tools_off_normalised_to_none(self):
+        """Empty/off/all values mean no per-tool filter."""
+        from gateway.display_config import resolve_display_setting
+
+        for value in (False, "", "off", "all", "*", ["all"], ["memory", "*"]):
+            config = {"display": {"tool_progress_tools": value}}
+            assert resolve_display_setting(config, "discord", "tool_progress_tools") is None
+
 
 # ---------------------------------------------------------------------------
 # Built-in platform defaults (tier system)

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -11,6 +11,7 @@ from gateway.platforms.base import (
     GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE,
     MessageEvent,
     safe_url_for_log,
+    SendResult,
     utf16_len,
     _log_safe_path,
     _prefix_within_utf16_limit,
@@ -1110,6 +1111,47 @@ class TestShouldSendMediaAsAudio:
         assert should_send_media_as_audio(Platform.TELEGRAM, ".mp3") is True
         assert should_send_media_as_audio(Platform.TELEGRAM, ".flac") is False
         assert should_send_media_as_audio(Platform.DISCORD, ".flac") is True
+
+
+# ---------------------------------------------------------------------------
+# _send_with_retry unsafe retry guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_with_retry_respects_unsafe_to_retry_result():
+    from gateway.config import Platform, PlatformConfig
+
+    class StubAdapter(BasePlatformAdapter):
+        def __init__(self):
+            super().__init__(config=PlatformConfig(enabled=True, token="test"), platform=Platform.DISCORD)
+            self.calls = 0
+
+        async def connect(self):
+            return True
+
+        async def disconnect(self):
+            pass
+
+        async def send(self, *a, **kw):
+            self.calls += 1
+            return SendResult(
+                success=False,
+                error="Forum thread creation failed after connection drop",
+                raw_response={"unsafe_to_retry": True},
+                retryable=True,
+            )
+
+        async def get_chat_info(self, *a):
+            return {}
+
+    adapter = StubAdapter()
+
+    result = await adapter._send_with_retry("123", "hello", max_retries=3, base_delay=0)
+
+    assert result.success is False
+    assert result.raw_response["unsafe_to_retry"] is True
+    assert adapter.calls == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_provider_api_failure_fallback.py
+++ b/tests/gateway/test_provider_api_failure_fallback.py
@@ -1,0 +1,60 @@
+"""Gateway fallback copy for provider/API failures."""
+
+from gateway.run import _format_provider_api_failure_for_gateway
+
+
+def test_openai_request_id_failure_is_hidden_from_user_response():
+    raw = (
+        "API call failed after 3 retries: An error occurred while processing your request. "
+        "You can retry your request, or contact us through our help center at help.openai.com "
+        "if the error persists. Please include the request ID "
+        "45c0c992-18ae-44c0-a62a-2caf0563b98b in your message."
+    )
+
+    visible = _format_provider_api_failure_for_gateway(
+        {"failed": True, "error": raw},
+        raw,
+    )
+
+    assert visible == "⚠️ モデル応答が一時的に失敗しました。少し待って再実行してください。\n詳細はログに記録しました。"
+    assert "API call failed" not in visible
+    assert "help.openai.com" not in visible
+    assert "45c0c992" not in visible
+    assert "request ID" not in visible
+
+
+def test_rate_limit_failure_gets_wait_and_retry_copy():
+    raw = "API call failed after 3 retries: 429 Too Many Requests — rate limit exceeded"
+
+    visible = _format_provider_api_failure_for_gateway(
+        {"failed": True, "error": "429 Too Many Requests"},
+        raw,
+    )
+
+    assert "混み合っています" in visible
+    assert "再実行" in visible
+    assert "429" not in visible
+
+
+def test_context_provider_failure_keeps_actionable_compact_guidance():
+    raw = "API call failed after 3 retries: prompt is too long: context window exceeded"
+
+    visible = _format_provider_api_failure_for_gateway(
+        {"failed": True, "error": raw},
+        raw,
+    )
+
+    assert "/compact" in visible
+    assert "/reset" in visible
+    assert "prompt is too long" not in visible
+
+
+def test_non_provider_failure_response_is_unchanged():
+    response = "普通の応答です。"
+
+    visible = _format_provider_api_failure_for_gateway(
+        {"completed": True},
+        response,
+    )
+
+    assert visible == response

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -145,6 +145,47 @@ class FakeAgent:
         }
 
 
+class MemoryOnlyProgressAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        if cb is not None:
+            cb("tool.started", "terminal", "pwd", {"command": "pwd"})
+            time.sleep(0.1)
+            cb("tool.started", "memory", "add user preference", {"action": "add"})
+            time.sleep(0.1)
+            cb("tool.started", "read_file", "/tmp/noisy.txt", {"path": "/tmp/noisy.txt"})
+            time.sleep(0.1)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class NoProgressAgent:
+    def __init__(self, **kwargs):
+        self.tools = []
+        self.model = "fake-model"
+        self.provider = "fake-provider"
+        self.base_url = "https://example.invalid"
+        self.api_key = "fake-key"
+        self.api_mode = "chat_completions"
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        return {
+            "final_response": "done",
+            "messages": [
+                {"role": "user", "content": message},
+                {"role": "assistant", "content": "done"},
+            ],
+            "api_calls": 1,
+        }
+
+
 class LongPreviewAgent:
     """Agent that emits a tool call with a very long preview string."""
     LONG_CMD = "cd /home/teknium/.hermes/hermes-agent/.worktrees/hermes-d8860339 && source .venv/bin/activate && python -m pytest tests/gateway/test_run_progress_topics.py -n0 -q"
@@ -329,6 +370,118 @@ async def test_run_agent_progress_edits_keep_originating_topic_metadata(monkeypa
     assert result["final_response"] == "done"
     assert adapter.edits
     assert all(call["metadata"] == {"thread_id": "17585"} for call in adapter.edits)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_progress_tool_allowlist_can_show_memory_only(monkeypatch, tmp_path):
+    """display.tool_progress_tools can keep memory visible while hiding noisy tools."""
+    import yaml
+
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "display": {
+                    "tool_progress": "off",
+                    "tool_progress_tools": ["Memory"],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = MemoryOnlyProgressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    import tools.memory_tool  # noqa: F401 - register memory emoji for this fake-agent test
+
+    adapter = ProgressCaptureAdapter(platform=Platform.DISCORD)
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="discord-channel",
+        chat_type="group",
+        thread_id="thread-1",
+    )
+
+    result = await runner._run_agent(
+        message="remember this",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-memory-only",
+        session_key="agent:main:discord:group:discord-channel:thread-1",
+    )
+
+    assert result["final_response"] == "done"
+    progress_contents = [item["content"] for item in adapter.sent]
+    assert progress_contents == ['🧠 memory: "add user preference"']
+    assert "terminal" not in "\n".join(progress_contents)
+    assert "read_file" not in "\n".join(progress_contents)
+
+
+@pytest.mark.asyncio
+async def test_gateway_auto_title_does_not_surface_aux_failure_callback(monkeypatch, tmp_path):
+    """Gateway auto-title generation must not emit post-answer auxiliary warnings."""
+    import yaml
+
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump({"display": {"tool_progress": "off"}}),
+        encoding="utf-8",
+    )
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = NoProgressAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    captured = []
+
+    def fake_maybe_auto_title(*args, **kwargs):
+        captured.append((args, kwargs))
+
+    import agent.title_generator as title_generator
+
+    monkeypatch.setattr(title_generator, "maybe_auto_title", fake_maybe_auto_title)
+
+    adapter = ProgressCaptureAdapter(platform=Platform.DISCORD)
+    runner = _make_runner(adapter)
+    runner._session_db = object()
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="discord-channel",
+        chat_type="group",
+        thread_id="thread-1",
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-title",
+        session_key="agent:main:discord:group:discord-channel:thread-1",
+    )
+
+    assert result["final_response"] == "done"
+    assert len(captured) == 1
+    _, kwargs = captured[0]
+    assert kwargs["failure_callback"] is None
+    assert kwargs["main_runtime"]["model"] == "fake-model"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_running_agent_session_toggles.py
+++ b/tests/gateway/test_running_agent_session_toggles.py
@@ -180,7 +180,7 @@ async def test_btw_dispatches_mid_run():
     """
     runner = _make_runner()
     runner._handle_background_command = AsyncMock(
-        return_value='🚀 Background task started: "what module owns titles?"'
+        return_value='🔄 バックグラウンド作業を開始しました: "what module owns titles?"'
     )
 
     result = await runner._handle_message(_make_event("/btw what module owns titles?"))

--- a/tests/gateway/test_send_retry.py
+++ b/tests/gateway/test_send_retry.py
@@ -204,7 +204,7 @@ class TestSendWithRetryNetworkRetry:
         assert result.success
         # 3 calls: initial (network) + 1 retry (non-network, breaks loop) + plain-text fallback
         assert len(adapter._send_calls) == 3
-        assert "plain text" in adapter._send_calls[-1][1].lower()
+        assert "プレーンテキスト" in adapter._send_calls[-1][1]
 
 
 # ---------------------------------------------------------------------------
@@ -226,7 +226,7 @@ class TestSendWithRetryExhausted:
         assert len(adapter._send_calls) == 4
         # The notice content should mention delivery failure
         notice_content = adapter._send_calls[-1][1]
-        assert "delivery failed" in notice_content.lower() or "Message delivery failed" in notice_content
+        assert "返信の送信に複数回失敗しました" in notice_content
 
     @pytest.mark.asyncio
     async def test_notice_send_exception_doesnt_propagate(self):
@@ -269,7 +269,7 @@ class TestSendWithRetryFallback:
         assert result.success
         assert len(adapter._send_calls) == 2
         # Fallback content should be plain-text notice
-        assert "plain text" in adapter._send_calls[1][1].lower()
+        assert "プレーンテキスト" in adapter._send_calls[1][1]
 
     @pytest.mark.asyncio
     async def test_fallback_failure_logged_but_not_raised(self):

--- a/tests/gateway/test_session_state_cleanup.py
+++ b/tests/gateway/test_session_state_cleanup.py
@@ -16,10 +16,11 @@ Also: SessionDB connections were never closed on gateway shutdown,
 leaving WAL locks in place until Python actually exited.
 """
 
+import asyncio
 import threading
 from unittest.mock import MagicMock
 
-
+import pytest
 
 def _make_runner():
     """Bare GatewayRunner wired with just the state the helper touches."""
@@ -29,6 +30,9 @@ def _make_runner():
     runner._running_agents = {}
     runner._running_agents_ts = {}
     runner._busy_ack_ts = {}
+    runner._draining = False
+    runner._restart_requested = False
+    runner._update_runtime_status = MagicMock()
     return runner
 
 
@@ -44,6 +48,24 @@ class TestReleaseRunningAgentStateUnit:
         assert "k" not in runner._running_agents
         assert "k" not in runner._running_agents_ts
         assert "k" not in runner._busy_ack_ts
+        runner._update_runtime_status.assert_called_once_with("running")
+
+    def test_release_preserves_draining_state_in_runtime_status(self):
+        """A release during restart/shutdown drain must not briefly report running."""
+        runner = _make_runner()
+        runner._draining = True
+        runner._running_agents["k"] = MagicMock()
+        runner._running_agents_ts["k"] = 123.0
+
+        runner._release_running_agent_state("k")
+
+        runner._update_runtime_status.assert_called_once_with("draining")
+
+    def test_runtime_status_active_state_follows_drain_flag(self):
+        runner = _make_runner()
+        assert runner._runtime_status_active_state() == "running"
+        runner._draining = True
+        assert runner._runtime_status_active_state() == "draining"
 
     def test_idempotent_on_missing_key(self):
         """Calling twice (or on an absent key) must not raise."""
@@ -110,6 +132,51 @@ class TestReleaseRunningAgentStateUnit:
         assert runner._running_agents == {}
         assert runner._running_agents_ts == {}
         assert runner._busy_ack_ts == {}
+
+    @pytest.mark.asyncio
+    async def test_runtime_status_heartbeat_refreshes_busy_gateway(self, monkeypatch):
+        """Long turns keep gateway_state.json fresh so watchdogs don't restart them."""
+        runner = _make_runner()
+        runner._running_agents["k"] = MagicMock()
+        monkeypatch.setenv("HERMES_GATEWAY_STATUS_HEARTBEAT_INTERVAL", "0.01")
+
+        task = asyncio.create_task(runner._runtime_status_heartbeat_loop("k"))
+        try:
+            for _ in range(20):
+                if runner._update_runtime_status.call_count >= 2:
+                    break
+                await asyncio.sleep(0.01)
+            assert runner._update_runtime_status.call_count >= 1
+            runner._update_runtime_status.assert_any_call("running")
+        finally:
+            runner._running_agents.clear()
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    @pytest.mark.asyncio
+    async def test_runtime_status_heartbeat_uses_draining_state(self, monkeypatch):
+        runner = _make_runner()
+        runner._draining = True
+        runner._running_agents["k"] = MagicMock()
+        monkeypatch.setenv("HERMES_GATEWAY_STATUS_HEARTBEAT_INTERVAL", "0.01")
+
+        task = asyncio.create_task(runner._runtime_status_heartbeat_loop("k"))
+        try:
+            for _ in range(20):
+                if runner._update_runtime_status.call_count:
+                    break
+                await asyncio.sleep(0.01)
+            runner._update_runtime_status.assert_any_call("draining")
+        finally:
+            runner._running_agents.clear()
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
 
 
 class TestNoMoreBareDeleteSites:


### PR DESCRIPTION
## Summary

This PR restores the local gateway noise/safety work from `backup/pre-pull-20260605-171449` onto current `main`, resolving conflicts against the newer Discord plugin adapter and gateway code.

Includes conflict-resolved reapplication of `f0f637cb2`.

Main changes:
- Reduce noisy Discord/gateway user-facing output and suppress mechanical/internal status leakage.
- Add Discord bot-to-bot dialogue guards to avoid closure/ack-only mention loops.
- Harden Discord send retries and partial-send handling.
- Soften provider/API and auxiliary failure replies for gateway users.
- Keep Codex auxiliary timeout/cache-eviction behavior from poisoning future aux calls.
- Preserve gateway runtime status heartbeat while long turns are active.

## Review focus

- Discord user-facing output should not expose raw tool/status/JSON.
- Clarification prompts should be natural, not mechanical labels.
- Bot-to-bot dialogue should not create unnecessary mention loops.
- Gateway progress messages should not be too noisy.
- Provider/auxiliary failures should degrade softly without hanging.

## Validation

Targeted related suite:

```text
python -m pytest tests/agent/test_auxiliary_client.py tests/gateway/test_discord_bot_dialogue_guard.py tests/gateway/test_display_config.py tests/gateway/test_run_progress_topics.py tests/gateway/test_session_state_cleanup.py tests/gateway/test_discord_send.py tests/gateway/test_platform_base.py tests/gateway/test_provider_api_failure_fallback.py tests/gateway/test_api_server.py tests/gateway/test_background_command.py tests/gateway/test_base_topic_sessions.py tests/gateway/test_running_agent_session_toggles.py tests/gateway/test_send_retry.py tests/cron/test_scheduler.py -o 'addopts=' -q
```

Result:

```text
873 passed, 107 warnings in 59.44s
```

Auxiliary focused check:

```text
python -m pytest tests/agent/test_auxiliary_client.py -o 'addopts=' -q
```

Result:

```text
221 passed, 1 warning in 14.03s
```
