### PR TITLE
fix(runtime_provider): resolve key_env/api_key_env from env for custom providers (#44666, #43586)

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -494,10 +494,11 @@ def _resolve_entry_key_env(entry: Dict[str, Any]) -> str:
     reference, reading ``os.environ`` *at request time*.
 
     Accepts the canonical ``key_env`` plus the documented snake_case
-    ``api_key_env`` alias and the camelCase ``apiKeyEnv`` spelling, mirroring
-    :func:`hermes_cli.config._normalize_custom_provider_entry`. ``key_env``
-    wins when more than one form is present. Returns ``""`` when no env-var
-    name is configured or the named variable is unset/blank.
+    ``api_key_env`` alias and the camelCase ``keyEnv`` / ``apiKeyEnv``
+    spellings, mirroring the alias map in
+    :func:`hermes_cli.config._normalize_custom_provider_entry` (canonical
+    snake_case keys win). Returns ``""`` when no env-var name is configured or
+    the named variable is unset/blank.
 
     This closes the gap behind GH #44666 (``api_key_env`` ignored on a
     ``providers:`` dict entry) and GH #43586 (``key_env``/``api_key_env`` on a
@@ -505,7 +506,7 @@ def _resolve_entry_key_env(entry: Dict[str, Any]) -> str:
     read only the literal ``api_key`` and fell through to ``no-key-required``.
     """
     env_name = ""
-    for field in ("key_env", "api_key_env", "apiKeyEnv"):
+    for field in ("key_env", "api_key_env", "keyEnv", "apiKeyEnv"):
         candidate = str(entry.get(field, "") or "").strip()
         if candidate:
             env_name = candidate

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -489,6 +489,30 @@ def _lift_max_output_tokens(entry: Dict[str, Any], result: Dict[str, Any]) -> No
             return
 
 
+def _resolve_entry_key_env(entry: Dict[str, Any]) -> str:
+    """Resolve a provider/model entry's API key from its ``key_env`` env-var
+    reference, reading ``os.environ`` *at request time*.
+
+    Accepts the canonical ``key_env`` plus the documented snake_case
+    ``api_key_env`` alias and the camelCase ``apiKeyEnv`` spelling, mirroring
+    :func:`hermes_cli.config._normalize_custom_provider_entry`. ``key_env``
+    wins when more than one form is present. Returns ``""`` when no env-var
+    name is configured or the named variable is unset/blank.
+
+    This closes the gap behind GH #44666 (``api_key_env`` ignored on a
+    ``providers:`` dict entry) and GH #43586 (``key_env``/``api_key_env`` on a
+    bare ``model: { provider: custom }`` block ignored): both paths used to
+    read only the literal ``api_key`` and fell through to ``no-key-required``.
+    """
+    env_name = ""
+    for field in ("key_env", "api_key_env", "apiKeyEnv"):
+        candidate = str(entry.get(field, "") or "").strip()
+        if candidate:
+            env_name = candidate
+            break
+    return os.getenv(env_name, "").strip() if env_name else ""
+
+
 def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, Any]]:
     requested_norm = _normalize_custom_provider_name(requested_provider or "")
     if not requested_norm:
@@ -538,9 +562,11 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                 continue
             # Match exact name or normalized name
             name_norm = _normalize_custom_provider_name(ep_name)
-            # Resolve the API key from the env var name stored in key_env
-            key_env = str(entry.get("key_env", "") or "").strip()
-            resolved_api_key = os.getenv(key_env, "").strip() if key_env else ""
+            # Resolve the API key from the env var named by key_env /
+            # api_key_env. The raw providers: dict is read here without going
+            # through _normalize_custom_provider_entry, so the api_key_env
+            # alias was previously dropped (GH #44666) — honor it explicitly.
+            resolved_api_key = _resolve_entry_key_env(entry)
             # Fall back to inline api_key when key_env is absent or unresolvable
             if not resolved_api_key:
                 resolved_api_key = str(entry.get("api_key", "") or "").strip()
@@ -758,6 +784,10 @@ def _resolve_named_custom_runtime(
         _da_is_openrouter   = base_url_host_matches(base_url, "openrouter.ai")
         api_key_candidates = [
             (explicit_api_key or "").strip(),
+            # Bare `model: { provider: custom, base_url, key_env }` reaches this
+            # direct-alias branch without a custom_providers entry, so resolve
+            # the model block's own key_env / api_key_env from env (GH #43586).
+            _resolve_entry_key_env(_get_model_config()),
             # Gate env key fallbacks on authoritative hosts (#28660)
             (os.getenv("OPENAI_API_KEY", "").strip()     if _da_is_openai_url else ""),
             (os.getenv("OPENROUTER_API_KEY", "").strip() if _da_is_openrouter  else ""),
@@ -860,6 +890,10 @@ def _resolve_openrouter_runtime(
         if isinstance(v, str) and v.strip():
             cfg_api_key = v.strip()
             break
+    # Resolve the model block's key_env / api_key_env from env at request time
+    # so a bare `provider: custom` config that authenticates via key_env isn't
+    # sent out as `no-key-required` (GH #43586).
+    cfg_key_env_value = _resolve_entry_key_env(model_cfg)
     requested_norm = (requested_provider or "").strip().lower()
     cfg_provider = cfg_provider.strip().lower()
     # GitHub #27132: provider aliases that resolve to "custom" (ollama,
@@ -938,6 +972,9 @@ def _resolve_openrouter_runtime(
         api_key_candidates = [
             explicit_api_key,
             (cfg_api_key if use_config_base_url else ""),
+            # Honor the model block's key_env / api_key_env when targeting the
+            # configured endpoint (GH #43586) — same gate as cfg_api_key.
+            (cfg_key_env_value if use_config_base_url else ""),
             (os.getenv("OLLAMA_API_KEY")     if _is_ollama_url                       else ""),
             (os.getenv("OPENAI_API_KEY")     if (_is_openai_url or _is_openai_azure) else ""),
             (os.getenv("OPENROUTER_API_KEY") if _is_openrouter_url                   else ""),

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -900,6 +900,42 @@ def test_named_custom_provider_uses_api_key_env_alias_from_providers_dict(monkey
     assert resolved["api_key"] == "litellm-secret"
 
 
+def test_named_custom_provider_uses_camelcase_keyenv_from_providers_dict(monkeypatch):
+    """GH #44666 (follow-up): the raw providers: dict bypasses the config
+    normalizer's camelCase alias map, which maps both `keyEnv` and `apiKeyEnv`
+    to `key_env`. Runtime resolution must honor the camelCase `keyEnv` spelling
+    too, otherwise it falls through to `no-key-required`."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("LITELLM_API_KEY", "litellm-secret")
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "litellm": {
+                    "base_url": "http://127.0.0.1:4000/v1",
+                    "keyEnv": "LITELLM_API_KEY",
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="custom:litellm")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_key"] == "litellm-secret"
+
+
 def test_bare_custom_model_resolves_key_env_from_config(monkeypatch):
     """GH #43586: a bare `model: { provider: custom, base_url, key_env }`
     block (no custom_providers/providers entry) must resolve its key_env from

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -863,6 +863,99 @@ def test_named_custom_provider_uses_key_env_from_providers_dict(monkeypatch):
     assert resolved["model"] == "acme-large"
 
 
+def test_named_custom_provider_uses_api_key_env_alias_from_providers_dict(monkeypatch):
+    """GH #44666: a providers: dict entry authenticating via the documented
+    `api_key_env` alias must resolve the key from env, not fall through to
+    `no-key-required`. The raw providers dict is read without the
+    config-level normalizer, so the alias has to be honored here too."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("LITELLM_API_KEY", "litellm-secret")
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "litellm": {
+                    "base_url": "http://127.0.0.1:4000/v1",
+                    "api_key_env": "LITELLM_API_KEY",
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="custom:litellm")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "http://127.0.0.1:4000/v1"
+    assert resolved["api_key"] == "litellm-secret"
+
+
+def test_bare_custom_model_resolves_key_env_from_config(monkeypatch):
+    """GH #43586: a bare `model: { provider: custom, base_url, key_env }`
+    block (no custom_providers/providers entry) must resolve its key_env from
+    env instead of sending `no-key-required`."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("MY_GATEWAY_TOKEN", "gateway-secret")
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "model": {
+                "default": "zai.glm-5",
+                "provider": "custom",
+                "base_url": "https://my-gateway.example.com/v1",
+                "key_env": "MY_GATEWAY_TOKEN",
+            }
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="custom")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "https://my-gateway.example.com/v1"
+    assert resolved["api_key"] == "gateway-secret"
+
+
+def test_bare_custom_model_resolves_api_key_env_via_direct_alias(monkeypatch):
+    """GH #43586: the direct-alias branch (explicit base_url propagated from a
+    model alias) must also honor the model block's key_env / api_key_env."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("MY_GATEWAY_TOKEN", "gateway-secret")
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "model": {
+                "default": "zai.glm-5",
+                "provider": "custom",
+                "base_url": "https://my-gateway.example.com/v1",
+                "api_key_env": "MY_GATEWAY_TOKEN",
+            }
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(
+        requested="custom",
+        explicit_base_url="https://my-gateway.example.com/v1",
+    )
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_key"] == "gateway-secret"
+    assert resolved["source"] == "direct-alias"
+
+
 def test_named_custom_provider_same_url_uses_matching_key_env_and_api_mode(monkeypatch):
     """Named custom providers on one gateway must keep their own credentials and protocol."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)


### PR DESCRIPTION
## What does this PR do?

Resolves a custom-provider API-key bug: named custom providers and bare `model: { provider: custom }` blocks that authenticate via an env-var reference (`key_env` / `api_key_env`) were sent upstream with the placeholder `no-key-required` instead of the resolved key — causing `401`/`400` auth failures on OpenAI-compatible gateways (e.g. a localhost LiteLLM proxy). A literal `api_key:` in the same block works, confirming this is a *resolution* bug, not a missing-env bug (the env var is present in the gateway process env).

This fixes both currently-open reports of the same class:

- **#44666** — `api_key_env` alias ignored on a `providers:` dict entry.
- **#43586** — `key_env` / `api_key_env` on a bare `model: { provider: custom }` block ignored.

## Related Issue

Fixes #44666
Fixes #43586

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

Root cause: two credential-resolution paths in `hermes_cli/runtime_provider.py` read the entry/model credentials without honoring the env-var reference.

- `_get_named_custom_provider()` scans the **raw** `providers:` dict directly, bypassing `_normalize_custom_provider_entry` (which maps `api_key_env` → `key_env`). So on the dict path only `key_env` resolved and the documented `api_key_env` alias was silently dropped → `no-key-required` (#44666). *(The `custom_providers:` list path already goes through the normalizer, so it was unaffected.)*
- The bare `model.provider: custom` path never resolved `model.key_env` / `model.api_key_env` into the api-key candidate lists — neither in the **direct-alias** branch nor in the **env/config** generic resolver → `no-key-required` (#43586).

Fix (`hermes_cli/runtime_provider.py`):
- Add a shared `_resolve_entry_key_env(entry)` helper that resolves `key_env`, the snake_case `api_key_env` alias, and the camelCase `apiKeyEnv` spelling from `os.environ` **at request time** (`key_env` wins when more than one is present — matching `_normalize_custom_provider_entry`'s contract).
- Use it in the `providers:` dict branch of `_get_named_custom_provider()` (#44666).
- Add the model block's resolved `key_env`/`api_key_env` as an api-key candidate in the direct-alias branch and the env/config resolver, gated the same way as the existing `cfg_api_key` candidate (#43586).

Tests (`tests/hermes_cli/test_runtime_provider_resolution.py`):
- `test_named_custom_provider_uses_api_key_env_alias_from_providers_dict` (#44666)
- `test_bare_custom_model_resolves_key_env_from_config` (#43586, env/config path)
- `test_bare_custom_model_resolves_api_key_env_via_direct_alias` (#43586, direct-alias branch)

## How to Test

Repro config that fails before this change (sends `no-key-required` → 401):

```yaml
# providers: dict + api_key_env  (#44666)
providers:
  litellm:
    base_url: http://127.0.0.1:4000/v1
    api_key_env: LITELLM_API_KEY
model: { default: base, provider: custom:litellm }
```

```yaml
# bare model.provider: custom + key_env  (#43586)
model:
  default: zai.glm-5
  provider: custom
  base_url: https://my-gateway.example.com/v1
  key_env: MY_GATEWAY_TOKEN
```

With `LITELLM_API_KEY` / `MY_GATEWAY_TOKEN` exported, `resolve_runtime_provider()` now returns the resolved key instead of `no-key-required`.

Automated:

```bash
pytest tests/hermes_cli/test_runtime_provider_resolution.py -q
```

→ all pass (132 in this file). Note: `tests/hermes_cli/test_custom_provider_model_switch.py` has 18 failures in my local sandbox, but they reproduce identically on a clean `main` (pre-existing, environment-related) and are untouched by this change.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(runtime_provider): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant suite and tests pass (see note above re: unrelated pre-existing failures)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.12.2

### Documentation & Housekeeping

- [x] Documentation — N/A (no config keys added; `key_env`/`api_key_env` already documented)
- [x] `cli-config.yaml.example` — N/A (no new config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (pure `os.environ` resolution, no platform-specific code)
- [x] Tool descriptions/schemas — N/A
