### PR TITLE
fix(config): wire reset_by_platform YAML field into load_gateway_config()

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -833,6 +833,9 @@ def load_gateway_config() -> GatewayConfig:
             if "reset_triggers" in yaml_cfg:
                 gw_data["reset_triggers"] = yaml_cfg["reset_triggers"]
 
+            if "reset_by_platform" in yaml_cfg:
+                gw_data["reset_by_platform"] = yaml_cfg["reset_by_platform"]
+
             if "always_log_local" in yaml_cfg:
                 gw_data["always_log_local"] = yaml_cfg["always_log_local"]
 


### PR DESCRIPTION
## Problem

`GatewayConfig` already declares `reset_by_platform` as a dataclass field with full `to_dict()` / `from_dict()` support, but `load_gateway_config()` never reads it from the YAML payload — so any `reset_by_platform:` entry in `gateway.yaml` is silently ignored.

## Fix

Add the missing YAML → Python bridge, following the identical pattern used by the two adjacent fields (`reset_triggers` and `always_log_local`):

```python
if "reset_by_platform" in yaml_cfg:
    gw_data["reset_by_platform"] = yaml_cfg["reset_by_platform"]
```

## Why this is safe

- 3-line addition, no logic change
- Follows an exact existing pattern in the same function
- `from_dict()` already handles malformed input gracefully
- No tests need updating; the field is already exercised by existing serialization tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)