### PR TITLE
fix(profiles): treat clone-from as cloned in next steps

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10139,7 +10139,7 @@ def cmd_profile(args):
             print(f"  {name} setup              Configure API keys and model")
             print(f"  {name} chat               Start chatting")
             print(f"  {name} gateway start      Start the messaging gateway")
-            if clone or clone_all:
+            if clone_config or clone_all:
                 print(f"\n  Edit {profile_dir_display}/.env for different API keys")
                 print(f"  Edit {profile_dir_display}/SOUL.md for different personality")
             else:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11175,7 +11175,7 @@ def cmd_profile(args):
             print(f"  {name} setup              Configure API keys and model")
             print(f"  {name} chat               Start chatting")
             print(f"  {name} gateway start      Start the messaging gateway")
-            if clone or clone_all:
+            if clone_config or clone_all:
                 print(f"\n  Edit {profile_dir_display}/.env for different API keys")
                 print(f"  Edit {profile_dir_display}/SOUL.md for different personality")
             else:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -764,20 +764,23 @@ def create_profile(
     name:
         Profile identifier (lowercase, alphanumeric, hyphens, underscores).
     clone_from:
-        Source profile to clone from. If ``None`` and clone_config/clone_all
-        is True, defaults to the currently active profile.
+        Source profile to clone from. Supplying this without ``clone_all``
+        copies the same config/skills/SOUL payload as ``clone_config``. If
+        ``None`` and clone_config/clone_all is True, defaults to the currently
+        active profile.
     clone_all:
         If True, do a full copytree of the source (all state).
     clone_config:
-        If True, copy config files (config.yaml, .env, SOUL.md), installed
-        skills, and selected profile identity files from the source profile.
+        If True, or if ``clone_from`` is set, copy config files (config.yaml,
+        .env, SOUL.md), installed skills, and selected profile identity files
+        from the source profile.
     no_alias:
         If True, skip wrapper script creation.
     no_skills:
         If True, create an empty profile with no bundled skills, and write
         a marker file so ``hermes update`` skips re-seeding this profile's
-        skills. Mutually exclusive with ``clone_config``/``clone_all`` (those
-        explicitly copy skills from the source).
+        skills. Mutually exclusive with ``clone_from``/``clone_config``/
+        ``clone_all`` (those explicitly copy skills from the source).
 
     Returns
     -------

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -9,6 +9,7 @@ import json
 import io
 import tarfile
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -403,6 +404,17 @@ class TestNoSkillsOptOut:
                 no_alias=True,
                 no_skills=True,
                 clone_all=True,
+            )
+
+    def test_no_skills_conflicts_with_clone_from(self, profile_env):
+        create_profile("source", no_alias=True)
+
+        with pytest.raises(ValueError, match="--clone-from"):
+            create_profile(
+                "orchestrator",
+                no_alias=True,
+                no_skills=True,
+                clone_from="source",
             )
 
     def test_seed_profile_skills_respects_marker(self, profile_env):
@@ -1454,6 +1466,54 @@ class TestEdgeCases:
         )
         assert (target_dir / "config.yaml").read_text() == "model: cloned"
         assert (target_dir / ".env").read_text() == "SECRET=yes"
+
+    def test_clone_from_without_clone_flag_implies_config_clone(self, profile_env):
+        """clone_from alone is the same config/skills clone documented by the CLI."""
+        source_dir = create_profile("source", no_alias=True)
+        (source_dir / "config.yaml").write_text("model: cloned")
+        (source_dir / ".env").write_text("SECRET=yes")
+        (source_dir / "SOUL.md").write_text("Source personality")
+        skill_dir = source_dir / "skills" / "custom" / "src-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\nname: src-skill\n---\n")
+
+        target_dir = create_profile("target", clone_from="source", no_alias=True)
+
+        assert (target_dir / "config.yaml").read_text() == "model: cloned"
+        assert (target_dir / ".env").read_text() == "SECRET=yes"
+        assert (target_dir / "SOUL.md").read_text() == "Source personality"
+        assert (
+            target_dir / "skills" / "custom" / "src-skill" / "SKILL.md"
+        ).exists()
+
+    def test_cmd_profile_clone_from_next_steps_treats_as_clone(
+        self, profile_env, capsys
+    ):
+        """CLI guidance should not tell clone_from users they have no API keys."""
+        from hermes_cli import main as main_mod
+
+        source_dir = create_profile("source", no_alias=True)
+        (source_dir / ".env").write_text("SECRET=yes")
+        (source_dir / "SOUL.md").write_text("Source personality")
+
+        main_mod.cmd_profile(
+            SimpleNamespace(
+                profile_action="create",
+                profile_name="target",
+                clone=False,
+                clone_all=False,
+                clone_from="source",
+                no_alias=True,
+                no_skills=False,
+                description=None,
+            )
+        )
+
+        output = capsys.readouterr().out
+        assert "Cloned config, .env, SOUL.md, and skills from source." in output
+        assert "/.env for different API keys" in output
+        assert "/SOUL.md for different personality" in output
+        assert "This profile has no API keys yet" not in output
 
     def test_delete_clears_active_profile(self, profile_env):
         """Deleting the active profile resets active to default."""

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -1041,6 +1041,35 @@ class TestEdgeCases:
         assert cloned_config["model"] == "cloned"
         assert (target_dir / ".env").read_text().strip() == "SECRET=yes"
 
+    def test_cmd_profile_clone_from_next_steps_treats_as_clone(
+        self, profile_env, capsys
+    ):
+        """CLI guidance should not tell clone-from users they have no API keys."""
+        from hermes_cli import main as main_mod
+
+        source_dir = create_profile("source", no_alias=True)
+        (source_dir / ".env").write_text("SECRET=yes")
+        (source_dir / "SOUL.md").write_text("Source personality")
+
+        main_mod.cmd_profile(
+            types.SimpleNamespace(
+                profile_action="create",
+                profile_name="target",
+                clone=False,
+                clone_all=False,
+                clone_from="source",
+                no_alias=True,
+                no_skills=False,
+                description=None,
+            )
+        )
+
+        output = capsys.readouterr().out
+        assert "Cloned config, .env, SOUL.md, and skills from source." in output
+        assert "/.env for different API keys" in output
+        assert "/SOUL.md for different personality" in output
+        assert "This profile has no API keys yet" not in output
+
 
 
 class TestProfilesToServe:
@@ -1135,5 +1164,4 @@ class TestResolveProfileEnvSpelling:
         # No HERMES_HOME: the platform default root applies (existing contract).
         monkeypatch.delenv("HERMES_HOME", raising=False)
         assert Path(resolve_profile_env("default")) == _get_default_hermes_home()
-
 


### PR DESCRIPTION
## Summary
- Treat `--clone-from` profiles as cloned profiles in the CLI next-step guidance.
- Clarify the `create_profile()` docstring so `clone_from` matches the documented CLI behavior.
- Add regression coverage for `clone_from` without `--clone` and its `--no-skills` conflict.

## Why
The profile docs show `hermes profile create work --clone-from coder` as implying a config/skills/SOUL clone. The create path already performs that clone, but the final "Next steps" block still checked only the literal `--clone` / `--clone-all` flags. That meant `--clone-from` users could be told the new profile had no API keys even though the source `.env` was copied.

## Tests
- `python3 -m pytest tests/hermes_cli/test_profiles.py -q`