### PR TITLE
fix(skills): raise system prompt description limit from 60 to 300 chars

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -615,14 +615,24 @@ def resolve_skill_config_values(
 # ── Description extraction ────────────────────────────────────────────────
 
 
+# Maximum description length injected into the system prompt skill index.
+# Must balance routing fidelity against prompt-cache pressure (every char
+# in the system prompt is paid for on every API call).  60 chars was too
+# short — most non-trivial skill descriptions were cut before their trigger
+# criteria.  300 chars preserves the first 2-3 sentences of a typical
+# description (enough for the model to decide whether to load the skill)
+# while keeping the index block ~3× smaller than the 1024-char runtime
+# limit in skills_tool.py.
+_SYSTEM_PROMPT_MAX_DESC = 300
+
 def extract_skill_description(frontmatter: Dict[str, Any]) -> str:
     """Extract a truncated description from parsed frontmatter."""
     raw_desc = frontmatter.get("description", "")
     if not raw_desc:
         return ""
     desc = str(raw_desc).strip().strip("'\"")
-    if len(desc) > 60:
-        return desc[:57] + "..."
+    if len(desc) > _SYSTEM_PROMPT_MAX_DESC:
+        return desc[:_SYSTEM_PROMPT_MAX_DESC - 3] + "..."
     return desc
 
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -163,10 +163,10 @@ class TestParseSkillFile:
 
     def test_long_description_truncated(self, tmp_path):
         skill_file = tmp_path / "SKILL.md"
-        long_desc = "A" * 100
+        long_desc = "A" * 400
         skill_file.write_text(f"---\ndescription: {long_desc}\n---\n")
         _, _, desc = _parse_skill_file(skill_file)
-        assert len(desc) <= 60
+        assert len(desc) <= 300
         assert desc.endswith("...")
 
     def test_nonexistent_file_returns_defaults(self, tmp_path):

--- a/tests/skills/test_darwinian_evolver_skill.py
+++ b/tests/skills/test_darwinian_evolver_skill.py
@@ -35,9 +35,9 @@ def test_skill_md_present() -> None:
     assert (SKILL_DIR / "SKILL.md").is_file()
 
 
-def test_description_under_60_chars(frontmatter) -> None:
+def test_description_under_300_chars(frontmatter) -> None:
     desc = frontmatter["description"]
-    assert len(desc) <= 60, f"description is {len(desc)} chars (hardline ≤60): {desc!r}"
+    assert len(desc) <= 300, f"description is {len(desc)} chars (hardline ≤300): {desc!r}"
 
 
 def test_name_matches_dir(frontmatter) -> None:


### PR DESCRIPTION
## Problem

The skill index injected into the system prompt hard-truncates every skill description to 60 characters via `extract_skill_description()` in `agent/skill_utils.py`. This strips trigger criteria and routing context from most non-trivial descriptions, undermining the model's ability to decide which skills to load.

Meanwhile, `skills_tool.py` defines `MAX_DESCRIPTION_LENGTH = 1024` for runtime `skills_list()` — but the system prompt builder uses a completely separate code path with its own hardcoded 60-char limit.

Closes #13944

## Changes

- **`agent/skill_utils.py`**: Raise truncation limit from 60 → 300 chars. Extract constant `_SYSTEM_PROMPT_MAX_DESC = 300` so it can be tuned without touching the function body.
- **`tests/agent/test_prompt_builder.py`**: Update `test_long_description_truncated` — 100→400 char input, assert ≤300.
- **`tests/skills/test_darwinian_evolver_skill.py`**: Update `test_description_under_60_chars` → `test_description_under_300_chars`, assert ≤300.

## Rationale for 300 chars

300 chars preserves the first 2-3 sentences of a typical skill description — enough for the model to see trigger conditions and decide whether to load the skill — while keeping the index block ~3× smaller than the 1024-char runtime limit. Every char in the system prompt is paid for on every API call, so this is a deliberate balance between routing fidelity and prompt-cache pressure.

## Testing

```
pytest tests/agent/test_prompt_builder.py::TestParseSkillFile::test_long_description_truncated
pytest tests/skills/test_darwinian_evolver_skill.py::test_description_under_300_chars
```

Both pass.