### PR TITLE
fix(package): correct casing in package.json GitHub URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/NousResearch/Hermes-Agent.git"
+    "url": "git+https://github.com/NousResearch/hermes-agent.git"
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/NousResearch/Hermes-Agent/issues"
+    "url": "https://github.com/NousResearch/hermes-agent/issues"
   },
-  "homepage": "https://github.com/NousResearch/Hermes-Agent#readme",
+  "homepage": "https://github.com/NousResearch/hermes-agent#readme",
   "dependencies": {
     "@streamdown/math": "^1.0.2",
     "agent-browser": "^0.26.0"

--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/NousResearch/Hermes-Agent.git"
+    "url": "git+https://github.com/NousResearch/hermes-agent.git"
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/NousResearch/Hermes-Agent/issues"
+    "url": "https://github.com/NousResearch/hermes-agent/issues"
   },
-  "homepage": "https://github.com/NousResearch/Hermes-Agent#readme",
+  "homepage": "https://github.com/NousResearch/hermes-agent#readme",
   "devDependencies": {
     "@eslint/js": "9.39.5",
     "typescript-eslint": "8.64.0",


### PR DESCRIPTION
## What

`package.json`'s `repository`, `bugs`, and `homepage` URLs use `Hermes-Agent` (wrong casing); the actual repository is `hermes-agent`. This PR corrects all three URLs.

## Why / root cause

npm registry metadata and package-manager URL handling are case-sensitive: tools that read `repository.url` / `bugs.url` / `homepage` resolve them against `github.com/NousResearch/hermes-agent`, so the uppercase `Hermes-Agent` path points at a non-existent repository. GitHub's web redirect is case-insensitive, which is why this went unnoticed — but the metadata is wrong for every consumer that does an exact lookup.

## Diff

```diff
-    "url": "git+https://github.com/NousResearch/Hermes-Agent.git"
+    "url": "git+https://github.com/NousResearch/hermes-agent.git"
-    "url": "https://github.com/NousResearch/Hermes-Agent/issues"
+    "url": "https://github.com/NousResearch/hermes-agent/issues"
-  "homepage": "https://github.com/NousResearch/Hermes-Agent#readme",
+  "homepage": "https://github.com/NousResearch/hermes-agent#readme",
```

## How to test

1. `grep -n "Hermes-Agent" package.json` → no matches after this change.
2. `node -e "console.log(require('./package.json').repository.url)"` → prints `git+https://github.com/NousResearch/hermes-agent.git`.
3. No dependency or lockfile changes (`package-lock.json` untouched); behavior is metadata-only.

## Platforms tested

- Linux (CI: amd64 + arm64 Docker builds, JS & TS checks pass; pure-metadata change, no platform-specific behavior).

Part of the findings in #45623.