### PR TITLE
fix: show account usage without active agent

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8206,7 +8206,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         which would otherwise early-return before any credits showed.
         """
         if not self.agent:
-            if not self._print_nous_credits_block():
+            printed_account = self._print_configured_account_usage_block()
+            printed_nous = self._print_nous_credits_block()
+            if not (printed_account or printed_nous):
                 print("(._.) No active agent -- send a message first.")
             return
 
@@ -8214,7 +8216,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         calls = agent.session_api_calls
 
         if calls == 0:
-            if not self._print_nous_credits_block():
+            printed_account = self._print_configured_account_usage_block(agent=agent)
+            printed_nous = self._print_nous_credits_block()
+            if not (printed_account or printed_nous):
                 print("(._.) No API calls made yet in this session.")
             return
 
@@ -8326,6 +8330,44 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # into stream-retry events, credential rotations, etc.
             # Console quietness is enforced by hermes_logging not
             # installing a console StreamHandler in non-verbose mode.
+
+    def _print_configured_account_usage_block(self, *, agent=None) -> bool:
+        """Print provider account limits using a live agent or config fallback.
+
+        This keeps `/usage` useful before the first API call / active agent,
+        especially for OpenAI Codex quota windows which are account-level data.
+        """
+        provider = getattr(agent, "provider", None) if agent is not None else None
+        base_url = getattr(agent, "base_url", None) if agent is not None else None
+        api_key = getattr(agent, "api_key", None) if agent is not None else None
+        if not provider:
+            provider = getattr(self, "provider", None)
+            base_url = base_url or getattr(self, "base_url", None)
+            api_key = api_key or getattr(self, "api_key", None)
+        if not provider:
+            try:
+                from hermes_cli.config import cfg_get, load_config
+
+                _cfg = load_config()
+                provider = cfg_get(_cfg, "model", "provider")
+                base_url = base_url or cfg_get(_cfg, "model", "base_url")
+            except Exception:
+                provider = None
+        if not provider:
+            return False
+        try:
+            from agent.account_usage import fetch_account_usage, render_account_usage_lines
+
+            snapshot = fetch_account_usage(provider, base_url=base_url, api_key=api_key)
+            lines = render_account_usage_lines(snapshot)
+        except Exception:
+            lines = []
+        if not lines:
+            return False
+        print()
+        for line in lines:
+            print(f"  {line}")
+        return True
 
     def _print_nous_credits_block(self) -> bool:
         """Print the Nous credits magnitudes + monthly-grant gauge when a Nous account

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -34,7 +34,7 @@ from agent.i18n import t
 from gateway.config import HomeChannel, Platform, PlatformConfig
 from gateway.platforms.base import EphemeralReply, MessageEvent, MessageType
 from gateway.session import SessionSource, build_session_key
-from hermes_cli.config import cfg_get
+from hermes_cli.config import cfg_get, load_config
 from utils import (
     atomic_json_write,
     atomic_yaml_write,
@@ -2979,6 +2979,22 @@ class GatewaySlashCommandsMixin:
                 persisted = {}
             provider = provider or persisted.get("billing_provider")
             base_url = base_url or persisted.get("billing_base_url")
+
+        # Account limits are account/provider-level data, not session-level data.
+        # A fresh gateway thread (or a slash command before the first agent turn)
+        # may have no resident agent and no persisted billing_provider yet; still
+        # fall back to the configured provider so `/usage` can answer quota checks
+        # like OpenAI Codex's 5-hour/weekly windows without requiring a prior chat
+        # message in that exact session/topic.
+        if not provider:
+            try:
+                # `self.config` is the gateway/platform config, not the Hermes
+                # model config, so read config.yaml directly for model.provider.
+                _cfg = load_config()
+                provider = cfg_get(_cfg, "model", "provider")
+                base_url = base_url or cfg_get(_cfg, "model", "base_url")
+            except Exception:
+                provider = None
 
         # Fetch account usage off the event loop so slow provider APIs don't
         # block the gateway. Failures are non-fatal -- account_lines stays [].

--- a/tests/gateway/test_usage_command.py
+++ b/tests/gateway/test_usage_command.py
@@ -256,3 +256,43 @@ class TestUsageAccountSection:
         assert account_call["kwargs"]["base_url"] == "https://chatgpt.com/backend-api/codex"
         assert "📊 **Session Info**" in result
         assert "📈 **Account limits**" in result
+
+    @pytest.mark.asyncio
+    async def test_usage_command_uses_configured_provider_before_first_agent_turn(self, monkeypatch):
+        runner = _make_runner(SK)
+        runner.config = {"model": {"provider": "openai-codex", "base_url": "https://chatgpt.com/backend-api/codex"}}
+        runner.session_store.get_or_create_session.return_value = MagicMock(session_id="sess-blank")
+        runner.session_store.load_transcript.return_value = []
+
+        calls = []
+
+        async def _fake_to_thread(fn, *args, **kwargs):
+            calls.append({"args": args, "kwargs": kwargs})
+            return fn(*args, **kwargs)
+
+        monkeypatch.setattr(
+            "gateway.slash_commands.load_config",
+            lambda: {"model": {"provider": "openai-codex", "base_url": "https://chatgpt.com/backend-api/codex"}},
+        )
+        monkeypatch.setattr("gateway.run.asyncio.to_thread", _fake_to_thread)
+        monkeypatch.setattr(
+            "gateway.slash_commands.fetch_account_usage",
+            lambda provider, base_url=None, api_key=None: object(),
+        )
+        monkeypatch.setattr(
+            "gateway.slash_commands.render_account_usage_lines",
+            lambda snapshot, markdown=False: [
+                "📈 **Account limits**",
+                "Provider: openai-codex (Plus)",
+                "Session: 44% remaining (56% used)",
+            ],
+        )
+        monkeypatch.setattr("agent.account_usage.nous_credits_lines", lambda markdown=False: [])
+
+        event = MagicMock()
+        result = await runner._handle_usage_command(event)
+
+        account_call = next(c for c in calls if c["args"] == ("openai-codex",))
+        assert account_call["kwargs"]["base_url"] == "https://chatgpt.com/backend-api/codex"
+        assert "📈 **Account limits**" in result
+        assert "Provider: openai-codex (Plus)" in result


### PR DESCRIPTION
## Summary
- allow `/usage` to fetch provider account limits before an agent exists or before the first API call in the current session
- fall back to the configured `model.provider` / `model.base_url` for account-level usage lookups
- add gateway coverage for OpenAI Codex-style account limits before the first agent turn

## Testing
- `uv run --with pytest --with pytest-asyncio --with pytest-xdist --with pyyaml pytest tests/gateway/test_usage_command.py -q -n 0 -o addopts=`
