### PR TITLE
fix(gateway): strip markdown image syntax cleanly in plain-text helper

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -173,6 +173,11 @@ _RE_ITALIC_UNDER = re.compile(r"\b_(?![\s_])(.+?)(?<![\s_])_\b", re.DOTALL)
 _RE_CODE_BLOCK = re.compile(r"```[a-zA-Z0-9_+-]*\n?")
 _RE_INLINE_CODE = re.compile(r"`(.+?)`")
 _RE_HEADING = re.compile(r"^#{1,6}\s+", re.MULTILINE)
+# Images must be stripped before links: an image is link syntax prefixed with
+# "!", so the link regex alone would leave a stray "!" (``![alt](url)`` →
+# ``!alt``) and skip empty-alt images (``![](url)``) entirely. Collapse images
+# to their alt text (empty when there is none).
+_RE_IMAGE = re.compile(r"!\[([^\]]*)\]\([^\)]+\)")
 _RE_LINK = re.compile(r"\[([^\]]+)\]\([^\)]+\)")
 _RE_MULTI_NEWLINE = re.compile(r"\n{3,}")
 
@@ -190,6 +195,7 @@ def strip_markdown(text: str) -> str:
     text = _RE_CODE_BLOCK.sub("", text)
     text = _RE_INLINE_CODE.sub(r"\1", text)
     text = _RE_HEADING.sub("", text)
+    text = _RE_IMAGE.sub(r"\1", text)
     text = _RE_LINK.sub(r"\1", text)
     text = _RE_MULTI_NEWLINE.sub("\n\n", text)
     return text.strip()

--- a/tests/gateway/test_strip_markdown.py
+++ b/tests/gateway/test_strip_markdown.py
@@ -1,0 +1,44 @@
+"""Tests for the shared ``strip_markdown`` plain-text helper.
+
+Regression coverage for markdown image syntax. The link regex alone treated
+an image (``![alt](url)``) as a link prefixed with ``!``, so it left a stray
+``!`` (``![alt](url)`` → ``!alt``) and skipped empty-alt images
+(``![](url)``) entirely. Images must be collapsed to their alt text before
+the link pass runs.
+"""
+
+from gateway.platforms.helpers import strip_markdown
+
+
+class TestStripMarkdownImages:
+    """Image syntax should reduce to alt text with no leftover markers."""
+
+    def test_image_with_alt_keeps_only_alt_text(self):
+        assert strip_markdown("![alt](http://x.png)") == "alt"
+
+    def test_image_inline_keeps_surrounding_text(self):
+        assert strip_markdown("See ![diagram](http://y.png) here") == "See diagram here"
+
+    def test_image_without_alt_is_removed(self):
+        assert strip_markdown("![](http://noalt.png)") == ""
+
+    def test_plain_link_unaffected(self):
+        assert strip_markdown("text [link](http://z.com) end") == "text link end"
+
+    def test_mixed_link_and_image(self):
+        assert (
+            strip_markdown("**bold** and [a](b) and ![img](c)")
+            == "bold and a and img"
+        )
+
+
+class TestStripMarkdownBasics:
+    """Guard the existing inline-formatting behaviour against regressions."""
+
+    def test_bold_italic_and_code(self):
+        assert strip_markdown("**hello**") == "hello"
+        assert strip_markdown("*hello*") == "hello"
+        assert strip_markdown("run `ls -la`") == "run ls -la"
+
+    def test_heading_stripped(self):
+        assert strip_markdown("# Title") == "Title"


### PR DESCRIPTION
The shared strip_markdown() helper handled links but not images. Since an image (![alt](url)) is link syntax prefixed with "!", the link regex alone left a stray "!" (![alt](url) -> !alt) and skipped empty-alt images (![](url)) entirely, leaking raw markdown to plain-text platforms (SMS, iMessage, Signal, Feishu).

Add an image regex applied before the link pass that collapses images to their alt text (empty when there is none). Adds regression tests.

https://claude.ai/code/session_01U3EuJiagfmMVggytbEN7Jo

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

