### PR TITLE
fix(mcp): validate tool timeout config values

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1848,7 +1848,13 @@ class MCPServerTask:
         connection drops unexpectedly (unless shutdown was requested).
         """
         self._config = config
-        self.tool_timeout = config.get("timeout", _DEFAULT_TOOL_TIMEOUT)
+        raw_timeout = config.get("timeout", _DEFAULT_TOOL_TIMEOUT)
+        try:
+            self.tool_timeout = float(raw_timeout)
+            if not math.isfinite(self.tool_timeout):
+                self.tool_timeout = float(_DEFAULT_TOOL_TIMEOUT)
+        except (TypeError, ValueError):
+            self.tool_timeout = float(_DEFAULT_TOOL_TIMEOUT)
         self._auth_type = (config.get("auth") or "").lower().strip()
 
         # Set up sampling handler if enabled and SDK types are available


### PR DESCRIPTION
## Problem

MCPServerTask accepted timeout config values without type validation. Non-numeric, `inf`, or `NaN` values from MCP server config would propagate silently, potentially causing indefinite hangs or crashes.

## Fix

Guard `config.get("timeout")` with `float()` coercion + `math.isfinite()` check. Falls back to `_DEFAULT_TOOL_TIMEOUT` for any invalid value.

## Tests

- Default timeout preserved when key absent
- Integer and string-numeric values coerced correctly
- `inf`, `nan`, `None`, and non-numeric strings fall back to default