### PR TITLE
fix(agent): harden early-turn persistence to survive session-DB failures (#45110)

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -221,6 +221,9 @@ def build_turn_context(
     messages.append(user_msg)
     current_turn_user_idx = len(messages) - 1
     agent._persist_user_message_idx = current_turn_user_idx
+    # Reset flush cursor to align with the current message list; prevents overshoot
+    # from a prior turn's cursor from skipping the new user message.
+    agent._last_flushed_db_idx = current_turn_user_idx
 
     if not agent.quiet_mode:
         _print_preview = summarize_user_message_for_log(user_message)
@@ -236,14 +239,24 @@ def build_turn_context(
     active_system_prompt = agent._cached_system_prompt
 
     # Crash-resilience: persist the inbound user turn as soon as the session row exists.
-    try:
-        agent._persist_session(messages, conversation_history)
-    except Exception:
-        logger.warning(
-            "Early turn-start session persistence failed for session=%s",
-            agent.session_id or "none",
-            exc_info=True,
-        )
+    # Retry once on transient DB failure (e.g. SQLite lock); log structured warning if it
+    # still fails so data loss is observable.
+    for _persist_attempt in range(2):
+        try:
+            agent._persist_session(messages, conversation_history)
+            break
+        except Exception:
+            if _persist_attempt == 0:
+                try:
+                    agent._ensure_db_session()
+                except Exception:
+                    pass
+            else:
+                logger.warning(
+                    "Early turn-start session persistence failed after retry for session=%s",
+                    agent.session_id or "none",
+                    exc_info=True,
+                )
 
     # ── Preflight context compression ──
     if (

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -239,24 +239,30 @@ def build_turn_context(
     active_system_prompt = agent._cached_system_prompt
 
     # Crash-resilience: persist the inbound user turn as soon as the session row exists.
-    # Retry once on transient DB failure (e.g. SQLite lock); log structured warning if it
-    # still fails so data loss is observable.
-    for _persist_attempt in range(2):
-        try:
-            agent._persist_session(messages, conversation_history)
-            break
-        except Exception:
-            if _persist_attempt == 0:
-                try:
-                    agent._ensure_db_session()
-                except Exception:
-                    pass
-            else:
-                logger.warning(
-                    "Early turn-start session persistence failed after retry for session=%s",
-                    agent.session_id or "none",
-                    exc_info=True,
-                )
+    # _persist_session swallows DB errors internally, so retry _ensure_db_session
+    # proactively when the session row hasn't been created yet.
+    if not getattr(agent, "_session_db_created", False):
+        for _db_attempt in range(2):
+            try:
+                agent._ensure_db_session()
+                break
+            except Exception:
+                if _db_attempt == 1:
+                    logger.warning(
+                        "Early turn-start _ensure_db_session failed after retry for session=%s",
+                        agent.session_id or "none",
+                        exc_info=True,
+                    )
+    _pre_persist_cursor = agent._last_flushed_db_idx
+    agent._persist_session(messages, conversation_history)
+    if agent._last_flushed_db_idx <= _pre_persist_cursor:
+        logger.warning(
+            "Early persist did not advance flush cursor for session=%s "
+            "(cursor=%d, expected>%d); user message may not be in session DB",
+            agent.session_id or "none",
+            agent._last_flushed_db_idx,
+            _pre_persist_cursor,
+        )
 
     # ── Preflight context compression ──
     if (

--- a/tests/agent/test_early_persist.py
+++ b/tests/agent/test_early_persist.py
@@ -1,0 +1,224 @@
+"""Unit tests for early turn-start session persistence hardening.
+
+These tests verify the three failure modes addressed in PR #45110:
+1. Retry on transient DB session creation failure (SQLite lock).
+2. Reset of the flush cursor to prevent skipping the user message.
+3. Structured logging when persistence still fails after retry.
+"""
+
+from __future__ import annotations
+
+import types
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from agent.turn_context import build_turn_context
+
+
+class _FakeTodoStore:
+    def has_items(self):
+        return True
+
+    def _hydrate(self, *_a, **_k):
+        pass
+
+
+class _FakeGuardrails:
+    def __init__(self):
+        self.reset_called = False
+
+    def reset_for_turn(self):
+        self.reset_called = True
+
+
+class _FakeAgent:
+    """Minimal stand-in covering only what the prologue touches."""
+
+    def __init__(self):
+        self.session_id = "sess-1"
+        self.model = "test/model"
+        self.provider = "openrouter"
+        self.base_url = "https://openrouter.ai/api/v1"
+        self.api_key = "sk-x"
+        self.api_mode = "chat_completions"
+        self.platform = "cli"
+        self.quiet_mode = True
+        self.max_iterations = 90
+        self.tools = []
+        self.valid_tool_names = set()
+        self.compression_enabled = False
+        self.context_compressor = types.SimpleNamespace(
+            protect_first_n=2, protect_last_n=2
+        )
+        self._cached_system_prompt = "SYSTEM"
+        self._memory_store = None
+        self._memory_manager = None
+        self._memory_nudge_interval = 0
+        self._turns_since_memory = 0
+        self._user_turn_count = 0
+        self._todo_store = _FakeTodoStore()
+        self._tool_guardrails = _FakeGuardrails()
+        self._compression_warning = None
+        self._interrupt_requested = False
+        self._memory_write_origin = "assistant_tool"
+        self._stream_context_scrubber = None
+        self._stream_think_scrubber = None
+        # Attributes the prologue assigns.
+        self._invalid_tool_retries = -1
+        self._vision_supported = None
+        self._persist_user_message_idx = None
+        self._last_flushed_db_idx = -1
+        self._session_db_created = True
+        # Track calls to _persist_session and _ensure_db_session for verification.
+        self._persist_session_calls = []
+        self._ensure_db_session_calls = 0
+
+    def _ensure_db_session(self):
+        self._ensure_db_session_calls += 1
+
+    def _restore_primary_runtime(self):
+        pass
+
+    def _cleanup_dead_connections(self):
+        return False
+
+    def _emit_status(self, _msg):
+        pass
+
+    def _replay_compression_warning(self):
+        pass
+
+    def _hydrate_todo_store(self, *_a, **_k):
+        pass
+
+    def _safe_print(self, *_a, **_k):
+        pass
+
+    def _persist_session(self, messages, conversation_history):
+        # Capture the messages list at the time of the call.
+        self._persist_session_calls.append({
+            "messages": list(messages),
+            "conversation_history": conversation_history,
+        })
+
+
+@pytest.fixture(autouse=True)
+def _stub_runtime_main():
+    """Stub out auxiliary_client.set_runtime_main to keep tests hermetic."""
+    with patch("agent.auxiliary_client.set_runtime_main", lambda *a, **k: None):
+        yield
+
+
+def _build(agent, **overrides):
+    kwargs = dict(
+        agent=agent,
+        user_message="hello",
+        system_message=None,
+        conversation_history=None,
+        task_id=None,
+        stream_callback=None,
+        persist_user_message=None,
+        restore_or_build_system_prompt=lambda *a, **k: None,
+        install_safe_stdio=lambda: None,
+        sanitize_surrogates=lambda s: s,
+        summarize_user_message_for_log=lambda s: s,
+        set_session_context=lambda _sid: None,
+        set_current_write_origin=lambda _o: None,
+        ra=lambda: types.SimpleNamespace(_set_interrupt=lambda *a, **k: None),
+    )
+    kwargs.update(overrides)
+    return build_turn_context(**kwargs)
+
+
+def test_early_persist_includes_user_message():
+    """Verify the user message appears in the first persist call, before any model response."""
+    agent = _FakeAgent()
+    ctx = _build(agent)
+
+    # Early persist should have been called once.
+    assert len(agent._persist_session_calls) == 1
+
+    # The persisted messages list should contain the user message.
+    persisted_messages = agent._persist_session_calls[0]["messages"]
+    assert len(persisted_messages) >= 1
+    assert persisted_messages[-1] == {"role": "user", "content": "hello"}
+
+
+def test_flush_cursor_reset_prevents_skip():
+    """Verify _last_flushed_db_idx is reset to the user message index.
+
+    This prevents a prior turn's cursor from causing the user message to be
+    skipped in the flush operation due to overshoot.
+    """
+    agent = _FakeAgent()
+    # Simulate a prior turn's overshoot: _last_flushed_db_idx > len(messages).
+    agent._last_flushed_db_idx = 999
+
+    ctx = _build(agent)
+
+    # After build_turn_context, _last_flushed_db_idx should be reset to point at
+    # the user message (current_turn_user_idx).
+    assert agent._last_flushed_db_idx == ctx.current_turn_user_idx
+    assert agent._last_flushed_db_idx == len(ctx.messages) - 1
+
+
+def test_early_persist_retries_on_db_failure():
+    """Verify early persist retries _ensure_db_session on transient failure."""
+    agent = _FakeAgent()
+
+    # Mock _persist_session to fail on first call, succeed on second.
+    call_count = [0]
+
+    def _persist_session_with_failure(messages, conversation_history):
+        call_count[0] += 1
+        agent._persist_session_calls.append({
+            "messages": list(messages),
+            "conversation_history": conversation_history,
+        })
+        if call_count[0] == 1:
+            raise RuntimeError("Transient DB failure (SQLite lock)")
+
+    agent._persist_session = _persist_session_with_failure
+
+    with patch.object(agent, "_ensure_db_session") as mock_ensure:
+        ctx = _build(agent)
+
+        # _ensure_db_session should have been called twice: once at prologue start,
+        # once during early persist retry on first persist failure.
+        assert mock_ensure.call_count == 2
+
+    # Despite the first persist failing, the second attempt should succeed.
+    assert call_count[0] == 2
+    assert len(agent._persist_session_calls) == 2
+
+
+def test_early_persist_logs_warning_after_retry_failure():
+    """Verify early persist logs a structured warning if persistence still fails."""
+    agent = _FakeAgent()
+
+    # Mock _persist_session to always fail.
+    def _persist_session_with_persistent_failure(messages, conversation_history):
+        raise RuntimeError("Persistent DB failure")
+
+    agent._persist_session = _persist_session_with_persistent_failure
+
+    # Mock logger.warning to capture the call.
+    with patch("agent.turn_context.logger.warning") as mock_warning:
+        with patch.object(agent, "_ensure_db_session"):
+            ctx = _build(agent)
+
+        # logger.warning should have been called with the retry-failed message.
+        assert mock_warning.called
+        call_args = mock_warning.call_args
+        assert "Early turn-start session persistence failed after retry" in call_args[0][0]
+        assert agent.session_id in call_args[0]
+
+
+def test_early_persist_user_message_idx_set():
+    """Verify _persist_user_message_idx is set to the user message index."""
+    agent = _FakeAgent()
+    ctx = _build(agent)
+
+    assert agent._persist_user_message_idx == ctx.current_turn_user_idx
+    assert agent._persist_user_message_idx == len(ctx.messages) - 1

--- a/tests/agent/test_early_persist.py
+++ b/tests/agent/test_early_persist.py
@@ -163,56 +163,72 @@ def test_flush_cursor_reset_prevents_skip():
     assert agent._last_flushed_db_idx == len(ctx.messages) - 1
 
 
-def test_early_persist_retries_on_db_failure():
-    """Verify early persist retries _ensure_db_session on transient failure."""
+def test_ensure_db_session_retried_on_transient_failure():
+    """Verify _ensure_db_session is retried when the session row isn't created."""
     agent = _FakeAgent()
 
-    # Mock _persist_session to fail on first call, succeed on second.
+    # Line 90 calls _ensure_db_session unconditionally (call 1, succeeds but
+    # _session_db_created stays False to simulate a no-op). Our retry block
+    # detects _session_db_created==False and retries: call 2 fails transiently,
+    # call 3 succeeds and sets _session_db_created=True.
     call_count = [0]
 
-    def _persist_session_with_failure(messages, conversation_history):
+    def _ensure_with_late_success():
         call_count[0] += 1
-        agent._persist_session_calls.append({
-            "messages": list(messages),
-            "conversation_history": conversation_history,
-        })
-        if call_count[0] == 1:
-            raise RuntimeError("Transient DB failure (SQLite lock)")
+        if call_count[0] == 2:
+            raise RuntimeError("Transient SQLite lock")
+        if call_count[0] == 3:
+            agent._session_db_created = True
 
-    agent._persist_session = _persist_session_with_failure
+    agent._ensure_db_session = _ensure_with_late_success
+    agent._session_db_created = False
 
-    with patch.object(agent, "_ensure_db_session") as mock_ensure:
-        ctx = _build(agent)
+    ctx = _build(agent)
 
-        # _ensure_db_session should have been called twice: once at prologue start,
-        # once during early persist retry on first persist failure.
-        assert mock_ensure.call_count == 2
-
-    # Despite the first persist failing, the second attempt should succeed.
-    assert call_count[0] == 2
-    assert len(agent._persist_session_calls) == 2
+    assert call_count[0] == 3
+    assert agent._session_db_created is True
 
 
-def test_early_persist_logs_warning_after_retry_failure():
-    """Verify early persist logs a structured warning if persistence still fails."""
+def test_ensure_db_session_logs_warning_after_retry_failure():
+    """Verify structured warning when _ensure_db_session fails in retry block."""
     agent = _FakeAgent()
 
-    # Mock _persist_session to always fail.
-    def _persist_session_with_persistent_failure(messages, conversation_history):
-        raise RuntimeError("Persistent DB failure")
+    # Call 1 from line 90 succeeds but _session_db_created stays False.
+    # Calls 2-3 from our retry block both fail.
+    call_count = [0]
 
-    agent._persist_session = _persist_session_with_persistent_failure
+    def _ensure_always_fails_in_retry():
+        call_count[0] += 1
+        if call_count[0] >= 2:
+            raise RuntimeError("Persistent SQLite lock")
 
-    # Mock logger.warning to capture the call.
+    agent._ensure_db_session = _ensure_always_fails_in_retry
+    agent._session_db_created = False
+
     with patch("agent.turn_context.logger.warning") as mock_warning:
-        with patch.object(agent, "_ensure_db_session"):
-            ctx = _build(agent)
+        ctx = _build(agent)
 
-        # logger.warning should have been called with the retry-failed message.
-        assert mock_warning.called
-        call_args = mock_warning.call_args
-        assert "Early turn-start session persistence failed after retry" in call_args[0][0]
-        assert agent.session_id in call_args[0]
+        warning_calls = [c for c in mock_warning.call_args_list
+                         if "_ensure_db_session failed after retry" in str(c)]
+        assert len(warning_calls) == 1
+        assert agent.session_id in warning_calls[0][0]
+
+
+def test_silent_persist_failure_detected_by_cursor():
+    """Verify warning when _persist_session silently fails (cursor doesn't advance)."""
+    agent = _FakeAgent()
+
+    def _persist_noop(messages, conversation_history):
+        pass
+
+    agent._persist_session = _persist_noop
+
+    with patch("agent.turn_context.logger.warning") as mock_warning:
+        ctx = _build(agent)
+
+        cursor_warnings = [c for c in mock_warning.call_args_list
+                           if "did not advance flush cursor" in str(c)]
+        assert len(cursor_warnings) == 1
 
 
 def test_early_persist_user_message_idx_set():


### PR DESCRIPTION
## Summary

When a model response never completes (client disconnect, mobile browser suspension, gateway timeout), the user's prompt vanishes from `state.db` as if the turn never happened. The early-persist call added in the `turn_context.py` extraction (commit `54870847c`) wraps `_persist_session()` in a bare `try/except` that silently continues on failure. Three failure modes let the prompt slip through: (1) `_ensure_db_session()` can fail on transient SQLite lock, leaving the session uncreated so `_flush_messages_to_session_db` skips the write; (2) the flush cursor from a prior turn can overshoot the new user message, causing it to be skipped entirely; (3) only debug-level logging occurs, making the data loss invisible.

This PR resets the flush cursor to the current user message index before the early persist to prevent overshoot, proactively retries `_ensure_db_session()` when the session row hasn't been created (the actual failure path, since `_persist_session` swallows its own DB errors), and checks post-persist cursor advancement to detect silent persistence failures with structured warnings.

## Changes

- `agent/turn_context.py` (+29 lines, -8 lines): Reset `_last_flushed_db_idx` to the current user message index after appending the message. Proactively retry `_ensure_db_session()` when `_session_db_created` is False. Check post-persist cursor advancement to detect silent persistence failures and log structured warning.
- `tests/agent/test_early_persist.py` (new file, 256 lines): Unit tests covering the three failure modes: cursor reset prevents overshoot, `_ensure_db_session` retry on transient failure, structured warning on persistent failure, cursor-based silent failure detection, and message index assignment.

## Validation

| Scenario | Before | After |
|---|---|---|
| Normal turn (response completes) | prompt persisted | prompt persisted (unchanged) |
| Disconnect before first response, DB healthy | prompt persisted by early persist | prompt persisted (unchanged) |
| Disconnect before first response, transient SQLite lock | prompt lost silently | `_ensure_db_session` retried; prompt persisted |
| Disconnect before first response, flush cursor overshoots | prompt skipped | cursor reset; prompt persisted |
| Disconnect + persistent DB failure | prompt lost silently | prompt lost, but structured warnings logged (retry failure + cursor non-advancement) |

## Test plan

- `pytest tests/agent/test_early_persist.py tests/agent/test_turn_context.py -v` — 12 passed

The full suite runs in CI; local scope is the early persist tests plus existing turn_context tests to confirm no regression.

## Why it's low-risk

The change is localized to the turn prologue (turn_context.py) and does not affect message flow, compression, or tool routing. The `_ensure_db_session` retry only fires when `_session_db_created` is False, preserving the fast path. Tests confirm no regression in existing turn-context behavior (all 6 existing tests pass).

## Upstream

Closes #45110.
Reported by @jffuree.
