### PR TITLE
-

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1235,6 +1235,11 @@ class APIServerAdapter(BasePlatformAdapter):
         self._runner: Optional["web.AppRunner"] = None
         self._site: Optional["web.TCPSite"] = None
         self._response_store = ResponseStore()
+        # Approval state is owned by the in-flight Responses resource, not by
+        # the conversation or memory key shared across concurrent requests.
+        # Active Responses approval state: response_id -> normalized request
+        # profile.  The response_id remains the approval-core session key.
+        self._response_approval_sessions: Dict[str, str] = {}
         # Active run streams: run_id -> asyncio.Queue of SSE event dicts
         self._run_streams: Dict[str, "asyncio.Queue[Optional[Dict]]"] = {}
         # Creation timestamps for orphaned-run TTL sweep
@@ -1780,6 +1785,11 @@ class APIServerAdapter(BasePlatformAdapter):
 
         return _profile_runtime_scope(get_profile_dir(profile))
 
+    @staticmethod
+    def _normalized_request_profile() -> str:
+        """Return the profile identity used for response ownership checks."""
+        return _api_request_profile.get() or "default"
+
     def _make_profile_prefix_middleware(self):
         """Reject unknown /p/<profile>/ prefixes and scope the request home."""
 
@@ -1829,6 +1839,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ("POST", "/v1/responses", self._handle_responses),
             ("GET", "/v1/responses/{response_id}", self._handle_get_response),
             ("DELETE", "/v1/responses/{response_id}", self._handle_delete_response),
+            ("POST", "/v1/responses/{response_id}/approval", self._handle_response_approval),
             # Generic platform HTTP event callback ingress. Authenticated by
             # the target adapter's own verifier (platform-signed bearer), NOT
             # API_SERVER_KEY — external platforms hold no API server key.
@@ -4276,6 +4287,7 @@ class APIServerAdapter(BasePlatformAdapter):
         store: bool,
         session_id: str,
         gateway_session_key: Optional[str] = None,
+        stream_open: Optional[list[bool]] = None,
     ) -> "web.StreamResponse":
         """Write an SSE stream for POST /v1/responses (OpenAI Responses API).
 
@@ -4305,8 +4317,6 @@ class APIServerAdapter(BasePlatformAdapter):
         ``previous_response_id`` chaining still have something to
         recover from.
         """
-        import queue as _q
-
         sse_headers = {
             "Content-Type": "text/event-stream",
             "Cache-Control": "no-cache",
@@ -4321,7 +4331,35 @@ class APIServerAdapter(BasePlatformAdapter):
         if gateway_session_key:
             sse_headers["X-Hermes-Session-Key"] = gateway_session_key
         response = web.StreamResponse(status=200, headers=sse_headers)
-        await response.prepare(request)
+
+        def _release_response_approval() -> None:
+            if stream_open is not None:
+                stream_open[0] = False
+            approval_owner = self._response_approval_sessions.pop(response_id, None)
+            if approval_owner is None:
+                return
+            try:
+                from tools.approval import unregister_gateway_notify
+
+                unregister_gateway_notify(response_id)
+            except Exception:
+                logger.debug(
+                    "Failed to release approval state for response %s",
+                    response_id,
+                    exc_info=True,
+                )
+
+        try:
+            await response.prepare(request)
+        except BaseException:
+            _release_response_approval()
+            if not agent_task.done():
+                agent_task.cancel()
+                try:
+                    await agent_task
+                except BaseException:
+                    pass
+            raise
 
         # State accumulated during the stream
         final_text_parts: List[str] = []
@@ -4574,7 +4612,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "item": output_item,
                 })
 
-            # Main drain loop — thread-safe queue fed by agent callbacks.
+            # Main drain loop — asyncio queue fed by agent callbacks.
             async def _dispatch(it) -> None:
                 """Route a queue item to the correct SSE emitter.
 
@@ -4594,6 +4632,12 @@ class APIServerAdapter(BasePlatformAdapter):
                         await _emit_tool_started(payload)
                     elif tag == "__tool_completed__":
                         await _emit_tool_completed(payload)
+                    elif tag == "__approval_request__":
+                        await _write_event("response.approval.requested", {
+                            "type": "response.approval.requested",
+                            "response_id": response_id,
+                            "approval": payload,
+                        })
                 elif isinstance(it, str):
                     # Batch text deltas — append to buffer, flush on timer
                     _batch_buf.append(it)
@@ -4627,11 +4671,10 @@ class APIServerAdapter(BasePlatformAdapter):
                         _batch_buf = []
                         await _emit_text_delta(combined)
 
-            loop = asyncio.get_running_loop()
             while True:
                 try:
-                    item = await loop.run_in_executor(None, lambda: stream_q.get(timeout=0.5))
-                except _q.Empty:
+                    item = await asyncio.wait_for(stream_q.get(), timeout=0.5)
+                except (asyncio.TimeoutError, asyncio.QueueEmpty):
                     if agent_task.done():
                         # Drain remaining
                         while True:
@@ -4641,7 +4684,7 @@ class APIServerAdapter(BasePlatformAdapter):
                                     break
                                 await _dispatch(item)
                                 last_activity = time.monotonic()
-                            except _q.Empty:
+                            except asyncio.QueueEmpty:
                                 break
                         break
                     if time.monotonic() - last_activity >= CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS:
@@ -4860,8 +4903,95 @@ class APIServerAdapter(BasePlatformAdapter):
             except Exception:
                 pass
             logger.error("Agent crashed mid-stream for %s: %s", response_id, str(agent_error)[:300])
+        finally:
+            _release_response_approval()
 
         return response
+
+    def _response_stream_callbacks(
+        self,
+        *,
+        response_id: str,
+        stream_q: "asyncio.Queue",
+        stream_loop,
+        stream_open: list[bool],
+    ) -> Dict[str, Any]:
+        """Build the worker-to-loop callbacks for one Responses stream."""
+        def _enqueue_stream_item(item) -> None:
+            """Transfer worker callbacks to the event-loop-owned queue."""
+            if not stream_open[0] or stream_loop.is_closed():
+                return
+
+            def _put_if_open() -> None:
+                if stream_open[0]:
+                    stream_q.put_nowait(item)
+
+            try:
+                stream_loop.call_soon_threadsafe(_put_if_open)
+            except RuntimeError:
+                # The loop may close after a client disconnects while a
+                # pooled worker is delivering its final callback.
+                return
+
+        def _on_delta(delta):
+            # None from the agent is a CLI box-close signal, not EOS.
+            # Forwarding would kill the SSE stream prematurely; the
+            # SSE writer detects completion via agent_task.done().
+            if delta is not None:
+                _enqueue_stream_item(delta)
+
+        def _on_tool_progress(event_type, name, preview, args, **kwargs):
+            """Queue non-start tool progress events if needed in future.
+
+            The structured Responses stream uses ``tool_start_callback``
+            and ``tool_complete_callback`` for exact call-id correlation,
+            so progress events are currently ignored here.
+            """
+            return
+
+        def _on_tool_start(tool_call_id, function_name, function_args):
+            """Queue a started tool for live function_call streaming."""
+            _enqueue_stream_item(("__tool_started__", {
+                "tool_call_id": tool_call_id,
+                "name": function_name,
+                "arguments": function_args or {},
+            }))
+
+        def _on_tool_complete(tool_call_id, function_name, function_args, function_result):
+            """Queue a completed tool result for live function_call_output streaming."""
+            _enqueue_stream_item(("__tool_completed__", {
+                "tool_call_id": tool_call_id,
+                "name": function_name,
+                "arguments": function_args or {},
+                "result": function_result,
+            }))
+
+        def _on_approval_request(approval_data: Dict[str, Any]) -> None:
+            """Queue a redacted approval request for live response streaming."""
+            event = dict(approval_data or {})
+            if "command" in event:
+                from gateway.run import _redact_approval_command
+
+                event["command"] = _redact_approval_command(event.get("command"))
+            event.update({
+                "event": "approval.request",
+                "response_id": response_id,
+                "timestamp": time.time(),
+                "choices": _approval_event_choices(
+                    smart_denied=bool(event.get("smart_denied")),
+                    allow_permanent=event.get("allow_permanent") is not False,
+                ),
+            })
+            _enqueue_stream_item(("__approval_request__", event))
+
+        return {
+            "enqueue_stream_item": _enqueue_stream_item,
+            "stream_delta_callback": _on_delta,
+            "tool_progress_callback": _on_tool_progress,
+            "tool_start_callback": _on_tool_start,
+            "tool_complete_callback": _on_tool_complete,
+            "approval_notify_callback": _on_approval_request,
+        }
 
     @_admit_api_agent_request
     async def _handle_responses(self, request: "web.Request") -> "web.Response":
@@ -4995,62 +5125,39 @@ class APIServerAdapter(BasePlatformAdapter):
             # Streaming branch — emit OpenAI Responses SSE events as the
             # agent runs so frontends can render text deltas and tool
             # calls in real time.  See _write_sse_responses for details.
-            import queue as _q
-            _stream_q: _q.Queue = _q.Queue()
+            _stream_q: asyncio.Queue = asyncio.Queue()
+            stream_loop = asyncio.get_running_loop()
+            stream_open = [True]
 
-            def _on_delta(delta):
-                # None from the agent is a CLI box-close signal, not EOS.
-                # Forwarding would kill the SSE stream prematurely; the
-                # SSE writer detects completion via agent_task.done().
-                if delta is not None:
-                    _stream_q.put(delta)
+            response_id = f"resp_{uuid.uuid4().hex[:28]}"
+            stream_callbacks = self._response_stream_callbacks(
+                response_id=response_id,
+                stream_q=_stream_q,
+                stream_loop=stream_loop,
+                stream_open=stream_open,
+            )
+            stream_enqueue = stream_callbacks.pop("enqueue_stream_item")
 
-            def _on_tool_progress(event_type, name, preview, args, **kwargs):
-                """Queue non-start tool progress events if needed in future.
-
-                The structured Responses stream uses ``tool_start_callback``
-                and ``tool_complete_callback`` for exact call-id correlation,
-                so progress events are currently ignored here.
-                """
-                return
-
-            def _on_tool_start(tool_call_id, function_name, function_args):
-                """Queue a started tool for live function_call streaming."""
-                _stream_q.put(("__tool_started__", {
-                    "tool_call_id": tool_call_id,
-                    "name": function_name,
-                    "arguments": function_args or {},
-                }))
-
-            def _on_tool_complete(tool_call_id, function_name, function_args, function_result):
-                """Queue a completed tool result for live function_call_output streaming."""
-                _stream_q.put(("__tool_completed__", {
-                    "tool_call_id": tool_call_id,
-                    "name": function_name,
-                    "arguments": function_args or {},
-                    "result": function_result,
-                }))
-
+            self._response_approval_sessions[response_id] = self._normalized_request_profile()
             agent_ref = [None]
             agent_task = asyncio.ensure_future(self._run_agent(
                 user_message=user_message,
                 conversation_history=conversation_history,
                 ephemeral_system_prompt=instructions,
                 session_id=session_id,
-                stream_delta_callback=_on_delta,
-                tool_progress_callback=_on_tool_progress,
-                tool_start_callback=_on_tool_start,
-                tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
                 **agent_overrides,
                 route=route,
+                approval_session_key=response_id,
+                **stream_callbacks,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
-            agent_task.add_done_callback(lambda _fut: _stream_q.put(None))
+            agent_task.add_done_callback(
+                lambda _fut: stream_enqueue(None)
+            )
 
-            response_id = f"resp_{uuid.uuid4().hex[:28]}"
             model_name = body.get("model", self._model_name)
             created_at = int(time.time())
 
@@ -5069,6 +5176,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 store=store,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                stream_open=stream_open,
             )
 
         async def _compute_response():
@@ -5215,6 +5323,90 @@ class APIServerAdapter(BasePlatformAdapter):
             "id": response_id,
             "object": "response",
             "deleted": True,
+        })
+
+    async def _handle_response_approval(self, request: "web.Request") -> "web.Response":
+        """POST /v1/responses/{response_id}/approval — resolve a pending approval."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        response_id = request.match_info["response_id"]
+        approval_owner = self._response_approval_sessions.get(response_id)
+        if approval_owner is None:
+            return web.json_response(
+                _openai_error(
+                    f"Response has no active approval session: {response_id}",
+                    code="approval_not_active",
+                ),
+                status=409,
+            )
+        request_profile = self._normalized_request_profile()
+        if approval_owner != request_profile:
+            return web.json_response(
+                _openai_error(
+                    f"Response approval belongs to another profile: {response_id}",
+                    code="approval_profile_mismatch",
+                ),
+                status=403,
+            )
+
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response(_openai_error("Invalid JSON"), status=400)
+        if not isinstance(body, dict):
+            return web.json_response(
+                _openai_error("Approval request body must be a JSON object"),
+                status=400,
+            )
+
+        raw_choice = str(body.get("choice", "")).strip().lower()
+        choice = {"approve": "once", "approved": "once", "allow": "once"}.get(
+            raw_choice, raw_choice
+        )
+        if choice not in {"once", "session", "always", "deny"}:
+            return web.json_response(
+                _openai_error(
+                    "Invalid approval choice; expected one of: once, session, always, deny",
+                    code="invalid_approval_choice",
+                ),
+                status=400,
+            )
+
+        resolve_all = (
+            _coerce_request_bool(body.get("all"), default=False)
+            or _coerce_request_bool(body.get("resolve_all"), default=False)
+        )
+        try:
+            from tools.approval import resolve_gateway_approval
+
+            resolved = resolve_gateway_approval(
+                response_id,
+                choice,
+                resolve_all=resolve_all,
+            )
+        except Exception as exc:
+            logger.exception(
+                "[api_server] approval resolution failed for response %s",
+                response_id,
+            )
+            return web.json_response(_openai_error(str(exc)), status=500)
+
+        if resolved <= 0:
+            return web.json_response(
+                _openai_error(
+                    f"Response has no pending approval: {response_id}",
+                    code="approval_not_pending",
+                ),
+                status=409,
+            )
+
+        return web.json_response({
+            "object": "hermes.response.approval_response",
+            "response_id": response_id,
+            "choice": choice,
+            "resolved": resolved,
         })
 
     # ------------------------------------------------------------------
@@ -5774,6 +5966,8 @@ class APIServerAdapter(BasePlatformAdapter):
         requested_runtime: Optional[Dict[str, Any]] = None,
         route_source: str = "global",
         confirmed_runtime_lock: bool = False,
+        approval_notify_callback=None,
+        approval_session_key: Optional[str] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -5815,7 +6009,12 @@ class APIServerAdapter(BasePlatformAdapter):
                     session_key=gateway_session_key or session_id or "",
                     session_id=session_id or "",
                 )
+                approval_token = None
                 try:
+                    if approval_notify_callback:
+                        from tools.approval import set_current_session_key
+
+                        approval_token = set_current_session_key(approval_session_key)
                     agent = self._create_agent(
                         ephemeral_system_prompt=ephemeral_system_prompt,
                         session_id=session_id,
@@ -5956,14 +6155,40 @@ class APIServerAdapter(BasePlatformAdapter):
                         {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
                     )
                 finally:
-                    clear_session_vars(tokens)
+                    try:
+                        if approval_token is not None:
+                            from tools.approval import reset_current_session_key
 
-        self._activate_admitted_request()
-        self._inflight_agent_runs += 1
+                            reset_current_session_key(approval_token)
+                    finally:
+                        try:
+                            if approval_notify_callback and approval_session_key:
+                                from tools.approval import clear_session
+
+                                clear_session(approval_session_key)
+                        finally:
+                            clear_session_vars(tokens)
+
+        approval_registered = False
+        if approval_notify_callback:
+            if not approval_session_key:
+                raise ValueError("approval_session_key is required with approval_notify_callback")
+            from tools.approval import register_gateway_notify
+
+            register_gateway_notify(approval_session_key, approval_notify_callback)
+            approval_registered = True
         try:
-            return await loop.run_in_executor(None, _run)
+            self._activate_admitted_request()
+            self._inflight_agent_runs += 1
+            try:
+                return await loop.run_in_executor(None, _run)
+            finally:
+                self._inflight_agent_runs -= 1
         finally:
-            self._inflight_agent_runs -= 1
+            if approval_registered:
+                from tools.approval import unregister_gateway_notify
+
+                unregister_gateway_notify(approval_session_key)
 
     # ------------------------------------------------------------------
     # /v1/runs — structured event streaming

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -318,11 +318,38 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/v1/responses", adapter._handle_responses)
     app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
     app.router.add_delete("/v1/responses/{response_id}", adapter._handle_delete_response)
+    app.router.add_post("/v1/responses/{response_id}/approval", adapter._handle_response_approval)
     app.router.add_post(
         "/api/platforms/{platform}/events",
         adapter._handle_platform_event_callback,
     )
     return app
+
+
+class _ApprovalRequest:
+    def __init__(self, response_id: str, body: dict):
+        self.headers = {"Authorization": "Bearer sk-secret"}
+        self.match_info = {"response_id": response_id}
+        self._body = body
+        self.method = "POST"
+        self.path_qs = f"/v1/responses/{response_id}/approval"
+        self.transport = None
+        self.remote = ""
+
+    async def json(self):
+        return self._body
+
+
+async def _wait_for_gateway_approval_state(approval_mod, response_id: str) -> None:
+    for _ in range(200):
+        with approval_mod._lock:
+            if (
+                response_id in approval_mod._gateway_notify_cbs
+                and approval_mod._gateway_queues.get(response_id)
+            ):
+                return
+        await asyncio.sleep(0.01)
+    pytest.fail(f"approval worker did not register state for {response_id}")
 
 
 class _FakeGoogleChatAdapter:
@@ -391,6 +418,70 @@ class TestAgentExecution:
             conversation_history=[],
             task_id="session-123",
         )
+
+    @pytest.mark.asyncio
+    async def test_response_approval_registration_cleans_up_on_completion_and_failure(self, adapter):
+        from tools import approval as approval_mod
+
+        callback = MagicMock()
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "ok"}
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+        with patch.object(adapter, "_create_agent", return_value=mock_agent):
+            await adapter._run_agent(
+                user_message="hello",
+                conversation_history=[],
+                session_id="conversation",
+                gateway_session_key="shared",
+                approval_notify_callback=callback,
+                approval_session_key="resp_complete",
+            )
+        with approval_mod._lock:
+            assert "resp_complete" not in approval_mod._gateway_notify_cbs
+            assert "resp_complete" not in approval_mod._gateway_queues
+
+        with patch.object(adapter, "_create_agent", side_effect=RuntimeError("create failed")):
+            with pytest.raises(RuntimeError, match="create failed"):
+                await adapter._run_agent(
+                    user_message="hello",
+                    conversation_history=[],
+                    session_id="conversation",
+                    gateway_session_key="shared",
+                    approval_notify_callback=callback,
+                    approval_session_key="resp_failed",
+                )
+        with approval_mod._lock:
+            assert "resp_failed" not in approval_mod._gateway_notify_cbs
+            assert "resp_failed" not in approval_mod._gateway_queues
+
+    @pytest.mark.asyncio
+    async def test_response_worker_clears_session_approval_state(self, adapter):
+        from tools import approval as approval_mod
+
+        response_id = "resp_session_cleanup"
+        mock_agent = MagicMock()
+        mock_agent.session_prompt_tokens = 0
+        mock_agent.session_completion_tokens = 0
+        mock_agent.session_total_tokens = 0
+
+        def run_conversation(**_kwargs):
+            approval_mod.approve_session(response_id, "execute_code")
+            return {"final_response": "ok"}
+
+        mock_agent.run_conversation.side_effect = run_conversation
+        with patch.object(adapter, "_create_agent", return_value=mock_agent):
+            await adapter._run_agent(
+                user_message="hello",
+                conversation_history=[],
+                session_id="conversation",
+                approval_notify_callback=lambda _event: None,
+                approval_session_key=response_id,
+            )
+
+        with approval_mod._lock:
+            assert response_id not in approval_mod._session_approved
 
 
 class TestRunEventCallback:
@@ -1109,6 +1200,8 @@ class TestResponsesEndpoint:
             assert data["output"][0]["type"] == "message"
             assert data["output"][0]["content"][0]["type"] == "output_text"
             assert data["output"][0]["content"][0]["text"] == "Paris is the capital of France."
+            assert "approval_notify_callback" not in mock_run.call_args.kwargs
+            assert "approval_session_key" not in mock_run.call_args.kwargs
 
 
     @pytest.mark.asyncio
@@ -1357,7 +1450,440 @@ class TestResponsesEndpoint:
             assert data["output"][0]["content"][0]["text"] != f"provider auth failed OPENAI_API_KEY={raw_secret}"
 
 
+class TestResponseApprovalEndpoint:
+    @pytest.mark.asyncio
+    async def test_root_and_profile_routes_resolve_by_response_id(self, adapter):
+        adapter._response_approval_sessions["resp_owned"] = "default"
+        app = web.Application()
+        for method, path, handler in adapter._http_route_table():
+            app.router.add_route(method, path, handler)
+            app.router.add_route(method, f"/p/{{profile}}{path}", handler)
+
+        assert any(
+            method == "POST" and path == "/v1/responses/{response_id}/approval"
+            for method, path, _handler in adapter._http_route_table()
+        )
+        with patch("tools.approval.resolve_gateway_approval", return_value=2) as resolve:
+            async with TestClient(TestServer(app)) as cli:
+                root = await cli.post(
+                    "/v1/responses/resp_owned/approval",
+                    json={"choice": "approve", "resolve_all": True},
+                )
+
+        assert root.status == 200
+        resolve.assert_called_once_with("resp_owned", "once", resolve_all=True)
+
+    @pytest.mark.asyncio
+    async def test_sibling_profile_cannot_resolve_response_approval(self, auth_adapter):
+        import gateway.platforms.api_server as api_mod
+
+        response_id = "resp_default_owned"
+        auth_adapter._response_approval_sessions[response_id] = "default"
+
+        @web.middleware
+        async def profile_scope(request, handler):
+            token = api_mod._api_request_profile.set("work")
+            try:
+                return await handler(request)
+            finally:
+                api_mod._api_request_profile.reset(token)
+
+        app = web.Application(middlewares=[profile_scope])
+        for method, path, handler in auth_adapter._http_route_table():
+            app.router.add_route(method, path, handler)
+            app.router.add_route(method, f"/p/{{profile}}{path}", handler)
+
+        with (
+            patch.object(auth_adapter, "_expected_api_key", return_value="sk-work"),
+            patch("tools.approval.resolve_gateway_approval") as resolve,
+        ):
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.post(
+                    f"/p/work/v1/responses/{response_id}/approval",
+                    headers={"Authorization": "Bearer sk-work"},
+                    json={"choice": "once"},
+                )
+                body = await response.json()
+
+        assert response.status == 403
+        assert body["error"]["code"] == "approval_profile_mismatch"
+        resolve.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_aliases_errors_and_inactive_response(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            inactive = await cli.post(
+                "/v1/responses/missing/approval",
+                json={"choice": "once"},
+            )
+            adapter._response_approval_sessions["resp_errors"] = "default"
+            non_object = await cli.post(
+                "/v1/responses/resp_errors/approval",
+                json=[],
+            )
+            invalid = await cli.post(
+                "/v1/responses/resp_errors/approval",
+                json={"choice": "later"},
+            )
+            no_pending = await cli.post(
+                "/v1/responses/resp_errors/approval",
+                json={"choice": "once"},
+            )
+            no_pending_body = await no_pending.json()
+
+        assert inactive.status == 409
+        assert non_object.status == 400
+        assert invalid.status == 400
+        assert no_pending.status == 409
+        assert no_pending_body["error"]["code"] == "approval_not_pending"
+
+
 class TestResponsesStreaming:
+
+    def test_response_approval_key_flows_through_production_seams(self):
+        import inspect
+
+        from gateway.platforms import api_server
+
+        source = inspect.getsource(api_server.APIServerAdapter)
+        required = (
+            "def _response_stream_callbacks(",
+            "stream_loop.is_closed()",
+            "stream_loop.call_soon_threadsafe(_put_if_open)",
+            "self._response_approval_sessions[response_id] = self._normalized_request_profile()",
+            '"approval_notify_callback": _on_approval_request',
+            "approval_session_key=response_id",
+            "register_gateway_notify(approval_session_key, approval_notify_callback)",
+            "set_current_session_key(approval_session_key)",
+            "unregister_gateway_notify(approval_session_key)",
+            "self._response_approval_sessions.get(response_id)",
+            "resolve_gateway_approval(\n                response_id,",
+            "resolve_all=resolve_all",
+        )
+        for fragment in required:
+            assert fragment in source, f"missing response-owned approval flow: {fragment}"
+
+    def test_response_stream_callbacks_ignore_closed_loop(self, adapter):
+        stream_loop = asyncio.new_event_loop()
+        try:
+            callbacks = adapter._response_stream_callbacks(
+                response_id="resp_closed_loop",
+                stream_q=asyncio.Queue(),
+                stream_loop=stream_loop,
+                stream_open=[True],
+            )
+            stream_loop.close()
+            callbacks["stream_delta_callback"]("late delta")
+        finally:
+            if not stream_loop.is_closed():
+                stream_loop.close()
+
+    @pytest.mark.asyncio
+    async def test_stream_sse_approval_payload_redacts_credentials(self, adapter):
+        raw_secret = "sk-proj-" + "X" * 40
+        raw_command = "curl -H 'Authorization: Bearer " + raw_secret + "' https://example.test"
+        app = _create_app(adapter)
+
+        async def _fake_run_agent(**kwargs):
+            kwargs["approval_notify_callback"]({
+                "command": raw_command,
+                "description": "credential-shaped approval",
+                "allow_permanent": True,
+            })
+            return (
+                {"final_response": "done", "messages": [], "api_calls": 1},
+                {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+            )
+
+        with patch.object(adapter, "_run_agent", side_effect=_fake_run_agent):
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "approve", "stream": True},
+                )
+                payload = await response.text()
+
+        assert response.status == 200
+        assert raw_secret not in payload
+        events = [
+            json.loads(line.removeprefix("data: "))
+            for line in payload.splitlines()
+            if line.startswith("data: ")
+        ]
+        approval_event = next(
+            event for event in events if event["type"] == "response.approval.requested"
+        )
+        approval = approval_event["approval"]
+        assert approval_event["response_id"].startswith("resp_")
+        assert approval["response_id"] == approval_event["response_id"]
+        from gateway.run import _redact_approval_command
+        assert approval["command"] == _redact_approval_command(raw_command)
+        assert approval["command"] != raw_command
+        assert approval["description"] == "credential-shaped approval"
+        assert approval["choices"] == ["once", "session", "always", "deny"]
+
+    @pytest.mark.asyncio
+    async def test_stream_approval_prompt_progresses_with_one_default_executor_worker(self, adapter):
+        from concurrent.futures import ThreadPoolExecutor
+        from tools import approval as approval_mod
+
+        app = _create_app(adapter)
+        loop = asyncio.get_running_loop()
+        executor = ThreadPoolExecutor(max_workers=1)
+        previous_executor = getattr(loop, "_default_executor", None)
+        loop.set_default_executor(executor)
+
+        class _BlockingAgent:
+            session_prompt_tokens = 0
+            session_completion_tokens = 0
+            session_total_tokens = 0
+
+            def __init__(self):
+                self.stream_delta_callback = None
+
+            def interrupt(self, _reason):
+                return None
+
+            def run_conversation(self, **_kwargs):
+                result = approval_mod.check_execute_code_guard("print('approval')", "local")
+                return {
+                    "final_response": "approved" if result["approved"] else "blocked",
+                    "messages": [],
+                }
+        try:
+            with (
+                patch.object(adapter, "_create_agent", return_value=_BlockingAgent()),
+                patch.object(approval_mod, "_get_approval_mode", return_value="ask"),
+                patch.object(approval_mod, "_get_approval_timeout", return_value=10),
+            ):
+                async with TestClient(TestServer(app)) as cli:
+                    response = await cli.post(
+                        "/v1/responses",
+                        json={"model": "hermes-agent", "input": "approve", "stream": True},
+                    )
+                    assert response.status == 200
+
+                    approval_event = None
+                    while approval_event is None:
+                        line = await asyncio.wait_for(response.content.readline(), timeout=2)
+                        assert line
+                        if line.startswith(b"data: "):
+                            event = json.loads(line.removeprefix(b"data: "))
+                            if event["type"] == "response.approval.requested":
+                                approval_event = event
+
+                    response_id = approval_event["response_id"]
+                    assert approval_event["approval"]["response_id"] == response_id
+                    assert approval_mod.resolve_gateway_approval(response_id, "once") == 1
+                    assert b"response.completed" in await response.read()
+        finally:
+            loop._default_executor = previous_executor
+            executor.shutdown(wait=True)
+
+    @pytest.mark.asyncio
+    async def test_concurrent_streams_isolate_approval_queues_and_resolve_all(self, auth_adapter):
+        from tools import approval as approval_mod
+        adapter = auth_adapter
+
+        class _BlockingAgent:
+            session_id = "shared-session"
+            session_prompt_tokens = 1
+            session_completion_tokens = 1
+
+            def run_conversation(self, **kwargs):
+                result = approval_mod.check_execute_code_guard("print('approval')", "local")
+                return {
+                    "final_response": "approved" if result["approved"] else "blocked",
+                    "messages": [],
+                    "api_calls": 1,
+                }
+
+        app = _create_app(adapter)
+        client_tasks = []
+        try:
+            with (
+                patch.object(adapter, "_create_agent", side_effect=lambda **_: _BlockingAgent()),
+                patch.object(approval_mod, "_get_approval_mode", return_value="ask"),
+                patch.object(approval_mod, "_get_approval_timeout", return_value=10),
+            ):
+                async with TestClient(TestServer(app)) as cli:
+                    headers = {
+                        "Authorization": "Bearer sk-secret",
+                        "X-Hermes-Session-Key": "shared-session",
+                    }
+                    client_tasks = [
+                        asyncio.create_task(cli.post(
+                            "/v1/responses",
+                            headers=headers,
+                            json={"model": "hermes-agent", "input": "one", "stream": True},
+                        )),
+                        asyncio.create_task(cli.post(
+                            "/v1/responses",
+                            headers=headers,
+                            json={"model": "hermes-agent", "input": "two", "stream": True},
+                        )),
+                    ]
+
+                    for _ in range(200):
+                        with approval_mod._lock:
+                            queue_keys = set(approval_mod._gateway_queues)
+                        response_ids = set(adapter._response_approval_sessions)
+                        if len(response_ids) >= 2 and len(queue_keys & response_ids) >= 2:
+                            break
+                        await asyncio.sleep(0.01)
+                    else:
+                        pytest.fail("both streaming response approval queues did not start")
+
+                    response_ids = list(adapter._response_approval_sessions)[:2]
+                    with approval_mod._lock:
+                        assert all(response_id in approval_mod._gateway_notify_cbs for response_id in response_ids)
+                        assert all(
+                            len(approval_mod._gateway_queues[response_id]) >= 1
+                            for response_id in response_ids
+                        )
+
+                    first = await adapter._handle_response_approval(
+                        _ApprovalRequest(response_ids[0], {"choice": "once", "resolve_all": True})
+                    )
+                    assert first.status == 200
+                    with approval_mod._lock:
+                        assert response_ids[0] not in approval_mod._gateway_queues
+                        assert len(approval_mod._gateway_queues[response_ids[1]]) == 1
+
+                    second = await adapter._handle_response_approval(
+                        _ApprovalRequest(response_ids[1], {"choice": "allow", "all": True})
+                    )
+                    assert second.status == 200
+                    responses = await asyncio.wait_for(asyncio.gather(*client_tasks), timeout=10)
+                    assert [response.status for response in responses] == [200, 200]
+                    for _ in range(200):
+                        with approval_mod._lock:
+                            clean = all(
+                                response_id not in approval_mod._gateway_notify_cbs
+                                and response_id not in approval_mod._gateway_queues
+                                for response_id in response_ids
+                            )
+                        if clean and all(
+                            response_id not in adapter._response_approval_sessions
+                            for response_id in response_ids
+                        ):
+                            break
+                        await asyncio.sleep(0.01)
+                    assert all(
+                        response_id not in adapter._response_approval_sessions
+                        for response_id in response_ids
+                    )
+                    with approval_mod._lock:
+                        assert all(
+                            response_id not in approval_mod._gateway_notify_cbs
+                            for response_id in response_ids
+                        )
+                        assert all(
+                            response_id not in approval_mod._gateway_queues
+                            for response_id in response_ids
+                        )
+        finally:
+            for task in client_tasks:
+                if not task.done():
+                    task.cancel()
+            if client_tasks:
+                await asyncio.gather(*client_tasks, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_response_prepare_failure_releases_owned_approval_state(self, adapter):
+        from tools import approval as approval_mod
+        import gateway.platforms.api_server as api_mod
+        response_id = "resp_prepare_failure"
+        adapter._response_approval_sessions[response_id] = "default"
+        approval_mod.register_gateway_notify(response_id, lambda _: None)
+        stream_q = asyncio.Queue()
+        never = asyncio.Event()
+
+        async def _agent_coro():
+            await never.wait()
+
+        agent_task = asyncio.create_task(_agent_coro())
+
+        class _FailingStreamResponse:
+            async def prepare(self, request):
+                raise RuntimeError("prepare failed")
+
+        request = MagicMock()
+        request.headers = {}
+        with patch.object(api_mod.web, "StreamResponse", return_value=_FailingStreamResponse()):
+            with pytest.raises(RuntimeError, match="prepare failed"):
+                await adapter._write_sse_responses(
+                    request=request,
+                    response_id=response_id,
+                    model="hermes-agent",
+                    created_at=int(time.time()),
+                    stream_q=stream_q,
+                    agent_task=agent_task,
+                    agent_ref=[None],
+                    conversation_history=[],
+                    user_message="prepare",
+                    instructions=None,
+                    conversation=None,
+                    store=False,
+                    session_id="conversation",
+                )
+
+        assert response_id not in adapter._response_approval_sessions
+        with approval_mod._lock:
+            assert response_id not in approval_mod._gateway_notify_cbs
+            assert response_id not in approval_mod._gateway_queues
+
+    @pytest.mark.asyncio
+    async def test_cancellation_before_executor_submission_releases_response_state(self, adapter):
+        import gateway.platforms.api_server as api_mod
+        from tools import approval as approval_mod
+        response_id = "resp_cancel_before_executor"
+        adapter._response_approval_sessions[response_id] = "default"
+        agent_task = asyncio.create_task(adapter._run_agent(
+            user_message="cancel",
+            conversation_history=[],
+            session_id="conversation",
+            approval_notify_callback=lambda _: None,
+            approval_session_key=response_id,
+        ))
+        agent_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await agent_task
+
+        class _StreamResponse:
+            async def prepare(self, request):
+                return None
+
+            async def write(self, payload):
+                return None
+
+        stream_q = asyncio.Queue()
+        stream_q.put_nowait(None)
+        request = MagicMock()
+        request.headers = {}
+        with patch.object(api_mod.web, "StreamResponse", return_value=_StreamResponse()):
+            with pytest.raises(asyncio.CancelledError):
+                await adapter._write_sse_responses(
+                    request=request,
+                    response_id=response_id,
+                    model="hermes-agent",
+                    created_at=int(time.time()),
+                    stream_q=stream_q,
+                    agent_task=agent_task,
+                    agent_ref=[None],
+                    conversation_history=[],
+                    user_message="cancel",
+                    instructions=None,
+                    conversation=None,
+                    store=False,
+                    session_id="conversation",
+                )
+
+        assert response_id not in adapter._response_approval_sessions
+        with approval_mod._lock:
+            assert response_id not in approval_mod._gateway_notify_cbs
+            assert response_id not in approval_mod._gateway_queues
 
 
     @pytest.mark.asyncio
@@ -1379,17 +1905,14 @@ class TestResponsesStreaming:
                 coro.close()
                 return fake_task
 
+            mock_run = AsyncMock(
+                return_value=(
+                    {"final_response": "ok", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+            )
             with (
-                patch.object(
-                    adapter,
-                    "_run_agent",
-                    new=AsyncMock(
-                        return_value=(
-                            {"final_response": "ok", "messages": [], "api_calls": 1},
-                            {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
-                        )
-                    ),
-                ),
+                patch.object(adapter, "_run_agent", new=mock_run),
                 patch("gateway.platforms.api_server.asyncio.ensure_future", side_effect=_fake_ensure_future),
                 patch.object(adapter, "_write_sse_responses", new_callable=AsyncMock) as mock_write_sse,
             ):
@@ -1404,7 +1927,15 @@ class TestResponsesStreaming:
             stream_q = mock_write_sse.call_args.kwargs["stream_q"]
             assert stream_q.empty()
             fake_task.callbacks[0](fake_task)
+            await asyncio.sleep(0)
             assert stream_q.get_nowait() is None
+
+            mock_write_sse.call_args.kwargs["stream_open"][0] = False
+            callbacks = mock_run.call_args.kwargs
+            callbacks["stream_delta_callback"]("late delta")
+            callbacks["tool_start_callback"]("late-call", "shell", {})
+            callbacks["approval_notify_callback"]({"command": "late"})
+            assert stream_q.empty()
 
 
     @pytest.mark.asyncio
@@ -1419,11 +1950,14 @@ class TestResponsesStreaming:
         handler, which makes end-to-end assertion on the final stored
         snapshot flaky).
         """
+        from tools import approval as approval_mod
+
         # Build a minimal fake request + stream queue the writer understands.
         fake_request = MagicMock()
         fake_request.headers = {}
 
         written_payloads: list = []
+        partial_written = asyncio.Event()
 
         class _FakeStreamResponse:
             async def prepare(self, req):
@@ -1431,41 +1965,81 @@ class TestResponsesStreaming:
 
             async def write(self, payload):
                 written_payloads.append(payload)
+                if b"response.output_text.delta" in payload:
+                    partial_written.set()
 
         # Patch web.StreamResponse for the duration of the writer call.
         import gateway.platforms.api_server as api_mod
-        import queue as _q
-
-        stream_q: _q.Queue = _q.Queue()
-
-        async def _agent_coro():
-            # Feed one partial delta into the stream queue...
-            stream_q.put("partial output")
-            # ...then give the drain loop a moment to pick it up before
-            # raising CancelledError to simulate a server-side cancel.
-            await asyncio.sleep(0.01)
-            raise asyncio.CancelledError()
-
-        agent_task = asyncio.ensure_future(_agent_coro())
+        stream_q = asyncio.Queue()
+        stream_open = [True]
+        loop = asyncio.get_running_loop()
         response_id = f"resp_{uuid.uuid4().hex[:28]}"
+        stream_callbacks = adapter._response_stream_callbacks(
+            response_id=response_id,
+            stream_q=stream_q,
+            stream_loop=loop,
+            stream_open=stream_open,
+        )
+        stream_callbacks.pop("enqueue_stream_item")
 
-        with patch.object(api_mod.web, "StreamResponse", return_value=_FakeStreamResponse()):
-            with pytest.raises(asyncio.CancelledError):
-                await adapter._write_sse_responses(
+        class _BlockingAgent:
+            session_prompt_tokens = 0
+            session_completion_tokens = 0
+            session_total_tokens = 0
+
+            def interrupt(self, _reason):
+                return None
+
+            def run_conversation(self, **kwargs):
+                self.stream_delta_callback("partial output")
+                approval_mod.check_execute_code_guard("print('approval')", "local")
+                return {"final_response": "done", "messages": [], "api_calls": 1}
+
+        def _create_agent(**kwargs):
+            agent = _BlockingAgent()
+            agent.stream_delta_callback = kwargs["stream_delta_callback"]
+            return agent
+
+        adapter._response_approval_sessions[response_id] = "default"
+        agent_ref = [None]
+        with (
+            patch.object(adapter, "_create_agent", side_effect=_create_agent),
+            patch.object(approval_mod, "_get_approval_mode", return_value="ask"),
+            patch.object(approval_mod, "_get_approval_timeout", return_value=10),
+        ):
+            agent_task = asyncio.create_task(adapter._run_agent(
+                user_message="will be cancelled",
+                conversation_history=[],
+                session_id=None,
+                agent_ref=agent_ref,
+                stream_delta_callback=stream_callbacks["stream_delta_callback"],
+                approval_notify_callback=stream_callbacks["approval_notify_callback"],
+                approval_session_key=response_id,
+            ))
+            await _wait_for_gateway_approval_state(approval_mod, response_id)
+
+            with patch.object(api_mod.web, "StreamResponse", return_value=_FakeStreamResponse()):
+                writer_task = asyncio.create_task(adapter._write_sse_responses(
                     request=fake_request,
                     response_id=response_id,
                     model="hermes-agent",
                     created_at=int(time.time()),
                     stream_q=stream_q,
                     agent_task=agent_task,
-                    agent_ref=[None],
+                    agent_ref=agent_ref,
                     conversation_history=[],
                     user_message="will be cancelled",
                     instructions=None,
                     conversation=None,
                     store=True,
                     session_id=None,
-                )
+                    stream_open=stream_open,
+                ))
+                await partial_written.wait()
+                writer_task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await writer_task
+            await asyncio.gather(agent_task, return_exceptions=True)
 
         # The in_progress snapshot was persisted on response.created,
         # and the CancelledError handler must have updated it to
@@ -1481,6 +2055,10 @@ class TestResponsesStreaming:
             for part in item.get("content", [])
         )
         assert "partial output" in output_text
+        assert response_id not in adapter._response_approval_sessions
+        with approval_mod._lock:
+            assert response_id not in approval_mod._gateway_notify_cbs
+            assert response_id not in approval_mod._gateway_queues
 
     @pytest.mark.asyncio
     async def test_stream_client_disconnect_persists_incomplete_snapshot(self, adapter):
@@ -1505,40 +2083,86 @@ class TestResponsesStreaming:
                     raise ConnectionResetError("simulated client disconnect")
 
         import gateway.platforms.api_server as api_mod
-        import queue as _q
+        from tools import approval as approval_mod
 
-        stream_q: _q.Queue = _q.Queue()
-        stream_q.put("some streamed text")
-        stream_q.put(None)  # EOS sentinel
-
-        async def _agent_coro():
-            await asyncio.sleep(0.01)
-            return ({"final_response": "", "messages": [], "api_calls": 0},
-                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
-
-        agent_task = asyncio.ensure_future(_agent_coro())
+        stream_q = asyncio.Queue()
+        stream_open = [True]
+        loop = asyncio.get_running_loop()
         response_id = f"resp_{uuid.uuid4().hex[:28]}"
+        stream_callbacks = adapter._response_stream_callbacks(
+            response_id=response_id,
+            stream_q=stream_q,
+            stream_loop=loop,
+            stream_open=stream_open,
+        )
+        stream_enqueue = stream_callbacks.pop("enqueue_stream_item")
 
-        with patch.object(api_mod.web, "StreamResponse", return_value=_DisconnectingStreamResponse()):
-            await adapter._write_sse_responses(
-                request=fake_request,
-                response_id=response_id,
-                model="hermes-agent",
-                created_at=int(time.time()),
-                stream_q=stream_q,
-                agent_task=agent_task,
-                agent_ref=[None],
-                conversation_history=[],
+        class _BlockingAgent:
+            session_prompt_tokens = 0
+            session_completion_tokens = 0
+            session_total_tokens = 0
+
+            def __init__(self):
+                self.stream_delta_callback = None
+
+            def interrupt(self, _reason):
+                return None
+
+            def run_conversation(self, **kwargs):
+                self.stream_delta_callback("some streamed text")
+                approval_mod.check_execute_code_guard("print('approval')", "local")
+                return {"final_response": "", "messages": [], "api_calls": 0}
+
+        def _create_agent(**kwargs):
+            agent = _BlockingAgent()
+            agent.stream_delta_callback = kwargs["stream_delta_callback"]
+            return agent
+
+        adapter._response_approval_sessions[response_id] = "default"
+        agent_ref = [None]
+        with (
+            patch.object(adapter, "_create_agent", side_effect=_create_agent),
+            patch.object(approval_mod, "_get_approval_mode", return_value="ask"),
+            patch.object(approval_mod, "_get_approval_timeout", return_value=10),
+        ):
+            agent_task = asyncio.create_task(adapter._run_agent(
                 user_message="will disconnect",
-                instructions=None,
-                conversation=None,
-                store=True,
+                conversation_history=[],
                 session_id=None,
-            )
+                agent_ref=agent_ref,
+                stream_delta_callback=stream_callbacks["stream_delta_callback"],
+                approval_notify_callback=stream_callbacks["approval_notify_callback"],
+                approval_session_key=response_id,
+            ))
+            await _wait_for_gateway_approval_state(approval_mod, response_id)
+            stream_enqueue(None)  # EOS sentinel through the production handoff
+
+            with patch.object(api_mod.web, "StreamResponse", return_value=_DisconnectingStreamResponse()):
+                await adapter._write_sse_responses(
+                    request=fake_request,
+                    response_id=response_id,
+                    model="hermes-agent",
+                    created_at=int(time.time()),
+                    stream_q=stream_q,
+                    agent_task=agent_task,
+                    agent_ref=agent_ref,
+                    conversation_history=[],
+                    user_message="will disconnect",
+                    instructions=None,
+                    conversation=None,
+                    store=True,
+                    session_id=None,
+                    stream_open=stream_open,
+                )
+            await asyncio.gather(agent_task, return_exceptions=True)
 
         stored = adapter._response_store.get(response_id)
         assert stored is not None, "snapshot must survive client disconnect"
         assert stored["response"]["status"] == "incomplete"
+        assert response_id not in adapter._response_approval_sessions
+        with approval_mod._lock:
+            assert response_id not in approval_mod._gateway_notify_cbs
+            assert response_id not in approval_mod._gateway_queues
 
 
 # ---------------------------------------------------------------------------
@@ -2616,5 +3240,3 @@ class TestCreateAgentModelRecovery:
         )
         adapter._create_agent(session_id="another-session", gateway_session_key="stable-chan-1")
         assert captured[1]["model"] == "minimax/minimax-m3"
-
-

--- a/tests/gateway/test_approval_prompt_redaction.py
+++ b/tests/gateway/test_approval_prompt_redaction.py
@@ -120,6 +120,11 @@ class TestApprovalCommandWiring:
 
         self._assert_redacts_then_uses(api_server, "_approval_notify", "put_nowait")
 
+    def test_responses_sse_path_redacts_before_enqueue(self):
+        from gateway.platforms import api_server
+
+        self._assert_redacts_then_uses(api_server, "_on_approval_request", "_enqueue_stream_item")
+
 
 class TestApprovalTextFallbackContract:
     def test_smart_deny_only_advertises_one_operation(self):

--- a/tests/tools/test_approval_interrupt.py
+++ b/tests/tools/test_approval_interrupt.py
@@ -91,6 +91,8 @@ class TestApprovalInterrupt:
             # been prompted.
             notified.set()
 
+        mod.register_gateway_notify(self.SESSION_KEY, _notify_cb)
+
         def _worker():
             result_holder["result"] = mod._await_gateway_decision(
                 self.SESSION_KEY, _notify_cb, approval_data
@@ -142,6 +144,8 @@ class TestApprovalInterrupt:
         def _notify_cb(_data):
             notified.set()
 
+        mod.register_gateway_notify(self.SESSION_KEY, _notify_cb)
+
         def _worker():
             result_holder["result"] = mod._await_gateway_decision(
                 self.SESSION_KEY, _notify_cb, approval_data
@@ -158,3 +162,59 @@ class TestApprovalInterrupt:
         assert not t.is_alive()
         # Timed out (no resolution) because the foreign interrupt was ignored.
         assert result_holder["result"] == {"resolved": False, "choice": None, "reason": None}
+
+    def test_captured_callback_cannot_register_after_disconnect(self, monkeypatch):
+        """A callback captured before teardown cannot create a new wait."""
+        from tools import approval as mod
+
+        mod._get_approval_config = lambda: {"timeout": 300}
+        approval_data = {
+            "command": "rm -rf /tmp/whatever",
+            "description": "recursive delete",
+            "pattern_key": "rm_rf",
+            "pattern_keys": ["rm_rf"],
+        }
+        callback_captured = threading.Event()
+        registration_attempted = threading.Event()
+        allow_registration = threading.Event()
+        result_holder = {}
+
+        def _notify_cb(_data):
+            pytest.fail("disconnected approval must not notify")
+
+        mod.register_gateway_notify(self.SESSION_KEY, _notify_cb)
+        original_register = mod._register_gateway_approval
+
+        def _coordinated_register(session_key, notify_cb, entry):
+            registration_attempted.set()
+            assert allow_registration.wait(timeout=5)
+            return original_register(session_key, notify_cb, entry)
+
+        monkeypatch.setattr(mod, "_register_gateway_approval", _coordinated_register)
+
+        def _worker():
+            with mod._lock:
+                captured_cb = mod._gateway_notify_cbs.get(self.SESSION_KEY)
+            callback_captured.set()
+            result_holder["result"] = mod._await_gateway_decision(
+                self.SESSION_KEY, captured_cb, approval_data
+            )
+
+        t = threading.Thread(target=_worker, daemon=True)
+        start = time.monotonic()
+        t.start()
+        assert callback_captured.wait(timeout=5)
+        assert registration_attempted.wait(timeout=5)
+
+        mod.unregister_gateway_notify(self.SESSION_KEY)
+        allow_registration.set()
+        t.join(timeout=5)
+
+        assert not t.is_alive(), "stale callback entered the approval wait"
+        assert result_holder["result"] == {
+            "resolved": False,
+            "choice": None,
+            "notify_failed": True,
+        }
+        assert self.SESSION_KEY not in mod._gateway_queues
+        assert time.monotonic() - start < 5

--- a/tests/tools/test_denial_circuit_breaker.py
+++ b/tests/tools/test_denial_circuit_breaker.py
@@ -228,3 +228,22 @@ def test_tally_evicts_oldest_sessions():
         with A._lock:
             A._denial_tally.clear()
             A._denial_tally.update(saved)
+
+
+def test_clear_session_removes_only_the_named_denial_tally():
+    session_key = "clear-denial-session"
+    other_key = "keep-denial-session"
+    A._reset_denials(session_key)
+    A._reset_denials(other_key)
+    try:
+        A._record_denial(session_key)
+        A._record_denial(other_key)
+
+        A.clear_session(session_key)
+
+        with A._lock:
+            assert session_key not in A._denial_tally
+            assert A._denial_tally[other_key] == 1
+    finally:
+        A._reset_denials(session_key)
+        A._reset_denials(other_key)

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2231,6 +2231,16 @@ def resolve_gateway_approval(session_key: str, choice: str,
     return len(targets)
 
 
+def _register_gateway_approval(session_key: str, notify_cb,
+                               entry: _ApprovalEntry) -> bool:
+    """Register an approval only while its captured callback is live."""
+    with _lock:
+        if _gateway_notify_cbs.get(session_key) is not notify_cb:
+            return False
+        _gateway_queues.setdefault(session_key, []).append(entry)
+    return True
+
+
 def has_blocking_approval(session_key: str) -> bool:
     """Check if a session has one or more blocking gateway approvals waiting."""
     with _lock:
@@ -2295,6 +2305,7 @@ def clear_session(session_key: str) -> None:
         _session_approved.pop(session_key, None)
         _session_yolo.discard(session_key)
         _pending.pop(session_key, None)
+        _denial_tally.pop(session_key, None)
         entries = _gateway_queues.pop(session_key, [])
     for entry in entries:
         # Session-boundary cleanup should cancel any blocked approval waits
@@ -3268,8 +3279,13 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     all_keys = approval_data.get("pattern_keys", [primary_key])
 
     entry = _ApprovalEntry(approval_data)
-    with _lock:
-        _gateway_queues.setdefault(session_key, []).append(entry)
+    if not _register_gateway_approval(session_key, notify_cb, entry):
+        logger.info(
+            "Gateway approval callback is no longer registered for %s; "
+            "failing closed",
+            session_key,
+        )
+        return {"resolved": False, "choice": None, "notify_failed": True}
 
     def _drop_entry() -> None:
         with _lock:


### PR DESCRIPTION
## Summary

The Responses API path was only half-wired for guarded approvals: `_write_sse_responses()` silently dropped the queued `__approval_request__` tuple, no resolution endpoint existed, and the non-streaming path registered a no-op approval callback that could block indefinitely.

This update completes the Responses approval transport with proper scope isolation. Streaming responses emit `response.approval.requested` SSE events keyed by the generated `response_id`. The approval callback, event-loop queue, resolution endpoint, `resolve_all`, profile ownership, and worker cleanup all use `response_id` as the sole key, so concurrent requests sharing a session or memory key cannot overwrite each other's notifier or resolve each other's pending actions. The non-streaming path remains callback-free.

## Changes

- `gateway/platforms/api_server.py`: scoped all Responses approval state to the generated `response_id`; added event-loop queue handoff with `call_soon_threadsafe`; redacted `event["command"]` through `_redact_approval_command` before SSE delivery; added `_response_approval_sessions` profile ownership map; added `POST /v1/responses/{response_id}/approval` with profile-scoped authentication and sibling-profile rejection; passed `approval_session_key=response_id` separately from the conversation key; registered approval state through the shared callback seam and cleared it in worker completion `finally`; removed the non-streaming no-op callback.
- `tools/approval.py`: added `_register_gateway_approval` to check callback identity atomically before queue insertion so a captured worker that loses its callback during disconnect teardown fails closed without entering the timeout loop; extended `clear_session` to evict the session key from `_denial_tally`.
- `tests/gateway/test_api_server.py`: added one-worker approval progression, same-session concurrency and `resolve_all` isolation, profile rejection, redaction contract, late-callback guard, lifecycle cleanup, and Runs preservation coverage.
- `tests/tools/test_approval_interrupt.py`: added callback teardown race regression.
- `tests/tools/test_denial_circuit_breaker.py`: added named-key denial-tally eviction regression.

## Validation

- `pytest tests/gateway/test_api_server.py tests/gateway/test_api_server_runs.py tests/gateway/test_approval_prompt_redaction.py tests/tools/test_approval_interrupt.py tests/tools/test_denial_circuit_breaker.py -v --timeout=0` — 137 passed

## Not in scope

This PR does not try to invent a second approval mechanism for normal chat replies in OpenAI-compatible clients. It only completes the existing gateway approval contract for the Responses API: structured approval events plus a matching resolution endpoint keyed by `response_id`.

## Upstream

Closes #45505.
Reported by @arnoulddw.
Thanks to @AIalliAI for the Responses approval wiring analysis.
