### PR TITLE
fix: stabilize Windows install and Copilot routing

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3137,7 +3137,8 @@ def copilot_model_api_mode(
     if _should_use_copilot_responses_api(normalized):
         return "codex_responses"
 
-    # Secondary: check catalog for non-GPT-5 models (Claude via /v1/messages, etc.)
+    # Secondary: honor endpoint-only catalog entries for models that are not
+    # covered by the GPT-5 name rule.
     if catalog:
         catalog_entry = next((item for item in catalog if item.get("id") == normalized), None)
         if isinstance(catalog_entry, dict):
@@ -3146,9 +3147,14 @@ def copilot_model_api_mode(
                 for endpoint in (catalog_entry.get("supported_endpoints") or [])
                 if str(endpoint).strip()
             }
-            # For non-GPT-5 models, check if they only support messages API
             if "/v1/messages" in supported_endpoints and "/chat/completions" not in supported_endpoints:
                 return "anthropic_messages"
+            if (
+                "/responses" in supported_endpoints
+                and "/chat/completions" not in supported_endpoints
+                and "/v1/messages" not in supported_endpoints
+            ):
+                return "codex_responses"
 
     return "chat_completions"
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1659,6 +1659,26 @@ except Exception:
             }
         }
     }
+
+    if (-not $NoVenv) {
+        $launcherPaths = @(
+            "$InstallDir\venv\Scripts\hermes.exe",
+            "$InstallDir\venv\Scripts\hermes-gateway.exe"
+        )
+        $missingLaunchers = @($launcherPaths | Where-Object { -not (Test-Path $_) })
+        if ($missingLaunchers.Count -gt 0) {
+            Write-Warn "Hermes command launcher missing from venv; repairing editable install..."
+            & $UvCmd pip install -e .
+            if ($LASTEXITCODE -ne 0) {
+                throw "Launcher repair failed. Run manually: cd '$InstallDir'; uv pip install -e ."
+            }
+            $stillMissing = @($launcherPaths | Where-Object { -not (Test-Path $_) })
+            if ($stillMissing.Count -gt 0) {
+                throw "Launcher repair completed but still missing: $($stillMissing -join ', ')"
+            }
+            Write-Success "Hermes command launchers repaired"
+        }
+    }
     
     Pop-Location
     
@@ -1991,11 +2011,55 @@ function Install-NodeDeps {
         }
     }
 
+    function _Run-NpmBuild([string]$label, [string]$buildDir, [string]$logPath, [string]$npmPath) {
+        Push-Location $buildDir
+        $prevEAP = $ErrorActionPreference
+        try {
+            $ErrorActionPreference = "Continue"
+            & $npmPath run build 2>&1 | ForEach-Object { "$_" } | Tee-Object -FilePath $logPath
+            $code = $LASTEXITCODE
+            $ErrorActionPreference = $prevEAP
+            if ($code -eq 0) {
+                Write-Success "$label built"
+                Remove-Item -Force $logPath -ErrorAction SilentlyContinue
+                return $true
+            }
+            Write-Warn "$label build failed -- exit code $code"
+            if (Test-Path $logPath) {
+                $errText = (Get-Content $logPath -Raw -ErrorAction SilentlyContinue)
+                if ($errText) {
+                    $snippet = if ($errText.Length -gt 1200) { $errText.Substring(0, 1200) + "..." } else { $errText }
+                    Write-Info "  npm output:"
+                    foreach ($line in $snippet -split "`n") {
+                        Write-Host "    $line" -ForegroundColor DarkGray
+                    }
+                    Write-Info "  Full log: $logPath"
+                    Show-NpmCertHint $errText | Out-Null
+                }
+            }
+            Write-Info "Run manually later: cd `"$buildDir`"; npm run build"
+            return $false
+        } catch {
+            if ($prevEAP) { $ErrorActionPreference = $prevEAP }
+            Write-Warn "$label build could not be launched: $_"
+            return $false
+        } finally {
+            Pop-Location
+        }
+    }
+
     # Browser tools
     if (Test-Path "$InstallDir\package.json") {
         Write-Info "Installing Node.js dependencies (browser tools)..."
         $browserLog = "$env:TEMP\hermes-npm-browser-$(Get-Random).log"
         $browserNpmOk = _Run-NpmInstall "Browser tools" $InstallDir $browserLog $npmExe
+
+        $webDir = "$InstallDir\web"
+        if ($browserNpmOk -and (Test-Path "$webDir\package.json")) {
+            Write-Info "Building dashboard web UI..."
+            $webLog = "$env:TEMP\hermes-npm-web-build-$(Get-Random).log"
+            [void](_Run-NpmBuild "Dashboard web UI" $webDir $webLog $npmExe)
+        }
 
         # Install Playwright Chromium (mirrors scripts/install.sh behaviour for
         # Linux).  Without this, tools/browser_tool.py::check_browser_requirements

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -359,6 +359,17 @@ class TestCopilotNormalization:
         }]
         assert copilot_model_api_mode("gpt-5.4", catalog=catalog) == "codex_responses"
 
+    def test_copilot_api_mode_honors_catalog_only_responses_for_claude(self):
+        catalog = [{
+            "id": "claude-opus-4.8",
+            "supported_endpoints": ["/responses"],
+            "capabilities": {"type": "chat"},
+        }]
+        assert copilot_model_api_mode(
+            "claude-opus-4.8",
+            catalog=catalog,
+        ) == copilot_model_api_mode("gpt-5.4")
+
     def test_normalize_opencode_model_id_strips_provider_prefix(self):
         assert normalize_opencode_model_id("opencode-go", "opencode-go/kimi-k2.5") == "kimi-k2.5"
         assert normalize_opencode_model_id("opencode-zen", "opencode-zen/claude-sonnet-4-6") == "claude-sonnet-4-6"

--- a/tests/test_windows_install_dashboard_repair.py
+++ b/tests/test_windows_install_dashboard_repair.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+
+INSTALL_PS1 = Path(__file__).resolve().parents[1] / "scripts" / "install.ps1"
+
+
+def _install_source() -> str:
+    return INSTALL_PS1.read_text(encoding="utf-8")
+
+
+def test_windows_installer_builds_dashboard_web_dist():
+    source = _install_source()
+
+    assert (
+        "function _Run-NpmBuild"
+        "([string]$label, [string]$buildDir, [string]$logPath, [string]$npmPath)"
+    ) in source
+    assert '$webDir = "$InstallDir\\web"' in source
+    assert '& $npmPath run build' in source
+    assert '"Dashboard web UI" $webDir $webLog $npmExe' in source
+
+
+def test_windows_installer_repairs_missing_command_launchers():
+    source = _install_source()
+
+    assert '$InstallDir\\venv\\Scripts\\hermes.exe' in source
+    assert '$InstallDir\\venv\\Scripts\\hermes-gateway.exe' in source
+    assert (
+        "$missingLaunchers = @($launcherPaths | Where-Object { -not (Test-Path $_) })"
+    ) in source
+    assert '& $UvCmd pip install -e .' in source


### PR DESCRIPTION
Summary
- Route Copilot models from the live catalog through the endpoint GitHub says they support when chat completions is not available.
- Repair missing Windows command launchers after dependency install.
- Build the dashboard web UI during Windows install so --skip-build has a dist to serve.

Validation
- $HOME/.hermes/hermes-agent/venv/bin/pytest -q tests/hermes_cli/test_model_validation.py::TestCopilotNormalization tests/test_windows_install_dashboard_repair.py
- $HOME/.hermes/hermes-agent/venv/bin/pytest -q tests/hermes_cli/test_model_switch_copilot_api_mode.py
- $HOME/.hermes/hermes-agent/venv/bin/pytest -q tests/test_install_unmerged_index.py tests/test_install_no_initial_commit.py tests/test_windows_install_dashboard_repair.py

Fixes #45813
Refs #45860