### PR TITLE
fix: route Copilot catalog endpoint models

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3340,7 +3340,8 @@ def copilot_model_api_mode(
     if _should_use_copilot_responses_api(normalized):
         return "codex_responses"
 
-    # Secondary: check catalog for non-GPT-5 models (Claude via /v1/messages, etc.)
+    # Secondary: honor endpoint-only catalog entries for models that are not
+    # covered by the GPT-5 name rule.
     if catalog:
         catalog_entry = next((item for item in catalog if item.get("id") == normalized), None)
         if isinstance(catalog_entry, dict):
@@ -3349,9 +3350,14 @@ def copilot_model_api_mode(
                 for endpoint in (catalog_entry.get("supported_endpoints") or [])
                 if str(endpoint).strip()
             }
-            # For non-GPT-5 models, check if they only support messages API
             if "/v1/messages" in supported_endpoints and "/chat/completions" not in supported_endpoints:
                 return "anthropic_messages"
+            if (
+                "/responses" in supported_endpoints
+                and "/chat/completions" not in supported_endpoints
+                and "/v1/messages" not in supported_endpoints
+            ):
+                return "codex_responses"
 
     return "chat_completions"
 

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -411,6 +411,17 @@ class TestCopilotNormalization:
         }]
         assert copilot_model_api_mode("gpt-5.4", catalog=catalog) == "codex_responses"
 
+    def test_copilot_api_mode_honors_catalog_only_responses_for_claude(self):
+        catalog = [{
+            "id": "claude-opus-4.8",
+            "supported_endpoints": ["/responses"],
+            "capabilities": {"type": "chat"},
+        }]
+        assert copilot_model_api_mode(
+            "claude-opus-4.8",
+            catalog=catalog,
+        ) == copilot_model_api_mode("gpt-5.4")
+
     def test_normalize_opencode_model_id_strips_provider_prefix(self):
         assert normalize_opencode_model_id("opencode-go", "opencode-go/kimi-k2.5") == "kimi-k2.5"
         assert normalize_opencode_model_id("opencode-zen", "opencode-zen/claude-sonnet-4-6") == "claude-sonnet-4-6"


### PR DESCRIPTION
Summary
- Honor Copilot live catalog endpoint support when selecting the request path.
- Keep the existing GPT-5 name rule, then use catalog metadata for models that are not available through chat completions.
- Add a regression test for a Claude Opus catalog entry that only advertises the response endpoint.

Validation
- $HOME/.hermes/hermes-agent/venv/bin/pytest -q tests/hermes_cli/test_model_validation.py::TestCopilotNormalization tests/hermes_cli/test_model_switch_copilot_api_mode.py

Fixes #45813