### PR TITLE
fix(agent): allow read-only file tools in background review whitelist

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -474,6 +474,11 @@ def _run_review_in_thread(
                     quiet_mode=True,
                 )
             }
+            # Allow read-only file tools — they have no side effects and
+            # are needed for the review agent to inspect config, prior
+            # outputs, or skill references (issue #45877).
+            review_whitelist.add("read_file")
+            review_whitelist.add("search_files")
             set_thread_tool_whitelist(
                 review_whitelist,
                 deny_msg_fmt=(

--- a/tests/run_agent/test_background_review_cache_parity.py
+++ b/tests/run_agent/test_background_review_cache_parity.py
@@ -237,3 +237,69 @@ def test_review_fork_inherits_parent_toolset_config():
         f"disabled_toolsets mismatch: {captured.get('disabled_toolsets')!r} "
         f"vs expected {agent.disabled_toolsets!r}"
     )
+
+
+def test_background_review_whitelist_includes_read_only_file_tools():
+    """read_file and search_files must be allowed in background review (issue #45877).
+
+    These tools are read-only and side-effect-free — blocking them forces
+    cron agents to use terminal(cat/grep) workarounds or operate blindly.
+    """
+    import run_agent
+
+    agent = _make_agent_stub(run_agent.AIAgent)
+
+    captured = {}
+
+    class _Recorder:
+        """Lightweight stand-in for AIAgent that avoids provider resolution."""
+
+        def __init__(self, *args, **kwargs):
+            self._cached_system_prompt = None
+            self._memory_write_origin = None
+            self._memory_write_context = None
+            self._memory_store = None
+            self._memory_enabled = None
+            self._user_profile_enabled = None
+            self._memory_nudge_interval = None
+            self._skill_nudge_interval = None
+            self.suppress_status_output = None
+            self.session_start = None
+            self.session_id = None
+            self.compression_enabled = True
+
+        def run_conversation(self, *args, **kwargs):
+            raise RuntimeError("stop after recording — don't actually call the API")
+
+        def shutdown_memory_provider(self):
+            pass
+
+        def close(self):
+            pass
+
+    # Intercept set_thread_tool_whitelist to capture the whitelist set.
+    def _capturing_stwl(whitelist, **kwargs):
+        captured["whitelist"] = set(whitelist)
+
+    import hermes_cli.plugins as _plugins_mod
+
+    with patch.object(run_agent, "AIAgent", _Recorder), \
+         patch("threading.Thread", _SyncThread), \
+         patch.object(_plugins_mod, "set_thread_tool_whitelist", _capturing_stwl):
+        agent._spawn_background_review(
+            messages_snapshot=[],
+            review_memory=True,
+            review_skills=False,
+        )
+
+    assert "whitelist" in captured, (
+        "set_thread_tool_whitelist was never called — "
+        "review may have failed before reaching whitelist setup"
+    )
+    tools = captured["whitelist"]
+    assert "read_file" in tools, (
+        "read_file must be in the background review whitelist"
+    )
+    assert "search_files" in tools, (
+        "search_files must be in the background review whitelist"
+    )


### PR DESCRIPTION
## What does this PR do?

Adds `read_file` and `search_files` to the background review tool whitelist, allowing the review agent to inspect configuration files, prior outputs, and skill references during its post-turn memory/skill review pass.

## Related Issue

Fixes #45877

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/background_review.py`: Added `read_file` and `search_files` to the `review_whitelist` set after the toolset-based whitelist is constructed. These tools are read-only and side-effect-free.
- `tests/run_agent/test_background_review_cache_parity.py`: Added `test_background_review_whitelist_includes_read_only_file_tools` to verify the whitelist includes both read-only file tools.

## How to Test

1. Run the updated test: `pytest tests/run_agent/test_background_review_cache_parity.py -xvs`
2. Verify the new test `test_background_review_whitelist_includes_read_only_file_tools` passes alongside the 3 existing tests
3. Confirm that only `read_file` and `search_files` were added (no write tools like `write_file` or `patch`)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/background_review.py` → `review_whitelist` construction (line 470), `set_thread_tool_whitelist` call (line 477)
- Blast radius: LOW — adds 2 tool names to a per-review-call whitelist set; no control flow changes
- Related patterns: read-only tool whitelisting, cron background review
