### PR TITLE
fix(cli): honor requested provider in /model picker

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6898,8 +6898,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         from hermes_cli.inventory import build_models_payload, load_picker_context
 
         try:
+            # Prefer an explicit requested provider over the resolved runtime
+            # provider so /model reflects config/session intent instead of
+            # whichever provider auto-detection happened to pick from env vars.
+            picker_provider = self.provider or ""
+            requested_provider = (self.requested_provider or "").strip()
+            if requested_provider and requested_provider.lower() != "auto":
+                picker_provider = requested_provider
+
             ctx = load_picker_context().with_overrides(
-                current_provider=self.provider or "",
+                current_provider=picker_provider,
                 current_model=self.model or "",
                 current_base_url=self.base_url or "",
             )
@@ -6914,7 +6922,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # No args at all: open prompt_toolkit-native picker modal
         if not model_input and not explicit_provider:
             model_display = self.model or "unknown"
-            provider_display = get_label(self.provider) if self.provider else "unknown"
+            provider_display = get_label(picker_provider) if picker_provider else "unknown"
 
             try:
                 if ctx is None:

--- a/tests/hermes_cli/test_model_picker_requested_provider.py
+++ b/tests/hermes_cli/test_model_picker_requested_provider.py
@@ -1,0 +1,127 @@
+"""Regression tests for `/model` picker provider overlays.
+
+When a session has an explicit configured provider (for example Bedrock) but
+the live runtime provider resolves to some other env-backed provider, the
+picker must still use the explicit requested provider for inventory/current-row
+state. Otherwise aws-sdk providers can disappear from the authenticated list.
+"""
+
+from __future__ import annotations
+
+from hermes_cli.inventory import ConfigContext
+
+
+class _StubCLI:
+    model = "global.anthropic.claude-sonnet-4-6"
+    provider = "openrouter"
+    requested_provider = "bedrock"
+    base_url = ""
+    api_key = ""
+
+    def __init__(self) -> None:
+        self.opened = None
+
+    def _open_model_picker(
+        self,
+        providers,
+        current_model,
+        current_provider,
+        user_provs=None,
+        custom_provs=None,
+    ) -> None:
+        self.opened = {
+            "providers": providers,
+            "current_model": current_model,
+            "current_provider": current_provider,
+            "user_provs": user_provs,
+            "custom_provs": custom_provs,
+        }
+
+
+def test_model_picker_prefers_requested_provider_over_resolved_runtime(monkeypatch):
+    import cli as cli_mod
+
+    stub = _StubCLI()
+    captured_ctx = {}
+
+    monkeypatch.setattr(
+        "hermes_cli.inventory.load_picker_context",
+        lambda: ConfigContext(
+            current_provider="bedrock",
+            current_model="global.anthropic.claude-sonnet-4-6",
+            current_base_url="",
+            user_providers={},
+            custom_providers=[],
+        ),
+    )
+
+    def _build_models_payload(ctx, max_models=50):
+        captured_ctx["provider"] = ctx.current_provider
+        captured_ctx["model"] = ctx.current_model
+        return {
+            "providers": [
+                {
+                    "slug": "bedrock",
+                    "name": "AWS Bedrock",
+                    "is_current": True,
+                    "is_user_defined": False,
+                    "models": ["global.anthropic.claude-sonnet-4-6"],
+                    "total_models": 1,
+                    "source": "hermes",
+                }
+            ]
+        }
+
+    monkeypatch.setattr("hermes_cli.inventory.build_models_payload", _build_models_payload)
+    monkeypatch.setattr(cli_mod, "_cprint", lambda *a, **k: None)
+
+    cli_mod.HermesCLI._handle_model_switch(stub, "/model")
+
+    assert captured_ctx["provider"] == "bedrock"
+    assert captured_ctx["model"] == "global.anthropic.claude-sonnet-4-6"
+    assert stub.opened is not None
+    assert stub.opened["current_provider"] == "AWS Bedrock"
+
+
+def test_model_picker_keeps_resolved_provider_when_requested_is_auto(monkeypatch):
+    import cli as cli_mod
+
+    stub = _StubCLI()
+    stub.requested_provider = "auto"
+    captured_ctx = {}
+
+    monkeypatch.setattr(
+        "hermes_cli.inventory.load_picker_context",
+        lambda: ConfigContext(
+            current_provider="auto",
+            current_model="gpt-5.4",
+            current_base_url="",
+            user_providers={},
+            custom_providers=[],
+        ),
+    )
+
+    def _build_models_payload(ctx, max_models=50):
+        captured_ctx["provider"] = ctx.current_provider
+        return {
+            "providers": [
+                {
+                    "slug": "openrouter",
+                    "name": "OpenRouter",
+                    "is_current": True,
+                    "is_user_defined": False,
+                    "models": ["gpt-5.4"],
+                    "total_models": 1,
+                    "source": "built-in",
+                }
+            ]
+        }
+
+    monkeypatch.setattr("hermes_cli.inventory.build_models_payload", _build_models_payload)
+    monkeypatch.setattr(cli_mod, "_cprint", lambda *a, **k: None)
+
+    cli_mod.HermesCLI._handle_model_switch(stub, "/model")
+
+    assert captured_ctx["provider"] == "openrouter"
+    assert stub.opened is not None
+    assert stub.opened["current_provider"] == "OpenRouter"


### PR DESCRIPTION
## Summary
- prefer `requested_provider` over the resolved runtime provider when opening the interactive `/model` picker
- keep `auto` sessions on the resolved runtime provider so the normal picker highlight still works
- add a regression test for the Bedrock case where unrelated env API keys would otherwise hide the configured provider

Closes #45838.

## Verification
- `pytest tests/hermes_cli/test_model_picker_requested_provider.py tests/hermes_cli/test_bedrock_model_picker.py`
- `ruff check cli.py tests/hermes_cli/test_model_picker_requested_provider.py`
- `git diff --check`
