### PR TITLE
fix(desktop): keep sidebar refresh visible on hover

### DIFF
--- a/apps/desktop/src/app/right-sidebar/header-actions.test.ts
+++ b/apps/desktop/src/app/right-sidebar/header-actions.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+
+import { HEADER_ACTION_LABEL_REVEAL } from './header-actions'
+
+describe('HEADER_ACTION_LABEL_REVEAL', () => {
+  it('keeps the refresh button visible and interactive on self hover', () => {
+    expect(HEADER_ACTION_LABEL_REVEAL).toContain('hover:pointer-events-auto')
+    expect(HEADER_ACTION_LABEL_REVEAL).toContain('hover:opacity-100')
+    expect(HEADER_ACTION_LABEL_REVEAL).toContain('peer-hover/project-label:pointer-events-auto')
+    expect(HEADER_ACTION_LABEL_REVEAL).toContain('peer-hover/project-label:opacity-100')
+  })
+})

--- a/apps/desktop/src/app/right-sidebar/header-actions.ts
+++ b/apps/desktop/src/app/right-sidebar/header-actions.ts
@@ -1,0 +1,4 @@
+export const HEADER_ACTION_CLASS =
+  'text-sidebar-foreground/70 hover:bg-sidebar-accent! hover:text-sidebar-accent-foreground! focus-visible:ring-sidebar-ring'
+
+export const HEADER_ACTION_LABEL_REVEAL = `${HEADER_ACTION_CLASS} pointer-events-none opacity-0 transition-opacity hover:pointer-events-auto hover:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 peer-focus-visible/project-label:pointer-events-auto peer-focus-visible/project-label:opacity-100 peer-hover/project-label:pointer-events-auto peer-hover/project-label:opacity-100`

--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -19,6 +19,7 @@ import { SidebarPanelLabel } from '../shell/sidebar-label'
 import { RemoteFolderPicker } from './files/remote-picker'
 import { ProjectTree } from './files/tree'
 import { useProjectTree } from './files/use-project-tree'
+import { HEADER_ACTION_CLASS, HEADER_ACTION_LABEL_REVEAL } from './header-actions'
 
 interface RightSidebarPaneProps {
   onActivateFile: (path: string) => void
@@ -125,13 +126,6 @@ interface FilesystemTabProps extends FileTreeBodyProps {
   onCollapseAll: () => void
   onRefresh: () => void
 }
-
-// Sidebar palette + hover-reveal: refresh tracks label hover; collapse-all
-// stays visible while any folder is expanded.
-const HEADER_ACTION_CLASS =
-  'text-sidebar-foreground/70 hover:bg-sidebar-accent! hover:text-sidebar-accent-foreground! focus-visible:ring-sidebar-ring'
-
-const HEADER_ACTION_LABEL_REVEAL = `${HEADER_ACTION_CLASS} pointer-events-none opacity-0 transition-opacity focus-visible:pointer-events-auto focus-visible:opacity-100 peer-focus-visible/project-label:pointer-events-auto peer-focus-visible/project-label:opacity-100 peer-hover/project-label:pointer-events-auto peer-hover/project-label:opacity-100`
 
 function FilesystemTab({
   canCollapse,


### PR DESCRIPTION
Fixes #45894.

## Summary
- keep the Filesystem refresh button visible and clickable while the cursor is on the button itself
- move the hover-reveal class constants into a small helper module so the behavior is easy to test
- add a narrow regression test covering the self-hover class contract

## Local proof
- `npx vitest run apps/desktop/src/app/right-sidebar/header-actions.test.ts`
- `git diff --check`
- `npx prettier --check apps/desktop/src/app/right-sidebar/index.tsx apps/desktop/src/app/right-sidebar/header-actions.ts apps/desktop/src/app/right-sidebar/header-actions.test.ts`

## Notes
- local `apps/desktop` eslint/typecheck was not runnable in this worktree because the JS workspace deps are not installed here; attempted commands failed before lint/type analysis with missing local packages
