### PR TITLE
Scope TUI config writes to resumed profile

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2896,6 +2896,55 @@ def test_config_set_yolo_global_scope_honors_explicit_value(tmp_path, monkeypatc
     assert yaml.safe_load(cfg_path.read_text())["approvals"]["mode"] == "off"
 
 
+def test_config_set_writes_resumed_profile_config(tmp_path, monkeypatch):
+    """config.set in a resumed remote-profile session must not mutate launch config."""
+    import yaml
+
+    launch_home = tmp_path / "default"
+    profile_home = tmp_path / "profiles" / "worker"
+    launch_home.mkdir()
+    profile_home.mkdir(parents=True)
+    launch_cfg = launch_home / "config.yaml"
+    profile_cfg = profile_home / "config.yaml"
+    launch_cfg.write_text(
+        yaml.safe_dump({"display": {"busy_input_mode": "interrupt"}}),
+        encoding="utf-8",
+    )
+    profile_cfg.write_text(
+        yaml.safe_dump({"display": {"busy_input_mode": "steer"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(server, "_hermes_home", launch_home)
+    server._cfg_cache = None
+    server._cfg_mtime = None
+    server._cfg_path = None
+    server._sessions["sid"] = _session(profile_home=str(profile_home))
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "config.set",
+                "params": {"session_id": "sid", "key": "busy", "value": "queue"},
+            }
+        )
+
+        assert resp["result"]["value"] == "queue"
+        assert (
+            yaml.safe_load(profile_cfg.read_text())["display"]["busy_input_mode"]
+            == "queue"
+        )
+        assert (
+            yaml.safe_load(launch_cfg.read_text())["display"]["busy_input_mode"]
+            == "interrupt"
+        )
+    finally:
+        server._sessions.pop("sid", None)
+        server._cfg_cache = None
+        server._cfg_mtime = None
+        server._cfg_path = None
+
+
 def test_config_set_fast_updates_live_agent_and_config(monkeypatch):
     writes = []
     emits = []

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1960,7 +1960,9 @@ def _save_cfg(cfg: dict):
 
     from hermes_cli.config import atomic_config_write
 
-    path = _hermes_home / "config.yaml"
+    override = get_hermes_home_override()
+    home = override if isinstance(override, str) and override else _hermes_home
+    path = Path(home) / "config.yaml"
     atomic_config_write(path, cfg)
     with _cfg_lock:
         _cfg_cache = copy.deepcopy(cfg)
@@ -11272,6 +11274,30 @@ def _(rid, params: dict) -> dict:
         return _ok(rid, {"project": proj})
     except Exception as e:
         return _err(rid, 5061, str(e))
+_config_set_unscoped = _methods.get("config.set")
+
+
+def _config_set_profile_scoped(rid, params: dict) -> dict:
+    if _config_set_unscoped is None:
+        return _err(rid, 5001, "config.set handler unavailable")
+    session = (
+        _sessions.get(params.get("session_id", ""))
+        if isinstance(params, dict)
+        else None
+    )
+    profile_home = session.get("profile_home") if isinstance(session, dict) else None
+    if not profile_home:
+        return _config_set_unscoped(rid, params)
+
+    token = set_hermes_home_override(str(profile_home))
+    try:
+        return _config_set_unscoped(rid, params)
+    finally:
+        reset_hermes_home_override(token)
+
+
+if _config_set_unscoped is not None:
+    _methods["config.set"] = _config_set_profile_scoped
 
 
 @method("config.get")

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -267,6 +267,30 @@ describe('createSlashHandler', () => {
     })
   })
 
+  it('keeps typed /skin switches scoped to the active session profile', () => {
+    patchUiState({ sid: 'sid-abc' })
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/skin noir')).toBe(true)
+    expect(ctx.gateway.rpc).toHaveBeenCalledWith('config.set', {
+      key: 'skin',
+      session_id: 'sid-abc',
+      value: 'noir'
+    })
+  })
+
+  it('keeps typed /busy switches scoped to the active session profile', () => {
+    patchUiState({ sid: 'sid-abc' })
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/busy queue')).toBe(true)
+    expect(ctx.gateway.rpc).toHaveBeenCalledWith('config.set', {
+      key: 'busy',
+      session_id: 'sid-abc',
+      value: 'queue'
+    })
+  })
+
   it('opens the skills hub locally for bare /skills', () => {
     const ctx = buildCtx()
 
@@ -534,7 +558,7 @@ describe('createSlashHandler', () => {
     ['/reload', 'reload.env', {}],
     ['/stop', 'process.stop', {}],
     ['/fast status', 'config.get', { key: 'fast', session_id: null }],
-    ['/busy status', 'config.get', { key: 'busy' }],
+    ['/busy status', 'config.get', { key: 'busy', session_id: null }],
     ['/indicator', 'config.get', { key: 'indicator' }]
   ])('routes %s through native RPC (no slash worker)', (command, method, params) => {
     const rpc = vi.fn(() => Promise.resolve({}))

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -378,12 +378,12 @@ export const sessionCommands: SlashCommand[] = [
     run: (arg, ctx) => {
       if (!arg) {
         return ctx.gateway
-          .rpc<ConfigGetValueResponse>('config.get', { key: 'skin' })
+          .rpc<ConfigGetValueResponse>('config.get', { key: 'skin', session_id: ctx.sid })
           .then(ctx.guarded<ConfigGetValueResponse>(r => ctx.transcript.sys(`skin: ${r.value || 'default'}`)))
       }
 
       ctx.gateway
-        .rpc<ConfigSetResponse>('config.set', { key: 'skin', value: arg })
+        .rpc<ConfigSetResponse>('config.set', { key: 'skin', session_id: ctx.sid, value: arg })
         .then(ctx.guarded<ConfigSetResponse>(r => r.value && ctx.transcript.sys(`skin → ${r.value}`)))
     }
   },
@@ -532,7 +532,7 @@ export const sessionCommands: SlashCommand[] = [
 
       if (!mode || mode === 'status') {
         return ctx.gateway
-          .rpc<ConfigGetValueResponse>('config.get', { key: 'busy' })
+          .rpc<ConfigGetValueResponse>('config.get', { key: 'busy', session_id: ctx.sid })
           .then(
             ctx.guarded<ConfigGetValueResponse>(r => {
               const current = r.value || 'interrupt'
@@ -543,7 +543,7 @@ export const sessionCommands: SlashCommand[] = [
       }
 
       ctx.gateway
-        .rpc<ConfigSetResponse>('config.set', { key: 'busy', value: mode })
+        .rpc<ConfigSetResponse>('config.set', { key: 'busy', session_id: ctx.sid, value: mode })
         .then(
           ctx.guarded<ConfigSetResponse>(r => {
             const next = r.value || mode


### PR DESCRIPTION
## Summary

This makes TUI `config.set` mutations honor the resumed session's `profile_home`. When a desktop/global-remote session is bound to another local profile, config reads and writes now target the same profile `config.yaml`.

## Why

`session.resume` can bind a TUI session to a non-launch profile by storing `profile_home` on the live session. `_load_cfg()` already honored the Hermes home override, but `_save_cfg()` always wrote to the gateway launch profile. As a result, changing settings from a resumed remote-profile session could mutate the wrong `config.yaml`.

For example, `/busy queue`, `/reasoning`, `/cwd`, `/skin`, or other `config.set` paths from a worker profile session could update the default/launch profile instead of the worker profile.

## Changes

- Make `_save_cfg()` write to the active Hermes home override when present.
- Wrap `config.set` calls in the session's `profile_home` override when the target session was resumed from another profile.
- Add regression coverage proving a resumed profile session updates only its own `config.yaml` and leaves the launch profile config unchanged.

## Tests

```text
python -m pytest tests/test_tui_gateway_server.py -k "config_set_writes_resumed_profile_config or config_set_yolo_global_scope_honors_explicit_value" -q --timeout-method=thread
2 passed, 268 deselected
```
