### PR TITLE
Run TUI shell exec in session cwd

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1598,6 +1598,34 @@ def _session(agent=None, **extra):
     }
 
 
+def test_shell_exec_uses_session_cwd(monkeypatch, tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    calls = {}
+
+    def fake_run(*args, **kwargs):
+        calls["args"] = args
+        calls["kwargs"] = kwargs
+        return types.SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    server._sessions["sid"] = _session(cwd=str(project))
+    monkeypatch.setattr(server.subprocess, "run", fake_run)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "shell.exec",
+                "params": {"session_id": "sid", "command": "pwd"},
+            }
+        )
+
+        assert resp["result"]["code"] == 0
+        assert calls["kwargs"]["cwd"] == str(project)
+    finally:
+        server._sessions.pop("sid", None)
+
+
 def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
     calls = {"hooks": []}
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -10271,6 +10271,8 @@ def _(rid, params: dict) -> dict:
     cmd = params.get("command", "")
     if not cmd:
         return _err(rid, 4004, "empty command")
+    session = _sessions.get(params.get("session_id", ""))
+    cwd = _session_cwd(session) if session else os.getcwd()
     try:
         from tools.approval import detect_dangerous_command, detect_hardline_command
 
@@ -10288,7 +10290,12 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5001, "shell.exec unavailable: approval safety module not importable")
     try:
         r = subprocess.run(
-            cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=os.getcwd(),
+            cmd,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            cwd=cwd,
             stdin=subprocess.DEVNULL,
         )
         return _ok(

--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -150,10 +150,14 @@ export function useSubmission(opts: UseSubmissionOptions) {
 
   const shellExec = useCallback(
     (cmd: string) => {
+      const sid = getUiState().sid
       appendMessage({ role: 'user', text: `!${cmd}` })
       patchUiState({ busy: true, status: 'running…' })
 
-      gw.request<ShellExecResponse>('shell.exec', { command: cmd })
+      gw.request<ShellExecResponse>('shell.exec', {
+        command: cmd,
+        ...(sid && { session_id: sid })
+      })
         .then(raw => {
           const r = asRpcResult<ShellExecResponse>(raw)
 
@@ -180,12 +184,16 @@ export function useSubmission(opts: UseSubmissionOptions) {
   const interpolate = useCallback(
     (text: string, then: (result: string) => void) => {
       patchUiState({ status: 'interpolating…' })
+      const sid = getUiState().sid
       const matches = [...text.matchAll(new RegExp(INTERPOLATION_RE.source, 'g'))]
 
       Promise.all(
         matches.map(m =>
           gw
-            .request<ShellExecResponse>('shell.exec', { command: m[1]! })
+            .request<ShellExecResponse>('shell.exec', {
+              command: m[1]!,
+              ...(sid && { session_id: sid })
+            })
             .then(raw => {
               const r = asRpcResult<ShellExecResponse>(raw)
 


### PR DESCRIPTION
## Summary

This makes TUI `shell.exec` run in the active session workspace instead of the Python gateway process directory. The TUI now sends the active `session_id` for both `!cmd` and inline shell interpolation, and the backend uses that session's cwd when executing the command.

## Why

The normal prompt path already carries `session_id` and resolves the session cwd before running tools. The `shell.exec` shortcut path did not: `ui-tui/src/app/useSubmission.ts` sent only `{ command }`, and `tui_gateway/server.py` always called `subprocess.run(..., cwd=os.getcwd())`.

That means `!pwd`, `!ls`, or `{!command}` could run from the gateway launch directory instead of the chat's selected workspace, especially in desktop/TUI launches where the gateway process cwd differs from the project cwd.

## Changes

- Send the active `session_id` with TUI `!cmd` shell execution.
- Send the active `session_id` with inline shell interpolation.
- Resolve `shell.exec` cwd from the target TUI session when available.
- Keep the existing process-cwd fallback for callers that do not provide a session id.
- Add regression coverage proving `shell.exec` passes the session cwd into `subprocess.run`.

## Tests

```text
python -m pytest tests/test_tui_gateway_server.py -k "shell_exec" -q --timeout-method=thread
1 passed, 269 deselected
```

Not run:

```text
npm run typecheck
```