### PR TITLE
fix(cron): allow read_file and search_files in background review tool whitelist

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -474,19 +474,21 @@ def _run_review_in_thread(
                     quiet_mode=True,
                 )
             }
+            # Allow read-only file tools for cron background review (issue #45877)
+            review_whitelist.update({"read_file", "search_files"})
             set_thread_tool_whitelist(
                 review_whitelist,
                 deny_msg_fmt=(
                     "Background review denied non-whitelisted tool: "
-                    "{tool_name}. Only memory/skill tools are allowed."
+                    "{tool_name}. Only memory/skill/read-only-file tools are allowed."
                 ),
             )
             try:
                 review_agent.run_conversation(
                     user_message=(
                         prompt
-                        + "\n\nYou can only call memory and skill "
-                        "management tools. Other tools will be denied "
+                        + "\n\nYou can only call memory, skill management, and read-only file "
+                        "tools (read_file, search_files). Other tools will be denied "
                         "at runtime — do not attempt them."
                     ),
                     conversation_history=messages_snapshot,

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -127,12 +127,18 @@ def test_background_review_installs_thread_local_whitelist():
     assert "skill_manage" in whitelist
     assert "skill_view" in whitelist
     assert "skills_list" in whitelist
+    # read-only file tools must be allowed (issue #45877)
+    assert "read_file" in whitelist
+    assert "search_files" in whitelist
     # dangerous tools must NOT be in the whitelist
     assert "terminal" not in whitelist
     assert "send_message" not in whitelist
     assert "delegate_task" not in whitelist
     assert "web_search" not in whitelist
     assert "execute_code" not in whitelist
+    # write file tools must NOT be in the whitelist
+    assert "write_file" not in whitelist
+    assert "patch" not in whitelist
 
 
 def test_background_review_agent_tools_are_limited():


### PR DESCRIPTION
## Summary

Expands the cron background review tool allowlist to include read-only file tools (, ) as requested in issue #45877.

## Changes

- **agent/background_review.py**: Added  and  to the thread-local whitelist for background review fork. Updated deny message and user prompt to reflect the expanded allowlist.
- **tests/run_agent/test_background_review_toolset_restriction.py**: Added assertions for the new allowed tools and verified write tools (, ) remain blocked.

## Rationale

The background review fork previously only allowed  and  tools. This blocked cron agents from reading configuration files, checking previous outputs, or inspecting skill references — forcing workarounds like  or blind operation.

 and  are side-effect-free read-only tools that pose no risk in a cron context. Write tools (, ) remain blocked.

## Testing

All existing background review tests pass, including the updated toolset restriction test.