### PR TITLE
fix(update): prevent desktop app breakage by checking build stamp file

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8850,11 +8850,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # False even though the user clearly has a desktop install. Without this
         # fallback, every update silently destroys the desktop app shortcut.
         desktop_dir = PROJECT_ROOT / "apps" / "desktop"
-        desktop_stamp = Path(os.environ.get("HERMES_HOME", HERMES_HOME)) / "desktop-build-stamp.json"
         has_desktop_app = (
             _desktop_packaged_executable(desktop_dir) is not None
             or _desktop_dist_exists(desktop_dir)
-            or desktop_stamp.exists()
+            or _desktop_stamp_path().exists()
         )
         if (desktop_dir / "package.json").exists() and shutil.which("npm") and has_desktop_app:
             print("→ Checking if desktop app needs rebuilding...")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8840,11 +8840,22 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # build.  ``hermes desktop --build-only`` uses the content-hash stamp
         # internally, so this is effectively a no-op when nothing changed.
         # Only bother if the user has a desktop app installed (indicated by
-        # an existing packaged executable or desktop dist); people who have
-        # never run ``hermes desktop`` shouldn't be forced into a full
-        # Electron build by ``hermes update``.
+        # an existing packaged executable, desktop dist, or build stamp);
+        # people who have never run ``hermes desktop`` shouldn't be forced into
+        # a full Electron build by ``hermes update``.
+        #
+        # NOTE: We also check the build stamp because git stash operations
+        # during update (`stash --include-untracked`) may temporarily remove
+        # release/win-unpacked/ and dist/, making the file-based checks return
+        # False even though the user clearly has a desktop install. Without this
+        # fallback, every update silently destroys the desktop app shortcut.
         desktop_dir = PROJECT_ROOT / "apps" / "desktop"
-        has_desktop_app = _desktop_packaged_executable(desktop_dir) is not None or _desktop_dist_exists(desktop_dir)
+        desktop_stamp = Path(os.environ.get("HERMES_HOME", HERMES_HOME)) / "desktop-build-stamp.json"
+        has_desktop_app = (
+            _desktop_packaged_executable(desktop_dir) is not None
+            or _desktop_dist_exists(desktop_dir)
+            or desktop_stamp.exists()
+        )
         if (desktop_dir / "package.json").exists() and shutil.which("npm") and has_desktop_app:
             print("→ Checking if desktop app needs rebuilding...")
             _desktop_build_cmd = [sys.executable, "-m", "hermes_cli.main", "desktop", "--build-only"]


### PR DESCRIPTION
## Problem

When running `hermes update`, the git stash operation (`stash --include-untracked`) removes `release/win-unpacked/` and `dist/` directories. This causes the file-based `has_desktop_app` checks (`_desktop_packaged_executable` and `_desktop_dist_exists`) to return `False` even though the user clearly has a desktop install.

**Result:** Every `hermes update` silently destroys the desktop app shortcut because the Electron rebuild is skipped when `has_desktop_app` is incorrectly `False`.

## Fix

Added a third fallback check — `desktop-build-stamp.json` in `HERMES_HOME`. This stamp file survives git stash operations and provides a reliable indicator that the desktop app was previously installed.

## Changes

```diff
- has_desktop_app = _desktop_packaged_executable(desktop_dir) is not None or _desktop_dist_exists(desktop_dir)
+ desktop_stamp = Path(os.environ.get("HERMES_HOME", HERMES_HOME)) / "desktop-build-stamp.json"
+ has_desktop_app = (
+     _desktop_packaged_executable(desktop_dir) is not None
+     or _desktop_dist_exists(desktop_dir)
+     or desktop_stamp.exists()
+ )
```

Also expanded the comment block to document why this check is needed.

(corrected — previous PR #45901 had an incorrect diff due to file encoding issues)
