### PR TITLE
fix(web): fail closed on missing explicit search backend

### DIFF
--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -537,6 +537,32 @@ class TestWebSearchSchema:
 class TestWebSearchErrorHandling:
     """Test suite for web_search_tool() error responses."""
 
+    def test_explicit_backend_missing_provider_does_not_fallback(self):
+        import tools.web_tools
+
+        with patch("tools.web_tools._load_web_config", return_value={"search_backend": "anysearch"}), \
+             patch("tools.web_tools._get_search_backend", return_value="anysearch"), \
+             patch("agent.web_search_registry.get_provider", return_value=None), \
+             patch("agent.web_search_registry.get_active_search_provider") as mock_active_provider, \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.object(tools.web_tools, "_ensure_web_plugins_loaded"), \
+             patch.object(tools.web_tools._debug, "log_call") as mock_log_call, \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(tools.web_tools.web_search_tool("test query", limit=3))
+
+        assert result == {
+            "success": False,
+            "error": (
+                "Configured web search backend 'anysearch' is not registered. "
+                "Check plugin loading or configuration."
+            ),
+        }
+        mock_active_provider.assert_not_called()
+
+        debug_payload = mock_log_call.call_args.args[1]
+        assert debug_payload["results_count"] == 0
+        assert debug_payload["final_response_size"] > 0
+
     def test_search_error_response_does_not_expose_diagnostics(self):
         import tools.web_tools
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -981,12 +981,46 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             get_provider as _wsp_get_provider,
         )
 
+        cfg = _load_web_config()
+        explicit_backend = (
+            (cfg.get("search_backend") or cfg.get("backend") or "")
+            .lower()
+            .strip()
+        )
         backend = _get_search_backend()
         provider = _wsp_get_provider(backend) if backend else None
-        if provider is None or not provider.supports_search():
-            # Fall back to availability-walked active provider when the
-            # configured backend isn't a registered search provider (typo,
-            # uninstalled plugin, or capability mismatch).
+        if provider is None:
+            if explicit_backend:
+                response_data = {
+                    "success": False,
+                    "error": (
+                        f"Configured web search backend '{backend}' is not "
+                        "registered. Check plugin loading or configuration."
+                    ),
+                }
+                debug_call_data["results_count"] = 0
+                result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+                debug_call_data["final_response_size"] = len(result_json)
+                _debug.log_call("web_search_tool", debug_call_data)
+                _debug.save()
+                return result_json
+            # No explicit config: pick the best available provider.
+            provider = get_active_search_provider()
+        elif not provider.supports_search():
+            if explicit_backend:
+                response_data = {
+                    "success": False,
+                    "error": (
+                        f"Configured web search backend '{backend}' does not "
+                        "support search."
+                    ),
+                }
+                debug_call_data["results_count"] = 0
+                result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+                debug_call_data["final_response_size"] = len(result_json)
+                _debug.log_call("web_search_tool", debug_call_data)
+                _debug.save()
+                return result_json
             provider = get_active_search_provider()
 
         if provider is None:


### PR DESCRIPTION
## Summary
- stop `web_search` from silently falling back when `search_backend` is explicitly configured
- return a clear error if the configured backend is missing or does not support search
- add a regression test covering a missing explicit backend without fallback

Closes #45876.

## Testing
- `pytest tests/tools/test_web_tools_config.py tests/plugins/web/test_web_search_provider_plugins.py -q`
- `git diff --check`
