### PR TITLE
fix(prompt): warn ssh sessions about host-local paths

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -727,6 +727,17 @@ _BACKEND_FALLBACK_DESCRIPTIONS: dict[str, str] = {
     "ssh": "a remote host reached over SSH (likely Linux)",
 }
 
+_SSH_HOST_PATH_ROUTING_HINT = (
+    "Path routing: with the `ssh` terminal backend, every `terminal`, "
+    "`read_file`, `write_file`, `patch`, and `search_files` call runs on the "
+    "remote host. If the user gives an obvious host-local path such as "
+    "`/Users/...`, `/home/...`, `C:\\Users\\...`, or `C:/Users/...`, do NOT "
+    "answer by saying the path is simply missing on the remote machine. "
+    "First explain that the active execution target is remote over SSH, then "
+    "ask whether they want to switch to local execution or provide the "
+    "corresponding path on the remote host."
+)
+
 
 # Cache the backend probe result per process so we only pay the probe cost
 # on the first prompt build of a session. Keyed by (env_type, cwd_hint) so
@@ -910,6 +921,8 @@ def build_environment_hints() -> str:
                 f"them, probe directly with a terminal call like "
                 f"`uname -a && whoami && pwd`."
             )
+        if backend == "ssh":
+            hints.append(_SSH_HOST_PATH_ROUTING_HINT)
 
     # Hermes desktop GUI — any agent running under the desktop app should know
     # it. HERMES_DESKTOP marks the backend powering the chat; HERMES_DESKTOP_TERMINAL

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1047,6 +1047,19 @@ class TestEnvironmentHints:
         assert "Linux 6.8.0" in result
         assert "/workspace" in result
 
+    def test_build_environment_hints_on_ssh_warns_about_host_local_paths(self, monkeypatch):
+        """SSH backends must warn the agent not to misdiagnose host-local paths as remote misses."""
+        import agent.prompt_builder as _pb
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        monkeypatch.setattr(_pb, "_probe_remote_backend", lambda _t: None)
+        _pb._clear_backend_probe_cache()
+        result = _pb.build_environment_hints()
+        assert "Terminal backend: ssh" in result
+        assert "/Users/..." in result
+        assert "remote over SSH" in result
+        assert "switch to local execution" in result
+
     def test_remote_backend_list_covers_known_sandboxes(self):
         """Regression guard: if someone adds a remote backend, they must list it here."""
         import agent.prompt_builder as _pb
@@ -1352,5 +1365,4 @@ class TestOpenAIModelExecutionGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
 


### PR DESCRIPTION
## Summary
- add an SSH-specific environment hint that explains terminal/file tools are operating on the remote host
- tell the agent not to answer that obvious host-local paths are simply "missing" on the remote machine
- add a regression test covering the new SSH path-routing guidance

Closes #45893.

## Testing
- `pytest tests/agent/test_prompt_builder.py -k 'build_environment_hints or remote_backend_list or wsl_hint_constant' -q`
- `ruff check agent/prompt_builder.py tests/agent/test_prompt_builder.py`
- `git diff --check`

## Notes
- A broader run of `tests/agent/test_prompt_builder.py` hit a pre-existing unrelated failure in `TestBuildSkillsSystemPrompt::test_excludes_disabled_skills`, so local proof stays scoped to the environment-hint surface touched here.
