### PR TITLE
fix(agent): return Anthropic-shaped partial stream stub in anthropic_messages mode

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2651,6 +2651,20 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     result["error"],
                 )
                 _stub_finish_reason = FINISH_REASON_LENGTH
+            if getattr(agent, "api_mode", None) == "anthropic_messages":
+                # Anthropic-shaped stub: validate_response() checks for
+                # response.content (a list), not response.choices.
+                _stub_content_block = SimpleNamespace(
+                    type="text", text=_partial_text or "",
+                )
+                return SimpleNamespace(
+                    id=PARTIAL_STREAM_STUB_ID,
+                    model=getattr(agent, "model", "unknown"),
+                    content=[_stub_content_block],
+                    stop_reason="max_tokens",
+                    usage=None,
+                    _dropped_tool_names=_partial_names or None,
+                )
             _stub_msg = SimpleNamespace(
                 role="assistant", content=_partial_text, tool_calls=None,
                 reasoning_content=None,

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -135,6 +135,76 @@ class TestPartialStreamStubFinishReason:
         assert "Stream stalled mid tool-call" in content
         assert "write_file" in content
 
+    @patch("run_agent.AIAgent._anthropic_client", create=True)
+    @patch("run_agent.AIAgent._try_refresh_anthropic_client_credentials", create=True)
+    def test_anthropic_mode_partial_returns_content_list(
+        self, _mock_refresh, _mock_client, monkeypatch,
+    ):
+        """#45908: In anthropic_messages mode, the partial-stream stub must
+        have .content (a list of blocks) so that validate_response() passes.
+        Previously the stub was always OpenAI-shaped (.choices), causing
+        AnthropicTransport.validate_response to fail and the conversation
+        loop to retry 10x with the same unrecoverable error."""
+
+        def _stalling_anthropic_stream(**kwargs):
+            class _FakeStream:
+                def __enter__(self):
+                    return self
+                def __exit__(self, *a):
+                    pass
+                def __iter__(self):
+                    yield SimpleNamespace(
+                        type="content_block_start",
+                        content_block=SimpleNamespace(type="text"),
+                        index=0,
+                    )
+                    yield SimpleNamespace(
+                        type="content_block_delta",
+                        delta=SimpleNamespace(type="text_delta", thinking=None, text="partial "),
+                        index=0,
+                    )
+                def get_final_message(self):
+                    raise IndexError("list index out of range")
+            return _FakeStream()
+
+        agent = _make_agent()
+        agent.api_mode = "anthropic_messages"
+        agent._anthropic_client = MagicMock()
+        agent._anthropic_client.messages.stream.side_effect = _stalling_anthropic_stream
+        agent._try_refresh_anthropic_client_credentials = lambda: None
+        agent._current_streamed_assistant_text = "partial "
+        agent._fire_stream_delta = lambda text: None
+        agent._fire_reasoning_delta = lambda text: None
+        agent._fire_first_delta = lambda: None
+        agent._touch_activity = lambda *a, **kw: None
+        agent._stream_diag_init = lambda: {}
+        agent._stream_diag_capture_response = lambda *a, **kw: None
+        agent._fire_tool_gen_started = lambda *a, **kw: None
+        agent._is_provider_stream_parse_error = lambda e: False
+        agent._emit_stream_drop = lambda **kw: None
+        agent._log_stream_retry = lambda **kw: None
+        agent._buffer_status = lambda *a, **kw: None
+        agent._reset_stream_delivery_tracking = lambda: None
+        agent._replace_primary_openai_client = lambda **kw: None
+
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id == PARTIAL_STREAM_STUB_ID
+        assert hasattr(response, "content"), (
+            "Anthropic partial stub must have .content attribute"
+        )
+        assert isinstance(response.content, list), (
+            "Anthropic partial stub .content must be a list"
+        )
+        assert len(response.content) > 0, (
+            "Anthropic partial stub .content must be non-empty"
+        )
+        assert response.content[0].type == "text"
+        assert response.content[0].text == "partial"
+        assert response.stop_reason == "max_tokens"
+        assert not hasattr(response, "choices") or response.choices is None
+
 
 # ── Clean stream-end mid-tool-call (no exception, no finish_reason) ─────────
 


### PR DESCRIPTION
## What does this PR do?

When `stream.get_final_message()` raises `IndexError` on a malformed Anthropic stream (non-contiguous `content_block` indices), the partial-stream recovery stub is now Anthropic-shaped (`.content` list) instead of OpenAI-shaped (`.choices`). This prevents `AnthropicTransport.validate_response()` from failing and the conversation loop from retrying 10x with the same unrecoverable error.

## Related Issue

Fixes #45908

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py`: When `api_mode == "anthropic_messages"`, return an Anthropic-shaped partial stream stub with `content=[text_block]` and `stop_reason="max_tokens"` so that `validate_response()` passes and the conversation loop's length-continuation path can recover the streamed text.
- `tests/run_agent/test_partial_stream_finish_reason.py`: Added `test_anthropic_mode_partial_returns_content_list` — verifies the stub has `.content` (non-empty list of text blocks), `.stop_reason="max_tokens"`, and no `.choices` attribute.

## How to Test

1. Run the updated test file: `pytest tests/run_agent/test_partial_stream_finish_reason.py -xvs`
2. Verify `test_anthropic_mode_partial_returns_content_list` passes alongside the 9 existing tests
3. Confirm the stub shape: `.content` is a list with a `SimpleNamespace(type="text", text=...)` block, `.stop_reason` is `"max_tokens"`, and no `.choices` attribute exists

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/run_agent/test_partial_stream_finish_reason.py -xvs` and all 10 tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — or N/A
- [x] I've considered cross-platform impact — N/A (streaming stub shape is platform-independent)
- [x] I've updated tool descriptions/schemas — or N/A

## Code Intelligence

- Analyzed: `agent/chat_completion_helpers.py` (partial stream stub creation, ~line 2654)
- Analyzed: `agent/transports/anthropic.py` (`validate_response`, `normalize_response`, `map_finish_reason`)
- Analyzed: `agent/conversation_loop.py` (response validation at ~line 1483, truncation handling at ~line 1702)
- Blast radius: LOW — only affects the error recovery path when `api_mode == "anthropic_messages"` and the stream dies with `IndexError`
- Related patterns: The OpenAI-shaped stub path (for `chat_completions` mode) is unchanged
