### PR TITLE
fix(desktop): guide first-run model setup (#45862)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -71,6 +71,48 @@ logger = logging.getLogger(__name__)
 INTERRUPT_WAITING_FOR_MODEL_PREFIX = "Operation interrupted: waiting for model response ("
 
 
+_FIRST_RUN_SETUP_GUIDANCE = (
+    "No usable model credentials are configured yet. Run `hermes setup` to "
+    "connect a provider, or `hermes model` to choose an already configured "
+    "model, then send your message again."
+)
+
+
+def _friendly_first_run_api_error(
+    summary: str,
+    *,
+    provider: str,
+    model: str,
+    error: BaseException | None = None,
+) -> str | None:
+    """Translate common first-run auth failures into setup guidance.
+
+    A fresh desktop install can fall into Bedrock/Converse with no valid AWS
+    credentials, which otherwise leaks provider-specific jargon into the chat
+    transcript (``UnrecognizedClientException`` / ``ConverseStream``).  Keep
+    this intentionally narrow so ordinary provider outages and non-auth errors
+    retain their diagnostic detail.
+    """
+    text = " ".join(
+        str(part or "")
+        for part in (summary, error, provider, model)
+    ).lower()
+    is_bedrock_route = provider.lower() == "bedrock" or "bedrock" in model.lower()
+    is_first_run_auth = any(
+        marker in text
+        for marker in (
+            "unrecognizedclientexception",
+            "security token included in the request is invalid",
+            "could not find credentials",
+            "unable to locate credentials",
+            "no credentials found",
+        )
+    )
+    if is_bedrock_route and is_first_run_auth:
+        return _FIRST_RUN_SETUP_GUIDANCE
+    return None
+
+
 def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str]:
     """Return a user-facing error when Ollama is loaded with too little context."""
     if not getattr(agent, "tools", None):
@@ -3192,7 +3234,15 @@ def run_conversation(
                             api_kwargs, reason="max_retries_exhausted", error=api_error,
                         )
                     agent._persist_session(messages, conversation_history)
-                    if classified.reason == FailoverReason.billing:
+                    friendly_first_run = _friendly_first_run_api_error(
+                        _final_summary,
+                        provider=_provider,
+                        model=_model,
+                        error=api_error,
+                    )
+                    if friendly_first_run:
+                        _final_response = friendly_first_run
+                    elif classified.reason == FailoverReason.billing:
                         _final_response = f"Billing or credits exhausted: {_final_summary}"
                         if _billing_guidance:
                             _final_response += f"\n\n{_billing_guidance}"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -752,6 +752,7 @@ AUTHOR_MAP = {
     "mgparkprint@gmail.com": "vlwkaos",
     "1317078257maroon@gmail.com": "Oxidane-bot",
     "tranquil_flow@protonmail.com": "Tranquil-Flow",
+    "dev@tranquil-flow.dev": "Tranquil-Flow",
     "66773372+Tranquil-Flow@users.noreply.github.com": "Tranquil-Flow",
     "LyleLengyel@gmail.com": "mcndjxlefnd",
     "wangshengyang2004@163.com": "Wangshengyang2004",

--- a/tests/run_agent/test_first_run_model_guidance.py
+++ b/tests/run_agent/test_first_run_model_guidance.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+
+from agent.conversation_loop import _friendly_first_run_api_error
+from tui_gateway.server import _probe_credentials
+
+
+class _ErrorWithResponse(Exception):
+    def __init__(self, message: str, status_code: int | None = None):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def test_bedrock_unrecognized_client_gets_setup_guidance():
+    raw = (
+        "An error occurred (UnrecognizedClientException) when calling the "
+        "ConverseStream operation: The security token included in the request is invalid."
+    )
+
+    friendly = _friendly_first_run_api_error(
+        raw,
+        provider="bedrock",
+        model="anthropic.claude-3-5-sonnet-20240620-v1:0",
+        error=_ErrorWithResponse(raw),
+    )
+
+    assert friendly is not None
+    assert "No usable model credentials are configured" in friendly
+    assert "hermes setup" in friendly
+    assert "hermes model" in friendly
+    assert "UnrecognizedClientException" not in friendly
+    assert "ConverseStream" not in friendly
+
+
+def test_ordinary_provider_errors_stay_raw():
+    raw = "HTTP 500: upstream unavailable"
+
+    assert (
+        _friendly_first_run_api_error(
+            raw,
+            provider="openai",
+            model="gpt-4o",
+            error=_ErrorWithResponse(raw, status_code=500),
+        )
+        is None
+    )
+
+
+def test_tui_gateway_missing_key_warning_is_actionable():
+    agent = SimpleNamespace(provider="bedrock", model="anthropic.claude", api_key="no-key-required")
+
+    warning = _probe_credentials(agent)
+
+    assert "No usable model credentials are configured" in warning
+    assert "hermes setup" in warning
+    assert "hermes model" in warning
+    assert "First message will fail" not in warning

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2306,7 +2306,11 @@ def _probe_credentials(agent) -> str:
         key = getattr(agent, "api_key", "") or ""
         provider = getattr(agent, "provider", "") or ""
         if not key or key == "no-key-required":
-            return f"No API key configured for provider '{provider}'. First message will fail."
+            return (
+                "No usable model credentials are configured yet. Run `hermes setup` "
+                "to connect a provider, or `hermes model` to choose an already "
+                f"configured model. Current provider: '{provider or 'auto'}'."
+            )
     except Exception:
         pass
     return ""

--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -101,6 +101,9 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
 
       if (ev.payload) {
         setInfo((prev) => ({ ...prev, ...ev.payload }));
+        if (!ev.payload.credential_warning) {
+          setError(null);
+        }
       }
     });
 


### PR DESCRIPTION
Fixes #45862.

## Summary
- Rewrites the common first-run Bedrock auth failure (`UnrecognizedClientException` / invalid security token) into plain setup guidance instead of leaking AWS jargon into the chat response.
- Makes the TUI/desktop credential warning actionable with `hermes setup` and `hermes model` instructions.
- Clears the sidebar error banner when a fresh `session.info` arrives without a credential warning, so stale setup errors disappear after the user fixes configuration.
- Adds the automation author email to `AUTHOR_MAP` so the repository's contributor-attribution CI can resolve this PR's commit author.

## Verification
- `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/run_agent/test_first_run_model_guidance.py -v -o "addopts=" --tb=short` → 3 passed, 1 warning.
- Local contributor-attribution check equivalent passed for `dev@tranquil-flow.dev`.
- Nearby `tests/test_tui_gateway_server.py` suite was sampled by the builder; one browser-manage test fails on clean upstream/main too and is unrelated to this patch.
- Branch rebased onto current upstream/main and verified exactly one commit ahead (`git rev-list --left-right --count upstream/main...HEAD` → `0 1`).

## Competitor / duplicate check
- Same-author issue search: no open Tranquil-Flow PR referencing #45862.
- Same-author branch search: no open `fix/45862*` PR.
- Open PR searches for `45862`, `first-run model configured setup guidance`, and `UnrecognizedClientException hermes setup`: no competing PRs found.

Auto-published by Moonsong via Path B automated pipeline.
