### PR TITLE
fix(desktop): stop thread settle from fighting user scroll

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread-list.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-list.test.tsx
@@ -1,0 +1,131 @@
+import { render } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ThreadMessageList } from './thread-list'
+
+type MockMessage = {
+  content: unknown[]
+  id: string
+  role: 'assistant' | 'user'
+}
+
+let mockedMessages: MockMessage[] = []
+
+let stickState: {
+  contentRef: { current: HTMLDivElement | null }
+  isAtBottom: boolean
+  scrollRef: { current: HTMLDivElement | null }
+  scrollToBottom: ReturnType<typeof vi.fn>
+  stopScroll: ReturnType<typeof vi.fn>
+}
+
+vi.mock('@assistant-ui/react', () => ({
+  ThreadPrimitive: {
+    MessageByIndex: ({ index }: { index: number }) => <div data-testid={`msg-${index}`}>message {index}</div>
+  },
+  useAuiEvent: () => {},
+  useAuiState: (selector: (state: { thread: { messages: MockMessage[] } }) => unknown) =>
+    selector({ thread: { messages: mockedMessages } })
+}))
+
+vi.mock('use-stick-to-bottom', () => ({
+  useStickToBottom: () => stickState
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      assistant: {
+        thread: {
+          showEarlier: 'Show earlier'
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...parts: Array<false | null | string | undefined>) => parts.filter(Boolean).join(' ')
+}))
+
+vi.mock('@/store/thread-scroll', () => ({
+  onScrollToBottomRequest: () => () => {},
+  onThreadEditClose: () => () => {},
+  onThreadEditOpen: () => () => {},
+  resetThreadScroll: () => {},
+  setThreadAtBottom: () => {}
+}))
+
+vi.mock('./message-render-boundary', () => ({
+  MessageRenderBoundary: ({ children }: { children: ReactNode }) => children
+}))
+
+describe('ThreadMessageList session settle', () => {
+  beforeEach(() => {
+    mockedMessages = [
+      { content: [{ text: 'prompt', type: 'text' }], id: 'user-1', role: 'user' },
+      { content: [{ text: 'reply', type: 'text' }], id: 'assistant-1', role: 'assistant' }
+    ]
+
+    stickState = {
+      contentRef: { current: null },
+      isAtBottom: true,
+      scrollRef: { current: null },
+      scrollToBottom: vi.fn(),
+      stopScroll: vi.fn()
+    }
+
+    vi.stubGlobal('requestAnimationFrame', vi.fn(() => 1))
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('does not restart session settle on ordinary rerenders', () => {
+    const initialStop = stickState.stopScroll
+    const sharedScrollRef = stickState.scrollRef
+    const sharedContentRef = stickState.contentRef
+
+    const { rerender } = render(
+      <ThreadMessageList clampToComposer={false} components={{}} loadingIndicator={null} sessionKey="session-a" />
+    )
+
+    expect(initialStop).toHaveBeenCalledTimes(1)
+
+    stickState = {
+      contentRef: sharedContentRef,
+      isAtBottom: false,
+      scrollRef: sharedScrollRef,
+      scrollToBottom: vi.fn(),
+      stopScroll: vi.fn()
+    }
+
+    rerender(<ThreadMessageList clampToComposer={false} components={{}} loadingIndicator={<div />} sessionKey="session-a" />)
+
+    expect(stickState.stopScroll).not.toHaveBeenCalled()
+  })
+
+  it('restarts session settle when the session key changes', () => {
+    const sharedScrollRef = stickState.scrollRef
+    const sharedContentRef = stickState.contentRef
+
+    const { rerender } = render(
+      <ThreadMessageList clampToComposer={false} components={{}} loadingIndicator={null} sessionKey="session-a" />
+    )
+
+    stickState = {
+      contentRef: sharedContentRef,
+      isAtBottom: true,
+      scrollRef: sharedScrollRef,
+      scrollToBottom: vi.fn(),
+      stopScroll: vi.fn()
+    }
+
+    rerender(<ThreadMessageList clampToComposer={false} components={{}} loadingIndicator={null} sessionKey="session-b" />)
+
+    expect(stickState.stopScroll).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread-list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-list.tsx
@@ -114,6 +114,12 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     resize: 'instant'
   })
 
+  const scrollToBottomRef = useRef(scrollToBottom)
+  const stopScrollRef = useRef(stopScroll)
+
+  scrollToBottomRef.current = scrollToBottom
+  stopScrollRef.current = stopScroll
+
   const [renderBudget, setRenderBudget] = useState(RENDER_BUDGET)
 
   // Walk turns newest-first, summing their part weights until the budget is met;
@@ -178,7 +184,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
       return
     }
 
-    stopScroll()
+    stopScrollRef.current()
     el.scrollTop = el.scrollHeight
 
     let frame = 0
@@ -200,7 +206,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
 
       // ~5 steady frames ≈ layout has settled; the frame cap bounds slow loads.
       if (stableFrames >= 5 || ++frame > 90) {
-        void scrollToBottom('instant')
+        void scrollToBottomRef.current('instant')
 
         return
       }
@@ -211,7 +217,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     let rafId = requestAnimationFrame(settle)
 
     return () => cancelAnimationFrame(rafId)
-  }, [scrollRef, scrollToBottom, sessionKey, stopScroll])
+  }, [scrollRef, sessionKey])
 
   // Prepend an older page while preserving the on-screen position. The user is
   // scrolled up (reading history) so the stick-to-bottom lock is escaped and


### PR DESCRIPTION
## Summary
- run the one-shot thread settle effect only when the session key changes
- keep the latest stick-to-bottom callbacks in refs so rerenders do not restart the settle loop
- add a regression test that ordinary rerenders do not fight manual scroll or outline jumps

Closes #45913

## Testing
- npx vitest run --environment jsdom src/components/assistant-ui/thread-list.test.tsx src/components/assistant-ui/streaming.test.tsx src/app/chat/scroll-to-bottom-button.test.tsx
- npx eslint src/components/assistant-ui/thread-list.tsx src/components/assistant-ui/thread-list.test.tsx
- git diff --check