### PR TITLE
Fix false local Ollama length truncation

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1318,6 +1318,17 @@ def run_conversation(
                             force=True,
                         )
                         finish_reason = "length"
+                    elif agent._should_treat_length_as_completed(
+                        finish_reason,
+                        assistant_message,
+                        response=response,
+                        api_kwargs=api_kwargs,
+                    ):
+                        agent._vprint(
+                            f"{agent.log_prefix}ℹ️  Treating suspicious local Ollama length response as complete",
+                            force=True,
+                        )
+                        finish_reason = "stop"
 
                 if finish_reason == "length":
                     if getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1347,6 +1347,16 @@ class AIAgent:
             return True
         return bool(self.base_url and is_local_endpoint(self.base_url))
 
+    def _is_local_ollama_backend(self) -> bool:
+        """Detect local Ollama-style chat backends that may misreport length."""
+        if not self.base_url:
+            return False
+        if ":11434" in self._base_url_lower or "ollama" in self._base_url_lower:
+            return True
+        if not is_local_endpoint(self.base_url):
+            return False
+        return getattr(self, "_ollama_num_ctx", None) is not None
+
     def _should_treat_stop_as_truncated(
         self,
         finish_reason: str,
@@ -1377,6 +1387,46 @@ class AIAgent:
             return False
 
         return not self._has_natural_response_ending(visible_text)
+
+    def _should_treat_length_as_completed(
+        self,
+        finish_reason: str,
+        assistant_message,
+        *,
+        response: Any = None,
+        api_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Detect short, naturally-finished local Ollama replies mislabeled as length."""
+        if finish_reason != "length" or self.api_mode != "chat_completions":
+            return False
+        if not self._is_local_ollama_backend():
+            return False
+        if assistant_message is None or getattr(assistant_message, "tool_calls", None):
+            return False
+
+        content = getattr(assistant_message, "content", None)
+        if not isinstance(content, str):
+            return False
+
+        visible_text = self._strip_think_blocks(content).strip()
+        if not visible_text or not self._has_natural_response_ending(visible_text):
+            return False
+
+        # Keep the heuristic intentionally narrow: if the provider actually
+        # spent the full requested output cap, trust the truncation signal. If
+        # there's no explicit cap, only waive suspiciously short finished replies.
+        requested_cap = self._requested_output_cap_from_api_kwargs(api_kwargs)
+        usage = getattr(response, "usage", None) if response is not None else None
+        raw_completion_tokens = getattr(usage, "completion_tokens", None) if usage is not None else None
+        try:
+            completion_tokens = int(raw_completion_tokens) if raw_completion_tokens is not None else None
+        except (TypeError, ValueError):
+            completion_tokens = None
+
+        if requested_cap is not None and completion_tokens is not None and completion_tokens >= requested_cap:
+            return False
+
+        return len(visible_text) <= 280
 
     def _looks_like_codex_intermediate_ack(
         self,

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4276,6 +4276,66 @@ class TestRunConversation:
         assert result["api_calls"] == 2
         assert result["final_response"] == "Based on the search results, the best next"
 
+    def test_local_ollama_short_natural_length_reply_is_treated_as_complete(self, agent):
+        """Short finished local Ollama replies should not trigger fake continuation."""
+        self._setup_agent(agent)
+        agent.base_url = "http://localhost:11434/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.provider = "custom"
+        agent.model = "gemma4:12b"
+
+        finished = _mock_response(
+            content="Hello! How can I help today?",
+            finish_reason="length",
+            usage={"completion_tokens": 12},
+        )
+        agent.client.chat.completions.create.return_value = finished
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert result["api_calls"] == 1
+        assert result["final_response"] == "Hello! How can I help today?"
+
+    def test_local_ollama_length_at_requested_cap_still_requests_continuation(self, agent):
+        """Do not waive length when the provider actually spent the full cap."""
+        self._setup_agent(agent)
+        agent.base_url = "http://localhost:11434/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.provider = "custom"
+        agent.model = "gemma4:12b"
+
+        capped = _mock_response(
+            content="Hello! How can I help today?",
+            finish_reason="length",
+            usage={"completion_tokens": 16},
+        )
+        agent.client.chat.completions.create.side_effect = [capped, capped, capped]
+
+        def _fake_build_api_kwargs(api_messages):
+            return {"model": agent.model, "messages": api_messages, "max_tokens": 16}
+
+        with (
+            patch.object(agent, "_build_api_kwargs", side_effect=_fake_build_api_kwargs),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is False
+        assert result["api_calls"] == 3
+        assert "continuation attempts" in (result["error"] or "").lower()
+
+        second_call_messages = agent.client.chat.completions.create.call_args_list[1].kwargs["messages"]
+        assert second_call_messages[-1]["role"] == "user"
+        assert "truncated by the output length limit" in second_call_messages[-1]["content"]
+
     def test_length_thinking_exhausted_skips_continuation(self, agent):
         """When finish_reason='length' but content is only thinking, skip retries."""
         self._setup_agent(agent)


### PR DESCRIPTION
## Summary
- treat short naturally-finished local Ollama replies as complete even when the backend mislabels them with `finish_reason="length"`
- keep the workaround narrow by requiring a local Ollama backend, no tool calls, a natural text boundary, and evidence that the response did not consume the full requested cap
- add regression coverage for both the false-truncation path and the real-cap control

## Testing
- /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest -q tests/run_agent/test_run_agent.py::TestRunConversation::test_length_finish_reason_requests_continuation tests/run_agent/test_run_agent.py::TestRunConversation::test_ollama_glm_stop_after_tools_without_terminal_boundary_requests_continuation tests/run_agent/test_run_agent.py::TestRunConversation::test_ollama_glm_stop_with_terminal_boundary_does_not_continue tests/run_agent/test_run_agent.py::TestRunConversation::test_local_ollama_short_natural_length_reply_is_treated_as_complete tests/run_agent/test_run_agent.py::TestRunConversation::test_local_ollama_length_at_requested_cap_still_requests_continuation
- uv run --active --frozen ruff check run_agent.py agent/conversation_loop.py tests/run_agent/test_run_agent.py
- git diff --check

Closes #45924