### PR TITLE
Make Telegram rich replies opt-in

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -419,11 +419,12 @@ class TelegramAdapter(BasePlatformAdapter):
         self._mention_patterns = self._compile_mention_patterns()
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
         self._disable_link_previews: bool = self._coerce_bool_extra("disable_link_previews", False)
-        # Bot API 10.1 Rich Messages: send final replies via sendRichMessage
-        # with the raw agent markdown so tables/task lists/etc. render natively.
-        # Latched off after a capability failure on sendRichMessage /
-        # sendRichMessageDraft (e.g. older python-telegram-bot without the
-        # endpoint) so later sends skip the doomed rich attempt entirely.
+        # Bot API 10.1 Rich Messages remain opt-in for Telegram because
+        # Telegram Web still cannot render them reliably for normal replies.
+        # When explicitly enabled, final replies use sendRichMessage with the
+        # raw agent markdown so tables/task lists/etc. render natively.
+        # Capability failures still latch the rich path off for the rest of
+        # the adapter lifetime so later sends skip the doomed roundtrip.
         self._rich_send_disabled: bool = False
         self._rich_draft_disabled: bool = False
         # Buffer rapid/album photo updates so Telegram image bursts are handled
@@ -950,11 +951,16 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         return inspect.iscoroutinefunction(getattr(self._bot, "do_api_request", None))
 
+    def _rich_messages_enabled(self) -> bool:
+        """Rich Telegram replies are opt-in until Web clients catch up."""
+        return self._coerce_bool_extra("rich_messages", False)
+
     def _should_attempt_rich(
         self, content: str, metadata: Optional[Dict[str, Any]] = None
     ) -> bool:
         return bool(
-            not getattr(self, "_rich_send_disabled", False)
+            self._rich_messages_enabled()
+            and not getattr(self, "_rich_send_disabled", False)
             and not (metadata or {}).get("expect_edits")
             and content
             and content.strip()
@@ -977,9 +983,9 @@ class TelegramAdapter(BasePlatformAdapter):
         ``metadata`` is intentionally ignored: the preview was sent with
         ``expect_edits=True`` (to stay on the editable path mid-stream), but the
         FINAL answer is a brand-new message that should render rich.  Gating
-        otherwise matches :meth:`_should_attempt_rich`: rich not latched off,
-        content present and within the rich character limit, and the bot exposes
-        an async ``do_api_request``.
+        otherwise matches :meth:`_should_attempt_rich`: rich explicitly
+        enabled, not latched off, content present and within the rich
+        character limit, and the bot exposes an async ``do_api_request``.
         """
         return self._should_attempt_rich(content)
 
@@ -989,13 +995,14 @@ class TelegramAdapter(BasePlatformAdapter):
         ``sendRichMessageDraft`` isn't fragmented at the 4,096 MarkdownV2 limit.
 
         Gated on the same rich capability as the send path (minus the
-        content-length check — raising that cap is the whole point): rich not
-        latched off and the bot exposes an async ``do_api_request``.  Returns
-        ``None`` (→ legacy 4,096 limit) when rich isn't available, so non-rich
-        streams split exactly as before.
+        content-length check — raising that cap is the whole point): rich
+        explicitly enabled, not latched off, and the bot exposes an async
+        ``do_api_request``.  Returns ``None`` (→ legacy 4,096 limit) when rich
+        isn't available, so non-rich streams split exactly as before.
         """
         if (
-            not getattr(self, "_rich_send_disabled", False)
+            self._rich_messages_enabled()
+            and not getattr(self, "_rich_send_disabled", False)
             and self._bot_supports_rich()
         ):
             return self.RICH_MESSAGE_MAX_CHARS
@@ -1184,7 +1191,8 @@ class TelegramAdapter(BasePlatformAdapter):
 
     def _should_attempt_rich_draft(self, content: str) -> bool:
         return bool(
-            not getattr(self, "_rich_send_disabled", False)
+            self._rich_messages_enabled()
+            and not getattr(self, "_rich_send_disabled", False)
             and not getattr(self, "_rich_draft_disabled", False)
             and content
             and content.strip()

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -1,9 +1,9 @@
 """Tests for Bot API 10.1 Rich Messages (sendRichMessage) on Telegram.
 
-Final / new-message replies opportunistically use ``sendRichMessage`` with the
-RAW agent markdown so tables, task lists, etc. render natively. The legacy
-MarkdownV2 ``send_message`` path stays as the fallback for unsupported /
-oversized content and for transports that lack the endpoint.
+When explicitly enabled, final / new-message replies use ``sendRichMessage``
+with the RAW agent markdown so tables, task lists, etc. render natively. The
+legacy MarkdownV2 ``send_message`` path stays as the fallback for disabled,
+unsupported, or oversized content and for transports that lack the endpoint.
 
 The ``telegram`` package is mocked by ``tests/gateway/conftest.py``
 (:func:`_ensure_telegram_mock`), so these tests construct a real
@@ -42,7 +42,8 @@ PTB_INVALID_TOKEN_404 = InvalidToken(
 
 def _make_adapter(extra=None):
     """Build a TelegramAdapter with a mock bot wired for the rich path."""
-    config = PlatformConfig(enabled=True, token="fake-token", extra=extra or {})
+    config_extra = {"rich_messages": True} if extra is None else extra
+    config = PlatformConfig(enabled=True, token="fake-token", extra=config_extra)
     adapter = TelegramAdapter(config)
     bot = MagicMock()
     # do_api_request as an AsyncMock makes inspect.iscoroutinefunction(...) True,
@@ -106,16 +107,25 @@ async def test_rich_happy_path_sends_raw_markdown():
 
 
 @pytest.mark.asyncio
-async def test_legacy_rich_messages_config_is_ignored():
+async def test_rich_messages_default_to_legacy_send():
+    adapter = _make_adapter(extra={})
+
+    result = await adapter.send("12345", RICH_CONTENT)
+
+    assert result.success is True
+    adapter._bot.do_api_request.assert_not_called()
+    adapter._bot.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_explicit_rich_messages_false_uses_legacy_send():
     adapter = _make_adapter(extra={"rich_messages": False})
 
     result = await adapter.send("12345", RICH_CONTENT)
 
     assert result.success is True
-    # The legacy toggle was removed; stale config entries must not disable the
-    # rich path.
-    adapter._bot.do_api_request.assert_awaited_once()
-    adapter._bot.send_message.assert_not_called()
+    adapter._bot.do_api_request.assert_not_called()
+    adapter._bot.send_message.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -238,7 +248,7 @@ async def test_real_ptb_endpoint_missing_falls_back_and_latches_off(exc):
 
 @pytest.mark.asyncio
 async def test_rich_payload_preserves_link_preview_disable():
-    adapter = _make_adapter(extra={"disable_link_previews": True})
+    adapter = _make_adapter(extra={"rich_messages": True, "disable_link_previews": True})
 
     result = await adapter.send("12345", "See https://example.com")
 
@@ -430,6 +440,17 @@ async def test_rich_draft_oversized_uses_legacy():
     adapter._bot.send_message_draft.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_rich_draft_disabled_uses_legacy():
+    adapter = _make_adapter(extra={"rich_messages": False})
+
+    result = await adapter.send_draft("12345", draft_id=7, content=RICH_CONTENT)
+
+    assert result.success is True
+    adapter._bot.do_api_request.assert_not_called()
+    adapter._bot.send_message_draft.assert_awaited_once()
+
+
 # ----------------------------------------------------------------------
 # prefers_fresh_final_streaming: the stream consumer asks the adapter whether
 # to finalize a streamed reply by sending a fresh (rich) message + deleting the
@@ -441,9 +462,9 @@ def test_prefers_fresh_final_streaming_when_rich_enabled():
     assert adapter.prefers_fresh_final_streaming(RICH_CONTENT) is True
 
 
-def test_prefers_fresh_final_streaming_ignores_legacy_toggle():
+def test_prefers_fresh_final_streaming_disabled_when_rich_opt_out():
     adapter = _make_adapter(extra={"rich_messages": False})
-    assert adapter.prefers_fresh_final_streaming(RICH_CONTENT) is True
+    assert adapter.prefers_fresh_final_streaming(RICH_CONTENT) is False
 
 
 # ----------------------------------------------------------------------
@@ -456,9 +477,9 @@ def test_streaming_overflow_limit_is_rich_cap_when_enabled():
     assert adapter.streaming_overflow_limit() == TelegramAdapter.RICH_MESSAGE_MAX_CHARS
 
 
-def test_streaming_overflow_limit_ignores_legacy_toggle():
+def test_streaming_overflow_limit_none_when_rich_opt_out():
     adapter = _make_adapter(extra={"rich_messages": False})
-    assert adapter.streaming_overflow_limit() == TelegramAdapter.RICH_MESSAGE_MAX_CHARS
+    assert adapter.streaming_overflow_limit() is None
 
 
 def test_streaming_overflow_limit_none_when_rich_latched_off():


### PR DESCRIPTION
## Summary
- keep Telegram rich-message sends behind an explicit `platforms.telegram.extra.rich_messages` opt-in because Telegram Web still cannot render them reliably
- preserve the existing rich path, rich drafts, and fresh-final streaming behavior when the opt-in is enabled
- add focused regression coverage for the default-off policy, explicit opt-in/out, and the legacy fallback behavior

## Testing
- /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/.base/.venv/bin/python -m pytest -q tests/gateway/test_telegram_rich_messages.py
- uv run --active --frozen ruff check gateway/platforms/telegram.py tests/gateway/test_telegram_rich_messages.py
- git diff --check

Closes #45785