### PR TITLE
fix: refresh Weixin poll session after transport failures

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1391,7 +1391,34 @@ class WeixinAdapter(BasePlatformAdapter):
                 logger.error("[%s] poll error (%d/%d): %s", self.name, consecutive_failures, MAX_CONSECUTIVE_FAILURES, exc)
                 await asyncio.sleep(BACKOFF_DELAY_SECONDS if consecutive_failures >= MAX_CONSECUTIVE_FAILURES else RETRY_DELAY_SECONDS)
                 if consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
+                    await self._refresh_poll_session_after_failures()
                     consecutive_failures = 0
+
+    async def _refresh_poll_session_after_failures(self) -> None:
+        """Recreate the long-poll HTTP session after repeated transport errors.
+
+        On some Windows networks the iLink long-poll connection can get stuck
+        after repeated SSL/socket failures. Keeping the same ClientSession can
+        leave the adapter apparently connected while inbound delivery remains
+        silent. Refreshing only the poll session is safe: the send session and
+        cached context tokens remain intact, while new getUpdates calls get a
+        fresh connector/socket pool.
+        """
+        if not AIOHTTP_AVAILABLE:
+            return
+        old_session = self._poll_session
+        try:
+            if old_session is not None and not old_session.closed:
+                await old_session.close()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[%s] failed to close stale Weixin poll session: %s", self.name, exc)
+        if not self._running:
+            return
+        self._poll_session = aiohttp.ClientSession(
+            trust_env=True,
+            connector=_make_ssl_connector(),
+        )
+        logger.warning("[%s] refreshed Weixin poll session after repeated failures", self.name)
 
     async def _process_message_safe(self, message: Dict[str, Any]) -> None:
         try:

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -1205,3 +1205,41 @@ class TestWeixinApiTimeout:
             )
         )
         assert result == {"ret": 0, "msgs": [], "get_updates_buf": "buf-123"}
+
+    def test_poll_loop_refreshes_session_after_repeated_transport_errors(self):
+        class PollSession:
+            def __init__(self):
+                self.closed = False
+                self.close_calls = 0
+
+            async def close(self):
+                self.close_calls += 1
+                self.closed = True
+
+        adapter = _make_adapter()
+        old_session = PollSession()
+        new_session = PollSession()
+        adapter._poll_session = old_session
+        adapter._running = True
+        adapter._hermes_home = os.getcwd()
+        calls = 0
+
+        async def failing_then_stop(*_args, **_kwargs):
+            nonlocal calls
+            calls += 1
+            if calls <= weixin.MAX_CONSECUTIVE_FAILURES:
+                raise OSError("Cannot connect to host ilinkai.weixin.qq.com:443 ssl:default")
+            adapter._running = False
+            return {"ret": 0, "msgs": [], "get_updates_buf": ""}
+
+        aiohttp_mock = Mock(ClientSession=Mock(return_value=new_session))
+        with patch("gateway.platforms.weixin._load_sync_buf", return_value=""), \
+             patch("gateway.platforms.weixin._get_updates", side_effect=failing_then_stop), \
+             patch("gateway.platforms.weixin._make_ssl_connector", return_value=None), \
+             patch("gateway.platforms.weixin.aiohttp", aiohttp_mock), \
+             patch("gateway.platforms.weixin.AIOHTTP_AVAILABLE", True), \
+             patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock):
+            asyncio.run(adapter._poll_loop())
+
+        assert old_session.close_calls == 1
+        assert adapter._poll_session is new_session


### PR DESCRIPTION
## Summary
- Recreate the Weixin long-poll `ClientSession` after repeated transport/SSL errors
- Keep the send session and context-token cache intact while giving `getUpdates` a fresh connector/socket pool
- Add regression coverage for repeated poll transport failures

## Test plan
- `python -m pytest tests/gateway/test_weixin.py -q`
- `python -m ruff check gateway/platforms/weixin.py tests/gateway/test_weixin.py`
- `git diff --check`

Refs #45931
