### PR TITLE
fix: use config.set for desktop model switches

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -1,8 +1,9 @@
-import { renderHook } from '@testing-library/react'
 import { QueryClient } from '@tanstack/react-query'
+import { act, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getGlobalModelInfo } from '@/hermes'
+import { notifyError } from '@/store/notifications'
 import {
   $activeSessionId,
   $currentModel,
@@ -16,6 +17,20 @@ import { useModelControls } from './use-model-controls'
 vi.mock('@/hermes', () => ({
   getGlobalModelInfo: vi.fn(),
   setGlobalModel: vi.fn()
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      desktop: {
+        modelSwitchFailed: 'Model switch failed'
+      }
+    }
+  })
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notifyError: vi.fn()
 }))
 
 describe('useModelControls.refreshCurrentModel', () => {
@@ -73,5 +88,70 @@ describe('useModelControls.refreshCurrentModel', () => {
 
     expect($currentModel.get()).toBe('deepseek/deepseek-v4-pro')
     expect($currentProvider.get()).toBe('deepseek')
+  })
+
+  it('uses config.set for live session model switches and preserves the explicit provider', async () => {
+    const requestGateway = vi.fn().mockResolvedValue({ value: 'deepseek/deepseek-v4-pro' })
+    const queryClient = new QueryClient()
+    setCurrentModel('qwen/qwen3-coder')
+    setCurrentProvider('qwen-oauth')
+    $activeSessionId.set('runtime-1')
+
+    const { result } = renderHook(() =>
+      useModelControls({
+        activeSessionId: 'runtime-1',
+        queryClient,
+        requestGateway
+      })
+    )
+
+    let ok = false
+    await act(async () => {
+      ok = await result.current.selectModel({
+        model: 'deepseek/deepseek-v4-pro',
+        persistGlobal: false,
+        provider: 'deepseek'
+      })
+    })
+
+    expect(ok).toBe(true)
+    expect(requestGateway).toHaveBeenCalledWith('config.set', {
+      confirm_expensive_model: true,
+      key: 'model',
+      session_id: 'runtime-1',
+      value: 'deepseek/deepseek-v4-pro --provider deepseek'
+    })
+    expect($currentModel.get()).toBe('deepseek/deepseek-v4-pro')
+    expect($currentProvider.get()).toBe('deepseek')
+  })
+
+  it('rolls back the optimistic live-session switch when config.set does not confirm success', async () => {
+    const requestGateway = vi.fn().mockResolvedValue({})
+    const queryClient = new QueryClient()
+    setCurrentModel('qwen/qwen3-coder')
+    setCurrentProvider('qwen-oauth')
+    $activeSessionId.set('runtime-1')
+
+    const { result } = renderHook(() =>
+      useModelControls({
+        activeSessionId: 'runtime-1',
+        queryClient,
+        requestGateway
+      })
+    )
+
+    let ok = true
+    await act(async () => {
+      ok = await result.current.selectModel({
+        model: 'deepseek/deepseek-v4-pro',
+        persistGlobal: false,
+        provider: 'deepseek'
+      })
+    })
+
+    expect(ok).toBe(false)
+    expect($currentModel.get()).toBe('qwen/qwen3-coder')
+    expect($currentProvider.get()).toBe('qwen-oauth')
+    expect(notifyError).toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-model-controls.ts
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.ts
@@ -28,6 +28,7 @@ interface ModelControlsOptions {
 export function useModelControls({ activeSessionId, queryClient, requestGateway }: ModelControlsOptions) {
   const { t } = useI18n()
   const copy = t.desktop
+
   const updateModelOptionsCache = useCallback(
     (provider: string, model: string, includeGlobal: boolean) => {
       const patch = (prev: ModelOptionsResponse | undefined) => ({ ...(prev ?? {}), provider, model })
@@ -82,10 +83,16 @@ export function useModelControls({ activeSessionId, queryClient, requestGateway 
 
       try {
         if (activeSessionId) {
-          await requestGateway('slash.exec', {
+          const result = await requestGateway<{ value?: string }>('config.set', {
+            confirm_expensive_model: true,
+            key: 'model',
             session_id: activeSessionId,
-            command: `/model ${selection.model} --provider ${selection.provider}${selection.persistGlobal ? ' --global' : ''}`
+            value: `${selection.model} --provider ${selection.provider}${selection.persistGlobal ? ' --global' : ''}`
           })
+
+          if (!result?.value) {
+            throw new Error('invalid response: model switch')
+          }
 
           if (selection.persistGlobal) {
             void refreshCurrentModel()


### PR DESCRIPTION
## Summary
- switch active desktop session model changes from `slash.exec` to structured `config.set`
- require a confirmed config-set result before keeping the optimistic model/provider UI state
- add hook tests for the live-session RPC path and rollback on failed confirmation

## Problem
Desktop live-session model switches were routed through `slash.exec`. That path can report success while `_mirror_slash_side_effects` only returns a warning string when the running session never applies the new provider/model. The UI then stays on the optimistic DeepSeek selection even though requests still route through the old backend.

## Verification
- `../../node_modules/.bin/vitest run --environment jsdom src/app/session/hooks/use-model-controls.test.tsx`
- `../../node_modules/.bin/eslint src/app/session/hooks/use-model-controls.ts src/app/session/hooks/use-model-controls.test.tsx`
- `git diff --check`

Closes #45689