### PR TITLE
fix(gateway): keep overflow stream chunks editable

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -744,39 +744,63 @@ class GatewayStreamConsumer:
                         and self._message_id is None
                     ):
                         # No existing message to edit (first message or after a
-                        # segment break).  Use truncate_message — the same
-                        # helper the non-streaming path uses — to split with
-                        # proper word/code-fence boundaries and chunk
-                        # indicators like "(1/2)".
-                        chunks = self.adapter.truncate_message(
-                            self._accumulated, _safe_limit, len_fn=_len_fn,
-                        )
+                        # segment break).  Seal only the overflowing head chunks
+                        # as fixed messages, then keep the trailing chunk in
+                        # _accumulated so the normal send/edit path below makes
+                        # it the active preview.  That lets chunk 2, 3, ... keep
+                        # updating in-place as later streamed deltas arrive
+                        # instead of posting every split as an immutable message.
                         chunks_delivered = False
-                        reply_to = self._message_id or self._initial_reply_to_id
-                        for chunk in chunks:
+                        reply_to = self._initial_reply_to_id
+                        while _len_fn(self._accumulated) > _safe_limit:
+                            _cp_budget = _custom_unit_to_cp(
+                                self._accumulated, _safe_limit, _len_fn,
+                            )
+                            split_at = self._accumulated.rfind("\n", 0, _cp_budget)
+                            if split_at < _cp_budget // 2:
+                                split_at = _cp_budget
+                            chunk = self._accumulated[:split_at]
                             new_id = await self._send_new_chunk(
                                 chunk,
                                 reply_to,
                                 final=got_done,
                             )
-                            if new_id is not None and new_id != reply_to:
-                                chunks_delivered = True
-                        self._accumulated = ""
-                        self._last_sent_text = ""
+                            if new_id is None or new_id == reply_to:
+                                # Failed to deliver the sealed head; keep the
+                                # full accumulated text intact so the gateway's
+                                # fallback path can still deliver it completely.
+                                chunks_delivered = False
+                                break
+                            chunks_delivered = True
+                            reply_to = new_id
+                            self._accumulated = self._accumulated[split_at:].lstrip("\n")
+                            # The head chunk is sealed.  Clear the edit target
+                            # so the remaining tail is sent as a fresh active
+                            # chunk, then edited by subsequent deltas.
+                            self._message_id = None
+                            self._message_created_ts = None
+                            self._last_sent_text = ""
+
                         self._last_edit_time = time.monotonic()
                         if got_done:
-                            # Only claim final delivery if THESE chunks actually
-                            # landed.  ``_already_sent`` may be True from prior
-                            # tool-progress edits or fallback-mode promotion (#10748)
-                            # — that doesn't mean the final answer reached the user.
-                            self._final_response_sent = chunks_delivered
-                            if chunks_delivered:
+                            tail_delivered = True
+                            if self._accumulated:
+                                tail_delivered = await self._send_or_edit(
+                                    self._accumulated, finalize=True,
+                                )
+                            # Only claim final delivery if the sealed chunks and
+                            # final tail actually landed.  ``_already_sent`` may
+                            # be True from prior progress/fallback state (#10748).
+                            self._final_response_sent = chunks_delivered and tail_delivered
+                            if self._final_response_sent:
                                 self._final_content_delivered = True
                             return
                         if got_segment_break:
                             self._message_id = None
                             self._fallback_final_send = False
                             self._fallback_prefix = ""
+                            if not self._accumulated:
+                                continue
 
                         # This iteration consumed a _FLUSH barrier and delivered
                         # the buffered prose via the chunk loop above, then takes
@@ -797,8 +821,8 @@ class GatewayStreamConsumer:
                             self._accumulated, _safe_limit, _len_fn,
                         )
                         split_at = self._accumulated.rfind("\n", 0, _cp_budget)
-                        if split_at < _safe_limit // 2:
-                            split_at = _safe_limit
+                        if split_at < _cp_budget // 2:
+                            split_at = _cp_budget
                         chunk = self._accumulated[:split_at]
                         # finalize=True so the adapter applies platform-specific
                         # rich-text markup (e.g. Telegram MarkdownV2). This
@@ -1087,8 +1111,8 @@ class GatewayStreamConsumer:
         while len_fn(remaining) > limit:
             _cp_budget = _custom_unit_to_cp(remaining, limit, len_fn)
             split_at = remaining.rfind("\n", 0, _cp_budget)
-            if split_at < limit // 2:
-                split_at = limit
+            if split_at < _cp_budget // 2:
+                split_at = _cp_budget
             chunks.append(remaining[:split_at])
             remaining = remaining[split_at:].lstrip("\n")
         if remaining:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -750,33 +750,46 @@ class GatewayStreamConsumer:
                         # it the active preview.  That lets chunk 2, 3, ... keep
                         # updating in-place as later streamed deltas arrive
                         # instead of posting every split as an immutable message.
-                        chunks_delivered = False
-                        reply_to = self._initial_reply_to_id
-                        while _len_fn(self._accumulated) > _safe_limit:
-                            _cp_budget = _custom_unit_to_cp(
+                        chunks = self._truncate_for_stream(
+                            self._accumulated, _safe_limit, _len_fn,
+                        )
+                        if len(chunks) <= 1:
+                            # A malformed/legacy adapter result must not leave
+                            # this overflow branch with an unsplittable payload.
+                            chunks = self._split_text_chunks(
                                 self._accumulated, _safe_limit, _len_fn,
                             )
-                            split_at = self._accumulated.rfind("\n", 0, _cp_budget)
-                            if split_at < _cp_budget // 2:
-                                split_at = _cp_budget
-                            chunk = self._accumulated[:split_at]
+                        chunks_delivered = False
+                        reply_to = self._initial_reply_to_id
+                        all_heads_delivered = len(chunks) > 1
+                        for chunk in chunks[:-1]:
                             new_id = await self._send_new_chunk(
                                 chunk,
                                 reply_to,
                                 final=got_done,
                             )
                             if new_id is None or new_id == reply_to:
-                                # Failed to deliver the sealed head; keep the
+                                # Failed to deliver a sealed head; keep the
                                 # full accumulated text intact so the gateway's
                                 # fallback path can still deliver it completely.
+                                all_heads_delivered = False
                                 chunks_delivered = False
                                 break
                             chunks_delivered = True
                             reply_to = new_id
-                            self._accumulated = self._accumulated[split_at:].lstrip("\n")
-                            # The head chunk is sealed.  Clear the edit target
+
+                        if all_heads_delivered:
+                            self._accumulated = chunks[-1]
+                            # The head chunks are sealed.  Clear the edit target
                             # so the remaining tail is sent as a fresh active
                             # chunk, then edited by subsequent deltas.
+                            self._message_id = None
+                            self._message_created_ts = None
+                            self._last_sent_text = ""
+                        else:
+                            # A prior head may have landed before a later head
+                            # failed.  Do not edit that sealed message with the
+                            # unsplit full payload; let the fallback path retry.
                             self._message_id = None
                             self._message_created_ts = None
                             self._last_sent_text = ""
@@ -1100,7 +1113,8 @@ class GatewayStreamConsumer:
 
     @staticmethod
     def _split_text_chunks(
-        text: str, limit: int,
+        text: str,
+        limit: int,
         len_fn: "Callable[[str], int]" = len,
     ) -> list[str]:
         """Split text into reasonably sized chunks for fallback sends."""
@@ -1118,6 +1132,33 @@ class GatewayStreamConsumer:
         if remaining:
             chunks.append(remaining)
         return chunks
+
+    def _truncate_for_stream(
+        self,
+        text: str,
+        limit: int,
+        len_fn: "Callable[[str], int]",
+    ) -> list[str]:
+        """Use the adapter's canonical splitter for streaming overflow.
+
+        Platform adapters may add word-boundary, code-fence, table, or
+        platform-specific formatting rules.  The consumer must not replace
+        those rules with newline-only slicing.  Non-base test doubles and
+        legacy adapters retain the historical two-argument call shape.
+        """
+        truncate = getattr(self.adapter, "truncate_message", None)
+        if not callable(truncate):
+            return self._split_text_chunks(text, limit, len_fn)
+
+        if isinstance(self.adapter, _BasePlatformAdapter):
+            chunks = truncate(text, limit, len_fn=len_fn)
+        else:
+            chunks = truncate(text, limit)
+        if not isinstance(chunks, (list, tuple)) or not all(
+            isinstance(chunk, str) for chunk in chunks
+        ):
+            return self._split_text_chunks(text, limit, len_fn)
+        return list(chunks)
 
     async def _send_fallback_final(self, text: str) -> None:
         """Send the final continuation after streaming edits stop working.

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -1229,6 +1229,58 @@ class TestInitialOverflowRollingEdit:
         )
         assert consumer.final_response_sent is True
 
+    @pytest.mark.asyncio
+    async def test_initial_overflow_uses_adapter_fence_aware_split(self):
+        """Initial rolling sends must preserve the adapter's fence contract."""
+        adapter = TestUtf16OverflowDetection()._make_telegram_like_adapter()
+        from gateway.platforms.base import utf16_len
+
+        msg_ids = iter(["msg_1", "msg_2", "msg_3"])
+        adapter.send = AsyncMock(
+            side_effect=lambda **kw: SimpleNamespace(
+                success=True,
+                message_id=next(msg_ids),
+            )
+        )
+        adapter.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_3"),
+        )
+        raw_limit = 700
+        setattr(adapter, "MAX_MESSAGE_LENGTH", raw_limit)
+        splitter = MagicMock(side_effect=adapter.truncate_message)
+        adapter.truncate_message = splitter
+
+        config = StreamConsumerConfig(
+            edit_interval=0.01,
+            buffer_threshold=5,
+            cursor=" ▉",
+        )
+        consumer = GatewayStreamConsumer(adapter, "chat_fenced", config)
+        fenced = "```python\n" + ("print('x')\n" * 100) + "```"
+        safe_limit = raw_limit - utf16_len(config.cursor) - 100
+        expected_chunks = adapter.truncate_message(
+            fenced, safe_limit, len_fn=adapter.message_len_fn,
+        )
+        splitter.reset_mock()
+
+        consumer.on_delta(fenced)
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.08)
+        consumer.on_delta("\nTail after the fenced stream.")
+        await asyncio.sleep(0.08)
+        consumer.finish()
+        await task
+
+        sent_texts = [call.kwargs["content"] for call in adapter.send.call_args_list]
+        edited_texts = [call.kwargs["content"] for call in adapter.edit_message.call_args_list]
+        assert splitter.call_count >= 1
+        assert all(text.count("```") % 2 == 0 for text in sent_texts + edited_texts)
+        assert len(sent_texts) == len(expected_chunks)
+        assert sent_texts[:-1] == expected_chunks[:-1]
+        assert sent_texts[-1].startswith(expected_chunks[-1])
+        assert any("Tail after the fenced stream." in text for text in edited_texts)
+        assert all(utf16_len(text) <= safe_limit for text in sent_texts)
+
 
 class TestEditOverflowSplitAndDeliver:
     """When edit_message split-and-delivers an oversized payload across the

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -1183,6 +1183,53 @@ class TestFinalContentDeliveredGuard:
         )
 
 
+class TestInitialOverflowRollingEdit:
+    @pytest.mark.asyncio
+    async def test_initial_overflow_keeps_last_chunk_as_edit_target(self):
+        """When the first visible flush already overflows, only sealed head
+        chunks should be posted as fixed messages.  The trailing chunk must
+        remain the active edit target so later streamed deltas update that
+        second message instead of overwriting or posting a new one."""
+        adapter = MagicMock()
+        msg_ids = iter(["msg_1", "msg_2"])
+        adapter.send = AsyncMock(
+            side_effect=lambda **kw: SimpleNamespace(
+                success=True,
+                message_id=next(msg_ids),
+            )
+        )
+        adapter.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_2"),
+        )
+        adapter.MAX_MESSAGE_LENGTH = 700
+
+        config = StreamConsumerConfig(
+            edit_interval=0.01,
+            buffer_threshold=5,
+            cursor=" ▉",
+        )
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        head = "A" * 650
+        tail = "B" * 25
+        consumer.on_delta(head)
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.08)
+        consumer.on_delta(tail)
+        await asyncio.sleep(0.08)
+        consumer.finish()
+        await task
+
+        assert adapter.send.call_count == 2
+        assert adapter.edit_message.call_count >= 1
+        edited_texts = [call.kwargs["content"] for call in adapter.edit_message.call_args_list]
+        assert any("A" * 20 in text and tail in text for text in edited_texts), (
+            "the second overflow chunk should be edited with its existing tail "
+            "plus later deltas, not overwritten by only the later delta"
+        )
+        assert consumer.final_response_sent is True
+
+
 class TestEditOverflowSplitAndDeliver:
     """When edit_message split-and-delivers an oversized payload across the
     original message + N continuations (Telegram >4096 UTF-16), the consumer
@@ -1985,11 +2032,6 @@ class TestUtf16OverflowDetection:
         adapter.edit_message = AsyncMock(
             return_value=SimpleNamespace(success=True),
         )
-        # truncate_message: emit two halves so we can assert the split fired
-        adapter.truncate_message = MagicMock(
-            side_effect=lambda text, limit, **kw: [text[:len(text)//2], text[len(text)//2:]],
-        )
-
         config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5)
         consumer = GatewayStreamConsumer(adapter, "chat_123", config)
 
@@ -2010,17 +2052,17 @@ class TestUtf16OverflowDetection:
         consumer.finish()
         await task
 
-        # The fix: stream consumer detects UTF-16 overflow and calls
-        # truncate_message to split. Without the fix, len() would return
-        # 2200 (under 4096) and no split would fire — Telegram would then
-        # reject the send or render \x00 artifacts.
-        adapter.truncate_message.assert_called(), (
+        # The fix: stream consumer detects UTF-16 overflow using the adapter's
+        # length function.  Without that, len() would return 2200 (under the
+        # limit) and Hermes would attempt a single over-limit Telegram send.
+        sent_texts = [call.kwargs["content"] for call in adapter.send.call_args_list]
+        assert len(sent_texts) == 2, (
             "UTF-16 overflow not detected — emoji text bypassed split path"
         )
-        # truncate_message must have been called with len_fn=utf16_len
-        call_kwargs = adapter.truncate_message.call_args[1]
-        assert call_kwargs.get("len_fn") is utf16_len, (
-            f"truncate_message called without utf16_len: {call_kwargs}"
+        max_units = 4096
+        assert all(utf16_len(text) <= max_units for text in sent_texts), (
+            f"split chunks still exceed Telegram UTF-16 limit: "
+            f"{[utf16_len(text) for text in sent_texts]}"
         )
 
     def test_codepoint_only_adapter_falls_back_to_len(self):


### PR DESCRIPTION
## What does this PR do?

Keeps the newest overflow chunk editable while gateway responses stream past a platform message limit.

Previously, when a streamed response overflowed before an editable message existed, the consumer split the entire accumulated response through `truncate_message()` and posted every chunk as an immutable standalone message. That meant the second Slack chunk could not keep updating while more tokens arrived. This PR seals only the overflowing head chunks, leaves the trailing chunk as the active preview, and lets later deltas edit that newest chunk in place.

It also fixes the same split helper fallback to use the computed codepoint budget when adapters count length in non-codepoint units (for example Telegram UTF-16 units), so overflow chunks do not accidentally exceed the adapter's real limit.

## Related Issue

No issue filed; reported from live Slack gateway behavior.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/stream_consumer.py`
  - For first-send/after-segment overflow, seal only completed head chunks.
  - Keep the remaining tail in `_accumulated` so `_send_or_edit()` creates it as the active editable chunk.
  - Preserve final-delivery guards by only marking final delivery when sealed chunks and the tail both land.
  - Use `_custom_unit_to_cp(...)`'s returned codepoint budget for split fallbacks, instead of mixing adapter length units with Python slice indexes.
- `tests/gateway/test_stream_consumer.py`
  - Added a regression test proving the second overflow chunk remains the edit target and later deltas update it.
  - Adjusted UTF-16 overflow coverage to assert the real delivered chunks stay within the adapter length limit.

## How to Test

1. RED: `python -m pytest tests/gateway/test_stream_consumer.py::TestInitialOverflowRollingEdit::test_initial_overflow_keeps_last_chunk_as_edit_target -q`
   - Failed before the fix with: `AssertionError: the second overflow chunk should be edited...`
2. GREEN: `python -m pytest tests/gateway/test_stream_consumer.py::TestInitialOverflowRollingEdit::test_initial_overflow_keeps_last_chunk_as_edit_target -q`
   - `1 passed`
3. Targeted gateway suite: `python -m pytest tests/gateway/test_stream_consumer.py -q`
   - `94 passed`
4. CI-style targeted gateway run: `scripts/run_tests.sh tests/gateway/test_stream_consumer.py tests/gateway/test_stream_consumer_fresh_final.py tests/gateway/test_stream_consumer_thread_routing.py tests/gateway/test_update_streaming.py -- -q`
   - `150 tests passed, 0 failed`
5. Cross-platform scan: `python scripts/check-windows-footguns.py gateway/stream_consumer.py`
   - `✓ No Windows footguns found (1 file(s) scanned).`
6. Syntax check: `python -m py_compile gateway/stream_consumer.py tests/gateway/test_stream_consumer.py`
   - Passed with no output.
7. Full suite attempt: `scripts/run_tests.sh -j 8 -- -q`
   - Attempted, but this local macOS worktree has unrelated existing failures outside the touched gateway files, including Anthropic adapter import/path issues, systemctl-only live guard tests on macOS, `/tmp` vs `/private/tmp` macOS path assertions, and a timing-sensitive delegate heartbeat assertion. The targeted gateway suites above passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no user-facing docs changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A — no new skill.

## Screenshots / Logs

Not applicable; behavior is covered by the gateway stream consumer regression tests above.
