### PR TITLE
fix: auto-subscribe on CLI kanban create + check SendResult in notifier

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -300,9 +300,13 @@ class GatewayKanbanWatchersMixin:
                             sub["chat_id"], sub.get("thread_id") or "",
                         )
                         try:
-                            await adapter.send(
+                            result = await adapter.send(
                                 sub["chat_id"], msg, metadata=metadata,
                             )
+                            if not result.success:
+                                raise RuntimeError(
+                                    f"SendResult success=False: {getattr(result, 'error', 'unknown')}"
+                                )
                             logger.debug(
                                 "kanban notifier: delivered %s event for %s to %s/%s on board %s",
                                 kind, sub["task_id"], platform_str, sub["chat_id"], board_slug,

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -195,3 +195,34 @@ def get_session_env(name: str, default: str = "") -> str:
             return value
     # Fall back to os.environ for CLI, cron, and test compatibility
     return os.getenv(name, default)
+
+
+def build_session_subprocess_env(base_env: dict | None = None) -> dict:
+    """Build a subprocess environment with current session vars from ContextVar.
+
+    Use this when spawning subprocesses that need ``HERMES_SESSION_*`` vars
+    (e.g. ``hermes kanban create`` for auto-subscribe).  ContextVars are
+    task-local and do not propagate to child processes, so we bridge them
+    explicitly here.
+
+    Resolution per var:
+    1. ContextVar value (set by ``set_session_vars``) — overrides os.environ.
+    2. ``os.environ`` — fallback for CLI / cron / non-gateway contexts.
+    3. (skipped if absent from both)
+
+    Returns a new dict; does not mutate the caller's env.
+    """
+    import os
+
+    env = dict(base_env) if base_env else {}
+    for var_name, var in _VAR_MAP.items():
+        value = var.get()
+        if value is _UNSET:
+            # Never set in this context — fall back to os.environ.
+            oval = os.environ.get(var_name, "")
+            if oval:
+                env[var_name] = oval
+        else:
+            # Explicitly set (even to "") — trust the ContextVar.
+            env[var_name] = value
+    return env

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -363,6 +363,27 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "to skip the brief running-to-blocked transition.")
     p_create.add_argument("--json", action="store_true", help="Emit JSON output")
 
+    p_create.add_argument(
+        "--subscribe-platform",
+        default=None,
+        help="Auto-subscribe platform (e.g. discord). Requires --subscribe-chat-id.",
+    )
+    p_create.add_argument(
+        "--subscribe-chat-id",
+        default=None,
+        help="Auto-subscribe chat/channel id. Requires --subscribe-platform.",
+    )
+    p_create.add_argument(
+        "--subscribe-thread-id",
+        default=None,
+        help="Auto-subscribe thread id (optional, required for Discord threads).",
+    )
+    p_create.add_argument(
+        "--subscribe-user-id",
+        default=None,
+        help="Auto-subscribe user id (optional).",
+    )
+
     # --- swarm ---
     p_swarm = sub.add_parser(
         "swarm",
@@ -1349,31 +1370,92 @@ def _cmd_create(args: argparse.Namespace) -> int:
         )
         task = kb.get_task(conn, task_id)
 
-        # Auto-subscribe when running inside a gateway chat session.
-        # Follows the same convention as the /kanban slash-command handler:
-        # JSON mode indicates scripting, skip implicit subscription.
+        # ── subscription (explicit --subscribe-* > env-based auto-subscribe) ──
         from gateway.session_context import get_session_env
 
-        session_platform = get_session_env("HERMES_SESSION_PLATFORM")
-        session_chat_id = get_session_env("HERMES_SESSION_CHAT_ID")
-        if (
-            session_platform
-            and session_chat_id
-            and not getattr(args, "json", False)
-        ):
-            kb.add_notify_sub(
-                conn,
-                task_id=task_id,
-                platform=session_platform,
-                chat_id=session_chat_id,
-                thread_id=get_session_env("HERMES_SESSION_THREAD_ID") or None,
-                user_id=get_session_env("HERMES_SESSION_USER_ID") or None,
-                notifier_profile=_profile_author(),
-            )
+        sub_platform: str | None = getattr(args, "subscribe_platform", None)
+        sub_chat_id: str | None = getattr(args, "subscribe_chat_id", None)
+        sub_thread_id: str | None = getattr(args, "subscribe_thread_id", None)
+        sub_user_id: str | None = getattr(args, "subscribe_user_id", None)
+
+        has_explicit = sub_platform is not None or sub_chat_id is not None
+        sub_created = False
+        sub_error: str | None = None
+
+        if has_explicit:
+            # Validate completeness: platform + chat-id are required.
+            if not sub_platform or not sub_chat_id:
+                print(
+                    "kanban: --subscribe-platform and --subscribe-chat-id "
+                    "are both required when using explicit subscription.",
+                    file=sys.stderr,
+                )
+                return 2
+
+            try:
+                kb.add_notify_sub(
+                    conn,
+                    task_id=task_id,
+                    platform=sub_platform,
+                    chat_id=sub_chat_id,
+                    thread_id=sub_thread_id or None,
+                    user_id=sub_user_id or None,
+                    notifier_profile=_profile_author(),
+                )
+                sub_created = True
+            except Exception as exc:
+                sub_error = str(exc)
+
+        elif not getattr(args, "json", False):
+            # JSON mode indicates scripting, skip implicit subscription.
+            # Fall back to env-based auto-subscribe (existing behaviour).
+            session_platform = get_session_env("HERMES_SESSION_PLATFORM")
+            session_chat_id = get_session_env("HERMES_SESSION_CHAT_ID")
+            if session_platform and session_chat_id:
+                sub_platform = session_platform
+                sub_chat_id = session_chat_id
+                sub_thread_id = get_session_env("HERMES_SESSION_THREAD_ID") or None
+                sub_user_id = get_session_env("HERMES_SESSION_USER_ID") or None
+                try:
+                    kb.add_notify_sub(
+                        conn,
+                        task_id=task_id,
+                        platform=sub_platform,
+                        chat_id=sub_chat_id,
+                        thread_id=sub_thread_id,
+                        user_id=sub_user_id,
+                        notifier_profile=_profile_author(),
+                    )
+                    sub_created = True
+                except Exception as exc:
+                    sub_error = str(exc)
+
     if getattr(args, "json", False):
-        print(json.dumps(_task_to_dict(task), indent=2, ensure_ascii=False))
+        result = _task_to_dict(task)
+        result["subscription"] = (
+            {"created": f"{sub_platform}:{sub_chat_id}"
+             + (f":{sub_thread_id}" if sub_thread_id else ""),
+             "method": "explicit" if has_explicit else "env"}
+            if sub_created
+            else {"created": False, "error": sub_error or "not attempted"}
+        )
+        print(json.dumps(result, indent=2, ensure_ascii=False))
     else:
         print(f"Created {task_id}  ({task.status}, assignee={task.assignee or '-'})")
+
+        # Subscription status line
+        if sub_created:
+            target = f"{sub_platform}:{sub_chat_id}"
+            if sub_thread_id:
+                target += f":{sub_thread_id}"
+            print(f"subscription: created {target}")
+        elif sub_error:
+            print(f"subscription: not created ({sub_error})", file=sys.stderr)
+        elif has_explicit:
+            print(
+                f"subscription: not created ({sub_error or 'unknown error'})",
+                file=sys.stderr,
+            )
 
         # Warn when the task would sit in `ready` because no dispatcher is
         # present. Only warn on ready+assigned tasks — triage/todo are

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1348,6 +1348,28 @@ def _cmd_create(args: argparse.Namespace) -> int:
             initial_status=getattr(args, "initial_status", "running"),
         )
         task = kb.get_task(conn, task_id)
+
+        # Auto-subscribe when running inside a gateway chat session.
+        # Follows the same convention as the /kanban slash-command handler:
+        # JSON mode indicates scripting, skip implicit subscription.
+        from gateway.session_context import get_session_env
+
+        session_platform = get_session_env("HERMES_SESSION_PLATFORM")
+        session_chat_id = get_session_env("HERMES_SESSION_CHAT_ID")
+        if (
+            session_platform
+            and session_chat_id
+            and not getattr(args, "json", False)
+        ):
+            kb.add_notify_sub(
+                conn,
+                task_id=task_id,
+                platform=session_platform,
+                chat_id=session_chat_id,
+                thread_id=get_session_env("HERMES_SESSION_THREAD_ID") or None,
+                user_id=get_session_env("HERMES_SESSION_USER_ID") or None,
+                notifier_profile=_profile_author(),
+            )
     if getattr(args, "json", False):
         print(json.dumps(_task_to_dict(task), indent=2, ensure_ascii=False))
     else:

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -566,3 +566,163 @@ def test_run_slash_board_override_does_not_change_boards_show_current(kanban_hom
     out = kc.run_slash("--board beta boards show")
 
     assert "Current board: alpha" in out
+
+
+# ---------------------------------------------------------------------------
+# _cmd_create --subscribe-* explicit subscription
+# ---------------------------------------------------------------------------
+
+
+def test_create_explicit_subscribe(kanban_home):
+    """--subscribe-platform + --subscribe-chat-id + --subscribe-thread-id
+    creates a subscription and reports it in the output."""
+    import re
+
+    out = kc.run_slash(
+        "create 'test sub' --assignee alice "
+        "--subscribe-platform discord "
+        "--subscribe-chat-id 12345 "
+        "--subscribe-thread-id 67890"
+    )
+    assert "Created" in out
+    assert "subscription: created discord:12345:67890" in out
+
+    tid = re.search(r"(t_[a-f0-9]+)", out).group(1)
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, tid)
+    finally:
+        conn.close()
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "discord"
+    assert subs[0]["chat_id"] == "12345"
+    assert subs[0]["thread_id"] == "67890"
+
+
+def test_create_explicit_subscribe_json_mode(kanban_home):
+    """Explicit --subscribe-* in JSON mode includes subscription in the JSON."""
+    import json
+    import re
+
+    out = kc.run_slash(
+        "create 'json sub' --assignee alice "
+        "--subscribe-platform discord "
+        "--subscribe-chat-id 12345 "
+        "--subscribe-thread-id 67890 "
+        "--json"
+    )
+    data = json.loads(out)
+    assert data["title"] == "json sub"
+    sub = data["subscription"]
+    assert sub["created"] == "discord:12345:67890"
+    assert sub["method"] == "explicit"
+
+    tid = data["id"]
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, tid)
+    finally:
+        conn.close()
+    assert len(subs) == 1
+
+
+def test_create_explicit_subscribe_incomplete_args(kanban_home):
+    """--subscribe-platform without --subscribe-chat-id must fail."""
+    out = kc.run_slash(
+        "create 'bad sub' --subscribe-platform discord"
+    )
+    assert "subscription: created" not in out
+    # The function returns 2 and should print an error
+    assert "both required" in out.lower() or "kanban:" in out
+
+
+def test_create_explicit_subscribe_chat_id_only(kanban_home):
+    """--subscribe-chat-id without --subscribe-platform must fail."""
+    out = kc.run_slash(
+        "create 'bad sub' --subscribe-chat-id 12345"
+    )
+    assert "subscription: created" not in out
+    assert "both required" in out.lower() or "kanban:" in out
+
+
+def test_create_no_subscribe_no_env(kanban_home, monkeypatch):
+    """Without explicit --subscribe-* and without HERMES_SESSION_* env,
+    no subscription is created and no false success reported."""
+    monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
+
+    out = kc.run_slash("create 'no sub' --assignee alice")
+    assert "Created" in out
+    # No subscription line at all
+    assert "subscription: not created" not in out
+    assert "subscription: created" not in out
+
+
+def test_create_env_auto_subscribe(kanban_home, monkeypatch):
+    """When HERMES_SESSION_* env vars are set and no explicit --subscribe-*,
+    auto-subscribe still works (existing behaviour preserved)."""
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "chat99")
+    monkeypatch.setenv("HERMES_SESSION_THREAD_ID", "th99")
+
+    import re
+    out = kc.run_slash("create 'env sub' --assignee alice")
+    assert "Created" in out
+    assert "subscription: created telegram:chat99:th99" in out
+
+    tid = re.search(r"(t_[a-f0-9]+)", out).group(1)
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, tid)
+    finally:
+        conn.close()
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "telegram"
+
+
+def test_create_explicit_beats_env(kanban_home, monkeypatch):
+    """Explicit --subscribe-* takes priority over HERMES_SESSION_* env vars."""
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "chat99")
+
+    import re
+    out = kc.run_slash(
+        "create 'explicit wins' --assignee alice "
+        "--subscribe-platform discord "
+        "--subscribe-chat-id 99999"
+    )
+    assert "subscription: created discord:99999" in out
+
+    tid = re.search(r"(t_[a-f0-9]+)", out).group(1)
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, tid)
+    finally:
+        conn.close()
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "discord"
+    assert subs[0]["chat_id"] == "99999"
+
+
+def test_create_subscription_failure_reported(kanban_home, monkeypatch):
+    """When add_notify_sub raises, card is still created but failure is reported.
+    No false 'subscription: created' in output."""
+    import hermes_cli.kanban_db as kb_module
+
+    # Force add_notify_sub to fail
+    real_add_notify_sub = kb_module.add_notify_sub
+
+    def _failing_add_notify_sub(*args, **kwargs):
+        raise RuntimeError("simulated db error")
+
+    monkeypatch.setattr(kb_module, "add_notify_sub", _failing_add_notify_sub)
+
+    out = kc.run_slash(
+        "create 'test failure' --assignee alice "
+        "--subscribe-platform discord "
+        "--subscribe-chat-id 12345"
+    )
+    assert "Created" in out
+    assert "subscription: not created" in out
+    assert "simulated db error" in out
+    assert "subscription: created" not in out

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from hermes_cli import kanban_db as kb
 from unittest.mock import AsyncMock, MagicMock, patch
+from gateway.platforms.base import SendResult
 
 
 # ---------------------------------------------------------------------------
@@ -51,6 +52,7 @@ async def test_notifier_unsubs_after_completed_event(kanban_home):
 
     async def _send_and_stop(chat_id, msg, metadata=None):
         runner._running = False
+        return SendResult(success=True)
 
     fake_adapter.send = AsyncMock(side_effect=_send_and_stop)
     runner.adapters = {Platform.TELEGRAM: fake_adapter}
@@ -111,6 +113,7 @@ async def test_notifier_unsubs_after_abnormal_events(kind, kanban_home):
 
     async def _send_and_stop(chat_id, msg, metadata=None):
         runner._running = False
+        return SendResult(success=True)
 
     fake_adapter.send = AsyncMock(side_effect=_send_and_stop)
     runner.adapters = {Platform.TELEGRAM: fake_adapter}
@@ -166,6 +169,7 @@ async def test_notifier_second_blocked_delivers(kanban_home):
 
     async def _capture_send(chat_id, msg, metadata=None):
         delivered_msgs.append(msg)
+        return SendResult(success=True)
 
     fake_adapter = MagicMock()
     fake_adapter.send = AsyncMock(side_effect=_capture_send)
@@ -412,6 +416,7 @@ async def test_notifier_delivers_subscription_owned_by_current_profile(kanban_ho
 
     async def _send_and_stop(chat_id, msg, metadata=None):
         runner._running = False
+        return SendResult(success=True)
 
     fake_adapter.send = AsyncMock(side_effect=_send_and_stop)
     runner.adapters = {Platform.TELEGRAM: fake_adapter}
@@ -546,6 +551,7 @@ async def test_notifier_uploads_artifacts_on_completion(kanban_home, tmp_path, m
     async def _send(chat_id, msg, metadata=None):
         sends.append((chat_id, msg))
         runner._running = False
+        return SendResult(success=True)
 
     async def _send_images(chat_id, images, metadata=None, **_kw):
         images_uploaded.extend(p for p, _ in images)
@@ -627,6 +633,7 @@ async def test_notifier_artifact_delivery_skips_missing_files(kanban_home, tmp_p
 
     async def _send(chat_id, msg, metadata=None):
         runner._running = False
+        return SendResult(success=True)
 
     async def _send_document(chat_id, file_path, metadata=None, **_kw):
         documents_uploaded.append(file_path)
@@ -653,3 +660,190 @@ async def test_notifier_artifact_delivery_skips_missing_files(kanban_home, tmp_p
     # Only the real file was uploaded.
     assert len(documents_uploaded) == 1
     assert "real.pdf" in documents_uploaded[0]
+
+
+# ---------------------------------------------------------------------------
+# SendResult.success=False handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_notifier_sendresult_false_preserves_sub_and_logs(kanban_home):
+    """When adapter.send returns SendResult(success=False), the subscription
+    is preserved (not deleted), cursor is rewound for retry, and error is logged."""
+    import hermes_cli.kanban_db as kb
+    from gateway.run import GatewayRunner
+    from gateway.config import Platform
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="fail task", assignee="worker1")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat1")
+        kb.complete_task(conn, tid, result="done")
+    finally:
+        conn.close()
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner._kanban_sub_fail_counts = {}
+
+    fake_adapter = MagicMock()
+
+    async def _send_failure(chat_id, msg, metadata=None):
+        runner._running = False
+        return SendResult(success=False, error="thread not found")
+
+    fake_adapter.send = AsyncMock(side_effect=_send_failure)
+    runner.adapters = {Platform.TELEGRAM: fake_adapter}
+
+    _orig_sleep = asyncio.sleep
+
+    async def _fast_sleep(_):
+        await _orig_sleep(0)
+
+    with patch("gateway.run.asyncio.sleep", side_effect=_fast_sleep):
+        await asyncio.wait_for(
+            runner._kanban_notifier_watcher(interval=1),
+            timeout=10.0,
+        )
+
+    # Send was called
+    fake_adapter.send.assert_called_once()
+    # But subscription is preserved — not deleted
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, tid)
+    finally:
+        conn.close()
+    assert len(subs) == 1, (
+        "Subscription must survive SendResult(success=False) so retry can happen"
+    )
+    # Cursor should still be rewound (0 for first event)
+    assert int(subs[0]["last_event_id"]) == 0
+
+
+@pytest.mark.asyncio
+async def test_notifier_mixed_subs_success_and_failure(kanban_home):
+    """Mixed subscriptions: one target succeeds, one fails.
+    Success sub can be deleted, failure sub must be preserved."""
+    import hermes_cli.kanban_db as kb
+    from gateway.run import GatewayRunner
+    from gateway.config import Platform
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="mixed task", assignee="worker1")
+        # Sub A: will succeed
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="good-chat")
+        # Sub B: will fail
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="bad-chat")
+        kb.complete_task(conn, tid, result="done")
+    finally:
+        conn.close()
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner._kanban_sub_fail_counts = {}
+
+    fake_adapter = MagicMock()
+    send_count = 0
+
+    async def _mixed_send(chat_id, msg, metadata=None):
+        nonlocal send_count
+        send_count += 1
+        if chat_id == "bad-chat":
+            return SendResult(success=False, error="thread not found")
+        return SendResult(success=True)
+
+    fake_adapter.send = AsyncMock(side_effect=_mixed_send)
+    runner.adapters = {Platform.TELEGRAM: fake_adapter}
+
+    _orig_sleep = asyncio.sleep
+    tick_count = 0
+
+    async def _fast_sleep(_):
+        nonlocal tick_count
+        await _orig_sleep(0)
+        tick_count += 1
+        # Let two ticks run: first processes both subs,
+        # good-chat succeeds and unsubs, bad-chat fails and rewinds.
+        # Second tick retries bad-chat (still fails, counter=2 < MAX).
+        if tick_count >= 2:
+            runner._running = False
+
+    with patch("gateway.run.asyncio.sleep", side_effect=_fast_sleep):
+        await asyncio.wait_for(
+            runner._kanban_notifier_watcher(interval=1),
+            timeout=10.0,
+        )
+
+    # Both subs were attempted at least once
+    assert send_count >= 2
+
+    # Check final subscription state
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, tid)
+    finally:
+        conn.close()
+
+    # Good-chat should be gone (unsubbed after successful delivery + terminal status)
+    good_subs = [s for s in subs if s["chat_id"] == "good-chat"]
+    assert len(good_subs) == 0, (
+        f"Successful subscription should be removed; got {good_subs}"
+    )
+
+    # Bad-chat should still be here (preserved after failure)
+    bad_subs = [s for s in subs if s["chat_id"] == "bad-chat"]
+    assert len(bad_subs) == 1, (
+        f"Failed subscription must survive for retry; got {bad_subs}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_notifier_adapter_exception_preserves_sub(kanban_home):
+    """When adapter.send raises an exception (not SendResult.success=False),
+    the old failure path still works: subscription preserved, cursor rewound."""
+    import hermes_cli.kanban_db as kb
+    from gateway.run import GatewayRunner
+    from gateway.config import Platform
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="exc task", assignee="worker1")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat1")
+        kb.complete_task(conn, tid, result="done")
+    finally:
+        conn.close()
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner._kanban_sub_fail_counts = {}
+
+    fake_adapter = MagicMock()
+
+    async def _send_exception(chat_id, msg, metadata=None):
+        runner._running = False
+        raise ConnectionError("network down")
+
+    fake_adapter.send = AsyncMock(side_effect=_send_exception)
+    runner.adapters = {Platform.TELEGRAM: fake_adapter}
+
+    _orig_sleep = asyncio.sleep
+
+    async def _fast_sleep(_):
+        await _orig_sleep(0)
+
+    with patch("gateway.run.asyncio.sleep", side_effect=_fast_sleep):
+        await asyncio.wait_for(
+            runner._kanban_notifier_watcher(interval=1),
+            timeout=10.0,
+        )
+
+    # Subscription must survive the exception
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, tid)
+    finally:
+        conn.close()
+    assert len(subs) == 1, "Subscription must survive adapter exception"

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -396,13 +396,12 @@ def _make_run_env(env: dict) -> dict:
         run_env["HOME"] = _profile_home
 
     # Inject ContextVar-based session vars into subprocess env.
-    # ContextVars don't propagate to child processes, so we bridge them here.
+    # ContextVars don't propagate to child processes, so we bridge them here
+    # via build_session_subprocess_env() which respects explicit empty values.
     try:
-        from gateway.session_context import _UNSET, _VAR_MAP
-        for var_name, var in _VAR_MAP.items():
-            value = var.get()
-            if value is not _UNSET and value:
-                run_env[var_name] = value
+        from gateway.session_context import build_session_subprocess_env
+        session_env = build_session_subprocess_env()
+        run_env.update(session_env)
     except Exception:
         pass
 


### PR DESCRIPTION
## Summary

Two related kanban notification fixes:

### 1. Auto-subscribe on CLI `kanban create`
`hermes kanban create` invoked via CLI did not auto-subscribe the caller. Added auto-subscribe to `_cmd_create` using `get_session_env()`.

- Added `build_session_subprocess_env()` in `gateway/session_context.py`
- Replaced inline ContextVar injection in `_make_run_env` with new helper
- Added auto-subscribe logic to `_cmd_create` in `hermes_cli/kanban.py`

### 2. Check SendResult.success in notifier
The notifier called `adapter.send()` but ignored the returned `SendResult`. Silent failures (thread not found, etc.) were treated as success — the notifier logged 'delivered', removed the subscription, and the user never received notifications.

- Now checks `result.success` after `adapter.send()`
- Raises `RuntimeError` on failure, caught by existing except block for proper rewinding

## Test Plan
- [x] `hermes kanban create` auto-subscribes correctly
- [x] Subscription target matches current thread
- [x] Notifier handles `SendResult(success=False)` by rewinding instead of deleting subscription