### PR TITLE
perf(execute-code): stop waiting on idle RPC accept

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -17,6 +17,7 @@ import pytest
 
 import json
 import os
+import time
 
 os.environ["TERMINAL_ENV"] = "local"
 
@@ -198,6 +199,16 @@ class TestExecuteCode(unittest.TestCase):
         self.assertEqual(result["status"], "success")
         self.assertIn("hello world", result["output"])
         self.assertEqual(result["tool_calls_made"], 0)
+
+    def test_no_tool_call_script_does_not_wait_for_rpc_accept_timeout(self):
+        """A no-tool script should not wait seconds for the idle RPC accept thread."""
+        start = time.monotonic()
+        result = self._run('print("fast")')
+        elapsed = time.monotonic() - start
+
+        self.assertEqual(result["status"], "success")
+        self.assertIn("fast", result["output"])
+        self.assertLess(elapsed, 2.0, f"execute_code took {elapsed:.3f}s")
 
     def test_repo_root_modules_are_importable(self):
         """Sandboxed scripts can import modules that live at the repo root."""

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -472,6 +472,7 @@ def _rpc_server_loop(
     tool_call_counter: list,   # mutable [int] so the thread can increment
     max_tool_calls: int,
     allowed_tools: frozenset,
+    stop_event: threading.Event,
 ):
     """
     Accept one client connection and dispatch tool-call requests until
@@ -481,8 +482,15 @@ def _rpc_server_loop(
 
     conn = None
     try:
-        server_sock.settimeout(5)
-        conn, _ = server_sock.accept()
+        server_sock.settimeout(0.05)
+        while not stop_event.is_set():
+            try:
+                conn, _ = server_sock.accept()
+                break
+            except socket.timeout:
+                continue
+        if conn is None:
+            return
         conn.settimeout(300)
 
         buf = b""
@@ -1157,6 +1165,7 @@ def execute_code(
     tool_call_counter = [0]  # mutable so the RPC thread can increment
     exec_start = time.monotonic()
     server_sock = None
+    stop_event = threading.Event()
 
     try:
         # Write the auto-generated hermes_tools module.
@@ -1204,7 +1213,7 @@ def execute_code(
             target=propagate_context_to_thread(_rpc_server_loop),
             args=(
                 server_sock, task_id, tool_call_log,
-                tool_call_counter, max_tool_calls, sandbox_tools,
+                tool_call_counter, max_tool_calls, sandbox_tools, stop_event,
             ),
             daemon=True,
         )
@@ -1369,23 +1378,33 @@ def execute_code(
             "last_touch": time.monotonic(),
             "start": exec_start,
         }
+        try:
+            from tools.environments.base import touch_activity_if_due
+        except Exception:
+            touch_activity_if_due = None
+        poll_interval = 0.005
         while proc.poll() is None:
             if _is_interrupted():
                 _kill_process_group(proc)
                 status = "interrupted"
                 break
-            if time.monotonic() > deadline:
+            now = time.monotonic()
+            if now > deadline:
                 _kill_process_group(proc, escalate=True)
                 status = "timeout"
                 break
             # Periodic activity touch so the gateway's inactivity timeout
             # doesn't kill the agent during long code execution (#10807).
+            if touch_activity_if_due is not None:
+                try:
+                    touch_activity_if_due(_activity_state, "execute_code running")
+                except Exception:
+                    pass
             try:
-                from tools.environments.base import touch_activity_if_due
-                touch_activity_if_due(_activity_state, "execute_code running")
-            except Exception:
+                proc.wait(timeout=min(poll_interval, max(0.0, deadline - now)))
+            except subprocess.TimeoutExpired:
                 pass
-            time.sleep(0.2)
+            poll_interval = min(0.2, poll_interval * 1.5)
 
         # Wait for readers to finish draining
         stdout_reader.join(timeout=3)
@@ -1411,6 +1430,7 @@ def execute_code(
         duration = round(time.monotonic() - exec_start, 2)
 
         # Wait for RPC thread to finish
+        stop_event.set()
         server_sock.close()  # break accept() so thread exits promptly
         server_sock = None  # prevent double close in finally
         rpc_thread.join(timeout=3)


### PR DESCRIPTION
## Summary
`execute_code` now exits promptly for no-tool scripts instead of waiting on the idle RPC listener accept timeout during cleanup.

## Changes
- `tools/code_execution_tool.py`: add a `stop_event` to the RPC listener thread so cleanup can stop an idle `accept()` loop immediately after the child process exits.
- `tools/code_execution_tool.py`: replace the fixed 200ms child-process poll sleep with a 5ms adaptive wait that backs off to the old 200ms steady state for long-running scripts.
- `tests/tools/test_code_execution.py`: add a regression test covering no-tool scripts returning without the old multi-second cleanup wait.

## Validation
| Check | Result |
|---|---|
| RED test before implementation | failed: `execute_code took 3.717s` |
| Targeted regression | passed: `1 passed in 0.65s` |
| Targeted behavior tests | `5 passed in 4.02s` |
| Targeted suite | `130 passed in 6.7s` |
| Live smoke | warm no-tool `execute_code("print(123)")`: median `53.62ms`, min `51.69ms` |

## Notes
- Preserves timeout, interrupt, output-drain, RPC tool-call, and long-running activity-touch behavior.
- The untracked `.plans/speed-optimization-audit.md` remains intentionally excluded from this PR.

## Infographic

![execute_code Fast Exit](https://v3b.fal.media/files/b/0a9e379d/ARB4h9wMAc9w1EjWgdKC-_Voa1Fudt.png)
