### PR TITLE
fix(gateway): rebuild cached agent when a session grows in another process

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12560,6 +12560,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if release_running_state:
             self._release_running_agent_state(session_key)
 
+    def _session_transcript_len(self, session_id: Optional[str]) -> Optional[int]:
+        """Cheap on-disk message count for ``session_id``, or None.
+
+        Used as a cross-process coherence signal for the agent cache. The
+        gateway caches an ``AIAgent`` (with its in-memory replayed history)
+        per session for prompt-prefix caching. If ANOTHER process sharing the
+        same ``HERMES_HOME`` (e.g. the desktop app's ``hermes dashboard``
+        backend) appends turns to the SAME session's transcript in the shared
+        SessionDB, the gateway's cached agent would otherwise never see them —
+        it replies with stale context and the on-disk transcript and the live
+        agent's history silently diverge (split-brain).
+
+        Returns ``SessionDB.message_count(session_id)`` (an indexed COUNT) so a
+        cache-hit can detect external growth. Returns None on any error or when
+        the DB / session_id is unavailable, so callers fail SAFE — degrading to
+        the existing reuse-the-cached-agent behavior rather than crashing a turn
+        or falsely evicting on a transient DB hiccup.
+        """
+        db = getattr(self, "_session_db", None)
+        if db is None or not session_id:
+            return None
+        try:
+            return db.message_count(session_id)
+        except Exception:
+            logger.debug(
+                "session transcript len probe failed for %s",
+                session_id,
+                exc_info=True,
+            )
+            return None
+
     def _evict_cached_agent(self, session_key: str) -> None:
         """Remove a cached agent for a session (called on /new, /model, etc).
 
@@ -14083,20 +14114,57 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             agent = None
             _cache_lock = getattr(self, "_agent_cache_lock", None)
             _cache = getattr(self, "_agent_cache", None)
+            _stale_cache_entry = False
             if _cache_lock and _cache is not None:
                 with _cache_lock:
                     cached = _cache.get(session_key)
                     if cached and cached[1] == _sig:
-                        agent = cached[0]
-                        # Refresh LRU order so the cap enforcement evicts
-                        # truly-oldest entries, not the one we just used.
-                        if hasattr(_cache, "move_to_end"):
-                            try:
-                                _cache.move_to_end(session_key)
-                            except KeyError:
-                                pass
-                        self._init_cached_agent_for_turn(agent, _interrupt_depth)
-                        logger.debug("Reusing cached agent for session %s", session_key)
+                        # Cross-process coherence guard. The cached agent holds
+                        # an in-memory replay of the transcript as it existed
+                        # when the agent was built. If another process sharing
+                        # this HERMES_HOME (e.g. the desktop's `hermes dashboard`
+                        # backend) appended turns to the SAME session since then,
+                        # reusing the cached agent would reply with stale context
+                        # and diverge from the on-disk transcript. Detect growth
+                        # via a cheap indexed COUNT and rebuild from disk when it
+                        # grew. ``cached_len`` is the snapshot stored alongside
+                        # the agent; a legacy 2-tuple (or a None snapshot, or a
+                        # None live count) skips the check and reuses as before.
+                        cached_len = cached[2] if len(cached) > 2 else None
+                        live_len = self._session_transcript_len(session_id)
+                        if (
+                            cached_len is not None
+                            and live_len is not None
+                            and live_len > cached_len
+                        ):
+                            # Mark stale; evict OUTSIDE this lock (the eviction
+                            # helper acquires _agent_cache_lock itself, so calling
+                            # it here would deadlock).
+                            _stale_cache_entry = True
+                            logger.debug(
+                                "Evicting cached agent for session %s: "
+                                "transcript grew externally (%d -> %d)",
+                                session_key,
+                                cached_len,
+                                live_len,
+                            )
+                        else:
+                            agent = cached[0]
+                            # Refresh LRU order so the cap enforcement evicts
+                            # truly-oldest entries, not the one we just used.
+                            if hasattr(_cache, "move_to_end"):
+                                try:
+                                    _cache.move_to_end(session_key)
+                                except KeyError:
+                                    pass
+                            self._init_cached_agent_for_turn(agent, _interrupt_depth)
+                            logger.debug("Reusing cached agent for session %s", session_key)
+            if _stale_cache_entry:
+                # The cached agent was rejected by the coherence guard above.
+                # Evict it (releases the stale agent's client pool) so the
+                # rebuild below replaces it with one built from the current
+                # on-disk transcript.
+                self._evict_cached_agent(session_key)
 
             if agent is None:
                 # Config changed or first message — create fresh agent
@@ -14134,7 +14202,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 if _cache_lock and _cache is not None:
                     with _cache_lock:
-                        _cache[session_key] = (agent, _sig)
+                        # Store the on-disk transcript length alongside the
+                        # agent so the next cache-hit can detect external
+                        # (cross-process) growth — see _session_transcript_len.
+                        _cache[session_key] = (
+                            agent,
+                            _sig,
+                            self._session_transcript_len(session_id),
+                        )
                         self._enforce_agent_cache_cap()
                 logger.debug("Created new agent for session %s (sig=%s)", session_key, _sig)
 

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -1546,3 +1546,132 @@ class TestAgentConfigSignatureUserId:
             user_id=None, user_id_alt=None,
         )
         assert sig_implicit == sig_explicit_none
+
+
+class TestAgentCacheCrossProcessCoherence:
+    """Cross-process cache coherence: a cached agent must be rebuilt when
+    another process appends to the SAME session's transcript on disk.
+
+    The gateway caches an AIAgent (with its in-memory replayed history) per
+    session for prompt-prefix caching. When a second process sharing the same
+    HERMES_HOME (e.g. the desktop's ``hermes dashboard`` backend) runs a turn
+    for the same session, it appends rows to the shared SessionDB. Without a
+    coherence guard the gateway reuses its stale cached agent and replies with
+    out-of-date context — the on-disk transcript and the live agent diverge
+    (split-brain). These tests pin the invariant: grew externally → rebuild;
+    unchanged → reuse (prompt cache preserved).
+    """
+
+    def _runner_with_db(self, db):
+        runner = _make_runner()
+        runner._session_db = db
+        return runner
+
+    def test_transcript_len_reads_live_count(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "sessions.db")
+        db.create_session("s1", source="telegram")
+        db.append_message("s1", role="user", content="hi")
+        db.append_message("s1", role="assistant", content="hello")
+
+        runner = self._runner_with_db(db)
+        assert runner._session_transcript_len("s1") == 2
+
+        # An external append is visible immediately (no caching in the probe).
+        db.append_message("s1", role="user", content="still there?")
+        assert runner._session_transcript_len("s1") == 3
+
+    def test_transcript_len_fails_safe(self, tmp_path):
+        """Missing DB / session_id / probe errors return None (fail-safe)."""
+        from hermes_state import SessionDB
+
+        # No session_db at all → None (degrade to legacy reuse behavior).
+        runner_no_db = _make_runner()
+        runner_no_db._session_db = None
+        assert runner_no_db._session_transcript_len("s1") is None
+
+        db = SessionDB(db_path=tmp_path / "sessions.db")
+        runner = self._runner_with_db(db)
+        # Falsy session_id → None, never a crash.
+        assert runner._session_transcript_len("") is None
+        assert runner._session_transcript_len(None) is None
+
+        # A probe that raises must be swallowed → None (never crash a turn).
+        class _BoomDB:
+            def message_count(self, session_id=None):
+                raise RuntimeError("db locked")
+
+        runner._session_db = _BoomDB()
+        assert runner._session_transcript_len("s1") is None
+
+    def test_external_growth_invalidates_cache_reuse(self, tmp_path):
+        """The reuse decision flips from True to False when the transcript
+        grows externally between two gateway turns.
+
+        Mirrors the cache-hit guard in the dispatch path: reuse the cached
+        agent only when the live on-disk count has NOT grown past the snapshot
+        taken when the agent was cached.
+        """
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "sessions.db")
+        db.create_session("s1", source="telegram")
+        db.append_message("s1", role="user", content="first")
+        db.append_message("s1", role="assistant", content="reply")
+
+        runner = self._runner_with_db(db)
+
+        # Gateway turn 1: cache an agent with the snapshot taken now (len == 2).
+        snapshot = runner._session_transcript_len("s1")
+        assert snapshot == 2
+        with runner._agent_cache_lock:
+            runner._agent_cache["telegram:s1"] = (object(), "sig", snapshot)
+
+        def _would_reuse() -> bool:
+            with runner._agent_cache_lock:
+                cached = runner._agent_cache.get("telegram:s1")
+            cached_len = cached[2] if len(cached) > 2 else None
+            live_len = runner._session_transcript_len("s1")
+            grew = (
+                cached_len is not None
+                and live_len is not None
+                and live_len > cached_len
+            )
+            return not grew
+
+        # Unchanged transcript → reuse (prompt cache preserved — sacred).
+        assert _would_reuse() is True
+
+        # Another process (e.g. the desktop dashboard backend) appends a turn
+        # to the SAME session in the shared DB.
+        db.append_message("s1", role="user", content="external turn from desktop")
+
+        # Now the cached agent is stale → must NOT be reused (rebuild from disk).
+        assert _would_reuse() is False
+
+    def test_legacy_two_tuple_entry_reuses(self, tmp_path):
+        """A pre-existing 2-tuple cache entry (no snapshot) skips the coherence
+        check and reuses — preserves in-flight caches across the rollout."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "sessions.db")
+        db.create_session("s1", source="telegram")
+        db.append_message("s1", role="user", content="hi")
+
+        runner = self._runner_with_db(db)
+        with runner._agent_cache_lock:
+            runner._agent_cache["telegram:s1"] = (object(), "sig")  # legacy 2-tuple
+
+        with runner._agent_cache_lock:
+            cached = runner._agent_cache.get("telegram:s1")
+        cached_len = cached[2] if len(cached) > 2 else None
+        # No snapshot → check is skipped → reuse path taken even after growth.
+        db.append_message("s1", role="assistant", content="grew")
+        live_len = runner._session_transcript_len("s1")
+        grew = (
+            cached_len is not None
+            and live_len is not None
+            and live_len > cached_len
+        )
+        assert grew is False  # legacy entries are never falsely evicted


### PR DESCRIPTION
Fixes #45966

## What & why

The gateway caches an `AIAgent` per session for prompt-prefix caching. The cached agent carries an **in-memory replay** of the transcript as it existed when the agent was built. When a **second process that shares the same `HERMES_HOME`** appends turns to the **same** session in the shared `SessionDB`, the gateway's cached agent never re-reads from disk, so the next platform turn replies with **stale context** and the on-disk transcript diverges from what the live agent reasons over (split-brain).

Concrete trigger: the desktop app spawns a `hermes dashboard` backend (a separate process from `hermes gateway run`). Both share the session DB, but each keeps its own `_agent_cache`. Reply to a platform-origin session from the desktop, then send another message from the platform — the gateway answers as if the desktop turn never happened, and the recorded transcript no longer matches the context the gateway used.

The existing eviction triggers (`/reset`, `/model`, context compression, auto-reset) all fire on **same-process** mutations via `_evict_cached_agent`. There was no signal for **external** (cross-process) transcript growth.

## The fix

Snapshot the session's on-disk message count next to the cached agent, and on a cache-hit compare it against the live count:

- Cache entry widens `(agent, sig)` → `(agent, sig, msg_count)`. All existing readers use index access (`cached[0]`/`cached[1]`, `isinstance(x, tuple)`) and tolerate a legacy 2-tuple, so in-flight caches survive the rollout (`snapshot=None` → check skipped → reuse).
- On hit: if `live_count > snapshot`, evict (releasing the stale agent's client pool) and fall through to the existing rebuild path, which reads the current transcript from disk. Otherwise reuse exactly as before — **the unchanged case is untouched, so prompt caching is preserved.**
- The count comes from `SessionDB.message_count(session_id)` (an indexed `COUNT`). A new `_session_transcript_len` helper wraps it and **fails safe**: missing DB / missing `session_id` / any probe error returns `None`, which degrades to the current reuse-the-cached-agent behavior — it never crashes a turn and never falsely evicts on a transient DB hiccup.

## How to test

Repro (no fix): run a gateway and a `hermes dashboard` against the same `HERMES_HOME`, open a platform session, reply to it through the dashboard's `/api/ws`, then send another platform message — the reply ignores the dashboard-added turn.

Automated:

```
python -m pytest tests/gateway/test_agent_cache.py -q
```

Adds `TestAgentCacheCrossProcessCoherence` (4 tests, real temp `SessionDB`):
- `test_transcript_len_reads_live_count` — probe reflects external appends immediately.
- `test_transcript_len_fails_safe` — no DB / falsy session_id / raising probe → `None`, never raises.
- `test_external_growth_invalidates_cache_reuse` — the reuse decision flips `True`→`False` after an external append; **asserts the unchanged case still reuses** (prompt-cache preserved).
- `test_legacy_two_tuple_entry_reuses` — a pre-existing 2-tuple entry skips the check and is never falsely evicted.

Verified the whole gateway cache/session/eviction surface stays green (`test_agent_cache.py` 69, plus `test_fallback_eviction.py`, `test_session.py`, `test_session_boundary_hooks.py`, `test_session_reset_notify.py`, `test_session_model_reset.py`, `test_model_switch_persistence.py` — 186 together), and the adjacent `test_run_progress_topics.py` / `test_telegram_*` files (which exercise the no-cache dispatch path) pass — that path is what caught an early version that referenced an unbound `cached` var outside the cache block, now fixed by an explicit `_stale_cache_entry` flag.

## Platforms

Developed and tested on Linux (Python 3.11). No platform-specific code; the change is in `gateway/run.py`'s session-agnostic cache path.
