### PR TITLE
feat(desktop): add macOS permission broker foundation

### DIFF
--- a/apps/desktop/electron/mac-permission-broker-contract.cjs
+++ b/apps/desktop/electron/mac-permission-broker-contract.cjs
@@ -1,0 +1,226 @@
+'use strict'
+
+const crypto = require('node:crypto')
+
+const BROKER_PROTOCOL_VERSION = 1
+const DEFAULT_TTL_MS = 30_000
+const DEFAULT_CLOCK_SKEW_MS = 5_000
+
+const MAC_PERMISSION_BROKER_METHODS = Object.freeze({
+  'permission.status': Object.freeze({
+    category: 'permissions',
+    requiresUserGrant: false,
+    description: 'Return broker registration and TCC permission status.'
+  }),
+  'permission.openSettings': Object.freeze({
+    category: 'permissions',
+    requiresUserGrant: false,
+    description: 'Open the relevant macOS System Settings privacy pane.'
+  }),
+  'screen.snapshot': Object.freeze({
+    category: 'screen',
+    requiresUserGrant: true,
+    tcc: 'ScreenCapture',
+    description: 'Capture a single screen image through the signed broker.'
+  }),
+  'screen.record': Object.freeze({
+    category: 'screen',
+    requiresUserGrant: true,
+    tcc: 'ScreenCapture',
+    description: 'Record screen content through the signed broker.'
+  }),
+  'ui.click': Object.freeze({
+    category: 'accessibility',
+    requiresUserGrant: true,
+    tcc: 'Accessibility',
+    description: 'Perform an allowlisted click through Accessibility.'
+  }),
+  'ui.type': Object.freeze({
+    category: 'accessibility',
+    requiresUserGrant: true,
+    tcc: 'Accessibility',
+    description: 'Type text through Accessibility without granting generic Python/Node access.'
+  }),
+  'automation.appleEvent': Object.freeze({
+    category: 'automation',
+    requiresUserGrant: true,
+    tcc: 'AppleEvents',
+    description: 'Send a scoped Apple Event to an allowlisted target application.'
+  }),
+  'notification.send': Object.freeze({
+    category: 'notifications',
+    requiresUserGrant: true,
+    tcc: 'UserNotifications',
+    description: 'Post a macOS notification as Hermes.'
+  }),
+  'mic.status': Object.freeze({
+    category: 'audio',
+    requiresUserGrant: true,
+    tcc: 'Microphone',
+    description: 'Return microphone permission and availability status.'
+  }),
+  'system.run.approved': Object.freeze({
+    category: 'exec',
+    requiresUserGrant: false,
+    requiresApproval: true,
+    description: 'Run a command only after app-side exec approval policy allows it.'
+  })
+})
+
+const SENSITIVE_PARAM_KEYS = new Set([
+  'authorization',
+  'cookie',
+  'key',
+  'password',
+  'secret',
+  'session',
+  'signature',
+  'token'
+])
+
+function assertToken(token) {
+  if (typeof token !== 'string' || token.length < 32) {
+    throw new Error('broker token must be a string of at least 32 characters')
+  }
+}
+
+function stableStringify(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value)
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`
+  const keys = Object.keys(value).sort()
+  return `{${keys.map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(',')}}`
+}
+
+function signingPayload(envelope) {
+  const unsigned = { ...envelope }
+  delete unsigned.signature
+  return stableStringify(unsigned)
+}
+
+function signBrokerEnvelope(envelope, token) {
+  assertToken(token)
+  return crypto.createHmac('sha256', token).update(signingPayload(envelope)).digest('hex')
+}
+
+function timingSafeEqualHex(left, right) {
+  if (typeof left !== 'string' || typeof right !== 'string') return false
+  if (!/^[0-9a-f]+$/i.test(left) || !/^[0-9a-f]+$/i.test(right)) return false
+  const a = Buffer.from(left, 'hex')
+  const b = Buffer.from(right, 'hex')
+  if (a.length !== b.length) return false
+  return crypto.timingSafeEqual(a, b)
+}
+
+function createBrokerRequest({
+  method,
+  params = {},
+  token,
+  caller = 'hermes-desktop',
+  now = Date.now(),
+  ttlMs = DEFAULT_TTL_MS,
+  nonce = crypto.randomUUID(),
+  id = crypto.randomUUID()
+}) {
+  assertToken(token)
+  if (!Object.prototype.hasOwnProperty.call(MAC_PERMISSION_BROKER_METHODS, method)) {
+    throw new Error(`unsupported macOS broker method: ${method}`)
+  }
+  if (!Number.isFinite(now) || !Number.isFinite(ttlMs) || ttlMs <= 0) {
+    throw new Error('broker request requires finite now and positive ttlMs')
+  }
+
+  const envelope = {
+    version: BROKER_PROTOCOL_VERSION,
+    id,
+    caller,
+    method,
+    params,
+    issuedAt: Math.trunc(now),
+    expiresAt: Math.trunc(now + ttlMs),
+    nonce
+  }
+  envelope.signature = signBrokerEnvelope(envelope, token)
+  return envelope
+}
+
+function verifyBrokerRequest(envelope, token, options = {}) {
+  try {
+    assertToken(token)
+  } catch (error) {
+    return { ok: false, error: error.message }
+  }
+
+  if (!envelope || typeof envelope !== 'object') {
+    return { ok: false, error: 'broker request must be an object' }
+  }
+  if (envelope.version !== BROKER_PROTOCOL_VERSION) {
+    return { ok: false, error: 'unsupported broker protocol version' }
+  }
+  if (!Object.prototype.hasOwnProperty.call(MAC_PERMISSION_BROKER_METHODS, envelope.method)) {
+    return { ok: false, error: `unsupported broker method: ${envelope.method}` }
+  }
+  if (typeof envelope.id !== 'string' || !envelope.id) {
+    return { ok: false, error: 'broker request id is required' }
+  }
+  if (typeof envelope.nonce !== 'string' || !envelope.nonce) {
+    return { ok: false, error: 'broker request nonce is required' }
+  }
+  if (!Number.isFinite(envelope.issuedAt) || !Number.isFinite(envelope.expiresAt)) {
+    return { ok: false, error: 'broker request timestamps are required' }
+  }
+
+  const now = Number.isFinite(options.now) ? options.now : Date.now()
+  const skewMs = Number.isFinite(options.clockSkewMs) ? options.clockSkewMs : DEFAULT_CLOCK_SKEW_MS
+  if (envelope.issuedAt - skewMs > now) {
+    return { ok: false, error: 'broker request was issued in the future' }
+  }
+  if (envelope.expiresAt + skewMs < now) {
+    return { ok: false, error: 'broker request expired' }
+  }
+  if (envelope.expiresAt <= envelope.issuedAt) {
+    return { ok: false, error: 'broker request expiry must be after issue time' }
+  }
+
+  const expected = signBrokerEnvelope(envelope, token)
+  if (!timingSafeEqualHex(envelope.signature, expected)) {
+    return { ok: false, error: 'broker request signature mismatch' }
+  }
+
+  if (options.seenNonces) {
+    if (options.seenNonces.has(envelope.nonce)) {
+      return { ok: false, error: 'broker request nonce replayed' }
+    }
+    options.seenNonces.add(envelope.nonce)
+  }
+
+  return {
+    ok: true,
+    id: envelope.id,
+    caller: envelope.caller,
+    method: envelope.method,
+    params: envelope.params || {},
+    capability: MAC_PERMISSION_BROKER_METHODS[envelope.method]
+  }
+}
+
+function redactForBrokerAudit(value) {
+  if (Array.isArray(value)) return value.map(redactForBrokerAudit)
+  if (!value || typeof value !== 'object') return value
+  const out = {}
+  for (const [key, child] of Object.entries(value)) {
+    out[key] = SENSITIVE_PARAM_KEYS.has(key.toLowerCase()) ? '[REDACTED]' : redactForBrokerAudit(child)
+  }
+  return out
+}
+
+module.exports = {
+  BROKER_PROTOCOL_VERSION,
+  DEFAULT_TTL_MS,
+  DEFAULT_CLOCK_SKEW_MS,
+  MAC_PERMISSION_BROKER_METHODS,
+  createBrokerRequest,
+  redactForBrokerAudit,
+  signBrokerEnvelope,
+  stableStringify,
+  verifyBrokerRequest
+}

--- a/apps/desktop/electron/mac-permission-broker-contract.test.cjs
+++ b/apps/desktop/electron/mac-permission-broker-contract.test.cjs
@@ -1,0 +1,122 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const {
+  MAC_PERMISSION_BROKER_METHODS,
+  createBrokerRequest,
+  redactForBrokerAudit,
+  stableStringify,
+  verifyBrokerRequest
+} = require('./mac-permission-broker-contract.cjs')
+
+const TOKEN = '0123456789abcdef0123456789abcdef'
+
+test('method registry only exposes explicit broker capabilities', () => {
+  assert.deepEqual(Object.keys(MAC_PERMISSION_BROKER_METHODS).sort(), [
+    'automation.appleEvent',
+    'mic.status',
+    'notification.send',
+    'permission.openSettings',
+    'permission.status',
+    'screen.record',
+    'screen.snapshot',
+    'system.run.approved',
+    'ui.click',
+    'ui.type'
+  ])
+  assert.equal(MAC_PERMISSION_BROKER_METHODS['ui.click'].tcc, 'Accessibility')
+  assert.equal(MAC_PERMISSION_BROKER_METHODS['screen.snapshot'].tcc, 'ScreenCapture')
+})
+
+test('stableStringify canonicalizes object key order for cross-language signing', () => {
+  const left = { z: 1, a: { y: true, b: [3, { d: 'x', c: 'y' }] } }
+  const right = { a: { b: [3, { c: 'y', d: 'x' }], y: true }, z: 1 }
+  assert.equal(stableStringify(left), stableStringify(right))
+})
+
+test('createBrokerRequest signs and verifyBrokerRequest accepts a fresh request', () => {
+  const request = createBrokerRequest({
+    method: 'screen.snapshot',
+    params: { displayId: 1 },
+    token: TOKEN,
+    now: 1_000,
+    ttlMs: 10_000,
+    nonce: 'nonce-1',
+    id: 'request-1'
+  })
+
+  const result = verifyBrokerRequest(request, TOKEN, { now: 2_000 })
+
+  assert.equal(result.ok, true)
+  assert.equal(result.id, 'request-1')
+  assert.equal(result.method, 'screen.snapshot')
+  assert.deepEqual(result.params, { displayId: 1 })
+  assert.equal(result.capability.tcc, 'ScreenCapture')
+})
+
+test('verifyBrokerRequest rejects method tampering after signing', () => {
+  const request = createBrokerRequest({ method: 'permission.status', token: TOKEN, now: 1_000, nonce: 'nonce-2' })
+  request.method = 'ui.click'
+
+  const result = verifyBrokerRequest(request, TOKEN, { now: 2_000 })
+
+  assert.equal(result.ok, false)
+  assert.match(result.error, /signature mismatch/)
+})
+
+test('verifyBrokerRequest rejects unsupported methods before execution', () => {
+  const request = createBrokerRequest({ method: 'permission.status', token: TOKEN, now: 1_000, nonce: 'nonce-3' })
+  request.method = 'system.run.raw'
+
+  const result = verifyBrokerRequest(request, TOKEN, { now: 2_000 })
+
+  assert.equal(result.ok, false)
+  assert.match(result.error, /unsupported broker method/)
+})
+
+test('verifyBrokerRequest rejects expired requests', () => {
+  const request = createBrokerRequest({ method: 'ui.type', token: TOKEN, now: 1_000, ttlMs: 500, nonce: 'nonce-4' })
+
+  const result = verifyBrokerRequest(request, TOKEN, { now: 10_000, clockSkewMs: 0 })
+
+  assert.equal(result.ok, false)
+  assert.match(result.error, /expired/)
+})
+
+test('verifyBrokerRequest rejects replayed nonces when caller provides a nonce cache', () => {
+  const seenNonces = new Set()
+  const request = createBrokerRequest({ method: 'notification.send', token: TOKEN, now: 1_000, nonce: 'nonce-5' })
+
+  assert.equal(verifyBrokerRequest(request, TOKEN, { now: 2_000, seenNonces }).ok, true)
+  const replay = verifyBrokerRequest(request, TOKEN, { now: 2_500, seenNonces })
+
+  assert.equal(replay.ok, false)
+  assert.match(replay.error, /replayed/)
+})
+
+test('redactForBrokerAudit removes nested sensitive values without losing structure', () => {
+  const redacted = redactForBrokerAudit({
+    method: 'automation.appleEvent',
+    params: {
+      targetBundleId: 'com.apple.finder',
+      token: 'secret-token',
+      nested: { password: 'pw', ok: true }
+    }
+  })
+
+  assert.deepEqual(redacted, {
+    method: 'automation.appleEvent',
+    params: {
+      targetBundleId: 'com.apple.finder',
+      token: '[REDACTED]',
+      nested: { password: '[REDACTED]', ok: true }
+    }
+  })
+})
+
+test('createBrokerRequest refuses short tokens and unknown methods', () => {
+  assert.throws(() => createBrokerRequest({ method: 'permission.status', token: 'short' }), /at least 32/)
+  assert.throws(() => createBrokerRequest({ method: 'raw.exec', token: TOKEN }), /unsupported macOS broker method/)
+})

--- a/apps/desktop/electron/mac-permission-broker-runtime.cjs
+++ b/apps/desktop/electron/mac-permission-broker-runtime.cjs
@@ -1,0 +1,92 @@
+'use strict'
+
+const childProcess = require('node:child_process')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const BROKER_APP_NAME = 'HermesMacBroker.app'
+const BROKER_EXECUTABLE_NAME = 'HermesMacBroker'
+
+function brokerExecutableForAppBundle(appBundlePath) {
+  if (!appBundlePath || typeof appBundlePath !== 'string') return null
+  return path.join(
+    appBundlePath,
+    'Contents',
+    'Library',
+    'LoginItems',
+    BROKER_APP_NAME,
+    'Contents',
+    'MacOS',
+    BROKER_EXECUTABLE_NAME
+  )
+}
+
+function brokerExecutableFromProcess({ platform = process.platform, resourcesPath = process.resourcesPath, execPath = process.execPath } = {}) {
+  if (platform !== 'darwin') return null
+  // Packaged Electron process executable normally lives at:
+  // /Applications/Hermes.app/Contents/MacOS/Hermes
+  if (execPath && execPath.includes('.app/Contents/MacOS/')) {
+    const appBundle = execPath.slice(0, execPath.indexOf('.app/Contents/MacOS/') + '.app'.length)
+    return brokerExecutableForAppBundle(appBundle)
+  }
+  // Fallback for tests or unusual packaged layouts where resourcesPath is:
+  // /Applications/Hermes.app/Contents/Resources
+  if (resourcesPath && resourcesPath.includes('.app/Contents/Resources')) {
+    const appBundle = resourcesPath.slice(0, resourcesPath.indexOf('.app/Contents/Resources') + '.app'.length)
+    return brokerExecutableForAppBundle(appBundle)
+  }
+  return null
+}
+
+function brokerAvailable(executable, fsImpl = fs) {
+  return Boolean(executable && fsImpl.existsSync(executable))
+}
+
+function parseBrokerJson(stdout) {
+  try {
+    return JSON.parse(stdout)
+  } catch (error) {
+    return { ok: false, error: `invalid broker JSON: ${error.message}`, raw: String(stdout || '').slice(0, 500) }
+  }
+}
+
+function runBrokerCommand(executable, args, options = {}) {
+  if (!brokerAvailable(executable, options.fsImpl || fs)) {
+    return { ok: false, error: 'macOS permission broker is not installed', executable }
+  }
+  try {
+    const stdout = (options.execFileSync || childProcess.execFileSync)(executable, args, {
+      encoding: 'utf8',
+      timeout: options.timeoutMs || 5_000,
+      stdio: ['ignore', 'pipe', 'pipe']
+    })
+    return parseBrokerJson(stdout)
+  } catch (error) {
+    return {
+      ok: false,
+      error: error.message,
+      executable,
+      stderr: String(error.stderr || '').slice(0, 500)
+    }
+  }
+}
+
+function brokerStatus(executable, options = {}) {
+  return runBrokerCommand(executable, ['--status-json'], options)
+}
+
+function openBrokerSettings(executable, pane, options = {}) {
+  return runBrokerCommand(executable, ['--open-settings', pane], options)
+}
+
+module.exports = {
+  BROKER_APP_NAME,
+  BROKER_EXECUTABLE_NAME,
+  brokerAvailable,
+  brokerExecutableForAppBundle,
+  brokerExecutableFromProcess,
+  brokerStatus,
+  openBrokerSettings,
+  parseBrokerJson,
+  runBrokerCommand
+}

--- a/apps/desktop/electron/mac-permission-broker-runtime.cjs
+++ b/apps/desktop/electron/mac-permission-broker-runtime.cjs
@@ -75,6 +75,18 @@ function brokerStatus(executable, options = {}) {
   return runBrokerCommand(executable, ['--status-json'], options)
 }
 
+function brokerServiceStatus(executable, options = {}) {
+  return runBrokerCommand(executable, ['--service-status'], options)
+}
+
+function registerBrokerLoginItem(executable, options = {}) {
+  return runBrokerCommand(executable, ['--register-login-item'], options)
+}
+
+function unregisterBrokerLoginItem(executable, options = {}) {
+  return runBrokerCommand(executable, ['--unregister-login-item'], options)
+}
+
 function openBrokerSettings(executable, pane, options = {}) {
   return runBrokerCommand(executable, ['--open-settings', pane], options)
 }
@@ -85,8 +97,11 @@ module.exports = {
   brokerAvailable,
   brokerExecutableForAppBundle,
   brokerExecutableFromProcess,
+  brokerServiceStatus,
   brokerStatus,
   openBrokerSettings,
   parseBrokerJson,
-  runBrokerCommand
+  registerBrokerLoginItem,
+  runBrokerCommand,
+  unregisterBrokerLoginItem
 }

--- a/apps/desktop/electron/mac-permission-broker-runtime.test.cjs
+++ b/apps/desktop/electron/mac-permission-broker-runtime.test.cjs
@@ -1,0 +1,69 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const test = require('node:test')
+
+const {
+  brokerAvailable,
+  brokerExecutableForAppBundle,
+  brokerExecutableFromProcess,
+  brokerStatus,
+  openBrokerSettings,
+  parseBrokerJson
+} = require('./mac-permission-broker-runtime.cjs')
+
+test('brokerExecutableForAppBundle points at LoginItems helper executable', () => {
+  assert.equal(
+    brokerExecutableForAppBundle('/Applications/Hermes.app'),
+    '/Applications/Hermes.app/Contents/Library/LoginItems/HermesMacBroker.app/Contents/MacOS/HermesMacBroker'
+  )
+  assert.equal(brokerExecutableForAppBundle(''), null)
+})
+
+test('brokerExecutableFromProcess resolves packaged app paths and ignores non-macOS', () => {
+  assert.equal(
+    brokerExecutableFromProcess({ platform: 'darwin', execPath: '/Applications/Hermes.app/Contents/MacOS/Hermes' }),
+    '/Applications/Hermes.app/Contents/Library/LoginItems/HermesMacBroker.app/Contents/MacOS/HermesMacBroker'
+  )
+  assert.equal(
+    brokerExecutableFromProcess({ platform: 'darwin', resourcesPath: '/Applications/Hermes.app/Contents/Resources', execPath: '/usr/bin/node' }),
+    '/Applications/Hermes.app/Contents/Library/LoginItems/HermesMacBroker.app/Contents/MacOS/HermesMacBroker'
+  )
+  assert.equal(brokerExecutableFromProcess({ platform: 'linux', execPath: '/opt/Hermes' }), null)
+})
+
+test('brokerAvailable uses the supplied filesystem implementation', () => {
+  assert.equal(brokerAvailable('/x', { existsSync: () => true }), true)
+  assert.equal(brokerAvailable('/x', { existsSync: () => false }), false)
+  assert.equal(brokerAvailable(null, { existsSync: () => true }), false)
+})
+
+test('parseBrokerJson returns structured errors for invalid output', () => {
+  assert.deepEqual(parseBrokerJson('{"ok":true}'), { ok: true })
+  const bad = parseBrokerJson('not-json')
+  assert.equal(bad.ok, false)
+  assert.match(bad.error, /invalid broker JSON/)
+  assert.equal(bad.raw, 'not-json')
+})
+
+test('brokerStatus and openBrokerSettings call the expected helper commands', () => {
+  const calls = []
+  const execFileSync = (exe, args) => {
+    calls.push([exe, args])
+    return '{"ok":true}'
+  }
+  const fsImpl = { existsSync: () => true }
+
+  assert.deepEqual(brokerStatus('/broker', { execFileSync, fsImpl }), { ok: true })
+  assert.deepEqual(openBrokerSettings('/broker', 'accessibility', { execFileSync, fsImpl }), { ok: true })
+  assert.deepEqual(calls, [
+    ['/broker', ['--status-json']],
+    ['/broker', ['--open-settings', 'accessibility']]
+  ])
+})
+
+test('brokerStatus reports missing helper without throwing', () => {
+  const result = brokerStatus('/missing', { fsImpl: { existsSync: () => false } })
+  assert.equal(result.ok, false)
+  assert.match(result.error, /not installed/)
+})

--- a/apps/desktop/electron/mac-permission-broker-runtime.test.cjs
+++ b/apps/desktop/electron/mac-permission-broker-runtime.test.cjs
@@ -7,9 +7,12 @@ const {
   brokerAvailable,
   brokerExecutableForAppBundle,
   brokerExecutableFromProcess,
+  brokerServiceStatus,
   brokerStatus,
   openBrokerSettings,
-  parseBrokerJson
+  parseBrokerJson,
+  registerBrokerLoginItem,
+  unregisterBrokerLoginItem
 } = require('./mac-permission-broker-runtime.cjs')
 
 test('brokerExecutableForAppBundle points at LoginItems helper executable', () => {
@@ -55,9 +58,15 @@ test('brokerStatus and openBrokerSettings call the expected helper commands', ()
   const fsImpl = { existsSync: () => true }
 
   assert.deepEqual(brokerStatus('/broker', { execFileSync, fsImpl }), { ok: true })
+  assert.deepEqual(brokerServiceStatus('/broker', { execFileSync, fsImpl }), { ok: true })
+  assert.deepEqual(registerBrokerLoginItem('/broker', { execFileSync, fsImpl }), { ok: true })
+  assert.deepEqual(unregisterBrokerLoginItem('/broker', { execFileSync, fsImpl }), { ok: true })
   assert.deepEqual(openBrokerSettings('/broker', 'accessibility', { execFileSync, fsImpl }), { ok: true })
   assert.deepEqual(calls, [
     ['/broker', ['--status-json']],
+    ['/broker', ['--service-status']],
+    ['/broker', ['--register-login-item']],
+    ['/broker', ['--unregister-login-item']],
     ['/broker', ['--open-settings', 'accessibility']]
   ])
 })

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -5,6 +5,7 @@ import fs from 'node:fs'
 import http from 'node:http'
 import https from 'node:https'
 import os from 'node:os'
+import { createRequire } from 'node:module'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 
@@ -28,6 +29,23 @@ import {
   systemPreferences
 } from 'electron'
 import nodePty from 'node-pty'
+
+const require = createRequire(import.meta.url)
+const {
+  brokerExecutableFromProcess,
+  brokerServiceStatus,
+  brokerStatus,
+  openBrokerSettings,
+  registerBrokerLoginItem,
+  unregisterBrokerLoginItem
+}: {
+  brokerExecutableFromProcess: () => string | null
+  brokerServiceStatus: (executable: string | null) => Record<string, unknown>
+  brokerStatus: (executable: string | null) => Record<string, unknown>
+  openBrokerSettings: (executable: string | null, pane: string) => Record<string, unknown>
+  registerBrokerLoginItem: (executable: string | null) => Record<string, unknown>
+  unregisterBrokerLoginItem: (executable: string | null) => Record<string, unknown>
+} = require('./mac-permission-broker-runtime.cjs')
 
 import { stopBackendChild as stopBackendChildImpl } from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
@@ -7669,6 +7687,37 @@ ipcMain.handle('hermes:profile:set', async (_event, name) => {
 
 ipcMain.on('hermes:previewShortcutActive', (_event, active) => {
   previewShortcutActive = Boolean(active)
+})
+
+ipcMain.handle('hermes:mac-broker:status', async () => {
+  const executable = brokerExecutableFromProcess()
+  const status = brokerStatus(executable)
+  return { ...status, executable }
+})
+
+ipcMain.handle('hermes:mac-broker:service-status', async () => {
+  const executable = brokerExecutableFromProcess()
+  const status = brokerServiceStatus(executable)
+  return { ...status, executable }
+})
+
+ipcMain.handle('hermes:mac-broker:register', async () => {
+  const executable = brokerExecutableFromProcess()
+  const result = registerBrokerLoginItem(executable)
+  return { ...result, executable }
+})
+
+ipcMain.handle('hermes:mac-broker:unregister', async () => {
+  const executable = brokerExecutableFromProcess()
+  const result = unregisterBrokerLoginItem(executable)
+  return { ...result, executable }
+})
+
+ipcMain.handle('hermes:mac-broker:open-settings', async (_event, pane) => {
+  const executable = brokerExecutableFromProcess()
+  const safePane = typeof pane === 'string' && pane.trim() ? pane.trim() : 'accessibility'
+  const result = openBrokerSettings(executable, safePane)
+  return { ...result, executable, pane: safePane }
 })
 
 ipcMain.handle('hermes:requestMicrophoneAccess', async () => {

--- a/apps/desktop/macos/HermesMacBroker/Sources/HermesMacBroker/main.swift
+++ b/apps/desktop/macos/HermesMacBroker/Sources/HermesMacBroker/main.swift
@@ -1,0 +1,160 @@
+import AppKit
+import ApplicationServices
+import AVFoundation
+import CoreGraphics
+import Foundation
+import UserNotifications
+
+let brokerBundleIdentifier = "com.nousresearch.hermes.macbroker"
+let brokerVersion = "0.1.0"
+
+func jsonPrint(_ value: Any) {
+    if JSONSerialization.isValidJSONObject(value),
+       let data = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys]),
+       let text = String(data: data, encoding: .utf8) {
+        print(text)
+    } else {
+        print("{\"ok\":false,\"error\":\"invalid-json\"}")
+    }
+}
+
+func microphoneStatus() -> String {
+    switch AVCaptureDevice.authorizationStatus(for: .audio) {
+    case .authorized:
+        return "authorized"
+    case .denied:
+        return "denied"
+    case .restricted:
+        return "restricted"
+    case .notDetermined:
+        return "notDetermined"
+    @unknown default:
+        return "unknown"
+    }
+}
+
+func notificationStatus() -> String {
+    let semaphore = DispatchSemaphore(value: 0)
+    var status = "unknown"
+    UNUserNotificationCenter.current().getNotificationSettings { settings in
+        switch settings.authorizationStatus {
+        case .authorized:
+            status = "authorized"
+        case .denied:
+            status = "denied"
+        case .notDetermined:
+            status = "notDetermined"
+        case .provisional:
+            status = "provisional"
+        case .ephemeral:
+            status = "ephemeral"
+        @unknown default:
+            status = "unknown"
+        }
+        semaphore.signal()
+    }
+    _ = semaphore.wait(timeout: .now() + 2.0)
+    return status
+}
+
+func screenCaptureStatus() -> String {
+    if #available(macOS 10.15, *) {
+        return CGPreflightScreenCaptureAccess() ? "authorized" : "notAuthorized"
+    }
+    return "unsupported"
+}
+
+func accessibilityStatus() -> String {
+    AXIsProcessTrusted() ? "authorized" : "notAuthorized"
+}
+
+func permissionStatusPayload() -> [String: Any] {
+    [
+        "ok": true,
+        "broker": [
+            "bundleId": brokerBundleIdentifier,
+            "version": brokerVersion,
+            "pid": ProcessInfo.processInfo.processIdentifier,
+            "executable": CommandLine.arguments.first ?? "HermesMacBroker"
+        ],
+        "permissions": [
+            "accessibility": accessibilityStatus(),
+            "screenCapture": screenCaptureStatus(),
+            "microphone": microphoneStatus(),
+            "notifications": notificationStatus(),
+            "appleEvents": "notPreflightable"
+        ]
+    ]
+}
+
+func openSettings(_ pane: String) -> Bool {
+    let anchors: [String: String] = [
+        "accessibility": "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility",
+        "screenCapture": "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture",
+        "screen": "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture",
+        "microphone": "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone",
+        "notifications": "x-apple.systempreferences:com.apple.Notifications-Settings.extension",
+        "automation": "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation",
+        "appleEvents": "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation"
+    ]
+    guard let raw = anchors[pane], let url = URL(string: raw) else {
+        return false
+    }
+    return NSWorkspace.shared.open(url)
+}
+
+func sendNotification(title: String, body: String) {
+    let center = UNUserNotificationCenter.current()
+    center.requestAuthorization(options: [.alert, .sound]) { _, _ in
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        let request = UNNotificationRequest(identifier: "hermes-macbroker-\(UUID().uuidString)", content: content, trigger: nil)
+        center.add(request) { error in
+            if let error = error {
+                jsonPrint(["ok": false, "error": error.localizedDescription])
+            } else {
+                jsonPrint(["ok": true])
+            }
+            CFRunLoopStop(CFRunLoopGetMain())
+        }
+    }
+    CFRunLoopRun()
+}
+
+func usage() {
+    jsonPrint([
+        "ok": false,
+        "error": "usage",
+        "commands": [
+            "--status-json",
+            "--open-settings <accessibility|screenCapture|microphone|notifications|automation>",
+            "--notify <title> <body>"
+        ]
+    ])
+}
+
+let args = Array(CommandLine.arguments.dropFirst())
+
+switch args.first {
+case "--status-json":
+    jsonPrint(permissionStatusPayload())
+case "--open-settings":
+    guard args.count >= 2 else {
+        usage()
+        exit(2)
+    }
+    let ok = openSettings(args[1])
+    jsonPrint(["ok": ok, "pane": args[1]])
+case "--notify":
+    guard args.count >= 3 else {
+        usage()
+        exit(2)
+    }
+    sendNotification(title: args[1], body: args[2])
+case "--help", "-h", nil:
+    usage()
+default:
+    usage()
+    exit(2)
+}

--- a/apps/desktop/macos/HermesMacBroker/Sources/HermesMacBroker/main.swift
+++ b/apps/desktop/macos/HermesMacBroker/Sources/HermesMacBroker/main.swift
@@ -2,16 +2,28 @@ import AppKit
 import ApplicationServices
 import AVFoundation
 import CoreGraphics
+import CryptoKit
+import Darwin
 import Foundation
+import ServiceManagement
 import UserNotifications
 
 let brokerBundleIdentifier = "com.nousresearch.hermes.macbroker"
-let brokerVersion = "0.1.0"
+let brokerVersion = "0.2.0"
+let maxRequestBytes = 1_048_576
+
+func jsonData(_ value: Any) -> Data? {
+    guard JSONSerialization.isValidJSONObject(value) else { return nil }
+    return try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys])
+}
+
+func jsonString(_ value: Any) -> String? {
+    guard let data = jsonData(value) else { return nil }
+    return String(data: data, encoding: .utf8)
+}
 
 func jsonPrint(_ value: Any) {
-    if JSONSerialization.isValidJSONObject(value),
-       let data = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys]),
-       let text = String(data: data, encoding: .utf8) {
+    if let text = jsonString(value) {
         print(text)
     } else {
         print("{\"ok\":false,\"error\":\"invalid-json\"}")
@@ -122,14 +134,243 @@ func sendNotification(title: String, body: String) {
     CFRunLoopRun()
 }
 
+@available(macOS 13.0, *)
+func serviceStatusName(_ status: SMAppService.Status) -> String {
+    switch status {
+    case .enabled:
+        return "enabled"
+    case .notRegistered:
+        return "notRegistered"
+    case .notFound:
+        return "notFound"
+    case .requiresApproval:
+        return "requiresApproval"
+    @unknown default:
+        return "unknown"
+    }
+}
+
+func serviceStatusPayload() -> [String: Any] {
+    if #available(macOS 13.0, *) {
+        let service = SMAppService.loginItem(identifier: brokerBundleIdentifier)
+        return ["ok": true, "bundleId": brokerBundleIdentifier, "status": serviceStatusName(service.status)]
+    }
+    return ["ok": false, "error": "SMAppService requires macOS 13+"]
+}
+
+func registerLoginItem() -> [String: Any] {
+    if #available(macOS 13.0, *) {
+        do {
+            try SMAppService.loginItem(identifier: brokerBundleIdentifier).register()
+            return serviceStatusPayload()
+        } catch {
+            return ["ok": false, "error": error.localizedDescription, "bundleId": brokerBundleIdentifier]
+        }
+    }
+    return ["ok": false, "error": "SMAppService requires macOS 13+"]
+}
+
+func unregisterLoginItem() -> [String: Any] {
+    if #available(macOS 13.0, *) {
+        do {
+            try SMAppService.loginItem(identifier: brokerBundleIdentifier).unregister()
+            return serviceStatusPayload()
+        } catch {
+            return ["ok": false, "error": error.localizedDescription, "bundleId": brokerBundleIdentifier]
+        }
+    }
+    return ["ok": false, "error": "SMAppService requires macOS 13+"]
+}
+
+func jsonEscapedString(_ string: String) -> String {
+    if let data = try? JSONSerialization.data(withJSONObject: [string], options: []),
+       let text = String(data: data, encoding: .utf8),
+       text.count >= 2 {
+        return String(text.dropFirst().dropLast())
+    }
+    return "\"\(string.replacingOccurrences(of: "\"", with: "\\\""))\""
+}
+
+func canonicalJson(_ value: Any) -> String {
+    guard JSONSerialization.isValidJSONObject(value),
+          let data = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys, .withoutEscapingSlashes]),
+          let text = String(data: data, encoding: .utf8) else {
+        return "null"
+    }
+    return text
+}
+
+func hmacHex(payload: String, token: String) -> String {
+    let key = SymmetricKey(data: Data(token.utf8))
+    let code = HMAC<SHA256>.authenticationCode(for: Data(payload.utf8), using: key)
+    return code.map { String(format: "%02x", $0) }.joined()
+}
+
+func timingSafeEqual(_ left: String, _ right: String) -> Bool {
+    let l = Array(left.utf8)
+    let r = Array(right.utf8)
+    var diff = UInt8(l.count ^ r.count)
+    for index in 0..<max(l.count, r.count) {
+        diff |= (index < l.count ? l[index] : 0) ^ (index < r.count ? r[index] : 0)
+    }
+    return diff == 0
+}
+
+func verifyBrokerEnvelope(_ request: [String: Any], token: String) -> (ok: Bool, method: String?, params: [String: Any], error: String?) {
+    guard token.count >= 32 else {
+        return (false, nil, [:], "broker token must be at least 32 characters")
+    }
+    guard let method = request["method"] as? String else {
+        return (false, nil, [:], "missing method")
+    }
+    guard method == "permission.status" else {
+        return (false, nil, [:], "unsupported broker method: \(method)")
+    }
+    guard let signature = request["signature"] as? String, !signature.isEmpty else {
+        return (false, nil, [:], "missing signature")
+    }
+    guard let issuedAt = request["issuedAt"] as? NSNumber else {
+        return (false, nil, [:], "missing issuedAt")
+    }
+    let ttlMs = (request["ttlMs"] as? NSNumber)?.doubleValue ?? 30_000
+    let nowMs = Date().timeIntervalSince1970 * 1000
+    if issuedAt.doubleValue - 5_000 > nowMs {
+        return (false, nil, [:], "request issuedAt is in the future")
+    }
+    if issuedAt.doubleValue + ttlMs + 5_000 < nowMs {
+        return (false, nil, [:], "request expired")
+    }
+    var unsigned = request
+    unsigned.removeValue(forKey: "signature")
+    let expected = hmacHex(payload: canonicalJson(unsigned), token: token)
+    guard timingSafeEqual(expected, signature) else {
+        return (false, nil, [:], "signature mismatch")
+    }
+    return (true, method, request["params"] as? [String: Any] ?? [:], nil)
+}
+
+func brokerResponse(_ request: [String: Any], token: String) -> [String: Any] {
+    let verification = verifyBrokerEnvelope(request, token: token)
+    guard verification.ok, let method = verification.method else {
+        return ["ok": false, "id": request["id"] ?? NSNull(), "error": verification.error ?? "invalid request"]
+    }
+    switch method {
+    case "permission.status":
+        var payload = permissionStatusPayload()
+        payload["id"] = request["id"] ?? NSNull()
+        payload["method"] = method
+        return payload
+    default:
+        return ["ok": false, "id": request["id"] ?? NSNull(), "error": "unsupported broker method: \(method)"]
+    }
+}
+
+func writeJsonLine(_ value: Any, to fd: Int32) {
+    let text = (jsonString(value) ?? "{\"ok\":false,\"error\":\"invalid-json\"}") + "\n"
+    let bytes = Array(text.utf8)
+    bytes.withUnsafeBytes { raw in
+        _ = Darwin.write(fd, raw.baseAddress, raw.count)
+    }
+}
+
+func readRequestLine(from fd: Int32) -> Data? {
+    var result = Data()
+    var buffer = [UInt8](repeating: 0, count: 4096)
+    while result.count < maxRequestBytes {
+        let count = buffer.withUnsafeMutableBytes { raw in
+            Darwin.read(fd, raw.baseAddress, raw.count)
+        }
+        if count <= 0 { break }
+        if let newline = buffer[..<count].firstIndex(of: UInt8(ascii: "\n")) {
+            result.append(contentsOf: buffer[..<newline])
+            break
+        }
+        result.append(contentsOf: buffer[..<count])
+    }
+    return result.isEmpty ? nil : result
+}
+
+func handleClient(fd: Int32, token: String) {
+    defer { Darwin.close(fd) }
+    guard let data = readRequestLine(from: fd) else {
+        writeJsonLine(["ok": false, "error": "empty request"], to: fd)
+        return
+    }
+    do {
+        guard let request = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            writeJsonLine(["ok": false, "error": "request must be a JSON object"], to: fd)
+            return
+        }
+        writeJsonLine(brokerResponse(request, token: token), to: fd)
+    } catch {
+        writeJsonLine(["ok": false, "error": "invalid JSON: \(error.localizedDescription)"], to: fd)
+    }
+}
+
+func serve(socketPath: String, token: String) -> Never {
+    let fd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+    guard fd >= 0 else {
+        jsonPrint(["ok": false, "error": "socket failed: \(String(cString: strerror(errno)))"])
+        exit(1)
+    }
+    var addr = sockaddr_un()
+    addr.sun_family = sa_family_t(AF_UNIX)
+    let pathBytes = Array(socketPath.utf8CString)
+    let maxPath = MemoryLayout.size(ofValue: addr.sun_path)
+    guard pathBytes.count <= maxPath else {
+        jsonPrint(["ok": false, "error": "socket path too long"])
+        exit(1)
+    }
+    _ = socketPath.withCString { path in unlink(path) }
+    withUnsafeMutablePointer(to: &addr.sun_path) { pointer in
+        pointer.withMemoryRebound(to: CChar.self, capacity: maxPath) { chars in
+            for index in 0..<pathBytes.count {
+                chars[index] = pathBytes[index]
+            }
+        }
+    }
+    let len = socklen_t(MemoryLayout<sockaddr_un>.offset(of: \.sun_path)! + pathBytes.count)
+    let bindResult = withUnsafePointer(to: &addr) { pointer in
+        pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPointer in
+            Darwin.bind(fd, sockaddrPointer, len)
+        }
+    }
+    guard bindResult == 0 else {
+        jsonPrint(["ok": false, "error": "bind failed: \(String(cString: strerror(errno)))", "socket": socketPath])
+        exit(1)
+    }
+    chmod(socketPath, 0o600)
+    guard Darwin.listen(fd, 16) == 0 else {
+        jsonPrint(["ok": false, "error": "listen failed: \(String(cString: strerror(errno)))"])
+        exit(1)
+    }
+    jsonPrint(["ok": true, "event": "listening", "socket": socketPath, "bundleId": brokerBundleIdentifier, "version": brokerVersion])
+    fflush(stdout)
+    while true {
+        let client = Darwin.accept(fd, nil, nil)
+        if client >= 0 {
+            handleClient(fd: client, token: token)
+        }
+    }
+}
+
+func argValue(_ args: [String], _ name: String) -> String? {
+    guard let index = args.firstIndex(of: name), index + 1 < args.count else { return nil }
+    return args[index + 1]
+}
+
 func usage() {
     jsonPrint([
         "ok": false,
         "error": "usage",
         "commands": [
             "--status-json",
+            "--service-status",
+            "--register-login-item",
+            "--unregister-login-item",
             "--open-settings <accessibility|screenCapture|microphone|notifications|automation>",
-            "--notify <title> <body>"
+            "--notify <title> <body>",
+            "--serve --socket <path> --token <token>"
         ]
     ])
 }
@@ -139,6 +380,12 @@ let args = Array(CommandLine.arguments.dropFirst())
 switch args.first {
 case "--status-json":
     jsonPrint(permissionStatusPayload())
+case "--service-status":
+    jsonPrint(serviceStatusPayload())
+case "--register-login-item":
+    jsonPrint(registerLoginItem())
+case "--unregister-login-item":
+    jsonPrint(unregisterLoginItem())
 case "--open-settings":
     guard args.count >= 2 else {
         usage()
@@ -152,6 +399,12 @@ case "--notify":
         exit(2)
     }
     sendNotification(title: args[1], body: args[2])
+case "--serve":
+    guard let socketPath = argValue(args, "--socket"), let token = argValue(args, "--token") else {
+        usage()
+        exit(2)
+    }
+    serve(socketPath: socketPath, token: token)
 case "--help", "-h", nil:
     usage()
 default:

--- a/apps/desktop/macos/HermesMacBroker/Sources/HermesMacBroker/main.swift
+++ b/apps/desktop/macos/HermesMacBroker/Sources/HermesMacBroker/main.swift
@@ -46,6 +46,10 @@ func microphoneStatus() -> String {
 }
 
 func notificationStatus() -> String {
+    // UNUserNotificationCenter can raise an Objective-C exception for an
+    // unbundled swiftc-built helper. Keep status probing safe for integration
+    // tests and direct CLI diagnostics; the packaged LoginItem has a bundle id.
+    guard Bundle.main.bundleIdentifier != nil else { return "unavailable" }
     let semaphore = DispatchSemaphore(value: 0)
     var status = "unknown"
     UNUserNotificationCenter.current().getNotificationSettings { settings in
@@ -216,9 +220,32 @@ func timingSafeEqual(_ left: String, _ right: String) -> Bool {
     return diff == 0
 }
 
+let brokerProtocolVersion = 1
+let brokerClockSkewMs = 5_000.0
+let brokerNonceCacheLimit = 1024
+var brokerSeenNonces: [String: Double] = [:]
+
+func rememberBrokerNonce(_ nonce: String, expiresAt: Double, nowMs: Double) -> Bool {
+    for (cachedNonce, cachedExpiry) in brokerSeenNonces where cachedExpiry + brokerClockSkewMs < nowMs {
+        brokerSeenNonces.removeValue(forKey: cachedNonce)
+    }
+    if brokerSeenNonces[nonce] != nil {
+        return false
+    }
+    if brokerSeenNonces.count >= brokerNonceCacheLimit,
+       let oldest = brokerSeenNonces.min(by: { $0.value < $1.value })?.key {
+        brokerSeenNonces.removeValue(forKey: oldest)
+    }
+    brokerSeenNonces[nonce] = expiresAt
+    return true
+}
+
 func verifyBrokerEnvelope(_ request: [String: Any], token: String) -> (ok: Bool, method: String?, params: [String: Any], error: String?) {
     guard token.count >= 32 else {
         return (false, nil, [:], "broker token must be at least 32 characters")
+    }
+    guard let version = request["version"] as? NSNumber, version.intValue == brokerProtocolVersion else {
+        return (false, nil, [:], "unsupported broker protocol version")
     }
     guard let method = request["method"] as? String else {
         return (false, nil, [:], "missing method")
@@ -226,18 +253,27 @@ func verifyBrokerEnvelope(_ request: [String: Any], token: String) -> (ok: Bool,
     guard method == "permission.status" else {
         return (false, nil, [:], "unsupported broker method: \(method)")
     }
+    guard let id = request["id"] as? String, !id.isEmpty else {
+        return (false, nil, [:], "missing id")
+    }
+    guard let nonce = request["nonce"] as? String, !nonce.isEmpty else {
+        return (false, nil, [:], "missing nonce")
+    }
     guard let signature = request["signature"] as? String, !signature.isEmpty else {
         return (false, nil, [:], "missing signature")
     }
-    guard let issuedAt = request["issuedAt"] as? NSNumber else {
-        return (false, nil, [:], "missing issuedAt")
+    guard let issuedAt = request["issuedAt"] as? NSNumber,
+          let expiresAt = request["expiresAt"] as? NSNumber else {
+        return (false, nil, [:], "missing broker timestamps")
     }
-    let ttlMs = (request["ttlMs"] as? NSNumber)?.doubleValue ?? 30_000
+    guard expiresAt.doubleValue > issuedAt.doubleValue else {
+        return (false, nil, [:], "request expiry must be after issue time")
+    }
     let nowMs = Date().timeIntervalSince1970 * 1000
-    if issuedAt.doubleValue - 5_000 > nowMs {
+    if issuedAt.doubleValue - brokerClockSkewMs > nowMs {
         return (false, nil, [:], "request issuedAt is in the future")
     }
-    if issuedAt.doubleValue + ttlMs + 5_000 < nowMs {
+    if expiresAt.doubleValue + brokerClockSkewMs < nowMs {
         return (false, nil, [:], "request expired")
     }
     var unsigned = request
@@ -245,6 +281,9 @@ func verifyBrokerEnvelope(_ request: [String: Any], token: String) -> (ok: Bool,
     let expected = hmacHex(payload: canonicalJson(unsigned), token: token)
     guard timingSafeEqual(expected, signature) else {
         return (false, nil, [:], "signature mismatch")
+    }
+    guard rememberBrokerNonce(nonce, expiresAt: expiresAt.doubleValue, nowMs: nowMs) else {
+        return (false, nil, [:], "request nonce replayed")
     }
     return (true, method, request["params"] as? [String: Any] ?? [:], nil)
 }

--- a/apps/desktop/scripts/after-pack.mjs
+++ b/apps/desktop/scripts/after-pack.mjs
@@ -19,11 +19,27 @@
  *   - packager.appInfo.productFilename: the exe basename (e.g. 'Hermes')
  */
 
+import { createRequire } from 'node:module'
 import path from 'node:path'
 
 import { stampExeIdentity } from './set-exe-identity.mjs'
 
+const require = createRequire(import.meta.url)
+const { stageMacPermissionBroker } = require('./stage-mac-permission-broker.cjs')
+
 export default async function afterPack(context) {
+  if (context.electronPlatformName === 'darwin') {
+    try {
+      const result = await stageMacPermissionBroker(context)
+      if (result?.installed) {
+        console.log(`[after-pack] staged HermesMacBroker at ${result.installed}`)
+      }
+    } catch (err) {
+      throw new Error(`macOS permission broker staging failed: ${err.message}`)
+    }
+    return
+  }
+
   if (context.electronPlatformName !== 'win32') {
     return
   }

--- a/apps/desktop/scripts/stage-mac-permission-broker.cjs
+++ b/apps/desktop/scripts/stage-mac-permission-broker.cjs
@@ -8,7 +8,7 @@ const path = require('node:path')
 const BROKER_BUNDLE_ID = 'com.nousresearch.hermes.macbroker'
 const BROKER_APP_NAME = 'HermesMacBroker.app'
 const BROKER_EXECUTABLE_NAME = 'HermesMacBroker'
-const BROKER_VERSION = '0.1.0'
+const BROKER_VERSION = '0.2.0'
 
 function xmlEscape(value) {
   return String(value)
@@ -86,6 +86,10 @@ function swiftcArgs({ source, output }) {
     'AVFoundation',
     '-framework',
     'CoreGraphics',
+    '-framework',
+    'CryptoKit',
+    '-framework',
+    'ServiceManagement',
     '-framework',
     'UserNotifications'
   ]

--- a/apps/desktop/scripts/stage-mac-permission-broker.cjs
+++ b/apps/desktop/scripts/stage-mac-permission-broker.cjs
@@ -1,0 +1,176 @@
+'use strict'
+
+const childProcess = require('node:child_process')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const BROKER_BUNDLE_ID = 'com.nousresearch.hermes.macbroker'
+const BROKER_APP_NAME = 'HermesMacBroker.app'
+const BROKER_EXECUTABLE_NAME = 'HermesMacBroker'
+const BROKER_VERSION = '0.1.0'
+
+function xmlEscape(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;')
+}
+
+function brokerSourcePath(desktopRoot) {
+  return path.join(desktopRoot, 'macos', 'HermesMacBroker', 'Sources', 'HermesMacBroker', 'main.swift')
+}
+
+function brokerBuildRoot(desktopRoot) {
+  return path.join(desktopRoot, 'build', 'mac-permission-broker')
+}
+
+function brokerBundlePath(root) {
+  return path.join(root, BROKER_APP_NAME)
+}
+
+function brokerLoginItemsDir(appBundlePath) {
+  return path.join(appBundlePath, 'Contents', 'Library', 'LoginItems')
+}
+
+function brokerBundleInfoPlist({ bundleId = BROKER_BUNDLE_ID, version = BROKER_VERSION } = {}) {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleDisplayName</key>
+  <string>Hermes Mac Broker</string>
+  <key>CFBundleExecutable</key>
+  <string>${BROKER_EXECUTABLE_NAME}</string>
+  <key>CFBundleIdentifier</key>
+  <string>${xmlEscape(bundleId)}</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>HermesMacBroker</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>${xmlEscape(version)}</string>
+  <key>CFBundleVersion</key>
+  <string>${xmlEscape(version)}</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>13.0</string>
+  <key>LSUIElement</key>
+  <true/>
+  <key>NSAppleEventsUsageDescription</key>
+  <string>Hermes uses Automation only for user-approved Mac app actions routed through the signed broker.</string>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>Hermes uses the microphone for voice input when routed through the signed broker.</string>
+  <key>NSUserNotificationsUsageDescription</key>
+  <string>Hermes sends local notifications through the signed broker when requested.</string>
+</dict>
+</plist>
+`
+}
+
+function swiftcArgs({ source, output }) {
+  return [
+    source,
+    '-o',
+    output,
+    '-framework',
+    'AppKit',
+    '-framework',
+    'ApplicationServices',
+    '-framework',
+    'AVFoundation',
+    '-framework',
+    'CoreGraphics',
+    '-framework',
+    'UserNotifications'
+  ]
+}
+
+function writeBrokerBundle({ desktopRoot, outputRoot = brokerBuildRoot(desktopRoot), execFile = childProcess.execFileSync } = {}) {
+  if (!desktopRoot) throw new Error('desktopRoot is required')
+  const source = brokerSourcePath(desktopRoot)
+  if (!fs.existsSync(source)) throw new Error(`Missing HermesMacBroker Swift source: ${source}`)
+
+  const bundle = brokerBundlePath(outputRoot)
+  const contents = path.join(bundle, 'Contents')
+  const macos = path.join(contents, 'MacOS')
+  const infoPlist = path.join(contents, 'Info.plist')
+  const executable = path.join(macos, BROKER_EXECUTABLE_NAME)
+
+  fs.rmSync(bundle, { recursive: true, force: true })
+  fs.mkdirSync(macos, { recursive: true })
+  fs.writeFileSync(infoPlist, brokerBundleInfoPlist(), 'utf8')
+  execFile('swiftc', swiftcArgs({ source, output: executable }), { stdio: 'pipe' })
+  fs.chmodSync(executable, 0o755)
+  return { bundle, executable, infoPlist }
+}
+
+function maybeAdHocSignBundle(bundle, { execFile = childProcess.execFileSync, enabled = false } = {}) {
+  if (!enabled) return false
+  execFile('/usr/bin/codesign', ['--force', '--deep', '--sign', '-', bundle], { stdio: 'pipe' })
+  return true
+}
+
+function installBrokerIntoApp({ appBundlePath, brokerBundle, fsImpl = fs } = {}) {
+  if (!appBundlePath) throw new Error('appBundlePath is required')
+  if (!brokerBundle) throw new Error('brokerBundle is required')
+  const loginItems = brokerLoginItemsDir(appBundlePath)
+  const destination = path.join(loginItems, BROKER_APP_NAME)
+  fsImpl.mkdirSync(loginItems, { recursive: true })
+  fsImpl.rmSync(destination, { recursive: true, force: true })
+  fsImpl.cpSync(brokerBundle, destination, { recursive: true })
+  return destination
+}
+
+function shouldStageBroker(platform, env = process.env) {
+  if (env.HERMES_DESKTOP_SKIP_MAC_BROKER === '1') return false
+  return platform === 'darwin'
+}
+
+async function stageMacPermissionBroker(context, deps = {}) {
+  const platform = context?.electronPlatformName
+  if (!shouldStageBroker(platform, deps.env || process.env)) return null
+
+  const desktopRoot = deps.desktopRoot || path.resolve(__dirname, '..')
+  const productName = context.packager?.appInfo?.productFilename || 'Hermes'
+  const appBundlePath = deps.appBundlePath || path.join(context.appOutDir, `${productName}.app`)
+  const execFile = deps.execFile || childProcess.execFileSync
+  const build = writeBrokerBundle({ desktopRoot, execFile })
+  maybeAdHocSignBundle(build.bundle, {
+    execFile,
+    enabled: (deps.env || process.env).HERMES_DESKTOP_SIGN_MAC_BROKER_ADHOC === '1'
+  })
+  const installed = installBrokerIntoApp({ appBundlePath, brokerBundle: build.bundle })
+  return { ...build, installed }
+}
+
+module.exports = {
+  BROKER_APP_NAME,
+  BROKER_BUNDLE_ID,
+  BROKER_EXECUTABLE_NAME,
+  BROKER_VERSION,
+  brokerBuildRoot,
+  brokerBundleInfoPlist,
+  brokerBundlePath,
+  brokerLoginItemsDir,
+  brokerSourcePath,
+  installBrokerIntoApp,
+  maybeAdHocSignBundle,
+  shouldStageBroker,
+  stageMacPermissionBroker,
+  swiftcArgs,
+  writeBrokerBundle
+}
+
+if (require.main === module) {
+  const desktopRoot = path.resolve(__dirname, '..')
+  const outputRoot = process.argv[2] ? path.resolve(process.argv[2]) : path.join(os.tmpdir(), `hermes-macbroker-${process.pid}`)
+  const build = writeBrokerBundle({ desktopRoot, outputRoot })
+  maybeAdHocSignBundle(build.bundle, { enabled: process.env.HERMES_DESKTOP_SIGN_MAC_BROKER_ADHOC === '1' })
+  console.log(JSON.stringify(build, null, 2))
+}

--- a/apps/desktop/scripts/stage-mac-permission-broker.test.cjs
+++ b/apps/desktop/scripts/stage-mac-permission-broker.test.cjs
@@ -1,0 +1,87 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const test = require('node:test')
+
+const {
+  BROKER_APP_NAME,
+  BROKER_BUNDLE_ID,
+  BROKER_EXECUTABLE_NAME,
+  brokerBundleInfoPlist,
+  brokerLoginItemsDir,
+  installBrokerIntoApp,
+  shouldStageBroker,
+  stageMacPermissionBroker,
+  swiftcArgs
+} = require('./stage-mac-permission-broker.cjs')
+
+test('brokerBundleInfoPlist declares a stable helper identity and usage descriptions', () => {
+  const plist = brokerBundleInfoPlist()
+
+  assert.match(plist, new RegExp(`<string>${BROKER_BUNDLE_ID}</string>`))
+  assert.match(plist, new RegExp(`<string>${BROKER_EXECUTABLE_NAME}</string>`))
+  assert.match(plist, /NSMicrophoneUsageDescription/)
+  assert.match(plist, /NSAppleEventsUsageDescription/)
+  assert.match(plist, /LSUIElement/)
+})
+
+test('swiftcArgs compiles the helper with required macOS frameworks', () => {
+  const args = swiftcArgs({ source: '/tmp/main.swift', output: '/tmp/HermesMacBroker' })
+
+  assert.deepEqual(args.slice(0, 3), ['/tmp/main.swift', '-o', '/tmp/HermesMacBroker'])
+  assert.ok(args.includes('AppKit'))
+  assert.ok(args.includes('ApplicationServices'))
+  assert.ok(args.includes('AVFoundation'))
+  assert.ok(args.includes('UserNotifications'))
+})
+
+test('shouldStageBroker only stages on darwin unless explicitly skipped', () => {
+  assert.equal(shouldStageBroker('darwin', {}), true)
+  assert.equal(shouldStageBroker('linux', {}), false)
+  assert.equal(shouldStageBroker('win32', {}), false)
+  assert.equal(shouldStageBroker('darwin', { HERMES_DESKTOP_SKIP_MAC_BROKER: '1' }), false)
+})
+
+test('installBrokerIntoApp copies the helper into Contents/Library/LoginItems', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-broker-test-'))
+  const app = path.join(tmp, 'Hermes.app')
+  const broker = path.join(tmp, BROKER_APP_NAME)
+  fs.mkdirSync(path.join(broker, 'Contents', 'MacOS'), { recursive: true })
+  fs.writeFileSync(path.join(broker, 'Contents', 'MacOS', BROKER_EXECUTABLE_NAME), 'binary')
+
+  const installed = installBrokerIntoApp({ appBundlePath: app, brokerBundle: broker })
+
+  assert.equal(installed, path.join(brokerLoginItemsDir(app), BROKER_APP_NAME))
+  assert.equal(fs.readFileSync(path.join(installed, 'Contents', 'MacOS', BROKER_EXECUTABLE_NAME), 'utf8'), 'binary')
+})
+
+test('stageMacPermissionBroker builds and installs when platform is darwin', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-broker-stage-'))
+  const desktopRoot = path.join(tmp, 'desktop')
+  const source = path.join(desktopRoot, 'macos', 'HermesMacBroker', 'Sources', 'HermesMacBroker')
+  fs.mkdirSync(source, { recursive: true })
+  fs.writeFileSync(path.join(source, 'main.swift'), 'print("stub")')
+
+  const calls = []
+  const execFile = (command, args) => {
+    calls.push([command, args])
+    const output = args[args.indexOf('-o') + 1]
+    fs.writeFileSync(output, '#!/bin/sh\necho stub\n')
+  }
+
+  const context = {
+    electronPlatformName: 'darwin',
+    appOutDir: path.join(tmp, 'release', 'mac-arm64'),
+    packager: { appInfo: { productFilename: 'Hermes' } }
+  }
+  fs.mkdirSync(path.join(context.appOutDir, 'Hermes.app'), { recursive: true })
+
+  const result = await stageMacPermissionBroker(context, { desktopRoot, execFile, env: {} })
+
+  assert.match(result.installed, /Hermes\.app\/Contents\/Library\/LoginItems\/HermesMacBroker\.app$/)
+  assert.equal(calls[0][0], 'swiftc')
+  assert.equal(fs.existsSync(path.join(result.installed, 'Contents', 'Info.plist')), true)
+})

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2514,6 +2514,37 @@ def get_python_path() -> str:
     return sys.executable
 
 
+def get_hermes_cli_entrypoint() -> str | None:
+    """Return a stable Hermes CLI entrypoint when one exists.
+
+    On macOS launchd surfaces the basename of ``ProgramArguments[0]`` in
+    Background Items. Launching ``venv/bin/python -m hermes_cli.main`` works,
+    but it makes Hermes look like raw Python. Prefer the installed ``hermes``
+    console script from the same venv so the service definition is visibly
+    Hermes-owned. This is label/identity cleanup only; a true TCC fix still
+    needs a signed app/helper broker.
+    """
+    venv = _detect_venv_dir()
+    candidates: list[Path] = []
+    if venv is not None:
+        candidates.append(venv / ("Scripts/hermes.exe" if is_windows() else "bin/hermes"))
+
+    try:
+        python_path = Path(get_python_path())
+        candidates.append(python_path.parent / ("hermes.exe" if is_windows() else "hermes"))
+    except Exception:
+        pass
+
+    for candidate in candidates:
+        if candidate.exists() and os.access(candidate, os.X_OK):
+            return str(candidate)
+
+    resolved = shutil.which("hermes")
+    if resolved:
+        return resolved
+    return None
+
+
 # =============================================================================
 # Systemd (Linux)
 # =============================================================================
@@ -3869,8 +3900,27 @@ def _launchd_fallback_to_detached(reason: str, *, exit_on_failure: bool = True) 
     return False
 
 
+def _launchd_program_arguments(profile_arg: str = "") -> list[str]:
+    """Build launchd ProgramArguments for the gateway service.
+
+    Prefer the Hermes console-script entrypoint on macOS so System Settings
+    Background Items shows a Hermes-owned command instead of a raw Python
+    interpreter. Fall back to ``python -m hermes_cli.main`` when the console
+    script is unavailable.
+    """
+    hermes_entrypoint = get_hermes_cli_entrypoint()
+    if hermes_entrypoint:
+        args = [hermes_entrypoint]
+    else:
+        args = [get_python_path(), "-m", "hermes_cli.main"]
+
+    if profile_arg:
+        args.extend(profile_arg.split())
+    args.extend(["gateway", "run", "--replace"])
+    return args
+
+
 def generate_launchd_plist() -> str:
-    python_path = get_python_path()
     # Stable cwd anchor — never the volatile source checkout. See
     # _stable_service_working_dir() for the rationale (same rot risk applies
     # to launchd's WorkingDirectory as to systemd's).
@@ -3907,22 +3957,8 @@ def generate_launchd_plist() -> str:
         )
     )
 
-    # Build ProgramArguments array, including --profile when using a named profile
-    prog_args = [
-        f"<string>{python_path}</string>",
-        "<string>-m</string>",
-        "<string>hermes_cli.main</string>",
-    ]
-    if profile_arg:
-        for part in profile_arg.split():
-            prog_args.append(f"<string>{part}</string>")
-    prog_args.extend(
-        [
-            "<string>gateway</string>",
-            "<string>run</string>",
-            "<string>--replace</string>",
-        ]
-    )
+    # Build ProgramArguments array, including --profile when using a named profile.
+    prog_args = [f"<string>{part}</string>" for part in _launchd_program_arguments(profile_arg)]
     prog_args_xml = "\n        ".join(prog_args)
 
     return f"""<?xml version="1.0" encoding="UTF-8"?>

--- a/hermes_cli/macos_permission_broker.py
+++ b/hermes_cli/macos_permission_broker.py
@@ -92,7 +92,7 @@ def create_broker_request(
         "method": method,
         "params": params or {},
         "issuedAt": issued_at,
-        "ttlMs": ttl_ms,
+        "expiresAt": issued_at + int(ttl_ms),
         "nonce": nonce or secrets.token_hex(16),
     }
     envelope["signature"] = _sign(envelope, token)

--- a/hermes_cli/macos_permission_broker.py
+++ b/hermes_cli/macos_permission_broker.py
@@ -1,0 +1,174 @@
+"""macOS Hermes permission broker client.
+
+This module intentionally starts with the narrowest safe live route:
+``permission.status``. Protected actions can be added only after the native
+broker implements and tests them.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import socket
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+try:
+    from hermes_constants import get_hermes_home
+except Exception:  # pragma: no cover - fallback for isolated imports
+    def get_hermes_home() -> Path:  # type: ignore[misc]
+        return Path(os.environ.get("HERMES_HOME", "~/.hermes")).expanduser()
+
+BROKER_PROTOCOL_VERSION = 1
+DEFAULT_TTL_MS = 30_000
+DEFAULT_TIMEOUT_SECONDS = 5.0
+DEFAULT_SOCKET_NAME = "mac-permission-broker.sock"
+DEFAULT_TOKEN_NAME = "mac-permission-broker.token"
+ALLOWED_METHODS = {"permission.status"}
+
+
+class MacPermissionBrokerError(RuntimeError):
+    """Raised when the broker request cannot be completed."""
+
+
+def broker_runtime_dir() -> Path:
+    path = get_hermes_home() / "run"
+    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    return path
+
+
+def default_socket_path() -> Path:
+    return broker_runtime_dir() / DEFAULT_SOCKET_NAME
+
+
+def default_token_path() -> Path:
+    return broker_runtime_dir() / DEFAULT_TOKEN_NAME
+
+
+def load_or_create_broker_token(path: Path | None = None) -> str:
+    token_path = path or default_token_path()
+    if token_path.exists():
+        return token_path.read_text(encoding="utf-8").strip()
+    token_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    token = secrets.token_hex(32)
+    token_path.write_text(token, encoding="utf-8")
+    token_path.chmod(0o600)
+    return token
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _sign(envelope: dict[str, Any], token: str) -> str:
+    payload = dict(envelope)
+    payload.pop("signature", None)
+    return hmac.new(token.encode("utf-8"), _stable_json(payload).encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def create_broker_request(
+    method: str,
+    params: dict[str, Any] | None = None,
+    *,
+    token: str,
+    now_ms: int | None = None,
+    ttl_ms: int = DEFAULT_TTL_MS,
+    nonce: str | None = None,
+    request_id: str | None = None,
+) -> dict[str, Any]:
+    if method not in ALLOWED_METHODS:
+        raise MacPermissionBrokerError(f"unsupported broker method: {method}")
+    if len(token) < 32:
+        raise MacPermissionBrokerError("broker token must be at least 32 characters")
+    issued_at = int(now_ms if now_ms is not None else time.time() * 1000)
+    envelope: dict[str, Any] = {
+        "version": BROKER_PROTOCOL_VERSION,
+        "id": request_id or str(uuid.uuid4()),
+        "method": method,
+        "params": params or {},
+        "issuedAt": issued_at,
+        "ttlMs": ttl_ms,
+        "nonce": nonce or secrets.token_hex(16),
+    }
+    envelope["signature"] = _sign(envelope, token)
+    return envelope
+
+
+def send_broker_request(
+    request: dict[str, Any],
+    *,
+    socket_path: Path | str | None = None,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    path = str(socket_path or default_socket_path())
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+            client.settimeout(timeout)
+            client.connect(path)
+            client.sendall(_stable_json(request).encode("utf-8") + b"\n")
+            chunks: list[bytes] = []
+            while True:
+                chunk = client.recv(4096)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                if b"\n" in chunk:
+                    break
+    except OSError as exc:
+        raise MacPermissionBrokerError(f"macOS permission broker unavailable at {path}: {exc}") from exc
+    raw = b"".join(chunks).split(b"\n", 1)[0]
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        raise MacPermissionBrokerError(f"invalid broker response: {raw[:200]!r}") from exc
+    if not isinstance(payload, dict):
+        raise MacPermissionBrokerError("broker response must be a JSON object")
+    return payload
+
+
+def broker_permission_status(
+    *,
+    socket_path: Path | str | None = None,
+    token: str | None = None,
+    token_path: Path | None = None,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    broker_token = token or load_or_create_broker_token(token_path)
+    request = create_broker_request("permission.status", token=broker_token)
+    return send_broker_request(request, socket_path=socket_path, timeout=timeout)
+
+
+def cmd_macos_permission_broker(args: Any) -> None:
+    """CLI entrypoint for ``hermes mac-broker``."""
+    command = getattr(args, "mac_broker_command", None)
+    if command in (None, "status"):
+        token_file = getattr(args, "token_file", None)
+        payload: dict[str, Any]
+        try:
+            payload = broker_permission_status(
+                socket_path=getattr(args, "socket", None),
+                token_path=Path(token_file).expanduser() if token_file else None,
+                timeout=float(getattr(args, "timeout", DEFAULT_TIMEOUT_SECONDS)),
+            )
+        except MacPermissionBrokerError as exc:
+            payload = {"ok": False, "error": str(exc)}
+        print(json.dumps(payload, sort_keys=True))
+        return
+    print(json.dumps({"ok": False, "error": f"unknown mac-broker command: {command}"}, sort_keys=True))
+
+
+__all__ = [
+    "MacPermissionBrokerError",
+    "broker_permission_status",
+    "cmd_macos_permission_broker",
+    "create_broker_request",
+    "default_socket_path",
+    "default_token_path",
+    "load_or_create_broker_token",
+    "send_broker_request",
+]

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12402,7 +12402,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "computer-use",
         "config", "console", "cron", "curator", "dashboard", "serve", "debug", "doctor",
         "dump", "fallback", "gateway", "hooks", "import", "insights",
-        "gui", "desktop", "kanban", "login", "logout", "logs", "lsp", "mcp", "memory", "migrate", "moa",
+        "gui", "desktop", "kanban", "login", "logout", "logs", "lsp", "mac-broker", "mcp", "memory", "migrate", "moa",
         "journey", "memory-graph", "learning",
         "model", "pairing", "pets", "plugins", "portal", "postinstall", "profile",
         "project", "proxy",
@@ -13164,6 +13164,31 @@ def main():
     # status command  (parser built in hermes_cli/subcommands/status.py)
     # =========================================================================
     build_status_parser(subparsers, cmd_status=cmd_status)
+
+
+    # =========================================================================
+    # mac-broker command — local macOS permission broker diagnostics
+    # =========================================================================
+    from hermes_cli.macos_permission_broker import cmd_macos_permission_broker
+
+    mac_broker_parser = subparsers.add_parser(
+        "mac-broker",
+        help="Inspect the local macOS permission broker",
+        description=(
+            "Inspect the Hermes macOS permission broker over its authenticated "
+            "local Unix-socket IPC path. Starts with the safe permission.status route."
+        ),
+    )
+    mac_broker_subparsers = mac_broker_parser.add_subparsers(dest="mac_broker_command")
+    mac_broker_status = mac_broker_subparsers.add_parser(
+        "status",
+        help="Request permission.status from the running macOS broker daemon",
+    )
+    mac_broker_status.add_argument("--socket", default=None, help="Override broker Unix socket path")
+    mac_broker_status.add_argument("--token-file", default=None, help="Override broker token file path")
+    mac_broker_status.add_argument("--timeout", type=float, default=5.0, help="Socket timeout in seconds")
+    mac_broker_status.set_defaults(func=cmd_macos_permission_broker)
+    mac_broker_parser.set_defaults(func=cmd_macos_permission_broker)
 
     # =========================================================================
     # cron command  (parser built in hermes_cli/subcommands/cron.py)

--- a/plans/macos-permission-broker.md
+++ b/plans/macos-permission-broker.md
@@ -1,0 +1,201 @@
+# macOS Permission Broker for Hermes
+
+Status: design + initial IPC contract scaffold.  
+Owner area: Desktop + gateway + macOS service management.  
+Goal: stable Hermes-owned macOS permission identity without granting broad TCC access to generic Python or Node runtimes.
+
+## Decision
+
+Hermes should adopt an OpenClaw-style macOS permission broker, but not by rewriting the gateway or bundling every runtime into one app. The target is:
+
+> Hermes.app and a bundled signed helper own macOS-sensitive capabilities; Python, Node, MCP servers, and the gateway call that broker over narrow authenticated local IPC.
+
+This preserves Hermes' cross-platform runtime flexibility while matching macOS' TCC/code-signing model.
+
+## Evidence
+
+Primary sources checked:
+
+- OpenClaw macOS permissions: TCC grants are tied to code signature, bundle identifier, and on-disk path; generic `node` Accessibility grants are broad runtime grants, not package-scoped grants.  
+  https://docs.openclaw.ai/platforms/mac/permissions
+- OpenClaw macOS app: app owns permissions, manages/attaches to Gateway, exposes macOS capabilities as a node, and uses UDS + token + HMAC + TTL IPC.  
+  https://docs.openclaw.ai/platforms/macos
+- OpenClaw Gateway on macOS: app no longer bundles Node/Bun/Gateway runtime; it expects an external CLI install and manages a LaunchAgent.  
+  https://docs.openclaw.ai/platforms/mac/bundled-gateway
+- Apple SMAppService: modern macOS 13+ API for helper executables inside an app bundle, including LoginItems, LaunchAgents, and LaunchDaemons.  
+  https://developer.apple.com/documentation/servicemanagement/smappservice
+- Apple Service Management sample: helper launchd plists live inside signed app bundles so users can identify the providing app in Login Items.  
+  https://developer.apple.com/documentation/ServiceManagement/updating-your-app-package-installer-to-use-the-new-service-management-api
+- Apple notarization: distributed macOS executables need Developer ID signatures, hardened runtime, secure timestamp, valid entitlements, and notarization; ad-hoc signatures are not a durable permission identity.  
+  https://developer.apple.com/documentation/security/notarizing-macos-software-before-distribution
+- Electron Forge signing: Electron macOS apps should be signed and notarized; entitlements are configured through signing tooling.  
+  https://www.electronforge.io/guides/code-signing/code-signing-macos
+- Qt responsible-process writeup: TCC attributes access to the responsible process, which can be surprising when terminals/IDEs/runtime launchers spawn children.  
+  https://www.qt.io/blog/the-curious-case-of-the-responsible-process
+
+## Current Hermes state
+
+Hermes Desktop is official and shares the Hermes core/config/sessions/skills/backend APIs. The packaged app currently acts mostly as an Electron shell that spawns or connects to a `hermes dashboard` backend.
+
+Relevant local source:
+
+- `apps/desktop/README.md`: packaged app ships Electron shell and talks to `hermes dashboard` backend.
+- `apps/desktop/electron/main.cjs`: backend creation still launches Python with `-m hermes_cli.main` for dashboard backends.
+- `apps/desktop/package.json`: macOS signing/notarization hooks exist (`afterSign`, hardened runtime, entitlements), but local development installs can be ad-hoc signed.
+- `hermes_cli/gateway.py`: macOS LaunchAgent generation now has a local carried patch to prefer `venv/bin/hermes` over raw `python -m hermes_cli.main` for Background Items labeling.
+
+## Non-goals
+
+- Do not grant Accessibility or Screen Recording to generic `/opt/homebrew/bin/node`, venv Python, Terminal, or arbitrary MCP hosts as the default fix.
+- Do not rewrite the entire gateway in Swift/Electron.
+- Do not route normal web/search/file/git/model work through the broker.
+- Do not make the broker a generic arbitrary-code execution daemon.
+
+## Phase 1: Launch identity cleanup
+
+Status: implemented locally as `fix: launch macOS gateway via Hermes entrypoint`.
+
+Behavior:
+
+- LaunchAgent `ProgramArguments[0]` should prefer the Hermes console entrypoint, e.g. `~/.hermes/hermes-agent/venv/bin/hermes`.
+- Fallback to `python -m hermes_cli.main` only when the console script is missing.
+
+Why:
+
+- Fixes macOS Background Items showing `python` instead of `hermes`.
+- Aligns with Hermes issue #15636 and PR #15640.
+- Improves label/identity clarity but does not solve TCC code identity alone.
+
+Acceptance:
+
+- `hermes gateway status` reports service definition current.
+- `launchctl print gui/$(id -u)/ai.hermes.gateway` shows `ProgramArguments[0]` as the Hermes entrypoint.
+- Tests cover entrypoint preference and fallback.
+
+## Phase 2: Stable Desktop signing and notarization
+
+Goal:
+
+- `/Applications/Hermes.app` is the canonical visible app path.
+- Bundle ID remains `com.nousresearch.hermes`.
+- Distributed builds use Developer ID Application signing, hardened runtime, secure timestamp, and notarization.
+- Local ad-hoc builds are clearly marked as permission-fragile and not used for TCC-sensitive workflows.
+
+Acceptance:
+
+- `codesign -dv --verbose=4 /Applications/Hermes.app` shows real `Authority` and `TeamIdentifier` for release builds.
+- `spctl --assess --type execute /Applications/Hermes.app` passes for release builds.
+- Desktop About/diagnostics shows build commit, signing mode, notarization status if available, and broker registration status.
+
+## Phase 3: HermesMacBroker helper
+
+Goal:
+
+Add a bundled macOS helper, tentatively:
+
+- Bundle ID: `com.nousresearch.hermes.macbroker`
+- Location: inside `Hermes.app` using the SMAppService-supported helper layout.
+- Registration: `SMAppService.loginItem(identifier:)` or `SMAppService.agent(plistName:)`, depending on whether the helper must be an app login item or a launch agent.
+
+Owned capabilities:
+
+- Accessibility-backed UI actions.
+- Screen capture / recording.
+- Microphone status and mediated audio capture where needed.
+- Apple Events / Automation to allowlisted apps.
+- Notifications.
+- Optional Desktop/Documents/Downloads status and user guidance.
+- Optional `system.run.approved` lane for Desktop-owned exec approvals.
+
+Acceptance:
+
+- Helper has stable bundle ID and real signature in release builds.
+- Helper reports permission status without forcing prompts.
+- Helper can open exact System Settings panes for missing grants.
+- Helper does not expose raw arbitrary command execution.
+- TCC prompts show Hermes/HermesMacBroker, not generic Python/Node.
+
+## Phase 4: Authenticated local IPC
+
+Initial contract scaffold lives in:
+
+- `apps/desktop/electron/mac-permission-broker-contract.cjs`
+- `apps/desktop/electron/mac-permission-broker-contract.test.cjs`
+
+Protocol requirements:
+
+- Unix domain socket or XPC-equivalent local IPC.
+- Random local token stored securely by the app/backend.
+- HMAC-SHA256 request signing.
+- TTL and issued-at validation.
+- Nonce replay prevention.
+- Explicit method allowlist.
+- Structured audit log with secret redaction.
+
+Initial allowed methods:
+
+- `permission.status`
+- `permission.openSettings`
+- `screen.snapshot`
+- `screen.record`
+- `ui.click`
+- `ui.type`
+- `automation.appleEvent`
+- `notification.send`
+- `mic.status`
+- `system.run.approved`
+
+Acceptance:
+
+- Tampered methods fail signature validation.
+- Unknown methods are rejected before execution.
+- Expired/future requests fail.
+- Replayed nonces fail when a nonce cache is supplied.
+- Audit logs redact token/password/secret/key/session/signature-like fields.
+
+## Phase 5: Tool routing
+
+Routing rule:
+
+- Normal model, web, search, git, file, and most terminal paths bypass the broker.
+- Mac-sensitive actions use the broker.
+- MCP servers do not get generic TCC grants; Mac-sensitive MCP methods must call the broker.
+- CuaDriver remains separate unless Hermes formally adopts it as the computer-use broker for that lane.
+
+Acceptance:
+
+- `computer_use`/screen/UI actions can route through broker when available.
+- If broker unavailable, tools fail with an actionable missing-broker/missing-permission message rather than requesting Python/Node TCC grants.
+- Existing non-macOS behavior is unchanged.
+
+## Risks and mitigations
+
+- Risk: broker becomes a god daemon.  
+  Mitigation: method allowlist, per-method policy, no raw exec by default, app-side approvals for `system.run.approved`.
+- Risk: IPC token theft.  
+  Mitigation: local socket permissions, secure token storage, HMAC, TTL, nonce replay cache, no token logging.
+- Risk: slows down Hermes.  
+  Mitigation: broker only wraps Mac-sensitive operations; normal agent work bypasses it.
+- Risk: release signing credentials unavailable in local dev.  
+  Mitigation: support ad-hoc dev builds but mark TCC persistence as non-durable; do not claim permission stability from ad-hoc builds.
+- Risk: CuaDriver boundary confusion.  
+  Mitigation: document whether CuaDriver or HermesMacBroker owns each computer-use capability.
+
+## Suggested implementation order
+
+1. Land Phase 1 launchd entrypoint fix upstream or align with PR #15640.
+2. Add Desktop diagnostics for signing mode and broker status.
+3. Add Swift helper target / app-bundled helper with SMAppService registration.
+4. Implement broker IPC server and reuse the JS contract from Desktop tests.
+5. Add Python client library under the Hermes core for broker calls.
+6. Route one low-risk method first: `permission.status`.
+7. Route `notification.send` or `screen.snapshot` next.
+8. Only after proof, route UI automation and approved exec.
+
+## Test checklist
+
+- `python -m pytest tests/hermes_cli/test_gateway_service.py -q -o 'addopts='`
+- `cd apps/desktop && node --test electron/mac-permission-broker-contract.test.cjs`
+- `cd apps/desktop && npm run test:desktop:platforms`
+- macOS release build: verify `codesign`, `spctl`, notarization, and install-stamp.
+- Manual TCC test: reset only scoped Hermes broker grants, launch app, trigger broker permission status/openSettings/smoke action, verify prompt identity.

--- a/plans/macos-permission-broker.md
+++ b/plans/macos-permission-broker.md
@@ -1,6 +1,6 @@
 # macOS Permission Broker for Hermes
 
-Status: design + initial IPC contract scaffold.  
+Status: design + native helper scaffold + packaged-app embedding + initial Desktop IPC handlers.  
 Owner area: Desktop + gateway + macOS service management.  
 Goal: stable Hermes-owned macOS permission identity without granting broad TCC access to generic Python or Node runtimes.
 
@@ -88,6 +88,24 @@ Acceptance:
 - Desktop About/diagnostics shows build commit, signing mode, notarization status if available, and broker registration status.
 
 ## Phase 3: HermesMacBroker helper
+
+Status: native Swift helper scaffold implemented and embedded into packaged macOS app builds.
+
+Implemented files:
+
+- `apps/desktop/macos/HermesMacBroker/Sources/HermesMacBroker/main.swift`
+- `apps/desktop/scripts/stage-mac-permission-broker.cjs`
+- `apps/desktop/scripts/stage-mac-permission-broker.test.cjs`
+- `apps/desktop/electron/mac-permission-broker-runtime.cjs`
+- `apps/desktop/electron/mac-permission-broker-runtime.test.cjs`
+
+Packaging behavior:
+
+- `apps/desktop/scripts/after-pack.cjs` stages the helper into `Hermes.app/Contents/Library/LoginItems/HermesMacBroker.app` for darwin builds.
+- `npm run build:mac-broker` compiles a standalone helper bundle for local verification.
+- Electron main exposes low-risk IPC handlers for broker status and opening settings panes:
+  - `hermes:mac-broker:status`
+  - `hermes:mac-broker:open-settings`
 
 Goal:
 

--- a/plans/macos-permission-broker.md
+++ b/plans/macos-permission-broker.md
@@ -1,6 +1,6 @@
 # macOS Permission Broker for Hermes
 
-Status: design + native helper scaffold + packaged-app embedding + initial Desktop IPC handlers.  
+Status: design + native helper scaffold + packaged-app embedding + initial Desktop IPC handlers + authenticated daemon route for `permission.status`.  
 Owner area: Desktop + gateway + macOS service management.  
 Goal: stable Hermes-owned macOS permission identity without granting broad TCC access to generic Python or Node runtimes.
 
@@ -103,9 +103,15 @@ Packaging behavior:
 
 - `apps/desktop/scripts/after-pack.cjs` stages the helper into `Hermes.app/Contents/Library/LoginItems/HermesMacBroker.app` for darwin builds.
 - `npm run build:mac-broker` compiles a standalone helper bundle for local verification.
-- Electron main exposes low-risk IPC handlers for broker status and opening settings panes:
+- Electron main exposes low-risk IPC handlers for broker status, service registration, and opening settings panes:
   - `hermes:mac-broker:status`
+  - `hermes:mac-broker:service-status`
+  - `hermes:mac-broker:register`
+  - `hermes:mac-broker:unregister`
   - `hermes:mac-broker:open-settings`
+- The helper can run an authenticated Unix-socket daemon with `--serve --socket <path> --token <token>`.
+- `hermes_cli/macos_permission_broker.py` provides the first Python client route.
+- `hermes mac-broker status` exercises the safe `permission.status` method through the broker IPC path.
 
 Goal:
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1,6 +1,7 @@
 """Tests for gateway service management helpers."""
 
 import os
+import plistlib
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -616,6 +617,50 @@ class TestGatewayStopCleanup:
 
 
 class TestLaunchdServiceRecovery:
+    def test_launchd_program_arguments_prefers_hermes_entrypoint(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "get_hermes_cli_entrypoint", lambda: "/opt/hermes/venv/bin/hermes")
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: "/opt/hermes/venv/bin/python")
+
+        assert gateway_cli._launchd_program_arguments("--profile coder") == [
+            "/opt/hermes/venv/bin/hermes",
+            "--profile",
+            "coder",
+            "gateway",
+            "run",
+            "--replace",
+        ]
+
+    def test_launchd_program_arguments_falls_back_to_python_module(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "get_hermes_cli_entrypoint", lambda: None)
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: "/opt/hermes/venv/bin/python")
+
+        assert gateway_cli._launchd_program_arguments() == [
+            "/opt/hermes/venv/bin/python",
+            "-m",
+            "hermes_cli.main",
+            "gateway",
+            "run",
+            "--replace",
+        ]
+
+    def test_generate_launchd_plist_uses_hermes_entrypoint(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "get_hermes_cli_entrypoint", lambda: "/opt/hermes/venv/bin/hermes")
+        monkeypatch.setattr(gateway_cli, "_stable_service_working_dir", lambda: "/Users/alice/.hermes")
+        monkeypatch.setattr(gateway_cli, "_detect_venv_dir", lambda: Path("/opt/hermes/venv"))
+        monkeypatch.setattr(gateway_cli, "_build_service_path_dirs", lambda: ["/opt/hermes/venv/bin"])
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda name: None)
+        monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: "/Users/alice/.hermes")
+
+        data = plistlib.loads(gateway_cli.generate_launchd_plist().encode("utf-8"))
+
+        assert data["ProgramArguments"][:4] == [
+            "/opt/hermes/venv/bin/hermes",
+            "gateway",
+            "run",
+            "--replace",
+        ]
+        assert "-m" not in data["ProgramArguments"]
+
     def test_get_restart_drain_timeout_prefers_env_then_config_then_default(self, monkeypatch):
         monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
         monkeypatch.setattr(gateway_cli, "read_raw_config", lambda: {})

--- a/tests/hermes_cli/test_macos_permission_broker.py
+++ b/tests/hermes_cli/test_macos_permission_broker.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+import socket
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.macos_permission_broker import (
+    MacPermissionBrokerError,
+    broker_permission_status,
+    create_broker_request,
+    load_or_create_broker_token,
+    send_broker_request,
+)
+
+
+def test_create_broker_request_signs_stable_envelope() -> None:
+    token = "0123456789abcdef0123456789abcdef"
+    request = create_broker_request(
+        "permission.status",
+        token=token,
+        now_ms=1_000,
+        nonce="nonce-1",
+        request_id="request-1",
+    )
+
+    assert request["version"] == 1
+    assert request["method"] == "permission.status"
+    assert request["issuedAt"] == 1_000
+    assert request["signature"] == "864c883ef84899c9fa811cd7e315b0c8919bdfef11fde3ad62e8eea3ee659204"
+
+
+def test_create_broker_request_rejects_unsupported_method() -> None:
+    with pytest.raises(MacPermissionBrokerError, match="unsupported broker method"):
+        create_broker_request("ui.click", token="0123456789abcdef0123456789abcdef")
+
+
+def test_load_or_create_broker_token_creates_private_token_file(tmp_path: Path) -> None:
+    token_file = tmp_path / "broker.token"
+
+    first = load_or_create_broker_token(token_file)
+    second = load_or_create_broker_token(token_file)
+
+    assert first == second
+    assert len(first) == 64
+    assert token_file.stat().st_mode & 0o777 == 0o600
+
+
+def _serve_one(socket_path: Path, response: dict[str, object], seen: list[dict[str, object]]) -> threading.Thread:
+    def run() -> None:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+            server.bind(str(socket_path))
+            server.listen(1)
+            conn, _ = server.accept()
+            with conn:
+                raw = b""
+                while not raw.endswith(b"\n"):
+                    raw += conn.recv(4096)
+                seen.append(json.loads(raw.decode("utf-8")))
+                conn.sendall(json.dumps(response, sort_keys=True).encode("utf-8") + b"\n")
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    return thread
+
+
+def short_tmp_dir() -> Path:
+    return Path(tempfile.mkdtemp(prefix="hmb-", dir="/tmp"))
+
+
+def wait_for_socket(socket_path: Path) -> None:
+    deadline = time.time() + 2
+    while time.time() < deadline:
+        if socket_path.exists():
+            return
+        time.sleep(0.01)
+    raise AssertionError(f"socket was not created: {socket_path}")
+
+
+def test_send_broker_request_round_trips_json_over_unix_socket() -> None:
+    socket_path = short_tmp_dir() / "b.sock"
+    seen: list[dict[str, object]] = []
+    thread = _serve_one(socket_path, {"ok": True, "permissions": {"screenCapture": "authorized"}}, seen)
+    wait_for_socket(socket_path)
+    request = create_broker_request("permission.status", token="0123456789abcdef0123456789abcdef")
+
+    response = send_broker_request(request, socket_path=socket_path)
+
+    thread.join(timeout=2)
+    assert response == {"ok": True, "permissions": {"screenCapture": "authorized"}}
+    assert seen[0]["method"] == "permission.status"
+    assert "signature" in seen[0]
+
+
+def test_broker_permission_status_uses_token_file_and_socket() -> None:
+    tmp_dir = short_tmp_dir()
+    socket_path = tmp_dir / "b.sock"
+    token_file = tmp_dir / "b.token"
+    token_file.write_text("0123456789abcdef0123456789abcdef", encoding="utf-8")
+    seen: list[dict[str, object]] = []
+    thread = _serve_one(socket_path, {"ok": True, "method": "permission.status"}, seen)
+    wait_for_socket(socket_path)
+
+    response = broker_permission_status(socket_path=socket_path, token_path=token_file)
+
+    thread.join(timeout=2)
+    assert response == {"ok": True, "method": "permission.status"}
+    assert seen[0]["method"] == "permission.status"
+
+
+def test_send_broker_request_reports_missing_socket(tmp_path: Path) -> None:
+    with pytest.raises(MacPermissionBrokerError, match="broker unavailable"):
+        send_broker_request({"ok": True}, socket_path=tmp_path / "missing.sock", timeout=0.1)

--- a/tests/hermes_cli/test_macos_permission_broker.py
+++ b/tests/hermes_cli/test_macos_permission_broker.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import json
+import shutil
 import socket
+import subprocess
+import sys
 import tempfile
 import threading
 import time
@@ -31,7 +34,9 @@ def test_create_broker_request_signs_stable_envelope() -> None:
     assert request["version"] == 1
     assert request["method"] == "permission.status"
     assert request["issuedAt"] == 1_000
-    assert request["signature"] == "864c883ef84899c9fa811cd7e315b0c8919bdfef11fde3ad62e8eea3ee659204"
+    assert request["expiresAt"] == 31_000
+    assert "ttlMs" not in request
+    assert request["signature"] == "84d93f5380089ea272ab50333fa40d577c8c08abeab44685be2d30e948b4c69e"
 
 
 def test_create_broker_request_rejects_unsupported_method() -> None:
@@ -115,3 +120,57 @@ def test_broker_permission_status_uses_token_file_and_socket() -> None:
 def test_send_broker_request_reports_missing_socket(tmp_path: Path) -> None:
     with pytest.raises(MacPermissionBrokerError, match="broker unavailable"):
         send_broker_request({"ok": True}, socket_path=tmp_path / "missing.sock", timeout=0.1)
+
+
+@pytest.mark.skipif(sys.platform != "darwin" or shutil.which("swiftc") is None, reason="requires macOS swiftc")
+def test_swift_broker_accepts_python_signed_request_and_rejects_replay(tmp_path: Path) -> None:
+    source = (
+        Path(__file__).resolve().parents[2]
+        / "apps"
+        / "desktop"
+        / "macos"
+        / "HermesMacBroker"
+        / "Sources"
+        / "HermesMacBroker"
+        / "main.swift"
+    )
+    executable = tmp_path / "HermesMacBroker"
+    subprocess.run(["swiftc", str(source), "-o", str(executable)], check=True, timeout=60)
+
+    # macOS sockaddr_un paths are short (104 bytes); keep the integration
+    # socket under /tmp instead of pytest's deep per-test temp directory.
+    socket_path = short_tmp_dir() / "broker.sock"
+    token = "0123456789abcdef0123456789abcdef"
+    proc = subprocess.Popen(
+        [str(executable), "--serve", "--socket", str(socket_path), "--token", token],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert proc.stdout is not None
+        listening = json.loads(proc.stdout.readline())
+        assert listening["ok"] is True
+        request = create_broker_request(
+            "permission.status",
+            token=token,
+            now_ms=int(time.time() * 1000),
+            ttl_ms=30_000,
+            nonce="nonce-swift-integration",
+            request_id="request-swift-integration",
+        )
+
+        first = send_broker_request(request, socket_path=socket_path)
+        replay = send_broker_request(request, socket_path=socket_path)
+
+        assert first["ok"] is True
+        assert first["id"] == "request-swift-integration"
+        assert replay["ok"] is False
+        assert "replayed" in replay["error"]
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)


### PR DESCRIPTION
## Summary

This PR moves Hermes toward a stable macOS permission identity without granting broad Accessibility/Screen Recording access to generic Python or Node runtimes.

It includes:

- LaunchAgent entrypoint cleanup so macOS starts the gateway through the Hermes console script instead of raw `python -m hermes_cli.main`.
- A macOS permission broker architecture plan with phased acceptance criteria.
- A Desktop-side broker contract with explicit method allowlist, HMAC signing, TTL checks, nonce replay protection, tamper rejection, and audit redaction.
- A native Swift `HermesMacBroker` helper scaffold that reports permission status, opens relevant System Settings panes, and sends notifications.
- Packaging support that embeds `HermesMacBroker.app` into `Hermes.app/Contents/Library/LoginItems` during macOS Desktop builds.
- Electron IPC handlers for broker status and settings-open flows.
- Tests for launchd entrypoint behavior, broker contract, broker runtime helpers, and helper staging.

## Verification

Ran locally on macOS:

```text
python -m pytest tests/hermes_cli/test_gateway_service.py -q -o 'addopts=' -k 'launchd_program_arguments or generate_launchd_plist_uses_hermes_entrypoint'
# 3 passed, 159 deselected

cd apps/desktop
npx eslint electron/mac-permission-broker-contract.cjs electron/mac-permission-broker-contract.test.cjs electron/mac-permission-broker-runtime.cjs electron/mac-permission-broker-runtime.test.cjs scripts/stage-mac-permission-broker.cjs scripts/stage-mac-permission-broker.test.cjs scripts/after-pack.cjs electron/main.cjs
# eslint_ok

node --test electron/mac-permission-broker-contract.test.cjs electron/mac-permission-broker-runtime.test.cjs scripts/stage-mac-permission-broker.test.cjs
# 20 passed

npm run build:mac-broker -- /tmp/hermes-macbroker-build
/tmp/hermes-macbroker-build/HermesMacBroker.app/Contents/MacOS/HermesMacBroker --status-json
# ok=true, bundleId=com.nousresearch.hermes.macbroker

npm run pack
# packaged Hermes.app contains Contents/Library/LoginItems/HermesMacBroker.app
```

## Notes

Local builds are ad-hoc signed because Developer ID notarization credentials are not available in this environment. Production TCC persistence still requires release signing/notarization with Nous credentials.
