### PR TITLE
fix(telegram): use direct_messages_topic_id for draft streaming in DM topics

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1212,9 +1212,10 @@ class TelegramAdapter(BasePlatformAdapter):
             "draft_id": int(draft_id),
             "rich_message": self._rich_message_payload(content),
         }
-        thread_id = self._metadata_thread_id(metadata)
-        if thread_id is not None:
-            payload["message_thread_id"] = int(thread_id)
+        thread_kwargs = self._thread_kwargs_for_send(
+            chat_id, self._metadata_thread_id(metadata), metadata,
+        )
+        payload.update({k: v for k, v in thread_kwargs.items() if v is not None})
         try:
             ok = await self._bot.do_api_request("sendRichMessageDraft", api_kwargs=payload)
             return bool(ok)
@@ -2928,7 +2929,9 @@ class TelegramAdapter(BasePlatformAdapter):
         text = content if len(content) <= self.MAX_MESSAGE_LENGTH else \
             self.truncate_message(content, self.MAX_MESSAGE_LENGTH, len_fn=utf16_len)[0]
 
-        thread_id = self._metadata_thread_id(metadata)
+        thread_kwargs = self._thread_kwargs_for_send(
+            chat_id, self._metadata_thread_id(metadata), metadata,
+        )
 
         # Apply the same MarkdownV2 conversion the regular ``send`` path uses
         # so the animated draft preview renders with identical formatting to
@@ -2947,8 +2950,7 @@ class TelegramAdapter(BasePlatformAdapter):
             }
             if use_markdown:
                 kwargs["parse_mode"] = ParseMode.MARKDOWN_V2
-            if thread_id is not None:
-                kwargs["message_thread_id"] = thread_id
+            kwargs.update({k: v for k, v in thread_kwargs.items() if v is not None})
 
             try:
                 ok = await self._bot.send_message_draft(**kwargs)

--- a/tests/gateway/test_telegram_draft_dm_topic.py
+++ b/tests/gateway/test_telegram_draft_dm_topic.py
@@ -1,0 +1,132 @@
+"""TelegramAdapter.send_draft uses direct_messages_topic_id for private DM topics.
+
+Regression tests for issue #45770: draft streaming in private DM topics must
+use ``direct_messages_topic_id`` (not ``message_thread_id``) so Telegram
+renders the draft in the correct topic lane.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.telegram import TelegramAdapter
+
+
+def _make_adapter(extra=None):
+    """Build a TelegramAdapter with a mock bot wired for draft sends."""
+    config = PlatformConfig(enabled=True, token="fake-token", extra=extra or {})
+    adapter = TelegramAdapter(config)
+    bot = MagicMock()
+    bot.do_api_request = AsyncMock(return_value=True)
+    bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
+    bot.send_chat_action = AsyncMock()
+    bot.send_message_draft = AsyncMock(return_value=True)
+    adapter._bot = bot
+    return adapter
+
+
+# ── Rich draft (sendRichMessageDraft) ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rich_draft_uses_direct_messages_topic_id_for_dm_topics():
+    """sendRichMessageDraft must use direct_messages_topic_id, not
+    message_thread_id, when metadata carries a DM topic identifier."""
+    adapter = _make_adapter()
+    metadata = {
+        "direct_messages_topic_id": "999",
+        "telegram_dm_topic_reply_fallback": True,
+    }
+
+    result = await adapter.send_draft(
+        "12345", draft_id=7, content="hello", metadata=metadata,
+    )
+
+    assert result.success is True
+    call = adapter._bot.do_api_request.call_args
+    assert call.args[0] == "sendRichMessageDraft"
+    api_kwargs = call.kwargs["api_kwargs"]
+    assert api_kwargs.get("direct_messages_topic_id") == 999
+    assert api_kwargs.get("message_thread_id") is None
+
+
+@pytest.mark.asyncio
+async def test_rich_draft_uses_message_thread_id_for_forum_topics():
+    """Forum/supergroup topics should still use message_thread_id."""
+    adapter = _make_adapter()
+    metadata = {"thread_id": "42"}
+
+    result = await adapter.send_draft(
+        "12345", draft_id=7, content="hello", metadata=metadata,
+    )
+
+    assert result.success is True
+    call = adapter._bot.do_api_request.call_args
+    api_kwargs = call.kwargs["api_kwargs"]
+    assert api_kwargs.get("message_thread_id") == 42
+    assert "direct_messages_topic_id" not in api_kwargs
+
+
+# ── Legacy plain-text draft (sendMessageDraft) ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_plain_draft_uses_direct_messages_topic_id_for_dm_topics():
+    """sendMessageDraft fallback must also use direct_messages_topic_id
+    for private DM topics."""
+    adapter = _make_adapter()
+    # Disable rich drafts so the legacy path runs.
+    adapter._rich_draft_disabled = True
+    metadata = {
+        "direct_messages_topic_id": "888",
+        "telegram_dm_topic_reply_fallback": True,
+    }
+
+    result = await adapter.send_draft(
+        "12345", draft_id=7, content="hello", metadata=metadata,
+    )
+
+    assert result.success is True
+    adapter._bot.send_message_draft.assert_awaited_once()
+    call = adapter._bot.send_message_draft.call_args
+    kwargs = call.kwargs
+    assert kwargs.get("direct_messages_topic_id") == 888
+    assert kwargs.get("message_thread_id") is None
+
+
+@pytest.mark.asyncio
+async def test_plain_draft_uses_message_thread_id_for_forum_topics():
+    """Forum topics should still use message_thread_id in legacy drafts."""
+    adapter = _make_adapter()
+    adapter._rich_draft_disabled = True
+    metadata = {"thread_id": "42"}
+
+    result = await adapter.send_draft(
+        "12345", draft_id=7, content="hello", metadata=metadata,
+    )
+
+    assert result.success is True
+    adapter._bot.send_message_draft.assert_awaited_once()
+    call = adapter._bot.send_message_draft.call_args
+    kwargs = call.kwargs
+    assert kwargs.get("message_thread_id") == 42
+    assert "direct_messages_topic_id" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_plain_draft_omits_thread_kwargs_when_no_metadata():
+    """No thread metadata → no thread kwargs at all."""
+    adapter = _make_adapter()
+    adapter._rich_draft_disabled = True
+
+    result = await adapter.send_draft(
+        "12345", draft_id=7, content="hello", metadata=None,
+    )
+
+    assert result.success is True
+    call = adapter._bot.send_message_draft.call_args
+    kwargs = call.kwargs
+    assert "message_thread_id" not in kwargs
+    assert "direct_messages_topic_id" not in kwargs


### PR DESCRIPTION
## What does this PR do?

Fixes draft streaming in Telegram private DM topics by routing `send_draft()` and `_try_send_rich_draft()` through the same `_thread_kwargs_for_send()` helper that the regular `send()` path uses. This ensures `direct_messages_topic_id` is emitted (instead of `message_thread_id`) when metadata carries a DM topic identifier.

## Related Issue

Fixes #45770

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/telegram.py`: Replace manual `message_thread_id` extraction in `_try_send_rich_draft()` and `send_draft()` with `_thread_kwargs_for_send()`, which correctly emits `direct_messages_topic_id` for private DM topics and `message_thread_id` for forum topics.
- `tests/gateway/test_telegram_draft_dm_topic.py`: 5 regression tests covering rich draft + legacy draft paths for DM topics, forum topics, and no-metadata cases.

## How to Test

1. Configure a Telegram private DM topic via `platforms.telegram.extra.dm_topics` in config.yaml
2. Enable streaming (`streaming.enabled: true`, `streaming.transport: auto`)
3. Send a message in the DM topic — the draft preview should now appear in the correct topic lane (not outside it)
4. Run `pytest tests/gateway/test_telegram_draft_dm_topic.py tests/gateway/test_telegram_rich_messages.py tests/gateway/test_telegram_send_draft_format.py -v` — all 43 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/platforms/telegram.py` — `send_draft()` (line 2892), `_try_send_rich_draft()` (line 1195), `_thread_kwargs_for_send()` (line 650)
- Blast radius: LOW — only affects draft streaming path in Telegram adapter; regular `send()` path unchanged
- Related patterns: `_thread_kwargs_for_send()` is already used by 15+ call sites in the same file for the regular send/edit paths; this change brings draft paths into alignment
