### PR TITLE
feat(acp): honor `--toolsets` and add per-session tool scoping

### DIFF
--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -143,6 +143,13 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Accept all prompts (currently used by --setup-browser to skip the "
              "~400 MB Chromium download confirmation).",
     )
+    parser.add_argument(
+        "--toolsets",
+        default=None,
+        help="Comma-separated toolsets enabled for every ACP session "
+             "(default: hermes-acp). Sessions may override per-session via "
+             "session/new.",
+    )
     return parser.parse_args(argv)
 
 
@@ -257,7 +264,7 @@ def main(argv: list[str] | None = None) -> None:
     except Exception:
         logger.debug("MCP tool discovery failed at ACP startup", exc_info=True)
 
-    agent = HermesACPAgent()
+    agent = HermesACPAgent(default_toolsets=getattr(args, "toolsets", None))
     try:
         asyncio.run(acp.run_agent(agent, use_unstable_protocol=True))
     except KeyboardInterrupt:

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -72,7 +72,12 @@ from acp_adapter.events import (
 )
 from acp_adapter.permissions import make_approval_callback
 from acp_adapter.provenance import session_provenance_meta
-from acp_adapter.session import SessionManager, SessionState, _expand_acp_enabled_toolsets
+from acp_adapter.session import (
+    SessionManager,
+    SessionState,
+    _expand_acp_enabled_toolsets,
+    _normalize_acp_toolsets,
+)
 from acp_adapter.tools import build_tool_complete, build_tool_start
 
 logger = logging.getLogger(__name__)
@@ -514,9 +519,15 @@ class HermesACPAgent(acp.Agent):
         value: key for key, value in _MODE_TO_EDIT_APPROVAL_POLICY.items()
     }
 
-    def __init__(self, session_manager: SessionManager | None = None):
+    def __init__(
+        self,
+        session_manager: SessionManager | None = None,
+        default_toolsets: list[str] | None = None,
+    ):
         super().__init__()
-        self.session_manager = session_manager or SessionManager()
+        self.session_manager = session_manager or SessionManager(
+            default_toolsets=default_toolsets
+        )
         self._conn: Optional[acp.Client] = None
 
     # ---- Connection lifecycle -----------------------------------------------
@@ -1106,13 +1117,28 @@ class HermesACPAgent(acp.Agent):
                     if plan_update is not None and not await _send(plan_update):
                         return
 
+    @staticmethod
+    def _toolsets_from_new_session_params(params: dict) -> list[str] | None:
+        """Pull an optional per-session toolset override from ``session/new``.
+
+        Accepts a top-level ``toolsets`` field or one nested under the ACP
+        ``_meta`` map, as a JSON array or a comma/space-delimited string.
+        """
+        value = params.get("toolsets")
+        if value is None:
+            meta = params.get("_meta") or params.get("meta")
+            if isinstance(meta, dict):
+                value = meta.get("toolsets")
+        return _normalize_acp_toolsets(value)
+
     async def new_session(
         self,
         cwd: str,
         mcp_servers: list | None = None,
         **kwargs: Any,
     ) -> NewSessionResponse:
-        state = self.session_manager.create_session(cwd=cwd)
+        toolsets = self._toolsets_from_new_session_params(kwargs)
+        state = self.session_manager.create_session(cwd=cwd, toolsets=toolsets)
         await self._register_session_mcp_servers(state, mcp_servers)
         logger.info("New session %s (cwd=%s)", state.session_id, cwd)
         self._schedule_available_commands_update(state.session_id)

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -155,6 +155,26 @@ def _expand_acp_enabled_toolsets(
     return expanded
 
 
+def _normalize_acp_toolsets(value: object) -> List[str] | None:
+    """Coerce a toolset spec (list, comma/space-delimited string, or ``None``)
+    into a clean list of names.
+
+    Returns ``None`` when nothing usable is provided so callers fall back to the
+    historical ``["hermes-acp"]`` default.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        items = [part.strip() for part in value.replace(",", " ").split()]
+    else:
+        try:
+            items = [str(part).strip() for part in value]
+        except TypeError:
+            return None
+    items = [item for item in items if item]
+    return items or None
+
+
 def _clear_task_cwd(task_id: str) -> None:
     """Remove task-specific cwd overrides for an ACP session."""
     if not task_id:
@@ -191,7 +211,7 @@ class SessionManager:
     via ``session_search``.
     """
 
-    def __init__(self, agent_factory=None, db=None):
+    def __init__(self, agent_factory=None, db=None, default_toolsets=None):
         """
         Args:
             agent_factory: Optional callable that creates an AIAgent-like object.
@@ -199,21 +219,31 @@ class SessionManager:
                            using the current Hermes runtime provider configuration.
             db:            Optional SessionDB instance. When omitted, the default
                            SessionDB (``~/.hermes/state.db``) is lazily created.
+            default_toolsets: Optional process-wide default toolset list applied
+                           to every ACP session that does not request its own
+                           (e.g. from ``hermes acp --toolsets``). Accepts a list
+                           or a comma/space-delimited string; ``None`` keeps the
+                           historical ``["hermes-acp"]`` default.
         """
         self._sessions: Dict[str, SessionState] = {}
         self._lock = Lock()
         self._agent_factory = agent_factory
         self._db_instance = db  # None → lazy-init on first use
+        self._default_toolsets = _normalize_acp_toolsets(default_toolsets)
 
     # ---- public API ---------------------------------------------------------
 
-    def create_session(self, cwd: str = ".") -> SessionState:
-        """Create a new session with a unique ID and a fresh AIAgent."""
+    def create_session(self, cwd: str = ".", toolsets=None) -> SessionState:
+        """Create a new session with a unique ID and a fresh AIAgent.
+
+        ``toolsets`` overrides the manager default for this session only; when
+        ``None`` the session uses the manager default (or ``["hermes-acp"]``).
+        """
         import threading
 
         cwd = _translate_acp_cwd(cwd)
         session_id = str(uuid.uuid4())
-        agent = self._make_agent(session_id=session_id, cwd=cwd)
+        agent = self._make_agent(session_id=session_id, cwd=cwd, toolsets=toolsets)
         state = SessionState(
             session_id=session_id,
             agent=agent,
@@ -555,6 +585,11 @@ class SessionManager:
 
     # ---- internal -----------------------------------------------------------
 
+    def _resolved_toolsets(self, toolsets=None) -> List[str]:
+        """Effective toolset list for a session: the per-session override, else
+        the manager default, else the historical ``["hermes-acp"]``."""
+        return _normalize_acp_toolsets(toolsets) or self._default_toolsets or ["hermes-acp"]
+
     def _make_agent(
         self,
         *,
@@ -564,6 +599,7 @@ class SessionManager:
         requested_provider: str | None = None,
         base_url: str | None = None,
         api_mode: str | None = None,
+        toolsets: List[str] | None = None,
     ):
         if self._agent_factory is not None:
             return self._agent_factory()
@@ -591,7 +627,7 @@ class SessionManager:
         kwargs = {
             "platform": "acp",
             "enabled_toolsets": _expand_acp_enabled_toolsets(
-                ["hermes-acp"],
+                self._resolved_toolsets(toolsets),
                 mcp_server_names=configured_mcp_servers,
             ),
             "quiet_mode": True,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12210,6 +12210,11 @@ def cmd_acp(args):
             acp_argv.append("--setup-browser")
         if getattr(args, "assume_yes", False):
             acp_argv.append("--yes")
+        toolsets = getattr(args, "toolsets", None)
+        if toolsets:
+            if isinstance(toolsets, (list, tuple)):
+                toolsets = ",".join(str(t) for t in toolsets)
+            acp_argv.extend(["--toolsets", str(toolsets)])
         acp_main(acp_argv)
     except ImportError:
         print("ACP dependencies not installed.", file=sys.stderr)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1728,6 +1728,7 @@ AUTHOR_MAP = {
     "steveonjava@gmail.com": "steveonjava",  # PR #29669 (redact secrets in kanban tool payloads)
     "afnlegion01@gmail.com": "Afnath-max",  # PR #49129 salvage (opencode-zen catalog refresh + uncapped/live-first picker)
     "sharma.priyanshu96@gmail.com": "ipriyaaanshu",  # PR #51488 salvage (clear stale base_url on gateway model switches; #25107)
+    "alan@wizemann.com": "awizemann",  # PR #45958 (ACP per-session toolset scoping; #45955)
 }
 
 

--- a/tests/acp_adapter/test_acp_toolsets.py
+++ b/tests/acp_adapter/test_acp_toolsets.py
@@ -1,0 +1,57 @@
+"""Per-session / per-process ACP toolset scoping (issue #45955).
+
+Covers the resolution chain that decides a session's ``enabled_toolsets``:
+per-session override > process default (``--toolsets``) > historical
+``["hermes-acp"]``.
+"""
+
+from acp_adapter.server import HermesACPAgent
+from acp_adapter.session import (
+    SessionManager,
+    _expand_acp_enabled_toolsets,
+    _normalize_acp_toolsets,
+)
+
+
+def test_normalize_handles_list_string_and_none():
+    assert _normalize_acp_toolsets(None) is None
+    assert _normalize_acp_toolsets(["web", "file"]) == ["web", "file"]
+    assert _normalize_acp_toolsets("web,file") == ["web", "file"]
+    assert _normalize_acp_toolsets("web, file") == ["web", "file"]
+    assert _normalize_acp_toolsets("web file") == ["web", "file"]
+    # Empty / whitespace-only input falls back to None so the default applies.
+    assert _normalize_acp_toolsets("") is None
+    assert _normalize_acp_toolsets([" ", ""]) is None
+
+
+def test_resolved_toolsets_precedence():
+    # No default + no override → historical hermes-acp toolset.
+    assert SessionManager()._resolved_toolsets(None) == ["hermes-acp"]
+
+    # Process default is normalized and honored.
+    mgr = SessionManager(default_toolsets="web,file")
+    assert mgr._default_toolsets == ["web", "file"]
+    assert mgr._resolved_toolsets(None) == ["web", "file"]
+
+    # Per-session override wins over the process default.
+    assert mgr._resolved_toolsets(["memory"]) == ["memory"]
+
+
+def test_resolved_toolsets_feed_expand_for_enabled_toolsets():
+    # The resolved list is exactly what the agent's enabled_toolsets is built
+    # from, so a scoped session sees only the requested toolsets (+ MCP).
+    mgr = SessionManager(default_toolsets=["web", "file"])
+    enabled = _expand_acp_enabled_toolsets(
+        mgr._resolved_toolsets(None), mcp_server_names=["github"]
+    )
+    assert enabled == ["web", "file", "mcp-github"]
+
+
+def test_new_session_param_extraction():
+    extract = HermesACPAgent._toolsets_from_new_session_params
+    assert extract({"toolsets": ["web"]}) == ["web"]
+    assert extract({"toolsets": "web, file"}) == ["web", "file"]
+    assert extract({"_meta": {"toolsets": ["memory"]}}) == ["memory"]
+    # Top-level wins over _meta when both are present.
+    assert extract({"toolsets": ["web"], "_meta": {"toolsets": ["memory"]}}) == ["web"]
+    assert extract({}) is None


### PR DESCRIPTION
Closes #45955.

### Problem

ACP sessions always received `enabled_toolsets=["hermes-acp"]`: `acp_adapter/session.py::_make_agent` hardcoded the list, and the `hermes acp --toolsets` flag was parsed but never threaded into the adapter. An ACP client driving a single long-lived `hermes acp` process across many sessions (e.g. a GUI with per-project chats) had no way to scope a session's tools.

### Change (additive, backward compatible)

- `SessionManager(default_toolsets=…)` — a process-wide default (accepts a list or a comma/space string).
- `create_session(toolsets=…)` → `_make_agent(toolsets=…)` resolve through a new `SessionManager._resolved_toolsets`, with precedence: **per-session override > process default > `["hermes-acp"]`**.
- `session/new` reads an optional per-session `toolsets` (top-level field or under ACP `_meta`).
- `hermes acp --toolsets` is forwarded (`cmd_acp` → `entry._parse_args` → `HermesACPAgent(default_toolsets=…)`) and finally honored.

A session that specifies nothing still resolves to `["hermes-acp"]`, so existing behavior is unchanged.

### Notes / scope

- Resumed/loaded sessions use the process default (per-session overrides aren't persisted to the session DB — could be a follow-up if desired).
- Open to adjusting the wire shape for the per-session override (top-level `toolsets` vs `_meta.toolsets`) — happy to align with whatever you prefer.

### Tests

`tests/acp_adapter/test_acp_toolsets.py` (4 tests) covering normalization, the resolution precedence, the resolved list feeding `_expand_acp_enabled_toolsets`, and `session/new` param extraction.

```
$ pytest tests/acp_adapter/ -q
23 passed
```
(19 existing + 4 new; modified modules import clean.)
