### PR TITLE
fix(codex): handle reasoning-only response streams

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -1049,8 +1049,14 @@ def _normalize_codex_response(
     if not isinstance(output, list) or not output:
         # The Codex backend can return empty output when the answer was
         # delivered entirely via stream events. Check output_text as a
-        # last-resort fallback before raising.
-        out_text = getattr(response, "output_text", None)
+        # last-resort fallback before raising. Some SDK convenience accessors
+        # reconstruct output_text from response.output and can themselves raise
+        # when output is malformed/None, so keep this defensive.
+        try:
+            out_text = getattr(response, "output_text", None)
+        except Exception as exc:
+            logger.debug("Codex response.output_text access failed: %s", exc)
+            out_text = None
         if isinstance(out_text, str) and out_text.strip():
             logger.debug(
                 "Codex response has empty output but output_text is present (%d chars); "
@@ -1204,8 +1210,12 @@ def _normalize_codex_response(
             ))
 
     final_text = "\n".join([p for p in content_parts if p]).strip()
-    if not final_text and hasattr(response, "output_text"):
-        out_text = getattr(response, "output_text", "")
+    if not final_text:
+        try:
+            out_text = getattr(response, "output_text", "")
+        except Exception as exc:
+            logger.debug("Codex response.output_text access failed: %s", exc)
+            out_text = ""
         if isinstance(out_text, str):
             final_text = out_text.strip()
 

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -422,6 +422,7 @@ def _consume_codex_event_stream(
     """
     collected_output_items: List[Any] = []
     collected_text_deltas: List[str] = []
+    collected_reasoning_deltas: List[str] = []
     has_tool_calls = False
     first_delta_fired = False
     terminal_status: str = "completed"
@@ -482,11 +483,13 @@ def _consume_codex_event_stream(
 
         if "reasoning" in event_type and "delta" in event_type:
             reasoning_text = _event_field(event, "delta", "")
-            if reasoning_text and on_reasoning_delta is not None:
-                try:
-                    on_reasoning_delta(reasoning_text)
-                except Exception:
-                    logger.debug("Codex stream on_reasoning_delta raised", exc_info=True)
+            if reasoning_text:
+                collected_reasoning_deltas.append(reasoning_text)
+                if on_reasoning_delta is not None:
+                    try:
+                        on_reasoning_delta(reasoning_text)
+                    except Exception:
+                        logger.debug("Codex stream on_reasoning_delta raised", exc_info=True)
             continue
 
         if event_type == "response.output_item.done":
@@ -531,6 +534,8 @@ def _consume_codex_event_stream(
     # Build the final output list.  Prefer items observed via output_item.done;
     # if none arrived but we streamed plain text deltas (no tool calls), synthesize
     # a single message item so downstream normalization has something to work with.
+    # Reasoning-only streams also need a concrete reasoning item; otherwise the
+    # normalizer sees an empty output and raises before it can continue the turn.
     if collected_output_items:
         output = list(collected_output_items)
     elif collected_text_deltas and not has_tool_calls:
@@ -541,6 +546,13 @@ def _consume_codex_event_stream(
             status="completed",
             content=[SimpleNamespace(type="output_text", text=assembled)],
         )]
+    elif collected_reasoning_deltas:
+        reasoning_text = "".join(collected_reasoning_deltas).strip()
+        output = [SimpleNamespace(
+            type="reasoning",
+            status="completed",
+            summary=[SimpleNamespace(type="summary_text", text=reasoning_text)],
+        )] if reasoning_text else []
     else:
         output = []
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1080,7 +1080,14 @@ def run_conversation(
                             else:
                                 # output_text fallback: stream backfill may have failed
                                 # but normalize can still recover from output_text
-                                _out_text = getattr(response, "output_text", None)
+                                try:
+                                    _out_text = getattr(response, "output_text", None)
+                                except Exception as exc:
+                                    logger.debug(
+                                        "Codex response.output_text access failed during validation: %s",
+                                        exc,
+                                    )
+                                    _out_text = None
                                 _out_text_stripped = _out_text.strip() if isinstance(_out_text, str) else ""
                                 if _out_text_stripped:
                                     logger.debug(

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -493,6 +493,34 @@ class TestCodexNormalizeResponse:
         assert tc.name == "terminal"
         assert '"command"' in tc.arguments
 
+    def test_reasoning_only_response_with_broken_output_text_is_incomplete(self, transport):
+        """SDK output_text access can fail when output contains no final message."""
+
+        class BrokenOutputTextResponse(SimpleNamespace):
+            @property
+            def output_text(self):
+                raise TypeError("'NoneType' object is not iterable")
+
+        r = BrokenOutputTextResponse(
+            output=[
+                SimpleNamespace(
+                    type="reasoning",
+                    summary=[SimpleNamespace(type="summary_text", text="Still thinking")],
+                    status="completed",
+                ),
+            ],
+            status="completed",
+            incomplete_details=None,
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5,
+                                  input_tokens_details=None, output_tokens_details=None),
+        )
+
+        nr = transport.normalize_response(r)
+
+        assert nr.content == ""
+        assert nr.reasoning == "Still thinking"
+        assert nr.finish_reason == "incomplete"
+
 
 
 class TestCodexTransportTimeout:

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -690,6 +690,37 @@ def test_run_codex_stream_ignores_completed_response_with_null_output(monkeypatc
     assert response.usage.total_tokens == 11
 
 
+def test_run_codex_stream_reasoning_only_create_stream_synthesizes_output(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    calls = {"create": 0}
+
+    create_stream = _FakeCreateStream(
+        [
+            SimpleNamespace(type="response.created"),
+            SimpleNamespace(type="response.reasoning.delta", delta="Primary reasoning"),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(output=None, status="completed"),
+            ),
+        ]
+    )
+
+    def _fake_create(**kwargs):
+        calls["create"] += 1
+        assert kwargs.get("stream") is True
+        return create_stream
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=_fake_create)
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert calls == {"create": 1}
+    assert response.output[0].type == "reasoning"
+    assert response.output[0].summary[0].text == "Primary reasoning"
+
+
 def test_run_conversation_codex_plain_text(monkeypatch):
     agent = _build_agent(monkeypatch)
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: _codex_message_response("OK"))


### PR DESCRIPTION
## Summary
- defensively handle SDK output_text access failures during Codex Responses normalization/validation
- synthesize reasoning-only output items from streamed reasoning deltas so continuation can proceed
- add regression coverage for broken output_text and reasoning-only streams

## Tests
- scripts/run_tests.sh tests/agent/transports/test_codex_transport.py tests/run_agent/test_run_agent_codex_responses.py