### PR TITLE
feat: allow fallback-specific reasoning config

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2684,6 +2684,11 @@ def init_agent(
         "api_mode": agent.api_mode,
         "api_key": getattr(agent, "api_key", ""),
         "client_kwargs": dict(agent._client_kwargs),
+        "reasoning_config": (
+            dict(agent.reasoning_config)
+            if isinstance(agent.reasoning_config, dict)
+            else agent.reasoning_config
+        ),
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,
         # Context engine state that _try_activate_fallback() overwrites.

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -3107,6 +3107,11 @@ def init_agent(
         "api_key": getattr(agent, "api_key", ""),
         "request_overrides": dict(getattr(agent, "request_overrides", {}) or {}),
         "client_kwargs": dict(agent._client_kwargs),
+        "reasoning_config": (
+            dict(agent.reasoning_config)
+            if isinstance(agent.reasoning_config, dict)
+            else agent.reasoning_config
+        ),
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,
         "reasoning_echo_flag": getattr(agent, "_reasoning_echo_flag", False),

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1468,6 +1468,12 @@ def restore_primary_runtime(agent) -> bool:
             agent._transport_cache.clear()
         agent.api_key = rt["api_key"]
         agent._client_kwargs = dict(rt["client_kwargs"])
+        _rt_reasoning_config = rt.get("reasoning_config")
+        agent.reasoning_config = (
+            dict(_rt_reasoning_config)
+            if isinstance(_rt_reasoning_config, dict)
+            else _rt_reasoning_config
+        )
         agent._use_prompt_caching = rt["use_prompt_caching"]
         # Default to native layout when the restored snapshot predates the
         # native-vs-proxy split (older sessions saved before this PR).

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1751,6 +1751,12 @@ def restore_primary_runtime(agent) -> bool:
         agent._reasoning_echo_flag = rt.get("reasoning_echo_flag", False)
         agent.request_overrides = dict(rt.get("request_overrides") or {})
         agent._client_kwargs = dict(rt["client_kwargs"])
+        _rt_reasoning_config = rt.get("reasoning_config")
+        agent.reasoning_config = (
+            dict(_rt_reasoning_config)
+            if isinstance(_rt_reasoning_config, dict)
+            else _rt_reasoning_config
+        )
         agent._use_prompt_caching = rt["use_prompt_caching"]
         # Default to native layout when the restored snapshot predates the
         # native-vs-proxy split (older sessions saved before this PR).

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1705,9 +1705,8 @@ def _fallback_reasoning_config(fallback_entry: Dict[str, Any]) -> Dict[str, Any]
     if isinstance(reasoning, dict):
         return dict(reasoning)
 
-    effort = fallback_entry.get("reasoning_effort")
-    if isinstance(effort, str):
-        return parse_reasoning_effort(effort)
+    if "reasoning_effort" in fallback_entry:
+        return parse_reasoning_effort(fallback_entry.get("reasoning_effort"))
 
     return None
 
@@ -1901,8 +1900,6 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         agent.base_url = fb_base_url
         agent.api_mode = fb_api_mode
         fb_reasoning_config = _fallback_reasoning_config(fb)
-        if fb_reasoning_config is not None:
-            agent.reasoning_config = fb_reasoning_config
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent._fallback_activated = True
@@ -2043,9 +2040,22 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             from hermes_cli.config import load_config
             from hermes_constants import resolve_reasoning_config
 
-            agent.reasoning_config = resolve_reasoning_config(
+            resolved_reasoning_config = resolve_reasoning_config(
                 load_config() or {}, agent.model
             )
+            if fb_reasoning_config is not None:
+                agent.reasoning_config = fb_reasoning_config
+            elif resolved_reasoning_config is not None:
+                agent.reasoning_config = resolved_reasoning_config
+            else:
+                primary_reasoning_config = (getattr(agent, "_primary_runtime", {}) or {}).get(
+                    "reasoning_config"
+                )
+                agent.reasoning_config = (
+                    dict(primary_reasoning_config)
+                    if isinstance(primary_reasoning_config, dict)
+                    else primary_reasoning_config
+                )
             logger.info(
                 "Fallback %s: reasoning_config resolved: %s",
                 agent.model, agent.reasoning_config,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -28,7 +28,7 @@ from types import SimpleNamespace
 from typing import Any, Dict, Optional
 
 from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale_timeout
-from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
+from hermes_constants import FINISH_REASON_LENGTH, PARTIAL_STREAM_STUB_ID, parse_reasoning_effort
 from agent.error_classifier import FailoverReason
 from agent.errors import EmptyStreamError
 from agent.turn_context import substitute_api_content
@@ -1690,6 +1690,27 @@ def _fallback_entry_unavailable_without_network(agent, fb: dict) -> Optional[str
     return None
 
 
+def _fallback_reasoning_config(fallback_entry: Dict[str, Any]) -> Dict[str, Any] | None:
+    """Return a reasoning override declared on a fallback entry, if any.
+
+    Supports either the full mapping form::
+
+        {"reasoning": {"enabled": True, "effort": "high"}}
+
+    or the shortcut used elsewhere in config/CLI::
+
+        {"reasoning_effort": "high"}
+    """
+    reasoning = fallback_entry.get("reasoning")
+    if isinstance(reasoning, dict):
+        return dict(reasoning)
+
+    effort = fallback_entry.get("reasoning_effort")
+    if isinstance(effort, str):
+        return parse_reasoning_effort(effort)
+
+    return None
+
 
 def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool:
     """Switch to the next fallback model/provider in the chain.
@@ -1879,6 +1900,9 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         agent.requested_provider = fb_provider
         agent.base_url = fb_base_url
         agent.api_mode = fb_api_mode
+        fb_reasoning_config = _fallback_reasoning_config(fb)
+        if fb_reasoning_config is not None:
+            agent.reasoning_config = fb_reasoning_config
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent._fallback_activated = True

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -28,7 +28,7 @@ from types import SimpleNamespace
 from typing import Any, Dict, Optional
 
 from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale_timeout
-from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
+from hermes_constants import FINISH_REASON_LENGTH, PARTIAL_STREAM_STUB_ID, parse_reasoning_effort
 from agent.error_classifier import (
     FailoverReason,
     PROVIDER_STREAM_NON_JSON_ERROR_CODE,
@@ -2456,6 +2456,28 @@ def _fallback_reason_text(reason: "FailoverReason | None") -> str:
     return str(value or reason or "provider failure").replace("_", " ")
 
 
+def _fallback_reasoning_config(fallback_entry: Dict[str, Any]) -> Dict[str, Any] | None:
+    """Return a reasoning override declared on a fallback entry, if any.
+
+    Supports either the full mapping form::
+
+        {"reasoning": {"enabled": True, "effort": "high"}}
+
+    or the shortcut used elsewhere in config/CLI::
+
+        {"reasoning_effort": "high"}
+    """
+    reasoning = fallback_entry.get("reasoning")
+    if isinstance(reasoning, dict) and reasoning:
+        return dict(reasoning)
+
+    if "reasoning_effort" in fallback_entry:
+        effort = fallback_entry.get("reasoning_effort")
+        return parse_reasoning_effort(effort)
+
+    return None
+
+
 def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool:
     """Switch to the next fallback model/provider in the chain.
 
@@ -2689,6 +2711,9 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # Read from the fallback entry so the flag travels with the active
         # provider; restore_primary_runtime will revert it from the snapshot.
         agent._reasoning_echo_flag = bool(fb.get("reasoning_echo", False))
+        fb_reasoning_config = _fallback_reasoning_config(fb)
+        if fb_reasoning_config is not None:
+            agent.reasoning_config = fb_reasoning_config
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent._fallback_activated = True

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2472,8 +2472,7 @@ def _fallback_reasoning_config(fallback_entry: Dict[str, Any]) -> Dict[str, Any]
         return dict(reasoning)
 
     if "reasoning_effort" in fallback_entry:
-        effort = fallback_entry.get("reasoning_effort")
-        return parse_reasoning_effort(effort)
+        return parse_reasoning_effort(fallback_entry.get("reasoning_effort"))
 
     return None
 
@@ -2712,8 +2711,6 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # provider; restore_primary_runtime will revert it from the snapshot.
         agent._reasoning_echo_flag = bool(fb.get("reasoning_echo", False))
         fb_reasoning_config = _fallback_reasoning_config(fb)
-        if fb_reasoning_config is not None:
-            agent.reasoning_config = fb_reasoning_config
         if hasattr(agent, "_transport_cache"):
             agent._transport_cache.clear()
         agent._fallback_activated = True
@@ -2854,9 +2851,22 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             from hermes_cli.config import load_config
             from hermes_constants import resolve_reasoning_config
 
-            agent.reasoning_config = resolve_reasoning_config(
+            resolved_reasoning_config = resolve_reasoning_config(
                 load_config() or {}, agent.model
             )
+            if fb_reasoning_config is not None:
+                agent.reasoning_config = fb_reasoning_config
+            elif resolved_reasoning_config is not None:
+                agent.reasoning_config = resolved_reasoning_config
+            else:
+                primary_reasoning_config = (getattr(agent, "_primary_runtime", {}) or {}).get(
+                    "reasoning_config"
+                )
+                agent.reasoning_config = (
+                    dict(primary_reasoning_config)
+                    if isinstance(primary_reasoning_config, dict)
+                    else primary_reasoning_config
+                )
             logger.info(
                 "Fallback %s: reasoning_config resolved: %s",
                 agent.model, agent.reasoning_config,

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -35,6 +35,7 @@ def _make_agent(
     provider="custom",
     base_url="https://my-llm.example.com/v1",
     request_overrides=None,
+    reasoning_config=None,
 ):
     """Create a minimal AIAgent with optional fallback config."""
     with (
@@ -61,6 +62,7 @@ def _make_agent(
             skip_memory=True,
             fallback_model=fallback_model,
             request_overrides=dict(request_overrides or {}),
+            reasoning_config=reasoning_config,
         )
         agent.client = MagicMock()
         return agent
@@ -105,6 +107,14 @@ class TestPrimaryRuntimeSnapshot:
         assert rt["compressor_provider"] == cc.provider
         assert rt["compressor_context_length"] == cc.context_length
         assert rt["compressor_threshold_tokens"] == cc.threshold_tokens
+
+    def test_snapshot_includes_reasoning_config(self):
+        agent = _make_agent(reasoning_config={"enabled": True, "effort": "medium"})
+
+        assert agent._primary_runtime["reasoning_config"] == {
+            "enabled": True,
+            "effort": "medium",
+        }
 
     def test_snapshot_includes_anthropic_state_when_applicable(self):
         """Anthropic-mode agents should snapshot Anthropic-specific state."""
@@ -177,6 +187,7 @@ class TestRestorePrimaryRuntime:
         agent._primary_runtime["model"] = "primary-model"
         original_model = agent.model
         original_provider = agent.provider
+
         mock_client = _mock_resolve()
         with patch(
             "agent.auxiliary_client.resolve_provider_client",
@@ -193,6 +204,29 @@ class TestRestorePrimaryRuntime:
             f"✅ Primary model restored: {original_model} via {original_provider}; "
             "fallback anthropic/claude-sonnet-4 via openrouter is no longer active."
         ]
+
+    def test_restores_primary_reasoning_config(self):
+        agent = _make_agent(
+            fallback_model={
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+                "reasoning_effort": "high",
+            },
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        mock_client = _mock_resolve()
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.reasoning_config == {"enabled": True, "effort": "high"}
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            assert agent._restore_primary_runtime() is True
+
+        assert agent.reasoning_config == {"enabled": True, "effort": "medium"}
 
     def test_does_not_label_temporary_model_restore_as_fallback_recovery(self):
         """`/model --once` reuses restore with no provider fallback lifecycle."""
@@ -711,7 +745,10 @@ class TestRestoreInRunConversation:
 
         # Turn 1: activate fallback
         mock_client = _mock_resolve()
-        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ):
             assert agent._try_activate_fallback() is True
 
         assert agent._fallback_activated is True

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -30,7 +30,12 @@ def _make_tool_defs(*names: str) -> list:
     ]
 
 
-def _make_agent(fallback_model=None, provider="custom", base_url="https://my-llm.example.com/v1"):
+def _make_agent(
+    fallback_model=None,
+    provider="custom",
+    base_url="https://my-llm.example.com/v1",
+    reasoning_config=None,
+):
     """Create a minimal AIAgent with optional fallback config."""
     with (
         patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
@@ -45,6 +50,7 @@ def _make_agent(fallback_model=None, provider="custom", base_url="https://my-llm
             skip_context_files=True,
             skip_memory=True,
             fallback_model=fallback_model,
+            reasoning_config=reasoning_config,
         )
         agent.client = MagicMock()
         return agent
@@ -82,6 +88,14 @@ class TestPrimaryRuntimeSnapshot:
         assert rt["compressor_provider"] == cc.provider
         assert rt["compressor_context_length"] == cc.context_length
         assert rt["compressor_threshold_tokens"] == cc.threshold_tokens
+
+    def test_snapshot_includes_reasoning_config(self):
+        agent = _make_agent(reasoning_config={"enabled": True, "effort": "medium"})
+
+        assert agent._primary_runtime["reasoning_config"] == {
+            "enabled": True,
+            "effort": "medium",
+        }
 
     def test_snapshot_includes_anthropic_state_when_applicable(self):
         """Anthropic-mode agents should snapshot Anthropic-specific state."""
@@ -145,6 +159,30 @@ class TestRestorePrimaryRuntime:
         assert agent._fallback_activated is False
         assert agent.model == original_model
         assert agent.provider == original_provider
+
+    def test_restores_primary_reasoning_config(self):
+        agent = _make_agent(
+            fallback_model={
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4",
+                "reasoning_effort": "high",
+            },
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+
+        mock_client = _mock_resolve()
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.reasoning_config == {"enabled": True, "effort": "high"}
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()):
+            assert agent._restore_primary_runtime() is True
+
+        assert agent.reasoning_config == {"enabled": True, "effort": "medium"}
 
     def test_resets_fallback_index(self):
         """After restore, the full fallback chain should be available again."""
@@ -510,7 +548,10 @@ class TestRestoreInRunConversation:
 
         # Turn 1: activate fallback
         mock_client = _mock_resolve()
-        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, None),
+        ):
             assert agent._try_activate_fallback() is True
 
         assert agent._fallback_activated is True

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 from run_agent import AIAgent, _pool_may_recover_from_rate_limit
 
 
-def _make_agent(fallback_model=None):
+def _make_agent(fallback_model=None, reasoning_config=None):
     """Create a minimal AIAgent with optional fallback config."""
     with (
         patch("run_agent.get_tool_definitions", return_value=[]),
@@ -24,6 +24,7 @@ def _make_agent(fallback_model=None):
             skip_context_files=True,
             skip_memory=True,
             fallback_model=fallback_model,
+            reasoning_config=reasoning_config,
         )
         agent.client = MagicMock()
         return agent
@@ -79,14 +80,25 @@ class TestFallbackChainAdvancement:
             {"provider": "zai", "model": "glm-4.7"},
         ]
         agent = _make_agent(fallback_model=fbs)
-        with patch("agent.auxiliary_client.resolve_provider_client",
-                    return_value=(_mock_client(), "gpt-4o")):
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(), "gpt-4o"),
+        ):
             assert agent._try_activate_fallback() is True
             assert agent._fallback_index == 1
             assert agent.model == "gpt-4o"
             assert agent._fallback_activated is True
 
 
+    def test_all_exhausted_returns_false(self):
+        fbs = [{"provider": "openai", "model": "gpt-4o"}]
+        agent = _make_agent(fallback_model=fbs)
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(), "gpt-4o"),
+        ):
+            assert agent._try_activate_fallback() is True
+            assert agent._try_activate_fallback() is False
 
     def test_skips_unconfigured_provider_to_next(self):
         """If resolve_provider_client returns None, skip to next in chain."""
@@ -230,6 +242,48 @@ class TestFallbackChainAdvancement:
 
         assert agent.api_mode == "chat_completions"
         assert agent.client is not None
+
+    def test_fallback_entry_reasoning_effort_overrides_current_config(self):
+        fbs = [
+            {
+                "provider": "openai",
+                "model": "gpt-4o",
+                "reasoning_effort": "high",
+            }
+        ]
+        agent = _make_agent(
+            fallback_model=fbs,
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(), "gpt-4o"),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.reasoning_config == {"enabled": True, "effort": "high"}
+
+    def test_fallback_entry_reasoning_mapping_overrides_current_config(self):
+        fbs = [
+            {
+                "provider": "openai",
+                "model": "gpt-4o",
+                "reasoning": {"enabled": False},
+            }
+        ]
+        agent = _make_agent(
+            fallback_model=fbs,
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(), "gpt-4o"),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.reasoning_config == {"enabled": False}
 
 
 # ── Pool-rotation vs fallback gating (#11314) ────────────────────────────

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -283,7 +283,57 @@ class TestFallbackChainAdvancement:
         ):
             assert agent._try_activate_fallback() is True
 
-        assert agent.reasoning_config == {"enabled": False}
+        assert getattr(agent, "reasoning_config") == {"enabled": False}
+
+    def test_fallback_entry_reasoning_effort_false_disables_reasoning(self):
+        fbs = [
+            {
+                "provider": "openai",
+                "model": "gpt-4o",
+                "reasoning_effort": False,
+            }
+        ]
+        agent = _make_agent(
+            fallback_model=fbs,
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(), "gpt-4o"),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert getattr(agent, "reasoning_config") == {"enabled": False}
+
+    def test_bare_fallback_after_override_restores_primary_reasoning_config(self):
+        fbs = [
+            {
+                "provider": "openai",
+                "model": "gpt-4o",
+                "reasoning_effort": "high",
+            },
+            {
+                "provider": "zai",
+                "model": "glm-4.7",
+            },
+        ]
+        agent = _make_agent(
+            fallback_model=fbs,
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(), "resolved"),
+        ):
+            assert agent._try_activate_fallback() is True
+            assert getattr(agent, "reasoning_config") == {"enabled": True, "effort": "high"}
+
+            assert agent._try_activate_fallback() is True
+
+        assert getattr(agent, "model") == "glm-4.7"
+        assert getattr(agent, "reasoning_config") == {"enabled": True, "effort": "medium"}
 
 
 # ── Pool-rotation vs fallback gating (#11314) ────────────────────────────

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -353,7 +353,78 @@ class TestFallbackChainAdvancement:
         ):
             assert agent._try_activate_fallback() is True
 
-        assert agent.reasoning_config == {"enabled": False}
+        assert getattr(agent, "reasoning_config") == {"enabled": False}
+
+    def test_empty_fallback_reasoning_mapping_keeps_primary_config(self):
+        fbs = [
+            {
+                "provider": "openai",
+                "model": "gpt-4o",
+                "reasoning": {},
+            }
+        ]
+        agent = _make_agent(
+            fallback_model=fbs,
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(), "gpt-4o"),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert getattr(agent, "reasoning_config") == {"enabled": True, "effort": "medium"}
+
+    def test_fallback_entry_reasoning_effort_false_disables_reasoning(self):
+        fbs = [
+            {
+                "provider": "openai",
+                "model": "gpt-4o",
+                "reasoning_effort": False,
+            }
+        ]
+        agent = _make_agent(
+            fallback_model=fbs,
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(), "gpt-4o"),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert getattr(agent, "reasoning_config") == {"enabled": False}
+
+    def test_bare_fallback_after_override_restores_primary_reasoning_config(self):
+        fbs = [
+            {
+                "provider": "openai",
+                "model": "gpt-4o",
+                "reasoning_effort": "high",
+            },
+            {
+                "provider": "zai",
+                "model": "glm-4.7",
+            },
+        ]
+        agent = _make_agent(
+            fallback_model=fbs,
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(), "resolved"),
+        ):
+            assert agent._try_activate_fallback() is True
+            assert getattr(agent, "reasoning_config") == {"enabled": True, "effort": "high"}
+
+            assert agent._try_activate_fallback() is True
+
+        assert getattr(agent, "model") == "glm-4.7"
+        assert getattr(agent, "reasoning_config") == {"enabled": True, "effort": "medium"}
 
 
 # ── Pool-rotation vs fallback gating (#11314) ────────────────────────────

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -14,7 +14,7 @@ from agent.error_classifier import FailoverReason
 from run_agent import AIAgent, _pool_may_recover_from_rate_limit
 
 
-def _make_agent(fallback_model=None):
+def _make_agent(fallback_model=None, reasoning_config=None):
     """Create a minimal AIAgent with optional fallback config."""
     with (
         patch("run_agent.get_tool_definitions", return_value=[]),
@@ -28,6 +28,7 @@ def _make_agent(fallback_model=None):
             skip_context_files=True,
             skip_memory=True,
             fallback_model=fallback_model,
+            reasoning_config=reasoning_config,
         )
         agent.client = MagicMock()
         return agent
@@ -105,8 +106,10 @@ class TestFallbackChainAdvancement:
             {"provider": "zai", "model": "glm-4.7"},
         ]
         agent = _make_agent(fallback_model=fbs)
-        with patch("agent.auxiliary_client.resolve_provider_client",
-                    return_value=(_mock_client(), "gpt-4o")):
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(), "gpt-4o"),
+        ):
             assert agent._try_activate_fallback() is True
             assert agent._fallback_index == 1
             assert agent.model == "gpt-4o"
@@ -130,6 +133,16 @@ class TestFallbackChainAdvancement:
         )
         assert agent._pending_fallback_notice == [expected]
         assert agent._retry_status_buffer[-1] == ("status", expected)
+
+    def test_all_exhausted_returns_false(self):
+        fbs = [{"provider": "openai", "model": "gpt-4o"}]
+        agent = _make_agent(fallback_model=fbs)
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(), "gpt-4o"),
+        ):
+            assert agent._try_activate_fallback() is True
+            assert agent._try_activate_fallback() is False
 
     def test_records_sequential_switches_in_order(self):
         agent = _make_agent(
@@ -299,6 +312,48 @@ class TestFallbackChainAdvancement:
 
         assert agent.api_mode == "chat_completions"
         assert agent.client is not None
+
+    def test_fallback_entry_reasoning_effort_overrides_current_config(self):
+        fbs = [
+            {
+                "provider": "openai",
+                "model": "gpt-4o",
+                "reasoning_effort": "high",
+            }
+        ]
+        agent = _make_agent(
+            fallback_model=fbs,
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(), "gpt-4o"),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.reasoning_config == {"enabled": True, "effort": "high"}
+
+    def test_fallback_entry_reasoning_mapping_overrides_current_config(self):
+        fbs = [
+            {
+                "provider": "openai",
+                "model": "gpt-4o",
+                "reasoning": {"enabled": False},
+            }
+        ]
+        agent = _make_agent(
+            fallback_model=fbs,
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(_mock_client(), "gpt-4o"),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.reasoning_config == {"enabled": False}
 
 
 # ── Pool-rotation vs fallback gating (#11314) ────────────────────────────

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -39,6 +39,32 @@ fallback_providers:
 
 Each entry requires both `provider` and `model`. Entries missing either field are ignored.
 
+Fallback entries may also override reasoning for that fallback only. Use the short
+`reasoning_effort` form for the standard levels (`none`, `minimal`, `low`,
+`medium`, `high`, `xhigh`):
+
+```yaml
+fallback_providers:
+  - provider: minimax
+    model: MiniMax-M2.7
+    reasoning_effort: high
+```
+
+For provider-specific reasoning options, use the full `reasoning` mapping:
+
+```yaml
+fallback_providers:
+  - provider: anthropic
+    model: claude-sonnet-4-5
+    reasoning:
+      enabled: true
+      effort: high
+```
+
+The override applies only while Hermes is running on that fallback. The next turn
+restores the primary model's normal reasoning configuration before trying the
+primary again.
+
 :::note `fallback_model` vs `fallback_providers`
 `fallback_providers` (plural, list) is the current config shape and supports multiple fallbacks tried in order. `fallback_model` (singular) is the legacy single-fallback key — Hermes still honors it for back-compat, but `hermes fallback` writes the current `fallback_providers` key and migrates legacy config on write. When both are set, `fallback_providers` takes priority.
 :::


### PR DESCRIPTION
## Summary
- add per-fallback reasoning overrides via `reasoning_effort` and `reasoning` on `fallback_providers` entries
- restore the primary model's reasoning config when the next turn switches back from fallback
- document the new YAML options for fallback providers

## Test Plan
- `scripts/run_tests.sh tests/run_agent/test_provider_fallback.py tests/run_agent/test_primary_runtime_restore.py`
- `python -m py_compile agent/chat_completion_helpers.py agent/agent_init.py agent/agent_runtime_helpers.py tests/run_agent/test_provider_fallback.py tests/run_agent/test_primary_runtime_restore.py`
- `git diff --check`

## Security / privacy
- changed-file scan for common high-risk token patterns returned 0 findings
- PR contains only code, tests, and docs changes; no local config, env, auth, or session files
