### PR TITLE
fix: add file browser hover reveal toggle

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -455,7 +455,7 @@ export function DesktopController() {
     requestGateway
   })
 
-  const { refreshHermesConfig, sttEnabled, voiceMaxRecordingSeconds } = useHermesConfig({
+  const { fileBrowserHoverReveal, refreshHermesConfig, sttEnabled, voiceMaxRecordingSeconds } = useHermesConfig({
     activeSessionIdRef,
     refreshProjectBranch
   })
@@ -1185,6 +1185,7 @@ export function DesktopController() {
       key="file-browser"
       maxWidth={FILE_BROWSER_MAX_WIDTH}
       minWidth={FILE_BROWSER_MIN_WIDTH}
+      pointerHoverReveal={fileBrowserHoverReveal}
       resizable
       side={railSide}
       width={FILE_BROWSER_DEFAULT_WIDTH}

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.test.ts
@@ -6,7 +6,7 @@ import { getHermesConfig } from '@/hermes'
 import { persistString } from '@/lib/storage'
 import { $currentCwd, setCurrentCwd } from '@/store/session'
 
-import { useHermesConfig } from './use-hermes-config'
+import { isFileBrowserHoverRevealEnabled, useHermesConfig } from './use-hermes-config'
 
 vi.mock('@/hermes', () => ({
   getHermesConfig: vi.fn(),
@@ -140,5 +140,20 @@ describe('useHermesConfig refreshHermesConfig', () => {
     })
 
     expect(refreshProjectBranch).toHaveBeenCalledWith('/workspace/attached-project')
+  })
+})
+
+describe('isFileBrowserHoverRevealEnabled', () => {
+  it('defaults to enabled for existing configs', () => {
+    expect(isFileBrowserHoverRevealEnabled({})).toBe(true)
+    expect(isFileBrowserHoverRevealEnabled({ display: {} })).toBe(true)
+  })
+
+  it('honors an explicit false value', () => {
+    expect(isFileBrowserHoverRevealEnabled({ display: { hover_reveal_file_browser: false } })).toBe(false)
+  })
+
+  it('keeps hover reveal enabled when explicitly true', () => {
+    expect(isFileBrowserHoverRevealEnabled({ display: { hover_reveal_file_browser: true } })).toBe(true)
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-hermes-config.ts
+++ b/apps/desktop/src/app/session/hooks/use-hermes-config.ts
@@ -16,6 +16,7 @@ import {
 import { applyAutoSpeakFromConfig } from '@/store/voice-prefs'
 
 const DEFAULT_VOICE_SECONDS = 120
+export const DEFAULT_FILE_BROWSER_HOVER_REVEAL = true
 const FAST_TIERS = new Set(['fast', 'priority', 'on'])
 
 function recordingLimit(value: unknown) {
@@ -39,12 +40,17 @@ function normalizeConfigEffort(value: unknown): string {
   return effort === 'false' || effort === 'disabled' ? 'none' : effort
 }
 
+export function isFileBrowserHoverRevealEnabled(config: { display?: { hover_reveal_file_browser?: boolean } }) {
+  return config.display?.hover_reveal_file_browser !== false
+}
+
 interface HermesConfigOptions {
   activeSessionIdRef: MutableRefObject<string | null>
   refreshProjectBranch: (cwd: string) => Promise<void>
 }
 
 export function useHermesConfig({ activeSessionIdRef, refreshProjectBranch }: HermesConfigOptions) {
+  const [fileBrowserHoverReveal, setFileBrowserHoverReveal] = useState(DEFAULT_FILE_BROWSER_HOVER_REVEAL)
   const [voiceMaxRecordingSeconds, setVoiceMaxRecordingSeconds] = useState(DEFAULT_VOICE_SECONDS)
   const [sttEnabled, setSttEnabled] = useState(true)
 
@@ -85,6 +91,7 @@ export function useHermesConfig({ activeSessionIdRef, refreshProjectBranch }: He
       setCurrentServiceTier(prev => (activeSessionIdRef.current ? prev : tier))
       setCurrentFastMode(prev => (activeSessionIdRef.current ? prev : FAST_TIERS.has(tier.toLowerCase())))
 
+      setFileBrowserHoverReveal(isFileBrowserHoverRevealEnabled(config))
       setVoiceMaxRecordingSeconds(recordingLimit(config.voice?.max_recording_seconds))
       setSttEnabled(config.stt?.enabled !== false)
       applyAutoSpeakFromConfig(config)
@@ -93,5 +100,5 @@ export function useHermesConfig({ activeSessionIdRef, refreshProjectBranch }: He
     }
   }, [activeSessionIdRef, refreshProjectBranch])
 
-  return { refreshHermesConfig, sttEnabled, voiceMaxRecordingSeconds }
+  return { fileBrowserHoverReveal, refreshHermesConfig, sttEnabled, voiceMaxRecordingSeconds }
 }

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -280,6 +280,7 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
   toolsets: 'Enabled Toolsets',
   timezone: 'Timezone',
   display: {
+    hoverRevealFileBrowser: 'File Browser Hover Reveal',
     personality: 'Personality',
     showReasoning: 'Reasoning Blocks'
   },
@@ -432,6 +433,7 @@ export const FIELD_DESCRIPTIONS: Record<string, string> = defineFieldCopy({
   modelContextLength: "Leave at 0 to use the selected model's detected context window.",
   fallbackProviders: 'Backup provider:model entries to try if the default model fails.',
   display: {
+    hoverRevealFileBrowser: 'Open the file browser as an edge overlay when the cursor nears the collapsed pane.',
     personality: 'Default assistant style for new sessions.',
     showReasoning: 'Show reasoning sections when the backend provides them.'
   },
@@ -525,6 +527,7 @@ export const SECTIONS: DesktopConfigSection[] = [
     keys: [
       'terminal.cwd',
       'code_execution.mode',
+      'display.hover_reveal_file_browser',
       'terminal.persistent_shell',
       'terminal.env_passthrough',
       'file_read_max_chars'

--- a/apps/desktop/src/app/settings/helpers.test.ts
+++ b/apps/desktop/src/app/settings/helpers.test.ts
@@ -44,6 +44,7 @@ describe('settings helpers', () => {
     it('maps schema keys to camelCase translation keys', () => {
       expect(schemaKeyToFieldCopyKey('model_context_length')).toBe('modelContextLength')
       expect(schemaKeyToFieldCopyKey('display.show_reasoning')).toBe('display.showReasoning')
+      expect(schemaKeyToFieldCopyKey('display.hover_reveal_file_browser')).toBe('display.hoverRevealFileBrowser')
       expect(schemaKeyToFieldCopyKey('tool_output.max_line_length')).toBe('toolOutput.maxLineLength')
       expect(schemaKeyToFieldCopyKey('updates.non_interactive_local_changes')).toBe(
         'updates.nonInteractiveLocalChanges'
@@ -53,6 +54,7 @@ describe('settings helpers', () => {
     it('looks up camelCase field copy by schema key with legacy fallback', () => {
       const copy = defineFieldCopy({
         display: {
+          hoverRevealFileBrowser: 'File Browser Hover Reveal',
           showReasoning: 'Reasoning Blocks'
         },
         file_read_max_chars: 'Legacy File Read Limit',
@@ -64,6 +66,7 @@ describe('settings helpers', () => {
 
       expect(fieldCopyForSchemaKey(copy, 'model_context_length')).toBe('Context Window')
       expect(fieldCopyForSchemaKey(copy, 'display.show_reasoning')).toBe('Reasoning Blocks')
+      expect(fieldCopyForSchemaKey(copy, 'display.hover_reveal_file_browser')).toBe('File Browser Hover Reveal')
       expect(fieldCopyForSchemaKey(copy, 'tool_output.max_line_length')).toBe('Line Length Limit')
       expect(fieldCopyForSchemaKey(copy, 'file_read_max_chars')).toBe('Legacy File Read Limit')
     })

--- a/apps/desktop/src/components/pane-shell/pane-shell.test.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { $paneStates, setPaneOpen, setPaneWidthOverride } from '@/store/panes'
 
-import { Pane, PaneMain, PaneShell } from './pane-shell'
+import { Pane, PANE_TOGGLE_REVEAL_EVENT, PaneMain, PaneShell } from './pane-shell'
 
 function gridContainer(rendered: ReturnType<typeof render>): HTMLElement {
   const root = rendered.container.firstElementChild
@@ -244,6 +244,26 @@ describe('PaneShell composition', () => {
 
     expect(cell.getAttribute('aria-hidden')).toBe('true')
     expect(cell.getAttribute('data-pane-open')).toBe('false')
+  })
+
+  it('keeps manual reveal when pointer hover is disabled', () => {
+    const rendered = render(
+      <PaneShell>
+        <Pane forceCollapsed hoverReveal id="files" pointerHoverReveal={false} side="right" width="240px">
+          files
+        </Pane>
+        <PaneMain>main</PaneMain>
+      </PaneShell>
+    )
+
+    const overlay = rendered.container.querySelector('[data-pane-hover-reveal]')
+
+    expect(overlay?.getAttribute('data-pane-hover-reveal')).toBe('closed')
+    expect(rendered.container.querySelector('[data-pane-reveal-trigger]')).toBeNull()
+
+    fireEvent(window, new CustomEvent(PANE_TOGGLE_REVEAL_EVENT, { detail: { id: 'files' } }))
+
+    expect(overlay?.getAttribute('data-pane-hover-reveal')).toBe('open')
   })
 
   it('passes through arbitrary non-Pane children for self-placement', () => {

--- a/apps/desktop/src/components/pane-shell/pane-shell.tsx
+++ b/apps/desktop/src/components/pane-shell/pane-shell.tsx
@@ -38,6 +38,8 @@ export interface PaneProps {
   forceCollapsed?: boolean
   /** When collapsed, float the contents over the main column on hover/focus instead of hiding them (track stays 0px). */
   hoverReveal?: boolean
+  /** Enable the pointer edge trigger for a collapsed overlay. Keyboard/manual reveal remains available when false. */
+  pointerHoverReveal?: boolean
   /**
    * Lay the pane out as a horizontal row beneath its rail (spanning every column on
    * its `side`) instead of as a vertical column. The pane then resizes on the Y axis.
@@ -350,6 +352,7 @@ export function Pane({
   maxWidth,
   minWidth,
   onOverlayActiveChange,
+  pointerHoverReveal = true,
   resizable = false,
   width
 }: PaneProps) {
@@ -500,12 +503,14 @@ export function Pane({
         ref={paneRef}
         style={{ gridColumn: slot.gridColumn, gridRow: slot.gridRow }}
       >
-        <div
-          aria-hidden="true"
-          className="pointer-events-auto absolute inset-y-0 z-30 [-webkit-app-region:no-drag]"
-          data-pane-reveal-trigger=""
-          style={{ [edge]: HOVER_REVEAL_EDGE_GUTTER, width: HOVER_REVEAL_TRIGGER_WIDTH }}
-        />
+        {pointerHoverReveal && (
+          <div
+            aria-hidden="true"
+            className="pointer-events-auto absolute inset-y-0 z-30 [-webkit-app-region:no-drag]"
+            data-pane-reveal-trigger=""
+            style={{ [edge]: HOVER_REVEAL_EDGE_GUTTER, width: HOVER_REVEAL_TRIGGER_WIDTH }}
+          />
+        )}
 
         {/* Keyed on side so flipping panes remounts off-screen on the new edge
             instead of transitioning the transform across the viewport. */}
@@ -513,7 +518,8 @@ export function Pane({
           className={cn(
             'pointer-events-none absolute inset-y-0 z-30 overflow-hidden transition-transform delay-0',
             offscreen,
-            'group-hover/reveal:pointer-events-auto group-hover/reveal:translate-x-0 group-hover/reveal:delay-[var(--reveal-enter-delay)] group-hover/reveal:shadow-[var(--reveal-shadow)]',
+            pointerHoverReveal &&
+              'group-hover/reveal:pointer-events-auto group-hover/reveal:translate-x-0 group-hover/reveal:delay-[var(--reveal-enter-delay)] group-hover/reveal:shadow-[var(--reveal-shadow)]',
             'group-data-[forced]/reveal:pointer-events-auto group-data-[forced]/reveal:translate-x-0 group-data-[forced]/reveal:delay-0 group-data-[forced]/reveal:shadow-[var(--reveal-shadow)]'
           )}
           key={edge}

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -207,6 +207,7 @@ export interface HermesConfig {
     service_tier?: string
   }
   display?: {
+    hover_reveal_file_browser?: boolean
     personality?: string
     skin?: string
   }

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1823,6 +1823,10 @@ DEFAULT_CONFIG = {
         #   "verbose" — include a compact content preview of what changed
         # Per-platform overrides via display.platforms.<platform>.memory_notifications.
         "memory_notifications": "on",
+        # Desktop file-browser pane: reveal the collapsed pane when the cursor
+        # approaches the window edge. Set false to keep manual keyboard reveal
+        # while disabling pointer-hover activation.
+        "hover_reveal_file_browser": True,
         "streaming": False,
         "timestamps": False,      # Show timestamp on user and assistant labels
         "timestamp_format": "%H:%M",  # strftime format for timestamps (e.g. "%b-%d %H:%M")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3776,6 +3776,15 @@ class TestBuildSchemaFromConfig:
         for cat, count in cats.items():
             assert count >= 2, f"Category '{cat}' has only {count} field(s) — should be merged"
 
+    def test_file_browser_hover_reveal_toggle_in_schema(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+        from hermes_cli.web_server import CONFIG_SCHEMA
+
+        assert DEFAULT_CONFIG["display"]["hover_reveal_file_browser"] is True
+        entry = CONFIG_SCHEMA["display.hover_reveal_file_browser"]
+        assert entry["type"] == "boolean"
+        assert entry["category"] == "display"
+
 
 # ---------------------------------------------------------------------------
 # Config round-trip tests


### PR DESCRIPTION
Summary:
- Add display.hover_reveal_file_browser to the default config so users can disable edge hover reveal for the desktop file browser.
- Wire the desktop runtime to read that setting while preserving the current enabled default.
- Surface the setting in the desktop Workspace settings and cover schema/config behavior with tests.

Tests:
- npm run test:ui --workspace apps/desktop -- use-hermes-config.test.ts helpers.test.ts
- npm exec --workspace apps/desktop -- eslint src/app/desktop-controller.tsx src/app/session/hooks/use-hermes-config.ts src/app/session/hooks/use-hermes-config.test.ts src/app/settings/constants.ts src/app/settings/helpers.test.ts src/types/hermes.ts
- $HOME/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_web_server.py::TestBuildSchemaFromConfig::test_file_browser_hover_reveal_toggle_in_schema -q
- npm run typecheck --workspace apps/desktop (blocked locally: missing use-stick-to-bottom dependency resolution in existing src/components/assistant-ui/thread-list.tsx)

Fixes #45928