### PR TITLE
fix(s6): prevent profile create from auto-starting gateway service

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1227,7 +1227,7 @@ def _maybe_register_gateway_service(profile_name: str) -> None:
     if not mgr.supports_runtime_registration():
         return  # host backend; no-op
     try:
-        mgr.register_profile_gateway(profile_name)
+        mgr.register_profile_gateway(profile_name, start_now=False)
     except ValueError:
         # Already registered (e.g. the container-boot reconciler ran
         # first and brought up a stale slot). That's fine.

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -77,6 +77,7 @@ class ServiceManager(Protocol):
         profile: str,
         *,
         extra_env: dict[str, str] | None = None,
+        start_now: bool = True,
     ) -> None: ...
     def unregister_profile_gateway(self, profile: str) -> None: ...
     def list_profile_gateways(self) -> list[str]: ...
@@ -175,6 +176,7 @@ class _RegistrationUnsupportedMixin:
         profile: str,
         *,
         extra_env: dict[str, str] | None = None,
+        start_now: bool = True,
     ) -> None:
         raise NotImplementedError(
             f"{type(self).__name__} does not support runtime profile "
@@ -823,15 +825,15 @@ class S6ServiceManager:
         profile: str,
         *,
         extra_env: dict[str, str] | None = None,
+        start_now: bool = True,
     ) -> None:
         """Create the s6 service directory for a profile gateway.
 
         Triggers ``s6-svscanctl -a`` so s6-svscan picks the new directory
-        up immediately. The service is created in the *up* state — to
-        register without auto-starting, follow up with ``stop(profile)``
-        (or pass the start flag via the future ``start_now=False`` arg,
-        which the Phase 4 reconciliation path uses via a ``down``
-        marker file written directly).
+        up immediately.  When *start_now* is ``True`` (the default) the
+        service starts immediately; when ``False`` a ``down`` marker file
+        is written so s6-supervise leaves the service stopped until the
+        user explicitly runs ``hermes -p <profile> gateway start``.
 
         Raises:
             ValueError: if the profile name is invalid or the service
@@ -878,6 +880,13 @@ class S6ServiceManager:
             # dirs. See ``_seed_supervise_skeleton`` for the full
             # rationale.
             _seed_supervise_skeleton(tmp_dir)
+
+            # When start_now is False, write a `down` marker so
+            # s6-supervise does not auto-start the service on rescan.
+            # Mirrors the same pattern in container_boot.py
+            # _register_gateway_slot when start=False.
+            if not start_now:
+                (tmp_dir / "down").touch()
 
             tmp_dir.rename(svc_dir)
         except Exception:

--- a/tests/hermes_cli/test_profiles_s6_hooks.py
+++ b/tests/hermes_cli/test_profiles_s6_hooks.py
@@ -54,10 +54,12 @@ class _S6Manager:
     def register_profile_gateway(
         self, profile: str, *,
         extra_env: dict[str, str] | None = None,
+        start_now: bool = True,
     ) -> None:
         if self.raise_on_register is not None:
             raise self.raise_on_register
         self.registered.append(profile)
+        self.last_start_now = start_now
 
     def unregister_profile_gateway(self, profile: str) -> None:
         if self.raise_on_unregister is not None:
@@ -105,6 +107,21 @@ def test_register_calls_through_on_s6(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     _maybe_register_gateway_service("coder")
     assert mgr.registered == ["coder"]
+
+
+def test_register_passes_start_now_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_maybe_register_gateway_service must register with start_now=False
+    so that profile creation does not auto-start a gateway that may
+    conflict with the main gateway's bot-token lock."""
+    _patch_detect_s6(monkeypatch)
+    mgr = _S6Manager()
+    monkeypatch.setattr(
+        "hermes_cli.service_manager.get_service_manager", lambda: mgr,
+    )
+    _maybe_register_gateway_service("coder")
+    assert mgr.last_start_now is False, (
+        "profile creation must not auto-start the gateway service"
+    )
 
 
 def test_register_swallows_duplicate_value_error(

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -572,6 +572,35 @@ def test_s6_register_creates_service_dir_and_triggers_scan(
     ), f"s6-svscanctl -a not invoked; saw: {fake_subprocess_run}"
 
 
+def test_s6_register_start_now_false_writes_down_marker(
+    s6_scandir, fake_subprocess_run,
+) -> None:
+    """When start_now=False, a `down` marker must be written so
+    s6-supervise does not auto-start the service on rescan."""
+    mgr = S6ServiceManager(scandir=s6_scandir)
+    mgr.register_profile_gateway("coder", start_now=False)
+
+    svc_dir = s6_scandir / "gateway-coder"
+    assert svc_dir.is_dir()
+    assert (svc_dir / "down").is_file(), (
+        "start_now=False must write a `down` marker file"
+    )
+
+
+def test_s6_register_start_now_true_no_down_marker(
+    s6_scandir, fake_subprocess_run,
+) -> None:
+    """When start_now=True (default), no `down` marker should exist."""
+    mgr = S6ServiceManager(scandir=s6_scandir)
+    mgr.register_profile_gateway("coder")
+
+    svc_dir = s6_scandir / "gateway-coder"
+    assert svc_dir.is_dir()
+    assert not (svc_dir / "down").exists(), (
+        "start_now=True must NOT write a `down` marker file"
+    )
+
+
 def test_s6_register_extra_env_is_quoted(s6_scandir, fake_subprocess_run) -> None:
     mgr = S6ServiceManager(scandir=s6_scandir)
     mgr.register_profile_gateway(


### PR DESCRIPTION
## What does this PR do?

Prevents `hermes profile create` from auto-starting a gateway service in s6 containers. Previously, every new profile's gateway started immediately on registration, causing profiles that share the main gateway's bot token (e.g. Kanban worker profiles like `coder`/`reviewer`) to fail with a token-lock conflict and persist `gateway_state: "running"` — becoming zombies that resurrect on every container restart.

## Related Issue

Fixes #45963

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/service_manager.py`: Added `start_now: bool = True` parameter to `S6ServiceManager.register_profile_gateway()`. When `start_now=False`, writes a `down` marker file (same pattern as `container_boot.py _register_gateway_slot`) so s6-supervise leaves the service stopped. Updated Protocol and `_RegistrationUnsupportedMixin` signatures for consistency.
- `hermes_cli/profiles.py`: Changed `_maybe_register_gateway_service()` to pass `start_now=False` so profile creation registers the s6 service without auto-starting it.
- `tests/hermes_cli/test_service_manager.py`: Added `test_s6_register_start_now_false_writes_down_marker` and `test_s6_register_start_now_true_no_down_marker`.
- `tests/hermes_cli/test_profiles_s6_hooks.py`: Added `test_register_passes_start_now_false` verifying the hook passes `start_now=False`. Updated `_S6Manager` mock to accept the new parameter.

## How to Test

1. Run `pytest tests/hermes_cli/test_service_manager.py -q` — all tests pass including the two new `start_now` tests
2. Run `pytest tests/hermes_cli/test_profiles_s6_hooks.py -q` — all tests pass including the new `start_now=False` assertion test
3. In an s6 container: `hermes profile create test-worker --clone-from default` should register the service but NOT start it (no `s6-svc -u` triggered); `hermes -p test-worker gateway start` should bring it up on demand

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — s6-only change, no cross-platform impact
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `S6ServiceManager.register_profile_gateway`, `_maybe_register_gateway_service` (callers: 1 each)
- Blast radius: LOW — s6 container only, no host impact
- Related patterns: `container_boot.py _register_gateway_slot` already uses the `down` marker pattern with `start=False` for the reconciler path
