### PR TITLE
fix(agent): return anthropic partial stream stubs

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2651,13 +2651,27 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     result["error"],
                 )
                 _stub_finish_reason = FINISH_REASON_LENGTH
+            _stub_model = getattr(agent, "model", None) or api_kwargs.get("model", "unknown")
+            if agent.api_mode == "anthropic_messages":
+                _content_text = _partial_text or ""
+                return SimpleNamespace(
+                    id=PARTIAL_STREAM_STUB_ID,
+                    type="message",
+                    role="assistant",
+                    model=_stub_model,
+                    content=[SimpleNamespace(type="text", text=_content_text)],
+                    stop_reason="max_tokens",
+                    stop_sequence=None,
+                    usage=None,
+                    _dropped_tool_names=_partial_names or None,
+                )
             _stub_msg = SimpleNamespace(
                 role="assistant", content=_partial_text, tool_calls=None,
                 reasoning_content=None,
             )
             return SimpleNamespace(
                 id=PARTIAL_STREAM_STUB_ID,
-                model=getattr(agent, "model", "unknown"),
+                model=_stub_model,
                 choices=[SimpleNamespace(
                     index=0, message=_stub_msg, finish_reason=_stub_finish_reason,
                 )],

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -6001,6 +6001,41 @@ class TestStreamingApiCall:
         assert resp.choices[0].message.content == "Hello"
         assert resp.model == "gpt-4"
 
+    def test_anthropic_partial_stream_error_returns_anthropic_message(self, agent):
+        class FakeAnthropicStream:
+            response = None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                yield SimpleNamespace(
+                    type="content_block_delta",
+                    delta=SimpleNamespace(type="text_delta", text="Recovered text"),
+                )
+
+            def get_final_message(self):
+                raise IndexError("list index out of range")
+
+        class FakeMessages:
+            def stream(self, **kwargs):
+                return FakeAnthropicStream()
+
+        agent.api_mode = "anthropic_messages"
+        agent.provider = "custom-anthropic"
+        agent._anthropic_client = SimpleNamespace(messages=FakeMessages())
+        agent.stream_delta_callback = MagicMock()
+
+        resp = agent._interruptible_streaming_api_call({"messages": [], "model": "claude-test"})
+
+        assert not hasattr(resp, "choices")
+        assert resp.content[0].type == "text"
+        assert resp.content[0].text == "Recovered text"
+        assert resp.stop_reason == "max_tokens"
+
 
 # ===================================================================
 # Interrupt _vprint force=True verification


### PR DESCRIPTION
## Summary
- fixes #45908
- returns Anthropic Message-shaped partial stream stubs for anthropic_messages after partial delivery failures
- adds a regression test for an Anthropic stream that emits text before get_final_message raises IndexError

## Testing
- `python3 -m pytest tests/run_agent/test_run_agent.py -q -k 'anthropic_partial_stream_error_returns_anthropic_message'`
- `python3 -m pytest tests/run_agent/test_run_agent.py -q -k 'StreamingApiCall'`
- `python3 -m pytest tests/run_agent/test_run_agent.py -q`
- `python3 -m py_compile agent/chat_completion_helpers.py tests/run_agent/test_run_agent.py`
- `python3 -m ruff check agent/chat_completion_helpers.py tests/run_agent/test_run_agent.py`
- `git diff --check`
- `python3 scripts/check-windows-footguns.py --diff origin/main`

## Notes
- Full repository test suite not run locally.