### PR TITLE
Fix DingTalk file attachments send and receive

### DIFF
--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -29,6 +29,7 @@ Configuration in config.yaml:
 import asyncio
 import json
 import logging
+import mimetypes
 import os
 import re
 import traceback
@@ -101,6 +102,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
+    cache_media_bytes,
 )
 
 logger = logging.getLogger(__name__)
@@ -812,6 +814,49 @@ class DingTalkAdapter(BasePlatformAdapter):
                                     msg_type = MessageType.DOCUMENT
 
         msg_type_str = getattr(message, "message_type", "") or ""
+        extensions = getattr(message, "extensions", None) or {}
+        ext_msg_type = extensions.get("msgtype", "") if isinstance(extensions, dict) else ""
+        ext_content = extensions.get("content") if isinstance(extensions, dict) else None
+        if msg_type_str == "file" or ext_msg_type == "file":
+            if isinstance(ext_content, str):
+                download_value = ext_content
+                file_type = ""
+                file_name = ""
+            elif isinstance(ext_content, dict):
+                download_value = (
+                    ext_content.get("downloadCode")
+                    or ext_content.get("download_code")
+                    or ext_content.get("fileId")
+                )
+                file_type = (
+                    ext_content.get("fileType")
+                    or ext_content.get("file_type")
+                    or ""
+                )
+                file_name = (
+                    ext_content.get("fileName")
+                    or ext_content.get("file_name")
+                    or ""
+                )
+            else:
+                download_value = ""
+                file_type = ""
+                file_name = ""
+
+            if download_value and download_value not in media_urls:
+                media_urls.append(download_value)
+                if file_type and "/" in file_type:
+                    media_type = file_type
+                else:
+                    suffix = str(file_type).lstrip(".")
+                    probe_name = file_name or (f"file.{suffix}" if suffix else str(download_value))
+                    media_type = (
+                        mimetypes.guess_type(probe_name)[0]
+                        or "application/octet-stream"
+                    )
+                media_types.append(media_type)
+                msg_type = MessageType.DOCUMENT
+
         if msg_type_str == "picture" and not media_urls:
             msg_type = MessageType.PHOTO
         elif msg_type_str == "richText":
@@ -970,13 +1015,14 @@ class DingTalkAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
-        """DingTalk webhook replies cannot send local image files directly."""
-        return SendResult(
-            success=False,
-            error=(
-                "DingTalk session webhook replies do not support local image uploads. "
-                "Only markdown/text replies are supported without OpenAPI media upload."
-            ),
+        """Upload a local image and send it as a DingTalk file attachment."""
+        return await self._send_local_file_attachment(
+            chat_id=chat_id,
+            file_path=image_path,
+            caption=caption,
+            file_name=os.path.basename(image_path),
+            reply_to=reply_to,
+            metadata=metadata,
         )
 
     async def send_document(
@@ -989,13 +1035,187 @@ class DingTalkAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
-        """DingTalk webhook replies cannot send local file attachments directly."""
+        """Upload and send a local file attachment via DingTalk OpenAPI."""
+        return await self._send_local_file_attachment(
+            chat_id=chat_id,
+            file_path=file_path,
+            caption=caption,
+            file_name=file_name,
+            reply_to=reply_to,
+            metadata=metadata,
+        )
+
+    def _session_webhook_for_send(
+        self,
+        chat_id: str,
+        metadata: Optional[Dict[str, Any]],
+    ) -> Optional[str]:
+        session_webhook = (metadata or {}).get("session_webhook")
+        if session_webhook:
+            return session_webhook
+        webhook_info = self._get_valid_webhook(chat_id)
+        return webhook_info[0] if webhook_info else None
+
+    async def _upload_local_media(
+        self,
+        file_path: str,
+        *,
+        file_name: Optional[str] = None,
+    ) -> Optional[str]:
+        """Upload a local file and return the DingTalk media id."""
+        if not self._http_client:
+            logger.warning("[%s] Cannot upload media: HTTP client not initialized", self.name)
+            return None
+        if not os.path.isfile(file_path):
+            logger.warning("[%s] Cannot upload missing media file: %s", self.name, file_path)
+            return None
+
+        token = await self._get_access_token()
+        if not token:
+            return None
+
+        name = os.path.basename(file_name or file_path) or "upload.bin"
+        content_type = mimetypes.guess_type(name)[0] or "application/octet-stream"
+
+        def _read_media_bytes() -> bytes:
+            with open(file_path, "rb") as file_handle:
+                return file_handle.read()
+
+        try:
+            data = await asyncio.to_thread(_read_media_bytes)
+        except OSError as exc:
+            logger.warning("[%s] Cannot read media file %s: %s", self.name, file_path, exc)
+            return None
+
+        url = (
+            "https://oapi.dingtalk.com/media/upload"
+            f"?access_token={token}&type=file"
+        )
+        try:
+            response = await self._http_client.post(
+                url,
+                files={"media": (name, data, content_type)},
+                timeout=60.0,
+            )
+        except Exception as exc:
+            logger.warning("[%s] DingTalk media upload failed: %s", self.name, exc)
+            return None
+
+        if response.status_code >= 300:
+            logger.warning(
+                "[%s] DingTalk media upload HTTP %s: %s",
+                self.name,
+                response.status_code,
+                getattr(response, "text", "")[:200],
+            )
+            return None
+
+        try:
+            result = response.json()
+        except Exception as exc:
+            logger.warning("[%s] DingTalk media upload returned invalid JSON: %s", self.name, exc)
+            return None
+        if not isinstance(result, dict) or result.get("errcode", 0) != 0:
+            logger.warning(
+                "[%s] DingTalk media upload error %s: %s",
+                self.name,
+                result.get("errcode") if isinstance(result, dict) else "unknown",
+                result.get("errmsg", "") if isinstance(result, dict) else "invalid response",
+            )
+            return None
+
+        nested_result = result.get("result")
+        if not isinstance(nested_result, dict):
+            nested_result = {}
+        media_id = (
+            result.get("media_id")
+            or result.get("mediaId")
+            or nested_result.get("media_id")
+            or nested_result.get("mediaId")
+        )
+        if not media_id:
+            logger.warning("[%s] DingTalk media upload returned no media_id", self.name)
+            return None
+        return str(media_id)
+
+    async def _send_local_file_attachment(
+        self,
+        *,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str],
+        file_name: Optional[str],
+        reply_to: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+    ) -> SendResult:
+        """Upload a local file, then send it through the chat's session webhook."""
+        session_webhook = self._session_webhook_for_send(chat_id, metadata)
+        if not session_webhook:
+            return SendResult(
+                success=False,
+                error="No valid session_webhook available for DingTalk file send.",
+            )
+        if not self._http_client:
+            return SendResult(success=False, error="HTTP client not initialized")
+
+        name = os.path.basename(file_name or file_path) or "file.bin"
+        media_id = await self._upload_local_media(file_path, file_name=name)
+        if not media_id:
+            return SendResult(success=False, error="DingTalk media upload failed")
+
+        if caption:
+            caption_result = await self.send(
+                chat_id=chat_id,
+                content=caption,
+                metadata=metadata,
+            )
+            if not caption_result.success:
+                logger.warning(
+                    "[%s] File caption send failed: %s", self.name, caption_result.error
+                )
+
+        extension = os.path.splitext(name)[1].lstrip(".").lower() or "bin"
+        payload = {
+            "msgtype": "file",
+            "file": {
+                "mediaId": media_id,
+                "fileName": name,
+                "fileType": extension,
+            },
+        }
+        try:
+            response = await self._http_client.post(
+                session_webhook,
+                json=payload,
+                timeout=15.0,
+            )
+        except Exception as exc:
+            logger.warning("[%s] DingTalk file send failed: %s", self.name, exc)
+            return SendResult(success=False, error=str(exc))
+
+        response_data = None
+        try:
+            response_data = response.json()
+        except Exception:
+            pass
+        api_error = (
+            response_data.get("errcode", 0)
+            if isinstance(response_data, dict)
+            else 0
+        )
+        if response.status_code < 300 and api_error == 0:
+            if reply_to is not None:
+                self._fire_done_reaction(chat_id)
+            return SendResult(success=True, message_id=uuid.uuid4().hex[:12])
+
+        error_text = (
+            response_data.get("errmsg", "")
+            if isinstance(response_data, dict)
+            else getattr(response, "text", "")[:200]
+        )
         return SendResult(
             success=False,
-            error=(
-                "DingTalk session webhook replies do not support local file attachments. "
-                "Only markdown/text replies are supported without OpenAPI message send."
-            ),
+            error=f"DingTalk file send failed ({response.status_code}): {error_text}",
         )
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
@@ -1299,7 +1519,7 @@ class DingTalkAdapter(BasePlatformAdapter):
             )
 
     async def _resolve_media_codes(self, message: "ChatbotMessage") -> None:
-        """Resolve download codes in message to actual URLs."""
+        """Resolve DingTalk download codes to cached local files or signed URLs."""
         token = await self._get_access_token()
         if not token:
             return
@@ -1311,42 +1531,117 @@ class DingTalkAdapter(BasePlatformAdapter):
         # 1. Single image content
         img_content = getattr(message, "image_content", None)
         if img_content and getattr(img_content, "download_code", None):
-            codes_to_resolve.append((img_content, "download_code"))
+            codes_to_resolve.append(
+                (
+                    img_content,
+                    "download_code",
+                    getattr(img_content, "file_name", "") or "",
+                    getattr(img_content, "file_type", "") or "",
+                    "image",
+                )
+            )
 
         # 2. Rich text list
-        rich_text = getattr(message, "rich_text_content", None)
+        rich_text = getattr(message, "rich_text_content", None) or getattr(
+            message, "rich_text", None
+        )
         if rich_text:
-            rich_list = getattr(rich_text, "rich_text_list", []) or []
+            rich_list = getattr(rich_text, "rich_text_list", None) or rich_text
             for item in rich_list:
                 if isinstance(item, dict):
                     for key in ("downloadCode", "pictureDownloadCode", "download_code"):
                         if item.get(key):
-                            codes_to_resolve.append((item, key))
+                            item_type = item.get("type", "")
+                            default_kind = DINGTALK_TYPE_MAPPING.get(item_type, "document")
+                            codes_to_resolve.append(
+                                (
+                                    item,
+                                    key,
+                                    item.get("fileName") or item.get("file_name") or "",
+                                    item.get("fileType") or item.get("file_type") or "",
+                                    default_kind,
+                                )
+                            )
+                            break
+
+        # 3. File callbacks commonly expose their payload only through
+        # extensions['content']. Update that same object so _extract_media sees
+        # the cached path rather than the opaque download code.
+        extensions = getattr(message, "extensions", None)
+        if isinstance(extensions, dict):
+            ext_msg_type = extensions.get("msgtype") or getattr(
+                message, "message_type", ""
+            )
+            ext_content = extensions.get("content")
+            if ext_msg_type == "file" and isinstance(ext_content, str):
+                ext_content = {"downloadCode": ext_content}
+                extensions["content"] = ext_content
+            if ext_msg_type == "file" and isinstance(ext_content, dict):
+                for key in ("downloadCode", "download_code", "fileId"):
+                    if ext_content.get(key):
+                        codes_to_resolve.append(
+                            (
+                                ext_content,
+                                key,
+                                ext_content.get("fileName")
+                                or ext_content.get("file_name")
+                                or "",
+                                ext_content.get("fileType")
+                                or ext_content.get("file_type")
+                                or "",
+                                "document",
+                            )
+                        )
+                        break
 
         if not codes_to_resolve:
             return
 
         # Resolve all codes in parallel
         tasks = []
-        for obj, key in codes_to_resolve:
+        seen = set()
+        for obj, key, file_name, file_type, default_kind in codes_to_resolve:
+            ref = (id(obj), key)
+            if ref in seen:
+                continue
+            seen.add(ref)
             code = getattr(obj, key, None) if hasattr(obj, key) else obj.get(key)
             if code:
                 tasks.append(
-                    self._fetch_download_url(code, robot_code, token, obj, key)
+                    self._fetch_download_url(
+                        code,
+                        robot_code,
+                        token,
+                        obj,
+                        key,
+                        file_name=file_name,
+                        file_type=file_type,
+                        default_kind=default_kind,
+                    )
                 )
 
         await asyncio.gather(*tasks, return_exceptions=True)
 
     async def _fetch_download_url(
-        self, code: str, robot_code: str, token: str, obj, key: str
+        self,
+        code: str,
+        robot_code: str,
+        token: str,
+        obj,
+        key: str,
+        *,
+        file_name: str = "",
+        file_type: str = "",
+        default_kind: str = "document",
     ) -> None:
-        """Fetch download URL for a single code using the robot SDK."""
+        """Resolve one download code and cache its bytes when possible."""
         if not self._robot_sdk:
             logger.warning(
                 "[%s] Robot SDK not initialized, cannot resolve media code",
                 self.name,
             )
             return
+        download_url = ""
         try:
             request = dingtalk_robot_models.RobotMessageFileDownloadRequest(
                 download_code=code,
@@ -1361,20 +1656,59 @@ class DingTalkAdapter(BasePlatformAdapter):
             )
             body = response.body if response else None
             if body:
-                url = getattr(body, "download_url", None)
-                if url:
-                    if hasattr(obj, key):
-                        setattr(obj, key, url)
-                    elif isinstance(obj, dict):
-                        obj[key] = url
-            else:
-                logger.warning(
-                    "[%s] Failed to download media: empty response for code %s",
-                    self.name,
-                    code,
-                )
+                download_url = getattr(body, "download_url", None) or ""
         except Exception as e:
             logger.error("[%s] Error resolving media code %s: %s", self.name, code, e)
+            return
+
+        if not download_url:
+            logger.warning(
+                "[%s] Failed to download media: empty response for code %s",
+                self.name,
+                code,
+            )
+            return
+
+        resolved_value = download_url
+        if self._http_client:
+            try:
+                file_response = await self._http_client.get(
+                    download_url,
+                    timeout=60.0,
+                    follow_redirects=True,
+                )
+                if file_response.status_code < 400:
+                    headers = getattr(file_response, "headers", {}) or {}
+                    response_type = str(headers.get("content-type", "")).split(";", 1)[0]
+                    cached = cache_media_bytes(
+                        file_response.content,
+                        filename=file_name,
+                        mime_type=file_type or response_type,
+                        default_kind=default_kind,
+                    )
+                    if cached:
+                        resolved_value = cached.path
+                        if isinstance(obj, dict):
+                            obj["fileType"] = cached.media_type
+                else:
+                    logger.warning(
+                        "[%s] DingTalk media download HTTP %s for code %s",
+                        self.name,
+                        file_response.status_code,
+                        code,
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "[%s] Failed to cache DingTalk media for code %s: %s",
+                    self.name,
+                    code,
+                    exc,
+                )
+
+        if hasattr(obj, key):
+            setattr(obj, key, resolved_value)
+        elif isinstance(obj, dict):
+            obj[key] = resolved_value
 
     @staticmethod
     def _normalize_markdown(text: str) -> str:
@@ -1541,6 +1875,14 @@ async def _standalone_send(
     out-of-process; this path uses the static DINGTALK_WEBHOOK_URL / extra
     webhook_url instead. Replaces the legacy _send_dingtalk helper.
     """
+    if media_files:
+        return {
+            "error": (
+                "DingTalk file delivery requires a live gateway adapter with "
+                "a valid session_webhook for the target chat."
+            )
+        }
+
     extra = getattr(pconfig, "extra", {}) or {}
     try:
         import httpx

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -1,7 +1,9 @@
 """Tests for DingTalk platform adapter."""
 import asyncio
 from datetime import datetime, timezone
+from pathlib import Path
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -323,24 +325,79 @@ class TestSend:
         assert payload["markdown"]["text"] == "Screenshot\n\n![image](https://example.com/demo.png)"
 
     @pytest.mark.asyncio
-    async def test_send_image_file_returns_explicit_unsupported_error(self):
+    async def test_send_image_file_uploads_and_sends_file_payload(self, tmp_path):
         from plugins.platforms.dingtalk.adapter import DingTalkAdapter
         adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        image_path = tmp_path / "demo.png"
+        image_path.write_bytes(b"png-bytes")
 
-        result = await adapter.send_image_file("chat-123", "/tmp/demo.png")
+        upload_response = MagicMock()
+        upload_response.status_code = 200
+        upload_response.json.return_value = {"errcode": 0, "media_id": "media-123"}
+        send_response = MagicMock()
+        send_response.status_code = 200
+        send_response.text = "OK"
+        mock_client = MagicMock()
+        mock_client.post = AsyncMock(side_effect=[upload_response, send_response])
+        adapter_any = cast(Any, adapter)
+        adapter_any._http_client = mock_client
+        adapter_any._get_access_token = AsyncMock(return_value="access-token")
+        adapter._session_webhooks["chat-123"] = (
+            "https://dingtalk.example/webhook",
+            0,
+        )
 
-        assert result.success is False
-        assert result.error and "do not support local image uploads" in result.error
+        result = await adapter.send_image_file("chat-123", str(image_path))
+
+        assert result.success is True
+        upload_call = mock_client.post.await_args_list[0]
+        assert upload_call.args[0].startswith(
+            "https://oapi.dingtalk.com/media/upload?access_token=access-token"
+        )
+        assert upload_call.kwargs["files"]["media"][0] == "demo.png"
+        send_call = mock_client.post.await_args_list[1]
+        assert send_call.args[0] == "https://dingtalk.example/webhook"
+        assert send_call.kwargs["json"] == {
+            "msgtype": "file",
+            "file": {
+                "mediaId": "media-123",
+                "fileName": "demo.png",
+                "fileType": "png",
+            },
+        }
 
     @pytest.mark.asyncio
-    async def test_send_document_returns_explicit_unsupported_error(self):
+    async def test_send_document_requires_session_webhook(self, tmp_path):
         from plugins.platforms.dingtalk.adapter import DingTalkAdapter
         adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        file_path = tmp_path / "demo.pdf"
+        file_path.write_bytes(b"%PDF-1.4")
 
-        result = await adapter.send_document("chat-123", "/tmp/demo.pdf")
+        result = await adapter.send_document("chat-123", str(file_path))
 
         assert result.success is False
-        assert result.error and "do not support local file attachments" in result.error
+        assert result.error and "session_webhook" in result.error
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_rejects_media_without_live_adapter(self, tmp_path):
+        from plugins.platforms.dingtalk.adapter import _standalone_send
+
+        file_path = tmp_path / "demo.txt"
+        file_path.write_text("demo", encoding="utf-8")
+        config = PlatformConfig(
+            enabled=True,
+            extra={"webhook_url": "https://oapi.dingtalk.com/robot/send"},
+        )
+
+        result = await _standalone_send(
+            config,
+            "chat-123",
+            "",
+            media_files=[(str(file_path), False)],
+        )
+
+        assert "live gateway adapter" in result["error"]
+        assert "session_webhook" in result["error"]
 
 
 # ---------------------------------------------------------------------------
@@ -621,6 +678,57 @@ class TestExtractMedia:
             assert mtypes == ["audio"]
         finally:
             del DINGTALK_TYPE_MAPPING["audio"]
+
+    @pytest.mark.asyncio
+    async def test_file_message_is_downloaded_and_extracted_from_extensions(
+        self, tmp_path, monkeypatch
+    ):
+        import gateway.platforms.base as base
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        from gateway.platforms.base import MessageType
+
+        monkeypatch.setattr(base, "DOCUMENT_CACHE_DIR", tmp_path)
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter_any = cast(Any, adapter)
+        adapter_any._get_access_token = AsyncMock(return_value="access-token")
+        adapter_any._robot_sdk = SimpleNamespace(
+            robot_message_file_download_with_options_async=AsyncMock(
+                return_value=SimpleNamespace(
+                    body=SimpleNamespace(download_url="https://signed.example/file")
+                )
+            )
+        )
+        file_response = MagicMock()
+        file_response.status_code = 200
+        file_response.content = b"hello from dingtalk"
+        file_response.headers = {"content-type": "text/plain"}
+        adapter_any._http_client = SimpleNamespace(
+            get=AsyncMock(return_value=file_response)
+        )
+        content = {
+            "downloadCode": "download-code-1",
+            "fileName": "git_diff.txt",
+            "fileType": "text/plain",
+        }
+        msg = SimpleNamespace(
+            message_type="file",
+            robot_code="robot-1",
+            image_content=None,
+            rich_text_content=None,
+            rich_text=None,
+            extensions={"msgtype": "file", "content": content},
+        )
+
+        await adapter._resolve_media_codes(cast(Any, msg))
+        msg_type, urls, media_types = adapter._extract_media(cast(Any, msg))
+
+        assert msg_type == MessageType.DOCUMENT
+        assert media_types == ["text/plain"]
+        assert len(urls) == 1
+        saved_path = Path(urls[0])
+        assert saved_path.parent == tmp_path
+        assert saved_path.name.endswith("_git_diff.txt")
+        assert saved_path.read_bytes() == b"hello from dingtalk"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -907,6 +907,69 @@ class TestSendToPlatformChunking:
         assert bot.send_message.await_count >= 3
         bot.send_photo.assert_awaited_once()
 
+    def test_dingtalk_media_uses_live_adapter_for_current_chat(self, tmp_path):
+        from gateway.platforms.base import SendResult
+
+        file_path = tmp_path / "git_diff.txt"
+        file_path.write_text("diff", encoding="utf-8")
+        calls = []
+
+        class FakeAdapter:
+            async def send(self, chat_id, content, metadata=None):
+                calls.append(("send", chat_id, content))
+                return SendResult(success=True, message_id="text-1")
+
+            async def send_document(self, chat_id, file_path, metadata=None):
+                calls.append(("send_document", chat_id, file_path))
+                return SendResult(success=True, message_id="file-1")
+
+        runner = SimpleNamespace(adapters={Platform.DINGTALK: FakeAdapter()})
+        with patch("gateway.run._gateway_runner_ref", return_value=runner):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.DINGTALK,
+                    SimpleNamespace(enabled=True, token=None, extra={}),
+                    "chat-current",
+                    "",
+                    media_files=[(str(file_path), False)],
+                )
+            )
+
+        assert result == {"success": True, "message_id": "file-1"}
+        assert calls == [("send_document", "chat-current", str(file_path))]
+        assert "media_deferred_to_gateway" not in result
+
+    def test_dingtalk_media_other_chat_propagates_missing_webhook(self, tmp_path):
+        from gateway.platforms.base import SendResult
+
+        file_path = tmp_path / "git_diff.txt"
+        file_path.write_text("diff", encoding="utf-8")
+
+        class FakeAdapter:
+            async def send(self, chat_id, content, metadata=None):
+                return SendResult(success=True, message_id="text-1")
+
+            async def send_document(self, chat_id, file_path, metadata=None):
+                return SendResult(
+                    success=False,
+                    error="No valid session_webhook available for target chat.",
+                )
+
+        runner = SimpleNamespace(adapters={Platform.DINGTALK: FakeAdapter()})
+        with patch("gateway.run._gateway_runner_ref", return_value=runner):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.DINGTALK,
+                    SimpleNamespace(enabled=True, token=None, extra={}),
+                    "chat-other",
+                    "",
+                    media_files=[(str(file_path), False)],
+                )
+            )
+
+        assert "session_webhook" in result["error"]
+        assert "media_deferred_to_gateway" not in result
+
     def test_matrix_media_uses_native_adapter_helper(self, tmp_path):
         doc_path = tmp_path / "test-send-message-matrix.pdf"
         doc_path.write_bytes(b"%PDF-1.4 test")

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -776,6 +776,81 @@ async def _send_via_adapter(
     }
 
 
+async def _send_dingtalk_files_via_live_adapter(
+    chat_id,
+    message,
+    media_files,
+    *,
+    thread_id=None,
+    force_document=False,
+):
+    """Send text and local files through an active gateway adapter.
+
+    Session-webhook platforms cannot deliver files from a standalone process:
+    the webhook belongs to the live conversation. Requiring the active adapter
+    also makes a missing target-chat webhook an explicit failure instead of a
+    deferred success that can attach the file to the wrong conversation.
+    """
+    from gateway.config import Platform
+
+    runner = None
+    try:
+        from gateway.run import _gateway_runner_ref
+        runner = _gateway_runner_ref()
+    except Exception:
+        runner = None
+
+    try:
+        adapter = runner.adapters.get(Platform.DINGTALK) if runner is not None else None
+    except Exception:
+        adapter = None
+    if adapter is None:
+        return {
+            "error": (
+                "DingTalk file delivery requires a live gateway adapter "
+                "for the target chat."
+            )
+        }
+
+    metadata = {"thread_id": thread_id} if thread_id else None
+    last_result = None
+    try:
+        if message.strip():
+            last_result = await adapter.send(
+                chat_id=chat_id,
+                content=message,
+                metadata=metadata,
+            )
+            if not last_result.success:
+                return {"error": f"Adapter send failed: {last_result.error}"}
+
+        image_extensions = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
+        for media_path, _is_voice in media_files or []:
+            extension = os.path.splitext(media_path)[1].lower()
+            if extension in image_extensions and not force_document:
+                last_result = await adapter.send_image_file(
+                    chat_id=chat_id,
+                    image_path=media_path,
+                    metadata=metadata,
+                )
+            else:
+                last_result = await adapter.send_document(
+                    chat_id=chat_id,
+                    file_path=media_path,
+                    metadata=metadata,
+                )
+            if not last_result.success:
+                return {"error": f"Adapter media send failed: {last_result.error}"}
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        return {"error": f"Adapter media send failed: {exc}"}
+
+    if last_result is None:
+        return {"error": "No DingTalk text or file content to send"}
+    return {"success": True, "message_id": last_result.message_id}
+
+
 async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
     """Route a message to the appropriate platform sender.
 
@@ -1023,6 +1098,25 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 chat_id,
                 chunk,
                 media_files=media_files if is_last else None,
+                thread_id=thread_id,
+                force_document=force_document,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
+    # DingTalk file messages require the per-conversation session webhook held
+    # by the running adapter. Sending through that adapter makes success mean
+    # the upload and target-chat webhook post both completed.
+    if platform == Platform.DINGTALK and media_files:
+        last_result = None
+        for index, chunk in enumerate(chunks):
+            is_last = index == len(chunks) - 1
+            result = await _send_dingtalk_files_via_live_adapter(
+                chat_id,
+                chunk,
+                media_files if is_last else [],
                 thread_id=thread_id,
                 force_document=force_document,
             )


### PR DESCRIPTION
## What does this PR do?

Fixes DingTalk file attachment send and receive support in the current plugin architecture.

### Behavior

- Parses inbound DingTalk `file` callbacks whose payload is stored in `message.extensions["content"]`.
- Resolves `downloadCode`, downloads the bytes, and stores them through Hermes' profile-aware shared media cache so agent tools receive a readable local path.
- Uploads outbound local files/images through DingTalk's media API and posts a native `file` payload through the target chat's active `session_webhook`.
- Routes DingTalk `send_message` attachments through the live adapter. Success now means the upload and target-chat webhook post completed; a different chat without a valid cached webhook returns an explicit error.
- Rejects media on the standalone static-webhook path because that path has no per-conversation `session_webhook`.

## Review feedback addressed

- Ported the implementation from the deleted `gateway/platforms/dingtalk.py` surface to `plugins/platforms/dingtalk/adapter.py`.
- Removed the old `media_deferred_to_gateway` behavior instead of deferring by platform alone, eliminating the cross-chat attachment misrouting path.
- Uses the existing canonical media cache rather than adding a new `DINGTALK_DOWNLOAD_DIR` behavioral environment variable or config key.
- Added current-chat, cross-chat failure, standalone failure, upload/send, and inbound download-to-cache regressions.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- Updated `plugins/platforms/dingtalk/adapter.py` with inbound file resolution/cache and outbound media upload/send support.
- Updated `tools/send_message_tool.py` to use the live DingTalk adapter for target-aware attachment delivery.
- Added regression coverage in `tests/gateway/test_dingtalk.py` and `tests/tools/test_send_message_tool.py`.

## How to Test

1. `scripts/run_tests.sh -j 3 tests/gateway/test_dingtalk.py tests/tools/test_send_message_tool.py tests/tools/test_send_message_missing_platforms.py`
2. `scripts/run_tests.sh -j 6 tests/gateway/test_dingtalk.py tests/gateway/test_media_extraction.py tests/gateway/test_document_cache.py tests/gateway/test_media_download_retry.py tests/gateway/test_send_image_file.py tests/tools/test_send_message_tool.py tests/tools/test_send_message_missing_platforms.py`
3. `ruff check .`
4. `python scripts/check-windows-footguns.py --all`

## Test Results

- Focused round: 243 passed, 0 failed.
- Adjacent media round: 350 passed, 0 failed.
- Blocking Ruff check: passed.
- Windows footgun check: passed.
- `ty` diff: no new diagnostics compared with `upstream/main`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A
