### PR TITLE
feat(kanban): bring-your-own-harness executor (cli-exec + tmux lanes, heartbeat + live progress)

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -77,6 +77,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "skills": list(t.skills) if t.skills else [],
         "max_retries": t.max_retries,
         "session_id": t.session_id,
+        "harness": t.harness,
         "workflow_template_id": t.workflow_template_id,
         "current_step_key": t.current_step_key,
     }
@@ -1519,6 +1520,8 @@ def _cmd_show(args: argparse.Namespace) -> int:
         print(f"  skills:    {', '.join(task.skills)}")
     if task.model_override:
         print(f"  model:     {task.model_override}")
+    if task.harness:
+        print(f"  harness:   {task.harness}")
     # Effective retry threshold. Show the per-task override if set,
     # otherwise the dispatcher's resolved value from config (or the
     # default if config doesn't set it either). Helps operators see

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -76,6 +76,7 @@ import json
 import os
 import re
 import secrets
+import shlex
 import shutil
 import sqlite3
 import subprocess
@@ -6836,14 +6837,21 @@ def resolve_spawn_backend(name: Optional[str]) -> SpawnBackend:
 def _select_spawn_backend(task: Task, board: Optional[str]) -> SpawnBackend:
     """Resolve which backend runs ``task``.
 
-    Per-task selection is honoured via the ``harness`` column on the task
-    (NULL -> the default ``hermes-native`` backend). Per-profile / per-board
-    config-driven defaults are a follow-up (C3); ``board`` is accepted now so
-    that wiring needs no signature change. An unknown/stale ``harness`` value
+    Selection precedence (first hit wins):
+
+    1. the task's ``harness`` column (explicit per-task override);
+    2. the board's ``kanban.harness`` default (``<board>/board.yaml``);
+    3. the executor profile's ``kanban.harness`` default
+       (``<assignee-profile>/config.yaml``);
+    4. the always-available ``hermes-native`` backend.
+
+    The board/profile config defaults let a whole board or profile opt into a
+    harness without stamping every task. An unknown/stale name at any level
     falls back to native with a warning rather than wedging dispatch -- see
     ``resolve_spawn_backend``.
     """
-    return resolve_spawn_backend(task.harness)
+    name = task.harness or _config_harness_name(task, board)
+    return resolve_spawn_backend(name)
 
 
 def _assemble_spawn_context(
@@ -7060,6 +7068,312 @@ class _HermesNativeBackend:
 
 
 register_spawn_backend(_HermesNativeBackend())
+
+
+# ---------------------------------------------------------------------------
+# Pluggable harness support: prompt compiler, profile/board config, and the
+# first non-native backend (the configured CLI run as a detached worker).
+# ---------------------------------------------------------------------------
+#
+# The spawn-backend seam (assemble context -> select backend -> launch) plus the
+# per-task ``harness`` column let a task run on a harness other than the in-tree
+# native worker. The three pieces below make a non-native harness usable:
+#
+#   * ``compile_task_prompt`` — renders the harness-agnostic ``SpawnContext``
+#     into the task brief an external CLI consumes (a file / stdin), since such
+#     CLIs don't take the native ``hermes -p <profile> chat -q`` argv.
+#   * profile/board harness config — a small schema + loader so a board or the
+#     executor profile can select and parametrise a backend (``kanban.harness``
+#     / ``kanban.harnesses.<name>``) without a per-task column.
+#   * ``CliExecBackend`` — runs the configured CLI non-interactively as a
+#     detached worker process (the native backend's launch shape), delivering
+#     the brief on stdin or as a file argument. No tmux: a one-shot exec needs
+#     no terminal, and the detached child already survives the dispatcher.
+
+
+def compile_task_prompt(ctx: SpawnContext) -> str:
+    """Render a harness-agnostic :class:`SpawnContext` into a CLI task brief.
+
+    The native backend hands the worker its context as argv + env. External
+    harnesses (codex / claude / agy / ...) instead read an instruction file or
+    stdin, so the same context (task, workspace, profile, resolved skills,
+    board) is compiled here into a deterministic Markdown brief any such CLI
+    can consume verbatim.
+
+    Vendor-neutral by construction: no CLI flags appear here. The board / DB /
+    task are pinned in the child env (``HERMES_KANBAN_*``), so the brief refers
+    to them by name (``$HERMES_KANBAN_TASK``) rather than hardcoding paths, and
+    states the kanban lifecycle contract the worker must honour to finish.
+    """
+    task = ctx.task
+    lines: list[str] = [f"# Kanban task {task.id}", ""]
+    if task.title and task.title.strip():
+        lines += [f"**{task.title.strip()}**", ""]
+    lines += [
+        f"- task id: `{task.id}`",
+        f"- board: `{ctx.board or get_current_board()}`",
+        f"- profile: `{ctx.profile}`",
+        f"- workspace: `{ctx.workspace}`",
+    ]
+    if task.branch_name:
+        lines.append(f"- branch: `{task.branch_name}`")
+    if task.model_override:
+        lines.append(f"- model: `{task.model_override}`")
+    lines.append("")
+
+    if task.body and task.body.strip():
+        lines += ["## Brief", "", task.body.strip(), ""]
+
+    if ctx.skills:
+        lines += [
+            "## Reference skills",
+            "",
+            "Load these skill pattern-libraries first (if your harness "
+            "supports skills):",
+        ]
+        lines += [f"- `{sk}`" for sk in ctx.skills]
+        lines.append("")
+
+    lines += [
+        "## Lifecycle (MANDATORY)",
+        "",
+        "You are a kanban worker. Your task id is in the environment as "
+        "`$HERMES_KANBAN_TASK`. When your work is committed and pushed, finish "
+        "the task:",
+        "",
+        "```sh",
+        'hermes kanban complete "$HERMES_KANBAN_TASK" --summary "<what you did>"',
+        "```",
+        "",
+        "If you are blocked (need review, missing input, failing dependency), "
+        "record it instead of exiting silently:",
+        "",
+        "```sh",
+        'hermes kanban block "$HERMES_KANBAN_TASK" --reason "<why>"',
+        "```",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+# --- profile/board harness config ------------------------------------------
+
+_KANBAN_CONFIG_KEY = "kanban"
+
+
+def _read_yaml_mapping(path: Path) -> dict:
+    """Best-effort load of a YAML mapping; ``{}`` on absent/broken/non-mapping.
+
+    A missing or malformed config file must never wedge dispatch: the caller
+    simply finds no harness override and falls back to native, exactly as for
+    an unknown harness name.
+    """
+    try:
+        if not path.is_file():
+            return {}
+        import yaml
+        with open(path, "r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+        return data if isinstance(data, dict) else {}
+    except Exception as exc:  # noqa: BLE001 - config errors are non-fatal
+        _log.warning("kanban: ignoring unreadable config %s (%s)", path, exc)
+        return {}
+
+
+def _profile_config_path(profile: Optional[str]) -> Optional[Path]:
+    """``<profile-home>/config.yaml`` for ``profile`` (``None`` if unresolvable)."""
+    if not profile:
+        return None
+    try:
+        from hermes_cli.profiles import get_profile_dir
+        return get_profile_dir(profile) / "config.yaml"
+    except Exception:
+        return None
+
+
+def _board_config_path(board: Optional[str]) -> Path:
+    """Optional per-board ``board.yaml`` (the board dir holds its kanban.db)."""
+    return kanban_db_path(board=board).parent / "board.yaml"
+
+
+def _kanban_config(profile: Optional[str], board: Optional[str]) -> dict:
+    """Effective ``kanban:`` config for ``(profile, board)``.
+
+    The board's ``board.yaml`` shallow-overlays the executor profile's
+    ``config.yaml``: scalar keys (``harness``) and per-backend ``harnesses.*``
+    params from the board win over the profile. Both sources are optional.
+    """
+    merged: dict = {}
+    for path in (_profile_config_path(profile), _board_config_path(board)):
+        if path is None:
+            continue
+        block = _read_yaml_mapping(path).get(_KANBAN_CONFIG_KEY)
+        if not isinstance(block, dict):
+            continue
+        for key, val in block.items():
+            if key == "harnesses" and isinstance(val, dict):
+                existing = merged.setdefault("harnesses", {})
+                if isinstance(existing, dict):
+                    existing.update(val)
+            else:
+                merged[key] = val
+    return merged
+
+
+def _config_harness_name(task: Task, board: Optional[str]) -> Optional[str]:
+    """Configured default backend name for ``task`` (board > profile), or None."""
+    cfg = _kanban_config(getattr(task, "assignee", None), board)
+    name = cfg.get("harness")
+    if not name:
+        return None
+    return str(name).strip() or None
+
+
+# --- cli-exec backend (run a CLI harness as a detached worker) --------------
+
+_CLI_PASS_PROMPT_MODES = ("stdin", "file-arg", "none")
+
+
+@dataclass(frozen=True)
+class CliExecConfig:
+    """Parameters for :class:`CliExecBackend`.
+
+    ``command`` is the harness CLI argv (e.g. ``["codex", "exec", "--model",
+    "gpt-5.4"]``). The compiled brief reaches it per ``pass_prompt``:
+
+    * ``stdin``    -> the brief file is the process's stdin (``codex exec … <
+      brief``, the shape codex/claude exec expect)
+    * ``file-arg`` -> the brief path is appended to ``command`` (``cli … brief``)
+    * ``none``     -> ``command`` only (the harness locates the brief itself)
+    """
+
+    command: tuple[str, ...]
+    prompt_file: str = ".hermes-task.md"
+    pass_prompt: str = "stdin"
+
+    @property
+    def binary(self) -> str:
+        return self.command[0]
+
+    @classmethod
+    def from_mapping(cls, data: Optional[dict]) -> "CliExecConfig":
+        if not isinstance(data, dict):
+            raise ValueError(
+                "cli-exec config missing or not a mapping; a task routed to the "
+                "cli-exec harness needs a kanban.harnesses.cli-exec block"
+            )
+        raw_cmd = data.get("command")
+        if isinstance(raw_cmd, str):
+            cmd = tuple(shlex.split(raw_cmd))
+        elif isinstance(raw_cmd, (list, tuple)):
+            cmd = tuple(str(p) for p in raw_cmd)
+        else:
+            cmd = ()
+        if not cmd:
+            raise ValueError("cli-exec config: 'command' must be a non-empty argv")
+        pass_prompt = str(data.get("pass_prompt", "stdin"))
+        if pass_prompt not in _CLI_PASS_PROMPT_MODES:
+            raise ValueError(
+                f"cli-exec config: pass_prompt {pass_prompt!r} not in "
+                f"{_CLI_PASS_PROMPT_MODES}"
+            )
+        return cls(
+            command=cmd,
+            prompt_file=str(data.get("prompt_file", ".hermes-task.md")),
+            pass_prompt=pass_prompt,
+        )
+
+
+def _load_cli_exec_config(
+    profile: Optional[str], board: Optional[str]
+) -> CliExecConfig:
+    cfg = _kanban_config(profile, board)
+    harnesses = cfg.get("harnesses")
+    block = harnesses.get("cli-exec") if isinstance(harnesses, dict) else None
+    return CliExecConfig.from_mapping(block)
+
+
+class CliExecBackend:
+    """Run a configured CLI harness for a task as a detached worker process.
+
+    Non-interactive by design: the harness (``codex exec``, ``claude -p``, ...)
+    starts, runs to completion, and exits, with stdout/stderr teed to the task's
+    kanban log. Same launch shape as the native backend — a detached ``Popen``
+    (``start_new_session=True``) that outlives a dispatcher restart and whose pid
+    is returned for crash detection — but it runs the configured argv instead of
+    the in-tree ``hermes`` worker, and delivers the compiled brief on stdin or as
+    a file argument. No terminal multiplexer is involved: a one-shot exec needs
+    none, and the detached child already survives the dispatcher.
+
+    Parameters (command, prompt delivery) come from the executor profile's /
+    board's ``kanban.harnesses.cli-exec`` block — see :class:`CliExecConfig`.
+    Selecting this backend with no usable config, or with the harness binary
+    absent on PATH, fails loudly (recorded as a spawn failure) rather than
+    silently degrading.
+    """
+
+    name = "cli-exec"
+
+    def __init__(self, config_loader=None):
+        # Indirection so tests can inject a config without a profile on disk.
+        self._config_loader = config_loader or _load_cli_exec_config
+
+    def launch(self, ctx: SpawnContext) -> Optional[int]:
+        import subprocess
+
+        cfg = self._config_loader(ctx.profile, ctx.board)
+
+        # Dispatch precondition: the harness binary must be present on PATH, so
+        # a task is never half-started against a missing CLI.
+        if shutil.which(cfg.binary) is None:
+            raise RuntimeError(
+                f"cli-exec backend: harness binary {cfg.binary!r} not found on "
+                f"PATH for task {ctx.task.id}; cannot dispatch."
+            )
+
+        # Compile + persist the task brief into the worktree.
+        prompt_path = Path(ctx.workspace) / cfg.prompt_file
+        prompt_path.parent.mkdir(parents=True, exist_ok=True)
+        prompt_path.write_text(compile_task_prompt(ctx), encoding="utf-8")
+
+        argv = list(cfg.command)
+        stdin_f = None
+        if cfg.pass_prompt == "file-arg":
+            argv.append(str(prompt_path))
+        elif cfg.pass_prompt == "stdin":
+            # The brief file IS the child's stdin (codex/claude exec read it).
+            stdin_f = open(prompt_path, "rb")
+
+        # Use 'a' so a re-run on unblock appends rather than overwrites.
+        log_f = open(ctx.log_path, "ab")
+        try:
+            proc = subprocess.Popen(  # noqa: S603 -- argv is a configured list
+                argv,
+                cwd=ctx.workspace if os.path.isdir(ctx.workspace) else None,
+                stdin=stdin_f if stdin_f is not None else subprocess.DEVNULL,
+                stdout=log_f,
+                stderr=subprocess.STDOUT,
+                env=ctx.env,
+                start_new_session=True,
+                creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
+            )
+        except FileNotFoundError:
+            log_f.close()
+            if stdin_f is not None:
+                stdin_f.close()
+            raise RuntimeError(
+                f"cli-exec backend: failed to launch {cfg.binary!r} for task "
+                f"{ctx.task.id}."
+            )
+        # The child has dup'd the brief fd; release the parent's handle. The log
+        # handle is intentionally left open (as in the native backend) so the
+        # detached child keeps writing after this returns.
+        if stdin_f is not None:
+            stdin_f.close()
+        return proc.pid
+
+
+register_spawn_backend(CliExecBackend())
 
 
 def _default_spawn(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -86,7 +86,7 @@ import time
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable, Optional, Protocol
 
 from toolsets import get_toolset_names
 
@@ -6720,25 +6720,116 @@ def _worker_terminal_timeout_env(
     return str(desired)
 
 
-def _default_spawn(
+# ---------------------------------------------------------------------------
+# Pluggable spawn backends ("bring-your-own harness")
+# ---------------------------------------------------------------------------
+#
+# A kanban task is executed by a *spawn backend*: a small object that knows how
+# to launch some agent harness for the task. The dispatcher assembles a
+# vendor-neutral ``SpawnContext`` (profile, env pins, prompt, workspace, log
+# path, resolved skills) and hands it to the backend's ``launch()``.
+#
+# Today exactly one backend ships and is always the default: ``hermes-native``,
+# which runs the in-tree ``hermes -p <profile> chat -q`` worker. The seam exists
+# so additional harnesses (driven via durable terminal lanes, external CLIs,
+# etc.) can be registered and selected per task/profile/board WITHOUT the engine
+# hardcoding any particular vendor CLI. Backend selection becomes data, not a
+# branch in this function.
+
+
+@dataclass(frozen=True)
+class SpawnContext:
+    """Everything a spawn backend needs to launch a worker for one task.
+
+    Assembled by ``_assemble_spawn_context`` and harness-agnostic: it carries
+    no ``hermes``-specific argv. A backend decides how to deliver ``prompt``
+    and ``skills`` to whatever harness it drives (CLI flags, prompt injection,
+    a terminal lane, ...).
+    """
+
+    task: Task
+    workspace: str
+    board: Optional[str]
+    profile: str
+    env: dict[str, str]
+    prompt: str
+    log_path: Path
+    skills: list[str]
+
+
+class SpawnBackend(Protocol):
+    """A harness launcher. Implementations may live in or out of tree.
+
+    ``launch`` starts the harness for ``ctx.task`` and returns the OS pid the
+    dispatcher should watch for crash detection (or ``None`` when the backend
+    is not process-trackable). It may raise to signal a spawn failure, which
+    the dispatcher records via ``_record_spawn_failure``.
+    """
+
+    name: str
+
+    def launch(self, ctx: SpawnContext) -> Optional[int]:
+        ...
+
+
+_SPAWN_BACKENDS: dict[str, SpawnBackend] = {}
+
+DEFAULT_SPAWN_BACKEND = "hermes-native"
+
+
+def register_spawn_backend(backend: SpawnBackend) -> None:
+    """Register a spawn backend under ``backend.name`` (last write wins)."""
+    _SPAWN_BACKENDS[backend.name] = backend
+
+
+def resolve_spawn_backend(name: Optional[str]) -> SpawnBackend:
+    """Look up a backend by name, falling back to the native default.
+
+    An unknown or empty name resolves to ``hermes-native`` rather than raising:
+    a stale or mistyped harness value must never wedge dispatch — the task still
+    runs on the always-available native backend (a warning is logged so the
+    misconfiguration is visible).
+    """
+    if name:
+        backend = _SPAWN_BACKENDS.get(name)
+        if backend is not None:
+            return backend
+        _log.warning(
+            "unknown spawn backend %r; falling back to %s",
+            name, DEFAULT_SPAWN_BACKEND,
+        )
+    return _SPAWN_BACKENDS[DEFAULT_SPAWN_BACKEND]
+
+
+def _select_spawn_backend(task: Task, board: Optional[str]) -> SpawnBackend:
+    """Resolve which backend runs ``task``.
+
+    Per-task / per-profile / per-board harness selection (backed by a
+    ``harness`` column + profile config) is a follow-up; today every task
+    resolves to the native backend. ``getattr`` keeps this forward-compatible
+    with that column without depending on it yet.
+    """
+    return resolve_spawn_backend(getattr(task, "harness", None))
+
+
+def _assemble_spawn_context(
     task: Task,
     workspace: str,
     *,
     board: Optional[str] = None,
-) -> Optional[int]:
-    """Fire-and-forget ``hermes -p <profile> chat -q ...`` subprocess.
+) -> SpawnContext:
+    """Build the harness-agnostic context for spawning ``task``'s worker.
 
-    Returns the spawned child's PID so the dispatcher can detect crashes
-    before the claim TTL expires. The child's completion is still observed
-    via the ``complete`` / ``block`` transitions the worker writes itself;
-    the PID check is a safety net for crashes, OOM kills, and Ctrl+C.
+    Resolves the profile, the fully-pinned child env (``HERMES_KANBAN_*`` board
+    / DB / workspaces / goal-mode / timeouts), the per-task log path (rotated),
+    and the availability-filtered skill list. No harness-specific argv is built
+    here — that is the backend's job.
 
-    ``board`` pins the child's kanban context to that board: the child's
-    ``HERMES_KANBAN_DB`` / ``HERMES_KANBAN_BOARD`` / workspaces_root env
-    vars all resolve to the same board the dispatcher claimed the task
-    from. Workers cannot accidentally see other boards.
+    ``board`` pins the child's kanban context to that board: the resulting
+    ``HERMES_KANBAN_DB`` / ``HERMES_KANBAN_BOARD`` / workspaces_root env vars
+    all resolve to the same board the dispatcher claimed the task from, so
+    workers cannot accidentally see other boards.
     """
-    import subprocess
     if not task.assignee:
         raise ValueError(f"task {task.id} has no assignee")
 
@@ -6815,97 +6906,152 @@ def _default_spawn(
     # attributed correctly regardless of how the child loads config.
     env["HERMES_PROFILE"] = profile_arg
 
-    cmd = [
-        *_resolve_hermes_argv(),
-        "-p", profile_arg,
-        # Worker subprocesses switch to a profile-scoped HERMES_HOME above,
-        # so they see that profile's shell-hook allowlist instead of the
-        # dispatcher's root allowlist. Pass --accept-hooks explicitly so
-        # profile-local worker sessions still register configured hooks.
-        "--accept-hooks",
-    ]
-    # Auto-load the kanban-worker skill so every dispatched worker
-    # has the pattern library (good summary/metadata shapes, retry
-    # diagnostics, block-reason examples) in its context, even if
-    # the profile hasn't wired it into skills config. The MANDATORY
-    # lifecycle is already in the system prompt via KANBAN_GUIDANCE;
-    # this skill is the deeper reference. Users can point a profile
-    # at a different/additional skill via config if they want —
-    # --skills is additive to the profile's default skill set.
+    # Resolve the per-task force-loaded skills, availability-filtered.
     #
-    # Only add the flag when the skill actually resolves for the home
-    # the worker runs under: the bundled skill is absent from many
-    # profile-scoped skills dirs, and preloading a missing skill is
-    # fatal at CLI startup. Omitting it is safe — the lifecycle
-    # contract still ships via KANBAN_GUIDANCE.
+    # The built-in kanban-worker skill loads first (when present): every
+    # dispatched worker gets the pattern library (good summary/metadata shapes,
+    # retry diagnostics, block-reason examples) in its context, even if the
+    # profile hasn't wired it into skills config. The MANDATORY lifecycle
+    # already ships in the system prompt via KANBAN_GUIDANCE; this skill is the
+    # deeper reference.
+    #
+    # Per-task skills follow, deduped against the built-in. EVERY name is
+    # availability-guarded: an unresolved skill is fatal at the worker's CLI
+    # startup (``Unknown skill(s): <name>``), crashing it before the agent loop
+    # runs. Drop-with-warning degrades gracefully — the task still runs, just
+    # without that skill's pattern library.
+    #
+    # How these names reach the harness (``--skills`` flags, prompt injection,
+    # ...) is the backend's concern; here we only decide *which* apply.
+    skills: list[str] = []
     if _kanban_worker_skill_available(env.get("HERMES_HOME")):
-        cmd.extend(["--skills", "kanban-worker"])
-    # Per-task force-loaded skills. Each name goes in its own
-    # `--skills X` pair rather than a single comma-joined arg: the CLI
-    # accepts both forms (action='append' + comma-split), but
-    # per-name pairs are easier to read in `ps` output and avoid any
-    # quoting ambiguity if a skill name ever contains unusual chars.
-    # Dedupe against the built-in so we don't double-load kanban-worker
-    # if a task author asks for it explicitly.
+        skills.append("kanban-worker")
     if task.skills:
         worker_home = env.get("HERMES_HOME")
         for sk in task.skills:
             if not sk or sk == "kanban-worker":
                 continue
-            # Availability-guard EVERY per-task force-loaded skill: an
-            # unresolved name is fatal at the worker's CLI startup
-            # (``Unknown skill(s): <name>``), crashing it before the agent loop
-            # runs. Drop-with-warning degrades gracefully — the task still runs,
-            # just without that skill's pattern library.
             if _kanban_skill_available(worker_home, sk):
-                cmd.extend(["--skills", sk])
+                skills.append(sk)
             else:
                 _log.warning(
                     "kanban task %s: dropping unresolved force-loaded skill %r "
                     "(not found under %s/skills) to avoid worker startup crash",
                     task.id, sk, worker_home or "~/.hermes",
                 )
-    if task.model_override:
-        cmd.extend(["-m", task.model_override])
-    cmd.extend([
-        "chat",
-        "-q", prompt,
-    ])
-    # Redirect output to a per-task log under <board-root>/logs/.
-    # Anchored at the board root (not the shared kanban root), so
-    # `hermes kanban log` on a specific board reads its own file and
-    # logs don't collide across boards that happen to share task ids.
+
+    # Per-task log under <board-root>/logs/. Anchored at the board root (not
+    # the shared kanban root) so `hermes kanban log` on a specific board reads
+    # its own file and logs don't collide across boards that share a task id.
     log_dir = worker_logs_dir(board=board)
     log_dir.mkdir(parents=True, exist_ok=True)
     log_path = log_dir / f"{task.id}.log"
     rotate_bytes, backup_count = worker_log_rotation_config()
     _rotate_worker_log(log_path, rotate_bytes, backup_count)
 
-    # Use 'a' so a re-run on unblock appends rather than overwrites.
-    log_f = open(log_path, "ab")
-    try:
-        proc = subprocess.Popen(  # noqa: S603 -- argv is a fixed list built above
-            cmd,
-            cwd=workspace if os.path.isdir(workspace) else None,
-            stdin=subprocess.DEVNULL,
-            stdout=log_f,
-            stderr=subprocess.STDOUT,
-            env=env,
-            start_new_session=True,
-            creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
-        )
-    except FileNotFoundError:
-        log_f.close()
-        raise RuntimeError(
-            "`hermes` executable not found on PATH. "
-            "Install Hermes Agent or activate its venv before running the kanban dispatcher."
-        )
-    # NOTE: we intentionally do NOT close log_f here — we want Popen's
-    # child process to keep writing after this function returns.  The
-    # handle is kept alive by the child's inheritance.  The parent's
-    # reference goes out of scope and is GC'd, but the OS-level FD stays
-    # open in the child until the child exits.
-    return proc.pid
+    return SpawnContext(
+        task=task,
+        workspace=workspace,
+        board=board,
+        profile=profile_arg,
+        env=env,
+        prompt=prompt,
+        log_path=log_path,
+        skills=skills,
+    )
+
+
+class _HermesNativeBackend:
+    """Default backend: the in-tree ``hermes -p <profile> chat -q`` worker.
+
+    Behavior-preserving — this is the exact argv + detached ``Popen`` the
+    dispatcher used before spawn backends existed. Always registered, and used
+    whenever a task does not select another harness.
+    """
+
+    name = "hermes-native"
+
+    def launch(self, ctx: SpawnContext) -> Optional[int]:
+        import subprocess
+
+        cmd = [
+            *_resolve_hermes_argv(),
+            "-p", ctx.profile,
+            # Worker subprocesses switch to a profile-scoped HERMES_HOME, so
+            # they see that profile's shell-hook allowlist instead of the
+            # dispatcher's root allowlist. Pass --accept-hooks explicitly so
+            # profile-local worker sessions still register configured hooks.
+            "--accept-hooks",
+        ]
+        # One `--skills X` pair per resolved skill rather than a single
+        # comma-joined arg: the CLI accepts both forms (action='append' +
+        # comma-split), but per-name pairs are easier to read in `ps` output
+        # and avoid quoting ambiguity if a skill name ever contains unusual
+        # chars. The list is already deduped + availability-filtered in
+        # _assemble_spawn_context (kanban-worker first, then per-task skills).
+        for sk in ctx.skills:
+            cmd.extend(["--skills", sk])
+        if ctx.task.model_override:
+            cmd.extend(["-m", ctx.task.model_override])
+        cmd.extend([
+            "chat",
+            "-q", ctx.prompt,
+        ])
+
+        # Use 'a' so a re-run on unblock appends rather than overwrites.
+        log_f = open(ctx.log_path, "ab")
+        try:
+            proc = subprocess.Popen(  # noqa: S603 -- argv is a fixed list built above
+                cmd,
+                cwd=ctx.workspace if os.path.isdir(ctx.workspace) else None,
+                stdin=subprocess.DEVNULL,
+                stdout=log_f,
+                stderr=subprocess.STDOUT,
+                env=ctx.env,
+                start_new_session=True,
+                creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
+            )
+        except FileNotFoundError:
+            log_f.close()
+            raise RuntimeError(
+                "`hermes` executable not found on PATH. "
+                "Install Hermes Agent or activate its venv before running the kanban dispatcher."
+            )
+        # NOTE: we intentionally do NOT close log_f here — we want Popen's
+        # child process to keep writing after this function returns.  The
+        # handle is kept alive by the child's inheritance.  The parent's
+        # reference goes out of scope and is GC'd, but the OS-level FD stays
+        # open in the child until the child exits.
+        return proc.pid
+
+
+register_spawn_backend(_HermesNativeBackend())
+
+
+def _default_spawn(
+    task: Task,
+    workspace: str,
+    *,
+    board: Optional[str] = None,
+) -> Optional[int]:
+    """Spawn a worker for ``task`` via its selected harness backend.
+
+    Thin orchestrator: assemble the harness-agnostic ``SpawnContext`` (profile,
+    pinned env, prompt, log path, resolved skills), pick the backend for the
+    task, and delegate the actual launch. Today every task resolves to the
+    ``hermes-native`` backend, which runs the in-tree ``hermes -p <profile>
+    chat -q`` worker — so the return contract is unchanged: the spawned child's
+    PID (so the dispatcher can detect crashes before the claim TTL expires), or
+    ``None``. The child's completion is still observed via the ``complete`` /
+    ``block`` transitions the worker writes itself; the PID check is a safety
+    net for crashes, OOM kills, and Ctrl+C.
+
+    ``board`` pins the child's kanban context to that board so workers cannot
+    accidentally see other boards (see ``_assemble_spawn_context``).
+    """
+    ctx = _assemble_spawn_context(task, workspace, board=board)
+    backend = _select_spawn_backend(task, board)
+    return backend.launch(ctx)
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3092,6 +3092,9 @@ def claim_review_task(
 ) -> Optional[Task]:
     """Atomically transition ``review -> running``.
 
+    Currently unreachable: the only caller is the dead review-column dispatch in
+    :func:`dispatch_once`; retained but marked for removal.
+
     Returns the claimed ``Task`` on success, ``None`` if the task was
     already claimed (or is not in ``review`` status).
 
@@ -6018,6 +6021,10 @@ def has_spawnable_review(conn: sqlite3.Connection) -> bool:
     Mirror of :func:`has_spawnable_ready` for the review column —
     used by the health telemetry to decide whether the dispatcher
     should have spawned a review agent.
+
+    Currently unreachable: the review-column dispatch never fires (nothing
+    transitions a task into status='review'), so this helper has no live
+    callers; retained but marked for removal.
     """
     rows = conn.execute(
         "SELECT DISTINCT assignee FROM tasks "
@@ -6350,6 +6357,14 @@ def dispatch_once(
                 result.auto_blocked.append(claimed.id)
 
     # ---- review column dispatch ----
+    #
+    # NOTE: this lane is currently unreachable and is marked for removal. No
+    # tool, CLI verb, MCP surface, or API transitions a task INTO
+    # status='review', so this loop never runs on any supported path, and the
+    # ``sdlc-review`` skill it force-loads below does not exist. Retained (not
+    # deleted) for now so the removal can be reviewed on its own — do not build
+    # on it.
+    #
     # Review tasks are tasks that a worker moved to 'review' after
     # creating a PR.  The dispatcher spawns a review agent (loading
     # sdlc-review skill) that verifies the PR and either merges (→ done)
@@ -6395,11 +6410,11 @@ def dispatch_once(
         # Persist the resolved workspace path so the worker can cd there.
         set_workspace_path(conn, claimed.id, str(workspace))
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
-        # Force-load sdlc-review skill for review agents.  The
-        # _default_spawn function already auto-loads kanban-worker, and
-        # appends task.skills via --skills.  Setting task.skills here
-        # means the review agent gets both kanban-worker (lifecycle)
-        # and sdlc-review (review logic: AC verification, merge, etc.).
+        # Unreachable (see note above): ``sdlc-review`` is a non-existent skill.
+        # This force-load previously crashed the review worker at CLI startup
+        # (Unknown skill(s): sdlc-review); _default_spawn now availability-guards
+        # per-task skills, so it is dropped-with-warning instead — but the whole
+        # review lane is unreachable and marked for removal regardless.
         claimed.skills = ["sdlc-review"]
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3966,29 +3966,52 @@ def _try_cleanup_parent_workspaces(conn: sqlite3.Connection, task_id: str) -> No
 
 
 def _cleanup_worker_tmux(conn: sqlite3.Connection, task_id: str) -> None:
-    """Kill the tmux session associated with a task's assignee, if dead."""
+    """Kill the dead tmux session(s) a finished task left behind.
+
+    Two session-naming conventions are reclaimed:
+
+    * ``swarm-<assignee>`` -- legacy swarm workers whose sessions are created
+      outside the engine;
+    * ``klane-<task_id>`` -- interactive terminal lanes spawned by
+      :class:`TmuxLaneBackend`.
+
+    A session is killed only once its pane is dead (the worker process exited),
+    so a still-running worker is never torn down. With ``remain-on-exit`` off
+    (the tmux default) a finished lane self-destroys and there is nothing to
+    reap; this is the belt-and-braces path for a pane that lingers. Best-effort
+    -- any error is swallowed so cleanup never blocks task completion.
+    """
     try:
+        # The lane session is keyed on the task id and needs no assignee.
+        sessions = [f"klane-{task_id}"]
         row = conn.execute(
             "SELECT assignee FROM tasks WHERE id = ?", (task_id,)
         ).fetchone()
-        if not row or not row["assignee"]:
-            return
-        assignee: str = row["assignee"]
-        # Workers named swarm1-12 use tmux sessions named swarm-swarm1 etc.
-        session = f"swarm-{assignee}"
-        # Check if session exists and pane is dead before killing
-        out = subprocess.run(
-            ["tmux", "list-panes", "-t", session, "-F", "#{pane_dead}"],
-            capture_output=True, text=True, timeout=5,
-        )
-        if out.stdout.strip() == "1":
-            subprocess.run(
-                ["tmux", "kill-session", "-t", session],
-                capture_output=True, timeout=5,
-            )
-            _log.debug("Killed stale tmux session: %s", session)
+        if row and row["assignee"]:
+            # Workers named swarm1-12 use tmux sessions named swarm-swarm1 etc.
+            sessions.append(f"swarm-{row['assignee']}")
+        for session in sessions:
+            _kill_tmux_session_if_dead(session)
     except Exception:
-        pass  # best-effort — never block completion
+        pass  # best-effort -- never block completion
+
+
+def _kill_tmux_session_if_dead(session: str) -> None:
+    """Kill ``session`` iff it exists and its pane is already dead.
+
+    A non-existent session makes ``list-panes`` exit non-zero with empty
+    output, so the dead-check fails closed and nothing is killed.
+    """
+    out = subprocess.run(
+        ["tmux", "list-panes", "-t", session, "-F", "#{pane_dead}"],
+        capture_output=True, text=True, timeout=5,
+    )
+    if out.stdout.strip() == "1":
+        subprocess.run(
+            ["tmux", "kill-session", "-t", session],
+            capture_output=True, timeout=5,
+        )
+        _log.debug("Killed stale tmux session: %s", session)
 
 
 # ---------------------------------------------------------------------------
@@ -7374,6 +7397,245 @@ class CliExecBackend:
 
 
 register_spawn_backend(CliExecBackend())
+
+
+# --- tmux terminal-lane backend (interactive harness in a durable PTY) ------
+#
+# Where cli-exec runs a one-shot, non-interactive CLI as a detached process,
+# the tmux lane gives an INTERACTIVE harness (a REPL like ``codex`` / ``claude``
+# in chat mode, ``aider``, ...) a real, durable PTY. The session is detached
+# (``new-session -d``) so it outlives a dispatcher restart -- the "durable
+# terminal lane" this seam was designed for. The brief is compiled to a file in
+# the workspace (as cli-exec does); the harness receives it by being told to
+# read that file (``send-keys``, the default -- it types a one-line pointer into
+# the live REPL), by a file argument (``file-arg``), or not at all (``none``,
+# the harness locates the brief itself).
+#
+# Decisions recorded for this backend (handoff item 1, step 4):
+#   * NAME = "tmux" -- mirrors the ``kanban.harnesses.tmux`` config key;
+#     "terminal-lane" was considered and rejected as longer with no upside.
+#   * Default prompt delivery = "send-keys" -- feeding a live REPL is the whole
+#     point of an interactive lane (vs cli-exec's stdin one-shot). The multi-
+#     line brief stays in the file; send-keys only types a short pointer to it,
+#     which is robust (no multi-line keystroke replay into a starting program).
+
+_TMUX_PASS_PROMPT_MODES = ("send-keys", "file-arg", "none")
+
+_DEFAULT_TMUX_SEND_KEYS = (
+    "Read {prompt_file} and complete this kanban task, following the "
+    "lifecycle instructions in it."
+)
+
+
+@dataclass(frozen=True)
+class TmuxLaneConfig:
+    """Parameters for :class:`TmuxLaneBackend`.
+
+    ``command`` is the interactive harness argv (e.g. ``["codex"]`` or
+    ``["claude"]`` started in its REPL). The compiled brief reaches it per
+    ``pass_prompt``:
+
+    * ``send-keys`` -> after the session is created, ``send_keys`` (with
+      ``{prompt_file}`` / ``{task_id}`` substituted) is typed into the live
+      pane followed by Enter; the brief itself stays in ``prompt_file``.
+    * ``file-arg``  -> the brief path is appended to ``command``.
+    * ``none``      -> ``command`` only (the harness locates the brief itself).
+
+    ``session_name`` is a template; ``{task_id}`` is substituted to form the
+    detached session name (default ``klane-<task_id>``), which
+    :func:`_cleanup_worker_tmux` reaps once the pane dies.
+    """
+
+    command: tuple[str, ...]
+    prompt_file: str = ".hermes-task.md"
+    pass_prompt: str = "send-keys"
+    session_name: str = "klane-{task_id}"
+    send_keys: str = _DEFAULT_TMUX_SEND_KEYS
+
+    @property
+    def binary(self) -> str:
+        return self.command[0]
+
+    @classmethod
+    def from_mapping(cls, data: Optional[dict]) -> "TmuxLaneConfig":
+        if not isinstance(data, dict):
+            raise ValueError(
+                "tmux config missing or not a mapping; a task routed to the "
+                "tmux harness needs a kanban.harnesses.tmux block"
+            )
+        raw_cmd = data.get("command")
+        if isinstance(raw_cmd, str):
+            cmd = tuple(shlex.split(raw_cmd))
+        elif isinstance(raw_cmd, (list, tuple)):
+            cmd = tuple(str(p) for p in raw_cmd)
+        else:
+            cmd = ()
+        if not cmd:
+            raise ValueError("tmux config: 'command' must be a non-empty argv")
+        pass_prompt = str(data.get("pass_prompt", "send-keys"))
+        if pass_prompt not in _TMUX_PASS_PROMPT_MODES:
+            raise ValueError(
+                f"tmux config: pass_prompt {pass_prompt!r} not in "
+                f"{_TMUX_PASS_PROMPT_MODES}"
+            )
+        return cls(
+            command=cmd,
+            prompt_file=str(data.get("prompt_file", ".hermes-task.md")),
+            pass_prompt=pass_prompt,
+            session_name=str(data.get("session_name", "klane-{task_id}")),
+            send_keys=str(data.get("send_keys", _DEFAULT_TMUX_SEND_KEYS)),
+        )
+
+
+def _load_tmux_lane_config(
+    profile: Optional[str], board: Optional[str]
+) -> TmuxLaneConfig:
+    cfg = _kanban_config(profile, board)
+    harnesses = cfg.get("harnesses")
+    block = harnesses.get("tmux") if isinstance(harnesses, dict) else None
+    return TmuxLaneConfig.from_mapping(block)
+
+
+def _parse_pane_pid(raw: str) -> Optional[int]:
+    """First parseable ``#{pane_pid}`` line from ``list-panes`` output, or None."""
+    for line in (raw or "").splitlines():
+        line = line.strip()
+        if line.isdigit():
+            return int(line)
+    return None
+
+
+class TmuxLaneBackend:
+    """Run an interactive harness for a task inside a detached tmux pane.
+
+    Unlike :class:`CliExecBackend` (a one-shot detached ``Popen``), this backend
+    gives the harness a real PTY via a detached tmux session
+    (``tmux new-session -d``). That session survives a dispatcher restart -- the
+    durable terminal lane this seam was built for -- and the harness can be an
+    interactive REPL rather than a non-interactive exec.
+
+    launch():
+      1. compile + persist the task brief into the workspace;
+      2. create the detached session (``-c`` workspace, ``-e KEY=VAL`` for the
+         pinned ``HERMES_KANBAN_*`` child env -- tmux >= 3.0);
+      3. tee the pane's output into the task log via ``pipe-pane`` (so the log
+         grows live, exactly as the native / cli-exec backends' logs do);
+      4. deliver the brief per ``pass_prompt`` (``send-keys`` types a pointer to
+         the brief file into the live REPL);
+      5. return the pane's ``#{pane_pid}`` for crash detection: when the harness
+         exits, that pid dies and the existing ``_pid_alive`` check reclaims the
+         task.
+
+    A missing ``tmux`` or harness binary fails loudly (recorded as a spawn
+    failure) rather than silently degrading. Parameters come from the executor
+    profile's / board's ``kanban.harnesses.tmux`` block -- see
+    :class:`TmuxLaneConfig`.
+    """
+
+    name = "tmux"
+
+    def __init__(self, config_loader=None):
+        # Indirection so tests can inject a config without a profile on disk.
+        self._config_loader = config_loader or _load_tmux_lane_config
+
+    def launch(self, ctx: SpawnContext) -> Optional[int]:
+        cfg = self._config_loader(ctx.profile, ctx.board)
+
+        # Preconditions: both tmux and the harness binary must be present, so a
+        # task is never half-started against a missing dependency.
+        if shutil.which("tmux") is None:
+            raise RuntimeError(
+                f"tmux backend: 'tmux' not found on PATH for task {ctx.task.id}; "
+                "cannot open a terminal lane."
+            )
+        if shutil.which(cfg.binary) is None:
+            raise RuntimeError(
+                f"tmux backend: harness binary {cfg.binary!r} not found on PATH "
+                f"for task {ctx.task.id}; cannot dispatch."
+            )
+
+        # Compile + persist the task brief into the workspace.
+        prompt_path = Path(ctx.workspace) / cfg.prompt_file
+        prompt_path.parent.mkdir(parents=True, exist_ok=True)
+        prompt_path.write_text(compile_task_prompt(ctx), encoding="utf-8")
+
+        session = cfg.session_name.format(task_id=ctx.task.id)
+
+        # Worker command for the pane. ``file-arg`` appends the brief path.
+        argv = list(cfg.command)
+        if cfg.pass_prompt == "file-arg":
+            argv.append(str(prompt_path))
+        shell_command = shlex.join(argv)
+
+        # Detached session. ``-e KEY=VAL`` (tmux >= 3.0) propagates the pinned
+        # child env even when an existing tmux server (with a different env)
+        # serves the new session. ``-c`` only when the workspace exists, else
+        # tmux rejects the start-directory.
+        new_session = ["tmux", "new-session", "-d", "-s", session]
+        if os.path.isdir(ctx.workspace):
+            new_session += ["-c", ctx.workspace]
+        for key, val in ctx.env.items():
+            new_session += ["-e", f"{key}={val}"]
+        new_session.append(shell_command)
+
+        created = subprocess.run(  # noqa: S603 -- argv is a built list
+            new_session, capture_output=True, text=True, timeout=15,
+        )
+        if created.returncode != 0:
+            raise RuntimeError(
+                f"tmux backend: failed to create session {session!r} for task "
+                f"{ctx.task.id}: "
+                f"{created.stderr.strip() or created.stdout.strip()}"
+            )
+
+        # Tee pane output into the task log so it grows live (items 2/3 build on
+        # log mtime + tailing). Best-effort: a logging gap must not wedge an
+        # otherwise-running worker.
+        try:
+            subprocess.run(  # noqa: S603
+                ["tmux", "pipe-pane", "-t", session, "-o",
+                 f"cat >> {shlex.quote(str(ctx.log_path))}"],
+                capture_output=True, text=True, timeout=5,
+            )
+        except Exception as exc:  # noqa: BLE001 -- logging is best-effort
+            _log.warning(
+                "tmux backend: could not pipe pane output to %s for task %s (%s)",
+                ctx.log_path, ctx.task.id, exc,
+            )
+
+        # Deliver the brief to the live REPL. ``-l`` types the pointer text
+        # literally; a separate ``Enter`` submits it. The bytes buffer in the
+        # PTY until the harness reads them, so this is safe right after launch.
+        if cfg.pass_prompt == "send-keys":
+            keys = cfg.send_keys.format(
+                prompt_file=cfg.prompt_file, task_id=ctx.task.id
+            )
+            subprocess.run(  # noqa: S603
+                ["tmux", "send-keys", "-t", session, "-l", keys],
+                capture_output=True, text=True, timeout=5,
+            )
+            subprocess.run(  # noqa: S603
+                ["tmux", "send-keys", "-t", session, "Enter"],
+                capture_output=True, text=True, timeout=5,
+            )
+
+        # The pane pid is the watchable host-local PID for crash detection. A
+        # freshly created session always has exactly one pane.
+        panes = subprocess.run(  # noqa: S603
+            ["tmux", "list-panes", "-t", session, "-F", "#{pane_pid}"],
+            capture_output=True, text=True, timeout=5,
+        )
+        pid = _parse_pane_pid(panes.stdout)
+        if pid is None:
+            _log.warning(
+                "tmux backend: no pane_pid for session %s (task %s); worker is "
+                "running but untracked for crash detection",
+                session, ctx.task.id,
+            )
+        return pid
+
+
+register_spawn_backend(TmuxLaneBackend())
 
 
 def _default_spawn(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -801,6 +801,13 @@ class Task:
     # set the env var. Lets clients render a per-session board without
     # relying on tenant + time-window heuristics.
     session_id: Optional[str] = None
+    # Name of the spawn backend that launches this task's worker, keyed
+    # into the spawn-backend registry (``register_spawn_backend``). NULL
+    # (the common case) selects the default ``hermes-native`` backend; an
+    # unknown/stale value falls back to native with a warning rather than
+    # wedging dispatch (see ``resolve_spawn_backend``). Honoured per-task
+    # by ``_select_spawn_backend``.
+    harness: Optional[str] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -875,6 +882,9 @@ class Task:
             ),
             session_id=(
                 row["session_id"] if "session_id" in keys else None
+            ),
+            harness=(
+                row["harness"] if "harness" in keys and row["harness"] else None
             ),
         )
 
@@ -1037,7 +1047,12 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- for tasks created from the CLI, dashboard, or any path that doesn't
     -- set the env var. Indexed so per-session list queries stay cheap on
     -- larger boards.
-    session_id           TEXT
+    session_id           TEXT,
+    -- Name of the spawn backend that launches this task's worker, keyed
+    -- into the spawn-backend registry. NULL (the common case) selects the
+    -- default ``hermes-native`` backend; unknown values fall back to native
+    -- with a warning. Honoured per-task by ``_select_spawn_backend``.
+    harness              TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -1693,6 +1708,15 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             conn, "tasks", "session_id", "session_id TEXT"
         )
 
+    if "harness" not in cols:
+        # Per-task spawn-backend selector for bring-your-own-harness
+        # dispatch. NULL on legacy rows and in the common case selects the
+        # default ``hermes-native`` backend, preserving the behaviour rows
+        # had before the column existed. Unknown values fall back to native
+        # with a warning (see ``resolve_spawn_backend``), so a stale value
+        # never wedges dispatch.
+        _add_column_if_missing(conn, "tasks", "harness", "harness TEXT")
+
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
     # parses each statement in ``executescript`` against the live schema, so a
@@ -2071,6 +2095,7 @@ def create_task(
     goal_max_turns: Optional[int] = None,
     initial_status: str = "running",
     session_id: Optional[str] = None,
+    harness: Optional[str] = None,
     board: Optional[str] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
@@ -2113,6 +2138,11 @@ def create_task(
         branch_name = str(branch_name).strip() or None
     if branch_name and workspace_kind != "worktree":
         raise ValueError("branch_name is only valid for worktree workspaces")
+    if harness is not None:
+        # Free-form backend name; empty/whitespace collapses to NULL so the
+        # dispatcher uses the default backend. Unknown-but-nonempty names are
+        # tolerated here and resolved (with a warning) at dispatch time.
+        harness = str(harness).strip() or None
     parents = tuple(p for p in parents if p)
 
     # Normalise + validate skills: strip whitespace, drop empties, dedupe
@@ -2236,8 +2266,9 @@ def create_task(
                         id, title, body, assignee, status, priority,
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, tenant, idempotency_key, max_runtime_seconds,
-                        skills, max_retries, goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        skills, max_retries, goal_mode, goal_max_turns, session_id,
+                        harness
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -2259,6 +2290,7 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        harness,
                     ),
                 )
                 for pid in parents:
@@ -6804,12 +6836,14 @@ def resolve_spawn_backend(name: Optional[str]) -> SpawnBackend:
 def _select_spawn_backend(task: Task, board: Optional[str]) -> SpawnBackend:
     """Resolve which backend runs ``task``.
 
-    Per-task / per-profile / per-board harness selection (backed by a
-    ``harness`` column + profile config) is a follow-up; today every task
-    resolves to the native backend. ``getattr`` keeps this forward-compatible
-    with that column without depending on it yet.
+    Per-task selection is honoured via the ``harness`` column on the task
+    (NULL -> the default ``hermes-native`` backend). Per-profile / per-board
+    config-driven defaults are a follow-up (C3); ``board`` is accepted now so
+    that wiring needs no signature change. An unknown/stale ``harness`` value
+    falls back to native with a warning rather than wedging dispatch -- see
+    ``resolve_spawn_backend``.
     """
-    return resolve_spawn_backend(getattr(task, "harness", None))
+    return resolve_spawn_backend(task.harness)
 
 
 def _assemble_spawn_context(

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4736,7 +4736,21 @@ def resolve_workspace(task: Task, *, board: Optional[str] = None) -> Path:
         return p
     if kind == "worktree":
         if not task.workspace_path:
-            # Default: .worktrees/<id>/ under CWD.  Worker skill creates it.
+            # Default worktree root: ``<assignee-profile-home>/.worktrees/<id>``.
+            # Anchor to the ASSIGNEE's profile home, NOT ``Path.cwd()``: the
+            # dispatcher runs inside whichever profile owns the gateway, so a
+            # CWD-relative root silently rooted every executor's worktree under
+            # the gateway profile's dir, mixing unrelated profiles' checkouts
+            # under one shared ``.git/worktrees`` registry. Resolving the
+            # assignee's home keeps each executor's worktrees under its own
+            # profile. Falls back to the legacy CWD-relative path only when no
+            # assignee is set or the profile cannot be resolved.
+            if task.assignee:
+                try:
+                    from hermes_cli.profiles import get_profile_dir
+                    return get_profile_dir(task.assignee) / ".worktrees" / task.id
+                except Exception:
+                    pass
             return Path.cwd() / ".worktrees" / task.id
         p = Path(task.workspace_path).expanduser()
         if not p.is_absolute():
@@ -6610,6 +6624,33 @@ def _resolve_hermes_argv() -> list[str]:
     return _module_hermes_argv()
 
 
+def _kanban_skill_available(hermes_home: Optional[str], skill_name: str) -> bool:
+    """True if a force-loadable skill ``skill_name`` resolves for the home the
+    spawned worker will run under.
+
+    Generalizes :func:`_kanban_worker_skill_available` to ANY per-task skill so
+    an unresolved name is dropped-with-warning at spawn time instead of crashing
+    the worker at CLI startup (``ValueError: Unknown skill(s): <name>``) before
+    the agent loop runs. An unset ``hermes_home`` means the worker falls back to
+    the default root home (``~/.hermes``).
+    """
+    from pathlib import Path as _Path
+
+    if not skill_name:
+        return False
+    base = _Path(hermes_home) if hermes_home else (_Path.home() / ".hermes")
+    skills_root = base / "skills"
+    if not skills_root.is_dir():
+        return False
+    try:
+        for skill_md in skills_root.rglob(f"{skill_name}/SKILL.md"):
+            if skill_md.is_file():
+                return True
+    except OSError:
+        pass
+    return False
+
+
 def _kanban_worker_skill_available(hermes_home: Optional[str]) -> bool:
     """True if the bundled ``kanban-worker`` skill resolves for the home the
     spawned worker will run under.
@@ -6626,23 +6667,12 @@ def _kanban_worker_skill_available(hermes_home: Optional[str]) -> bool:
     """
     from pathlib import Path as _Path
 
-    # An unset HERMES_HOME means the worker falls back to the default root
-    # home (``~/.hermes``), which ships the bundled skill.
-    base = _Path(hermes_home) if hermes_home else (_Path.home() / ".hermes")
-    skills_root = base / "skills"
-    if not skills_root.is_dir():
-        return False
-    # Canonical bundled location first (cheap), then a bounded scan for
+    # Canonical bundled location first (cheap), then the general resolver for
     # profiles that have it nested elsewhere.
-    if (skills_root / "devops" / "kanban-worker" / "SKILL.md").is_file():
+    base = _Path(hermes_home) if hermes_home else (_Path.home() / ".hermes")
+    if (base / "skills" / "devops" / "kanban-worker" / "SKILL.md").is_file():
         return True
-    try:
-        for skill_md in skills_root.rglob("kanban-worker/SKILL.md"):
-            if skill_md.is_file():
-                return True
-    except OSError:
-        pass
-    return False
+    return _kanban_skill_available(hermes_home, "kanban-worker")
 
 
 def _worker_terminal_timeout_env(
@@ -6803,9 +6833,23 @@ def _default_spawn(
     # Dedupe against the built-in so we don't double-load kanban-worker
     # if a task author asks for it explicitly.
     if task.skills:
+        worker_home = env.get("HERMES_HOME")
         for sk in task.skills:
-            if sk and sk != "kanban-worker":
+            if not sk or sk == "kanban-worker":
+                continue
+            # Availability-guard EVERY per-task force-loaded skill: an
+            # unresolved name is fatal at the worker's CLI startup
+            # (``Unknown skill(s): <name>``), crashing it before the agent loop
+            # runs. Drop-with-warning degrades gracefully — the task still runs,
+            # just without that skill's pattern library.
+            if _kanban_skill_available(worker_home, sk):
                 cmd.extend(["--skills", sk])
+            else:
+                _log.warning(
+                    "kanban task %s: dropping unresolved force-loaded skill %r "
+                    "(not found under %s/skills) to avoid worker startup crash",
+                    task.id, sk, worker_home or "~/.hermes",
+                )
     if task.model_override:
         cmd.extend(["-m", task.model_override])
     cmd.extend([

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -122,6 +122,41 @@ DEFAULT_CLAIM_TTL_SECONDS = 15 * 60
 # effect of normal API traffic.
 DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS = 60 * 60
 
+# Default runtime cap for NON-native (external-harness) workers when the task
+# has no explicit ``max_runtime_seconds``. Native workers stay fresh via
+# ``_touch_activity`` and are reclaimed by the heartbeat-stale backstop when
+# wedged; an opaque external CLI (cli-exec, tmux lane) has no such API-traffic
+# signal, so its heartbeat-stale backstop is driven by worker-log mtime
+# (``supervise_external_workers``) and bounded above by this cap. Two hours is
+# long enough for a substantial autonomous coding session but short enough to
+# reclaim a wedged/silent opaque worker without an operator noticing. Override
+# with ``HERMES_KANBAN_EXTERNAL_MAX_RUNTIME_SECONDS`` for legitimately long
+# external jobs.
+DEFAULT_EXTERNAL_WORKER_MAX_RUNTIME_SECONDS = 2 * 60 * 60
+
+# Maximum size (bytes) of a single ``worker_log`` progress excerpt emitted per
+# dispatcher tick. The log-tailer truncates to the most-recent bytes so a
+# chatty external worker can't flood ``task_events``.
+WORKER_LOG_EVENT_MAX_BYTES = 2000
+
+
+def _resolve_external_max_runtime_seconds() -> int:
+    """Effective runtime cap for external workers with no explicit cap.
+
+    A positive integer in ``HERMES_KANBAN_EXTERNAL_MAX_RUNTIME_SECONDS``
+    overrides the built-in default; invalid/non-positive values fall back
+    silently so existing installs keep working.
+    """
+    raw = os.environ.get("HERMES_KANBAN_EXTERNAL_MAX_RUNTIME_SECONDS", "").strip()
+    if raw:
+        try:
+            parsed = int(raw)
+        except ValueError:
+            parsed = 0
+        if parsed > 0:
+            return parsed
+    return DEFAULT_EXTERNAL_WORKER_MAX_RUNTIME_SECONDS
+
 
 def _resolve_claim_ttl_seconds(ttl_seconds: Optional[int] = None) -> int:
     """Return the effective claim TTL, honoring the kanban env override.
@@ -809,6 +844,11 @@ class Task:
     # wedging dispatch (see ``resolve_spawn_backend``). Honoured per-task
     # by ``_select_spawn_backend``.
     harness: Optional[str] = None
+    # Byte offset into the worker log up to which the external-worker
+    # supervisor has already emitted ``worker_log`` progress events. Lets the
+    # log-tailer resume across dispatcher ticks without re-emitting old lines.
+    # NULL/0 = nothing tailed yet. Only meaningful for non-native backends.
+    worker_log_offset: Optional[int] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -886,6 +926,11 @@ class Task:
             ),
             harness=(
                 row["harness"] if "harness" in keys and row["harness"] else None
+            ),
+            worker_log_offset=(
+                row["worker_log_offset"]
+                if "worker_log_offset" in keys and row["worker_log_offset"]
+                else None
             ),
         )
 
@@ -1053,7 +1098,12 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- into the spawn-backend registry. NULL (the common case) selects the
     -- default ``hermes-native`` backend; unknown values fall back to native
     -- with a warning. Honoured per-task by ``_select_spawn_backend``.
-    harness              TEXT
+    harness              TEXT,
+    -- Byte offset into the worker log already surfaced as ``worker_log``
+    -- progress events by the external-worker supervisor. Lets the log-tailer
+    -- resume across dispatcher ticks without re-emitting old lines. NULL/0 =
+    -- nothing tailed yet; only meaningful for non-native backends.
+    worker_log_offset    INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -1717,6 +1767,15 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         # with a warning (see ``resolve_spawn_backend``), so a stale value
         # never wedges dispatch.
         _add_column_if_missing(conn, "tasks", "harness", "harness TEXT")
+
+    if "worker_log_offset" not in cols:
+        # Persisted log-tail offset for the external-worker supervisor's
+        # progress tailer. NULL on legacy rows = nothing tailed yet, the
+        # correct default (the tailer starts from offset 0). Only non-native
+        # backends ever write it.
+        _add_column_if_missing(
+            conn, "tasks", "worker_log_offset", "worker_log_offset INTEGER"
+        )
 
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
@@ -3225,9 +3284,182 @@ def heartbeat_claim(
         return False
 
 
+# ---------------------------------------------------------------------------
+# External (non-native) worker supervision: heartbeat (log-mtime bridge) +
+# live card progress (log-tailer). External harnesses (cli-exec, tmux lane)
+# never call the kanban heartbeat/comment tools — they just write to the
+# board-anchored worker log. This block bridges that one observable signal
+# (the log) into the dispatcher's liveness + progress machinery via a single
+# per-task supervisor: it is the external equivalent of the native worker's
+# ``_touch_activity`` heartbeat bridge plus its ``kanban_comment`` progress
+# reports.
+# ---------------------------------------------------------------------------
+
+# ANSI escape sequences (colour/cursor) that an interactive harness piped into
+# the log via ``tmux pipe-pane`` would otherwise embed in a progress excerpt.
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_ESCAPE_RE.sub("", text)
+
+
+def _task_is_native(task: "Task", board: Optional[str]) -> bool:
+    """True when ``task`` runs on the always-available native backend.
+
+    Resolution honours the full selection precedence (task column > board >
+    profile > native). Any failure to resolve falls back to *native* so a
+    classification hiccup never changes reclaim/timeout behaviour for the
+    common case.
+    """
+    try:
+        return _select_spawn_backend(task, board).name == DEFAULT_SPAWN_BACKEND
+    except Exception:
+        return True
+
+
+def _worker_log_mtime(task_id: str, board: Optional[str]) -> Optional[int]:
+    """Integer mtime of the task's worker log, or None when it's absent."""
+    try:
+        return int(worker_log_path(task_id, board=board).stat().st_mtime)
+    except OSError:
+        return None
+
+
+def _effective_last_activity(
+    task: "Task",
+    board: Optional[str],
+    last_heartbeat_at: Optional[int],
+) -> Optional[int]:
+    """Liveness timestamp used by the heartbeat-stale backstop.
+
+    Native workers report progress as API traffic, bridged into
+    ``last_heartbeat_at`` by ``_touch_activity`` — so for them this is just
+    ``last_heartbeat_at`` unchanged.
+
+    Non-native workers never call the heartbeat APIs; their observable
+    progress is worker-log output. Fold the log mtime in so an actively
+    logging external worker stays alive even with a stale ``last_heartbeat_at``
+    (the false-reclaim this guards against), while one silent for longer than
+    the stale threshold is still treated as wedged and reclaimed.
+    """
+    hb = int(last_heartbeat_at) if last_heartbeat_at is not None else None
+    if _task_is_native(task, board):
+        return hb
+    mtime = _worker_log_mtime(task.id, board)
+    if mtime is None:
+        return hb
+    return max(hb or 0, mtime)
+
+
+def supervise_external_workers(
+    conn: sqlite3.Connection,
+    *,
+    board: Optional[str] = None,
+) -> int:
+    """Per-task supervisor for running NON-native (external-harness) workers.
+
+    For every ``running`` task whose backend is non-native this:
+
+      * **bridges** the worker-log mtime into ``last_heartbeat_at``
+        (``max(last_heartbeat_at, log_mtime)``) — the external equivalent of
+        the native ``_touch_activity`` heartbeat, so dashboards and the
+        heartbeat-stale backstop see real progress; and
+      * **tails** new log bytes since the persisted ``worker_log_offset`` and
+        appends at most one throttled, truncated ``worker_log`` progress
+        event, then advances the offset (no duplicate lines next tick).
+
+    PID-liveness / crash handling stays with ``detect_crashed_workers`` and the
+    runtime cap with ``enforce_max_runtime``; this supervisor never reclaims a
+    task. Returns the number of ``worker_log`` events emitted (for telemetry /
+    tests). Wired into ``dispatch_once`` BEFORE the reclaim steps so the bridge
+    is visible to ``release_stale_claims`` in the same tick.
+    """
+    rows = conn.execute(
+        "SELECT id, last_heartbeat_at, worker_log_offset, current_run_id "
+        "FROM tasks WHERE status = 'running'"
+    ).fetchall()
+    emitted = 0
+    for row in rows:
+        tid = row["id"]
+        try:
+            task = get_task(conn, tid)
+            if task is None or _task_is_native(task, board):
+                continue
+            log_path = worker_log_path(tid, board=board)
+            try:
+                size = log_path.stat().st_size
+                mtime = int(log_path.stat().st_mtime)
+            except OSError:
+                continue  # no log yet — nothing to bridge or tail
+
+            # (i) heartbeat bridge: fold log mtime into last_heartbeat_at.
+            hb = row["last_heartbeat_at"]
+            if mtime > (int(hb) if hb is not None else 0):
+                with write_txn(conn):
+                    conn.execute(
+                        "UPDATE tasks SET last_heartbeat_at = ? WHERE id = ?",
+                        (mtime, tid),
+                    )
+                    run_id = row["current_run_id"]
+                    if run_id is not None:
+                        conn.execute(
+                            "UPDATE task_runs SET last_heartbeat_at = ? "
+                            "WHERE id = ?",
+                            (mtime, run_id),
+                        )
+
+            # (ii) log-tailer: emit one throttled+truncated worker_log event
+            # for new bytes, then advance the offset.
+            offset = int(row["worker_log_offset"] or 0)
+            if offset > size:
+                # File shrank → rotated/truncated. Re-read from the start.
+                offset = 0
+            if size <= offset:
+                continue  # no new output this tick
+            try:
+                with open(log_path, "rb") as f:
+                    f.seek(offset)
+                    raw = f.read(size - offset)
+            except OSError:
+                continue
+            delta_bytes = len(raw)
+            excerpt = _strip_ansi(raw.decode("utf-8", errors="replace")).strip()
+            truncated = False
+            if len(excerpt) > WORKER_LOG_EVENT_MAX_BYTES:
+                # Keep the most-recent bytes — that's where progress is.
+                excerpt = excerpt[-WORKER_LOG_EVENT_MAX_BYTES:]
+                truncated = True
+            with write_txn(conn):
+                conn.execute(
+                    "UPDATE tasks SET worker_log_offset = ? WHERE id = ?",
+                    (size, tid),
+                )
+                if excerpt:
+                    _append_event(
+                        conn, tid, "worker_log",
+                        {
+                            "excerpt": excerpt,
+                            "bytes": delta_bytes,
+                            "offset": offset,
+                            "truncated": truncated,
+                        },
+                        run_id=row["current_run_id"],
+                    )
+                    emitted += 1
+        except Exception:
+            # A single misbehaving task must never break the dispatcher tick.
+            _log.debug(
+                "supervise_external_workers: skipping task %s", tid, exc_info=True
+            )
+            continue
+    return emitted
+
+
 def release_stale_claims(
     conn: sqlite3.Connection,
     *,
+    board: Optional[str] = None,
     signal_fn=None,
 ) -> int:
     """Reset any ``running`` task whose claim has expired.
@@ -3268,11 +3500,25 @@ def release_stale_claims(
     for row in stale:
         lock = row["claim_lock"] or ""
         host_local = lock.startswith(host_prefix)
-        hb = row["last_heartbeat_at"]
-        # Heartbeat staleness backstop: if we have a heartbeat at all
-        # and it's older than the max-stale threshold, the worker is
-        # not making observable progress.  Reclaim instead of extending,
-        # even if the PID is still alive (it's likely in a logic loop).
+        # Backend-aware liveness signal. Native workers report progress as
+        # API traffic bridged into ``last_heartbeat_at``; an external harness
+        # (cli-exec, tmux lane) never calls the heartbeat APIs, so its
+        # observable-progress signal is worker-log output. ``_effective_last_
+        # activity`` folds the log mtime in for non-native backends (leaving
+        # native unchanged), so an actively-logging external worker isn't
+        # falsely reclaimed despite a stale ``last_heartbeat_at``, while one
+        # silent past the threshold is still treated as wedged.
+        _stale_task = get_task(conn, row["id"])
+        hb = (
+            _effective_last_activity(_stale_task, board, row["last_heartbeat_at"])
+            if _stale_task is not None
+            else row["last_heartbeat_at"]
+        )
+        # Heartbeat staleness backstop: if we have a (possibly log-bridged)
+        # liveness timestamp at all and it's older than the max-stale
+        # threshold, the worker is not making observable progress.  Reclaim
+        # instead of extending, even if the PID is still alive (it's likely
+        # in a logic loop, or — for an opaque external CLI — wedged/silent).
         heartbeat_stale = (
             hb is not None
             and (now - int(hb)) > DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS
@@ -5263,15 +5509,23 @@ def heartbeat_worker(
 def enforce_max_runtime(
     conn: sqlite3.Connection,
     *,
+    board: Optional[str] = None,
     signal_fn=None,
 ) -> list[str]:
-    """Terminate workers whose per-task ``max_runtime_seconds`` has elapsed.
+    """Terminate workers whose effective ``max_runtime`` has elapsed.
 
     Sends SIGTERM, waits a short grace window, then SIGKILL. Emits a
     ``timed_out`` event and drops the task back to ``ready`` so the next
     dispatcher tick re-spawns it — unless the spawn-failure circuit
     breaker has already given up, in which case the task stays blocked
     where ``_record_spawn_failure`` parked it.
+
+    The effective limit is the task's explicit ``max_runtime_seconds`` when
+    set; otherwise NON-native (external-harness) tasks fall back to
+    ``_resolve_external_max_runtime_seconds`` (the relaxed-heartbeat-backstop
+    bound — an opaque external worker has no API-traffic liveness signal, so
+    this runtime cap is its hard upper bound). Native tasks with no explicit
+    cap stay unbounded here, exactly as before.
 
     Runs host-local: only tasks claimed by this host are candidates
     (same reasoning as ``detect_crashed_workers``). ``signal_fn`` is a
@@ -5288,7 +5542,7 @@ def enforce_max_runtime(
         "       t.max_runtime_seconds, t.claim_lock "
         "FROM tasks t "
         "LEFT JOIN task_runs r ON r.id = t.current_run_id "
-        "WHERE t.status = 'running' AND t.max_runtime_seconds IS NOT NULL "
+        "WHERE t.status = 'running' "
         "  AND COALESCE(r.started_at, t.started_at) IS NOT NULL "
         "  AND t.worker_pid IS NOT NULL"
     ).fetchall()
@@ -5296,11 +5550,20 @@ def enforce_max_runtime(
         lock = row["claim_lock"] or ""
         if not lock.startswith(host_prefix):
             continue
+        # Effective limit: explicit cap wins; else external workers fall back
+        # to the default external cap; native-with-no-cap stays unbounded.
+        if row["max_runtime_seconds"] is not None:
+            limit = int(row["max_runtime_seconds"])
+        else:
+            _rt_task = get_task(conn, row["id"])
+            if _rt_task is None or _task_is_native(_rt_task, board):
+                continue
+            limit = _resolve_external_max_runtime_seconds()
         # Runtime is per attempt, not lifetime-of-task. ``tasks.started_at``
         # intentionally records the first time a task ever started, so retries
         # must be measured from the active task_runs row when present.
         elapsed = now - int(row["active_started_at"])
-        if elapsed < int(row["max_runtime_seconds"]):
+        if elapsed < limit:
             continue
 
         pid = int(row["worker_pid"])
@@ -5343,13 +5606,13 @@ def enforce_max_runtime(
                 payload = {
                     "pid": pid,
                     "elapsed_seconds": int(elapsed),
-                    "limit_seconds": int(row["max_runtime_seconds"]),
+                    "limit_seconds": int(limit),
                     "sigkill": killed,
                 }
                 run_id = _end_run(
                     conn, tid,
                     outcome="timed_out", status="timed_out",
-                    error=f"elapsed {int(elapsed)}s > limit {int(row['max_runtime_seconds'])}s",
+                    error=f"elapsed {int(elapsed)}s > limit {int(limit)}s",
                     metadata=payload,
                 )
                 _append_event(
@@ -5364,7 +5627,7 @@ def enforce_max_runtime(
         if cur.rowcount == 1:
             _record_task_failure(
                 conn, tid,
-                error=f"elapsed {int(elapsed)}s > limit {int(row['max_runtime_seconds'])}s",
+                error=f"elapsed {int(elapsed)}s > limit {int(limit)}s",
                 outcome="timed_out",
                 release_claim=False,
                 end_run=False,
@@ -6145,8 +6408,15 @@ def dispatch_once(
     # reap_worker_zombies() for the full rationale.
     reap_worker_zombies()
 
+    # Supervise running NON-native workers BEFORE the reclaim steps: bridge
+    # their worker-log mtime into ``last_heartbeat_at`` (so the heartbeat-stale
+    # backstop in ``release_stale_claims`` below sees observable progress this
+    # same tick) and surface incremental log output as ``worker_log`` progress
+    # events. External harnesses never call the kanban heartbeat/comment tools,
+    # so this is their only liveness + progress bridge.
     result = DispatchResult()
-    result.reclaimed = release_stale_claims(conn)
+    supervise_external_workers(conn, board=board)
+    result.reclaimed = release_stale_claims(conn, board=board)
     result.stale = detect_stale_running(
         conn, stale_timeout_seconds=stale_timeout_seconds,
     )
@@ -6167,7 +6437,7 @@ def dispatch_once(
     )
     if _crash_rate_limited:
         result.rate_limited.extend(_crash_rate_limited)
-    result.timed_out = enforce_max_runtime(conn)
+    result.timed_out = enforce_max_runtime(conn, board=board)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
 
     # Count tasks already running so max_spawn enforces concurrency rather

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2985,8 +2985,14 @@ def test_create_task_skills_lists_all_toolset_typos(kanban_home):
 
 def test_default_spawn_appends_per_task_skills(kanban_home, monkeypatch):
     """Dispatcher argv must carry one `--skills X` pair per task skill,
-    in addition to the built-in kanban-worker."""
+    in addition to the built-in kanban-worker.
+
+    Resolution is mocked True here so the test stays focused on argv *shaping*;
+    the per-skill availability guard is exercised separately in
+    ``test_default_spawn_drops_unresolved_per_task_skills``.
+    """
     monkeypatch.setattr(kb, "_kanban_worker_skill_available", lambda _h: True)
+    monkeypatch.setattr(kb, "_kanban_skill_available", lambda _h, _s: True)
     captured = {}
 
     class FakeProc:
@@ -3032,6 +3038,50 @@ def test_default_spawn_appends_per_task_skills(kanban_home, monkeypatch):
     assert last_skills_idx < chat_idx, (
         f"--skills must come before 'chat' in argv: {cmd}"
     )
+
+
+def test_default_spawn_drops_unresolved_per_task_skills(kanban_home, monkeypatch):
+    """A per-task skill that does not resolve under the worker's skills dir is
+    dropped from the spawn argv (with a warning) instead of being appended —
+    force-loading an unknown skill crashes the worker at CLI startup before the
+    agent loop runs."""
+    monkeypatch.setattr(kb, "_kanban_worker_skill_available", lambda _h: True)
+    # Use the REAL _kanban_skill_available: nothing exists under the isolated
+    # test skills dir, so any per-task skill is unresolved and must be dropped.
+    captured = {}
+
+    class FakeProc:
+        def __init__(self):
+            self.pid = 42
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return FakeProc()
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="ghost-skill worker",
+            assignee="linguist",
+            skills=["does-not-exist"],
+        )
+        task = kb.get_task(conn, tid)
+        workspace = kb.resolve_workspace(task)
+        kb._default_spawn(task, str(workspace))
+    finally:
+        conn.close()
+
+    cmd = captured["cmd"]
+    skill_names = [
+        cmd[i + 1] for i, tok in enumerate(cmd)
+        if tok == "--skills" and i + 1 < len(cmd)
+    ]
+    assert "does-not-exist" not in skill_names
+    # The built-in worker skill (mocked available) is still passed.
+    assert "kanban-worker" in skill_names
 
 
 def test_default_spawn_dedupes_kanban_worker_from_task_skills(kanban_home, monkeypatch):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1929,6 +1929,44 @@ def test_worktree_workspace_returns_intended_path(kanban_home, tmp_path):
     assert str(ws) == target
 
 
+def test_worktree_default_anchors_under_assignee_profile(kanban_home):
+    """A worktree task with no explicit path roots its worktree under the
+    ASSIGNEE's profile home (``<profiles>/<assignee>/.worktrees/<id>``), NOT the
+    dispatcher's CWD — so executors never share a ``.git/worktrees`` registry
+    with whichever profile happens to own the gateway."""
+    from hermes_cli.profiles import get_profile_dir
+    with kb.connect() as conn:
+        t = kb.create_task(
+            conn, title="code slice", workspace_kind="worktree", assignee="alice"
+        )
+        task = kb.get_task(conn, t)
+        ws = kb.resolve_workspace(task)
+    assert ws == get_profile_dir("alice") / ".worktrees" / t
+
+
+def test_worktree_default_falls_back_to_cwd_without_assignee(kanban_home):
+    """Fallback: with no assignee the legacy CWD-relative root is used."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="orphan slice", workspace_kind="worktree")
+        task = kb.get_task(conn, t)
+        ws = kb.resolve_workspace(task)
+    assert ws.name == t
+    assert ws.parent.name == ".worktrees"
+
+
+def test_kanban_skill_available_resolves_and_rejects(tmp_path):
+    """The per-task skill availability guard resolves a present skill and
+    rejects an absent one, so an unresolved force-loaded skill is dropped at
+    spawn time rather than crashing the worker at CLI startup."""
+    skill_dir = tmp_path / "skills" / "devops" / "my-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# my-skill\n")
+    home = str(tmp_path)
+    assert kb._kanban_skill_available(home, "my-skill") is True
+    assert kb._kanban_skill_available(home, "absent-skill") is False
+    assert kb._kanban_skill_available(home, "") is False
+
+
 # ---------------------------------------------------------------------------
 # Scratch cleanup containment (#28818)
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4519,3 +4519,178 @@ def test_select_spawn_backend_honours_harness(kanban_home):
         assert kb._select_spawn_backend(t_unknown, None) is native_backend
     finally:
         kb._SPAWN_BACKENDS.pop("fake-c2-backend", None)
+
+
+# ---------------------------------------------------------------------------
+# Pluggable harness — prompt compiler, profile/board config, cli-exec backend
+# ---------------------------------------------------------------------------
+
+
+class _FakePopen:
+    """Capture argv/kwargs instead of spawning. The cli-exec backend imports
+    subprocess locally, so monkeypatching kb.subprocess.Popen intercepts it."""
+
+    last = None
+
+    def __init__(self, cmd, **kw):
+        self.cmd = cmd
+        self.kw = kw
+        self.pid = 4242
+        _FakePopen.last = self
+
+
+def _cli_loader(command=("echo", "run"), pass_prompt="stdin",
+                prompt_file=".hermes-task.md"):
+    def loader(profile, board):
+        return kb.CliExecConfig.from_mapping({
+            "command": list(command),
+            "pass_prompt": pass_prompt,
+            "prompt_file": prompt_file,
+        })
+    return loader
+
+
+def _ctx(tmp_path, **task_kw):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title=task_kw.pop("title", "task"), **task_kw)
+        task = kb.get_task(conn, tid)
+    ws = str(tmp_path / "ws")
+    os.makedirs(ws, exist_ok=True)
+    return kb._assemble_spawn_context(task, ws, board=None), task, ws
+
+
+def test_compile_task_prompt_deterministic_and_vendor_neutral(kanban_home, tmp_path):
+    ctx, task, _ = _ctx(tmp_path, title="S0 schema", body="Parse nodes.", assignee="coder")
+    a = kb.compile_task_prompt(ctx)
+    assert a == kb.compile_task_prompt(ctx)            # deterministic
+    assert task.id in a
+    assert "S0 schema" in a and "Parse nodes." in a
+    assert 'hermes kanban complete "$HERMES_KANBAN_TASK"' in a
+    assert 'hermes kanban block "$HERMES_KANBAN_TASK"' in a
+    assert "hermes -p" not in a                        # no native argv leaks in
+
+
+def test_compile_task_prompt_skills_section(kanban_home, tmp_path):
+    import dataclasses
+    ctx, _, _ = _ctx(tmp_path, title="sk", assignee="coder")
+    assert "## Reference skills" not in kb.compile_task_prompt(ctx)   # none resolved
+    with_skills = dataclasses.replace(ctx, skills=["kanban-worker", "extra-skill"])
+    rendered = kb.compile_task_prompt(with_skills)
+    assert "## Reference skills" in rendered
+    assert "kanban-worker" in rendered and "extra-skill" in rendered
+
+
+def test_cli_exec_config_from_mapping_valid():
+    c = kb.CliExecConfig.from_mapping(
+        {"command": ["codex", "exec", "--model", "gpt-5.4"], "pass_prompt": "stdin"}
+    )
+    assert c.command == ("codex", "exec", "--model", "gpt-5.4")
+    assert c.binary == "codex"
+    # string command is shlex-split
+    assert kb.CliExecConfig.from_mapping({"command": "claude -p"}).command == (
+        "claude", "-p",
+    )
+
+
+@pytest.mark.parametrize("bad", [
+    None, {}, {"command": []},
+    {"command": ["x"], "pass_prompt": "telepathy"},
+])
+def test_cli_exec_config_rejects_invalid(bad):
+    with pytest.raises(ValueError):
+        kb.CliExecConfig.from_mapping(bad)
+
+
+def _write_profile_harness(profile, harness, with_command=True):
+    import yaml
+    from hermes_cli.profiles import get_profile_dir
+    d = get_profile_dir(profile)
+    d.mkdir(parents=True, exist_ok=True)
+    block = {"harness": harness}
+    if with_command:
+        block["harnesses"] = {"cli-exec": {"command": ["codex", "exec"]}}
+    (d / "config.yaml").write_text(yaml.safe_dump({"kanban": block}), encoding="utf-8")
+
+
+def test_select_spawn_backend_profile_config_default(kanban_home):
+    _write_profile_harness("coder", "cli-exec")
+    with kb.connect() as conn:
+        t = kb.get_task(conn, kb.create_task(conn, title="p", assignee="coder"))
+    assert kb._select_spawn_backend(t, None).name == "cli-exec"
+
+
+def test_select_spawn_backend_task_column_overrides_profile(kanban_home):
+    _write_profile_harness("coder", "cli-exec")
+    with kb.connect() as conn:
+        t = kb.get_task(
+            conn, kb.create_task(conn, title="x", assignee="coder", harness="hermes-native")
+        )
+    assert kb._select_spawn_backend(t, None).name == "hermes-native"
+
+
+def test_select_spawn_backend_board_overrides_profile(kanban_home):
+    import yaml
+    _write_profile_harness("coder", "cli-exec")
+    board_dir = kb.kanban_db_path(board=None).parent
+    (board_dir / "board.yaml").write_text(
+        yaml.safe_dump({"kanban": {"harness": "hermes-native"}}), encoding="utf-8"
+    )
+    with kb.connect() as conn:
+        t = kb.get_task(conn, kb.create_task(conn, title="b", assignee="coder"))
+    assert kb._select_spawn_backend(t, None).name == "hermes-native"
+
+
+def test_select_spawn_backend_no_config_is_native(kanban_home):
+    with kb.connect() as conn:
+        t = kb.get_task(conn, kb.create_task(conn, title="n", assignee="researcher"))
+    assert kb._select_spawn_backend(t, None).name == "hermes-native"
+
+
+def test_cli_exec_backend_registered():
+    assert "cli-exec" in kb._SPAWN_BACKENDS
+    assert kb._SPAWN_BACKENDS["cli-exec"].name == "cli-exec"
+
+
+def test_cli_exec_backend_launch_stdin(kanban_home, tmp_path, monkeypatch):
+    ctx, task, ws = _ctx(tmp_path, title="launch", assignee="coder")
+    monkeypatch.setattr(kb.subprocess, "Popen", _FakePopen)
+    kb.CliExecBackend(config_loader=_cli_loader(("echo", "run"), "stdin")).launch(ctx)
+    p = _FakePopen.last
+    assert p.pid == 4242
+    assert p.cmd == ["echo", "run"]                       # configured argv, unmodified
+    assert p.kw["cwd"] == ws                              # runs in the worktree
+    assert p.kw["env"].get("HERMES_KANBAN_TASK") == task.id
+    assert p.kw.get("start_new_session") is True          # detached worker
+    stdin = p.kw["stdin"]                                 # brief delivered on stdin
+    assert getattr(stdin, "name", "").endswith(".hermes-task.md")
+    brief = Path(ws) / ".hermes-task.md"
+    assert brief.is_file()
+    assert brief.read_text() == kb.compile_task_prompt(ctx)
+
+
+def test_cli_exec_backend_launch_file_arg(kanban_home, tmp_path, monkeypatch):
+    ctx, _, _ = _ctx(tmp_path, title="filearg", assignee="coder")
+    monkeypatch.setattr(kb.subprocess, "Popen", _FakePopen)
+    kb.CliExecBackend(config_loader=_cli_loader(("echo",), "file-arg")).launch(ctx)
+    p = _FakePopen.last
+    assert p.cmd[-1].endswith(".hermes-task.md")          # brief path appended
+    assert p.kw["stdin"] == kb.subprocess.DEVNULL         # not via stdin
+
+
+def test_cli_exec_backend_launch_none(kanban_home, tmp_path, monkeypatch):
+    ctx, _, _ = _ctx(tmp_path, title="none", assignee="coder")
+    monkeypatch.setattr(kb.subprocess, "Popen", _FakePopen)
+    kb.CliExecBackend(config_loader=_cli_loader(("echo",), "none")).launch(ctx)
+    p = _FakePopen.last
+    assert p.cmd == ["echo"]                              # argv only
+    assert p.kw["stdin"] == kb.subprocess.DEVNULL
+
+
+def test_cli_exec_backend_missing_binary_raises(kanban_home, tmp_path):
+    ctx, _, _ = _ctx(tmp_path, title="missing", assignee="coder")
+
+    def loader(profile, board):
+        return kb.CliExecConfig.from_mapping({"command": ["nope-no-such-binary-xyz"]})
+
+    with pytest.raises(RuntimeError):
+        kb.CliExecBackend(config_loader=loader).launch(ctx)

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4694,3 +4694,246 @@ def test_cli_exec_backend_missing_binary_raises(kanban_home, tmp_path):
 
     with pytest.raises(RuntimeError):
         kb.CliExecBackend(config_loader=loader).launch(ctx)
+
+
+# ---------------------------------------------------------------------------
+# tmux terminal-lane backend (interactive harness in a durable PTY)
+# ---------------------------------------------------------------------------
+
+
+class _FakeTmuxRun:
+    """Record module-level ``subprocess.run`` calls and fake tmux output.
+
+    The tmux backend and ``_cleanup_worker_tmux`` both call the module-level
+    ``subprocess.run`` for every tmux subcommand, so monkeypatching
+    ``kb.subprocess.run`` intercepts them all.
+
+    * ``new-session`` returns ``new_session_rc``;
+    * ``list-panes -F '#{pane_pid}'`` returns ``pane_pid`` (None -> empty);
+    * ``list-panes -F '#{pane_dead}'`` returns ``pane_dead``;
+    * everything else returns success.
+    """
+
+    def __init__(self, pane_pid="31337", new_session_rc=0, pane_dead="1"):
+        self.calls = []
+        self.pane_pid = pane_pid
+        self.new_session_rc = new_session_rc
+        self.pane_dead = pane_dead
+
+    def __call__(self, cmd, **kw):
+        argv = list(cmd)
+        self.calls.append(argv)
+        rc, out = 0, ""
+        if argv[:2] == ["tmux", "new-session"]:
+            rc = self.new_session_rc
+        elif argv[:2] == ["tmux", "list-panes"]:
+            if "#{pane_pid}" in argv:
+                out = "" if self.pane_pid is None else f"{self.pane_pid}\n"
+            elif "#{pane_dead}" in argv:
+                out = self.pane_dead
+        return kb.subprocess.CompletedProcess(argv, rc, stdout=out, stderr="")
+
+    def first(self, *head):
+        """The first recorded call whose argv starts with ``head``."""
+        head = list(head)
+        return next((c for c in self.calls if c[:len(head)] == head), None)
+
+    def has(self, *head):
+        return self.first(*head) is not None
+
+
+def _tmux_loader(command=("repl",), pass_prompt="send-keys",
+                 prompt_file=".hermes-task.md", session_name="klane-{task_id}",
+                 send_keys=None):
+    data = {
+        "command": list(command),
+        "pass_prompt": pass_prompt,
+        "prompt_file": prompt_file,
+        "session_name": session_name,
+    }
+    if send_keys is not None:
+        data["send_keys"] = send_keys
+
+    def loader(profile, board):
+        return kb.TmuxLaneConfig.from_mapping(data)
+
+    return loader
+
+
+def _which_present(monkeypatch):
+    """Make every binary look installed so precondition checks pass."""
+    monkeypatch.setattr(kb.shutil, "which", lambda b: f"/usr/bin/{b}")
+
+
+def test_tmux_lane_config_from_mapping_valid():
+    c = kb.TmuxLaneConfig.from_mapping(
+        {"command": ["codex"], "pass_prompt": "send-keys"}
+    )
+    assert c.command == ("codex",)
+    assert c.binary == "codex"
+    assert c.pass_prompt == "send-keys"                      # interactive default
+    assert c.session_name == "klane-{task_id}"
+    assert "{prompt_file}" in c.send_keys
+    # string command is shlex-split, like cli-exec
+    assert kb.TmuxLaneConfig.from_mapping({"command": "claude --repl"}).command == (
+        "claude", "--repl",
+    )
+
+
+def test_tmux_lane_config_default_pass_prompt_is_send_keys():
+    # Decision: interactive lanes default to send-keys (vs cli-exec's stdin).
+    assert kb.TmuxLaneConfig.from_mapping({"command": ["x"]}).pass_prompt == "send-keys"
+
+
+@pytest.mark.parametrize("bad", [
+    None, {}, {"command": []},
+    {"command": ["x"], "pass_prompt": "stdin"},     # stdin is a cli-exec mode
+    {"command": ["x"], "pass_prompt": "telepathy"},
+])
+def test_tmux_lane_config_rejects_invalid(bad):
+    with pytest.raises(ValueError):
+        kb.TmuxLaneConfig.from_mapping(bad)
+
+
+def test_tmux_lane_backend_registered():
+    assert "tmux" in kb._SPAWN_BACKENDS
+    assert kb._SPAWN_BACKENDS["tmux"].name == "tmux"
+
+
+def test_tmux_lane_backend_launch_send_keys(kanban_home, tmp_path, monkeypatch):
+    ctx, task, ws = _ctx(tmp_path, title="lane", assignee="coder")
+    _which_present(monkeypatch)
+    fake = _FakeTmuxRun(pane_pid="31337")
+    monkeypatch.setattr(kb.subprocess, "run", fake)
+
+    pid = kb.TmuxLaneBackend(config_loader=_tmux_loader(("repl",), "send-keys")).launch(ctx)
+
+    assert pid == 31337                                      # pane_pid is tracked
+    ns = fake.first("tmux", "new-session")
+    assert ns is not None
+    assert "-d" in ns                                        # detached
+    assert ns[ns.index("-s") + 1] == f"klane-{task.id}"      # session per task id
+    assert ns[ns.index("-c") + 1] == ws                      # start-dir = workspace
+    assert f"HERMES_KANBAN_TASK={task.id}" in ns             # pinned env via -e
+    assert ns[-1] == "repl"                                  # harness argv, unmodified
+    # send-keys delivers a pointer to the brief, then Enter
+    assert fake.has("tmux", "send-keys")
+    sk = fake.first("tmux", "send-keys", "-t", f"klane-{task.id}", "-l")
+    assert sk is not None and ".hermes-task.md" in sk[-1]
+    assert fake.has("tmux", "send-keys", "-t", f"klane-{task.id}", "Enter")
+    # brief written verbatim, like cli-exec
+    brief = Path(ws) / ".hermes-task.md"
+    assert brief.is_file()
+    assert brief.read_text() == kb.compile_task_prompt(ctx)
+
+
+def test_tmux_lane_backend_pipes_pane_to_log(kanban_home, tmp_path, monkeypatch):
+    ctx, task, ws = _ctx(tmp_path, title="pipe", assignee="coder")
+    _which_present(monkeypatch)
+    fake = _FakeTmuxRun()
+    monkeypatch.setattr(kb.subprocess, "run", fake)
+    kb.TmuxLaneBackend(config_loader=_tmux_loader(("repl",))).launch(ctx)
+    pp = fake.first("tmux", "pipe-pane")
+    assert pp is not None
+    assert str(ctx.log_path) in pp[-1]                       # output tee'd to task log
+
+
+def test_tmux_lane_backend_launch_file_arg(kanban_home, tmp_path, monkeypatch):
+    ctx, task, ws = _ctx(tmp_path, title="filearg", assignee="coder")
+    _which_present(monkeypatch)
+    fake = _FakeTmuxRun()
+    monkeypatch.setattr(kb.subprocess, "run", fake)
+    kb.TmuxLaneBackend(config_loader=_tmux_loader(("repl",), "file-arg")).launch(ctx)
+    ns = fake.first("tmux", "new-session")
+    assert ns[-1].endswith(".hermes-task.md")                # brief path in pane cmd
+    assert not fake.has("tmux", "send-keys")                 # no keystrokes in file-arg
+
+
+def test_tmux_lane_backend_launch_none(kanban_home, tmp_path, monkeypatch):
+    ctx, task, ws = _ctx(tmp_path, title="none", assignee="coder")
+    _which_present(monkeypatch)
+    fake = _FakeTmuxRun()
+    monkeypatch.setattr(kb.subprocess, "run", fake)
+    kb.TmuxLaneBackend(config_loader=_tmux_loader(("repl",), "none")).launch(ctx)
+    ns = fake.first("tmux", "new-session")
+    assert ns[-1] == "repl"                                  # argv only
+    assert not fake.has("tmux", "send-keys")
+
+
+def test_tmux_lane_backend_missing_tmux_raises(kanban_home, tmp_path, monkeypatch):
+    ctx, _, _ = _ctx(tmp_path, title="notmux", assignee="coder")
+    monkeypatch.setattr(kb.shutil, "which", lambda b: None if b == "tmux" else "/usr/bin/x")
+    with pytest.raises(RuntimeError):
+        kb.TmuxLaneBackend(config_loader=_tmux_loader(("repl",))).launch(ctx)
+
+
+def test_tmux_lane_backend_missing_binary_raises(kanban_home, tmp_path, monkeypatch):
+    ctx, _, _ = _ctx(tmp_path, title="nobin", assignee="coder")
+    monkeypatch.setattr(
+        kb.shutil, "which", lambda b: "/usr/bin/tmux" if b == "tmux" else None
+    )
+    with pytest.raises(RuntimeError):
+        kb.TmuxLaneBackend(
+            config_loader=_tmux_loader(("nope-no-such-binary-xyz",))
+        ).launch(ctx)
+
+
+def test_tmux_lane_backend_new_session_failure_raises(kanban_home, tmp_path, monkeypatch):
+    ctx, _, _ = _ctx(tmp_path, title="failns", assignee="coder")
+    _which_present(monkeypatch)
+    monkeypatch.setattr(kb.subprocess, "run", _FakeTmuxRun(new_session_rc=1))
+    with pytest.raises(RuntimeError):
+        kb.TmuxLaneBackend(config_loader=_tmux_loader(("repl",))).launch(ctx)
+
+
+def test_tmux_lane_backend_no_pane_pid_returns_none(kanban_home, tmp_path, monkeypatch):
+    ctx, _, _ = _ctx(tmp_path, title="nopid", assignee="coder")
+    _which_present(monkeypatch)
+    monkeypatch.setattr(kb.subprocess, "run", _FakeTmuxRun(pane_pid=None))
+    # Session created but no pane_pid -> untracked, not a spawn failure.
+    pid = kb.TmuxLaneBackend(config_loader=_tmux_loader(("repl",))).launch(ctx)
+    assert pid is None
+
+
+def test_tmux_lane_select_via_board_config(kanban_home):
+    import yaml
+    board_dir = kb.kanban_db_path(board=None).parent
+    (board_dir / "board.yaml").write_text(
+        yaml.safe_dump({"kanban": {"harness": "tmux"}}), encoding="utf-8"
+    )
+    with kb.connect() as conn:
+        t = kb.get_task(conn, kb.create_task(conn, title="b", assignee="coder"))
+    assert kb._select_spawn_backend(t, None).name == "tmux"
+
+
+def test_cleanup_worker_tmux_targets_klane_session(kanban_home, tmp_path, monkeypatch):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="lane", assignee="coder")
+    fake = _FakeTmuxRun(pane_dead="1")
+    monkeypatch.setattr(kb.subprocess, "run", fake)
+    with kb.connect() as conn:
+        kb._cleanup_worker_tmux(conn, tid)
+    # the lane session keyed on the task id is reaped once its pane is dead
+    assert fake.has("tmux", "list-panes", "-t", f"klane-{tid}")
+    assert fake.has("tmux", "kill-session", "-t", f"klane-{tid}")
+
+
+def test_cleanup_worker_tmux_still_handles_swarm(kanban_home, tmp_path, monkeypatch):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="swarm", assignee="swarm1")
+    fake = _FakeTmuxRun(pane_dead="1")
+    monkeypatch.setattr(kb.subprocess, "run", fake)
+    with kb.connect() as conn:
+        kb._cleanup_worker_tmux(conn, tid)
+    # legacy swarm-<assignee> naming still reaped (regression guard)
+    assert fake.has("tmux", "kill-session", "-t", "swarm-swarm1")
+
+
+def test_cleanup_worker_tmux_skips_live_pane(kanban_home, tmp_path, monkeypatch):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="live", assignee="coder")
+    fake = _FakeTmuxRun(pane_dead="0")          # pane still alive
+    monkeypatch.setattr(kb.subprocess, "run", fake)
+    with kb.connect() as conn:
+        kb._cleanup_worker_tmux(conn, tid)
+    assert not fake.has("tmux", "kill-session")  # never tear down a running worker

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4410,3 +4410,112 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# harness column (BYO-harness, Phase 2 C2)
+# ---------------------------------------------------------------------------
+
+def test_create_task_persists_harness(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="byo", harness="tmux-cli")
+        t = kb.get_task(conn, tid)
+    assert t is not None
+    assert t.harness == "tmux-cli"
+
+
+def test_create_task_harness_defaults_none(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="native")
+        t = kb.get_task(conn, tid)
+    assert t is not None
+    assert t.harness is None
+
+
+def test_create_task_blank_harness_collapses_to_none(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="blank", harness="   ")
+        t = kb.get_task(conn, tid)
+    assert t is not None
+    assert t.harness is None
+
+
+def test_connect_migrates_legacy_db_adds_harness_column(tmp_path):
+    """A board predating the harness column migrates cleanly; the legacy row
+    reads back with harness=None (i.e. the default native backend)."""
+    db_path = tmp_path / "legacy-harness.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("""
+        CREATE TABLE tasks (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            body TEXT,
+            assignee TEXT,
+            status TEXT NOT NULL,
+            priority INTEGER NOT NULL DEFAULT 0,
+            created_by TEXT,
+            created_at INTEGER NOT NULL,
+            started_at INTEGER,
+            completed_at INTEGER,
+            workspace_kind TEXT NOT NULL DEFAULT 'scratch',
+            workspace_path TEXT,
+            claim_lock TEXT,
+            claim_expires INTEGER
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE task_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            payload TEXT,
+            created_at INTEGER NOT NULL
+        )
+    """)
+    conn.execute(
+        "INSERT INTO tasks (id, title, status, created_at) "
+        "VALUES ('legacy', 'old board task', 'ready', 1)"
+    )
+    conn.commit()
+    conn.close()
+
+    with kb.connect(db_path) as migrated:
+        task_columns = {
+            row["name"] for row in migrated.execute("PRAGMA table_info(tasks)")
+        }
+        legacy = kb.get_task(migrated, "legacy")
+
+    assert "harness" in task_columns
+    assert legacy is not None
+    assert legacy.harness is None
+
+
+def test_select_spawn_backend_honours_harness(kanban_home):
+    """_select_spawn_backend routes by the task's harness column, falling
+    back to the native default for NULL or unknown backend names."""
+
+    class _FakeBackend:
+        name = "fake-c2-backend"
+
+        def launch(self, ctx):  # pragma: no cover - never launched in this test
+            return None
+
+    fake = _FakeBackend()
+    kb.register_spawn_backend(fake)
+    try:
+        with kb.connect() as conn:
+            routed = kb.create_task(conn, title="routed", harness="fake-c2-backend")
+            native = kb.create_task(conn, title="native")
+            unknown = kb.create_task(
+                conn, title="unknown", harness="nope-not-registered"
+            )
+            t_routed = kb.get_task(conn, routed)
+            t_native = kb.get_task(conn, native)
+            t_unknown = kb.get_task(conn, unknown)
+
+        native_backend = kb.resolve_spawn_backend(None)
+        assert kb._select_spawn_backend(t_routed, None) is fake
+        assert kb._select_spawn_backend(t_native, None) is native_backend
+        assert kb._select_spawn_backend(t_unknown, None) is native_backend
+    finally:
+        kb._SPAWN_BACKENDS.pop("fake-c2-backend", None)

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -4937,3 +4937,448 @@ def test_cleanup_worker_tmux_skips_live_pane(kanban_home, tmp_path, monkeypatch)
     with kb.connect() as conn:
         kb._cleanup_worker_tmux(conn, tid)
     assert not fake.has("tmux", "kill-session")  # never tear down a running worker
+
+
+# ---------------------------------------------------------------------------
+# Per-task external-worker supervisor: heartbeat (log-mtime bridge +
+# backend-aware backstop) and live card progress (log-tailer -> worker_log
+# events).  Items 2+3 of the BYO-harness work — one supervisor, build once.
+# ---------------------------------------------------------------------------
+
+
+def _supervisor_running_task(
+    conn, *, harness=None, assignee="coder", pid=4242,
+    max_runtime_seconds=None,
+):
+    """Create a claimed, running task with a worker PID recorded.
+
+    ``harness`` selects the spawn backend ("cli-exec"/"tmux" are non-native
+    and registered at import; None resolves to hermes-native).
+    """
+    host = kb._claimer_id().split(":", 1)[0]
+    tid = kb.create_task(
+        conn, title="rt", assignee=assignee, harness=harness,
+        max_runtime_seconds=max_runtime_seconds,
+    )
+    kb.claim_task(conn, tid, claimer=f"{host}:worker")
+    kb._set_worker_pid(conn, tid, pid)
+    return tid
+
+
+def _write_worker_log(tid, text, *, mtime=None, board=None, mode="ab"):
+    """Append ``text`` to the task's worker log; optionally pin its mtime."""
+    p = kb.worker_log_path(tid, board=board)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    data = text.encode() if isinstance(text, str) else text
+    with open(p, mode) as f:
+        f.write(data)
+    if mtime is not None:
+        os.utime(p, (mtime, mtime))
+    return p
+
+
+def _worker_log_events(conn, tid):
+    return conn.execute(
+        "SELECT payload FROM task_events "
+        "WHERE task_id = ? AND kind = 'worker_log' ORDER BY id",
+        (tid,),
+    ).fetchall()
+
+
+def _offset(conn, tid):
+    row = conn.execute(
+        "SELECT worker_log_offset FROM tasks WHERE id = ?", (tid,)
+    ).fetchone()
+    return row["worker_log_offset"]
+
+
+# --- schema / migration -----------------------------------------------------
+
+def test_worker_log_offset_column_exists_on_fresh_db(kanban_home):
+    with kb.connect() as conn:
+        cols = {r["name"] for r in conn.execute("PRAGMA table_info(tasks)")}
+    assert "worker_log_offset" in cols
+
+
+def test_worker_log_offset_added_to_legacy_db(tmp_path):
+    """A legacy DB missing the column is migrated forward on connect."""
+    db_path = tmp_path / "legacy-offset-kanban.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("""
+        CREATE TABLE tasks (
+            id TEXT PRIMARY KEY,
+            title TEXT NOT NULL,
+            body TEXT,
+            assignee TEXT,
+            status TEXT NOT NULL,
+            priority INTEGER NOT NULL DEFAULT 0,
+            created_by TEXT,
+            created_at INTEGER NOT NULL,
+            started_at INTEGER,
+            completed_at INTEGER,
+            workspace_kind TEXT NOT NULL DEFAULT 'scratch',
+            workspace_path TEXT,
+            claim_lock TEXT,
+            claim_expires INTEGER
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE task_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            task_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            payload TEXT,
+            created_at INTEGER NOT NULL
+        )
+    """)
+    conn.execute(
+        "INSERT INTO tasks (id, title, status, created_at) "
+        "VALUES ('legacy', 'old board task', 'ready', 1)"
+    )
+    conn.commit()
+    conn.close()
+    with kb.connect(db_path) as migrated:
+        cols = {r["name"] for r in migrated.execute("PRAGMA table_info(tasks)")}
+        legacy = kb.get_task(migrated, "legacy")
+    assert "worker_log_offset" in cols
+    assert legacy is not None and legacy.worker_log_offset is None
+
+
+# --- classification + helpers -----------------------------------------------
+
+def test_task_is_native_classification(kanban_home):
+    with kb.connect() as conn:
+        native = kb.get_task(conn, kb.create_task(conn, title="n", assignee="coder"))
+        nonnative = kb.get_task(
+            conn, kb.create_task(conn, title="x", assignee="coder", harness="cli-exec")
+        )
+        bogus = kb.get_task(
+            conn, kb.create_task(conn, title="b", assignee="coder", harness="nope")
+        )
+    assert kb._task_is_native(native, None) is True
+    assert kb._task_is_native(nonnative, None) is False
+    # Unknown backend names fall back to native (never wedge dispatch).
+    assert kb._task_is_native(bogus, None) is True
+
+
+def test_worker_log_mtime_none_when_missing(kanban_home):
+    assert kb._worker_log_mtime("t_does_not_exist", None) is None
+
+
+def test_worker_log_mtime_reads_file(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="m", assignee="coder")
+    when = int(time.time()) - 123
+    _write_worker_log(tid, "hi\n", mtime=when)
+    assert kb._worker_log_mtime(tid, None) == when
+
+
+# --- item 2b: log-mtime heartbeat bridge ------------------------------------
+
+def test_supervisor_bridges_log_mtime_into_heartbeat(kanban_home):
+    now = int(time.time())
+    with kb.connect() as conn:
+        tid = _supervisor_running_task(conn, harness="cli-exec")
+        conn.execute(
+            "UPDATE tasks SET last_heartbeat_at = ? WHERE id = ?",
+            (now - 7200, tid),
+        )
+        _write_worker_log(tid, "working\n", mtime=now)
+        kb.supervise_external_workers(conn, board=None)
+        hb = kb.get_task(conn, tid).last_heartbeat_at
+    assert hb == now  # bridged up to the live log mtime
+
+
+def test_supervisor_does_not_bridge_native_tasks(kanban_home):
+    now = int(time.time())
+    with kb.connect() as conn:
+        tid = _supervisor_running_task(conn, harness=None)  # native
+        conn.execute(
+            "UPDATE tasks SET last_heartbeat_at = ? WHERE id = ?",
+            (now - 7200, tid),
+        )
+        _write_worker_log(tid, "native chatter\n", mtime=now)
+        kb.supervise_external_workers(conn, board=None)
+        hb = kb.get_task(conn, tid).last_heartbeat_at
+    assert hb == now - 7200  # native heartbeat untouched by log mtime
+
+
+# --- item 2a: backend-aware release_stale_claims ----------------------------
+
+def test_release_stale_claims_keeps_fresh_nonnative_via_log_mtime(
+    kanban_home, monkeypatch,
+):
+    """A non-native worker that never calls the heartbeat APIs but is
+    actively writing its log must NOT be reclaimed even though
+    ``last_heartbeat_at`` is hours stale — the log mtime is its
+    observable-progress signal."""
+    import hermes_cli.kanban_db as _kb
+    now = int(time.time())
+    with kb.connect() as conn:
+        tid = _supervisor_running_task(conn, harness="cli-exec")
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ?, last_heartbeat_at = ? "
+            "WHERE id = ?",
+            (now - 60, now - 7200, tid),   # TTL expired, hb 2h stale
+        )
+        _write_worker_log(tid, "step 3/6\n", mtime=now)  # fresh output
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+        killed: list[int] = []
+        reclaimed = kb.release_stale_claims(
+            conn, board=None, signal_fn=lambda _p, sig: killed.append(sig),
+        )
+        task = kb.get_task(conn, tid)
+    assert reclaimed == 0
+    assert task.status == "running"
+    assert killed == []
+
+
+def test_release_stale_claims_reclaims_silent_nonnative_worker(
+    kanban_home, monkeypatch,
+):
+    """A non-native worker whose log has been silent for >1h (no output) is
+    wedged and IS reclaimed even though its PID is still alive."""
+    import hermes_cli.kanban_db as _kb
+    now = int(time.time())
+    with kb.connect() as conn:
+        tid = _supervisor_running_task(conn, harness="cli-exec")
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ?, last_heartbeat_at = ? "
+            "WHERE id = ?",
+            (now - 60, now - 7200, tid),
+        )
+        _write_worker_log(tid, "old output\n", mtime=now - 7200)  # silent 2h
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+        reclaimed = kb.release_stale_claims(
+            conn, board=None, signal_fn=lambda _p, _s: None,
+        )
+        task = kb.get_task(conn, tid)
+    assert reclaimed == 1
+    assert task.status == "ready"
+
+
+def test_release_stale_claims_native_still_reclaimed_by_backstop(
+    kanban_home, monkeypatch,
+):
+    """The native 1h heartbeat-stale backstop is unchanged: a native worker
+    with a stale ``last_heartbeat_at`` is reclaimed even if its log file is
+    fresh and its PID alive (native ignores log mtime)."""
+    import hermes_cli.kanban_db as _kb
+    now = int(time.time())
+    with kb.connect() as conn:
+        tid = _supervisor_running_task(conn, harness=None)  # native
+        conn.execute(
+            "UPDATE tasks SET claim_expires = ?, last_heartbeat_at = ? "
+            "WHERE id = ?",
+            (now - 60, now - 7200, tid),
+        )
+        _write_worker_log(tid, "fresh native log\n", mtime=now)
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+        reclaimed = kb.release_stale_claims(
+            conn, board=None, signal_fn=lambda _p, _s: None,
+        )
+        task = kb.get_task(conn, tid)
+    assert reclaimed == 1
+    assert task.status == "ready"
+
+
+# --- item 3a: log-tailer -> worker_log progress events ----------------------
+
+def test_supervisor_emits_worker_log_event_for_new_lines(kanban_home):
+    now = int(time.time())
+    with kb.connect() as conn:
+        tid = _supervisor_running_task(conn, harness="cli-exec")
+        size = _write_worker_log(tid, "step 1/6\nstep 2/6\n", mtime=now).stat().st_size
+        emitted = kb.supervise_external_workers(conn, board=None)
+        events = _worker_log_events(conn, tid)
+        off = _offset(conn, tid)
+    assert emitted >= 1
+    assert len(events) == 1
+    assert "step 2/6" in events[0]["payload"]
+    assert off == size  # offset advanced to end of file
+
+
+def test_supervisor_tailer_no_event_when_no_new_bytes(kanban_home):
+    with kb.connect() as conn:
+        tid = _supervisor_running_task(conn, harness="cli-exec")
+        _write_worker_log(tid, "line\n", mtime=int(time.time()))
+        kb.supervise_external_workers(conn, board=None)
+        first = _offset(conn, tid)
+        # Second tick, nothing new written.
+        kb.supervise_external_workers(conn, board=None)
+        events = _worker_log_events(conn, tid)
+        second = _offset(conn, tid)
+    assert len(events) == 1          # no duplicate event
+    assert second == first           # offset unchanged
+
+
+def test_supervisor_tailer_advances_offset_no_dupes(kanban_home):
+    with kb.connect() as conn:
+        tid = _supervisor_running_task(conn, harness="cli-exec")
+        _write_worker_log(tid, "alpha\n", mtime=int(time.time()))
+        kb.supervise_external_workers(conn, board=None)
+        # New output on the next tick.
+        _write_worker_log(tid, "bravo\n", mtime=int(time.time()))
+        kb.supervise_external_workers(conn, board=None)
+        events = _worker_log_events(conn, tid)
+    assert len(events) == 2
+    # The second event carries only the NEW line, not the old one.
+    assert "bravo" in events[1]["payload"]
+    assert "alpha" not in events[1]["payload"]
+
+
+def test_supervisor_tailer_truncates_large_delta(kanban_home):
+    with kb.connect() as conn:
+        tid = _supervisor_running_task(conn, harness="cli-exec")
+        big = ("x" * 50 + "\n") * 200   # ~10KB, well over the cap
+        _write_worker_log(tid, big, mtime=int(time.time()))
+        kb.supervise_external_workers(conn, board=None)
+        events = _worker_log_events(conn, tid)
+    import json as _json
+    payload = _json.loads(events[0]["payload"])
+    assert payload["truncated"] is True
+    assert len(payload["excerpt"]) <= kb.WORKER_LOG_EVENT_MAX_BYTES
+
+
+def test_supervisor_tailer_handles_log_rotation(kanban_home):
+    """If the file shrank below the persisted offset (rotation/truncation),
+    the tailer resets to 0 and re-reads from the start instead of crashing
+    or skipping."""
+    with kb.connect() as conn:
+        tid = _supervisor_running_task(conn, harness="cli-exec")
+        # Pretend a previous, larger generation advanced the offset far past
+        # the current (rotated, smaller) file.
+        conn.execute(
+            "UPDATE tasks SET worker_log_offset = ? WHERE id = ?", (999999, tid)
+        )
+        size = _write_worker_log(
+            tid, "post-rotation line\n", mtime=int(time.time()), mode="wb"
+        ).stat().st_size
+        emitted = kb.supervise_external_workers(conn, board=None)
+        events = _worker_log_events(conn, tid)
+        off = _offset(conn, tid)
+    assert emitted == 1
+    assert "post-rotation line" in events[0]["payload"]
+    assert off == size
+
+
+def test_supervisor_skips_native_tailer(kanban_home):
+    """Native workers report progress via their own kanban_comment tool; the
+    log-tailer only runs for non-native backends."""
+    with kb.connect() as conn:
+        tid = _supervisor_running_task(conn, harness=None)
+        _write_worker_log(tid, "native line\n", mtime=int(time.time()))
+        kb.supervise_external_workers(conn, board=None)
+        events = _worker_log_events(conn, tid)
+    assert events == []
+
+
+# --- item 2a bound: default external max_runtime ----------------------------
+
+def test_enforce_max_runtime_applies_default_for_nonnative(
+    kanban_home, monkeypatch,
+):
+    import hermes_cli.kanban_db as _kb
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    now = int(time.time())
+    with kb.connect() as conn:
+        tid = _supervisor_running_task(conn, harness="cli-exec")  # NULL max_runtime
+        old = now - (kb.DEFAULT_EXTERNAL_WORKER_MAX_RUNTIME_SECONDS + 600)
+        conn.execute("UPDATE tasks SET started_at = ? WHERE id = ?", (old, tid))
+        conn.execute(
+            "UPDATE task_runs SET started_at = ? WHERE task_id = ?", (old, tid)
+        )
+        timed_out = kb.enforce_max_runtime(conn, board=None, signal_fn=lambda _p, _s: None)
+        task = kb.get_task(conn, tid)
+    assert tid in timed_out
+    assert task.status == "ready"
+
+
+def test_enforce_max_runtime_default_does_not_bound_native(
+    kanban_home, monkeypatch,
+):
+    import hermes_cli.kanban_db as _kb
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    now = int(time.time())
+    with kb.connect() as conn:
+        tid = _supervisor_running_task(conn, harness=None)  # native, NULL max_runtime
+        old = now - (kb.DEFAULT_EXTERNAL_WORKER_MAX_RUNTIME_SECONDS + 600)
+        conn.execute("UPDATE tasks SET started_at = ? WHERE id = ?", (old, tid))
+        conn.execute(
+            "UPDATE task_runs SET started_at = ? WHERE task_id = ?", (old, tid)
+        )
+        timed_out = kb.enforce_max_runtime(conn, board=None, signal_fn=lambda _p, _s: None)
+        task = kb.get_task(conn, tid)
+    assert tid not in timed_out          # native with no explicit cap is unbounded
+    assert task.status == "running"
+
+
+def test_external_max_runtime_env_override(kanban_home, monkeypatch):
+    import hermes_cli.kanban_db as _kb
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    monkeypatch.setenv("HERMES_KANBAN_EXTERNAL_MAX_RUNTIME_SECONDS", "100")
+    now = int(time.time())
+    with kb.connect() as conn:
+        tid = _supervisor_running_task(conn, harness="cli-exec")
+        conn.execute("UPDATE tasks SET started_at = ? WHERE id = ?", (now - 200, tid))
+        conn.execute(
+            "UPDATE task_runs SET started_at = ? WHERE task_id = ?", (now - 200, tid)
+        )
+        timed_out = kb.enforce_max_runtime(conn, board=None, signal_fn=lambda _p, _s: None)
+    assert tid in timed_out  # 200s elapsed > 100s override
+
+
+def test_explicit_max_runtime_wins_over_external_default(kanban_home, monkeypatch):
+    """A task with an explicit max_runtime_seconds keeps it; the external
+    default only fills in for NULL."""
+    import hermes_cli.kanban_db as _kb
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+    now = int(time.time())
+    with kb.connect() as conn:
+        tid = _supervisor_running_task(
+            conn, harness="cli-exec", max_runtime_seconds=99999,
+        )
+        conn.execute("UPDATE tasks SET started_at = ? WHERE id = ?", (now - 300, tid))
+        conn.execute(
+            "UPDATE task_runs SET started_at = ? WHERE task_id = ?", (now - 300, tid)
+        )
+        timed_out = kb.enforce_max_runtime(conn, board=None, signal_fn=lambda _p, _s: None)
+    assert tid not in timed_out  # 300s < explicit 99999s cap
+
+
+# --- supervisor integration (bridge + tail together) + dispatch wiring ------
+
+def test_supervise_external_workers_bridges_and_tails_together(kanban_home):
+    now = int(time.time())
+    with kb.connect() as conn:
+        tid = _supervisor_running_task(conn, harness="cli-exec")
+        conn.execute(
+            "UPDATE tasks SET last_heartbeat_at = ? WHERE id = ?", (now - 7200, tid)
+        )
+        _write_worker_log(tid, "progress 1\nprogress 2\n", mtime=now)
+        emitted = kb.supervise_external_workers(conn, board=None)
+        task = kb.get_task(conn, tid)
+        events = _worker_log_events(conn, tid)
+    assert emitted == 1
+    assert task.last_heartbeat_at == now          # bridged
+    assert len(events) == 1                        # tailed
+    assert task.worker_log_offset is not None and task.worker_log_offset > 0
+
+
+def test_dispatch_once_invokes_supervisor(kanban_home, monkeypatch):
+    import hermes_cli.kanban_db as _kb
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: True)
+    now = int(time.time())
+    with kb.connect() as conn:
+        tid = _supervisor_running_task(conn, harness="cli-exec")
+        conn.execute(
+            "UPDATE tasks SET last_heartbeat_at = ? WHERE id = ?", (now - 600, tid)
+        )
+        _write_worker_log(tid, "tick-step a\ntick-step b\n", mtime=now)
+        kb.dispatch_once(conn, spawn_fn=lambda *a, **k: None, board=None)
+        task = kb.get_task(conn, tid)
+        events = _worker_log_events(conn, tid)
+    assert task.status == "running"               # not falsely reclaimed
+    assert task.last_heartbeat_at == now          # heartbeat bridged in the tick
+    assert len(events) == 1                        # progress surfaced
+    assert "tick-step b" in events[0]["payload"]


### PR DESCRIPTION
## Summary

Make the kanban dispatcher able to run a task's worker on harnesses other than
the in-tree hermes worker, without the engine hardcoding any particular CLI.
Native (`hermes-native`) dispatch is byte-for-byte unchanged throughout — a
task only uses another harness when a task column, a `board.yaml`, or a profile
config opts in.

> Builds on #44844. Until that PR merges this branch includes its two commits as
> ancestors; afterwards the diff here is just the five commits below.

## What's added

1. **Pluggable spawn-backend seam.** Split worker spawn into a harness-agnostic
   `SpawnContext` (assembled by `_assemble_spawn_context`) and a `SpawnBackend`
   protocol + name-keyed registry, with an always-available `hermes-native`
   default. Unknown/empty names fall back to native with a warning so a stale
   value never wedges dispatch. Pure refactor, no behaviour change.

2. **`harness` task column.** Thread backend selection through the data layer
   (additive column + idempotent migration; legacy rows read NULL = native).
   Selection precedence: `task.harness` > board > profile > `hermes-native`.

3. **cli-exec backend + prompt compiler + config.** `compile_task_prompt`
   renders the `SpawnContext` into a deterministic, vendor-neutral Markdown
   brief an external CLI consumes (stdin or file); it states the kanban
   lifecycle contract the worker must honour (complete/block via
   `$HERMES_KANBAN_TASK`). `CliExecBackend` runs a configured one-shot CLI as a
   detached worker (same launch shape as native — `start_new_session` Popen,
   pid returned for crash detection), with stdout/stderr teed to the task log.
   Profile/board `kanban.harness` + `kanban.harnesses.<name>` config select and
   parametrise a backend without a per-task column.

4. **tmux terminal-lane backend.** For INTERACTIVE harnesses (a REPL needing a
   live PTY): a durable detached tmux lane, `pipe-pane` tees pane output into
   the task log, `#{pane_pid}` returned for crash detection, lane auto-cleaned
   when the worker exits.

5. **External-worker supervisor (heartbeat + live progress).** External
   harnesses never call the kanban heartbeat/comment tools, so a per-task
   supervisor bridges their worker-log mtime into `last_heartbeat_at` (the
   external equivalent of the native `_touch_activity` heartbeat, so the
   heartbeat-stale backstop doesn't reclaim a healthy external worker) and
   tails new log lines into throttled, truncated `worker_log` progress events
   on the card. `release_stale_claims` becomes backend-aware (folds log mtime
   for non-native, native unchanged); `enforce_max_runtime` gains a default cap
   for external workers (no explicit `max_runtime_seconds`). Schema: additive
   `worker_log_offset` column.

## Tests

TDD throughout. `tests/hermes_cli/test_kanban_db.py` passes in full (280 tests).
Native dispatch is unchanged.

## Test plan

- [ ] Native tasks dispatch exactly as before when no harness is configured.
- [ ] cli-exec board: a one-shot CLI worker writes + commits and reaches `done`.
- [ ] tmux board: an interactive REPL worker runs in a lane and reaches `done`.
- [ ] An external worker survives multiple dispatch ticks without a false
      reclaim, and its incremental log surfaces as `worker_log` events on the
      card (`kanban show <id>`).
