### PR TITLE
fix(gateway): show active fallback model in /model command

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1005,6 +1005,25 @@ class GatewaySlashCommandsMixin:
             current_base_url = override.get("base_url", current_base_url)
             current_api_key = override.get("api_key", current_api_key)
 
+        # If a fallback model is actively handling this session, show the
+        # runtime model instead of the config default.  This restores the
+        # behaviour lost in the v0.15.0 refactor (PR #1660 → #45970).
+        _fallback_active = False
+        _configured_model = current_model
+        _configured_provider = current_provider
+        _running = getattr(self, "_running_agents", {}).get(session_key)
+        if _running is not None:
+            from gateway.run import _AGENT_PENDING_SENTINEL
+            if _running is not _AGENT_PENDING_SENTINEL:
+                if getattr(_running, "_fallback_activated", False):
+                    _rt_model = getattr(_running, "model", None)
+                    _rt_provider = getattr(_running, "provider", None)
+                    if _rt_model and _rt_model != current_model:
+                        current_model = _rt_model
+                        _fallback_active = True
+                    if _rt_provider and _rt_provider != current_provider:
+                        current_provider = _rt_provider
+
         # No args: show interactive picker (Telegram/Discord) or text list
         if not model_input and not explicit_provider:
             # Try interactive picker if the platform supports it
@@ -1162,7 +1181,10 @@ class GatewaySlashCommandsMixin:
 
             # Fallback: text list (for platforms without picker or if picker failed)
             provider_label = get_label(current_provider)
-            lines = [t("gateway.model.current_label", model=current_model or "unknown", provider=provider_label), ""]
+            _display_model = current_model or "unknown"
+            if _fallback_active:
+                _display_model = f"{_display_model} _(fallback from `{_configured_model}`)_"
+            lines = [t("gateway.model.current_label", model=_display_model, provider=provider_label), ""]
 
             try:
                 providers = list_authenticated_providers(

--- a/tests/gateway/test_model_command_fallback_display.py
+++ b/tests/gateway/test_model_command_fallback_display.py
@@ -1,0 +1,203 @@
+"""Regression tests for /model command showing the active fallback model.
+
+When a fallback model is actively handling a session (e.g., after a 429 on
+the primary), ``/model`` should display the runtime model — not the config
+default.  This behaviour was restored after being lost in the v0.15.0 refactor
+(PR #1660 → issue #45970).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner, _AGENT_PENDING_SENTINEL
+from gateway.session import SessionSource
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_runner(**overrides):
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._session_model_overrides = {}
+    runner._running_agents = {}
+    for k, v in overrides.items():
+        setattr(runner, k, v)
+    return runner
+
+
+def _make_event(text="/model"):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm"
+        ),
+    )
+
+
+def _fake_agent(model="gpt-4o", provider="openrouter", fallback_activated=False):
+    """Minimal agent stub with fallback state."""
+    return SimpleNamespace(
+        model=model,
+        provider=provider,
+        _fallback_activated=fallback_activated,
+    )
+
+
+def _setup_config(tmp_path, monkeypatch, model_default="gpt-5.5", provider="openrouter"):
+    """Write a config.yaml and patch _hermes_home."""
+    import yaml
+    import gateway.run as gateway_run
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    cfg_path = hermes_home / "config.yaml"
+    cfg_path.write_text(
+        yaml.safe_dump({"model": {"default": model_default, "provider": provider}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: hermes_home)
+    monkeypatch.setattr("hermes_cli.config.get_hermes_home", lambda: hermes_home)
+    return hermes_home
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_model_command_shows_fallback_model_when_active(tmp_path, monkeypatch):
+    """When a fallback model is active, /model should show the runtime model."""
+    _setup_config(tmp_path, monkeypatch, model_default="gpt-5.5")
+
+    runner = _make_runner()
+    session_key = "telegram:12345"
+    fallback_agent = _fake_agent(
+        model="claude-sonnet-4", provider="anthropic", fallback_activated=True
+    )
+    runner._running_agents = {session_key: fallback_agent}
+
+    # Stub _session_key_for_source and _normalize_source_for_session_key
+    monkeypatch.setattr(
+        runner, "_session_key_for_source", lambda source: session_key
+    )
+    monkeypatch.setattr(
+        runner, "_normalize_source_for_session_key", lambda source: source
+    )
+    monkeypatch.setattr(
+        runner, "_session_key_for_source", lambda source: session_key
+    )
+
+    result = await runner._handle_model_command(_make_event())
+
+    assert result is not None
+    assert "claude-sonnet-4" in result
+    assert "fallback" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_model_command_shows_config_model_when_no_fallback(tmp_path, monkeypatch):
+    """Without fallback, /model shows the config default."""
+    _setup_config(tmp_path, monkeypatch, model_default="gpt-5.5")
+
+    runner = _make_runner()
+    session_key = "telegram:12345"
+    # Agent exists but fallback is NOT active
+    normal_agent = _fake_agent(
+        model="gpt-5.5", provider="openrouter", fallback_activated=False
+    )
+    runner._running_agents = {session_key: normal_agent}
+
+    monkeypatch.setattr(
+        runner, "_normalize_source_for_session_key", lambda source: source
+    )
+    monkeypatch.setattr(
+        runner, "_session_key_for_source", lambda source: session_key
+    )
+
+    result = await runner._handle_model_command(_make_event())
+
+    assert result is not None
+    assert "gpt-5.5" in result
+    assert "fallback" not in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_model_command_ignores_pending_sentinel(tmp_path, monkeypatch):
+    """When the running agent is _PENDING_SENTINEL, don't crash."""
+    _setup_config(tmp_path, monkeypatch, model_default="gpt-5.5")
+
+    runner = _make_runner()
+    session_key = "telegram:12345"
+    runner._running_agents = {session_key: _AGENT_PENDING_SENTINEL}
+
+    monkeypatch.setattr(
+        runner, "_normalize_source_for_session_key", lambda source: source
+    )
+    monkeypatch.setattr(
+        runner, "_session_key_for_source", lambda source: session_key
+    )
+
+    result = await runner._handle_model_command(_make_event())
+
+    assert result is not None
+    assert "gpt-5.5" in result
+    assert "fallback" not in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_model_command_no_running_agent_shows_config(tmp_path, monkeypatch):
+    """When no running agent exists, /model shows the config default."""
+    _setup_config(tmp_path, monkeypatch, model_default="gpt-5.5")
+
+    runner = _make_runner()
+    # No running agents at all
+
+    session_key = "telegram:12345"
+    monkeypatch.setattr(
+        runner, "_normalize_source_for_session_key", lambda source: source
+    )
+    monkeypatch.setattr(
+        runner, "_session_key_for_source", lambda source: session_key
+    )
+
+    result = await runner._handle_model_command(_make_event())
+
+    assert result is not None
+    assert "gpt-5.5" in result
+    assert "fallback" not in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_model_command_fallback_same_model_no_indicator(tmp_path, monkeypatch):
+    """When fallback model equals config model, no fallback indicator shown."""
+    _setup_config(tmp_path, monkeypatch, model_default="gpt-5.5")
+
+    runner = _make_runner()
+    session_key = "telegram:12345"
+    # Fallback active but model is the same as config
+    agent = _fake_agent(
+        model="gpt-5.5", provider="openrouter", fallback_activated=True
+    )
+    runner._running_agents = {session_key: agent}
+
+    monkeypatch.setattr(
+        runner, "_normalize_source_for_session_key", lambda source: source
+    )
+    monkeypatch.setattr(
+        runner, "_session_key_for_source", lambda source: session_key
+    )
+
+    result = await runner._handle_model_command(_make_event())
+
+    assert result is not None
+    assert "gpt-5.5" in result
+    assert "fallback" not in result.lower()


### PR DESCRIPTION
## What does this PR do?

Restores fallback-model awareness to the `/model` command in gateway sessions. When a fallback model is actively handling a session (e.g., after a 429 rate-limit on the primary provider), `/model` now shows the runtime model with a fallback indicator instead of silently displaying the config default.

## Related Issue

Fixes #45970

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/slash_commands.py`: After resolving session overrides, check `_running_agents` for an active fallback state. If the running agent's `_fallback_activated` flag is set and its model differs from config, use the runtime model for display. In the text fallback path, append `_(fallback from \`config_model\`)_` to indicate the active fallback.
- `tests/gateway/test_model_command_fallback_display.py`: 5 regression tests covering: fallback active → shows runtime model, no fallback → shows config, pending sentinel → no crash, no running agent → shows config, fallback with same model → no indicator.

## How to Test

1. Configure a primary model with a fallback provider in config.yaml
2. Start a gateway session and trigger a model fallback (e.g., hit rate limit on primary)
3. Run `/model` — should show the fallback model with `(fallback from ...)` indicator
4. After the session ends or resets, `/model` should show the config default again
5. Run `pytest tests/gateway/test_model_command_fallback_display.py -xvs` — all 5 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/slash_commands.py::_handle_model_command` (callers: 1 via command dispatch)
- Blast radius: LOW — display-only change, no model-switching logic affected
- Related patterns: `_session_model_overrides` (session-scoped state), `_running_agents` (mid-turn agent tracking), `_AGENT_PENDING_SENTINEL` (pending agent guard)
