### PR TITLE
feat(discord): configure prompt view timeout

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -31,6 +31,9 @@ _DISCORD_COMMAND_SYNC_STATE_SUBDIR = "gateway"
 _DISCORD_COMMAND_SYNC_STATE_FILENAME = "discord_command_sync_state.json"
 _DISCORD_COMMAND_SYNC_MUTATION_INTERVAL_SECONDS = 4.5
 _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS = 30.0
+_DISCORD_PROMPT_TIMEOUT_DEFAULT_SECONDS = 300.0
+_DISCORD_PROMPT_TIMEOUT_MIN_SECONDS = 30.0
+_DISCORD_PROMPT_TIMEOUT_MAX_SECONDS = 900.0
 
 try:
     import discord
@@ -593,6 +596,34 @@ def _read_dm_role_auth_guild() -> Optional[int]:
     except (TypeError, ValueError):
         return None
     return guild_id if guild_id > 0 else None
+
+
+def _read_discord_prompt_timeout() -> float:
+    """Return configured Discord interactive prompt timeout in seconds.
+
+    Reads ``approvals.discord_prompt_timeout`` from config.yaml. Values are
+    clamped to keep prompts usable and avoid exceeding Discord's interaction
+    token lifetime.
+    """
+    try:
+        from hermes_cli.config import read_raw_config
+        cfg = read_raw_config() or {}
+        approvals_cfg = cfg.get("approvals", {}) or {}
+        raw = approvals_cfg.get("discord_prompt_timeout")
+    except Exception:
+        return _DISCORD_PROMPT_TIMEOUT_DEFAULT_SECONDS
+    if raw is None or raw == "":
+        return _DISCORD_PROMPT_TIMEOUT_DEFAULT_SECONDS
+    try:
+        timeout = float(raw)
+    except (TypeError, ValueError):
+        return _DISCORD_PROMPT_TIMEOUT_DEFAULT_SECONDS
+    if timeout <= 0:
+        return _DISCORD_PROMPT_TIMEOUT_DEFAULT_SECONDS
+    return min(
+        _DISCORD_PROMPT_TIMEOUT_MAX_SECONDS,
+        max(_DISCORD_PROMPT_TIMEOUT_MIN_SECONDS, timeout),
+    )
 
 
 class DiscordAdapter(BasePlatformAdapter):
@@ -5426,7 +5457,8 @@ def _define_discord_view_classes() -> None:
         Shows four buttons: Allow Once, Allow Session, Always Allow, Deny.
         Clicking a button calls ``resolve_gateway_approval()`` to unblock the
         waiting agent thread — the same mechanism as the text ``/approve`` flow.
-        Only users in the allowed list can click.  Times out after 5 minutes.
+        Only users in the allowed list can click.  Times out after the
+        configured Discord prompt timeout.
         """
 
         def __init__(
@@ -5435,7 +5467,7 @@ def _define_discord_view_classes() -> None:
             allowed_user_ids: set,
             allowed_role_ids: Optional[set] = None,
         ):
-            super().__init__(timeout=300)  # 5-minute timeout
+            super().__init__(timeout=_read_discord_prompt_timeout())
             self.session_key = session_key
             self.allowed_user_ids = allowed_user_ids
             self.allowed_role_ids = allowed_role_ids or set()
@@ -5545,7 +5577,7 @@ def _define_discord_view_classes() -> None:
         ``tools.slash_confirm.resolve(session_key, confirm_id, choice)``
         which runs the handler the runner stored for this ``session_key``.
         Only users in the adapter's allowlist can click.  Times out after
-        5 minutes (matches the gateway primitive's timeout).
+        the configured Discord prompt timeout.
         """
 
         def __init__(
@@ -5555,7 +5587,7 @@ def _define_discord_view_classes() -> None:
             allowed_user_ids: set,
             allowed_role_ids: Optional[set] = None,
         ):
-            super().__init__(timeout=300)
+            super().__init__(timeout=_read_discord_prompt_timeout())
             self.session_key = session_key
             self.confirm_id = confirm_id
             self.allowed_user_ids = allowed_user_ids
@@ -5650,8 +5682,7 @@ def _define_discord_view_classes() -> None:
 
         Clicking a button writes the answer to ``.update_response`` so the
         detached update process can pick it up.  Only authorized users can
-        click.  Times out after 5 minutes (the update process also has a
-        5-minute timeout on its side).
+        click.  Times out after the configured Discord prompt timeout.
         """
 
         def __init__(
@@ -5660,7 +5691,7 @@ def _define_discord_view_classes() -> None:
             allowed_user_ids: set,
             allowed_role_ids: Optional[set] = None,
         ):
-            super().__init__(timeout=300)
+            super().__init__(timeout=_read_discord_prompt_timeout())
             self.session_key = session_key
             self.allowed_user_ids = allowed_user_ids
             self.allowed_role_ids = allowed_role_ids or set()
@@ -6084,7 +6115,7 @@ def _define_discord_view_classes() -> None:
             allowed_user_ids: set,
             allowed_role_ids: Optional[set] = None,
         ):
-            super().__init__(timeout=300)  # 5-minute timeout
+            super().__init__(timeout=_read_discord_prompt_timeout())
             self.choices = list(choices)[:24]
             self.clarify_id = clarify_id
             self.allowed_user_ids = allowed_user_ids

--- a/tests/gateway/test_discord_component_auth.py
+++ b/tests/gateway/test_discord_component_auth.py
@@ -25,6 +25,7 @@ from plugins.platforms.discord.adapter import (  # noqa: E402
     SlashConfirmView,
     UpdatePromptView,
     _component_check_auth,
+    _read_discord_prompt_timeout,
 )
 
 
@@ -58,6 +59,49 @@ def _interaction(user_id, role_ids=None, *, drop_user=False, drop_roles=False):
     if not drop_roles:
         user_kwargs["roles"] = [SimpleNamespace(id=r) for r in (role_ids or [])]
     return SimpleNamespace(user=SimpleNamespace(**user_kwargs))
+
+
+def _set_raw_config(monkeypatch, cfg):
+    import hermes_cli.config as cfg_mod
+    monkeypatch.setattr(cfg_mod, "read_raw_config", lambda: cfg, raising=True)
+
+
+def test_discord_prompt_timeout_defaults_and_clamps(monkeypatch):
+    _set_raw_config(monkeypatch, {})
+    assert _read_discord_prompt_timeout() == 300.0
+
+    _set_raw_config(monkeypatch, {"approvals": {"discord_prompt_timeout": "12"}})
+    assert _read_discord_prompt_timeout() == 30.0
+
+    _set_raw_config(monkeypatch, {"approvals": {"discord_prompt_timeout": 600}})
+    assert _read_discord_prompt_timeout() == 600.0
+
+    _set_raw_config(monkeypatch, {"approvals": {"discord_prompt_timeout": 1200}})
+    assert _read_discord_prompt_timeout() == 900.0
+
+    _set_raw_config(monkeypatch, {"approvals": {"discord_prompt_timeout": "not-a-number"}})
+    assert _read_discord_prompt_timeout() == 300.0
+
+
+@pytest.mark.parametrize(
+    "view_factory",
+    [
+        lambda: ExecApprovalView(session_key="s", allowed_user_ids={"11111"}),
+        lambda: SlashConfirmView(session_key="s", confirm_id="c", allowed_user_ids={"11111"}),
+        lambda: UpdatePromptView(session_key="s", allowed_user_ids={"11111"}),
+        lambda: ClarifyChoiceView(
+            choices=["one"],
+            clarify_id="c",
+            allowed_user_ids={"11111"},
+        ),
+    ],
+)
+def test_discord_prompt_views_use_configured_timeout(monkeypatch, view_factory):
+    _set_raw_config(monkeypatch, {"approvals": {"discord_prompt_timeout": 720}})
+
+    view = view_factory()
+
+    assert view.timeout == 720.0
 
 
 # ── no policy configured -> deny unless allow-all is explicit ──────────────


### PR DESCRIPTION
Fixes #45903

## Summary
- add `approvals.discord_prompt_timeout` for Discord interactive approval/confirm/update/clarify views
- default to 300 seconds for existing behavior
- clamp configured values to 30-900 seconds so prompts stay usable and below Discord interaction expiry

## Tests
- `python -m pytest tests/gateway/test_discord_component_auth.py`
  - 33 passed
- `python -m py_compile plugins/platforms/discord/adapter.py tests/gateway/test_discord_component_auth.py`
- `git diff --check`
