### PR TITLE
fix(web): fail closed on explicit unknown backend

### DIFF
--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -140,8 +140,8 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
        provider that supports *capability*, return it even if its
        :meth:`is_available` returns False — the dispatcher will surface a
        precise "X_API_KEY is not set" error to the user instead of silently
-       routing somewhere else. Matches legacy
-       :func:`tools.web_tools._get_backend` behavior for configured names.
+       routing somewhere else. If the configured name is missing or
+       capability-incompatible, fail closed rather than silently rerouting.
 
     2. **Single-provider shortcut.** When only one registered provider
        supports *capability* AND ``is_available()`` reports True, return it.
@@ -187,14 +187,15 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
             return provider
         if provider is None:
             logger.debug(
-                "web backend '%s' configured but not registered; falling back",
+                "web backend '%s' configured but not registered",
                 configured,
             )
         else:
             logger.debug(
-                "web backend '%s' configured but does not support '%s'; falling back",
+                "web backend '%s' configured but does not support '%s'",
                 configured, capability,
             )
+        return None
 
     # 2. + 3. Fallback path — filter by availability so we don't surface
     #    a provider the user has no credentials for. Without this filter,

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -280,40 +280,33 @@ class TestRegistryResolution:
         # a typed credential-missing error to the caller.
         assert result.is_available() is False
 
-    def test_unknown_configured_name_falls_back_to_available_provider(
+    def test_unknown_configured_name_does_not_fall_back_to_available_provider(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Typo / uninstalled plugin → walk legacy preference, pick available."""
+        """Typo / late-loaded plugin → fail closed instead of silent reroute."""
         _ensure_plugins_loaded()
         from agent.web_search_registry import _resolve
 
         monkeypatch.setenv("EXA_API_KEY", "real")
         result = _resolve("not-a-real-provider", capability="search")
-        # Either ddgs (no-key fallback) or exa (the only available
-        # premium provider) — both are valid. The point is the unknown
-        # name shouldn't return None when SOMETHING is available.
-        assert result is not None
-        assert result.is_available() is True
+        assert result is None
 
-    def test_explicit_search_only_provider_for_extract_falls_back(
+    def test_explicit_search_only_provider_for_extract_does_not_fall_back(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Asking for extract via a search-only backend → fall back.
+        """Asking for extract via a search-only backend fails closed.
 
         ``brave-free`` is search-only (``supports_extract() is False``).
-        When the registry resolves it for an extract capability, the
-        explicit-config branch rejects it as capability-incompatible
-        and the fallback walk picks an extract-capable provider.
+        When the registry resolves it for an extract capability, the explicit
+        config branch rejects it as capability-incompatible instead of silently
+        routing extraction through a different backend.
         """
         _ensure_plugins_loaded()
         from agent.web_search_registry import _resolve
 
         monkeypatch.setenv("EXA_API_KEY", "real")
         result = _resolve("brave-free", capability="extract")
-        # Should land on exa (only extract-capable available provider).
-        assert result is not None
-        assert result.supports_extract() is True
-        assert result.is_available() is True
+        assert result is None
 
     def test_no_config_no_credentials_returns_none(
         self,


### PR DESCRIPTION
Fixes #45876

## Summary
- stop silently rerouting an explicitly configured but unregistered web backend through another provider such as DDGS
- stop falling back to a different backend when the explicit backend does not support the requested capability
- keep the existing auto-selection fallback for sessions with no configured backend

This makes explicit web backend configuration fail closed instead of masking late-loaded or missing provider registration.

## Tests
- python -m pytest tests/plugins/web/test_web_search_provider_plugins.py
- python -m py_compile agent/web_search_registry.py tests/plugins/web/test_web_search_provider_plugins.py
- git diff --check