### PR TITLE
fix(discord): /skill autocomplete leaks the skill catalog when no allowlist is set

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -2694,6 +2694,20 @@ class DiscordAdapter(BasePlatformAdapter):
     # default. Deployments that DO set any DISCORD_ALLOWED_* var get slash
     # parity with on_message.
 
+    def _slash_allow_all_enabled(self) -> bool:
+        """Explicit operator opt-in that opens a slash surface with no allowlist.
+
+        Mirrors ``_component_check_auth`` and the gateway runner's default
+        (SECURITY.md §2.6): ``DISCORD_ALLOW_ALL_USERS`` or the cross-platform
+        ``GATEWAY_ALLOW_ALL_USERS``.
+        """
+        return (
+            os.getenv("DISCORD_ALLOW_ALL_USERS", "").strip().lower()
+            in {"true", "1", "yes"}
+            or os.getenv("GATEWAY_ALLOW_ALL_USERS", "").strip().lower()
+            in {"true", "1", "yes"}
+        )
+
     def _evaluate_slash_authorization(
         self, interaction: "discord.Interaction",
     ) -> Tuple[bool, Optional[str]]:
@@ -3703,6 +3717,22 @@ class DiscordAdapter(BasePlatformAdapter):
                 since process start shows up on the very next keystroke.
                 """
                 try:
+                    # Autocomplete responses are returned straight to Discord
+                    # and never pass through the gateway runner's
+                    # _is_user_authorized() gate that re-gates message/slash
+                    # dispatch fail-closed. So _evaluate_slash_authorization's
+                    # no-allowlist fail-open (the documented dispatch
+                    # back-compat) would relay the installed skill catalog to
+                    # any guild member here, with nothing downstream to deny
+                    # it. Withhold it: with no user/role allowlist configured,
+                    # require an explicit allow-all opt-in, mirroring
+                    # _component_check_auth and the runner default
+                    # (SECURITY.md §2.6).
+                    if not (
+                        getattr(self, "_allowed_user_ids", None)
+                        or getattr(self, "_allowed_role_ids", None)
+                    ) and not self._slash_allow_all_enabled():
+                        return []
                     allowed, _reason = self._evaluate_slash_authorization(interaction)
                 except Exception:
                     # Defensive: never raise from autocomplete. Fail

--- a/tests/gateway/test_discord_slash_auth.py
+++ b/tests/gateway/test_discord_slash_auth.py
@@ -97,6 +97,8 @@ def _isolate_discord_env(monkeypatch):
         "DISCORD_IGNORED_CHANNELS",
         "DISCORD_HIDE_SLASH_COMMANDS",
         "DISCORD_ALLOW_BOTS",
+        "DISCORD_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
     ):
         monkeypatch.delenv(var, raising=False)
 
@@ -653,6 +655,68 @@ async def test_skill_autocomplete_returns_choices_for_authorized(
     result = await autocomplete(interaction, "")
     assert len(result) == 2
     assert {choice.value for choice in result} == {"alpha", "beta"}
+
+
+@pytest.mark.asyncio
+async def test_skill_autocomplete_empty_allowlist_withholds_catalog(
+    adapter, monkeypatch,
+):
+    """No allowlist configured: the autocomplete must NOT leak the installed
+    skill catalog. Unlike message/slash dispatch — which the gateway runner
+    re-gates fail-closed via _is_user_authorized() — an autocomplete response
+    is returned straight to Discord with no runner backstop. So the adapter's
+    documented no-allowlist fail-open (fine for dispatch) must not surface
+    skill names here, where nothing downstream denies them (SECURITY.md §2.6:
+    adapters must not relay output until an allowlist is set)."""
+    # The adapter fixture has neither _allowed_user_ids nor _allowed_role_ids.
+    entries = [
+        ("alpha", "First skill", "/alpha"),
+        ("beta", "Second skill", "/beta"),
+    ]
+    _handler, autocomplete = _capture_skill_registration(
+        adapter, monkeypatch, entries,
+    )
+
+    interaction = _make_interaction("999999999")
+    result = await autocomplete(interaction, "")
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_skill_autocomplete_empty_allowlist_allow_all_surfaces_catalog(
+    adapter, monkeypatch,
+):
+    """Explicit operator opt-in (DISCORD_ALLOW_ALL_USERS) restores the open
+    catalog, mirroring _component_check_auth and the gateway runner default."""
+    monkeypatch.setenv("DISCORD_ALLOW_ALL_USERS", "true")
+    entries = [
+        ("alpha", "First skill", "/alpha"),
+        ("beta", "Second skill", "/beta"),
+    ]
+    _handler, autocomplete = _capture_skill_registration(
+        adapter, monkeypatch, entries,
+    )
+
+    interaction = _make_interaction("999999999")
+    result = await autocomplete(interaction, "")
+    assert {choice.value for choice in result} == {"alpha", "beta"}
+
+
+@pytest.mark.asyncio
+async def test_skill_autocomplete_empty_allowlist_gateway_allow_all_surfaces_catalog(
+    adapter, monkeypatch,
+):
+    """GATEWAY_ALLOW_ALL_USERS is the cross-platform equivalent opt-in and
+    must open the catalog the same way."""
+    monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
+    entries = [("alpha", "First skill", "/alpha")]
+    _handler, autocomplete = _capture_skill_registration(
+        adapter, monkeypatch, entries,
+    )
+
+    interaction = _make_interaction("999999999")
+    result = await autocomplete(interaction, "")
+    assert {choice.value for choice in result} == {"alpha"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What
`/skill` autocomplete leaks the installed skill catalog (names + descriptions)
to any guild member when no allowlist is configured.

## Why
The autocomplete callback gates only on `_evaluate_slash_authorization()`,
which fails open with no allowlist. Unlike message/slash **dispatch** — which
the gateway runner re-gates fail-closed via `_is_user_authorized()` — an
autocomplete response is returned straight to Discord and never reaches the
runner, so nothing backstops the leak. This contradicts the callback's own
stated goal ("the installed skill catalog is not leaked") and SECURITY.md §2.6
(adapters must not relay output until an allowlist is set; a code path that
fails open with no allowlist is in scope under §3.1).

## Fix
Withhold the catalog when no user/role allowlist is configured, unless an
explicit allow-all opt-in (`DISCORD_ALLOW_ALL_USERS` / `GATEWAY_ALLOW_ALL_USERS`)
is set — mirroring `_component_check_auth` and the gateway runner default.
Dispatch authorization is unchanged, so the existing no-allowlist dispatch
behavior is preserved.

## Tests
New cases in `tests/gateway/test_discord_slash_auth.py`:
- empty allowlist → autocomplete returns `[]` (no leak)
- empty allowlist + `DISCORD_ALLOW_ALL_USERS` → catalog restored
- empty allowlist + `GATEWAY_ALLOW_ALL_USERS` → catalog restored
- configured-allowlist behavior unchanged (existing cases still pass)

**Results**
- `test_discord_slash_auth.py`: **35 passed** (32 existing + 3 new)
- full Discord gateway suite: **382 passed**
- e2e adapter (`tests/e2e/test_discord_adapter.py`): **6 passed**