### PR TITLE
fix(desktop): guard destroyed mainWindow in getWindowState/getWindowButtonPosition

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -3275,7 +3275,8 @@ async function waitForHermes(baseUrl, token) {
 
 function getWindowButtonPosition() {
   if (!IS_MAC) return null
-  return mainWindow?.getWindowButtonPosition?.() || WINDOW_BUTTON_POSITION
+  if (!mainWindow || mainWindow.isDestroyed()) return WINDOW_BUTTON_POSITION
+  return mainWindow.getWindowButtonPosition() || WINDOW_BUTTON_POSITION
 }
 
 function getNativeOverlayWidth() {
@@ -3287,8 +3288,9 @@ function getNativeOverlayWidth() {
 }
 
 function getWindowState() {
+  const destroyed = !mainWindow || mainWindow.isDestroyed()
   return {
-    isFullscreen: Boolean(mainWindow?.isFullScreen?.()),
+    isFullscreen: destroyed ? false : Boolean(mainWindow.isFullScreen()),
     nativeOverlayWidth: getNativeOverlayWidth(),
     windowButtonPosition: getWindowButtonPosition()
   }


### PR DESCRIPTION
## Problem

Desktop app crashes on every auto-update restart with:

```
TypeError: Object has been destroyed
    at getWindowState (main.cjs:3094:53)
```

## Root Cause

During auto-update, the updater replaces the asar and restarts the app. The old `BrowserWindow` is destroyed, but `getWindowState()` and `getWindowButtonPosition()` use optional chaining (`?.`) which only guards against `null`/`undefined` — not a destroyed Electron window object.

Calling `.isFullScreen()` or `.getWindowButtonPosition()` on a destroyed window throws `Object has been destroyed`.

## Fix

Add explicit `isDestroyed()` checks, matching the pattern already used by `sendBackendExit()` and other window-accessing functions in the same file:

```js
// getWindowButtonPosition
- return mainWindow?.getWindowButtonPosition?.() || WINDOW_BUTTON_POSITION
+ if (!mainWindow || mainWindow.isDestroyed()) return WINDOW_BUTTON_POSITION
+ return mainWindow.getWindowButtonPosition() || WINDOW_BUTTON_POSITION

// getWindowState
+ const destroyed = !mainWindow || mainWindow.isDestroyed()
  return {
-   isFullscreen: Boolean(mainWindow?.isFullScreen?.()),
+   isFullscreen: destroyed ? false : Boolean(mainWindow.isFullScreen()),
    ...
  }
```

## Testing

- Reproduced crash by triggering desktop auto-update restart
- After patch: desktop restarts cleanly without crash