### PR TITLE
feat(web): make search default limit configurable

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1017,6 +1017,7 @@ DEFAULT_CONFIG = {
         "backend": "",           # shared fallback — applies to both search and extract
         "search_backend": "",    # per-capability override for web_search (e.g. "searxng")
         "extract_backend": "",   # per-capability override for web_extract (e.g. "native")
+        "search_default_limit": 5,  # Default web_search result count when the model omits limit. Range 1..100.
     },
 
     "browser": {

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -505,7 +505,17 @@ class TestWebSearchSchema:
             result = entry.handler({"query": "docs"})
 
         assert result == '{"success": true}'
-        mock_search.assert_called_once_with("docs", limit=5)
+        mock_search.assert_called_once_with("docs", limit=None)
+
+    def test_configured_default_limit_is_clamped(self):
+        import tools.web_tools
+
+        with patch("tools.web_tools._load_web_config", return_value={"search_default_limit": "20"}):
+            assert tools.web_tools._get_search_default_limit() == 20
+        with patch("tools.web_tools._load_web_config", return_value={"search_default_limit": 500}):
+            assert tools.web_tools._get_search_default_limit() == 100
+        with patch("tools.web_tools._load_web_config", return_value={"search_default_limit": "bad"}):
+            assert tools.web_tools._get_search_default_limit() == 5
 
     def test_web_search_clamps_limit_before_backend_call(self):
         import tools.web_tools
@@ -532,6 +542,28 @@ class TestWebSearchSchema:
 
         assert result == {"success": True, "data": {"web": []}}
         fake_search.assert_called_once_with("docs", 100)
+
+    def test_web_search_uses_configured_default_limit_when_omitted(self):
+        import tools.web_tools
+
+        fake_search = MagicMock(return_value={"success": True, "data": {"web": []}})
+        fake_provider = MagicMock(
+            name="ParallelWebSearchProvider",
+            supports_search=MagicMock(return_value=True),
+        )
+        fake_provider.search = fake_search
+        fake_provider.name = "parallel"
+
+        with patch("tools.web_tools._load_web_config", return_value={"search_default_limit": 12}), \
+             patch("tools.web_tools._get_search_backend", return_value="parallel"), \
+             patch("agent.web_search_registry.get_provider", return_value=fake_provider), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.object(tools.web_tools._debug, "log_call"), \
+             patch.object(tools.web_tools._debug, "save"):
+            result = json.loads(tools.web_tools.web_search_tool("docs"))
+
+        assert result == {"success": True, "data": {"web": []}}
+        fake_search.assert_called_once_with("docs", 12)
 
 
 class TestWebSearchErrorHandling:

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -141,6 +141,18 @@ def _load_web_config() -> dict:
     except (ImportError, Exception):
         return {}
 
+
+def _coerce_search_limit(raw: Any, *, default: int = 5) -> int:
+    try:
+        limit = int(raw)
+    except (TypeError, ValueError):
+        limit = default
+    return min(max(limit, 1), 100)
+
+
+def _get_search_default_limit() -> int:
+    return _coerce_search_limit(_load_web_config().get("search_default_limit"), default=5)
+
 # Recognized web backend names (config values accepted in ``web.backend`` /
 # ``web.search_backend`` / ``web.extract_backend``). Kept as a single source of
 # truth for config validation across the selection helpers.
@@ -915,7 +927,7 @@ def _register_bundled_web_providers_directly() -> None:
             )
 
 
-def web_search_tool(query: str, limit: int = 5) -> str:
+def web_search_tool(query: str, limit: Optional[int] = None) -> str:
     """
     Search the web for information using available search API backend.
 
@@ -927,7 +939,7 @@ def web_search_tool(query: str, limit: int = 5) -> str:
     
     Args:
         query (str): The search query to look up
-        limit (int): Maximum number of results to return (default: 5)
+        limit (int): Maximum number of results to return (defaults to web.search_default_limit)
     
     Returns:
         str: JSON string containing search results with the following structure:
@@ -949,11 +961,7 @@ def web_search_tool(query: str, limit: int = 5) -> str:
     Raises:
         Exception: If search fails or API key is not set
     """
-    try:
-        limit = int(limit)
-    except (TypeError, ValueError):
-        limit = 5
-    limit = min(max(limit, 1), 100)
+    limit = _get_search_default_limit() if limit is None else _coerce_search_limit(limit)
 
     debug_call_data = {
         "parameters": {
@@ -1506,9 +1514,11 @@ if __name__ == "__main__":
 # ---------------------------------------------------------------------------
 from tools.registry import registry, tool_error
 
+_WEB_SEARCH_DEFAULT_LIMIT = _get_search_default_limit()
+
 WEB_SEARCH_SCHEMA = {
     "name": "web_search",
-    "description": "Search the web for information. Returns up to 5 results by default with titles, URLs, and descriptions. The query is passed through to the configured backend, so operators such as site:domain, filetype:pdf, intitle:word, -term, and \"exact phrase\" may work when the backend supports them.",
+    "description": "Search the web for information. Returns the configured default number of results with titles, URLs, and descriptions. The query is passed through to the configured backend, so operators such as site:domain, filetype:pdf, intitle:word, -term, and \"exact phrase\" may work when the backend supports them.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -1518,10 +1528,10 @@ WEB_SEARCH_SCHEMA = {
             },
             "limit": {
                 "type": "integer",
-                "description": "Maximum number of results to return. Defaults to 5.",
+                "description": "Maximum number of results to return. Defaults to web.search_default_limit.",
                 "minimum": 1,
                 "maximum": 100,
-                "default": 5
+                "default": _WEB_SEARCH_DEFAULT_LIMIT
             }
         },
         "required": ["query"]
@@ -1549,7 +1559,7 @@ registry.register(
     name="web_search",
     toolset="web",
     schema=WEB_SEARCH_SCHEMA,
-    handler=lambda args, **kw: web_search_tool(args.get("query", ""), limit=args.get("limit", 5)),
+    handler=lambda args, **kw: web_search_tool(args.get("query", ""), limit=args.get("limit")),
     check_fn=web_tools_registered,
     requires_env=_web_requires_env(),
     emoji="🔍",


### PR DESCRIPTION
Fixes #45701

## Summary
- add `web.search_default_limit` to the default config
- use that configured value when `web_search` is called without an explicit `limit`
- expose the configured default in the tool schema and clamp invalid values to 1..100

## Tests
- python -m pytest tests/tools/test_web_tools_config.py::TestWebSearchSchema -q
- python -m py_compile tools/web_tools.py hermes_cli/config.py tests/tools/test_web_tools_config.py
- git diff --check

Note: running the full `tests/tools/test_web_tools_config.py` file in this environment still hits existing environment issues unrelated to this change: missing async pytest support and Parallel SDK lazy-install import refresh failures. The focused schema/handler/default-limit tests pass.
