### PR TITLE
fix(telegram): reserve rich messages for rich markdown

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -953,6 +953,25 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         return inspect.iscoroutinefunction(getattr(self._bot, "do_api_request", None))
 
+    def _needs_rich_rendering(self, content: str) -> bool:
+        """Return True for markdown constructs that the legacy path degrades.
+
+        Keep ordinary replies on the pre-rich MarkdownV2 path so Telegram
+        clients render a consistent font weight/spacing. The rich endpoint is
+        reserved for constructs where raw markdown materially improves output.
+        """
+        if not content:
+            return False
+        if _TABLE_SEPARATOR_RE.search(content):
+            return True
+        if re.search(r"(?m)^\s*[-*]\s+\[[ xX]\]\s+", content):
+            return True
+        if re.search(r"(?m)^<details\b|^</details>|^<summary\b|^</summary>", content):
+            return True
+        if "$$" in content:
+            return True
+        return False
+
     def _should_attempt_rich(
         self, content: str, metadata: Optional[Dict[str, Any]] = None
     ) -> bool:
@@ -962,6 +981,7 @@ class TelegramAdapter(BasePlatformAdapter):
             and not (metadata or {}).get("expect_edits")
             and content
             and content.strip()
+            and self._needs_rich_rendering(content)
             and self._content_fits_rich_limits(content)
             and self._bot_supports_rich()
         )

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -10,6 +10,7 @@ The ``telegram`` package is mocked by ``tests/gateway/conftest.py``
 ``TelegramAdapter`` and wire a mock bot.
 """
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -142,6 +143,25 @@ async def test_rich_messages_default_is_enabled():
     assert bot is not None
     bot.do_api_request.assert_awaited_once()
     bot.send_message.assert_not_called()
+
+
+def test_plain_markdown_stays_on_legacy_path_for_consistent_rendering():
+    adapter = _make_adapter()
+
+    result = asyncio.run(adapter.send("12345", "Hello **there**\n\nA normal reply."))
+
+    assert result.success is True
+    bot = adapter._bot
+    assert bot is not None
+    bot.do_api_request.assert_not_called()
+    bot.send_message.assert_awaited()
+
+
+def test_prefers_fresh_final_streaming_only_for_rich_constructs():
+    adapter = _make_adapter()
+
+    assert adapter.prefers_fresh_final_streaming("Plain **markdown**") is False
+    assert adapter.prefers_fresh_final_streaming(RICH_CONTENT) is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #45911

## Summary
- keep ordinary Telegram replies on the legacy MarkdownV2 send path for consistent client rendering
- reserve Bot API 10.1 rich messages for markdown that benefits from the rich renderer, such as tables, task lists, details blocks, and display math
- keep rich final streaming enabled for those rich constructs

## Tests
- python -m pytest tests/gateway/test_telegram_rich_messages.py::test_plain_markdown_stays_on_legacy_path_for_consistent_rendering tests/gateway/test_telegram_rich_messages.py::test_prefers_fresh_final_streaming_only_for_rich_constructs -q
- python -m py_compile gateway/platforms/telegram.py tests/gateway/test_telegram_rich_messages.py
- git diff --check

Note: the full Telegram rich-message test file still requires async pytest support in this environment; the two focused regression tests above pass locally.
