### PR TITLE
fix(desktop): keep sidebar refresh visible on hover

### DIFF
--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -131,7 +131,7 @@ interface FilesystemTabProps extends FileTreeBodyProps {
 const HEADER_ACTION_CLASS =
   'text-sidebar-foreground/70 hover:bg-sidebar-accent! hover:text-sidebar-accent-foreground! focus-visible:ring-sidebar-ring'
 
-const HEADER_ACTION_LABEL_REVEAL = `${HEADER_ACTION_CLASS} pointer-events-none opacity-0 transition-opacity focus-visible:pointer-events-auto focus-visible:opacity-100 peer-focus-visible/project-label:pointer-events-auto peer-focus-visible/project-label:opacity-100 peer-hover/project-label:pointer-events-auto peer-hover/project-label:opacity-100`
+const HEADER_ACTION_LABEL_REVEAL = `${HEADER_ACTION_CLASS} pointer-events-none opacity-0 transition-opacity hover:pointer-events-auto hover:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100 peer-focus-visible/project-label:pointer-events-auto peer-focus-visible/project-label:opacity-100 peer-hover/project-label:pointer-events-auto peer-hover/project-label:opacity-100`
 
 function FilesystemTab({
   canCollapse,


### PR DESCRIPTION
Fixes #45894

## Summary
- keep the right-sidebar filesystem refresh button visible and pointer-enabled while the cursor is over the button itself
- preserve the existing peer-hover/project-label reveal behavior

## Tests
- git diff --check

Attempted but blocked by the local checkout missing frontend dependencies:
- npm --workspace apps/desktop run typecheck
- npm --workspace apps/desktop run lint -- --quiet apps/desktop/src/app/right-sidebar/index.tsx

Both fail before checking this file because packages such as React, nanostores, vitest, and eslint are not installed/resolvable in this environment.
