### PR TITLE
fix(desktop): show hidden main window on launch

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5196,6 +5196,14 @@ function createWindow() {
   mainWindow.once('ready-to-show', () => {
     if (mainWindow && !mainWindow.isDestroyed()) mainWindow.show()
   })
+  // Some Linux desktop stacks can complete the backend/renderer boot but still
+  // leave the BrowserWindow hidden if ready-to-show is delayed or the compositor
+  // misses the initial map. Do not let a successful launch look like a no-op.
+  setTimeout(() => {
+    if (mainWindow && !mainWindow.isDestroyed() && !mainWindow.isVisible()) {
+      focusWindow(mainWindow)
+    }
+  }, 4000).unref?.()
 
   mainWindow.on('will-enter-full-screen', () => sendWindowStateChanged(true))
   mainWindow.on('enter-full-screen', () => sendWindowStateChanged(true))
@@ -6448,9 +6456,10 @@ if (!_gotSingleInstanceLock) {
   app.on('second-instance', (_event, argv) => {
     const url = _extractDeepLink(argv)
     if (url) handleDeepLink(url)
-    else if (mainWindow) {
-      if (mainWindow.isMinimized()) mainWindow.restore()
-      mainWindow.focus()
+    else if (mainWindow && !mainWindow.isDestroyed()) {
+      focusWindow(mainWindow)
+    } else if (app.isReady()) {
+      createWindow()
     }
   })
 }


### PR DESCRIPTION
## Summary

- Add a bounded fallback after `createWindow()` so a successful boot cannot leave the primary `BrowserWindow` hidden when `ready-to-show` is delayed or the compositor misses the initial map.
- Route `second-instance` activation through `focusWindow(mainWindow)` so hidden-but-running windows are restored/shown/focused instead of only focused.
- Recreate the main window on `second-instance` if the stored main-window ref is missing/destroyed and the app is already ready.

Fixes #45991.

## Motivation

On Ubuntu 26.04 / GNOME Shell 50.1 / native Wayland, launching Hermes Desktop from a trusted desktop icon can successfully start the Electron process and backend (`HERMES_DASHBOARD_READY`) while no main window becomes visible. From the user's perspective, double-clicking the desktop icon appears to do nothing.

A local patch with the same visibility fallback was validated on the affected machine: after rebuilding, launching with `gio launch ~/桌面/hermes-desktop.desktop` and double-clicking the desktop icon made the window visible again.

## Test Plan

- [x] `node --check apps/desktop/electron/main.cjs`
- [x] `npm --workspace apps/desktop run test:desktop:platforms` was run. It passed 163 tests and skipped 1, with the only failure in `electron/windows-child-process.test.cjs` (`missing call site: execFileSync(pyExe`). The same targeted test fails on a clean `origin/main` tree before this change, so it is pre-existing and unrelated to this PR.
- [x] Local manual validation on Ubuntu 26.04 / GNOME Shell 50.1 / Wayland: desktop icon launch shows the Hermes Desktop window after rebuild.

## Related

- #45068
- #45229
- #45045
- #45102
