### PR TITLE
fix(kimi-coding): correct base URL path and User-Agent for Kimi Coding Plan API

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -761,7 +761,7 @@ def init_agent(
                 client_kwargs["default_headers"] = copilot_default_headers()
             elif base_url_host_matches(effective_base, "api.kimi.com"):
                 client_kwargs["default_headers"] = {
-                    "User-Agent": "claude-code/0.1.0",
+                    "User-Agent": "KimiCLI/1.3",
                 }
             elif base_url_host_matches(effective_base, "portal.qwen.ai"):
                 client_kwargs["default_headers"] = _ra()._qwen_portal_headers()

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -503,16 +503,17 @@ def get_anthropic_key() -> str:
 # =============================================================================
 
 # Kimi Code (kimi.com/code) issues keys prefixed "sk-kimi-" that only work
-# on api.kimi.com/coding.  Legacy keys from platform.moonshot.ai work on
+# on api.kimi.com/coding/v1.  Legacy keys from platform.moonshot.ai work on
 # api.moonshot.ai/v1 (the old default).  Auto-detect when user hasn't set
 # KIMI_BASE_URL explicitly.
 #
-# Note: the base URL intentionally has NO /v1 suffix.  The /coding endpoint
-# speaks the Anthropic Messages protocol, and the anthropic SDK appends
-# "/v1/messages" internally — so "/coding" + SDK suffix → "/coding/v1/messages"
-# (the correct target). Using "/coding/v1" here would produce
-# "/coding/v1/v1/messages" (a 404).
-KIMI_CODE_BASE_URL = "https://api.kimi.com/coding"
+# Note: the base URL includes the /v1 suffix because the kimi-coding provider
+# uses OpenAI chat-completions transport (not Anthropic Messages).  The OpenAI
+# SDK expects a base URL ending in /v1 and appends /chat/completions, so
+# "/coding/v1" + SDK suffix → "/coding/v1/chat/completions" (the correct
+# OpenAI-compatible target for the Kimi Coding Plan API).
+# Using "/coding" here would produce "/coding/chat/completions" (wrong path).
+KIMI_CODE_BASE_URL = "https://api.kimi.com/coding/v1"
 
 
 def _resolve_kimi_base_url(api_key: str, default_url: str, env_override: str) -> str:

--- a/plugins/model-providers/kimi-coding/__init__.py
+++ b/plugins/model-providers/kimi-coding/__init__.py
@@ -61,7 +61,12 @@ kimi = KimiProfile(
     base_url="https://api.moonshot.ai/v1",
     fixed_temperature=OMIT_TEMPERATURE,
     default_max_tokens=32000,
-    default_headers={"User-Agent": "hermes-agent/1.0"},
+    # User-Agent: The Kimi Coding Plan API (api.kimi.com/coding) checks the
+    # User-Agent header and only allows whitelisted agents (Kimi CLI, Claude
+    # Code, Roo Code, Kilo Code, etc.). Send "KimiCLI/1.3" so requests to the
+    # coding endpoint succeed. The Moonshot Open Platform (api.moonshot.ai)
+    # doesn't check User-Agent, so this is harmless for both endpoints.
+    default_headers={"User-Agent": "KimiCLI/1.3"},
     default_aux_model="kimi-k2-turbo-preview",
 )
 
@@ -72,7 +77,7 @@ kimi_cn = KimiProfile(
     base_url="https://api.moonshot.cn/v1",
     fixed_temperature=OMIT_TEMPERATURE,
     default_max_tokens=32000,
-    default_headers={"User-Agent": "hermes-agent/1.0"},
+    default_headers={"User-Agent": "KimiCLI/1.3"},
     default_aux_model="kimi-k2-turbo-preview",
 )
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -3875,7 +3875,7 @@ class AIAgent:
 
             self._client_kwargs["default_headers"] = copilot_default_headers()
         elif base_url_host_matches(base_url, "api.kimi.com"):
-            self._client_kwargs["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
+            self._client_kwargs["default_headers"] = {"User-Agent": "KimiCLI/1.3"}
         elif base_url_host_matches(base_url, "portal.qwen.ai"):
             self._client_kwargs["default_headers"] = _qwen_portal_headers()
         elif base_url_host_matches(base_url, "chatgpt.com"):


### PR DESCRIPTION
The Kimi Coding Plan API at `api.kimi.com/coding` uses an OpenAI-compatible chat/completions transport, not Anthropic Messages.

## Changes

### 1. Base URL fix (`hermes_cli/auth.py`)
Changed `KIMI_CODE_BASE_URL` from `https://api.kimi.com/coding` to `https://api.kimi.com/coding/v1`. The OpenAI SDK expects the base URL to end in `/v1` and appends `/chat/completions`, so this produces the correct path `/coding/v1/chat/completions`.

### 2. User-Agent header (4 files)
Changed `User-Agent` from `hermes-agent/1.0` / `claude-code/0.1.0` to `KimiCLI/1.3` across all Kimi API call sites:
- `plugins/model-providers/kimi-coding/__init__.py`
- `agent/agent_init.py`
- `run_agent.py`
- `hermes_cli/auth.py` (updated doc comment only)

The Kimi Coding Plan API checks the `User-Agent` header and only allows whitelisted agents (Kimi CLI, Claude Code, Roo Code, Kilo Code, etc.). The Moonshot Open Platform (`api.moonshot.ai`) doesn't check User-Agent, so this is harmless for both endpoints.