### PR TITLE
fix(custom-providers): apply extra_headers to Anthropic clients

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -698,7 +698,33 @@ def _build_anthropic_client_with_bearer_hook(
     if common_betas:
         kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
 
+    _apply_configured_anthropic_extra_headers(kwargs, base_url)
+
     return _anthropic_sdk.Anthropic(**kwargs)
+
+
+def _apply_configured_anthropic_extra_headers(
+    client_kwargs: Dict[str, Any],
+    base_url: str | None,
+) -> None:
+    """Merge endpoint-scoped custom-provider headers into Anthropic kwargs.
+
+    The shared config helper preserves SDK/provider defaults such as
+    ``anthropic-beta`` while allowing the matching ``extra_headers`` entry to
+    add or explicitly override headers. Header values may contain credentials
+    and must never be logged.
+    """
+    if not base_url:
+        return
+    try:
+        from hermes_cli.config import apply_custom_provider_extra_headers_to_client_kwargs
+
+        apply_custom_provider_extra_headers_to_client_kwargs(client_kwargs, base_url)
+    except Exception as exc:
+        logger.debug(
+            "Could not resolve custom-provider headers for Anthropic endpoint: %s",
+            type(exc).__name__,
+        )
 
 
 def build_anthropic_client(
@@ -826,6 +852,8 @@ def build_anthropic_client(
         kwargs["api_key"] = api_key
         if common_betas:
             kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
+
+    _apply_configured_anthropic_extra_headers(kwargs, base_url)
 
     return _anthropic_sdk.Anthropic(**kwargs)
 

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -633,11 +633,42 @@ def _build_anthropic_client_with_bearer_hook(
     if common_betas:
         kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
 
+    _apply_configured_anthropic_extra_headers(kwargs, base_url)
+
     client = _anthropic_sdk.Anthropic(**kwargs)
     # Same env-inference trap as build_anthropic_client: auth_token-only
     # construction would otherwise also send ANTHROPIC_API_KEY as X-Api-Key.
     client.api_key = None
     return client
+
+
+def _apply_configured_anthropic_extra_headers(
+    client_kwargs: Dict[str, Any],
+    base_url: str | None,
+) -> None:
+    """Merge endpoint-scoped custom-provider headers into Anthropic kwargs.
+
+    The shared config helper (``hermes_cli.config``) preserves SDK/provider
+    defaults such as ``anthropic-beta`` while allowing the matching
+    ``extra_headers`` entry to add or explicitly override headers — the
+    provider entry is the most specific configuration level. Covers every
+    native Anthropic client construction path (initial build, agent rebuilds
+    after provider switch / interrupt / credential recovery) because both
+    builders here call it right before SDK construction.
+
+    SECURITY: header values may carry credentials and must never be logged.
+    """
+    if not base_url:
+        return
+    try:
+        from hermes_cli.config import apply_custom_provider_extra_headers_to_client_kwargs
+
+        apply_custom_provider_extra_headers_to_client_kwargs(client_kwargs, base_url)
+    except Exception as exc:
+        logger.debug(
+            "Could not resolve custom-provider headers for Anthropic endpoint: %s",
+            type(exc).__name__,
+        )
 
 
 def build_anthropic_client(
@@ -783,6 +814,12 @@ def build_anthropic_client(
         headers.setdefault("X-Title", "Hermes Agent")
         headers.setdefault("User-Agent", f"HermesAgent/{_HERMES_VERSION}")
         kwargs["default_headers"] = headers
+
+    # Endpoint-scoped extra_headers from the matching providers/custom_providers
+    # entry are merged last so user-configured headers (e.g. Cloudflare Access
+    # service tokens, WAF-required User-Agents) win over the hardcoded provider
+    # attribution sets above.
+    _apply_configured_anthropic_extra_headers(kwargs, base_url)
 
     client = _anthropic_sdk.Anthropic(**kwargs)
     # Bearer-only construction leaves ``api_key`` unset, so the SDK fills it

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -113,6 +113,57 @@ class TestBuildAnthropicClient:
                 "anthropic-beta": "interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14"
             }
 
+    def test_custom_provider_extra_headers_merge_with_anthropic_betas(self):
+        base_url = "https://proxy.example.com/anthropic/v1"
+        config = {
+            "custom_providers": [
+                {
+                    "name": "anthropic-proxy",
+                    "base_url": base_url,
+                    "api_mode": "anthropic_messages",
+                    "extra_headers": {
+                        "User-Agent": "hermes-custom/1.0",
+                        "CF-Access-Client-Id": "client-id",
+                    },
+                }
+            ]
+        }
+
+        with (
+            patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk,
+            patch("hermes_cli.config.load_config", return_value=config),
+        ):
+            build_anthropic_client("sk-test", base_url=base_url)
+
+        kwargs = mock_sdk.Anthropic.call_args.kwargs
+        assert kwargs["base_url"] == "https://proxy.example.com/anthropic"
+        assert kwargs["default_headers"]["User-Agent"] == "hermes-custom/1.0"
+        assert kwargs["default_headers"]["CF-Access-Client-Id"] == "client-id"
+        assert "interleaved-thinking-2025-05-14" in kwargs["default_headers"]["anthropic-beta"]
+
+    def test_custom_provider_without_extra_headers_preserves_sdk_defaults(self):
+        base_url = "https://proxy.example.com/anthropic"
+        config = {
+            "custom_providers": [
+                {
+                    "name": "anthropic-proxy",
+                    "base_url": base_url,
+                    "api_mode": "anthropic_messages",
+                }
+            ]
+        }
+
+        with (
+            patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk,
+            patch("hermes_cli.config.load_config", return_value=config),
+        ):
+            build_anthropic_client("sk-test", base_url=base_url)
+
+        headers = mock_sdk.Anthropic.call_args.kwargs["default_headers"]
+        assert "User-Agent" not in headers
+        assert "user-agent" not in headers
+        assert "interleaved-thinking-2025-05-14" in headers["anthropic-beta"]
+
     def test_custom_base_url_strips_trailing_v1(self):
         with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
             build_anthropic_client(

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -61,6 +61,56 @@ class TestBuildAnthropicClient:
             assert "oauth-2025-04-20" not in betas  # OAuth-only beta NOT present
             assert "claude-code-20250219" not in betas  # OAuth-only beta NOT present
 
+    def test_custom_provider_extra_headers_merge_with_anthropic_betas(self):
+        base_url = "https://proxy.example.com/anthropic/v1"
+        config = {
+            "custom_providers": [
+                {
+                    "name": "anthropic-proxy",
+                    "base_url": base_url,
+                    "api_mode": "anthropic_messages",
+                    "extra_headers": {
+                        "User-Agent": "hermes-custom/1.0",
+                        "CF-Access-Client-Id": "client-id",
+                    },
+                }
+            ]
+        }
+
+        with (
+            patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk,
+            patch("hermes_cli.config.load_config", return_value=config),
+        ):
+            build_anthropic_client("sk-test", base_url=base_url)
+
+        kwargs = mock_sdk.Anthropic.call_args.kwargs
+        assert kwargs["base_url"] == "https://proxy.example.com/anthropic"
+        assert kwargs["default_headers"]["User-Agent"] == "hermes-custom/1.0"
+        assert kwargs["default_headers"]["CF-Access-Client-Id"] == "client-id"
+        assert "interleaved-thinking-2025-05-14" in kwargs["default_headers"]["anthropic-beta"]
+
+    def test_custom_provider_without_extra_headers_preserves_sdk_defaults(self):
+        base_url = "https://proxy.example.com/anthropic"
+        config = {
+            "custom_providers": [
+                {
+                    "name": "anthropic-proxy",
+                    "base_url": base_url,
+                    "api_mode": "anthropic_messages",
+                }
+            ]
+        }
+
+        with (
+            patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk,
+            patch("hermes_cli.config.load_config", return_value=config),
+        ):
+            build_anthropic_client("sk-test", base_url=base_url)
+
+        headers = mock_sdk.Anthropic.call_args.kwargs["default_headers"]
+        assert "User-Agent" not in headers
+        assert "user-agent" not in headers
+        assert "interleaved-thinking-2025-05-14" in headers["anthropic-beta"]
 
 
 

--- a/tests/run_agent/test_anthropic_extra_headers_rebuild.py
+++ b/tests/run_agent/test_anthropic_extra_headers_rebuild.py
@@ -1,0 +1,38 @@
+"""Anthropic client rebuilds must preserve endpoint-scoped extra headers."""
+
+from unittest.mock import patch
+
+from run_agent import AIAgent
+
+
+def test_rebuild_anthropic_client_reapplies_configured_extra_headers():
+    base_url = "https://proxy.example.com/anthropic"
+    config = {
+        "custom_providers": [
+            {
+                "name": "anthropic-proxy",
+                "base_url": base_url,
+                "api_mode": "anthropic_messages",
+                "extra_headers": {"User-Agent": "hermes-rebuild/1.0"},
+            }
+        ]
+    }
+
+    agent = AIAgent.__new__(AIAgent)
+    agent.provider = "anthropic-proxy"
+    agent.model = "claude-compatible"
+    agent._anthropic_api_key = "sk-test"
+    agent._anthropic_base_url = base_url
+    agent._oauth_1m_beta_disabled = False
+
+    with (
+        patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk,
+        patch("hermes_cli.config.load_config", return_value=config),
+        patch("run_agent.get_provider_request_timeout", return_value=42.0),
+    ):
+        agent._rebuild_anthropic_client()
+
+    kwargs = mock_sdk.Anthropic.call_args.kwargs
+    assert kwargs["default_headers"]["User-Agent"] == "hermes-rebuild/1.0"
+    assert "interleaved-thinking-2025-05-14" in kwargs["default_headers"]["anthropic-beta"]
+    assert kwargs["timeout"].read == 42.0

--- a/tests/run_agent/test_anthropic_extra_headers_rebuild.py
+++ b/tests/run_agent/test_anthropic_extra_headers_rebuild.py
@@ -1,0 +1,46 @@
+"""Anthropic client rebuilds must preserve endpoint-scoped extra headers.
+
+``AIAgent._rebuild_anthropic_client`` runs after interrupts, provider
+switches, fallbacks, and credential recovery. It must re-apply the
+``extra_headers`` declared on the matching ``custom_providers`` entry —
+losing them mid-session re-breaks WAF/proxy endpoints (#46002).
+"""
+
+from unittest.mock import patch
+
+from run_agent import AIAgent
+
+
+def test_rebuild_anthropic_client_reapplies_configured_extra_headers():
+    base_url = "https://proxy.example.com/anthropic"
+    config = {
+        "custom_providers": [
+            {
+                "name": "anthropic-proxy",
+                "base_url": base_url,
+                "api_mode": "anthropic_messages",
+                "extra_headers": {"User-Agent": "hermes-rebuild/1.0"},
+            }
+        ]
+    }
+
+    agent = AIAgent.__new__(AIAgent)
+    agent.provider = "anthropic-proxy"
+    agent.model = "claude-compatible"
+    agent._anthropic_api_key = "sk-test"
+    agent._anthropic_base_url = base_url
+    agent._oauth_1m_beta_disabled = False
+
+    with (
+        patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk,
+        patch("hermes_cli.config.load_config", return_value=config),
+        patch("run_agent.get_provider_request_timeout", return_value=42.0),
+    ):
+        agent._rebuild_anthropic_client()
+
+    kwargs = mock_sdk.Anthropic.call_args.kwargs
+    assert kwargs["default_headers"]["User-Agent"] == "hermes-rebuild/1.0"
+    assert (
+        "interleaved-thinking-2025-05-14" in kwargs["default_headers"]["anthropic-beta"]
+    )
+    assert kwargs["timeout"].read == 42.0

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1229,6 +1229,21 @@ extra_body:
     enable_thinking: false
 ```
 
+Endpoints behind a proxy or access gateway can also declare HTTP headers with `extra_headers`. The headers are matched by the exact `base_url` and applied to both OpenAI-compatible clients and native Anthropic Messages clients, including clients rebuilt after a provider switch, fallback, interrupt, or credential recovery:
+
+```yaml
+custom_providers:
+  - name: anthropic-proxy
+    base_url: https://proxy.example.com/anthropic
+    key_env: ANTHROPIC_PROXY_KEY
+    api_mode: anthropic_messages
+    extra_headers:
+      User-Agent: hermes-agent
+      CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}
+```
+
+Header values may contain credentials. Store secret material in environment variables and do not include resolved values in logs or bug reports. Custom headers are merged with SDK-required defaults, so adding `User-Agent` does not remove Hermes's `anthropic-beta` capabilities.
+
 The `hermes model` → Custom Endpoint wizard now prompts for `api_mode` explicitly and persists your answer to `config.yaml`. URL-based auto-detection (e.g. `/anthropic` paths → `anthropic_messages`) still happens as a fallback when the field is left blank.
 
 **Native vision for custom-provider models.** If your custom endpoint serves a vision-capable model that isn't in models.dev, set `model.supports_vision: true` so Hermes routes attached images natively (as `image_url` parts) instead of pre-processing them through `vision_analyze`. Single knob — no need to also set `agent.image_input_mode: native`.

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1351,6 +1351,21 @@ extra_body:
     enable_thinking: false
 ```
 
+Endpoints behind a proxy or access gateway can also declare HTTP headers with `extra_headers`. The headers are matched by the exact `base_url` and applied to both OpenAI-compatible clients and native Anthropic Messages clients, including clients rebuilt after a provider switch, fallback, interrupt, or credential recovery:
+
+```yaml
+custom_providers:
+  - name: anthropic-proxy
+    base_url: https://proxy.example.com/anthropic
+    key_env: ANTHROPIC_PROXY_KEY
+    api_mode: anthropic_messages
+    extra_headers:
+      User-Agent: hermes-agent
+      CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}
+```
+
+Header values may contain credentials. Store secret material in environment variables and do not include resolved values in logs or bug reports. Custom headers are merged with SDK-required defaults, so adding `User-Agent` does not remove Hermes's `anthropic-beta` capabilities.
+
 The configured `extra_body` follows the provider everywhere: it is merged at agent construction, **survives every gateway turn** (including turns where `/fast` layers `service_tier`/`speed` overrides on top — those merge over your `extra_body` rather than replacing it), and is **re-derived on `/model` switches** — switching to a named custom provider applies its `extra_body`, and switching away clears it so it never leaks to another provider.
 
 The `hermes model` → Custom Endpoint wizard now prompts for the API mode explicitly and persists your answer to `config.yaml` (as `transport` on the provider entry). URL-based auto-detection (e.g. `/anthropic` paths → `anthropic_messages`) still happens as a fallback when the field is left blank.


### PR DESCRIPTION
## What does this PR do?

Fixes endpoint-scoped `extra_headers` propagation for custom providers using the native Anthropic Messages protocol. A custom Anthropic-compatible endpoint can now set headers such as `User-Agent` or Cloudflare Access headers through the same existing configuration surface used by OpenAI-compatible clients.

## Related Issue

Fixes #46000

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes existing configuration propagation)

## Changes Made

- Reuse the existing `custom_providers[].extra_headers` / `providers.<name>.extra_headers` configuration instead of adding a dedicated `user_agent` key.
- Apply configured headers centrally inside `build_anthropic_client()` and the callable-bearer Azure Foundry construction path.
- Cover initial construction, provider switches, fallback, interrupts, credential recovery, auxiliary clients, and direct rebuilds without duplicating lookup logic at each call site.
- Merge configured headers with SDK/provider defaults so adding `User-Agent` does not remove `anthropic-beta` capabilities.
- Preserve the Anthropic SDK default User-Agent when no matching `extra_headers` entry exists.
- Document `extra_headers` for Anthropic-compatible custom providers, including environment-variable substitution for secrets.

## Configuration

```yaml
custom_providers:
  - name: anthropic-proxy
    base_url: https://proxy.example.com/anthropic
    key_env: ANTHROPIC_PROXY_KEY
    api_mode: anthropic_messages
    extra_headers:
      User-Agent: hermes-agent
      CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}
```

## How Tested

- 191 related tests passed through `scripts/run_tests.sh`.
- Coverage includes Anthropic client construction, config normalization/matching, existing OpenAI client header propagation, missing-config SDK defaults, `anthropic-beta` preservation, and Anthropic client rebuilds.
- Rebased onto current `upstream/main`.
- CI pending.

Co-authored-by: gpt-5.6-sol <215057067+openai-codex[bot]@users.noreply.github.com>
