### PR TITLE
fix(desktop): allow queued prompts to expand

### DIFF
--- a/apps/desktop/src/app/chat/composer/queue-panel.tsx
+++ b/apps/desktop/src/app/chat/composer/queue-panel.tsx
@@ -1,9 +1,10 @@
+import { useState } from 'react'
 import { StatusRow } from '@/components/chat/status-row'
 import { StatusSection } from '@/components/chat/status-section'
 import { Button } from '@/components/ui/button'
 import { Tip } from '@/components/ui/tooltip'
 import { type Translations, useI18n } from '@/i18n'
-import { ArrowUp, Pencil, Trash2 } from '@/lib/icons'
+import { ArrowUp, ChevronDown, Pencil, Trash2 } from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import type { QueuedPromptEntry } from '@/store/composer-queue'
 
@@ -19,9 +20,12 @@ interface QueuePanelProps {
 const entryPreview = (entry: QueuedPromptEntry, c: Translations['composer']) =>
   entry.text.trim() || (entry.attachments.length > 0 ? c.attachmentOnly : c.emptyTurn)
 
+const shouldOfferExpandedPreview = (preview: string) => preview.length > 140 || preview.includes('\n')
+
 export function QueuePanel({ busy, editingId, entries, onDelete, onEdit, onSendNow }: QueuePanelProps) {
   const { t } = useI18n()
   const c = t.composer
+  const [expandedIds, setExpandedIds] = useState<ReadonlySet<string>>(() => new Set())
 
   if (entries.length === 0) {
     return null
@@ -32,6 +36,9 @@ export function QueuePanel({ busy, editingId, entries, onDelete, onEdit, onSendN
       {entries.map(entry => {
         const isEditing = editingId === entry.id
         const attachmentsCount = entry.attachments.length
+        const preview = entryPreview(entry, c)
+        const canExpand = shouldOfferExpandedPreview(preview)
+        const isExpanded = expandedIds.has(entry.id)
 
         return (
           <StatusRow
@@ -42,6 +49,31 @@ export function QueuePanel({ busy, editingId, entries, onDelete, onEdit, onSendN
             key={entry.id}
             trailing={
               <>
+                {canExpand && (
+                  <Tip label={isExpanded ? c.queueCollapse : c.queueExpand}>
+                    <Button
+                      aria-expanded={isExpanded}
+                      aria-label={isExpanded ? c.queueCollapse : c.queueExpand}
+                      className="size-5 rounded-md"
+                      onClick={() => {
+                        setExpandedIds(current => {
+                          const next = new Set(current)
+                          if (next.has(entry.id)) {
+                            next.delete(entry.id)
+                          } else {
+                            next.add(entry.id)
+                          }
+                          return next
+                        })
+                      }}
+                      size="icon-xs"
+                      type="button"
+                      variant="ghost"
+                    >
+                      <ChevronDown className={cn('transition-transform', isExpanded && 'rotate-180')} size={11} />
+                    </Button>
+                  </Tip>
+                )}
                 <Tip label={c.queueEdit}>
                   <Button
                     aria-label={c.queueEdit}
@@ -85,7 +117,14 @@ export function QueuePanel({ busy, editingId, entries, onDelete, onEdit, onSendN
             trailingVisible={isEditing}
           >
             <div className="min-w-0 flex-1">
-              <p className="truncate text-[0.73rem] leading-4 text-foreground/92">{entryPreview(entry, c)}</p>
+              <p
+                className={cn(
+                  'text-[0.73rem] leading-4 text-foreground/92',
+                  isExpanded ? 'max-h-40 overflow-y-auto whitespace-pre-wrap pr-1' : 'line-clamp-2 break-words'
+                )}
+              >
+                {preview}
+              </p>
               {(attachmentsCount > 0 || isEditing) && (
                 <div className="mt-0.5 flex items-center gap-1.5 text-[0.64rem] text-muted-foreground/75">
                   {attachmentsCount > 0 && <span>{c.attachments(attachmentsCount)}</span>}

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1268,6 +1268,8 @@ export const en: Translations = {
     editingInComposer: 'Editing in composer',
     editingQueuedInComposer: 'Editing queued turn in composer',
     queueEdit: 'Edit',
+    queueExpand: 'Expand',
+    queueCollapse: 'Collapse',
     queueSendNext: 'Next',
     queueSend: 'Send',
     queueDelete: 'Delete',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1407,6 +1407,8 @@ export const ja = defineLocale({
     editingInComposer: 'コンポーザーで編集中',
     editingQueuedInComposer: 'コンポーザーでキュー済みターンを編集中',
     queueEdit: '編集',
+    queueExpand: '展開',
+    queueCollapse: '折りたたむ',
     queueSendNext: '次に送信',
     queueSend: '送信',
     queueDelete: '削除',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -966,6 +966,8 @@ export interface Translations {
     editingInComposer: string
     editingQueuedInComposer: string
     queueEdit: string
+    queueExpand: string
+    queueCollapse: string
     queueSendNext: string
     queueSend: string
     queueDelete: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1361,6 +1361,8 @@ export const zhHant = defineLocale({
     editingInComposer: '在輸入框中編輯',
     editingQueuedInComposer: '在輸入框中編輯排隊回合',
     queueEdit: '編輯',
+    queueExpand: '展開',
+    queueCollapse: '收起',
     queueSendNext: '下一個',
     queueSend: '傳送',
     queueDelete: '刪除',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1455,6 +1455,8 @@ export const zh: Translations = {
     editingInComposer: '正在输入框中编辑',
     editingQueuedInComposer: '正在输入框中编辑排队回合',
     queueEdit: '编辑',
+    queueExpand: '展开',
+    queueCollapse: '收起',
     queueSendNext: '下一个',
     queueSend: '发送',
     queueDelete: '删除',


### PR DESCRIPTION
Fixes #45664

## Summary
- show queued prompt previews across two wrapped lines instead of a single truncated line
- add an expand/collapse icon for long or multiline queued prompts
- keep existing edit/send/delete actions unchanged and add localized tooltip labels

## Tests
- `git diff --check`

## Validation blocked
- `npm --workspace apps/desktop run typecheck` is blocked in this checkout because desktop dependencies are missing; the first failures are missing `react`, `@nanostores/react`, and `vitest` type declarations.
