### PR TITLE
fix(desktop): raise image data-url read cap

### DIFF
--- a/apps/desktop/electron/hardening.cjs
+++ b/apps/desktop/electron/hardening.cjs
@@ -4,7 +4,7 @@ const path = require('node:path')
 const { fileURLToPath } = require('node:url')
 
 const DEFAULT_FETCH_TIMEOUT_MS = 15_000
-const DATA_URL_READ_MAX_BYTES = 16 * 1024 * 1024
+const DATA_URL_READ_MAX_BYTES = 25 * 1024 * 1024
 const TEXT_PREVIEW_SOURCE_MAX_BYTES = 64 * 1024 * 1024
 
 const SAFE_ENV_SUFFIXES = new Set(['dist', 'example', 'sample', 'template'])

--- a/apps/desktop/electron/hardening.test.cjs
+++ b/apps/desktop/electron/hardening.test.cjs
@@ -6,6 +6,7 @@ const test = require('node:test')
 const { pathToFileURL } = require('node:url')
 
 const {
+  DATA_URL_READ_MAX_BYTES,
   DEFAULT_FETCH_TIMEOUT_MS,
   encryptDesktopSecret,
   resolveDirectoryForIpc,
@@ -27,6 +28,10 @@ test('resolveTimeoutMs falls back to defaults and accepts overrides', () => {
   assert.equal(resolveTimeoutMs(0), DEFAULT_FETCH_TIMEOUT_MS)
   assert.equal(resolveTimeoutMs(-25), DEFAULT_FETCH_TIMEOUT_MS)
   assert.equal(resolveTimeoutMs('2750'), 2750)
+})
+
+test('data URL reads allow desktop images up to the gateway image cap', () => {
+  assert.equal(DATA_URL_READ_MAX_BYTES, 25 * 1024 * 1024)
 })
 
 test('encryptDesktopSecret requires available secure storage', () => {

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -588,7 +588,7 @@ app.setAboutPanelOptions({
 
 // Custom scheme for streaming local media (video/audio) into the renderer.
 // Reading large media through `readFileDataUrl` failed: it base64-loads the
-// whole file into memory and is hard-capped at DATA_URL_READ_MAX_BYTES (16 MB),
+// whole file into memory and is hard-capped at DATA_URL_READ_MAX_BYTES (25 MB),
 // so any non-trivial video silently refused to load. Streaming via a protocol
 // handler removes the size cap and gives the <video> element seekable,
 // range-aware playback. Must be registered before the app is ready.

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions.ts
@@ -188,7 +188,7 @@ async function readFileDataUrlForAttach(filePath: string): Promise<string | null
 }
 
 // The readFileDataUrl IPC base64-loads the whole file into memory and is
-// hard-capped (DATA_URL_READ_MAX_BYTES, 16 MB) in electron/hardening.cjs, which
+// hard-capped (DATA_URL_READ_MAX_BYTES, 25 MB) in electron/hardening.cjs, which
 // rejects with a raw "file is too large (N bytes; limit M bytes)" string. In
 // remote mode every attachment's bytes go through that read, so a big file
 // surfaces that internal message verbatim in the failure toast. Translate it


### PR DESCRIPTION
Fixes #45780

## Summary
- raise Desktop `readFileDataUrl` cap from 16 MB to 25 MB
- align the Electron-side data URL limit with the gateway `image.attach_bytes` per-image cap
- update comments and add a hardening regression assertion for the cap

## Tests
- `node --test apps/desktop/electron/hardening.test.cjs`
- `git diff --check`
