### PR TITLE
feat(gateway): add mutable message received hook

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -11,6 +11,7 @@ Events:
   - session:start       -- New session created (first message of a new session)
   - session:end         -- Session ends (user ran /new or /reset)
   - session:reset       -- Session reset completed (new session entry created)
+  - message:received    -- Inbound message prepared; handlers may mutate message
   - agent:start         -- Agent begins processing a message
   - agent:step          -- Each turn in the tool-calling loop
   - agent:end           -- Agent finishes processing
@@ -18,7 +19,7 @@ Events:
 
 Errors in hooks are caught and logged but never block the main pipeline.
 
-Context dict passed to ``agent:start`` / ``agent:end`` handlers:
+Context dict passed to ``message:received`` / ``agent:start`` / ``agent:end`` handlers:
   platform     -- source platform name (e.g. "telegram", "matrix", "slack")
   user_id      -- platform user id of the sender
   chat_id      -- platform chat id (group/DM identifier)
@@ -26,7 +27,9 @@ Context dict passed to ``agent:start`` / ``agent:end`` handlers:
                   when not in a thread / topic)
   chat_type    -- "dm" | "group" | "forum" (empty if unknown)
   session_id   -- Hermes session id
-  message      -- inbound message text (truncated to 500 chars)
+  message      -- inbound message text. ``message:received`` receives the full
+                  prepared text and may replace this value before agent dispatch;
+                  ``agent:start`` receives a 500-character preview.
 
 ``agent:end`` adds:
   response     -- agent response text (truncated to 500 chars)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7895,6 +7895,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         return message_text
 
+    async def _emit_message_received_hook(
+        self,
+        *,
+        source: SessionSource,
+        session_id: str,
+        message_text: str,
+    ) -> str:
+        """Emit the mutable pre-agent inbound-message hook."""
+        hook_ctx = {
+            "platform": source.platform.value if source.platform else "",
+            "user_id": source.user_id,
+            "chat_id": source.chat_id or "",
+            "thread_id": str(getattr(source, "thread_id", None)) if getattr(source, "thread_id", None) else "",
+            "chat_type": getattr(source, "chat_type", "") or "",
+            "session_id": session_id,
+            "message": message_text,
+        }
+        await self.hooks.emit("message:received", hook_ctx)
+        updated_message = hook_ctx.get("message")
+        if isinstance(updated_message, str) and updated_message != message_text:
+            return updated_message
+        return message_text
+
     def _consume_pending_native_image_paths(self, session_key: str) -> List[str]:
         pending_native = getattr(self, "_pending_native_image_paths_by_session", None)
         if not pending_native:
@@ -8592,6 +8615,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
 
         try:
+            message_text = await self._emit_message_received_hook(
+                source=source,
+                session_id=session_entry.session_id,
+                message_text=message_text,
+            )
+
             # Emit agent:start hook
             hook_ctx = {
                 "platform": source.platform.value if source.platform else "",

--- a/tests/gateway/test_message_received_hook.py
+++ b/tests/gateway/test_message_received_hook.py
@@ -1,0 +1,89 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _make_runner():
+    runner = object.__new__(GatewayRunner)
+    runner.hooks = SimpleNamespace(emit=AsyncMock())
+    return runner
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="user-123",
+        chat_id="chat-456",
+        thread_id="789",
+        chat_type="forum",
+    )
+
+
+def test_message_received_hook_receives_full_message_context():
+    runner = _make_runner()
+    source = _make_source()
+    message = "x" * 800
+
+    result = asyncio.run(
+        runner._emit_message_received_hook(
+            source=source,
+            session_id="session-1",
+            message_text=message,
+        )
+    )
+
+    assert result == message
+    runner.hooks.emit.assert_awaited_once()
+    event_type, context = runner.hooks.emit.await_args.args
+    assert event_type == "message:received"
+    assert context == {
+        "platform": "telegram",
+        "user_id": "user-123",
+        "chat_id": "chat-456",
+        "thread_id": "789",
+        "chat_type": "forum",
+        "session_id": "session-1",
+        "message": message,
+    }
+
+
+def test_message_received_hook_can_mutate_message_text():
+    runner = _make_runner()
+
+    async def _mutate(_event_type, context):
+        context["message"] = "rewritten by hook"
+
+    runner.hooks.emit.side_effect = _mutate
+
+    result = asyncio.run(
+        runner._emit_message_received_hook(
+            source=_make_source(),
+            session_id="session-1",
+            message_text="original",
+        )
+    )
+
+    assert result == "rewritten by hook"
+
+
+def test_message_received_hook_ignores_non_string_message_mutation():
+    runner = _make_runner()
+
+    async def _mutate(_event_type, context):
+        context["message"] = {"unexpected": "value"}
+
+    runner.hooks.emit.side_effect = _mutate
+
+    result = asyncio.run(
+        runner._emit_message_received_hook(
+            source=_make_source(),
+            session_id="session-1",
+            message_text="original",
+        )
+    )
+
+    assert result == "original"


### PR DESCRIPTION
## Summary
- add a mutable `message:received` gateway hook after inbound message preparation and before `agent:start`
- pass the full prepared message text to the hook, then read back string mutations before agent dispatch
- document the new event in `gateway/hooks.py`
- add focused tests for full-message context, mutation, and non-string mutation safety

Fixes #45708.

## Validation
- `python -m pytest tests/gateway/test_message_received_hook.py -q` (3 passed)
- `python -m py_compile gateway/run.py gateway/hooks.py tests/gateway/test_message_received_hook.py`
- `git diff --check`
