### PR TITLE
fix(agent): surface model refusals as content_filter (salvage #43108 + edge-case fix)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1348,6 +1348,116 @@ def run_conversation(
                         )
                         finish_reason = "length"
 
+                # ── Content-policy refusal (HTTP 200) ──────────────────
+                # The model — or the provider's safety system — returned a
+                # *successful* response whose stop/finish reason is a refusal:
+                # Anthropic ``stop_reason="refusal"`` → ``content_filter``;
+                # OpenAI / portal ``finish_reason="content_filter"`` or a
+                # populated ``message.refusal`` (mapped in the chat_completions
+                # transport); Bedrock ``guardrail_intervened``. The content is
+                # typically empty, so without this branch the response falls
+                # through to the empty-response / invalid-response retry loops
+                # and is mis-surfaced as "rate limited" / "no content after
+                # retries" — burning paid attempts reproducing a deterministic
+                # refusal. Surface it clearly and stop. Mirrors the
+                # exception-based ``content_policy_blocked`` recovery: try a
+                # configured fallback once, otherwise return the refusal.
+                if finish_reason == "content_filter":
+                    _refusal_transport = agent._get_transport()
+                    if agent.api_mode == "anthropic_messages":
+                        _refusal_result = _refusal_transport.normalize_response(
+                            response, strip_tool_prefix=agent._is_anthropic_oauth
+                        )
+                    else:
+                        _refusal_result = _refusal_transport.normalize_response(response)
+                    _refusal_text = (getattr(_refusal_result, "content", None) or "").strip()
+                    # Some refusals carry the explanation only in the reasoning
+                    # channel; fall back to it so the user sees *something*.
+                    if not _refusal_text:
+                        _refusal_text = (agent._extract_reasoning(_refusal_result) or "").strip()
+
+                    agent._invoke_api_request_error_hook(
+                        task_id=effective_task_id,
+                        turn_id=turn_id,
+                        api_request_id=api_request_id,
+                        api_call_count=api_call_count,
+                        api_start_time=api_start_time,
+                        api_kwargs=api_kwargs,
+                        error_type="ContentPolicyBlocked",
+                        error_message=_refusal_text or "model declined to respond (content_filter)",
+                        status_code=None,
+                        retry_count=retry_count,
+                        max_retries=max_retries,
+                        retryable=False,
+                        reason="content_policy_blocked",
+                    )
+
+                    if thinking_spinner:
+                        thinking_spinner.stop("")
+                        thinking_spinner = None
+                    if agent.thinking_callback:
+                        agent.thinking_callback("")
+
+                    # Deterministic for the unchanged prompt — never retry.
+                    # Try a configured fallback once (a different model may not
+                    # refuse); otherwise surface the refusal terminally.
+                    if agent._has_pending_fallback():
+                        agent._buffer_status(
+                            "⚠️ Model declined to respond (safety refusal) — trying fallback..."
+                        )
+                    if agent._try_activate_fallback():
+                        retry_count = 0
+                        compression_attempts = 0
+                        _retry.primary_recovery_attempted = False
+                        continue
+
+                    agent._flush_status_buffer()
+                    _refusal_log = (
+                        _refusal_text[:500] + "..."
+                        if len(_refusal_text) > 500
+                        else _refusal_text
+                    )
+                    logger.warning(
+                        "%sModel declined to respond (finish_reason=content_filter). "
+                        "model=%s provider=%s refusal=%s",
+                        agent.log_prefix, agent.model, agent.provider,
+                        _refusal_log or "(no text)",
+                    )
+                    agent._emit_status(
+                        "⚠️ The model declined to respond to this request (safety refusal)."
+                    )
+
+                    if _refusal_text:
+                        _refusal_response = (
+                            "⚠️  The model declined to respond to this request "
+                            "(safety refusal — not a Hermes/gateway failure).\n\n"
+                            f"Model's explanation: {_refusal_text}\n\n"
+                            "Try rephrasing the request, narrowing the context, or "
+                            "adding a fallback provider with `hermes fallback add`."
+                        )
+                    else:
+                        _refusal_response = (
+                            "⚠️  The model declined to respond to this request "
+                            "(safety refusal — not a Hermes/gateway failure). The "
+                            "model returned no explanation.\n\n"
+                            "Try rephrasing the request, narrowing the context, or "
+                            "adding a fallback provider with `hermes fallback add`."
+                        )
+
+                    agent._cleanup_task_resources(effective_task_id)
+                    agent._persist_session(messages, conversation_history)
+                    return {
+                        "final_response": _refusal_response,
+                        "messages": messages,
+                        "api_calls": api_call_count,
+                        "completed": False,
+                        "failed": True,
+                        "error": (
+                            "content_policy_blocked: "
+                            + (_refusal_text or "model declined (content_filter)")
+                        ),
+                    }
+
                 if finish_reason == "length":
                     if getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID:
                         agent._vprint(

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -397,6 +397,42 @@ def _get_continuation_prompt(is_partial_stub: bool, dropped_tools: Optional[List
         )
 
 
+# Shared recovery hint appended to every content-policy refusal message. Both
+# the HTTP-200 refusal path (``finish_reason=content_filter``) and the
+# exception path (a provider moderation error classified as
+# ``content_policy_blocked``) end with the same actionable next steps, so they
+# share one trailer to keep the guidance from drifting between the two sites.
+_CONTENT_POLICY_RECOVERY_HINT = (
+    "Try rephrasing the request, narrowing the context, or "
+    "adding a fallback provider with `hermes fallback add`."
+)
+
+
+def _content_policy_blocked_result(
+    messages: List[Dict],
+    api_call_count: int,
+    *,
+    final_response: str,
+    error_detail: str,
+) -> Dict[str, Any]:
+    """Build the terminal turn result for a content-policy block.
+
+    A content-policy refusal is deterministic for the unchanged prompt, so the
+    turn ends here (no retry). Both the HTTP-200 refusal handler and the
+    exception-path handler return the identical shape — a failed, non-completed
+    turn carrying the user-facing message and a ``content_policy_blocked:``
+    prefixed error — so they funnel through this one builder.
+    """
+    return {
+        "final_response": final_response,
+        "messages": messages,
+        "api_calls": api_call_count,
+        "completed": False,
+        "failed": True,
+        "error": f"content_policy_blocked: {error_detail}",
+    }
+
+
 def run_conversation(
     agent,
     user_message: str,
@@ -1389,7 +1425,7 @@ def run_conversation(
                         retry_count=retry_count,
                         max_retries=max_retries,
                         retryable=False,
-                        reason="content_policy_blocked",
+                        reason=FailoverReason.content_policy_blocked.value,
                     )
 
                     if thinking_spinner:
@@ -1427,36 +1463,26 @@ def run_conversation(
                         "⚠️ The model declined to respond to this request (safety refusal)."
                     )
 
-                    if _refusal_text:
-                        _refusal_response = (
-                            "⚠️  The model declined to respond to this request "
-                            "(safety refusal — not a Hermes/gateway failure).\n\n"
-                            f"Model's explanation: {_refusal_text}\n\n"
-                            "Try rephrasing the request, narrowing the context, or "
-                            "adding a fallback provider with `hermes fallback add`."
-                        )
-                    else:
-                        _refusal_response = (
-                            "⚠️  The model declined to respond to this request "
-                            "(safety refusal — not a Hermes/gateway failure). The "
-                            "model returned no explanation.\n\n"
-                            "Try rephrasing the request, narrowing the context, or "
-                            "adding a fallback provider with `hermes fallback add`."
-                        )
+                    _refusal_detail = (
+                        f"Model's explanation: {_refusal_text}"
+                        if _refusal_text
+                        else "The model returned no explanation."
+                    )
+                    _refusal_response = (
+                        "⚠️  The model declined to respond to this request "
+                        "(safety refusal — not a Hermes/gateway failure).\n\n"
+                        f"{_refusal_detail}\n\n"
+                        f"{_CONTENT_POLICY_RECOVERY_HINT}"
+                    )
 
                     agent._cleanup_task_resources(effective_task_id)
                     agent._persist_session(messages, conversation_history)
-                    return {
-                        "final_response": _refusal_response,
-                        "messages": messages,
-                        "api_calls": api_call_count,
-                        "completed": False,
-                        "failed": True,
-                        "error": (
-                            "content_policy_blocked: "
-                            + (_refusal_text or "model declined (content_filter)")
-                        ),
-                    }
+                    return _content_policy_blocked_result(
+                        messages,
+                        api_call_count,
+                        final_response=_refusal_response,
+                        error_detail=_refusal_text or "model declined (content_filter)",
+                    )
 
                 if finish_reason == "length":
                     if getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID:
@@ -3229,20 +3255,17 @@ def run_conversation(
                     if classified.reason == FailoverReason.content_policy_blocked:
                         _summary = agent._summarize_api_error(api_error)
                         _policy_response = (
-                            f"⚠️  The model provider's safety filter blocked this request "
-                            f"(not a Hermes/gateway failure).\n\n"
+                            "⚠️  The model provider's safety filter blocked this request "
+                            "(not a Hermes/gateway failure).\n\n"
                             f"Provider message: {_summary}\n\n"
-                            f"Try rephrasing the request, narrowing the context, or "
-                            f"adding a fallback provider with `hermes fallback add`."
+                            f"{_CONTENT_POLICY_RECOVERY_HINT}"
                         )
-                        return {
-                            "final_response": _policy_response,
-                            "messages": messages,
-                            "api_calls": api_call_count,
-                            "completed": False,
-                            "failed": True,
-                            "error": f"content_policy_blocked: {_summary}",
-                        }
+                        return _content_policy_blocked_result(
+                            messages,
+                            api_call_count,
+                            final_response=_policy_response,
+                            error_detail=_summary,
+                        )
                     return {
                         "final_response": None,
                         "messages": messages,

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -186,10 +186,21 @@ class AnthropicTransport(ProviderTransport):
     def validate_response(self, response: Any) -> bool:
         """Check Anthropic response structure is valid.
 
-        An empty content list is legitimate when ``stop_reason == "end_turn"``
-        — the model's canonical way of signalling "nothing more to add" after
-        a tool turn that already delivered the user-facing text. Treating it
-        as invalid falsely retries a completed response.
+        An empty content list is legitimate for terminal stop reasons that
+        carry no text payload:
+
+        - ``end_turn`` — the model's canonical "nothing more to add" after a
+          tool turn that already delivered the user-facing text.
+        - ``refusal`` — the model declined to respond (Claude 4.5+). The
+          Messages API returns an empty ``content`` list with this stop
+          reason. Treating it as invalid sends a deterministic refusal into
+          the invalid-response retry loop, which reproduces the refusal on
+          every attempt and surfaces a misleading "rate limited / invalid
+          response" error instead of the refusal. ``normalize_response`` maps
+          ``refusal`` → ``content_filter`` so the agent loop's refusal handler
+          can surface it.
+
+        Treating either as invalid falsely retries a completed response.
         """
         if response is None:
             return False
@@ -197,7 +208,7 @@ class AnthropicTransport(ProviderTransport):
         if not isinstance(content_blocks, list):
             return False
         if not content_blocks:
-            return getattr(response, "stop_reason", None) == "end_turn"
+            return getattr(response, "stop_reason", None) in {"end_turn", "refusal"}
         return True
 
     def extract_cache_stats(self, response: Any) -> Optional[Dict[str, int]]:

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -682,11 +682,21 @@ class ChatCompletionsTransport(ProviderTransport):
             if isinstance(_msg_extra, dict):
                 refusal = _msg_extra.get("refusal")
         if isinstance(refusal, str) and refusal.strip():
-            if not (isinstance(content, str) and content.strip()):
-                content = refusal
-            if finish_reason in (None, "stop"):
-                finish_reason = "content_filter"
+            # Record the refusal explanation regardless — it's useful provider
+            # metadata even when the model also returned a usable payload.
             provider_data["refusal"] = refusal
+            _has_text = isinstance(content, str) and content.strip()
+            _has_tool_calls = bool(tool_calls)
+            # Only promote to a terminal ``content_filter`` when the refusal is
+            # the *sole* payload — no visible text and no tool calls. A response
+            # that carries real content (or tool calls) alongside a refusal note
+            # is a normal, usable turn: surfacing it as a failed safety refusal
+            # would discard the model's actual work. In the empty-payload case,
+            # adopt the refusal as content so the loop has something to show.
+            if not _has_text and not _has_tool_calls:
+                content = refusal
+                if finish_reason in (None, "stop"):
+                    finish_reason = "content_filter"
 
         return NormalizedResponse(
             content=content,

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -664,8 +664,32 @@ class ChatCompletionsTransport(ProviderTransport):
         if rd:
             provider_data["reasoning_details"] = rd
 
+        # OpenAI structured-refusal field. When a model declines, the SDK
+        # populates ``message.refusal`` with the explanation and leaves
+        # ``content`` empty. OpenAI-compatible proxies that front Anthropic /
+        # Bedrock (e.g. Nous Portal) surface a Claude refusal this way — or via
+        # ``finish_reason="content_filter"`` — instead of the native
+        # ``stop_reason="refusal"``. Without capturing it the refusal looks
+        # like an empty response, so the agent loop retries a deterministic
+        # refusal three times and gives up with "no content after retries".
+        # Promote it to content + a ``content_filter`` finish reason so the
+        # loop's refusal handler surfaces it clearly and stops. ``refusal`` is
+        # ``None`` for normal responses, so this is a no-op in the common case.
+        content = msg.content
+        refusal = getattr(msg, "refusal", None)
+        if refusal is None and hasattr(msg, "model_extra"):
+            _msg_extra = getattr(msg, "model_extra", None) or {}
+            if isinstance(_msg_extra, dict):
+                refusal = _msg_extra.get("refusal")
+        if isinstance(refusal, str) and refusal.strip():
+            if not (isinstance(content, str) and content.strip()):
+                content = refusal
+            if finish_reason in (None, "stop"):
+                finish_reason = "content_filter"
+            provider_data["refusal"] = refusal
+
         return NormalizedResponse(
-            content=msg.content,
+            content=content,
             tool_calls=tool_calls,
             finish_reason=finish_reason,
             reasoning=reasoning,

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -923,8 +923,10 @@ class TestChatCompletionsNormalize:
         assert nr.content is None
 
     def test_refusal_does_not_clobber_existing_content(self, transport):
-        """If the model emitted partial text *and* a refusal, keep the visible
-        text as content but still flag the refusal via content_filter."""
+        """If the model emitted real text *and* a refusal note, the turn is a
+        normal usable response: keep the visible text, record the refusal in
+        provider_data, and do NOT promote to a terminal content_filter (which
+        would discard the model's actual work by reframing it as a failure)."""
         r = SimpleNamespace(
             choices=[SimpleNamespace(
                 message=SimpleNamespace(
@@ -937,7 +939,32 @@ class TestChatCompletionsNormalize:
         )
         nr = transport.normalize_response(r)
         assert nr.content == "partial answer"
-        assert nr.finish_reason == "content_filter"
+        assert nr.finish_reason == "stop"
+        assert nr.provider_data == {"refusal": "cannot continue"}
+
+    def test_refusal_with_tool_calls_is_not_promoted(self, transport):
+        """A response that carries tool calls alongside a refusal note is a
+        usable tool turn — record the refusal but keep the tool calls and do
+        NOT terminate it as a content_filter refusal."""
+        tc = SimpleNamespace(
+            id="call_1", type="function",
+            function=SimpleNamespace(name="do_thing", arguments="{}"),
+        )
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content=None, tool_calls=[tc],
+                    reasoning_content=None, refusal="cannot continue",
+                ),
+                finish_reason="tool_calls",
+            )],
+            usage=None,
+        )
+        nr = transport.normalize_response(r)
+        # Tool calls survive; finish reason is untouched; content not clobbered.
+        assert nr.tool_calls and nr.tool_calls[0].name == "do_thing"
+        assert nr.finish_reason == "tool_calls"
+        assert nr.content in (None, "")
         assert nr.provider_data == {"refusal": "cannot continue"}
 
 

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -843,6 +843,81 @@ class TestChatCompletionsNormalize:
         nr = transport.normalize_response(r)
         assert nr.provider_data == {"reasoning_content": "model-extra scratchpad"}
 
+    def test_refusal_field_promoted_to_content_filter(self, transport):
+        """OpenAI-compatible proxies (e.g. Nous Portal fronting Anthropic) can
+        surface a Claude refusal via ``message.refusal`` with empty content and
+        ``finish_reason="stop"``. Promote it to content + a ``content_filter``
+        finish reason so the agent loop's refusal handler surfaces it instead
+        of retrying an empty response three times and giving up."""
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content=None, tool_calls=None, reasoning_content=None,
+                    refusal="I can't help with that.",
+                ),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+        nr = transport.normalize_response(r)
+        assert nr.finish_reason == "content_filter"
+        assert nr.content == "I can't help with that."
+        assert nr.provider_data == {"refusal": "I can't help with that."}
+
+    def test_refusal_none_is_noop(self, transport):
+        """The common case: ``refusal`` is None → behavior unchanged."""
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content="hello", tool_calls=None, reasoning_content=None,
+                    refusal=None,
+                ),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+        nr = transport.normalize_response(r)
+        assert nr.finish_reason == "stop"
+        assert nr.content == "hello"
+        assert nr.provider_data is None
+
+    def test_refusal_preserves_explicit_content_filter_finish_reason(self, transport):
+        """When the proxy already sets ``finish_reason="content_filter"`` and
+        also provides refusal text, surface the text without disturbing the
+        finish reason."""
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content=None, tool_calls=None, reasoning_content=None,
+                    refusal="declined",
+                ),
+                finish_reason="content_filter",
+            )],
+            usage=None,
+        )
+        nr = transport.normalize_response(r)
+        assert nr.finish_reason == "content_filter"
+        assert nr.content == "declined"
+        assert nr.provider_data == {"refusal": "declined"}
+
+    def test_refusal_does_not_clobber_existing_content(self, transport):
+        """If the model emitted partial text *and* a refusal, keep the visible
+        text as content but still flag the refusal via content_filter."""
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content="partial answer", tool_calls=None,
+                    reasoning_content=None, refusal="cannot continue",
+                ),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+        nr = transport.normalize_response(r)
+        assert nr.content == "partial answer"
+        assert nr.finish_reason == "content_filter"
+        assert nr.provider_data == {"refusal": "cannot continue"}
+
 
 class TestChatCompletionsCacheStats:
 

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -900,6 +900,28 @@ class TestChatCompletionsNormalize:
         assert nr.content == "declined"
         assert nr.provider_data == {"refusal": "declined"}
 
+    def test_explicit_content_filter_finish_reason_passes_through(self, transport):
+        """OpenRouter (and other OpenAI-compatible providers) surface an
+        upstream Claude / moderation refusal as ``finish_reason="content_filter"``
+        — often with empty content and no ``message.refusal`` field. The
+        transport must pass that finish reason straight through so the loop's
+        content_filter refusal handler fires; no ``message.refusal`` required.
+        This is the OpenRouter coverage path (OpenRouter uses the default
+        chat_completions transport)."""
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content=None, tool_calls=None, reasoning_content=None,
+                    refusal=None,
+                ),
+                finish_reason="content_filter",
+            )],
+            usage=None,
+        )
+        nr = transport.normalize_response(r)
+        assert nr.finish_reason == "content_filter"
+        assert nr.content is None
+
     def test_refusal_does_not_clobber_existing_content(self, transport):
         """If the model emitted partial text *and* a refusal, keep the visible
         text as content but still flag the refusal via content_filter."""

--- a/tests/agent/transports/test_transport.py
+++ b/tests/agent/transports/test_transport.py
@@ -128,6 +128,15 @@ class TestAnthropicTransport:
         r = SimpleNamespace(content=[], stop_reason="tool_use")
         assert transport.validate_response(r) is False
 
+    def test_validate_response_empty_content_with_refusal_is_valid(self, transport):
+        # Claude 4.5+ returns an empty content list with stop_reason="refusal"
+        # when it declines to respond. It must validate so the response flows
+        # through to normalize_response (which maps refusal → content_filter)
+        # and the loop's refusal handler — instead of being rejected as an
+        # "invalid response" and retried as a deterministic refusal.
+        r = SimpleNamespace(content=[], stop_reason="refusal")
+        assert transport.validate_response(r) is True
+
     def test_validate_response_valid(self, transport):
         r = SimpleNamespace(content=[SimpleNamespace(type="text", text="hello")])
         assert transport.validate_response(r) is True

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4660,6 +4660,47 @@ class TestRetryExhaustion:
         assert "error" in result
         assert "Invalid API response" in result["error"]
 
+    def test_content_filter_refusal_surfaced_not_retried(self, agent):
+        """A model refusal must be surfaced immediately, NOT laundered into
+        the empty-response retry loop and reported as "rate limited" / "no
+        content after retries".
+
+        Regression: running a Claude refusal through an OpenAI-compatible
+        portal (Nous Portal fronting Anthropic) returns ``message.refusal``
+        with empty content. The transport now promotes that to a
+        ``content_filter`` finish reason and the loop surfaces it as a terminal
+        ``content_policy_blocked`` result instead of retrying a deterministic
+        refusal three times.
+        """
+        self._setup_agent(agent)
+        refusal_resp = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content=None, tool_calls=None, reasoning=None,
+                    reasoning_content=None, refusal="I won't help with that.",
+                ),
+                finish_reason="stop",
+            )],
+            model="test/model",
+            usage=None,
+            id="resp_1",
+        )
+        agent.client.chat.completions.create.return_value = refusal_resp
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("please do something disallowed")
+        assert result.get("completed") is False
+        assert result.get("failed") is True
+        assert "content_policy_blocked" in result.get("error", "")
+        # The model's refusal text is surfaced to the user, not swallowed.
+        assert "I won't help with that." in (result.get("final_response") or "")
+        # Crucial regression guard: a deterministic refusal is NOT retried —
+        # exactly one API call, no empty-response retry loop.
+        assert agent.client.chat.completions.create.call_count == 1
+
     def test_api_error_returns_gracefully_after_retries(self, agent):
         """Exhausted retries on API errors must return error result, not crash."""
         self._setup_agent(agent)


### PR DESCRIPTION
## Summary

Salvages @SHL0MS's refusal-handling fix from #43108 onto current `main`, with two follow-up commits that fix an edge case and apply a reuse cleanup. Authorship on the original work is preserved in git history.

A Claude model can return **HTTP 200 with a refusal** — a deterministic, server-side safety halt. Hermes mislabeled it as a transient infra error and retried it 3× (burning paid attempts) with no signal that the prompt was actually refused. The fix routes every backend through one normalized `content_filter` dispatch:

- **`AnthropicTransport.validate_response`** — accept empty `content` when `stop_reason == "refusal"` (a complete response, not a truncation), so it flows through `normalize_response` → `content_filter`.
- **`ChatCompletionsTransport.normalize_response`** — promote OpenAI's `message.refusal` (and the `model_extra` proxy variant) to content + a `content_filter` finish reason; bare `content_filter` (OpenRouter) passes straight through.
- **`conversation_loop.py`** — handle `finish_reason == "content_filter"` once: fire the `api_request_error` hook with `reason=content_policy_blocked`, try one configured fallback, otherwise return an honest terminal result. No retry burn — the block is deterministic.

One fix covers Anthropic-direct, Nous Portal, OpenRouter, other OpenAI-compatible providers, and Bedrock (whose `guardrail_intervened` already maps to `content_filter`), because the handler keys on the normalized finish reason rather than a path-specific flag.

## Commits

1. **`fix(agent): surface model refusals…`** — @SHL0MS's original fix (authorship preserved).
2. **`test(transports): lock in content_filter passthrough for OpenRouter`** — @SHL0MS's transport tests (authorship preserved).
3. **`fix(transports): only treat a refusal as terminal when it is the sole payload`** — edge-case fix. A chat-completions response that carries **real text or tool calls alongside** a `message.refusal` note is a normal, usable turn. The prior logic flipped `finish_reason → content_filter` whenever a refusal string was present, so a content-bearing turn was reframed as a *failed* safety refusal (`failed=True`) and the model's actual output was buried in the "model declined" template, or its tool calls dropped. Now promotion to terminal `content_filter` happens **only when the refusal is the sole payload** (no visible text AND no tool calls); the explanation is still recorded in `provider_data` in every case. Refusal-only responses (the bug this PR targets) are unaffected and still surface terminally. Adds a partial-content regression guard and a tool-calls-alongside-refusal guard (both proven to fail on the prior behavior).
4. **`refactor(agent): share the content_policy_blocked result builder + recovery hint`** — the HTTP-200 refusal handler and the existing exception-path handler independently built the same terminal result dict and ended their message with the same `hermes fallback add` trailer copied verbatim. Funnel both through a shared `_content_policy_blocked_result()` builder + `_CONTENT_POLICY_RECOVERY_HINT` constant, collapse the HTTP-200 path's two near-identical templates into one, and pass `reason=FailoverReason.content_policy_blocked.value` instead of a string literal (matching the sibling hook call). Behavior-preserving: the provider-filter vs model-declined lead-in wording stays distinct, and the with-text and exception messages are byte-identical to before.

## Tests

- `tests/agent/transports/test_transport.py` — empty-content `refusal` validates.
- `tests/agent/transports/test_chat_completions.py` — `message.refusal` promotion; bare `content_filter` passthrough (OpenRouter); no-op when absent; **partial-content not terminated** and **tool-calls-alongside-refusal not terminated** (commit 3 guards).
- `tests/run_agent/test_run_agent.py::TestRetryExhaustion::test_content_filter_refusal_surfaced_not_retried` — end-to-end: a portal-style `message.refusal` is surfaced as `content_policy_blocked` with the refusal text, model called **exactly once** (no retry loop).
- Existing `tests/run_agent/test_18028_content_policy_blocked.py` (exception path) stays green through the shared-helper refactor.

Local: `ruff` clean; full transports + run_agent + content-policy + fallback suites pass (740 passed).

Closes #43108
