### PR TITLE
fix(config): honor api_key_env alias in providers dict and custom_providers list

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -539,7 +539,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             # Match exact name or normalized name
             name_norm = _normalize_custom_provider_name(ep_name)
             # Resolve the API key from the env var name stored in key_env
-            key_env = str(entry.get("key_env", "") or "").strip()
+            key_env = str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
             resolved_api_key = os.getenv(key_env, "").strip() if key_env else ""
             # Fall back to inline api_key when key_env is absent or unresolvable
             if not resolved_api_key:
@@ -626,7 +626,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             "base_url": base_url.strip(),
             "api_key": str(entry.get("api_key", "") or "").strip(),
         }
-        key_env = str(entry.get("key_env", "") or "").strip()
+        key_env = str(entry.get("key_env") or entry.get("api_key_env") or "").strip()
         if key_env:
             result["key_env"] = key_env
         if provider_key:
@@ -813,7 +813,7 @@ def _resolve_named_custom_runtime(
     api_key_candidates = [
         (explicit_api_key or "").strip(),
         str(custom_provider.get("api_key", "") or "").strip(),
-        os.getenv(str(custom_provider.get("key_env", "") or "").strip(), "").strip(),
+        os.getenv(str(custom_provider.get("key_env") or custom_provider.get("api_key_env") or "").strip(), "").strip(),
         # Gate provider env keys on their authoritative hosts — sending
         # OPENAI_API_KEY to a local-llm endpoint leaks credentials (#28660).
         (os.getenv("OPENAI_API_KEY", "").strip()     if _cp_is_openai_url  else ""),

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -862,6 +862,110 @@ def test_named_custom_provider_uses_key_env_from_providers_dict(monkeypatch):
     assert resolved["source"] == "custom_provider:MyCorp Proxy"
     assert resolved["model"] == "acme-large"
 
+def test_named_custom_provider_uses_api_key_env_alias_from_providers_dict(monkeypatch):
+    """providers dict entries with api_key_env (alias) should resolve API key from env var."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("MYCORP_API_KEY", "env-secret-alias")
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "mycorp-proxy": {
+                    "base_url": "https://proxy.example.com/v1",
+                    "default_model": "acme-large",
+                    "api_key_env": "MYCORP_API_KEY",
+                    "name": "MyCorp Proxy",
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="mycorp-proxy")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_key"] == "env-secret-alias"
+    assert resolved["base_url"] == "https://proxy.example.com/v1"
+
+
+def test_named_custom_provider_key_env_takes_precedence_over_api_key_env(monkeypatch):
+    """When both key_env and api_key_env are set, key_env takes precedence."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("PRIMARY_KEY", "primary-secret")
+    monkeypatch.setenv("ALIAS_KEY", "alias-secret")
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "mycorp-proxy": {
+                    "base_url": "https://proxy.example.com/v1",
+                    "key_env": "PRIMARY_KEY",
+                    "api_key_env": "ALIAS_KEY",
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="mycorp-proxy")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_key"] == "primary-secret"
+
+
+def test_custom_providers_list_uses_api_key_env_alias(monkeypatch):
+    """Legacy custom_providers list entries with api_key_env should resolve from env var."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("LEGACY_KEY", "legacy-secret")
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "legacy-provider",
+                    "base_url": "https://legacy.example.com/v1",
+                    "api_key_env": "LEGACY_KEY",
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="legacy-provider")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_key"] == "legacy-secret"
+
 
 def test_named_custom_provider_same_url_uses_matching_key_env_and_api_mode(monkeypatch):
     """Named custom providers on one gateway must keep their own credentials and protocol."""


### PR DESCRIPTION
## What does this PR do?

Resolves the documented `api_key_env` field as an alias for `key_env` in three code paths within `hermes_cli/runtime_provider.py`, so named custom providers configured with `api_key_env:` (as documented in the config reference) correctly resolve the API key from the environment variable instead of silently falling through to the `"no-key-required"` placeholder.

## Related Issue

Fixes #44666

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/runtime_provider.py`: Added `api_key_env` as a fallback for `key_env` in three locations:
  - Line 542: `providers:` dict path in `_get_named_custom_provider()`
  - Line 629: `custom_providers:` list path in `_get_named_custom_provider()`
  - Line 816: `api_key_candidates` list in `_resolve_named_custom_runtime()`
- `tests/hermes_cli/test_runtime_provider_resolution.py`: Added 3 regression tests:
  - `api_key_env` alias resolves from `providers:` dict entries
  - `key_env` takes precedence when both `key_env` and `api_key_env` are present
  - `api_key_env` alias works in legacy `custom_providers:` list entries

## How to Test

1. Configure a named provider with `api_key_env` in `~/.hermes/config.yaml`:
   ```yaml
   providers:
     myproxy:
       base_url: https://proxy.example.com/v1
       api_key_env: MY_API_KEY
   ```
2. Export `MY_API_KEY=<your-key>` and set `model.provider: myproxy`
3. Verify the gateway sends the actual API key (not `"no-key-required"`)
4. Run: `pytest tests/hermes_cli/test_runtime_provider_resolution.py -k api_key_env -xvs`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/runtime_provider.py` (`_get_named_custom_provider`, `_resolve_named_custom_runtime`)
- Blast radius: LOW — config field alias, no control flow changes
- Related patterns: Line 1599 already uses `for hint_key in ("key_env", "api_key_env"):` for the fallback_providers path. This PR extends the same pattern to the providers dict and custom_providers list paths.
