### PR TITLE
Integrate voice-native WhatsApp audio and calling sidecar

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes
 | [CLI Usage](https://hermes-agent.nousresearch.com/docs/user-guide/cli)                              | Commands, keybindings, personalities, sessions             |
 | [Configuration](https://hermes-agent.nousresearch.com/docs/user-guide/configuration)                | Config file, providers, models, all options                |
 | [Messaging Gateway](https://hermes-agent.nousresearch.com/docs/user-guide/messaging)                | Telegram, Discord, Slack, WhatsApp, Signal, Home Assistant |
+| [Voice-Native WhatsApp Stack](docs/voice-native-whatsapp.md)                                        | Local `voice` TTS/STT, WhatsApp-ready Opus voice notes, and WebRTC sidecar verification |
 | [Security](https://hermes-agent.nousresearch.com/docs/user-guide/security)                          | Command approval, DM pairing, container isolation          |
 | [Tools & Toolsets](https://hermes-agent.nousresearch.com/docs/user-guide/features/tools)            | 40+ tools, toolset system, terminal backends               |
 | [Skills System](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills)              | Procedural memory, Skills Hub, creating skills             |

--- a/docs/voice-native-whatsapp.md
+++ b/docs/voice-native-whatsapp.md
@@ -99,15 +99,17 @@ stt:
 
 ## Verification
 
-The installer prints five verifier commands under `verify_commands`:
+The installer prints seven verifier commands under `verify_commands`:
 
 | Key | Use |
 | --- | --- |
 | `local_stack` | Isolated local checks without touching the running gateway. |
 | `live_gateway` | Running-gateway checks only. |
 | `live_gateway_cloud_only` | Running-gateway checks only, skipping local Baileys bridge health. |
+| `live_gateway_cloud_ready` | Same as `live_gateway_cloud_only`, plus non-contacting WhatsApp Cloud credential and recipient-authorization readiness. |
 | `local_stack_live_gateway` | Full local stack plus running-gateway checks. |
 | `local_stack_live_gateway_cloud_only` | Same as `local_stack_live_gateway`, but skips local Baileys bridge health. |
+| `local_stack_live_gateway_cloud_ready` | Same as `local_stack_live_gateway_cloud_only`, plus the WhatsApp Cloud readiness gate. |
 
 For a local Cloud-API-focused deployment, run the generated
 `local_stack_live_gateway_cloud_only` command. It should include:
@@ -128,6 +130,14 @@ python3 scripts/verify_voice_local_stack.py \
   --live-gateway-voice-daemon-service voiced.service \
   --skip-live-gateway-bridge-health
 ```
+
+Before pointing Meta webhooks at the host, run the generated
+`local_stack_live_gateway_cloud_ready` command. It adds
+`--require-live-gateway-whatsapp-cloud-readiness`, which verifies
+`WHATSAPP_CLOUD_PHONE_NUMBER_ID`, `WHATSAPP_CLOUD_ACCESS_TOKEN`,
+`WHATSAPP_CLOUD_APP_SECRET`, `WHATSAPP_CLOUD_VERIFY_TOKEN`, and either
+`WHATSAPP_CLOUD_ALLOWED_USERS` or `WHATSAPP_CLOUD_ALLOW_ALL_USERS` without
+printing secret values.
 
 That aggregate verifier proves:
 

--- a/docs/voice-native-whatsapp.md
+++ b/docs/voice-native-whatsapp.md
@@ -106,7 +106,7 @@ The installer prints seven verifier commands under `verify_commands`:
 | `local_stack` | Isolated local checks without touching the running gateway. |
 | `live_gateway` | Running-gateway checks only. |
 | `live_gateway_cloud_only` | Running-gateway checks only, skipping local Baileys bridge health. |
-| `live_gateway_cloud_ready` | Same as `live_gateway_cloud_only`, plus non-contacting WhatsApp Cloud credential, recipient-authorization, and local webhook health readiness. |
+| `live_gateway_cloud_ready` | Same as `live_gateway_cloud_only`, plus non-contacting WhatsApp Cloud credential, recipient-authorization, local webhook health, and verify-token handshake readiness. |
 | `local_stack_live_gateway` | Full local stack plus running-gateway checks. |
 | `local_stack_live_gateway_cloud_only` | Same as `local_stack_live_gateway`, but skips local Baileys bridge health. |
 | `local_stack_live_gateway_cloud_ready` | Same as `local_stack_live_gateway_cloud_only`, plus the WhatsApp Cloud readiness gate. |
@@ -137,8 +137,8 @@ Before pointing Meta webhooks at the host, run the generated
 `WHATSAPP_CLOUD_PHONE_NUMBER_ID`, `WHATSAPP_CLOUD_ACCESS_TOKEN`,
 `WHATSAPP_CLOUD_APP_SECRET`, `WHATSAPP_CLOUD_VERIFY_TOKEN`, and either
 `WHATSAPP_CLOUD_ALLOWED_USERS` or `WHATSAPP_CLOUD_ALLOW_ALL_USERS`, then probes
-the running local WhatsApp Cloud `/health` endpoint without printing secret
-values.
+the running local WhatsApp Cloud `/health` endpoint and local Meta subscription
+challenge handshake without printing secret values.
 
 That aggregate verifier proves:
 

--- a/docs/voice-native-whatsapp.md
+++ b/docs/voice-native-whatsapp.md
@@ -28,6 +28,16 @@ The target shape is:
 
 ## Install Plan
 
+Install and start the `voice` daemon before applying the Hermes wiring. On
+Linux, `voice daemon install` registers and starts the `voiced.service`
+systemd user unit. The sidecar unit generated below orders after that daemon
+and pulls it in with `Wants=voiced.service`.
+
+```bash
+voice daemon install
+voice daemon status
+```
+
 Run the installer in dry-run mode first. The output is JSON with the files it
 would write and the verifier commands to run afterward.
 
@@ -37,6 +47,7 @@ python3 scripts/install_voice_local_stack.py \
   --live-hermes-root ~/.hermes/hermes-agent-voice-stack \
   --voice-repo ~/code/src/github.com/rgbkrk/voice \
   --voice-bin ~/.local/bin/voice \
+  --voice-daemon-service voiced.service \
   --webrtc-python-bin /tmp/voice-webrtc-venv/bin/python \
   --configure-tts \
   --configure-stt
@@ -54,6 +65,7 @@ python3 scripts/install_voice_local_stack.py \
   --live-hermes-root ~/.hermes/hermes-agent-voice-stack \
   --voice-repo ~/code/src/github.com/rgbkrk/voice \
   --voice-bin ~/.local/bin/voice \
+  --voice-daemon-service voiced.service \
   --webrtc-python-bin /tmp/voice-webrtc-venv/bin/python \
   --configure-tts \
   --configure-stt
@@ -112,6 +124,7 @@ python3 scripts/verify_voice_local_stack.py \
   --live-gateway-hermes-home ~/.hermes \
   --run-live-gateway-stt-smoke \
   --live-gateway-sidecar-service voice-webrtc-sidecar.service \
+  --live-gateway-voice-daemon-service voiced.service \
   --skip-live-gateway-bridge-health
 ```
 

--- a/docs/voice-native-whatsapp.md
+++ b/docs/voice-native-whatsapp.md
@@ -123,6 +123,7 @@ python3 scripts/verify_voice_local_stack.py \
   --live-gateway-python-bin ~/.hermes/hermes-agent/venv/bin/python \
   --live-gateway-hermes-home ~/.hermes \
   --run-live-gateway-stt-smoke \
+  --run-live-gateway-calling-live-sidecar-smoke \
   --live-gateway-sidecar-service voice-webrtc-sidecar.service \
   --live-gateway-voice-daemon-service voiced.service \
   --skip-live-gateway-bridge-health
@@ -143,6 +144,10 @@ That aggregate verifier proves:
   readiness.
 - A real local sidecar can answer an `aiortc` SDP offer and report
   `ready_for_accept: true`.
+- The deployed Hermes checkout can handle a synthetic WhatsApp Calling
+  `connect` webhook, POST the offer to a real in-process sidecar, send
+  `pre_accept` and `accept`, move PCM in both directions, and close the
+  sidecar session on `terminate`.
 - The installed `hermes-gateway.service` process imports from the expected
   checkout and points at the expected sidecar URL.
 - The installed `voiced.service` daemon is active and runs the expected

--- a/docs/voice-native-whatsapp.md
+++ b/docs/voice-native-whatsapp.md
@@ -132,6 +132,8 @@ That aggregate verifier proves:
   `ready_for_accept: true`.
 - The installed `hermes-gateway.service` process imports from the expected
   checkout and points at the expected sidecar URL.
+- The installed `voiced.service` daemon is active and runs the expected
+  `voice daemon start` command for live-call stream TTS.
 - The installed `voice-webrtc-sidecar.service` runs the expected `voice` binary
   and `voice` checkout.
 

--- a/docs/voice-native-whatsapp.md
+++ b/docs/voice-native-whatsapp.md
@@ -1,0 +1,158 @@
+# Voice-Native WhatsApp Stack
+
+This document describes the local Hermes + `voice` integration path for
+WhatsApp voice notes and WhatsApp Calling/WebRTC experiments.
+
+The target shape is:
+
+- `voice` is the source of truth for speech audio formats.
+- Hermes asks `voice` for WhatsApp-ready Ogg/Opus files for voice notes.
+- Hermes sends native Opus voice notes without a redundant ffmpeg conversion.
+- Hermes uses a local WebRTC sidecar for WhatsApp Calling SDP and PCM frame
+  exchange.
+- `voice` keeps the local media contract stable through
+  `voice stream-contract`.
+
+## Components
+
+| Component | Role |
+| --- | --- |
+| `voice say --format ogg-opus` | Writes completed WhatsApp-ready Ogg/Opus voice-note files. |
+| `voice stream` | Emits raw 48 kHz mono 20 ms PCM frames or streamed Ogg/Opus files. |
+| `voice stream-transcribe` | Transcribes files or decoded PCM frames from the sidecar. |
+| `voice-webrtc-sidecar.service` | Runs the Python `aiortc` sidecar from the `voice` checkout. |
+| `hermes-gateway.service` drop-in | Points the running gateway at the checkout and sidecar stream command. |
+| `scripts/install_voice_local_stack.py` | Produces or applies the local systemd/config wiring. |
+| `scripts/verify_voice_local_stack.py` | Proves the isolated and optional live local voice stack. |
+| `scripts/verify_voice_live_gateway.py` | Proves the installed gateway process and sidecar are in sync. |
+
+## Install Plan
+
+Run the installer in dry-run mode first. The output is JSON with the files it
+would write and the verifier commands to run afterward.
+
+```bash
+python3 scripts/install_voice_local_stack.py \
+  --hermes-home ~/.hermes \
+  --live-hermes-root ~/.hermes/hermes-agent-voice-stack \
+  --voice-repo ~/code/src/github.com/rgbkrk/voice \
+  --voice-bin ~/.local/bin/voice \
+  --webrtc-python-bin /tmp/voice-webrtc-venv/bin/python \
+  --configure-tts \
+  --configure-stt
+```
+
+Use `--apply` to write the systemd user unit, gateway drop-in, and optional
+Hermes TTS/STT config updates. Use `--restart-hermes` when the gateway should
+reload the new drop-in immediately.
+
+```bash
+python3 scripts/install_voice_local_stack.py \
+  --apply \
+  --restart-hermes \
+  --hermes-home ~/.hermes \
+  --live-hermes-root ~/.hermes/hermes-agent-voice-stack \
+  --voice-repo ~/code/src/github.com/rgbkrk/voice \
+  --voice-bin ~/.local/bin/voice \
+  --webrtc-python-bin /tmp/voice-webrtc-venv/bin/python \
+  --configure-tts \
+  --configure-stt
+```
+
+The generated TTS provider asks `voice` for native Opus:
+
+```yaml
+tts:
+  provider: kokoro
+  providers:
+    kokoro:
+      type: command
+      command: voice say --format ogg-opus --input-file {input_path} --output {output_path} --voice {voice} --speed {speed}
+      output_format: ogg
+      voice_compatible: true
+```
+
+The generated STT provider routes files through `voice stream-transcribe`:
+
+```yaml
+stt:
+  enabled: true
+  provider: voice
+  providers:
+    voice:
+      type: command
+      command: voice stream-transcribe --quiet {input_path}
+      format: txt
+```
+
+## Verification
+
+The installer prints five verifier commands under `verify_commands`:
+
+| Key | Use |
+| --- | --- |
+| `local_stack` | Isolated local checks without touching the running gateway. |
+| `live_gateway` | Running-gateway checks only. |
+| `live_gateway_cloud_only` | Running-gateway checks only, skipping local Baileys bridge health. |
+| `local_stack_live_gateway` | Full local stack plus running-gateway checks. |
+| `local_stack_live_gateway_cloud_only` | Same as `local_stack_live_gateway`, but skips local Baileys bridge health. |
+
+For a local Cloud-API-focused deployment, run the generated
+`local_stack_live_gateway_cloud_only` command. It should include:
+
+```bash
+python3 scripts/verify_voice_local_stack.py \
+  --voice-bin ~/.local/bin/voice \
+  --voice-repo ~/code/src/github.com/rgbkrk/voice \
+  --webrtc-python-bin /tmp/voice-webrtc-venv/bin/python \
+  --live-hermes-root ~/.hermes/hermes-agent-voice-stack \
+  --run-live-gateway \
+  --calling-sidecar-url http://127.0.0.1:8787 \
+  --live-gateway-python-bin ~/.hermes/hermes-agent/venv/bin/python \
+  --live-gateway-hermes-home ~/.hermes \
+  --run-live-gateway-stt-smoke \
+  --live-gateway-sidecar-service voice-webrtc-sidecar.service \
+  --skip-live-gateway-bridge-health
+```
+
+That aggregate verifier proves:
+
+- `voice` can produce WhatsApp-ready Ogg/Opus.
+- `voice stream-contract` matches the checked-in sidecar contract.
+- Hermes command TTS returns `voice_compatible: true` Opus voice-note media.
+- Hermes command STT transcribes through `voice stream-transcribe`.
+- `voice stream` returns raw 48 kHz mono 20 ms PCM frames.
+- The local Baileys bridge keeps native `.ogg`/`.opus` media as voice notes
+  when the bridge check is not skipped.
+- The WhatsApp Cloud adapter uploads `.ogg`/Opus with
+  `audio/ogg; codecs=opus`.
+- The synthetic WhatsApp Calling control plane gates accept on sidecar
+  readiness.
+- A real local sidecar can answer an `aiortc` SDP offer and report
+  `ready_for_accept: true`.
+- The installed `hermes-gateway.service` process imports from the expected
+  checkout and points at the expected sidecar URL.
+- The installed `voice-webrtc-sidecar.service` runs the expected `voice` binary
+  and `voice` checkout.
+
+## Readiness Boundary
+
+The local WebRTC sidecar exposes `state.ready_for_accept` and per-check
+`state.readiness` booleans. Hermes should send WhatsApp Graph `pre_accept` and
+`accept` only after the sidecar reports `ready_for_accept: true`.
+
+This local proof does not contact Meta's Graph API, receive a real WhatsApp
+Calling webhook, or prove media against a real WhatsApp client. It proves the
+local Hermes/voice boundary up to the point where an external WhatsApp
+Calling event can be handed to the sidecar and accepted safely.
+
+## Troubleshooting
+
+- If `--run-sidecar-offer-smoke` fails, inspect the sidecar `/health` and
+  `/contract` endpoints first.
+- If Opus checks fail, make sure `ffmpeg` and `ffprobe` are installed and on
+  `PATH`.
+- If the live verifier imports old code, confirm the gateway systemd drop-in
+  sets `PYTHONPATH` to the intended checkout.
+- If the sidecar service check fails, confirm `VOICE_BIN`, `WorkingDirectory`,
+  `--host`, and `--port` in `systemctl --user show voice-webrtc-sidecar.service`.

--- a/docs/voice-native-whatsapp.md
+++ b/docs/voice-native-whatsapp.md
@@ -140,7 +140,9 @@ Before pointing Meta webhooks at the host, run the generated
 the running local WhatsApp Cloud `/health` endpoint and local Meta subscription
 challenge handshake. It also sends a signed synthetic delivery-receipt POST to
 prove inbound HMAC verification accepts Meta-shaped webhook delivery without
-dispatching an agent message or printing secret values.
+dispatching an agent message or printing secret values. If setup is incomplete,
+the verifier reports every missing or malformed Cloud setting it can detect in
+one redacted failure.
 
 That aggregate verifier proves:
 

--- a/docs/voice-native-whatsapp.md
+++ b/docs/voice-native-whatsapp.md
@@ -145,7 +145,7 @@ That aggregate verifier proves:
 - A real local sidecar can answer an `aiortc` SDP offer and report
   `ready_for_accept: true`.
 - The deployed Hermes checkout can handle a synthetic WhatsApp Calling
-  `connect` webhook, POST the offer to a real in-process sidecar, send
+  `connect` webhook, POST the offer to the configured local sidecar, send
   `pre_accept` and `accept`, move PCM in both directions, and close the
   sidecar session on `terminate`.
 - The installed `hermes-gateway.service` process imports from the expected

--- a/docs/voice-native-whatsapp.md
+++ b/docs/voice-native-whatsapp.md
@@ -25,6 +25,7 @@ The target shape is:
 | `scripts/install_voice_local_stack.py` | Produces or applies the local systemd/config wiring. |
 | `scripts/verify_voice_local_stack.py` | Proves the isolated and optional live local voice stack. |
 | `scripts/verify_voice_live_gateway.py` | Proves the installed gateway process and sidecar are in sync. |
+| `scripts/verify_voice_whatsapp_cloud_webhook.py` | Proves local Cloud webhook health, verify-token, and signed POST handling without live Meta calls. |
 
 ## Install Plan
 
@@ -155,6 +156,9 @@ That aggregate verifier proves:
   when the bridge check is not skipped.
 - The WhatsApp Cloud adapter uploads `.ogg`/Opus with
   `audio/ogg; codecs=opus`.
+- The WhatsApp Cloud webhook path answers local health and verify-token
+  handshakes, and accepts signed status-only POST payloads without dispatching
+  agent messages.
 - The synthetic WhatsApp Calling control plane gates accept on sidecar
   readiness.
 - A real local sidecar can answer an `aiortc` SDP offer and report

--- a/docs/voice-native-whatsapp.md
+++ b/docs/voice-native-whatsapp.md
@@ -106,7 +106,7 @@ The installer prints seven verifier commands under `verify_commands`:
 | `local_stack` | Isolated local checks without touching the running gateway. |
 | `live_gateway` | Running-gateway checks only. |
 | `live_gateway_cloud_only` | Running-gateway checks only, skipping local Baileys bridge health. |
-| `live_gateway_cloud_ready` | Same as `live_gateway_cloud_only`, plus non-contacting WhatsApp Cloud credential, recipient-authorization, local webhook health, and verify-token handshake readiness. |
+| `live_gateway_cloud_ready` | Same as `live_gateway_cloud_only`, plus non-contacting WhatsApp Cloud credential, recipient-authorization, local webhook health, verify-token handshake, and signed POST readiness. |
 | `local_stack_live_gateway` | Full local stack plus running-gateway checks. |
 | `local_stack_live_gateway_cloud_only` | Same as `local_stack_live_gateway`, but skips local Baileys bridge health. |
 | `local_stack_live_gateway_cloud_ready` | Same as `local_stack_live_gateway_cloud_only`, plus the WhatsApp Cloud readiness gate. |
@@ -138,7 +138,9 @@ Before pointing Meta webhooks at the host, run the generated
 `WHATSAPP_CLOUD_APP_SECRET`, `WHATSAPP_CLOUD_VERIFY_TOKEN`, and either
 `WHATSAPP_CLOUD_ALLOWED_USERS` or `WHATSAPP_CLOUD_ALLOW_ALL_USERS`, then probes
 the running local WhatsApp Cloud `/health` endpoint and local Meta subscription
-challenge handshake without printing secret values.
+challenge handshake. It also sends a signed synthetic delivery-receipt POST to
+prove inbound HMAC verification accepts Meta-shaped webhook delivery without
+dispatching an agent message or printing secret values.
 
 That aggregate verifier proves:
 

--- a/docs/voice-native-whatsapp.md
+++ b/docs/voice-native-whatsapp.md
@@ -25,7 +25,7 @@ The target shape is:
 | `scripts/install_voice_local_stack.py` | Produces or applies the local systemd/config wiring. |
 | `scripts/verify_voice_local_stack.py` | Proves the isolated and optional live local voice stack. |
 | `scripts/verify_voice_live_gateway.py` | Proves the installed gateway process and sidecar are in sync. |
-| `scripts/verify_voice_whatsapp_cloud_webhook.py` | Proves local Cloud webhook health, verify-token, and signed POST handling without live Meta calls. |
+| `scripts/verify_voice_whatsapp_cloud_webhook.py` | Proves local Cloud webhook health, verify-token, signed POST handling, and inbound voice-note media caching without live Meta calls. |
 
 ## Install Plan
 
@@ -157,8 +157,9 @@ That aggregate verifier proves:
 - The WhatsApp Cloud adapter uploads `.ogg`/Opus with
   `audio/ogg; codecs=opus`.
 - The WhatsApp Cloud webhook path answers local health and verify-token
-  handshakes, and accepts signed status-only POST payloads without dispatching
-  agent messages.
+  handshakes, accepts signed status-only POST payloads without dispatching
+  agent messages, and accepts a signed synthetic audio webhook that caches an
+  Opus/Ogg voice note for downstream STT dispatch.
 - The synthetic WhatsApp Calling control plane gates accept on sidecar
   readiness.
 - A real local sidecar can answer an `aiortc` SDP offer and report

--- a/docs/voice-native-whatsapp.md
+++ b/docs/voice-native-whatsapp.md
@@ -106,7 +106,7 @@ The installer prints seven verifier commands under `verify_commands`:
 | `local_stack` | Isolated local checks without touching the running gateway. |
 | `live_gateway` | Running-gateway checks only. |
 | `live_gateway_cloud_only` | Running-gateway checks only, skipping local Baileys bridge health. |
-| `live_gateway_cloud_ready` | Same as `live_gateway_cloud_only`, plus non-contacting WhatsApp Cloud credential and recipient-authorization readiness. |
+| `live_gateway_cloud_ready` | Same as `live_gateway_cloud_only`, plus non-contacting WhatsApp Cloud credential, recipient-authorization, and local webhook health readiness. |
 | `local_stack_live_gateway` | Full local stack plus running-gateway checks. |
 | `local_stack_live_gateway_cloud_only` | Same as `local_stack_live_gateway`, but skips local Baileys bridge health. |
 | `local_stack_live_gateway_cloud_ready` | Same as `local_stack_live_gateway_cloud_only`, plus the WhatsApp Cloud readiness gate. |
@@ -136,8 +136,9 @@ Before pointing Meta webhooks at the host, run the generated
 `--require-live-gateway-whatsapp-cloud-readiness`, which verifies
 `WHATSAPP_CLOUD_PHONE_NUMBER_ID`, `WHATSAPP_CLOUD_ACCESS_TOKEN`,
 `WHATSAPP_CLOUD_APP_SECRET`, `WHATSAPP_CLOUD_VERIFY_TOKEN`, and either
-`WHATSAPP_CLOUD_ALLOWED_USERS` or `WHATSAPP_CLOUD_ALLOW_ALL_USERS` without
-printing secret values.
+`WHATSAPP_CLOUD_ALLOWED_USERS` or `WHATSAPP_CLOUD_ALLOW_ALL_USERS`, then probes
+the running local WhatsApp Cloud `/health` endpoint without printing secret
+values.
 
 That aggregate verifier proves:
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1495,6 +1495,23 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 ] = float(wa_cloud_calling_sidecar_timeout)
             except ValueError:
                 pass
+        wa_cloud_calling_sidecar_tts_stream_command = os.getenv(
+            "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND"
+        )
+        if wa_cloud_calling_sidecar_tts_stream_command:
+            config.platforms[Platform.WHATSAPP_CLOUD].extra[
+                "calling_sidecar_tts_stream_command"
+            ] = wa_cloud_calling_sidecar_tts_stream_command
+        wa_cloud_calling_sidecar_tts_stream_timeout = os.getenv(
+            "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT"
+        )
+        if wa_cloud_calling_sidecar_tts_stream_timeout:
+            try:
+                config.platforms[Platform.WHATSAPP_CLOUD].extra[
+                    "calling_sidecar_tts_stream_timeout"
+                ] = float(wa_cloud_calling_sidecar_tts_stream_timeout)
+            except ValueError:
+                pass
     whatsapp_cloud_home = os.getenv("WHATSAPP_CLOUD_HOME_CHANNEL")
     if whatsapp_cloud_home and Platform.WHATSAPP_CLOUD in config.platforms:
         config.platforms[Platform.WHATSAPP_CLOUD].home_channel = HomeChannel(

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1479,6 +1479,22 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         wa_cloud_api_version = os.getenv("WHATSAPP_CLOUD_API_VERSION")
         if wa_cloud_api_version:
             config.platforms[Platform.WHATSAPP_CLOUD].extra["api_version"] = wa_cloud_api_version
+        # Optional: local WhatsApp Calling/WebRTC SDP sidecar
+        wa_cloud_calling_sidecar_url = os.getenv("WHATSAPP_CLOUD_CALLING_SIDECAR_URL")
+        if wa_cloud_calling_sidecar_url:
+            config.platforms[Platform.WHATSAPP_CLOUD].extra[
+                "calling_sidecar_url"
+            ] = wa_cloud_calling_sidecar_url
+        wa_cloud_calling_sidecar_timeout = os.getenv(
+            "WHATSAPP_CLOUD_CALLING_SIDECAR_TIMEOUT"
+        )
+        if wa_cloud_calling_sidecar_timeout:
+            try:
+                config.platforms[Platform.WHATSAPP_CLOUD].extra[
+                    "calling_sidecar_timeout"
+                ] = float(wa_cloud_calling_sidecar_timeout)
+            except ValueError:
+                pass
     whatsapp_cloud_home = os.getenv("WHATSAPP_CLOUD_HOME_CHANNEL")
     if whatsapp_cloud_home and Platform.WHATSAPP_CLOUD in config.platforms:
         config.platforms[Platform.WHATSAPP_CLOUD].home_channel = HomeChannel(

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2785,6 +2785,20 @@ class BasePlatformAdapter(ABC):
         """
         return await self.send_voice(chat_id=chat_id, audio_path=audio_path, **kwargs)
 
+    async def play_tts_text(
+        self,
+        chat_id: str,
+        text: str,
+        **kwargs,
+    ) -> SendResult:
+        """
+        Play auto-TTS directly from text when a platform can stream audio.
+
+        The default returns failure so callers fall back to file-based
+        ``text_to_speech_tool`` generation and ``play_tts`` delivery.
+        """
+        return SendResult(success=False, error="Direct TTS playback is not supported")
+
     async def send_video(
         self,
         chat_id: str,
@@ -4278,17 +4292,29 @@ class BasePlatformAdapter(ABC):
                         and text_content
                         and not media_files):
                     try:
-                        from tools.tts_tool import text_to_speech_tool, check_tts_requirements
-                        if check_tts_requirements():
-                            import json as _json
-                            speech_text = self.prepare_tts_text(text_content)
-                            if not speech_text:
-                                raise ValueError("Empty text after markdown cleanup")
-                            tts_result_str = await asyncio.to_thread(
-                                text_to_speech_tool, text=speech_text
+                        speech_text = self.prepare_tts_text(text_content)
+                        if not speech_text:
+                            raise ValueError("Empty text after markdown cleanup")
+
+                        direct_tts = await self.play_tts_text(
+                            chat_id=event.source.chat_id,
+                            text=speech_text,
+                            metadata=_thread_metadata,
+                        )
+                        if not bool(getattr(direct_tts, "success", False)):
+                            from tools.tts_tool import text_to_speech_tool, check_tts_requirements
+                            if check_tts_requirements():
+                                import json as _json
+                                tts_result_str = await asyncio.to_thread(
+                                    text_to_speech_tool, text=speech_text
+                                )
+                                tts_data = _json.loads(tts_result_str)
+                                _tts_path = tts_data.get("file_path")
+                        else:
+                            logger.debug(
+                                "[%s] Auto-TTS delivered directly from text",
+                                self.name,
                             )
-                            tts_data = _json.loads(tts_result_str)
-                            _tts_path = tts_data.get("file_path")
                     except Exception as tts_err:
                         logger.warning("[%s] Auto-TTS failed: %s", self.name, tts_err)
 

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -2234,6 +2234,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 call_id,
                 pre_accept.error,
             )
+            await self._close_calling_sidecar_session(call_id)
             return
 
         accept = await self._send_call_action(call_id, "accept", sdp=answer.sdp)
@@ -2243,6 +2244,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 call_id,
                 accept.error,
             )
+            await self._close_calling_sidecar_session(call_id)
             return
 
         logger.info("[whatsapp_cloud] accepted call %s via calling sidecar", call_id)

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -688,6 +688,118 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
         return SendResult(success=True, raw_response=body)
 
+    def _calling_sidecar_call_id_from_metadata(
+        self,
+        metadata: Optional[Dict[str, Any]],
+    ) -> Optional[str]:
+        """Return an active sidecar call id carried by delivery metadata."""
+        if not isinstance(metadata, dict):
+            return None
+        for key in ("whatsapp_call_id", "call_id", "thread_id"):
+            candidate = str(metadata.get(key) or "").strip()
+            if candidate and candidate in self._calling_sidecar_call_ids:
+                return candidate
+        return None
+
+    async def _decode_call_audio_file_to_pcm(
+        self,
+        audio_path: str,
+    ) -> tuple[Optional[bytes], Optional[str]]:
+        """Decode a local audio file into the sidecar's fixed PCM shape."""
+        if not audio_path or audio_path.startswith(("http://", "https://")):
+            return None, "Calling sidecar audio requires a local file"
+        if not os.path.isfile(audio_path):
+            return None, f"Audio file not found: {audio_path}"
+        if not _FFMPEG_PATH:
+            return None, "ffmpeg is required to decode TTS audio for live calls"
+
+        proc = await asyncio.create_subprocess_exec(
+            _FFMPEG_PATH,
+            "-v",
+            "error",
+            "-i",
+            audio_path,
+            "-f",
+            "s16le",
+            "-acodec",
+            "pcm_s16le",
+            "-ar",
+            str(CALLING_PCM_SAMPLE_RATE),
+            "-ac",
+            str(CALLING_PCM_CHANNELS),
+            "pipe:1",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(),
+                timeout=max(self._calling_sidecar_timeout, 30.0),
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.communicate()
+            return None, "ffmpeg timed out while decoding TTS audio for live call"
+
+        if proc.returncode != 0:
+            detail = (stderr or b"").decode("utf-8", errors="replace").strip()
+            return None, (
+                "ffmpeg failed to decode TTS audio for live call"
+                + (f": {detail[:500]}" if detail else "")
+            )
+        if not stdout:
+            return None, "ffmpeg produced no PCM for live call audio"
+        if len(stdout) % CALLING_PCM_BYTES_PER_SAMPLE:
+            return None, "ffmpeg produced partial s16le samples for live call audio"
+        return stdout, None
+
+    async def _send_calling_sidecar_audio_file(
+        self,
+        call_id: str,
+        audio_path: str,
+    ) -> SendResult:
+        """Decode a TTS file and pace it into the live sidecar call."""
+        pcm, error = await self._decode_call_audio_file_to_pcm(audio_path)
+        if error:
+            return SendResult(success=False, error=error)
+        if not pcm:
+            return SendResult(success=False, error="No PCM decoded from TTS audio")
+
+        sequence = 0
+        for offset in range(0, len(pcm), CALLING_PCM_FRAME_BYTES):
+            frame = pcm[offset : offset + CALLING_PCM_FRAME_BYTES]
+            if len(frame) < CALLING_PCM_FRAME_BYTES:
+                frame += b"\x00" * (CALLING_PCM_FRAME_BYTES - len(frame))
+
+            result = await self._send_calling_sidecar_audio(
+                call_id,
+                frame,
+                sequence=sequence,
+            )
+            if not result.success and result.retryable:
+                await asyncio.sleep(CALLING_PCM_FRAME_MS / 1_000)
+                result = await self._send_calling_sidecar_audio(
+                    call_id,
+                    frame,
+                    sequence=sequence,
+                )
+            if not result.success:
+                return result
+
+            sequence += 1
+            if offset + CALLING_PCM_FRAME_BYTES < len(pcm):
+                await asyncio.sleep(CALLING_PCM_FRAME_MS / 1_000)
+
+        return SendResult(
+            success=True,
+            raw_response={
+                "call_id": call_id,
+                "queued_pcm_bytes": len(pcm),
+                "frames": sequence,
+                "audio": CALLING_AUDIO_CONTRACT,
+            },
+        )
+
     async def _receive_calling_sidecar_audio(
         self,
         call_id: str,
@@ -1723,6 +1835,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         audio_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
         """Send an audio file as a WhatsApp voice message.
@@ -1733,6 +1846,10 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         ffmpeg conversion to opus first and fall back to sending the
         MP3 as-is when ffmpeg is unavailable.
         """
+        call_id = self._calling_sidecar_call_id_from_metadata(metadata)
+        if call_id:
+            return await self._send_calling_sidecar_audio_file(call_id, audio_path)
+
         source = audio_path
         mime_type: Optional[str] = None
 

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -282,6 +282,7 @@ class CallingSidecarAnswer:
     call_id: str
     sdp: str
     audio: Dict[str, Any]
+    state: Dict[str, Any]
 
 
 @dataclass(frozen=True)
@@ -658,9 +659,10 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
         The sidecar contract mirrors the voice repo's prototype:
         POST /offer with {"call_id", "type": "offer", "sdp"} and expect
-        {"type": "answer", "sdp": "...", "audio": {...}}. Full Meta
-        Calling webhook handling can call this once it has extracted the
-        inbound offer.
+        {"type": "answer", "sdp": "...", "audio": {...}, "state": {...}}.
+        Full Meta Calling webhook handling can call this once it has extracted
+        the inbound offer. The connect handler requires state.ready_for_accept
+        before sending Graph pre_accept/accept actions.
         """
         if not self._calling_sidecar_enabled():
             return None
@@ -743,10 +745,33 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 answer_call_id,
             )
             return None
+
+        state = data.get("state")
+        if not isinstance(state, dict):
+            state = {}
         return CallingSidecarAnswer(
             call_id=normalized_call_id,
             sdp=sdp,
             audio=audio,
+            state=dict(state),
+        )
+
+    @staticmethod
+    def _calling_sidecar_accept_readiness_error(state: Any) -> Optional[str]:
+        """Return a human-readable readiness error, or None when accept is safe."""
+        if not isinstance(state, dict):
+            return "sidecar answer missing call state"
+        if state.get("ready_for_accept") is True:
+            return None
+
+        readiness = state.get("readiness")
+        if isinstance(readiness, dict):
+            failed = sorted(str(key) for key, value in readiness.items() if value is not True)
+            if failed:
+                return "sidecar not ready for accept; failed checks: " + ", ".join(failed)
+        return (
+            "sidecar not ready for accept; ready_for_accept="
+            f"{state.get('ready_for_accept')!r}"
         )
 
     async def _send_calling_sidecar_audio(
@@ -3181,6 +3206,24 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 )
             return
         self._calling_sidecar_call_ids.add(call_id)
+
+        readiness_error = self._calling_sidecar_accept_readiness_error(answer.state)
+        if readiness_error is not None:
+            logger.warning(
+                "[whatsapp_cloud] sidecar answer for %s is not ready for accept: %s",
+                call_id,
+                readiness_error,
+            )
+            await self._close_calling_sidecar_session(call_id)
+            reject = await self._send_call_action(call_id, "reject")
+            if not reject.success:
+                logger.warning(
+                    "[whatsapp_cloud] reject failed for %s after sidecar readiness "
+                    "failure: %s",
+                    call_id,
+                    reject.error,
+                )
+            return
 
         pre_accept = await self._send_call_action(
             call_id,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -2459,6 +2459,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         try:
             proc = await asyncio.create_subprocess_exec(
                 _FFMPEG_PATH, "-y", "-i", audio_path,
+                "-ac", "1", "-ar", "48000",
                 "-c:a", "libopus", "-b:a", "32k", "-vbr", "on",
                 "-application", "voip", out_path,
                 stdout=asyncio.subprocess.DEVNULL,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -53,6 +53,7 @@ import mimetypes
 import os
 import re
 import shutil
+import struct
 import wave
 import uuid
 from collections import OrderedDict
@@ -120,6 +121,14 @@ CALLING_PCM_MAX_INBOUND_QUEUE_BYTES = (
     CALLING_PCM_SAMPLE_RATE * CALLING_PCM_CHANNELS * CALLING_PCM_BYTES_PER_SAMPLE * 10
 )
 CALLING_PCM_ENCODING = "pcm_s16le"
+CALLING_PCM_SPEECH_PEAK_THRESHOLD = 384
+CALLING_PCM_MAX_SEGMENT_BYTES = (
+    CALLING_PCM_SAMPLE_RATE * CALLING_PCM_CHANNELS * CALLING_PCM_BYTES_PER_SAMPLE * 5
+)
+CALLING_PCM_MIN_DISPATCH_BYTES = (
+    CALLING_PCM_SAMPLE_RATE * CALLING_PCM_CHANNELS * CALLING_PCM_BYTES_PER_SAMPLE // 4
+)
+CALLING_PCM_TRAILING_SILENCE_POLLS = 2
 CALLING_AUDIO_CONTRACT = {
     "sample_rate": CALLING_PCM_SAMPLE_RATE,
     "channels": CALLING_PCM_CHANNELS,
@@ -955,6 +964,26 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             wav.writeframes(pcm_s16le)
         return str(out_path)
 
+    @staticmethod
+    def _calling_sidecar_pcm_peak(pcm_s16le: bytes) -> int:
+        """Return the absolute peak amplitude of signed 16-bit PCM."""
+        if not pcm_s16le or len(pcm_s16le) % CALLING_PCM_BYTES_PER_SAMPLE:
+            return 0
+        peak = 0
+        for (sample,) in struct.iter_unpack("<h", pcm_s16le):
+            magnitude = abs(sample)
+            if magnitude > peak:
+                peak = magnitude
+        return peak
+
+    @staticmethod
+    def _calling_sidecar_pcm_has_speech(pcm_s16le: bytes) -> bool:
+        """Cheap silence gate for decoded call audio before STT dispatch."""
+        return (
+            WhatsAppCloudAdapter._calling_sidecar_pcm_peak(pcm_s16le)
+            >= CALLING_PCM_SPEECH_PEAK_THRESHOLD
+        )
+
     async def _dispatch_calling_sidecar_pcm(
         self,
         call_id: str,
@@ -1064,27 +1093,44 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         """Long-poll sidecar PCM and dispatch speech-ish chunks to Hermes."""
         buffer = bytearray()
         silent_polls = 0
-        segment_limit = CALLING_PCM_SAMPLE_RATE * CALLING_PCM_BYTES_PER_SAMPLE * 5
 
         try:
             while call_id in self._calling_sidecar_call_ids:
                 audio = await self._receive_calling_sidecar_audio(call_id)
                 if audio is not None and audio.pcm_s16le:
-                    buffer.extend(audio.pcm_s16le)
-                    silent_polls = 0
-                    if len(buffer) >= segment_limit:
-                        await self._dispatch_calling_sidecar_pcm(
-                            call_id,
-                            chat_id,
-                            sender_name,
-                            bytes(buffer),
-                        )
-                        buffer.clear()
+                    pcm = audio.pcm_s16le
+                    if self._calling_sidecar_pcm_has_speech(pcm):
+                        buffer.extend(pcm)
+                        silent_polls = 0
+                        if len(buffer) >= CALLING_PCM_MAX_SEGMENT_BYTES:
+                            await self._dispatch_calling_sidecar_pcm(
+                                call_id,
+                                chat_id,
+                                sender_name,
+                                bytes(buffer),
+                            )
+                            buffer.clear()
+                        continue
+
+                    if buffer:
+                        silent_polls += 1
+                        if silent_polls == 1:
+                            buffer.extend(pcm)
+                        if silent_polls >= CALLING_PCM_TRAILING_SILENCE_POLLS:
+                            if len(buffer) >= CALLING_PCM_MIN_DISPATCH_BYTES:
+                                await self._dispatch_calling_sidecar_pcm(
+                                    call_id,
+                                    chat_id,
+                                    sender_name,
+                                    bytes(buffer),
+                                )
+                            buffer.clear()
+                            silent_polls = 0
                     continue
 
                 if buffer:
                     silent_polls += 1
-                    if silent_polls >= 2:
+                    if silent_polls >= CALLING_PCM_TRAILING_SILENCE_POLLS:
                         await self._dispatch_calling_sidecar_pcm(
                             call_id,
                             chat_id,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -106,6 +106,7 @@ CALLING_PCM_FRAME_BYTES = (
     * CALLING_PCM_FRAME_MS
     // 1_000
 )
+CALLING_PCM_DRAIN_WAIT_MS = 500
 CALLING_PCM_ENCODING = "pcm_s16le"
 GRAPH_API_BASE = "https://graph.facebook.com"
 # Meta retries failed webhooks for up to 7 days. We don't need to remember
@@ -533,6 +534,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         call_id: str,
         *,
         max_bytes: int = CALLING_PCM_FRAME_BYTES,
+        wait_ms: int = CALLING_PCM_DRAIN_WAIT_MS,
     ) -> Optional[CallingSidecarAudio]:
         """Drain decoded inbound 48 kHz PCM from a local WebRTC sidecar call."""
         if not self._calling_sidecar_enabled():
@@ -558,13 +560,16 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "[whatsapp_cloud] sidecar audio max_bytes must preserve s16le samples"
             )
             return None
+        if not isinstance(wait_ms, int) or wait_ms < 0:
+            logger.warning("[whatsapp_cloud] invalid sidecar audio wait_ms=%r", wait_ms)
+            return None
 
         encoded_call_id = quote(normalized_call_id, safe="")
         url = f"{self._calling_sidecar_url}/calls/{encoded_call_id}/audio"
         try:
             resp = await self._http_client.get(
                 url,
-                params={"max_bytes": max_bytes},
+                params={"max_bytes": max_bytes, "wait_ms": wait_ms},
                 timeout=self._calling_sidecar_timeout,
             )
         except Exception:

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -118,6 +118,7 @@ _DEFAULT_MIME = {
     "document": "application/octet-stream",
     "sticker": "image/webp",
 }
+_WHATSAPP_OPUS_MIME = "audio/ogg; codecs=opus"
 
 # ffmpeg location at import time. ``shutil.which`` honours PATHEXT on
 # Windows so a user's ``ffmpeg.exe`` is picked up. None means MP3 voice
@@ -1099,14 +1100,12 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
         WhatsApp renders ``audio/ogg; codecs=opus`` as the green
         voice-note bubble; other audio types (MP3, WAV, AAC, etc.) appear as
-        a generic audio attachment. Hermes TTS providers may produce any
-        supported audio container, so we try ffmpeg conversion to Opus first
-        for local non-Opus files and fall back to sending the original audio
-        when ffmpeg is unavailable.
+        a generic audio attachment. Native Ogg/Opus is uploaded as-is. For
+        local non-Opus files, we try ffmpeg conversion to Opus first and
+        fall back to sending the original audio when ffmpeg is unavailable.
         """
         source = audio_path
         mime_type: Optional[str] = None
-
         is_local_file = (
             not audio_path.startswith(("http://", "https://"))
             and os.path.exists(audio_path)
@@ -1114,18 +1113,20 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         suffix = Path(audio_path).suffix.lower()
         is_opus_voice = suffix in {".ogg", ".opus"}
 
-        if is_local_file and not is_opus_voice:
+        if is_local_file and is_opus_voice:
+            mime_type = _WHATSAPP_OPUS_MIME
+        elif is_local_file:
             opus_path = await self._convert_to_opus(audio_path)
             if opus_path:
                 try:
                     result = await self._send_media_from_path_or_link(
                         chat_id, opus_path, "audio",
                         caption=caption, reply_to=reply_to,
-                        mime_type="audio/ogg; codecs=opus",
+                        mime_type=_WHATSAPP_OPUS_MIME,
                     )
                 finally:
                     # The .ogg is a transient conversion artifact next to
-                    # the source MP3 — clean it up after upload so voice
+                    # the source audio, so clean it up after upload to keep
                     # sends don't leak a file per message.
                     try:
                         os.unlink(opus_path)
@@ -1136,8 +1137,6 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # Warn-once is logged inside _convert_to_opus.
             if suffix == ".mp3":
                 mime_type = "audio/mpeg"
-        elif is_local_file and is_opus_voice:
-            mime_type = "audio/ogg; codecs=opus"
 
         return await self._send_media_from_path_or_link(
             chat_id, source, "audio",

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -2231,6 +2231,14 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "[whatsapp_cloud] sidecar did not produce an SDP answer for %s",
                 call_id,
             )
+            reject = await self._send_call_action(call_id, "reject")
+            if not reject.success:
+                logger.warning(
+                    "[whatsapp_cloud] reject failed for %s after sidecar answer "
+                    "failure: %s",
+                    call_id,
+                    reject.error,
+                )
             return
         self._calling_sidecar_call_ids.add(call_id)
 

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -39,6 +39,10 @@ Optional / Phase-3+:
 - WHATSAPP_CLOUD_API_VERSION      (default v20.0)
 - WHATSAPP_CLOUD_CALLING_SIDECAR_URL      (optional WebRTC SDP bridge)
 - WHATSAPP_CLOUD_CALLING_SIDECAR_TIMEOUT  (default 10.0 seconds)
+- WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND
+                                     (optional raw pcm_s16le TTS command)
+- WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT
+                                     (default 180.0 seconds)
 """
 
 from __future__ import annotations
@@ -54,6 +58,7 @@ import os
 import re
 import shutil
 import struct
+import tempfile
 import wave
 import uuid
 from collections import OrderedDict
@@ -98,6 +103,7 @@ DEFAULT_WEBHOOK_HOST = "0.0.0.0"
 DEFAULT_WEBHOOK_PORT = 8090
 DEFAULT_WEBHOOK_PATH = "/whatsapp/webhook"
 DEFAULT_CALLING_SIDECAR_TIMEOUT = 10.0
+DEFAULT_CALLING_SIDECAR_TTS_STREAM_TIMEOUT = 180.0
 CALLING_PCM_SAMPLE_RATE = 48_000
 CALLING_PCM_CHANNELS = 1
 CALLING_PCM_FRAME_MS = 20
@@ -343,6 +349,18 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             or extra.get("callingSidecarTimeout")
             or os.getenv("WHATSAPP_CLOUD_CALLING_SIDECAR_TIMEOUT"),
             DEFAULT_CALLING_SIDECAR_TIMEOUT,
+        )
+        self._calling_sidecar_tts_stream_command: str = str(
+            extra.get("calling_sidecar_tts_stream_command")
+            or extra.get("callingSidecarTtsStreamCommand")
+            or os.getenv("WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND")
+            or ""
+        ).strip()
+        self._calling_sidecar_tts_stream_timeout: float = self._coerce_positive_float(
+            extra.get("calling_sidecar_tts_stream_timeout")
+            or extra.get("callingSidecarTtsStreamTimeout")
+            or os.getenv("WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT"),
+            DEFAULT_CALLING_SIDECAR_TTS_STREAM_TIMEOUT,
         )
 
         # Behavior-mixin contract: these names are read by the mixin's
@@ -863,6 +881,226 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "audio": audio,
             },
         )
+
+    async def _send_calling_sidecar_tts_stream_command(
+        self,
+        call_id: str,
+        text: str,
+    ) -> SendResult:
+        """Run a raw-PCM TTS stream command and post frames to the sidecar."""
+        command_template = str(
+            getattr(self, "_calling_sidecar_tts_stream_command", "") or ""
+        ).strip()
+        if not command_template:
+            return SendResult(
+                success=False,
+                error="Calling sidecar TTS stream command not configured",
+            )
+
+        normalized_call_id = str(call_id or "").strip()
+        text = str(text or "").strip()
+        if not normalized_call_id or not text:
+            return SendResult(success=False, error="Missing call_id or TTS text")
+
+        audio = self._calling_sidecar_audio_contract()
+        frame_bytes = int(audio["frame_bytes"])
+        frame_ms = int(audio["frame_ms"])
+        timeout = float(
+            getattr(
+                self,
+                "_calling_sidecar_tts_stream_timeout",
+                DEFAULT_CALLING_SIDECAR_TTS_STREAM_TIMEOUT,
+            )
+        )
+
+        async def terminate_process(proc: Any) -> None:
+            if getattr(proc, "returncode", None) is not None:
+                return
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                return
+            except Exception:
+                logger.debug(
+                    "[whatsapp_cloud] failed to kill TTS stream command",
+                    exc_info=True,
+                )
+                return
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=2.0)
+            except Exception:
+                pass
+
+        async def send_frame(frame: bytes, sequence: int) -> SendResult:
+            result = await self._send_calling_sidecar_audio(
+                normalized_call_id,
+                frame,
+                sequence=sequence,
+            )
+            if not result.success and result.retryable:
+                await asyncio.sleep(frame_ms / 1_000)
+                result = await self._send_calling_sidecar_audio(
+                    normalized_call_id,
+                    frame,
+                    sequence=sequence,
+                )
+            return result
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            text_path = Path(tmpdir) / "input.txt"
+            text_path.write_text(text, encoding="utf-8")
+
+            try:
+                from tools.tts_tool import _render_command_tts_template
+
+                command = _render_command_tts_template(
+                    command_template,
+                    {
+                        "input_path": str(text_path),
+                        "text_path": str(text_path),
+                        "text": text,
+                        "sample_rate": str(int(audio["sample_rate"])),
+                        "channels": str(int(audio["channels"])),
+                        "frame_ms": str(frame_ms),
+                        "encoding": str(audio["encoding"]),
+                        "voice": "",
+                        "speed": "",
+                    },
+                )
+            except Exception as exc:
+                return SendResult(
+                    success=False,
+                    error=f"Failed to render TTS stream command: {exc}",
+                )
+
+            try:
+                proc = await asyncio.create_subprocess_shell(
+                    command,
+                    stdin=asyncio.subprocess.DEVNULL,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+            except Exception as exc:
+                logger.exception("[whatsapp_cloud] failed to start TTS stream command")
+                return SendResult(success=False, error=str(exc), retryable=True)
+
+            if proc.stdout is None:
+                await terminate_process(proc)
+                return SendResult(
+                    success=False,
+                    error="TTS stream command did not expose stdout",
+                )
+
+            stderr_task = (
+                asyncio.create_task(proc.stderr.read())
+                if proc.stderr is not None
+                else None
+            )
+
+            async def cancel_stderr_task() -> None:
+                if stderr_task is None or stderr_task.done():
+                    return
+                stderr_task.cancel()
+                try:
+                    await stderr_task
+                except asyncio.CancelledError:
+                    pass
+                except Exception:
+                    pass
+
+            pending = bytearray()
+            sequence = 0
+            accepted_bytes = 0
+
+            try:
+                while True:
+                    chunk = await asyncio.wait_for(
+                        proc.stdout.read(frame_bytes * 8),
+                        timeout=timeout,
+                    )
+                    if not chunk:
+                        break
+                    pending.extend(chunk)
+                    while len(pending) >= frame_bytes:
+                        frame = bytes(pending[:frame_bytes])
+                        del pending[:frame_bytes]
+                        result = await send_frame(frame, sequence)
+                        if not result.success:
+                            await terminate_process(proc)
+                            await cancel_stderr_task()
+                            return result
+                        sequence += 1
+                        accepted_bytes += len(frame)
+
+                if pending:
+                    frame = bytes(pending)
+                    frame += b"\x00" * (frame_bytes - len(frame))
+                    result = await send_frame(frame, sequence)
+                    if not result.success:
+                        await terminate_process(proc)
+                        await cancel_stderr_task()
+                        return result
+                    sequence += 1
+                    accepted_bytes += len(pending)
+
+                returncode = await asyncio.wait_for(proc.wait(), timeout=5.0)
+            except asyncio.TimeoutError:
+                await terminate_process(proc)
+                await cancel_stderr_task()
+                return SendResult(
+                    success=False,
+                    error=f"TTS stream command timed out after {timeout:g}s",
+                    retryable=True,
+                )
+
+            stderr = b""
+            if stderr_task is not None:
+                try:
+                    stderr = await stderr_task
+                except Exception:
+                    stderr = b""
+
+            if returncode != 0:
+                detail = stderr.decode("utf-8", errors="replace").strip()
+                return SendResult(
+                    success=False,
+                    error=(
+                        f"TTS stream command exited with code {returncode}"
+                        + (f": {detail[:500]}" if detail else "")
+                    ),
+                )
+            if sequence == 0:
+                return SendResult(
+                    success=False,
+                    error="TTS stream command produced no PCM frames",
+                )
+
+        return SendResult(
+            success=True,
+            raw_response={
+                "call_id": normalized_call_id,
+                "queued_pcm_bytes": accepted_bytes,
+                "frames": sequence,
+                "audio": audio,
+            },
+        )
+
+    async def play_tts_text(
+        self,
+        chat_id: str,
+        text: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Stream synthesized reply text directly into an active sidecar call."""
+        call_id = self._calling_sidecar_call_id_from_metadata(metadata)
+        if not call_id:
+            return SendResult(
+                success=False,
+                error="No active calling sidecar call for TTS text",
+            )
+        return await self._send_calling_sidecar_tts_stream_command(call_id, text)
 
     async def _receive_calling_sidecar_audio(
         self,
@@ -2352,6 +2590,9 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "calling_sidecar_contract_loaded": isinstance(
                     getattr(self, "_calling_sidecar_contract", None),
                     dict,
+                ),
+                "calling_sidecar_tts_stream_configured": bool(
+                    getattr(self, "_calling_sidecar_tts_stream_command", ""),
                 ),
                 "ffmpeg_present": _FFMPEG_PATH is not None,
                 "accepted": self._accepted_count,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -408,6 +408,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         # Runtime
         self._runner = None
         self._http_client: Optional["httpx.AsyncClient"] = None
+        self._calling_sidecar_call_ids: set[str] = set()
 
     # ------------------------------------------------------------------ helpers
     @staticmethod
@@ -896,6 +897,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "[whatsapp_cloud] sidecar had no session for terminated call %s",
                 normalized_call_id,
             )
+            self._calling_sidecar_call_ids.discard(normalized_call_id)
             return True
         if resp.status_code != 200:
             logger.warning(
@@ -905,7 +907,13 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 str(getattr(resp, "text", ""))[:500],
             )
             return False
+        self._calling_sidecar_call_ids.discard(normalized_call_id)
         return True
+
+    async def _close_all_calling_sidecar_sessions(self) -> None:
+        """Best-effort close for every local sidecar session Hermes created."""
+        for call_id in sorted(self._calling_sidecar_call_ids):
+            await self._close_calling_sidecar_session(call_id)
 
     @staticmethod
     def _bounded_put(cache: "OrderedDict[str, str]", key: str, value: str) -> None:
@@ -1015,6 +1023,8 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             except Exception:
                 logger.exception("[whatsapp_cloud] webhook server cleanup failed")
             self._runner = None
+        if self._calling_sidecar_call_ids:
+            await self._close_all_calling_sidecar_sessions()
         if self._http_client is not None:
             try:
                 await self._http_client.aclose()
@@ -2222,6 +2232,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 call_id,
             )
             return
+        self._calling_sidecar_call_ids.add(call_id)
 
         pre_accept = await self._send_call_action(
             call_id,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import binascii
 import hashlib
 import hmac
 import logging
@@ -97,6 +98,14 @@ DEFAULT_CALLING_SIDECAR_TIMEOUT = 10.0
 CALLING_PCM_SAMPLE_RATE = 48_000
 CALLING_PCM_CHANNELS = 1
 CALLING_PCM_FRAME_MS = 20
+CALLING_PCM_BYTES_PER_SAMPLE = 2
+CALLING_PCM_FRAME_BYTES = (
+    CALLING_PCM_SAMPLE_RATE
+    * CALLING_PCM_CHANNELS
+    * CALLING_PCM_BYTES_PER_SAMPLE
+    * CALLING_PCM_FRAME_MS
+    // 1_000
+)
 CALLING_PCM_ENCODING = "pcm_s16le"
 GRAPH_API_BASE = "https://graph.facebook.com"
 # Meta retries failed webhooks for up to 7 days. We don't need to remember
@@ -181,6 +190,17 @@ class CallingSidecarAnswer:
 
     call_id: str
     sdp: str
+    audio: Dict[str, Any]
+
+
+@dataclass(frozen=True)
+class CallingSidecarAudio:
+    """Decoded inbound PCM drained from the local WhatsApp Calling sidecar."""
+
+    call_id: str
+    pcm_s16le: bytes
+    returned_bytes: int
+    queued_rx_bytes: int
     audio: Dict[str, Any]
 
 
@@ -507,6 +527,117 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             return SendResult(success=False, error=error_msg, raw_response=body)
 
         return SendResult(success=True, raw_response=body)
+
+    async def _receive_calling_sidecar_audio(
+        self,
+        call_id: str,
+        *,
+        max_bytes: int = CALLING_PCM_FRAME_BYTES,
+    ) -> Optional[CallingSidecarAudio]:
+        """Drain decoded inbound 48 kHz PCM from a local WebRTC sidecar call."""
+        if not self._calling_sidecar_enabled():
+            return None
+        if self._http_client is None:
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar configured but HTTP client "
+                "is unavailable"
+            )
+            return None
+
+        normalized_call_id = str(call_id or "").strip()
+        if not normalized_call_id:
+            return None
+        if not isinstance(max_bytes, int) or max_bytes <= 0:
+            logger.warning(
+                "[whatsapp_cloud] invalid sidecar audio max_bytes=%r",
+                max_bytes,
+            )
+            return None
+        if max_bytes % CALLING_PCM_BYTES_PER_SAMPLE:
+            logger.warning(
+                "[whatsapp_cloud] sidecar audio max_bytes must preserve s16le samples"
+            )
+            return None
+
+        encoded_call_id = quote(normalized_call_id, safe="")
+        url = f"{self._calling_sidecar_url}/calls/{encoded_call_id}/audio"
+        try:
+            resp = await self._http_client.get(
+                url,
+                params={"max_bytes": max_bytes},
+                timeout=self._calling_sidecar_timeout,
+            )
+        except Exception:
+            logger.exception(
+                "[whatsapp_cloud] calling sidecar audio drain failed for %s",
+                normalized_call_id,
+            )
+            return None
+
+        if resp.status_code != 200:
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar audio drain rejected "
+                "(status=%d): %s",
+                resp.status_code,
+                str(getattr(resp, "text", ""))[:500],
+            )
+            return None
+
+        try:
+            data = resp.json()
+        except Exception:
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar audio drain returned invalid JSON"
+            )
+            return None
+        if not isinstance(data, dict):
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar audio drain response is not an object"
+            )
+            return None
+
+        try:
+            pcm = base64.b64decode(
+                str(data.get("pcm_s16le_base64") or ""),
+                validate=True,
+            )
+        except (binascii.Error, ValueError):
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar audio drain had invalid base64"
+            )
+            return None
+
+        try:
+            returned_bytes = int(data.get("returned_bytes") or 0)
+            queued_rx_bytes = int(data.get("queued_rx_bytes") or 0)
+        except (TypeError, ValueError):
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar audio drain had invalid byte counts"
+            )
+            return None
+        if returned_bytes != len(pcm):
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar audio drain byte count mismatch "
+                "(reported=%d, decoded=%d)",
+                returned_bytes,
+                len(pcm),
+            )
+            return None
+        if len(pcm) % CALLING_PCM_BYTES_PER_SAMPLE:
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar audio drain returned partial s16le sample"
+            )
+            return None
+
+        audio = data.get("audio")
+        answer_call_id = str(data.get("call_id") or "").strip() or normalized_call_id
+        return CallingSidecarAudio(
+            call_id=answer_call_id,
+            pcm_s16le=pcm,
+            returned_bytes=returned_bytes,
+            queued_rx_bytes=queued_rx_bytes,
+            audio=audio if isinstance(audio, dict) else {},
+        )
 
     async def _send_call_action(
         self,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -428,6 +428,67 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             audio=audio if isinstance(audio, dict) else {},
         )
 
+    async def _send_call_action(
+        self,
+        call_id: str,
+        action: str,
+        *,
+        sdp: Optional[str] = None,
+    ) -> SendResult:
+        """Send a WhatsApp Calling action to Graph API.
+
+        ``pre_accept`` and ``accept`` require an SDP answer session; ``reject``
+        and ``terminate`` do not.
+        """
+        if self._http_client is None:
+            return SendResult(success=False, error="Not connected")
+
+        normalized_call_id = str(call_id or "").strip()
+        normalized_action = str(action or "").strip()
+        if not normalized_call_id or not normalized_action:
+            return SendResult(success=False, error="Missing call_id or action")
+
+        payload: Dict[str, Any] = {
+            "messaging_product": "whatsapp",
+            "call_id": normalized_call_id,
+            "action": normalized_action,
+        }
+        if sdp is not None:
+            sdp_text = str(sdp)
+            if not sdp_text.strip():
+                return SendResult(success=False, error="Missing SDP answer")
+            payload["session"] = {
+                "sdp_type": "answer",
+                "sdp": sdp_text,
+            }
+
+        url = self._graph_url("calls")
+        headers = {
+            "Authorization": f"Bearer {self._access_token}",
+            "Content-Type": "application/json",
+        }
+        try:
+            resp = await self._http_client.post(url, headers=headers, json=payload)
+        except Exception as exc:
+            logger.exception("[whatsapp_cloud] call action %s failed", normalized_action)
+            return SendResult(success=False, error=str(exc))
+
+        if resp.status_code != 200:
+            try:
+                body = resp.json()
+            except Exception:
+                body = {"raw": resp.text[:500]}
+            error_msg = self._format_graph_error(body, resp.status_code)
+            logger.warning(
+                "[whatsapp_cloud] call action %s rejected (status=%d): %s",
+                normalized_action,
+                resp.status_code,
+                error_msg,
+            )
+            return SendResult(success=False, error=error_msg)
+
+        return SendResult(success=True)
+
     @staticmethod
     def _bounded_put(cache: "OrderedDict[str, str]", key: str, value: str) -> None:
         """Insert into a FIFO-capped OrderedDict, evicting oldest entries."""
@@ -1584,16 +1645,19 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         return True
 
     async def _dispatch_payload(self, payload: Dict[str, Any]) -> None:
-        """Walk a verified Meta webhook payload and dispatch each message.
+        """Walk a verified Meta webhook payload and dispatch each message/call.
 
         Payload shape (truncated):
           {object, entry: [{id, changes: [{value: {messages, contacts,
-          statuses, metadata}, field: "messages"}]}]}
+          statuses, metadata}, field: "messages"|"calls"}]}]}
 
         We surface ``messages`` events as MessageEvents; ``statuses``
         events (sent/delivered/read/failed) are logged but not dispatched
         — the agent doesn't currently consume delivery receipts and
         forwarding them would create noisy synthetic events.
+
+        ``calls`` connect events are routed to the optional local WebRTC
+        sidecar when configured.
         """
         if payload.get("object") != "whatsapp_business_account":
             logger.debug(
@@ -1607,12 +1671,16 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             for change in entry.get("changes") or []:
                 if not isinstance(change, dict):
                     continue
-                if change.get("field") != "messages":
+                field = change.get("field")
+                value = change.get("value") or {}
+                if field == "calls":
+                    await self._dispatch_call_events(value)
+                    continue
+                if field != "messages":
                     # Other fields (account_alerts, template_status_update,
                     # etc.) are subscription-dependent and not message
                     # ingress. Silent skip.
                     continue
-                value = change.get("value") or {}
                 contacts = value.get("contacts") or []
                 metadata = value.get("metadata") or {}
                 # Build a wa_id → profile-name index for the messages we're
@@ -1674,6 +1742,90 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                             status.get("status"),
                             status.get("id"),
                         )
+
+    async def _dispatch_call_events(self, value: Dict[str, Any]) -> None:
+        """Handle WhatsApp Calling webhook events from a verified payload."""
+        for raw_call in value.get("calls") or []:
+            if not isinstance(raw_call, dict):
+                continue
+            event = str(raw_call.get("event") or "").strip().lower()
+            call_id = str(raw_call.get("id") or "").strip()
+            if event == "connect":
+                await self._handle_call_connect(raw_call)
+            elif event == "terminate":
+                logger.info(
+                    "[whatsapp_cloud] call terminated (call_id=%s, status=%s)",
+                    call_id,
+                    raw_call.get("status"),
+                )
+            else:
+                logger.debug(
+                    "[whatsapp_cloud] ignoring call event %r for %s",
+                    raw_call.get("event"),
+                    call_id,
+                )
+
+    async def _handle_call_connect(self, raw_call: Dict[str, Any]) -> None:
+        """Handle an inbound WhatsApp Calling connect offer."""
+        call_id = str(raw_call.get("id") or "").strip()
+        session = raw_call.get("session") or {}
+        if not isinstance(session, dict):
+            logger.warning(
+                "[whatsapp_cloud] call connect %s had non-object session",
+                call_id or "<missing>",
+            )
+            return
+
+        sdp_type = str(session.get("sdp_type") or "").strip().lower()
+        remote_sdp = str(session.get("sdp") or "")
+        if not call_id or sdp_type != "offer" or not remote_sdp.strip():
+            logger.warning(
+                "[whatsapp_cloud] ignoring malformed call connect "
+                "(call_id=%s, sdp_type=%s)",
+                call_id or "<missing>",
+                sdp_type or "<missing>",
+            )
+            return
+
+        if not self._calling_sidecar_enabled():
+            logger.info(
+                "[whatsapp_cloud] received call connect %s but no calling "
+                "sidecar is configured",
+                call_id,
+            )
+            return
+
+        answer = await self._request_calling_sidecar_answer(call_id, remote_sdp)
+        if answer is None:
+            logger.warning(
+                "[whatsapp_cloud] sidecar did not produce an SDP answer for %s",
+                call_id,
+            )
+            return
+
+        pre_accept = await self._send_call_action(
+            call_id,
+            "pre_accept",
+            sdp=answer.sdp,
+        )
+        if not pre_accept.success:
+            logger.warning(
+                "[whatsapp_cloud] pre_accept failed for %s: %s",
+                call_id,
+                pre_accept.error,
+            )
+            return
+
+        accept = await self._send_call_action(call_id, "accept", sdp=answer.sdp)
+        if not accept.success:
+            logger.warning(
+                "[whatsapp_cloud] accept failed for %s: %s",
+                call_id,
+                accept.error,
+            )
+            return
+
+        logger.info("[whatsapp_cloud] accepted call %s via calling sidecar", call_id)
 
     async def _dispatch_interactive_reply(
         self,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -37,6 +37,8 @@ Optional / Phase-3+:
 - WHATSAPP_CLOUD_WEBHOOK_PORT     (default 8090)
 - WHATSAPP_CLOUD_WEBHOOK_PATH     (default /whatsapp/webhook)
 - WHATSAPP_CLOUD_API_VERSION      (default v20.0)
+- WHATSAPP_CLOUD_CALLING_SIDECAR_URL      (optional WebRTC SDP bridge)
+- WHATSAPP_CLOUD_CALLING_SIDECAR_TIMEOUT  (default 10.0 seconds)
 """
 
 from __future__ import annotations
@@ -51,6 +53,7 @@ import re
 import shutil
 import uuid
 from collections import OrderedDict
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -88,6 +91,7 @@ DEFAULT_API_VERSION = "v20.0"
 DEFAULT_WEBHOOK_HOST = "0.0.0.0"
 DEFAULT_WEBHOOK_PORT = 8090
 DEFAULT_WEBHOOK_PATH = "/whatsapp/webhook"
+DEFAULT_CALLING_SIDECAR_TIMEOUT = 10.0
 GRAPH_API_BASE = "https://graph.facebook.com"
 # Meta retries failed webhooks for up to 7 days. We don't need to remember
 # every wamid for the full retry window — the practical risk is duplicate
@@ -165,6 +169,15 @@ def _ext_for_mime(mime: str) -> Optional[str]:
 _INBOUND_MEDIA_CACHE = Path(get_hermes_dir("platforms/whatsapp_cloud/media", "whatsapp_cloud/media"))
 
 
+@dataclass(frozen=True)
+class CallingSidecarAnswer:
+    """Validated SDP answer returned by the local WhatsApp Calling sidecar."""
+
+    call_id: str
+    sdp: str
+    audio: Dict[str, Any]
+
+
 def check_whatsapp_cloud_requirements() -> bool:
     """Return whether transport dependencies are available.
 
@@ -214,13 +227,27 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         # Graph API
         self._api_version: str = str(extra.get("api_version", DEFAULT_API_VERSION))
 
+        # Optional WhatsApp Calling/WebRTC sidecar. This is intentionally
+        # separate from Graph API calls: the sidecar owns SDP/media bridging
+        # while the Cloud adapter remains the webhook/session boundary.
+        self._calling_sidecar_url: str = str(
+            extra.get("calling_sidecar_url")
+            or extra.get("callingSidecarUrl")
+            or os.getenv("WHATSAPP_CLOUD_CALLING_SIDECAR_URL")
+            or ""
+        ).strip().rstrip("/")
+        self._calling_sidecar_timeout: float = self._coerce_positive_float(
+            extra.get("calling_sidecar_timeout")
+            or extra.get("callingSidecarTimeout")
+            or os.getenv("WHATSAPP_CLOUD_CALLING_SIDECAR_TIMEOUT"),
+            DEFAULT_CALLING_SIDECAR_TIMEOUT,
+        )
+
         # Behavior-mixin contract: these names are read by the mixin's
         # gating methods. WHATSAPP_CLOUD_* env vars take precedence so the
         # two adapters can run in parallel with independent policies; the
         # shared WHATSAPP_* names remain as fallback for single-adapter
         # setups.
-        import os
-
         self._reply_prefix: Optional[str] = extra.get("reply_prefix")
         self._dm_policy: str = str(
             extra.get("dm_policy")
@@ -302,6 +329,104 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if path.startswith("/"):
             path = path[1:]
         return f"{GRAPH_API_BASE}/{self._api_version}/{self._phone_number_id}/{path}"
+
+    @staticmethod
+    def _coerce_positive_float(value: Any, default: float) -> float:
+        if value is None:
+            return default
+        try:
+            parsed = float(value)
+        except (TypeError, ValueError):
+            return default
+        return parsed if parsed > 0 else default
+
+    def _calling_sidecar_enabled(self) -> bool:
+        return bool(self._calling_sidecar_url)
+
+    async def _request_calling_sidecar_answer(
+        self,
+        call_id: str,
+        remote_sdp: str,
+    ) -> Optional[CallingSidecarAnswer]:
+        """Ask the configured local WebRTC sidecar for an SDP answer.
+
+        The sidecar contract mirrors the voice repo's prototype:
+        POST /offer with {"call_id", "type": "offer", "sdp"} and expect
+        {"type": "answer", "sdp": "...", "audio": {...}}. Full Meta
+        Calling webhook handling can call this once it has extracted the
+        inbound offer.
+        """
+        if not self._calling_sidecar_enabled():
+            return None
+        if self._http_client is None:
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar configured but HTTP client "
+                "is unavailable"
+            )
+            return None
+
+        normalized_call_id = str(call_id or "").strip()
+        remote_sdp_text = str(remote_sdp or "")
+        if not normalized_call_id or not remote_sdp_text.strip():
+            logger.warning(
+                "[whatsapp_cloud] refusing calling sidecar request with empty "
+                "call_id or sdp"
+            )
+            return None
+
+        url = f"{self._calling_sidecar_url}/offer"
+        payload = {
+            "call_id": normalized_call_id,
+            "type": "offer",
+            "sdp": remote_sdp_text,
+        }
+        try:
+            resp = await self._http_client.post(
+                url,
+                json=payload,
+                timeout=self._calling_sidecar_timeout,
+            )
+        except Exception:
+            logger.exception("[whatsapp_cloud] calling sidecar offer request failed")
+            return None
+
+        if resp.status_code != 200:
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar rejected offer "
+                "(status=%d): %s",
+                resp.status_code,
+                str(getattr(resp, "text", ""))[:500],
+            )
+            return None
+
+        try:
+            data = resp.json()
+        except Exception:
+            logger.warning("[whatsapp_cloud] calling sidecar returned invalid JSON")
+            return None
+
+        if not isinstance(data, dict):
+            logger.warning("[whatsapp_cloud] calling sidecar response is not an object")
+            return None
+        if data.get("type") != "answer":
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar response type was %r, not 'answer'",
+                data.get("type"),
+            )
+            return None
+
+        sdp = str(data.get("sdp") or "")
+        if not sdp.strip():
+            logger.warning("[whatsapp_cloud] calling sidecar answer missing sdp")
+            return None
+
+        audio = data.get("audio")
+        answer_call_id = str(data.get("call_id") or "").strip() or normalized_call_id
+        return CallingSidecarAnswer(
+            call_id=answer_call_id,
+            sdp=sdp,
+            audio=audio if isinstance(audio, dict) else {},
+        )
 
     @staticmethod
     def _bounded_put(cache: "OrderedDict[str, str]", key: str, value: str) -> None:
@@ -1312,6 +1437,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "webhook_path": self._webhook_path,
                 "verify_token_configured": bool(self._verify_token),
                 "app_secret_configured": bool(self._app_secret),
+                "calling_sidecar_configured": self._calling_sidecar_enabled(),
                 "ffmpeg_present": _FFMPEG_PATH is not None,
                 "accepted": self._accepted_count,
                 "duplicates": self._duplicate_count,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -287,6 +287,10 @@ class CallingSidecarAudio:
     returned_bytes: int
     queued_rx_bytes: int
     audio: Dict[str, Any]
+    returned_ms: Optional[int] = None
+    queued_rx_ms: Optional[int] = None
+    max_rx_queue_bytes: Optional[int] = None
+    max_rx_queue_ms: Optional[int] = None
 
 
 def check_whatsapp_cloud_requirements() -> bool:
@@ -512,6 +516,42 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             return False
         spec = endpoints.get(endpoint)
         return isinstance(spec, dict) and bool(str(spec.get("path") or "").strip())
+
+    @staticmethod
+    def _calling_sidecar_optional_nonnegative_int(
+        data: Dict[str, Any],
+        key: str,
+    ) -> Optional[int]:
+        if key not in data or data.get(key) is None:
+            return None
+        try:
+            value = int(data[key])
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{key} must be an integer") from exc
+        if value < 0:
+            raise ValueError(f"{key} must be non-negative")
+        return value
+
+    @classmethod
+    def _normalize_calling_sidecar_telemetry(
+        cls,
+        body: Any,
+        fields: tuple[str, ...],
+    ) -> tuple[Any, Optional[str]]:
+        if not isinstance(body, dict):
+            return body, None
+        normalized = dict(body)
+        for field in fields:
+            try:
+                value = cls._calling_sidecar_optional_nonnegative_int(
+                    normalized,
+                    field,
+                )
+            except ValueError as exc:
+                return body, str(exc)
+            if value is not None:
+                normalized[field] = value
+        return normalized, None
 
     async def _ensure_calling_sidecar_contract(self) -> Optional[Dict[str, Any]]:
         """Fetch the optional sidecar contract once per adapter lifetime."""
@@ -776,6 +816,24 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 retryable=resp.status_code == 429,
             )
 
+        body, telemetry_error = self._normalize_calling_sidecar_telemetry(
+            body,
+            (
+                "accepted_bytes",
+                "accepted_ms",
+                "queued_tx_bytes",
+                "queued_tx_ms",
+                "max_tx_queue_bytes",
+                "max_tx_queue_ms",
+            ),
+        )
+        if telemetry_error:
+            return SendResult(
+                success=False,
+                error=f"calling sidecar audio telemetry invalid: {telemetry_error}",
+                raw_response=body,
+            )
+
         return SendResult(success=True, raw_response=body)
 
     async def _clear_calling_sidecar_audio(self, call_id: str) -> SendResult:
@@ -834,6 +892,27 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 error=error_msg,
                 raw_response=body,
                 retryable=resp.status_code == 429,
+            )
+
+        body, telemetry_error = self._normalize_calling_sidecar_telemetry(
+            body,
+            (
+                "dropped_tx_bytes",
+                "dropped_tx_ms",
+                "queued_tx_bytes",
+                "queued_tx_ms",
+                "max_tx_queue_bytes",
+                "max_tx_queue_ms",
+            ),
+        )
+        if telemetry_error:
+            return SendResult(
+                success=False,
+                error=(
+                    "calling sidecar audio clear telemetry invalid: "
+                    f"{telemetry_error}"
+                ),
+                raw_response=body,
             )
 
         return SendResult(success=True, raw_response=body)
@@ -1293,6 +1372,29 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "[whatsapp_cloud] calling sidecar audio drain had invalid byte counts"
             )
             return None
+        try:
+            returned_ms = self._calling_sidecar_optional_nonnegative_int(
+                data,
+                "returned_ms",
+            )
+            queued_rx_ms = self._calling_sidecar_optional_nonnegative_int(
+                data,
+                "queued_rx_ms",
+            )
+            max_rx_queue_bytes = self._calling_sidecar_optional_nonnegative_int(
+                data,
+                "max_rx_queue_bytes",
+            )
+            max_rx_queue_ms = self._calling_sidecar_optional_nonnegative_int(
+                data,
+                "max_rx_queue_ms",
+            )
+        except ValueError as exc:
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar audio drain had invalid telemetry: %s",
+                exc,
+            )
+            return None
         if returned_bytes != len(pcm):
             logger.warning(
                 "[whatsapp_cloud] calling sidecar audio drain byte count mismatch "
@@ -1330,6 +1432,10 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             returned_bytes=returned_bytes,
             queued_rx_bytes=queued_rx_bytes,
             audio=audio,
+            returned_ms=returned_ms,
+            queued_rx_ms=queued_rx_ms,
+            max_rx_queue_bytes=max_rx_queue_bytes,
+            max_rx_queue_ms=max_rx_queue_ms,
         )
 
     def _write_calling_sidecar_pcm_wav(self, call_id: str, pcm_s16le: bytes) -> str:

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -1098,20 +1098,23 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         """Send an audio file as a WhatsApp voice message.
 
         WhatsApp renders ``audio/ogg; codecs=opus`` as the green
-        voice-note bubble; other audio types (MP3, AAC, etc.) appear as
-        a generic audio attachment. Hermes TTS produces MP3, so we try
-        ffmpeg conversion to opus first and fall back to sending the
-        MP3 as-is when ffmpeg is unavailable.
+        voice-note bubble; other audio types (MP3, WAV, AAC, etc.) appear as
+        a generic audio attachment. Hermes TTS providers may produce any
+        supported audio container, so we try ffmpeg conversion to Opus first
+        for local non-Opus files and fall back to sending the original audio
+        when ffmpeg is unavailable.
         """
         source = audio_path
         mime_type: Optional[str] = None
 
-        is_local_mp3 = (
+        is_local_file = (
             not audio_path.startswith(("http://", "https://"))
-            and audio_path.lower().endswith(".mp3")
             and os.path.exists(audio_path)
         )
-        if is_local_mp3:
+        suffix = Path(audio_path).suffix.lower()
+        is_opus_voice = suffix in {".ogg", ".opus"}
+
+        if is_local_file and not is_opus_voice:
             opus_path = await self._convert_to_opus(audio_path)
             if opus_path:
                 try:
@@ -1129,9 +1132,12 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     except OSError:
                         pass
                 return result
-            # Will deliver as MP3 attachment, not voice bubble.
+            # Will deliver as a plain audio attachment, not a voice bubble.
             # Warn-once is logged inside _convert_to_opus.
-            mime_type = "audio/mpeg"
+            if suffix == ".mp3":
+                mime_type = "audio/mpeg"
+        elif is_local_file and is_opus_voice:
+            mime_type = "audio/ogg; codecs=opus"
 
         return await self._send_media_from_path_or_link(
             chat_id, source, "audio",
@@ -1156,12 +1162,12 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         )
 
     # ------------------------------------------------------------------ opus conversion
-    async def _convert_to_opus(self, mp3_path: str) -> Optional[str]:
-        """Convert an MP3 to ``audio/ogg; codecs=opus`` for voice bubbles.
+    async def _convert_to_opus(self, audio_path: str) -> Optional[str]:
+        """Convert an audio file to ``audio/ogg; codecs=opus`` for voice bubbles.
 
         Returns the path to the converted file, or None if ffmpeg is
         missing / conversion fails (caller falls back to sending the
-        original MP3 as an audio file).
+        original audio file).
 
         ``-application voip`` tunes the opus encoder for speech.
         ``-b:a 32k -vbr on`` matches the bitrate WhatsApp produces for
@@ -1171,10 +1177,10 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             self._warn_once_no_ffmpeg()
             return None
 
-        out_path = mp3_path.rsplit(".", 1)[0] + ".ogg"
+        out_path = audio_path.rsplit(".", 1)[0] + ".ogg"
         try:
             proc = await asyncio.create_subprocess_exec(
-                _FFMPEG_PATH, "-y", "-i", mp3_path,
+                _FFMPEG_PATH, "-y", "-i", audio_path,
                 "-c:a", "libopus", "-b:a", "32k", "-vbr", "on",
                 "-application", "voip", out_path,
                 stdout=asyncio.subprocess.DEVNULL,
@@ -1200,7 +1206,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._warned_no_ffmpeg = True
         logger.warning(
             "[whatsapp_cloud] ffmpeg not found on PATH — voice messages will "
-            "be delivered as MP3 audio attachments instead of native voice "
+            "be delivered as audio attachments instead of native voice "
             "notes (green waveform bubble). Install ffmpeg to enable: "
             "Windows `winget install Gyan.FFmpeg`, macOS `brew install ffmpeg`, "
             "Linux package manager."

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -56,6 +56,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional
+from urllib.parse import quote
 
 try:
     from aiohttp import web
@@ -488,6 +489,51 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             return SendResult(success=False, error=error_msg)
 
         return SendResult(success=True)
+
+    async def _close_calling_sidecar_session(self, call_id: str) -> bool:
+        """Best-effort close for a local WebRTC sidecar call session."""
+        if not self._calling_sidecar_enabled():
+            return False
+        if self._http_client is None:
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar configured but HTTP client "
+                "is unavailable"
+            )
+            return False
+
+        normalized_call_id = str(call_id or "").strip()
+        if not normalized_call_id:
+            return False
+
+        encoded_call_id = quote(normalized_call_id, safe="")
+        url = f"{self._calling_sidecar_url}/calls/{encoded_call_id}/close"
+        try:
+            resp = await self._http_client.post(
+                url,
+                timeout=self._calling_sidecar_timeout,
+            )
+        except Exception:
+            logger.exception(
+                "[whatsapp_cloud] calling sidecar close request failed for %s",
+                normalized_call_id,
+            )
+            return False
+
+        if resp.status_code == 404:
+            logger.debug(
+                "[whatsapp_cloud] sidecar had no session for terminated call %s",
+                normalized_call_id,
+            )
+            return True
+        if resp.status_code != 200:
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar close rejected "
+                "(status=%d): %s",
+                resp.status_code,
+                str(getattr(resp, "text", ""))[:500],
+            )
+            return False
+        return True
 
     @staticmethod
     def _bounded_put(cache: "OrderedDict[str, str]", key: str, value: str) -> None:
@@ -1753,6 +1799,8 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if event == "connect":
                 await self._handle_call_connect(raw_call)
             elif event == "terminate":
+                if call_id:
+                    await self._close_calling_sidecar_session(call_id)
                 logger.info(
                     "[whatsapp_cloud] call terminated (call_id=%s, status=%s)",
                     call_id,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -148,6 +148,12 @@ CALLING_AUDIO_CONTRACT = {
     "max_outbound_queue_bytes": CALLING_PCM_MAX_OUTBOUND_QUEUE_BYTES,
     "max_inbound_queue_bytes": CALLING_PCM_MAX_INBOUND_QUEUE_BYTES,
 }
+CALLING_SIDECAR_TX_QUEUE_FIELDS = (
+    "queued_tx_bytes",
+    "queued_tx_ms",
+    "max_tx_queue_bytes",
+    "max_tx_queue_ms",
+)
 GRAPH_API_BASE = "https://graph.facebook.com"
 # Meta retries failed webhooks for up to 7 days. We don't need to remember
 # every wamid for the full retry window — the practical risk is duplicate
@@ -552,6 +558,19 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if value is not None:
                 normalized[field] = value
         return normalized, None
+
+    @staticmethod
+    def _attach_calling_sidecar_tx_summary(
+        summary: Dict[str, Any],
+        raw_response: Any,
+    ) -> Dict[str, Any]:
+        if not isinstance(raw_response, dict):
+            return summary
+        summary["last_sidecar_response"] = raw_response
+        for field in CALLING_SIDECAR_TX_QUEUE_FIELDS:
+            if field in raw_response:
+                summary[field] = raw_response[field]
+        return summary
 
     async def _ensure_calling_sidecar_contract(self) -> Optional[Dict[str, Any]]:
         """Fetch the optional sidecar contract once per adapter lifetime."""
@@ -999,6 +1018,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         frame_bytes = int(audio["frame_bytes"])
         frame_ms = int(audio["frame_ms"])
         sequence = 0
+        last_sidecar_response: Any = None
         for offset in range(0, len(pcm), frame_bytes):
             frame = pcm[offset : offset + frame_bytes]
             if len(frame) < frame_bytes:
@@ -1019,18 +1039,23 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if not result.success:
                 return result
 
+            last_sidecar_response = result.raw_response
             sequence += 1
             if offset + frame_bytes < len(pcm):
                 await asyncio.sleep(frame_ms / 1_000)
 
-        return SendResult(
-            success=True,
-            raw_response={
+        raw_response = self._attach_calling_sidecar_tx_summary(
+            {
                 "call_id": call_id,
                 "queued_pcm_bytes": len(pcm),
                 "frames": sequence,
                 "audio": audio,
             },
+            last_sidecar_response,
+        )
+        return SendResult(
+            success=True,
+            raw_response=raw_response,
         )
 
     async def _send_calling_sidecar_tts_stream_command(
@@ -1163,6 +1188,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             sequence = 0
             accepted_bytes = 0
             next_frame_at: Optional[float] = None
+            last_sidecar_response: Any = None
 
             async def pace_frame() -> None:
                 """Keep sidecar outbound audio close to WebRTC playback time."""
@@ -1196,6 +1222,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                             await terminate_process(proc)
                             await cancel_stderr_task()
                             return result
+                        last_sidecar_response = result.raw_response
                         sequence += 1
                         accepted_bytes += len(frame)
 
@@ -1208,6 +1235,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         await terminate_process(proc)
                         await cancel_stderr_task()
                         return result
+                    last_sidecar_response = result.raw_response
                     sequence += 1
                     accepted_bytes += len(pending)
 
@@ -1243,14 +1271,18 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     error="TTS stream command produced no PCM frames",
                 )
 
-        return SendResult(
-            success=True,
-            raw_response={
+        raw_response = self._attach_calling_sidecar_tx_summary(
+            {
                 "call_id": normalized_call_id,
                 "queued_pcm_bytes": accepted_bytes,
                 "frames": sequence,
                 "audio": audio,
             },
+            last_sidecar_response,
+        )
+        return SendResult(
+            success=True,
+            raw_response=raw_response,
         )
 
     async def play_tts_text(

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -589,9 +589,17 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             )
             return None
 
-        answer_call_id = str(data.get("call_id") or "").strip() or normalized_call_id
+        answer_call_id = str(data.get("call_id") or "").strip()
+        if answer_call_id and answer_call_id != normalized_call_id:
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar answer call_id mismatch "
+                "(expected=%s, got=%s)",
+                normalized_call_id,
+                answer_call_id,
+            )
+            return None
         return CallingSidecarAnswer(
-            call_id=answer_call_id,
+            call_id=normalized_call_id,
             sdp=sdp,
             audio=audio,
         )
@@ -793,9 +801,17 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             )
             return None
 
-        answer_call_id = str(data.get("call_id") or "").strip() or normalized_call_id
+        answer_call_id = str(data.get("call_id") or "").strip()
+        if answer_call_id and answer_call_id != normalized_call_id:
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar audio drain call_id mismatch "
+                "(expected=%s, got=%s)",
+                normalized_call_id,
+                answer_call_id,
+            )
+            return None
         return CallingSidecarAudio(
-            call_id=answer_call_id,
+            call_id=normalized_call_id,
             pcm_s16le=pcm,
             returned_bytes=returned_bytes,
             queued_rx_bytes=queued_rx_bytes,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -1083,6 +1083,21 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             pending = bytearray()
             sequence = 0
             accepted_bytes = 0
+            next_frame_at: Optional[float] = None
+
+            async def pace_frame() -> None:
+                """Keep sidecar outbound audio close to WebRTC playback time."""
+                nonlocal next_frame_at
+                loop = asyncio.get_running_loop()
+                now = loop.time()
+                frame_interval = frame_ms / 1_000
+                if next_frame_at is None:
+                    next_frame_at = now + frame_interval
+                    return
+                if now < next_frame_at:
+                    await asyncio.sleep(next_frame_at - now)
+                    now = loop.time()
+                next_frame_at = max(next_frame_at, now) + frame_interval
 
             try:
                 while True:
@@ -1096,6 +1111,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     while len(pending) >= frame_bytes:
                         frame = bytes(pending[:frame_bytes])
                         del pending[:frame_bytes]
+                        await pace_frame()
                         result = await send_frame(frame, sequence)
                         if not result.success:
                             await terminate_process(proc)
@@ -1107,6 +1123,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 if pending:
                     frame = bytes(pending)
                     frame += b"\x00" * (frame_bytes - len(frame))
+                    await pace_frame()
                     result = await send_frame(frame, sequence)
                     if not result.success:
                         await terminate_process(proc)

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -44,6 +44,7 @@ Optional / Phase-3+:
 from __future__ import annotations
 
 import asyncio
+import base64
 import hashlib
 import hmac
 import logging
@@ -93,6 +94,10 @@ DEFAULT_WEBHOOK_HOST = "0.0.0.0"
 DEFAULT_WEBHOOK_PORT = 8090
 DEFAULT_WEBHOOK_PATH = "/whatsapp/webhook"
 DEFAULT_CALLING_SIDECAR_TIMEOUT = 10.0
+CALLING_PCM_SAMPLE_RATE = 48_000
+CALLING_PCM_CHANNELS = 1
+CALLING_PCM_FRAME_MS = 20
+CALLING_PCM_ENCODING = "pcm_s16le"
 GRAPH_API_BASE = "https://graph.facebook.com"
 # Meta retries failed webhooks for up to 7 days. We don't need to remember
 # every wamid for the full retry window — the practical risk is duplicate
@@ -428,6 +433,80 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             sdp=sdp,
             audio=audio if isinstance(audio, dict) else {},
         )
+
+    async def _send_calling_sidecar_audio(
+        self,
+        call_id: str,
+        pcm_s16le: bytes,
+        *,
+        sequence: Optional[int] = None,
+    ) -> SendResult:
+        """Queue outbound 48 kHz 20 ms PCM for a local WebRTC sidecar call."""
+        if not self._calling_sidecar_enabled():
+            return SendResult(success=False, error="Calling sidecar not configured")
+        if self._http_client is None:
+            return SendResult(success=False, error="Not connected")
+
+        normalized_call_id = str(call_id or "").strip()
+        if not normalized_call_id:
+            return SendResult(success=False, error="Missing call_id")
+        if not isinstance(pcm_s16le, (bytes, bytearray, memoryview)):
+            return SendResult(success=False, error="PCM payload must be bytes")
+
+        pcm_bytes = bytes(pcm_s16le)
+        if not pcm_bytes:
+            return SendResult(success=False, error="PCM payload is empty")
+        if len(pcm_bytes) % 2:
+            return SendResult(
+                success=False,
+                error="PCM payload must contain whole s16le samples",
+            )
+
+        encoded_call_id = quote(normalized_call_id, safe="")
+        url = f"{self._calling_sidecar_url}/calls/{encoded_call_id}/audio"
+        payload: Dict[str, Any] = {
+            "sample_rate": CALLING_PCM_SAMPLE_RATE,
+            "channels": CALLING_PCM_CHANNELS,
+            "frame_ms": CALLING_PCM_FRAME_MS,
+            "encoding": CALLING_PCM_ENCODING,
+            "pcm_s16le_base64": base64.b64encode(pcm_bytes).decode("ascii"),
+        }
+        if sequence is not None:
+            payload["sequence"] = sequence
+
+        try:
+            resp = await self._http_client.post(
+                url,
+                json=payload,
+                timeout=self._calling_sidecar_timeout,
+            )
+        except Exception as exc:
+            logger.exception(
+                "[whatsapp_cloud] calling sidecar audio request failed for %s",
+                normalized_call_id,
+            )
+            return SendResult(success=False, error=str(exc), retryable=True)
+
+        try:
+            body = resp.json()
+        except Exception:
+            body = {"raw": str(getattr(resp, "text", ""))[:500]}
+
+        if resp.status_code != 200:
+            error_msg = ""
+            if isinstance(body, dict):
+                error_msg = str(body.get("error") or "")
+            if not error_msg:
+                error_msg = f"calling sidecar audio failed with HTTP {resp.status_code}"
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar audio rejected "
+                "(status=%d): %s",
+                resp.status_code,
+                error_msg,
+            )
+            return SendResult(success=False, error=error_msg, raw_response=body)
+
+        return SendResult(success=True, raw_response=body)
 
     async def _send_call_action(
         self,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -19,9 +19,9 @@ Phase scope (this file evolves across phases):
             + wamid replay protection + dispatch via handle_message. Phase 3
             adapter is end-to-end usable for text DMs.
 - Phase 4 — media upload + send (image/video/audio/document), inbound
-            media download via the Graph media endpoint, voice-note opus
-            conversion via ffmpeg with graceful MP3 fallback when ffmpeg
-            isn't on PATH. Document text injection for readable types.
+            media download via the Graph media endpoint, voice-note Ogg/Opus
+            pass-through with ffmpeg conversion fallback when needed.
+            Document text injection for readable types.
 - Phase 5 — 24-hour conversation window + template fallback.
 
 Required env vars to enable the adapter:
@@ -179,9 +179,12 @@ _DEFAULT_MIME = {
     "sticker": "image/webp",
 }
 
+_WHATSAPP_OPUS_MIME = "audio/ogg; codecs=opus"
+_WHATSAPP_OPUS_EXTENSIONS = (".ogg", ".opus")
+
 # ffmpeg location at import time. ``shutil.which`` honours PATHEXT on
-# Windows so a user's ``ffmpeg.exe`` is picked up. None means MP3 voice
-# falls back to "audio file attachment" rendering in WhatsApp.
+# Windows so a user's ``ffmpeg.exe`` is picked up. None means non-Opus
+# voice output falls back to "audio file attachment" rendering in WhatsApp.
 _FFMPEG_PATH = shutil.which("ffmpeg")
 
 # Python's mimetypes module returns RFC-correct but real-world-uncommon
@@ -2369,9 +2372,9 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
         WhatsApp renders ``audio/ogg; codecs=opus`` as the green
         voice-note bubble; other audio types (MP3, AAC, etc.) appear as
-        a generic audio attachment. Hermes TTS produces MP3, so we try
-        ffmpeg conversion to opus first and fall back to sending the
-        MP3 as-is when ffmpeg is unavailable.
+        a generic audio attachment. Existing Ogg/Opus files are uploaded
+        directly with the WhatsApp voice MIME; other local audio is
+        converted to Ogg/Opus with ffmpeg when available.
         """
         call_id = self._calling_sidecar_call_id_from_metadata(metadata)
         if call_id:
@@ -2380,32 +2383,33 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         source = audio_path
         mime_type: Optional[str] = None
 
-        is_local_mp3 = (
-            not audio_path.startswith(("http://", "https://"))
-            and audio_path.lower().endswith(".mp3")
-            and os.path.exists(audio_path)
-        )
-        if is_local_mp3:
+        is_remote = audio_path.startswith(("http://", "https://"))
+        is_local_existing = not is_remote and os.path.exists(audio_path)
+        lower_path = audio_path.lower()
+
+        if is_local_existing and lower_path.endswith(_WHATSAPP_OPUS_EXTENSIONS):
+            mime_type = _WHATSAPP_OPUS_MIME
+        elif is_local_existing:
             opus_path = await self._convert_to_opus(audio_path)
             if opus_path:
                 try:
                     result = await self._send_media_from_path_or_link(
                         chat_id, opus_path, "audio",
                         caption=caption, reply_to=reply_to,
-                        mime_type="audio/ogg; codecs=opus",
+                        mime_type=_WHATSAPP_OPUS_MIME,
                     )
                 finally:
-                    # The .ogg is a transient conversion artifact next to
-                    # the source MP3 — clean it up after upload so voice
-                    # sends don't leak a file per message.
+                    # The .ogg is a transient conversion artifact; clean
+                    # it up after upload so voice sends don't leak files.
                     try:
                         os.unlink(opus_path)
                     except OSError:
                         pass
                 return result
-            # Will deliver as MP3 attachment, not voice bubble.
+            # Will deliver as an audio attachment, not a voice bubble.
             # Warn-once is logged inside _convert_to_opus.
-            mime_type = "audio/mpeg"
+            if lower_path.endswith(".mp3"):
+                mime_type = "audio/mpeg"
 
         return await self._send_media_from_path_or_link(
             chat_id, source, "audio",
@@ -2430,12 +2434,12 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         )
 
     # ------------------------------------------------------------------ opus conversion
-    async def _convert_to_opus(self, mp3_path: str) -> Optional[str]:
-        """Convert an MP3 to ``audio/ogg; codecs=opus`` for voice bubbles.
+    async def _convert_to_opus(self, audio_path: str) -> Optional[str]:
+        """Convert audio to ``audio/ogg; codecs=opus`` for voice bubbles.
 
         Returns the path to the converted file, or None if ffmpeg is
         missing / conversion fails (caller falls back to sending the
-        original MP3 as an audio file).
+        original audio as an attachment).
 
         ``-application voip`` tunes the opus encoder for speech.
         ``-b:a 32k -vbr on`` matches the bitrate WhatsApp produces for
@@ -2445,10 +2449,16 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             self._warn_once_no_ffmpeg()
             return None
 
-        out_path = mp3_path.rsplit(".", 1)[0] + ".ogg"
+        out_file = tempfile.NamedTemporaryFile(
+            prefix="hermes_whatsapp_voice_",
+            suffix=".ogg",
+            delete=False,
+        )
+        out_path = out_file.name
+        out_file.close()
         try:
             proc = await asyncio.create_subprocess_exec(
-                _FFMPEG_PATH, "-y", "-i", mp3_path,
+                _FFMPEG_PATH, "-y", "-i", audio_path,
                 "-c:a", "libopus", "-b:a", "32k", "-vbr", "on",
                 "-application", "voip", out_path,
                 stdout=asyncio.subprocess.DEVNULL,
@@ -2462,10 +2472,18 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     proc.returncode,
                     (stderr or b"").decode("utf-8", errors="replace")[:500],
                 )
+                try:
+                    os.unlink(out_path)
+                except OSError:
+                    pass
                 return None
             return out_path
         except Exception:
             logger.exception("[whatsapp_cloud] ffmpeg subprocess raised")
+            try:
+                os.unlink(out_path)
+            except OSError:
+                pass
             return None
 
     def _warn_once_no_ffmpeg(self) -> None:
@@ -2474,7 +2492,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._warned_no_ffmpeg = True
         logger.warning(
             "[whatsapp_cloud] ffmpeg not found on PATH — voice messages will "
-            "be delivered as MP3 audio attachments instead of native voice "
+            "be delivered as audio attachments instead of native voice "
             "notes (green waveform bubble). Install ffmpeg to enable: "
             "Windows `winget install Gyan.FFmpeg`, macOS `brew install ffmpeg`, "
             "Linux package manager."

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -1180,6 +1180,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         try:
             proc = await asyncio.create_subprocess_exec(
                 _FFMPEG_PATH, "-y", "-i", audio_path,
+                "-ac", "1", "-ar", "48000",
                 "-c:a", "libopus", "-b:a", "32k", "-vbr", "on",
                 "-application", "voip", out_path,
                 stdout=asyncio.subprocess.DEVNULL,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -53,6 +53,7 @@ import mimetypes
 import os
 import re
 import shutil
+import wave
 import uuid
 from collections import OrderedDict
 from dataclasses import dataclass
@@ -85,6 +86,7 @@ from gateway.platforms.base import (
     SUPPORTED_DOCUMENT_TYPES,
 )
 from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin
+from gateway.session import SessionSource
 from hermes_constants import get_hermes_dir
 
 logger = logging.getLogger(__name__)
@@ -409,6 +411,8 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._runner = None
         self._http_client: Optional["httpx.AsyncClient"] = None
         self._calling_sidecar_call_ids: set[str] = set()
+        self._calling_sidecar_tasks: Dict[str, asyncio.Task] = {}
+        self._calling_sidecar_auto_tts_chats: Dict[str, str] = {}
 
     # ------------------------------------------------------------------ helpers
     @staticmethod
@@ -930,6 +934,173 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             audio=audio,
         )
 
+    def _write_calling_sidecar_pcm_wav(self, call_id: str, pcm_s16le: bytes) -> str:
+        """Persist decoded sidecar PCM as a WAV file for Hermes STT."""
+        if not pcm_s16le:
+            raise ValueError("pcm_s16le must not be empty")
+        if len(pcm_s16le) % CALLING_PCM_BYTES_PER_SAMPLE:
+            raise ValueError("pcm_s16le must contain whole s16le samples")
+
+        safe_call_id = re.sub(r"[^A-Za-z0-9._-]+", "_", call_id).strip("_")
+        if not safe_call_id:
+            safe_call_id = "call"
+        out_dir = _INBOUND_MEDIA_CACHE / "calls"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = out_dir / f"call_{safe_call_id}_{uuid.uuid4().hex[:12]}.wav"
+
+        with wave.open(str(out_path), "wb") as wav:
+            wav.setnchannels(CALLING_PCM_CHANNELS)
+            wav.setsampwidth(CALLING_PCM_BYTES_PER_SAMPLE)
+            wav.setframerate(CALLING_PCM_SAMPLE_RATE)
+            wav.writeframes(pcm_s16le)
+        return str(out_path)
+
+    async def _dispatch_calling_sidecar_pcm(
+        self,
+        call_id: str,
+        chat_id: str,
+        sender_name: str,
+        pcm_s16le: bytes,
+    ) -> None:
+        """Dispatch one decoded call-audio segment through Hermes STT."""
+        normalized_call_id = str(call_id or "").strip()
+        normalized_chat_id = str(chat_id or "").strip()
+        if not normalized_call_id or not normalized_chat_id or not pcm_s16le:
+            return
+
+        try:
+            wav_path = self._write_calling_sidecar_pcm_wav(
+                normalized_call_id,
+                pcm_s16le,
+            )
+        except Exception:
+            logger.exception(
+                "[whatsapp_cloud] failed to write call audio segment for %s",
+                normalized_call_id,
+            )
+            return
+
+        source = SessionSource(
+            platform=self.platform,
+            chat_id=normalized_chat_id,
+            user_id=normalized_chat_id,
+            user_name=sender_name or normalized_chat_id,
+            chat_type="dm",
+            thread_id=normalized_call_id,
+        )
+        event = MessageEvent(
+            source=source,
+            text="(The user sent a message with no text content)",
+            message_type=MessageType.VOICE,
+            raw_message={
+                "type": "whatsapp_call_audio",
+                "call_id": normalized_call_id,
+            },
+            message_id=f"{normalized_call_id}:{uuid.uuid4().hex[:12]}",
+            media_urls=[wav_path],
+            media_types=["audio/wav"],
+        )
+        await self.handle_message(event)
+
+    def _enable_calling_sidecar_auto_tts(self, call_id: str, chat_id: str) -> None:
+        """Temporarily force voice replies while a live call is active."""
+        if not chat_id:
+            return
+        enabled = getattr(self, "_auto_tts_enabled_chats", None)
+        if not isinstance(enabled, set):
+            return
+        if chat_id not in enabled:
+            enabled.add(chat_id)
+            self._calling_sidecar_auto_tts_chats[call_id] = chat_id
+
+    def _disable_calling_sidecar_auto_tts(self, call_id: str) -> None:
+        chat_id = self._calling_sidecar_auto_tts_chats.pop(call_id, None)
+        if not chat_id:
+            return
+        enabled = getattr(self, "_auto_tts_enabled_chats", None)
+        if isinstance(enabled, set):
+            enabled.discard(chat_id)
+
+    def _start_calling_sidecar_drain(
+        self,
+        call_id: str,
+        chat_id: str,
+        sender_name: str = "",
+    ) -> None:
+        """Start draining decoded inbound sidecar PCM into Hermes turns."""
+        normalized_call_id = str(call_id or "").strip()
+        normalized_chat_id = str(chat_id or "").strip()
+        if not normalized_call_id or not normalized_chat_id:
+            return
+        if self._message_handler is None:
+            return
+
+        self._enable_calling_sidecar_auto_tts(normalized_call_id, normalized_chat_id)
+        existing = self._calling_sidecar_tasks.get(normalized_call_id)
+        if existing is not None and not existing.done():
+            existing.cancel()
+
+        task = asyncio.create_task(
+            self._run_calling_sidecar_audio_loop(
+                normalized_call_id,
+                normalized_chat_id,
+                sender_name,
+            )
+        )
+        self._calling_sidecar_tasks[normalized_call_id] = task
+        task.add_done_callback(
+            lambda _task, _call_id=normalized_call_id: self._calling_sidecar_tasks.pop(
+                _call_id,
+                None,
+            )
+        )
+
+    async def _run_calling_sidecar_audio_loop(
+        self,
+        call_id: str,
+        chat_id: str,
+        sender_name: str,
+    ) -> None:
+        """Long-poll sidecar PCM and dispatch speech-ish chunks to Hermes."""
+        buffer = bytearray()
+        silent_polls = 0
+        segment_limit = CALLING_PCM_SAMPLE_RATE * CALLING_PCM_BYTES_PER_SAMPLE * 5
+
+        try:
+            while call_id in self._calling_sidecar_call_ids:
+                audio = await self._receive_calling_sidecar_audio(call_id)
+                if audio is not None and audio.pcm_s16le:
+                    buffer.extend(audio.pcm_s16le)
+                    silent_polls = 0
+                    if len(buffer) >= segment_limit:
+                        await self._dispatch_calling_sidecar_pcm(
+                            call_id,
+                            chat_id,
+                            sender_name,
+                            bytes(buffer),
+                        )
+                        buffer.clear()
+                    continue
+
+                if buffer:
+                    silent_polls += 1
+                    if silent_polls >= 2:
+                        await self._dispatch_calling_sidecar_pcm(
+                            call_id,
+                            chat_id,
+                            sender_name,
+                            bytes(buffer),
+                        )
+                        buffer.clear()
+                        silent_polls = 0
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception(
+                "[whatsapp_cloud] calling sidecar audio loop failed for %s",
+                call_id,
+            )
+
     async def _send_call_action(
         self,
         call_id: str,
@@ -993,6 +1164,16 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
     async def _close_calling_sidecar_session(self, call_id: str) -> bool:
         """Best-effort close for a local WebRTC sidecar call session."""
+        normalized_call_id = str(call_id or "").strip()
+        if not normalized_call_id:
+            return False
+
+        task = self._calling_sidecar_tasks.pop(normalized_call_id, None)
+        if task is not None and not task.done():
+            task.cancel()
+        self._disable_calling_sidecar_auto_tts(normalized_call_id)
+        self._calling_sidecar_call_ids.discard(normalized_call_id)
+
         if not self._calling_sidecar_enabled():
             return False
         if self._http_client is None:
@@ -1000,10 +1181,6 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "[whatsapp_cloud] calling sidecar configured but HTTP client "
                 "is unavailable"
             )
-            return False
-
-        normalized_call_id = str(call_id or "").strip()
-        if not normalized_call_id:
             return False
 
         encoded_call_id = quote(normalized_call_id, safe="")
@@ -2306,13 +2483,23 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
     async def _dispatch_call_events(self, value: Dict[str, Any]) -> None:
         """Handle WhatsApp Calling webhook events from a verified payload."""
+        contacts_by_waid: Dict[str, str] = {}
+        for contact in value.get("contacts") or []:
+            if not isinstance(contact, dict):
+                continue
+            wa_id = str(contact.get("wa_id") or "").strip()
+            profile = contact.get("profile") or {}
+            name = str(profile.get("name") or "").strip()
+            if wa_id:
+                contacts_by_waid[wa_id] = name
+
         for raw_call in value.get("calls") or []:
             if not isinstance(raw_call, dict):
                 continue
             event = str(raw_call.get("event") or "").strip().lower()
             call_id = str(raw_call.get("id") or "").strip()
             if event == "connect":
-                await self._handle_call_connect(raw_call)
+                await self._handle_call_connect(raw_call, contacts_by_waid)
             elif event == "terminate":
                 if call_id:
                     await self._close_calling_sidecar_session(call_id)
@@ -2328,7 +2515,11 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     call_id,
                 )
 
-    async def _handle_call_connect(self, raw_call: Dict[str, Any]) -> None:
+    async def _handle_call_connect(
+        self,
+        raw_call: Dict[str, Any],
+        contacts_by_waid: Optional[Dict[str, str]] = None,
+    ) -> None:
         """Handle an inbound WhatsApp Calling connect offer."""
         call_id = str(raw_call.get("id") or "").strip()
         session = raw_call.get("session") or {}
@@ -2400,6 +2591,9 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             return
 
         logger.info("[whatsapp_cloud] accepted call %s via calling sidecar", call_id)
+        chat_id = str(raw_call.get("from") or "").strip()
+        sender_name = (contacts_by_waid or {}).get(chat_id, "")
+        self._start_calling_sidecar_drain(call_id, chat_id, sender_name)
 
     async def _dispatch_interactive_reply(
         self,

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -111,6 +111,9 @@ CALLING_PCM_DEFAULT_DRAIN_BYTES = (
 )
 CALLING_PCM_DRAIN_WAIT_MS = 500
 CALLING_PCM_MAX_DRAIN_WAIT_MS = 5_000
+CALLING_PCM_MAX_OUTBOUND_QUEUE_BYTES = (
+    CALLING_PCM_SAMPLE_RATE * CALLING_PCM_CHANNELS * CALLING_PCM_BYTES_PER_SAMPLE * 10
+)
 CALLING_PCM_ENCODING = "pcm_s16le"
 CALLING_AUDIO_CONTRACT = {
     "sample_rate": CALLING_PCM_SAMPLE_RATE,
@@ -122,6 +125,7 @@ CALLING_AUDIO_CONTRACT = {
     "frame_bytes": CALLING_PCM_FRAME_BYTES,
     "default_drain_bytes": CALLING_PCM_DEFAULT_DRAIN_BYTES,
     "max_drain_wait_ms": CALLING_PCM_MAX_DRAIN_WAIT_MS,
+    "max_outbound_queue_bytes": CALLING_PCM_MAX_OUTBOUND_QUEUE_BYTES,
 }
 GRAPH_API_BASE = "https://graph.facebook.com"
 # Meta retries failed webhooks for up to 7 days. We don't need to remember
@@ -212,6 +216,24 @@ def _matches_calling_audio_contract(audio: Any) -> bool:
         and frame_ms == CALLING_PCM_FRAME_MS
         and encoding == CALLING_PCM_ENCODING
     )
+
+
+def _normalize_calling_audio_contract(audio: Dict[str, Any]) -> Dict[str, Any]:
+    """Fill optional sidecar contract fields with Hermes' local defaults."""
+    normalized = dict(audio)
+    normalized.setdefault("bytes_per_sample", CALLING_PCM_BYTES_PER_SAMPLE)
+    normalized.setdefault(
+        "samples_per_frame",
+        CALLING_PCM_SAMPLE_RATE * CALLING_PCM_FRAME_MS // 1_000,
+    )
+    normalized.setdefault("frame_bytes", CALLING_PCM_FRAME_BYTES)
+    normalized.setdefault("default_drain_bytes", CALLING_PCM_DEFAULT_DRAIN_BYTES)
+    normalized.setdefault("max_drain_wait_ms", CALLING_PCM_MAX_DRAIN_WAIT_MS)
+    normalized.setdefault(
+        "max_outbound_queue_bytes",
+        CALLING_PCM_MAX_OUTBOUND_QUEUE_BYTES,
+    )
+    return normalized
 
 
 # Inbound media cache lives under the user's hermes dir so it survives
@@ -469,6 +491,8 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "Hermes PCM settings"
             )
             return None
+        data = dict(data)
+        data["audio"] = _normalize_calling_audio_contract(data["audio"])
         return data
 
     async def _request_calling_sidecar_answer(
@@ -626,14 +650,24 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if isinstance(body, dict):
                 error_msg = str(body.get("error") or "")
             if not error_msg:
-                error_msg = f"calling sidecar audio failed with HTTP {resp.status_code}"
+                if resp.status_code == 429:
+                    error_msg = "calling sidecar audio backpressure"
+                else:
+                    error_msg = (
+                        f"calling sidecar audio failed with HTTP {resp.status_code}"
+                    )
             logger.warning(
                 "[whatsapp_cloud] calling sidecar audio rejected "
                 "(status=%d): %s",
                 resp.status_code,
                 error_msg,
             )
-            return SendResult(success=False, error=error_msg, raw_response=body)
+            return SendResult(
+                success=False,
+                error=error_msg,
+                raw_response=body,
+                retryable=resp.status_code == 429,
+            )
 
         return SendResult(success=True, raw_response=body)
 

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -135,6 +135,7 @@ CALLING_PCM_MIN_DISPATCH_BYTES = (
     CALLING_PCM_SAMPLE_RATE * CALLING_PCM_CHANNELS * CALLING_PCM_BYTES_PER_SAMPLE // 4
 )
 CALLING_PCM_TRAILING_SILENCE_POLLS = 2
+CALLING_SIDECAR_EMPTY_DRAIN_BACKOFF_SECONDS = 0.05
 CALLING_AUDIO_CONTRACT = {
     "sample_rate": CALLING_PCM_SAMPLE_RATE,
     "channels": CALLING_PCM_CHANNELS,
@@ -1707,6 +1708,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         buffer.clear()
                         silent_polls = 0
                         cleared_outbound_for_segment = False
+                await asyncio.sleep(CALLING_SIDECAR_EMPTY_DRAIN_BACKOFF_SECONDS)
         except asyncio.CancelledError:
             raise
         except Exception:

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -419,6 +419,8 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         # Runtime
         self._runner = None
         self._http_client: Optional["httpx.AsyncClient"] = None
+        self._calling_sidecar_contract: Optional[Dict[str, Any]] = None
+        self._calling_sidecar_contract_checked: bool = False
         self._calling_sidecar_call_ids: set[str] = set()
         self._calling_sidecar_tasks: Dict[str, asyncio.Task] = {}
         self._calling_sidecar_auto_tts_chats: Dict[str, str] = {}
@@ -447,6 +449,47 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
     def _calling_sidecar_enabled(self) -> bool:
         return bool(self._calling_sidecar_url)
+
+    def _calling_sidecar_audio_contract(self) -> Dict[str, Any]:
+        """Return the cached sidecar audio shape or Hermes' legacy default."""
+        contract = getattr(self, "_calling_sidecar_contract", None)
+        if isinstance(contract, dict):
+            audio = contract.get("audio")
+            if isinstance(audio, dict) and _matches_calling_audio_contract(audio):
+                return _normalize_calling_audio_contract(audio)
+        return dict(CALLING_AUDIO_CONTRACT)
+
+    def _calling_sidecar_endpoint_url(
+        self,
+        endpoint: str,
+        default_path: str,
+        *,
+        call_id: Optional[str] = None,
+    ) -> str:
+        """Build a sidecar URL from the cached contract with legacy fallback."""
+        path = default_path
+        contract = getattr(self, "_calling_sidecar_contract", None)
+        endpoints = contract.get("endpoints") if isinstance(contract, dict) else None
+        if isinstance(endpoints, dict):
+            spec = endpoints.get(endpoint)
+            if isinstance(spec, dict):
+                candidate = str(spec.get("path") or "").strip()
+                if candidate:
+                    path = candidate
+
+        if call_id is not None:
+            path = path.replace("{call_id}", quote(call_id, safe=""))
+        if not path.startswith("/"):
+            path = f"/{path}"
+        return f"{self._calling_sidecar_url}{path}"
+
+    async def _ensure_calling_sidecar_contract(self) -> Optional[Dict[str, Any]]:
+        """Fetch the optional sidecar contract once per adapter lifetime."""
+        if getattr(self, "_calling_sidecar_contract_checked", False):
+            return getattr(self, "_calling_sidecar_contract", None)
+        self._calling_sidecar_contract_checked = True
+        self._calling_sidecar_contract = await self._request_calling_sidecar_contract()
+        return self._calling_sidecar_contract
 
     async def _request_calling_sidecar_contract(self) -> Optional[Dict[str, Any]]:
         """Fetch and validate the local sidecar's optional machine contract."""
@@ -548,7 +591,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             )
             return None
 
-        url = f"{self._calling_sidecar_url}/offer"
+        url = self._calling_sidecar_endpoint_url("offer", "/offer")
         payload = {
             "call_id": normalized_call_id,
             "type": "offer",
@@ -645,13 +688,17 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 error="PCM payload must contain whole s16le samples",
             )
 
-        encoded_call_id = quote(normalized_call_id, safe="")
-        url = f"{self._calling_sidecar_url}/calls/{encoded_call_id}/audio"
+        audio = self._calling_sidecar_audio_contract()
+        url = self._calling_sidecar_endpoint_url(
+            "send_audio",
+            "/calls/{call_id}/audio",
+            call_id=normalized_call_id,
+        )
         payload: Dict[str, Any] = {
-            "sample_rate": CALLING_PCM_SAMPLE_RATE,
-            "channels": CALLING_PCM_CHANNELS,
-            "frame_ms": CALLING_PCM_FRAME_MS,
-            "encoding": CALLING_PCM_ENCODING,
+            "sample_rate": int(audio["sample_rate"]),
+            "channels": int(audio["channels"]),
+            "frame_ms": int(audio["frame_ms"]),
+            "encoding": str(audio["encoding"]),
             "pcm_s16le_base64": base64.b64encode(pcm_bytes).decode("ascii"),
         }
         if sequence is not None:
@@ -726,6 +773,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if not _FFMPEG_PATH:
             return None, "ffmpeg is required to decode TTS audio for live calls"
 
+        audio = self._calling_sidecar_audio_contract()
         proc = await asyncio.create_subprocess_exec(
             _FFMPEG_PATH,
             "-v",
@@ -737,9 +785,9 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             "-acodec",
             "pcm_s16le",
             "-ar",
-            str(CALLING_PCM_SAMPLE_RATE),
+            str(int(audio["sample_rate"])),
             "-ac",
-            str(CALLING_PCM_CHANNELS),
+            str(int(audio["channels"])),
             "pipe:1",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
@@ -778,11 +826,14 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         if not pcm:
             return SendResult(success=False, error="No PCM decoded from TTS audio")
 
+        audio = self._calling_sidecar_audio_contract()
+        frame_bytes = int(audio["frame_bytes"])
+        frame_ms = int(audio["frame_ms"])
         sequence = 0
-        for offset in range(0, len(pcm), CALLING_PCM_FRAME_BYTES):
-            frame = pcm[offset : offset + CALLING_PCM_FRAME_BYTES]
-            if len(frame) < CALLING_PCM_FRAME_BYTES:
-                frame += b"\x00" * (CALLING_PCM_FRAME_BYTES - len(frame))
+        for offset in range(0, len(pcm), frame_bytes):
+            frame = pcm[offset : offset + frame_bytes]
+            if len(frame) < frame_bytes:
+                frame += b"\x00" * (frame_bytes - len(frame))
 
             result = await self._send_calling_sidecar_audio(
                 call_id,
@@ -790,7 +841,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 sequence=sequence,
             )
             if not result.success and result.retryable:
-                await asyncio.sleep(CALLING_PCM_FRAME_MS / 1_000)
+                await asyncio.sleep(frame_ms / 1_000)
                 result = await self._send_calling_sidecar_audio(
                     call_id,
                     frame,
@@ -800,8 +851,8 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 return result
 
             sequence += 1
-            if offset + CALLING_PCM_FRAME_BYTES < len(pcm):
-                await asyncio.sleep(CALLING_PCM_FRAME_MS / 1_000)
+            if offset + frame_bytes < len(pcm):
+                await asyncio.sleep(frame_ms / 1_000)
 
         return SendResult(
             success=True,
@@ -809,7 +860,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "call_id": call_id,
                 "queued_pcm_bytes": len(pcm),
                 "frames": sequence,
-                "audio": CALLING_AUDIO_CONTRACT,
+                "audio": audio,
             },
         )
 
@@ -817,8 +868,8 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self,
         call_id: str,
         *,
-        max_bytes: int = CALLING_PCM_DEFAULT_DRAIN_BYTES,
-        wait_ms: int = CALLING_PCM_DRAIN_WAIT_MS,
+        max_bytes: Optional[int] = None,
+        wait_ms: Optional[int] = None,
     ) -> Optional[CallingSidecarAudio]:
         """Drain decoded inbound 48 kHz PCM from a local WebRTC sidecar call."""
         if not self._calling_sidecar_enabled():
@@ -833,6 +884,14 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         normalized_call_id = str(call_id or "").strip()
         if not normalized_call_id:
             return None
+        audio_contract = self._calling_sidecar_audio_contract()
+        if max_bytes is None:
+            max_bytes = int(audio_contract["default_drain_bytes"])
+        if wait_ms is None:
+            wait_ms = min(
+                CALLING_PCM_DRAIN_WAIT_MS,
+                int(audio_contract["max_drain_wait_ms"]),
+            )
         if not isinstance(max_bytes, int) or max_bytes <= 0:
             logger.warning(
                 "[whatsapp_cloud] invalid sidecar audio max_bytes=%r",
@@ -848,8 +907,11 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             logger.warning("[whatsapp_cloud] invalid sidecar audio wait_ms=%r", wait_ms)
             return None
 
-        encoded_call_id = quote(normalized_call_id, safe="")
-        url = f"{self._calling_sidecar_url}/calls/{encoded_call_id}/audio"
+        url = self._calling_sidecar_endpoint_url(
+            "receive_audio",
+            "/calls/{call_id}/audio",
+            call_id=normalized_call_id,
+        )
         try:
             resp = await self._http_client.get(
                 url,
@@ -957,10 +1019,11 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         out_dir.mkdir(parents=True, exist_ok=True)
         out_path = out_dir / f"call_{safe_call_id}_{uuid.uuid4().hex[:12]}.wav"
 
+        audio = self._calling_sidecar_audio_contract()
         with wave.open(str(out_path), "wb") as wav:
-            wav.setnchannels(CALLING_PCM_CHANNELS)
-            wav.setsampwidth(CALLING_PCM_BYTES_PER_SAMPLE)
-            wav.setframerate(CALLING_PCM_SAMPLE_RATE)
+            wav.setnchannels(int(audio["channels"]))
+            wav.setsampwidth(int(audio["bytes_per_sample"]))
+            wav.setframerate(int(audio["sample_rate"]))
             wav.writeframes(pcm_s16le)
         return str(out_path)
 
@@ -1229,8 +1292,11 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             )
             return False
 
-        encoded_call_id = quote(normalized_call_id, safe="")
-        url = f"{self._calling_sidecar_url}/calls/{encoded_call_id}/close"
+        url = self._calling_sidecar_endpoint_url(
+            "close_call",
+            "/calls/{call_id}/close",
+            call_id=normalized_call_id,
+        )
         try:
             resp = await self._http_client.post(
                 url,
@@ -2283,6 +2349,10 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 "verify_token_configured": bool(self._verify_token),
                 "app_secret_configured": bool(self._app_secret),
                 "calling_sidecar_configured": self._calling_sidecar_enabled(),
+                "calling_sidecar_contract_loaded": isinstance(
+                    getattr(self, "_calling_sidecar_contract", None),
+                    dict,
+                ),
                 "ffmpeg_present": _FFMPEG_PATH is not None,
                 "accepted": self._accepted_count,
                 "duplicates": self._duplicate_count,
@@ -2595,6 +2665,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             )
             return
 
+        await self._ensure_calling_sidecar_contract()
         answer = await self._request_calling_sidecar_answer(call_id, remote_sdp)
         if answer is None:
             logger.warning(

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -114,6 +114,9 @@ CALLING_PCM_MAX_DRAIN_WAIT_MS = 5_000
 CALLING_PCM_MAX_OUTBOUND_QUEUE_BYTES = (
     CALLING_PCM_SAMPLE_RATE * CALLING_PCM_CHANNELS * CALLING_PCM_BYTES_PER_SAMPLE * 10
 )
+CALLING_PCM_MAX_INBOUND_QUEUE_BYTES = (
+    CALLING_PCM_SAMPLE_RATE * CALLING_PCM_CHANNELS * CALLING_PCM_BYTES_PER_SAMPLE * 10
+)
 CALLING_PCM_ENCODING = "pcm_s16le"
 CALLING_AUDIO_CONTRACT = {
     "sample_rate": CALLING_PCM_SAMPLE_RATE,
@@ -126,6 +129,7 @@ CALLING_AUDIO_CONTRACT = {
     "default_drain_bytes": CALLING_PCM_DEFAULT_DRAIN_BYTES,
     "max_drain_wait_ms": CALLING_PCM_MAX_DRAIN_WAIT_MS,
     "max_outbound_queue_bytes": CALLING_PCM_MAX_OUTBOUND_QUEUE_BYTES,
+    "max_inbound_queue_bytes": CALLING_PCM_MAX_INBOUND_QUEUE_BYTES,
 }
 GRAPH_API_BASE = "https://graph.facebook.com"
 # Meta retries failed webhooks for up to 7 days. We don't need to remember
@@ -232,6 +236,10 @@ def _normalize_calling_audio_contract(audio: Dict[str, Any]) -> Dict[str, Any]:
     normalized.setdefault(
         "max_outbound_queue_bytes",
         CALLING_PCM_MAX_OUTBOUND_QUEUE_BYTES,
+    )
+    normalized.setdefault(
+        "max_inbound_queue_bytes",
+        CALLING_PCM_MAX_INBOUND_QUEUE_BYTES,
     )
     return normalized
 

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -108,6 +108,12 @@ CALLING_PCM_FRAME_BYTES = (
 )
 CALLING_PCM_DRAIN_WAIT_MS = 500
 CALLING_PCM_ENCODING = "pcm_s16le"
+CALLING_AUDIO_CONTRACT = {
+    "sample_rate": CALLING_PCM_SAMPLE_RATE,
+    "channels": CALLING_PCM_CHANNELS,
+    "frame_ms": CALLING_PCM_FRAME_MS,
+    "encoding": CALLING_PCM_ENCODING,
+}
 GRAPH_API_BASE = "https://graph.facebook.com"
 # Meta retries failed webhooks for up to 7 days. We don't need to remember
 # every wamid for the full retry window — the practical risk is duplicate
@@ -178,6 +184,25 @@ def _ext_for_mime(mime: str) -> Optional[str]:
     if override:
         return override
     return mimetypes.guess_extension(primary) or None
+
+
+def _matches_calling_audio_contract(audio: Any) -> bool:
+    """Return whether a sidecar audio object matches Hermes' PCM frame shape."""
+    if not isinstance(audio, dict):
+        return False
+    try:
+        sample_rate = int(audio.get("sample_rate"))
+        channels = int(audio.get("channels"))
+        frame_ms = int(audio.get("frame_ms"))
+    except (TypeError, ValueError):
+        return False
+    encoding = str(audio.get("encoding") or "").strip().lower()
+    return (
+        sample_rate == CALLING_PCM_SAMPLE_RATE
+        and channels == CALLING_PCM_CHANNELS
+        and frame_ms == CALLING_PCM_FRAME_MS
+        and encoding == CALLING_PCM_ENCODING
+    )
 
 
 # Inbound media cache lives under the user's hermes dir so it survives
@@ -370,6 +395,73 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     def _calling_sidecar_enabled(self) -> bool:
         return bool(self._calling_sidecar_url)
 
+    async def _request_calling_sidecar_contract(self) -> Optional[Dict[str, Any]]:
+        """Fetch and validate the local sidecar's optional machine contract."""
+        if not self._calling_sidecar_enabled():
+            return None
+        if self._http_client is None:
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar configured but HTTP client "
+                "is unavailable"
+            )
+            return None
+
+        url = f"{self._calling_sidecar_url}/contract"
+        try:
+            resp = await self._http_client.get(
+                url,
+                timeout=self._calling_sidecar_timeout,
+            )
+        except Exception:
+            logger.exception("[whatsapp_cloud] calling sidecar contract request failed")
+            return None
+
+        if resp.status_code == 404:
+            logger.debug(
+                "[whatsapp_cloud] calling sidecar does not expose /contract yet"
+            )
+            return None
+        if resp.status_code != 200:
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar contract request failed "
+                "(status=%d): %s",
+                resp.status_code,
+                str(getattr(resp, "text", ""))[:500],
+            )
+            return None
+
+        try:
+            data = resp.json()
+        except Exception:
+            logger.warning("[whatsapp_cloud] calling sidecar contract returned invalid JSON")
+            return None
+        if not isinstance(data, dict):
+            logger.warning("[whatsapp_cloud] calling sidecar contract is not an object")
+            return None
+        if data.get("contract") != "voice.webrtc_sidecar":
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar contract id was %r",
+                data.get("contract"),
+            )
+            return None
+        try:
+            version = int(data.get("version") or 0)
+        except (TypeError, ValueError):
+            version = 0
+        if version < 1:
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar contract version is invalid: %r",
+                data.get("version"),
+            )
+            return None
+        if not _matches_calling_audio_contract(data.get("audio")):
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar audio contract does not match "
+                "Hermes PCM settings"
+            )
+            return None
+        return data
+
     async def _request_calling_sidecar_answer(
         self,
         call_id: str,
@@ -448,11 +540,18 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             return None
 
         audio = data.get("audio")
+        if not _matches_calling_audio_contract(audio):
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar answer audio contract does not "
+                "match Hermes PCM settings"
+            )
+            return None
+
         answer_call_id = str(data.get("call_id") or "").strip() or normalized_call_id
         return CallingSidecarAnswer(
             call_id=answer_call_id,
             sdp=sdp,
-            audio=audio if isinstance(audio, dict) else {},
+            audio=audio,
         )
 
     async def _send_calling_sidecar_audio(
@@ -635,13 +734,20 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             return None
 
         audio = data.get("audio")
+        if not _matches_calling_audio_contract(audio):
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar audio drain contract does not "
+                "match Hermes PCM settings"
+            )
+            return None
+
         answer_call_id = str(data.get("call_id") or "").strip() or normalized_call_id
         return CallingSidecarAudio(
             call_id=answer_call_id,
             pcm_s16le=pcm,
             returned_bytes=returned_bytes,
             queued_rx_bytes=queued_rx_bytes,
-            audio=audio if isinstance(audio, dict) else {},
+            audio=audio,
         )
 
     async def _send_call_action(

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -106,13 +106,22 @@ CALLING_PCM_FRAME_BYTES = (
     * CALLING_PCM_FRAME_MS
     // 1_000
 )
+CALLING_PCM_DEFAULT_DRAIN_BYTES = (
+    CALLING_PCM_SAMPLE_RATE * CALLING_PCM_CHANNELS * CALLING_PCM_BYTES_PER_SAMPLE
+)
 CALLING_PCM_DRAIN_WAIT_MS = 500
+CALLING_PCM_MAX_DRAIN_WAIT_MS = 5_000
 CALLING_PCM_ENCODING = "pcm_s16le"
 CALLING_AUDIO_CONTRACT = {
     "sample_rate": CALLING_PCM_SAMPLE_RATE,
     "channels": CALLING_PCM_CHANNELS,
     "frame_ms": CALLING_PCM_FRAME_MS,
     "encoding": CALLING_PCM_ENCODING,
+    "bytes_per_sample": CALLING_PCM_BYTES_PER_SAMPLE,
+    "samples_per_frame": CALLING_PCM_SAMPLE_RATE * CALLING_PCM_FRAME_MS // 1_000,
+    "frame_bytes": CALLING_PCM_FRAME_BYTES,
+    "default_drain_bytes": CALLING_PCM_DEFAULT_DRAIN_BYTES,
+    "max_drain_wait_ms": CALLING_PCM_MAX_DRAIN_WAIT_MS,
 }
 GRAPH_API_BASE = "https://graph.facebook.com"
 # Meta retries failed webhooks for up to 7 days. We don't need to remember
@@ -632,7 +641,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self,
         call_id: str,
         *,
-        max_bytes: int = CALLING_PCM_FRAME_BYTES,
+        max_bytes: int = CALLING_PCM_DEFAULT_DRAIN_BYTES,
         wait_ms: int = CALLING_PCM_DRAIN_WAIT_MS,
     ) -> Optional[CallingSidecarAudio]:
         """Drain decoded inbound 48 kHz PCM from a local WebRTC sidecar call."""

--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -504,6 +504,15 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             path = f"/{path}"
         return f"{self._calling_sidecar_url}{path}"
 
+    def _calling_sidecar_has_endpoint(self, endpoint: str) -> bool:
+        """Return whether the loaded sidecar contract advertises an endpoint."""
+        contract = getattr(self, "_calling_sidecar_contract", None)
+        endpoints = contract.get("endpoints") if isinstance(contract, dict) else None
+        if not isinstance(endpoints, dict):
+            return False
+        spec = endpoints.get(endpoint)
+        return isinstance(spec, dict) and bool(str(spec.get("path") or "").strip())
+
     async def _ensure_calling_sidecar_contract(self) -> Optional[Dict[str, Any]]:
         """Fetch the optional sidecar contract once per adapter lifetime."""
         if getattr(self, "_calling_sidecar_contract_checked", False):
@@ -756,6 +765,66 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     )
             logger.warning(
                 "[whatsapp_cloud] calling sidecar audio rejected "
+                "(status=%d): %s",
+                resp.status_code,
+                error_msg,
+            )
+            return SendResult(
+                success=False,
+                error=error_msg,
+                raw_response=body,
+                retryable=resp.status_code == 429,
+            )
+
+        return SendResult(success=True, raw_response=body)
+
+    async def _clear_calling_sidecar_audio(self, call_id: str) -> SendResult:
+        """Drop queued outbound PCM for a sidecar call when barge-in starts."""
+        if not self._calling_sidecar_enabled():
+            return SendResult(success=False, error="Calling sidecar not configured")
+        if self._http_client is None:
+            return SendResult(success=False, error="Not connected")
+
+        normalized_call_id = str(call_id or "").strip()
+        if not normalized_call_id:
+            return SendResult(success=False, error="Missing call_id")
+
+        if not self._calling_sidecar_has_endpoint("clear_audio"):
+            return SendResult(
+                success=True,
+                raw_response={"skipped": "clear_audio endpoint not advertised"},
+            )
+
+        url = self._calling_sidecar_endpoint_url(
+            "clear_audio",
+            "/calls/{call_id}/audio/clear",
+            call_id=normalized_call_id,
+        )
+        try:
+            resp = await self._http_client.post(
+                url,
+                timeout=self._calling_sidecar_timeout,
+            )
+        except Exception as exc:
+            logger.exception(
+                "[whatsapp_cloud] calling sidecar audio clear request failed for %s",
+                normalized_call_id,
+            )
+            return SendResult(success=False, error=str(exc), retryable=True)
+
+        try:
+            body = resp.json()
+        except Exception:
+            body = {"raw": str(getattr(resp, "text", ""))[:500]}
+
+        if resp.status_code != 200:
+            error_msg = ""
+            if isinstance(body, dict):
+                error_msg = str(body.get("error") or "")
+            if not error_msg:
+                error_msg = f"calling sidecar audio clear failed with HTTP {resp.status_code}"
+            logger.warning(
+                "[whatsapp_cloud] calling sidecar audio clear rejected "
                 "(status=%d): %s",
                 resp.status_code,
                 error_msg,
@@ -1397,6 +1466,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         """Long-poll sidecar PCM and dispatch speech-ish chunks to Hermes."""
         buffer = bytearray()
         silent_polls = 0
+        cleared_outbound_for_segment = False
 
         try:
             while call_id in self._calling_sidecar_call_ids:
@@ -1404,6 +1474,18 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 if audio is not None and audio.pcm_s16le:
                     pcm = audio.pcm_s16le
                     if self._calling_sidecar_pcm_has_speech(pcm):
+                        if not buffer and not cleared_outbound_for_segment:
+                            clear_result = await self._clear_calling_sidecar_audio(
+                                call_id
+                            )
+                            if not clear_result.success:
+                                logger.debug(
+                                    "[whatsapp_cloud] sidecar audio clear failed "
+                                    "for %s: %s",
+                                    call_id,
+                                    clear_result.error,
+                                )
+                            cleared_outbound_for_segment = True
                         buffer.extend(pcm)
                         silent_polls = 0
                         if len(buffer) >= CALLING_PCM_MAX_SEGMENT_BYTES:
@@ -1430,6 +1512,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                 )
                             buffer.clear()
                             silent_polls = 0
+                            cleared_outbound_for_segment = False
                     continue
 
                 if buffer:
@@ -1443,6 +1526,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         )
                         buffer.clear()
                         silent_polls = 0
+                        cleared_outbound_for_segment = False
         except asyncio.CancelledError:
             raise
         except Exception:

--- a/scripts/install_voice_local_stack.py
+++ b/scripts/install_voice_local_stack.py
@@ -248,13 +248,46 @@ def build_verify_commands(
     stt_provider_name: str,
     stt_timeout: int,
 ) -> dict[str, list[str]]:
+    hermes_python_bin = str(hermes_home / "hermes-agent" / "venv" / "bin" / "python")
+    local_stack_command = [
+        verifier_python_bin,
+        str(repo_root() / "scripts" / "verify_voice_local_stack.py"),
+        "--voice-bin",
+        voice_bin,
+        "--voice-repo",
+        str(voice_repo),
+        "--webrtc-python-bin",
+        webrtc_python_bin,
+        "--live-hermes-root",
+        str(live_hermes_root),
+    ]
+    local_stack_live_gateway_command = [
+        *local_stack_command,
+        "--run-live-gateway",
+        "--calling-sidecar-url",
+        sidecar_url,
+        "--live-gateway-python-bin",
+        hermes_python_bin,
+        "--live-gateway-hermes-home",
+        str(hermes_home),
+    ]
+    if run_stt_smoke:
+        local_stack_live_gateway_command.append("--run-live-gateway-stt-smoke")
+    if sidecar_service:
+        local_stack_live_gateway_command.extend(
+            [
+                "--live-gateway-sidecar-service",
+                sidecar_service,
+            ]
+        )
+
     live_gateway_command = [
         verifier_python_bin,
         str(repo_root() / "scripts" / "verify_voice_live_gateway.py"),
         "--live-hermes-root",
         str(live_hermes_root),
         "--python-bin",
-        str(hermes_home / "hermes-agent" / "venv" / "bin" / "python"),
+        hermes_python_bin,
         "--hermes-home",
         str(hermes_home),
         "--calling-sidecar-url",
@@ -286,17 +319,11 @@ def build_verify_commands(
             ]
         )
     return {
-        "local_stack": [
-            verifier_python_bin,
-            str(repo_root() / "scripts" / "verify_voice_local_stack.py"),
-            "--voice-bin",
-            voice_bin,
-            "--voice-repo",
-            str(voice_repo),
-            "--webrtc-python-bin",
-            webrtc_python_bin,
-            "--live-hermes-root",
-            str(live_hermes_root),
+        "local_stack": local_stack_command,
+        "local_stack_live_gateway": local_stack_live_gateway_command,
+        "local_stack_live_gateway_cloud_only": [
+            *local_stack_live_gateway_command,
+            "--skip-live-gateway-bridge-health",
         ],
         "live_gateway": live_gateway_command,
         "live_gateway_cloud_only": [*live_gateway_command, "--skip-bridge-health"],

--- a/scripts/install_voice_local_stack.py
+++ b/scripts/install_voice_local_stack.py
@@ -262,6 +262,9 @@ def build_verify_commands(
         "--voice-bin",
         voice_bin,
         "--run-tts-smoke",
+        "--run-sidecar-offer-smoke",
+        "--webrtc-python-bin",
+        webrtc_python_bin,
     ]
     if run_stt_smoke:
         live_gateway_command.extend(

--- a/scripts/install_voice_local_stack.py
+++ b/scripts/install_voice_local_stack.py
@@ -279,6 +279,7 @@ def build_verify_commands(
         hermes_python_bin,
         "--live-gateway-hermes-home",
         str(hermes_home),
+        "--run-live-gateway-calling-live-sidecar-smoke",
     ]
     if run_stt_smoke:
         local_stack_live_gateway_command.append("--run-live-gateway-stt-smoke")
@@ -312,6 +313,7 @@ def build_verify_commands(
         voice_bin,
         "--run-tts-smoke",
         "--run-sidecar-offer-smoke",
+        "--run-calling-live-sidecar-smoke",
         "--webrtc-python-bin",
         webrtc_python_bin,
     ]

--- a/scripts/install_voice_local_stack.py
+++ b/scripts/install_voice_local_stack.py
@@ -226,6 +226,7 @@ def build_verify_commands(
     voice_bin: str,
     webrtc_python_bin: str,
     sidecar_url: str,
+    sidecar_service: str | None,
 ) -> dict[str, list[str]]:
     live_gateway_command = [
         verifier_python_bin,
@@ -242,6 +243,15 @@ def build_verify_commands(
         voice_bin,
         "--run-tts-smoke",
     ]
+    if sidecar_service:
+        live_gateway_command.extend(
+            [
+                "--sidecar-service",
+                sidecar_service,
+                "--voice-repo",
+                str(voice_repo),
+            ]
+        )
     return {
         "local_stack": [
             verifier_python_bin,
@@ -455,6 +465,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
             voice_bin=voice_bin,
             webrtc_python_bin=webrtc_python_bin,
             sidecar_url=args.sidecar_url.rstrip("/"),
+            sidecar_service=None if args.skip_sidecar_service else args.sidecar_service,
         ),
     }
 

--- a/scripts/install_voice_local_stack.py
+++ b/scripts/install_voice_local_stack.py
@@ -223,16 +223,40 @@ def configure_tts_provider(
     provider_name: str,
     provider: dict[str, Any],
 ) -> dict[str, Any]:
-    from ruamel.yaml import YAML
-
-    yaml = YAML()
-    yaml.default_flow_style = False
-
     if config_path.exists():
-        with config_path.open("r", encoding="utf-8") as handle:
-            data = yaml.load(handle) or {}
+        text = config_path.read_text(encoding="utf-8")
     else:
-        data = {}
+        text = ""
+
+    try:
+        from ruamel.yaml import YAML
+    except ModuleNotFoundError:
+        try:
+            import yaml
+        except ModuleNotFoundError as exc:
+            raise SystemExit(
+                "updating Hermes config requires PyYAML or ruamel.yaml; "
+                "rerun without --configure-tts or install one of those packages"
+            ) from exc
+
+        data = yaml.safe_load(text) if text.strip() else {}
+
+        def dump_yaml(value: dict[str, Any], handle: Any) -> None:
+            yaml.safe_dump(
+                value,
+                handle,
+                default_flow_style=False,
+                sort_keys=False,
+            )
+    else:
+        yaml = YAML()
+        yaml.default_flow_style = False
+        data = yaml.load(text) if text.strip() else {}
+
+        def dump_yaml(value: dict[str, Any], handle: Any) -> None:
+            yaml.dump(value, handle)
+
+    data = data or {}
 
     if not isinstance(data, dict):
         raise SystemExit(f"Hermes config root must be a mapping: {config_path}")
@@ -250,7 +274,7 @@ def configure_tts_provider(
     providers[provider_name] = provider
     config_path.parent.mkdir(parents=True, exist_ok=True)
     with config_path.open("w", encoding="utf-8") as handle:
-        yaml.dump(data, handle)
+        dump_yaml(data, handle)
 
     return {
         "path": str(config_path),

--- a/scripts/install_voice_local_stack.py
+++ b/scripts/install_voice_local_stack.py
@@ -32,6 +32,7 @@ DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8787
 DEFAULT_HERMES_SERVICE = "hermes-gateway.service"
 DEFAULT_SIDECAR_SERVICE = "voice-webrtc-sidecar.service"
+DEFAULT_VOICE_DAEMON_SERVICE = "voiced.service"
 DEFAULT_STREAM_TIMEOUT = 180.0
 DEFAULT_STT_TIMEOUT = 300
 
@@ -125,6 +126,7 @@ def render_sidecar_unit(
     voice_repo: Path,
     voice_bin: str,
     webrtc_python_bin: str,
+    voice_daemon_service: str,
     host: str,
     port: int,
     rx_pcm_path: Path,
@@ -143,11 +145,16 @@ def render_sidecar_unit(
         "--log-level",
         log_level,
     ]
-    return "\n".join(
+    after_units = dedupe_preserve_order(["network.target", voice_daemon_service])
+    unit_lines = [
+        "[Unit]",
+        "Description=Voice WebRTC Sidecar",
+        "After=" + " ".join(after_units),
+    ]
+    if voice_daemon_service:
+        unit_lines.append(f"Wants={voice_daemon_service}")
+    unit_lines.extend(
         [
-            "[Unit]",
-            "Description=Voice WebRTC Sidecar",
-            "After=network.target voiced.service",
             "",
             "[Service]",
             "Type=simple",
@@ -162,6 +169,7 @@ def render_sidecar_unit(
             "",
         ]
     )
+    return "\n".join(unit_lines)
 
 
 def render_hermes_dropin(
@@ -244,6 +252,7 @@ def build_verify_commands(
     webrtc_python_bin: str,
     sidecar_url: str,
     sidecar_service: str | None,
+    voice_daemon_service: str | None,
     run_stt_smoke: bool,
     stt_provider_name: str,
     stt_timeout: int,
@@ -278,6 +287,13 @@ def build_verify_commands(
             [
                 "--live-gateway-sidecar-service",
                 sidecar_service,
+            ]
+        )
+    if sidecar_service and voice_daemon_service:
+        local_stack_live_gateway_command.extend(
+            [
+                "--live-gateway-voice-daemon-service",
+                voice_daemon_service,
             ]
         )
 
@@ -316,6 +332,13 @@ def build_verify_commands(
                 sidecar_service,
                 "--voice-repo",
                 str(voice_repo),
+            ]
+        )
+    if sidecar_service and voice_daemon_service:
+        live_gateway_command.extend(
+            [
+                "--voice-daemon-service",
+                voice_daemon_service,
             ]
         )
     return {
@@ -544,6 +567,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
                     voice_repo=voice_repo,
                     voice_bin=voice_bin,
                     webrtc_python_bin=webrtc_python_bin,
+                    voice_daemon_service=args.voice_daemon_service,
                     host=sidecar_host,
                     port=sidecar_port,
                     rx_pcm_path=rx_pcm_path,
@@ -580,6 +604,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         "sidecar_url": args.sidecar_url.rstrip("/"),
         "hermes_service": args.hermes_service,
         "sidecar_service": args.sidecar_service,
+        "voice_daemon_service": args.voice_daemon_service,
         "paths": {
             "systemd_user_dir": str(systemd_user_dir),
             "hermes_dropin": str(hermes_dropin_path),
@@ -599,6 +624,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
             webrtc_python_bin=webrtc_python_bin,
             sidecar_url=args.sidecar_url.rstrip("/"),
             sidecar_service=None if args.skip_sidecar_service else args.sidecar_service,
+            voice_daemon_service=args.voice_daemon_service,
             run_stt_smoke=args.configure_stt,
             stt_provider_name=args.stt_provider_name,
             stt_timeout=args.stt_timeout,
@@ -713,6 +739,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--log-level", default="INFO")
     parser.add_argument("--hermes-service", default=DEFAULT_HERMES_SERVICE)
     parser.add_argument("--sidecar-service", default=DEFAULT_SIDECAR_SERVICE)
+    parser.add_argument(
+        "--voice-daemon-service",
+        default=DEFAULT_VOICE_DAEMON_SERVICE,
+        help=(
+            "systemd user service name for the voice daemon that the sidecar "
+            "orders after and the live verifier checks; pass an empty string "
+            "to skip daemon service verification"
+        ),
+    )
     parser.add_argument(
         "--systemd-user-dir",
         default=str(Path.home() / ".config" / "systemd" / "user"),

--- a/scripts/install_voice_local_stack.py
+++ b/scripts/install_voice_local_stack.py
@@ -350,8 +350,18 @@ def build_verify_commands(
             *local_stack_live_gateway_command,
             "--skip-live-gateway-bridge-health",
         ],
+        "local_stack_live_gateway_cloud_ready": [
+            *local_stack_live_gateway_command,
+            "--skip-live-gateway-bridge-health",
+            "--require-live-gateway-whatsapp-cloud-readiness",
+        ],
         "live_gateway": live_gateway_command,
         "live_gateway_cloud_only": [*live_gateway_command, "--skip-bridge-health"],
+        "live_gateway_cloud_ready": [
+            *live_gateway_command,
+            "--skip-bridge-health",
+            "--require-whatsapp-cloud-readiness",
+        ],
     }
 
 

--- a/scripts/install_voice_local_stack.py
+++ b/scripts/install_voice_local_stack.py
@@ -217,6 +217,49 @@ def build_tts_provider(
     }
 
 
+def build_verify_commands(
+    *,
+    verifier_python_bin: str,
+    live_hermes_root: Path,
+    hermes_home: Path,
+    voice_repo: Path,
+    voice_bin: str,
+    webrtc_python_bin: str,
+    sidecar_url: str,
+) -> dict[str, list[str]]:
+    live_gateway_command = [
+        verifier_python_bin,
+        str(repo_root() / "scripts" / "verify_voice_live_gateway.py"),
+        "--live-hermes-root",
+        str(live_hermes_root),
+        "--python-bin",
+        str(hermes_home / "hermes-agent" / "venv" / "bin" / "python"),
+        "--hermes-home",
+        str(hermes_home),
+        "--calling-sidecar-url",
+        sidecar_url,
+        "--voice-bin",
+        voice_bin,
+        "--run-tts-smoke",
+    ]
+    return {
+        "local_stack": [
+            verifier_python_bin,
+            str(repo_root() / "scripts" / "verify_voice_local_stack.py"),
+            "--voice-bin",
+            voice_bin,
+            "--voice-repo",
+            str(voice_repo),
+            "--webrtc-python-bin",
+            webrtc_python_bin,
+            "--live-hermes-root",
+            str(live_hermes_root),
+        ],
+        "live_gateway": live_gateway_command,
+        "live_gateway_cloud_only": [*live_gateway_command, "--skip-bridge-health"],
+    }
+
+
 def configure_tts_provider(
     *,
     config_path: Path,
@@ -404,6 +447,15 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         },
         "files": files,
         "tts_provider": tts_provider,
+        "verify_commands": build_verify_commands(
+            verifier_python_bin=sys.executable,
+            live_hermes_root=live_hermes_root,
+            hermes_home=hermes_home,
+            voice_repo=voice_repo,
+            voice_bin=voice_bin,
+            webrtc_python_bin=webrtc_python_bin,
+            sidecar_url=args.sidecar_url.rstrip("/"),
+        ),
     }
 
 

--- a/scripts/install_voice_local_stack.py
+++ b/scripts/install_voice_local_stack.py
@@ -1,0 +1,523 @@
+#!/usr/bin/env python3
+"""Install local voice-native Hermes wiring for WhatsApp voice and calling.
+
+The script writes the two Linux user-service pieces that are otherwise easy to
+misconfigure by hand:
+
+1. A ``voice-webrtc-sidecar.service`` user unit for the voice repo sidecar.
+2. A ``hermes-gateway.service`` drop-in that points Hermes at the checkout with
+   the WhatsApp voice/calling stack and exposes the sidecar stream command.
+
+By default the script is a dry run and prints the files it would write. Pass
+``--apply`` to write them, reload systemd, and optionally restart Hermes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+from typing import Any
+from urllib.parse import urlparse
+
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8787
+DEFAULT_HERMES_SERVICE = "hermes-gateway.service"
+DEFAULT_SIDECAR_SERVICE = "voice-webrtc-sidecar.service"
+DEFAULT_STREAM_TIMEOUT = 180.0
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def resolve_executable(value: str, *, label: str) -> str:
+    if "/" in value:
+        path = Path(value).expanduser()
+        if not path.is_file() or not os.access(path, os.X_OK):
+            raise SystemExit(f"{label} is not executable: {path}")
+        return os.path.abspath(os.path.expanduser(value))
+
+    found = shutil.which(value)
+    if not found:
+        raise SystemExit(f"{label} not found on PATH: {value}")
+    return found
+
+
+def default_voice_repo() -> str:
+    configured = os.environ.get("VOICE_REPO")
+    if configured:
+        return configured
+    return str(Path.home() / "code" / "src" / "github.com" / "rgbkrk" / "voice")
+
+
+def default_webrtc_python() -> str:
+    return os.environ.get("VOICE_WEBRTC_PYTHON", "python3")
+
+
+def parse_sidecar_url(value: str) -> tuple[str, int]:
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"}:
+        raise SystemExit(f"sidecar URL must be http(s): {value!r}")
+    if not parsed.hostname:
+        raise SystemExit(f"sidecar URL must include a host: {value!r}")
+    if parsed.path not in {"", "/"}:
+        raise SystemExit(f"sidecar URL must not include a path: {value!r}")
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    return parsed.hostname, port
+
+
+def systemd_env_line(key: str, value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'Environment="{key}={escaped}"'
+
+
+def dedupe_preserve_order(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+def default_gateway_path(
+    *,
+    hermes_home: Path,
+    voice_bin: str,
+    bridge_bin_dir: Path | None,
+) -> str:
+    home = Path.home()
+    parts = [
+        str(hermes_home / "hermes-agent" / "venv" / "bin"),
+        str(bridge_bin_dir) if bridge_bin_dir else "",
+    ]
+    if "/" in voice_bin:
+        parts.append(str(Path(voice_bin).resolve().parent))
+    parts.extend(
+        [
+            str(home / ".local" / "bin"),
+            str(home / ".cargo" / "bin"),
+            "/usr/local/sbin",
+            "/usr/local/bin",
+            "/usr/sbin",
+            "/usr/bin",
+            "/sbin",
+            "/bin",
+        ]
+    )
+    return os.pathsep.join(dedupe_preserve_order(parts))
+
+
+def render_sidecar_unit(
+    *,
+    voice_repo: Path,
+    voice_bin: str,
+    webrtc_python_bin: str,
+    host: str,
+    port: int,
+    rx_pcm_path: Path,
+    log_level: str,
+) -> str:
+    sidecar = voice_repo / "examples" / "webrtc-sidecar" / "sidecar.py"
+    command = [
+        webrtc_python_bin,
+        str(sidecar),
+        "--host",
+        host,
+        "--port",
+        str(port),
+        "--rx-pcm",
+        str(rx_pcm_path),
+        "--log-level",
+        log_level,
+    ]
+    return "\n".join(
+        [
+            "[Unit]",
+            "Description=Voice WebRTC Sidecar",
+            "After=network.target voice-daemon.service",
+            "",
+            "[Service]",
+            "Type=simple",
+            f"WorkingDirectory={voice_repo}",
+            systemd_env_line("VOICE_BIN", voice_bin),
+            "ExecStart=" + " ".join(command),
+            "Restart=on-failure",
+            "RestartSec=2",
+            "",
+            "[Install]",
+            "WantedBy=default.target",
+            "",
+        ]
+    )
+
+
+def render_hermes_dropin(
+    *,
+    live_hermes_root: Path,
+    gateway_path: str,
+    sidecar_url: str,
+    voice_bin: str,
+    voice: str,
+    speed: str,
+    stream_timeout: float,
+) -> str:
+    stream_command = (
+        f"{voice_bin} stream --quiet --sample-rate {{sample_rate}} "
+        f"--frame-ms {{frame_ms}} --raw-output - --input-file {{input_path}} "
+        f"--voice {voice} --speed {speed}"
+    )
+    return "\n".join(
+        [
+            "[Service]",
+            systemd_env_line("PYTHONPATH", str(live_hermes_root)),
+            systemd_env_line("PATH", gateway_path),
+            systemd_env_line("WHATSAPP_CLOUD_CALLING_SIDECAR_URL", sidecar_url),
+            systemd_env_line(
+                "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND",
+                stream_command,
+            ),
+            systemd_env_line(
+                "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT",
+                str(stream_timeout),
+            ),
+            "",
+        ]
+    )
+
+
+def build_tts_provider(
+    *,
+    voice_bin: str,
+    voice: str,
+    speed: str,
+    timeout: int,
+    max_text_length: int,
+) -> dict[str, Any]:
+    return {
+        "type": "command",
+        "command": (
+            f"{voice_bin} say --format ogg-opus --input-file {{input_path}} "
+            f"--output {{output_path}} --voice {{voice}} --speed {{speed}}"
+        ),
+        "output_format": "ogg",
+        "voice_compatible": True,
+        "voice": voice,
+        "speed": float(speed),
+        "timeout": timeout,
+        "max_text_length": max_text_length,
+    }
+
+
+def configure_tts_provider(
+    *,
+    config_path: Path,
+    provider_name: str,
+    provider: dict[str, Any],
+) -> dict[str, Any]:
+    from ruamel.yaml import YAML
+
+    yaml = YAML()
+    yaml.default_flow_style = False
+
+    if config_path.exists():
+        with config_path.open("r", encoding="utf-8") as handle:
+            data = yaml.load(handle) or {}
+    else:
+        data = {}
+
+    if not isinstance(data, dict):
+        raise SystemExit(f"Hermes config root must be a mapping: {config_path}")
+
+    tts = data.setdefault("tts", {})
+    if not isinstance(tts, dict):
+        raise SystemExit(f"Hermes config tts section must be a mapping: {config_path}")
+    providers = tts.setdefault("providers", {})
+    if not isinstance(providers, dict):
+        raise SystemExit(
+            f"Hermes config tts.providers section must be a mapping: {config_path}"
+        )
+
+    tts["provider"] = provider_name
+    providers[provider_name] = provider
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    with config_path.open("w", encoding="utf-8") as handle:
+        yaml.dump(data, handle)
+
+    return {
+        "path": str(config_path),
+        "provider": provider_name,
+        "output_format": provider["output_format"],
+        "voice_compatible": provider["voice_compatible"],
+    }
+
+
+def run_systemctl(command: list[str], *, timeout: float) -> None:
+    completed = subprocess.run(
+        ["systemctl", "--user", *command],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+        stdin=subprocess.DEVNULL,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise SystemExit(
+            "systemctl --user "
+            + " ".join(command)
+            + f" failed with exit code {completed.returncode}"
+            + (f": {detail}" if detail else "")
+        )
+
+
+def build_plan(args: argparse.Namespace) -> dict[str, Any]:
+    sidecar_host, sidecar_port = parse_sidecar_url(args.sidecar_url)
+    if args.host and args.host != sidecar_host:
+        raise SystemExit(
+            f"--host {args.host!r} does not match --sidecar-url host {sidecar_host!r}"
+        )
+    if args.port and args.port != sidecar_port:
+        raise SystemExit(
+            f"--port {args.port!r} does not match --sidecar-url port {sidecar_port!r}"
+        )
+
+    hermes_home = Path(args.hermes_home).expanduser().resolve()
+    live_hermes_root = Path(args.live_hermes_root).expanduser().resolve()
+    voice_repo = Path(args.voice_repo).expanduser().resolve()
+    voice_bin = resolve_executable(args.voice_bin, label="voice binary")
+    webrtc_python_bin = resolve_executable(
+        args.webrtc_python_bin,
+        label="WebRTC sidecar Python",
+    )
+    bridge_bin_dir = (
+        Path(args.bridge_bin_dir).expanduser().resolve()
+        if args.bridge_bin_dir
+        else live_hermes_root / "scripts" / "whatsapp-bridge" / "node_modules" / ".bin"
+    )
+    gateway_path = args.gateway_path or default_gateway_path(
+        hermes_home=hermes_home,
+        voice_bin=voice_bin,
+        bridge_bin_dir=bridge_bin_dir,
+    )
+    systemd_user_dir = Path(args.systemd_user_dir).expanduser().resolve()
+    rx_pcm_path = (
+        Path(args.rx_pcm_path).expanduser().resolve()
+        if args.rx_pcm_path
+        else hermes_home / "voice-webrtc-sidecar" / "inbound.s16le"
+    )
+    hermes_dropin_dir = systemd_user_dir / f"{args.hermes_service}.d"
+    hermes_dropin_path = hermes_dropin_dir / "voice-stack.conf"
+    sidecar_unit_path = systemd_user_dir / args.sidecar_service
+    config_path = Path(args.config_path).expanduser().resolve()
+    tts_provider = build_tts_provider(
+        voice_bin=voice_bin,
+        voice=args.voice,
+        speed=args.speed,
+        timeout=args.tts_timeout,
+        max_text_length=args.max_text_length,
+    )
+
+    files: list[dict[str, str]] = []
+    if not args.skip_sidecar_service:
+        files.append(
+            {
+                "path": str(sidecar_unit_path),
+                "kind": "systemd_user_service",
+                "content": render_sidecar_unit(
+                    voice_repo=voice_repo,
+                    voice_bin=voice_bin,
+                    webrtc_python_bin=webrtc_python_bin,
+                    host=sidecar_host,
+                    port=sidecar_port,
+                    rx_pcm_path=rx_pcm_path,
+                    log_level=args.log_level,
+                ),
+            }
+        )
+    if not args.skip_hermes_dropin:
+        files.append(
+            {
+                "path": str(hermes_dropin_path),
+                "kind": "systemd_user_dropin",
+                "content": render_hermes_dropin(
+                    live_hermes_root=live_hermes_root,
+                    gateway_path=gateway_path,
+                    sidecar_url=args.sidecar_url.rstrip("/"),
+                    voice_bin=voice_bin,
+                    voice=args.voice,
+                    speed=args.speed,
+                    stream_timeout=args.stream_timeout,
+                ),
+            }
+        )
+
+    return {
+        "apply": args.apply,
+        "configure_tts": args.configure_tts,
+        "hermes_home": str(hermes_home),
+        "live_hermes_root": str(live_hermes_root),
+        "voice_repo": str(voice_repo),
+        "voice_bin": voice_bin,
+        "webrtc_python_bin": webrtc_python_bin,
+        "sidecar_url": args.sidecar_url.rstrip("/"),
+        "hermes_service": args.hermes_service,
+        "sidecar_service": args.sidecar_service,
+        "paths": {
+            "systemd_user_dir": str(systemd_user_dir),
+            "hermes_dropin": str(hermes_dropin_path),
+            "sidecar_unit": str(sidecar_unit_path),
+            "rx_pcm": str(rx_pcm_path),
+            "config": str(config_path),
+        },
+        "files": files,
+        "tts_provider": tts_provider,
+    }
+
+
+def apply_plan(plan: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
+    written: list[str] = []
+    for file_plan in plan["files"]:
+        path = Path(file_plan["path"])
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(file_plan["content"], encoding="utf-8")
+        written.append(str(path))
+
+    Path(plan["paths"]["rx_pcm"]).parent.mkdir(parents=True, exist_ok=True)
+    config_result = None
+    if plan["configure_tts"]:
+        config_result = configure_tts_provider(
+            config_path=Path(plan["paths"]["config"]),
+            provider_name=args.provider_name,
+            provider=plan["tts_provider"],
+        )
+
+    systemctl_actions: list[str] = []
+    if not args.no_systemctl:
+        run_systemctl(["daemon-reload"], timeout=args.systemctl_timeout)
+        systemctl_actions.append("daemon-reload")
+        if not args.skip_sidecar_service and not args.no_start:
+            run_systemctl(
+                ["enable", "--now", plan["sidecar_service"]],
+                timeout=args.systemctl_timeout,
+            )
+            systemctl_actions.append(f"enable --now {plan['sidecar_service']}")
+        if args.restart_hermes:
+            run_systemctl(
+                ["restart", plan["hermes_service"]],
+                timeout=args.systemctl_timeout,
+            )
+            systemctl_actions.append(f"restart {plan['hermes_service']}")
+
+    return {
+        "written": written,
+        "configured_tts": config_result,
+        "systemctl": systemctl_actions,
+    }
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true", help="write files")
+    parser.add_argument(
+        "--configure-tts",
+        action="store_true",
+        help="update config.yaml to use voice say --format ogg-opus",
+    )
+    parser.add_argument(
+        "--restart-hermes",
+        action="store_true",
+        help="restart the Hermes gateway service after writing the drop-in",
+    )
+    parser.add_argument(
+        "--no-start",
+        action="store_true",
+        help="write the sidecar unit without enabling or starting it",
+    )
+    parser.add_argument(
+        "--no-systemctl",
+        action="store_true",
+        help="write files without invoking systemctl --user",
+    )
+    parser.add_argument(
+        "--skip-sidecar-service",
+        action="store_true",
+        help="do not write the voice WebRTC sidecar service",
+    )
+    parser.add_argument(
+        "--skip-hermes-dropin",
+        action="store_true",
+        help="do not write the Hermes gateway drop-in",
+    )
+    parser.add_argument("--hermes-home", default=str(Path.home() / ".hermes"))
+    parser.add_argument(
+        "--live-hermes-root",
+        default=str(repo_root()),
+        help="Hermes checkout imported by the live gateway",
+    )
+    parser.add_argument("--voice-repo", default=default_voice_repo())
+    parser.add_argument("--voice-bin", default="voice")
+    parser.add_argument("--webrtc-python-bin", default=default_webrtc_python())
+    parser.add_argument(
+        "--sidecar-url",
+        default=f"http://{DEFAULT_HOST}:{DEFAULT_PORT}",
+        help="loopback base URL exposed by the voice WebRTC sidecar",
+    )
+    parser.add_argument("--host", default=DEFAULT_HOST)
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT)
+    parser.add_argument("--rx-pcm-path")
+    parser.add_argument("--log-level", default="INFO")
+    parser.add_argument("--hermes-service", default=DEFAULT_HERMES_SERVICE)
+    parser.add_argument("--sidecar-service", default=DEFAULT_SIDECAR_SERVICE)
+    parser.add_argument(
+        "--systemd-user-dir",
+        default=str(Path.home() / ".config" / "systemd" / "user"),
+    )
+    parser.add_argument("--bridge-bin-dir")
+    parser.add_argument("--gateway-path")
+    parser.add_argument(
+        "--config-path",
+        default=str(Path.home() / ".hermes" / "config.yaml"),
+    )
+    parser.add_argument("--provider-name", default="kokoro")
+    parser.add_argument("--voice", default="af_heart")
+    parser.add_argument("--speed", default="1.0")
+    parser.add_argument("--stream-timeout", type=float, default=DEFAULT_STREAM_TIMEOUT)
+    parser.add_argument("--tts-timeout", type=int, default=180)
+    parser.add_argument("--max-text-length", type=int, default=2000)
+    parser.add_argument("--systemctl-timeout", type=float, default=15.0)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    if args.restart_hermes and not args.apply:
+        raise SystemExit("--restart-hermes requires --apply")
+    if args.no_start and not args.apply:
+        raise SystemExit("--no-start is only meaningful with --apply")
+    if args.no_systemctl and not args.apply:
+        raise SystemExit("--no-systemctl is only meaningful with --apply")
+
+    plan = build_plan(args)
+    result: dict[str, Any] = {
+        "success": True,
+        "applied": args.apply,
+        "plan": plan,
+    }
+    if args.apply:
+        result["apply_result"] = apply_plan(plan, args)
+
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install_voice_local_stack.py
+++ b/scripts/install_voice_local_stack.py
@@ -244,6 +244,9 @@ def build_verify_commands(
     webrtc_python_bin: str,
     sidecar_url: str,
     sidecar_service: str | None,
+    run_stt_smoke: bool,
+    stt_provider_name: str,
+    stt_timeout: int,
 ) -> dict[str, list[str]]:
     live_gateway_command = [
         verifier_python_bin,
@@ -260,6 +263,16 @@ def build_verify_commands(
         voice_bin,
         "--run-tts-smoke",
     ]
+    if run_stt_smoke:
+        live_gateway_command.extend(
+            [
+                "--run-stt-smoke",
+                "--stt-provider",
+                stt_provider_name,
+                "--stt-timeout",
+                str(stt_timeout),
+            ]
+        )
     if sidecar_service:
         live_gateway_command.extend(
             [
@@ -556,6 +569,9 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
             webrtc_python_bin=webrtc_python_bin,
             sidecar_url=args.sidecar_url.rstrip("/"),
             sidecar_service=None if args.skip_sidecar_service else args.sidecar_service,
+            run_stt_smoke=args.configure_stt,
+            stt_provider_name=args.stt_provider_name,
+            stt_timeout=args.stt_timeout,
         ),
     }
 

--- a/scripts/install_voice_local_stack.py
+++ b/scripts/install_voice_local_stack.py
@@ -10,6 +10,9 @@ misconfigure by hand:
 
 By default the script is a dry run and prints the files it would write. Pass
 ``--apply`` to write them, reload systemd, and optionally restart Hermes.
+Pass ``--configure-tts`` / ``--configure-stt`` to point Hermes at the local
+``voice`` binary for WhatsApp-ready speech output and voice-native
+``stream-transcribe`` input.
 """
 
 from __future__ import annotations
@@ -30,6 +33,7 @@ DEFAULT_PORT = 8787
 DEFAULT_HERMES_SERVICE = "hermes-gateway.service"
 DEFAULT_SIDECAR_SERVICE = "voice-webrtc-sidecar.service"
 DEFAULT_STREAM_TIMEOUT = 180.0
+DEFAULT_STT_TIMEOUT = 300
 
 
 def repo_root() -> Path:
@@ -217,6 +221,19 @@ def build_tts_provider(
     }
 
 
+def build_stt_provider(
+    *,
+    voice_bin: str,
+    timeout: int,
+) -> dict[str, Any]:
+    return {
+        "type": "command",
+        "command": f"{voice_bin} stream-transcribe --quiet {{input_path}}",
+        "format": "txt",
+        "timeout": timeout,
+    }
+
+
 def build_verify_commands(
     *,
     verifier_python_bin: str,
@@ -337,6 +354,73 @@ def configure_tts_provider(
     }
 
 
+def configure_stt_provider(
+    *,
+    config_path: Path,
+    provider_name: str,
+    provider: dict[str, Any],
+) -> dict[str, Any]:
+    if config_path.exists():
+        text = config_path.read_text(encoding="utf-8")
+    else:
+        text = ""
+
+    try:
+        from ruamel.yaml import YAML
+    except ModuleNotFoundError:
+        try:
+            import yaml
+        except ModuleNotFoundError as exc:
+            raise SystemExit(
+                "updating Hermes config requires PyYAML or ruamel.yaml; "
+                "rerun without --configure-stt or install one of those packages"
+            ) from exc
+
+        data = yaml.safe_load(text) if text.strip() else {}
+
+        def dump_yaml(value: dict[str, Any], handle: Any) -> None:
+            yaml.safe_dump(
+                value,
+                handle,
+                default_flow_style=False,
+                sort_keys=False,
+            )
+    else:
+        yaml = YAML()
+        yaml.default_flow_style = False
+        data = yaml.load(text) if text.strip() else {}
+
+        def dump_yaml(value: dict[str, Any], handle: Any) -> None:
+            yaml.dump(value, handle)
+
+    data = data or {}
+
+    if not isinstance(data, dict):
+        raise SystemExit(f"Hermes config root must be a mapping: {config_path}")
+
+    stt = data.setdefault("stt", {})
+    if not isinstance(stt, dict):
+        raise SystemExit(f"Hermes config stt section must be a mapping: {config_path}")
+    providers = stt.setdefault("providers", {})
+    if not isinstance(providers, dict):
+        raise SystemExit(
+            f"Hermes config stt.providers section must be a mapping: {config_path}"
+        )
+
+    stt["enabled"] = True
+    stt["provider"] = provider_name
+    providers[provider_name] = provider
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    with config_path.open("w", encoding="utf-8") as handle:
+        dump_yaml(data, handle)
+
+    return {
+        "path": str(config_path),
+        "provider": provider_name,
+        "format": provider["format"],
+    }
+
+
 def run_systemctl(command: list[str], *, timeout: float) -> None:
     completed = subprocess.run(
         ["systemctl", "--user", *command],
@@ -402,6 +486,10 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         timeout=args.tts_timeout,
         max_text_length=args.max_text_length,
     )
+    stt_provider = build_stt_provider(
+        voice_bin=voice_bin,
+        timeout=args.stt_timeout,
+    )
 
     files: list[dict[str, str]] = []
     if not args.skip_sidecar_service:
@@ -440,6 +528,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
     return {
         "apply": args.apply,
         "configure_tts": args.configure_tts,
+        "configure_stt": args.configure_stt,
         "hermes_home": str(hermes_home),
         "live_hermes_root": str(live_hermes_root),
         "voice_repo": str(voice_repo),
@@ -457,6 +546,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         },
         "files": files,
         "tts_provider": tts_provider,
+        "stt_provider": stt_provider,
         "verify_commands": build_verify_commands(
             verifier_python_bin=sys.executable,
             live_hermes_root=live_hermes_root,
@@ -480,11 +570,18 @@ def apply_plan(plan: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]
 
     Path(plan["paths"]["rx_pcm"]).parent.mkdir(parents=True, exist_ok=True)
     config_result = None
+    stt_config_result = None
     if plan["configure_tts"]:
         config_result = configure_tts_provider(
             config_path=Path(plan["paths"]["config"]),
             provider_name=args.provider_name,
             provider=plan["tts_provider"],
+        )
+    if plan["configure_stt"]:
+        stt_config_result = configure_stt_provider(
+            config_path=Path(plan["paths"]["config"]),
+            provider_name=args.stt_provider_name,
+            provider=plan["stt_provider"],
         )
 
     systemctl_actions: list[str] = []
@@ -507,6 +604,7 @@ def apply_plan(plan: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]
     return {
         "written": written,
         "configured_tts": config_result,
+        "configured_stt": stt_config_result,
         "systemctl": systemctl_actions,
     }
 
@@ -518,6 +616,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "--configure-tts",
         action="store_true",
         help="update config.yaml to use voice say --format ogg-opus",
+    )
+    parser.add_argument(
+        "--configure-stt",
+        action="store_true",
+        help="update config.yaml to use voice stream-transcribe for STT",
     )
     parser.add_argument(
         "--restart-hermes",
@@ -575,10 +678,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         default=str(Path.home() / ".hermes" / "config.yaml"),
     )
     parser.add_argument("--provider-name", default="kokoro")
+    parser.add_argument("--stt-provider-name", default="voice")
     parser.add_argument("--voice", default="af_heart")
     parser.add_argument("--speed", default="1.0")
     parser.add_argument("--stream-timeout", type=float, default=DEFAULT_STREAM_TIMEOUT)
     parser.add_argument("--tts-timeout", type=int, default=180)
+    parser.add_argument("--stt-timeout", type=int, default=DEFAULT_STT_TIMEOUT)
     parser.add_argument("--max-text-length", type=int, default=2000)
     parser.add_argument("--systemctl-timeout", type=float, default=15.0)
     return parser.parse_args(argv)

--- a/scripts/install_voice_local_stack.py
+++ b/scripts/install_voice_local_stack.py
@@ -147,7 +147,7 @@ def render_sidecar_unit(
         [
             "[Unit]",
             "Description=Voice WebRTC Sidecar",
-            "After=network.target voice-daemon.service",
+            "After=network.target voiced.service",
             "",
             "[Service]",
             "Type=simple",

--- a/scripts/verify_voice_command_stt.py
+++ b/scripts/verify_voice_command_stt.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Validate a voice-backed Hermes command STT provider.
+
+By default this script writes a temporary Hermes config that points
+``stt.providers.voice`` at ``voice stream-transcribe --quiet {input_path}``,
+generates a small WAV fixture with ``voice say``, runs Hermes'
+``transcribe_audio`` entry point, and verifies the transcript/provider.
+
+Pass ``--use-existing-config`` to validate a deployed HERMES_HOME without
+rewriting config.yaml.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+
+DEFAULT_TEXT = "hello world"
+DEFAULT_EXPECT_WORDS = ("hello", "world")
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def resolve_executable(value: str, *, label: str) -> str:
+    if "/" in value:
+        path = Path(value).expanduser()
+        if not path.is_file() or not os.access(path, os.X_OK):
+            raise SystemExit(f"{label} is not executable: {path}")
+        return str(path.resolve())
+
+    found = shutil.which(value)
+    if not found:
+        raise SystemExit(f"{label} not found on PATH: {value}")
+    return found
+
+
+def build_config(*, provider: str, voice_bin: str, timeout: float) -> str:
+    command = f"{shlex.quote(voice_bin)} stream-transcribe --quiet {{input_path}}"
+    return (
+        "stt:\n"
+        "  enabled: true\n"
+        f"  provider: {provider}\n"
+        "  providers:\n"
+        f"    {provider}:\n"
+        "      type: command\n"
+        f"      command: {json.dumps(command)}\n"
+        "      format: txt\n"
+        f"      timeout: {timeout:g}\n"
+    )
+
+
+def write_isolated_config(
+    hermes_home: Path,
+    *,
+    provider: str,
+    voice_bin: str,
+    timeout: float,
+    force: bool,
+) -> Path:
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    config_path = hermes_home / "config.yaml"
+    if config_path.exists() and not force:
+        raise SystemExit(
+            f"{config_path} already exists; pass --force to overwrite it"
+        )
+    config_path.write_text(
+        build_config(provider=provider, voice_bin=voice_bin, timeout=timeout),
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def default_hermes_home() -> Path:
+    return Path(os.environ.get("HERMES_HOME", "~/.hermes")).expanduser()
+
+
+def existing_config_path(hermes_home: Path) -> Path:
+    config_path = hermes_home / "config.yaml"
+    if not config_path.is_file():
+        raise SystemExit(
+            f"{config_path} does not exist; remove --use-existing-config or pass --hermes-home"
+        )
+    return config_path
+
+
+def generate_audio(
+    *,
+    voice_bin: str,
+    text: str,
+    output_path: Path,
+    voice: str,
+    speed: str,
+    timeout: float,
+) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    command = [
+        voice_bin,
+        "--quiet",
+        "say",
+        "--format",
+        "wav",
+        "--output",
+        str(output_path),
+        "--voice",
+        voice,
+        "--speed",
+        speed,
+        text,
+    ]
+    completed = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+        stdin=subprocess.DEVNULL,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise SystemExit(
+            f"voice say failed with exit code {completed.returncode}"
+            + (f": {detail[:1000]}" if detail else "")
+        )
+    if not output_path.is_file() or output_path.stat().st_size == 0:
+        raise SystemExit(f"voice say did not create a non-empty WAV: {output_path}")
+
+
+def run_transcription_tool(*, hermes_home: Path, audio_path: Path) -> dict[str, Any]:
+    os.environ["HERMES_HOME"] = str(hermes_home)
+    sys.path.insert(0, str(repo_root()))
+
+    from tools.transcription_tools import transcribe_audio
+
+    result = transcribe_audio(str(audio_path))
+    if not result.get("success"):
+        raise SystemExit(
+            "transcribe_audio failed: "
+            + json.dumps(result, ensure_ascii=False, indent=2)
+        )
+    return result
+
+
+def transcript_text(result: dict[str, Any]) -> str:
+    return str(result.get("transcript") or result.get("text") or "")
+
+
+def validate_result(
+    result: dict[str, Any],
+    *,
+    expected_provider: str,
+    expected_words: list[str],
+) -> None:
+    transcript = transcript_text(result)
+    transcript_lower = transcript.lower()
+    failures: list[str] = []
+
+    if result.get("provider") != expected_provider:
+        failures.append(
+            f"expected provider {expected_provider}, got {result.get('provider')!r}"
+        )
+    if not transcript.strip():
+        failures.append("expected a non-empty transcript")
+    for word in expected_words:
+        if word.lower() not in transcript_lower:
+            failures.append(f"expected transcript to contain {word!r}: {transcript!r}")
+
+    if failures:
+        raise SystemExit("validation failed:\n- " + "\n- ".join(failures))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run Hermes STT against a command provider backed by "
+            "`voice stream-transcribe --quiet` and verify the transcript."
+        )
+    )
+    parser.add_argument("--voice-bin", default=os.environ.get("VOICE_BIN", "voice"))
+    parser.add_argument("--hermes-home", type=Path)
+    parser.add_argument(
+        "--use-existing-config",
+        action="store_true",
+        help=(
+            "Use the existing config.yaml under --hermes-home or HERMES_HOME. "
+            "The default mode writes an isolated temporary config."
+        ),
+    )
+    parser.add_argument("--keep-home", action="store_true")
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument("--audio-path", type=Path)
+    parser.add_argument(
+        "--provider",
+        default="voice",
+        help=(
+            "Provider name to write in isolated mode, and expected result "
+            "provider in --use-existing-config mode."
+        ),
+    )
+    parser.add_argument("--voice", default="af_heart")
+    parser.add_argument("--speed", default="1.0")
+    parser.add_argument("--timeout", type=float, default=300.0)
+    parser.add_argument("--generate-timeout", type=float, default=180.0)
+    parser.add_argument("--text", default=DEFAULT_TEXT)
+    parser.add_argument(
+        "--expect-word",
+        action="append",
+        default=None,
+        help="word expected in the transcript; repeatable",
+    )
+    args = parser.parse_args()
+    if args.expect_word is None:
+        args.expect_word = list(DEFAULT_EXPECT_WORDS)
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    voice_bin = resolve_executable(args.voice_bin, label="voice binary")
+
+    if args.use_existing_config:
+        temporary_home = False
+        hermes_home = (
+            args.hermes_home.expanduser().resolve()
+            if args.hermes_home is not None
+            else default_hermes_home().resolve()
+        )
+        config_path = existing_config_path(hermes_home)
+        mode = "existing"
+    else:
+        temporary_home = args.hermes_home is None
+        hermes_home = (
+            Path(tempfile.mkdtemp(prefix="hermes-voice-command-stt."))
+            if temporary_home
+            else args.hermes_home.expanduser().resolve()
+        )
+        config_path = write_isolated_config(
+            hermes_home,
+            provider=args.provider,
+            voice_bin=voice_bin,
+            timeout=args.timeout,
+            force=args.force or temporary_home,
+        )
+        mode = "isolated"
+
+    audio_temp_dir: tempfile.TemporaryDirectory[str] | None = None
+    if args.audio_path is None:
+        audio_temp_dir = tempfile.TemporaryDirectory(
+            prefix="hermes-voice-command-stt-audio."
+        )
+        audio_path = Path(audio_temp_dir.name) / "input.wav"
+        generated_audio = True
+    else:
+        audio_path = args.audio_path.expanduser().resolve()
+        generated_audio = False
+
+    try:
+        if generated_audio:
+            generate_audio(
+                voice_bin=voice_bin,
+                text=args.text,
+                output_path=audio_path,
+                voice=args.voice,
+                speed=args.speed,
+                timeout=args.generate_timeout,
+            )
+        elif not audio_path.is_file() or audio_path.stat().st_size == 0:
+            raise SystemExit(f"--audio-path is not a non-empty file: {audio_path}")
+
+        result = run_transcription_tool(hermes_home=hermes_home, audio_path=audio_path)
+        validate_result(
+            result,
+            expected_provider=args.provider,
+            expected_words=args.expect_word,
+        )
+        retained_audio = not generated_audio
+        print(
+            json.dumps(
+                {
+                    "success": True,
+                    "mode": mode,
+                    "hermes_home": str(hermes_home),
+                    "config_path": str(config_path),
+                    "retained": bool(args.keep_home or not temporary_home),
+                    "audio_path": (
+                        str(audio_path)
+                        if retained_audio
+                        else "<temporary; pass --audio-path to use a retained fixture>"
+                    ),
+                    "provider": result.get("provider"),
+                    "transcript": transcript_text(result),
+                    "expected_words": args.expect_word,
+                },
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
+        return 0
+    finally:
+        if audio_temp_dir is not None:
+            audio_temp_dir.cleanup()
+        if temporary_home and not args.keep_home:
+            shutil.rmtree(hermes_home, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_voice_command_tts.py
+++ b/scripts/verify_voice_command_tts.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
-"""Validate a voice-backed Hermes command TTS provider in an isolated home.
+"""Validate a voice-backed Hermes command TTS provider.
 
-This script writes a temporary Hermes config that points a command provider at
-`voice say --format ogg-opus`, runs Hermes' real text_to_speech_tool entry
-point, and verifies the resulting audio is WhatsApp-ready Ogg/Opus.
+By default this script writes a temporary Hermes config that points a command
+provider at `voice say --format ogg-opus`, runs Hermes' real
+text_to_speech_tool entry point, and verifies the resulting audio is
+WhatsApp-ready Ogg/Opus.
+
+Pass `--use-existing-config` to validate a deployed HERMES_HOME without
+rewriting config.yaml.
 """
 
 from __future__ import annotations
@@ -91,7 +95,26 @@ def write_isolated_config(
     return config_path
 
 
-def run_tts_tool(*, hermes_home: Path, text: str, output_path: str | None, platform: str) -> dict[str, Any]:
+def default_hermes_home() -> Path:
+    return Path(os.environ.get("HERMES_HOME", "~/.hermes")).expanduser()
+
+
+def existing_config_path(hermes_home: Path) -> Path:
+    config_path = hermes_home / "config.yaml"
+    if not config_path.is_file():
+        raise SystemExit(
+            f"{config_path} does not exist; remove --use-existing-config or pass --hermes-home"
+        )
+    return config_path
+
+
+def run_tts_tool(
+    *,
+    hermes_home: Path,
+    text: str,
+    output_path: str | None,
+    platform: str,
+) -> dict[str, Any]:
     os.environ["HERMES_HOME"] = str(hermes_home)
     os.environ["HERMES_SESSION_PLATFORM"] = platform
     sys.path.insert(0, str(repo_root()))
@@ -142,13 +165,20 @@ def probe_audio(path: Path, *, ffprobe_bin: str) -> dict[str, str]:
     return parse_ffprobe(completed.stdout)
 
 
-def validate_result(result: dict[str, Any], probe: dict[str, str]) -> None:
+def validate_result(
+    result: dict[str, Any],
+    probe: dict[str, str],
+    *,
+    expected_provider: str,
+) -> None:
     path = Path(str(result.get("file_path") or ""))
     media_tag = str(result.get("media_tag") or "")
     failures: list[str] = []
 
-    if result.get("provider") != "kokoro":
-        failures.append(f"expected provider kokoro, got {result.get('provider')!r}")
+    if result.get("provider") != expected_provider:
+        failures.append(
+            f"expected provider {expected_provider}, got {result.get('provider')!r}"
+        )
     if result.get("voice_compatible") is not True:
         failures.append("expected voice_compatible=true")
     if not media_tag.startswith("[[audio_as_voice]]\nMEDIA:"):
@@ -171,17 +201,32 @@ def validate_result(result: dict[str, Any], probe: dict[str, str]) -> None:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "Run Hermes TTS against an isolated command provider backed by "
+            "Run Hermes TTS against a command provider backed by "
             "`voice say --format ogg-opus` and verify Ogg/Opus output."
         )
     )
     parser.add_argument("--voice-bin", default=os.environ.get("VOICE_BIN", "voice"))
     parser.add_argument("--ffprobe-bin", default=os.environ.get("FFPROBE_BIN", "ffprobe"))
     parser.add_argument("--hermes-home", type=Path)
+    parser.add_argument(
+        "--use-existing-config",
+        action="store_true",
+        help=(
+            "Use the existing config.yaml under --hermes-home or HERMES_HOME. "
+            "The default mode writes an isolated temporary config."
+        ),
+    )
     parser.add_argument("--keep-home", action="store_true")
     parser.add_argument("--force", action="store_true")
     parser.add_argument("--output-path")
-    parser.add_argument("--provider", default="kokoro")
+    parser.add_argument(
+        "--provider",
+        default="kokoro",
+        help=(
+            "Provider name to write in isolated mode, and expected result "
+            "provider in --use-existing-config mode."
+        ),
+    )
     parser.add_argument("--voice", default="af_heart")
     parser.add_argument("--speed", default="1.0")
     parser.add_argument("--timeout", type=float, default=180.0)
@@ -192,17 +237,25 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    voice_bin = resolve_executable(args.voice_bin, label="voice binary")
     ffprobe_bin = resolve_executable(args.ffprobe_bin, label="ffprobe")
 
-    temporary_home = args.hermes_home is None
-    hermes_home = (
-        Path(tempfile.mkdtemp(prefix="hermes-voice-command-tts."))
-        if temporary_home
-        else args.hermes_home.expanduser().resolve()
-    )
-
-    try:
+    if args.use_existing_config:
+        temporary_home = False
+        hermes_home = (
+            args.hermes_home.expanduser().resolve()
+            if args.hermes_home is not None
+            else default_hermes_home().resolve()
+        )
+        config_path = existing_config_path(hermes_home)
+        mode = "existing"
+    else:
+        voice_bin = resolve_executable(args.voice_bin, label="voice binary")
+        temporary_home = args.hermes_home is None
+        hermes_home = (
+            Path(tempfile.mkdtemp(prefix="hermes-voice-command-tts."))
+            if temporary_home
+            else args.hermes_home.expanduser().resolve()
+        )
         config_path = write_isolated_config(
             hermes_home,
             provider=args.provider,
@@ -212,6 +265,9 @@ def main() -> int:
             timeout=args.timeout,
             force=args.force or temporary_home,
         )
+        mode = "isolated"
+
+    try:
         result = run_tts_tool(
             hermes_home=hermes_home,
             text=args.text,
@@ -220,12 +276,13 @@ def main() -> int:
         )
         audio_path = Path(str(result["file_path"]))
         probe = probe_audio(audio_path, ffprobe_bin=ffprobe_bin)
-        validate_result(result, probe)
-        retained = not (temporary_home and not args.keep_home)
+        validate_result(result, probe, expected_provider=args.provider)
+        retained = bool(args.output_path) or not (temporary_home and not args.keep_home)
         print(
             json.dumps(
                 {
                     "success": True,
+                    "mode": mode,
                     "hermes_home": str(hermes_home),
                     "config_path": str(config_path),
                     "retained": retained,

--- a/scripts/verify_voice_command_tts.py
+++ b/scripts/verify_voice_command_tts.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Validate a voice-backed Hermes command TTS provider in an isolated home.
+
+This script writes a temporary Hermes config that points a command provider at
+`voice say --format ogg-opus`, runs Hermes' real text_to_speech_tool entry
+point, and verifies the resulting audio is WhatsApp-ready Ogg/Opus.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_TEXT = "Hermes voice command provider smoke test."
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def resolve_executable(value: str, *, label: str) -> str:
+    if "/" in value:
+        path = Path(value).expanduser()
+        if not path.is_file() or not os.access(path, os.X_OK):
+            raise SystemExit(f"{label} is not executable: {path}")
+        return str(path.resolve())
+
+    found = shutil.which(value)
+    if not found:
+        raise SystemExit(f"{label} not found on PATH: {value}")
+    return found
+
+
+def build_config(*, provider: str, voice_bin: str, voice: str, speed: str, timeout: float) -> str:
+    command = (
+        f"{shlex.quote(voice_bin)} say --format ogg-opus "
+        "--input-file {input_path} --output {output_path} "
+        "--voice {voice} --speed {speed}"
+    )
+    return (
+        "tts:\n"
+        f"  provider: {provider}\n"
+        "  providers:\n"
+        f"    {provider}:\n"
+        "      type: command\n"
+        f"      command: {json.dumps(command)}\n"
+        "      output_format: ogg\n"
+        "      voice_compatible: true\n"
+        f"      voice: {json.dumps(voice)}\n"
+        f"      speed: {json.dumps(speed)}\n"
+        f"      timeout: {timeout:g}\n"
+        "      max_text_length: 2000\n"
+    )
+
+
+def write_isolated_config(
+    hermes_home: Path,
+    *,
+    provider: str,
+    voice_bin: str,
+    voice: str,
+    speed: str,
+    timeout: float,
+    force: bool,
+) -> Path:
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    config_path = hermes_home / "config.yaml"
+    if config_path.exists() and not force:
+        raise SystemExit(
+            f"{config_path} already exists; pass --force to overwrite it"
+        )
+    config_path.write_text(
+        build_config(
+            provider=provider,
+            voice_bin=voice_bin,
+            voice=voice,
+            speed=speed,
+            timeout=timeout,
+        ),
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def run_tts_tool(*, hermes_home: Path, text: str, output_path: str | None, platform: str) -> dict[str, Any]:
+    os.environ["HERMES_HOME"] = str(hermes_home)
+    os.environ["HERMES_SESSION_PLATFORM"] = platform
+    sys.path.insert(0, str(repo_root()))
+
+    from tools.tts_tool import text_to_speech_tool
+
+    raw = text_to_speech_tool(text, output_path=output_path)
+    try:
+        result = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"text_to_speech_tool returned invalid JSON: {raw}") from exc
+
+    if not result.get("success"):
+        raise SystemExit(
+            "text_to_speech_tool failed: "
+            + json.dumps(result, ensure_ascii=False, indent=2)
+        )
+    return result
+
+
+def parse_ffprobe(output: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in output.splitlines():
+        key, sep, value = line.partition("=")
+        if sep:
+            values[key] = value
+    return values
+
+
+def probe_audio(path: Path, *, ffprobe_bin: str) -> dict[str, str]:
+    completed = subprocess.run(
+        [
+            ffprobe_bin,
+            "-v",
+            "error",
+            "-select_streams",
+            "a:0",
+            "-show_entries",
+            "stream=codec_name,sample_rate,channels",
+            "-of",
+            "default=noprint_wrappers=1",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return parse_ffprobe(completed.stdout)
+
+
+def validate_result(result: dict[str, Any], probe: dict[str, str]) -> None:
+    path = Path(str(result.get("file_path") or ""))
+    media_tag = str(result.get("media_tag") or "")
+    failures: list[str] = []
+
+    if result.get("provider") != "kokoro":
+        failures.append(f"expected provider kokoro, got {result.get('provider')!r}")
+    if result.get("voice_compatible") is not True:
+        failures.append("expected voice_compatible=true")
+    if not media_tag.startswith("[[audio_as_voice]]\nMEDIA:"):
+        failures.append("expected media_tag to start with [[audio_as_voice]] and MEDIA:")
+    if path.suffix.lower() != ".ogg":
+        failures.append(f"expected .ogg output, got {path}")
+    if not path.is_file() or path.stat().st_size == 0:
+        failures.append(f"expected non-empty output file at {path}")
+    if probe.get("codec_name") != "opus":
+        failures.append(f"expected codec_name=opus, got {probe.get('codec_name')!r}")
+    if probe.get("sample_rate") != "48000":
+        failures.append(f"expected sample_rate=48000, got {probe.get('sample_rate')!r}")
+    if probe.get("channels") != "1":
+        failures.append(f"expected channels=1, got {probe.get('channels')!r}")
+
+    if failures:
+        raise SystemExit("validation failed:\n- " + "\n- ".join(failures))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run Hermes TTS against an isolated command provider backed by "
+            "`voice say --format ogg-opus` and verify Ogg/Opus output."
+        )
+    )
+    parser.add_argument("--voice-bin", default=os.environ.get("VOICE_BIN", "voice"))
+    parser.add_argument("--ffprobe-bin", default=os.environ.get("FFPROBE_BIN", "ffprobe"))
+    parser.add_argument("--hermes-home", type=Path)
+    parser.add_argument("--keep-home", action="store_true")
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument("--output-path")
+    parser.add_argument("--provider", default="kokoro")
+    parser.add_argument("--voice", default="af_heart")
+    parser.add_argument("--speed", default="1.0")
+    parser.add_argument("--timeout", type=float, default=180.0)
+    parser.add_argument("--platform", default="whatsapp")
+    parser.add_argument("--text", default=DEFAULT_TEXT)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    voice_bin = resolve_executable(args.voice_bin, label="voice binary")
+    ffprobe_bin = resolve_executable(args.ffprobe_bin, label="ffprobe")
+
+    temporary_home = args.hermes_home is None
+    hermes_home = (
+        Path(tempfile.mkdtemp(prefix="hermes-voice-command-tts."))
+        if temporary_home
+        else args.hermes_home.expanduser().resolve()
+    )
+
+    try:
+        config_path = write_isolated_config(
+            hermes_home,
+            provider=args.provider,
+            voice_bin=voice_bin,
+            voice=args.voice,
+            speed=args.speed,
+            timeout=args.timeout,
+            force=args.force or temporary_home,
+        )
+        result = run_tts_tool(
+            hermes_home=hermes_home,
+            text=args.text,
+            output_path=args.output_path,
+            platform=args.platform,
+        )
+        audio_path = Path(str(result["file_path"]))
+        probe = probe_audio(audio_path, ffprobe_bin=ffprobe_bin)
+        validate_result(result, probe)
+        retained = not (temporary_home and not args.keep_home)
+        print(
+            json.dumps(
+                {
+                    "success": True,
+                    "hermes_home": str(hermes_home),
+                    "config_path": str(config_path),
+                    "retained": retained,
+                    "file_path": (
+                        str(audio_path)
+                        if retained
+                        else "<temporary; pass --keep-home or --output-path to retain>"
+                    ),
+                    "provider": result.get("provider"),
+                    "voice_compatible": result.get("voice_compatible"),
+                    "media_tag_prefix": str(result.get("media_tag", "")).splitlines()[0],
+                    "codec_name": probe.get("codec_name"),
+                    "sample_rate": probe.get("sample_rate"),
+                    "channels": probe.get("channels"),
+                },
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
+        return 0
+    finally:
+        if temporary_home and not args.keep_home:
+            shutil.rmtree(hermes_home, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_voice_full_duplex_sidecar.py
+++ b/scripts/verify_voice_full_duplex_sidecar.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Validate the voice WebRTC sidecar full-duplex preflight from Hermes.
+
+This is a small Hermes-side wrapper around the optional voice repo smoke:
+
+    examples/webrtc-sidecar/full_duplex_loopback_smoke.py
+
+It keeps the heavy WebRTC dependencies in the voice smoke environment, captures
+the machine-readable JSON output, and verifies the fields Hermes cares about
+before an operator attempts a real WhatsApp Calling session.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+
+DEFAULT_INBOUND_TEXT = "hello world"
+DEFAULT_OUTBOUND_TEXT = "Hello from Hermes through the voice WebRTC sidecar."
+DEFAULT_EXPECT_WORDS = ("hello", "world")
+DEFAULT_TIMEOUT = 90.0
+
+
+def resolve_executable(value: str, *, label: str) -> str:
+    if "/" in value:
+        path = Path(value).expanduser()
+        if not path.is_file() or not os.access(path, os.X_OK):
+            raise SystemExit(f"{label} is not executable: {path}")
+        # Preserve virtualenv entrypoint symlinks. Resolving
+        # /tmp/venv/bin/python to the base interpreter bypasses pyvenv.cfg and
+        # drops the sidecar dependencies installed in that venv.
+        return os.path.abspath(os.path.expanduser(value))
+
+    found = shutil.which(value)
+    if not found:
+        raise SystemExit(f"{label} not found on PATH: {value}")
+    return found
+
+
+def default_python_bin() -> str:
+    configured = os.environ.get("VOICE_WEBRTC_PYTHON")
+    if configured:
+        return configured
+    common_venv = Path("/tmp/voice-webrtc-venv/bin/python")
+    if common_venv.is_file() and os.access(common_venv, os.X_OK):
+        return str(common_venv)
+    return sys.executable
+
+
+def full_duplex_smoke_path(voice_repo: Path) -> Path:
+    return (
+        voice_repo
+        / "examples"
+        / "webrtc-sidecar"
+        / "full_duplex_loopback_smoke.py"
+    )
+
+
+def resolve_voice_smoke(voice_repo: Path) -> Path:
+    path = full_duplex_smoke_path(voice_repo.expanduser().resolve())
+    if not path.is_file():
+        raise SystemExit(
+            "voice full-duplex sidecar smoke not found: "
+            f"{path}. Pass --voice-repo pointing at rgbkrk/voice main."
+        )
+    return path
+
+
+def build_smoke_command(
+    *,
+    python_bin: str,
+    smoke_path: Path,
+    voice_bin: str,
+    inbound_text: str,
+    outbound_text: str,
+    voice: str,
+    speed: str,
+    timeout: float,
+    expect_words: list[str],
+) -> list[str]:
+    command = [
+        python_bin,
+        str(smoke_path),
+        "--voice-bin",
+        voice_bin,
+        "--inbound-text",
+        inbound_text,
+        "--outbound-text",
+        outbound_text,
+        "--voice",
+        voice,
+        "--speed",
+        speed,
+        "--timeout",
+        f"{timeout:g}",
+    ]
+    for word in expect_words:
+        command.extend(["--expect-word", word])
+    return command
+
+
+def run_smoke_command(
+    command: list[str],
+    *,
+    timeout: float,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def parse_smoke_json(stdout: str) -> dict[str, Any]:
+    decoder = json.JSONDecoder()
+    text = stdout.strip()
+    for index, char in enumerate(text):
+        if char != "{":
+            continue
+        try:
+            parsed, end = decoder.raw_decode(text[index:])
+        except json.JSONDecodeError:
+            continue
+        if text[index + end :].strip():
+            continue
+        if not isinstance(parsed, dict):
+            raise ValueError("full-duplex smoke JSON root must be an object")
+        return parsed
+    raise ValueError("full-duplex smoke did not print a JSON object")
+
+
+def validate_smoke_result(result: dict[str, Any]) -> None:
+    failures: list[str] = []
+
+    if result.get("success") is not True:
+        failures.append("success must be true")
+
+    audio = result.get("audio")
+    if not isinstance(audio, dict):
+        failures.append("audio must be an object")
+    else:
+        if int(audio.get("sample_rate") or 0) != 48_000:
+            failures.append("audio.sample_rate must be 48000")
+        if int(audio.get("channels") or 0) != 1:
+            failures.append("audio.channels must be 1")
+        if int(audio.get("frame_ms") or 0) != 20:
+            failures.append("audio.frame_ms must be 20")
+        if str(audio.get("encoding") or "") != "pcm_s16le":
+            failures.append("audio.encoding must be pcm_s16le")
+
+    transcript = str(result.get("transcript") or "").strip()
+    if not transcript:
+        failures.append("transcript must be non-empty")
+    if int(result.get("outbound_webrtc_bytes") or 0) <= 0:
+        failures.append("outbound_webrtc_bytes must be positive")
+    if int(result.get("decoded_pcm_bytes") or 0) <= 0:
+        failures.append("decoded_pcm_bytes must be positive")
+
+    stt = result.get("stt")
+    if not isinstance(stt, dict):
+        failures.append("stt must be an object")
+    elif not str(stt.get("text") or "").strip():
+        failures.append("stt.text must be non-empty")
+
+    if failures:
+        raise SystemExit("validation failed:\n- " + "\n- ".join(failures))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--voice-repo",
+        type=Path,
+        default=Path(os.environ.get("VOICE_REPO", ".")),
+        help="Path to an rgbkrk/voice checkout containing examples/webrtc-sidecar",
+    )
+    parser.add_argument("--python-bin", default=default_python_bin())
+    parser.add_argument("--voice-bin", default=os.environ.get("VOICE_BIN", "voice"))
+    parser.add_argument("--voice", default="af_heart")
+    parser.add_argument("--speed", default="1.0")
+    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
+    parser.add_argument("--inbound-text", default=DEFAULT_INBOUND_TEXT)
+    parser.add_argument("--outbound-text", default=DEFAULT_OUTBOUND_TEXT)
+    parser.add_argument(
+        "--expect-word",
+        action="append",
+        default=None,
+        help="word expected in the inbound transcript; repeatable",
+    )
+    args = parser.parse_args()
+    if args.expect_word is None:
+        args.expect_word = list(DEFAULT_EXPECT_WORDS)
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    python_bin = resolve_executable(args.python_bin, label="sidecar Python")
+    voice_bin = resolve_executable(args.voice_bin, label="voice binary")
+    smoke_path = resolve_voice_smoke(args.voice_repo)
+    command = build_smoke_command(
+        python_bin=python_bin,
+        smoke_path=smoke_path,
+        voice_bin=voice_bin,
+        inbound_text=args.inbound_text,
+        outbound_text=args.outbound_text,
+        voice=args.voice,
+        speed=args.speed,
+        timeout=args.timeout,
+        expect_words=args.expect_word,
+    )
+
+    completed = run_smoke_command(command, timeout=args.timeout + 5)
+    if completed.returncode != 0:
+        stderr = completed.stderr.strip()
+        raise SystemExit(
+            f"full-duplex smoke exited with code {completed.returncode}"
+            + (f": {stderr[:1000]}" if stderr else "")
+        )
+
+    try:
+        result = parse_smoke_json(completed.stdout)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    validate_smoke_result(result)
+
+    print(
+        json.dumps(
+            {
+                "success": True,
+                "voice_repo": str(args.voice_repo.expanduser().resolve()),
+                "voice_bin": voice_bin,
+                "python_bin": python_bin,
+                "smoke": result,
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_voice_full_duplex_sidecar.py
+++ b/scripts/verify_voice_full_duplex_sidecar.py
@@ -26,6 +26,7 @@ DEFAULT_INBOUND_TEXT = "hello world"
 DEFAULT_OUTBOUND_TEXT = "Hello from Hermes through the voice WebRTC sidecar."
 DEFAULT_EXPECT_WORDS = ("hello", "world")
 DEFAULT_TIMEOUT = 90.0
+DEFAULT_MAX_QUEUED_TX_MS = 1_000
 MAX_CHILD_ERROR_CHARS = 4000
 
 
@@ -85,6 +86,7 @@ def build_smoke_command(
     speed: str,
     timeout: float,
     expect_words: list[str],
+    max_queued_tx_ms: int,
 ) -> list[str]:
     command = [
         python_bin,
@@ -101,6 +103,8 @@ def build_smoke_command(
         speed,
         "--timeout",
         f"{timeout:g}",
+        "--max-queued-tx-ms",
+        str(max_queued_tx_ms),
     ]
     for word in expect_words:
         command.extend(["--expect-word", word])
@@ -147,7 +151,26 @@ def parse_smoke_json(stdout: str) -> dict[str, Any]:
     raise ValueError("full-duplex smoke did not print a JSON object")
 
 
-def validate_smoke_result(result: dict[str, Any]) -> None:
+def queued_tx_ms(queued_tx_bytes: object, audio: dict[str, Any]) -> int:
+    try:
+        queued_bytes = int(queued_tx_bytes or 0)
+        sample_rate = int(audio.get("sample_rate") or 0)
+        channels = int(audio.get("channels") or 0)
+        bytes_per_sample = int(audio.get("bytes_per_sample") or 2)
+    except (TypeError, ValueError):
+        return 0
+
+    bytes_per_second = sample_rate * channels * bytes_per_sample
+    if queued_bytes <= 0 or bytes_per_second <= 0:
+        return 0
+    return round(queued_bytes * 1_000 / bytes_per_second)
+
+
+def validate_smoke_result(
+    result: dict[str, Any],
+    *,
+    max_queued_tx_ms: int,
+) -> None:
     failures: list[str] = []
 
     if result.get("success") is not True:
@@ -165,6 +188,19 @@ def validate_smoke_result(result: dict[str, Any]) -> None:
             failures.append("audio.frame_ms must be 20")
         if str(audio.get("encoding") or "") != "pcm_s16le":
             failures.append("audio.encoding must be pcm_s16le")
+        queued_ms = result.get("queued_tx_ms")
+        if queued_ms is None:
+            queued_ms = queued_tx_ms(result.get("queued_tx_bytes"), audio)
+        try:
+            queued_ms_int = int(queued_ms)
+        except (TypeError, ValueError):
+            failures.append("queued_tx_ms must be an integer")
+        else:
+            if queued_ms_int > max_queued_tx_ms:
+                failures.append(
+                    "queued_tx_ms must be <= "
+                    f"{max_queued_tx_ms} (got {queued_ms_int})"
+                )
 
     transcript = str(result.get("transcript") or "").strip()
     if not transcript:
@@ -200,12 +236,23 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--inbound-text", default=DEFAULT_INBOUND_TEXT)
     parser.add_argument("--outbound-text", default=DEFAULT_OUTBOUND_TEXT)
     parser.add_argument(
+        "--max-queued-tx-ms",
+        type=int,
+        default=DEFAULT_MAX_QUEUED_TX_MS,
+        help=(
+            "Maximum outbound sidecar queue depth allowed at the end of the "
+            "full-duplex smoke."
+        ),
+    )
+    parser.add_argument(
         "--expect-word",
         action="append",
         default=None,
         help="word expected in the inbound transcript; repeatable",
     )
     args = parser.parse_args()
+    if args.max_queued_tx_ms < 0:
+        parser.error("--max-queued-tx-ms must be non-negative")
     if args.expect_word is None:
         args.expect_word = list(DEFAULT_EXPECT_WORDS)
     return args
@@ -226,6 +273,7 @@ def main() -> int:
         speed=args.speed,
         timeout=args.timeout,
         expect_words=args.expect_word,
+        max_queued_tx_ms=args.max_queued_tx_ms,
     )
 
     completed = run_smoke_command(command, timeout=args.timeout + 5)
@@ -240,7 +288,7 @@ def main() -> int:
         result = parse_smoke_json(completed.stdout)
     except ValueError as exc:
         raise SystemExit(str(exc)) from exc
-    validate_smoke_result(result)
+    validate_smoke_result(result, max_queued_tx_ms=args.max_queued_tx_ms)
 
     print(
         json.dumps(

--- a/scripts/verify_voice_full_duplex_sidecar.py
+++ b/scripts/verify_voice_full_duplex_sidecar.py
@@ -26,6 +26,7 @@ DEFAULT_INBOUND_TEXT = "hello world"
 DEFAULT_OUTBOUND_TEXT = "Hello from Hermes through the voice WebRTC sidecar."
 DEFAULT_EXPECT_WORDS = ("hello", "world")
 DEFAULT_TIMEOUT = 90.0
+MAX_CHILD_ERROR_CHARS = 4000
 
 
 def resolve_executable(value: str, *, label: str) -> str:
@@ -118,6 +119,14 @@ def run_smoke_command(
         timeout=timeout,
         check=False,
     )
+
+
+def format_child_error(text: str, *, max_chars: int = MAX_CHILD_ERROR_CHARS) -> str:
+    stripped = text.strip()
+    if len(stripped) <= max_chars:
+        return stripped
+    omitted = len(stripped) - max_chars
+    return f"... omitted {omitted} chars from child stderr ...\n{stripped[-max_chars:]}"
 
 
 def parse_smoke_json(stdout: str) -> dict[str, Any]:
@@ -221,10 +230,10 @@ def main() -> int:
 
     completed = run_smoke_command(command, timeout=args.timeout + 5)
     if completed.returncode != 0:
-        stderr = completed.stderr.strip()
+        stderr = format_child_error(completed.stderr)
         raise SystemExit(
             f"full-duplex smoke exited with code {completed.returncode}"
-            + (f": {stderr[:1000]}" if stderr else "")
+            + (f": {stderr}" if stderr else "")
         )
 
     try:

--- a/scripts/verify_voice_live_gateway.py
+++ b/scripts/verify_voice_live_gateway.py
@@ -48,6 +48,51 @@ CONTRACT_COMPARE_KEYS = (
     "endpoints",
     "payloads",
 )
+REQUIRED_VOICE_SURFACES = {
+    "completed_voice_note": {
+        "output": "audio/ogg; codecs=opus",
+        "transport": "completed_file",
+    },
+    "streamed_voice_note": {
+        "output": "audio/ogg; codecs=opus",
+        "transport": "daemon_stream_encoded_file",
+    },
+    "raw_outbound_pcm": {
+        "output": "pcm_s16le",
+        "transport": "stdout_pcm_frames",
+    },
+    "raw_inbound_pcm": {
+        "input": "pcm_s16le",
+        "transport": "stdin_pcm_frames",
+    },
+    "file_transcription_smoke": {
+        "input": "audio_file",
+        "transport": "decoded_file_to_daemon_frames",
+    },
+}
+REQUIRED_ENDPOINTS = {
+    "contract": ("GET", "/contract"),
+    "health": ("GET", "/health"),
+    "offer": ("POST", "/offer"),
+    "call_status": ("GET", "/calls/{call_id}"),
+    "receive_audio": ("GET", "/calls/{call_id}/audio"),
+    "send_audio": ("POST", "/calls/{call_id}/audio"),
+    "clear_audio": ("POST", "/calls/{call_id}/audio/clear"),
+    "close_call": ("POST", "/calls/{call_id}/close"),
+}
+REQUIRED_PAYLOADS = (
+    "offer_request",
+    "offer_response",
+    "call_state",
+    "call_status_response",
+    "close_call_response",
+    "send_audio_request",
+    "send_audio_response",
+    "clear_audio_response",
+    "receive_audio_response",
+    "audio_shape",
+    "error_response",
+)
 IMPORT_MODULES = (
     "hermes_cli.main",
     "tools.tts_tool",
@@ -432,11 +477,107 @@ def validate_calling_sidecar_contract(contract: dict[str, Any]) -> dict[str, Any
             "calling sidecar audio contract does not match Hermes WebRTC PCM "
             f"shape: {mismatches}"
         )
+    required_sections = validate_required_contract_sections(contract, audio=audio)
     return {
         "contract": str(contract.get("contract")),
         "version": contract.get("version"),
         "audio": {key: audio.get(key) for key in expected_audio},
+        "required_sections": required_sections,
     }
+
+
+def required_mapping(contract: dict[str, Any], section: str) -> dict[str, Any]:
+    value = contract.get(section)
+    if not isinstance(value, dict):
+        raise SystemExit(f"calling sidecar contract missing {section} object")
+    return value
+
+
+def validate_required_contract_sections(
+    contract: dict[str, Any],
+    *,
+    audio: dict[str, Any],
+) -> dict[str, list[str]]:
+    surfaces = required_mapping(contract, "voice_surfaces")
+    endpoints = required_mapping(contract, "endpoints")
+    payloads = required_mapping(contract, "payloads")
+
+    validate_voice_surface_contracts(surfaces, audio=audio)
+    validate_endpoint_contracts(endpoints)
+    missing_payloads = [name for name in REQUIRED_PAYLOADS if name not in payloads]
+    if missing_payloads:
+        raise SystemExit(
+            "calling sidecar contract payloads missing keys: "
+            + ", ".join(missing_payloads)
+        )
+
+    return {
+        "voice_surfaces": list(REQUIRED_VOICE_SURFACES),
+        "endpoints": list(REQUIRED_ENDPOINTS),
+        "payloads": list(REQUIRED_PAYLOADS),
+    }
+
+
+def validate_voice_surface_contracts(
+    surfaces: dict[str, Any],
+    *,
+    audio: dict[str, Any],
+) -> None:
+    missing = [name for name in REQUIRED_VOICE_SURFACES if name not in surfaces]
+    if missing:
+        raise SystemExit(
+            "calling sidecar contract voice_surfaces missing keys: "
+            + ", ".join(missing)
+        )
+
+    for name, expected in REQUIRED_VOICE_SURFACES.items():
+        surface = surfaces.get(name)
+        if not isinstance(surface, dict):
+            raise SystemExit(
+                f"calling sidecar contract voice_surfaces.{name} must be an object"
+            )
+        for field, expected_value in expected.items():
+            if surface.get(field) != expected_value:
+                raise SystemExit(
+                    "calling sidecar contract voice_surfaces."
+                    f"{name}.{field} must be {expected_value!r}: "
+                    f"{surface.get(field)!r}"
+                )
+        command = str(surface.get("command") or "")
+        if not command:
+            raise SystemExit(
+                f"calling sidecar contract voice_surfaces.{name}.command is empty"
+            )
+
+    raw_frame_bytes = audio.get("frame_bytes")
+    for name in ("raw_outbound_pcm", "raw_inbound_pcm"):
+        surface = surfaces[name]
+        if surface.get("frame_bytes") != raw_frame_bytes:
+            raise SystemExit(
+                f"calling sidecar contract voice_surfaces.{name}.frame_bytes "
+                f"must match audio.frame_bytes: {surface.get('frame_bytes')!r}"
+            )
+
+
+def validate_endpoint_contracts(endpoints: dict[str, Any]) -> None:
+    missing = [name for name in REQUIRED_ENDPOINTS if name not in endpoints]
+    if missing:
+        raise SystemExit(
+            "calling sidecar contract endpoints missing keys: "
+            + ", ".join(missing)
+        )
+
+    for name, (method, path) in REQUIRED_ENDPOINTS.items():
+        endpoint = endpoints.get(name)
+        if not isinstance(endpoint, dict):
+            raise SystemExit(
+                f"calling sidecar contract endpoints.{name} must be an object"
+            )
+        if endpoint.get("method") != method or endpoint.get("path") != path:
+            raise SystemExit(
+                f"calling sidecar contract endpoints.{name} must be "
+                f"{method} {path}: {endpoint!r}"
+            )
 
 
 def get_calling_sidecar_status(url: str, *, timeout: float) -> dict[str, Any]:
@@ -494,6 +635,7 @@ def compare_voice_and_sidecar_contracts(
         "version": validated["version"],
         "audio": validated["audio"],
         "matched_keys": list(CONTRACT_COMPARE_KEYS),
+        "required_sections": validated["required_sections"],
     }
 
 

--- a/scripts/verify_voice_live_gateway.py
+++ b/scripts/verify_voice_live_gateway.py
@@ -44,6 +44,12 @@ DEFAULT_TTS_TEXT = "Hermes live voice gateway smoke."
 DEFAULT_STT_TEXT = "hello world"
 DEFAULT_STT_EXPECT_WORDS = ("hello", "world")
 CALLING_TTS_STREAM_ENV = "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND"
+WHATSAPP_CLOUD_REQUIRED_ENV = (
+    "WHATSAPP_CLOUD_PHONE_NUMBER_ID",
+    "WHATSAPP_CLOUD_ACCESS_TOKEN",
+    "WHATSAPP_CLOUD_APP_SECRET",
+    "WHATSAPP_CLOUD_VERIFY_TOKEN",
+)
 CONTRACT_COMPARE_KEYS = (
     "contract",
     "version",
@@ -253,6 +259,171 @@ def parse_proc_environ(data: bytes) -> dict[str, str]:
             "utf-8", errors="replace"
         )
     return env
+
+
+def parse_dotenv_text(text: str) -> dict[str, str]:
+    env: dict[str, str] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].lstrip()
+        if "=" not in line:
+            continue
+        key, raw_value = line.split("=", 1)
+        key = key.strip()
+        if not key:
+            continue
+        value = raw_value.strip()
+        if (
+            len(value) >= 2
+            and value[0] == value[-1]
+            and value[0] in {"'", '"'}
+        ):
+            value = value[1:-1]
+        elif " #" in value:
+            value = value.split(" #", 1)[0].rstrip()
+        env[key] = value
+    return env
+
+
+def load_hermes_env_file(hermes_home: Path) -> dict[str, str]:
+    env_path = hermes_home / ".env"
+    if not env_path.is_file():
+        raise SystemExit(f"Hermes env file not found: {env_path}")
+    return parse_dotenv_text(env_path.read_text(encoding="utf-8", errors="replace"))
+
+
+def configured_value(
+    key: str,
+    *,
+    file_env: dict[str, str],
+    process_env: dict[str, str],
+) -> tuple[str, str]:
+    process_value = str(process_env.get(key) or "").strip()
+    if process_value:
+        return process_value, "process"
+    file_value = str(file_env.get(key) or "").strip()
+    if file_value:
+        return file_value, "env_file"
+    return "", "missing"
+
+
+def _looks_like_placeholder(value: str) -> bool:
+    lowered = value.strip().lower()
+    if lowered in {
+        "changeme",
+        "change-me",
+        "placeholder",
+        "example",
+        "your-token",
+        "your_token",
+        "your_verify_token",
+        "verify_token",
+        "token",
+    }:
+        return True
+    return any(token in lowered for token in ("<", ">", "paste_", "replace_"))
+
+
+def validate_whatsapp_cloud_field(key: str, value: str) -> dict[str, Any]:
+    if not value:
+        raise SystemExit(f"{key} is not configured")
+    if _looks_like_placeholder(value):
+        raise SystemExit(f"{key} still looks like a placeholder")
+
+    if key == "WHATSAPP_CLOUD_PHONE_NUMBER_ID":
+        if not value.isdigit():
+            raise SystemExit(f"{key} must be numeric")
+        if 10 <= len(value) <= 12:
+            raise SystemExit(
+                f"{key} looks like a phone number; use Meta's Phone Number ID"
+            )
+        if len(value) < 13 or len(value) > 20:
+            raise SystemExit(f"{key} should be 13-20 digits")
+        return {"present": True, "source_shape": "meta_phone_number_id"}
+
+    if key == "WHATSAPP_CLOUD_ACCESS_TOKEN":
+        if not value.startswith("EAA"):
+            raise SystemExit(f"{key} should start with EAA")
+        if len(value) < 100:
+            raise SystemExit(f"{key} looks too short for a Meta access token")
+        return {"present": True, "source_shape": "meta_access_token"}
+
+    if key == "WHATSAPP_CLOUD_APP_SECRET":
+        if not re.fullmatch(r"[0-9a-fA-F]{32}", value):
+            raise SystemExit(f"{key} should be exactly 32 hex characters")
+        return {"present": True, "source_shape": "meta_app_secret"}
+
+    if key == "WHATSAPP_CLOUD_VERIFY_TOKEN":
+        if len(value) < 16:
+            raise SystemExit(f"{key} should be at least 16 characters")
+        return {"present": True, "source_shape": "webhook_verify_token"}
+
+    raise SystemExit(f"unsupported WhatsApp Cloud readiness field: {key}")
+
+
+def truthy_env(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def validate_whatsapp_cloud_authorization(
+    *,
+    file_env: dict[str, str],
+    process_env: dict[str, str],
+) -> dict[str, Any]:
+    allowed_users, allowed_source = configured_value(
+        "WHATSAPP_CLOUD_ALLOWED_USERS",
+        file_env=file_env,
+        process_env=process_env,
+    )
+    allow_all, allow_all_source = configured_value(
+        "WHATSAPP_CLOUD_ALLOW_ALL_USERS",
+        file_env=file_env,
+        process_env=process_env,
+    )
+    allow_all_enabled = truthy_env(allow_all)
+    allowed_count = len([part for part in allowed_users.split(",") if part.strip()])
+    if allowed_count == 0 and not allow_all_enabled:
+        raise SystemExit(
+            "WhatsApp Cloud recipient authorization is not configured; set "
+            "WHATSAPP_CLOUD_ALLOWED_USERS or WHATSAPP_CLOUD_ALLOW_ALL_USERS"
+        )
+    return {
+        "allowed_users_configured": allowed_count > 0,
+        "allowed_users_count": allowed_count,
+        "allowed_users_source": allowed_source if allowed_count > 0 else "missing",
+        "allow_all_users": allow_all_enabled,
+        "allow_all_users_source": allow_all_source if allow_all else "missing",
+    }
+
+
+def validate_whatsapp_cloud_readiness(
+    *,
+    hermes_home: Path,
+    process_env: dict[str, str],
+) -> dict[str, Any]:
+    file_env = load_hermes_env_file(hermes_home)
+    fields: dict[str, Any] = {}
+    for key in WHATSAPP_CLOUD_REQUIRED_ENV:
+        value, source = configured_value(
+            key,
+            file_env=file_env,
+            process_env=process_env,
+        )
+        field = validate_whatsapp_cloud_field(key, value)
+        field["source"] = source
+        fields[key] = field
+
+    return {
+        "env_file": str((hermes_home / ".env").resolve()),
+        "required_fields": fields,
+        "authorization": validate_whatsapp_cloud_authorization(
+            file_env=file_env,
+            process_env=process_env,
+        ),
+    }
 
 
 def read_process_env(pid: int) -> dict[str, str]:
@@ -1148,6 +1319,15 @@ def parse_args() -> argparse.Namespace:
             "WhatsApp bridge."
         ),
     )
+    parser.add_argument(
+        "--require-whatsapp-cloud-readiness",
+        action="store_true",
+        help=(
+            "Require non-placeholder WhatsApp Cloud credentials and recipient "
+            "authorization in HERMES_HOME/.env or the running process "
+            "environment. Secret values are never printed."
+        ),
+    )
     parser.add_argument("--run-tts-smoke", action="store_true")
     parser.add_argument("--tts-platform", default="whatsapp")
     parser.add_argument("--tts-text", default=DEFAULT_TTS_TEXT)
@@ -1269,6 +1449,11 @@ def main() -> int:
             bridge_bin_dir=bridge_bin_dir,
         ),
     }
+    if args.require_whatsapp_cloud_readiness:
+        checks["whatsapp_cloud_readiness"] = validate_whatsapp_cloud_readiness(
+            hermes_home=hermes_home,
+            process_env=process_env,
+        )
 
     if args.calling_sidecar_url:
         checks["calling_sidecar"] = {

--- a/scripts/verify_voice_live_gateway.py
+++ b/scripts/verify_voice_live_gateway.py
@@ -32,7 +32,7 @@ import subprocess
 import sys
 from typing import Any
 from urllib.error import URLError
-from urllib.parse import urlparse
+from urllib.parse import urlencode, urlparse
 from urllib.request import urlopen
 
 from verify_voice_local_stack import audit_live_hermes_root
@@ -51,6 +51,8 @@ WHATSAPP_CLOUD_REQUIRED_ENV = (
     "WHATSAPP_CLOUD_VERIFY_TOKEN",
 )
 DEFAULT_WHATSAPP_CLOUD_WEBHOOK_PORT = 8090
+DEFAULT_WHATSAPP_CLOUD_WEBHOOK_PATH = "/whatsapp/webhook"
+DEFAULT_WHATSAPP_CLOUD_VERIFY_CHALLENGE = "hermes-local-cloud-verify-smoke"
 CONTRACT_COMPARE_KEYS = (
     "contract",
     "version",
@@ -476,6 +478,26 @@ def whatsapp_cloud_health_url_from_env(
     return f"http://{host}:{port}/health"
 
 
+def whatsapp_cloud_webhook_url_from_env(
+    *,
+    file_env: dict[str, str],
+    process_env: dict[str, str],
+) -> str:
+    health_url = whatsapp_cloud_health_url_from_env(
+        file_env=file_env,
+        process_env=process_env,
+    )
+    parsed = urlparse(health_url)
+    path = configured_value(
+        "WHATSAPP_CLOUD_WEBHOOK_PATH",
+        file_env=file_env,
+        process_env=process_env,
+    )[0] or DEFAULT_WHATSAPP_CLOUD_WEBHOOK_PATH
+    if not path.startswith("/"):
+        path = "/" + path
+    return f"{parsed.scheme}://{parsed.netloc}{path}"
+
+
 def validate_whatsapp_cloud_health(
     health: dict[str, Any],
     *,
@@ -554,6 +576,66 @@ def check_whatsapp_cloud_health(
             expected_phone_number_id=expected_phone_number_id,
             expect_calling_sidecar=expect_calling_sidecar,
         ),
+    }
+
+
+def get_text_url(target: str, *, timeout: float, label: str) -> tuple[int, str]:
+    try:
+        with urlopen(target, timeout=timeout) as response:
+            body = response.read().decode("utf-8", errors="replace")
+            status = int(getattr(response, "status", 200))
+    except URLError as exc:
+        raise SystemExit(f"request failed for {label}: {exc}") from exc
+    return status, body
+
+
+def check_whatsapp_cloud_verify_handshake(
+    *,
+    readiness: dict[str, Any],
+    webhook_url: str | None,
+    challenge: str,
+    timeout: float,
+) -> dict[str, Any]:
+    private = readiness.get("_private")
+    if not isinstance(private, dict):
+        raise SystemExit("WhatsApp Cloud readiness private data missing")
+    file_env = private.get("file_env")
+    process_env = private.get("process_env")
+    if not isinstance(file_env, dict) or not isinstance(process_env, dict):
+        raise SystemExit("WhatsApp Cloud readiness env data missing")
+    verify_token = configured_value(
+        "WHATSAPP_CLOUD_VERIFY_TOKEN",
+        file_env={str(k): str(v) for k, v in file_env.items()},
+        process_env={str(k): str(v) for k, v in process_env.items()},
+    )[0]
+    if not verify_token:
+        raise SystemExit("WHATSAPP_CLOUD_VERIFY_TOKEN is not configured")
+
+    target_base = webhook_url or whatsapp_cloud_webhook_url_from_env(
+        file_env={str(k): str(v) for k, v in file_env.items()},
+        process_env={str(k): str(v) for k, v in process_env.items()},
+    )
+    query = urlencode(
+        {
+            "hub.mode": "subscribe",
+            "hub.verify_token": verify_token,
+            "hub.challenge": challenge,
+        }
+    )
+    separator = "&" if "?" in target_base else "?"
+    status, body = get_text_url(
+        f"{target_base}{separator}{query}",
+        timeout=timeout,
+        label=target_base,
+    )
+    if status != 200:
+        raise SystemExit(f"WhatsApp Cloud verify handshake returned HTTP {status}")
+    if body != challenge:
+        raise SystemExit("WhatsApp Cloud verify handshake did not echo the challenge")
+    return {
+        "url": target_base,
+        "status": status,
+        "challenge_echoed": True,
     }
 
 
@@ -1476,6 +1558,28 @@ def parse_args() -> argparse.Namespace:
             "probe."
         ),
     )
+    parser.add_argument(
+        "--whatsapp-cloud-webhook-url",
+        help=(
+            "Override the local WhatsApp Cloud webhook URL used with "
+            "--require-whatsapp-cloud-readiness. Defaults to "
+            "http://127.0.0.1:8090/whatsapp/webhook, or the configured "
+            "webhook port/path."
+        ),
+    )
+    parser.add_argument(
+        "--skip-whatsapp-cloud-verify",
+        action="store_true",
+        help=(
+            "With --require-whatsapp-cloud-readiness, skip the local Meta "
+            "GET subscription verify-token handshake probe."
+        ),
+    )
+    parser.add_argument(
+        "--whatsapp-cloud-verify-challenge",
+        default=DEFAULT_WHATSAPP_CLOUD_VERIFY_CHALLENGE,
+        help=argparse.SUPPRESS,
+    )
     parser.add_argument("--run-tts-smoke", action="store_true")
     parser.add_argument("--tts-platform", default="whatsapp")
     parser.add_argument("--tts-text", default=DEFAULT_TTS_TEXT)
@@ -1618,6 +1722,21 @@ def main() -> int:
                 health_url=args.whatsapp_cloud_health_url,
                 timeout=args.timeout,
                 expect_calling_sidecar=bool(args.calling_sidecar_url),
+            )
+        if args.skip_whatsapp_cloud_verify:
+            checks["whatsapp_cloud_verify_handshake"] = {
+                "success": True,
+                "skipped": True,
+                "reason": "--skip-whatsapp-cloud-verify was provided",
+            }
+        else:
+            checks["whatsapp_cloud_verify_handshake"] = (
+                check_whatsapp_cloud_verify_handshake(
+                    readiness=cloud_readiness,
+                    webhook_url=args.whatsapp_cloud_webhook_url,
+                    challenge=args.whatsapp_cloud_verify_challenge,
+                    timeout=args.timeout,
+                )
             )
 
     if args.calling_sidecar_url:

--- a/scripts/verify_voice_live_gateway.py
+++ b/scripts/verify_voice_live_gateway.py
@@ -867,6 +867,70 @@ asyncio.run(main())
     }
 
 
+def run_calling_live_sidecar_smoke(
+    *,
+    python_bin: str,
+    live_root: Path,
+    hermes_home: Path,
+    voice_repo: Path,
+    timeout: float,
+) -> dict[str, Any]:
+    """Run the Hermes connect-path smoke against imports from live_root."""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(live_root)
+    env["HERMES_HOME"] = str(hermes_home)
+    completed = subprocess.run(
+        [
+            python_bin,
+            str(
+                Path(__file__).resolve().parent
+                / "verify_voice_whatsapp_calling_live_sidecar.py"
+            ),
+            "--voice-repo",
+            str(voice_repo),
+            "--timeout",
+            f"{timeout:g}",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=timeout + 15,
+        check=False,
+        env=env,
+        cwd=str(live_root),
+        stdin=subprocess.DEVNULL,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise SystemExit(f"calling live-sidecar smoke failed: {detail}")
+    try:
+        result = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(
+            f"calling live-sidecar smoke returned invalid JSON: {completed.stdout!r}"
+        ) from exc
+    if not isinstance(result, dict):
+        raise SystemExit("calling live-sidecar smoke JSON root must be an object")
+    if result.get("success") is not True:
+        raise SystemExit(f"calling live-sidecar smoke reported failure: {result}")
+    actions = result.get("graph_actions")
+    if not isinstance(actions, list) or actions[:2] != ["pre_accept", "accept"]:
+        raise SystemExit(
+            f"calling live-sidecar smoke did not pre_accept then accept: {result}"
+        )
+    if result.get("sidecar_ready_for_accept") is not True:
+        raise SystemExit(f"calling live-sidecar smoke sidecar was not ready: {result}")
+    try:
+        outbound_bytes = int(result.get("outbound_webrtc_bytes") or 0)
+        inbound_bytes = int(result.get("inbound_drain_bytes") or 0)
+    except (TypeError, ValueError) as exc:
+        raise SystemExit(
+            f"calling live-sidecar smoke returned invalid byte counts: {result}"
+        ) from exc
+    if outbound_bytes <= 0 or inbound_bytes <= 0:
+        raise SystemExit(f"calling live-sidecar smoke did not move audio: {result}")
+    return result
+
+
 def validate_bridge_health(health: dict[str, Any], *, require_connected: bool) -> None:
     if require_connected and health.get("status") != "connected":
         raise SystemExit(f"bridge is not connected: {health}")
@@ -1090,8 +1154,19 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--run-calling-live-sidecar-smoke",
+        action="store_true",
+        help=(
+            "Run the Hermes WhatsApp Calling connect-path smoke against imports "
+            "from --live-hermes-root, using a real in-process voice sidecar and "
+            "a fake Graph /calls endpoint."
+        ),
+    )
+    parser.add_argument(
         "--webrtc-python-bin",
-        help="Python with aiortc/aiohttp installed for --run-sidecar-offer-smoke",
+        help=(
+            "Python with aiortc/aiohttp installed for sidecar/WebRTC smokes."
+        ),
     )
     parser.add_argument(
         "--sidecar-offer-call-id",
@@ -1138,6 +1213,15 @@ def main() -> int:
             raise SystemExit("--run-sidecar-offer-smoke requires --calling-sidecar-url")
         if not webrtc_python_bin:
             raise SystemExit("--run-sidecar-offer-smoke requires --webrtc-python-bin")
+    if args.run_calling_live_sidecar_smoke:
+        if not voice_repo:
+            raise SystemExit(
+                "--run-calling-live-sidecar-smoke requires --voice-repo"
+            )
+        if not webrtc_python_bin:
+            raise SystemExit(
+                "--run-calling-live-sidecar-smoke requires --webrtc-python-bin"
+            )
     bridge_bin_dir = live_root / "scripts" / "whatsapp-bridge" / "node_modules" / ".bin"
 
     checks: dict[str, Any] = {}
@@ -1206,6 +1290,15 @@ def main() -> int:
             )
     elif voice_bin and not args.sidecar_service:
         raise SystemExit("--voice-bin requires --calling-sidecar-url or --sidecar-service")
+
+    if args.run_calling_live_sidecar_smoke:
+        checks["calling_live_sidecar_smoke"] = run_calling_live_sidecar_smoke(
+            python_bin=str(webrtc_python_bin),
+            live_root=live_root,
+            hermes_home=hermes_home,
+            voice_repo=voice_repo,
+            timeout=args.timeout,
+        )
 
     if args.sidecar_service:
         if args.voice_daemon_service:

--- a/scripts/verify_voice_live_gateway.py
+++ b/scripts/verify_voice_live_gateway.py
@@ -11,6 +11,8 @@ that Hermes returns a WhatsApp-ready Ogg/Opus voice-note file.
 
 Pass ``--voice-bin`` with ``--calling-sidecar-url`` to compare the running
 sidecar's machine-readable contract with the installed ``voice stream-contract``.
+Pass ``--sidecar-service`` to also verify the systemd user unit that runs the
+local WebRTC sidecar.
 """
 
 from __future__ import annotations
@@ -104,6 +106,10 @@ def get_service_state(service: str, *, timeout: float) -> dict[str, str]:
             "Environment",
             "-p",
             "DropInPaths",
+            "-p",
+            "ExecStart",
+            "-p",
+            "WorkingDirectory",
             "--no-pager",
         ],
         timeout=timeout,
@@ -152,16 +158,20 @@ def path_is_under(path: Path, root: Path) -> bool:
     return True
 
 
-def validate_service_state(state: dict[str, str]) -> int:
+def validate_service_state(state: dict[str, str], *, label: str = "gateway service") -> int:
     if state.get("ActiveState") != "active":
-        raise SystemExit(f"gateway service is not active: {state}")
+        raise SystemExit(f"{label} is not active: {state}")
     try:
         pid = int(state.get("MainPID") or "0")
     except ValueError as exc:
-        raise SystemExit(f"gateway service MainPID is invalid: {state.get('MainPID')!r}") from exc
+        raise SystemExit(f"{label} MainPID is invalid: {state.get('MainPID')!r}") from exc
     if pid <= 0:
-        raise SystemExit(f"gateway service has no running MainPID: {state}")
+        raise SystemExit(f"{label} has no running MainPID: {state}")
     return pid
+
+
+def normalized_path_text(value: str) -> str:
+    return str(Path(value).expanduser().resolve())
 
 
 def validate_env_points_at_root(
@@ -220,6 +230,55 @@ def validate_calling_sidecar_env(env: dict[str, str], expected_url: str) -> dict
             "",
         ),
     }
+
+
+def validate_sidecar_service_state(
+    state: dict[str, str],
+    *,
+    service: str,
+    voice_bin: str | None,
+    voice_repo: Path | None,
+) -> dict[str, Any]:
+    pid = validate_service_state(state, label=service)
+    env = parse_systemd_environment(state.get("Environment", ""))
+    result: dict[str, Any] = {
+        "service": service,
+        "pid": pid,
+    }
+
+    if voice_bin is not None:
+        configured_voice_bin = str(env.get("VOICE_BIN") or "")
+        if not configured_voice_bin:
+            raise SystemExit(f"{service} does not set VOICE_BIN")
+        if normalized_path_text(configured_voice_bin) != normalized_path_text(voice_bin):
+            raise SystemExit(
+                f"{service} VOICE_BIN does not match {voice_bin!r}: "
+                f"{configured_voice_bin!r}"
+            )
+        result["voice_bin"] = configured_voice_bin
+
+    if voice_repo is not None:
+        expected_root = voice_repo.expanduser().resolve()
+        working_directory = str(state.get("WorkingDirectory") or "")
+        if not working_directory:
+            raise SystemExit(f"{service} does not set WorkingDirectory")
+        if Path(working_directory).expanduser().resolve() != expected_root:
+            raise SystemExit(
+                f"{service} WorkingDirectory does not match {expected_root}: "
+                f"{working_directory!r}"
+            )
+
+        sidecar_path = expected_root / "examples" / "webrtc-sidecar" / "sidecar.py"
+        exec_start = str(state.get("ExecStart") or "")
+        if str(sidecar_path) not in exec_start:
+            raise SystemExit(
+                f"{service} ExecStart does not reference expected sidecar "
+                f"{sidecar_path}: {exec_start!r}"
+            )
+        result["working_directory"] = working_directory
+        result["sidecar_path"] = str(sidecar_path)
+
+    return result
 
 
 def import_smoke(
@@ -491,7 +550,16 @@ print(json.dumps(json.loads(tts_tool.text_to_speech_tool(%r)), sort_keys=True))
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--service", default=DEFAULT_SERVICE)
+    parser.add_argument(
+        "--sidecar-service",
+        help=(
+            "Optional systemd user service name for the WebRTC sidecar. When "
+            "provided, verify it is active and points at --voice-bin / "
+            "--voice-repo."
+        ),
+    )
     parser.add_argument("--live-hermes-root", type=Path, required=True)
+    parser.add_argument("--voice-repo", type=Path)
     parser.add_argument("--hermes-home", type=Path, default=Path("~/.hermes"))
     parser.add_argument("--python-bin", default="~/.hermes/hermes-agent/venv/bin/python")
     parser.add_argument("--bridge-url", default=DEFAULT_BRIDGE_URL)
@@ -538,6 +606,7 @@ def main() -> int:
         if args.voice_bin
         else None
     )
+    voice_repo = args.voice_repo.expanduser().resolve() if args.voice_repo else None
     ffprobe_bin = (
         resolve_executable(args.ffprobe_bin, label="ffprobe")
         if args.run_tts_smoke
@@ -602,8 +671,16 @@ def main() -> int:
                     timeout=args.timeout,
                 ),
             )
-    elif voice_bin:
-        raise SystemExit("--voice-bin requires --calling-sidecar-url")
+    elif voice_bin and not args.sidecar_service:
+        raise SystemExit("--voice-bin requires --calling-sidecar-url or --sidecar-service")
+
+    if args.sidecar_service:
+        checks["sidecar_service"] = validate_sidecar_service_state(
+            get_service_state(args.sidecar_service, timeout=args.timeout),
+            service=args.sidecar_service,
+            voice_bin=voice_bin,
+            voice_repo=voice_repo,
+        )
 
     checks["imports"] = import_smoke(
         python_bin=python_bin,

--- a/scripts/verify_voice_live_gateway.py
+++ b/scripts/verify_voice_live_gateway.py
@@ -352,6 +352,7 @@ def validate_sidecar_service_state(
     voice_bin: str | None,
     voice_repo: Path | None,
     sidecar_url: str | None,
+    voice_daemon_service: str | None,
 ) -> dict[str, Any]:
     pid = validate_service_state(state, label=service)
     env = parse_systemd_environment(state.get("Environment", ""))
@@ -365,8 +366,10 @@ def validate_sidecar_service_state(
             f"{service} still orders after deprecated voice-daemon.service; "
             "rerun install_voice_local_stack.py so it uses voiced.service"
         )
-    if "voiced.service" not in after_units:
-        raise SystemExit(f"{service} does not order after voiced.service")
+    if voice_daemon_service and voice_daemon_service not in after_units:
+        raise SystemExit(
+            f"{service} does not order after {voice_daemon_service}"
+        )
     result["after"] = sorted(after_units)
 
     if voice_bin is not None:
@@ -1217,6 +1220,7 @@ def main() -> int:
             voice_bin=voice_bin,
             voice_repo=voice_repo,
             sidecar_url=args.calling_sidecar_url,
+            voice_daemon_service=args.voice_daemon_service,
         )
 
     checks["imports"] = import_smoke(

--- a/scripts/verify_voice_live_gateway.py
+++ b/scripts/verify_voice_live_gateway.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""Verify a running local Hermes gateway is using the voice-native stack.
+
+This is the live-service counterpart to ``verify_voice_local_stack.py``. It is
+intentionally read-mostly: it inspects the systemd user service, verifies the
+running process environment points at the expected checkout, confirms imports
+resolve from that checkout, and checks the local WhatsApp bridge health.
+
+Pass ``--run-tts-smoke`` to also generate one live-config TTS reply and verify
+that Hermes returns a WhatsApp-ready Ogg/Opus voice-note file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import sys
+from typing import Any
+from urllib.error import URLError
+from urllib.request import urlopen
+
+from verify_voice_local_stack import audit_live_hermes_root
+
+
+DEFAULT_SERVICE = "hermes-gateway.service"
+DEFAULT_BRIDGE_URL = "http://127.0.0.1:3000"
+DEFAULT_TTS_TEXT = "Hermes live voice gateway smoke."
+IMPORT_MODULES = (
+    "hermes_cli.main",
+    "tools.tts_tool",
+    "tools.tirith_security",
+    "gateway.platforms.whatsapp_cloud",
+    "gateway.platforms.whatsapp",
+)
+
+
+def resolve_executable(value: str, *, label: str) -> str:
+    if "/" in value:
+        path = Path(value).expanduser()
+        if not path.is_file() or not os.access(path, os.X_OK):
+            raise SystemExit(f"{label} is not executable: {path}")
+        return os.path.abspath(os.path.expanduser(value))
+
+    found = shutil.which(value)
+    if not found:
+        raise SystemExit(f"{label} not found on PATH: {value}")
+    return found
+
+
+def run_command(command: list[str], *, timeout: float) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def parse_systemctl_show(output: str) -> dict[str, str]:
+    data: dict[str, str] = {}
+    for line in output.splitlines():
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        data[key] = value
+    return data
+
+
+def get_service_state(service: str, *, timeout: float) -> dict[str, str]:
+    completed = run_command(
+        [
+            "systemctl",
+            "--user",
+            "show",
+            service,
+            "-p",
+            "ActiveState",
+            "-p",
+            "SubState",
+            "-p",
+            "MainPID",
+            "-p",
+            "Environment",
+            "-p",
+            "DropInPaths",
+            "--no-pager",
+        ],
+        timeout=timeout,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise SystemExit(f"systemctl show failed for {service}: {detail}")
+    return parse_systemctl_show(completed.stdout)
+
+
+def parse_systemd_environment(value: str) -> dict[str, str]:
+    env: dict[str, str] = {}
+    for part in shlex.split(value):
+        if "=" not in part:
+            continue
+        key, raw = part.split("=", 1)
+        env[key] = raw
+    return env
+
+
+def parse_proc_environ(data: bytes) -> dict[str, str]:
+    env: dict[str, str] = {}
+    for item in data.split(b"\0"):
+        if not item or b"=" not in item:
+            continue
+        key, value = item.split(b"=", 1)
+        env[key.decode("utf-8", errors="replace")] = value.decode(
+            "utf-8", errors="replace"
+        )
+    return env
+
+
+def read_process_env(pid: int) -> dict[str, str]:
+    path = Path("/proc") / str(pid) / "environ"
+    try:
+        return parse_proc_environ(path.read_bytes())
+    except OSError as exc:
+        raise SystemExit(f"failed to read process environment for PID {pid}: {exc}") from exc
+
+
+def path_is_under(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def validate_service_state(state: dict[str, str]) -> int:
+    if state.get("ActiveState") != "active":
+        raise SystemExit(f"gateway service is not active: {state}")
+    try:
+        pid = int(state.get("MainPID") or "0")
+    except ValueError as exc:
+        raise SystemExit(f"gateway service MainPID is invalid: {state.get('MainPID')!r}") from exc
+    if pid <= 0:
+        raise SystemExit(f"gateway service has no running MainPID: {state}")
+    return pid
+
+
+def validate_env_points_at_root(
+    env: dict[str, str],
+    root: Path,
+    *,
+    label: str,
+    bridge_bin_dir: Path | None = None,
+) -> dict[str, Any]:
+    root_text = str(root.resolve())
+    pythonpath = env.get("PYTHONPATH", "")
+    if root_text not in pythonpath.split(os.pathsep):
+        raise SystemExit(f"{label} PYTHONPATH does not include {root_text}: {pythonpath!r}")
+
+    result: dict[str, Any] = {
+        "PYTHONPATH": pythonpath,
+    }
+    if bridge_bin_dir is not None:
+        path = env.get("PATH", "")
+        bridge_bin_text = str(bridge_bin_dir.resolve())
+        if bridge_bin_text not in path.split(os.pathsep):
+            raise SystemExit(
+                f"{label} PATH does not include bridge bin dir "
+                f"{bridge_bin_text}: {path!r}"
+            )
+        result["bridge_bin_on_path"] = True
+    return result
+
+
+def import_smoke(
+    *,
+    python_bin: str,
+    live_root: Path,
+    hermes_home: Path,
+    timeout: float,
+) -> dict[str, str]:
+    code = """
+import importlib
+import inspect
+import json
+
+modules = {}
+for name in %r:
+    module = importlib.import_module(name)
+    modules[name] = inspect.getfile(module)
+print(json.dumps(modules, sort_keys=True))
+""" % (IMPORT_MODULES,)
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(live_root)
+    env["HERMES_HOME"] = str(hermes_home)
+    completed = subprocess.run(
+        [python_bin, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+        env=env,
+        cwd=str(live_root),
+        stdin=subprocess.DEVNULL,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise SystemExit(f"import smoke failed: {detail}")
+    try:
+        parsed = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"import smoke did not return JSON: {completed.stdout!r}") from exc
+    if not isinstance(parsed, dict):
+        raise SystemExit("import smoke JSON root must be an object")
+
+    for module, file_path in parsed.items():
+        if not path_is_under(Path(str(file_path)), live_root):
+            raise SystemExit(
+                f"module {module} resolved outside live root {live_root}: {file_path}"
+            )
+    return {str(key): str(value) for key, value in parsed.items()}
+
+
+def get_bridge_health(url: str, *, timeout: float) -> dict[str, Any]:
+    target = url.rstrip("/") + "/health"
+    try:
+        with urlopen(target, timeout=timeout) as response:
+            body = response.read().decode("utf-8", errors="replace")
+    except URLError as exc:
+        raise SystemExit(f"bridge health request failed for {target}: {exc}") from exc
+    try:
+        parsed = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"bridge health returned invalid JSON: {body!r}") from exc
+    if not isinstance(parsed, dict):
+        raise SystemExit("bridge health JSON root must be an object")
+    return parsed
+
+
+def validate_bridge_health(health: dict[str, Any], *, require_connected: bool) -> None:
+    if require_connected and health.get("status") != "connected":
+        raise SystemExit(f"bridge is not connected: {health}")
+
+
+def parse_ffprobe_json(output: str) -> dict[str, str]:
+    data = json.loads(output)
+    streams = data.get("streams")
+    if not isinstance(streams, list) or not streams:
+        raise ValueError("ffprobe output has no streams")
+    stream = streams[0]
+    if not isinstance(stream, dict):
+        raise ValueError("ffprobe stream must be an object")
+    return {
+        "codec_name": str(stream.get("codec_name") or ""),
+        "sample_rate": str(stream.get("sample_rate") or ""),
+        "channels": str(stream.get("channels") or ""),
+    }
+
+
+def probe_audio(path: Path, *, ffprobe_bin: str, timeout: float) -> dict[str, str]:
+    completed = run_command(
+        [
+            ffprobe_bin,
+            "-v",
+            "error",
+            "-select_streams",
+            "a:0",
+            "-show_entries",
+            "stream=codec_name,sample_rate,channels",
+            "-of",
+            "json",
+            str(path),
+        ],
+        timeout=timeout,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise SystemExit(f"ffprobe failed for {path}: {detail}")
+    try:
+        return parse_ffprobe_json(completed.stdout)
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise SystemExit(f"ffprobe output invalid for {path}: {completed.stdout!r}") from exc
+
+
+def run_tts_smoke(
+    *,
+    python_bin: str,
+    live_root: Path,
+    hermes_home: Path,
+    platform: str,
+    text: str,
+    ffprobe_bin: str,
+    timeout: float,
+) -> dict[str, Any]:
+    code = """
+import json
+from tools import tts_tool
+print(json.dumps(json.loads(tts_tool.text_to_speech_tool(%r)), sort_keys=True))
+""" % (text,)
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(live_root)
+    env["HERMES_HOME"] = str(hermes_home)
+    env["HERMES_SESSION_PLATFORM"] = platform
+    completed = subprocess.run(
+        [python_bin, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+        env=env,
+        cwd=str(live_root),
+        stdin=subprocess.DEVNULL,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise SystemExit(f"TTS smoke failed: {detail}")
+    try:
+        result = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"TTS smoke returned invalid JSON: {completed.stdout!r}") from exc
+    if result.get("success") is not True:
+        raise SystemExit(f"TTS smoke reported failure: {result}")
+    if result.get("voice_compatible") is not True:
+        raise SystemExit(f"TTS smoke was not voice-compatible: {result}")
+    media_tag = str(result.get("media_tag") or "")
+    if not media_tag.startswith("[[audio_as_voice]]\nMEDIA:"):
+        raise SystemExit(f"TTS smoke media tag is not a voice note: {media_tag!r}")
+    audio_path = Path(str(result.get("file_path") or ""))
+    if not audio_path.is_file():
+        raise SystemExit(f"TTS smoke file does not exist: {audio_path}")
+    probe = probe_audio(audio_path, ffprobe_bin=ffprobe_bin, timeout=timeout)
+    if probe != {"codec_name": "opus", "sample_rate": "48000", "channels": "1"}:
+        raise SystemExit(f"TTS smoke audio is not mono 48 kHz Opus: {probe}")
+    return {
+        "result": result,
+        "probe": probe,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--service", default=DEFAULT_SERVICE)
+    parser.add_argument("--live-hermes-root", type=Path, required=True)
+    parser.add_argument("--hermes-home", type=Path, default=Path("~/.hermes"))
+    parser.add_argument("--python-bin", default="~/.hermes/hermes-agent/venv/bin/python")
+    parser.add_argument("--bridge-url", default=DEFAULT_BRIDGE_URL)
+    parser.add_argument("--ffprobe-bin", default=os.environ.get("FFPROBE_BIN", "ffprobe"))
+    parser.add_argument("--timeout", type=float, default=15.0)
+    parser.add_argument("--allow-disconnected-bridge", action="store_true")
+    parser.add_argument("--run-tts-smoke", action="store_true")
+    parser.add_argument("--tts-platform", default="whatsapp")
+    parser.add_argument("--tts-text", default=DEFAULT_TTS_TEXT)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    live_root = args.live_hermes_root.expanduser().resolve()
+    hermes_home = args.hermes_home.expanduser().resolve()
+    python_bin = resolve_executable(args.python_bin, label="Hermes Python")
+    ffprobe_bin = (
+        resolve_executable(args.ffprobe_bin, label="ffprobe")
+        if args.run_tts_smoke
+        else ""
+    )
+    bridge_bin_dir = live_root / "scripts" / "whatsapp-bridge" / "node_modules" / ".bin"
+
+    checks: dict[str, Any] = {}
+    live_root_audit = audit_live_hermes_root(live_root)
+    if live_root_audit.get("success") is not True:
+        raise SystemExit(
+            "live root audit failed:\n- "
+            + "\n- ".join(str(item) for item in live_root_audit.get("failures", []))
+        )
+    checks["live_root"] = live_root_audit
+
+    service_state = get_service_state(args.service, timeout=args.timeout)
+    pid = validate_service_state(service_state)
+    unit_env = parse_systemd_environment(service_state.get("Environment", ""))
+    checks["systemd_unit"] = {
+        "service": args.service,
+        "pid": pid,
+        "drop_in_paths": service_state.get("DropInPaths", ""),
+        "env": validate_env_points_at_root(
+            unit_env,
+            live_root,
+            label="systemd unit",
+            bridge_bin_dir=bridge_bin_dir,
+        ),
+    }
+
+    process_env = read_process_env(pid)
+    checks["running_process"] = {
+        "pid": pid,
+        "env": validate_env_points_at_root(
+            process_env,
+            live_root,
+            label="running gateway process",
+            bridge_bin_dir=bridge_bin_dir,
+        ),
+    }
+
+    checks["imports"] = import_smoke(
+        python_bin=python_bin,
+        live_root=live_root,
+        hermes_home=hermes_home,
+        timeout=args.timeout,
+    )
+
+    bridge_health = get_bridge_health(args.bridge_url, timeout=args.timeout)
+    validate_bridge_health(
+        bridge_health,
+        require_connected=not args.allow_disconnected_bridge,
+    )
+    checks["bridge_health"] = bridge_health
+
+    if args.run_tts_smoke:
+        checks["tts_smoke"] = run_tts_smoke(
+            python_bin=python_bin,
+            live_root=live_root,
+            hermes_home=hermes_home,
+            platform=args.tts_platform,
+            text=args.tts_text,
+            ffprobe_bin=ffprobe_bin,
+            timeout=args.timeout,
+        )
+
+    print(
+        json.dumps(
+            {
+                "success": True,
+                "live_hermes_root": str(live_root),
+                "hermes_home": str(hermes_home),
+                "checks": checks,
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_voice_live_gateway.py
+++ b/scripts/verify_voice_live_gateway.py
@@ -101,6 +101,8 @@ REQUIRED_PAYLOADS = (
 )
 REQUIRED_PAYLOAD_FIELDS = {
     "call_state": (
+        "ready_for_accept",
+        "readiness",
         "queued_tx_bytes",
         "queued_tx_ms",
         "max_tx_queue_bytes",
@@ -700,6 +702,129 @@ def compare_voice_and_sidecar_contracts(
     }
 
 
+def run_calling_sidecar_offer_smoke(
+    *,
+    python_bin: str,
+    sidecar_url: str,
+    call_id: str,
+    timeout: float,
+) -> dict[str, Any]:
+    """POST a real local SDP offer to a running sidecar and require readiness."""
+    code = r"""
+import asyncio
+import json
+import sys
+
+from aiohttp import ClientSession
+from aiortc import RTCPeerConnection, RTCSessionDescription
+
+
+async def wait_for_ice_complete(pc, timeout):
+    if pc.iceGatheringState == "complete":
+        return
+    done = asyncio.Event()
+
+    @pc.on("icegatheringstatechange")
+    def on_icegatheringstatechange():
+        if pc.iceGatheringState == "complete":
+            done.set()
+
+    await asyncio.wait_for(done.wait(), timeout=timeout)
+
+
+async def main():
+    sidecar_url = sys.argv[1].rstrip("/")
+    call_id = sys.argv[2]
+    timeout = float(sys.argv[3])
+    pc = RTCPeerConnection()
+    close_body = None
+    try:
+        pc.addTransceiver("audio", direction="recvonly")
+        offer = await pc.createOffer()
+        await pc.setLocalDescription(offer)
+        await wait_for_ice_complete(pc, timeout)
+        async with ClientSession() as session:
+            response = await session.post(
+                f"{sidecar_url}/offer",
+                json={
+                    "call_id": call_id,
+                    "type": pc.localDescription.type,
+                    "sdp": pc.localDescription.sdp,
+                },
+                timeout=timeout,
+            )
+            body = await response.json()
+            if response.status == 200:
+                await pc.setRemoteDescription(
+                    RTCSessionDescription(sdp=body["sdp"], type=body["type"])
+                )
+                close = await session.post(
+                    f"{sidecar_url}/calls/{call_id}/close",
+                    timeout=timeout,
+                )
+                close_body = await close.json()
+            print(json.dumps({
+                "status": response.status,
+                "body": body,
+                "close": close_body,
+            }, sort_keys=True))
+    finally:
+        await pc.close()
+
+
+asyncio.run(main())
+"""
+    completed = subprocess.run(
+        [python_bin, "-c", code, sidecar_url, call_id, f"{timeout:g}"],
+        capture_output=True,
+        text=True,
+        timeout=timeout + 10,
+        check=False,
+        stdin=subprocess.DEVNULL,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise SystemExit(f"calling sidecar offer smoke failed: {detail}")
+    try:
+        result = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(
+            f"calling sidecar offer smoke returned invalid JSON: {completed.stdout!r}"
+        ) from exc
+    if not isinstance(result, dict):
+        raise SystemExit("calling sidecar offer smoke JSON root must be an object")
+    if result.get("status") != 200:
+        raise SystemExit(f"calling sidecar offer smoke returned non-200: {result}")
+
+    body = result.get("body")
+    if not isinstance(body, dict):
+        raise SystemExit(f"calling sidecar offer smoke body is not an object: {result}")
+    state = body.get("state")
+    if not isinstance(state, dict):
+        raise SystemExit(f"calling sidecar offer response missing state: {body}")
+    readiness = state.get("readiness")
+    if not isinstance(readiness, dict):
+        raise SystemExit(f"calling sidecar readiness checks missing: {state}")
+    failed = sorted(str(key) for key, value in readiness.items() if value is not True)
+    if failed:
+        raise SystemExit(
+            "calling sidecar readiness checks failed: " + ", ".join(failed)
+        )
+    if state.get("ready_for_accept") is not True:
+        raise SystemExit(f"calling sidecar was not ready for accept: {state}")
+
+    close = result.get("close")
+    if not isinstance(close, dict) or close.get("closed") is not True:
+        raise SystemExit(f"calling sidecar offer smoke did not close cleanly: {result}")
+    return {
+        "success": True,
+        "call_id": call_id,
+        "ready_for_accept": state["ready_for_accept"],
+        "readiness": readiness,
+        "close": close,
+    }
+
+
 def validate_bridge_health(health: dict[str, Any], *, require_connected: bool) -> None:
     if require_connected and health.get("status") != "connected":
         raise SystemExit(f"bridge is not connected: {health}")
@@ -907,6 +1032,23 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--stt-timeout", type=float, default=300.0)
     parser.add_argument("--stt-generate-timeout", type=float, default=180.0)
     parser.add_argument(
+        "--run-sidecar-offer-smoke",
+        action="store_true",
+        help=(
+            "POST a real aiortc SDP offer to --calling-sidecar-url and require "
+            "state.ready_for_accept before closing the smoke call."
+        ),
+    )
+    parser.add_argument(
+        "--webrtc-python-bin",
+        help="Python with aiortc/aiohttp installed for --run-sidecar-offer-smoke",
+    )
+    parser.add_argument(
+        "--sidecar-offer-call-id",
+        default="live-gateway-readiness-smoke",
+        help="call_id to use for --run-sidecar-offer-smoke",
+    )
+    parser.add_argument(
         "--stt-expect-word",
         action="append",
         default=None,
@@ -929,6 +1071,11 @@ def main() -> int:
         else None
     )
     voice_repo = args.voice_repo.expanduser().resolve() if args.voice_repo else None
+    webrtc_python_bin = (
+        resolve_executable(args.webrtc_python_bin, label="WebRTC Python")
+        if args.webrtc_python_bin
+        else None
+    )
     ffprobe_bin = (
         resolve_executable(args.ffprobe_bin, label="ffprobe")
         if args.run_tts_smoke
@@ -936,6 +1083,11 @@ def main() -> int:
     )
     if args.run_stt_smoke and not voice_bin:
         raise SystemExit("--run-stt-smoke requires --voice-bin")
+    if args.run_sidecar_offer_smoke:
+        if not args.calling_sidecar_url:
+            raise SystemExit("--run-sidecar-offer-smoke requires --calling-sidecar-url")
+        if not webrtc_python_bin:
+            raise SystemExit("--run-sidecar-offer-smoke requires --webrtc-python-bin")
     bridge_bin_dir = live_root / "scripts" / "whatsapp-bridge" / "node_modules" / ".bin"
 
     checks: dict[str, Any] = {}
@@ -994,6 +1146,13 @@ def main() -> int:
                     args.calling_sidecar_url,
                     timeout=args.timeout,
                 ),
+            )
+        if args.run_sidecar_offer_smoke:
+            checks["calling_sidecar_offer_smoke"] = run_calling_sidecar_offer_smoke(
+                python_bin=str(webrtc_python_bin),
+                sidecar_url=args.calling_sidecar_url,
+                call_id=args.sidecar_offer_call_id,
+                timeout=args.timeout,
             )
     elif voice_bin and not args.sidecar_service:
         raise SystemExit("--voice-bin requires --calling-sidecar-url or --sidecar-service")

--- a/scripts/verify_voice_live_gateway.py
+++ b/scripts/verify_voice_live_gateway.py
@@ -50,6 +50,7 @@ WHATSAPP_CLOUD_REQUIRED_ENV = (
     "WHATSAPP_CLOUD_APP_SECRET",
     "WHATSAPP_CLOUD_VERIFY_TOKEN",
 )
+DEFAULT_WHATSAPP_CLOUD_WEBHOOK_PORT = 8090
 CONTRACT_COMPARE_KEYS = (
     "contract",
     "version",
@@ -422,6 +423,136 @@ def validate_whatsapp_cloud_readiness(
         "authorization": validate_whatsapp_cloud_authorization(
             file_env=file_env,
             process_env=process_env,
+        ),
+        "_private": {
+            "file_env": file_env,
+            "process_env": process_env,
+            "phone_number_id": configured_value(
+                "WHATSAPP_CLOUD_PHONE_NUMBER_ID",
+                file_env=file_env,
+                process_env=process_env,
+            )[0],
+        },
+    }
+
+
+def remove_private_readiness_data(readiness: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in readiness.items() if key != "_private"}
+
+
+def whatsapp_cloud_health_url_from_env(
+    *,
+    file_env: dict[str, str],
+    process_env: dict[str, str],
+) -> str:
+    raw_host = configured_value(
+        "WHATSAPP_CLOUD_WEBHOOK_HOST",
+        file_env=file_env,
+        process_env=process_env,
+    )[0]
+    host = raw_host or "127.0.0.1"
+    if host in {"0.0.0.0", "::", "[::]"}:
+        host = "127.0.0.1"
+
+    raw_port = configured_value(
+        "WHATSAPP_CLOUD_WEBHOOK_PORT",
+        file_env=file_env,
+        process_env=process_env,
+    )[0]
+    if raw_port:
+        try:
+            port = int(raw_port)
+        except ValueError as exc:
+            raise SystemExit(
+                f"WHATSAPP_CLOUD_WEBHOOK_PORT is not an integer: {raw_port!r}"
+            ) from exc
+        if port <= 0 or port > 65535:
+            raise SystemExit(
+                f"WHATSAPP_CLOUD_WEBHOOK_PORT is out of range: {raw_port!r}"
+            )
+    else:
+        port = DEFAULT_WHATSAPP_CLOUD_WEBHOOK_PORT
+
+    return f"http://{host}:{port}/health"
+
+
+def validate_whatsapp_cloud_health(
+    health: dict[str, Any],
+    *,
+    expected_phone_number_id: str,
+    expect_calling_sidecar: bool,
+) -> dict[str, Any]:
+    if health.get("status") != "ok":
+        raise SystemExit(
+            f"WhatsApp Cloud health status is not ok: {health.get('status')!r}"
+        )
+    if health.get("platform") != "whatsapp_cloud":
+        raise SystemExit(
+            "WhatsApp Cloud health endpoint reported wrong platform: "
+            f"{health.get('platform')!r}"
+        )
+    if str(health.get("phone_number_id") or "") != expected_phone_number_id:
+        raise SystemExit(
+            "WhatsApp Cloud health phone_number_id does not match configured "
+            "WHATSAPP_CLOUD_PHONE_NUMBER_ID"
+        )
+    if health.get("verify_token_configured") is not True:
+        raise SystemExit("WhatsApp Cloud health reports verify token is not configured")
+    if health.get("app_secret_configured") is not True:
+        raise SystemExit("WhatsApp Cloud health reports app secret is not configured")
+    if expect_calling_sidecar:
+        if health.get("calling_sidecar_configured") is not True:
+            raise SystemExit(
+                "WhatsApp Cloud health reports calling sidecar is not configured"
+            )
+        if health.get("calling_sidecar_tts_stream_configured") is not True:
+            raise SystemExit(
+                "WhatsApp Cloud health reports calling sidecar TTS stream is "
+                "not configured"
+            )
+
+    return {
+        "status": str(health.get("status")),
+        "platform": str(health.get("platform")),
+        "webhook_path": str(health.get("webhook_path") or ""),
+        "verify_token_configured": health.get("verify_token_configured") is True,
+        "app_secret_configured": health.get("app_secret_configured") is True,
+        "calling_sidecar_configured": health.get("calling_sidecar_configured") is True,
+        "calling_sidecar_contract_loaded": (
+            health.get("calling_sidecar_contract_loaded") is True
+        ),
+        "calling_sidecar_tts_stream_configured": (
+            health.get("calling_sidecar_tts_stream_configured") is True
+        ),
+    }
+
+
+def check_whatsapp_cloud_health(
+    *,
+    readiness: dict[str, Any],
+    health_url: str | None,
+    timeout: float,
+    expect_calling_sidecar: bool,
+) -> dict[str, Any]:
+    private = readiness.get("_private")
+    if not isinstance(private, dict):
+        raise SystemExit("WhatsApp Cloud readiness private data missing")
+    file_env = private.get("file_env")
+    process_env = private.get("process_env")
+    expected_phone_number_id = str(private.get("phone_number_id") or "")
+    if not isinstance(file_env, dict) or not isinstance(process_env, dict):
+        raise SystemExit("WhatsApp Cloud readiness env data missing")
+    target = health_url or whatsapp_cloud_health_url_from_env(
+        file_env={str(k): str(v) for k, v in file_env.items()},
+        process_env={str(k): str(v) for k, v in process_env.items()},
+    )
+    health = get_json_url(target, timeout=timeout)
+    return {
+        "url": target,
+        **validate_whatsapp_cloud_health(
+            health,
+            expected_phone_number_id=expected_phone_number_id,
+            expect_calling_sidecar=expect_calling_sidecar,
         ),
     }
 
@@ -1328,6 +1459,23 @@ def parse_args() -> argparse.Namespace:
             "environment. Secret values are never printed."
         ),
     )
+    parser.add_argument(
+        "--whatsapp-cloud-health-url",
+        help=(
+            "Override the local WhatsApp Cloud health URL used with "
+            "--require-whatsapp-cloud-readiness. Defaults to "
+            "http://127.0.0.1:8090/health, or the configured webhook port."
+        ),
+    )
+    parser.add_argument(
+        "--skip-whatsapp-cloud-health",
+        action="store_true",
+        help=(
+            "With --require-whatsapp-cloud-readiness, only validate local "
+            "configuration shape and skip the running Cloud webhook /health "
+            "probe."
+        ),
+    )
     parser.add_argument("--run-tts-smoke", action="store_true")
     parser.add_argument("--tts-platform", default="whatsapp")
     parser.add_argument("--tts-text", default=DEFAULT_TTS_TEXT)
@@ -1449,11 +1597,28 @@ def main() -> int:
             bridge_bin_dir=bridge_bin_dir,
         ),
     }
+    cloud_readiness: dict[str, Any] | None = None
     if args.require_whatsapp_cloud_readiness:
-        checks["whatsapp_cloud_readiness"] = validate_whatsapp_cloud_readiness(
+        cloud_readiness = validate_whatsapp_cloud_readiness(
             hermes_home=hermes_home,
             process_env=process_env,
         )
+        checks["whatsapp_cloud_readiness"] = remove_private_readiness_data(
+            cloud_readiness
+        )
+        if args.skip_whatsapp_cloud_health:
+            checks["whatsapp_cloud_health"] = {
+                "success": True,
+                "skipped": True,
+                "reason": "--skip-whatsapp-cloud-health was provided",
+            }
+        else:
+            checks["whatsapp_cloud_health"] = check_whatsapp_cloud_health(
+                readiness=cloud_readiness,
+                health_url=args.whatsapp_cloud_health_url,
+                timeout=args.timeout,
+                expect_calling_sidecar=bool(args.calling_sidecar_url),
+            )
 
     if args.calling_sidecar_url:
         checks["calling_sidecar"] = {

--- a/scripts/verify_voice_live_gateway.py
+++ b/scripts/verify_voice_live_gateway.py
@@ -22,6 +22,8 @@ local WebRTC sidecar.
 from __future__ import annotations
 
 import argparse
+import hashlib
+import hmac
 import json
 import os
 from pathlib import Path
@@ -33,7 +35,7 @@ import sys
 from typing import Any
 from urllib.error import URLError
 from urllib.parse import urlencode, urlparse
-from urllib.request import urlopen
+from urllib.request import Request, urlopen
 
 from verify_voice_local_stack import audit_live_hermes_root
 
@@ -589,6 +591,24 @@ def get_text_url(target: str, *, timeout: float, label: str) -> tuple[int, str]:
     return status, body
 
 
+def post_json_url(
+    target: str,
+    *,
+    body: bytes,
+    headers: dict[str, str],
+    timeout: float,
+    label: str,
+) -> tuple[int, str]:
+    request = Request(target, data=body, headers=headers, method="POST")
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            response_body = response.read().decode("utf-8", errors="replace")
+            status = int(getattr(response, "status", 200))
+    except URLError as exc:
+        raise SystemExit(f"request failed for {label}: {exc}") from exc
+    return status, response_body
+
+
 def check_whatsapp_cloud_verify_handshake(
     *,
     readiness: dict[str, Any],
@@ -636,6 +656,92 @@ def check_whatsapp_cloud_verify_handshake(
         "url": target_base,
         "status": status,
         "challenge_echoed": True,
+    }
+
+
+def whatsapp_cloud_status_payload(*, phone_number_id: str) -> dict[str, Any]:
+    return {
+        "object": "whatsapp_business_account",
+        "entry": [
+            {
+                "id": "local-cloud-readiness",
+                "changes": [
+                    {
+                        "field": "messages",
+                        "value": {
+                            "messaging_product": "whatsapp",
+                            "metadata": {
+                                "display_phone_number": "15555550100",
+                                "phone_number_id": phone_number_id,
+                            },
+                            "statuses": [
+                                {
+                                    "id": "wamid.local-cloud-readiness",
+                                    "status": "delivered",
+                                    "timestamp": "1760000000",
+                                    "recipient_id": "15555550101",
+                                }
+                            ],
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def check_whatsapp_cloud_signed_post(
+    *,
+    readiness: dict[str, Any],
+    webhook_url: str | None,
+    timeout: float,
+) -> dict[str, Any]:
+    private = readiness.get("_private")
+    if not isinstance(private, dict):
+        raise SystemExit("WhatsApp Cloud readiness private data missing")
+    file_env = private.get("file_env")
+    process_env = private.get("process_env")
+    phone_number_id = str(private.get("phone_number_id") or "")
+    if not isinstance(file_env, dict) or not isinstance(process_env, dict):
+        raise SystemExit("WhatsApp Cloud readiness env data missing")
+    app_secret = configured_value(
+        "WHATSAPP_CLOUD_APP_SECRET",
+        file_env={str(k): str(v) for k, v in file_env.items()},
+        process_env={str(k): str(v) for k, v in process_env.items()},
+    )[0]
+    if not app_secret:
+        raise SystemExit("WHATSAPP_CLOUD_APP_SECRET is not configured")
+    target_base = webhook_url or whatsapp_cloud_webhook_url_from_env(
+        file_env={str(k): str(v) for k, v in file_env.items()},
+        process_env={str(k): str(v) for k, v in process_env.items()},
+    )
+    body = json.dumps(
+        whatsapp_cloud_status_payload(phone_number_id=phone_number_id),
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    signature = hmac.new(
+        app_secret.encode("utf-8"),
+        body,
+        hashlib.sha256,
+    ).hexdigest()
+    status, _body = post_json_url(
+        target_base,
+        body=body,
+        headers={
+            "Content-Type": "application/json",
+            "X-Hub-Signature-256": f"sha256={signature}",
+        },
+        timeout=timeout,
+        label=target_base,
+    )
+    if status != 200:
+        raise SystemExit(f"WhatsApp Cloud signed webhook POST returned HTTP {status}")
+    return {
+        "url": target_base,
+        "status": status,
+        "payload": "status_delivery_receipt",
+        "signature_accepted": True,
     }
 
 
@@ -1576,6 +1682,14 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--skip-whatsapp-cloud-signed-post",
+        action="store_true",
+        help=(
+            "With --require-whatsapp-cloud-readiness, skip the local signed "
+            "webhook POST probe."
+        ),
+    )
+    parser.add_argument(
         "--whatsapp-cloud-verify-challenge",
         default=DEFAULT_WHATSAPP_CLOUD_VERIFY_CHALLENGE,
         help=argparse.SUPPRESS,
@@ -1737,6 +1851,18 @@ def main() -> int:
                     challenge=args.whatsapp_cloud_verify_challenge,
                     timeout=args.timeout,
                 )
+            )
+        if args.skip_whatsapp_cloud_signed_post:
+            checks["whatsapp_cloud_signed_post"] = {
+                "success": True,
+                "skipped": True,
+                "reason": "--skip-whatsapp-cloud-signed-post was provided",
+            }
+        else:
+            checks["whatsapp_cloud_signed_post"] = check_whatsapp_cloud_signed_post(
+                readiness=cloud_readiness,
+                webhook_url=args.whatsapp_cloud_webhook_url,
+                timeout=args.timeout,
             )
 
     if args.calling_sidecar_url:

--- a/scripts/verify_voice_live_gateway.py
+++ b/scripts/verify_voice_live_gateway.py
@@ -30,6 +30,7 @@ from verify_voice_local_stack import audit_live_hermes_root
 DEFAULT_SERVICE = "hermes-gateway.service"
 DEFAULT_BRIDGE_URL = "http://127.0.0.1:3000"
 DEFAULT_TTS_TEXT = "Hermes live voice gateway smoke."
+CALLING_TTS_STREAM_ENV = "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND"
 IMPORT_MODULES = (
     "hermes_cli.main",
     "tools.tts_tool",
@@ -177,6 +178,37 @@ def validate_env_points_at_root(
     return result
 
 
+def validate_calling_sidecar_env(env: dict[str, str], expected_url: str) -> dict[str, Any]:
+    expected = expected_url.rstrip("/")
+    configured = str(env.get("WHATSAPP_CLOUD_CALLING_SIDECAR_URL") or "").rstrip("/")
+    if configured != expected:
+        raise SystemExit(
+            "running gateway process WHATSAPP_CLOUD_CALLING_SIDECAR_URL "
+            f"does not match {expected!r}: {configured!r}"
+        )
+
+    stream_command = str(env.get(CALLING_TTS_STREAM_ENV) or "")
+    missing = [
+        token
+        for token in ("--raw-output", "{input_path}", "{sample_rate}", "{frame_ms}")
+        if token not in stream_command
+    ]
+    if missing:
+        raise SystemExit(
+            f"running gateway process {CALLING_TTS_STREAM_ENV} is missing "
+            f"{', '.join(missing)}: {stream_command!r}"
+        )
+
+    return {
+        "url": configured,
+        "tts_stream_command": stream_command,
+        "tts_stream_timeout": env.get(
+            "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT",
+            "",
+        ),
+    }
+
+
 def import_smoke(
     *,
     python_bin: str,
@@ -226,20 +258,73 @@ print(json.dumps(modules, sort_keys=True))
     return {str(key): str(value) for key, value in parsed.items()}
 
 
-def get_bridge_health(url: str, *, timeout: float) -> dict[str, Any]:
-    target = url.rstrip("/") + "/health"
+def get_json_url(target: str, *, timeout: float) -> dict[str, Any]:
     try:
         with urlopen(target, timeout=timeout) as response:
             body = response.read().decode("utf-8", errors="replace")
     except URLError as exc:
-        raise SystemExit(f"bridge health request failed for {target}: {exc}") from exc
+        raise SystemExit(f"request failed for {target}: {exc}") from exc
     try:
         parsed = json.loads(body)
     except json.JSONDecodeError as exc:
-        raise SystemExit(f"bridge health returned invalid JSON: {body!r}") from exc
+        raise SystemExit(f"request returned invalid JSON for {target}: {body!r}") from exc
     if not isinstance(parsed, dict):
-        raise SystemExit("bridge health JSON root must be an object")
+        raise SystemExit(f"JSON root must be an object for {target}")
     return parsed
+
+
+def get_bridge_health(url: str, *, timeout: float) -> dict[str, Any]:
+    target = url.rstrip("/") + "/health"
+    return get_json_url(target, timeout=timeout)
+
+
+def validate_calling_sidecar_contract(contract: dict[str, Any]) -> dict[str, Any]:
+    if contract.get("contract") != "voice.webrtc_sidecar":
+        raise SystemExit(
+            "calling sidecar contract id is not voice.webrtc_sidecar: "
+            f"{contract.get('contract')!r}"
+        )
+    audio = contract.get("audio")
+    if not isinstance(audio, dict):
+        raise SystemExit("calling sidecar contract missing audio object")
+    expected_audio = {
+        "sample_rate": 48_000,
+        "channels": 1,
+        "frame_ms": 20,
+        "encoding": "pcm_s16le",
+        "frame_bytes": 1_920,
+    }
+    mismatches = {
+        key: audio.get(key)
+        for key, expected in expected_audio.items()
+        if audio.get(key) != expected
+    }
+    if mismatches:
+        raise SystemExit(
+            "calling sidecar audio contract does not match Hermes WebRTC PCM "
+            f"shape: {mismatches}"
+        )
+    return {
+        "contract": str(contract.get("contract")),
+        "version": contract.get("version"),
+        "audio": {key: audio.get(key) for key in expected_audio},
+    }
+
+
+def get_calling_sidecar_status(url: str, *, timeout: float) -> dict[str, Any]:
+    base = url.rstrip("/")
+    contract = get_json_url(base + "/contract", timeout=timeout)
+    health = get_json_url(base + "/health", timeout=timeout)
+    if health.get("ok") is not True:
+        raise SystemExit(f"calling sidecar health is not ok: {health}")
+    return {
+        "contract": validate_calling_sidecar_contract(contract),
+        "health": {
+            "ok": health.get("ok"),
+            "sessions": health.get("sessions"),
+            "call_ids": health.get("call_ids"),
+        },
+    }
 
 
 def validate_bridge_health(health: dict[str, Any], *, require_connected: bool) -> None:
@@ -349,6 +434,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--hermes-home", type=Path, default=Path("~/.hermes"))
     parser.add_argument("--python-bin", default="~/.hermes/hermes-agent/venv/bin/python")
     parser.add_argument("--bridge-url", default=DEFAULT_BRIDGE_URL)
+    parser.add_argument(
+        "--calling-sidecar-url",
+        help=(
+            "Optional expected local WhatsApp Calling sidecar URL. When set, "
+            "the verifier requires the running gateway process to be configured "
+            "with this URL and validates the sidecar /contract and /health."
+        ),
+    )
     parser.add_argument("--ffprobe-bin", default=os.environ.get("FFPROBE_BIN", "ffprobe"))
     parser.add_argument("--timeout", type=float, default=15.0)
     parser.add_argument("--allow-disconnected-bridge", action="store_true")
@@ -413,6 +506,18 @@ def main() -> int:
             bridge_bin_dir=bridge_bin_dir,
         ),
     }
+
+    if args.calling_sidecar_url:
+        checks["calling_sidecar"] = {
+            "env": validate_calling_sidecar_env(
+                process_env,
+                args.calling_sidecar_url,
+            ),
+            "sidecar": get_calling_sidecar_status(
+                args.calling_sidecar_url,
+                timeout=args.timeout,
+            ),
+        }
 
     checks["imports"] = import_smoke(
         python_bin=python_bin,

--- a/scripts/verify_voice_live_gateway.py
+++ b/scripts/verify_voice_live_gateway.py
@@ -21,12 +21,14 @@ import argparse
 import json
 import os
 from pathlib import Path
+import re
 import shlex
 import shutil
 import subprocess
 import sys
 from typing import Any
 from urllib.error import URLError
+from urllib.parse import urlparse
 from urllib.request import urlopen
 
 from verify_voice_local_stack import audit_live_hermes_root
@@ -87,6 +89,24 @@ def parse_systemctl_show(output: str) -> dict[str, str]:
         key, value = line.split("=", 1)
         data[key] = value
     return data
+
+
+def parse_exec_start_argv(exec_start: str) -> list[str]:
+    match = re.search(r"argv\[\]=(.*?)(?:\s;\s|\s\})", exec_start)
+    if match:
+        return shlex.split(match.group(1))
+    return shlex.split(exec_start)
+
+
+def option_values(argv: list[str], option: str) -> list[str]:
+    values: list[str] = []
+    prefix = f"{option}="
+    for index, arg in enumerate(argv):
+        if arg == option and index + 1 < len(argv):
+            values.append(argv[index + 1])
+        elif arg.startswith(prefix):
+            values.append(arg.removeprefix(prefix))
+    return values
 
 
 def get_service_state(service: str, *, timeout: float) -> dict[str, str]:
@@ -238,6 +258,7 @@ def validate_sidecar_service_state(
     service: str,
     voice_bin: str | None,
     voice_repo: Path | None,
+    sidecar_url: str | None,
 ) -> dict[str, Any]:
     pid = validate_service_state(state, label=service)
     env = parse_systemd_environment(state.get("Environment", ""))
@@ -257,6 +278,36 @@ def validate_sidecar_service_state(
             )
         result["voice_bin"] = configured_voice_bin
 
+    exec_start = str(state.get("ExecStart") or "")
+    exec_argv = parse_exec_start_argv(exec_start)
+
+    if sidecar_url:
+        parsed_url = urlparse(sidecar_url)
+        expected_host = parsed_url.hostname
+        expected_port = parsed_url.port or (443 if parsed_url.scheme == "https" else 80)
+        if not expected_host:
+            raise SystemExit(f"sidecar URL has no host: {sidecar_url!r}")
+        host_candidates = {expected_host}
+        if expected_host == "localhost":
+            host_candidates.add("127.0.0.1")
+        elif expected_host == "127.0.0.1":
+            host_candidates.add("localhost")
+
+        host_values = set(option_values(exec_argv, "--host"))
+        port_values = set(option_values(exec_argv, "--port"))
+        has_host = bool(host_candidates & host_values)
+        has_port = str(expected_port) in port_values
+        if not has_host or not has_port:
+            raise SystemExit(
+                f"{service} ExecStart does not bind expected sidecar URL "
+                f"{sidecar_url}: {exec_start!r}"
+            )
+        result["sidecar_url"] = sidecar_url.rstrip("/")
+        result["bind"] = {
+            "host": expected_host,
+            "port": expected_port,
+        }
+
     if voice_repo is not None:
         expected_root = voice_repo.expanduser().resolve()
         working_directory = str(state.get("WorkingDirectory") or "")
@@ -269,7 +320,6 @@ def validate_sidecar_service_state(
             )
 
         sidecar_path = expected_root / "examples" / "webrtc-sidecar" / "sidecar.py"
-        exec_start = str(state.get("ExecStart") or "")
         if str(sidecar_path) not in exec_start:
             raise SystemExit(
                 f"{service} ExecStart does not reference expected sidecar "
@@ -680,6 +730,7 @@ def main() -> int:
             service=args.sidecar_service,
             voice_bin=voice_bin,
             voice_repo=voice_repo,
+            sidecar_url=args.calling_sidecar_url,
         )
 
     checks["imports"] = import_smoke(

--- a/scripts/verify_voice_live_gateway.py
+++ b/scripts/verify_voice_live_gateway.py
@@ -93,6 +93,43 @@ REQUIRED_PAYLOADS = (
     "audio_shape",
     "error_response",
 )
+REQUIRED_PAYLOAD_FIELDS = {
+    "call_state": (
+        "queued_tx_bytes",
+        "queued_tx_ms",
+        "max_tx_queue_bytes",
+        "max_tx_queue_ms",
+        "queued_rx_bytes",
+        "queued_rx_ms",
+        "max_rx_queue_bytes",
+        "max_rx_queue_ms",
+    ),
+    "send_audio_response": (
+        "accepted_bytes",
+        "accepted_ms",
+        "queued_tx_bytes",
+        "queued_tx_ms",
+        "max_tx_queue_bytes",
+        "max_tx_queue_ms",
+    ),
+    "clear_audio_response": (
+        "dropped_tx_bytes",
+        "dropped_tx_ms",
+        "queued_tx_bytes",
+        "queued_tx_ms",
+        "max_tx_queue_bytes",
+        "max_tx_queue_ms",
+    ),
+    "receive_audio_response": (
+        "returned_bytes",
+        "returned_ms",
+        "queued_rx_bytes",
+        "queued_rx_ms",
+        "max_rx_queue_bytes",
+        "max_rx_queue_ms",
+        "pcm_s16le_base64",
+    ),
+}
 IMPORT_MODULES = (
     "hermes_cli.main",
     "tools.tts_tool",
@@ -510,12 +547,29 @@ def validate_required_contract_sections(
             "calling sidecar contract payloads missing keys: "
             + ", ".join(missing_payloads)
         )
+    validate_payload_contracts(payloads)
 
     return {
         "voice_surfaces": list(REQUIRED_VOICE_SURFACES),
         "endpoints": list(REQUIRED_ENDPOINTS),
         "payloads": list(REQUIRED_PAYLOADS),
     }
+
+
+def validate_payload_contracts(payloads: dict[str, Any]) -> None:
+    for payload_name, required_fields in REQUIRED_PAYLOAD_FIELDS.items():
+        payload = payloads.get(payload_name)
+        if not isinstance(payload, dict):
+            raise SystemExit(
+                f"calling sidecar contract payloads.{payload_name} must be an object"
+            )
+        missing_fields = [field for field in required_fields if field not in payload]
+        if missing_fields:
+            raise SystemExit(
+                "calling sidecar contract payloads."
+                f"{payload_name} missing fields: "
+                + ", ".join(missing_fields)
+            )
 
 
 def validate_voice_surface_contracts(

--- a/scripts/verify_voice_live_gateway.py
+++ b/scripts/verify_voice_live_gateway.py
@@ -433,6 +433,34 @@ def validate_sidecar_service_state(
     return result
 
 
+def validate_voice_daemon_service_state(
+    state: dict[str, str],
+    *,
+    service: str,
+    voice_bin: str | None,
+) -> dict[str, Any]:
+    pid = validate_service_state(state, label=service)
+    result: dict[str, Any] = {
+        "service": service,
+        "pid": pid,
+    }
+
+    exec_start = str(state.get("ExecStart") or "")
+    exec_argv = parse_exec_start_argv(exec_start)
+    if "daemon" not in exec_argv or "start" not in exec_argv:
+        raise SystemExit(f"{service} ExecStart is not a voice daemon start command")
+    if voice_bin is not None and (
+        not exec_argv
+        or normalized_path_text(exec_argv[0]) != normalized_path_text(voice_bin)
+    ):
+        raise SystemExit(
+            f"{service} ExecStart does not reference expected voice binary "
+            f"{voice_bin!r}: {exec_start!r}"
+        )
+    result["exec_start"] = exec_start
+    return result
+
+
 def import_smoke(
     *,
     python_bin: str,
@@ -1002,6 +1030,14 @@ def parse_args() -> argparse.Namespace:
             "--voice-repo."
         ),
     )
+    parser.add_argument(
+        "--voice-daemon-service",
+        default="voiced.service",
+        help=(
+            "systemd user service name for the voice daemon required by "
+            "live-call voice stream commands; pass an empty string to skip."
+        ),
+    )
     parser.add_argument("--live-hermes-root", type=Path, required=True)
     parser.add_argument("--voice-repo", type=Path)
     parser.add_argument("--hermes-home", type=Path, default=Path("~/.hermes"))
@@ -1169,6 +1205,12 @@ def main() -> int:
         raise SystemExit("--voice-bin requires --calling-sidecar-url or --sidecar-service")
 
     if args.sidecar_service:
+        if args.voice_daemon_service:
+            checks["voice_daemon_service"] = validate_voice_daemon_service_state(
+                get_service_state(args.voice_daemon_service, timeout=args.timeout),
+                service=args.voice_daemon_service,
+                voice_bin=voice_bin,
+            )
         checks["sidecar_service"] = validate_sidecar_service_state(
             get_service_state(args.sidecar_service, timeout=args.timeout),
             service=args.sidecar_service,

--- a/scripts/verify_voice_live_gateway.py
+++ b/scripts/verify_voice_live_gateway.py
@@ -8,6 +8,9 @@ resolve from that checkout, and checks the local WhatsApp bridge health.
 
 Pass ``--run-tts-smoke`` to also generate one live-config TTS reply and verify
 that Hermes returns a WhatsApp-ready Ogg/Opus voice-note file.
+
+Pass ``--voice-bin`` with ``--calling-sidecar-url`` to compare the running
+sidecar's machine-readable contract with the installed ``voice stream-contract``.
 """
 
 from __future__ import annotations
@@ -31,6 +34,16 @@ DEFAULT_SERVICE = "hermes-gateway.service"
 DEFAULT_BRIDGE_URL = "http://127.0.0.1:3000"
 DEFAULT_TTS_TEXT = "Hermes live voice gateway smoke."
 CALLING_TTS_STREAM_ENV = "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND"
+CONTRACT_COMPARE_KEYS = (
+    "contract",
+    "version",
+    "status",
+    "summary",
+    "audio",
+    "voice_surfaces",
+    "endpoints",
+    "payloads",
+)
 IMPORT_MODULES = (
     "hermes_cli.main",
     "tools.tts_tool",
@@ -278,6 +291,12 @@ def get_bridge_health(url: str, *, timeout: float) -> dict[str, Any]:
     return get_json_url(target, timeout=timeout)
 
 
+def get_calling_sidecar_contract(url: str, *, timeout: float) -> dict[str, Any]:
+    contract = get_json_url(url.rstrip("/") + "/contract", timeout=timeout)
+    validate_calling_sidecar_contract(contract)
+    return contract
+
+
 def validate_calling_sidecar_contract(contract: dict[str, Any]) -> dict[str, Any]:
     if contract.get("contract") != "voice.webrtc_sidecar":
         raise SystemExit(
@@ -313,7 +332,7 @@ def validate_calling_sidecar_contract(contract: dict[str, Any]) -> dict[str, Any
 
 def get_calling_sidecar_status(url: str, *, timeout: float) -> dict[str, Any]:
     base = url.rstrip("/")
-    contract = get_json_url(base + "/contract", timeout=timeout)
+    contract = get_calling_sidecar_contract(base, timeout=timeout)
     health = get_json_url(base + "/health", timeout=timeout)
     if health.get("ok") is not True:
         raise SystemExit(f"calling sidecar health is not ok: {health}")
@@ -324,6 +343,48 @@ def get_calling_sidecar_status(url: str, *, timeout: float) -> dict[str, Any]:
             "sessions": health.get("sessions"),
             "call_ids": health.get("call_ids"),
         },
+    }
+
+
+def load_voice_stream_contract(voice_bin: str, *, timeout: float) -> dict[str, Any]:
+    completed = run_command([voice_bin, "stream-contract"], timeout=timeout)
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise SystemExit(f"voice stream-contract failed: {detail}")
+    try:
+        parsed = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(
+            f"voice stream-contract returned invalid JSON: {completed.stdout!r}"
+        ) from exc
+    if not isinstance(parsed, dict):
+        raise SystemExit("voice stream-contract JSON root must be an object")
+    validate_calling_sidecar_contract(parsed)
+    return parsed
+
+
+def compare_voice_and_sidecar_contracts(
+    *,
+    voice_contract: dict[str, Any],
+    sidecar_contract: dict[str, Any],
+) -> dict[str, Any]:
+    mismatches = [
+        key
+        for key in CONTRACT_COMPARE_KEYS
+        if voice_contract.get(key) != sidecar_contract.get(key)
+    ]
+    if mismatches:
+        raise SystemExit(
+            "voice stream-contract does not match running sidecar /contract "
+            f"for: {', '.join(mismatches)}"
+        )
+    validated = validate_calling_sidecar_contract(voice_contract)
+    return {
+        "success": True,
+        "contract": validated["contract"],
+        "version": validated["version"],
+        "audio": validated["audio"],
+        "matched_keys": list(CONTRACT_COMPARE_KEYS),
     }
 
 
@@ -442,6 +503,13 @@ def parse_args() -> argparse.Namespace:
             "with this URL and validates the sidecar /contract and /health."
         ),
     )
+    parser.add_argument(
+        "--voice-bin",
+        help=(
+            "Optional voice binary. With --calling-sidecar-url, compare "
+            "`voice stream-contract` with the running sidecar /contract."
+        ),
+    )
     parser.add_argument("--ffprobe-bin", default=os.environ.get("FFPROBE_BIN", "ffprobe"))
     parser.add_argument("--timeout", type=float, default=15.0)
     parser.add_argument("--allow-disconnected-bridge", action="store_true")
@@ -465,6 +533,11 @@ def main() -> int:
     live_root = args.live_hermes_root.expanduser().resolve()
     hermes_home = args.hermes_home.expanduser().resolve()
     python_bin = resolve_executable(args.python_bin, label="Hermes Python")
+    voice_bin = (
+        resolve_executable(args.voice_bin, label="voice binary")
+        if args.voice_bin
+        else None
+    )
     ffprobe_bin = (
         resolve_executable(args.ffprobe_bin, label="ffprobe")
         if args.run_tts_smoke
@@ -518,6 +591,19 @@ def main() -> int:
                 timeout=args.timeout,
             ),
         }
+        if voice_bin:
+            checks["voice_sidecar_contract"] = compare_voice_and_sidecar_contracts(
+                voice_contract=load_voice_stream_contract(
+                    voice_bin,
+                    timeout=args.timeout,
+                ),
+                sidecar_contract=get_calling_sidecar_contract(
+                    args.calling_sidecar_url,
+                    timeout=args.timeout,
+                ),
+            )
+    elif voice_bin:
+        raise SystemExit("--voice-bin requires --calling-sidecar-url")
 
     checks["imports"] = import_smoke(
         python_bin=python_bin,

--- a/scripts/verify_voice_live_gateway.py
+++ b/scripts/verify_voice_live_gateway.py
@@ -873,24 +873,28 @@ def run_calling_live_sidecar_smoke(
     live_root: Path,
     hermes_home: Path,
     voice_repo: Path,
+    sidecar_url: str | None,
     timeout: float,
 ) -> dict[str, Any]:
     """Run the Hermes connect-path smoke against imports from live_root."""
     env = os.environ.copy()
     env["PYTHONPATH"] = str(live_root)
     env["HERMES_HOME"] = str(hermes_home)
+    command = [
+        python_bin,
+        str(
+            Path(__file__).resolve().parent
+            / "verify_voice_whatsapp_calling_live_sidecar.py"
+        ),
+        "--voice-repo",
+        str(voice_repo),
+        "--timeout",
+        f"{timeout:g}",
+    ]
+    if sidecar_url:
+        command.extend(["--sidecar-url", sidecar_url])
     completed = subprocess.run(
-        [
-            python_bin,
-            str(
-                Path(__file__).resolve().parent
-                / "verify_voice_whatsapp_calling_live_sidecar.py"
-            ),
-            "--voice-repo",
-            str(voice_repo),
-            "--timeout",
-            f"{timeout:g}",
-        ],
+        command,
         capture_output=True,
         text=True,
         timeout=timeout + 15,
@@ -1297,6 +1301,7 @@ def main() -> int:
             live_root=live_root,
             hermes_home=hermes_home,
             voice_repo=voice_repo,
+            sidecar_url=args.calling_sidecar_url,
             timeout=args.timeout,
         )
 

--- a/scripts/verify_voice_live_gateway.py
+++ b/scripts/verify_voice_live_gateway.py
@@ -332,52 +332,64 @@ def _looks_like_placeholder(value: str) -> bool:
     return any(token in lowered for token in ("<", ">", "paste_", "replace_"))
 
 
-def validate_whatsapp_cloud_field(key: str, value: str) -> dict[str, Any]:
+def whatsapp_cloud_field_status(
+    key: str,
+    value: str,
+) -> tuple[dict[str, Any], str | None]:
+    status: dict[str, Any] = {"present": bool(value)}
     if not value:
-        raise SystemExit(f"{key} is not configured")
+        return status, f"{key} is not configured"
     if _looks_like_placeholder(value):
-        raise SystemExit(f"{key} still looks like a placeholder")
+        return status, f"{key} still looks like a placeholder"
 
     if key == "WHATSAPP_CLOUD_PHONE_NUMBER_ID":
         if not value.isdigit():
-            raise SystemExit(f"{key} must be numeric")
+            return status, f"{key} must be numeric"
         if 10 <= len(value) <= 12:
-            raise SystemExit(
-                f"{key} looks like a phone number; use Meta's Phone Number ID"
+            return (
+                status,
+                f"{key} looks like a phone number; use Meta's Phone Number ID",
             )
         if len(value) < 13 or len(value) > 20:
-            raise SystemExit(f"{key} should be 13-20 digits")
-        return {"present": True, "source_shape": "meta_phone_number_id"}
+            return status, f"{key} should be 13-20 digits"
+        return {**status, "source_shape": "meta_phone_number_id"}, None
 
     if key == "WHATSAPP_CLOUD_ACCESS_TOKEN":
         if not value.startswith("EAA"):
-            raise SystemExit(f"{key} should start with EAA")
+            return status, f"{key} should start with EAA"
         if len(value) < 100:
-            raise SystemExit(f"{key} looks too short for a Meta access token")
-        return {"present": True, "source_shape": "meta_access_token"}
+            return status, f"{key} looks too short for a Meta access token"
+        return {**status, "source_shape": "meta_access_token"}, None
 
     if key == "WHATSAPP_CLOUD_APP_SECRET":
         if not re.fullmatch(r"[0-9a-fA-F]{32}", value):
-            raise SystemExit(f"{key} should be exactly 32 hex characters")
-        return {"present": True, "source_shape": "meta_app_secret"}
+            return status, f"{key} should be exactly 32 hex characters"
+        return {**status, "source_shape": "meta_app_secret"}, None
 
     if key == "WHATSAPP_CLOUD_VERIFY_TOKEN":
         if len(value) < 16:
-            raise SystemExit(f"{key} should be at least 16 characters")
-        return {"present": True, "source_shape": "webhook_verify_token"}
+            return status, f"{key} should be at least 16 characters"
+        return {**status, "source_shape": "webhook_verify_token"}, None
 
-    raise SystemExit(f"unsupported WhatsApp Cloud readiness field: {key}")
+    return status, f"unsupported WhatsApp Cloud readiness field: {key}"
+
+
+def validate_whatsapp_cloud_field(key: str, value: str) -> dict[str, Any]:
+    status, failure = whatsapp_cloud_field_status(key, value)
+    if failure is not None:
+        raise SystemExit(failure)
+    return status
 
 
 def truthy_env(value: str) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
-def validate_whatsapp_cloud_authorization(
+def whatsapp_cloud_authorization_status(
     *,
     file_env: dict[str, str],
     process_env: dict[str, str],
-) -> dict[str, Any]:
+) -> tuple[dict[str, Any], str | None]:
     allowed_users, allowed_source = configured_value(
         "WHATSAPP_CLOUD_ALLOWED_USERS",
         file_env=file_env,
@@ -390,18 +402,34 @@ def validate_whatsapp_cloud_authorization(
     )
     allow_all_enabled = truthy_env(allow_all)
     allowed_count = len([part for part in allowed_users.split(",") if part.strip()])
-    if allowed_count == 0 and not allow_all_enabled:
-        raise SystemExit(
-            "WhatsApp Cloud recipient authorization is not configured; set "
-            "WHATSAPP_CLOUD_ALLOWED_USERS or WHATSAPP_CLOUD_ALLOW_ALL_USERS"
-        )
-    return {
+    status = {
         "allowed_users_configured": allowed_count > 0,
         "allowed_users_count": allowed_count,
         "allowed_users_source": allowed_source if allowed_count > 0 else "missing",
         "allow_all_users": allow_all_enabled,
         "allow_all_users_source": allow_all_source if allow_all else "missing",
     }
+    if allowed_count == 0 and not allow_all_enabled:
+        return (
+            status,
+            "WhatsApp Cloud recipient authorization is not configured; set "
+            "WHATSAPP_CLOUD_ALLOWED_USERS or WHATSAPP_CLOUD_ALLOW_ALL_USERS",
+        )
+    return status, None
+
+
+def validate_whatsapp_cloud_authorization(
+    *,
+    file_env: dict[str, str],
+    process_env: dict[str, str],
+) -> dict[str, Any]:
+    status, failure = whatsapp_cloud_authorization_status(
+        file_env=file_env,
+        process_env=process_env,
+    )
+    if failure is not None:
+        raise SystemExit(failure)
+    return status
 
 
 def validate_whatsapp_cloud_readiness(
@@ -411,23 +439,35 @@ def validate_whatsapp_cloud_readiness(
 ) -> dict[str, Any]:
     file_env = load_hermes_env_file(hermes_home)
     fields: dict[str, Any] = {}
+    failures: list[str] = []
     for key in WHATSAPP_CLOUD_REQUIRED_ENV:
         value, source = configured_value(
             key,
             file_env=file_env,
             process_env=process_env,
         )
-        field = validate_whatsapp_cloud_field(key, value)
+        field, failure = whatsapp_cloud_field_status(key, value)
         field["source"] = source
         fields[key] = field
+        if failure is not None:
+            failures.append(failure)
+
+    authorization, auth_failure = whatsapp_cloud_authorization_status(
+        file_env=file_env,
+        process_env=process_env,
+    )
+    if auth_failure is not None:
+        failures.append(auth_failure)
+
+    if failures:
+        raise SystemExit(
+            "WhatsApp Cloud readiness failed:\n- " + "\n- ".join(failures)
+        )
 
     return {
         "env_file": str((hermes_home / ".env").resolve()),
         "required_fields": fields,
-        "authorization": validate_whatsapp_cloud_authorization(
-            file_env=file_env,
-            process_env=process_env,
-        ),
+        "authorization": authorization,
         "_private": {
             "file_env": file_env,
             "process_env": process_env,

--- a/scripts/verify_voice_live_gateway.py
+++ b/scripts/verify_voice_live_gateway.py
@@ -923,6 +923,13 @@ def run_calling_live_sidecar_smoke(
         )
     if result.get("sidecar_ready_for_accept") is not True:
         raise SystemExit(f"calling live-sidecar smoke sidecar was not ready: {result}")
+    statuses = result.get("webhook_statuses")
+    if not isinstance(statuses, dict) or statuses.get("connect") != 200 or statuses.get(
+        "terminate"
+    ) != 200:
+        raise SystemExit(
+            f"calling live-sidecar smoke did not use signed webhooks cleanly: {result}"
+        )
     try:
         outbound_bytes = int(result.get("outbound_webrtc_bytes") or 0)
         inbound_bytes = int(result.get("inbound_drain_bytes") or 0)

--- a/scripts/verify_voice_live_gateway.py
+++ b/scripts/verify_voice_live_gateway.py
@@ -214,6 +214,8 @@ def get_service_state(service: str, *, timeout: float) -> dict[str, str]:
             "-p",
             "MainPID",
             "-p",
+            "After",
+            "-p",
             "Environment",
             "-p",
             "DropInPaths",
@@ -357,6 +359,15 @@ def validate_sidecar_service_state(
         "service": service,
         "pid": pid,
     }
+    after_units = set(str(state.get("After") or "").split())
+    if "voice-daemon.service" in after_units:
+        raise SystemExit(
+            f"{service} still orders after deprecated voice-daemon.service; "
+            "rerun install_voice_local_stack.py so it uses voiced.service"
+        )
+    if "voiced.service" not in after_units:
+        raise SystemExit(f"{service} does not order after voiced.service")
+    result["after"] = sorted(after_units)
 
     if voice_bin is not None:
         configured_voice_bin = str(env.get("VOICE_BIN") or "")

--- a/scripts/verify_voice_live_gateway.py
+++ b/scripts/verify_voice_live_gateway.py
@@ -1453,6 +1453,19 @@ def run_calling_live_sidecar_smoke(
         )
     if result.get("sidecar_ready_for_accept") is not True:
         raise SystemExit(f"calling live-sidecar smoke sidecar was not ready: {result}")
+    readiness = result.get("sidecar_readiness")
+    if not isinstance(readiness, dict):
+        raise SystemExit(
+            f"calling live-sidecar smoke did not report readiness checks: {result}"
+        )
+    failed_readiness = sorted(
+        str(key) for key, value in readiness.items() if value is not True
+    )
+    if failed_readiness:
+        raise SystemExit(
+            "calling live-sidecar smoke readiness checks failed: "
+            + ", ".join(failed_readiness)
+        )
     statuses = result.get("webhook_statuses")
     if not isinstance(statuses, dict) or statuses.get("connect") != 200 or statuses.get(
         "terminate"
@@ -1469,6 +1482,31 @@ def run_calling_live_sidecar_smoke(
         ) from exc
     if outbound_bytes <= 0 or inbound_bytes <= 0:
         raise SystemExit(f"calling live-sidecar smoke did not move audio: {result}")
+    clear_audio = result.get("clear_audio")
+    if not isinstance(clear_audio, dict):
+        raise SystemExit(
+            f"calling live-sidecar smoke did not report clear audio telemetry: {result}"
+        )
+    if clear_audio.get("skipped"):
+        raise SystemExit(
+            f"calling live-sidecar smoke skipped clear audio endpoint: {result}"
+        )
+    try:
+        queued_after_clear = int(clear_audio.get("queued_tx_bytes"))
+        dropped_tx_bytes = int(clear_audio.get("dropped_tx_bytes"))
+    except (TypeError, ValueError) as exc:
+        raise SystemExit(
+            f"calling live-sidecar smoke returned invalid clear audio telemetry: {result}"
+        ) from exc
+    if queued_after_clear != 0 or dropped_tx_bytes < 0:
+        raise SystemExit(
+            f"calling live-sidecar smoke did not clear outbound audio: {result}"
+        )
+    close = result.get("sidecar_close")
+    if not isinstance(close, dict) or close.get("closed") is not True:
+        raise SystemExit(
+            f"calling live-sidecar smoke did not close sidecar cleanly: {result}"
+        )
     return result
 
 

--- a/scripts/verify_voice_live_gateway.py
+++ b/scripts/verify_voice_live_gateway.py
@@ -352,6 +352,15 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--ffprobe-bin", default=os.environ.get("FFPROBE_BIN", "ffprobe"))
     parser.add_argument("--timeout", type=float, default=15.0)
     parser.add_argument("--allow-disconnected-bridge", action="store_true")
+    parser.add_argument(
+        "--skip-bridge-health",
+        action="store_true",
+        help=(
+            "Skip the local Baileys bridge /health check. Use this for "
+            "Cloud-API-only gateway deployments that do not run the Node "
+            "WhatsApp bridge."
+        ),
+    )
     parser.add_argument("--run-tts-smoke", action="store_true")
     parser.add_argument("--tts-platform", default="whatsapp")
     parser.add_argument("--tts-text", default=DEFAULT_TTS_TEXT)
@@ -412,12 +421,19 @@ def main() -> int:
         timeout=args.timeout,
     )
 
-    bridge_health = get_bridge_health(args.bridge_url, timeout=args.timeout)
-    validate_bridge_health(
-        bridge_health,
-        require_connected=not args.allow_disconnected_bridge,
-    )
-    checks["bridge_health"] = bridge_health
+    if args.skip_bridge_health:
+        checks["bridge_health"] = {
+            "success": True,
+            "skipped": True,
+            "reason": "--skip-bridge-health was provided",
+        }
+    else:
+        bridge_health = get_bridge_health(args.bridge_url, timeout=args.timeout)
+        validate_bridge_health(
+            bridge_health,
+            require_connected=not args.allow_disconnected_bridge,
+        )
+        checks["bridge_health"] = bridge_health
 
     if args.run_tts_smoke:
         checks["tts_smoke"] = run_tts_smoke(

--- a/scripts/verify_voice_live_gateway.py
+++ b/scripts/verify_voice_live_gateway.py
@@ -9,6 +9,10 @@ resolve from that checkout, and checks the local WhatsApp bridge health.
 Pass ``--run-tts-smoke`` to also generate one live-config TTS reply and verify
 that Hermes returns a WhatsApp-ready Ogg/Opus voice-note file.
 
+Pass ``--run-stt-smoke`` with ``--voice-bin`` to also generate one WAV fixture
+and verify that the live Hermes config transcribes it through the configured
+voice command STT provider.
+
 Pass ``--voice-bin`` with ``--calling-sidecar-url`` to compare the running
 sidecar's machine-readable contract with the installed ``voice stream-contract``.
 Pass ``--sidecar-service`` to also verify the systemd user unit that runs the
@@ -37,6 +41,8 @@ from verify_voice_local_stack import audit_live_hermes_root
 DEFAULT_SERVICE = "hermes-gateway.service"
 DEFAULT_BRIDGE_URL = "http://127.0.0.1:3000"
 DEFAULT_TTS_TEXT = "Hermes live voice gateway smoke."
+DEFAULT_STT_TEXT = "hello world"
+DEFAULT_STT_EXPECT_WORDS = ("hello", "world")
 CALLING_TTS_STREAM_ENV = "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND"
 CONTRACT_COMPARE_KEYS = (
     "contract",
@@ -133,6 +139,7 @@ REQUIRED_PAYLOAD_FIELDS = {
 IMPORT_MODULES = (
     "hermes_cli.main",
     "tools.tts_tool",
+    "tools.transcription_tools",
     "tools.tirith_security",
     "gateway.platforms.whatsapp_cloud",
     "gateway.platforms.whatsapp",
@@ -793,6 +800,61 @@ print(json.dumps(json.loads(tts_tool.text_to_speech_tool(%r)), sort_keys=True))
     }
 
 
+def run_stt_smoke(
+    *,
+    python_bin: str,
+    live_root: Path,
+    hermes_home: Path,
+    voice_bin: str,
+    provider: str,
+    text: str,
+    expect_words: list[str],
+    stt_timeout: float,
+    generate_timeout: float,
+    process_timeout: float,
+) -> dict[str, Any]:
+    script = live_root / "scripts" / "verify_voice_command_stt.py"
+    if not script.is_file():
+        raise SystemExit(f"STT smoke verifier not found in live root: {script}")
+
+    command = [
+        python_bin,
+        str(script),
+        "--use-existing-config",
+        "--hermes-home",
+        str(hermes_home),
+        "--voice-bin",
+        voice_bin,
+        "--provider",
+        provider,
+        "--timeout",
+        f"{stt_timeout:g}",
+        "--generate-timeout",
+        f"{generate_timeout:g}",
+        "--text",
+        text,
+    ]
+    for word in expect_words:
+        command.extend(["--expect-word", word])
+
+    completed = run_command(command, timeout=process_timeout)
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise SystemExit(f"STT smoke failed: {detail}")
+    try:
+        result = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"STT smoke returned invalid JSON: {completed.stdout!r}") from exc
+    if result.get("success") is not True:
+        raise SystemExit(f"STT smoke reported failure: {result}")
+    if result.get("provider") != provider:
+        raise SystemExit(
+            f"STT smoke provider mismatch: expected {provider!r}, "
+            f"got {result.get('provider')!r}"
+        )
+    return result
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--service", default=DEFAULT_SERVICE)
@@ -839,7 +901,21 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--run-tts-smoke", action="store_true")
     parser.add_argument("--tts-platform", default="whatsapp")
     parser.add_argument("--tts-text", default=DEFAULT_TTS_TEXT)
-    return parser.parse_args()
+    parser.add_argument("--run-stt-smoke", action="store_true")
+    parser.add_argument("--stt-provider", default="voice")
+    parser.add_argument("--stt-text", default=DEFAULT_STT_TEXT)
+    parser.add_argument("--stt-timeout", type=float, default=300.0)
+    parser.add_argument("--stt-generate-timeout", type=float, default=180.0)
+    parser.add_argument(
+        "--stt-expect-word",
+        action="append",
+        default=None,
+        help="word expected in the live STT smoke transcript; repeatable",
+    )
+    args = parser.parse_args()
+    if args.stt_expect_word is None:
+        args.stt_expect_word = list(DEFAULT_STT_EXPECT_WORDS)
+    return args
 
 
 def main() -> int:
@@ -858,6 +934,8 @@ def main() -> int:
         if args.run_tts_smoke
         else ""
     )
+    if args.run_stt_smoke and not voice_bin:
+        raise SystemExit("--run-stt-smoke requires --voice-bin")
     bridge_bin_dir = live_root / "scripts" / "whatsapp-bridge" / "node_modules" / ".bin"
 
     checks: dict[str, Any] = {}
@@ -959,6 +1037,19 @@ def main() -> int:
             text=args.tts_text,
             ffprobe_bin=ffprobe_bin,
             timeout=args.timeout,
+        )
+    if args.run_stt_smoke:
+        checks["stt_smoke"] = run_stt_smoke(
+            python_bin=python_bin,
+            live_root=live_root,
+            hermes_home=hermes_home,
+            voice_bin=str(voice_bin),
+            provider=args.stt_provider,
+            text=args.stt_text,
+            expect_words=args.stt_expect_word,
+            stt_timeout=args.stt_timeout,
+            generate_timeout=args.stt_generate_timeout,
+            process_timeout=args.stt_timeout + args.stt_generate_timeout + 30,
         )
 
     print(

--- a/scripts/verify_voice_local_stack.py
+++ b/scripts/verify_voice_local_stack.py
@@ -12,7 +12,8 @@ This aggregate preflight runs the existing focused verifiers in a safe order:
 6. Hermes command-provider STT transcribes through voice stream-transcribe.
 7. Hermes' stream command path returns raw 48 kHz mono 20 ms pcm_s16le frames.
 8. Hermes' WhatsApp Calling control plane accepts a synthetic SDP offer.
-9. Optionally, the voice WebRTC sidecar full-duplex smoke passes locally.
+9. Hermes' WhatsApp Calling control plane can answer through a real local sidecar.
+10. Optionally, the voice WebRTC sidecar full-duplex smoke passes locally.
 
 By default the script creates a temporary Hermes home and removes it after a
 passing or failing run. Pass --keep-home to inspect the generated config.
@@ -423,6 +424,21 @@ def calling_control_plane_command(args: argparse.Namespace) -> list[str]:
     ]
 
 
+def calling_live_sidecar_command(
+    args: argparse.Namespace,
+    *,
+    voice_repo: Path,
+) -> list[str]:
+    return [
+        args.webrtc_python_bin or sys.executable,
+        str(script_path("verify_voice_whatsapp_calling_live_sidecar.py")),
+        "--voice-repo",
+        str(voice_repo),
+        "--timeout",
+        f"{args.calling_live_sidecar_timeout:g}",
+    ]
+
+
 def resolve_voice_repo_for_full_duplex(args: argparse.Namespace) -> Path | None:
     if args.skip_full_duplex:
         return None
@@ -485,6 +501,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--stt-timeout", type=float, default=300.0)
     parser.add_argument("--stream-timeout", type=float, default=180.0)
     parser.add_argument("--calling-control-plane-timeout", type=float, default=10.0)
+    parser.add_argument("--calling-live-sidecar-timeout", type=float, default=12.0)
     parser.add_argument("--full-duplex-timeout", type=float, default=90.0)
     parser.add_argument(
         "--full-duplex-max-queued-tx-ms",
@@ -529,6 +546,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--skip-whatsapp-cloud-voice", action="store_true")
     parser.add_argument("--skip-command-stt", action="store_true")
     parser.add_argument("--skip-calling-control-plane", action="store_true")
+    parser.add_argument("--skip-calling-live-sidecar", action="store_true")
     parser.add_argument("--skip-full-duplex", action="store_true")
     parser.add_argument(
         "--full-duplex-inbound-text",
@@ -683,6 +701,25 @@ def main() -> int:
                 "WhatsApp Calling control-plane verifier",
                 calling_control_plane_command(args),
                 timeout=args.calling_control_plane_timeout + 5,
+                env=env,
+            )
+        if args.skip_calling_live_sidecar:
+            checks["calling_live_sidecar"] = {
+                "success": True,
+                "skipped": True,
+                "reason": "--skip-calling-live-sidecar was provided",
+            }
+        elif voice_repo is None:
+            checks["calling_live_sidecar"] = {
+                "success": True,
+                "skipped": True,
+                "reason": "--skip-full-duplex was provided",
+            }
+        else:
+            checks["calling_live_sidecar"] = run_json_step(
+                "WhatsApp Calling live-sidecar verifier",
+                calling_live_sidecar_command(args, voice_repo=voice_repo),
+                timeout=args.calling_live_sidecar_timeout + 15,
                 env=env,
             )
         if voice_repo is None:

--- a/scripts/verify_voice_local_stack.py
+++ b/scripts/verify_voice_local_stack.py
@@ -9,9 +9,10 @@ This aggregate preflight runs the existing focused verifiers in a safe order:
 3. The local Baileys bridge keeps Ogg/Opus as native voice notes.
 4. The WhatsApp Cloud adapter uploads Ogg/Opus with voice-note MIME.
 5. Hermes command-provider TTS returns WhatsApp-ready Ogg/Opus from voice.
-6. Hermes' stream command path returns raw 48 kHz mono 20 ms pcm_s16le frames.
-7. Hermes' WhatsApp Calling control plane accepts a synthetic SDP offer.
-8. Optionally, the voice WebRTC sidecar full-duplex smoke passes locally.
+6. Hermes command-provider STT transcribes through voice stream-transcribe.
+7. Hermes' stream command path returns raw 48 kHz mono 20 ms pcm_s16le frames.
+8. Hermes' WhatsApp Calling control plane accepts a synthetic SDP offer.
+9. Optionally, the voice WebRTC sidecar full-duplex smoke passes locally.
 
 By default the script creates a temporary Hermes home and removes it after a
 passing or failing run. Pass --keep-home to inspect the generated config.
@@ -34,6 +35,7 @@ from typing import Any
 
 
 DEFAULT_COMMAND_TEXT = "Hermes local voice command preflight."
+DEFAULT_COMMAND_STT_TEXT = "hello world"
 DEFAULT_VOICE_CONTRACT_TEXT = "Hermes voice contract preflight."
 DEFAULT_STREAM_TEXT = "Hermes local voice stream preflight."
 DEFAULT_FULL_DUPLEX_INBOUND_TEXT = "hello world"
@@ -51,6 +53,15 @@ LIVE_ROOT_REQUIREMENTS = (
             "libopus",
             "-application",
             "voip",
+        ),
+    },
+    {
+        "path": "tools/transcription_tools.py",
+        "description": "command-provider STT routing",
+        "tokens": (
+            "stt.providers",
+            "_transcribe_command_stt",
+            "transcribe_audio",
         ),
     },
     {
@@ -297,6 +308,39 @@ def command_tts_command(
     return command
 
 
+def command_stt_command(
+    args: argparse.Namespace,
+    *,
+    voice_bin: str,
+    hermes_home: Path,
+) -> list[str]:
+    command = [
+        sys.executable,
+        str(script_path("verify_voice_command_stt.py")),
+        "--voice-bin",
+        voice_bin,
+        "--hermes-home",
+        str(hermes_home),
+        "--force",
+        "--provider",
+        args.stt_provider,
+        "--voice",
+        args.voice,
+        "--speed",
+        args.speed,
+        "--timeout",
+        f"{args.stt_timeout:g}",
+        "--generate-timeout",
+        f"{args.tts_timeout:g}",
+    ]
+    if args.keep_home:
+        command.append("--keep-home")
+    command.extend(["--text", args.command_stt_text])
+    for word in args.stt_expect_word:
+        command.extend(["--expect-word", word])
+    return command
+
+
 def stream_tts_command(
     args: argparse.Namespace,
     *,
@@ -434,9 +478,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--hermes-home", type=Path)
     parser.add_argument("--keep-home", action="store_true")
     parser.add_argument("--provider", default="kokoro")
+    parser.add_argument("--stt-provider", default="voice")
     parser.add_argument("--voice", default="af_heart")
     parser.add_argument("--speed", default="1.0")
     parser.add_argument("--tts-timeout", type=float, default=180.0)
+    parser.add_argument("--stt-timeout", type=float, default=300.0)
     parser.add_argument("--stream-timeout", type=float, default=180.0)
     parser.add_argument("--calling-control-plane-timeout", type=float, default=10.0)
     parser.add_argument("--full-duplex-timeout", type=float, default=90.0)
@@ -451,6 +497,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--cli-timeout", type=float, default=10.0)
     parser.add_argument("--command-text", default=DEFAULT_COMMAND_TEXT)
+    parser.add_argument("--command-stt-text", default=DEFAULT_COMMAND_STT_TEXT)
     parser.add_argument("--voice-contract-text", default=DEFAULT_VOICE_CONTRACT_TEXT)
     parser.add_argument("--voice-contract-timeout", type=float, default=240.0)
     parser.add_argument(
@@ -480,6 +527,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--skip-voice-contract", action="store_true")
     parser.add_argument("--skip-whatsapp-bridge-media", action="store_true")
     parser.add_argument("--skip-whatsapp-cloud-voice", action="store_true")
+    parser.add_argument("--skip-command-stt", action="store_true")
     parser.add_argument("--skip-calling-control-plane", action="store_true")
     parser.add_argument("--skip-full-duplex", action="store_true")
     parser.add_argument(
@@ -489,6 +537,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--full-duplex-outbound-text",
         default=DEFAULT_FULL_DUPLEX_OUTBOUND_TEXT,
+    )
+    parser.add_argument(
+        "--stt-expect-word",
+        action="append",
+        default=None,
+        help="word expected in the command-STT transcript; repeatable",
     )
     parser.add_argument(
         "--expect-word",
@@ -501,6 +555,8 @@ def parse_args() -> argparse.Namespace:
         parser.error("--full-duplex-max-queued-tx-ms must be non-negative")
     if args.expect_word is None:
         args.expect_word = ["hello", "world"]
+    if args.stt_expect_word is None:
+        args.stt_expect_word = ["hello", "world"]
     return args
 
 
@@ -593,6 +649,23 @@ def main() -> int:
             timeout=args.tts_timeout + 30,
             env=env,
         )
+        if args.skip_command_stt:
+            checks["command_stt"] = {
+                "success": True,
+                "skipped": True,
+                "reason": "--skip-command-stt was provided",
+            }
+        else:
+            checks["command_stt"] = run_json_step(
+                "command STT verifier",
+                command_stt_command(
+                    args,
+                    voice_bin=voice_bin,
+                    hermes_home=hermes_home,
+                ),
+                timeout=args.stt_timeout + args.tts_timeout + 30,
+                env=env,
+            )
         checks["stream_tts"] = run_json_step(
             "stream TTS verifier",
             stream_tts_command(args, voice_bin=voice_bin),

--- a/scripts/verify_voice_local_stack.py
+++ b/scripts/verify_voice_local_stack.py
@@ -551,6 +551,8 @@ def live_gateway_command(
         command.append("--run-calling-live-sidecar-smoke")
     if args.skip_live_gateway_bridge_health:
         command.append("--skip-bridge-health")
+    if args.require_live_gateway_whatsapp_cloud_readiness:
+        command.append("--require-whatsapp-cloud-readiness")
     return command
 
 
@@ -648,6 +650,14 @@ def parse_args() -> argparse.Namespace:
         "--skip-live-gateway-bridge-health",
         action="store_true",
         help="Pass --skip-bridge-health to the live gateway verifier.",
+    )
+    parser.add_argument(
+        "--require-live-gateway-whatsapp-cloud-readiness",
+        action="store_true",
+        help=(
+            "Pass --require-whatsapp-cloud-readiness to the live gateway "
+            "verifier."
+        ),
     )
     parser.add_argument(
         "--run-live-gateway-stt-smoke",

--- a/scripts/verify_voice_local_stack.py
+++ b/scripts/verify_voice_local_stack.py
@@ -6,10 +6,11 @@ This aggregate preflight runs the existing focused verifiers in a safe order:
 1. The local Hermes CLI entrypoint starts with an isolated HERMES_HOME.
 2. The voice checkout's own WhatsApp contract verifier proves the installed
    voice binary can emit Ogg/Opus and WebRTC-shaped PCM frames.
-3. Hermes command-provider TTS returns WhatsApp-ready Ogg/Opus from voice.
-4. Hermes' stream command path returns raw 48 kHz mono 20 ms pcm_s16le frames.
-5. Hermes' WhatsApp Calling control plane accepts a synthetic SDP offer.
-6. Optionally, the voice WebRTC sidecar full-duplex smoke passes locally.
+3. The local Baileys bridge keeps Ogg/Opus as native voice notes.
+4. Hermes command-provider TTS returns WhatsApp-ready Ogg/Opus from voice.
+5. Hermes' stream command path returns raw 48 kHz mono 20 ms pcm_s16le frames.
+6. Hermes' WhatsApp Calling control plane accepts a synthetic SDP offer.
+7. Optionally, the voice WebRTC sidecar full-duplex smoke passes locally.
 
 By default the script creates a temporary Hermes home and removes it after a
 passing or failing run. Pass --keep-home to inspect the generated config.
@@ -36,6 +37,7 @@ DEFAULT_VOICE_CONTRACT_TEXT = "Hermes voice contract preflight."
 DEFAULT_STREAM_TEXT = "Hermes local voice stream preflight."
 DEFAULT_FULL_DUPLEX_INBOUND_TEXT = "hello world"
 DEFAULT_FULL_DUPLEX_OUTBOUND_TEXT = "Hello from Hermes through the local voice sidecar."
+DEFAULT_WHATSAPP_BRIDGE_MEDIA_TIMEOUT = 15.0
 
 LIVE_ROOT_REQUIREMENTS = (
     {
@@ -251,6 +253,17 @@ def run_json_step(
     }
 
 
+def child_env(*, hermes_home: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(hermes_home)
+    root = str(repo_root())
+    existing_pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        f"{root}{os.pathsep}{existing_pythonpath}" if existing_pythonpath else root
+    )
+    return env
+
+
 def command_tts_command(
     args: argparse.Namespace,
     *,
@@ -342,6 +355,13 @@ def voice_contract_command(
     return command
 
 
+def whatsapp_bridge_media_payload_command(*, node_bin: str) -> list[str]:
+    test_path = repo_root() / "scripts" / "whatsapp-bridge" / "media-payload.test.mjs"
+    if not test_path.is_file():
+        raise SystemExit(f"WhatsApp bridge media-payload test not found: {test_path}")
+    return [node_bin, "--test", str(test_path)]
+
+
 def calling_control_plane_command(args: argparse.Namespace) -> list[str]:
     return [
         sys.executable,
@@ -414,6 +434,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--command-text", default=DEFAULT_COMMAND_TEXT)
     parser.add_argument("--voice-contract-text", default=DEFAULT_VOICE_CONTRACT_TEXT)
     parser.add_argument("--voice-contract-timeout", type=float, default=240.0)
+    parser.add_argument(
+        "--whatsapp-bridge-media-timeout",
+        type=float,
+        default=DEFAULT_WHATSAPP_BRIDGE_MEDIA_TIMEOUT,
+    )
+    parser.add_argument("--node-bin", default=os.environ.get("NODE_BIN", "node"))
     parser.add_argument("--stream-text", default=DEFAULT_STREAM_TEXT)
     parser.add_argument("--stream-command-template")
     parser.add_argument(
@@ -428,6 +454,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--voice-repo", type=Path, default=default_voice_repo())
     parser.add_argument("--webrtc-python-bin", default=os.environ.get("VOICE_WEBRTC_PYTHON"))
     parser.add_argument("--skip-voice-contract", action="store_true")
+    parser.add_argument("--skip-whatsapp-bridge-media", action="store_true")
     parser.add_argument("--skip-calling-control-plane", action="store_true")
     parser.add_argument("--skip-full-duplex", action="store_true")
     parser.add_argument(
@@ -454,6 +481,11 @@ def main() -> int:
     args = parse_args()
     voice_bin = resolve_executable(args.voice_bin, label="voice binary")
     hermes_bin = resolve_executable(args.hermes_bin, label="Hermes CLI")
+    node_bin = (
+        None
+        if args.skip_whatsapp_bridge_media
+        else resolve_executable(args.node_bin, label="Node.js")
+    )
     voice_contract_script = resolve_voice_contract_script(args)
     voice_repo = resolve_voice_repo_for_full_duplex(args)
 
@@ -465,8 +497,7 @@ def main() -> int:
     )
     hermes_home.mkdir(parents=True, exist_ok=True)
 
-    env = os.environ.copy()
-    env["HERMES_HOME"] = str(hermes_home)
+    env = child_env(hermes_home=hermes_home)
 
     checks: dict[str, Any] = {}
     try:
@@ -499,6 +530,20 @@ def main() -> int:
                     script=voice_contract_script,
                 ),
                 timeout=args.voice_contract_timeout,
+                env=env,
+                include_stdout_lines=True,
+            )
+        if node_bin is None:
+            checks["whatsapp_bridge_media_payload"] = {
+                "success": True,
+                "skipped": True,
+                "reason": "--skip-whatsapp-bridge-media was provided",
+            }
+        else:
+            checks["whatsapp_bridge_media_payload"] = run_plain_step(
+                "WhatsApp bridge media-payload verifier",
+                whatsapp_bridge_media_payload_command(node_bin=node_bin),
+                timeout=args.whatsapp_bridge_media_timeout,
                 env=env,
                 include_stdout_lines=True,
             )
@@ -549,6 +594,7 @@ def main() -> int:
                     "retained": bool(args.keep_home or not temporary_home),
                     "voice_bin": voice_bin,
                     "hermes_bin": hermes_bin,
+                    "node_bin": node_bin,
                     "voice_repo": str(voice_repo) if voice_repo is not None else None,
                     "checks": checks,
                 },

--- a/scripts/verify_voice_local_stack.py
+++ b/scripts/verify_voice_local_stack.py
@@ -535,6 +535,13 @@ def live_gateway_command(
         command.extend(["--sidecar-service", args.live_gateway_sidecar_service])
         if voice_repo is not None:
             command.extend(["--voice-repo", str(voice_repo)])
+    if args.live_gateway_sidecar_service and args.live_gateway_voice_daemon_service:
+        command.extend(
+            [
+                "--voice-daemon-service",
+                args.live_gateway_voice_daemon_service,
+            ]
+        )
     if args.skip_live_gateway_bridge_health:
         command.append("--skip-bridge-health")
     return command
@@ -621,6 +628,14 @@ def parse_args() -> argparse.Namespace:
         "--live-gateway-sidecar-service",
         default="voice-webrtc-sidecar.service",
         help="systemd user service name for the running WebRTC sidecar.",
+    )
+    parser.add_argument(
+        "--live-gateway-voice-daemon-service",
+        default="voiced.service",
+        help=(
+            "systemd user service name for the running voice daemon checked by "
+            "the live gateway verifier; pass an empty string to skip it."
+        ),
     )
     parser.add_argument(
         "--skip-live-gateway-bridge-health",

--- a/scripts/verify_voice_local_stack.py
+++ b/scripts/verify_voice_local_stack.py
@@ -7,10 +7,11 @@ This aggregate preflight runs the existing focused verifiers in a safe order:
 2. The voice checkout's own WhatsApp contract verifier proves the installed
    voice binary can emit Ogg/Opus and WebRTC-shaped PCM frames.
 3. The local Baileys bridge keeps Ogg/Opus as native voice notes.
-4. Hermes command-provider TTS returns WhatsApp-ready Ogg/Opus from voice.
-5. Hermes' stream command path returns raw 48 kHz mono 20 ms pcm_s16le frames.
-6. Hermes' WhatsApp Calling control plane accepts a synthetic SDP offer.
-7. Optionally, the voice WebRTC sidecar full-duplex smoke passes locally.
+4. The WhatsApp Cloud adapter uploads Ogg/Opus with voice-note MIME.
+5. Hermes command-provider TTS returns WhatsApp-ready Ogg/Opus from voice.
+6. Hermes' stream command path returns raw 48 kHz mono 20 ms pcm_s16le frames.
+7. Hermes' WhatsApp Calling control plane accepts a synthetic SDP offer.
+8. Optionally, the voice WebRTC sidecar full-duplex smoke passes locally.
 
 By default the script creates a temporary Hermes home and removes it after a
 passing or failing run. Pass --keep-home to inspect the generated config.
@@ -38,6 +39,7 @@ DEFAULT_STREAM_TEXT = "Hermes local voice stream preflight."
 DEFAULT_FULL_DUPLEX_INBOUND_TEXT = "hello world"
 DEFAULT_FULL_DUPLEX_OUTBOUND_TEXT = "Hello from Hermes through the local voice sidecar."
 DEFAULT_WHATSAPP_BRIDGE_MEDIA_TIMEOUT = 15.0
+DEFAULT_WHATSAPP_CLOUD_VOICE_TIMEOUT = 15.0
 
 LIVE_ROOT_REQUIREMENTS = (
     {
@@ -362,6 +364,10 @@ def whatsapp_bridge_media_payload_command(*, node_bin: str) -> list[str]:
     return [node_bin, "--test", str(test_path)]
 
 
+def whatsapp_cloud_voice_note_command() -> list[str]:
+    return [sys.executable, str(script_path("verify_voice_whatsapp_cloud_voice_note.py"))]
+
+
 def calling_control_plane_command(args: argparse.Namespace) -> list[str]:
     return [
         sys.executable,
@@ -439,6 +445,11 @@ def parse_args() -> argparse.Namespace:
         type=float,
         default=DEFAULT_WHATSAPP_BRIDGE_MEDIA_TIMEOUT,
     )
+    parser.add_argument(
+        "--whatsapp-cloud-voice-timeout",
+        type=float,
+        default=DEFAULT_WHATSAPP_CLOUD_VOICE_TIMEOUT,
+    )
     parser.add_argument("--node-bin", default=os.environ.get("NODE_BIN", "node"))
     parser.add_argument("--stream-text", default=DEFAULT_STREAM_TEXT)
     parser.add_argument("--stream-command-template")
@@ -455,6 +466,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--webrtc-python-bin", default=os.environ.get("VOICE_WEBRTC_PYTHON"))
     parser.add_argument("--skip-voice-contract", action="store_true")
     parser.add_argument("--skip-whatsapp-bridge-media", action="store_true")
+    parser.add_argument("--skip-whatsapp-cloud-voice", action="store_true")
     parser.add_argument("--skip-calling-control-plane", action="store_true")
     parser.add_argument("--skip-full-duplex", action="store_true")
     parser.add_argument(
@@ -546,6 +558,19 @@ def main() -> int:
                 timeout=args.whatsapp_bridge_media_timeout,
                 env=env,
                 include_stdout_lines=True,
+            )
+        if args.skip_whatsapp_cloud_voice:
+            checks["whatsapp_cloud_voice_note"] = {
+                "success": True,
+                "skipped": True,
+                "reason": "--skip-whatsapp-cloud-voice was provided",
+            }
+        else:
+            checks["whatsapp_cloud_voice_note"] = run_json_step(
+                "WhatsApp Cloud voice-note verifier",
+                whatsapp_cloud_voice_note_command(),
+                timeout=args.whatsapp_cloud_voice_timeout,
+                env=env,
             )
         checks["command_tts"] = run_json_step(
             "command TTS verifier",

--- a/scripts/verify_voice_local_stack.py
+++ b/scripts/verify_voice_local_stack.py
@@ -4,10 +4,12 @@
 This aggregate preflight runs the existing focused verifiers in a safe order:
 
 1. The local Hermes CLI entrypoint starts with an isolated HERMES_HOME.
-2. Hermes command-provider TTS returns WhatsApp-ready Ogg/Opus from voice.
-3. Hermes' stream command path returns raw 48 kHz mono 20 ms pcm_s16le frames.
-4. Hermes' WhatsApp Calling control plane accepts a synthetic SDP offer.
-5. Optionally, the voice WebRTC sidecar full-duplex smoke passes locally.
+2. The voice checkout's own WhatsApp contract verifier proves the installed
+   voice binary can emit Ogg/Opus and WebRTC-shaped PCM frames.
+3. Hermes command-provider TTS returns WhatsApp-ready Ogg/Opus from voice.
+4. Hermes' stream command path returns raw 48 kHz mono 20 ms pcm_s16le frames.
+5. Hermes' WhatsApp Calling control plane accepts a synthetic SDP offer.
+6. Optionally, the voice WebRTC sidecar full-duplex smoke passes locally.
 
 By default the script creates a temporary Hermes home and removes it after a
 passing or failing run. Pass --keep-home to inspect the generated config.
@@ -30,6 +32,7 @@ from typing import Any
 
 
 DEFAULT_COMMAND_TEXT = "Hermes local voice command preflight."
+DEFAULT_VOICE_CONTRACT_TEXT = "Hermes voice contract preflight."
 DEFAULT_STREAM_TEXT = "Hermes local voice stream preflight."
 DEFAULT_FULL_DUPLEX_INBOUND_TEXT = "hello world"
 DEFAULT_FULL_DUPLEX_OUTBOUND_TEXT = "Hello from Hermes through the local voice sidecar."
@@ -195,6 +198,7 @@ def run_plain_step(
     *,
     timeout: float,
     env: dict[str, str],
+    include_stdout_lines: bool = False,
 ) -> dict[str, Any]:
     completed = run_process(command, timeout=timeout, env=env)
     if completed.returncode != 0:
@@ -207,11 +211,14 @@ def run_plain_step(
         (line for line in completed.stdout.splitlines() if line.strip()),
         "",
     )
-    return {
+    result: dict[str, Any] = {
         "success": True,
         "command": shell_join(command),
         "stdout_first_line": first_line,
     }
+    if include_stdout_lines:
+        result["stdout_lines"] = completed.stdout.splitlines()
+    return result
 
 
 def run_json_step(
@@ -297,6 +304,44 @@ def stream_tts_command(
     return command
 
 
+def resolve_voice_contract_script(args: argparse.Namespace) -> Path | None:
+    if args.skip_voice_contract:
+        return None
+    if args.voice_repo is None:
+        return None
+
+    script = (
+        args.voice_repo.expanduser().resolve()
+        / "scripts"
+        / "verify_whatsapp_voice_contract.sh"
+    )
+    if not script.is_file():
+        raise SystemExit(
+            f"voice WhatsApp contract verifier not found: {script}; "
+            "update the voice checkout or pass --skip-voice-contract"
+        )
+    if not os.access(script, os.X_OK):
+        raise SystemExit(f"voice WhatsApp contract verifier is not executable: {script}")
+    return script
+
+
+def voice_contract_command(
+    args: argparse.Namespace,
+    *,
+    voice_bin: str,
+    script: Path,
+) -> list[str]:
+    command = [
+        str(script),
+        "--voice-bin",
+        voice_bin,
+        "--text",
+        args.voice_contract_text,
+        "--require-daemon",
+    ]
+    return command
+
+
 def calling_control_plane_command(args: argparse.Namespace) -> list[str]:
     return [
         sys.executable,
@@ -367,6 +412,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--full-duplex-timeout", type=float, default=90.0)
     parser.add_argument("--cli-timeout", type=float, default=10.0)
     parser.add_argument("--command-text", default=DEFAULT_COMMAND_TEXT)
+    parser.add_argument("--voice-contract-text", default=DEFAULT_VOICE_CONTRACT_TEXT)
+    parser.add_argument("--voice-contract-timeout", type=float, default=240.0)
     parser.add_argument("--stream-text", default=DEFAULT_STREAM_TEXT)
     parser.add_argument("--stream-command-template")
     parser.add_argument(
@@ -380,6 +427,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--voice-repo", type=Path, default=default_voice_repo())
     parser.add_argument("--webrtc-python-bin", default=os.environ.get("VOICE_WEBRTC_PYTHON"))
+    parser.add_argument("--skip-voice-contract", action="store_true")
     parser.add_argument("--skip-calling-control-plane", action="store_true")
     parser.add_argument("--skip-full-duplex", action="store_true")
     parser.add_argument(
@@ -406,6 +454,7 @@ def main() -> int:
     args = parse_args()
     voice_bin = resolve_executable(args.voice_bin, label="voice binary")
     hermes_bin = resolve_executable(args.hermes_bin, label="Hermes CLI")
+    voice_contract_script = resolve_voice_contract_script(args)
     voice_repo = resolve_voice_repo_for_full_duplex(args)
 
     temporary_home = args.hermes_home is None
@@ -431,6 +480,28 @@ def main() -> int:
             timeout=args.cli_timeout,
             env=env,
         )
+        if voice_contract_script is None:
+            checks["voice_contract"] = {
+                "success": True,
+                "skipped": True,
+                "reason": (
+                    "--skip-voice-contract was provided"
+                    if args.skip_voice_contract
+                    else "--voice-repo or VOICE_REPO was not provided"
+                ),
+            }
+        else:
+            checks["voice_contract"] = run_plain_step(
+                "voice WhatsApp contract verifier",
+                voice_contract_command(
+                    args,
+                    voice_bin=voice_bin,
+                    script=voice_contract_script,
+                ),
+                timeout=args.voice_contract_timeout,
+                env=env,
+                include_stdout_lines=True,
+            )
         checks["command_tts"] = run_json_step(
             "command TTS verifier",
             command_tts_command(args, voice_bin=voice_bin, hermes_home=hermes_home),

--- a/scripts/verify_voice_local_stack.py
+++ b/scripts/verify_voice_local_stack.py
@@ -6,7 +6,8 @@ This aggregate preflight runs the existing focused verifiers in a safe order:
 1. The local Hermes CLI entrypoint starts with an isolated HERMES_HOME.
 2. Hermes command-provider TTS returns WhatsApp-ready Ogg/Opus from voice.
 3. Hermes' stream command path returns raw 48 kHz mono 20 ms pcm_s16le frames.
-4. Optionally, the voice WebRTC sidecar full-duplex smoke passes locally.
+4. Hermes' WhatsApp Calling control plane accepts a synthetic SDP offer.
+5. Optionally, the voice WebRTC sidecar full-duplex smoke passes locally.
 
 By default the script creates a temporary Hermes home and removes it after a
 passing or failing run. Pass --keep-home to inspect the generated config.
@@ -296,6 +297,15 @@ def stream_tts_command(
     return command
 
 
+def calling_control_plane_command(args: argparse.Namespace) -> list[str]:
+    return [
+        sys.executable,
+        str(script_path("verify_voice_whatsapp_calling_control_plane.py")),
+        "--timeout",
+        f"{args.calling_control_plane_timeout:g}",
+    ]
+
+
 def resolve_voice_repo_for_full_duplex(args: argparse.Namespace) -> Path | None:
     if args.skip_full_duplex:
         return None
@@ -353,6 +363,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--speed", default="1.0")
     parser.add_argument("--tts-timeout", type=float, default=180.0)
     parser.add_argument("--stream-timeout", type=float, default=180.0)
+    parser.add_argument("--calling-control-plane-timeout", type=float, default=10.0)
     parser.add_argument("--full-duplex-timeout", type=float, default=90.0)
     parser.add_argument("--cli-timeout", type=float, default=10.0)
     parser.add_argument("--command-text", default=DEFAULT_COMMAND_TEXT)
@@ -369,6 +380,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--voice-repo", type=Path, default=default_voice_repo())
     parser.add_argument("--webrtc-python-bin", default=os.environ.get("VOICE_WEBRTC_PYTHON"))
+    parser.add_argument("--skip-calling-control-plane", action="store_true")
     parser.add_argument("--skip-full-duplex", action="store_true")
     parser.add_argument(
         "--full-duplex-inbound-text",
@@ -431,6 +443,19 @@ def main() -> int:
             timeout=args.stream_timeout + 30,
             env=env,
         )
+        if args.skip_calling_control_plane:
+            checks["calling_control_plane"] = {
+                "success": True,
+                "skipped": True,
+                "reason": "--skip-calling-control-plane was provided",
+            }
+        else:
+            checks["calling_control_plane"] = run_json_step(
+                "WhatsApp Calling control-plane verifier",
+                calling_control_plane_command(args),
+                timeout=args.calling_control_plane_timeout + 5,
+                env=env,
+            )
         if voice_repo is None:
             checks["full_duplex_sidecar"] = {
                 "success": True,

--- a/scripts/verify_voice_local_stack.py
+++ b/scripts/verify_voice_local_stack.py
@@ -502,6 +502,10 @@ def live_gateway_command(
         raise SystemExit("--run-live-gateway requires --calling-sidecar-url")
     if not args.webrtc_python_bin:
         raise SystemExit("--run-live-gateway requires --webrtc-python-bin")
+    if args.run_live_gateway_calling_live_sidecar_smoke and voice_repo is None:
+        raise SystemExit(
+            "--run-live-gateway-calling-live-sidecar-smoke requires --voice-repo"
+        )
 
     command = [
         sys.executable,
@@ -542,6 +546,8 @@ def live_gateway_command(
                 args.live_gateway_voice_daemon_service,
             ]
         )
+    if args.run_live_gateway_calling_live_sidecar_smoke:
+        command.append("--run-calling-live-sidecar-smoke")
     if args.skip_live_gateway_bridge_health:
         command.append("--skip-bridge-health")
     return command
@@ -646,6 +652,14 @@ def parse_args() -> argparse.Namespace:
         "--run-live-gateway-stt-smoke",
         action="store_true",
         help="Also run the live gateway command-STT smoke.",
+    )
+    parser.add_argument(
+        "--run-live-gateway-calling-live-sidecar-smoke",
+        action="store_true",
+        help=(
+            "Also run the live gateway Hermes connect-path sidecar smoke "
+            "against imports from --live-hermes-root."
+        ),
     )
     parser.add_argument("--live-gateway-timeout", type=float, default=360.0)
     parser.add_argument("--skip-voice-contract", action="store_true")

--- a/scripts/verify_voice_local_stack.py
+++ b/scripts/verify_voice_local_stack.py
@@ -10,6 +10,8 @@ This aggregate preflight runs the existing focused verifiers in a safe order:
 
 By default the script creates a temporary Hermes home and removes it after a
 passing or failing run. Pass --keep-home to inspect the generated config.
+Pass --live-hermes-root to also prove the checkout used by a local gateway has
+the voice-native WhatsApp and sidecar surfaces from this branch.
 """
 
 from __future__ import annotations
@@ -30,6 +32,30 @@ DEFAULT_COMMAND_TEXT = "Hermes local voice command preflight."
 DEFAULT_STREAM_TEXT = "Hermes local voice stream preflight."
 DEFAULT_FULL_DUPLEX_INBOUND_TEXT = "hello world"
 DEFAULT_FULL_DUPLEX_OUTBOUND_TEXT = "Hello from Hermes through the local voice sidecar."
+
+LIVE_ROOT_REQUIREMENTS = (
+    {
+        "path": "tools/tts_tool.py",
+        "description": "command-provider voice-compatible Opus routing",
+        "tokens": (
+            "voice_compatible",
+            "libopus",
+            "-application",
+            "voip",
+        ),
+    },
+    {
+        "path": "gateway/platforms/whatsapp_cloud.py",
+        "description": "WhatsApp Cloud voice notes and calling sidecar client",
+        "tokens": (
+            "calling_sidecar_url",
+            "voice.webrtc_sidecar",
+            "_send_calling_sidecar_tts_stream_command",
+            "-application",
+            "voip",
+        ),
+    },
+)
 
 
 def repo_root() -> Path:
@@ -105,6 +131,61 @@ def run_process(
         env=env,
         stdin=subprocess.DEVNULL,
     )
+
+
+def audit_live_hermes_root(root: Path) -> dict[str, Any]:
+    resolved = root.expanduser().resolve()
+    failures: list[str] = []
+    checked: list[dict[str, Any]] = []
+
+    if not resolved.is_dir():
+        failures.append(f"live Hermes root is not a directory: {resolved}")
+        return {
+            "success": False,
+            "root": str(resolved),
+            "checked": checked,
+            "failures": failures,
+        }
+
+    for requirement in LIVE_ROOT_REQUIREMENTS:
+        rel_path = str(requirement["path"])
+        required_tokens = tuple(str(token) for token in requirement["tokens"])
+        path = resolved / rel_path
+        check = {
+            "path": rel_path,
+            "description": requirement["description"],
+            "required_tokens": list(required_tokens),
+        }
+        if not path.is_file():
+            check["present"] = False
+            failures.append(f"{rel_path} is missing")
+            checked.append(check)
+            continue
+
+        text = path.read_text(encoding="utf-8", errors="replace")
+        missing = [token for token in required_tokens if token not in text]
+        check["present"] = True
+        check["missing_tokens"] = missing
+        if missing:
+            failures.append(f"{rel_path} is missing tokens: {', '.join(missing)}")
+        checked.append(check)
+
+    return {
+        "success": not failures,
+        "root": str(resolved),
+        "checked": checked,
+        "failures": failures,
+    }
+
+
+def require_live_hermes_root(root: Path) -> dict[str, Any]:
+    result = audit_live_hermes_root(root)
+    if result["success"] is not True:
+        raise SystemExit(
+            "live Hermes root is missing voice-native integration surfaces:\n- "
+            + "\n- ".join(result["failures"])
+        )
+    return result
 
 
 def run_plain_step(
@@ -277,6 +358,15 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--command-text", default=DEFAULT_COMMAND_TEXT)
     parser.add_argument("--stream-text", default=DEFAULT_STREAM_TEXT)
     parser.add_argument("--stream-command-template")
+    parser.add_argument(
+        "--live-hermes-root",
+        type=Path,
+        help=(
+            "Optional checkout used by a running local gateway. When provided, "
+            "fail unless that checkout contains the voice-native WhatsApp "
+            "and calling sidecar integration surfaces."
+        ),
+    )
     parser.add_argument("--voice-repo", type=Path, default=default_voice_repo())
     parser.add_argument("--webrtc-python-bin", default=os.environ.get("VOICE_WEBRTC_PYTHON"))
     parser.add_argument("--skip-full-duplex", action="store_true")
@@ -319,6 +409,10 @@ def main() -> int:
 
     checks: dict[str, Any] = {}
     try:
+        if args.live_hermes_root is not None:
+            checks["live_hermes_root"] = require_live_hermes_root(
+                args.live_hermes_root
+            )
         checks["hermes_cli"] = run_plain_step(
             "Hermes CLI",
             [hermes_bin, "--help"],

--- a/scripts/verify_voice_local_stack.py
+++ b/scripts/verify_voice_local_stack.py
@@ -403,6 +403,7 @@ def voice_contract_command(
         "--text",
         args.voice_contract_text,
         "--require-daemon",
+        "--run-stt-smoke",
     ]
     return command
 

--- a/scripts/verify_voice_local_stack.py
+++ b/scripts/verify_voice_local_stack.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""Validate the local Hermes + voice stack without touching the live gateway.
+
+This aggregate preflight runs the existing focused verifiers in a safe order:
+
+1. The local Hermes CLI entrypoint starts with an isolated HERMES_HOME.
+2. Hermes command-provider TTS returns WhatsApp-ready Ogg/Opus from voice.
+3. Hermes' stream command path returns raw 48 kHz mono 20 ms pcm_s16le frames.
+4. Optionally, the voice WebRTC sidecar full-duplex smoke passes locally.
+
+By default the script creates a temporary Hermes home and removes it after a
+passing or failing run. Pass --keep-home to inspect the generated config.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+
+DEFAULT_COMMAND_TEXT = "Hermes local voice command preflight."
+DEFAULT_STREAM_TEXT = "Hermes local voice stream preflight."
+DEFAULT_FULL_DUPLEX_INBOUND_TEXT = "hello world"
+DEFAULT_FULL_DUPLEX_OUTBOUND_TEXT = "Hello from Hermes through the local voice sidecar."
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def script_path(name: str) -> Path:
+    path = repo_root() / "scripts" / name
+    if not path.is_file():
+        raise SystemExit(f"script not found: {path}")
+    return path
+
+
+def resolve_executable(value: str, *, label: str) -> str:
+    if "/" in value:
+        path = Path(value).expanduser()
+        if not path.is_file() or not os.access(path, os.X_OK):
+            raise SystemExit(f"{label} is not executable: {path}")
+        return os.path.abspath(os.path.expanduser(value))
+
+    found = shutil.which(value)
+    if not found:
+        raise SystemExit(f"{label} not found on PATH: {value}")
+    return found
+
+
+def default_hermes_bin() -> str:
+    local = repo_root() / ".venv" / "bin" / "hermes"
+    if local.is_file() and os.access(local, os.X_OK):
+        return str(local)
+    return "hermes"
+
+
+def default_voice_repo() -> Path | None:
+    configured = os.environ.get("VOICE_REPO")
+    return Path(configured) if configured else None
+
+
+def shell_join(command: list[str]) -> str:
+    return " ".join(shlex.quote(part) for part in command)
+
+
+def parse_json_object(stdout: str) -> dict[str, Any]:
+    decoder = json.JSONDecoder()
+    text = stdout.strip()
+    for index, char in enumerate(text):
+        if char != "{":
+            continue
+        try:
+            parsed, end = decoder.raw_decode(text[index:])
+        except json.JSONDecodeError:
+            continue
+        if text[index + end :].strip():
+            continue
+        if not isinstance(parsed, dict):
+            raise ValueError("JSON root must be an object")
+        return parsed
+    raise ValueError("command did not print a JSON object")
+
+
+def run_process(
+    command: list[str],
+    *,
+    timeout: float,
+    env: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+        env=env,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def run_plain_step(
+    name: str,
+    command: list[str],
+    *,
+    timeout: float,
+    env: dict[str, str],
+) -> dict[str, Any]:
+    completed = run_process(command, timeout=timeout, env=env)
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise SystemExit(
+            f"{name} failed with exit code {completed.returncode}"
+            + (f": {detail[:1000]}" if detail else "")
+        )
+    first_line = next(
+        (line for line in completed.stdout.splitlines() if line.strip()),
+        "",
+    )
+    return {
+        "success": True,
+        "command": shell_join(command),
+        "stdout_first_line": first_line,
+    }
+
+
+def run_json_step(
+    name: str,
+    command: list[str],
+    *,
+    timeout: float,
+    env: dict[str, str],
+) -> dict[str, Any]:
+    completed = run_process(command, timeout=timeout, env=env)
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise SystemExit(
+            f"{name} failed with exit code {completed.returncode}"
+            + (f": {detail[:1000]}" if detail else "")
+        )
+    try:
+        result = parse_json_object(completed.stdout)
+    except ValueError as exc:
+        raise SystemExit(f"{name} did not return JSON: {exc}") from exc
+    if result.get("success") is not True:
+        raise SystemExit(
+            f"{name} reported failure: "
+            + json.dumps(result, ensure_ascii=False, indent=2)
+        )
+    return {
+        "success": True,
+        "command": shell_join(command),
+        "result": result,
+    }
+
+
+def command_tts_command(
+    args: argparse.Namespace,
+    *,
+    voice_bin: str,
+    hermes_home: Path,
+) -> list[str]:
+    command = [
+        sys.executable,
+        str(script_path("verify_voice_command_tts.py")),
+        "--voice-bin",
+        voice_bin,
+        "--hermes-home",
+        str(hermes_home),
+        "--force",
+        "--provider",
+        args.provider,
+        "--voice",
+        args.voice,
+        "--speed",
+        args.speed,
+        "--timeout",
+        f"{args.tts_timeout:g}",
+    ]
+    if args.keep_home:
+        command.append("--keep-home")
+    command.extend(["--text", args.command_text])
+    return command
+
+
+def stream_tts_command(
+    args: argparse.Namespace,
+    *,
+    voice_bin: str,
+) -> list[str]:
+    command = [
+        sys.executable,
+        str(script_path("verify_voice_stream_tts.py")),
+        "--voice-bin",
+        voice_bin,
+        "--voice",
+        args.voice,
+        "--speed",
+        args.speed,
+        "--timeout",
+        f"{args.stream_timeout:g}",
+        "--text",
+        args.stream_text,
+    ]
+    if args.stream_command_template:
+        command.extend(["--command-template", args.stream_command_template])
+    return command
+
+
+def resolve_voice_repo_for_full_duplex(args: argparse.Namespace) -> Path | None:
+    if args.skip_full_duplex:
+        return None
+    if args.voice_repo is None:
+        raise SystemExit(
+            "full-duplex validation needs --voice-repo or VOICE_REPO; "
+            "pass --skip-full-duplex to validate only command and stream TTS"
+        )
+    voice_repo = args.voice_repo.expanduser().resolve()
+    smoke = voice_repo / "examples" / "webrtc-sidecar" / "full_duplex_loopback_smoke.py"
+    if not smoke.is_file():
+        raise SystemExit(f"voice full-duplex smoke not found: {smoke}")
+    return voice_repo
+
+
+def full_duplex_command(
+    args: argparse.Namespace,
+    *,
+    voice_bin: str,
+    voice_repo: Path,
+) -> list[str]:
+    command = [
+        sys.executable,
+        str(script_path("verify_voice_full_duplex_sidecar.py")),
+        "--voice-repo",
+        str(voice_repo),
+        "--voice-bin",
+        voice_bin,
+        "--voice",
+        args.voice,
+        "--speed",
+        args.speed,
+        "--timeout",
+        f"{args.full_duplex_timeout:g}",
+        "--inbound-text",
+        args.full_duplex_inbound_text,
+        "--outbound-text",
+        args.full_duplex_outbound_text,
+    ]
+    if args.webrtc_python_bin:
+        command.extend(["--python-bin", args.webrtc_python_bin])
+    for word in args.expect_word:
+        command.extend(["--expect-word", word])
+    return command
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--voice-bin", default=os.environ.get("VOICE_BIN", "voice"))
+    parser.add_argument("--hermes-bin", default=os.environ.get("HERMES_BIN", default_hermes_bin()))
+    parser.add_argument("--hermes-home", type=Path)
+    parser.add_argument("--keep-home", action="store_true")
+    parser.add_argument("--provider", default="kokoro")
+    parser.add_argument("--voice", default="af_heart")
+    parser.add_argument("--speed", default="1.0")
+    parser.add_argument("--tts-timeout", type=float, default=180.0)
+    parser.add_argument("--stream-timeout", type=float, default=180.0)
+    parser.add_argument("--full-duplex-timeout", type=float, default=90.0)
+    parser.add_argument("--cli-timeout", type=float, default=10.0)
+    parser.add_argument("--command-text", default=DEFAULT_COMMAND_TEXT)
+    parser.add_argument("--stream-text", default=DEFAULT_STREAM_TEXT)
+    parser.add_argument("--stream-command-template")
+    parser.add_argument("--voice-repo", type=Path, default=default_voice_repo())
+    parser.add_argument("--webrtc-python-bin", default=os.environ.get("VOICE_WEBRTC_PYTHON"))
+    parser.add_argument("--skip-full-duplex", action="store_true")
+    parser.add_argument(
+        "--full-duplex-inbound-text",
+        default=DEFAULT_FULL_DUPLEX_INBOUND_TEXT,
+    )
+    parser.add_argument(
+        "--full-duplex-outbound-text",
+        default=DEFAULT_FULL_DUPLEX_OUTBOUND_TEXT,
+    )
+    parser.add_argument(
+        "--expect-word",
+        action="append",
+        default=None,
+        help="word expected in the inbound full-duplex transcript; repeatable",
+    )
+    args = parser.parse_args()
+    if args.expect_word is None:
+        args.expect_word = ["hello", "world"]
+    return args
+
+
+def main() -> int:
+    args = parse_args()
+    voice_bin = resolve_executable(args.voice_bin, label="voice binary")
+    hermes_bin = resolve_executable(args.hermes_bin, label="Hermes CLI")
+    voice_repo = resolve_voice_repo_for_full_duplex(args)
+
+    temporary_home = args.hermes_home is None
+    hermes_home = (
+        Path(tempfile.mkdtemp(prefix="hermes-voice-local-stack."))
+        if temporary_home
+        else args.hermes_home.expanduser().resolve()
+    )
+    hermes_home.mkdir(parents=True, exist_ok=True)
+
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(hermes_home)
+
+    checks: dict[str, Any] = {}
+    try:
+        checks["hermes_cli"] = run_plain_step(
+            "Hermes CLI",
+            [hermes_bin, "--help"],
+            timeout=args.cli_timeout,
+            env=env,
+        )
+        checks["command_tts"] = run_json_step(
+            "command TTS verifier",
+            command_tts_command(args, voice_bin=voice_bin, hermes_home=hermes_home),
+            timeout=args.tts_timeout + 30,
+            env=env,
+        )
+        checks["stream_tts"] = run_json_step(
+            "stream TTS verifier",
+            stream_tts_command(args, voice_bin=voice_bin),
+            timeout=args.stream_timeout + 30,
+            env=env,
+        )
+        if voice_repo is None:
+            checks["full_duplex_sidecar"] = {
+                "success": True,
+                "skipped": True,
+                "reason": "--skip-full-duplex was provided",
+            }
+        else:
+            checks["full_duplex_sidecar"] = run_json_step(
+                "full-duplex sidecar verifier",
+                full_duplex_command(args, voice_bin=voice_bin, voice_repo=voice_repo),
+                timeout=args.full_duplex_timeout + 15,
+                env=env,
+            )
+
+        print(
+            json.dumps(
+                {
+                    "success": True,
+                    "hermes_home": str(hermes_home),
+                    "retained": bool(args.keep_home or not temporary_home),
+                    "voice_bin": voice_bin,
+                    "hermes_bin": hermes_bin,
+                    "voice_repo": str(voice_repo) if voice_repo is not None else None,
+                    "checks": checks,
+                },
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
+        return 0
+    finally:
+        if temporary_home and not args.keep_home:
+            shutil.rmtree(hermes_home, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_voice_local_stack.py
+++ b/scripts/verify_voice_local_stack.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
-"""Validate the local Hermes + voice stack without touching the live gateway.
+"""Validate the local Hermes + voice stack.
 
-This aggregate preflight runs the existing focused verifiers in a safe order:
+By default this aggregate preflight runs the existing focused verifiers without
+touching the live gateway:
 
 1. The local Hermes CLI entrypoint starts with an isolated HERMES_HOME.
 2. The voice checkout's own WhatsApp contract verifier proves the installed
@@ -19,6 +20,8 @@ By default the script creates a temporary Hermes home and removes it after a
 passing or failing run. Pass --keep-home to inspect the generated config.
 Pass --live-hermes-root to also prove the checkout used by a local gateway has
 the voice-native WhatsApp and sidecar surfaces from this branch.
+Pass --run-live-gateway to also inspect the running local gateway and require
+the live WebRTC sidecar to answer a real SDP offer with ready_for_accept=true.
 """
 
 from __future__ import annotations
@@ -487,6 +490,56 @@ def full_duplex_command(
     return command
 
 
+def live_gateway_command(
+    args: argparse.Namespace,
+    *,
+    voice_bin: str,
+    voice_repo: Path | None,
+) -> list[str]:
+    if args.live_hermes_root is None:
+        raise SystemExit("--run-live-gateway requires --live-hermes-root")
+    if not args.calling_sidecar_url:
+        raise SystemExit("--run-live-gateway requires --calling-sidecar-url")
+    if not args.webrtc_python_bin:
+        raise SystemExit("--run-live-gateway requires --webrtc-python-bin")
+
+    command = [
+        sys.executable,
+        str(script_path("verify_voice_live_gateway.py")),
+        "--live-hermes-root",
+        str(args.live_hermes_root.expanduser().resolve()),
+        "--python-bin",
+        args.live_gateway_python_bin,
+        "--hermes-home",
+        str(args.live_gateway_hermes_home.expanduser()),
+        "--calling-sidecar-url",
+        args.calling_sidecar_url,
+        "--voice-bin",
+        voice_bin,
+        "--run-tts-smoke",
+        "--run-sidecar-offer-smoke",
+        "--webrtc-python-bin",
+        args.webrtc_python_bin,
+    ]
+    if args.run_live_gateway_stt_smoke:
+        command.extend(
+            [
+                "--run-stt-smoke",
+                "--stt-provider",
+                args.stt_provider,
+                "--stt-timeout",
+                f"{args.stt_timeout:g}",
+            ]
+        )
+    if args.live_gateway_sidecar_service:
+        command.extend(["--sidecar-service", args.live_gateway_sidecar_service])
+        if voice_repo is not None:
+            command.extend(["--voice-repo", str(voice_repo)])
+    if args.skip_live_gateway_bridge_health:
+        command.append("--skip-bridge-health")
+    return command
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--voice-bin", default=os.environ.get("VOICE_BIN", "voice"))
@@ -541,6 +594,45 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--voice-repo", type=Path, default=default_voice_repo())
     parser.add_argument("--webrtc-python-bin", default=os.environ.get("VOICE_WEBRTC_PYTHON"))
+    parser.add_argument(
+        "--run-live-gateway",
+        action="store_true",
+        help=(
+            "Also run verify_voice_live_gateway.py against the installed local "
+            "gateway and sidecar."
+        ),
+    )
+    parser.add_argument(
+        "--live-gateway-python-bin",
+        default="~/.hermes/hermes-agent/venv/bin/python",
+        help="Python interpreter used by the running Hermes gateway checkout.",
+    )
+    parser.add_argument(
+        "--live-gateway-hermes-home",
+        type=Path,
+        default=Path("~/.hermes"),
+        help="Hermes home used by the running local gateway.",
+    )
+    parser.add_argument(
+        "--calling-sidecar-url",
+        help="Expected base URL for the running local WebRTC sidecar.",
+    )
+    parser.add_argument(
+        "--live-gateway-sidecar-service",
+        default="voice-webrtc-sidecar.service",
+        help="systemd user service name for the running WebRTC sidecar.",
+    )
+    parser.add_argument(
+        "--skip-live-gateway-bridge-health",
+        action="store_true",
+        help="Pass --skip-bridge-health to the live gateway verifier.",
+    )
+    parser.add_argument(
+        "--run-live-gateway-stt-smoke",
+        action="store_true",
+        help="Also run the live gateway command-STT smoke.",
+    )
+    parser.add_argument("--live-gateway-timeout", type=float, default=360.0)
     parser.add_argument("--skip-voice-contract", action="store_true")
     parser.add_argument("--skip-whatsapp-bridge-media", action="store_true")
     parser.add_argument("--skip-whatsapp-cloud-voice", action="store_true")
@@ -733,6 +825,17 @@ def main() -> int:
                 "full-duplex sidecar verifier",
                 full_duplex_command(args, voice_bin=voice_bin, voice_repo=voice_repo),
                 timeout=args.full_duplex_timeout + 15,
+                env=env,
+            )
+        if args.run_live_gateway:
+            checks["live_gateway"] = run_json_step(
+                "live gateway verifier",
+                live_gateway_command(
+                    args,
+                    voice_bin=voice_bin,
+                    voice_repo=voice_repo,
+                ),
+                timeout=args.live_gateway_timeout,
                 env=env,
             )
 

--- a/scripts/verify_voice_local_stack.py
+++ b/scripts/verify_voice_local_stack.py
@@ -59,6 +59,7 @@ LIVE_ROOT_REQUIREMENTS = (
             "calling_sidecar_url",
             "voice.webrtc_sidecar",
             "_send_calling_sidecar_tts_stream_command",
+            "_clear_calling_sidecar_audio",
             "-application",
             "voip",
         ),

--- a/scripts/verify_voice_local_stack.py
+++ b/scripts/verify_voice_local_stack.py
@@ -46,6 +46,7 @@ DEFAULT_FULL_DUPLEX_INBOUND_TEXT = "hello world"
 DEFAULT_FULL_DUPLEX_OUTBOUND_TEXT = "Hello from Hermes through the local voice sidecar."
 DEFAULT_FULL_DUPLEX_MAX_QUEUED_TX_MS = 1_000
 DEFAULT_WHATSAPP_BRIDGE_MEDIA_TIMEOUT = 15.0
+DEFAULT_WHATSAPP_CLOUD_WEBHOOK_TIMEOUT = 15.0
 DEFAULT_WHATSAPP_CLOUD_VOICE_TIMEOUT = 15.0
 
 LIVE_ROOT_REQUIREMENTS = (
@@ -419,6 +420,10 @@ def whatsapp_cloud_voice_note_command() -> list[str]:
     return [sys.executable, str(script_path("verify_voice_whatsapp_cloud_voice_note.py"))]
 
 
+def whatsapp_cloud_webhook_command() -> list[str]:
+    return [sys.executable, str(script_path("verify_voice_whatsapp_cloud_webhook.py"))]
+
+
 def calling_control_plane_command(args: argparse.Namespace) -> list[str]:
     return [
         sys.executable,
@@ -596,6 +601,11 @@ def parse_args() -> argparse.Namespace:
         type=float,
         default=DEFAULT_WHATSAPP_CLOUD_VOICE_TIMEOUT,
     )
+    parser.add_argument(
+        "--whatsapp-cloud-webhook-timeout",
+        type=float,
+        default=DEFAULT_WHATSAPP_CLOUD_WEBHOOK_TIMEOUT,
+    )
     parser.add_argument("--node-bin", default=os.environ.get("NODE_BIN", "node"))
     parser.add_argument("--stream-text", default=DEFAULT_STREAM_TEXT)
     parser.add_argument("--stream-command-template")
@@ -675,6 +685,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--live-gateway-timeout", type=float, default=360.0)
     parser.add_argument("--skip-voice-contract", action="store_true")
     parser.add_argument("--skip-whatsapp-bridge-media", action="store_true")
+    parser.add_argument("--skip-whatsapp-cloud-webhook", action="store_true")
     parser.add_argument("--skip-whatsapp-cloud-voice", action="store_true")
     parser.add_argument("--skip-command-stt", action="store_true")
     parser.add_argument("--skip-calling-control-plane", action="store_true")
@@ -791,6 +802,19 @@ def main() -> int:
                 "WhatsApp Cloud voice-note verifier",
                 whatsapp_cloud_voice_note_command(),
                 timeout=args.whatsapp_cloud_voice_timeout,
+                env=env,
+            )
+        if args.skip_whatsapp_cloud_webhook:
+            checks["whatsapp_cloud_webhook"] = {
+                "success": True,
+                "skipped": True,
+                "reason": "--skip-whatsapp-cloud-webhook was provided",
+            }
+        else:
+            checks["whatsapp_cloud_webhook"] = run_json_step(
+                "WhatsApp Cloud webhook verifier",
+                whatsapp_cloud_webhook_command(),
+                timeout=args.whatsapp_cloud_webhook_timeout,
                 env=env,
             )
         checks["command_tts"] = run_json_step(

--- a/scripts/verify_voice_local_stack.py
+++ b/scripts/verify_voice_local_stack.py
@@ -38,6 +38,7 @@ DEFAULT_VOICE_CONTRACT_TEXT = "Hermes voice contract preflight."
 DEFAULT_STREAM_TEXT = "Hermes local voice stream preflight."
 DEFAULT_FULL_DUPLEX_INBOUND_TEXT = "hello world"
 DEFAULT_FULL_DUPLEX_OUTBOUND_TEXT = "Hello from Hermes through the local voice sidecar."
+DEFAULT_FULL_DUPLEX_MAX_QUEUED_TX_MS = 1_000
 DEFAULT_WHATSAPP_BRIDGE_MEDIA_TIMEOUT = 15.0
 DEFAULT_WHATSAPP_CLOUD_VOICE_TIMEOUT = 15.0
 
@@ -412,6 +413,8 @@ def full_duplex_command(
         args.speed,
         "--timeout",
         f"{args.full_duplex_timeout:g}",
+        "--max-queued-tx-ms",
+        str(args.full_duplex_max_queued_tx_ms),
         "--inbound-text",
         args.full_duplex_inbound_text,
         "--outbound-text",
@@ -437,6 +440,15 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--stream-timeout", type=float, default=180.0)
     parser.add_argument("--calling-control-plane-timeout", type=float, default=10.0)
     parser.add_argument("--full-duplex-timeout", type=float, default=90.0)
+    parser.add_argument(
+        "--full-duplex-max-queued-tx-ms",
+        type=int,
+        default=DEFAULT_FULL_DUPLEX_MAX_QUEUED_TX_MS,
+        help=(
+            "Maximum outbound sidecar queue depth allowed at the end of the "
+            "full-duplex smoke."
+        ),
+    )
     parser.add_argument("--cli-timeout", type=float, default=10.0)
     parser.add_argument("--command-text", default=DEFAULT_COMMAND_TEXT)
     parser.add_argument("--voice-contract-text", default=DEFAULT_VOICE_CONTRACT_TEXT)
@@ -485,6 +497,8 @@ def parse_args() -> argparse.Namespace:
         help="word expected in the inbound full-duplex transcript; repeatable",
     )
     args = parser.parse_args()
+    if args.full_duplex_max_queued_tx_ms < 0:
+        parser.error("--full-duplex-max-queued-tx-ms must be non-negative")
     if args.expect_word is None:
         args.expect_word = ["hello", "world"]
     return args

--- a/scripts/verify_voice_stream_tts.py
+++ b/scripts/verify_voice_stream_tts.py
@@ -40,6 +40,9 @@ class AudioContract:
     frame_ms: int = DEFAULT_FRAME_MS
     encoding: str = DEFAULT_ENCODING
     bytes_per_sample: int = DEFAULT_BYTES_PER_SAMPLE
+    raw_outbound_pcm_command: str = ""
+    raw_inbound_pcm_command: str = ""
+    completed_voice_note_command: str = ""
 
     @property
     def samples_per_frame(self) -> int:
@@ -108,6 +111,137 @@ def build_default_command_template(voice_bin: str) -> str:
         f"--raw-output - --input-file {{input_path}} "
         f"--voice {{voice}} --speed {{speed}}"
     )
+
+
+def load_voice_stream_contract(voice_bin: str, *, timeout: float = 5.0) -> dict[str, Any]:
+    completed = subprocess.run(
+        [voice_bin, "stream-contract"],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=True,
+    )
+    parsed = json.loads(completed.stdout)
+    if not isinstance(parsed, dict):
+        raise ValueError("voice stream-contract root must be an object")
+    return parsed
+
+
+def audio_contract_from_voice(
+    voice_bin: str,
+    *,
+    fallback: AudioContract,
+) -> AudioContract:
+    try:
+        contract = load_voice_stream_contract(voice_bin)
+    except (
+        FileNotFoundError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        json.JSONDecodeError,
+        ValueError,
+    ) as exc:
+        raise SystemExit(f"failed to load `voice stream-contract`: {exc}") from exc
+
+    audio = contract.get("audio")
+    if not isinstance(audio, dict):
+        raise SystemExit("voice stream-contract audio section must be an object")
+
+    surface_commands = validate_voice_surfaces(contract.get("voice_surfaces"), audio)
+    return AudioContract(
+        sample_rate=int(audio.get("sample_rate") or fallback.sample_rate),
+        channels=int(audio.get("channels") or fallback.channels),
+        frame_ms=int(audio.get("frame_ms") or fallback.frame_ms),
+        encoding=str(audio.get("encoding") or fallback.encoding),
+        bytes_per_sample=int(audio.get("bytes_per_sample") or fallback.bytes_per_sample),
+        raw_outbound_pcm_command=surface_commands.get("raw_outbound_pcm", ""),
+        raw_inbound_pcm_command=surface_commands.get("raw_inbound_pcm", ""),
+        completed_voice_note_command=surface_commands.get("completed_voice_note", ""),
+    )
+
+
+def validate_voice_surfaces(
+    surfaces: object,
+    audio: dict[str, object],
+) -> dict[str, str]:
+    if surfaces is None:
+        raise SystemExit("voice stream-contract is missing voice_surfaces")
+    if not isinstance(surfaces, dict):
+        raise SystemExit("voice stream-contract voice_surfaces section must be an object")
+
+    frame_bytes = int(audio.get("frame_bytes") or 0)
+    encoding = str(audio.get("encoding") or "")
+    commands: dict[str, str] = {}
+
+    completed = surface_object(surfaces, "completed_voice_note")
+    if completed.get("output") != "audio/ogg; codecs=opus":
+        raise SystemExit("completed_voice_note output must be audio/ogg; codecs=opus")
+    if completed.get("transport") != "completed_file":
+        raise SystemExit("completed_voice_note transport must be completed_file")
+    completed_command = surface_command(completed, "completed_voice_note")
+    require_command_parts(
+        completed_command,
+        "completed_voice_note",
+        ["voice say", "--format ogg-opus", "--output"],
+    )
+    commands["completed_voice_note"] = completed_command
+
+    outbound = surface_object(surfaces, "raw_outbound_pcm")
+    if outbound.get("output") != encoding:
+        raise SystemExit("raw_outbound_pcm output must match audio.encoding")
+    if outbound.get("transport") != "stdout_pcm_frames":
+        raise SystemExit("raw_outbound_pcm transport must be stdout_pcm_frames")
+    if int(outbound.get("frame_bytes") or 0) != frame_bytes:
+        raise SystemExit("raw_outbound_pcm frame_bytes must match audio.frame_bytes")
+    outbound_command = surface_command(outbound, "raw_outbound_pcm")
+    require_command_parts(
+        outbound_command,
+        "raw_outbound_pcm",
+        ["voice stream", "--raw-output", "--sample-rate", "--frame-ms"],
+    )
+    commands["raw_outbound_pcm"] = outbound_command
+
+    inbound = surface_object(surfaces, "raw_inbound_pcm")
+    if inbound.get("input") != encoding:
+        raise SystemExit("raw_inbound_pcm input must match audio.encoding")
+    if inbound.get("transport") != "stdin_pcm_frames":
+        raise SystemExit("raw_inbound_pcm transport must be stdin_pcm_frames")
+    if int(inbound.get("frame_bytes") or 0) != frame_bytes:
+        raise SystemExit("raw_inbound_pcm frame_bytes must match audio.frame_bytes")
+    inbound_command = surface_command(inbound, "raw_inbound_pcm")
+    require_command_parts(
+        inbound_command,
+        "raw_inbound_pcm",
+        ["voice stream-transcribe", "--raw-input", "--sample-rate", "--frame-ms"],
+    )
+    commands["raw_inbound_pcm"] = inbound_command
+
+    return commands
+
+
+def surface_object(surfaces: dict[str, object], name: str) -> dict[str, object]:
+    surface = surfaces.get(name)
+    if not isinstance(surface, dict):
+        raise SystemExit(f"voice stream-contract voice_surfaces.{name} must be an object")
+    return surface
+
+
+def surface_command(surface: dict[str, object], name: str) -> str:
+    command = str(surface.get("command") or "")
+    if not command:
+        raise SystemExit(
+            f"voice stream-contract voice_surfaces.{name}.command must be non-empty"
+        )
+    return command
+
+
+def require_command_parts(command: str, name: str, parts: list[str]) -> None:
+    missing = [part for part in parts if part not in command]
+    if missing:
+        raise SystemExit(
+            f"voice stream-contract voice_surfaces.{name}.command is missing: "
+            + ", ".join(missing)
+        )
 
 
 def render_stream_command(
@@ -229,11 +363,12 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     voice_bin = resolve_executable(args.voice_bin, label="voice binary")
-    contract = AudioContract(
+    fallback_contract = AudioContract(
         sample_rate=args.sample_rate,
         channels=args.channels,
         frame_ms=args.frame_ms,
     )
+    contract = audio_contract_from_voice(voice_bin, fallback=fallback_contract)
     contract.validate()
     command_template = args.command_template or build_default_command_template(voice_bin)
 
@@ -272,6 +407,11 @@ def main() -> int:
                     "retained": retained,
                     "command_template": command_template,
                     "audio": contract.as_dict(),
+                    "voice_surfaces": {
+                        "raw_outbound_pcm_command": contract.raw_outbound_pcm_command,
+                        "raw_inbound_pcm_command": contract.raw_inbound_pcm_command,
+                        "completed_voice_note_command": contract.completed_voice_note_command,
+                    },
                     "pcm": stats,
                 },
                 indent=2,

--- a/scripts/verify_voice_stream_tts.py
+++ b/scripts/verify_voice_stream_tts.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Validate a voice-backed WhatsApp Calling TTS stream command.
+
+This script renders the same command template Hermes uses for
+``calling_sidecar_tts_stream_command``, runs it against a temporary input file,
+and verifies that stdout is raw 48 kHz mono 20 ms ``pcm_s16le`` frames suitable
+for the voice WebRTC sidecar.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import shlex
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+from typing import Any
+
+
+DEFAULT_TEXT = "Hermes voice stream command smoke test."
+DEFAULT_SAMPLE_RATE = 48_000
+DEFAULT_CHANNELS = 1
+DEFAULT_FRAME_MS = 20
+DEFAULT_BYTES_PER_SAMPLE = 2
+DEFAULT_ENCODING = "pcm_s16le"
+DEFAULT_MIN_PEAK = 384
+DEFAULT_MIN_DURATION_MS = 200
+
+
+@dataclass(frozen=True)
+class AudioContract:
+    sample_rate: int = DEFAULT_SAMPLE_RATE
+    channels: int = DEFAULT_CHANNELS
+    frame_ms: int = DEFAULT_FRAME_MS
+    encoding: str = DEFAULT_ENCODING
+    bytes_per_sample: int = DEFAULT_BYTES_PER_SAMPLE
+
+    @property
+    def samples_per_frame(self) -> int:
+        return self.sample_rate * self.frame_ms // 1_000
+
+    @property
+    def frame_bytes(self) -> int:
+        return self.samples_per_frame * self.channels * self.bytes_per_sample
+
+    @property
+    def bytes_per_second(self) -> int:
+        return self.sample_rate * self.channels * self.bytes_per_sample
+
+    def validate(self) -> None:
+        failures: list[str] = []
+        if self.sample_rate <= 0:
+            failures.append("sample_rate must be positive")
+        if self.channels <= 0:
+            failures.append("channels must be positive")
+        if self.frame_ms <= 0:
+            failures.append("frame_ms must be positive")
+        if self.bytes_per_sample <= 0:
+            failures.append("bytes_per_sample must be positive")
+        if self.encoding != DEFAULT_ENCODING:
+            failures.append(f"encoding must be {DEFAULT_ENCODING}")
+        if self.samples_per_frame <= 0:
+            failures.append("samples_per_frame must be positive")
+        if self.frame_bytes <= 0:
+            failures.append("frame_bytes must be positive")
+        if failures:
+            raise SystemExit("invalid audio contract:\n- " + "\n- ".join(failures))
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "sample_rate": self.sample_rate,
+            "channels": self.channels,
+            "frame_ms": self.frame_ms,
+            "encoding": self.encoding,
+            "bytes_per_sample": self.bytes_per_sample,
+            "samples_per_frame": self.samples_per_frame,
+            "frame_bytes": self.frame_bytes,
+        }
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def resolve_executable(value: str, *, label: str) -> str:
+    if "/" in value:
+        path = Path(value).expanduser()
+        if not path.is_file() or not os.access(path, os.X_OK):
+            raise SystemExit(f"{label} is not executable: {path}")
+        return str(path.resolve())
+
+    found = shutil.which(value)
+    if not found:
+        raise SystemExit(f"{label} not found on PATH: {value}")
+    return found
+
+
+def build_default_command_template(voice_bin: str) -> str:
+    return (
+        f"{shlex.quote(voice_bin)} stream --quiet "
+        f"--sample-rate {{sample_rate}} --frame-ms {{frame_ms}} "
+        f"--raw-output - --input-file {{input_path}} "
+        f"--voice {{voice}} --speed {{speed}}"
+    )
+
+
+def render_stream_command(
+    command_template: str,
+    *,
+    input_path: Path,
+    text: str,
+    contract: AudioContract,
+    voice: str,
+    speed: str,
+) -> str:
+    sys.path.insert(0, str(repo_root()))
+    from tools.tts_tool import _render_command_tts_template
+
+    return _render_command_tts_template(
+        command_template,
+        {
+            "input_path": str(input_path),
+            "text_path": str(input_path),
+            "text": text,
+            "sample_rate": str(contract.sample_rate),
+            "channels": str(contract.channels),
+            "frame_ms": str(contract.frame_ms),
+            "encoding": contract.encoding,
+            "voice": voice,
+            "speed": speed,
+        },
+    )
+
+
+def max_abs_pcm_s16le(pcm: bytes) -> int:
+    if len(pcm) % DEFAULT_BYTES_PER_SAMPLE:
+        raise ValueError("pcm_s16le payload must contain whole samples")
+    if not pcm:
+        return 0
+    return max(abs(sample[0]) for sample in struct.iter_unpack("<h", pcm))
+
+
+def validate_pcm(
+    pcm: bytes,
+    *,
+    contract: AudioContract,
+    min_peak: int = DEFAULT_MIN_PEAK,
+    min_duration_ms: int = DEFAULT_MIN_DURATION_MS,
+) -> dict[str, Any]:
+    contract.validate()
+    failures: list[str] = []
+
+    if not pcm:
+        failures.append("stream command produced no PCM")
+    if len(pcm) % contract.bytes_per_sample:
+        failures.append("PCM byte length is not aligned to whole s16le samples")
+    if len(pcm) % contract.frame_bytes:
+        failures.append(
+            f"PCM byte length {len(pcm)} is not aligned to {contract.frame_bytes}-byte frames"
+        )
+
+    duration_ms = (
+        len(pcm) * 1_000 // contract.bytes_per_second
+        if contract.bytes_per_second > 0
+        else 0
+    )
+    if duration_ms < min_duration_ms:
+        failures.append(
+            f"PCM duration {duration_ms}ms is shorter than minimum {min_duration_ms}ms"
+        )
+
+    peak = 0
+    if len(pcm) % contract.bytes_per_sample == 0:
+        peak = max_abs_pcm_s16le(pcm)
+        if peak < min_peak:
+            failures.append(f"PCM peak {peak} is below minimum {min_peak}")
+
+    if failures:
+        raise SystemExit("validation failed:\n- " + "\n- ".join(failures))
+
+    return {
+        "bytes": len(pcm),
+        "frames": len(pcm) // contract.frame_bytes,
+        "duration_ms": duration_ms,
+        "peak": peak,
+    }
+
+
+def run_stream_command(command: str, *, timeout: float) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        command,
+        shell=True,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a Hermes WhatsApp Calling TTS stream command and verify raw "
+            "pcm_s16le frame output."
+        )
+    )
+    parser.add_argument("--voice-bin", default=os.environ.get("VOICE_BIN", "voice"))
+    parser.add_argument("--command-template")
+    parser.add_argument("--voice", default="af_heart")
+    parser.add_argument("--speed", default="1.0")
+    parser.add_argument("--sample-rate", type=int, default=DEFAULT_SAMPLE_RATE)
+    parser.add_argument("--channels", type=int, default=DEFAULT_CHANNELS)
+    parser.add_argument("--frame-ms", type=int, default=DEFAULT_FRAME_MS)
+    parser.add_argument("--timeout", type=float, default=180.0)
+    parser.add_argument("--text", default=DEFAULT_TEXT)
+    parser.add_argument("--min-peak", type=int, default=DEFAULT_MIN_PEAK)
+    parser.add_argument("--min-duration-ms", type=int, default=DEFAULT_MIN_DURATION_MS)
+    parser.add_argument("--keep-input", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    voice_bin = resolve_executable(args.voice_bin, label="voice binary")
+    contract = AudioContract(
+        sample_rate=args.sample_rate,
+        channels=args.channels,
+        frame_ms=args.frame_ms,
+    )
+    contract.validate()
+    command_template = args.command_template or build_default_command_template(voice_bin)
+
+    tmpdir = Path(tempfile.mkdtemp(prefix="hermes-voice-stream-tts."))
+    try:
+        input_path = tmpdir / "input.txt"
+        input_path.write_text(args.text, encoding="utf-8")
+        command = render_stream_command(
+            command_template,
+            input_path=input_path,
+            text=args.text,
+            contract=contract,
+            voice=args.voice,
+            speed=args.speed,
+        )
+        completed = run_stream_command(command, timeout=args.timeout)
+        if completed.returncode != 0:
+            detail = completed.stderr.decode("utf-8", errors="replace").strip()
+            raise SystemExit(
+                f"stream command exited with code {completed.returncode}"
+                + (f": {detail[:1000]}" if detail else "")
+            )
+
+        stats = validate_pcm(
+            completed.stdout,
+            contract=contract,
+            min_peak=args.min_peak,
+            min_duration_ms=args.min_duration_ms,
+        )
+        retained = bool(args.keep_input)
+        print(
+            json.dumps(
+                {
+                    "success": True,
+                    "input_path": str(input_path) if retained else "<temporary>",
+                    "retained": retained,
+                    "command_template": command_template,
+                    "audio": contract.as_dict(),
+                    "pcm": stats,
+                },
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
+        return 0
+    finally:
+        if not args.keep_input:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_voice_stream_tts.py
+++ b/scripts/verify_voice_stream_tts.py
@@ -43,6 +43,7 @@ class AudioContract:
     raw_outbound_pcm_command: str = ""
     raw_inbound_pcm_command: str = ""
     completed_voice_note_command: str = ""
+    streamed_voice_note_command: str = ""
 
     @property
     def samples_per_frame(self) -> int:
@@ -157,6 +158,7 @@ def audio_contract_from_voice(
         raw_outbound_pcm_command=surface_commands.get("raw_outbound_pcm", ""),
         raw_inbound_pcm_command=surface_commands.get("raw_inbound_pcm", ""),
         completed_voice_note_command=surface_commands.get("completed_voice_note", ""),
+        streamed_voice_note_command=surface_commands.get("streamed_voice_note", ""),
     )
 
 
@@ -185,6 +187,19 @@ def validate_voice_surfaces(
         ["voice say", "--format ogg-opus", "--output"],
     )
     commands["completed_voice_note"] = completed_command
+
+    streamed = surface_object(surfaces, "streamed_voice_note")
+    if streamed.get("output") != "audio/ogg; codecs=opus":
+        raise SystemExit("streamed_voice_note output must be audio/ogg; codecs=opus")
+    if streamed.get("transport") != "daemon_stream_encoded_file":
+        raise SystemExit("streamed_voice_note transport must be daemon_stream_encoded_file")
+    streamed_command = surface_command(streamed, "streamed_voice_note")
+    require_command_parts(
+        streamed_command,
+        "streamed_voice_note",
+        ["voice stream", "--output", "--format ogg-opus"],
+    )
+    commands["streamed_voice_note"] = streamed_command
 
     outbound = surface_object(surfaces, "raw_outbound_pcm")
     if outbound.get("output") != encoding:
@@ -338,6 +353,107 @@ def run_stream_command(command: str, *, timeout: float) -> subprocess.CompletedP
     )
 
 
+def build_streamed_ogg_command(
+    *,
+    voice_bin: str,
+    input_path: Path,
+    output_path: Path,
+    contract: AudioContract,
+    voice: str,
+    speed: str,
+) -> list[str]:
+    return [
+        voice_bin,
+        "stream",
+        "--quiet",
+        "--sample-rate",
+        str(contract.sample_rate),
+        "--frame-ms",
+        str(contract.frame_ms),
+        "--output",
+        str(output_path),
+        "--format",
+        "ogg-opus",
+        "--input-file",
+        str(input_path),
+        "--voice",
+        voice,
+        "--speed",
+        speed,
+    ]
+
+
+def run_streamed_ogg_command(
+    command: list[str],
+    *,
+    timeout: float,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def parse_ffprobe(output: str) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for line in output.splitlines():
+        key, sep, value = line.partition("=")
+        if sep:
+            values[key] = value
+    return values
+
+
+def probe_audio(path: Path, *, ffprobe_bin: str) -> dict[str, str]:
+    completed = subprocess.run(
+        [
+            ffprobe_bin,
+            "-v",
+            "error",
+            "-select_streams",
+            "a:0",
+            "-show_entries",
+            "stream=codec_name,sample_rate,channels",
+            "-of",
+            "default=noprint_wrappers=1",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return parse_ffprobe(completed.stdout)
+
+
+def validate_streamed_ogg(path: Path, *, probe: dict[str, str]) -> dict[str, Any]:
+    failures: list[str] = []
+
+    if path.suffix.lower() not in {".ogg", ".opus"}:
+        failures.append(f"expected .ogg or .opus output, got {path}")
+    if not path.is_file() or path.stat().st_size == 0:
+        failures.append(f"expected non-empty streamed Ogg/Opus output at {path}")
+    if probe.get("codec_name") != "opus":
+        failures.append(f"expected codec_name=opus, got {probe.get('codec_name')!r}")
+    if probe.get("sample_rate") != "48000":
+        failures.append(f"expected sample_rate=48000, got {probe.get('sample_rate')!r}")
+    if probe.get("channels") != "1":
+        failures.append(f"expected channels=1, got {probe.get('channels')!r}")
+
+    if failures:
+        raise SystemExit("streamed Ogg/Opus validation failed:\n- " + "\n- ".join(failures))
+
+    return {
+        "bytes": path.stat().st_size,
+        "codec_name": probe.get("codec_name"),
+        "sample_rate": probe.get("sample_rate"),
+        "channels": probe.get("channels"),
+    }
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
@@ -346,6 +462,7 @@ def parse_args() -> argparse.Namespace:
         )
     )
     parser.add_argument("--voice-bin", default=os.environ.get("VOICE_BIN", "voice"))
+    parser.add_argument("--ffprobe-bin", default=os.environ.get("FFPROBE_BIN", "ffprobe"))
     parser.add_argument("--command-template")
     parser.add_argument("--voice", default="af_heart")
     parser.add_argument("--speed", default="1.0")
@@ -357,12 +474,22 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--min-peak", type=int, default=DEFAULT_MIN_PEAK)
     parser.add_argument("--min-duration-ms", type=int, default=DEFAULT_MIN_DURATION_MS)
     parser.add_argument("--keep-input", action="store_true")
+    parser.add_argument(
+        "--skip-streamed-ogg",
+        action="store_true",
+        help="validate the advertised streamed_voice_note surface without running it",
+    )
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
     voice_bin = resolve_executable(args.voice_bin, label="voice binary")
+    ffprobe_bin = (
+        None
+        if args.skip_streamed_ogg
+        else resolve_executable(args.ffprobe_bin, label="ffprobe")
+    )
     fallback_contract = AudioContract(
         sample_rate=args.sample_rate,
         channels=args.channels,
@@ -398,6 +525,40 @@ def main() -> int:
             min_peak=args.min_peak,
             min_duration_ms=args.min_duration_ms,
         )
+
+        streamed_ogg: dict[str, Any]
+        if args.skip_streamed_ogg:
+            streamed_ogg = {
+                "success": True,
+                "skipped": True,
+                "reason": "--skip-streamed-ogg was provided",
+            }
+        else:
+            ogg_path = tmpdir / "streamed.ogg"
+            ogg_command = build_streamed_ogg_command(
+                voice_bin=voice_bin,
+                input_path=input_path,
+                output_path=ogg_path,
+                contract=contract,
+                voice=args.voice,
+                speed=args.speed,
+            )
+            ogg_completed = run_streamed_ogg_command(ogg_command, timeout=args.timeout)
+            if ogg_completed.returncode != 0:
+                detail = ogg_completed.stderr.strip() or ogg_completed.stdout.strip()
+                raise SystemExit(
+                    f"streamed Ogg/Opus command exited with code {ogg_completed.returncode}"
+                    + (f": {detail[:1000]}" if detail else "")
+                )
+            probe = probe_audio(ogg_path, ffprobe_bin=ffprobe_bin or "ffprobe")
+            ogg_stats = validate_streamed_ogg(ogg_path, probe=probe)
+            streamed_ogg = {
+                "success": True,
+                "path": str(ogg_path) if args.keep_input else "<temporary>",
+                "command": " ".join(shlex.quote(part) for part in ogg_command),
+                **ogg_stats,
+            }
+
         retained = bool(args.keep_input)
         print(
             json.dumps(
@@ -411,8 +572,10 @@ def main() -> int:
                         "raw_outbound_pcm_command": contract.raw_outbound_pcm_command,
                         "raw_inbound_pcm_command": contract.raw_inbound_pcm_command,
                         "completed_voice_note_command": contract.completed_voice_note_command,
+                        "streamed_voice_note_command": contract.streamed_voice_note_command,
                     },
                     "pcm": stats,
+                    "streamed_ogg": streamed_ogg,
                 },
                 indent=2,
                 ensure_ascii=False,

--- a/scripts/verify_voice_whatsapp_calling_control_plane.py
+++ b/scripts/verify_voice_whatsapp_calling_control_plane.py
@@ -51,6 +51,16 @@ CALLING_AUDIO_CONTRACT = {
     "max_inbound_queue_bytes": 960_000,
     "max_drain_wait_ms": 5_000,
 }
+CALLING_READY_STATE = {
+    "ready_for_accept": True,
+    "readiness": {
+        "not_closed": True,
+        "local_sdp_answer": True,
+        "signaling_stable": True,
+        "ice_gathering_complete": True,
+        "outbound_audio_track": True,
+    },
+}
 
 
 @dataclass
@@ -118,6 +128,7 @@ class RecordingHttpClient:
                     "type": "answer",
                     "sdp": self.answer_sdp,
                     "audio": CALLING_AUDIO_CONTRACT,
+                    "state": CALLING_READY_STATE,
                 },
             )
 
@@ -353,6 +364,7 @@ async def run_control_plane_smoke(args: argparse.Namespace) -> dict[str, Any]:
         "sidecar_close_url": sidecar_close["url"] if sidecar_close else None,
         "drain_starts": drain_starts,
         "audio": CALLING_AUDIO_CONTRACT,
+        "sidecar_ready_for_accept": True,
     }
 
 

--- a/scripts/verify_voice_whatsapp_calling_control_plane.py
+++ b/scripts/verify_voice_whatsapp_calling_control_plane.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""Verify the WhatsApp Cloud Calling control plane without contacting Meta.
+
+This is a synthetic smoke for the Hermes side of WhatsApp Calling. It feeds a
+realistic ``calls`` webhook payload into the Cloud adapter, records the local
+sidecar and Graph API requests the adapter would make, and validates the
+expected sequence:
+
+1. Fetch the optional ``voice.webrtc_sidecar`` contract.
+2. POST the WhatsApp SDP offer to the local sidecar.
+3. POST ``pre_accept`` to Graph with the sidecar SDP answer.
+4. POST ``accept`` to Graph with the same answer.
+5. Start the inbound sidecar drain for the caller.
+6. On a terminate webhook, close the local sidecar call session.
+
+The script uses an in-process fake HTTP client. It does not require WhatsApp
+credentials, a public webhook URL, or a running sidecar.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from dataclasses import dataclass
+import json
+from typing import Any
+
+from gateway.config import PlatformConfig
+from gateway.platforms.whatsapp_cloud import WhatsAppCloudAdapter
+
+
+DEFAULT_CALL_ID = "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh"
+DEFAULT_CALLER = "13557825698"
+DEFAULT_CALLEE = "15551797781"
+DEFAULT_CONTACT_NAME = "Jessica Laverdetman"
+DEFAULT_REMOTE_SDP = "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n"
+DEFAULT_ANSWER_SDP = "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n"
+DEFAULT_SIDECAR_URL = "http://127.0.0.1:8787"
+DEFAULT_PHONE_NUMBER_ID = "7794189252778687"
+
+CALLING_AUDIO_CONTRACT = {
+    "sample_rate": 48_000,
+    "channels": 1,
+    "frame_ms": 20,
+    "encoding": "pcm_s16le",
+    "bytes_per_sample": 2,
+    "samples_per_frame": 960,
+    "frame_bytes": 1_920,
+    "default_drain_bytes": 96_000,
+    "max_outbound_queue_bytes": 960_000,
+    "max_inbound_queue_bytes": 960_000,
+    "max_drain_wait_ms": 5_000,
+}
+
+
+@dataclass
+class FakeResponse:
+    status_code: int
+    body: dict[str, Any]
+
+    @property
+    def text(self) -> str:
+        return json.dumps(self.body, sort_keys=True)
+
+    def json(self) -> dict[str, Any]:
+        return self.body
+
+
+class RecordingHttpClient:
+    """Small async httpx-like fake for sidecar and Graph requests."""
+
+    def __init__(
+        self,
+        *,
+        sidecar_url: str,
+        api_version: str,
+        phone_number_id: str,
+        call_id: str,
+        answer_sdp: str,
+    ) -> None:
+        self.sidecar_url = sidecar_url.rstrip("/")
+        self.graph_calls_url = (
+            f"https://graph.facebook.com/{api_version}/{phone_number_id}/calls"
+        )
+        self.call_id = call_id
+        self.answer_sdp = answer_sdp
+        self.requests: list[dict[str, Any]] = []
+
+    async def get(self, url: str, **kwargs: Any) -> FakeResponse:
+        self.requests.append({"method": "GET", "url": url, "kwargs": kwargs})
+        if url == f"{self.sidecar_url}/contract":
+            return FakeResponse(
+                200,
+                {
+                    "contract": "voice.webrtc_sidecar",
+                    "version": 1,
+                    "audio": CALLING_AUDIO_CONTRACT,
+                    "endpoints": {
+                        "offer": {"method": "POST", "path": "/offer"},
+                        "close_call": {
+                            "method": "POST",
+                            "path": "/calls/{call_id}/close",
+                        },
+                    },
+                },
+            )
+        return FakeResponse(404, {"error": "not found"})
+
+    async def post(self, url: str, **kwargs: Any) -> FakeResponse:
+        self.requests.append({"method": "POST", "url": url, "kwargs": kwargs})
+        payload = kwargs.get("json") if isinstance(kwargs.get("json"), dict) else {}
+
+        if url == f"{self.sidecar_url}/offer":
+            return FakeResponse(
+                200,
+                {
+                    "call_id": payload.get("call_id") or self.call_id,
+                    "type": "answer",
+                    "sdp": self.answer_sdp,
+                    "audio": CALLING_AUDIO_CONTRACT,
+                },
+            )
+
+        if url == self.graph_calls_url:
+            action = str(payload.get("action") or "")
+            if action in {"pre_accept", "accept", "reject", "terminate"}:
+                return FakeResponse(200, {"success": True, "action": action})
+            return FakeResponse(400, {"error": {"message": "unknown action"}})
+
+        if url == f"{self.sidecar_url}/calls/{self.call_id}/close":
+            return FakeResponse(200, {"call_id": self.call_id, "closed": True})
+
+        return FakeResponse(404, {"error": "not found"})
+
+
+def call_connect_payload(
+    *,
+    call_id: str,
+    caller: str,
+    callee: str,
+    contact_name: str,
+    remote_sdp: str,
+) -> dict[str, Any]:
+    return {
+        "object": "whatsapp_business_account",
+        "entry": [
+            {
+                "id": "215589313241560883",
+                "changes": [
+                    {
+                        "field": "calls",
+                        "value": {
+                            "messaging_product": "whatsapp",
+                            "metadata": {
+                                "display_phone_number": callee,
+                                "phone_number_id": DEFAULT_PHONE_NUMBER_ID,
+                            },
+                            "contacts": [
+                                {
+                                    "profile": {"name": contact_name},
+                                    "wa_id": caller,
+                                }
+                            ],
+                            "calls": [
+                                {
+                                    "id": call_id,
+                                    "from": caller,
+                                    "to": callee,
+                                    "event": "connect",
+                                    "timestamp": "1762216151",
+                                    "direction": "USER_INITIATED",
+                                    "session": {
+                                        "sdp_type": "offer",
+                                        "sdp": remote_sdp,
+                                    },
+                                }
+                            ],
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def call_terminate_payload(*, call_id: str, caller: str, callee: str) -> dict[str, Any]:
+    return {
+        "object": "whatsapp_business_account",
+        "entry": [
+            {
+                "id": "215589313241560883",
+                "changes": [
+                    {
+                        "field": "calls",
+                        "value": {
+                            "messaging_product": "whatsapp",
+                            "metadata": {
+                                "display_phone_number": callee,
+                                "phone_number_id": DEFAULT_PHONE_NUMBER_ID,
+                            },
+                            "calls": [
+                                {
+                                    "id": call_id,
+                                    "from": caller,
+                                    "to": callee,
+                                    "event": "terminate",
+                                    "timestamp": "1762216199",
+                                    "direction": "USER_INITIATED",
+                                    "status": "COMPLETED",
+                                }
+                            ],
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+
+
+async def run_control_plane_smoke(args: argparse.Namespace) -> dict[str, Any]:
+    sidecar_url = args.sidecar_url.rstrip("/")
+    config = PlatformConfig(
+        enabled=True,
+        extra={
+            "phone_number_id": args.phone_number_id,
+            "access_token": "synthetic-token",
+            "calling_sidecar_url": sidecar_url,
+            "calling_sidecar_timeout": args.timeout,
+        },
+    )
+    adapter = WhatsAppCloudAdapter(config)
+    http_client = RecordingHttpClient(
+        sidecar_url=sidecar_url,
+        api_version=adapter._api_version,
+        phone_number_id=args.phone_number_id,
+        call_id=args.call_id,
+        answer_sdp=args.answer_sdp,
+    )
+    adapter._http_client = http_client
+
+    dispatched_messages: list[Any] = []
+
+    async def capture_message(event: Any) -> None:
+        dispatched_messages.append(event)
+
+    drain_starts: list[dict[str, str]] = []
+
+    def capture_drain(call_id: str, chat_id: str, sender_name: str = "") -> None:
+        drain_starts.append(
+            {"call_id": call_id, "chat_id": chat_id, "sender_name": sender_name}
+        )
+
+    adapter.handle_message = capture_message
+    adapter._start_calling_sidecar_drain = capture_drain  # type: ignore[method-assign]
+
+    await adapter._dispatch_payload(
+        call_connect_payload(
+            call_id=args.call_id,
+            caller=args.caller,
+            callee=args.callee,
+            contact_name=args.contact_name,
+            remote_sdp=args.remote_sdp,
+        )
+    )
+
+    await adapter._dispatch_payload(
+        call_terminate_payload(
+            call_id=args.call_id,
+            caller=args.caller,
+            callee=args.callee,
+        )
+    )
+
+    graph_actions = [
+        request["kwargs"]["json"]["action"]
+        for request in http_client.requests
+        if request["method"] == "POST"
+        and request["url"] == http_client.graph_calls_url
+        and isinstance(request["kwargs"].get("json"), dict)
+    ]
+    sidecar_offer = next(
+        (
+            request
+            for request in http_client.requests
+            if request["method"] == "POST"
+            and request["url"] == f"{sidecar_url}/offer"
+        ),
+        None,
+    )
+    sidecar_close = next(
+        (
+            request
+            for request in http_client.requests
+            if request["method"] == "POST"
+            and request["url"] == f"{sidecar_url}/calls/{args.call_id}/close"
+        ),
+        None,
+    )
+
+    failures: list[str] = []
+    if dispatched_messages:
+        failures.append("calling payload should not dispatch a text MessageEvent")
+    if sidecar_offer is None:
+        failures.append("sidecar offer request was not sent")
+    elif sidecar_offer["kwargs"]["json"] != {
+        "call_id": args.call_id,
+        "type": "offer",
+        "sdp": args.remote_sdp,
+    }:
+        failures.append("sidecar offer payload did not match expected SDP offer")
+    if graph_actions[:2] != ["pre_accept", "accept"]:
+        failures.append(f"expected graph actions pre_accept, accept; got {graph_actions}")
+    if sidecar_close is None:
+        failures.append("sidecar close request was not sent after terminate")
+    if drain_starts != [
+        {
+            "call_id": args.call_id,
+            "chat_id": args.caller,
+            "sender_name": args.contact_name,
+        }
+    ]:
+        failures.append(f"unexpected sidecar drain starts: {drain_starts}")
+    if adapter._calling_sidecar_call_ids:
+        failures.append(
+            f"call ids should be empty after terminate: {adapter._calling_sidecar_call_ids}"
+        )
+
+    session_payloads = [
+        request["kwargs"]["json"].get("session")
+        for request in http_client.requests
+        if request["method"] == "POST"
+        and request["url"] == http_client.graph_calls_url
+        and request["kwargs"]["json"].get("action") in {"pre_accept", "accept"}
+    ]
+    if session_payloads != [
+        {"sdp_type": "answer", "sdp": args.answer_sdp},
+        {"sdp_type": "answer", "sdp": args.answer_sdp},
+    ]:
+        failures.append("pre_accept and accept did not carry the sidecar SDP answer")
+
+    if failures:
+        raise SystemExit("control-plane smoke failed:\n- " + "\n- ".join(failures))
+
+    return {
+        "success": True,
+        "call_id": args.call_id,
+        "caller": args.caller,
+        "sidecar_url": sidecar_url,
+        "contract_loaded": adapter._calling_sidecar_contract is not None,
+        "sidecar_offer_url": sidecar_offer["url"] if sidecar_offer else None,
+        "graph_calls_url": http_client.graph_calls_url,
+        "graph_actions": graph_actions,
+        "sidecar_close_url": sidecar_close["url"] if sidecar_close else None,
+        "drain_starts": drain_starts,
+        "audio": CALLING_AUDIO_CONTRACT,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sidecar-url", default=DEFAULT_SIDECAR_URL)
+    parser.add_argument("--phone-number-id", default=DEFAULT_PHONE_NUMBER_ID)
+    parser.add_argument("--call-id", default=DEFAULT_CALL_ID)
+    parser.add_argument("--caller", default=DEFAULT_CALLER)
+    parser.add_argument("--callee", default=DEFAULT_CALLEE)
+    parser.add_argument("--contact-name", default=DEFAULT_CONTACT_NAME)
+    parser.add_argument("--remote-sdp", default=DEFAULT_REMOTE_SDP)
+    parser.add_argument("--answer-sdp", default=DEFAULT_ANSWER_SDP)
+    parser.add_argument("--timeout", type=float, default=10.0)
+    return parser.parse_args()
+
+
+def main() -> int:
+    result = asyncio.run(run_control_plane_smoke(parse_args()))
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_voice_whatsapp_calling_live_sidecar.py
+++ b/scripts/verify_voice_whatsapp_calling_live_sidecar.py
@@ -1,0 +1,468 @@
+#!/usr/bin/env python3
+"""Verify Hermes WhatsApp Calling control flow against a real local sidecar.
+
+This smoke does not contact Meta. It starts the voice repo's Python aiortc
+sidecar in-process, feeds a synthetic WhatsApp Calling ``connect`` webhook into
+Hermes, lets Hermes POST the real SDP offer to the sidecar, fakes only the
+Graph ``/calls`` actions, and verifies WebRTC audio can move both ways.
+
+Run it with a Python environment that has the voice sidecar extras installed.
+The local stack installer exposes that as ``--webrtc-python-bin``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+from dataclasses import dataclass
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+from aiohttp import ClientSession, web
+
+from gateway.config import PlatformConfig
+from gateway.platforms.whatsapp_cloud import WhatsAppCloudAdapter
+
+
+DEFAULT_CALL_ID = "wacid.local-sidecar-smoke"
+DEFAULT_CALLER = "13557825698"
+DEFAULT_CALLEE = "15551797781"
+DEFAULT_CONTACT_NAME = "Hermes Voice Smoke"
+DEFAULT_PHONE_NUMBER_ID = "7794189252778687"
+DEFAULT_TIMEOUT = 12.0
+
+
+@dataclass
+class RecordedResponse:
+    status_code: int
+    body: dict[str, Any]
+
+    @property
+    def text(self) -> str:
+        return json.dumps(self.body, sort_keys=True)
+
+    def json(self) -> dict[str, Any]:
+        return self.body
+
+
+def load_sidecar_module(voice_repo: Path):
+    path = voice_repo.expanduser().resolve() / "examples" / "webrtc-sidecar" / "sidecar.py"
+    if not path.is_file():
+        raise SystemExit(f"voice WebRTC sidecar not found: {path}")
+    spec = importlib.util.spec_from_file_location("voice_webrtc_sidecar_live_smoke", path)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"failed to load voice WebRTC sidecar module: {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def pcm_frame(sidecar: Any, sample: int = 12_000) -> bytes:
+    return sample.to_bytes(2, byteorder="little", signed=True) * int(
+        sidecar.SAMPLES_PER_FRAME
+    )
+
+
+def make_pcm_track_class(sidecar: Any, *, frame_bytes: bytes):
+    class SyntheticPcmTrack(sidecar.MediaStreamTrack):
+        kind = "audio"
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.pts = 0
+
+        async def recv(self) -> Any:
+            await asyncio.sleep(sidecar.FRAME_MS / 1_000)
+            frame = sidecar.av.AudioFrame(
+                format="s16",
+                layout="mono",
+                samples=sidecar.SAMPLES_PER_FRAME,
+            )
+            frame.planes[0].update(frame_bytes)
+            frame.sample_rate = sidecar.SAMPLE_RATE
+            frame.time_base = sidecar.Fraction(1, sidecar.SAMPLE_RATE)
+            frame.pts = self.pts
+            self.pts += sidecar.SAMPLES_PER_FRAME
+            return frame
+
+    return SyntheticPcmTrack
+
+
+async def start_sidecar_app(sidecar: Any) -> tuple[web.AppRunner, str]:
+    source = sidecar.PcmSource(None)
+    app = sidecar.create_app(source, None)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    host, port = runner.addresses[0][:2]
+    return runner, f"http://{host}:{port}"
+
+
+class RecordingHybridHttpClient:
+    """httpx-like async client: real sidecar HTTP, fake Graph /calls."""
+
+    def __init__(
+        self,
+        *,
+        sidecar_url: str,
+        graph_calls_url: str,
+        timeout: float,
+    ) -> None:
+        self.sidecar_url = sidecar_url.rstrip("/")
+        self.graph_calls_url = graph_calls_url
+        self.timeout = timeout
+        self.session = ClientSession()
+        self.requests: list[dict[str, Any]] = []
+        self.sidecar_offer_response: dict[str, Any] | None = None
+
+    async def aclose(self) -> None:
+        await self.session.close()
+
+    async def get(self, url: str, **kwargs: Any) -> RecordedResponse:
+        return await self._request("GET", url, **kwargs)
+
+    async def post(self, url: str, **kwargs: Any) -> RecordedResponse:
+        return await self._request("POST", url, **kwargs)
+
+    async def _request(self, method: str, url: str, **kwargs: Any) -> RecordedResponse:
+        request = {"method": method, "url": url, "kwargs": kwargs}
+        self.requests.append(request)
+
+        if url == self.graph_calls_url and method == "POST":
+            payload = kwargs.get("json") if isinstance(kwargs.get("json"), dict) else {}
+            action = str(payload.get("action") or "")
+            if action in {"pre_accept", "accept", "reject", "terminate"}:
+                return RecordedResponse(200, {"success": True, "action": action})
+            return RecordedResponse(400, {"error": {"message": "unknown action"}})
+
+        if url.startswith(self.sidecar_url + "/"):
+            async with self.session.request(
+                method,
+                url,
+                json=kwargs.get("json"),
+                params=kwargs.get("params"),
+                timeout=self.timeout,
+            ) as response:
+                text = await response.text()
+                try:
+                    body = json.loads(text)
+                except json.JSONDecodeError:
+                    body = {"raw": text}
+            if method == "POST" and url == f"{self.sidecar_url}/offer":
+                self.sidecar_offer_response = body
+            return RecordedResponse(response.status, body)
+
+        return RecordedResponse(404, {"error": "not found"})
+
+
+def call_connect_payload(
+    *,
+    call_id: str,
+    caller: str,
+    callee: str,
+    contact_name: str,
+    remote_sdp: str,
+) -> dict[str, Any]:
+    return {
+        "object": "whatsapp_business_account",
+        "entry": [
+            {
+                "id": "215589313241560883",
+                "changes": [
+                    {
+                        "field": "calls",
+                        "value": {
+                            "messaging_product": "whatsapp",
+                            "metadata": {
+                                "display_phone_number": callee,
+                                "phone_number_id": DEFAULT_PHONE_NUMBER_ID,
+                            },
+                            "contacts": [
+                                {
+                                    "profile": {"name": contact_name},
+                                    "wa_id": caller,
+                                }
+                            ],
+                            "calls": [
+                                {
+                                    "id": call_id,
+                                    "from": caller,
+                                    "to": callee,
+                                    "event": "connect",
+                                    "timestamp": "1762216151",
+                                    "direction": "USER_INITIATED",
+                                    "session": {
+                                        "sdp_type": "offer",
+                                        "sdp": remote_sdp,
+                                    },
+                                }
+                            ],
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def call_terminate_payload(*, call_id: str, caller: str, callee: str) -> dict[str, Any]:
+    return {
+        "object": "whatsapp_business_account",
+        "entry": [
+            {
+                "id": "215589313241560883",
+                "changes": [
+                    {
+                        "field": "calls",
+                        "value": {
+                            "messaging_product": "whatsapp",
+                            "metadata": {
+                                "display_phone_number": callee,
+                                "phone_number_id": DEFAULT_PHONE_NUMBER_ID,
+                            },
+                            "calls": [
+                                {
+                                    "id": call_id,
+                                    "from": caller,
+                                    "to": callee,
+                                    "event": "terminate",
+                                    "timestamp": "1762216199",
+                                    "direction": "USER_INITIATED",
+                                    "status": "COMPLETED",
+                                }
+                            ],
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+
+
+async def wait_for_ice_complete(sidecar: Any, pc: Any, timeout: float) -> None:
+    await sidecar.wait_for_ice_complete(pc, timeout=timeout)
+    if pc.localDescription is None:
+        raise RuntimeError("local WebRTC peer did not produce a local description")
+
+
+async def wait_for_non_silent_track(track: Any, *, timeout_s: float) -> int:
+    deadline = asyncio.get_running_loop().time() + timeout_s
+    while asyncio.get_running_loop().time() < deadline:
+        frame = await asyncio.wait_for(track.recv(), timeout=min(2.0, timeout_s))
+        frame_bytes = b"".join(bytes(plane) for plane in frame.planes)
+        if any(frame_bytes):
+            return len(frame_bytes)
+    raise TimeoutError("local WebRTC peer only received silence")
+
+
+async def wait_for_non_silent_sidecar_drain(
+    adapter: WhatsAppCloudAdapter,
+    call_id: str,
+    *,
+    timeout_s: float,
+) -> Any:
+    deadline = asyncio.get_running_loop().time() + timeout_s
+    while asyncio.get_running_loop().time() < deadline:
+        audio = await adapter._receive_calling_sidecar_audio(  # noqa: SLF001
+            call_id,
+            max_bytes=1_920,
+            wait_ms=500,
+        )
+        if audio is not None and any(audio.pcm_s16le):
+            return audio
+    raise TimeoutError("sidecar inbound drain stayed silent")
+
+
+def graph_actions(requests: list[dict[str, Any]], graph_calls_url: str) -> list[str]:
+    return [
+        str(request["kwargs"]["json"].get("action") or "")
+        for request in requests
+        if request["method"] == "POST"
+        and request["url"] == graph_calls_url
+        and isinstance(request["kwargs"].get("json"), dict)
+    ]
+
+
+async def run_live_sidecar_smoke(args: argparse.Namespace) -> dict[str, Any]:
+    voice_repo = args.voice_repo.expanduser().resolve()
+    sidecar = load_sidecar_module(voice_repo)
+    runner, sidecar_url = await start_sidecar_app(sidecar)
+    pc = sidecar.RTCPeerConnection()
+    http_client: RecordingHybridHttpClient | None = None
+    try:
+        inbound_frame = pcm_frame(sidecar, sample=-10_000)
+        pc.addTrack(make_pcm_track_class(sidecar, frame_bytes=inbound_frame)())
+        track_future = asyncio.get_running_loop().create_future()
+
+        @pc.on("track")
+        def on_track(track: Any) -> None:
+            if track.kind == "audio" and not track_future.done():
+                track_future.set_result(track)
+
+        offer = await pc.createOffer()
+        await pc.setLocalDescription(offer)
+        await wait_for_ice_complete(sidecar, pc, args.timeout)
+
+        config = PlatformConfig(
+            enabled=True,
+            extra={
+                "phone_number_id": args.phone_number_id,
+                "access_token": "synthetic-token",
+                "calling_sidecar_url": sidecar_url,
+                "calling_sidecar_timeout": args.timeout,
+            },
+        )
+        adapter = WhatsAppCloudAdapter(config)
+        graph_calls_url = (
+            f"https://graph.facebook.com/{adapter._api_version}/{args.phone_number_id}/calls"  # noqa: SLF001
+        )
+        http_client = RecordingHybridHttpClient(
+            sidecar_url=sidecar_url,
+            graph_calls_url=graph_calls_url,
+            timeout=args.timeout,
+        )
+        adapter._http_client = http_client  # noqa: SLF001
+
+        dispatched_messages: list[Any] = []
+
+        async def capture_message(event: Any) -> None:
+            dispatched_messages.append(event)
+
+        drain_starts: list[dict[str, str]] = []
+
+        def capture_drain(call_id: str, chat_id: str, sender_name: str = "") -> None:
+            drain_starts.append(
+                {"call_id": call_id, "chat_id": chat_id, "sender_name": sender_name}
+            )
+
+        adapter.handle_message = capture_message
+        adapter._start_calling_sidecar_drain = capture_drain  # type: ignore[method-assign]  # noqa: SLF001
+
+        await adapter._dispatch_payload(  # noqa: SLF001
+            call_connect_payload(
+                call_id=args.call_id,
+                caller=args.caller,
+                callee=args.callee,
+                contact_name=args.contact_name,
+                remote_sdp=pc.localDescription.sdp,
+            )
+        )
+
+        if dispatched_messages:
+            raise RuntimeError("calling connect dispatched an unexpected MessageEvent")
+        if http_client.sidecar_offer_response is None:
+            raise RuntimeError("Hermes did not POST a real offer to the sidecar")
+        if http_client.sidecar_offer_response.get("type") != "answer":
+            raise RuntimeError(
+                f"sidecar did not return an SDP answer: {http_client.sidecar_offer_response}"
+            )
+        if args.call_id not in adapter._calling_sidecar_call_ids:  # noqa: SLF001
+            raise RuntimeError("adapter did not track the active sidecar call id")
+
+        await pc.setRemoteDescription(
+            sidecar.RTCSessionDescription(
+                sdp=str(http_client.sidecar_offer_response["sdp"]),
+                type="answer",
+            )
+        )
+
+        outbound_result = await adapter._send_calling_sidecar_audio(  # noqa: SLF001
+            args.call_id,
+            pcm_frame(sidecar, sample=12_000),
+        )
+        if not outbound_result.success:
+            raise RuntimeError(f"sidecar outbound audio send failed: {outbound_result}")
+
+        track = await asyncio.wait_for(track_future, timeout=args.timeout)
+        outbound_webrtc_bytes = await wait_for_non_silent_track(
+            track,
+            timeout_s=args.timeout,
+        )
+        inbound_audio = await wait_for_non_silent_sidecar_drain(
+            adapter,
+            args.call_id,
+            timeout_s=args.timeout,
+        )
+
+        actions = graph_actions(http_client.requests, graph_calls_url)
+        if actions[:2] != ["pre_accept", "accept"]:
+            raise RuntimeError(f"expected pre_accept, accept; got {actions}")
+        if drain_starts != [
+            {
+                "call_id": args.call_id,
+                "chat_id": args.caller,
+                "sender_name": args.contact_name,
+            }
+        ]:
+            raise RuntimeError(f"unexpected drain starts: {drain_starts}")
+
+        await adapter._dispatch_payload(  # noqa: SLF001
+            call_terminate_payload(
+                call_id=args.call_id,
+                caller=args.caller,
+                callee=args.callee,
+            )
+        )
+        if adapter._calling_sidecar_call_ids:  # noqa: SLF001
+            raise RuntimeError(
+                f"call ids should be empty after terminate: {adapter._calling_sidecar_call_ids}"  # noqa: SLF001
+            )
+
+        close_requests = [
+            request
+            for request in http_client.requests
+            if request["method"] == "POST"
+            and request["url"] == f"{sidecar_url}/calls/{args.call_id}/close"
+        ]
+        if not close_requests:
+            raise RuntimeError("Hermes did not close the real sidecar call session")
+
+        return {
+            "success": True,
+            "call_id": args.call_id,
+            "caller": args.caller,
+            "sidecar_url": sidecar_url,
+            "graph_calls_url": graph_calls_url,
+            "graph_actions": actions,
+            "drain_starts": drain_starts,
+            "sidecar_offer_url": f"{sidecar_url}/offer",
+            "sidecar_close_url": close_requests[-1]["url"],
+            "outbound_webrtc_bytes": outbound_webrtc_bytes,
+            "inbound_drain_bytes": inbound_audio.returned_bytes,
+            "queued_rx_ms": inbound_audio.queued_rx_ms,
+            "sent_audio": outbound_result.raw_response,
+            "audio": sidecar.audio_contract(),
+        }
+    finally:
+        await pc.close()
+        if http_client is not None:
+            await http_client.aclose()
+        await runner.cleanup()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--voice-repo", type=Path, required=True)
+    parser.add_argument("--phone-number-id", default=DEFAULT_PHONE_NUMBER_ID)
+    parser.add_argument("--call-id", default=DEFAULT_CALL_ID)
+    parser.add_argument("--caller", default=DEFAULT_CALLER)
+    parser.add_argument("--callee", default=DEFAULT_CALLEE)
+    parser.add_argument("--contact-name", default=DEFAULT_CONTACT_NAME)
+    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
+    return parser.parse_args()
+
+
+def main() -> int:
+    result = asyncio.run(run_live_sidecar_smoke(parse_args()))
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_voice_whatsapp_calling_live_sidecar.py
+++ b/scripts/verify_voice_whatsapp_calling_live_sidecar.py
@@ -362,6 +362,13 @@ async def run_live_sidecar_smoke(args: argparse.Namespace) -> dict[str, Any]:
             raise RuntimeError(
                 f"sidecar did not return an SDP answer: {http_client.sidecar_offer_response}"
             )
+        sidecar_state = http_client.sidecar_offer_response.get("state")
+        if not isinstance(sidecar_state, dict):
+            raise RuntimeError(
+                f"sidecar answer did not include call state: {http_client.sidecar_offer_response}"
+            )
+        if sidecar_state.get("ready_for_accept") is not True:
+            raise RuntimeError(f"sidecar was not ready for accept: {sidecar_state}")
         if args.call_id not in adapter._calling_sidecar_call_ids:  # noqa: SLF001
             raise RuntimeError("adapter did not track the active sidecar call id")
 
@@ -433,6 +440,8 @@ async def run_live_sidecar_smoke(args: argparse.Namespace) -> dict[str, Any]:
             "drain_starts": drain_starts,
             "sidecar_offer_url": f"{sidecar_url}/offer",
             "sidecar_close_url": close_requests[-1]["url"],
+            "sidecar_ready_for_accept": sidecar_state["ready_for_accept"],
+            "sidecar_readiness": sidecar_state.get("readiness"),
             "outbound_webrtc_bytes": outbound_webrtc_bytes,
             "inbound_drain_bytes": inbound_audio.returned_bytes,
             "queued_rx_ms": inbound_audio.queued_rx_ms,

--- a/scripts/verify_voice_whatsapp_calling_live_sidecar.py
+++ b/scripts/verify_voice_whatsapp_calling_live_sidecar.py
@@ -141,6 +141,7 @@ class RecordingHybridHttpClient:
         self.session = ClientSession()
         self.requests: list[dict[str, Any]] = []
         self.sidecar_offer_response: dict[str, Any] | None = None
+        self.sidecar_close_responses: list[dict[str, Any]] = []
 
     async def aclose(self) -> None:
         await self.session.close()
@@ -177,6 +178,12 @@ class RecordingHybridHttpClient:
                     body = {"raw": text}
             if method == "POST" and url == f"{self.sidecar_url}/offer":
                 self.sidecar_offer_response = body
+            if (
+                method == "POST"
+                and url.startswith(f"{self.sidecar_url}/calls/")
+                and url.endswith("/close")
+            ):
+                self.sidecar_close_responses.append(body)
             return RecordedResponse(response.status, body)
 
         return RecordedResponse(404, {"error": "not found"})
@@ -432,6 +439,37 @@ async def run_live_sidecar_smoke(args: argparse.Namespace) -> dict[str, Any]:
             timeout_s=args.timeout,
         )
 
+        clear_probe = await adapter._send_calling_sidecar_audio(  # noqa: SLF001
+            args.call_id,
+            pcm_frame(sidecar, sample=14_000),
+            sequence=1,
+        )
+        if not clear_probe.success:
+            raise RuntimeError(
+                f"sidecar clear probe audio send failed: {clear_probe}"
+            )
+        clear_result = await adapter._clear_calling_sidecar_audio(  # noqa: SLF001
+            args.call_id,
+        )
+        if not clear_result.success:
+            raise RuntimeError(f"sidecar clear audio failed: {clear_result}")
+        clear_body = clear_result.raw_response
+        if not isinstance(clear_body, dict):
+            raise RuntimeError(f"sidecar clear response was not an object: {clear_body}")
+        if clear_body.get("skipped"):
+            raise RuntimeError(f"sidecar clear endpoint was skipped: {clear_body}")
+        try:
+            queued_after_clear = int(clear_body.get("queued_tx_bytes"))
+            dropped_tx_bytes = int(clear_body.get("dropped_tx_bytes"))
+        except (TypeError, ValueError) as exc:
+            raise RuntimeError(
+                f"sidecar clear response missing byte telemetry: {clear_body}"
+            ) from exc
+        if queued_after_clear != 0 or dropped_tx_bytes < 0:
+            raise RuntimeError(
+                f"sidecar clear response did not drain outbound queue: {clear_body}"
+            )
+
         actions = graph_actions(http_client.requests, graph_calls_url)
         if actions[:2] != ["pre_accept", "accept"]:
             raise RuntimeError(f"expected pre_accept, accept; got {actions}")
@@ -471,6 +509,13 @@ async def run_live_sidecar_smoke(args: argparse.Namespace) -> dict[str, Any]:
         ]
         if not close_requests:
             raise RuntimeError("Hermes did not close the real sidecar call session")
+        sidecar_close = (
+            http_client.sidecar_close_responses[-1]
+            if http_client.sidecar_close_responses
+            else None
+        )
+        if not isinstance(sidecar_close, dict) or sidecar_close.get("closed") is not True:
+            raise RuntimeError(f"sidecar close did not report closed=true: {sidecar_close}")
 
         return {
             "success": True,
@@ -487,12 +532,15 @@ async def run_live_sidecar_smoke(args: argparse.Namespace) -> dict[str, Any]:
             },
             "sidecar_offer_url": f"{sidecar_url}/offer",
             "sidecar_close_url": close_requests[-1]["url"],
+            "sidecar_close": sidecar_close,
             "sidecar_ready_for_accept": sidecar_state["ready_for_accept"],
             "sidecar_readiness": sidecar_state.get("readiness"),
             "outbound_webrtc_bytes": outbound_webrtc_bytes,
             "inbound_drain_bytes": inbound_audio.returned_bytes,
             "queued_rx_ms": inbound_audio.queued_rx_ms,
             "sent_audio": outbound_result.raw_response,
+            "clear_probe": clear_probe.raw_response,
+            "clear_audio": clear_body,
             "audio": sidecar.audio_contract(),
         }
     finally:

--- a/scripts/verify_voice_whatsapp_calling_live_sidecar.py
+++ b/scripts/verify_voice_whatsapp_calling_live_sidecar.py
@@ -17,6 +17,8 @@ import argparse
 import asyncio
 import base64
 from dataclasses import dataclass
+import hashlib
+import hmac
 import importlib.util
 import json
 from pathlib import Path
@@ -34,6 +36,7 @@ DEFAULT_CALLER = "13557825698"
 DEFAULT_CALLEE = "15551797781"
 DEFAULT_CONTACT_NAME = "Hermes Voice Smoke"
 DEFAULT_PHONE_NUMBER_ID = "7794189252778687"
+DEFAULT_APP_SECRET = "synthetic-whatsapp-calling-secret"
 DEFAULT_TIMEOUT = 12.0
 
 
@@ -48,6 +51,23 @@ class RecordedResponse:
 
     def json(self) -> dict[str, Any]:
         return self.body
+
+
+class SignedWebhookRequest:
+    """Small aiohttp.web.Request stand-in for the Cloud webhook handler."""
+
+    def __init__(self, raw: bytes, signature: str) -> None:
+        self._raw = raw
+        self.headers = {"X-Hub-Signature-256": signature}
+
+    async def read(self) -> bytes:
+        return self._raw
+
+
+def signed_webhook_request(payload: dict[str, Any], *, app_secret: str) -> SignedWebhookRequest:
+    raw = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    digest = hmac.new(app_secret.encode("utf-8"), raw, hashlib.sha256).hexdigest()
+    return SignedWebhookRequest(raw, f"sha256={digest}")
 
 
 def load_sidecar_module(voice_repo: Path):
@@ -321,6 +341,7 @@ async def run_live_sidecar_smoke(args: argparse.Namespace) -> dict[str, Any]:
             extra={
                 "phone_number_id": args.phone_number_id,
                 "access_token": "synthetic-token",
+                "app_secret": args.app_secret,
                 "calling_sidecar_url": sidecar_url,
                 "calling_sidecar_timeout": args.timeout,
             },
@@ -351,15 +372,22 @@ async def run_live_sidecar_smoke(args: argparse.Namespace) -> dict[str, Any]:
         adapter.handle_message = capture_message
         adapter._start_calling_sidecar_drain = capture_drain  # type: ignore[method-assign]  # noqa: SLF001
 
-        await adapter._dispatch_payload(  # noqa: SLF001
-            call_connect_payload(
-                call_id=args.call_id,
-                caller=args.caller,
-                callee=args.callee,
-                contact_name=args.contact_name,
-                remote_sdp=pc.localDescription.sdp,
+        connect_response = await adapter._handle_webhook(  # noqa: SLF001
+            signed_webhook_request(
+                call_connect_payload(
+                    call_id=args.call_id,
+                    caller=args.caller,
+                    callee=args.callee,
+                    contact_name=args.contact_name,
+                    remote_sdp=pc.localDescription.sdp,
+                ),
+                app_secret=args.app_secret,
             )
         )
+        if connect_response.status != 200:
+            raise RuntimeError(
+                f"signed connect webhook returned HTTP {connect_response.status}"
+            )
 
         if dispatched_messages:
             raise RuntimeError("calling connect dispatched an unexpected MessageEvent")
@@ -416,13 +444,20 @@ async def run_live_sidecar_smoke(args: argparse.Namespace) -> dict[str, Any]:
         ]:
             raise RuntimeError(f"unexpected drain starts: {drain_starts}")
 
-        await adapter._dispatch_payload(  # noqa: SLF001
-            call_terminate_payload(
-                call_id=args.call_id,
-                caller=args.caller,
-                callee=args.callee,
+        terminate_response = await adapter._handle_webhook(  # noqa: SLF001
+            signed_webhook_request(
+                call_terminate_payload(
+                    call_id=args.call_id,
+                    caller=args.caller,
+                    callee=args.callee,
+                ),
+                app_secret=args.app_secret,
             )
         )
+        if terminate_response.status != 200:
+            raise RuntimeError(
+                f"signed terminate webhook returned HTTP {terminate_response.status}"
+            )
         if adapter._calling_sidecar_call_ids:  # noqa: SLF001
             raise RuntimeError(
                 f"call ids should be empty after terminate: {adapter._calling_sidecar_call_ids}"  # noqa: SLF001
@@ -446,6 +481,10 @@ async def run_live_sidecar_smoke(args: argparse.Namespace) -> dict[str, Any]:
             "graph_calls_url": graph_calls_url,
             "graph_actions": actions,
             "drain_starts": drain_starts,
+            "webhook_statuses": {
+                "connect": connect_response.status,
+                "terminate": terminate_response.status,
+            },
             "sidecar_offer_url": f"{sidecar_url}/offer",
             "sidecar_close_url": close_requests[-1]["url"],
             "sidecar_ready_for_accept": sidecar_state["ready_for_accept"],
@@ -479,6 +518,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--caller", default=DEFAULT_CALLER)
     parser.add_argument("--callee", default=DEFAULT_CALLEE)
     parser.add_argument("--contact-name", default=DEFAULT_CONTACT_NAME)
+    parser.add_argument("--app-secret", default=DEFAULT_APP_SECRET)
     parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
     return parser.parse_args()
 

--- a/scripts/verify_voice_whatsapp_calling_live_sidecar.py
+++ b/scripts/verify_voice_whatsapp_calling_live_sidecar.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """Verify Hermes WhatsApp Calling control flow against a real local sidecar.
 
-This smoke does not contact Meta. It starts the voice repo's Python aiortc
-sidecar in-process, feeds a synthetic WhatsApp Calling ``connect`` webhook into
-Hermes, lets Hermes POST the real SDP offer to the sidecar, fakes only the
-Graph ``/calls`` actions, and verifies WebRTC audio can move both ways.
+This smoke does not contact Meta. It feeds a synthetic WhatsApp Calling
+``connect`` webhook into Hermes, lets Hermes POST the real SDP offer to a
+voice WebRTC sidecar, fakes only the Graph ``/calls`` actions, and verifies
+WebRTC audio can move both ways. By default it starts the sidecar in-process;
+pass ``--sidecar-url`` to target an already-running local sidecar service.
 
 Run it with a Python environment that has the voice sidecar extras installed.
 The local stack installer exposes that as ``--webrtc-python-bin``.
@@ -292,7 +293,13 @@ def graph_actions(requests: list[dict[str, Any]], graph_calls_url: str) -> list[
 async def run_live_sidecar_smoke(args: argparse.Namespace) -> dict[str, Any]:
     voice_repo = args.voice_repo.expanduser().resolve()
     sidecar = load_sidecar_module(voice_repo)
-    runner, sidecar_url = await start_sidecar_app(sidecar)
+    if args.sidecar_url:
+        runner = None
+        sidecar_url = args.sidecar_url.rstrip("/")
+        sidecar_mode = "running"
+    else:
+        runner, sidecar_url = await start_sidecar_app(sidecar)
+        sidecar_mode = "in_process"
     pc = sidecar.RTCPeerConnection()
     http_client: RecordingHybridHttpClient | None = None
     try:
@@ -435,6 +442,7 @@ async def run_live_sidecar_smoke(args: argparse.Namespace) -> dict[str, Any]:
             "call_id": args.call_id,
             "caller": args.caller,
             "sidecar_url": sidecar_url,
+            "sidecar_mode": sidecar_mode,
             "graph_calls_url": graph_calls_url,
             "graph_actions": actions,
             "drain_starts": drain_starts,
@@ -452,12 +460,20 @@ async def run_live_sidecar_smoke(args: argparse.Namespace) -> dict[str, Any]:
         await pc.close()
         if http_client is not None:
             await http_client.aclose()
-        await runner.cleanup()
+        if runner is not None:
+            await runner.cleanup()
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--voice-repo", type=Path, required=True)
+    parser.add_argument(
+        "--sidecar-url",
+        help=(
+            "Existing local voice WebRTC sidecar URL. When omitted, the smoke "
+            "starts an in-process sidecar from --voice-repo."
+        ),
+    )
     parser.add_argument("--phone-number-id", default=DEFAULT_PHONE_NUMBER_ID)
     parser.add_argument("--call-id", default=DEFAULT_CALL_ID)
     parser.add_argument("--caller", default=DEFAULT_CALLER)

--- a/scripts/verify_voice_whatsapp_cloud_voice_note.py
+++ b/scripts/verify_voice_whatsapp_cloud_voice_note.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Verify WhatsApp Cloud voice-note upload behavior without live Graph calls."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import OrderedDict
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from gateway.config import Platform
+from gateway.platforms.whatsapp_cloud import WhatsAppCloudAdapter
+
+
+WHATSAPP_OPUS_MIME = "audio/ogg; codecs=opus"
+
+
+class VerificationError(RuntimeError):
+    pass
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise VerificationError(message)
+
+
+def make_response(body: dict[str, Any], *, status_code: int = 200) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.json = MagicMock(return_value=body)
+    response.text = json.dumps(body)
+    return response
+
+
+def upload_response(media_id: str) -> MagicMock:
+    return make_response({"id": media_id})
+
+
+def message_response(wamid: str = "wamid.voice-note") -> MagicMock:
+    return make_response({"messages": [{"id": wamid}]})
+
+
+def temp_file(suffix: str, content: bytes) -> str:
+    fd, path = tempfile.mkstemp(suffix=suffix)
+    with os.fdopen(fd, "wb") as handle:
+        handle.write(content)
+    return path
+
+
+def make_adapter() -> WhatsAppCloudAdapter:
+    adapter = WhatsAppCloudAdapter.__new__(WhatsAppCloudAdapter)
+    adapter.platform = Platform.WHATSAPP_CLOUD
+    adapter.config = MagicMock()
+    adapter.config.extra = {}
+    adapter._phone_number_id = "1234567890"
+    adapter._access_token = "test-token"
+    adapter._api_version = "v20.0"
+    adapter._http_client = None
+    adapter._calling_sidecar_call_ids = set()
+    adapter._seen_wamids = OrderedDict()
+    adapter._warned_no_ffmpeg = False
+    return adapter
+
+
+def upload_files(adapter: WhatsAppCloudAdapter) -> dict[str, Any]:
+    return adapter._http_client.post.call_args_list[0].kwargs["files"]
+
+
+def send_payload(adapter: WhatsAppCloudAdapter) -> dict[str, Any]:
+    return adapter._http_client.post.call_args_list[1].kwargs["json"]
+
+
+async def verify_direct_ogg_upload() -> dict[str, Any]:
+    adapter = make_adapter()
+    adapter._http_client = MagicMock()
+    adapter._http_client.post = AsyncMock(
+        side_effect=[upload_response("voice_id"), message_response()]
+    )
+    adapter._convert_to_opus = AsyncMock()
+
+    path = temp_file(".ogg", b"OggS")
+    try:
+        result = await adapter.send_voice("15551234567", path)
+        require(result.success is True, f"direct Ogg send failed: {result.error}")
+        adapter._convert_to_opus.assert_not_awaited()
+        files = upload_files(adapter)
+        payload = send_payload(adapter)
+        require(
+            files["file"][2] == WHATSAPP_OPUS_MIME,
+            f"direct Ogg file MIME was {files['file'][2]!r}",
+        )
+        require(
+            files["type"][1] == WHATSAPP_OPUS_MIME,
+            f"direct Ogg type MIME was {files['type'][1]!r}",
+        )
+        require(payload["type"] == "audio", "direct Ogg did not send audio type")
+        require(payload["audio"]["id"] == "voice_id", "direct Ogg media id mismatch")
+        return {
+            "success": True,
+            "converted": False,
+            "upload_mime": files["file"][2],
+            "send_type": payload["type"],
+        }
+    finally:
+        os.unlink(path)
+
+
+async def verify_converted_upload() -> dict[str, Any]:
+    adapter = make_adapter()
+    adapter._http_client = MagicMock()
+    adapter._http_client.post = AsyncMock(
+        side_effect=[upload_response("converted_id"), message_response()]
+    )
+
+    source_path = temp_file(".mp3", b"ID3")
+    opus_path = temp_file(".ogg", b"OggS")
+    adapter._convert_to_opus = AsyncMock(return_value=opus_path)
+    try:
+        result = await adapter.send_voice("15551234567", source_path)
+        require(result.success is True, f"converted send failed: {result.error}")
+        adapter._convert_to_opus.assert_awaited_once_with(source_path)
+        files = upload_files(adapter)
+        payload = send_payload(adapter)
+        require(
+            files["file"][2] == WHATSAPP_OPUS_MIME,
+            f"converted file MIME was {files['file'][2]!r}",
+        )
+        require(
+            files["type"][1] == WHATSAPP_OPUS_MIME,
+            f"converted type MIME was {files['type'][1]!r}",
+        )
+        require(payload["type"] == "audio", "converted send did not use audio type")
+        require(not os.path.exists(opus_path), "temporary converted Ogg was not removed")
+        return {
+            "success": True,
+            "converted": True,
+            "upload_mime": files["file"][2],
+            "send_type": payload["type"],
+            "temporary_removed": True,
+        }
+    finally:
+        os.unlink(source_path)
+        if os.path.exists(opus_path):
+            os.unlink(opus_path)
+
+
+async def verify_mp3_fallback() -> dict[str, Any]:
+    adapter = make_adapter()
+    adapter._http_client = MagicMock()
+    adapter._http_client.post = AsyncMock(
+        side_effect=[upload_response("audio_id"), message_response()]
+    )
+    adapter._convert_to_opus = AsyncMock(return_value=None)
+
+    path = temp_file(".mp3", b"ID3")
+    try:
+        result = await adapter.send_voice("15551234567", path)
+        require(result.success is True, f"fallback send failed: {result.error}")
+        adapter._convert_to_opus.assert_awaited_once_with(path)
+        files = upload_files(adapter)
+        payload = send_payload(adapter)
+        require(
+            files["file"][2] == "audio/mpeg",
+            f"fallback file MIME was {files['file'][2]!r}",
+        )
+        require(
+            files["type"][1] == "audio/mpeg",
+            f"fallback type MIME was {files['type'][1]!r}",
+        )
+        require(payload["type"] == "audio", "fallback send did not use audio type")
+        return {
+            "success": True,
+            "converted": False,
+            "upload_mime": files["file"][2],
+            "send_type": payload["type"],
+        }
+    finally:
+        os.unlink(path)
+
+
+async def verify() -> dict[str, Any]:
+    return {
+        "success": True,
+        "checks": {
+            "direct_ogg": await verify_direct_ogg_upload(),
+            "converted_audio": await verify_converted_upload(),
+            "fallback_audio": await verify_mp3_fallback(),
+        },
+    }
+
+
+def main() -> int:
+    try:
+        result = asyncio.run(verify())
+    except VerificationError as exc:
+        print(json.dumps({"success": False, "error": str(exc)}, indent=2))
+        return 1
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_voice_whatsapp_cloud_webhook.py
+++ b/scripts/verify_voice_whatsapp_cloud_webhook.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Verify WhatsApp Cloud webhook ingress locally without live Meta calls."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+from aiohttp import ClientSession
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from gateway.config import PlatformConfig
+from gateway.platforms.whatsapp_cloud import WhatsAppCloudAdapter
+
+
+PHONE_NUMBER_ID = "7794189252778687"
+VERIFY_TOKEN = "local-verify-token-value"
+APP_SECRET = "0123456789abcdef0123456789abcdef"
+WEBHOOK_PATH = "/whatsapp/webhook"
+VERIFY_CHALLENGE = "hermes-local-cloud-webhook-smoke"
+
+
+class VerificationError(RuntimeError):
+    pass
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise VerificationError(message)
+
+
+def bound_port(adapter: WhatsAppCloudAdapter) -> int:
+    runner = getattr(adapter, "_runner", None)
+    sites = list(getattr(runner, "sites", []) or [])
+    for site in sites:
+        server = getattr(site, "_server", None)
+        sockets = getattr(server, "sockets", None) or []
+        for sock in sockets:
+            return int(sock.getsockname()[1])
+    raise VerificationError("could not determine local webhook port")
+
+
+def status_payload() -> dict[str, Any]:
+    return {
+        "object": "whatsapp_business_account",
+        "entry": [
+            {
+                "id": "local-cloud-webhook-smoke",
+                "changes": [
+                    {
+                        "field": "messages",
+                        "value": {
+                            "messaging_product": "whatsapp",
+                            "metadata": {
+                                "display_phone_number": "15555550100",
+                                "phone_number_id": PHONE_NUMBER_ID,
+                            },
+                            "statuses": [
+                                {
+                                    "id": "wamid.local-cloud-webhook-smoke",
+                                    "status": "delivered",
+                                    "timestamp": "1760000000",
+                                    "recipient_id": "15555550101",
+                                }
+                            ],
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def signature_header(body: bytes) -> str:
+    digest = hmac.new(APP_SECRET.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+async def verify() -> dict[str, Any]:
+    config = PlatformConfig(
+        enabled=True,
+        extra={
+            "phone_number_id": PHONE_NUMBER_ID,
+            "access_token": "EAA" + ("x" * 120),
+            "app_secret": APP_SECRET,
+            "verify_token": VERIFY_TOKEN,
+            "webhook_host": "127.0.0.1",
+            "webhook_port": 0,
+            "webhook_path": WEBHOOK_PATH,
+        },
+    )
+    adapter = WhatsAppCloudAdapter(config)
+    dispatched_messages: list[Any] = []
+
+    async def capture_message(event: Any) -> None:
+        dispatched_messages.append(event)
+
+    adapter.handle_message = capture_message
+
+    connected = await adapter.connect()
+    require(connected is True, "WhatsApp Cloud adapter did not connect")
+    try:
+        port = bound_port(adapter)
+        base_url = f"http://127.0.0.1:{port}"
+        webhook_url = base_url + WEBHOOK_PATH
+        async with ClientSession() as session:
+            async with session.get(base_url + "/health") as response:
+                health = await response.json()
+            require(health.get("status") == "ok", f"health was not ok: {health}")
+            require(
+                health.get("verify_token_configured") is True,
+                "health did not report verify token configured",
+            )
+            require(
+                health.get("app_secret_configured") is True,
+                "health did not report app secret configured",
+            )
+
+            async with session.get(
+                webhook_url,
+                params={
+                    "hub.mode": "subscribe",
+                    "hub.verify_token": VERIFY_TOKEN,
+                    "hub.challenge": VERIFY_CHALLENGE,
+                },
+            ) as response:
+                verify_body = await response.text()
+                verify_status = response.status
+            require(verify_status == 200, f"verify handshake status {verify_status}")
+            require(
+                verify_body == VERIFY_CHALLENGE,
+                "verify handshake did not echo challenge",
+            )
+
+            body = json.dumps(
+                status_payload(),
+                separators=(",", ":"),
+                sort_keys=True,
+            ).encode("utf-8")
+            async with session.post(
+                webhook_url,
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Hub-Signature-256": signature_header(body),
+                },
+            ) as response:
+                post_status = response.status
+                await response.text()
+            require(post_status == 200, f"signed POST status {post_status}")
+
+            async with session.get(base_url + "/health") as response:
+                final_health = await response.json()
+            require(
+                final_health.get("rejected_signature") == 0,
+                "signed POST unexpectedly incremented rejected_signature",
+            )
+            require(
+                final_health.get("accepted") == 0,
+                "status-only POST unexpectedly dispatched a message",
+            )
+            require(
+                not dispatched_messages,
+                "status-only POST unexpectedly reached handle_message",
+            )
+
+        return {
+            "success": True,
+            "checks": {
+                "health": {
+                    "status": health.get("status"),
+                    "platform": health.get("platform"),
+                    "verify_token_configured": (
+                        health.get("verify_token_configured") is True
+                    ),
+                    "app_secret_configured": health.get("app_secret_configured")
+                    is True,
+                },
+                "verify_handshake": {
+                    "status": verify_status,
+                    "challenge_echoed": True,
+                },
+                "signed_post": {
+                    "status": post_status,
+                    "payload": "status_delivery_receipt",
+                    "signature_accepted": True,
+                    "dispatched_messages": len(dispatched_messages),
+                },
+            },
+        }
+    finally:
+        await adapter.disconnect()
+
+
+def main() -> int:
+    try:
+        result = asyncio.run(verify())
+    except VerificationError as exc:
+        print(json.dumps({"success": False, "error": str(exc)}, indent=2))
+        return 1
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_voice_whatsapp_cloud_webhook.py
+++ b/scripts/verify_voice_whatsapp_cloud_webhook.py
@@ -9,6 +9,7 @@ import hmac
 import json
 from pathlib import Path
 import sys
+import tempfile
 from typing import Any
 
 from aiohttp import ClientSession
@@ -18,6 +19,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from gateway.config import PlatformConfig
+from gateway.platforms import whatsapp_cloud as whatsapp_cloud_module
 from gateway.platforms.whatsapp_cloud import WhatsAppCloudAdapter
 
 
@@ -26,6 +28,8 @@ VERIFY_TOKEN = "local-verify-token-value"
 APP_SECRET = "0123456789abcdef0123456789abcdef"
 WEBHOOK_PATH = "/whatsapp/webhook"
 VERIFY_CHALLENGE = "hermes-local-cloud-webhook-smoke"
+VOICE_MEDIA_ID = "media_voice_note_abc"
+VOICE_BYTES = b"OggS\x00\x02voice-note"
 
 
 class VerificationError(RuntimeError):
@@ -79,9 +83,114 @@ def status_payload() -> dict[str, Any]:
     }
 
 
+def voice_payload() -> dict[str, Any]:
+    return {
+        "object": "whatsapp_business_account",
+        "entry": [
+            {
+                "id": "local-cloud-webhook-smoke",
+                "changes": [
+                    {
+                        "field": "messages",
+                        "value": {
+                            "messaging_product": "whatsapp",
+                            "metadata": {
+                                "display_phone_number": "15555550100",
+                                "phone_number_id": PHONE_NUMBER_ID,
+                            },
+                            "contacts": [
+                                {
+                                    "profile": {"name": "Hermes Voice Smoke"},
+                                    "wa_id": "15555550101",
+                                }
+                            ],
+                            "messages": [
+                                {
+                                    "from": "15555550101",
+                                    "id": "wamid.local-cloud-voice-note",
+                                    "timestamp": "1760000001",
+                                    "type": "audio",
+                                    "audio": {
+                                        "id": VOICE_MEDIA_ID,
+                                        "mime_type": "audio/ogg; codecs=opus",
+                                        "sha256": "synthetic",
+                                        "voice": True,
+                                    },
+                                }
+                            ],
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+
+
 def signature_header(body: bytes) -> str:
     digest = hmac.new(APP_SECRET.encode("utf-8"), body, hashlib.sha256).hexdigest()
     return f"sha256={digest}"
+
+
+class FakeResponse:
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        body: dict[str, Any] | None = None,
+        content: bytes = b"",
+    ) -> None:
+        self.status_code = status_code
+        self._body = body or {}
+        self.content = content
+
+    def json(self) -> dict[str, Any]:
+        return self._body
+
+
+class FakeMediaClient:
+    def __init__(self, *, media_id: str, content: bytes) -> None:
+        self.media_id = media_id
+        self.content = content
+        self.get_urls: list[str] = []
+        self.closed = False
+
+    async def get(self, url: str, **_kwargs: Any) -> FakeResponse:
+        self.get_urls.append(url)
+        if url.endswith(f"/{self.media_id}"):
+            return FakeResponse(
+                status_code=200,
+                body={
+                    "url": "https://lookaside.fbsbx.com/whatsapp/m/local-voice",
+                    "mime_type": "audio/ogg; codecs=opus",
+                    "id": self.media_id,
+                },
+            )
+        if url == "https://lookaside.fbsbx.com/whatsapp/m/local-voice":
+            return FakeResponse(status_code=200, content=self.content)
+        return FakeResponse(status_code=404, body={"error": "not found"})
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+async def signed_post(
+    *,
+    session: ClientSession,
+    webhook_url: str,
+    payload: dict[str, Any],
+) -> int:
+    body = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    async with session.post(
+        webhook_url,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "X-Hub-Signature-256": signature_header(body),
+        },
+    ) as response:
+        status = response.status
+        await response.text()
+    return status
 
 
 async def verify() -> dict[str, Any]:
@@ -105,72 +214,100 @@ async def verify() -> dict[str, Any]:
 
     adapter.handle_message = capture_message
 
+    original_cache = whatsapp_cloud_module._INBOUND_MEDIA_CACHE
     connected = await adapter.connect()
     require(connected is True, "WhatsApp Cloud adapter did not connect")
     try:
         port = bound_port(adapter)
         base_url = f"http://127.0.0.1:{port}"
         webhook_url = base_url + WEBHOOK_PATH
-        async with ClientSession() as session:
-            async with session.get(base_url + "/health") as response:
-                health = await response.json()
-            require(health.get("status") == "ok", f"health was not ok: {health}")
-            require(
-                health.get("verify_token_configured") is True,
-                "health did not report verify token configured",
-            )
-            require(
-                health.get("app_secret_configured") is True,
-                "health did not report app secret configured",
-            )
+        with tempfile.TemporaryDirectory(prefix="hermes-cloud-webhook-media.") as tmp:
+            whatsapp_cloud_module._INBOUND_MEDIA_CACHE = Path(tmp)
+            async with ClientSession() as session:
+                async with session.get(base_url + "/health") as response:
+                    health = await response.json()
+                require(health.get("status") == "ok", f"health was not ok: {health}")
+                require(
+                    health.get("verify_token_configured") is True,
+                    "health did not report verify token configured",
+                )
+                require(
+                    health.get("app_secret_configured") is True,
+                    "health did not report app secret configured",
+                )
 
-            async with session.get(
-                webhook_url,
-                params={
-                    "hub.mode": "subscribe",
-                    "hub.verify_token": VERIFY_TOKEN,
-                    "hub.challenge": VERIFY_CHALLENGE,
-                },
-            ) as response:
-                verify_body = await response.text()
-                verify_status = response.status
-            require(verify_status == 200, f"verify handshake status {verify_status}")
-            require(
-                verify_body == VERIFY_CHALLENGE,
-                "verify handshake did not echo challenge",
-            )
+                async with session.get(
+                    webhook_url,
+                    params={
+                        "hub.mode": "subscribe",
+                        "hub.verify_token": VERIFY_TOKEN,
+                        "hub.challenge": VERIFY_CHALLENGE,
+                    },
+                ) as response:
+                    verify_body = await response.text()
+                    verify_status = response.status
+                require(verify_status == 200, f"verify handshake status {verify_status}")
+                require(
+                    verify_body == VERIFY_CHALLENGE,
+                    "verify handshake did not echo challenge",
+                )
 
-            body = json.dumps(
-                status_payload(),
-                separators=(",", ":"),
-                sort_keys=True,
-            ).encode("utf-8")
-            async with session.post(
-                webhook_url,
-                data=body,
-                headers={
-                    "Content-Type": "application/json",
-                    "X-Hub-Signature-256": signature_header(body),
-                },
-            ) as response:
-                post_status = response.status
-                await response.text()
-            require(post_status == 200, f"signed POST status {post_status}")
+                post_status = await signed_post(
+                    session=session,
+                    webhook_url=webhook_url,
+                    payload=status_payload(),
+                )
+                require(post_status == 200, f"signed POST status {post_status}")
 
-            async with session.get(base_url + "/health") as response:
-                final_health = await response.json()
-            require(
-                final_health.get("rejected_signature") == 0,
-                "signed POST unexpectedly incremented rejected_signature",
-            )
-            require(
-                final_health.get("accepted") == 0,
-                "status-only POST unexpectedly dispatched a message",
-            )
-            require(
-                not dispatched_messages,
-                "status-only POST unexpectedly reached handle_message",
-            )
+                async with session.get(base_url + "/health") as response:
+                    final_health = await response.json()
+                require(
+                    final_health.get("rejected_signature") == 0,
+                    "signed POST unexpectedly incremented rejected_signature",
+                )
+                require(
+                    final_health.get("accepted") == 0,
+                    "status-only POST unexpectedly dispatched a message",
+                )
+                require(
+                    not dispatched_messages,
+                    "status-only POST unexpectedly reached handle_message",
+                )
+                status_dispatched_messages = len(dispatched_messages)
+
+                existing_http_client = adapter._http_client
+                if existing_http_client is not None:
+                    await existing_http_client.aclose()
+                media_client = FakeMediaClient(
+                    media_id=VOICE_MEDIA_ID,
+                    content=VOICE_BYTES,
+                )
+                adapter._http_client = media_client
+                voice_status = await signed_post(
+                    session=session,
+                    webhook_url=webhook_url,
+                    payload=voice_payload(),
+                )
+                require(voice_status == 200, f"voice webhook status {voice_status}")
+                require(len(dispatched_messages) == 1, "voice webhook did not dispatch")
+                voice_dispatched_messages = len(dispatched_messages)
+                voice_event = dispatched_messages[0]
+                require(
+                    getattr(voice_event, "media_types", []) == [
+                        "audio/ogg; codecs=opus"
+                    ],
+                    "voice event media type mismatch",
+                )
+                media_urls = list(getattr(voice_event, "media_urls", []) or [])
+                require(len(media_urls) == 1, "voice event missing cached media URL")
+                media_path = Path(media_urls[0])
+                require(media_path.suffix == ".ogg", "voice media did not cache as .ogg")
+                require(media_path.read_bytes() == VOICE_BYTES, "voice media bytes changed")
+                require(
+                    any(url.endswith(f"/{VOICE_MEDIA_ID}") for url in media_client.get_urls),
+                    "media metadata endpoint was not requested",
+                )
+        whatsapp_cloud_module._INBOUND_MEDIA_CACHE = original_cache
 
         return {
             "success": True,
@@ -192,11 +329,19 @@ async def verify() -> dict[str, Any]:
                     "status": post_status,
                     "payload": "status_delivery_receipt",
                     "signature_accepted": True,
-                    "dispatched_messages": len(dispatched_messages),
+                    "dispatched_messages": status_dispatched_messages,
+                },
+                "voice_note": {
+                    "status": voice_status,
+                    "media_type": voice_event.media_types[0],
+                    "cached_extension": media_path.suffix,
+                    "cached_bytes": len(VOICE_BYTES),
+                    "dispatched_messages": voice_dispatched_messages,
                 },
             },
         }
     finally:
+        whatsapp_cloud_module._INBOUND_MEDIA_CACHE = original_cache
         await adapter.disconnect()
 
 

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -23,13 +23,12 @@ import express from 'express';
 import { Boom } from '@hapi/boom';
 import pino from 'pino';
 import path from 'path';
-import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync, unlinkSync } from 'fs';
+import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { randomBytes, createHash } from 'crypto';
-import { execSync } from 'child_process';
-import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import { buildMediaPayload } from './media-payload.js';
 
 // Parse CLI args
 const args = process.argv.slice(2);
@@ -576,25 +575,6 @@ app.post('/edit', async (req, res) => {
   }
 });
 
-// MIME type map and media type inference for /send-media
-const MIME_MAP = {
-  jpg: 'image/jpeg', jpeg: 'image/jpeg', png: 'image/png',
-  webp: 'image/webp', gif: 'image/gif',
-  mp4: 'video/mp4', mov: 'video/quicktime', avi: 'video/x-msvideo',
-  mkv: 'video/x-matroska', '3gp': 'video/3gpp',
-  pdf: 'application/pdf',
-  doc: 'application/msword',
-  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-};
-
-function inferMediaType(ext) {
-  if (['jpg', 'jpeg', 'png', 'webp', 'gif'].includes(ext)) return 'image';
-  if (['mp4', 'mov', 'avi', 'mkv', '3gp'].includes(ext)) return 'video';
-  if (['ogg', 'opus', 'mp3', 'wav', 'm4a'].includes(ext)) return 'audio';
-  return 'document';
-}
-
 // Send media (image, video, document) natively
 app.post('/send-media', async (req, res) => {
   if (!sock || connectionState !== 'connected') {
@@ -611,55 +591,9 @@ app.post('/send-media', async (req, res) => {
       return res.status(404).json({ error: `File not found: ${filePath}` });
     }
 
-    const buffer = readFileSync(filePath);
-    const ext = filePath.toLowerCase().split('.').pop();
-    const type = mediaType || inferMediaType(ext);
-    let msgPayload;
-
-    switch (type) {
-      case 'image':
-        msgPayload = { image: buffer, caption: caption || undefined, mimetype: MIME_MAP[ext] || 'image/jpeg' };
-        break;
-      case 'video':
-        msgPayload = { video: buffer, caption: caption || undefined, mimetype: MIME_MAP[ext] || 'video/mp4' };
-        break;
-      case 'audio': {
-        // WhatsApp only renders a native voice bubble (ptt) when the file is ogg/opus.
-        // If the caller passes mp3, wav, m4a etc. (e.g. from Edge TTS / NeuTTS),
-        // silently convert to ogg/opus via ffmpeg so ptt is always honoured.
-        let audioBuffer = buffer;
-        let audioExt = ext;
-        const needsConversion = !['ogg', 'opus'].includes(ext);
-        let tmpPath = null;
-        if (needsConversion) {
-          tmpPath = path.join(tmpdir(), `hermes_voice_${randomBytes(6).toString('hex')}.ogg`);
-          try {
-            execSync(
-              `ffmpeg -y -i ${JSON.stringify(filePath)} -ar 48000 -ac 1 -c:a libopus ${JSON.stringify(tmpPath)}`,
-              { timeout: 30000, stdio: 'pipe' }
-            );
-            audioBuffer = readFileSync(tmpPath);
-            audioExt = 'ogg';
-          } catch (convErr) {
-            // ffmpeg not available or conversion failed — fall back to original format
-            console.warn('[bridge] ffmpeg conversion failed, sending as file attachment:', convErr.message);
-          } finally {
-            try { if (tmpPath && existsSync(tmpPath)) unlinkSync(tmpPath); } catch (_) {}
-          }
-        }
-        const audioMime = (audioExt === 'ogg' || audioExt === 'opus') ? 'audio/ogg; codecs=opus' : 'audio/mpeg';
-        msgPayload = { audio: audioBuffer, mimetype: audioMime, ptt: audioExt === 'ogg' || audioExt === 'opus' };
-        break;
-      }
-      case 'document':
-      default:
-        msgPayload = {
-          document: buffer,
-          fileName: fileName || path.basename(filePath),
-          caption: caption || undefined,
-          mimetype: MIME_MAP[ext] || 'application/octet-stream',
-        };
-        break;
+    const { payload: msgPayload, warning } = buildMediaPayload({ filePath, mediaType, caption, fileName });
+    if (warning) {
+      console.warn('[bridge] ffmpeg conversion failed, sending as file attachment:', warning);
     }
 
     const sent = await sendWithTimeout(chatId, msgPayload);

--- a/scripts/whatsapp-bridge/media-payload.js
+++ b/scripts/whatsapp-bridge/media-payload.js
@@ -67,7 +67,7 @@ export function buildMediaPayload({
         tmpPath = makeTempPath(filePath);
         try {
           exec(
-            `ffmpeg -y -i ${JSON.stringify(filePath)} -ar 48000 -ac 1 -c:a libopus ${JSON.stringify(tmpPath)}`,
+            `ffmpeg -y -i ${JSON.stringify(filePath)} -ar 48000 -ac 1 -c:a libopus -b:a 32k -vbr on -application voip ${JSON.stringify(tmpPath)}`,
             { timeout: 30000, stdio: 'pipe' },
           );
           audioBuffer = readFile(tmpPath);

--- a/scripts/whatsapp-bridge/media-payload.js
+++ b/scripts/whatsapp-bridge/media-payload.js
@@ -1,0 +1,105 @@
+import path from 'path';
+import { execSync } from 'child_process';
+import { randomBytes } from 'crypto';
+import { existsSync, readFileSync, unlinkSync } from 'fs';
+import { tmpdir } from 'os';
+
+export const MIME_MAP = {
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  webp: 'image/webp',
+  gif: 'image/gif',
+  mp4: 'video/mp4',
+  mov: 'video/quicktime',
+  avi: 'video/x-msvideo',
+  mkv: 'video/x-matroska',
+  '3gp': 'video/3gpp',
+  pdf: 'application/pdf',
+  doc: 'application/msword',
+  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+};
+
+export function inferMediaType(ext) {
+  if (['jpg', 'jpeg', 'png', 'webp', 'gif'].includes(ext)) return 'image';
+  if (['mp4', 'mov', 'avi', 'mkv', '3gp'].includes(ext)) return 'video';
+  if (['ogg', 'opus', 'mp3', 'wav', 'm4a'].includes(ext)) return 'audio';
+  return 'document';
+}
+
+function defaultTempPath() {
+  return path.join(tmpdir(), `hermes_voice_${randomBytes(6).toString('hex')}.ogg`);
+}
+
+export function buildMediaPayload({
+  filePath,
+  mediaType,
+  caption,
+  fileName,
+  readFile = readFileSync,
+  exists = existsSync,
+  remove = unlinkSync,
+  exec = execSync,
+  makeTempPath = defaultTempPath,
+} = {}) {
+  const buffer = readFile(filePath);
+  const ext = filePath.toLowerCase().split('.').pop();
+  const type = mediaType || inferMediaType(ext);
+
+  switch (type) {
+    case 'image':
+      return {
+        payload: { image: buffer, caption: caption || undefined, mimetype: MIME_MAP[ext] || 'image/jpeg' },
+      };
+    case 'video':
+      return {
+        payload: { video: buffer, caption: caption || undefined, mimetype: MIME_MAP[ext] || 'video/mp4' },
+      };
+    case 'audio': {
+      let audioBuffer = buffer;
+      let audioExt = ext;
+      const needsConversion = !['ogg', 'opus'].includes(ext);
+      let tmpPath = null;
+      let warning = null;
+
+      if (needsConversion) {
+        tmpPath = makeTempPath(filePath);
+        try {
+          exec(
+            `ffmpeg -y -i ${JSON.stringify(filePath)} -ar 48000 -ac 1 -c:a libopus ${JSON.stringify(tmpPath)}`,
+            { timeout: 30000, stdio: 'pipe' },
+          );
+          audioBuffer = readFile(tmpPath);
+          audioExt = 'ogg';
+        } catch (convErr) {
+          warning = convErr?.message || String(convErr);
+        } finally {
+          try {
+            if (tmpPath && exists(tmpPath)) remove(tmpPath);
+          } catch (_) {}
+        }
+      }
+
+      const isVoiceNote = audioExt === 'ogg' || audioExt === 'opus';
+      return {
+        payload: {
+          audio: audioBuffer,
+          mimetype: isVoiceNote ? 'audio/ogg; codecs=opus' : 'audio/mpeg',
+          ptt: isVoiceNote,
+        },
+        warning,
+      };
+    }
+    case 'document':
+    default:
+      return {
+        payload: {
+          document: buffer,
+          fileName: fileName || path.basename(filePath),
+          caption: caption || undefined,
+          mimetype: MIME_MAP[ext] || 'application/octet-stream',
+        },
+      };
+  }
+}

--- a/scripts/whatsapp-bridge/media-payload.test.mjs
+++ b/scripts/whatsapp-bridge/media-payload.test.mjs
@@ -62,6 +62,12 @@ test('buildMediaPayload converts non-Opus audio to a native voice note when ffmp
 
     assert.equal(warning, null);
     assert.match(execCommand, /^ffmpeg -y -i /);
+    assert.match(execCommand, / -ar 48000 /);
+    assert.match(execCommand, / -ac 1 /);
+    assert.match(execCommand, / -c:a libopus /);
+    assert.match(execCommand, / -b:a 32k /);
+    assert.match(execCommand, / -vbr on /);
+    assert.match(execCommand, / -application voip /);
     assert.deepEqual(payload.audio, converted);
     assert.equal(payload.mimetype, 'audio/ogg; codecs=opus');
     assert.equal(payload.ptt, true);

--- a/scripts/whatsapp-bridge/media-payload.test.mjs
+++ b/scripts/whatsapp-bridge/media-payload.test.mjs
@@ -1,0 +1,96 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+
+import { buildMediaPayload, inferMediaType } from './media-payload.js';
+
+function withTempDir(fn) {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'hermes-wa-media-'));
+  try {
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+for (const ext of ['ogg', 'opus']) {
+  test(`buildMediaPayload sends .${ext} audio as a native voice note without ffmpeg`, () => {
+    withTempDir((dir) => {
+      const filePath = path.join(dir, `reply.${ext}`);
+      const original = Buffer.from(`voice-${ext}`);
+      writeFileSync(filePath, original);
+
+      const { payload, warning } = buildMediaPayload({
+        filePath,
+        exec: () => {
+          throw new Error('ffmpeg should not run');
+        },
+      });
+
+      assert.equal(warning, null);
+      assert.deepEqual(payload.audio, original);
+      assert.equal(payload.mimetype, 'audio/ogg; codecs=opus');
+      assert.equal(payload.ptt, true);
+    });
+  });
+}
+
+test('buildMediaPayload converts non-Opus audio to a native voice note when ffmpeg succeeds', () => {
+  withTempDir((dir) => {
+    const filePath = path.join(dir, 'reply.mp3');
+    const tmpPath = path.join(dir, 'reply-converted.ogg');
+    const converted = Buffer.from('converted-opus');
+    writeFileSync(filePath, Buffer.from('original-mp3'));
+    let execCommand = '';
+    let cleaned = false;
+
+    const { payload, warning } = buildMediaPayload({
+      filePath,
+      makeTempPath: () => tmpPath,
+      exec: (command, options) => {
+        execCommand = command;
+        assert.deepEqual(options, { timeout: 30000, stdio: 'pipe' });
+        writeFileSync(tmpPath, converted);
+      },
+      remove: (target) => {
+        assert.equal(target, tmpPath);
+        cleaned = true;
+      },
+    });
+
+    assert.equal(warning, null);
+    assert.match(execCommand, /^ffmpeg -y -i /);
+    assert.deepEqual(payload.audio, converted);
+    assert.equal(payload.mimetype, 'audio/ogg; codecs=opus');
+    assert.equal(payload.ptt, true);
+    assert.equal(cleaned, true);
+  });
+});
+
+test('buildMediaPayload falls back to original audio when ffmpeg conversion fails', () => {
+  withTempDir((dir) => {
+    const filePath = path.join(dir, 'reply.mp3');
+    const original = Buffer.from('original-mp3');
+    writeFileSync(filePath, original);
+
+    const { payload, warning } = buildMediaPayload({
+      filePath,
+      makeTempPath: () => path.join(dir, 'reply-converted.ogg'),
+      exec: () => {
+        throw new Error('missing ffmpeg');
+      },
+    });
+
+    assert.equal(warning, 'missing ffmpeg');
+    assert.deepEqual(payload.audio, original);
+    assert.equal(payload.mimetype, 'audio/mpeg');
+    assert.equal(payload.ptt, false);
+  });
+});
+
+test('inferMediaType classifies WhatsApp voice-note formats as audio', () => {
+  assert.equal(inferMediaType('ogg'), 'audio');
+  assert.equal(inferMediaType('opus'), 'audio');
+});

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -542,6 +542,92 @@ class TestCallingSidecarClient:
         assert result.raw_response == {"error": "sample_rate must be 48000"}
 
     @pytest.mark.asyncio
+    async def test_receive_calling_sidecar_audio_drains_pcm_payload(self):
+        adapter = _make_adapter(
+            calling_sidecar_url="http://127.0.0.1:8787",
+            calling_sidecar_timeout=2.5,
+        )
+        adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(
+                200,
+                {
+                    "call_id": "wacid.call/with/slash",
+                    "returned_bytes": 4,
+                    "queued_rx_bytes": 8,
+                    "pcm_s16le_base64": base64.b64encode(
+                        b"\x01\x00\xff\xff"
+                    ).decode("ascii"),
+                    "audio": {
+                        "sample_rate": 48000,
+                        "channels": 1,
+                        "frame_ms": 20,
+                        "encoding": "pcm_s16le",
+                    },
+                },
+            )
+        )
+
+        audio = await adapter._receive_calling_sidecar_audio(
+            "wacid.call/with/slash",
+            max_bytes=4,
+        )
+
+        assert audio is not None
+        assert audio.call_id == "wacid.call/with/slash"
+        assert audio.pcm_s16le == b"\x01\x00\xff\xff"
+        assert audio.returned_bytes == 4
+        assert audio.queued_rx_bytes == 8
+        assert audio.audio["encoding"] == "pcm_s16le"
+        call = adapter._http_client.get.call_args
+        assert call.args[0] == (
+            "http://127.0.0.1:8787/calls/wacid.call%2Fwith%2Fslash/audio"
+        )
+        assert call.kwargs["params"] == {"max_bytes": 4}
+        assert call.kwargs["timeout"] == 2.5
+
+    @pytest.mark.asyncio
+    async def test_receive_calling_sidecar_audio_requires_sidecar(self):
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock()
+
+        audio = await adapter._receive_calling_sidecar_audio("call-1")
+
+        assert audio is None
+        adapter._http_client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_receive_calling_sidecar_audio_rejects_partial_sample_request(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock()
+
+        audio = await adapter._receive_calling_sidecar_audio("call-1", max_bytes=1)
+
+        assert audio is None
+        adapter._http_client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_receive_calling_sidecar_audio_rejects_bad_sidecar_payload(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(
+                200,
+                {
+                    "returned_bytes": 99,
+                    "queued_rx_bytes": 0,
+                    "pcm_s16le_base64": base64.b64encode(b"\x00\x00").decode("ascii"),
+                },
+            )
+        )
+
+        audio = await adapter._receive_calling_sidecar_audio("call-1")
+
+        assert audio is None
+
+    @pytest.mark.asyncio
     async def test_close_calling_sidecar_session_posts_close(self):
         adapter = _make_adapter(
             calling_sidecar_url="http://127.0.0.1:8787",

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -426,6 +426,55 @@ class TestCallingSidecarClient:
 
         assert answer is None
 
+    @pytest.mark.asyncio
+    async def test_send_call_action_posts_session_answer(self):
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(200, {"success": True})
+        )
+
+        result = await adapter._send_call_action(
+            "wacid.call-1",
+            "pre_accept",
+            sdp="v=0\r\n",
+        )
+
+        assert result.success is True
+        call = adapter._http_client.post.call_args
+        assert call.args[0] == "https://graph.facebook.com/v20.0/1234567890/calls"
+        assert call.kwargs["headers"]["Authorization"] == "Bearer test-token"
+        assert call.kwargs["json"] == {
+            "messaging_product": "whatsapp",
+            "call_id": "wacid.call-1",
+            "action": "pre_accept",
+            "session": {
+                "sdp_type": "answer",
+                "sdp": "v=0\r\n",
+            },
+        }
+
+    @pytest.mark.asyncio
+    async def test_send_call_action_returns_graph_error(self):
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(
+                400,
+                {
+                    "error": {
+                        "code": 100,
+                        "message": "Invalid call id",
+                    }
+                },
+            )
+        )
+
+        result = await adapter._send_call_action("bad-call", "accept", sdp="v=0\r\n")
+
+        assert result.success is False
+        assert "graph error 100" in result.error
+
 
 # ---------------------------------------------------------------------------
 # Inbound webhook verify (GET) handshake
@@ -565,6 +614,51 @@ _SAMPLE_INBOUND_TEXT_PAYLOAD = {
                                 "timestamp": "1758254144",
                                 "text": {"body": "Hi!"},
                                 "type": "text",
+                            }
+                        ],
+                    },
+                }
+            ],
+        }
+    ],
+}
+
+
+_SAMPLE_CALL_CONNECT_PAYLOAD = {
+    "object": "whatsapp_business_account",
+    "entry": [
+        {
+            "id": "215589313241560883",
+            "changes": [
+                {
+                    "field": "calls",
+                    "value": {
+                        "messaging_product": "whatsapp",
+                        "metadata": {
+                            "display_phone_number": "15551797781",
+                            "phone_number_id": "7794189252778687",
+                        },
+                        "contacts": [
+                            {
+                                "profile": {"name": "Jessica Laverdetman"},
+                                "wa_id": "13557825698",
+                            }
+                        ],
+                        "calls": [
+                            {
+                                "id": "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh",
+                                "from": "13557825698",
+                                "to": "15551797781",
+                                "event": "connect",
+                                "timestamp": "1762216151",
+                                "direction": "USER_INITIATED",
+                                "session": {
+                                    "sdp_type": "offer",
+                                    "sdp": (
+                                        "v=0\r\n"
+                                        "m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n"
+                                    ),
+                                },
                             }
                         ],
                     },
@@ -825,6 +919,125 @@ class TestWebhookDispatch:
         )
         assert response.status == 200
         adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_call_connect_without_sidecar_does_not_dispatch_message(self):
+        adapter = _make_adapter(app_secret="key")
+        adapter.handle_message = AsyncMock()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock()
+        body = json.dumps(_SAMPLE_CALL_CONNECT_PAYLOAD).encode("utf-8")
+        sig = _sign("key", body)
+
+        response = await adapter._handle_webhook(
+            _post_request(body, {"X-Hub-Signature-256": sig})
+        )
+
+        assert response.status == 200
+        adapter.handle_message.assert_not_called()
+        adapter._http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_call_connect_routes_offer_to_sidecar_and_accepts(self):
+        adapter = _make_adapter(
+            app_secret="key",
+            calling_sidecar_url="http://127.0.0.1:8787",
+        )
+        adapter.handle_message = AsyncMock()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(side_effect=[
+            _mock_httpx_response(
+                200,
+                {
+                    "call_id": "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh",
+                    "type": "answer",
+                    "sdp": "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
+                    "audio": {
+                        "codec": "opus",
+                        "sample_rate": 48000,
+                        "channels": 1,
+                        "frame_ms": 20,
+                    },
+                },
+            ),
+            _mock_httpx_response(200, {"success": True}),
+            _mock_httpx_response(200, {"success": True}),
+        ])
+        body = json.dumps(_SAMPLE_CALL_CONNECT_PAYLOAD).encode("utf-8")
+        sig = _sign("key", body)
+
+        response = await adapter._handle_webhook(
+            _post_request(body, {"X-Hub-Signature-256": sig})
+        )
+
+        assert response.status == 200
+        adapter.handle_message.assert_not_called()
+        assert adapter._http_client.post.call_count == 3
+
+        sidecar_call = adapter._http_client.post.call_args_list[0]
+        assert sidecar_call.args[0] == "http://127.0.0.1:8787/offer"
+        assert sidecar_call.kwargs["json"] == {
+            "call_id": "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh",
+            "type": "offer",
+            "sdp": "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
+        }
+
+        pre_accept_call = adapter._http_client.post.call_args_list[1]
+        accept_call = adapter._http_client.post.call_args_list[2]
+        assert pre_accept_call.args[0].endswith("/calls")
+        assert accept_call.args[0].endswith("/calls")
+        assert pre_accept_call.kwargs["json"]["action"] == "pre_accept"
+        assert accept_call.kwargs["json"]["action"] == "accept"
+        assert pre_accept_call.kwargs["json"]["session"] == {
+            "sdp_type": "answer",
+            "sdp": "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
+        }
+        assert accept_call.kwargs["json"]["session"] == {
+            "sdp_type": "answer",
+            "sdp": "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
+        }
+
+    @pytest.mark.asyncio
+    async def test_call_connect_sidecar_failure_skips_graph_accept(self):
+        adapter = _make_adapter(
+            app_secret="key",
+            calling_sidecar_url="http://127.0.0.1:8787",
+        )
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(503, {"error": "down"})
+        )
+        body = json.dumps(_SAMPLE_CALL_CONNECT_PAYLOAD).encode("utf-8")
+        sig = _sign("key", body)
+
+        response = await adapter._handle_webhook(
+            _post_request(body, {"X-Hub-Signature-256": sig})
+        )
+
+        assert response.status == 200
+        assert adapter._http_client.post.call_count == 1
+        assert adapter._http_client.post.call_args.args[0].endswith("/offer")
+
+    @pytest.mark.asyncio
+    async def test_call_connect_malformed_offer_skips_sidecar(self):
+        adapter = _make_adapter(
+            app_secret="key",
+            calling_sidecar_url="http://127.0.0.1:8787",
+        )
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock()
+        payload = json.loads(json.dumps(_SAMPLE_CALL_CONNECT_PAYLOAD))
+        session = payload["entry"][0]["changes"][0]["value"]["calls"][0]["session"]
+        session["sdp_type"] = "answer"
+        body = json.dumps(payload).encode("utf-8")
+        sig = _sign("key", body)
+
+        response = await adapter._handle_webhook(
+            _post_request(body, {"X-Hub-Signature-256": sig})
+        )
+
+        assert response.status == 200
+        adapter._http_client.post.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_dispatch_handles_button_reply(self):

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -1131,6 +1131,33 @@ class TestSendDocument:
 class TestSendVoice:
     """Local non-Opus audio converts to Opus; fallback sends the original."""
 
+    @pytest.mark.parametrize("suffix", [".ogg", ".opus"])
+    @pytest.mark.asyncio
+    async def test_send_voice_native_opus_uploads_without_conversion(self, suffix):
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(side_effect=[
+            _mock_upload_response("voice_id"),
+            _mock_message_response(),
+        ])
+        adapter._convert_to_opus = AsyncMock()
+
+        path = _tmpfile(suffix, content=b"OggS")
+        try:
+            result = await adapter.send_voice("15551234567", path)
+            assert result.success is True
+            adapter._convert_to_opus.assert_not_awaited()
+
+            upload_files = adapter._http_client.post.call_args_list[0].kwargs["files"]
+            assert upload_files["file"][2] == "audio/ogg; codecs=opus"
+            assert upload_files["type"] == (None, "audio/ogg; codecs=opus")
+
+            send_payload = adapter._http_client.post.call_args_list[1].kwargs["json"]
+            assert send_payload["type"] == "audio"
+            assert send_payload["audio"]["id"] == "voice_id"
+        finally:
+            _os.unlink(path)
+
     @pytest.mark.asyncio
     async def test_send_voice_no_ffmpeg_falls_back_to_mp3(self):
         adapter = _make_adapter()

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -752,7 +752,14 @@ class TestCallingSidecarClient:
         adapter._http_client.post = AsyncMock(
             return_value=_mock_httpx_response(
                 200,
-                {"accepted_bytes": 4, "queued_tx_bytes": 4},
+                {
+                    "accepted_bytes": "4",
+                    "accepted_ms": "1",
+                    "queued_tx_bytes": "4",
+                    "queued_tx_ms": "1",
+                    "max_tx_queue_bytes": "960000",
+                    "max_tx_queue_ms": "10000",
+                },
             )
         )
 
@@ -763,7 +770,14 @@ class TestCallingSidecarClient:
         )
 
         assert result.success is True
-        assert result.raw_response == {"accepted_bytes": 4, "queued_tx_bytes": 4}
+        assert result.raw_response == {
+            "accepted_bytes": 4,
+            "accepted_ms": 1,
+            "queued_tx_bytes": 4,
+            "queued_tx_ms": 1,
+            "max_tx_queue_bytes": 960000,
+            "max_tx_queue_ms": 10000,
+        }
         call = adapter._http_client.post.call_args
         assert call.args[0] == (
             "http://127.0.0.1:8787/calls/wacid.call%2Fwith%2Fslash/audio"
@@ -827,6 +841,25 @@ class TestCallingSidecarClient:
         assert result.retryable is True
 
     @pytest.mark.asyncio
+    async def test_send_calling_sidecar_audio_rejects_invalid_latency_telemetry(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(
+                200,
+                {
+                    "accepted_bytes": 4,
+                    "queued_tx_ms": "soon",
+                },
+            )
+        )
+
+        result = await adapter._send_calling_sidecar_audio("call-1", b"\x00\x00")
+
+        assert result.success is False
+        assert "queued_tx_ms must be an integer" in result.error
+
+    @pytest.mark.asyncio
     async def test_clear_calling_sidecar_audio_posts_contract_endpoint(self):
         contract = {
             "contract": "voice.webrtc_sidecar",
@@ -851,14 +884,28 @@ class TestCallingSidecarClient:
         adapter._http_client.post = AsyncMock(
             return_value=_mock_httpx_response(
                 200,
-                {"dropped_tx_bytes": 3840, "queued_tx_bytes": 0},
+                {
+                    "dropped_tx_bytes": "3840",
+                    "dropped_tx_ms": "40",
+                    "queued_tx_bytes": "0",
+                    "queued_tx_ms": "0",
+                    "max_tx_queue_bytes": "960000",
+                    "max_tx_queue_ms": "10000",
+                },
             )
         )
 
         result = await adapter._clear_calling_sidecar_audio("call/1")
 
         assert result.success is True
-        assert result.raw_response == {"dropped_tx_bytes": 3840, "queued_tx_bytes": 0}
+        assert result.raw_response == {
+            "dropped_tx_bytes": 3840,
+            "dropped_tx_ms": 40,
+            "queued_tx_bytes": 0,
+            "queued_tx_ms": 0,
+            "max_tx_queue_bytes": 960000,
+            "max_tx_queue_ms": 10000,
+        }
         call = adapter._http_client.post.call_args
         assert call.args[0] == "http://127.0.0.1:8787/v1/calls/call%2F1/clear-audio"
         assert call.kwargs["timeout"] == 2.5
@@ -1031,7 +1078,11 @@ class TestCallingSidecarClient:
                 {
                     "call_id": "wacid.call/with/slash",
                     "returned_bytes": 4,
+                    "returned_ms": 1,
                     "queued_rx_bytes": 8,
+                    "queued_rx_ms": 1,
+                    "max_rx_queue_bytes": 960000,
+                    "max_rx_queue_ms": 10000,
                     "pcm_s16le_base64": base64.b64encode(
                         b"\x01\x00\xff\xff"
                     ).decode("ascii"),
@@ -1054,7 +1105,11 @@ class TestCallingSidecarClient:
         assert audio.call_id == "wacid.call/with/slash"
         assert audio.pcm_s16le == b"\x01\x00\xff\xff"
         assert audio.returned_bytes == 4
+        assert audio.returned_ms == 1
         assert audio.queued_rx_bytes == 8
+        assert audio.queued_rx_ms == 1
+        assert audio.max_rx_queue_bytes == 960000
+        assert audio.max_rx_queue_ms == 10000
         assert audio.audio["encoding"] == "pcm_s16le"
         call = adapter._http_client.get.call_args
         assert call.args[0] == (
@@ -1134,6 +1189,32 @@ class TestCallingSidecarClient:
                     "returned_bytes": 99,
                     "queued_rx_bytes": 0,
                     "pcm_s16le_base64": base64.b64encode(b"\x00\x00").decode("ascii"),
+                },
+            )
+        )
+
+        audio = await adapter._receive_calling_sidecar_audio("call-1")
+
+        assert audio is None
+
+    @pytest.mark.asyncio
+    async def test_receive_calling_sidecar_audio_rejects_bad_latency_telemetry(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(
+                200,
+                {
+                    "returned_bytes": 2,
+                    "queued_rx_bytes": 0,
+                    "queued_rx_ms": -1,
+                    "pcm_s16le_base64": base64.b64encode(b"\x00\x00").decode("ascii"),
+                    "audio": {
+                        "sample_rate": 48000,
+                        "channels": 1,
+                        "frame_ms": 20,
+                        "encoding": "pcm_s16le",
+                    },
                 },
             )
         )

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -53,6 +53,7 @@ def _make_adapter(**overrides):
     adapter._calling_sidecar_timeout = overrides.pop("calling_sidecar_timeout", 10.0)
     adapter._runner = None
     adapter._http_client = None
+    adapter._calling_sidecar_call_ids = set()
 
     # Behavior-mixin contract
     adapter._reply_prefix = None
@@ -803,6 +804,7 @@ class TestCallingSidecarClient:
             calling_sidecar_url="http://127.0.0.1:8787",
             calling_sidecar_timeout=2.5,
         )
+        adapter._calling_sidecar_call_ids.add("wacid.call/with/slash")
         adapter._http_client = MagicMock()
         adapter._http_client.post = AsyncMock(
             return_value=_mock_httpx_response(200, {"closed": True})
@@ -816,10 +818,12 @@ class TestCallingSidecarClient:
             "http://127.0.0.1:8787/calls/wacid.call%2Fwith%2Fslash/close"
         )
         assert call.kwargs["timeout"] == 2.5
+        assert adapter._calling_sidecar_call_ids == set()
 
     @pytest.mark.asyncio
     async def test_close_calling_sidecar_session_treats_404_as_closed(self):
         adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._calling_sidecar_call_ids.add("wacid.missing")
         adapter._http_client = MagicMock()
         adapter._http_client.post = AsyncMock(
             return_value=_mock_httpx_response(404, {"error": "unknown call_id"})
@@ -828,6 +832,29 @@ class TestCallingSidecarClient:
         closed = await adapter._close_calling_sidecar_session("wacid.missing")
 
         assert closed is True
+        assert adapter._calling_sidecar_call_ids == set()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_closes_tracked_sidecar_sessions_before_http_close(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._calling_sidecar_call_ids.update({"wacid.two", "wacid.one"})
+        http_client = MagicMock()
+        http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(200, {"closed": True})
+        )
+        http_client.aclose = AsyncMock()
+        adapter._http_client = http_client
+
+        await adapter.disconnect()
+
+        assert adapter._http_client is None
+        posted_urls = [call.args[0] for call in http_client.post.call_args_list]
+        assert posted_urls == [
+            "http://127.0.0.1:8787/calls/wacid.one/close",
+            "http://127.0.0.1:8787/calls/wacid.two/close",
+        ]
+        http_client.aclose.assert_awaited_once()
+        assert adapter._calling_sidecar_call_ids == set()
 
 
 # ---------------------------------------------------------------------------
@@ -1383,6 +1410,9 @@ class TestWebhookDispatch:
             "sdp_type": "answer",
             "sdp": "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
         }
+        assert adapter._calling_sidecar_call_ids == {
+            "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh"
+        }
 
     @pytest.mark.asyncio
     async def test_call_connect_sidecar_failure_skips_graph_accept(self):
@@ -1444,6 +1474,7 @@ class TestWebhookDispatch:
             "http://127.0.0.1:8787/calls/"
             "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh/close"
         )
+        assert adapter._calling_sidecar_call_ids == set()
 
     @pytest.mark.asyncio
     async def test_call_connect_accept_failure_closes_sidecar(self):
@@ -1486,6 +1517,7 @@ class TestWebhookDispatch:
             "http://127.0.0.1:8787/calls/"
             "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh/close"
         )
+        assert adapter._calling_sidecar_call_ids == set()
 
     @pytest.mark.asyncio
     async def test_call_connect_malformed_offer_skips_sidecar(self):
@@ -1515,6 +1547,7 @@ class TestWebhookDispatch:
             calling_sidecar_url="http://127.0.0.1:8787",
         )
         adapter.handle_message = AsyncMock()
+        adapter._calling_sidecar_call_ids.add("wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh")
         adapter._http_client = MagicMock()
         adapter._http_client.post = AsyncMock(
             return_value=_mock_httpx_response(200, {"closed": True})
@@ -1533,6 +1566,7 @@ class TestWebhookDispatch:
             "http://127.0.0.1:8787/calls/"
             "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh/close"
         )
+        assert adapter._calling_sidecar_call_ids == set()
 
     @pytest.mark.asyncio
     async def test_call_terminate_without_sidecar_skips_http(self):

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -475,6 +475,38 @@ class TestCallingSidecarClient:
         assert result.success is False
         assert "graph error 100" in result.error
 
+    @pytest.mark.asyncio
+    async def test_close_calling_sidecar_session_posts_close(self):
+        adapter = _make_adapter(
+            calling_sidecar_url="http://127.0.0.1:8787",
+            calling_sidecar_timeout=2.5,
+        )
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(200, {"closed": True})
+        )
+
+        closed = await adapter._close_calling_sidecar_session("wacid.call/with/slash")
+
+        assert closed is True
+        call = adapter._http_client.post.call_args
+        assert call.args[0] == (
+            "http://127.0.0.1:8787/calls/wacid.call%2Fwith%2Fslash/close"
+        )
+        assert call.kwargs["timeout"] == 2.5
+
+    @pytest.mark.asyncio
+    async def test_close_calling_sidecar_session_treats_404_as_closed(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(404, {"error": "unknown call_id"})
+        )
+
+        closed = await adapter._close_calling_sidecar_session("wacid.missing")
+
+        assert closed is True
+
 
 # ---------------------------------------------------------------------------
 # Inbound webhook verify (GET) handshake
@@ -659,6 +691,39 @@ _SAMPLE_CALL_CONNECT_PAYLOAD = {
                                         "m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n"
                                     ),
                                 },
+                            }
+                        ],
+                    },
+                }
+            ],
+        }
+    ],
+}
+
+
+_SAMPLE_CALL_TERMINATE_PAYLOAD = {
+    "object": "whatsapp_business_account",
+    "entry": [
+        {
+            "id": "215589313241560883",
+            "changes": [
+                {
+                    "field": "calls",
+                    "value": {
+                        "messaging_product": "whatsapp",
+                        "metadata": {
+                            "display_phone_number": "15551797781",
+                            "phone_number_id": "7794189252778687",
+                        },
+                        "calls": [
+                            {
+                                "id": "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh",
+                                "from": "13557825698",
+                                "to": "15551797781",
+                                "event": "terminate",
+                                "timestamp": "1762216199",
+                                "direction": "USER_INITIATED",
+                                "status": "COMPLETED",
                             }
                         ],
                     },
@@ -1030,6 +1095,47 @@ class TestWebhookDispatch:
         session = payload["entry"][0]["changes"][0]["value"]["calls"][0]["session"]
         session["sdp_type"] = "answer"
         body = json.dumps(payload).encode("utf-8")
+        sig = _sign("key", body)
+
+        response = await adapter._handle_webhook(
+            _post_request(body, {"X-Hub-Signature-256": sig})
+        )
+
+        assert response.status == 200
+        adapter._http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_call_terminate_closes_sidecar_session(self):
+        adapter = _make_adapter(
+            app_secret="key",
+            calling_sidecar_url="http://127.0.0.1:8787",
+        )
+        adapter.handle_message = AsyncMock()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(200, {"closed": True})
+        )
+        body = json.dumps(_SAMPLE_CALL_TERMINATE_PAYLOAD).encode("utf-8")
+        sig = _sign("key", body)
+
+        response = await adapter._handle_webhook(
+            _post_request(body, {"X-Hub-Signature-256": sig})
+        )
+
+        assert response.status == 200
+        adapter.handle_message.assert_not_called()
+        adapter._http_client.post.assert_awaited_once()
+        assert adapter._http_client.post.call_args.args[0] == (
+            "http://127.0.0.1:8787/calls/"
+            "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh/close"
+        )
+
+    @pytest.mark.asyncio
+    async def test_call_terminate_without_sidecar_skips_http(self):
+        adapter = _make_adapter(app_secret="key")
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock()
+        body = json.dumps(_SAMPLE_CALL_TERMINATE_PAYLOAD).encode("utf-8")
         sig = _sign("key", body)
 
         response = await adapter._handle_webhook(

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -1406,6 +1406,88 @@ class TestWebhookDispatch:
         assert adapter._http_client.post.call_args.args[0].endswith("/offer")
 
     @pytest.mark.asyncio
+    async def test_call_connect_pre_accept_failure_closes_sidecar(self):
+        adapter = _make_adapter(
+            app_secret="key",
+            calling_sidecar_url="http://127.0.0.1:8787",
+        )
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(side_effect=[
+            _mock_httpx_response(
+                200,
+                {
+                    "call_id": "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh",
+                    "type": "answer",
+                    "sdp": "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
+                    "audio": {
+                        "sample_rate": 48000,
+                        "channels": 1,
+                        "frame_ms": 20,
+                        "encoding": "pcm_s16le",
+                    },
+                },
+            ),
+            _mock_httpx_response(500, {"error": {"message": "pre_accept failed"}}),
+            _mock_httpx_response(200, {"closed": True}),
+        ])
+        body = json.dumps(_SAMPLE_CALL_CONNECT_PAYLOAD).encode("utf-8")
+        sig = _sign("key", body)
+
+        response = await adapter._handle_webhook(
+            _post_request(body, {"X-Hub-Signature-256": sig})
+        )
+
+        assert response.status == 200
+        assert adapter._http_client.post.call_count == 3
+        assert adapter._http_client.post.call_args_list[1].kwargs["json"]["action"] == "pre_accept"
+        assert adapter._http_client.post.call_args_list[2].args[0] == (
+            "http://127.0.0.1:8787/calls/"
+            "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh/close"
+        )
+
+    @pytest.mark.asyncio
+    async def test_call_connect_accept_failure_closes_sidecar(self):
+        adapter = _make_adapter(
+            app_secret="key",
+            calling_sidecar_url="http://127.0.0.1:8787",
+        )
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(side_effect=[
+            _mock_httpx_response(
+                200,
+                {
+                    "call_id": "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh",
+                    "type": "answer",
+                    "sdp": "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
+                    "audio": {
+                        "sample_rate": 48000,
+                        "channels": 1,
+                        "frame_ms": 20,
+                        "encoding": "pcm_s16le",
+                    },
+                },
+            ),
+            _mock_httpx_response(200, {"success": True}),
+            _mock_httpx_response(500, {"error": {"message": "accept failed"}}),
+            _mock_httpx_response(200, {"closed": True}),
+        ])
+        body = json.dumps(_SAMPLE_CALL_CONNECT_PAYLOAD).encode("utf-8")
+        sig = _sign("key", body)
+
+        response = await adapter._handle_webhook(
+            _post_request(body, {"X-Hub-Signature-256": sig})
+        )
+
+        assert response.status == 200
+        assert adapter._http_client.post.call_count == 4
+        assert adapter._http_client.post.call_args_list[1].kwargs["json"]["action"] == "pre_accept"
+        assert adapter._http_client.post.call_args_list[2].kwargs["json"]["action"] == "accept"
+        assert adapter._http_client.post.call_args_list[3].args[0] == (
+            "http://127.0.0.1:8787/calls/"
+            "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh/close"
+        )
+
+    @pytest.mark.asyncio
     async def test_call_connect_malformed_offer_skips_sidecar(self):
         adapter = _make_adapter(
             app_secret="key",

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -908,6 +908,122 @@ class TestCallingSidecarClient:
                 except OSError:
                     pass
 
+    def test_calling_sidecar_pcm_speech_gate_ignores_silence(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        silence = b"\x00\x00" * 960
+        speech = (1000).to_bytes(2, "little", signed=True) * 960
+
+        assert adapter._calling_sidecar_pcm_peak(silence) == 0
+        assert adapter._calling_sidecar_pcm_has_speech(silence) is False
+        assert adapter._calling_sidecar_pcm_peak(speech) == 1000
+        assert adapter._calling_sidecar_pcm_has_speech(speech) is True
+
+    @pytest.mark.asyncio
+    async def test_calling_sidecar_audio_loop_ignores_pure_silence(self):
+        from gateway.platforms.whatsapp_cloud import (
+            CALLING_AUDIO_CONTRACT,
+            CALLING_PCM_DEFAULT_DRAIN_BYTES,
+            CallingSidecarAudio,
+        )
+
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._calling_sidecar_call_ids.add("call-1")
+        adapter._dispatch_calling_sidecar_pcm = AsyncMock()
+        silence = b"\x00" * CALLING_PCM_DEFAULT_DRAIN_BYTES
+        responses = [
+            CallingSidecarAudio(
+                call_id="call-1",
+                pcm_s16le=silence,
+                returned_bytes=len(silence),
+                queued_rx_bytes=0,
+                audio=dict(CALLING_AUDIO_CONTRACT),
+            ),
+            CallingSidecarAudio(
+                call_id="call-1",
+                pcm_s16le=silence,
+                returned_bytes=len(silence),
+                queued_rx_bytes=0,
+                audio=dict(CALLING_AUDIO_CONTRACT),
+            ),
+        ]
+
+        async def receive(_call_id):
+            if responses:
+                return responses.pop(0)
+            adapter._calling_sidecar_call_ids.discard("call-1")
+            return None
+
+        adapter._receive_calling_sidecar_audio = receive
+
+        await adapter._run_calling_sidecar_audio_loop(
+            "call-1",
+            "13557825698",
+            "Jessica Laverdetman",
+        )
+
+        adapter._dispatch_calling_sidecar_pcm.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_calling_sidecar_audio_loop_flushes_speech_after_silence(self):
+        from gateway.platforms.whatsapp_cloud import (
+            CALLING_AUDIO_CONTRACT,
+            CALLING_PCM_DEFAULT_DRAIN_BYTES,
+            CallingSidecarAudio,
+        )
+
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._calling_sidecar_call_ids.add("call-1")
+        adapter._dispatch_calling_sidecar_pcm = AsyncMock()
+        speech = (
+            (1000).to_bytes(2, "little", signed=True)
+            * (CALLING_PCM_DEFAULT_DRAIN_BYTES // 2)
+        )
+        silence = b"\x00" * CALLING_PCM_DEFAULT_DRAIN_BYTES
+        responses = [
+            CallingSidecarAudio(
+                call_id="call-1",
+                pcm_s16le=speech,
+                returned_bytes=len(speech),
+                queued_rx_bytes=0,
+                audio=dict(CALLING_AUDIO_CONTRACT),
+            ),
+            CallingSidecarAudio(
+                call_id="call-1",
+                pcm_s16le=silence,
+                returned_bytes=len(silence),
+                queued_rx_bytes=0,
+                audio=dict(CALLING_AUDIO_CONTRACT),
+            ),
+            CallingSidecarAudio(
+                call_id="call-1",
+                pcm_s16le=silence,
+                returned_bytes=len(silence),
+                queued_rx_bytes=0,
+                audio=dict(CALLING_AUDIO_CONTRACT),
+            ),
+        ]
+
+        async def receive(_call_id):
+            if responses:
+                return responses.pop(0)
+            adapter._calling_sidecar_call_ids.discard("call-1")
+            return None
+
+        adapter._receive_calling_sidecar_audio = receive
+
+        await adapter._run_calling_sidecar_audio_loop(
+            "call-1",
+            "13557825698",
+            "Jessica Laverdetman",
+        )
+
+        adapter._dispatch_calling_sidecar_pcm.assert_awaited_once()
+        call = adapter._dispatch_calling_sidecar_pcm.call_args
+        assert call.args[:3] == ("call-1", "13557825698", "Jessica Laverdetman")
+        dispatched_pcm = call.args[3]
+        assert dispatched_pcm.startswith(speech)
+        assert len(dispatched_pcm) == len(speech) + len(silence)
+
     @pytest.mark.asyncio
     async def test_close_calling_sidecar_session_posts_close(self):
         adapter = _make_adapter(

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -48,6 +48,8 @@ def _make_adapter(**overrides):
     adapter._webhook_path = "/whatsapp/webhook"
     adapter._health_path = "/health"
     adapter._api_version = overrides.pop("api_version", "v20.0")
+    adapter._calling_sidecar_url = overrides.pop("calling_sidecar_url", "")
+    adapter._calling_sidecar_timeout = overrides.pop("calling_sidecar_timeout", 10.0)
     adapter._runner = None
     adapter._http_client = None
 
@@ -288,6 +290,141 @@ class TestSendText:
         result = await adapter.send("15551234567", "hi")
         assert result.success is False
         assert "boom" in result.error
+
+
+# ---------------------------------------------------------------------------
+# WhatsApp Calling sidecar client
+# ---------------------------------------------------------------------------
+
+class TestCallingSidecarClient:
+    def test_init_reads_calling_sidecar_config_from_extra(self, monkeypatch):
+        from gateway.platforms.whatsapp_cloud import WhatsAppCloudAdapter
+
+        monkeypatch.delenv("WHATSAPP_CLOUD_CALLING_SIDECAR_URL", raising=False)
+        monkeypatch.delenv("WHATSAPP_CLOUD_CALLING_SIDECAR_TIMEOUT", raising=False)
+
+        config = MagicMock()
+        config.extra = {
+            "phone_number_id": "123",
+            "access_token": "tok",
+            "calling_sidecar_url": "http://127.0.0.1:8787/",
+            "calling_sidecar_timeout": "2.5",
+        }
+
+        adapter = WhatsAppCloudAdapter(config)
+
+        assert adapter._calling_sidecar_url == "http://127.0.0.1:8787"
+        assert adapter._calling_sidecar_timeout == 2.5
+        assert adapter._calling_sidecar_enabled() is True
+
+    def test_gateway_env_overrides_populate_calling_sidecar(self, monkeypatch):
+        from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+
+        monkeypatch.setenv("WHATSAPP_CLOUD_PHONE_NUMBER_ID", "phone-123")
+        monkeypatch.setenv("WHATSAPP_CLOUD_ACCESS_TOKEN", "token-123")
+        monkeypatch.setenv(
+            "WHATSAPP_CLOUD_CALLING_SIDECAR_URL",
+            "http://127.0.0.1:8787",
+        )
+        monkeypatch.setenv("WHATSAPP_CLOUD_CALLING_SIDECAR_TIMEOUT", "4.25")
+
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+
+        extra = config.platforms[Platform.WHATSAPP_CLOUD].extra
+        assert extra["phone_number_id"] == "phone-123"
+        assert extra["access_token"] == "token-123"
+        assert extra["calling_sidecar_url"] == "http://127.0.0.1:8787"
+        assert extra["calling_sidecar_timeout"] == 4.25
+
+    @pytest.mark.asyncio
+    async def test_disabled_without_url(self):
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock()
+
+        answer = await adapter._request_calling_sidecar_answer("call-1", "v=0\r\n")
+
+        assert answer is None
+        adapter._http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_request_posts_offer_and_returns_answer(self):
+        adapter = _make_adapter(
+            calling_sidecar_url="http://127.0.0.1:8787",
+            calling_sidecar_timeout=2.5,
+        )
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(
+                200,
+                {
+                    "call_id": "call-1",
+                    "type": "answer",
+                    "sdp": "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
+                    "audio": {
+                        "codec": "opus",
+                        "sample_rate": 48000,
+                        "channels": 1,
+                        "frame_ms": 20,
+                    },
+                },
+            )
+        )
+
+        answer = await adapter._request_calling_sidecar_answer("call-1", "v=0\r\n")
+
+        assert answer is not None
+        assert answer.call_id == "call-1"
+        assert answer.sdp.startswith("v=0")
+        assert answer.audio["codec"] == "opus"
+        adapter._http_client.post.assert_awaited_once()
+        call = adapter._http_client.post.call_args
+        assert call.args[0] == "http://127.0.0.1:8787/offer"
+        assert call.kwargs["timeout"] == 2.5
+        assert call.kwargs["json"] == {
+            "call_id": "call-1",
+            "type": "offer",
+            "sdp": "v=0\r\n",
+        }
+
+    @pytest.mark.asyncio
+    async def test_request_requires_connected_http_client(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+
+        answer = await adapter._request_calling_sidecar_answer("call-1", "v=0\r\n")
+
+        assert answer is None
+
+    @pytest.mark.asyncio
+    async def test_request_rejects_non_200(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(503, {"error": "sidecar down"})
+        )
+
+        answer = await adapter._request_calling_sidecar_answer("call-1", "v=0\r\n")
+
+        assert answer is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("body", [
+        {"type": "offer", "sdp": "v=0"},
+        {"type": "answer"},
+        {"type": "answer", "sdp": ""},
+        ["not", "an", "object"],
+    ])
+    async def test_request_rejects_invalid_answer(self, body):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(200, body)
+        )
+
+        answer = await adapter._request_calling_sidecar_answer("call-1", "v=0\r\n")
+
+        assert answer is None
 
 
 # ---------------------------------------------------------------------------
@@ -803,6 +940,7 @@ class TestHealth:
         assert body["phone_number_id"] == "555"
         assert body["verify_token_configured"] is True
         assert body["app_secret_configured"] is True
+        assert body["calling_sidecar_configured"] is False
         assert body["accepted"] == 0
         assert body["duplicates"] == 0
         assert body["rejected_signature"] == 0

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import base64
 import asyncio
 import json
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -52,6 +52,14 @@ def _make_adapter(**overrides):
     adapter._api_version = overrides.pop("api_version", "v20.0")
     adapter._calling_sidecar_url = overrides.pop("calling_sidecar_url", "")
     adapter._calling_sidecar_timeout = overrides.pop("calling_sidecar_timeout", 10.0)
+    adapter._calling_sidecar_tts_stream_command = overrides.pop(
+        "calling_sidecar_tts_stream_command",
+        "",
+    )
+    adapter._calling_sidecar_tts_stream_timeout = overrides.pop(
+        "calling_sidecar_tts_stream_timeout",
+        180.0,
+    )
     adapter._runner = None
     adapter._http_client = None
     adapter._calling_sidecar_contract = overrides.pop("calling_sidecar_contract", None)
@@ -102,6 +110,7 @@ def _make_adapter(**overrides):
     adapter._auto_tts_default = False
     adapter._auto_tts_enabled_chats = set()
     adapter._auto_tts_disabled_chats = set()
+    adapter._typing_paused = set()
 
     # Apply any leftover overrides directly
     for key, value in overrides.items():
@@ -314,6 +323,14 @@ class TestCallingSidecarClient:
 
         monkeypatch.delenv("WHATSAPP_CLOUD_CALLING_SIDECAR_URL", raising=False)
         monkeypatch.delenv("WHATSAPP_CLOUD_CALLING_SIDECAR_TIMEOUT", raising=False)
+        monkeypatch.delenv(
+            "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND",
+            raising=False,
+        )
+        monkeypatch.delenv(
+            "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT",
+            raising=False,
+        )
 
         config = MagicMock()
         config.extra = {
@@ -321,12 +338,18 @@ class TestCallingSidecarClient:
             "access_token": "tok",
             "calling_sidecar_url": "http://127.0.0.1:8787/",
             "calling_sidecar_timeout": "2.5",
+            "calling_sidecar_tts_stream_command": (
+                "voice stream --raw-output - --input-file {input_path}"
+            ),
+            "calling_sidecar_tts_stream_timeout": "30",
         }
 
         adapter = WhatsAppCloudAdapter(config)
 
         assert adapter._calling_sidecar_url == "http://127.0.0.1:8787"
         assert adapter._calling_sidecar_timeout == 2.5
+        assert adapter._calling_sidecar_tts_stream_command.startswith("voice stream")
+        assert adapter._calling_sidecar_tts_stream_timeout == 30.0
         assert adapter._calling_sidecar_enabled() is True
 
     def test_gateway_env_overrides_populate_calling_sidecar(self, monkeypatch):
@@ -339,6 +362,14 @@ class TestCallingSidecarClient:
             "http://127.0.0.1:8787",
         )
         monkeypatch.setenv("WHATSAPP_CLOUD_CALLING_SIDECAR_TIMEOUT", "4.25")
+        monkeypatch.setenv(
+            "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND",
+            "voice stream --raw-output - --input-file {input_path}",
+        )
+        monkeypatch.setenv(
+            "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT",
+            "45.5",
+        )
 
         config = GatewayConfig()
         _apply_env_overrides(config)
@@ -348,6 +379,8 @@ class TestCallingSidecarClient:
         assert extra["access_token"] == "token-123"
         assert extra["calling_sidecar_url"] == "http://127.0.0.1:8787"
         assert extra["calling_sidecar_timeout"] == 4.25
+        assert extra["calling_sidecar_tts_stream_command"].startswith("voice stream")
+        assert extra["calling_sidecar_tts_stream_timeout"] == 45.5
 
     @pytest.mark.asyncio
     async def test_disabled_without_url(self):
@@ -792,6 +825,133 @@ class TestCallingSidecarClient:
         assert result.error == "outbound PCM queue is full"
         assert result.raw_response == {"error": "outbound PCM queue is full"}
         assert result.retryable is True
+
+    @pytest.mark.asyncio
+    async def test_play_tts_text_stream_command_posts_pcm_frames(self, monkeypatch):
+        from gateway.platforms.base import SendResult
+
+        frame = b"\x01\x00" * 960
+        chunks = [frame + frame[:100], frame[100:], b""]
+        commands = []
+
+        class FakeStream:
+            def __init__(self, values):
+                self._values = list(values)
+
+            async def read(self, _n=-1):
+                if self._values:
+                    return self._values.pop(0)
+                return b""
+
+        class FakeProc:
+            def __init__(self):
+                self.stdout = FakeStream(chunks)
+                self.stderr = FakeStream([b""])
+                self.returncode = None
+                self.killed = False
+
+            async def wait(self):
+                self.returncode = 0
+                return 0
+
+            def kill(self):
+                self.killed = True
+                self.returncode = -9
+
+        async def fake_create_subprocess_shell(command, **_kwargs):
+            commands.append(command)
+            return FakeProc()
+
+        monkeypatch.setattr(
+            "gateway.platforms.whatsapp_cloud.asyncio.create_subprocess_shell",
+            fake_create_subprocess_shell,
+        )
+        adapter = _make_adapter(
+            calling_sidecar_url="http://127.0.0.1:8787",
+            calling_sidecar_tts_stream_command=(
+                "voice stream --quiet --sample-rate {sample_rate} "
+                "--frame-ms {frame_ms} --raw-output - --input-file {input_path}"
+            ),
+        )
+        adapter._calling_sidecar_call_ids.add("call-1")
+        adapter._send_calling_sidecar_audio = AsyncMock(
+            return_value=SendResult(success=True)
+        )
+
+        result = await adapter.play_tts_text(
+            "15551234567",
+            "Hello from the call",
+            metadata={"thread_id": "call-1"},
+        )
+
+        assert result.success is True
+        assert result.raw_response["frames"] == 2
+        assert result.raw_response["queued_pcm_bytes"] == len(frame) * 2
+        assert commands
+        assert "--sample-rate 48000" in commands[0]
+        assert "--frame-ms 20" in commands[0]
+        assert adapter._send_calling_sidecar_audio.await_count == 2
+        first = adapter._send_calling_sidecar_audio.await_args_list[0]
+        second = adapter._send_calling_sidecar_audio.await_args_list[1]
+        assert first.args == ("call-1", frame)
+        assert first.kwargs["sequence"] == 0
+        assert second.args == ("call-1", frame)
+        assert second.kwargs["sequence"] == 1
+
+    @pytest.mark.asyncio
+    async def test_play_tts_text_without_stream_command_falls_back(self, monkeypatch):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._calling_sidecar_call_ids.add("call-1")
+
+        result = await adapter.play_tts_text(
+            "15551234567",
+            "Hello from the call",
+            metadata={"thread_id": "call-1"},
+        )
+
+        assert result.success is False
+        assert "not configured" in result.error
+
+    @pytest.mark.asyncio
+    async def test_base_auto_tts_uses_direct_text_stream_before_file_tts(self):
+        from gateway.platforms.base import MessageEvent, MessageType, SendResult
+        from gateway.platforms.whatsapp_cloud import WhatsAppCloudAdapter
+        from gateway.session import SessionSource, build_session_key
+
+        config = MagicMock()
+        config.extra = {
+            "phone_number_id": "123",
+            "access_token": "tok",
+            "calling_sidecar_url": "http://127.0.0.1:8787",
+            "calling_sidecar_tts_stream_command": "voice stream --raw-output -",
+        }
+        adapter = WhatsAppCloudAdapter(config)
+        adapter._message_handler = AsyncMock(return_value="Hello **there**")
+        adapter._auto_tts_enabled_chats.add("15551234567")
+        adapter.play_tts_text = AsyncMock(return_value=SendResult(success=True))
+        adapter.send = AsyncMock(
+            return_value=SendResult(success=True, message_id="text-1")
+        )
+        event = MessageEvent(
+            source=SessionSource(
+                platform=Platform.WHATSAPP_CLOUD,
+                chat_id="15551234567",
+                chat_type="dm",
+            ),
+            text="voice input",
+            message_type=MessageType.VOICE,
+        )
+
+        with patch("tools.tts_tool.text_to_speech_tool") as tts_tool:
+            await adapter._process_message_background(
+                event,
+                build_session_key(event.source),
+            )
+
+        adapter.play_tts_text.assert_awaited_once()
+        assert adapter.play_tts_text.await_args.kwargs["text"] == "Hello there"
+        tts_tool.assert_not_called()
+        adapter.send.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_receive_calling_sidecar_audio_drains_pcm_payload(self):
@@ -2090,6 +2250,7 @@ class TestHealth:
         assert body["app_secret_configured"] is True
         assert body["calling_sidecar_configured"] is False
         assert body["calling_sidecar_contract_loaded"] is False
+        assert body["calling_sidecar_tts_stream_configured"] is False
         assert body["accepted"] == 0
         assert body["duplicates"] == 0
         assert body["rejected_signature"] == 0

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -127,6 +127,42 @@ def _mock_httpx_response(status_code: int, json_body: dict):
     return resp
 
 
+def _calling_sidecar_ready_state(**overrides):
+    checks = {
+        "not_closed": True,
+        "local_sdp_answer": True,
+        "signaling_stable": True,
+        "ice_gathering_complete": True,
+        "outbound_audio_track": True,
+    }
+    checks.update(overrides)
+    return {
+        "ready_for_accept": all(checks.values()),
+        "readiness": checks,
+    }
+
+
+def _calling_sidecar_answer_body(
+    *,
+    call_id="wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh",
+    sdp="v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
+    audio=None,
+    state=None,
+):
+    return {
+        "call_id": call_id,
+        "type": "answer",
+        "sdp": sdp,
+        "audio": audio or {
+            "sample_rate": 48000,
+            "channels": 1,
+            "frame_ms": 20,
+            "encoding": "pcm_s16le",
+        },
+        "state": _calling_sidecar_ready_state() if state is None else state,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Outbound send via Graph API
 # ---------------------------------------------------------------------------
@@ -403,17 +439,7 @@ class TestCallingSidecarClient:
         adapter._http_client.post = AsyncMock(
             return_value=_mock_httpx_response(
                 200,
-                {
-                    "call_id": "call-1",
-                    "type": "answer",
-                    "sdp": "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
-                    "audio": {
-                        "sample_rate": 48000,
-                        "channels": 1,
-                        "frame_ms": 20,
-                        "encoding": "pcm_s16le",
-                    },
-                },
+                _calling_sidecar_answer_body(call_id="call-1"),
             )
         )
 
@@ -423,6 +449,7 @@ class TestCallingSidecarClient:
         assert answer.call_id == "call-1"
         assert answer.sdp.startswith("v=0")
         assert answer.audio["encoding"] == "pcm_s16le"
+        assert answer.state["ready_for_accept"] is True
         adapter._http_client.post.assert_awaited_once()
         call = adapter._http_client.post.call_args
         assert call.args[0] == "http://127.0.0.1:8787/offer"
@@ -536,12 +563,11 @@ class TestCallingSidecarClient:
         adapter._http_client.post = AsyncMock(side_effect=[
             _mock_httpx_response(
                 200,
-                {
-                    "call_id": "call/1",
-                    "type": "answer",
-                    "sdp": "v=0\r\n",
-                    "audio": contract["audio"],
-                },
+                _calling_sidecar_answer_body(
+                    call_id="call/1",
+                    sdp="v=0\r\n",
+                    audio=contract["audio"],
+                ),
             ),
             _mock_httpx_response(
                 200,
@@ -2072,17 +2098,7 @@ class TestWebhookDispatch:
         adapter._http_client.post = AsyncMock(side_effect=[
             _mock_httpx_response(
                 200,
-                {
-                    "call_id": "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh",
-                    "type": "answer",
-                    "sdp": "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
-                    "audio": {
-                        "sample_rate": 48000,
-                        "channels": 1,
-                        "frame_ms": 20,
-                        "encoding": "pcm_s16le",
-                    },
-                },
+                _calling_sidecar_answer_body(),
             ),
             _mock_httpx_response(200, {"success": True}),
             _mock_httpx_response(200, {"success": True}),
@@ -2130,6 +2146,53 @@ class TestWebhookDispatch:
         )
 
     @pytest.mark.asyncio
+    async def test_call_connect_not_ready_sidecar_answer_closes_and_rejects(self):
+        adapter = _make_adapter(
+            app_secret="key",
+            calling_sidecar_url="http://127.0.0.1:8787",
+        )
+        adapter.handle_message = AsyncMock()
+        adapter._start_calling_sidecar_drain = MagicMock()
+        adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(404, {"error": "not found"})
+        )
+        adapter._http_client.post = AsyncMock(side_effect=[
+            _mock_httpx_response(
+                200,
+                _calling_sidecar_answer_body(
+                    state=_calling_sidecar_ready_state(
+                        ice_gathering_complete=False,
+                    ),
+                ),
+            ),
+            _mock_httpx_response(200, {"closed": True}),
+            _mock_httpx_response(200, {"success": True}),
+        ])
+        body = json.dumps(_SAMPLE_CALL_CONNECT_PAYLOAD).encode("utf-8")
+        sig = _sign("key", body)
+
+        response = await adapter._handle_webhook(
+            _post_request(body, {"X-Hub-Signature-256": sig})
+        )
+
+        assert response.status == 200
+        adapter.handle_message.assert_not_called()
+        adapter._start_calling_sidecar_drain.assert_not_called()
+        assert adapter._http_client.post.call_count == 3
+        sidecar_call = adapter._http_client.post.call_args_list[0]
+        close_call = adapter._http_client.post.call_args_list[1]
+        reject_call = adapter._http_client.post.call_args_list[2]
+        assert sidecar_call.args[0] == "http://127.0.0.1:8787/offer"
+        assert close_call.args[0] == (
+            "http://127.0.0.1:8787/calls/"
+            "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh/close"
+        )
+        assert reject_call.args[0].endswith("/calls")
+        assert reject_call.kwargs["json"]["action"] == "reject"
+        assert adapter._calling_sidecar_call_ids == set()
+
+    @pytest.mark.asyncio
     async def test_call_connect_sidecar_failure_rejects_graph_call(self):
         adapter = _make_adapter(
             app_secret="key",
@@ -2174,17 +2237,7 @@ class TestWebhookDispatch:
         adapter._http_client.post = AsyncMock(side_effect=[
             _mock_httpx_response(
                 200,
-                {
-                    "call_id": "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh",
-                    "type": "answer",
-                    "sdp": "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
-                    "audio": {
-                        "sample_rate": 48000,
-                        "channels": 1,
-                        "frame_ms": 20,
-                        "encoding": "pcm_s16le",
-                    },
-                },
+                _calling_sidecar_answer_body(),
             ),
             _mock_httpx_response(500, {"error": {"message": "pre_accept failed"}}),
             _mock_httpx_response(200, {"closed": True}),
@@ -2218,17 +2271,7 @@ class TestWebhookDispatch:
         adapter._http_client.post = AsyncMock(side_effect=[
             _mock_httpx_response(
                 200,
-                {
-                    "call_id": "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh",
-                    "type": "answer",
-                    "sdp": "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
-                    "audio": {
-                        "sample_rate": 48000,
-                        "channels": 1,
-                        "frame_ms": 20,
-                        "encoding": "pcm_s16le",
-                    },
-                },
+                _calling_sidecar_answer_body(),
             ),
             _mock_httpx_response(200, {"success": True}),
             _mock_httpx_response(500, {"error": {"message": "accept failed"}}),

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -583,7 +583,7 @@ class TestCallingSidecarClient:
         assert call.args[0] == (
             "http://127.0.0.1:8787/calls/wacid.call%2Fwith%2Fslash/audio"
         )
-        assert call.kwargs["params"] == {"max_bytes": 4}
+        assert call.kwargs["params"] == {"max_bytes": 4, "wait_ms": 500}
         assert call.kwargs["timeout"] == 2.5
 
     @pytest.mark.asyncio
@@ -604,6 +604,17 @@ class TestCallingSidecarClient:
         adapter._http_client.get = AsyncMock()
 
         audio = await adapter._receive_calling_sidecar_audio("call-1", max_bytes=1)
+
+        assert audio is None
+        adapter._http_client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_receive_calling_sidecar_audio_rejects_negative_wait(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock()
+
+        audio = await adapter._receive_calling_sidecar_audio("call-1", wait_ms=-1)
 
         assert audio is None
         adapter._http_client.get.assert_not_called()

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -849,6 +849,21 @@ class TestCallingSidecarClient:
 
         assert audio is None
 
+    def test_calling_sidecar_call_id_from_metadata_requires_active_call(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._calling_sidecar_call_ids.add("wacid.call-1")
+
+        assert adapter._calling_sidecar_call_id_from_metadata({
+            "whatsapp_call_id": "wacid.call-1",
+        }) == "wacid.call-1"
+        assert adapter._calling_sidecar_call_id_from_metadata({
+            "thread_id": "wacid.call-1",
+        }) == "wacid.call-1"
+        assert adapter._calling_sidecar_call_id_from_metadata({
+            "whatsapp_call_id": "wacid.unknown",
+        }) is None
+        assert adapter._calling_sidecar_call_id_from_metadata(None) is None
+
     @pytest.mark.asyncio
     async def test_close_calling_sidecar_session_posts_close(self):
         adapter = _make_adapter(
@@ -2133,6 +2148,55 @@ class TestSendVoice:
             _os.unlink(mp3_path)
             if _os.path.exists(opus_path):
                 _os.unlink(opus_path)
+
+    @pytest.mark.asyncio
+    async def test_send_voice_active_call_metadata_posts_pcm_to_sidecar(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._calling_sidecar_call_ids.add("wacid.call/1")
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(
+                200,
+                {
+                    "call_id": "wacid.call/1",
+                    "accepted_bytes": 1920,
+                    "queued_tx_bytes": 1920,
+                    "audio": {
+                        "sample_rate": 48000,
+                        "channels": 1,
+                        "frame_ms": 20,
+                        "encoding": "pcm_s16le",
+                    },
+                },
+            )
+        )
+        adapter._decode_call_audio_file_to_pcm = AsyncMock(
+            return_value=(b"\x01\x00\xff\xff", None)
+        )
+        audio_path = _tmpfile(".ogg", content=b"OggS")
+        try:
+            result = await adapter.send_voice(
+                "15551234567",
+                audio_path,
+                metadata={"thread_id": "wacid.call/1"},
+            )
+        finally:
+            _os.unlink(audio_path)
+
+        assert result.success is True
+        assert adapter._http_client.post.call_count == 1
+        call = adapter._http_client.post.call_args
+        assert call.args[0] == "http://127.0.0.1:8787/calls/wacid.call%2F1/audio"
+        payload = call.kwargs["json"]
+        assert payload["sample_rate"] == 48000
+        assert payload["channels"] == 1
+        assert payload["frame_ms"] == 20
+        assert payload["encoding"] == "pcm_s16le"
+        assert payload["sequence"] == 0
+        pcm = base64.b64decode(payload["pcm_s16le_base64"])
+        assert pcm.startswith(b"\x01\x00\xff\xff")
+        assert len(pcm) == 1920
+        assert result.raw_response["queued_pcm_bytes"] == 4
 
     @pytest.mark.asyncio
     async def test_warn_once_no_ffmpeg_actually_only_warns_once(self):

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -2709,6 +2709,14 @@ class TestSendVoice:
             args = spawn.await_args.args
             assert args[0] == "ffmpeg"
             assert args[3] == source_path
+            assert "-ac" in args
+            assert args[args.index("-ac") + 1] == "1"
+            assert "-ar" in args
+            assert args[args.index("-ar") + 1] == "48000"
+            assert "-c:a" in args
+            assert args[args.index("-c:a") + 1] == "libopus"
+            assert "-application" in args
+            assert args[args.index("-application") + 1] == "voip"
             assert args[-1] == opus_path
         finally:
             _os.unlink(source_path)

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -1415,14 +1415,17 @@ class TestWebhookDispatch:
         }
 
     @pytest.mark.asyncio
-    async def test_call_connect_sidecar_failure_skips_graph_accept(self):
+    async def test_call_connect_sidecar_failure_rejects_graph_call(self):
         adapter = _make_adapter(
             app_secret="key",
             calling_sidecar_url="http://127.0.0.1:8787",
         )
         adapter._http_client = MagicMock()
         adapter._http_client.post = AsyncMock(
-            return_value=_mock_httpx_response(503, {"error": "down"})
+            side_effect=[
+                _mock_httpx_response(503, {"error": "down"}),
+                _mock_httpx_response(200, {"success": True}),
+            ]
         )
         body = json.dumps(_SAMPLE_CALL_CONNECT_PAYLOAD).encode("utf-8")
         sig = _sign("key", body)
@@ -1432,8 +1435,13 @@ class TestWebhookDispatch:
         )
 
         assert response.status == 200
-        assert adapter._http_client.post.call_count == 1
-        assert adapter._http_client.post.call_args.args[0].endswith("/offer")
+        assert adapter._http_client.post.call_count == 2
+        sidecar_call = adapter._http_client.post.call_args_list[0]
+        reject_call = adapter._http_client.post.call_args_list[1]
+        assert sidecar_call.args[0] == "http://127.0.0.1:8787/offer"
+        assert reject_call.args[0].endswith("/calls")
+        assert reject_call.kwargs["json"]["action"] == "reject"
+        assert "session" not in reject_call.kwargs["json"]
 
     @pytest.mark.asyncio
     async def test_call_connect_pre_accept_failure_closes_sidecar(self):

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -1129,7 +1129,7 @@ class TestSendDocument:
 
 
 class TestSendVoice:
-    """MP3 voice with ffmpeg present -> opus; without ffmpeg -> MP3 fallback."""
+    """Local non-Opus audio converts to Opus; fallback sends the original."""
 
     @pytest.mark.asyncio
     async def test_send_voice_no_ffmpeg_falls_back_to_mp3(self):
@@ -1179,6 +1179,54 @@ class TestSendVoice:
             _os.unlink(mp3_path)
             if _os.path.exists(opus_path):
                 _os.unlink(opus_path)
+
+    @pytest.mark.asyncio
+    async def test_send_voice_wav_uses_opus_conversion(self):
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(side_effect=[
+            _mock_upload_response("voice_id"),
+            _mock_message_response(),
+        ])
+        # Pretend ffmpeg conversion succeeded by returning a fake Opus path.
+        opus_path = _tmpfile(".ogg", content=b"OggS")
+        adapter._convert_to_opus = AsyncMock(return_value=opus_path)
+
+        wav_path = _tmpfile(".wav", content=b"RIFF\x24\x00\x00\x00WAVE")
+        try:
+            result = await adapter.send_voice("15551234567", wav_path)
+            assert result.success is True
+            adapter._convert_to_opus.assert_awaited_once_with(wav_path)
+            upload_files = adapter._http_client.post.call_args_list[0].kwargs["files"]
+            assert upload_files["file"][0] == _os.path.basename(opus_path)
+            assert upload_files["file"][2] == "audio/ogg; codecs=opus"
+            send_payload = adapter._http_client.post.call_args_list[1].kwargs["json"]
+            assert send_payload["type"] == "audio"
+        finally:
+            _os.unlink(wav_path)
+            if _os.path.exists(opus_path):
+                _os.unlink(opus_path)
+
+    @pytest.mark.asyncio
+    async def test_send_voice_existing_ogg_uploads_as_opus_without_conversion(self):
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(side_effect=[
+            _mock_upload_response("voice_id"),
+            _mock_message_response(),
+        ])
+        adapter._convert_to_opus = AsyncMock()
+
+        ogg_path = _tmpfile(".ogg", content=b"OggS")
+        try:
+            result = await adapter.send_voice("15551234567", ogg_path)
+            assert result.success is True
+            adapter._convert_to_opus.assert_not_awaited()
+            upload_files = adapter._http_client.post.call_args_list[0].kwargs["files"]
+            assert upload_files["file"][0] == _os.path.basename(ogg_path)
+            assert upload_files["file"][2] == "audio/ogg; codecs=opus"
+        finally:
+            _os.unlink(ogg_path)
 
     @pytest.mark.asyncio
     async def test_warn_once_no_ffmpeg_actually_only_warns_once(self):

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -2577,7 +2577,31 @@ class TestSendDocument:
 
 
 class TestSendVoice:
-    """MP3 voice with ffmpeg present -> opus; without ffmpeg -> MP3 fallback."""
+    """WhatsApp voice-note routing: direct Opus, conversion, and fallback."""
+
+    @pytest.mark.asyncio
+    async def test_send_voice_direct_ogg_uploads_with_opus_mime(self):
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(side_effect=[
+            _mock_upload_response("voice_id"),
+            _mock_message_response(),
+        ])
+        adapter._convert_to_opus = AsyncMock()
+
+        path = _tmpfile(".ogg", content=b"OggS")
+        try:
+            result = await adapter.send_voice("15551234567", path)
+            assert result.success is True
+            adapter._convert_to_opus.assert_not_awaited()
+            upload_files = adapter._http_client.post.call_args_list[0].kwargs["files"]
+            assert upload_files["file"][2] == "audio/ogg; codecs=opus"
+            assert upload_files["type"][1] == "audio/ogg; codecs=opus"
+            send_payload = adapter._http_client.post.call_args_list[1].kwargs["json"]
+            assert send_payload["type"] == "audio"
+            assert send_payload["audio"]["id"] == "voice_id"
+        finally:
+            _os.unlink(path)
 
     @pytest.mark.asyncio
     async def test_send_voice_no_ffmpeg_falls_back_to_mp3(self):
@@ -2621,11 +2645,74 @@ class TestSendVoice:
             # Conversion was invoked with the original MP3
             uploaded_path = adapter._convert_to_opus.call_args.args[0]
             assert uploaded_path == mp3_path
+            upload_files = adapter._http_client.post.call_args_list[0].kwargs["files"]
+            assert upload_files["file"][2] == "audio/ogg; codecs=opus"
+            assert upload_files["type"][1] == "audio/ogg; codecs=opus"
             send_payload = adapter._http_client.post.call_args_list[1].kwargs["json"]
             assert send_payload["type"] == "audio"
         finally:
             _os.unlink(mp3_path)
             if _os.path.exists(opus_path):
+                _os.unlink(opus_path)
+
+    @pytest.mark.asyncio
+    async def test_send_voice_wav_uses_ffmpeg_opus_when_available(self):
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(side_effect=[
+            _mock_upload_response("voice_id"),
+            _mock_message_response(),
+        ])
+        opus_path = _tmpfile(".ogg", content=b"OggS")
+        adapter._convert_to_opus = AsyncMock(return_value=opus_path)
+
+        wav_path = _tmpfile(".wav", content=b"RIFF....WAVE")
+        try:
+            result = await adapter.send_voice("15551234567", wav_path)
+            assert result.success is True
+            adapter._convert_to_opus.assert_awaited_once_with(wav_path)
+            upload_files = adapter._http_client.post.call_args_list[0].kwargs["files"]
+            assert upload_files["file"][2] == "audio/ogg; codecs=opus"
+            assert upload_files["type"][1] == "audio/ogg; codecs=opus"
+        finally:
+            _os.unlink(wav_path)
+            if _os.path.exists(opus_path):
+                _os.unlink(opus_path)
+
+    @pytest.mark.asyncio
+    async def test_convert_to_opus_uses_temp_output_path(self):
+        from pathlib import Path
+
+        from gateway.platforms import whatsapp_cloud as wac
+
+        class _Proc:
+            returncode = 0
+
+            async def communicate(self):
+                return b"", b""
+
+        adapter = _make_adapter()
+        source_path = _tmpfile(".wav", content=b"RIFF....WAVE")
+        spawn = AsyncMock(return_value=_Proc())
+
+        try:
+            with _patch.object(wac, "_FFMPEG_PATH", "ffmpeg"), _patch(
+                "gateway.platforms.whatsapp_cloud.asyncio.create_subprocess_exec",
+                new=spawn,
+            ):
+                opus_path = await adapter._convert_to_opus(source_path)
+
+            assert opus_path is not None
+            assert _os.path.exists(opus_path)
+            assert _os.path.basename(opus_path).startswith("hermes_whatsapp_voice_")
+            assert opus_path != str(Path(source_path).with_suffix(".ogg"))
+            args = spawn.await_args.args
+            assert args[0] == "ffmpeg"
+            assert args[3] == source_path
+            assert args[-1] == opus_path
+        finally:
+            _os.unlink(source_path)
+            if "opus_path" in locals() and opus_path and _os.path.exists(opus_path):
                 _os.unlink(opus_path)
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -13,6 +13,7 @@ exercised with synthetic ``Request`` objects.
 from __future__ import annotations
 
 import base64
+import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock
 
@@ -54,6 +55,8 @@ def _make_adapter(**overrides):
     adapter._runner = None
     adapter._http_client = None
     adapter._calling_sidecar_call_ids = set()
+    adapter._calling_sidecar_tasks = {}
+    adapter._calling_sidecar_auto_tts_chats = {}
 
     # Behavior-mixin contract
     adapter._reply_prefix = None
@@ -91,6 +94,8 @@ def _make_adapter(**overrides):
     adapter._active_sessions = {}
     adapter._pending_messages = {}
     adapter._background_tasks = set()
+    adapter._auto_tts_default = False
+    adapter._auto_tts_enabled_chats = set()
     adapter._auto_tts_disabled_chats = set()
 
     # Apply any leftover overrides directly
@@ -865,6 +870,45 @@ class TestCallingSidecarClient:
         assert adapter._calling_sidecar_call_id_from_metadata(None) is None
 
     @pytest.mark.asyncio
+    async def test_dispatch_calling_sidecar_pcm_creates_voice_event(self):
+        from gateway.platforms.base import MessageType
+        import wave as _wave
+
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter.handle_message = AsyncMock()
+        pcm = b"\x01\x00" * 960
+
+        await adapter._dispatch_calling_sidecar_pcm(
+            "wacid.call/1",
+            "13557825698",
+            "Jessica Laverdetman",
+            pcm,
+        )
+
+        adapter.handle_message.assert_awaited_once()
+        event = adapter.handle_message.call_args.args[0]
+        try:
+            assert event.message_type == MessageType.VOICE
+            assert event.source.platform == Platform.WHATSAPP_CLOUD
+            assert event.source.chat_id == "13557825698"
+            assert event.source.user_id == "13557825698"
+            assert event.source.user_name == "Jessica Laverdetman"
+            assert event.source.thread_id == "wacid.call/1"
+            assert event.media_types == ["audio/wav"]
+            assert event.media_urls and _os.path.exists(event.media_urls[0])
+            with _wave.open(event.media_urls[0], "rb") as wav:
+                assert wav.getframerate() == 48000
+                assert wav.getnchannels() == 1
+                assert wav.getsampwidth() == 2
+                assert wav.readframes(960) == pcm
+        finally:
+            for path in event.media_urls:
+                try:
+                    _os.unlink(path)
+                except OSError:
+                    pass
+
+    @pytest.mark.asyncio
     async def test_close_calling_sidecar_session_posts_close(self):
         adapter = _make_adapter(
             calling_sidecar_url="http://127.0.0.1:8787",
@@ -899,6 +943,56 @@ class TestCallingSidecarClient:
 
         assert closed is True
         assert adapter._calling_sidecar_call_ids == set()
+
+    @pytest.mark.asyncio
+    async def test_close_calling_sidecar_session_cancels_drain_task(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._calling_sidecar_call_ids.add("wacid.call-1")
+        adapter._auto_tts_enabled_chats.add("13557825698")
+        adapter._calling_sidecar_auto_tts_chats["wacid.call-1"] = "13557825698"
+        task = asyncio.create_task(asyncio.sleep(60))
+        adapter._calling_sidecar_tasks["wacid.call-1"] = task
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(200, {"closed": True})
+        )
+
+        try:
+            closed = await adapter._close_calling_sidecar_session("wacid.call-1")
+            await asyncio.sleep(0)
+        finally:
+            if not task.done():
+                task.cancel()
+
+        assert closed is True
+        assert task.cancelled()
+        assert adapter._calling_sidecar_tasks == {}
+        assert adapter._calling_sidecar_auto_tts_chats == {}
+        assert adapter._auto_tts_enabled_chats == set()
+
+    @pytest.mark.asyncio
+    async def test_close_calling_sidecar_session_cleans_local_state_without_http(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._calling_sidecar_call_ids.add("wacid.call-1")
+        adapter._auto_tts_enabled_chats.add("13557825698")
+        adapter._calling_sidecar_auto_tts_chats["wacid.call-1"] = "13557825698"
+        task = asyncio.create_task(asyncio.sleep(60))
+        adapter._calling_sidecar_tasks["wacid.call-1"] = task
+        adapter._http_client = None
+
+        try:
+            closed = await adapter._close_calling_sidecar_session("wacid.call-1")
+            await asyncio.sleep(0)
+        finally:
+            if not task.done():
+                task.cancel()
+
+        assert closed is False
+        assert task.cancelled()
+        assert adapter._calling_sidecar_call_ids == set()
+        assert adapter._calling_sidecar_tasks == {}
+        assert adapter._calling_sidecar_auto_tts_chats == {}
+        assert adapter._auto_tts_enabled_chats == set()
 
     @pytest.mark.asyncio
     async def test_disconnect_closes_tracked_sidecar_sessions_before_http_close(self):
@@ -1424,6 +1518,7 @@ class TestWebhookDispatch:
             calling_sidecar_url="http://127.0.0.1:8787",
         )
         adapter.handle_message = AsyncMock()
+        adapter._start_calling_sidecar_drain = MagicMock()
         adapter._http_client = MagicMock()
         adapter._http_client.post = AsyncMock(side_effect=[
             _mock_httpx_response(
@@ -1479,6 +1574,11 @@ class TestWebhookDispatch:
         assert adapter._calling_sidecar_call_ids == {
             "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh"
         }
+        adapter._start_calling_sidecar_drain.assert_called_once_with(
+            "wacid.ABGGFjFVU2AfAgo6V-Hc5eCgK5Gh",
+            "13557825698",
+            "Jessica Laverdetman",
+        )
 
     @pytest.mark.asyncio
     async def test_call_connect_sidecar_failure_rejects_graph_call(self):

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -440,6 +440,7 @@ class TestCallingSidecarClient:
         assert contract["audio"]["frame_bytes"] == 1920
         assert contract["audio"]["default_drain_bytes"] == 96000
         assert contract["audio"]["max_drain_wait_ms"] == 5000
+        assert contract["audio"]["max_outbound_queue_bytes"] == 960000
         call = adapter._http_client.get.call_args
         assert call.args[0] == "http://127.0.0.1:8787/contract"
         assert call.kwargs["timeout"] == 2.5
@@ -636,6 +637,25 @@ class TestCallingSidecarClient:
         assert result.success is False
         assert result.error == "sample_rate must be 48000"
         assert result.raw_response == {"error": "sample_rate must be 48000"}
+        assert result.retryable is False
+
+    @pytest.mark.asyncio
+    async def test_send_calling_sidecar_audio_treats_429_as_backpressure(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(
+                429,
+                {"error": "outbound PCM queue is full"},
+            )
+        )
+
+        result = await adapter._send_calling_sidecar_audio("call-1", b"\x00\x00")
+
+        assert result.success is False
+        assert result.error == "outbound PCM queue is full"
+        assert result.raw_response == {"error": "outbound PCM queue is full"}
+        assert result.retryable is True
 
     @pytest.mark.asyncio
     async def test_receive_calling_sidecar_audio_drains_pcm_payload(self):

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -54,6 +54,11 @@ def _make_adapter(**overrides):
     adapter._calling_sidecar_timeout = overrides.pop("calling_sidecar_timeout", 10.0)
     adapter._runner = None
     adapter._http_client = None
+    adapter._calling_sidecar_contract = overrides.pop("calling_sidecar_contract", None)
+    adapter._calling_sidecar_contract_checked = overrides.pop(
+        "calling_sidecar_contract_checked",
+        False,
+    )
     adapter._calling_sidecar_call_ids = set()
     adapter._calling_sidecar_tasks = {}
     adapter._calling_sidecar_auto_tts_chats = {}
@@ -466,6 +471,90 @@ class TestCallingSidecarClient:
         call = adapter._http_client.get.call_args
         assert call.args[0] == "http://127.0.0.1:8787/contract"
         assert call.kwargs["timeout"] == 2.5
+
+    @pytest.mark.asyncio
+    async def test_cached_contract_drives_sidecar_paths_and_audio_window(self):
+        contract = {
+            "contract": "voice.webrtc_sidecar",
+            "version": 1,
+            "audio": {
+                "sample_rate": 48000,
+                "channels": 1,
+                "frame_ms": 20,
+                "encoding": "pcm_s16le",
+                "bytes_per_sample": 2,
+                "frame_bytes": 1920,
+                "default_drain_bytes": 3840,
+                "max_drain_wait_ms": 200,
+            },
+            "endpoints": {
+                "offer": {"path": "/v1/offer"},
+                "send_audio": {"path": "/v1/calls/{call_id}/tx"},
+                "receive_audio": {"path": "/v1/calls/{call_id}/rx"},
+                "close_call": {"path": "/v1/calls/{call_id}/done"},
+            },
+        }
+        adapter = _make_adapter(
+            calling_sidecar_url="http://127.0.0.1:8787",
+            calling_sidecar_contract=contract,
+            calling_sidecar_contract_checked=True,
+        )
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(side_effect=[
+            _mock_httpx_response(
+                200,
+                {
+                    "call_id": "call/1",
+                    "type": "answer",
+                    "sdp": "v=0\r\n",
+                    "audio": contract["audio"],
+                },
+            ),
+            _mock_httpx_response(
+                200,
+                {"accepted_bytes": 2, "queued_tx_bytes": 2},
+            ),
+            _mock_httpx_response(200, {"closed": True}),
+        ])
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(
+                200,
+                {
+                    "call_id": "call/1",
+                    "returned_bytes": 2,
+                    "queued_rx_bytes": 0,
+                    "pcm_s16le_base64": base64.b64encode(b"\x01\x00").decode("ascii"),
+                    "audio": contract["audio"],
+                },
+            )
+        )
+
+        answer = await adapter._request_calling_sidecar_answer("call/1", "v=0\r\n")
+        sent = await adapter._send_calling_sidecar_audio("call/1", b"\x01\x00")
+        received = await adapter._receive_calling_sidecar_audio("call/1")
+        adapter._calling_sidecar_call_ids.add("call/1")
+        closed = await adapter._close_calling_sidecar_session("call/1")
+
+        assert answer is not None
+        assert sent.success is True
+        assert received is not None
+        assert closed is True
+        assert adapter._http_client.post.call_args_list[0].args[0] == (
+            "http://127.0.0.1:8787/v1/offer"
+        )
+        assert adapter._http_client.post.call_args_list[1].args[0] == (
+            "http://127.0.0.1:8787/v1/calls/call%2F1/tx"
+        )
+        assert adapter._http_client.get.call_args.args[0] == (
+            "http://127.0.0.1:8787/v1/calls/call%2F1/rx"
+        )
+        assert adapter._http_client.get.call_args.kwargs["params"] == {
+            "max_bytes": 3840,
+            "wait_ms": 200,
+        }
+        assert adapter._http_client.post.call_args_list[2].args[0] == (
+            "http://127.0.0.1:8787/v1/calls/call%2F1/done"
+        )
 
     @pytest.mark.asyncio
     async def test_request_contract_tolerates_older_sidecar_404(self):
@@ -1636,6 +1725,9 @@ class TestWebhookDispatch:
         adapter.handle_message = AsyncMock()
         adapter._start_calling_sidecar_drain = MagicMock()
         adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(404, {"error": "not found"})
+        )
         adapter._http_client.post = AsyncMock(side_effect=[
             _mock_httpx_response(
                 200,
@@ -1703,6 +1795,9 @@ class TestWebhookDispatch:
             calling_sidecar_url="http://127.0.0.1:8787",
         )
         adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(404, {"error": "not found"})
+        )
         adapter._http_client.post = AsyncMock(
             side_effect=[
                 _mock_httpx_response(503, {"error": "down"}),
@@ -1732,6 +1827,9 @@ class TestWebhookDispatch:
             calling_sidecar_url="http://127.0.0.1:8787",
         )
         adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(404, {"error": "not found"})
+        )
         adapter._http_client.post = AsyncMock(side_effect=[
             _mock_httpx_response(
                 200,
@@ -1773,6 +1871,9 @@ class TestWebhookDispatch:
             calling_sidecar_url="http://127.0.0.1:8787",
         )
         adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(404, {"error": "not found"})
+        )
         adapter._http_client.post = AsyncMock(side_effect=[
             _mock_httpx_response(
                 200,
@@ -1988,6 +2089,7 @@ class TestHealth:
         assert body["verify_token_configured"] is True
         assert body["app_secret_configured"] is True
         assert body["calling_sidecar_configured"] is False
+        assert body["calling_sidecar_contract_loaded"] is False
         assert body["accepted"] == 0
         assert body["duplicates"] == 0
         assert body["rejected_signature"] == 0

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -542,6 +542,31 @@ class TestCallingSidecarClient:
         assert answer is None
 
     @pytest.mark.asyncio
+    async def test_request_rejects_mismatched_answer_call_id(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(
+                200,
+                {
+                    "call_id": "other-call",
+                    "type": "answer",
+                    "sdp": "v=0\r\n",
+                    "audio": {
+                        "sample_rate": 48000,
+                        "channels": 1,
+                        "frame_ms": 20,
+                        "encoding": "pcm_s16le",
+                    },
+                },
+            )
+        )
+
+        answer = await adapter._request_calling_sidecar_answer("call-1", "v=0\r\n")
+
+        assert answer is None
+
+    @pytest.mark.asyncio
     async def test_send_call_action_posts_session_answer(self):
         adapter = _make_adapter()
         adapter._http_client = MagicMock()
@@ -790,6 +815,32 @@ class TestCallingSidecarClient:
                     "returned_bytes": 99,
                     "queued_rx_bytes": 0,
                     "pcm_s16le_base64": base64.b64encode(b"\x00\x00").decode("ascii"),
+                },
+            )
+        )
+
+        audio = await adapter._receive_calling_sidecar_audio("call-1")
+
+        assert audio is None
+
+    @pytest.mark.asyncio
+    async def test_receive_calling_sidecar_audio_rejects_mismatched_call_id(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(
+                200,
+                {
+                    "call_id": "other-call",
+                    "returned_bytes": 2,
+                    "queued_rx_bytes": 0,
+                    "pcm_s16le_base64": base64.b64encode(b"\x00\x00").decode("ascii"),
+                    "audio": {
+                        "sample_rate": 48000,
+                        "channels": 1,
+                        "frame_ms": 20,
+                        "encoding": "pcm_s16le",
+                    },
                 },
             )
         )

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -12,6 +12,7 @@ exercised with synthetic ``Request`` objects.
 
 from __future__ import annotations
 
+import base64
 import json
 from unittest.mock import AsyncMock, MagicMock
 
@@ -474,6 +475,71 @@ class TestCallingSidecarClient:
 
         assert result.success is False
         assert "graph error 100" in result.error
+
+    @pytest.mark.asyncio
+    async def test_send_calling_sidecar_audio_posts_pcm_payload(self):
+        adapter = _make_adapter(
+            calling_sidecar_url="http://127.0.0.1:8787",
+            calling_sidecar_timeout=2.5,
+        )
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(
+                200,
+                {"accepted_bytes": 4, "queued_tx_bytes": 4},
+            )
+        )
+
+        result = await adapter._send_calling_sidecar_audio(
+            "wacid.call/with/slash",
+            b"\x01\x00\xff\xff",
+            sequence=17,
+        )
+
+        assert result.success is True
+        assert result.raw_response == {"accepted_bytes": 4, "queued_tx_bytes": 4}
+        call = adapter._http_client.post.call_args
+        assert call.args[0] == (
+            "http://127.0.0.1:8787/calls/wacid.call%2Fwith%2Fslash/audio"
+        )
+        assert call.kwargs["timeout"] == 2.5
+        assert call.kwargs["json"] == {
+            "sequence": 17,
+            "sample_rate": 48000,
+            "channels": 1,
+            "frame_ms": 20,
+            "encoding": "pcm_s16le",
+            "pcm_s16le_base64": base64.b64encode(b"\x01\x00\xff\xff").decode("ascii"),
+        }
+
+    @pytest.mark.asyncio
+    async def test_send_calling_sidecar_audio_requires_sidecar(self):
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock()
+
+        result = await adapter._send_calling_sidecar_audio("call-1", b"\x00\x00")
+
+        assert result.success is False
+        assert result.error == "Calling sidecar not configured"
+        adapter._http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_send_calling_sidecar_audio_returns_sidecar_error(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(
+                400,
+                {"error": "sample_rate must be 48000"},
+            )
+        )
+
+        result = await adapter._send_calling_sidecar_audio("call-1", b"\x00\x00")
+
+        assert result.success is False
+        assert result.error == "sample_rate must be 48000"
+        assert result.raw_response == {"error": "sample_rate must be 48000"}
 
     @pytest.mark.asyncio
     async def test_close_calling_sidecar_session_posts_close(self):

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -1265,6 +1265,52 @@ class TestSendVoice:
         adapter._warn_once_no_ffmpeg()
         assert adapter._warned_no_ffmpeg is True
 
+    @pytest.mark.asyncio
+    async def test_convert_to_opus_forces_whatsapp_voice_note_shape(self):
+        from pathlib import Path
+
+        from gateway.platforms import whatsapp_cloud as wac
+
+        class _Proc:
+            returncode = 0
+
+            async def communicate(self):
+                return b"", b""
+
+        adapter = _make_adapter()
+        source_path = _tmpfile(".wav", content=b"RIFF....WAVE")
+        captured_args = None
+
+        async def fake_create_subprocess_exec(*args, **_kwargs):
+            nonlocal captured_args
+            captured_args = args
+            Path(str(args[-1])).write_bytes(b"OggS")
+            return _Proc()
+
+        try:
+            with _patch.object(wac, "_FFMPEG_PATH", "ffmpeg"), _patch(
+                "gateway.platforms.whatsapp_cloud.asyncio.create_subprocess_exec",
+                new=fake_create_subprocess_exec,
+            ):
+                opus_path = await adapter._convert_to_opus(source_path)
+
+            assert opus_path is not None
+            args = captured_args
+            assert args is not None
+            assert args[0] == "ffmpeg"
+            assert args[3] == source_path
+            assert args[args.index("-ac") + 1] == "1"
+            assert args[args.index("-ar") + 1] == "48000"
+            assert args[args.index("-c:a") + 1] == "libopus"
+            assert args[args.index("-b:a") + 1] == "32k"
+            assert args[args.index("-vbr") + 1] == "on"
+            assert args[args.index("-application") + 1] == "voip"
+            assert args[-1] == opus_path
+        finally:
+            _os.unlink(source_path)
+            if "opus_path" in locals() and opus_path and _os.path.exists(opus_path):
+                _os.unlink(opus_path)
+
 
 # ---------------------------------------------------------------------------
 # Inbound media — Graph two-step download (Phase 4)

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -441,6 +441,7 @@ class TestCallingSidecarClient:
         assert contract["audio"]["default_drain_bytes"] == 96000
         assert contract["audio"]["max_drain_wait_ms"] == 5000
         assert contract["audio"]["max_outbound_queue_bytes"] == 960000
+        assert contract["audio"]["max_inbound_queue_bytes"] == 960000
         call = adapter._http_client.get.call_args
         assert call.args[0] == "http://127.0.0.1:8787/contract"
         assert call.kwargs["timeout"] == 2.5

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -827,6 +827,59 @@ class TestCallingSidecarClient:
         assert result.retryable is True
 
     @pytest.mark.asyncio
+    async def test_clear_calling_sidecar_audio_posts_contract_endpoint(self):
+        contract = {
+            "contract": "voice.webrtc_sidecar",
+            "version": 1,
+            "audio": {
+                "sample_rate": 48000,
+                "channels": 1,
+                "frame_ms": 20,
+                "encoding": "pcm_s16le",
+            },
+            "endpoints": {
+                "clear_audio": {"path": "/v1/calls/{call_id}/clear-audio"},
+            },
+        }
+        adapter = _make_adapter(
+            calling_sidecar_url="http://127.0.0.1:8787",
+            calling_sidecar_timeout=2.5,
+            calling_sidecar_contract=contract,
+            calling_sidecar_contract_checked=True,
+        )
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(
+                200,
+                {"dropped_tx_bytes": 3840, "queued_tx_bytes": 0},
+            )
+        )
+
+        result = await adapter._clear_calling_sidecar_audio("call/1")
+
+        assert result.success is True
+        assert result.raw_response == {"dropped_tx_bytes": 3840, "queued_tx_bytes": 0}
+        call = adapter._http_client.post.call_args
+        assert call.args[0] == "http://127.0.0.1:8787/v1/calls/call%2F1/clear-audio"
+        assert call.kwargs["timeout"] == 2.5
+
+    @pytest.mark.asyncio
+    async def test_clear_calling_sidecar_audio_skips_without_contract_endpoint(self):
+        adapter = _make_adapter(
+            calling_sidecar_url="http://127.0.0.1:8787",
+            calling_sidecar_contract={"contract": "voice.webrtc_sidecar", "version": 1},
+            calling_sidecar_contract_checked=True,
+        )
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock()
+
+        result = await adapter._clear_calling_sidecar_audio("call-1")
+
+        assert result.success is True
+        assert result.raw_response == {"skipped": "clear_audio endpoint not advertised"}
+        adapter._http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_play_tts_text_stream_command_posts_pcm_frames(self, monkeypatch):
         from gateway.platforms.base import SendResult
 
@@ -1178,6 +1231,7 @@ class TestCallingSidecarClient:
         adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
         adapter._calling_sidecar_call_ids.add("call-1")
         adapter._dispatch_calling_sidecar_pcm = AsyncMock()
+        adapter._clear_calling_sidecar_audio = AsyncMock()
         silence = b"\x00" * CALLING_PCM_DEFAULT_DRAIN_BYTES
         responses = [
             CallingSidecarAudio(
@@ -1211,9 +1265,11 @@ class TestCallingSidecarClient:
         )
 
         adapter._dispatch_calling_sidecar_pcm.assert_not_awaited()
+        adapter._clear_calling_sidecar_audio.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_calling_sidecar_audio_loop_flushes_speech_after_silence(self):
+        from gateway.platforms.base import SendResult
         from gateway.platforms.whatsapp_cloud import (
             CALLING_AUDIO_CONTRACT,
             CALLING_PCM_DEFAULT_DRAIN_BYTES,
@@ -1223,6 +1279,9 @@ class TestCallingSidecarClient:
         adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
         adapter._calling_sidecar_call_ids.add("call-1")
         adapter._dispatch_calling_sidecar_pcm = AsyncMock()
+        adapter._clear_calling_sidecar_audio = AsyncMock(
+            return_value=SendResult(success=True)
+        )
         speech = (
             (1000).to_bytes(2, "little", signed=True)
             * (CALLING_PCM_DEFAULT_DRAIN_BYTES // 2)
@@ -1267,6 +1326,7 @@ class TestCallingSidecarClient:
         )
 
         adapter._dispatch_calling_sidecar_pcm.assert_awaited_once()
+        adapter._clear_calling_sidecar_audio.assert_awaited_once_with("call-1")
         call = adapter._dispatch_calling_sidecar_pcm.call_args
         assert call.args[:3] == ("call-1", "13557825698", "Jessica Laverdetman")
         dispatched_pcm = call.args[3]

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -364,10 +364,10 @@ class TestCallingSidecarClient:
                     "type": "answer",
                     "sdp": "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
                     "audio": {
-                        "codec": "opus",
                         "sample_rate": 48000,
                         "channels": 1,
                         "frame_ms": 20,
+                        "encoding": "pcm_s16le",
                     },
                 },
             )
@@ -378,7 +378,7 @@ class TestCallingSidecarClient:
         assert answer is not None
         assert answer.call_id == "call-1"
         assert answer.sdp.startswith("v=0")
-        assert answer.audio["codec"] == "opus"
+        assert answer.audio["encoding"] == "pcm_s16le"
         adapter._http_client.post.assert_awaited_once()
         call = adapter._http_client.post.call_args
         assert call.args[0] == "http://127.0.0.1:8787/offer"
@@ -410,6 +410,75 @@ class TestCallingSidecarClient:
         assert answer is None
 
     @pytest.mark.asyncio
+    async def test_request_fetches_machine_readable_contract(self):
+        adapter = _make_adapter(
+            calling_sidecar_url="http://127.0.0.1:8787",
+            calling_sidecar_timeout=2.5,
+        )
+        adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(
+                200,
+                {
+                    "contract": "voice.webrtc_sidecar",
+                    "version": 1,
+                    "audio": {
+                        "sample_rate": 48000,
+                        "channels": 1,
+                        "frame_ms": 20,
+                        "encoding": "pcm_s16le",
+                        "frame_bytes": 1920,
+                    },
+                },
+            )
+        )
+
+        contract = await adapter._request_calling_sidecar_contract()
+
+        assert contract is not None
+        assert contract["contract"] == "voice.webrtc_sidecar"
+        assert contract["audio"]["frame_bytes"] == 1920
+        call = adapter._http_client.get.call_args
+        assert call.args[0] == "http://127.0.0.1:8787/contract"
+        assert call.kwargs["timeout"] == 2.5
+
+    @pytest.mark.asyncio
+    async def test_request_contract_tolerates_older_sidecar_404(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(404, {"error": "not found"})
+        )
+
+        contract = await adapter._request_calling_sidecar_contract()
+
+        assert contract is None
+
+    @pytest.mark.asyncio
+    async def test_request_contract_rejects_mismatched_audio_shape(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(
+                200,
+                {
+                    "contract": "voice.webrtc_sidecar",
+                    "version": 1,
+                    "audio": {
+                        "sample_rate": 16000,
+                        "channels": 1,
+                        "frame_ms": 20,
+                        "encoding": "pcm_s16le",
+                    },
+                },
+            )
+        )
+
+        contract = await adapter._request_calling_sidecar_contract()
+
+        assert contract is None
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("body", [
         {"type": "offer", "sdp": "v=0"},
         {"type": "answer"},
@@ -421,6 +490,31 @@ class TestCallingSidecarClient:
         adapter._http_client = MagicMock()
         adapter._http_client.post = AsyncMock(
             return_value=_mock_httpx_response(200, body)
+        )
+
+        answer = await adapter._request_calling_sidecar_answer("call-1", "v=0\r\n")
+
+        assert answer is None
+
+    @pytest.mark.asyncio
+    async def test_request_rejects_mismatched_answer_audio_shape(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(
+                200,
+                {
+                    "call_id": "call-1",
+                    "type": "answer",
+                    "sdp": "v=0\r\n",
+                    "audio": {
+                        "sample_rate": 16000,
+                        "channels": 1,
+                        "frame_ms": 20,
+                        "encoding": "pcm_s16le",
+                    },
+                },
+            )
         )
 
         answer = await adapter._request_calling_sidecar_answer("call-1", "v=0\r\n")
@@ -1181,10 +1275,10 @@ class TestWebhookDispatch:
                     "type": "answer",
                     "sdp": "v=0\r\nm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
                     "audio": {
-                        "codec": "opus",
                         "sample_rate": 48000,
                         "channels": 1,
                         "frame_ms": 20,
+                        "encoding": "pcm_s16le",
                     },
                 },
             ),

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -985,7 +985,30 @@ class TestCallingSidecarClient:
         )
         adapter._calling_sidecar_call_ids.add("call-1")
         adapter._send_calling_sidecar_audio = AsyncMock(
-            return_value=SendResult(success=True)
+            side_effect=[
+                SendResult(
+                    success=True,
+                    raw_response={
+                        "accepted_bytes": 1920,
+                        "accepted_ms": 20,
+                        "queued_tx_bytes": 1920,
+                        "queued_tx_ms": 20,
+                        "max_tx_queue_bytes": 960000,
+                        "max_tx_queue_ms": 10000,
+                    },
+                ),
+                SendResult(
+                    success=True,
+                    raw_response={
+                        "accepted_bytes": 1920,
+                        "accepted_ms": 20,
+                        "queued_tx_bytes": 3840,
+                        "queued_tx_ms": 40,
+                        "max_tx_queue_bytes": 960000,
+                        "max_tx_queue_ms": 10000,
+                    },
+                ),
+            ]
         )
 
         result = await adapter.play_tts_text(
@@ -997,6 +1020,11 @@ class TestCallingSidecarClient:
         assert result.success is True
         assert result.raw_response["frames"] == 2
         assert result.raw_response["queued_pcm_bytes"] == len(frame) * 2
+        assert result.raw_response["queued_tx_bytes"] == 3840
+        assert result.raw_response["queued_tx_ms"] == 40
+        assert result.raw_response["max_tx_queue_bytes"] == 960000
+        assert result.raw_response["max_tx_queue_ms"] == 10000
+        assert result.raw_response["last_sidecar_response"]["accepted_ms"] == 20
         assert commands
         assert "--sample-rate 48000" in commands[0]
         assert "--frame-ms 20" in commands[0]
@@ -2887,7 +2915,11 @@ class TestSendVoice:
                 {
                     "call_id": "wacid.call/1",
                     "accepted_bytes": 1920,
+                    "accepted_ms": 20,
                     "queued_tx_bytes": 1920,
+                    "queued_tx_ms": 20,
+                    "max_tx_queue_bytes": 960000,
+                    "max_tx_queue_ms": 10000,
                     "audio": {
                         "sample_rate": 48000,
                         "channels": 1,
@@ -2924,6 +2956,9 @@ class TestSendVoice:
         assert pcm.startswith(b"\x01\x00\xff\xff")
         assert len(pcm) == 1920
         assert result.raw_response["queued_pcm_bytes"] == 4
+        assert result.raw_response["queued_tx_bytes"] == 1920
+        assert result.raw_response["queued_tx_ms"] == 20
+        assert result.raw_response["last_sidecar_response"]["accepted_ms"] == 20
 
     @pytest.mark.asyncio
     async def test_warn_once_no_ffmpeg_actually_only_warns_once(self):

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -429,6 +429,18 @@ class TestCallingSidecarClient:
                         "encoding": "pcm_s16le",
                         "frame_bytes": 1920,
                     },
+                    "payloads": {
+                        "offer_request": {
+                            "call_id": "Required call session identifier from the WhatsApp Calling webhook.",
+                            "sdp": "Required remote SDP offer from WhatsApp.",
+                        },
+                        "offer_response": {
+                            "sdp": "Local SDP answer to pass unchanged to WhatsApp pre_accept and accept actions.",
+                        },
+                        "call_state": {
+                            "queued_rx_bytes": "Inbound decoded PCM bytes queued for Hermes to drain.",
+                        },
+                    },
                 },
             )
         )
@@ -442,6 +454,9 @@ class TestCallingSidecarClient:
         assert contract["audio"]["max_drain_wait_ms"] == 5000
         assert contract["audio"]["max_outbound_queue_bytes"] == 960000
         assert contract["audio"]["max_inbound_queue_bytes"] == 960000
+        assert contract["payloads"]["offer_request"]["call_id"].startswith("Required")
+        assert "pre_accept" in contract["payloads"]["offer_response"]["sdp"]
+        assert "queued_rx_bytes" in contract["payloads"]["call_state"]
         call = adapter._http_client.get.call_args
         assert call.args[0] == "http://127.0.0.1:8787/contract"
         assert call.kwargs["timeout"] == 2.5

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -886,6 +886,8 @@ class TestCallingSidecarClient:
         frame = b"\x01\x00" * 960
         chunks = [frame + frame[:100], frame[100:], b""]
         commands = []
+        sleeps = []
+        original_sleep = asyncio.sleep
 
         class FakeStream:
             def __init__(self, values):
@@ -915,9 +917,17 @@ class TestCallingSidecarClient:
             commands.append(command)
             return FakeProc()
 
+        async def fake_sleep(delay):
+            sleeps.append(delay)
+            await original_sleep(0)
+
         monkeypatch.setattr(
             "gateway.platforms.whatsapp_cloud.asyncio.create_subprocess_shell",
             fake_create_subprocess_shell,
+        )
+        monkeypatch.setattr(
+            "gateway.platforms.whatsapp_cloud.asyncio.sleep",
+            fake_sleep,
         )
         adapter = _make_adapter(
             calling_sidecar_url="http://127.0.0.1:8787",
@@ -950,6 +960,8 @@ class TestCallingSidecarClient:
         assert first.kwargs["sequence"] == 0
         assert second.args == ("call-1", frame)
         assert second.kwargs["sequence"] == 1
+        assert len(sleeps) == 1
+        assert 0 < sleeps[0] <= 0.021
 
     @pytest.mark.asyncio
     async def test_play_tts_text_without_stream_command_falls_back(self, monkeypatch):

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -438,6 +438,8 @@ class TestCallingSidecarClient:
         assert contract is not None
         assert contract["contract"] == "voice.webrtc_sidecar"
         assert contract["audio"]["frame_bytes"] == 1920
+        assert contract["audio"]["default_drain_bytes"] == 96000
+        assert contract["audio"]["max_drain_wait_ms"] == 5000
         call = adapter._http_client.get.call_args
         assert call.args[0] == "http://127.0.0.1:8787/contract"
         assert call.kwargs["timeout"] == 2.5
@@ -679,6 +681,33 @@ class TestCallingSidecarClient:
         )
         assert call.kwargs["params"] == {"max_bytes": 4, "wait_ms": 500}
         assert call.kwargs["timeout"] == 2.5
+
+    @pytest.mark.asyncio
+    async def test_receive_calling_sidecar_audio_defaults_to_contract_window(self):
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._http_client = MagicMock()
+        adapter._http_client.get = AsyncMock(
+            return_value=_mock_httpx_response(
+                200,
+                {
+                    "returned_bytes": 0,
+                    "queued_rx_bytes": 0,
+                    "pcm_s16le_base64": "",
+                    "audio": {
+                        "sample_rate": 48000,
+                        "channels": 1,
+                        "frame_ms": 20,
+                        "encoding": "pcm_s16le",
+                    },
+                },
+            )
+        )
+
+        audio = await adapter._receive_calling_sidecar_audio("call-1")
+
+        assert audio is not None
+        call = adapter._http_client.get.call_args
+        assert call.kwargs["params"] == {"max_bytes": 96000, "wait_ms": 500}
 
     @pytest.mark.asyncio
     async def test_receive_calling_sidecar_audio_requires_sidecar(self):

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -1481,6 +1481,58 @@ class TestCallingSidecarClient:
         assert len(dispatched_pcm) == len(speech) + len(silence)
 
     @pytest.mark.asyncio
+    async def test_calling_sidecar_audio_loop_backs_off_after_empty_drain(
+        self,
+        monkeypatch,
+    ):
+        from gateway.platforms.whatsapp_cloud import (
+            CALLING_AUDIO_CONTRACT,
+            CALLING_SIDECAR_EMPTY_DRAIN_BACKOFF_SECONDS,
+            CallingSidecarAudio,
+        )
+
+        adapter = _make_adapter(calling_sidecar_url="http://127.0.0.1:8787")
+        adapter._calling_sidecar_call_ids.add("call-1")
+        adapter._dispatch_calling_sidecar_pcm = AsyncMock()
+        adapter._clear_calling_sidecar_audio = AsyncMock()
+        sleeps = []
+        responses = [
+            CallingSidecarAudio(
+                call_id="call-1",
+                pcm_s16le=b"",
+                returned_bytes=0,
+                queued_rx_bytes=0,
+                audio=dict(CALLING_AUDIO_CONTRACT),
+            )
+        ]
+
+        async def receive(_call_id):
+            if responses:
+                return responses.pop(0)
+            adapter._calling_sidecar_call_ids.discard("call-1")
+            return None
+
+        async def fake_sleep(delay):
+            sleeps.append(delay)
+            adapter._calling_sidecar_call_ids.discard("call-1")
+
+        monkeypatch.setattr(
+            "gateway.platforms.whatsapp_cloud.asyncio.sleep",
+            fake_sleep,
+        )
+        adapter._receive_calling_sidecar_audio = receive
+
+        await adapter._run_calling_sidecar_audio_loop(
+            "call-1",
+            "13557825698",
+            "Jessica Laverdetman",
+        )
+
+        assert sleeps == [CALLING_SIDECAR_EMPTY_DRAIN_BACKOFF_SECONDS]
+        adapter._dispatch_calling_sidecar_pcm.assert_not_awaited()
+        adapter._clear_calling_sidecar_audio.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_close_calling_sidecar_session_posts_close(self):
         adapter = _make_adapter(
             calling_sidecar_url="http://127.0.0.1:8787",

--- a/tests/tools/test_install_voice_local_stack_script.py
+++ b/tests/tools/test_install_voice_local_stack_script.py
@@ -144,6 +144,11 @@ def test_build_plan_generates_sidecar_unit_and_gateway_dropin(tmp_path: Path):
     assert "http://127.0.0.1:8787" in live_gateway
     assert "--voice-bin" in live_gateway
     assert "--run-tts-smoke" in live_gateway
+    assert "--run-sidecar-offer-smoke" in live_gateway
+    assert (
+        live_gateway[live_gateway.index("--webrtc-python-bin") + 1]
+        == sys.executable
+    )
     assert "--run-stt-smoke" not in live_gateway
     assert "--sidecar-service" in live_gateway
     assert "voice-webrtc-sidecar.service" in live_gateway

--- a/tests/tools/test_install_voice_local_stack_script.py
+++ b/tests/tools/test_install_voice_local_stack_script.py
@@ -1,9 +1,11 @@
+import builtins
 import importlib.util
 import json
 from pathlib import Path
 import sys
 
 from ruamel.yaml import YAML
+import yaml
 
 
 SCRIPT_PATH = (
@@ -152,6 +154,42 @@ def test_configure_tts_provider_writes_voice_compatible_ogg_provider(tmp_path: P
     )
     assert configured["output_format"] == "ogg"
     assert configured["voice_compatible"] is True
+
+
+def test_configure_tts_provider_falls_back_to_pyyaml(
+    tmp_path: Path,
+    monkeypatch,
+):
+    script = _load_script_module()
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("gateway:\n  enabled: true\n", encoding="utf-8")
+    provider = script.build_tts_provider(
+        voice_bin="/home/user/.local/bin/voice",
+        voice="af_heart",
+        speed="1.0",
+        timeout=180,
+        max_text_length=2000,
+    )
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "ruamel.yaml":
+            raise ModuleNotFoundError("No module named 'ruamel'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    result = script.configure_tts_provider(
+        config_path=config_path,
+        provider_name="kokoro",
+        provider=provider,
+    )
+
+    parsed = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert result["provider"] == "kokoro"
+    assert parsed["gateway"]["enabled"] is True
+    assert parsed["tts"]["providers"]["kokoro"]["output_format"] == "ogg"
+    assert parsed["tts"]["providers"]["kokoro"]["voice_compatible"] is True
 
 
 def test_apply_without_systemctl_writes_files_and_config(

--- a/tests/tools/test_install_voice_local_stack_script.py
+++ b/tests/tools/test_install_voice_local_stack_script.py
@@ -140,6 +140,10 @@ def test_build_plan_generates_sidecar_unit_and_gateway_dropin(tmp_path: Path):
     assert "http://127.0.0.1:8787" in live_gateway
     assert "--voice-bin" in live_gateway
     assert "--run-tts-smoke" in live_gateway
+    assert "--sidecar-service" in live_gateway
+    assert "voice-webrtc-sidecar.service" in live_gateway
+    assert "--voice-repo" in live_gateway
+    assert str(voice_repo.resolve()) in live_gateway
     assert "--skip-bridge-health" not in live_gateway
     assert plan["verify_commands"]["live_gateway_cloud_only"][-1] == (
         "--skip-bridge-health"

--- a/tests/tools/test_install_voice_local_stack_script.py
+++ b/tests/tools/test_install_voice_local_stack_script.py
@@ -163,6 +163,10 @@ def test_build_plan_generates_sidecar_unit_and_gateway_dropin(tmp_path: Path):
     assert plan["verify_commands"]["local_stack_live_gateway_cloud_only"][-1] == (
         "--skip-live-gateway-bridge-health"
     )
+    assert plan["verify_commands"]["local_stack_live_gateway_cloud_ready"][-2:] == [
+        "--skip-live-gateway-bridge-health",
+        "--require-live-gateway-whatsapp-cloud-readiness",
+    ]
     live_gateway = plan["verify_commands"]["live_gateway"]
     assert live_gateway[:2] == [
         sys.executable,
@@ -190,6 +194,10 @@ def test_build_plan_generates_sidecar_unit_and_gateway_dropin(tmp_path: Path):
     assert plan["verify_commands"]["live_gateway_cloud_only"][-1] == (
         "--skip-bridge-health"
     )
+    assert plan["verify_commands"]["live_gateway_cloud_ready"][-2:] == [
+        "--skip-bridge-health",
+        "--require-whatsapp-cloud-readiness",
+    ]
 
 
 def test_build_plan_adds_live_stt_smoke_when_configuring_stt(tmp_path: Path):

--- a/tests/tools/test_install_voice_local_stack_script.py
+++ b/tests/tools/test_install_voice_local_stack_script.py
@@ -135,6 +135,25 @@ def test_build_plan_generates_sidecar_unit_and_gateway_dropin(tmp_path: Path):
     assert "--webrtc-python-bin" in local_stack
     assert "--live-hermes-root" in local_stack
     assert str(live_root.resolve()) in local_stack
+    local_stack_live = plan["verify_commands"]["local_stack_live_gateway"]
+    assert local_stack_live[: len(local_stack)] == local_stack
+    assert "--run-live-gateway" in local_stack_live
+    assert local_stack_live[local_stack_live.index("--calling-sidecar-url") + 1] == (
+        "http://127.0.0.1:8787"
+    )
+    assert local_stack_live[local_stack_live.index("--live-gateway-python-bin") + 1] == (
+        str(hermes_home.resolve() / "hermes-agent" / "venv" / "bin" / "python")
+    )
+    assert local_stack_live[
+        local_stack_live.index("--live-gateway-hermes-home") + 1
+    ] == str(hermes_home.resolve())
+    assert local_stack_live[
+        local_stack_live.index("--live-gateway-sidecar-service") + 1
+    ] == "voice-webrtc-sidecar.service"
+    assert "--run-live-gateway-stt-smoke" not in local_stack_live
+    assert plan["verify_commands"]["local_stack_live_gateway_cloud_only"][-1] == (
+        "--skip-live-gateway-bridge-health"
+    )
     live_gateway = plan["verify_commands"]["live_gateway"]
     assert live_gateway[:2] == [
         sys.executable,
@@ -186,10 +205,12 @@ def test_build_plan_adds_live_stt_smoke_when_configuring_stt(tmp_path: Path):
 
     plan = script.build_plan(args)
     live_gateway = plan["verify_commands"]["live_gateway"]
+    local_stack_live = plan["verify_commands"]["local_stack_live_gateway"]
 
     assert "--run-stt-smoke" in live_gateway
     assert live_gateway[live_gateway.index("--stt-provider") + 1] == "voice"
     assert live_gateway[live_gateway.index("--stt-timeout") + 1] == "123"
+    assert "--run-live-gateway-stt-smoke" in local_stack_live
 
 
 def test_configure_tts_provider_writes_voice_compatible_ogg_provider(tmp_path: Path):

--- a/tests/tools/test_install_voice_local_stack_script.py
+++ b/tests/tools/test_install_voice_local_stack_script.py
@@ -35,6 +35,7 @@ def test_render_sidecar_unit_points_at_voice_repo_and_pcm_sink(tmp_path: Path):
         voice_repo=voice_repo,
         voice_bin="/home/user/.local/bin/voice",
         webrtc_python_bin="/tmp/voice-webrtc-venv/bin/python",
+        voice_daemon_service="voiced.service",
         host="127.0.0.1",
         port=8787,
         rx_pcm_path=rx_pcm,
@@ -43,6 +44,7 @@ def test_render_sidecar_unit_points_at_voice_repo_and_pcm_sink(tmp_path: Path):
 
     assert "Description=Voice WebRTC Sidecar" in unit
     assert "After=network.target voiced.service" in unit
+    assert "Wants=voiced.service" in unit
     assert "voice-daemon.service" not in unit
     assert f"WorkingDirectory={voice_repo}" in unit
     assert 'Environment="VOICE_BIN=/home/user/.local/bin/voice"' in unit
@@ -109,6 +111,7 @@ def test_build_plan_generates_sidecar_unit_and_gateway_dropin(tmp_path: Path):
     assert plan["sidecar_url"] == "http://127.0.0.1:8787"
     assert plan["voice_bin"] == sys.executable
     assert plan["webrtc_python_bin"] == sys.executable
+    assert plan["voice_daemon_service"] == "voiced.service"
     assert plan["paths"]["hermes_dropin"] == str(
         systemd_dir / "hermes-gateway.service.d" / "voice-stack.conf"
     )
@@ -152,6 +155,9 @@ def test_build_plan_generates_sidecar_unit_and_gateway_dropin(tmp_path: Path):
     assert local_stack_live[
         local_stack_live.index("--live-gateway-sidecar-service") + 1
     ] == "voice-webrtc-sidecar.service"
+    assert local_stack_live[
+        local_stack_live.index("--live-gateway-voice-daemon-service") + 1
+    ] == "voiced.service"
     assert "--run-live-gateway-stt-smoke" not in local_stack_live
     assert plan["verify_commands"]["local_stack_live_gateway_cloud_only"][-1] == (
         "--skip-live-gateway-bridge-health"
@@ -173,6 +179,9 @@ def test_build_plan_generates_sidecar_unit_and_gateway_dropin(tmp_path: Path):
     assert "--run-stt-smoke" not in live_gateway
     assert "--sidecar-service" in live_gateway
     assert "voice-webrtc-sidecar.service" in live_gateway
+    assert live_gateway[live_gateway.index("--voice-daemon-service") + 1] == (
+        "voiced.service"
+    )
     assert "--voice-repo" in live_gateway
     assert str(voice_repo.resolve()) in live_gateway
     assert "--skip-bridge-health" not in live_gateway
@@ -213,6 +222,47 @@ def test_build_plan_adds_live_stt_smoke_when_configuring_stt(tmp_path: Path):
     assert live_gateway[live_gateway.index("--stt-provider") + 1] == "voice"
     assert live_gateway[live_gateway.index("--stt-timeout") + 1] == "123"
     assert "--run-live-gateway-stt-smoke" in local_stack_live
+
+
+def test_build_plan_threads_custom_voice_daemon_service(tmp_path: Path):
+    script = _load_script_module()
+    args = script.parse_args(
+        [
+            "--systemd-user-dir",
+            str(tmp_path / "systemd"),
+            "--hermes-home",
+            str(tmp_path / ".hermes"),
+            "--live-hermes-root",
+            str(tmp_path / "hermes-agent"),
+            "--voice-repo",
+            str(tmp_path / "voice"),
+            "--voice-bin",
+            sys.executable,
+            "--webrtc-python-bin",
+            sys.executable,
+            "--voice-daemon-service",
+            "custom-voiced.service",
+        ]
+    )
+
+    plan = script.build_plan(args)
+    sidecar_unit = next(
+        item["content"]
+        for item in plan["files"]
+        if item["kind"] == "systemd_user_service"
+    )
+
+    assert plan["voice_daemon_service"] == "custom-voiced.service"
+    assert "After=network.target custom-voiced.service" in sidecar_unit
+    assert "Wants=custom-voiced.service" in sidecar_unit
+    local_stack_live = plan["verify_commands"]["local_stack_live_gateway"]
+    assert local_stack_live[
+        local_stack_live.index("--live-gateway-voice-daemon-service") + 1
+    ] == "custom-voiced.service"
+    live_gateway = plan["verify_commands"]["live_gateway"]
+    assert live_gateway[live_gateway.index("--voice-daemon-service") + 1] == (
+        "custom-voiced.service"
+    )
 
 
 def test_configure_tts_provider_writes_voice_compatible_ogg_provider(tmp_path: Path):

--- a/tests/tools/test_install_voice_local_stack_script.py
+++ b/tests/tools/test_install_voice_local_stack_script.py
@@ -1,0 +1,204 @@
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+from ruamel.yaml import YAML
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "install_voice_local_stack.py"
+)
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "install_voice_local_stack",
+        SCRIPT_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_render_sidecar_unit_points_at_voice_repo_and_pcm_sink(tmp_path: Path):
+    script = _load_script_module()
+    voice_repo = tmp_path / "voice"
+    rx_pcm = tmp_path / ".hermes" / "voice-webrtc-sidecar" / "inbound.s16le"
+
+    unit = script.render_sidecar_unit(
+        voice_repo=voice_repo,
+        voice_bin="/home/user/.local/bin/voice",
+        webrtc_python_bin="/tmp/voice-webrtc-venv/bin/python",
+        host="127.0.0.1",
+        port=8787,
+        rx_pcm_path=rx_pcm,
+        log_level="INFO",
+    )
+
+    assert "Description=Voice WebRTC Sidecar" in unit
+    assert f"WorkingDirectory={voice_repo}" in unit
+    assert 'Environment="VOICE_BIN=/home/user/.local/bin/voice"' in unit
+    assert "/tmp/voice-webrtc-venv/bin/python" in unit
+    assert str(voice_repo / "examples" / "webrtc-sidecar" / "sidecar.py") in unit
+    assert "--host 127.0.0.1 --port 8787" in unit
+    assert f"--rx-pcm {rx_pcm}" in unit
+
+
+def test_render_hermes_dropin_exposes_voice_stream_contract(tmp_path: Path):
+    script = _load_script_module()
+    live_root = tmp_path / "hermes-agent"
+
+    dropin = script.render_hermes_dropin(
+        live_hermes_root=live_root,
+        gateway_path="/venv/bin:/bridge/bin:/usr/bin",
+        sidecar_url="http://127.0.0.1:8787",
+        voice_bin="/home/user/.local/bin/voice",
+        voice="af_heart",
+        speed="1.0",
+        stream_timeout=180.0,
+    )
+
+    assert f'Environment="PYTHONPATH={live_root}"' in dropin
+    assert 'Environment="PATH=/venv/bin:/bridge/bin:/usr/bin"' in dropin
+    assert (
+        'Environment="WHATSAPP_CLOUD_CALLING_SIDECAR_URL=http://127.0.0.1:8787"'
+        in dropin
+    )
+    assert "voice stream --quiet --sample-rate {sample_rate}" in dropin
+    assert "--frame-ms {frame_ms} --raw-output - --input-file {input_path}" in dropin
+    assert "--voice af_heart --speed 1.0" in dropin
+
+
+def test_build_plan_generates_sidecar_unit_and_gateway_dropin(tmp_path: Path):
+    script = _load_script_module()
+    systemd_dir = tmp_path / "systemd"
+    hermes_home = tmp_path / ".hermes"
+    live_root = tmp_path / "hermes-agent"
+    voice_repo = tmp_path / "voice"
+
+    args = script.parse_args(
+        [
+            "--systemd-user-dir",
+            str(systemd_dir),
+            "--hermes-home",
+            str(hermes_home),
+            "--config-path",
+            str(hermes_home / "config.yaml"),
+            "--live-hermes-root",
+            str(live_root),
+            "--voice-repo",
+            str(voice_repo),
+            "--voice-bin",
+            sys.executable,
+            "--webrtc-python-bin",
+            sys.executable,
+        ]
+    )
+
+    plan = script.build_plan(args)
+
+    assert plan["apply"] is False
+    assert plan["sidecar_url"] == "http://127.0.0.1:8787"
+    assert plan["voice_bin"] == sys.executable
+    assert plan["webrtc_python_bin"] == sys.executable
+    assert plan["paths"]["hermes_dropin"] == str(
+        systemd_dir / "hermes-gateway.service.d" / "voice-stack.conf"
+    )
+    assert plan["paths"]["sidecar_unit"] == str(
+        systemd_dir / "voice-webrtc-sidecar.service"
+    )
+    assert [item["kind"] for item in plan["files"]] == [
+        "systemd_user_service",
+        "systemd_user_dropin",
+    ]
+    assert plan["tts_provider"]["output_format"] == "ogg"
+    assert plan["tts_provider"]["voice_compatible"] is True
+
+
+def test_configure_tts_provider_writes_voice_compatible_ogg_provider(tmp_path: Path):
+    script = _load_script_module()
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("gateway:\n  enabled: true\n", encoding="utf-8")
+    provider = script.build_tts_provider(
+        voice_bin="/home/user/.local/bin/voice",
+        voice="af_heart",
+        speed="1.0",
+        timeout=180,
+        max_text_length=2000,
+    )
+
+    result = script.configure_tts_provider(
+        config_path=config_path,
+        provider_name="kokoro",
+        provider=provider,
+    )
+
+    parsed = YAML().load(config_path.read_text(encoding="utf-8"))
+    configured = parsed["tts"]["providers"]["kokoro"]
+    assert result == {
+        "path": str(config_path),
+        "provider": "kokoro",
+        "output_format": "ogg",
+        "voice_compatible": True,
+    }
+    assert parsed["gateway"]["enabled"] is True
+    assert parsed["tts"]["provider"] == "kokoro"
+    assert configured["command"].startswith(
+        "/home/user/.local/bin/voice say --format ogg-opus"
+    )
+    assert configured["output_format"] == "ogg"
+    assert configured["voice_compatible"] is True
+
+
+def test_apply_without_systemctl_writes_files_and_config(
+    tmp_path: Path,
+    capsys,
+):
+    script = _load_script_module()
+    systemd_dir = tmp_path / "systemd"
+    hermes_home = tmp_path / ".hermes"
+    live_root = tmp_path / "hermes-agent"
+    voice_repo = tmp_path / "voice"
+    config_path = hermes_home / "config.yaml"
+
+    exit_code = script.main(
+        [
+            "--apply",
+            "--no-systemctl",
+            "--no-start",
+            "--configure-tts",
+            "--systemd-user-dir",
+            str(systemd_dir),
+            "--hermes-home",
+            str(hermes_home),
+            "--config-path",
+            str(config_path),
+            "--live-hermes-root",
+            str(live_root),
+            "--voice-repo",
+            str(voice_repo),
+            "--voice-bin",
+            sys.executable,
+            "--webrtc-python-bin",
+            sys.executable,
+        ]
+    )
+
+    output = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert output["success"] is True
+    assert output["applied"] is True
+    assert output["apply_result"]["systemctl"] == []
+    assert (
+        systemd_dir / "voice-webrtc-sidecar.service"
+    ).read_text(encoding="utf-8").startswith("[Unit]")
+    assert (
+        systemd_dir / "hermes-gateway.service.d" / "voice-stack.conf"
+    ).read_text(encoding="utf-8").startswith("[Service]")
+    parsed = YAML().load(config_path.read_text(encoding="utf-8"))
+    assert parsed["tts"]["providers"]["kokoro"]["output_format"] == "ogg"
+    assert parsed["tts"]["providers"]["kokoro"]["voice_compatible"] is True

--- a/tests/tools/test_install_voice_local_stack_script.py
+++ b/tests/tools/test_install_voice_local_stack_script.py
@@ -119,6 +119,31 @@ def test_build_plan_generates_sidecar_unit_and_gateway_dropin(tmp_path: Path):
     ]
     assert plan["tts_provider"]["output_format"] == "ogg"
     assert plan["tts_provider"]["voice_compatible"] is True
+    local_stack = plan["verify_commands"]["local_stack"]
+    assert local_stack[:2] == [
+        sys.executable,
+        str(script.repo_root() / "scripts" / "verify_voice_local_stack.py"),
+    ]
+    assert "--voice-bin" in local_stack
+    assert sys.executable in local_stack
+    assert "--voice-repo" in local_stack
+    assert str(voice_repo.resolve()) in local_stack
+    assert "--webrtc-python-bin" in local_stack
+    assert "--live-hermes-root" in local_stack
+    assert str(live_root.resolve()) in local_stack
+    live_gateway = plan["verify_commands"]["live_gateway"]
+    assert live_gateway[:2] == [
+        sys.executable,
+        str(script.repo_root() / "scripts" / "verify_voice_live_gateway.py"),
+    ]
+    assert "--calling-sidecar-url" in live_gateway
+    assert "http://127.0.0.1:8787" in live_gateway
+    assert "--voice-bin" in live_gateway
+    assert "--run-tts-smoke" in live_gateway
+    assert "--skip-bridge-health" not in live_gateway
+    assert plan["verify_commands"]["live_gateway_cloud_only"][-1] == (
+        "--skip-bridge-health"
+    )
 
 
 def test_configure_tts_provider_writes_voice_compatible_ogg_provider(tmp_path: Path):

--- a/tests/tools/test_install_voice_local_stack_script.py
+++ b/tests/tools/test_install_voice_local_stack_script.py
@@ -152,6 +152,7 @@ def test_build_plan_generates_sidecar_unit_and_gateway_dropin(tmp_path: Path):
     assert local_stack_live[
         local_stack_live.index("--live-gateway-hermes-home") + 1
     ] == str(hermes_home.resolve())
+    assert "--run-live-gateway-calling-live-sidecar-smoke" in local_stack_live
     assert local_stack_live[
         local_stack_live.index("--live-gateway-sidecar-service") + 1
     ] == "voice-webrtc-sidecar.service"
@@ -172,6 +173,7 @@ def test_build_plan_generates_sidecar_unit_and_gateway_dropin(tmp_path: Path):
     assert "--voice-bin" in live_gateway
     assert "--run-tts-smoke" in live_gateway
     assert "--run-sidecar-offer-smoke" in live_gateway
+    assert "--run-calling-live-sidecar-smoke" in live_gateway
     assert (
         live_gateway[live_gateway.index("--webrtc-python-bin") + 1]
         == sys.executable

--- a/tests/tools/test_install_voice_local_stack_script.py
+++ b/tests/tools/test_install_voice_local_stack_script.py
@@ -119,6 +119,10 @@ def test_build_plan_generates_sidecar_unit_and_gateway_dropin(tmp_path: Path):
     ]
     assert plan["tts_provider"]["output_format"] == "ogg"
     assert plan["tts_provider"]["voice_compatible"] is True
+    assert plan["stt_provider"]["command"] == (
+        f"{sys.executable} stream-transcribe --quiet {{input_path}}"
+    )
+    assert plan["stt_provider"]["format"] == "txt"
     local_stack = plan["verify_commands"]["local_stack"]
     assert local_stack[:2] == [
         sys.executable,
@@ -185,6 +189,44 @@ def test_configure_tts_provider_writes_voice_compatible_ogg_provider(tmp_path: P
     assert configured["voice_compatible"] is True
 
 
+def test_configure_stt_provider_writes_voice_stream_transcribe_provider(
+    tmp_path: Path,
+):
+    script = _load_script_module()
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "gateway:\n  enabled: true\nstt:\n  enabled: true\n  provider: local\n",
+        encoding="utf-8",
+    )
+    provider = script.build_stt_provider(
+        voice_bin="/home/user/.local/bin/voice",
+        timeout=300,
+    )
+
+    result = script.configure_stt_provider(
+        config_path=config_path,
+        provider_name="voice",
+        provider=provider,
+    )
+
+    parsed = YAML().load(config_path.read_text(encoding="utf-8"))
+    configured = parsed["stt"]["providers"]["voice"]
+    assert result == {
+        "path": str(config_path),
+        "provider": "voice",
+        "format": "txt",
+    }
+    assert parsed["gateway"]["enabled"] is True
+    assert parsed["stt"]["enabled"] is True
+    assert parsed["stt"]["provider"] == "voice"
+    assert configured["type"] == "command"
+    assert configured["command"] == (
+        "/home/user/.local/bin/voice stream-transcribe --quiet {input_path}"
+    )
+    assert configured["format"] == "txt"
+    assert configured["timeout"] == 300
+
+
 def test_configure_tts_provider_falls_back_to_pyyaml(
     tmp_path: Path,
     monkeypatch,
@@ -238,6 +280,7 @@ def test_apply_without_systemctl_writes_files_and_config(
             "--no-systemctl",
             "--no-start",
             "--configure-tts",
+            "--configure-stt",
             "--systemd-user-dir",
             str(systemd_dir),
             "--hermes-home",
@@ -269,3 +312,8 @@ def test_apply_without_systemctl_writes_files_and_config(
     parsed = YAML().load(config_path.read_text(encoding="utf-8"))
     assert parsed["tts"]["providers"]["kokoro"]["output_format"] == "ogg"
     assert parsed["tts"]["providers"]["kokoro"]["voice_compatible"] is True
+    assert parsed["stt"]["provider"] == "voice"
+    assert parsed["stt"]["providers"]["voice"]["command"] == (
+        f"{sys.executable} stream-transcribe --quiet {{input_path}}"
+    )
+    assert parsed["stt"]["providers"]["voice"]["format"] == "txt"

--- a/tests/tools/test_install_voice_local_stack_script.py
+++ b/tests/tools/test_install_voice_local_stack_script.py
@@ -42,6 +42,8 @@ def test_render_sidecar_unit_points_at_voice_repo_and_pcm_sink(tmp_path: Path):
     )
 
     assert "Description=Voice WebRTC Sidecar" in unit
+    assert "After=network.target voiced.service" in unit
+    assert "voice-daemon.service" not in unit
     assert f"WorkingDirectory={voice_repo}" in unit
     assert 'Environment="VOICE_BIN=/home/user/.local/bin/voice"' in unit
     assert "/tmp/voice-webrtc-venv/bin/python" in unit

--- a/tests/tools/test_install_voice_local_stack_script.py
+++ b/tests/tools/test_install_voice_local_stack_script.py
@@ -144,6 +144,7 @@ def test_build_plan_generates_sidecar_unit_and_gateway_dropin(tmp_path: Path):
     assert "http://127.0.0.1:8787" in live_gateway
     assert "--voice-bin" in live_gateway
     assert "--run-tts-smoke" in live_gateway
+    assert "--run-stt-smoke" not in live_gateway
     assert "--sidecar-service" in live_gateway
     assert "voice-webrtc-sidecar.service" in live_gateway
     assert "--voice-repo" in live_gateway
@@ -152,6 +153,38 @@ def test_build_plan_generates_sidecar_unit_and_gateway_dropin(tmp_path: Path):
     assert plan["verify_commands"]["live_gateway_cloud_only"][-1] == (
         "--skip-bridge-health"
     )
+
+
+def test_build_plan_adds_live_stt_smoke_when_configuring_stt(tmp_path: Path):
+    script = _load_script_module()
+    args = script.parse_args(
+        [
+            "--systemd-user-dir",
+            str(tmp_path / "systemd"),
+            "--hermes-home",
+            str(tmp_path / ".hermes"),
+            "--live-hermes-root",
+            str(tmp_path / "hermes-agent"),
+            "--voice-repo",
+            str(tmp_path / "voice"),
+            "--voice-bin",
+            sys.executable,
+            "--webrtc-python-bin",
+            sys.executable,
+            "--configure-stt",
+            "--stt-provider-name",
+            "voice",
+            "--stt-timeout",
+            "123",
+        ]
+    )
+
+    plan = script.build_plan(args)
+    live_gateway = plan["verify_commands"]["live_gateway"]
+
+    assert "--run-stt-smoke" in live_gateway
+    assert live_gateway[live_gateway.index("--stt-provider") + 1] == "voice"
+    assert live_gateway[live_gateway.index("--stt-timeout") + 1] == "123"
 
 
 def test_configure_tts_provider_writes_voice_compatible_ogg_provider(tmp_path: Path):

--- a/tests/tools/test_tts_command_providers.py
+++ b/tests/tools/test_tts_command_providers.py
@@ -33,6 +33,7 @@ from tools.tts_tool import (
     _has_any_command_tts_provider,
     _is_command_provider_config,
     _is_command_tts_voice_compatible,
+    _is_native_ogg_opus,
     _iter_command_providers,
     _render_command_tts_template,
     _resolve_command_provider_config,
@@ -47,6 +48,9 @@ from tools.tts_tool import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+OPUS_OGG_BYTES = b"OggS\x00\x02" + (b"\x00" * 20) + b"OpusHead" + (b"\x00" * 16)
+
+
 def _python_copy_command(output_placeholder: str = "{output_path}") -> str:
     """Return a cross-platform shell command that copies {input_path} -> output."""
     interpreter = sys.executable
@@ -54,6 +58,19 @@ def _python_copy_command(output_placeholder: str = "{output_path}") -> str:
         f'"{interpreter}" -c "import shutil, sys; '
         f'shutil.copyfile(sys.argv[1], sys.argv[2])" '
         f'{{input_path}} {output_placeholder}'
+    )
+
+
+def _python_write_bytes_command(
+    payload: bytes,
+    output_placeholder: str = "{output_path}",
+) -> str:
+    """Return a command that writes fixed bytes to {output_path}."""
+    interpreter = sys.executable
+    return (
+        f'"{interpreter}" -c "from pathlib import Path; import sys; '
+        f'Path(sys.argv[1]).write_bytes(bytes.fromhex(sys.argv[2]))" '
+        f'{output_placeholder} {payload.hex()}'
     )
 
 
@@ -197,14 +214,20 @@ class TestConfigGetters:
     def test_output_format_path_override(self):
         assert _get_command_tts_output_format({}, "/tmp/clip.wav") == "wav"
 
+    def test_output_format_path_override_opus(self):
+        assert _get_command_tts_output_format({}, "/tmp/clip.opus") == "opus"
+
     def test_output_format_unknown_path_falls_back_to_config(self):
         assert _get_command_tts_output_format({"format": "ogg"}, "/tmp/clip.xyz") == "ogg"
+
+    def test_output_format_accepts_opus(self):
+        assert _get_command_tts_output_format({"format": "opus"}) == "opus"
 
     def test_output_format_rejects_unknown(self):
         assert _get_command_tts_output_format({"format": "m4a"}) == DEFAULT_COMMAND_TTS_OUTPUT_FORMAT
 
     def test_output_format_supported_set(self):
-        assert COMMAND_TTS_OUTPUT_FORMATS == frozenset({"mp3", "wav", "ogg", "flac"})
+        assert COMMAND_TTS_OUTPUT_FORMATS == frozenset({"mp3", "wav", "ogg", "opus", "flac"})
 
     def test_voice_compatible_boolean(self):
         assert _is_command_tts_voice_compatible({"voice_compatible": True}) is True
@@ -452,13 +475,13 @@ class TestTextToSpeechToolWithCommandProvider:
 
     def test_voice_compatible_opt_in_toggles_flag(self, tmp_path):
         """voice_compatible=true is reflected in the response when the
-        file is already .ogg (no ffmpeg needed)."""
+        file is already Ogg/Opus (no ffmpeg needed)."""
         cfg = {
             "provider": "py-copy-ogg",
             "providers": {
                 "py-copy-ogg": {
                     "type": "command",
-                    "command": _python_copy_command(),
+                    "command": _python_write_bytes_command(OPUS_OGG_BYTES),
                     "output_format": "ogg",
                     "voice_compatible": True,
                 },
@@ -471,7 +494,55 @@ class TestTextToSpeechToolWithCommandProvider:
         data = json.loads(result)
         assert data["success"] is True
         assert data["voice_compatible"] is True
+        assert _is_native_ogg_opus(data["file_path"]) is True
         assert data["media_tag"].startswith("[[audio_as_voice]]")
+
+    def test_voice_compatible_opt_in_accepts_opus_extension(self, tmp_path):
+        cfg = {
+            "provider": "py-opus",
+            "providers": {
+                "py-opus": {
+                    "type": "command",
+                    "command": _python_write_bytes_command(OPUS_OGG_BYTES),
+                    "output_format": "opus",
+                    "voice_compatible": True,
+                },
+            },
+        }
+        out = tmp_path / "clip"
+
+        with patch("tools.tts_tool._load_tts_config", return_value=cfg):
+            result = text_to_speech_tool(text="hi", output_path=str(out))
+        data = json.loads(result)
+        opus_path = tmp_path / "clip.opus"
+        assert data["success"] is True
+        assert data["file_path"] == str(opus_path)
+        assert data["voice_compatible"] is True
+        assert data["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{opus_path}"
+
+    def test_voice_compatible_opt_in_rejects_fake_ogg(self, tmp_path):
+        cfg = {
+            "provider": "py-fake-ogg",
+            "providers": {
+                "py-fake-ogg": {
+                    "type": "command",
+                    "command": _python_write_bytes_command(b"not opus"),
+                    "output_format": "ogg",
+                    "voice_compatible": True,
+                },
+            },
+        }
+        out = tmp_path / "clip.ogg"
+
+        with patch("tools.tts_tool._load_tts_config", return_value=cfg), \
+             patch("tools.tts_tool._convert_to_opus", return_value=None) as convert:
+            result = text_to_speech_tool(text="hi", output_path=str(out))
+        data = json.loads(result)
+        assert data["success"] is True
+        assert data["file_path"] == str(out)
+        assert data["voice_compatible"] is False
+        assert data["media_tag"] == f"MEDIA:{out}"
+        convert.assert_called_once_with(str(out))
 
     def test_missing_command_falls_through_to_builtin(self, tmp_path):
         """A provider entry with an empty command is not a command

--- a/tests/tools/test_tts_dotenv_fallback.py
+++ b/tests/tools/test_tts_dotenv_fallback.py
@@ -56,6 +56,20 @@ class TestDotenvFallbackPerProvider:
 
             mock_import.return_value.assert_called_once_with(api_key="el-dotenv-key")
 
+    def test_elevenlabs_opus_extension_requests_opus_format(self, tmp_path):
+        from tools import tts_tool
+
+        with patch.object(tts_tool, "get_env_value", return_value="el-dotenv-key"), \
+             patch.object(tts_tool, "_import_elevenlabs") as mock_import:
+            mock_client = MagicMock()
+            mock_client.text_to_speech.convert.return_value = iter([b"audio"])
+            mock_import.return_value = MagicMock(return_value=mock_client)
+
+            tts_tool._generate_elevenlabs("hi", str(tmp_path / "out.opus"), {})
+
+        kwargs = mock_client.text_to_speech.convert.call_args[1]
+        assert kwargs["output_format"] == "opus_48000_64"
+
     def test_xai_reads_dotenv_key(self, tmp_path):
         """xAI TTS now resolves credentials through ``tools.xai_http``; the
         dotenv fallback contract from #17140 is preserved by patching the

--- a/tests/tools/test_tts_gemini.py
+++ b/tests/tools/test_tts_gemini.py
@@ -1,6 +1,7 @@
 """Tests for the Google Gemini TTS provider in tools/tts_tool.py."""
 
 import base64
+import subprocess
 import struct
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -114,6 +115,29 @@ class TestGenerateGeminiTts:
         assert data[8:12] == b"WAVE"
         # Audio payload should match the PCM we put in
         assert data[44:] == fake_pcm_bytes
+
+    def test_opus_output_uses_libopus_ffmpeg(
+        self, tmp_path, monkeypatch, mock_gemini_response
+    ):
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        output_path = str(tmp_path / "test.opus")
+        seen_cmd: list[str] = []
+
+        def fake_run(cmd, **_kwargs):
+            seen_cmd[:] = cmd
+            (tmp_path / "test.opus").write_bytes(b"OggS\x00\x02OpusHead")
+            return subprocess.CompletedProcess(cmd, 0, b"", b"")
+
+        with patch("requests.post", return_value=mock_gemini_response), \
+             patch("tools.tts_tool.shutil.which", return_value="/usr/bin/ffmpeg"), \
+             patch("tools.tts_tool.subprocess.run", side_effect=fake_run):
+            result = _generate_gemini_tts("Hi", output_path, {})
+
+        assert result == output_path
+        assert "-acodec" in seen_cmd
+        assert "libopus" in seen_cmd
 
     def test_default_voice_and_model(self, tmp_path, monkeypatch, mock_gemini_response):
         from tools.tts_tool import (

--- a/tests/tools/test_tts_mistral.py
+++ b/tests/tools/test_tts_mistral.py
@@ -54,7 +54,13 @@ class TestGenerateMistralTts:
 
     @pytest.mark.parametrize(
         "extension, expected_format",
-        [(".ogg", "opus"), (".wav", "wav"), (".flac", "flac"), (".mp3", "mp3")],
+        [
+            (".ogg", "opus"),
+            (".opus", "opus"),
+            (".wav", "wav"),
+            (".flac", "flac"),
+            (".mp3", "mp3"),
+        ],
     )
     def test_response_format_from_extension(
         self, tmp_path, mock_mistral_module, monkeypatch, extension, expected_format

--- a/tests/tools/test_tts_opus_routing.py
+++ b/tests/tools/test_tts_opus_routing.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -69,3 +70,31 @@ def test_edge_voice_note_platforms_convert_to_opus_voice(tmp_path, monkeypatch, 
     assert result["voice_compatible"] is True
     assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{opus}"
     convert.assert_called_once_with(str(out))
+
+
+def test_tts_opus_conversion_forces_whatsapp_ready_shape(tmp_path, monkeypatch):
+    source = tmp_path / "speech.mp3"
+    source.write_bytes(b"mp3")
+    output = tmp_path / "speech.ogg"
+    commands = []
+
+    def fake_run(command, **kwargs):
+        commands.append((command, kwargs))
+        output.write_bytes(b"OggS")
+        return subprocess.CompletedProcess(command, 0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(tts_tool, "_has_ffmpeg", lambda: True)
+    monkeypatch.setattr(tts_tool.subprocess, "run", fake_run)
+
+    result = tts_tool._convert_to_opus(str(source))
+
+    assert result == str(output)
+    assert commands
+    command, kwargs = commands[0]
+    assert command[:4] == ["ffmpeg", "-i", str(source), "-acodec"]
+    assert "libopus" in command
+    assert command[command.index("-ac") + 1] == "1"
+    assert command[command.index("-ar") + 1] == "48000"
+    assert command[command.index("-application") + 1] == "voip"
+    assert command[-2:] == [str(output), "-y"]
+    assert kwargs["stdin"] is subprocess.DEVNULL

--- a/tests/tools/test_tts_opus_routing.py
+++ b/tests/tools/test_tts_opus_routing.py
@@ -44,7 +44,8 @@ def test_edge_cli_preserves_native_mp3(tmp_path, monkeypatch):
     convert.assert_not_called()
 
 
-def test_edge_telegram_converts_to_opus_voice(tmp_path, monkeypatch):
+@pytest.mark.parametrize("platform", ["telegram", "whatsapp", "whatsapp_cloud"])
+def test_edge_voice_platforms_convert_to_opus_voice(tmp_path, monkeypatch, platform):
     out = tmp_path / "speech.mp3"
     opus = tmp_path / "speech.ogg"
 
@@ -55,7 +56,7 @@ def test_edge_telegram_converts_to_opus_voice(tmp_path, monkeypatch):
 
     convert = Mock(side_effect=fake_convert)
 
-    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", platform)
     monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "edge"})
     monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
     monkeypatch.setattr(tts_tool, "_generate_edge_tts", _write_edge_output)

--- a/tests/tools/test_tts_opus_routing.py
+++ b/tests/tools/test_tts_opus_routing.py
@@ -44,7 +44,8 @@ def test_edge_cli_preserves_native_mp3(tmp_path, monkeypatch):
     convert.assert_not_called()
 
 
-def test_edge_telegram_converts_to_opus_voice(tmp_path, monkeypatch):
+@pytest.mark.parametrize("platform", ["telegram", "whatsapp", "whatsapp_cloud"])
+def test_edge_voice_note_platforms_convert_to_opus_voice(tmp_path, monkeypatch, platform):
     out = tmp_path / "speech.mp3"
     opus = tmp_path / "speech.ogg"
 
@@ -55,7 +56,7 @@ def test_edge_telegram_converts_to_opus_voice(tmp_path, monkeypatch):
 
     convert = Mock(side_effect=fake_convert)
 
-    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", platform)
     monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "edge"})
     monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
     monkeypatch.setattr(tts_tool, "_generate_edge_tts", _write_edge_output)

--- a/tests/tools/test_tts_opus_routing.py
+++ b/tests/tools/test_tts_opus_routing.py
@@ -8,6 +8,9 @@ from gateway.session_context import _UNSET, _VAR_MAP
 from tools import tts_tool
 
 
+OPUS_OGG_BYTES = b"OggS\x00\x02" + (b"\x00" * 20) + b"OpusHead" + (b"\x00" * 16)
+
+
 def _reset_session_context() -> None:
     for var in _VAR_MAP.values():
         var.set(_UNSET)
@@ -51,7 +54,7 @@ def test_edge_voice_platforms_convert_to_opus_voice(tmp_path, monkeypatch, platf
 
     def fake_convert(path: str) -> str:
         assert path == str(out)
-        opus.write_bytes(b"ogg")
+        opus.write_bytes(OPUS_OGG_BYTES)
         return str(opus)
 
     convert = Mock(side_effect=fake_convert)
@@ -69,3 +72,26 @@ def test_edge_voice_platforms_convert_to_opus_voice(tmp_path, monkeypatch, platf
     assert result["voice_compatible"] is True
     assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{opus}"
     convert.assert_called_once_with(str(out))
+
+
+def test_voice_platform_rejects_invalid_opus_conversion(tmp_path, monkeypatch):
+    out = tmp_path / "speech.mp3"
+    opus = tmp_path / "speech.ogg"
+
+    def fake_convert(path: str) -> str:
+        assert path == str(out)
+        opus.write_bytes(b"not opus")
+        return str(opus)
+
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "whatsapp_cloud")
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "edge"})
+    monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
+    monkeypatch.setattr(tts_tool, "_generate_edge_tts", _write_edge_output)
+    monkeypatch.setattr(tts_tool, "_convert_to_opus", Mock(side_effect=fake_convert))
+
+    result = json.loads(tts_tool.text_to_speech_tool("hello", output_path=str(out)))
+
+    assert result["success"] is True
+    assert result["file_path"] == str(out)
+    assert result["voice_compatible"] is False
+    assert result["media_tag"] == f"MEDIA:{out}"

--- a/tests/tools/test_tts_opus_routing.py
+++ b/tests/tools/test_tts_opus_routing.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -95,3 +96,31 @@ def test_voice_platform_rejects_invalid_opus_conversion(tmp_path, monkeypatch):
     assert result["file_path"] == str(out)
     assert result["voice_compatible"] is False
     assert result["media_tag"] == f"MEDIA:{out}"
+
+
+def test_tts_opus_conversion_forces_whatsapp_ready_shape(tmp_path, monkeypatch):
+    source = tmp_path / "speech.mp3"
+    source.write_bytes(b"mp3")
+    output = tmp_path / "speech.ogg"
+    commands = []
+
+    def fake_run(command, **kwargs):
+        commands.append((command, kwargs))
+        output.write_bytes(OPUS_OGG_BYTES)
+        return subprocess.CompletedProcess(command, 0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(tts_tool, "_has_ffmpeg", lambda: True)
+    monkeypatch.setattr(tts_tool.subprocess, "run", fake_run)
+
+    result = tts_tool._convert_to_opus(str(source))
+
+    assert result == str(output)
+    assert commands
+    command, kwargs = commands[0]
+    assert command[:4] == ["ffmpeg", "-i", str(source), "-acodec"]
+    assert "libopus" in command
+    assert command[command.index("-ac") + 1] == "1"
+    assert command[command.index("-ar") + 1] == "48000"
+    assert command[command.index("-application") + 1] == "voip"
+    assert command[-2:] == [str(output), "-y"]
+    assert kwargs["stdin"] is subprocess.DEVNULL

--- a/tests/tools/test_tts_speed.py
+++ b/tests/tools/test_tts_speed.py
@@ -69,7 +69,7 @@ class TestEdgeTtsSpeed:
 # ---------------------------------------------------------------------------
 
 class TestOpenaiTtsSpeed:
-    def _run(self, tts_config, tmp_path, monkeypatch):
+    def _run(self, tts_config, tmp_path, monkeypatch, output_name="out.mp3"):
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")
         mock_response = MagicMock()
         mock_client = MagicMock()
@@ -80,7 +80,7 @@ class TestOpenaiTtsSpeed:
              patch("tools.tts_tool._resolve_openai_audio_client_config",
                    return_value=("test-key", None)):
             from tools.tts_tool import _generate_openai_tts
-            _generate_openai_tts("Hello", str(tmp_path / "out.mp3"), tts_config)
+            _generate_openai_tts("Hello", str(tmp_path / output_name), tts_config)
         return mock_client.audio.speech.create
 
     def test_default_no_speed_kwarg(self, tmp_path, monkeypatch):
@@ -112,6 +112,11 @@ class TestOpenaiTtsSpeed:
         create = self._run({"speed": 10.0}, tmp_path, monkeypatch)
         kwargs = create.call_args[1]
         assert kwargs["speed"] == 4.0
+
+    def test_opus_extension_requests_opus_response_format(self, tmp_path, monkeypatch):
+        create = self._run({}, tmp_path, monkeypatch, output_name="out.opus")
+        kwargs = create.call_args[1]
+        assert kwargs["response_format"] == "opus"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_verify_voice_command_stt_script.py
+++ b/tests/tools/test_verify_voice_command_stt_script.py
@@ -1,0 +1,88 @@
+import importlib.util
+import shlex
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "verify_voice_command_stt.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location("verify_voice_command_stt", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_config_uses_voice_stream_transcribe_command():
+    script = _load_script_module()
+
+    config = script.build_config(
+        provider="voice",
+        voice_bin="/tmp/bin/voice with spaces",
+        timeout=300.0,
+    )
+
+    assert "enabled: true" in config
+    assert "provider: voice" in config
+    assert "type: command" in config
+    assert "format: txt" in config
+    assert "stream-transcribe --quiet {input_path}" in config
+    assert shlex.quote("/tmp/bin/voice with spaces") in config
+
+
+def test_existing_config_path_requires_config_yaml(tmp_path: Path):
+    script = _load_script_module()
+
+    with pytest.raises(SystemExit) as excinfo:
+        script.existing_config_path(tmp_path)
+
+    assert "config.yaml does not exist" in str(excinfo.value)
+
+
+def test_existing_config_path_returns_deployed_config(tmp_path: Path):
+    script = _load_script_module()
+    config = tmp_path / "config.yaml"
+    config.write_text("stt:\n  provider: voice\n", encoding="utf-8")
+
+    assert script.existing_config_path(tmp_path) == config
+
+
+def test_transcript_text_accepts_transcript_or_text_field():
+    script = _load_script_module()
+
+    assert script.transcript_text({"transcript": "hello"}) == "hello"
+    assert script.transcript_text({"text": "world"}) == "world"
+    assert script.transcript_text({}) == ""
+
+
+def test_validate_result_requires_expected_provider_and_words():
+    script = _load_script_module()
+    result = {"provider": "voice", "transcript": "Hello world."}
+
+    script.validate_result(
+        result,
+        expected_provider="voice",
+        expected_words=["hello", "world"],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        script.validate_result(
+            result,
+            expected_provider="other",
+            expected_words=["hello"],
+        )
+
+    assert "expected provider other" in str(excinfo.value)
+
+    with pytest.raises(SystemExit) as excinfo:
+        script.validate_result(
+            result,
+            expected_provider="voice",
+            expected_words=["missing"],
+        )
+
+    assert "expected transcript to contain" in str(excinfo.value)

--- a/tests/tools/test_verify_voice_command_tts_script.py
+++ b/tests/tools/test_verify_voice_command_tts_script.py
@@ -2,6 +2,8 @@ import importlib.util
 import shlex
 from pathlib import Path
 
+import pytest
+
 
 SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "verify_voice_command_tts.py"
 
@@ -43,3 +45,41 @@ def test_parse_ffprobe_output_extracts_stream_fields():
         "sample_rate": "48000",
         "channels": "1",
     }
+
+
+def test_existing_config_path_requires_config_yaml(tmp_path: Path):
+    script = _load_script_module()
+
+    with pytest.raises(SystemExit) as excinfo:
+        script.existing_config_path(tmp_path)
+
+    assert "config.yaml does not exist" in str(excinfo.value)
+
+
+def test_existing_config_path_returns_deployed_config(tmp_path: Path):
+    script = _load_script_module()
+    config = tmp_path / "config.yaml"
+    config.write_text("tts:\n  provider: kokoro\n", encoding="utf-8")
+
+    assert script.existing_config_path(tmp_path) == config
+
+
+def test_validate_result_uses_expected_provider(tmp_path: Path):
+    script = _load_script_module()
+    audio = tmp_path / "reply.ogg"
+    audio.write_bytes(b"OggS")
+
+    result = {
+        "provider": "kokoro",
+        "voice_compatible": True,
+        "media_tag": f"[[audio_as_voice]]\nMEDIA:{audio}",
+        "file_path": str(audio),
+    }
+    probe = {"codec_name": "opus", "sample_rate": "48000", "channels": "1"}
+
+    script.validate_result(result, probe, expected_provider="kokoro")
+
+    with pytest.raises(SystemExit) as excinfo:
+        script.validate_result(result, probe, expected_provider="other")
+
+    assert "expected provider other" in str(excinfo.value)

--- a/tests/tools/test_verify_voice_command_tts_script.py
+++ b/tests/tools/test_verify_voice_command_tts_script.py
@@ -1,0 +1,45 @@
+import importlib.util
+import shlex
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "verify_voice_command_tts.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location("verify_voice_command_tts", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_config_uses_explicit_ogg_opus_voice_command():
+    script = _load_script_module()
+
+    config = script.build_config(
+        provider="kokoro",
+        voice_bin="/tmp/bin/voice with spaces",
+        voice="af_heart",
+        speed="1.0",
+        timeout=180.0,
+    )
+
+    assert "provider: kokoro" in config
+    assert "output_format: ogg" in config
+    assert "voice_compatible: true" in config
+    assert "--format ogg-opus" in config
+    assert "--input-file {input_path}" in config
+    assert "--output {output_path}" in config
+    assert shlex.quote("/tmp/bin/voice with spaces") in config
+
+
+def test_parse_ffprobe_output_extracts_stream_fields():
+    script = _load_script_module()
+
+    assert script.parse_ffprobe("codec_name=opus\nsample_rate=48000\nchannels=1\n") == {
+        "codec_name": "opus",
+        "sample_rate": "48000",
+        "channels": "1",
+    }

--- a/tests/tools/test_verify_voice_full_duplex_sidecar_script.py
+++ b/tests/tools/test_verify_voice_full_duplex_sidecar_script.py
@@ -1,0 +1,156 @@
+import importlib.util
+import json
+import os
+from pathlib import Path
+import sys
+
+import pytest
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "verify_voice_full_duplex_sidecar.py"
+)
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "verify_voice_full_duplex_sidecar",
+        SCRIPT_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _valid_result():
+    return {
+        "success": True,
+        "transcript": "Hello World",
+        "outbound_webrtc_bytes": 23_040,
+        "decoded_pcm_bytes": 124_992,
+        "audio": {
+            "sample_rate": 48_000,
+            "channels": 1,
+            "frame_ms": 20,
+            "encoding": "pcm_s16le",
+        },
+        "stt": {"text": "Hello World"},
+    }
+
+
+def test_build_smoke_command_points_at_voice_full_duplex_smoke():
+    script = _load_script_module()
+    smoke_path = Path("/repo/examples/webrtc-sidecar/full_duplex_loopback_smoke.py")
+
+    command = script.build_smoke_command(
+        python_bin="/tmp/venv/bin/python",
+        smoke_path=smoke_path,
+        voice_bin="/usr/local/bin/voice",
+        inbound_text="hello world",
+        outbound_text="hello back",
+        voice="af_heart",
+        speed="1.0",
+        timeout=90.0,
+        expect_words=["hello", "world"],
+    )
+
+    assert command[:4] == [
+        "/tmp/venv/bin/python",
+        str(smoke_path),
+        "--voice-bin",
+        "/usr/local/bin/voice",
+    ]
+    assert "--inbound-text" in command
+    assert "--outbound-text" in command
+    assert command[-4:] == ["--expect-word", "hello", "--expect-word", "world"]
+
+
+def test_full_duplex_smoke_path_uses_voice_repo_layout():
+    script = _load_script_module()
+
+    assert script.full_duplex_smoke_path(Path("/voice")) == Path(
+        "/voice/examples/webrtc-sidecar/full_duplex_loopback_smoke.py"
+    )
+
+
+def test_resolve_executable_preserves_virtualenv_symlink(tmp_path: Path):
+    script = _load_script_module()
+    target = tmp_path / "python3"
+    target.write_text("#!/bin/sh\n", encoding="utf-8")
+    target.chmod(0o755)
+    symlink = tmp_path / "python"
+    symlink.symlink_to(target.name)
+
+    resolved = script.resolve_executable(str(symlink), label="python")
+
+    assert resolved == os.path.abspath(str(symlink))
+    assert Path(resolved).is_symlink()
+
+
+def test_parse_smoke_json_accepts_progress_prefix():
+    script = _load_script_module()
+    result = _valid_result()
+
+    parsed = script.parse_smoke_json("progress line\n" + json.dumps(result))
+
+    assert parsed == result
+
+
+def test_parse_smoke_json_rejects_missing_json():
+    script = _load_script_module()
+
+    with pytest.raises(ValueError, match="did not print"):
+        script.parse_smoke_json("not json")
+
+
+def test_validate_smoke_result_accepts_voice_contract_shape():
+    script = _load_script_module()
+
+    script.validate_smoke_result(_valid_result())
+
+
+def test_validate_smoke_result_rejects_silent_outbound():
+    script = _load_script_module()
+    result = _valid_result()
+    result["outbound_webrtc_bytes"] = 0
+
+    with pytest.raises(SystemExit, match="outbound_webrtc_bytes"):
+        script.validate_smoke_result(result)
+
+
+def test_parse_args_uses_default_expected_words(monkeypatch):
+    script = _load_script_module()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["verify_voice_full_duplex_sidecar.py", "--voice-repo", "/voice"],
+    )
+
+    args = script.parse_args()
+
+    assert args.voice_repo == Path("/voice")
+    assert args.expect_word == ["hello", "world"]
+
+
+def test_parse_args_replaces_default_expected_words(monkeypatch):
+    script = _load_script_module()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "verify_voice_full_duplex_sidecar.py",
+            "--voice-repo",
+            "/voice",
+            "--expect-word",
+            "testing",
+        ],
+    )
+
+    args = script.parse_args()
+
+    assert args.expect_word == ["testing"]

--- a/tests/tools/test_verify_voice_full_duplex_sidecar_script.py
+++ b/tests/tools/test_verify_voice_full_duplex_sidecar_script.py
@@ -108,6 +108,17 @@ def test_parse_smoke_json_rejects_missing_json():
         script.parse_smoke_json("not json")
 
 
+def test_format_child_error_preserves_tail():
+    script = _load_script_module()
+    stderr = "Traceback header\n" + ("x" * 1200) + "\nRuntimeError: useful tail"
+
+    formatted = script.format_child_error(stderr, max_chars=80)
+
+    assert "omitted" in formatted
+    assert "Traceback header" not in formatted
+    assert "RuntimeError: useful tail" in formatted
+
+
 def test_validate_smoke_result_accepts_voice_contract_shape():
     script = _load_script_module()
 

--- a/tests/tools/test_verify_voice_full_duplex_sidecar_script.py
+++ b/tests/tools/test_verify_voice_full_duplex_sidecar_script.py
@@ -38,7 +38,10 @@ def _valid_result():
             "channels": 1,
             "frame_ms": 20,
             "encoding": "pcm_s16le",
+            "bytes_per_sample": 2,
         },
+        "queued_tx_bytes": 1_920,
+        "queued_tx_ms": 20,
         "stt": {"text": "Hello World"},
     }
 
@@ -57,6 +60,7 @@ def test_build_smoke_command_points_at_voice_full_duplex_smoke():
         speed="1.0",
         timeout=90.0,
         expect_words=["hello", "world"],
+        max_queued_tx_ms=1_000,
     )
 
     assert command[:4] == [
@@ -67,6 +71,8 @@ def test_build_smoke_command_points_at_voice_full_duplex_smoke():
     ]
     assert "--inbound-text" in command
     assert "--outbound-text" in command
+    assert "--max-queued-tx-ms" in command
+    assert "1000" in command
     assert command[-4:] == ["--expect-word", "hello", "--expect-word", "world"]
 
 
@@ -122,7 +128,7 @@ def test_format_child_error_preserves_tail():
 def test_validate_smoke_result_accepts_voice_contract_shape():
     script = _load_script_module()
 
-    script.validate_smoke_result(_valid_result())
+    script.validate_smoke_result(_valid_result(), max_queued_tx_ms=1_000)
 
 
 def test_validate_smoke_result_rejects_silent_outbound():
@@ -131,7 +137,26 @@ def test_validate_smoke_result_rejects_silent_outbound():
     result["outbound_webrtc_bytes"] = 0
 
     with pytest.raises(SystemExit, match="outbound_webrtc_bytes"):
-        script.validate_smoke_result(result)
+        script.validate_smoke_result(result, max_queued_tx_ms=1_000)
+
+
+def test_validate_smoke_result_rejects_excessive_queued_tx():
+    script = _load_script_module()
+    result = _valid_result()
+    result["queued_tx_ms"] = 2_000
+
+    with pytest.raises(SystemExit, match="queued_tx_ms"):
+        script.validate_smoke_result(result, max_queued_tx_ms=1_000)
+
+
+def test_validate_smoke_result_calculates_queued_tx_ms_when_missing():
+    script = _load_script_module()
+    result = _valid_result()
+    result.pop("queued_tx_ms")
+    result["queued_tx_bytes"] = 192_000
+
+    with pytest.raises(SystemExit, match="queued_tx_ms"):
+        script.validate_smoke_result(result, max_queued_tx_ms=1_000)
 
 
 def test_parse_args_uses_default_expected_words(monkeypatch):
@@ -146,6 +171,7 @@ def test_parse_args_uses_default_expected_words(monkeypatch):
 
     assert args.voice_repo == Path("/voice")
     assert args.expect_word == ["hello", "world"]
+    assert args.max_queued_tx_ms == script.DEFAULT_MAX_QUEUED_TX_MS
 
 
 def test_parse_args_replaces_default_expected_words(monkeypatch):
@@ -165,3 +191,22 @@ def test_parse_args_replaces_default_expected_words(monkeypatch):
     args = script.parse_args()
 
     assert args.expect_word == ["testing"]
+
+
+def test_parse_args_rejects_negative_queue_budget(monkeypatch):
+    script = _load_script_module()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "verify_voice_full_duplex_sidecar.py",
+            "--voice-repo",
+            "/voice",
+            "--max-queued-tx-ms",
+            "-1",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        script.parse_args()
+    assert exc.value.code == 2

--- a/tests/tools/test_verify_voice_live_gateway_script.py
+++ b/tests/tools/test_verify_voice_live_gateway_script.py
@@ -36,6 +36,10 @@ def _write_voice_native_root(root: Path) -> None:
         "\n".join(["voice_compatible", "libopus", "-application", "voip"]),
         encoding="utf-8",
     )
+    (tools_dir / "transcription_tools.py").write_text(
+        "\n".join(["stt.providers", "_transcribe_command_stt", "transcribe_audio"]),
+        encoding="utf-8",
+    )
     (gateway_dir / "whatsapp_cloud.py").write_text(
         "\n".join(
             [

--- a/tests/tools/test_verify_voice_live_gateway_script.py
+++ b/tests/tools/test_verify_voice_live_gateway_script.py
@@ -1,0 +1,316 @@
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "verify_voice_live_gateway.py"
+)
+SCRIPTS_DIR = SCRIPT_PATH.parent
+
+
+def _load_script_module():
+    if str(SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    spec = importlib.util.spec_from_file_location("verify_voice_live_gateway", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_voice_native_root(root: Path) -> None:
+    tools_dir = root / "tools"
+    gateway_dir = root / "gateway" / "platforms"
+    bridge_bin = root / "scripts" / "whatsapp-bridge" / "node_modules" / ".bin"
+    tools_dir.mkdir(parents=True)
+    gateway_dir.mkdir(parents=True)
+    bridge_bin.mkdir(parents=True)
+    (tools_dir / "tts_tool.py").write_text(
+        "\n".join(["voice_compatible", "libopus", "-application", "voip"]),
+        encoding="utf-8",
+    )
+    (gateway_dir / "whatsapp_cloud.py").write_text(
+        "\n".join(
+            [
+                "calling_sidecar_url",
+                "voice.webrtc_sidecar",
+                "_send_calling_sidecar_tts_stream_command",
+                "-application",
+                "voip",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_parse_systemctl_show_keeps_key_values():
+    script = _load_script_module()
+
+    parsed = script.parse_systemctl_show(
+        "ActiveState=active\nMainPID=123\nignored line\nEnvironment=A=B\n"
+    )
+
+    assert parsed == {
+        "ActiveState": "active",
+        "MainPID": "123",
+        "Environment": "A=B",
+    }
+
+
+def test_parse_systemd_environment_handles_quoted_values():
+    script = _load_script_module()
+
+    parsed = script.parse_systemd_environment(
+        'PYTHONPATH=/live PATH=/bin "EXTRA=value with spaces"'
+    )
+
+    assert parsed == {
+        "PYTHONPATH": "/live",
+        "PATH": "/bin",
+        "EXTRA": "value with spaces",
+    }
+
+
+def test_parse_proc_environ_reads_nul_separated_environment():
+    script = _load_script_module()
+
+    parsed = script.parse_proc_environ(b"PYTHONPATH=/live\0PATH=/bin\0bad\0")
+
+    assert parsed == {"PYTHONPATH": "/live", "PATH": "/bin"}
+
+
+def test_path_is_under_accepts_children_and_rejects_siblings(tmp_path: Path):
+    script = _load_script_module()
+    root = tmp_path / "root"
+    child = root / "pkg" / "module.py"
+    sibling = tmp_path / "root-other" / "module.py"
+    child.parent.mkdir(parents=True)
+    sibling.parent.mkdir(parents=True)
+    child.write_text("", encoding="utf-8")
+    sibling.write_text("", encoding="utf-8")
+
+    assert script.path_is_under(child, root) is True
+    assert script.path_is_under(sibling, root) is False
+
+
+def test_validate_service_state_requires_active_service_and_pid():
+    script = _load_script_module()
+
+    assert script.validate_service_state({"ActiveState": "active", "MainPID": "42"}) == 42
+
+    with pytest.raises(SystemExit, match="not active"):
+        script.validate_service_state({"ActiveState": "inactive", "MainPID": "42"})
+    with pytest.raises(SystemExit, match="MainPID is invalid"):
+        script.validate_service_state({"ActiveState": "active", "MainPID": "nope"})
+    with pytest.raises(SystemExit, match="no running MainPID"):
+        script.validate_service_state({"ActiveState": "active", "MainPID": "0"})
+
+
+def test_validate_env_points_at_root_requires_pythonpath_and_bridge_path(tmp_path: Path):
+    script = _load_script_module()
+    root = tmp_path / "hermes"
+    bridge_bin = root / "scripts" / "whatsapp-bridge" / "node_modules" / ".bin"
+    bridge_bin.mkdir(parents=True)
+    env = {
+        "PYTHONPATH": str(root),
+        "PATH": f"/usr/bin:{bridge_bin}",
+    }
+
+    result = script.validate_env_points_at_root(
+        env,
+        root,
+        label="unit",
+        bridge_bin_dir=bridge_bin,
+    )
+
+    assert result["PYTHONPATH"] == str(root)
+    assert result["bridge_bin_on_path"] is True
+
+    with pytest.raises(SystemExit, match="PYTHONPATH"):
+        script.validate_env_points_at_root({}, root, label="unit")
+    with pytest.raises(SystemExit, match="PATH"):
+        script.validate_env_points_at_root(
+            {"PYTHONPATH": str(root), "PATH": "/usr/bin"},
+            root,
+            label="unit",
+            bridge_bin_dir=bridge_bin,
+        )
+
+
+def test_validate_bridge_health_requires_connected_when_requested():
+    script = _load_script_module()
+
+    script.validate_bridge_health({"status": "connected"}, require_connected=True)
+    script.validate_bridge_health({"status": "connecting"}, require_connected=False)
+    with pytest.raises(SystemExit, match="not connected"):
+        script.validate_bridge_health({"status": "connecting"}, require_connected=True)
+
+
+def test_parse_ffprobe_json_extracts_audio_shape():
+    script = _load_script_module()
+
+    parsed = script.parse_ffprobe_json(
+        json.dumps(
+            {
+                "streams": [
+                    {
+                        "codec_name": "opus",
+                        "sample_rate": "48000",
+                        "channels": 1,
+                    }
+                ]
+            }
+        )
+    )
+
+    assert parsed == {"codec_name": "opus", "sample_rate": "48000", "channels": "1"}
+
+    with pytest.raises(ValueError, match="no streams"):
+        script.parse_ffprobe_json(json.dumps({"streams": []}))
+
+
+def test_import_smoke_runs_from_live_root(tmp_path: Path, monkeypatch):
+    script = _load_script_module()
+    live_root = tmp_path / "live"
+    module_path = live_root / "tools" / "tts_tool.py"
+    module_path.parent.mkdir(parents=True)
+    module_path.write_text("", encoding="utf-8")
+
+    def fake_run(_command, **kwargs):
+        assert kwargs["cwd"] == str(live_root)
+        return subprocess.CompletedProcess(
+            _command,
+            0,
+            stdout=json.dumps({"tools.tts_tool": str(module_path)}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(script.subprocess, "run", fake_run)
+
+    result = script.import_smoke(
+        python_bin="/python",
+        live_root=live_root,
+        hermes_home=tmp_path / "home",
+        timeout=1.0,
+    )
+
+    assert result == {"tools.tts_tool": str(module_path)}
+
+
+def test_run_tts_smoke_runs_from_live_root(tmp_path: Path, monkeypatch):
+    script = _load_script_module()
+    live_root = tmp_path / "live"
+    audio_path = tmp_path / "speech.ogg"
+    live_root.mkdir()
+    audio_path.write_bytes(b"OggS")
+
+    def fake_run(_command, **kwargs):
+        assert kwargs["cwd"] == str(live_root)
+        return subprocess.CompletedProcess(
+            _command,
+            0,
+            stdout=json.dumps(
+                {
+                    "success": True,
+                    "voice_compatible": True,
+                    "media_tag": f"[[audio_as_voice]]\nMEDIA:{audio_path}",
+                    "file_path": str(audio_path),
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(script.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        script,
+        "probe_audio",
+        lambda *_args, **_kwargs: {
+            "codec_name": "opus",
+            "sample_rate": "48000",
+            "channels": "1",
+        },
+    )
+
+    result = script.run_tts_smoke(
+        python_bin="/python",
+        live_root=live_root,
+        hermes_home=tmp_path / "home",
+        platform="whatsapp",
+        text="hello",
+        ffprobe_bin="/ffprobe",
+        timeout=1.0,
+    )
+
+    assert result["probe"]["codec_name"] == "opus"
+
+
+def test_main_skips_ffprobe_when_tts_smoke_is_disabled(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    script = _load_script_module()
+    live_root = tmp_path / "hermes"
+    _write_voice_native_root(live_root)
+    bridge_bin = live_root / "scripts" / "whatsapp-bridge" / "node_modules" / ".bin"
+
+    labels = []
+
+    def fake_resolve(value, *, label):
+        labels.append(label)
+        if label == "ffprobe":
+            raise AssertionError("ffprobe should only be needed for TTS smoke")
+        return value
+
+    monkeypatch.setattr(script, "resolve_executable", fake_resolve)
+    monkeypatch.setattr(
+        script,
+        "get_service_state",
+        lambda *_args, **_kwargs: {
+            "ActiveState": "active",
+            "MainPID": "123",
+            "Environment": (
+                f"PYTHONPATH={live_root} PATH=/usr/bin:{bridge_bin}"
+            ),
+            "DropInPaths": "/drop-in.conf",
+        },
+    )
+    monkeypatch.setattr(
+        script,
+        "read_process_env",
+        lambda _pid: {"PYTHONPATH": str(live_root), "PATH": f"/usr/bin:{bridge_bin}"},
+    )
+    monkeypatch.setattr(
+        script,
+        "import_smoke",
+        lambda **_kwargs: {"tools.tts_tool": str(live_root / "tools" / "tts_tool.py")},
+    )
+    monkeypatch.setattr(
+        script,
+        "get_bridge_health",
+        lambda *_args, **_kwargs: {"status": "connected", "queueLength": 0},
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "verify_voice_live_gateway.py",
+            "--live-hermes-root",
+            str(live_root),
+            "--python-bin",
+            "/python",
+        ],
+    )
+
+    assert script.main() == 0
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["success"] is True
+    assert labels == ["Hermes Python"]

--- a/tests/tools/test_verify_voice_live_gateway_script.py
+++ b/tests/tools/test_verify_voice_live_gateway_script.py
@@ -198,6 +198,91 @@ def test_parse_proc_environ_reads_nul_separated_environment():
     assert parsed == {"PYTHONPATH": "/live", "PATH": "/bin"}
 
 
+def test_parse_dotenv_text_handles_quotes_exports_and_comments():
+    script = _load_script_module()
+
+    parsed = script.parse_dotenv_text(
+        "\n".join(
+            [
+                "# ignored",
+                "export WHATSAPP_CLOUD_PHONE_NUMBER_ID=7794189252778687",
+                'WHATSAPP_CLOUD_VERIFY_TOKEN="verify-token-value"',
+                "WHATSAPP_CLOUD_ALLOWED_USERS=15551234567 # operator note",
+            ]
+        )
+    )
+
+    assert parsed == {
+        "WHATSAPP_CLOUD_PHONE_NUMBER_ID": "7794189252778687",
+        "WHATSAPP_CLOUD_VERIFY_TOKEN": "verify-token-value",
+        "WHATSAPP_CLOUD_ALLOWED_USERS": "15551234567",
+    }
+
+
+def test_validate_whatsapp_cloud_readiness_reports_sources_without_secrets(
+    tmp_path: Path,
+):
+    script = _load_script_module()
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    access_token = "EAA" + ("x" * 120)
+    app_secret = "0123456789abcdef0123456789abcdef"
+    verify_token = "verify-token-value-long-enough"
+    (hermes_home / ".env").write_text(
+        "\n".join(
+            [
+                "WHATSAPP_CLOUD_PHONE_NUMBER_ID=7794189252778687",
+                f"WHATSAPP_CLOUD_ACCESS_TOKEN={access_token}",
+                f"WHATSAPP_CLOUD_APP_SECRET={app_secret}",
+                f"WHATSAPP_CLOUD_VERIFY_TOKEN={verify_token}",
+                "WHATSAPP_CLOUD_ALLOWED_USERS=15551234567,15557654321",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = script.validate_whatsapp_cloud_readiness(
+        hermes_home=hermes_home,
+        process_env={},
+    )
+
+    assert result["required_fields"]["WHATSAPP_CLOUD_ACCESS_TOKEN"] == {
+        "present": True,
+        "source_shape": "meta_access_token",
+        "source": "env_file",
+    }
+    assert result["authorization"]["allowed_users_count"] == 2
+    serialized = json.dumps(result)
+    assert access_token not in serialized
+    assert app_secret not in serialized
+    assert verify_token not in serialized
+
+
+def test_validate_whatsapp_cloud_readiness_rejects_missing_authorization(
+    tmp_path: Path,
+):
+    script = _load_script_module()
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / ".env").write_text(
+        "\n".join(
+            [
+                "WHATSAPP_CLOUD_PHONE_NUMBER_ID=7794189252778687",
+                "WHATSAPP_CLOUD_ACCESS_TOKEN=EAA" + ("x" * 120),
+                "WHATSAPP_CLOUD_APP_SECRET=0123456789abcdef0123456789abcdef",
+                "WHATSAPP_CLOUD_VERIFY_TOKEN=verify-token-value-long-enough",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit, match="recipient authorization"):
+        script.validate_whatsapp_cloud_readiness(
+            hermes_home=hermes_home,
+            process_env={},
+        )
+
+
 def test_path_is_under_accepts_children_and_rejects_siblings(tmp_path: Path):
     script = _load_script_module()
     root = tmp_path / "root"
@@ -1122,6 +1207,92 @@ def test_main_can_skip_bridge_health_for_cloud_only_gateway(
         "skipped": True,
         "reason": "--skip-bridge-health was provided",
     }
+
+
+def test_main_can_require_whatsapp_cloud_readiness_without_printing_secrets(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    script = _load_script_module()
+    live_root = tmp_path / "hermes"
+    hermes_home = tmp_path / ".hermes"
+    _write_voice_native_root(live_root)
+    hermes_home.mkdir()
+    bridge_bin = live_root / "scripts" / "whatsapp-bridge" / "node_modules" / ".bin"
+    access_token = "EAA" + ("x" * 120)
+    app_secret = "0123456789abcdef0123456789abcdef"
+    verify_token = "verify-token-value-long-enough"
+    (hermes_home / ".env").write_text(
+        "\n".join(
+            [
+                "WHATSAPP_CLOUD_PHONE_NUMBER_ID=7794189252778687",
+                f"WHATSAPP_CLOUD_ACCESS_TOKEN={access_token}",
+                f"WHATSAPP_CLOUD_APP_SECRET={app_secret}",
+                f"WHATSAPP_CLOUD_VERIFY_TOKEN={verify_token}",
+                "WHATSAPP_CLOUD_ALLOWED_USERS=15551234567",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(script, "resolve_executable", lambda value, *, label: value)
+    monkeypatch.setattr(
+        script,
+        "get_service_state",
+        lambda *_args, **_kwargs: {
+            "ActiveState": "active",
+            "MainPID": "123",
+            "Environment": (
+                f"PYTHONPATH={live_root} PATH=/usr/bin:{bridge_bin}"
+            ),
+            "DropInPaths": "/drop-in.conf",
+        },
+    )
+    monkeypatch.setattr(
+        script,
+        "read_process_env",
+        lambda _pid: {"PYTHONPATH": str(live_root), "PATH": f"/usr/bin:{bridge_bin}"},
+    )
+    monkeypatch.setattr(
+        script,
+        "import_smoke",
+        lambda **_kwargs: {"tools.tts_tool": str(live_root / "tools" / "tts_tool.py")},
+    )
+    monkeypatch.setattr(
+        script,
+        "get_bridge_health",
+        lambda *_args, **_kwargs: {"status": "connected"},
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "verify_voice_live_gateway.py",
+            "--live-hermes-root",
+            str(live_root),
+            "--hermes-home",
+            str(hermes_home),
+            "--python-bin",
+            "/python",
+            "--require-whatsapp-cloud-readiness",
+        ],
+    )
+
+    assert script.main() == 0
+
+    output_text = capsys.readouterr().out
+    output = json.loads(output_text)
+    readiness = output["checks"]["whatsapp_cloud_readiness"]
+    assert readiness["required_fields"]["WHATSAPP_CLOUD_ACCESS_TOKEN"] == {
+        "present": True,
+        "source_shape": "meta_access_token",
+        "source": "env_file",
+    }
+    assert readiness["authorization"]["allowed_users_count"] == 1
+    assert access_token not in output_text
+    assert app_secret not in output_text
+    assert verify_token not in output_text
 
 
 def test_main_validates_calling_sidecar_when_requested(

--- a/tests/tools/test_verify_voice_live_gateway_script.py
+++ b/tests/tools/test_verify_voice_live_gateway_script.py
@@ -42,12 +42,87 @@ def _write_voice_native_root(root: Path) -> None:
                 "calling_sidecar_url",
                 "voice.webrtc_sidecar",
                 "_send_calling_sidecar_tts_stream_command",
+                "_clear_calling_sidecar_audio",
                 "-application",
                 "voip",
             ]
         ),
         encoding="utf-8",
     )
+
+
+def _voice_sidecar_contract() -> dict:
+    audio = {
+        "sample_rate": 48_000,
+        "channels": 1,
+        "frame_ms": 20,
+        "encoding": "pcm_s16le",
+        "bytes_per_sample": 2,
+        "samples_per_frame": 960,
+        "frame_bytes": 1_920,
+    }
+    return {
+        "contract": "voice.webrtc_sidecar",
+        "version": 1,
+        "status": "experimental",
+        "summary": "Local HTTP/WebRTC bridge contract.",
+        "audio": audio,
+        "voice_surfaces": {
+            "completed_voice_note": {
+                "command": 'voice say --format ogg-opus --output reply.ogg "hello"',
+                "output": "audio/ogg; codecs=opus",
+                "transport": "completed_file",
+            },
+            "streamed_voice_note": {
+                "command": 'voice stream --output reply.ogg --format ogg-opus "hello"',
+                "output": "audio/ogg; codecs=opus",
+                "transport": "daemon_stream_encoded_file",
+            },
+            "raw_outbound_pcm": {
+                "command": 'voice stream --sample-rate 48000 --frame-ms 20 --raw-output - "hello"',
+                "output": "pcm_s16le",
+                "transport": "stdout_pcm_frames",
+                "frame_bytes": audio["frame_bytes"],
+            },
+            "raw_inbound_pcm": {
+                "command": "voice stream-transcribe --raw-input - --sample-rate 48000 --frame-ms 20",
+                "input": "pcm_s16le",
+                "transport": "stdin_pcm_frames",
+                "frame_bytes": audio["frame_bytes"],
+            },
+            "file_transcription_smoke": {
+                "command": "voice stream-transcribe recording.ogg",
+                "input": "audio_file",
+                "transport": "decoded_file_to_daemon_frames",
+            },
+        },
+        "endpoints": {
+            "contract": {"method": "GET", "path": "/contract"},
+            "health": {"method": "GET", "path": "/health"},
+            "offer": {"method": "POST", "path": "/offer"},
+            "call_status": {"method": "GET", "path": "/calls/{call_id}"},
+            "receive_audio": {"method": "GET", "path": "/calls/{call_id}/audio"},
+            "send_audio": {"method": "POST", "path": "/calls/{call_id}/audio"},
+            "clear_audio": {
+                "method": "POST",
+                "path": "/calls/{call_id}/audio/clear",
+            },
+            "close_call": {"method": "POST", "path": "/calls/{call_id}/close"},
+        },
+        "payloads": {
+            "offer_request": {"sdp": "required"},
+            "offer_response": {"sdp": "answer"},
+            "call_state": {"queued_tx_bytes": "bytes"},
+            "call_status_response": "call_state",
+            "close_call_response": {"closed": True},
+            "send_audio_request": {"pcm_s16le_base64": "required"},
+            "send_audio_response": {"accepted_bytes": "bytes"},
+            "clear_audio_response": {"dropped_tx_bytes": "bytes"},
+            "receive_audio_response": {"pcm_s16le_base64": "data"},
+            "audio_shape": {"sample_rate": "audio.sample_rate"},
+            "error_response": {"error": "message"},
+        },
+    }
 
 
 def test_parse_systemctl_show_keeps_key_values():
@@ -285,22 +360,13 @@ def test_validate_sidecar_service_state_rejects_wrong_bind_port(tmp_path: Path):
 
 def test_validate_calling_sidecar_contract_requires_voice_pcm_shape():
     script = _load_script_module()
-    contract = {
-        "contract": "voice.webrtc_sidecar",
-        "version": 1,
-        "audio": {
-            "sample_rate": 48_000,
-            "channels": 1,
-            "frame_ms": 20,
-            "encoding": "pcm_s16le",
-            "frame_bytes": 1_920,
-        },
-    }
+    contract = _voice_sidecar_contract()
 
     result = script.validate_calling_sidecar_contract(contract)
 
     assert result["contract"] == "voice.webrtc_sidecar"
     assert result["audio"]["frame_bytes"] == 1_920
+    assert result["required_sections"]["endpoints"] == list(script.REQUIRED_ENDPOINTS)
 
     bad = {**contract, "contract": "other"}
     with pytest.raises(SystemExit, match="contract id"):
@@ -313,19 +379,47 @@ def test_validate_calling_sidecar_contract_requires_voice_pcm_shape():
         script.validate_calling_sidecar_contract(drifted)
 
 
-def test_load_voice_stream_contract_runs_voice_binary(monkeypatch):
+def test_validate_calling_sidecar_contract_requires_named_surfaces_and_endpoints():
     script = _load_script_module()
-    contract = {
-        "contract": "voice.webrtc_sidecar",
-        "version": 1,
-        "audio": {
-            "sample_rate": 48_000,
-            "channels": 1,
-            "frame_ms": 20,
-            "encoding": "pcm_s16le",
-            "frame_bytes": 1_920,
+    contract = _voice_sidecar_contract()
+
+    missing_surface = {
+        **contract,
+        "voice_surfaces": {
+            key: value
+            for key, value in contract["voice_surfaces"].items()
+            if key != "raw_inbound_pcm"
         },
     }
+    with pytest.raises(SystemExit, match="voice_surfaces missing keys"):
+        script.validate_calling_sidecar_contract(missing_surface)
+
+    missing_clear = {
+        **contract,
+        "endpoints": {
+            key: value
+            for key, value in contract["endpoints"].items()
+            if key != "clear_audio"
+        },
+    }
+    with pytest.raises(SystemExit, match="endpoints missing keys"):
+        script.validate_calling_sidecar_contract(missing_clear)
+
+    missing_clear_payload = {
+        **contract,
+        "payloads": {
+            key: value
+            for key, value in contract["payloads"].items()
+            if key != "clear_audio_response"
+        },
+    }
+    with pytest.raises(SystemExit, match="payloads missing keys"):
+        script.validate_calling_sidecar_contract(missing_clear_payload)
+
+
+def test_load_voice_stream_contract_runs_voice_binary(monkeypatch):
+    script = _load_script_module()
+    contract = _voice_sidecar_contract()
     calls = []
 
     def fake_run(command, *, timeout):
@@ -347,22 +441,7 @@ def test_load_voice_stream_contract_runs_voice_binary(monkeypatch):
 
 def test_compare_voice_and_sidecar_contracts_requires_exact_machine_contract():
     script = _load_script_module()
-    contract = {
-        "contract": "voice.webrtc_sidecar",
-        "version": 1,
-        "status": "experimental",
-        "summary": "summary",
-        "audio": {
-            "sample_rate": 48_000,
-            "channels": 1,
-            "frame_ms": 20,
-            "encoding": "pcm_s16le",
-            "frame_bytes": 1_920,
-        },
-        "voice_surfaces": {"raw_outbound_pcm": {"frame_bytes": 1_920}},
-        "endpoints": {"offer": {"path": "/offer"}},
-        "payloads": {"offer_request": {"sdp": "required"}},
-    }
+    contract = _voice_sidecar_contract()
 
     result = script.compare_voice_and_sidecar_contracts(
         voice_contract=contract,
@@ -371,6 +450,7 @@ def test_compare_voice_and_sidecar_contracts_requires_exact_machine_contract():
 
     assert result["success"] is True
     assert result["matched_keys"] == list(script.CONTRACT_COMPARE_KEYS)
+    assert result["required_sections"]["payloads"] == list(script.REQUIRED_PAYLOADS)
 
     drifted = {
         **contract,
@@ -390,17 +470,7 @@ def test_get_calling_sidecar_status_fetches_contract_and_health(monkeypatch):
     def fake_json_url(target, *, timeout):
         calls.append((target, timeout))
         if target.endswith("/contract"):
-            return {
-                "contract": "voice.webrtc_sidecar",
-                "version": 1,
-                "audio": {
-                    "sample_rate": 48_000,
-                    "channels": 1,
-                    "frame_ms": 20,
-                    "encoding": "pcm_s16le",
-                    "frame_bytes": 1_920,
-                },
-            }
+            return _voice_sidecar_contract()
         return {"ok": True, "sessions": 0, "call_ids": []}
 
     monkeypatch.setattr(script, "get_json_url", fake_json_url)

--- a/tests/tools/test_verify_voice_live_gateway_script.py
+++ b/tests/tools/test_verify_voice_live_gateway_script.py
@@ -319,6 +319,7 @@ def test_validate_sidecar_service_state_accepts_expected_unit(tmp_path: Path):
         voice_bin=str(voice_bin),
         voice_repo=voice_repo,
         sidecar_url="http://127.0.0.1:8787",
+        voice_daemon_service="voiced.service",
     )
 
     assert result["service"] == "voice-webrtc-sidecar.service"
@@ -345,6 +346,7 @@ def test_validate_sidecar_service_state_rejects_deprecated_daemon_unit():
             voice_bin=None,
             voice_repo=None,
             sidecar_url=None,
+            voice_daemon_service="voiced.service",
         )
 
 
@@ -362,6 +364,7 @@ def test_validate_sidecar_service_state_requires_voiced_ordering():
             voice_bin=None,
             voice_repo=None,
             sidecar_url=None,
+            voice_daemon_service="voiced.service",
         )
 
 
@@ -386,6 +389,7 @@ def test_validate_sidecar_service_state_rejects_stale_voice_bin(tmp_path: Path):
             voice_bin=str(expected_voice),
             voice_repo=None,
             sidecar_url=None,
+            voice_daemon_service="voiced.service",
         )
 
 
@@ -412,6 +416,7 @@ def test_validate_sidecar_service_state_rejects_wrong_voice_repo(tmp_path: Path)
             voice_bin=None,
             voice_repo=voice_repo,
             sidecar_url=None,
+            voice_daemon_service="voiced.service",
         )
 
 
@@ -431,7 +436,27 @@ def test_validate_sidecar_service_state_rejects_wrong_bind_port(tmp_path: Path):
             voice_bin=None,
             voice_repo=None,
             sidecar_url="http://127.0.0.1:8787",
+            voice_daemon_service="voiced.service",
         )
+
+
+def test_validate_sidecar_service_state_accepts_custom_daemon_ordering():
+    script = _load_script_module()
+
+    result = script.validate_sidecar_service_state(
+        {
+            "ActiveState": "active",
+            "MainPID": "42",
+            "After": "network.target custom-voiced.service",
+        },
+        service="voice-webrtc-sidecar.service",
+        voice_bin=None,
+        voice_repo=None,
+        sidecar_url=None,
+        voice_daemon_service="custom-voiced.service",
+    )
+
+    assert "custom-voiced.service" in result["after"]
 
 
 def test_validate_voice_daemon_service_state_accepts_expected_unit(tmp_path: Path):

--- a/tests/tools/test_verify_voice_live_gateway_script.py
+++ b/tests/tools/test_verify_voice_live_gateway_script.py
@@ -757,6 +757,89 @@ def test_run_calling_sidecar_offer_smoke_rejects_failed_readiness(monkeypatch):
         )
 
 
+def test_run_calling_live_sidecar_smoke_uses_live_root_imports(
+    tmp_path: Path,
+    monkeypatch,
+):
+    script = _load_script_module()
+    live_root = tmp_path / "live"
+    hermes_home = tmp_path / ".hermes"
+    voice_repo = tmp_path / "voice"
+    live_root.mkdir()
+    hermes_home.mkdir()
+    voice_repo.mkdir()
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(
+                {
+                    "success": True,
+                    "graph_actions": ["pre_accept", "accept"],
+                    "sidecar_ready_for_accept": True,
+                    "outbound_webrtc_bytes": 23040,
+                    "inbound_drain_bytes": 1920,
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(script.subprocess, "run", fake_run)
+
+    result = script.run_calling_live_sidecar_smoke(
+        python_bin="/tmp/voice-webrtc-venv/bin/python",
+        live_root=live_root,
+        hermes_home=hermes_home,
+        voice_repo=voice_repo,
+        timeout=12,
+    )
+
+    assert result["graph_actions"] == ["pre_accept", "accept"]
+    command, kwargs = calls[0]
+    assert command[:2] == [
+        "/tmp/voice-webrtc-venv/bin/python",
+        str(SCRIPT_PATH.parent / "verify_voice_whatsapp_calling_live_sidecar.py"),
+    ]
+    assert command[-4:] == ["--voice-repo", str(voice_repo), "--timeout", "12"]
+    assert kwargs["env"]["PYTHONPATH"] == str(live_root)
+    assert kwargs["env"]["HERMES_HOME"] == str(hermes_home)
+    assert kwargs["cwd"] == str(live_root)
+
+
+def test_run_calling_live_sidecar_smoke_rejects_missing_audio(monkeypatch, tmp_path):
+    script = _load_script_module()
+
+    def fake_run(command, **_kwargs):
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(
+                {
+                    "success": True,
+                    "graph_actions": ["pre_accept", "accept"],
+                    "sidecar_ready_for_accept": True,
+                    "outbound_webrtc_bytes": 0,
+                    "inbound_drain_bytes": 1920,
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(script.subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit, match="did not move audio"):
+        script.run_calling_live_sidecar_smoke(
+            python_bin="/tmp/voice-webrtc-venv/bin/python",
+            live_root=tmp_path,
+            hermes_home=tmp_path,
+            voice_repo=tmp_path,
+            timeout=12,
+        )
+
+
 def test_parse_ffprobe_json_extracts_audio_shape():
     script = _load_script_module()
 
@@ -1106,6 +1189,86 @@ def test_main_validates_calling_sidecar_when_requested(
     output = json.loads(capsys.readouterr().out)
     assert output["checks"]["calling_sidecar"]["env"]["url"] == sidecar_url
     assert output["checks"]["calling_sidecar"]["sidecar"]["health"]["ok"] is True
+
+
+def test_main_runs_calling_live_sidecar_smoke_when_requested(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    script = _load_script_module()
+    live_root = tmp_path / "hermes"
+    voice_repo = tmp_path / "voice"
+    _write_voice_native_root(live_root)
+    voice_repo.mkdir()
+    bridge_bin = live_root / "scripts" / "whatsapp-bridge" / "node_modules" / ".bin"
+
+    monkeypatch.setattr(script, "resolve_executable", lambda value, *, label: value)
+    monkeypatch.setattr(
+        script,
+        "get_service_state",
+        lambda *_args, **_kwargs: {
+            "ActiveState": "active",
+            "MainPID": "123",
+            "Environment": f"PYTHONPATH={live_root} PATH=/usr/bin:{bridge_bin}",
+            "DropInPaths": "/drop-in.conf",
+        },
+    )
+    monkeypatch.setattr(
+        script,
+        "read_process_env",
+        lambda _pid: {"PYTHONPATH": str(live_root), "PATH": f"/usr/bin:{bridge_bin}"},
+    )
+    monkeypatch.setattr(
+        script,
+        "import_smoke",
+        lambda **_kwargs: {"tools.tts_tool": str(live_root / "tools" / "tts_tool.py")},
+    )
+    monkeypatch.setattr(
+        script,
+        "get_bridge_health",
+        lambda *_args, **_kwargs: {"status": "connected"},
+    )
+
+    def fake_live_sidecar_smoke(**kwargs):
+        assert kwargs["python_bin"] == "/tmp/voice-webrtc-venv/bin/python"
+        assert kwargs["live_root"] == live_root.resolve()
+        assert kwargs["voice_repo"] == voice_repo.resolve()
+        return {
+            "success": True,
+            "graph_actions": ["pre_accept", "accept"],
+            "sidecar_ready_for_accept": True,
+        }
+
+    monkeypatch.setattr(
+        script,
+        "run_calling_live_sidecar_smoke",
+        fake_live_sidecar_smoke,
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "verify_voice_live_gateway.py",
+            "--live-hermes-root",
+            str(live_root),
+            "--python-bin",
+            "/python",
+            "--voice-repo",
+            str(voice_repo),
+            "--webrtc-python-bin",
+            "/tmp/voice-webrtc-venv/bin/python",
+            "--run-calling-live-sidecar-smoke",
+        ],
+    )
+
+    assert script.main() == 0
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["checks"]["calling_live_sidecar_smoke"]["graph_actions"] == [
+        "pre_accept",
+        "accept",
+    ]
 
 
 def test_main_validates_sidecar_service_when_requested(

--- a/tests/tools/test_verify_voice_live_gateway_script.py
+++ b/tests/tools/test_verify_voice_live_gateway_script.py
@@ -273,6 +273,21 @@ def test_whatsapp_cloud_health_url_uses_loopback_for_wildcard_host():
     assert result == "http://127.0.0.1:8091/health"
 
 
+def test_whatsapp_cloud_webhook_url_uses_configured_path():
+    script = _load_script_module()
+
+    result = script.whatsapp_cloud_webhook_url_from_env(
+        file_env={
+            "WHATSAPP_CLOUD_WEBHOOK_HOST": "0.0.0.0",
+            "WHATSAPP_CLOUD_WEBHOOK_PORT": "8091",
+            "WHATSAPP_CLOUD_WEBHOOK_PATH": "whatsapp/webhook",
+        },
+        process_env={},
+    )
+
+    assert result == "http://127.0.0.1:8091/whatsapp/webhook"
+
+
 def test_validate_whatsapp_cloud_health_returns_redacted_summary():
     script = _load_script_module()
 
@@ -322,6 +337,55 @@ def test_validate_whatsapp_cloud_health_rejects_unloaded_calling_sidecar():
             expected_phone_number_id="7794189252778687",
             expect_calling_sidecar=True,
         )
+
+
+def test_check_whatsapp_cloud_verify_handshake_uses_token_without_reporting_it(
+    tmp_path: Path,
+    monkeypatch,
+):
+    script = _load_script_module()
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    verify_token = "verify-token-value-long-enough"
+    (hermes_home / ".env").write_text(
+        "\n".join(
+            [
+                "WHATSAPP_CLOUD_PHONE_NUMBER_ID=7794189252778687",
+                "WHATSAPP_CLOUD_ACCESS_TOKEN=EAA" + ("x" * 120),
+                "WHATSAPP_CLOUD_APP_SECRET=0123456789abcdef0123456789abcdef",
+                f"WHATSAPP_CLOUD_VERIFY_TOKEN={verify_token}",
+                "WHATSAPP_CLOUD_ALLOWED_USERS=15551234567",
+                "WHATSAPP_CLOUD_WEBHOOK_PORT=8091",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    readiness = script.validate_whatsapp_cloud_readiness(
+        hermes_home=hermes_home,
+        process_env={},
+    )
+
+    def fake_get_text_url(target, *, timeout, label):
+        assert verify_token in target
+        assert verify_token not in label
+        assert label == "http://127.0.0.1:8091/whatsapp/webhook"
+        return 200, "challenge-ok"
+
+    monkeypatch.setattr(script, "get_text_url", fake_get_text_url)
+
+    result = script.check_whatsapp_cloud_verify_handshake(
+        readiness=readiness,
+        webhook_url=None,
+        challenge="challenge-ok",
+        timeout=1.0,
+    )
+
+    assert result == {
+        "url": "http://127.0.0.1:8091/whatsapp/webhook",
+        "status": 200,
+        "challenge_echoed": True,
+    }
+    assert verify_token not in json.dumps(result)
 
 
 def test_validate_whatsapp_cloud_readiness_rejects_missing_authorization(
@@ -1345,6 +1409,13 @@ def test_main_can_require_whatsapp_cloud_readiness_without_printing_secrets(
             "calling_sidecar_tts_stream_configured": False,
         },
     )
+
+    def fake_get_text_url(target, *, timeout, label):
+        assert verify_token in target
+        assert verify_token not in label
+        return 200, "hermes-local-cloud-verify-smoke"
+
+    monkeypatch.setattr(script, "get_text_url", fake_get_text_url)
     monkeypatch.setattr(
         sys,
         "argv",
@@ -1381,6 +1452,11 @@ def test_main_can_require_whatsapp_cloud_readiness_without_printing_secrets(
         "calling_sidecar_configured": False,
         "calling_sidecar_contract_loaded": False,
         "calling_sidecar_tts_stream_configured": False,
+    }
+    assert output["checks"]["whatsapp_cloud_verify_handshake"] == {
+        "url": "http://127.0.0.1:8090/whatsapp/webhook",
+        "status": 200,
+        "challenge_echoed": True,
     }
     assert access_token not in output_text
     assert app_secret not in output_text

--- a/tests/tools/test_verify_voice_live_gateway_script.py
+++ b/tests/tools/test_verify_voice_live_gateway_script.py
@@ -181,6 +181,82 @@ def test_validate_calling_sidecar_env_requires_url_and_stream_command():
         )
 
 
+def test_validate_sidecar_service_state_accepts_expected_unit(tmp_path: Path):
+    script = _load_script_module()
+    voice_repo = tmp_path / "voice"
+    sidecar_path = voice_repo / "examples" / "webrtc-sidecar" / "sidecar.py"
+    sidecar_path.parent.mkdir(parents=True)
+    sidecar_path.write_text("", encoding="utf-8")
+    voice_bin = tmp_path / "bin" / "voice"
+    voice_bin.parent.mkdir()
+    voice_bin.write_text("", encoding="utf-8")
+
+    result = script.validate_sidecar_service_state(
+        {
+            "ActiveState": "active",
+            "MainPID": "42",
+            "Environment": f"VOICE_BIN={voice_bin}",
+            "WorkingDirectory": str(voice_repo),
+            "ExecStart": f"{{ argv[]={sys.executable} {sidecar_path} --port 8787 }}",
+        },
+        service="voice-webrtc-sidecar.service",
+        voice_bin=str(voice_bin),
+        voice_repo=voice_repo,
+    )
+
+    assert result["service"] == "voice-webrtc-sidecar.service"
+    assert result["pid"] == 42
+    assert result["voice_bin"] == str(voice_bin)
+    assert result["working_directory"] == str(voice_repo)
+    assert result["sidecar_path"] == str(sidecar_path)
+
+
+def test_validate_sidecar_service_state_rejects_stale_voice_bin(tmp_path: Path):
+    script = _load_script_module()
+    expected_voice = tmp_path / "expected" / "voice"
+    stale_voice = tmp_path / "stale" / "voice"
+    expected_voice.parent.mkdir()
+    stale_voice.parent.mkdir()
+    expected_voice.write_text("", encoding="utf-8")
+    stale_voice.write_text("", encoding="utf-8")
+
+    with pytest.raises(SystemExit, match="VOICE_BIN"):
+        script.validate_sidecar_service_state(
+            {
+                "ActiveState": "active",
+                "MainPID": "42",
+                "Environment": f"VOICE_BIN={stale_voice}",
+            },
+            service="voice-webrtc-sidecar.service",
+            voice_bin=str(expected_voice),
+            voice_repo=None,
+        )
+
+
+def test_validate_sidecar_service_state_rejects_wrong_voice_repo(tmp_path: Path):
+    script = _load_script_module()
+    voice_repo = tmp_path / "voice"
+    stale_repo = tmp_path / "old-voice"
+    sidecar_path = voice_repo / "examples" / "webrtc-sidecar" / "sidecar.py"
+    sidecar_path.parent.mkdir(parents=True)
+    sidecar_path.write_text("", encoding="utf-8")
+    stale_repo.mkdir()
+
+    with pytest.raises(SystemExit, match="WorkingDirectory"):
+        script.validate_sidecar_service_state(
+            {
+                "ActiveState": "active",
+                "MainPID": "42",
+                "Environment": "",
+                "WorkingDirectory": str(stale_repo),
+                "ExecStart": f"{{ argv[]={sys.executable} {sidecar_path} }}",
+            },
+            service="voice-webrtc-sidecar.service",
+            voice_bin=None,
+            voice_repo=voice_repo,
+        )
+
+
 def test_validate_calling_sidecar_contract_requires_voice_pcm_shape():
     script = _load_script_module()
     contract = {
@@ -613,3 +689,80 @@ def test_main_validates_calling_sidecar_when_requested(
     output = json.loads(capsys.readouterr().out)
     assert output["checks"]["calling_sidecar"]["env"]["url"] == sidecar_url
     assert output["checks"]["calling_sidecar"]["sidecar"]["health"]["ok"] is True
+
+
+def test_main_validates_sidecar_service_when_requested(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    script = _load_script_module()
+    live_root = tmp_path / "hermes"
+    voice_repo = tmp_path / "voice"
+    sidecar_path = voice_repo / "examples" / "webrtc-sidecar" / "sidecar.py"
+    voice_bin = tmp_path / "bin" / "voice"
+    _write_voice_native_root(live_root)
+    sidecar_path.parent.mkdir(parents=True)
+    sidecar_path.write_text("", encoding="utf-8")
+    voice_bin.parent.mkdir()
+    voice_bin.write_text("", encoding="utf-8")
+    bridge_bin = live_root / "scripts" / "whatsapp-bridge" / "node_modules" / ".bin"
+
+    monkeypatch.setattr(script, "resolve_executable", lambda value, *, label: value)
+
+    def fake_service_state(service, *, timeout):
+        if service == "voice-webrtc-sidecar.service":
+            return {
+                "ActiveState": "active",
+                "MainPID": "456",
+                "Environment": f"VOICE_BIN={voice_bin}",
+                "WorkingDirectory": str(voice_repo),
+                "ExecStart": f"{{ argv[]=/python {sidecar_path} --port 8787 }}",
+            }
+        return {
+            "ActiveState": "active",
+            "MainPID": "123",
+            "Environment": f"PYTHONPATH={live_root} PATH=/usr/bin:{bridge_bin}",
+            "DropInPaths": "/drop-in.conf",
+        }
+
+    monkeypatch.setattr(script, "get_service_state", fake_service_state)
+    monkeypatch.setattr(
+        script,
+        "read_process_env",
+        lambda _pid: {"PYTHONPATH": str(live_root), "PATH": f"/usr/bin:{bridge_bin}"},
+    )
+    monkeypatch.setattr(
+        script,
+        "import_smoke",
+        lambda **_kwargs: {"tools.tts_tool": str(live_root / "tools" / "tts_tool.py")},
+    )
+    monkeypatch.setattr(
+        script,
+        "get_bridge_health",
+        lambda *_args, **_kwargs: {"status": "connected"},
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "verify_voice_live_gateway.py",
+            "--live-hermes-root",
+            str(live_root),
+            "--python-bin",
+            "/python",
+            "--voice-bin",
+            str(voice_bin),
+            "--voice-repo",
+            str(voice_repo),
+            "--sidecar-service",
+            "voice-webrtc-sidecar.service",
+        ],
+    )
+
+    assert script.main() == 0
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["checks"]["sidecar_service"]["pid"] == 456
+    assert output["checks"]["sidecar_service"]["voice_bin"] == str(voice_bin)
+    assert output["checks"]["sidecar_service"]["working_directory"] == str(voice_repo)

--- a/tests/tools/test_verify_voice_live_gateway_script.py
+++ b/tests/tools/test_verify_voice_live_gateway_script.py
@@ -197,11 +197,15 @@ def test_validate_sidecar_service_state_accepts_expected_unit(tmp_path: Path):
             "MainPID": "42",
             "Environment": f"VOICE_BIN={voice_bin}",
             "WorkingDirectory": str(voice_repo),
-            "ExecStart": f"{{ argv[]={sys.executable} {sidecar_path} --port 8787 }}",
+            "ExecStart": (
+                f"{{ argv[]={sys.executable} {sidecar_path} "
+                "--host 127.0.0.1 --port 8787 }}"
+            ),
         },
         service="voice-webrtc-sidecar.service",
         voice_bin=str(voice_bin),
         voice_repo=voice_repo,
+        sidecar_url="http://127.0.0.1:8787",
     )
 
     assert result["service"] == "voice-webrtc-sidecar.service"
@@ -209,6 +213,8 @@ def test_validate_sidecar_service_state_accepts_expected_unit(tmp_path: Path):
     assert result["voice_bin"] == str(voice_bin)
     assert result["working_directory"] == str(voice_repo)
     assert result["sidecar_path"] == str(sidecar_path)
+    assert result["sidecar_url"] == "http://127.0.0.1:8787"
+    assert result["bind"] == {"host": "127.0.0.1", "port": 8787}
 
 
 def test_validate_sidecar_service_state_rejects_stale_voice_bin(tmp_path: Path):
@@ -230,6 +236,7 @@ def test_validate_sidecar_service_state_rejects_stale_voice_bin(tmp_path: Path):
             service="voice-webrtc-sidecar.service",
             voice_bin=str(expected_voice),
             voice_repo=None,
+            sidecar_url=None,
         )
 
 
@@ -254,6 +261,25 @@ def test_validate_sidecar_service_state_rejects_wrong_voice_repo(tmp_path: Path)
             service="voice-webrtc-sidecar.service",
             voice_bin=None,
             voice_repo=voice_repo,
+            sidecar_url=None,
+        )
+
+
+def test_validate_sidecar_service_state_rejects_wrong_bind_port(tmp_path: Path):
+    script = _load_script_module()
+
+    with pytest.raises(SystemExit, match="expected sidecar URL"):
+        script.validate_sidecar_service_state(
+            {
+                "ActiveState": "active",
+                "MainPID": "42",
+                "Environment": "",
+                "ExecStart": "{ argv[]=/python sidecar.py --host 127.0.0.1 --port 87870 }",
+            },
+            service="voice-webrtc-sidecar.service",
+            voice_bin=None,
+            voice_repo=None,
+            sidecar_url="http://127.0.0.1:8787",
         )
 
 

--- a/tests/tools/test_verify_voice_live_gateway_script.py
+++ b/tests/tools/test_verify_voice_live_gateway_script.py
@@ -241,10 +241,11 @@ def test_validate_whatsapp_cloud_readiness_reports_sources_without_secrets(
         encoding="utf-8",
     )
 
-    result = script.validate_whatsapp_cloud_readiness(
+    raw_result = script.validate_whatsapp_cloud_readiness(
         hermes_home=hermes_home,
         process_env={},
     )
+    result = script.remove_private_readiness_data(raw_result)
 
     assert result["required_fields"]["WHATSAPP_CLOUD_ACCESS_TOKEN"] == {
         "present": True,
@@ -256,6 +257,71 @@ def test_validate_whatsapp_cloud_readiness_reports_sources_without_secrets(
     assert access_token not in serialized
     assert app_secret not in serialized
     assert verify_token not in serialized
+
+
+def test_whatsapp_cloud_health_url_uses_loopback_for_wildcard_host():
+    script = _load_script_module()
+
+    result = script.whatsapp_cloud_health_url_from_env(
+        file_env={
+            "WHATSAPP_CLOUD_WEBHOOK_HOST": "0.0.0.0",
+            "WHATSAPP_CLOUD_WEBHOOK_PORT": "8091",
+        },
+        process_env={},
+    )
+
+    assert result == "http://127.0.0.1:8091/health"
+
+
+def test_validate_whatsapp_cloud_health_returns_redacted_summary():
+    script = _load_script_module()
+
+    result = script.validate_whatsapp_cloud_health(
+        {
+            "status": "ok",
+            "platform": "whatsapp_cloud",
+            "phone_number_id": "7794189252778687",
+            "webhook_path": "/whatsapp/webhook",
+            "verify_token_configured": True,
+            "app_secret_configured": True,
+            "calling_sidecar_configured": True,
+            "calling_sidecar_contract_loaded": True,
+            "calling_sidecar_tts_stream_configured": True,
+        },
+        expected_phone_number_id="7794189252778687",
+        expect_calling_sidecar=True,
+    )
+
+    assert result == {
+        "status": "ok",
+        "platform": "whatsapp_cloud",
+        "webhook_path": "/whatsapp/webhook",
+        "verify_token_configured": True,
+        "app_secret_configured": True,
+        "calling_sidecar_configured": True,
+        "calling_sidecar_contract_loaded": True,
+        "calling_sidecar_tts_stream_configured": True,
+    }
+    assert "phone_number_id" not in result
+
+
+def test_validate_whatsapp_cloud_health_rejects_unloaded_calling_sidecar():
+    script = _load_script_module()
+
+    with pytest.raises(SystemExit, match="calling sidecar is not configured"):
+        script.validate_whatsapp_cloud_health(
+            {
+                "status": "ok",
+                "platform": "whatsapp_cloud",
+                "phone_number_id": "7794189252778687",
+                "verify_token_configured": True,
+                "app_secret_configured": True,
+                "calling_sidecar_configured": False,
+                "calling_sidecar_tts_stream_configured": True,
+            },
+            expected_phone_number_id="7794189252778687",
+            expect_calling_sidecar=True,
+        )
 
 
 def test_validate_whatsapp_cloud_readiness_rejects_missing_authorization(
@@ -1265,6 +1331,21 @@ def test_main_can_require_whatsapp_cloud_readiness_without_printing_secrets(
         lambda *_args, **_kwargs: {"status": "connected"},
     )
     monkeypatch.setattr(
+        script,
+        "get_json_url",
+        lambda *_args, **_kwargs: {
+            "status": "ok",
+            "platform": "whatsapp_cloud",
+            "phone_number_id": "7794189252778687",
+            "webhook_path": "/whatsapp/webhook",
+            "verify_token_configured": True,
+            "app_secret_configured": True,
+            "calling_sidecar_configured": False,
+            "calling_sidecar_contract_loaded": False,
+            "calling_sidecar_tts_stream_configured": False,
+        },
+    )
+    monkeypatch.setattr(
         sys,
         "argv",
         [
@@ -1290,6 +1371,17 @@ def test_main_can_require_whatsapp_cloud_readiness_without_printing_secrets(
         "source": "env_file",
     }
     assert readiness["authorization"]["allowed_users_count"] == 1
+    assert output["checks"]["whatsapp_cloud_health"] == {
+        "url": "http://127.0.0.1:8090/health",
+        "status": "ok",
+        "platform": "whatsapp_cloud",
+        "webhook_path": "/whatsapp/webhook",
+        "verify_token_configured": True,
+        "app_secret_configured": True,
+        "calling_sidecar_configured": False,
+        "calling_sidecar_contract_loaded": False,
+        "calling_sidecar_tts_stream_configured": False,
+    }
     assert access_token not in output_text
     assert app_secret not in output_text
     assert verify_token not in output_text

--- a/tests/tools/test_verify_voice_live_gateway_script.py
+++ b/tests/tools/test_verify_voice_live_gateway_script.py
@@ -211,6 +211,76 @@ def test_validate_calling_sidecar_contract_requires_voice_pcm_shape():
         script.validate_calling_sidecar_contract(drifted)
 
 
+def test_load_voice_stream_contract_runs_voice_binary(monkeypatch):
+    script = _load_script_module()
+    contract = {
+        "contract": "voice.webrtc_sidecar",
+        "version": 1,
+        "audio": {
+            "sample_rate": 48_000,
+            "channels": 1,
+            "frame_ms": 20,
+            "encoding": "pcm_s16le",
+            "frame_bytes": 1_920,
+        },
+    }
+    calls = []
+
+    def fake_run(command, *, timeout):
+        calls.append((command, timeout))
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(contract),
+            stderr="",
+        )
+
+    monkeypatch.setattr(script, "run_command", fake_run)
+
+    result = script.load_voice_stream_contract("/usr/bin/voice", timeout=3)
+
+    assert result == contract
+    assert calls == [(["/usr/bin/voice", "stream-contract"], 3)]
+
+
+def test_compare_voice_and_sidecar_contracts_requires_exact_machine_contract():
+    script = _load_script_module()
+    contract = {
+        "contract": "voice.webrtc_sidecar",
+        "version": 1,
+        "status": "experimental",
+        "summary": "summary",
+        "audio": {
+            "sample_rate": 48_000,
+            "channels": 1,
+            "frame_ms": 20,
+            "encoding": "pcm_s16le",
+            "frame_bytes": 1_920,
+        },
+        "voice_surfaces": {"raw_outbound_pcm": {"frame_bytes": 1_920}},
+        "endpoints": {"offer": {"path": "/offer"}},
+        "payloads": {"offer_request": {"sdp": "required"}},
+    }
+
+    result = script.compare_voice_and_sidecar_contracts(
+        voice_contract=contract,
+        sidecar_contract=dict(contract),
+    )
+
+    assert result["success"] is True
+    assert result["matched_keys"] == list(script.CONTRACT_COMPARE_KEYS)
+
+    drifted = {
+        **contract,
+        "voice_surfaces": {"raw_outbound_pcm": {"frame_bytes": 960}},
+    }
+    with pytest.raises(SystemExit, match="voice_surfaces"):
+        script.compare_voice_and_sidecar_contracts(
+            voice_contract=contract,
+            sidecar_contract=drifted,
+        )
+
+
 def test_get_calling_sidecar_status_fetches_contract_and_health(monkeypatch):
     script = _load_script_module()
     calls = []

--- a/tests/tools/test_verify_voice_live_gateway_script.py
+++ b/tests/tools/test_verify_voice_live_gateway_script.py
@@ -470,6 +470,41 @@ def test_validate_whatsapp_cloud_readiness_rejects_missing_authorization(
         )
 
 
+def test_validate_whatsapp_cloud_readiness_reports_all_missing_fields(
+    tmp_path: Path,
+):
+    script = _load_script_module()
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / ".env").write_text(
+        "\n".join(
+            [
+                "WHATSAPP_CLOUD_PHONE_NUMBER_ID=15551234567",
+                "WHATSAPP_CLOUD_ACCESS_TOKEN=sk-not-meta",
+                "WHATSAPP_CLOUD_APP_SECRET=too-short",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        script.validate_whatsapp_cloud_readiness(
+            hermes_home=hermes_home,
+            process_env={},
+        )
+
+    message = str(exc_info.value)
+    assert "WhatsApp Cloud readiness failed:" in message
+    assert "WHATSAPP_CLOUD_PHONE_NUMBER_ID looks like a phone number" in message
+    assert "WHATSAPP_CLOUD_ACCESS_TOKEN should start with EAA" in message
+    assert "WHATSAPP_CLOUD_APP_SECRET should be exactly 32 hex characters" in message
+    assert "WHATSAPP_CLOUD_VERIFY_TOKEN is not configured" in message
+    assert "recipient authorization is not configured" in message
+    assert "15551234567" not in message
+    assert "sk-not-meta" not in message
+    assert "too-short" not in message
+
+
 def test_path_is_under_accepts_children_and_rejects_siblings(tmp_path: Path):
     script = _load_script_module()
     root = tmp_path / "root"

--- a/tests/tools/test_verify_voice_live_gateway_script.py
+++ b/tests/tools/test_verify_voice_live_gateway_script.py
@@ -780,6 +780,7 @@ def test_run_calling_live_sidecar_smoke_uses_live_root_imports(
                     "success": True,
                     "graph_actions": ["pre_accept", "accept"],
                     "sidecar_ready_for_accept": True,
+                    "webhook_statuses": {"connect": 200, "terminate": 200},
                     "outbound_webrtc_bytes": 23040,
                     "inbound_drain_bytes": 1920,
                 }
@@ -829,6 +830,7 @@ def test_run_calling_live_sidecar_smoke_rejects_missing_audio(monkeypatch, tmp_p
                     "success": True,
                     "graph_actions": ["pre_accept", "accept"],
                     "sidecar_ready_for_accept": True,
+                    "webhook_statuses": {"connect": 200, "terminate": 200},
                     "outbound_webrtc_bytes": 0,
                     "inbound_drain_bytes": 1920,
                 }

--- a/tests/tools/test_verify_voice_live_gateway_script.py
+++ b/tests/tools/test_verify_voice_live_gateway_script.py
@@ -388,6 +388,63 @@ def test_check_whatsapp_cloud_verify_handshake_uses_token_without_reporting_it(
     assert verify_token not in json.dumps(result)
 
 
+def test_check_whatsapp_cloud_signed_post_uses_hmac_without_reporting_secret(
+    tmp_path: Path,
+    monkeypatch,
+):
+    script = _load_script_module()
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    app_secret = "0123456789abcdef0123456789abcdef"
+    (hermes_home / ".env").write_text(
+        "\n".join(
+            [
+                "WHATSAPP_CLOUD_PHONE_NUMBER_ID=7794189252778687",
+                "WHATSAPP_CLOUD_ACCESS_TOKEN=EAA" + ("x" * 120),
+                f"WHATSAPP_CLOUD_APP_SECRET={app_secret}",
+                "WHATSAPP_CLOUD_VERIFY_TOKEN=verify-token-value-long-enough",
+                "WHATSAPP_CLOUD_ALLOWED_USERS=15551234567",
+                "WHATSAPP_CLOUD_WEBHOOK_PORT=8091",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    readiness = script.validate_whatsapp_cloud_readiness(
+        hermes_home=hermes_home,
+        process_env={},
+    )
+
+    def fake_post_json_url(target, *, body, headers, timeout, label):
+        assert target == "http://127.0.0.1:8091/whatsapp/webhook"
+        assert label == target
+        assert app_secret.encode("utf-8") not in body
+        assert headers["Content-Type"] == "application/json"
+        signature = headers["X-Hub-Signature-256"]
+        assert signature.startswith("sha256=")
+        assert app_secret not in signature
+        payload = json.loads(body.decode("utf-8"))
+        assert payload["entry"][0]["changes"][0]["value"]["statuses"][0][
+            "status"
+        ] == "delivered"
+        return 200, ""
+
+    monkeypatch.setattr(script, "post_json_url", fake_post_json_url)
+
+    result = script.check_whatsapp_cloud_signed_post(
+        readiness=readiness,
+        webhook_url=None,
+        timeout=1.0,
+    )
+
+    assert result == {
+        "url": "http://127.0.0.1:8091/whatsapp/webhook",
+        "status": 200,
+        "payload": "status_delivery_receipt",
+        "signature_accepted": True,
+    }
+    assert app_secret not in json.dumps(result)
+
+
 def test_validate_whatsapp_cloud_readiness_rejects_missing_authorization(
     tmp_path: Path,
 ):
@@ -1417,6 +1474,11 @@ def test_main_can_require_whatsapp_cloud_readiness_without_printing_secrets(
 
     monkeypatch.setattr(script, "get_text_url", fake_get_text_url)
     monkeypatch.setattr(
+        script,
+        "post_json_url",
+        lambda *_args, **_kwargs: (200, ""),
+    )
+    monkeypatch.setattr(
         sys,
         "argv",
         [
@@ -1457,6 +1519,12 @@ def test_main_can_require_whatsapp_cloud_readiness_without_printing_secrets(
         "url": "http://127.0.0.1:8090/whatsapp/webhook",
         "status": 200,
         "challenge_echoed": True,
+    }
+    assert output["checks"]["whatsapp_cloud_signed_post"] == {
+        "url": "http://127.0.0.1:8090/whatsapp/webhook",
+        "status": 200,
+        "payload": "status_delivery_receipt",
+        "signature_accepted": True,
     }
     assert access_token not in output_text
     assert app_secret not in output_text

--- a/tests/tools/test_verify_voice_live_gateway_script.py
+++ b/tests/tools/test_verify_voice_live_gateway_script.py
@@ -632,6 +632,55 @@ def test_run_tts_smoke_runs_from_live_root(tmp_path: Path, monkeypatch):
     assert result["probe"]["codec_name"] == "opus"
 
 
+def test_run_stt_smoke_runs_existing_config_verifier(tmp_path: Path, monkeypatch):
+    script = _load_script_module()
+    live_root = tmp_path / "live"
+    verifier = live_root / "scripts" / "verify_voice_command_stt.py"
+    verifier.parent.mkdir(parents=True)
+    verifier.write_text("", encoding="utf-8")
+
+    def fake_run(command, *, timeout):
+        assert command[:2] == ["/python", str(verifier)]
+        assert "--use-existing-config" in command
+        assert "--hermes-home" in command
+        assert str(tmp_path / "home") in command
+        assert "--voice-bin" in command
+        assert "/voice" in command
+        assert "--provider" in command
+        assert "voice" in command
+        assert "--expect-word" in command
+        assert timeout == 7.0
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(
+                {
+                    "success": True,
+                    "provider": "voice",
+                    "transcript": "Hello world.",
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(script, "run_command", fake_run)
+
+    result = script.run_stt_smoke(
+        python_bin="/python",
+        live_root=live_root,
+        hermes_home=tmp_path / "home",
+        voice_bin="/voice",
+        provider="voice",
+        text="hello world",
+        expect_words=["hello"],
+        stt_timeout=3.0,
+        generate_timeout=4.0,
+        process_timeout=7.0,
+    )
+
+    assert result["transcript"] == "Hello world."
+
+
 def test_main_skips_ffprobe_when_tts_smoke_is_disabled(
     tmp_path: Path,
     monkeypatch,

--- a/tests/tools/test_verify_voice_live_gateway_script.py
+++ b/tests/tools/test_verify_voice_live_gateway_script.py
@@ -112,13 +112,44 @@ def _voice_sidecar_contract() -> dict:
         "payloads": {
             "offer_request": {"sdp": "required"},
             "offer_response": {"sdp": "answer"},
-            "call_state": {"queued_tx_bytes": "bytes"},
+            "call_state": {
+                "queued_tx_bytes": "bytes",
+                "queued_tx_ms": "ms",
+                "max_tx_queue_bytes": "bytes",
+                "max_tx_queue_ms": "ms",
+                "queued_rx_bytes": "bytes",
+                "queued_rx_ms": "ms",
+                "max_rx_queue_bytes": "bytes",
+                "max_rx_queue_ms": "ms",
+            },
             "call_status_response": "call_state",
             "close_call_response": {"closed": True},
             "send_audio_request": {"pcm_s16le_base64": "required"},
-            "send_audio_response": {"accepted_bytes": "bytes"},
-            "clear_audio_response": {"dropped_tx_bytes": "bytes"},
-            "receive_audio_response": {"pcm_s16le_base64": "data"},
+            "send_audio_response": {
+                "accepted_bytes": "bytes",
+                "accepted_ms": "ms",
+                "queued_tx_bytes": "bytes",
+                "queued_tx_ms": "ms",
+                "max_tx_queue_bytes": "bytes",
+                "max_tx_queue_ms": "ms",
+            },
+            "clear_audio_response": {
+                "dropped_tx_bytes": "bytes",
+                "dropped_tx_ms": "ms",
+                "queued_tx_bytes": "bytes",
+                "queued_tx_ms": "ms",
+                "max_tx_queue_bytes": "bytes",
+                "max_tx_queue_ms": "ms",
+            },
+            "receive_audio_response": {
+                "returned_bytes": "bytes",
+                "returned_ms": "ms",
+                "queued_rx_bytes": "bytes",
+                "queued_rx_ms": "ms",
+                "max_rx_queue_bytes": "bytes",
+                "max_rx_queue_ms": "ms",
+                "pcm_s16le_base64": "data",
+            },
             "audio_shape": {"sample_rate": "audio.sample_rate"},
             "error_response": {"error": "message"},
         },
@@ -415,6 +446,20 @@ def test_validate_calling_sidecar_contract_requires_named_surfaces_and_endpoints
     }
     with pytest.raises(SystemExit, match="payloads missing keys"):
         script.validate_calling_sidecar_contract(missing_clear_payload)
+
+    missing_queue_ms = {
+        **contract,
+        "payloads": {
+            **contract["payloads"],
+            "call_state": {
+                key: value
+                for key, value in contract["payloads"]["call_state"].items()
+                if key != "queued_tx_ms"
+            },
+        },
+    }
+    with pytest.raises(SystemExit, match="payloads.call_state missing fields"):
+        script.validate_calling_sidecar_contract(missing_queue_ms)
 
 
 def test_load_voice_stream_contract_runs_voice_binary(monkeypatch):

--- a/tests/tools/test_verify_voice_live_gateway_script.py
+++ b/tests/tools/test_verify_voice_live_gateway_script.py
@@ -117,6 +117,8 @@ def _voice_sidecar_contract() -> dict:
             "offer_request": {"sdp": "required"},
             "offer_response": {"sdp": "answer"},
             "call_state": {
+                "ready_for_accept": "ready",
+                "readiness": "checks",
                 "queued_tx_bytes": "bytes",
                 "queued_tx_ms": "ms",
                 "max_tx_queue_bytes": "bytes",
@@ -465,6 +467,20 @@ def test_validate_calling_sidecar_contract_requires_named_surfaces_and_endpoints
     with pytest.raises(SystemExit, match="payloads.call_state missing fields"):
         script.validate_calling_sidecar_contract(missing_queue_ms)
 
+    missing_readiness = {
+        **contract,
+        "payloads": {
+            **contract["payloads"],
+            "call_state": {
+                key: value
+                for key, value in contract["payloads"]["call_state"].items()
+                if key != "ready_for_accept"
+            },
+        },
+    }
+    with pytest.raises(SystemExit, match="payloads.call_state missing fields"):
+        script.validate_calling_sidecar_contract(missing_readiness)
+
 
 def test_load_voice_stream_contract_runs_voice_binary(monkeypatch):
     script = _load_script_module()
@@ -532,6 +548,92 @@ def test_get_calling_sidecar_status_fetches_contract_and_health(monkeypatch):
         ("http://127.0.0.1:8787/contract", 3),
         ("http://127.0.0.1:8787/health", 3),
     ]
+
+
+def test_run_calling_sidecar_offer_smoke_requires_ready_answer(monkeypatch):
+    script = _load_script_module()
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(
+                {
+                    "status": 200,
+                    "body": {
+                        "state": {
+                            "ready_for_accept": True,
+                            "readiness": {
+                                "not_closed": True,
+                                "local_sdp_answer": True,
+                                "signaling_stable": True,
+                                "ice_gathering_complete": True,
+                                "outbound_audio_track": True,
+                            },
+                        }
+                    },
+                    "close": {"call_id": "call-1", "closed": True},
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(script.subprocess, "run", fake_run)
+
+    result = script.run_calling_sidecar_offer_smoke(
+        python_bin="/tmp/webrtc-python",
+        sidecar_url="http://127.0.0.1:8787/",
+        call_id="call-1",
+        timeout=3,
+    )
+
+    assert result["success"] is True
+    assert result["ready_for_accept"] is True
+    assert result["readiness"]["outbound_audio_track"] is True
+    assert calls[0][0][0] == "/tmp/webrtc-python"
+    assert calls[0][0][1] == "-c"
+    assert calls[0][0][-3:] == ["http://127.0.0.1:8787/", "call-1", "3"]
+
+
+def test_run_calling_sidecar_offer_smoke_rejects_failed_readiness(monkeypatch):
+    script = _load_script_module()
+
+    def fake_run(command, **_kwargs):
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(
+                {
+                    "status": 200,
+                    "body": {
+                        "state": {
+                            "ready_for_accept": False,
+                            "readiness": {
+                                "not_closed": True,
+                                "local_sdp_answer": True,
+                                "signaling_stable": True,
+                                "ice_gathering_complete": False,
+                                "outbound_audio_track": True,
+                            },
+                        }
+                    },
+                    "close": {"call_id": "call-1", "closed": True},
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(script.subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit, match="ice_gathering_complete"):
+        script.run_calling_sidecar_offer_smoke(
+            python_bin="/tmp/webrtc-python",
+            sidecar_url="http://127.0.0.1:8787",
+            call_id="call-1",
+            timeout=3,
+        )
 
 
 def test_parse_ffprobe_json_extracts_audio_shape():

--- a/tests/tools/test_verify_voice_live_gateway_script.py
+++ b/tests/tools/test_verify_voice_live_gateway_script.py
@@ -314,3 +314,64 @@ def test_main_skips_ffprobe_when_tts_smoke_is_disabled(
     output = json.loads(capsys.readouterr().out)
     assert output["success"] is True
     assert labels == ["Hermes Python"]
+
+
+def test_main_can_skip_bridge_health_for_cloud_only_gateway(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    script = _load_script_module()
+    live_root = tmp_path / "hermes"
+    _write_voice_native_root(live_root)
+    bridge_bin = live_root / "scripts" / "whatsapp-bridge" / "node_modules" / ".bin"
+
+    monkeypatch.setattr(script, "resolve_executable", lambda value, *, label: value)
+    monkeypatch.setattr(
+        script,
+        "get_service_state",
+        lambda *_args, **_kwargs: {
+            "ActiveState": "active",
+            "MainPID": "123",
+            "Environment": (
+                f"PYTHONPATH={live_root} PATH=/usr/bin:{bridge_bin}"
+            ),
+            "DropInPaths": "/drop-in.conf",
+        },
+    )
+    monkeypatch.setattr(
+        script,
+        "read_process_env",
+        lambda _pid: {"PYTHONPATH": str(live_root), "PATH": f"/usr/bin:{bridge_bin}"},
+    )
+    monkeypatch.setattr(
+        script,
+        "import_smoke",
+        lambda **_kwargs: {"tools.tts_tool": str(live_root / "tools" / "tts_tool.py")},
+    )
+
+    def fail_bridge_health(*_args, **_kwargs):
+        raise AssertionError("bridge health should be skipped")
+
+    monkeypatch.setattr(script, "get_bridge_health", fail_bridge_health)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "verify_voice_live_gateway.py",
+            "--live-hermes-root",
+            str(live_root),
+            "--python-bin",
+            "/python",
+            "--skip-bridge-health",
+        ],
+    )
+
+    assert script.main() == 0
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["checks"]["bridge_health"] == {
+        "success": True,
+        "skipped": True,
+        "reason": "--skip-bridge-health was provided",
+    }

--- a/tests/tools/test_verify_voice_live_gateway_script.py
+++ b/tests/tools/test_verify_voice_live_gateway_script.py
@@ -794,6 +794,7 @@ def test_run_calling_live_sidecar_smoke_uses_live_root_imports(
         live_root=live_root,
         hermes_home=hermes_home,
         voice_repo=voice_repo,
+        sidecar_url="http://127.0.0.1:8787",
         timeout=12,
     )
 
@@ -803,7 +804,14 @@ def test_run_calling_live_sidecar_smoke_uses_live_root_imports(
         "/tmp/voice-webrtc-venv/bin/python",
         str(SCRIPT_PATH.parent / "verify_voice_whatsapp_calling_live_sidecar.py"),
     ]
-    assert command[-4:] == ["--voice-repo", str(voice_repo), "--timeout", "12"]
+    assert command[-6:] == [
+        "--voice-repo",
+        str(voice_repo),
+        "--timeout",
+        "12",
+        "--sidecar-url",
+        "http://127.0.0.1:8787",
+    ]
     assert kwargs["env"]["PYTHONPATH"] == str(live_root)
     assert kwargs["env"]["HERMES_HOME"] == str(hermes_home)
     assert kwargs["cwd"] == str(live_root)
@@ -836,6 +844,7 @@ def test_run_calling_live_sidecar_smoke_rejects_missing_audio(monkeypatch, tmp_p
             live_root=tmp_path,
             hermes_home=tmp_path,
             voice_repo=tmp_path,
+            sidecar_url=None,
             timeout=12,
         )
 
@@ -1234,6 +1243,7 @@ def test_main_runs_calling_live_sidecar_smoke_when_requested(
         assert kwargs["python_bin"] == "/tmp/voice-webrtc-venv/bin/python"
         assert kwargs["live_root"] == live_root.resolve()
         assert kwargs["voice_repo"] == voice_repo.resolve()
+        assert kwargs["sidecar_url"] is None
         return {
             "success": True,
             "graph_actions": ["pre_accept", "accept"],
@@ -1269,6 +1279,100 @@ def test_main_runs_calling_live_sidecar_smoke_when_requested(
         "pre_accept",
         "accept",
     ]
+
+
+def test_main_passes_calling_sidecar_url_to_live_sidecar_smoke(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    script = _load_script_module()
+    live_root = tmp_path / "hermes"
+    voice_repo = tmp_path / "voice"
+    _write_voice_native_root(live_root)
+    voice_repo.mkdir()
+    bridge_bin = live_root / "scripts" / "whatsapp-bridge" / "node_modules" / ".bin"
+    sidecar_url = "http://127.0.0.1:8787"
+
+    monkeypatch.setattr(script, "resolve_executable", lambda value, *, label: value)
+    monkeypatch.setattr(
+        script,
+        "get_service_state",
+        lambda *_args, **_kwargs: {
+            "ActiveState": "active",
+            "MainPID": "123",
+            "Environment": f"PYTHONPATH={live_root} PATH=/usr/bin:{bridge_bin}",
+            "DropInPaths": "/drop-in.conf",
+        },
+    )
+    monkeypatch.setattr(
+        script,
+        "read_process_env",
+        lambda _pid: {
+            "PYTHONPATH": str(live_root),
+            "PATH": f"/usr/bin:{bridge_bin}",
+            "WHATSAPP_CLOUD_CALLING_SIDECAR_URL": sidecar_url,
+            "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND": (
+                "voice stream --raw-output - --input-file {input_path} "
+                "--sample-rate {sample_rate} --frame-ms {frame_ms}"
+            ),
+        },
+    )
+    monkeypatch.setattr(
+        script,
+        "import_smoke",
+        lambda **_kwargs: {"tools.tts_tool": str(live_root / "tools" / "tts_tool.py")},
+    )
+    monkeypatch.setattr(
+        script,
+        "get_calling_sidecar_status",
+        lambda *_args, **_kwargs: {
+            "contract": {"contract": "voice.webrtc_sidecar"},
+            "health": {"ok": True, "sessions": 0, "call_ids": []},
+        },
+    )
+    monkeypatch.setattr(
+        script,
+        "get_bridge_health",
+        lambda *_args, **_kwargs: {"status": "connected"},
+    )
+
+    def fake_live_sidecar_smoke(**kwargs):
+        assert kwargs["sidecar_url"] == sidecar_url
+        return {
+            "success": True,
+            "graph_actions": ["pre_accept", "accept"],
+            "sidecar_ready_for_accept": True,
+        }
+
+    monkeypatch.setattr(
+        script,
+        "run_calling_live_sidecar_smoke",
+        fake_live_sidecar_smoke,
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "verify_voice_live_gateway.py",
+            "--live-hermes-root",
+            str(live_root),
+            "--python-bin",
+            "/python",
+            "--voice-repo",
+            str(voice_repo),
+            "--webrtc-python-bin",
+            "/tmp/voice-webrtc-venv/bin/python",
+            "--calling-sidecar-url",
+            sidecar_url,
+            "--run-calling-live-sidecar-smoke",
+        ],
+    )
+
+    assert script.main() == 0
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["checks"]["calling_sidecar"]["env"]["url"] == sidecar_url
 
 
 def test_main_validates_sidecar_service_when_requested(

--- a/tests/tools/test_verify_voice_live_gateway_script.py
+++ b/tests/tools/test_verify_voice_live_gateway_script.py
@@ -307,6 +307,7 @@ def test_validate_sidecar_service_state_accepts_expected_unit(tmp_path: Path):
         {
             "ActiveState": "active",
             "MainPID": "42",
+            "After": "network.target voiced.service",
             "Environment": f"VOICE_BIN={voice_bin}",
             "WorkingDirectory": str(voice_repo),
             "ExecStart": (
@@ -327,6 +328,41 @@ def test_validate_sidecar_service_state_accepts_expected_unit(tmp_path: Path):
     assert result["sidecar_path"] == str(sidecar_path)
     assert result["sidecar_url"] == "http://127.0.0.1:8787"
     assert result["bind"] == {"host": "127.0.0.1", "port": 8787}
+    assert "voiced.service" in result["after"]
+
+
+def test_validate_sidecar_service_state_rejects_deprecated_daemon_unit():
+    script = _load_script_module()
+
+    with pytest.raises(SystemExit, match="deprecated voice-daemon.service"):
+        script.validate_sidecar_service_state(
+            {
+                "ActiveState": "active",
+                "MainPID": "42",
+                "After": "network.target voice-daemon.service",
+            },
+            service="voice-webrtc-sidecar.service",
+            voice_bin=None,
+            voice_repo=None,
+            sidecar_url=None,
+        )
+
+
+def test_validate_sidecar_service_state_requires_voiced_ordering():
+    script = _load_script_module()
+
+    with pytest.raises(SystemExit, match="does not order after voiced.service"):
+        script.validate_sidecar_service_state(
+            {
+                "ActiveState": "active",
+                "MainPID": "42",
+                "After": "network.target",
+            },
+            service="voice-webrtc-sidecar.service",
+            voice_bin=None,
+            voice_repo=None,
+            sidecar_url=None,
+        )
 
 
 def test_validate_sidecar_service_state_rejects_stale_voice_bin(tmp_path: Path):
@@ -343,6 +379,7 @@ def test_validate_sidecar_service_state_rejects_stale_voice_bin(tmp_path: Path):
             {
                 "ActiveState": "active",
                 "MainPID": "42",
+                "After": "network.target voiced.service",
                 "Environment": f"VOICE_BIN={stale_voice}",
             },
             service="voice-webrtc-sidecar.service",
@@ -366,6 +403,7 @@ def test_validate_sidecar_service_state_rejects_wrong_voice_repo(tmp_path: Path)
             {
                 "ActiveState": "active",
                 "MainPID": "42",
+                "After": "network.target voiced.service",
                 "Environment": "",
                 "WorkingDirectory": str(stale_repo),
                 "ExecStart": f"{{ argv[]={sys.executable} {sidecar_path} }}",
@@ -385,6 +423,7 @@ def test_validate_sidecar_service_state_rejects_wrong_bind_port(tmp_path: Path):
             {
                 "ActiveState": "active",
                 "MainPID": "42",
+                "After": "network.target voiced.service",
                 "Environment": "",
                 "ExecStart": "{ argv[]=/python sidecar.py --host 127.0.0.1 --port 87870 }",
             },
@@ -1011,6 +1050,7 @@ def test_main_validates_sidecar_service_when_requested(
             return {
                 "ActiveState": "active",
                 "MainPID": "456",
+                "After": "network.target voiced.service",
                 "Environment": f"VOICE_BIN={voice_bin}",
                 "WorkingDirectory": str(voice_repo),
                 "ExecStart": f"{{ argv[]=/python {sidecar_path} --port 8787 }}",

--- a/tests/tools/test_verify_voice_live_gateway_script.py
+++ b/tests/tools/test_verify_voice_live_gateway_script.py
@@ -153,6 +153,96 @@ def test_validate_bridge_health_requires_connected_when_requested():
         script.validate_bridge_health({"status": "connecting"}, require_connected=True)
 
 
+def test_validate_calling_sidecar_env_requires_url_and_stream_command():
+    script = _load_script_module()
+    env = {
+        "WHATSAPP_CLOUD_CALLING_SIDECAR_URL": "http://127.0.0.1:8787/",
+        "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND": (
+            "voice stream --raw-output - --input-file {input_path} "
+            "--sample-rate {sample_rate} --frame-ms {frame_ms}"
+        ),
+        "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT": "180",
+    }
+
+    result = script.validate_calling_sidecar_env(env, "http://127.0.0.1:8787")
+
+    assert result["url"] == "http://127.0.0.1:8787"
+    assert result["tts_stream_timeout"] == "180"
+
+    with pytest.raises(SystemExit, match="does not match"):
+        script.validate_calling_sidecar_env(env, "http://127.0.0.1:9999")
+    with pytest.raises(SystemExit, match="missing"):
+        script.validate_calling_sidecar_env(
+            {
+                "WHATSAPP_CLOUD_CALLING_SIDECAR_URL": "http://127.0.0.1:8787",
+                "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND": "voice stream",
+            },
+            "http://127.0.0.1:8787",
+        )
+
+
+def test_validate_calling_sidecar_contract_requires_voice_pcm_shape():
+    script = _load_script_module()
+    contract = {
+        "contract": "voice.webrtc_sidecar",
+        "version": 1,
+        "audio": {
+            "sample_rate": 48_000,
+            "channels": 1,
+            "frame_ms": 20,
+            "encoding": "pcm_s16le",
+            "frame_bytes": 1_920,
+        },
+    }
+
+    result = script.validate_calling_sidecar_contract(contract)
+
+    assert result["contract"] == "voice.webrtc_sidecar"
+    assert result["audio"]["frame_bytes"] == 1_920
+
+    bad = {**contract, "contract": "other"}
+    with pytest.raises(SystemExit, match="contract id"):
+        script.validate_calling_sidecar_contract(bad)
+    drifted = {
+        **contract,
+        "audio": {**contract["audio"], "sample_rate": 16_000},
+    }
+    with pytest.raises(SystemExit, match="audio contract"):
+        script.validate_calling_sidecar_contract(drifted)
+
+
+def test_get_calling_sidecar_status_fetches_contract_and_health(monkeypatch):
+    script = _load_script_module()
+    calls = []
+
+    def fake_json_url(target, *, timeout):
+        calls.append((target, timeout))
+        if target.endswith("/contract"):
+            return {
+                "contract": "voice.webrtc_sidecar",
+                "version": 1,
+                "audio": {
+                    "sample_rate": 48_000,
+                    "channels": 1,
+                    "frame_ms": 20,
+                    "encoding": "pcm_s16le",
+                    "frame_bytes": 1_920,
+                },
+            }
+        return {"ok": True, "sessions": 0, "call_ids": []}
+
+    monkeypatch.setattr(script, "get_json_url", fake_json_url)
+
+    result = script.get_calling_sidecar_status("http://127.0.0.1:8787/", timeout=3)
+
+    assert result["contract"]["contract"] == "voice.webrtc_sidecar"
+    assert result["health"] == {"ok": True, "sessions": 0, "call_ids": []}
+    assert calls == [
+        ("http://127.0.0.1:8787/contract", 3),
+        ("http://127.0.0.1:8787/health", 3),
+    ]
+
+
 def test_parse_ffprobe_json_extracts_audio_shape():
     script = _load_script_module()
 
@@ -375,3 +465,81 @@ def test_main_can_skip_bridge_health_for_cloud_only_gateway(
         "skipped": True,
         "reason": "--skip-bridge-health was provided",
     }
+
+
+def test_main_validates_calling_sidecar_when_requested(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+):
+    script = _load_script_module()
+    live_root = tmp_path / "hermes"
+    _write_voice_native_root(live_root)
+    bridge_bin = live_root / "scripts" / "whatsapp-bridge" / "node_modules" / ".bin"
+    sidecar_url = "http://127.0.0.1:8787"
+    stream_command = (
+        "voice stream --raw-output - --input-file {input_path} "
+        "--sample-rate {sample_rate} --frame-ms {frame_ms}"
+    )
+
+    monkeypatch.setattr(script, "resolve_executable", lambda value, *, label: value)
+    monkeypatch.setattr(
+        script,
+        "get_service_state",
+        lambda *_args, **_kwargs: {
+            "ActiveState": "active",
+            "MainPID": "123",
+            "Environment": (
+                f"PYTHONPATH={live_root} PATH=/usr/bin:{bridge_bin}"
+            ),
+            "DropInPaths": "/drop-in.conf",
+        },
+    )
+    monkeypatch.setattr(
+        script,
+        "read_process_env",
+        lambda _pid: {
+            "PYTHONPATH": str(live_root),
+            "PATH": f"/usr/bin:{bridge_bin}",
+            "WHATSAPP_CLOUD_CALLING_SIDECAR_URL": sidecar_url,
+            "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND": stream_command,
+            "WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT": "180",
+        },
+    )
+    monkeypatch.setattr(
+        script,
+        "import_smoke",
+        lambda **_kwargs: {"tools.tts_tool": str(live_root / "tools" / "tts_tool.py")},
+    )
+    monkeypatch.setattr(
+        script,
+        "get_bridge_health",
+        lambda *_args, **_kwargs: {"status": "connected"},
+    )
+    monkeypatch.setattr(
+        script,
+        "get_calling_sidecar_status",
+        lambda *_args, **_kwargs: {
+            "contract": {"contract": "voice.webrtc_sidecar"},
+            "health": {"ok": True, "sessions": 0, "call_ids": []},
+        },
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "verify_voice_live_gateway.py",
+            "--live-hermes-root",
+            str(live_root),
+            "--python-bin",
+            "/python",
+            "--calling-sidecar-url",
+            sidecar_url,
+        ],
+    )
+
+    assert script.main() == 0
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["checks"]["calling_sidecar"]["env"]["url"] == sidecar_url
+    assert output["checks"]["calling_sidecar"]["sidecar"]["health"]["ok"] is True

--- a/tests/tools/test_verify_voice_live_gateway_script.py
+++ b/tests/tools/test_verify_voice_live_gateway_script.py
@@ -434,6 +434,63 @@ def test_validate_sidecar_service_state_rejects_wrong_bind_port(tmp_path: Path):
         )
 
 
+def test_validate_voice_daemon_service_state_accepts_expected_unit(tmp_path: Path):
+    script = _load_script_module()
+    voice_bin = tmp_path / "bin" / "voice"
+    voice_bin.parent.mkdir()
+    voice_bin.write_text("", encoding="utf-8")
+
+    result = script.validate_voice_daemon_service_state(
+        {
+            "ActiveState": "active",
+            "MainPID": "24",
+            "ExecStart": f"{{ argv[]={voice_bin} daemon start --tts-only }}",
+        },
+        service="voiced.service",
+        voice_bin=str(voice_bin),
+    )
+
+    assert result["service"] == "voiced.service"
+    assert result["pid"] == 24
+    assert "daemon start" in result["exec_start"]
+
+
+def test_validate_voice_daemon_service_state_rejects_wrong_voice_bin(tmp_path: Path):
+    script = _load_script_module()
+    expected_voice = tmp_path / "expected" / "voice"
+    stale_voice = tmp_path / "stale" / "voice"
+    expected_voice.parent.mkdir()
+    stale_voice.parent.mkdir()
+    expected_voice.write_text("", encoding="utf-8")
+    stale_voice.write_text("", encoding="utf-8")
+
+    with pytest.raises(SystemExit, match="expected voice binary"):
+        script.validate_voice_daemon_service_state(
+            {
+                "ActiveState": "active",
+                "MainPID": "24",
+                "ExecStart": f"{{ argv[]={stale_voice} daemon start --tts-only }}",
+            },
+            service="voiced.service",
+            voice_bin=str(expected_voice),
+        )
+
+
+def test_validate_voice_daemon_service_state_rejects_non_daemon_command():
+    script = _load_script_module()
+
+    with pytest.raises(SystemExit, match="not a voice daemon start command"):
+        script.validate_voice_daemon_service_state(
+            {
+                "ActiveState": "active",
+                "MainPID": "24",
+                "ExecStart": "{ argv[]=/usr/bin/voice say hello }",
+            },
+            service="voiced.service",
+            voice_bin="/usr/bin/voice",
+        )
+
+
 def test_validate_calling_sidecar_contract_requires_voice_pcm_shape():
     script = _load_script_module()
     contract = _voice_sidecar_contract()
@@ -1046,6 +1103,12 @@ def test_main_validates_sidecar_service_when_requested(
     monkeypatch.setattr(script, "resolve_executable", lambda value, *, label: value)
 
     def fake_service_state(service, *, timeout):
+        if service == "voiced.service":
+            return {
+                "ActiveState": "active",
+                "MainPID": "789",
+                "ExecStart": f"{{ argv[]={voice_bin} daemon start --tts-only }}",
+            }
         if service == "voice-webrtc-sidecar.service":
             return {
                 "ActiveState": "active",
@@ -1100,5 +1163,6 @@ def test_main_validates_sidecar_service_when_requested(
 
     output = json.loads(capsys.readouterr().out)
     assert output["checks"]["sidecar_service"]["pid"] == 456
+    assert output["checks"]["voice_daemon_service"]["pid"] == 789
     assert output["checks"]["sidecar_service"]["voice_bin"] == str(voice_bin)
     assert output["checks"]["sidecar_service"]["working_directory"] == str(voice_repo)

--- a/tests/tools/test_verify_voice_live_gateway_script.py
+++ b/tests/tools/test_verify_voice_live_gateway_script.py
@@ -1064,6 +1064,31 @@ def test_run_calling_sidecar_offer_smoke_rejects_failed_readiness(monkeypatch):
         )
 
 
+def _successful_live_sidecar_result(**overrides):
+    result = {
+        "success": True,
+        "graph_actions": ["pre_accept", "accept"],
+        "sidecar_ready_for_accept": True,
+        "sidecar_readiness": {
+            "not_closed": True,
+            "local_sdp_answer": True,
+            "signaling_stable": True,
+            "ice_gathering_complete": True,
+            "outbound_audio_track": True,
+        },
+        "webhook_statuses": {"connect": 200, "terminate": 200},
+        "outbound_webrtc_bytes": 23040,
+        "inbound_drain_bytes": 1920,
+        "clear_audio": {
+            "dropped_tx_bytes": 1920,
+            "queued_tx_bytes": 0,
+        },
+        "sidecar_close": {"closed": True},
+    }
+    result.update(overrides)
+    return result
+
+
 def test_run_calling_live_sidecar_smoke_uses_live_root_imports(
     tmp_path: Path,
     monkeypatch,
@@ -1082,16 +1107,7 @@ def test_run_calling_live_sidecar_smoke_uses_live_root_imports(
         return subprocess.CompletedProcess(
             command,
             0,
-            stdout=json.dumps(
-                {
-                    "success": True,
-                    "graph_actions": ["pre_accept", "accept"],
-                    "sidecar_ready_for_accept": True,
-                    "webhook_statuses": {"connect": 200, "terminate": 200},
-                    "outbound_webrtc_bytes": 23040,
-                    "inbound_drain_bytes": 1920,
-                }
-            ),
+            stdout=json.dumps(_successful_live_sidecar_result()),
             stderr="",
         )
 
@@ -1133,14 +1149,7 @@ def test_run_calling_live_sidecar_smoke_rejects_missing_audio(monkeypatch, tmp_p
             command,
             0,
             stdout=json.dumps(
-                {
-                    "success": True,
-                    "graph_actions": ["pre_accept", "accept"],
-                    "sidecar_ready_for_accept": True,
-                    "webhook_statuses": {"connect": 200, "terminate": 200},
-                    "outbound_webrtc_bytes": 0,
-                    "inbound_drain_bytes": 1920,
-                }
+                _successful_live_sidecar_result(outbound_webrtc_bytes=0)
             ),
             stderr="",
         )
@@ -1148,6 +1157,96 @@ def test_run_calling_live_sidecar_smoke_rejects_missing_audio(monkeypatch, tmp_p
     monkeypatch.setattr(script.subprocess, "run", fake_run)
 
     with pytest.raises(SystemExit, match="did not move audio"):
+        script.run_calling_live_sidecar_smoke(
+            python_bin="/tmp/voice-webrtc-venv/bin/python",
+            live_root=tmp_path,
+            hermes_home=tmp_path,
+            voice_repo=tmp_path,
+            sidecar_url=None,
+            timeout=12,
+        )
+
+
+def test_run_calling_live_sidecar_smoke_rejects_missing_readiness(
+    monkeypatch,
+    tmp_path,
+):
+    script = _load_script_module()
+
+    def fake_run(command, **_kwargs):
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(
+                _successful_live_sidecar_result(sidecar_readiness=None)
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(script.subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit, match="did not report readiness"):
+        script.run_calling_live_sidecar_smoke(
+            python_bin="/tmp/voice-webrtc-venv/bin/python",
+            live_root=tmp_path,
+            hermes_home=tmp_path,
+            voice_repo=tmp_path,
+            sidecar_url=None,
+            timeout=12,
+        )
+
+
+def test_run_calling_live_sidecar_smoke_rejects_uncleared_audio(
+    monkeypatch,
+    tmp_path,
+):
+    script = _load_script_module()
+
+    def fake_run(command, **_kwargs):
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(
+                _successful_live_sidecar_result(
+                    clear_audio={
+                        "dropped_tx_bytes": 0,
+                        "queued_tx_bytes": 1920,
+                    }
+                )
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(script.subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit, match="did not clear outbound audio"):
+        script.run_calling_live_sidecar_smoke(
+            python_bin="/tmp/voice-webrtc-venv/bin/python",
+            live_root=tmp_path,
+            hermes_home=tmp_path,
+            voice_repo=tmp_path,
+            sidecar_url=None,
+            timeout=12,
+        )
+
+
+def test_run_calling_live_sidecar_smoke_rejects_missing_close(
+    monkeypatch,
+    tmp_path,
+):
+    script = _load_script_module()
+
+    def fake_run(command, **_kwargs):
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(_successful_live_sidecar_result(sidecar_close=None)),
+            stderr="",
+        )
+
+    monkeypatch.setattr(script.subprocess, "run", fake_run)
+
+    with pytest.raises(SystemExit, match="did not close sidecar cleanly"):
         script.run_calling_live_sidecar_smoke(
             python_bin="/tmp/voice-webrtc-venv/bin/python",
             live_root=tmp_path,
@@ -1688,11 +1787,7 @@ def test_main_runs_calling_live_sidecar_smoke_when_requested(
         assert kwargs["live_root"] == live_root.resolve()
         assert kwargs["voice_repo"] == voice_repo.resolve()
         assert kwargs["sidecar_url"] is None
-        return {
-            "success": True,
-            "graph_actions": ["pre_accept", "accept"],
-            "sidecar_ready_for_accept": True,
-        }
+        return _successful_live_sidecar_result()
 
     monkeypatch.setattr(
         script,
@@ -1783,11 +1878,7 @@ def test_main_passes_calling_sidecar_url_to_live_sidecar_smoke(
 
     def fake_live_sidecar_smoke(**kwargs):
         assert kwargs["sidecar_url"] == sidecar_url
-        return {
-            "success": True,
-            "graph_actions": ["pre_accept", "accept"],
-            "sidecar_ready_for_accept": True,
-        }
+        return _successful_live_sidecar_result()
 
     monkeypatch.setattr(
         script,

--- a/tests/tools/test_verify_voice_local_stack_script.py
+++ b/tests/tools/test_verify_voice_local_stack_script.py
@@ -62,6 +62,7 @@ def _args(**overrides):
         "live_gateway_sidecar_service": "voice-webrtc-sidecar.service",
         "live_gateway_voice_daemon_service": "voiced.service",
         "skip_live_gateway_bridge_health": False,
+        "require_live_gateway_whatsapp_cloud_readiness": False,
         "run_live_gateway_stt_smoke": False,
         "run_live_gateway_calling_live_sidecar_smoke": False,
         "live_gateway_timeout": 360.0,
@@ -286,6 +287,7 @@ def test_live_gateway_command_runs_offer_readiness_smoke():
             run_live_gateway_stt_smoke=True,
             run_live_gateway_calling_live_sidecar_smoke=True,
             skip_live_gateway_bridge_health=True,
+            require_live_gateway_whatsapp_cloud_readiness=True,
         ),
         voice_bin="/home/user/.local/bin/voice",
         voice_repo=Path("/voice"),
@@ -322,6 +324,7 @@ def test_live_gateway_command_runs_offer_readiness_smoke():
     assert command[command.index("--voice-daemon-service") + 1] == "voiced.service"
     assert command[command.index("--voice-repo") + 1] == "/voice"
     assert "--skip-bridge-health" in command
+    assert "--require-whatsapp-cloud-readiness" in command
 
 
 def test_live_gateway_command_passes_custom_voice_daemon_service():

--- a/tests/tools/test_verify_voice_local_stack_script.py
+++ b/tests/tools/test_verify_voice_local_stack_script.py
@@ -30,10 +30,12 @@ def _args(**overrides):
         "speed": "1.0",
         "tts_timeout": 180.0,
         "stream_timeout": 180.0,
+        "calling_control_plane_timeout": 10.0,
         "full_duplex_timeout": 90.0,
         "command_text": "command smoke",
         "stream_text": "stream smoke",
         "stream_command_template": None,
+        "skip_calling_control_plane": False,
         "skip_full_duplex": False,
         "voice_repo": Path("/voice"),
         "webrtc_python_bin": None,
@@ -98,6 +100,20 @@ def test_full_duplex_command_passes_voice_repo_and_python():
     assert "--python-bin" in command
     assert "/tmp/venv/bin/python" in command
     assert command[-2:] == ["--expect-word", "testing"]
+
+
+def test_calling_control_plane_command_uses_synthetic_verifier():
+    script = _load_script_module()
+
+    command = script.calling_control_plane_command(
+        _args(calling_control_plane_timeout=12.5)
+    )
+
+    assert command[:2] == [
+        sys.executable,
+        str(script.script_path("verify_voice_whatsapp_calling_control_plane.py")),
+    ]
+    assert command[-2:] == ["--timeout", "12.5"]
 
 
 def test_resolve_voice_repo_requires_full_duplex_checkout(tmp_path: Path):

--- a/tests/tools/test_verify_voice_local_stack_script.py
+++ b/tests/tools/test_verify_voice_local_stack_script.py
@@ -147,6 +147,7 @@ def test_voice_contract_command_requires_daemon_and_passes_text():
         "--text",
         "contract text",
         "--require-daemon",
+        "--run-stt-smoke",
     ]
 
 

--- a/tests/tools/test_verify_voice_local_stack_script.py
+++ b/tests/tools/test_verify_voice_local_stack_script.py
@@ -1,6 +1,7 @@
 import argparse
 import importlib.util
 import json
+import os
 from pathlib import Path
 import subprocess
 import sys
@@ -35,9 +36,12 @@ def _args(**overrides):
         "command_text": "command smoke",
         "voice_contract_text": "contract smoke",
         "voice_contract_timeout": 240.0,
+        "whatsapp_bridge_media_timeout": 15.0,
+        "node_bin": "node",
         "stream_text": "stream smoke",
         "stream_command_template": None,
         "skip_voice_contract": False,
+        "skip_whatsapp_bridge_media": False,
         "skip_calling_control_plane": False,
         "skip_full_duplex": False,
         "voice_repo": Path("/voice"),
@@ -101,6 +105,23 @@ def test_voice_contract_command_requires_daemon_and_passes_text():
         "--text",
         "contract text",
         "--require-daemon",
+    ]
+
+
+def test_whatsapp_bridge_media_payload_command_runs_node_test():
+    script = _load_script_module()
+
+    command = script.whatsapp_bridge_media_payload_command(node_bin="/usr/bin/node")
+
+    assert command == [
+        "/usr/bin/node",
+        "--test",
+        str(
+            Path(__file__).resolve().parents[2]
+            / "scripts"
+            / "whatsapp-bridge"
+            / "media-payload.test.mjs"
+        ),
     ]
 
 
@@ -208,6 +229,21 @@ def test_run_json_step_rejects_unsuccessful_result(monkeypatch):
 
     with pytest.raises(SystemExit, match="reported failure"):
         script.run_json_step("demo", ["demo"], timeout=1.0, env={})
+
+
+def test_child_env_sets_hermes_home_and_checkout_pythonpath(
+    monkeypatch, tmp_path: Path
+):
+    script = _load_script_module()
+    monkeypatch.setenv("PYTHONPATH", "/existing")
+
+    env = script.child_env(hermes_home=tmp_path)
+
+    assert env["HERMES_HOME"] == str(tmp_path)
+    assert env["PYTHONPATH"].split(os.pathsep)[:2] == [
+        str(Path(__file__).resolve().parents[2]),
+        "/existing",
+    ]
 
 
 def _write_live_root(root: Path, *, include_cloud: bool = True) -> None:

--- a/tests/tools/test_verify_voice_local_stack_script.py
+++ b/tests/tools/test_verify_voice_local_stack_script.py
@@ -37,11 +37,13 @@ def _args(**overrides):
         "voice_contract_text": "contract smoke",
         "voice_contract_timeout": 240.0,
         "whatsapp_bridge_media_timeout": 15.0,
+        "whatsapp_cloud_voice_timeout": 15.0,
         "node_bin": "node",
         "stream_text": "stream smoke",
         "stream_command_template": None,
         "skip_voice_contract": False,
         "skip_whatsapp_bridge_media": False,
+        "skip_whatsapp_cloud_voice": False,
         "skip_calling_control_plane": False,
         "skip_full_duplex": False,
         "voice_repo": Path("/voice"),
@@ -122,6 +124,17 @@ def test_whatsapp_bridge_media_payload_command_runs_node_test():
             / "whatsapp-bridge"
             / "media-payload.test.mjs"
         ),
+    ]
+
+
+def test_whatsapp_cloud_voice_note_command_runs_json_verifier():
+    script = _load_script_module()
+
+    command = script.whatsapp_cloud_voice_note_command()
+
+    assert command == [
+        sys.executable,
+        str(script.script_path("verify_voice_whatsapp_cloud_voice_note.py")),
     ]
 
 

--- a/tests/tools/test_verify_voice_local_stack_script.py
+++ b/tests/tools/test_verify_voice_local_stack_script.py
@@ -34,6 +34,7 @@ def _args(**overrides):
         "stt_timeout": 300.0,
         "stream_timeout": 180.0,
         "calling_control_plane_timeout": 10.0,
+        "calling_live_sidecar_timeout": 12.0,
         "full_duplex_timeout": 90.0,
         "full_duplex_max_queued_tx_ms": 1000,
         "command_text": "command smoke",
@@ -50,6 +51,7 @@ def _args(**overrides):
         "skip_whatsapp_cloud_voice": False,
         "skip_command_stt": False,
         "skip_calling_control_plane": False,
+        "skip_calling_live_sidecar": False,
         "skip_full_duplex": False,
         "voice_repo": Path("/voice"),
         "webrtc_python_bin": None,
@@ -237,6 +239,27 @@ def test_calling_control_plane_command_uses_synthetic_verifier():
         str(script.script_path("verify_voice_whatsapp_calling_control_plane.py")),
     ]
     assert command[-2:] == ["--timeout", "12.5"]
+
+
+def test_calling_live_sidecar_command_uses_webrtc_python_and_voice_repo():
+    script = _load_script_module()
+
+    command = script.calling_live_sidecar_command(
+        _args(
+            webrtc_python_bin="/tmp/voice-webrtc-venv/bin/python",
+            calling_live_sidecar_timeout=9.5,
+        ),
+        voice_repo=Path("/voice"),
+    )
+
+    assert command == [
+        "/tmp/voice-webrtc-venv/bin/python",
+        str(script.script_path("verify_voice_whatsapp_calling_live_sidecar.py")),
+        "--voice-repo",
+        "/voice",
+        "--timeout",
+        "9.5",
+    ]
 
 
 def test_resolve_voice_repo_requires_full_duplex_checkout(tmp_path: Path):

--- a/tests/tools/test_verify_voice_local_stack_script.py
+++ b/tests/tools/test_verify_voice_local_stack_script.py
@@ -27,14 +27,17 @@ def _load_script_module():
 def _args(**overrides):
     values = {
         "provider": "kokoro",
+        "stt_provider": "voice",
         "voice": "af_heart",
         "speed": "1.0",
         "tts_timeout": 180.0,
+        "stt_timeout": 300.0,
         "stream_timeout": 180.0,
         "calling_control_plane_timeout": 10.0,
         "full_duplex_timeout": 90.0,
         "full_duplex_max_queued_tx_ms": 1000,
         "command_text": "command smoke",
+        "command_stt_text": "hello world",
         "voice_contract_text": "contract smoke",
         "voice_contract_timeout": 240.0,
         "whatsapp_bridge_media_timeout": 15.0,
@@ -45,12 +48,14 @@ def _args(**overrides):
         "skip_voice_contract": False,
         "skip_whatsapp_bridge_media": False,
         "skip_whatsapp_cloud_voice": False,
+        "skip_command_stt": False,
         "skip_calling_control_plane": False,
         "skip_full_duplex": False,
         "voice_repo": Path("/voice"),
         "webrtc_python_bin": None,
         "full_duplex_inbound_text": "hello world",
         "full_duplex_outbound_text": "hello back",
+        "stt_expect_word": ["hello", "world"],
         "expect_word": ["hello", "world"],
         "keep_home": False,
     }
@@ -75,6 +80,28 @@ def test_command_tts_command_uses_isolated_hermes_home():
     assert "--force" in command
     assert "--keep-home" in command
     assert command[-2:] == ["--text", "command smoke"]
+
+
+def test_command_stt_command_uses_isolated_hermes_home():
+    script = _load_script_module()
+
+    command = script.command_stt_command(
+        _args(keep_home=True, stt_expect_word=["hello"]),
+        voice_bin="/tmp/voice",
+        hermes_home=Path("/tmp/hermes-home"),
+    )
+
+    assert command[:2] == [sys.executable, str(script.script_path("verify_voice_command_stt.py"))]
+    assert "--voice-bin" in command
+    assert "/tmp/voice" in command
+    assert "--hermes-home" in command
+    assert "/tmp/hermes-home" in command
+    assert "--force" in command
+    assert "--keep-home" in command
+    assert "--provider" in command
+    assert "voice" in command
+    assert "--generate-timeout" in command
+    assert command[-4:] == ["--text", "hello world", "--expect-word", "hello"]
 
 
 def test_stream_tts_command_can_use_custom_template():
@@ -275,6 +302,10 @@ def _write_live_root(root: Path, *, include_cloud: bool = True) -> None:
         "\n".join(["voice_compatible", "libopus", "-application", "voip"]),
         encoding="utf-8",
     )
+    (tools_dir / "transcription_tools.py").write_text(
+        "\n".join(["stt.providers", "_transcribe_command_stt", "transcribe_audio"]),
+        encoding="utf-8",
+    )
     if include_cloud:
         (gateway_dir / "whatsapp_cloud.py").write_text(
             "\n".join(
@@ -301,6 +332,7 @@ def test_audit_live_hermes_root_accepts_voice_native_checkout(tmp_path: Path):
     assert result["failures"] == []
     assert [check["path"] for check in result["checked"]] == [
         "tools/tts_tool.py",
+        "tools/transcription_tools.py",
         "gateway/platforms/whatsapp_cloud.py",
     ]
 

--- a/tests/tools/test_verify_voice_local_stack_script.py
+++ b/tests/tools/test_verify_voice_local_stack_script.py
@@ -63,6 +63,7 @@ def _args(**overrides):
         "live_gateway_voice_daemon_service": "voiced.service",
         "skip_live_gateway_bridge_health": False,
         "run_live_gateway_stt_smoke": False,
+        "run_live_gateway_calling_live_sidecar_smoke": False,
         "live_gateway_timeout": 360.0,
         "full_duplex_inbound_text": "hello world",
         "full_duplex_outbound_text": "hello back",
@@ -282,6 +283,7 @@ def test_live_gateway_command_runs_offer_readiness_smoke():
             calling_sidecar_url="http://127.0.0.1:8787",
             webrtc_python_bin="/tmp/voice-webrtc-venv/bin/python",
             run_live_gateway_stt_smoke=True,
+            run_live_gateway_calling_live_sidecar_smoke=True,
             skip_live_gateway_bridge_health=True,
         ),
         voice_bin="/home/user/.local/bin/voice",
@@ -312,6 +314,7 @@ def test_live_gateway_command_runs_offer_readiness_smoke():
     )
     assert "--run-stt-smoke" in command
     assert command[command.index("--stt-provider") + 1] == "voice"
+    assert "--run-calling-live-sidecar-smoke" in command
     assert command[command.index("--sidecar-service") + 1] == (
         "voice-webrtc-sidecar.service"
     )
@@ -337,6 +340,22 @@ def test_live_gateway_command_passes_custom_voice_daemon_service():
     assert command[command.index("--voice-daemon-service") + 1] == (
         "custom-voiced.service"
     )
+
+
+def test_live_gateway_command_requires_voice_repo_for_calling_sidecar_smoke():
+    script = _load_script_module()
+
+    with pytest.raises(SystemExit, match="requires --voice-repo"):
+        script.live_gateway_command(
+            _args(
+                live_hermes_root=Path("/checkout/hermes-agent"),
+                calling_sidecar_url="http://127.0.0.1:8787",
+                webrtc_python_bin="/tmp/voice-webrtc-venv/bin/python",
+                run_live_gateway_calling_live_sidecar_smoke=True,
+            ),
+            voice_bin="/home/user/.local/bin/voice",
+            voice_repo=None,
+        )
 
 
 def test_live_gateway_command_skips_daemon_service_without_sidecar_service():

--- a/tests/tools/test_verify_voice_local_stack_script.py
+++ b/tests/tools/test_verify_voice_local_stack_script.py
@@ -60,6 +60,7 @@ def _args(**overrides):
         "live_gateway_hermes_home": Path("/home/user/.hermes"),
         "calling_sidecar_url": None,
         "live_gateway_sidecar_service": "voice-webrtc-sidecar.service",
+        "live_gateway_voice_daemon_service": "voiced.service",
         "skip_live_gateway_bridge_health": False,
         "run_live_gateway_stt_smoke": False,
         "live_gateway_timeout": 360.0,
@@ -314,8 +315,46 @@ def test_live_gateway_command_runs_offer_readiness_smoke():
     assert command[command.index("--sidecar-service") + 1] == (
         "voice-webrtc-sidecar.service"
     )
+    assert command[command.index("--voice-daemon-service") + 1] == "voiced.service"
     assert command[command.index("--voice-repo") + 1] == "/voice"
     assert "--skip-bridge-health" in command
+
+
+def test_live_gateway_command_passes_custom_voice_daemon_service():
+    script = _load_script_module()
+
+    command = script.live_gateway_command(
+        _args(
+            live_hermes_root=Path("/checkout/hermes-agent"),
+            calling_sidecar_url="http://127.0.0.1:8787",
+            webrtc_python_bin="/tmp/voice-webrtc-venv/bin/python",
+            live_gateway_voice_daemon_service="custom-voiced.service",
+        ),
+        voice_bin="/home/user/.local/bin/voice",
+        voice_repo=Path("/voice"),
+    )
+
+    assert command[command.index("--voice-daemon-service") + 1] == (
+        "custom-voiced.service"
+    )
+
+
+def test_live_gateway_command_skips_daemon_service_without_sidecar_service():
+    script = _load_script_module()
+
+    command = script.live_gateway_command(
+        _args(
+            live_hermes_root=Path("/checkout/hermes-agent"),
+            calling_sidecar_url="http://127.0.0.1:8787",
+            webrtc_python_bin="/tmp/voice-webrtc-venv/bin/python",
+            live_gateway_sidecar_service="",
+        ),
+        voice_bin="/home/user/.local/bin/voice",
+        voice_repo=Path("/voice"),
+    )
+
+    assert "--sidecar-service" not in command
+    assert "--voice-daemon-service" not in command
 
 
 def test_live_gateway_command_requires_live_inputs():

--- a/tests/tools/test_verify_voice_local_stack_script.py
+++ b/tests/tools/test_verify_voice_local_stack_script.py
@@ -33,8 +33,11 @@ def _args(**overrides):
         "calling_control_plane_timeout": 10.0,
         "full_duplex_timeout": 90.0,
         "command_text": "command smoke",
+        "voice_contract_text": "contract smoke",
+        "voice_contract_timeout": 240.0,
         "stream_text": "stream smoke",
         "stream_command_template": None,
+        "skip_voice_contract": False,
         "skip_calling_control_plane": False,
         "skip_full_duplex": False,
         "voice_repo": Path("/voice"),
@@ -80,6 +83,58 @@ def test_stream_tts_command_can_use_custom_template():
     assert "/tmp/voice" in command
     assert "--command-template" in command
     assert "voice stream --raw-output -" in command
+
+
+def test_voice_contract_command_requires_daemon_and_passes_text():
+    script = _load_script_module()
+
+    command = script.voice_contract_command(
+        _args(voice_contract_text="contract text"),
+        voice_bin="/tmp/voice",
+        script=Path("/voice/scripts/verify_whatsapp_voice_contract.sh"),
+    )
+
+    assert command == [
+        "/voice/scripts/verify_whatsapp_voice_contract.sh",
+        "--voice-bin",
+        "/tmp/voice",
+        "--text",
+        "contract text",
+        "--require-daemon",
+    ]
+
+
+def test_resolve_voice_contract_script_uses_voice_checkout(tmp_path: Path):
+    script = _load_script_module()
+    verifier = tmp_path / "scripts" / "verify_whatsapp_voice_contract.sh"
+    verifier.parent.mkdir(parents=True)
+    verifier.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    verifier.chmod(0o755)
+
+    resolved = script.resolve_voice_contract_script(_args(voice_repo=tmp_path))
+
+    assert resolved == verifier
+
+
+def test_resolve_voice_contract_script_can_skip_or_fail(tmp_path: Path):
+    script = _load_script_module()
+
+    assert (
+        script.resolve_voice_contract_script(
+            _args(skip_voice_contract=True, voice_repo=None)
+        )
+        is None
+    )
+    assert script.resolve_voice_contract_script(_args(voice_repo=None)) is None
+    with pytest.raises(SystemExit, match="contract verifier not found"):
+        script.resolve_voice_contract_script(_args(voice_repo=tmp_path))
+
+    verifier = tmp_path / "scripts" / "verify_whatsapp_voice_contract.sh"
+    verifier.parent.mkdir(parents=True)
+    verifier.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    verifier.chmod(0o644)
+    with pytest.raises(SystemExit, match="not executable"):
+        script.resolve_voice_contract_script(_args(voice_repo=tmp_path))
 
 
 def test_full_duplex_command_passes_voice_repo_and_python():

--- a/tests/tools/test_verify_voice_local_stack_script.py
+++ b/tests/tools/test_verify_voice_local_stack_script.py
@@ -137,3 +137,58 @@ def test_run_json_step_rejects_unsuccessful_result(monkeypatch):
 
     with pytest.raises(SystemExit, match="reported failure"):
         script.run_json_step("demo", ["demo"], timeout=1.0, env={})
+
+
+def _write_live_root(root: Path, *, include_cloud: bool = True) -> None:
+    tools_dir = root / "tools"
+    gateway_dir = root / "gateway" / "platforms"
+    tools_dir.mkdir(parents=True)
+    gateway_dir.mkdir(parents=True)
+    (tools_dir / "tts_tool.py").write_text(
+        "\n".join(["voice_compatible", "libopus", "-application", "voip"]),
+        encoding="utf-8",
+    )
+    if include_cloud:
+        (gateway_dir / "whatsapp_cloud.py").write_text(
+            "\n".join(
+                [
+                    "calling_sidecar_url",
+                    "voice.webrtc_sidecar",
+                    "_send_calling_sidecar_tts_stream_command",
+                    "-application",
+                    "voip",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+
+def test_audit_live_hermes_root_accepts_voice_native_checkout(tmp_path: Path):
+    script = _load_script_module()
+    _write_live_root(tmp_path)
+
+    result = script.audit_live_hermes_root(tmp_path)
+
+    assert result["success"] is True
+    assert result["failures"] == []
+    assert [check["path"] for check in result["checked"]] == [
+        "tools/tts_tool.py",
+        "gateway/platforms/whatsapp_cloud.py",
+    ]
+
+
+def test_audit_live_hermes_root_reports_stale_checkout(tmp_path: Path):
+    script = _load_script_module()
+    _write_live_root(tmp_path, include_cloud=False)
+
+    result = script.audit_live_hermes_root(tmp_path)
+
+    assert result["success"] is False
+    assert "gateway/platforms/whatsapp_cloud.py is missing" in result["failures"]
+
+
+def test_require_live_hermes_root_fails_on_missing_surfaces(tmp_path: Path):
+    script = _load_script_module()
+
+    with pytest.raises(SystemExit, match="voice-native integration surfaces"):
+        script.require_live_hermes_root(tmp_path / "missing")

--- a/tests/tools/test_verify_voice_local_stack_script.py
+++ b/tests/tools/test_verify_voice_local_stack_script.py
@@ -275,6 +275,7 @@ def _write_live_root(root: Path, *, include_cloud: bool = True) -> None:
                     "calling_sidecar_url",
                     "voice.webrtc_sidecar",
                     "_send_calling_sidecar_tts_stream_command",
+                    "_clear_calling_sidecar_audio",
                     "-application",
                     "voip",
                 ]

--- a/tests/tools/test_verify_voice_local_stack_script.py
+++ b/tests/tools/test_verify_voice_local_stack_script.py
@@ -42,12 +42,14 @@ def _args(**overrides):
         "voice_contract_text": "contract smoke",
         "voice_contract_timeout": 240.0,
         "whatsapp_bridge_media_timeout": 15.0,
+        "whatsapp_cloud_webhook_timeout": 15.0,
         "whatsapp_cloud_voice_timeout": 15.0,
         "node_bin": "node",
         "stream_text": "stream smoke",
         "stream_command_template": None,
         "skip_voice_contract": False,
         "skip_whatsapp_bridge_media": False,
+        "skip_whatsapp_cloud_webhook": False,
         "skip_whatsapp_cloud_voice": False,
         "skip_command_stt": False,
         "skip_calling_control_plane": False,
@@ -177,6 +179,17 @@ def test_whatsapp_cloud_voice_note_command_runs_json_verifier():
     assert command == [
         sys.executable,
         str(script.script_path("verify_voice_whatsapp_cloud_voice_note.py")),
+    ]
+
+
+def test_whatsapp_cloud_webhook_command_runs_json_verifier():
+    script = _load_script_module()
+
+    command = script.whatsapp_cloud_webhook_command()
+
+    assert command == [
+        sys.executable,
+        str(script.script_path("verify_voice_whatsapp_cloud_webhook.py")),
     ]
 
 

--- a/tests/tools/test_verify_voice_local_stack_script.py
+++ b/tests/tools/test_verify_voice_local_stack_script.py
@@ -1,0 +1,139 @@
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "verify_voice_local_stack.py"
+)
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location("verify_voice_local_stack", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _args(**overrides):
+    values = {
+        "provider": "kokoro",
+        "voice": "af_heart",
+        "speed": "1.0",
+        "tts_timeout": 180.0,
+        "stream_timeout": 180.0,
+        "full_duplex_timeout": 90.0,
+        "command_text": "command smoke",
+        "stream_text": "stream smoke",
+        "stream_command_template": None,
+        "skip_full_duplex": False,
+        "voice_repo": Path("/voice"),
+        "webrtc_python_bin": None,
+        "full_duplex_inbound_text": "hello world",
+        "full_duplex_outbound_text": "hello back",
+        "expect_word": ["hello", "world"],
+        "keep_home": False,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def test_command_tts_command_uses_isolated_hermes_home():
+    script = _load_script_module()
+
+    command = script.command_tts_command(
+        _args(keep_home=True),
+        voice_bin="/tmp/voice",
+        hermes_home=Path("/tmp/hermes-home"),
+    )
+
+    assert command[:2] == [sys.executable, str(script.script_path("verify_voice_command_tts.py"))]
+    assert "--voice-bin" in command
+    assert "/tmp/voice" in command
+    assert "--hermes-home" in command
+    assert "/tmp/hermes-home" in command
+    assert "--force" in command
+    assert "--keep-home" in command
+    assert command[-2:] == ["--text", "command smoke"]
+
+
+def test_stream_tts_command_can_use_custom_template():
+    script = _load_script_module()
+
+    command = script.stream_tts_command(
+        _args(stream_command_template="voice stream --raw-output -"),
+        voice_bin="/tmp/voice",
+    )
+
+    assert command[:2] == [sys.executable, str(script.script_path("verify_voice_stream_tts.py"))]
+    assert "--voice-bin" in command
+    assert "/tmp/voice" in command
+    assert "--command-template" in command
+    assert "voice stream --raw-output -" in command
+
+
+def test_full_duplex_command_passes_voice_repo_and_python():
+    script = _load_script_module()
+
+    command = script.full_duplex_command(
+        _args(webrtc_python_bin="/tmp/venv/bin/python", expect_word=["testing"]),
+        voice_bin="/tmp/voice",
+        voice_repo=Path("/voice"),
+    )
+
+    assert command[:2] == [
+        sys.executable,
+        str(script.script_path("verify_voice_full_duplex_sidecar.py")),
+    ]
+    assert "--voice-repo" in command
+    assert "/voice" in command
+    assert "--python-bin" in command
+    assert "/tmp/venv/bin/python" in command
+    assert command[-2:] == ["--expect-word", "testing"]
+
+
+def test_resolve_voice_repo_requires_full_duplex_checkout(tmp_path: Path):
+    script = _load_script_module()
+
+    with pytest.raises(SystemExit, match="full-duplex validation needs"):
+        script.resolve_voice_repo_for_full_duplex(_args(voice_repo=None))
+
+    assert script.resolve_voice_repo_for_full_duplex(
+        _args(skip_full_duplex=True, voice_repo=None)
+    ) is None
+
+    with pytest.raises(SystemExit, match="voice full-duplex smoke not found"):
+        script.resolve_voice_repo_for_full_duplex(_args(voice_repo=tmp_path))
+
+
+def test_parse_json_object_accepts_progress_prefix():
+    script = _load_script_module()
+
+    parsed = script.parse_json_object('progress\n{"success": true, "value": 1}\n')
+
+    assert parsed == {"success": True, "value": 1}
+
+
+def test_run_json_step_rejects_unsuccessful_result(monkeypatch):
+    script = _load_script_module()
+
+    def fake_run(command, **kwargs):
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps({"success": False, "error": "bad"}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(script, "run_process", fake_run)
+
+    with pytest.raises(SystemExit, match="reported failure"):
+        script.run_json_step("demo", ["demo"], timeout=1.0, env={})

--- a/tests/tools/test_verify_voice_local_stack_script.py
+++ b/tests/tools/test_verify_voice_local_stack_script.py
@@ -55,6 +55,14 @@ def _args(**overrides):
         "skip_full_duplex": False,
         "voice_repo": Path("/voice"),
         "webrtc_python_bin": None,
+        "run_live_gateway": False,
+        "live_gateway_python_bin": "/home/user/.hermes/hermes-agent/venv/bin/python",
+        "live_gateway_hermes_home": Path("/home/user/.hermes"),
+        "calling_sidecar_url": None,
+        "live_gateway_sidecar_service": "voice-webrtc-sidecar.service",
+        "skip_live_gateway_bridge_health": False,
+        "run_live_gateway_stt_smoke": False,
+        "live_gateway_timeout": 360.0,
         "full_duplex_inbound_text": "hello world",
         "full_duplex_outbound_text": "hello back",
         "stt_expect_word": ["hello", "world"],
@@ -260,6 +268,89 @@ def test_calling_live_sidecar_command_uses_webrtc_python_and_voice_repo():
         "--timeout",
         "9.5",
     ]
+
+
+def test_live_gateway_command_runs_offer_readiness_smoke():
+    script = _load_script_module()
+
+    command = script.live_gateway_command(
+        _args(
+            live_hermes_root=Path("/checkout/hermes-agent"),
+            live_gateway_python_bin="/home/user/.hermes/hermes-agent/venv/bin/python",
+            live_gateway_hermes_home=Path("/home/user/.hermes"),
+            calling_sidecar_url="http://127.0.0.1:8787",
+            webrtc_python_bin="/tmp/voice-webrtc-venv/bin/python",
+            run_live_gateway_stt_smoke=True,
+            skip_live_gateway_bridge_health=True,
+        ),
+        voice_bin="/home/user/.local/bin/voice",
+        voice_repo=Path("/voice"),
+    )
+
+    assert command[:2] == [
+        sys.executable,
+        str(script.script_path("verify_voice_live_gateway.py")),
+    ]
+    assert command[command.index("--live-hermes-root") + 1] == (
+        str(Path("/checkout/hermes-agent").resolve())
+    )
+    assert command[command.index("--python-bin") + 1] == (
+        "/home/user/.hermes/hermes-agent/venv/bin/python"
+    )
+    assert command[command.index("--hermes-home") + 1] == "/home/user/.hermes"
+    assert command[command.index("--calling-sidecar-url") + 1] == (
+        "http://127.0.0.1:8787"
+    )
+    assert command[command.index("--voice-bin") + 1] == (
+        "/home/user/.local/bin/voice"
+    )
+    assert "--run-tts-smoke" in command
+    assert "--run-sidecar-offer-smoke" in command
+    assert command[command.index("--webrtc-python-bin") + 1] == (
+        "/tmp/voice-webrtc-venv/bin/python"
+    )
+    assert "--run-stt-smoke" in command
+    assert command[command.index("--stt-provider") + 1] == "voice"
+    assert command[command.index("--sidecar-service") + 1] == (
+        "voice-webrtc-sidecar.service"
+    )
+    assert command[command.index("--voice-repo") + 1] == "/voice"
+    assert "--skip-bridge-health" in command
+
+
+def test_live_gateway_command_requires_live_inputs():
+    script = _load_script_module()
+
+    with pytest.raises(SystemExit, match="requires --live-hermes-root"):
+        script.live_gateway_command(
+            _args(
+                live_hermes_root=None,
+                calling_sidecar_url="http://127.0.0.1:8787",
+                webrtc_python_bin="/tmp/voice-webrtc-venv/bin/python",
+            ),
+            voice_bin="/tmp/voice",
+            voice_repo=Path("/voice"),
+        )
+    with pytest.raises(SystemExit, match="requires --calling-sidecar-url"):
+        script.live_gateway_command(
+            _args(
+                live_hermes_root=Path("/checkout/hermes-agent"),
+                calling_sidecar_url=None,
+                webrtc_python_bin="/tmp/voice-webrtc-venv/bin/python",
+            ),
+            voice_bin="/tmp/voice",
+            voice_repo=Path("/voice"),
+        )
+    with pytest.raises(SystemExit, match="requires --webrtc-python-bin"):
+        script.live_gateway_command(
+            _args(
+                live_hermes_root=Path("/checkout/hermes-agent"),
+                calling_sidecar_url="http://127.0.0.1:8787",
+                webrtc_python_bin=None,
+            ),
+            voice_bin="/tmp/voice",
+            voice_repo=Path("/voice"),
+        )
 
 
 def test_resolve_voice_repo_requires_full_duplex_checkout(tmp_path: Path):

--- a/tests/tools/test_verify_voice_local_stack_script.py
+++ b/tests/tools/test_verify_voice_local_stack_script.py
@@ -33,6 +33,7 @@ def _args(**overrides):
         "stream_timeout": 180.0,
         "calling_control_plane_timeout": 10.0,
         "full_duplex_timeout": 90.0,
+        "full_duplex_max_queued_tx_ms": 1000,
         "command_text": "command smoke",
         "voice_contract_text": "contract smoke",
         "voice_contract_timeout": 240.0,
@@ -175,7 +176,11 @@ def test_full_duplex_command_passes_voice_repo_and_python():
     script = _load_script_module()
 
     command = script.full_duplex_command(
-        _args(webrtc_python_bin="/tmp/venv/bin/python", expect_word=["testing"]),
+        _args(
+            webrtc_python_bin="/tmp/venv/bin/python",
+            expect_word=["testing"],
+            full_duplex_max_queued_tx_ms=250,
+        ),
         voice_bin="/tmp/voice",
         voice_repo=Path("/voice"),
     )
@@ -188,6 +193,8 @@ def test_full_duplex_command_passes_voice_repo_and_python():
     assert "/voice" in command
     assert "--python-bin" in command
     assert "/tmp/venv/bin/python" in command
+    assert "--max-queued-tx-ms" in command
+    assert "250" in command
     assert command[-2:] == ["--expect-word", "testing"]
 
 

--- a/tests/tools/test_verify_voice_stream_tts_script.py
+++ b/tests/tools/test_verify_voice_stream_tts_script.py
@@ -51,6 +51,72 @@ def test_audio_contract_matches_voice_sidecar_pcm_shape():
     }
 
 
+def stream_contract_json(**surface_overrides):
+    raw_outbound = {
+        "command": 'voice stream --sample-rate 48000 --frame-ms 20 --raw-output - "hello"',
+        "output": "pcm_s16le",
+        "transport": "stdout_pcm_frames",
+        "frame_bytes": 1_920,
+    }
+    raw_outbound.update(surface_overrides)
+    return {
+        "audio": {
+            "sample_rate": 48_000,
+            "channels": 1,
+            "frame_ms": 20,
+            "encoding": "pcm_s16le",
+            "bytes_per_sample": 2,
+            "frame_bytes": 1_920,
+        },
+        "voice_surfaces": {
+            "completed_voice_note": {
+                "command": 'voice say --format ogg-opus --output reply.ogg "hello"',
+                "output": "audio/ogg; codecs=opus",
+                "transport": "completed_file",
+            },
+            "raw_outbound_pcm": raw_outbound,
+            "raw_inbound_pcm": {
+                "command": "voice stream-transcribe --raw-input - --sample-rate 48000 --frame-ms 20",
+                "input": "pcm_s16le",
+                "transport": "stdin_pcm_frames",
+                "frame_bytes": 1_920,
+            },
+        },
+    }
+
+
+def test_audio_contract_from_voice_reads_stream_contract(monkeypatch):
+    script = _load_script_module()
+
+    def fake_load(_voice_bin):
+        return stream_contract_json()
+
+    monkeypatch.setattr(script, "load_voice_stream_contract", fake_load)
+
+    contract = script.audio_contract_from_voice(
+        "/tmp/voice",
+        fallback=script.AudioContract(sample_rate=16_000),
+    )
+
+    assert contract.sample_rate == 48_000
+    assert contract.frame_bytes == 1_920
+    assert "voice stream" in contract.raw_outbound_pcm_command
+    assert "--raw-input" in contract.raw_inbound_pcm_command
+    assert "--format ogg-opus" in contract.completed_voice_note_command
+
+
+def test_audio_contract_from_voice_rejects_surface_frame_drift(monkeypatch):
+    script = _load_script_module()
+
+    def fake_load(_voice_bin):
+        return stream_contract_json(frame_bytes=960)
+
+    monkeypatch.setattr(script, "load_voice_stream_contract", fake_load)
+
+    with pytest.raises(SystemExit, match="raw_outbound_pcm frame_bytes"):
+        script.audio_contract_from_voice("/tmp/voice", fallback=script.AudioContract())
+
+
 def test_validate_pcm_accepts_non_silent_whole_frames():
     script = _load_script_module()
     contract = script.AudioContract()

--- a/tests/tools/test_verify_voice_stream_tts_script.py
+++ b/tests/tools/test_verify_voice_stream_tts_script.py
@@ -1,0 +1,90 @@
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "verify_voice_stream_tts.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location("verify_voice_stream_tts", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_default_command_template_streams_raw_pcm_stdout():
+    script = _load_script_module()
+
+    template = script.build_default_command_template("/tmp/bin/voice with spaces")
+
+    assert template.startswith("'/tmp/bin/voice with spaces' stream --quiet")
+    assert "--sample-rate {sample_rate}" in template
+    assert "--frame-ms {frame_ms}" in template
+    assert "--raw-output -" in template
+    assert "--input-file {input_path}" in template
+    assert "--voice {voice}" in template
+    assert "--speed {speed}" in template
+
+
+def test_audio_contract_matches_voice_sidecar_pcm_shape():
+    script = _load_script_module()
+
+    contract = script.AudioContract()
+
+    assert contract.samples_per_frame == 960
+    assert contract.frame_bytes == 1920
+    assert contract.bytes_per_second == 96_000
+    assert contract.as_dict() == {
+        "sample_rate": 48_000,
+        "channels": 1,
+        "frame_ms": 20,
+        "encoding": "pcm_s16le",
+        "bytes_per_sample": 2,
+        "samples_per_frame": 960,
+        "frame_bytes": 1920,
+    }
+
+
+def test_validate_pcm_accepts_non_silent_whole_frames():
+    script = _load_script_module()
+    contract = script.AudioContract()
+    frame = (12_000).to_bytes(2, byteorder="little", signed=True) * 960
+
+    stats = script.validate_pcm(frame * 10, contract=contract)
+
+    assert stats == {
+        "bytes": 19_200,
+        "frames": 10,
+        "duration_ms": 200,
+        "peak": 12_000,
+    }
+
+
+def test_validate_pcm_rejects_silence():
+    script = _load_script_module()
+    contract = script.AudioContract()
+
+    with pytest.raises(SystemExit, match="PCM peak 0 is below minimum"):
+        script.validate_pcm(b"\x00" * contract.frame_bytes, contract=contract)
+
+
+def test_validate_pcm_rejects_partial_sample():
+    script = _load_script_module()
+    contract = script.AudioContract()
+
+    with pytest.raises(SystemExit, match="whole s16le samples"):
+        script.validate_pcm(b"\x00", contract=contract)
+
+
+def test_validate_pcm_rejects_partial_frame():
+    script = _load_script_module()
+    contract = script.AudioContract()
+
+    with pytest.raises(SystemExit, match="not aligned to 1920-byte frames"):
+        script.validate_pcm(b"\x01\x00" * 100, contract=contract)

--- a/tests/tools/test_verify_voice_stream_tts_script.py
+++ b/tests/tools/test_verify_voice_stream_tts_script.py
@@ -74,6 +74,11 @@ def stream_contract_json(**surface_overrides):
                 "output": "audio/ogg; codecs=opus",
                 "transport": "completed_file",
             },
+            "streamed_voice_note": {
+                "command": 'voice stream --output reply.ogg --format ogg-opus "hello"',
+                "output": "audio/ogg; codecs=opus",
+                "transport": "daemon_stream_encoded_file",
+            },
             "raw_outbound_pcm": raw_outbound,
             "raw_inbound_pcm": {
                 "command": "voice stream-transcribe --raw-input - --sample-rate 48000 --frame-ms 20",
@@ -103,6 +108,7 @@ def test_audio_contract_from_voice_reads_stream_contract(monkeypatch):
     assert "voice stream" in contract.raw_outbound_pcm_command
     assert "--raw-input" in contract.raw_inbound_pcm_command
     assert "--format ogg-opus" in contract.completed_voice_note_command
+    assert "voice stream" in contract.streamed_voice_note_command
 
 
 def test_audio_contract_from_voice_rejects_surface_frame_drift(monkeypatch):
@@ -154,3 +160,45 @@ def test_validate_pcm_rejects_partial_frame():
 
     with pytest.raises(SystemExit, match="not aligned to 1920-byte frames"):
         script.validate_pcm(b"\x01\x00" * 100, contract=contract)
+
+
+def test_build_streamed_ogg_command_uses_daemon_stream_output(tmp_path: Path):
+    script = _load_script_module()
+    contract = script.AudioContract()
+
+    command = script.build_streamed_ogg_command(
+        voice_bin="/tmp/voice",
+        input_path=tmp_path / "input.txt",
+        output_path=tmp_path / "reply.ogg",
+        contract=contract,
+        voice="af_heart",
+        speed="1.0",
+    )
+
+    assert command[:3] == ["/tmp/voice", "stream", "--quiet"]
+    assert "--output" in command
+    assert str(tmp_path / "reply.ogg") in command
+    assert "--format" in command
+    assert "ogg-opus" in command
+    assert "--sample-rate" in command
+    assert "48000" in command
+
+
+def test_validate_streamed_ogg_requires_real_opus_file(tmp_path: Path):
+    script = _load_script_module()
+    output = tmp_path / "reply.ogg"
+    output.write_bytes(b"OggS")
+
+    stats = script.validate_streamed_ogg(
+        output,
+        probe={"codec_name": "opus", "sample_rate": "48000", "channels": "1"},
+    )
+
+    assert stats["bytes"] == 4
+    assert stats["codec_name"] == "opus"
+
+    with pytest.raises(SystemExit, match="codec_name=opus"):
+        script.validate_streamed_ogg(
+            output,
+            probe={"codec_name": "vorbis", "sample_rate": "48000", "channels": "1"},
+        )

--- a/tests/tools/test_verify_voice_whatsapp_calling_control_plane_script.py
+++ b/tests/tools/test_verify_voice_whatsapp_calling_control_plane_script.py
@@ -1,0 +1,144 @@
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "verify_voice_whatsapp_calling_control_plane.py"
+)
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "verify_voice_whatsapp_calling_control_plane",
+        SCRIPT_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _args(**overrides):
+    script = _load_script_module()
+    values = {
+        "sidecar_url": script.DEFAULT_SIDECAR_URL,
+        "phone_number_id": script.DEFAULT_PHONE_NUMBER_ID,
+        "call_id": script.DEFAULT_CALL_ID,
+        "caller": script.DEFAULT_CALLER,
+        "callee": script.DEFAULT_CALLEE,
+        "contact_name": script.DEFAULT_CONTACT_NAME,
+        "remote_sdp": script.DEFAULT_REMOTE_SDP,
+        "answer_sdp": script.DEFAULT_ANSWER_SDP,
+        "timeout": 10.0,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def test_call_connect_payload_matches_meta_calls_shape():
+    script = _load_script_module()
+
+    payload = script.call_connect_payload(
+        call_id="wacid.call-1",
+        caller="15551234567",
+        callee="15557654321",
+        contact_name="Alice",
+        remote_sdp="v=0\r\n",
+    )
+
+    assert payload["object"] == "whatsapp_business_account"
+    change = payload["entry"][0]["changes"][0]
+    assert change["field"] == "calls"
+    value = change["value"]
+    assert value["contacts"][0]["profile"]["name"] == "Alice"
+    call = value["calls"][0]
+    assert call["id"] == "wacid.call-1"
+    assert call["event"] == "connect"
+    assert call["session"] == {"sdp_type": "offer", "sdp": "v=0\r\n"}
+
+
+@pytest.mark.asyncio
+async def test_fake_http_client_records_contract_offer_graph_and_close():
+    script = _load_script_module()
+    client = script.RecordingHttpClient(
+        sidecar_url="http://127.0.0.1:8787",
+        api_version="v20.0",
+        phone_number_id="phone-1",
+        call_id="call-1",
+        answer_sdp="v=0\r\nanswer\r\n",
+    )
+
+    contract = await client.get("http://127.0.0.1:8787/contract", timeout=1)
+    offer = await client.post(
+        "http://127.0.0.1:8787/offer",
+        json={"call_id": "call-1", "type": "offer", "sdp": "v=0\r\n"},
+    )
+    graph = await client.post(
+        "https://graph.facebook.com/v20.0/phone-1/calls",
+        json={"call_id": "call-1", "action": "pre_accept"},
+    )
+    closed = await client.post("http://127.0.0.1:8787/calls/call-1/close")
+
+    assert contract.json()["contract"] == "voice.webrtc_sidecar"
+    assert offer.json()["type"] == "answer"
+    assert offer.json()["sdp"] == "v=0\r\nanswer\r\n"
+    assert graph.json()["action"] == "pre_accept"
+    assert closed.json()["closed"] is True
+    assert [request["method"] for request in client.requests] == [
+        "GET",
+        "POST",
+        "POST",
+        "POST",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_control_plane_smoke_proves_accept_and_terminate_sequence():
+    script = _load_script_module()
+
+    result = await script.run_control_plane_smoke(_args(call_id="wacid.call-1"))
+
+    assert result["success"] is True
+    assert result["call_id"] == "wacid.call-1"
+    assert result["contract_loaded"] is True
+    assert result["sidecar_offer_url"] == "http://127.0.0.1:8787/offer"
+    assert result["graph_actions"] == ["pre_accept", "accept"]
+    assert result["sidecar_close_url"] == (
+        "http://127.0.0.1:8787/calls/wacid.call-1/close"
+    )
+    assert result["drain_starts"] == [
+        {
+            "call_id": "wacid.call-1",
+            "chat_id": script.DEFAULT_CALLER,
+            "sender_name": script.DEFAULT_CONTACT_NAME,
+        }
+    ]
+    assert result["audio"]["frame_bytes"] == 1920
+
+
+def test_main_prints_json(monkeypatch, capsys):
+    script = _load_script_module()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "verify_voice_whatsapp_calling_control_plane.py",
+            "--call-id",
+            "wacid.call-2",
+        ],
+    )
+
+    assert script.main() == 0
+
+    output = json.loads(capsys.readouterr().out)
+    assert output["success"] is True
+    assert output["call_id"] == "wacid.call-2"

--- a/tests/tools/test_verify_voice_whatsapp_calling_control_plane_script.py
+++ b/tests/tools/test_verify_voice_whatsapp_calling_control_plane_script.py
@@ -91,6 +91,7 @@ async def test_fake_http_client_records_contract_offer_graph_and_close():
     assert contract.json()["contract"] == "voice.webrtc_sidecar"
     assert offer.json()["type"] == "answer"
     assert offer.json()["sdp"] == "v=0\r\nanswer\r\n"
+    assert offer.json()["state"]["ready_for_accept"] is True
     assert graph.json()["action"] == "pre_accept"
     assert closed.json()["closed"] is True
     assert [request["method"] for request in client.requests] == [
@@ -112,6 +113,7 @@ async def test_control_plane_smoke_proves_accept_and_terminate_sequence():
     assert result["contract_loaded"] is True
     assert result["sidecar_offer_url"] == "http://127.0.0.1:8787/offer"
     assert result["graph_actions"] == ["pre_accept", "accept"]
+    assert result["sidecar_ready_for_accept"] is True
     assert result["sidecar_close_url"] == (
         "http://127.0.0.1:8787/calls/wacid.call-1/close"
     )

--- a/tests/tools/test_verify_voice_whatsapp_calling_live_sidecar_script.py
+++ b/tests/tools/test_verify_voice_whatsapp_calling_live_sidecar_script.py
@@ -1,0 +1,90 @@
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "verify_voice_whatsapp_calling_live_sidecar.py"
+)
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "verify_voice_whatsapp_calling_live_sidecar",
+        SCRIPT_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_call_connect_payload_carries_offer_session():
+    script = _load_script_module()
+
+    payload = script.call_connect_payload(
+        call_id="wacid.call",
+        caller="1355",
+        callee="1555",
+        contact_name="Tester",
+        remote_sdp="v=0\r\n",
+    )
+
+    call = payload["entry"][0]["changes"][0]["value"]["calls"][0]
+    contact = payload["entry"][0]["changes"][0]["value"]["contacts"][0]
+    assert call["id"] == "wacid.call"
+    assert call["event"] == "connect"
+    assert call["session"] == {"sdp_type": "offer", "sdp": "v=0\r\n"}
+    assert contact["wa_id"] == "1355"
+    assert contact["profile"]["name"] == "Tester"
+
+
+def test_call_terminate_payload_carries_completed_status():
+    script = _load_script_module()
+
+    payload = script.call_terminate_payload(
+        call_id="wacid.call",
+        caller="1355",
+        callee="1555",
+    )
+
+    call = payload["entry"][0]["changes"][0]["value"]["calls"][0]
+    assert call["id"] == "wacid.call"
+    assert call["event"] == "terminate"
+    assert call["status"] == "COMPLETED"
+
+
+def test_graph_actions_extracts_pre_accept_and_accept():
+    script = _load_script_module()
+    requests = [
+        {"method": "GET", "url": "https://graph.facebook.com/v20.0/1/calls", "kwargs": {}},
+        {
+            "method": "POST",
+            "url": "https://graph.facebook.com/v20.0/1/calls",
+            "kwargs": {"json": {"action": "pre_accept"}},
+        },
+        {
+            "method": "POST",
+            "url": "https://graph.facebook.com/v20.0/1/calls",
+            "kwargs": {"json": {"action": "accept"}},
+        },
+    ]
+
+    assert script.graph_actions(
+        requests,
+        "https://graph.facebook.com/v20.0/1/calls",
+    ) == ["pre_accept", "accept"]
+
+
+def test_recorded_response_behaves_like_httpx_response():
+    script = _load_script_module()
+    response = script.RecordedResponse(200, {"success": True})
+
+    assert response.status_code == 200
+    assert response.json() == {"success": True}
+    assert json.loads(response.text) == {"success": True}

--- a/tests/tools/test_verify_voice_whatsapp_calling_live_sidecar_script.py
+++ b/tests/tools/test_verify_voice_whatsapp_calling_live_sidecar_script.py
@@ -88,3 +88,23 @@ def test_recorded_response_behaves_like_httpx_response():
     assert response.status_code == 200
     assert response.json() == {"success": True}
     assert json.loads(response.text) == {"success": True}
+
+
+def test_parse_args_accepts_existing_sidecar_url(monkeypatch):
+    script = _load_script_module()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "verify_voice_whatsapp_calling_live_sidecar.py",
+            "--voice-repo",
+            "/voice",
+            "--sidecar-url",
+            "http://127.0.0.1:8787/",
+        ],
+    )
+
+    args = script.parse_args()
+
+    assert args.voice_repo == Path("/voice")
+    assert args.sidecar_url == "http://127.0.0.1:8787/"

--- a/tests/tools/test_verify_voice_whatsapp_calling_live_sidecar_script.py
+++ b/tests/tools/test_verify_voice_whatsapp_calling_live_sidecar_script.py
@@ -3,6 +3,8 @@ import json
 from pathlib import Path
 import sys
 
+import pytest
+
 
 SCRIPT_PATH = (
     Path(__file__).resolve().parents[2]
@@ -90,6 +92,24 @@ def test_recorded_response_behaves_like_httpx_response():
     assert json.loads(response.text) == {"success": True}
 
 
+@pytest.mark.asyncio
+async def test_signed_webhook_request_carries_valid_hmac_signature():
+    script = _load_script_module()
+    payload = {"object": "whatsapp_business_account", "entry": []}
+
+    request = script.signed_webhook_request(payload, app_secret="secret")
+    raw = await request.read()
+
+    assert json.loads(raw.decode("utf-8")) == payload
+    adapter = script.WhatsAppCloudAdapter(
+        script.PlatformConfig(enabled=True, extra={"app_secret": "secret"})
+    )
+    assert adapter._verify_signature(  # noqa: SLF001
+        raw,
+        request.headers["X-Hub-Signature-256"],
+    )
+
+
 def test_parse_args_accepts_existing_sidecar_url(monkeypatch):
     script = _load_script_module()
     monkeypatch.setattr(
@@ -101,6 +121,8 @@ def test_parse_args_accepts_existing_sidecar_url(monkeypatch):
             "/voice",
             "--sidecar-url",
             "http://127.0.0.1:8787/",
+            "--app-secret",
+            "secret",
         ],
     )
 
@@ -108,3 +130,4 @@ def test_parse_args_accepts_existing_sidecar_url(monkeypatch):
 
     assert args.voice_repo == Path("/voice")
     assert args.sidecar_url == "http://127.0.0.1:8787/"
+    assert args.app_secret == "secret"

--- a/tests/tools/test_verify_voice_whatsapp_cloud_voice_note_script.py
+++ b/tests/tools/test_verify_voice_whatsapp_cloud_voice_note_script.py
@@ -1,0 +1,39 @@
+import asyncio
+import importlib.util
+from pathlib import Path
+import sys
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "verify_voice_whatsapp_cloud_voice_note.py"
+)
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "verify_voice_whatsapp_cloud_voice_note", SCRIPT_PATH
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_verify_cloud_voice_note_paths():
+    script = _load_script_module()
+
+    result = asyncio.run(script.verify())
+
+    assert result["success"] is True
+    assert result["checks"]["direct_ogg"]["upload_mime"] == "audio/ogg; codecs=opus"
+    assert result["checks"]["direct_ogg"]["converted"] is False
+    assert result["checks"]["converted_audio"]["upload_mime"] == (
+        "audio/ogg; codecs=opus"
+    )
+    assert result["checks"]["converted_audio"]["converted"] is True
+    assert result["checks"]["converted_audio"]["temporary_removed"] is True
+    assert result["checks"]["fallback_audio"]["upload_mime"] == "audio/mpeg"

--- a/tests/tools/test_verify_voice_whatsapp_cloud_webhook_script.py
+++ b/tests/tools/test_verify_voice_whatsapp_cloud_webhook_script.py
@@ -1,0 +1,43 @@
+import asyncio
+import importlib.util
+from pathlib import Path
+import sys
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "verify_voice_whatsapp_cloud_webhook.py"
+)
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "verify_voice_whatsapp_cloud_webhook", SCRIPT_PATH
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_verify_cloud_webhook_http_smoke():
+    script = _load_script_module()
+
+    result = asyncio.run(script.verify())
+
+    assert result["success"] is True
+    assert result["checks"]["health"]["verify_token_configured"] is True
+    assert result["checks"]["health"]["app_secret_configured"] is True
+    assert result["checks"]["verify_handshake"] == {
+        "status": 200,
+        "challenge_echoed": True,
+    }
+    assert result["checks"]["signed_post"] == {
+        "status": 200,
+        "payload": "status_delivery_receipt",
+        "signature_accepted": True,
+        "dispatched_messages": 0,
+    }

--- a/tests/tools/test_verify_voice_whatsapp_cloud_webhook_script.py
+++ b/tests/tools/test_verify_voice_whatsapp_cloud_webhook_script.py
@@ -41,3 +41,10 @@ def test_verify_cloud_webhook_http_smoke():
         "signature_accepted": True,
         "dispatched_messages": 0,
     }
+    assert result["checks"]["voice_note"] == {
+        "status": 200,
+        "media_type": "audio/ogg; codecs=opus",
+        "cached_extension": ".ogg",
+        "cached_bytes": len(script.VOICE_BYTES),
+        "dispatched_messages": 1,
+    }

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -899,8 +899,14 @@ def _convert_to_opus(mp3_path: str) -> Optional[str]:
     ogg_path = mp3_path.rsplit(".", 1)[0] + ".ogg"
     try:
         result = subprocess.run(
-            ["ffmpeg", "-i", mp3_path, "-acodec", "libopus",
-             "-ac", "1", "-b:a", "64k", "-vbr", "off", ogg_path, "-y"],
+            [
+                "ffmpeg", "-i", mp3_path,
+                "-acodec", "libopus",
+                "-ac", "1", "-ar", "48000",
+                "-b:a", "64k", "-vbr", "off",
+                "-application", "voip",
+                ogg_path, "-y",
+            ],
             capture_output=True, timeout=30,
             stdin=subprocess.DEVNULL,
         )

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -22,8 +22,9 @@ Custom command providers:
   See the Local Command section of ``website/docs/user-guide/features/tts.md``.
 
 Output formats:
-- Opus (.ogg) for Telegram voice bubbles (requires ffmpeg for Edge TTS)
-- MP3 (.mp3) for everything else (CLI, Discord, WhatsApp)
+- Opus (.ogg) for native voice bubbles/notes on Telegram and WhatsApp
+  surfaces (requires ffmpeg for providers that only emit MP3/WAV)
+- MP3 (.mp3) for everything else (CLI, Discord)
 
 Configuration is loaded from ~/.hermes/config.yaml under the 'tts:' key.
 The user chooses the provider and voice; the model just sends text.
@@ -390,6 +391,7 @@ DEFAULT_COMMAND_TTS_TIMEOUT_SECONDS = 120
 DEFAULT_COMMAND_TTS_OUTPUT_FORMAT = "mp3"
 COMMAND_TTS_OUTPUT_FORMATS = frozenset({"mp3", "wav", "ogg", "flac"})
 DEFAULT_COMMAND_TTS_MAX_TEXT_LENGTH = 5000
+OPUS_VOICE_PLATFORMS = frozenset({"telegram", "whatsapp", "whatsapp_cloud"})
 
 
 def _get_provider_section(tts_config: Dict[str, Any], name: str) -> Dict[str, Any]:
@@ -2059,12 +2061,13 @@ def text_to_speech_tool(
         text = text[:max_len]
 
     # Detect platform from gateway env var to choose the best output format.
-    # Telegram voice bubbles require Opus (.ogg); OpenAI and ElevenLabs can
-    # produce Opus natively (no ffmpeg needed).  Edge TTS always outputs MP3
-    # and needs ffmpeg for conversion.
+    # Telegram voice bubbles and WhatsApp voice notes require Opus (.ogg).
+    # OpenAI, ElevenLabs, Mistral, and Gemini can produce Opus natively
+    # (no ffmpeg needed). Edge TTS always outputs MP3 and needs ffmpeg
+    # for conversion.
     from gateway.session_context import get_session_env
     platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
-    want_opus = (platform == "telegram")
+    want_opus = platform in OPUS_VOICE_PLATFORMS
 
     # Determine output path
     if output_path:
@@ -2702,7 +2705,7 @@ from tools.registry import registry, tool_error
 
 TTS_SCHEMA = {
     "name": "text_to_speech",
-    "description": "Convert text to speech audio. Returns a MEDIA: path that the platform delivers as native audio. Compatible providers render as a voice bubble on Telegram; otherwise audio is sent as a regular attachment. In CLI mode, saves to ~/voice-memos/. Voice and provider are user-configured (built-in providers like edge/openai or custom command providers under tts.providers.<name>), not model-selected.",
+    "description": "Convert text to speech audio. Returns a MEDIA: path that the platform delivers as native audio. Compatible providers render as a voice bubble/note on Telegram and WhatsApp; otherwise audio is sent as a regular attachment. In CLI mode, saves to ~/voice-memos/. Voice and provider are user-configured (built-in providers like edge/openai or custom command providers under tts.providers.<name>), not model-selected.",
     "parameters": {
         "type": "object",
         "properties": {

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -22,7 +22,7 @@ Custom command providers:
   See the Local Command section of ``website/docs/user-guide/features/tts.md``.
 
 Output formats:
-- Opus (.ogg) for native voice bubbles/notes on Telegram and WhatsApp
+- Opus (.ogg/.opus) for native voice bubbles/notes on Telegram and WhatsApp
   surfaces (requires ffmpeg for providers that only emit MP3/WAV)
 - MP3 (.mp3) for everything else (CLI, Discord)
 
@@ -389,9 +389,11 @@ BUILTIN_TTS_PROVIDERS = frozenset({
 
 DEFAULT_COMMAND_TTS_TIMEOUT_SECONDS = 120
 DEFAULT_COMMAND_TTS_OUTPUT_FORMAT = "mp3"
-COMMAND_TTS_OUTPUT_FORMATS = frozenset({"mp3", "wav", "ogg", "flac"})
+COMMAND_TTS_OUTPUT_FORMATS = frozenset({"mp3", "wav", "ogg", "opus", "flac"})
 DEFAULT_COMMAND_TTS_MAX_TEXT_LENGTH = 5000
 OPUS_VOICE_PLATFORMS = frozenset({"telegram", "whatsapp", "whatsapp_cloud"})
+OGG_OPUS_EXTENSIONS = frozenset({".ogg", ".opus"})
+OGG_OPUS_SIGNATURE_SCAN_BYTES = 64 * 1024
 
 
 def _get_provider_section(tts_config: Dict[str, Any], name: str) -> Dict[str, Any]:
@@ -602,7 +604,7 @@ def _get_command_tts_output_format(
     config: Dict[str, Any],
     output_path: Optional[str] = None,
 ) -> str:
-    """Return the validated output format (mp3/wav/ogg/flac)."""
+    """Return the validated output format (mp3/wav/ogg/opus/flac)."""
     if output_path:
         suffix = Path(output_path).suffix.lower().strip().lstrip(".")
         if suffix in COMMAND_TTS_OUTPUT_FORMATS:
@@ -622,6 +624,26 @@ def _is_command_tts_voice_compatible(config: Dict[str, Any]) -> bool:
     if isinstance(value, str):
         return value.strip().lower() in {"1", "true", "yes", "on"}
     return bool(value)
+
+
+def _wants_ogg_opus_output(path: str) -> bool:
+    """Return True when *path* asks for an Ogg/Opus container extension."""
+    return Path(path).suffix.lower() in OGG_OPUS_EXTENSIONS
+
+
+def _is_native_ogg_opus(path: str) -> bool:
+    """Return True when *path* is a non-empty Ogg container with Opus audio."""
+    file_path = Path(path)
+    if file_path.suffix.lower() not in OGG_OPUS_EXTENSIONS:
+        return False
+    try:
+        if file_path.stat().st_size <= 0:
+            return False
+        with file_path.open("rb") as f:
+            header = f.read(OGG_OPUS_SIGNATURE_SCAN_BYTES)
+    except OSError:
+        return False
+    return header.startswith(b"OggS") and b"OpusHead" in header
 
 
 def _shell_quote_context(command_template: str, position: int) -> Optional[str]:
@@ -878,19 +900,19 @@ def _has_any_command_tts_provider(tts_config: Optional[Dict[str, Any]] = None) -
 
 
 # ===========================================================================
-# ffmpeg Opus conversion (Edge TTS MP3 -> OGG Opus for Telegram)
+# ffmpeg Opus conversion for voice-note platforms
 # ===========================================================================
 def _has_ffmpeg() -> bool:
     """Check if ffmpeg is available on the system."""
     return shutil.which("ffmpeg") is not None
 
 
-def _convert_to_opus(mp3_path: str) -> Optional[str]:
+def _convert_to_opus(audio_path: str) -> Optional[str]:
     """
-    Convert an MP3 file to OGG Opus format for Telegram voice bubbles.
+    Convert an audio file to OGG Opus format for voice bubbles.
 
     Args:
-        mp3_path: Path to the input MP3 file.
+        audio_path: Path to the input audio file.
 
     Returns:
         Path to the .ogg file, or None if conversion fails.
@@ -898,10 +920,13 @@ def _convert_to_opus(mp3_path: str) -> Optional[str]:
     if not _has_ffmpeg():
         return None
 
-    ogg_path = mp3_path.rsplit(".", 1)[0] + ".ogg"
+    source = Path(audio_path)
+    ogg_path = str(source.with_suffix(".ogg"))
+    if os.path.abspath(ogg_path) == os.path.abspath(audio_path):
+        ogg_path = str(source.with_name(f"{source.stem}.opus.ogg"))
     try:
         result = subprocess.run(
-            ["ffmpeg", "-i", mp3_path, "-acodec", "libopus",
+            ["ffmpeg", "-i", audio_path, "-acodec", "libopus",
              "-ac", "1", "-b:a", "64k", "-vbr", "off", ogg_path, "-y"],
             capture_output=True, timeout=30,
             stdin=subprocess.DEVNULL,
@@ -910,7 +935,7 @@ def _convert_to_opus(mp3_path: str) -> Optional[str]:
             logger.warning("ffmpeg conversion failed with return code %d: %s", 
                           result.returncode, result.stderr.decode('utf-8', errors='ignore')[:200])
             return None
-        if os.path.exists(ogg_path) and os.path.getsize(ogg_path) > 0:
+        if _is_native_ogg_opus(ogg_path):
             return ogg_path
     except subprocess.TimeoutExpired:
         logger.warning("ffmpeg OGG conversion timed out after 30s")
@@ -918,6 +943,16 @@ def _convert_to_opus(mp3_path: str) -> Optional[str]:
         logger.warning("ffmpeg not found in PATH")
     except Exception as e:
         logger.warning("ffmpeg OGG conversion failed: %s", e, exc_info=True)
+    return None
+
+
+def _ensure_ogg_opus_voice_file(audio_path: str) -> Optional[str]:
+    """Return a verified Ogg/Opus file path, converting when needed."""
+    if _is_native_ogg_opus(audio_path):
+        return audio_path
+    opus_path = _convert_to_opus(audio_path)
+    if opus_path and _is_native_ogg_opus(opus_path):
+        return opus_path
     return None
 
 
@@ -975,7 +1010,7 @@ def _generate_elevenlabs(text: str, output_path: str, tts_config: Dict[str, Any]
     model_id = el_config.get("model_id", DEFAULT_ELEVENLABS_MODEL_ID)
 
     # Determine output format based on file extension
-    if output_path.endswith(".ogg"):
+    if _wants_ogg_opus_output(output_path):
         output_format = "opus_48000_64"
     else:
         output_format = "mp3_44100_128"
@@ -1021,7 +1056,7 @@ def _generate_openai_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     speed = float(oai_config.get("speed", tts_config.get("speed", 1.0)))
 
     # Determine response format from extension
-    if output_path.endswith(".ogg"):
+    if _wants_ogg_opus_output(output_path):
         response_format = "opus"
     else:
         response_format = "mp3"
@@ -1334,7 +1369,7 @@ def _generate_mistral_tts(text: str, output_path: str, tts_config: Dict[str, Any
     model = mi_config.get("model", DEFAULT_MISTRAL_TTS_MODEL)
     voice_id = mi_config.get("voice_id") or DEFAULT_MISTRAL_TTS_VOICE_ID
 
-    if output_path.endswith(".ogg"):
+    if _wants_ogg_opus_output(output_path):
         response_format = "opus"
     elif output_path.endswith(".wav"):
         response_format = "wav"
@@ -1567,7 +1602,7 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
     Args:
         text: Text to convert (prompt-style; supports inline direction like
               "Say cheerfully:" and audio tags like [whispers]).
-        output_path: Where to save the audio file (.wav, .mp3, or .ogg).
+        output_path: Where to save the audio file (.wav, .mp3, .ogg, or .opus).
         tts_config: TTS config dict.
 
     Returns:
@@ -1662,7 +1697,7 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         return output_path
 
     # Otherwise write WAV to a temp file and ffmpeg-convert to the target
-    # format (.mp3 or .ogg). If ffmpeg is missing, fall back to renaming the
+    # format (.mp3, .ogg, or .opus). If ffmpeg is missing, fall back to renaming the
     # WAV -- this matches the NeuTTS behavior and keeps the tool usable on
     # systems without ffmpeg (audio still plays, just with a misleading
     # extension).
@@ -1675,7 +1710,7 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         if ffmpeg:
             # For .ogg output, force libopus encoding (Telegram voice bubbles
             # require Opus specifically; ffmpeg's default for .ogg is Vorbis).
-            if output_path.lower().endswith(".ogg"):
+            if _wants_ogg_opus_output(output_path):
                 cmd = [
                     ffmpeg, "-i", wav_path,
                     "-acodec", "libopus", "-ac", "1",
@@ -2061,7 +2096,7 @@ def text_to_speech_tool(
         text = text[:max_len]
 
     # Detect platform from gateway env var to choose the best output format.
-    # Telegram voice bubbles and WhatsApp voice notes require Opus (.ogg).
+    # Telegram voice bubbles and WhatsApp voice notes require Opus (.ogg/.opus).
     # OpenAI, ElevenLabs, Mistral, and Gemini can produce Opus natively
     # (no ffmpeg needed). Edge TTS always outputs MP3 and needs ffmpeg
     # for conversion.
@@ -2268,11 +2303,10 @@ def text_to_speech_tool(
             # delivery only kicks in when the user explicitly opts in
             # via ``voice_compatible: true`` in their provider config.
             if _is_command_tts_voice_compatible(command_provider_config):
-                if not file_str.endswith(".ogg"):
-                    opus_path = _convert_to_opus(file_str)
-                    if opus_path:
-                        file_str = opus_path
-                voice_compatible = file_str.endswith(".ogg")
+                opus_path = _ensure_ogg_opus_voice_file(file_str)
+                if opus_path:
+                    file_str = opus_path
+                    voice_compatible = True
         elif provider not in BUILTIN_TTS_PROVIDERS:
             # Plugin-registered provider (issue #30398). Voice-bubble
             # delivery opts in via ``TTSProvider.voice_compatible``
@@ -2280,22 +2314,20 @@ def text_to_speech_tool(
             # already write Opus skip the ffmpeg conversion.
             plugin_voice_compatible = _plugin_provider_is_voice_compatible(provider)
             if plugin_voice_compatible:
-                if not file_str.endswith(".ogg"):
-                    opus_path = _convert_to_opus(file_str)
-                    if opus_path:
-                        file_str = opus_path
-                voice_compatible = file_str.endswith(".ogg")
+                opus_path = _ensure_ogg_opus_voice_file(file_str)
+                if opus_path:
+                    file_str = opus_path
+                    voice_compatible = True
         elif (
             want_opus
             and provider in {"edge", "neutts", "minimax", "xai", "kittentts", "piper"}
-            and not file_str.endswith(".ogg")
         ):
-            opus_path = _convert_to_opus(file_str)
+            opus_path = _ensure_ogg_opus_voice_file(file_str)
             if opus_path:
                 file_str = opus_path
                 voice_compatible = True
         elif provider in {"elevenlabs", "openai", "mistral", "gemini"}:
-            voice_compatible = want_opus and file_str.endswith(".ogg")
+            voice_compatible = want_opus and _is_native_ogg_opus(file_str)
 
         file_size = os.path.getsize(file_str)
         logger.info("TTS audio saved: %s (%s bytes, provider: %s)", file_str, f"{file_size:,}", provider)

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -926,8 +926,14 @@ def _convert_to_opus(audio_path: str) -> Optional[str]:
         ogg_path = str(source.with_name(f"{source.stem}.opus.ogg"))
     try:
         result = subprocess.run(
-            ["ffmpeg", "-i", audio_path, "-acodec", "libopus",
-             "-ac", "1", "-b:a", "64k", "-vbr", "off", ogg_path, "-y"],
+            [
+                "ffmpeg", "-i", audio_path,
+                "-acodec", "libopus",
+                "-ac", "1", "-ar", "48000",
+                "-b:a", "64k", "-vbr", "off",
+                "-application", "voip",
+                ogg_path, "-y",
+            ],
             capture_output=True, timeout=30,
             stdin=subprocess.DEVNULL,
         )

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2059,12 +2059,12 @@ def text_to_speech_tool(
         text = text[:max_len]
 
     # Detect platform from gateway env var to choose the best output format.
-    # Telegram voice bubbles require Opus (.ogg); OpenAI and ElevenLabs can
-    # produce Opus natively (no ffmpeg needed).  Edge TTS always outputs MP3
-    # and needs ffmpeg for conversion.
+    # Telegram voice bubbles and WhatsApp voice notes require Opus (.ogg).
+    # OpenAI and ElevenLabs can produce Opus natively (no ffmpeg needed).
+    # Edge TTS always outputs MP3 and needs ffmpeg for conversion.
     from gateway.session_context import get_session_env
     platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
-    want_opus = (platform == "telegram")
+    want_opus = platform in {"telegram", "whatsapp", "whatsapp_cloud"}
 
     # Determine output path
     if output_path:
@@ -2101,8 +2101,9 @@ def text_to_speech_tool(
         if command_provider_config is not None:
             fmt = _get_command_tts_output_format(command_provider_config)
             file_path = out_dir / f"tts_{timestamp}.{fmt}"
-        # Use .ogg for Telegram with providers that support native Opus output,
-        # otherwise fall back to .mp3 (Edge TTS will attempt ffmpeg conversion later).
+        # Use .ogg for platforms with native voice-note/bubble delivery when
+        # providers support native Opus output; otherwise fall back to .mp3
+        # (Edge TTS will attempt ffmpeg conversion later).
         elif want_opus and provider in {"openai", "elevenlabs", "mistral", "gemini"}:
             file_path = out_dir / f"tts_{timestamp}.ogg"
         else:

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -340,6 +340,15 @@ config that calls `voice say --format ogg-opus`, runs Hermes'
 run proves Hermes receives a `voice_compatible` media tag and that the audio is
 real Opus in an Ogg container, mono, at 48 kHz.
 
+To validate an already deployed Hermes home without rewriting its config:
+
+```bash
+scripts/verify_voice_command_tts.py --use-existing-config --hermes-home ~/.hermes
+```
+
+In this mode the script uses the configured `tts.provider` path and only writes
+the generated audio cache entry.
+
 #### Security
 
 Command-type providers run whatever shell command you configure, with your user's permissions. Hermes quotes placeholder values and enforces the configured timeout, but the command template itself is trusted local input — treat it the same way you would a shell script on your PATH.

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -165,18 +165,18 @@ tts:
 
 Only positive integers are honored. Zero, negative, non-numeric, or boolean values fall through to the provider default, so a broken config can't accidentally disable truncation.
 
-### Telegram Voice Bubbles & ffmpeg
+### Voice Bubbles / Notes & ffmpeg
 
-Telegram voice bubbles require Opus/OGG audio format:
+Telegram voice bubbles and WhatsApp voice notes require Opus/OGG audio format:
 
 - **OpenAI, ElevenLabs, and Mistral** produce Opus natively — no extra setup
-- **Edge TTS** (default) outputs MP3 and needs **ffmpeg** to convert:
-- **MiniMax TTS** outputs MP3 and needs **ffmpeg** to convert for Telegram voice bubbles
-- **Google Gemini TTS** outputs raw PCM and uses **ffmpeg** to encode Opus directly for Telegram voice bubbles
-- **xAI TTS** outputs MP3 and needs **ffmpeg** to convert for Telegram voice bubbles
-- **NeuTTS** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
-- **KittenTTS** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
-- **Piper** outputs WAV and also needs **ffmpeg** to convert for Telegram voice bubbles
+- **Edge TTS** (default) outputs MP3 and needs **ffmpeg** to convert.
+- **MiniMax TTS** outputs MP3 and needs **ffmpeg** to convert for native voice delivery
+- **Google Gemini TTS** outputs raw PCM and uses **ffmpeg** to encode Opus directly for native voice delivery
+- **xAI TTS** outputs MP3 and needs **ffmpeg** to convert for native voice delivery
+- **NeuTTS** outputs WAV and also needs **ffmpeg** to convert for native voice delivery
+- **KittenTTS** outputs WAV and also needs **ffmpeg** to convert for native voice delivery
+- **Piper** outputs WAV and also needs **ffmpeg** to convert for native voice delivery
 
 ```bash
 # Ubuntu/Debian
@@ -189,10 +189,10 @@ brew install ffmpeg
 sudo dnf install ffmpeg
 ```
 
-Without ffmpeg, Edge TTS, MiniMax TTS, NeuTTS, KittenTTS, and Piper audio are sent as regular audio files (playable, but shown as a rectangular player instead of a voice bubble).
+Without ffmpeg, Edge TTS, MiniMax TTS, NeuTTS, KittenTTS, and Piper audio are sent as regular audio files (playable, but shown as a rectangular player instead of a native voice bubble/note).
 
 :::tip
-If you want voice bubbles without installing ffmpeg, switch to the OpenAI, ElevenLabs, or Mistral provider.
+If you want native voice delivery without installing ffmpeg, switch to the OpenAI, ElevenLabs, Mistral, or an Ogg/Opus command provider such as `voice`.
 :::
 
 ### xAI Custom Voices (voice cloning)

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -35,7 +35,7 @@ Convert text to speech with ten providers:
 |----------|----------|--------|
 | Telegram | Voice bubble (plays inline) | Opus `.ogg` |
 | Discord | Voice bubble (Opus/OGG), falls back to file attachment | Opus/MP3 |
-| WhatsApp | Audio file attachment | MP3 |
+| WhatsApp | Native voice note with `voice_compatible`; regular attachment otherwise | Ogg/Opus preferred; MP3/WAV fallback |
 | CLI | Saved to `~/.hermes/audio_cache/` | MP3 |
 
 ### Configuration
@@ -404,7 +404,7 @@ Override these on your provider class for richer integration:
 - `list_models()` → list of `{id, display, languages, max_text_length}` dicts.
 - `get_setup_schema()` → return `{name, badge, tag, env_vars: [{key, prompt, url}]}` to power the picker row in `hermes tools` / `hermes setup`. Without this, the plugin still works but its row in the picker is minimal.
 - `stream(text, *, voice, model, format, **extra)` → iterator yielding audio bytes for streaming delivery (default raises `NotImplementedError`).
-- `voice_compatible` property → set `True` if your output is Opus-compatible and the gateway should deliver it as a voice bubble (default `False` = regular audio attachment).
+- `voice_compatible` property → set `True` when your output should use native voice-message delivery. Ogg/Opus output is sent directly; MP3/WAV output may be converted by gateways that support conversion (default `False` = regular audio attachment).
 
 See `agent/tts_provider.py` for the full ABC including docstrings.
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -325,6 +325,21 @@ Use `{{` and `}}` for literal braces.
 - **`type: command` is the default when `command:` is set.** Writing `type: command` explicitly is good practice but not required; an entry with a non-empty `command` string is treated as a command provider.
 - **`{input_path}` / `{text_path}` are interchangeable.** Use whichever reads better in your command.
 
+#### Local Ogg/Opus validation
+
+When using [`voice`](https://github.com/rgbkrk/voice) as a command provider,
+validate the integration before restarting a live gateway:
+
+```bash
+VOICE_BIN=/path/to/voice scripts/verify_voice_command_tts.py
+```
+
+The script creates a temporary `HERMES_HOME`, writes a Kokoro command-provider
+config that calls `voice say --format ogg-opus`, runs Hermes'
+`text_to_speech_tool`, and checks the generated file with `ffprobe`. A passing
+run proves Hermes receives a `voice_compatible` media tag and that the audio is
+real Opus in an Ogg container, mono, at 48 kHz.
+
 #### Security
 
 Command-type providers run whatever shell command you configure, with your user's permissions. Hermes quotes placeholder values and enforces the configured timeout, but the command template itself is trusted local input — treat it the same way you would a shell script on your PATH.

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -252,7 +252,7 @@ tts:
       command: "voxcpm --ref ~/voice.wav --text-file {input_path} --out {output_path}"
       output_format: mp3
       timeout: 180
-      voice_compatible: true       # try to deliver as a Telegram voice bubble
+      voice_compatible: true       # try to deliver as a native voice note/bubble
 
     mlx-kokoro:
       type: command
@@ -312,7 +312,7 @@ Use `{{` and `}}` for literal braces.
 |--------------------|---------|------------------------------------------------------------------------------------------------------------|
 | `timeout`          | `120`   | Seconds; the process tree is killed on expiry (Unix `killpg`, Windows `taskkill /T`).                       |
 | `output_format`    | `mp3`   | One of `mp3` / `wav` / `ogg` / `flac`. Auto-inferred from the output extension if Hermes picks a path.      |
-| `voice_compatible` | `false` | When `true`, Hermes converts MP3/WAV output to Opus/OGG via ffmpeg so Telegram renders a voice bubble.      |
+| `voice_compatible` | `false` | When `true`, Hermes routes the output through native voice-message delivery. Existing Ogg/Opus output is sent directly; MP3/WAV output is converted to Ogg/Opus via ffmpeg when the platform requires it. |
 | `max_text_length`  | `5000`  | Input is truncated to this length before rendering the command.                                             |
 | `voice` / `model`  | empty   | Passed to the command as placeholder values only.                                                           |
 
@@ -320,6 +320,7 @@ Use `{{` and `}}` for literal braces.
 
 - **Built-in names always win.** A `tts.providers.openai` entry never shadows the native OpenAI provider, so no user config can silently replace a built-in.
 - **Default delivery is a document.** Command providers deliver as regular audio attachments on every platform. Opt in to voice-bubble delivery per-provider with `voice_compatible: true`.
+- **Prefer native Ogg/Opus when your engine can write it.** For WhatsApp voice notes and Telegram voice bubbles, set `output_format: ogg` and have the command produce real Opus in an Ogg container. Hermes can then skip conversion and hand the file directly to the platform adapter.
 - **Command failures surface to the agent.** Non-zero exit, empty output, or timeout all return an error with the command's stderr/stdout included so you can debug the provider from the conversation.
 - **`type: command` is the default when `command:` is set.** Writing `type: command` explicitly is good practice but not required; an entry with a non-empty `command` string is treated as a command provider.
 - **`{input_path}` / `{text_path}` are interchangeable.** Use whichever reads better in your command.

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -432,6 +432,12 @@ That writes `~/.config/systemd/user/voice-webrtc-sidecar.service`, writes
 `voice say --format ogg-opus`, reloads systemd, starts the sidecar, and restarts
 `hermes-gateway.service`.
 
+The JSON plan also includes `verify_commands.local_stack`,
+`verify_commands.live_gateway`, and `verify_commands.live_gateway_cloud_only`.
+Run the emitted `local_stack` command before changing the live service, then
+run `live_gateway` after restart. Use the `cloud_only` variant when this host
+does not run the local Baileys bridge.
+
 The generated service files should look like this:
 
 ```ini

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -446,10 +446,13 @@ That writes `~/.config/systemd/user/voice-webrtc-sidecar.service`, writes
 live-call WAV segments.
 
 The JSON plan also includes `verify_commands.local_stack`,
-`verify_commands.live_gateway`, and `verify_commands.live_gateway_cloud_only`.
-Run the emitted `local_stack` command before changing the live service, then
-run `live_gateway` after restart. Use the `cloud_only` variant when this host
-does not run the local Baileys bridge.
+`verify_commands.live_gateway`, `verify_commands.live_gateway_cloud_only`, and
+`verify_commands.live_gateway_cloud_ready`. Run the emitted `local_stack`
+command before changing the live service, then run `live_gateway` after
+restart. Use the `cloud_only` variant when this host does not run the local
+Baileys bridge. Use the `cloud_ready` variant before routing real Meta
+webhooks to the host; it checks WhatsApp Cloud credential shape and recipient
+authorization without printing secret values.
 
 The generated service files should look like this:
 

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -349,7 +349,9 @@ scripts/verify_voice_live_gateway.py \
   --python-bin ~/.hermes/hermes-agent/venv/bin/python \
   --hermes-home ~/.hermes \
   --voice-bin /path/to/voice \
+  --voice-repo /path/to/voice \
   --calling-sidecar-url http://127.0.0.1:8787 \
+  --sidecar-service voice-webrtc-sidecar.service \
   --skip-bridge-health \
   --run-tts-smoke
 ```
@@ -357,7 +359,9 @@ scripts/verify_voice_live_gateway.py \
 When `--voice-bin` is passed with `--calling-sidecar-url`, the live verifier
 also compares the running sidecar `/contract` with `voice stream-contract` so
 PCM shape, endpoint paths, payload definitions, and advertised `voice`
-surfaces cannot drift silently.
+surfaces cannot drift silently. When `--sidecar-service` is included, it also
+checks the sidecar systemd user unit is active and points at the expected
+`VOICE_BIN`, `WorkingDirectory`, and `examples/webrtc-sidecar/sidecar.py`.
 
 That live check inspects the systemd user service, verifies the running process
 environment, confirms imports resolve from the expected checkout, validates the

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -514,7 +514,9 @@ outbound sidecar queue budget; adjust it with `--max-queued-tx-ms` on the
 wrapper or `--full-duplex-max-queued-tx-ms` on the aggregate verifier. Current
 sidecars report queue depth as both bytes and whole milliseconds
 (`queued_tx_bytes`/`queued_tx_ms`, `queued_rx_bytes`/`queued_rx_ms`) so Hermes
-can enforce latency budgets without duplicating PCM duration math.
+can enforce latency budgets without duplicating PCM duration math. Hermes
+accepts older sidecars that omit those fields, but rejects malformed telemetry
+when a sidecar does report it.
 
 To validate just the Cloud Calling control plane without sidecar media
 dependencies, run:

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -385,8 +385,39 @@ WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND='voice stream --quiet --sample
 WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT=180
 ```
 
-For a local user-service deployment, run the sidecar on loopback and expose the
-same values to `hermes-gateway.service`:
+For a local Linux user-service deployment, let Hermes generate the sidecar unit
+and gateway drop-in first. The default is a dry run that prints the files and
+config it would write:
+
+```bash
+scripts/install_voice_local_stack.py \
+  --live-hermes-root /path/to/hermes-agent \
+  --voice-repo /path/to/voice \
+  --voice-bin /path/to/voice/target/release/voice \
+  --webrtc-python-bin /tmp/voice-webrtc-venv/bin/python \
+  --configure-tts
+```
+
+When the JSON plan looks right, apply it and restart the gateway:
+
+```bash
+scripts/install_voice_local_stack.py \
+  --apply \
+  --configure-tts \
+  --restart-hermes \
+  --live-hermes-root /path/to/hermes-agent \
+  --voice-repo /path/to/voice \
+  --voice-bin /path/to/voice/target/release/voice \
+  --webrtc-python-bin /tmp/voice-webrtc-venv/bin/python
+```
+
+That writes `~/.config/systemd/user/voice-webrtc-sidecar.service`, writes
+`~/.config/systemd/user/hermes-gateway.service.d/voice-stack.conf`, updates
+`~/.hermes/config.yaml` so the Kokoro command provider emits Ogg/Opus through
+`voice say --format ogg-opus`, reloads systemd, starts the sidecar, and restarts
+`hermes-gateway.service`.
+
+The generated service files should look like this:
 
 ```ini
 # ~/.config/systemd/user/voice-webrtc-sidecar.service
@@ -397,8 +428,8 @@ After=network.target voice-daemon.service
 [Service]
 Type=simple
 WorkingDirectory=/path/to/voice
-Environment="VOICE_BIN=/path/to/voice"
-ExecStart=/tmp/voice-webrtc-venv/bin/python /path/to/voice/examples/webrtc-sidecar/sidecar.py --host 127.0.0.1 --port 8787 --rx-pcm %h/.hermes/voice-webrtc-sidecar/inbound.s16le --log-level INFO
+Environment="VOICE_BIN=/path/to/voice/target/release/voice"
+ExecStart=/tmp/voice-webrtc-venv/bin/python /path/to/voice/examples/webrtc-sidecar/sidecar.py --host 127.0.0.1 --port 8787 --rx-pcm /home/you/.hermes/voice-webrtc-sidecar/inbound.s16le --log-level INFO
 Restart=on-failure
 RestartSec=2
 
@@ -409,17 +440,10 @@ WantedBy=default.target
 ```ini
 # ~/.config/systemd/user/hermes-gateway.service.d/voice-stack.conf
 [Service]
+Environment="PYTHONPATH=/path/to/hermes-agent"
 Environment="WHATSAPP_CLOUD_CALLING_SIDECAR_URL=http://127.0.0.1:8787"
-Environment="WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND=/path/to/voice stream --quiet --sample-rate {sample_rate} --frame-ms {frame_ms} --raw-output - --input-file {input_path} --voice af_heart --speed 1.0"
+Environment="WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND=/path/to/voice/target/release/voice stream --quiet --sample-rate {sample_rate} --frame-ms {frame_ms} --raw-output - --input-file {input_path} --voice af_heart --speed 1.0"
 Environment="WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT=180"
-```
-
-Then reload and restart:
-
-```bash
-systemctl --user daemon-reload
-systemctl --user enable --now voice-webrtc-sidecar.service
-systemctl --user restart hermes-gateway.service
 ```
 
 Validate the installed command shape before a live call:

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -324,8 +324,12 @@ scripts/verify_voice_local_stack.py \
 
 That aggregate check starts the local Hermes CLI, verifies command-provider
 Ogg/Opus output, verifies the raw `voice stream` PCM contract, and then runs
-the full-duplex sidecar smoke from the `voice` checkout. Pass
-`--skip-full-duplex` when the WebRTC sidecar dependencies are not installed yet.
+the WhatsApp Calling control-plane smoke plus the full-duplex sidecar smoke
+from the `voice` checkout. The control-plane smoke is synthetic and local: it
+feeds Hermes a representative Meta `calls` webhook and verifies the sidecar
+offer, Graph `pre_accept`, Graph `accept`, drain startup, and terminate cleanup
+without contacting Meta. Pass `--skip-calling-control-plane` or
+`--skip-full-duplex` when you only want part of the preflight.
 
 After installing a local gateway service, verify the running process is using
 the expected voice-native checkout:
@@ -414,6 +418,18 @@ drains the decoded PCM through `voice stream-transcribe`, and simultaneously
 queues outbound `voice stream` PCM back to the same peer. A passing run proves
 the sidecar, PCM contract, inbound STT bridge, and outbound TTS bridge agree
 before a real WhatsApp call is attempted.
+
+To validate just the Cloud Calling control plane without sidecar media
+dependencies, run:
+
+```bash
+scripts/verify_voice_whatsapp_calling_control_plane.py
+```
+
+That synthetic smoke proves Hermes turns a representative call offer into a
+sidecar SDP request, Graph `pre_accept`, Graph `accept`, and local sidecar close
+on termination. It does not contact Meta and does not prove RTP media flow; use
+the full-duplex sidecar smoke above for the media path.
 
 Supported stream-command placeholders:
 

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -452,8 +452,8 @@ command before changing the live service, then run `live_gateway` after
 restart. Use the `cloud_only` variant when this host does not run the local
 Baileys bridge. Use the `cloud_ready` variant before routing real Meta
 webhooks to the host; it checks WhatsApp Cloud credential shape and recipient
-authorization, then probes the running local Cloud `/health` endpoint without
-printing secret values.
+authorization, then probes the running local Cloud `/health` endpoint and local
+Meta subscription challenge handshake without printing secret values.
 
 The generated service files should look like this:
 

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -349,15 +349,20 @@ involving Meta's Graph API:
 cd /path/to/voice
 python3 -m venv /tmp/voice-webrtc-venv
 /tmp/voice-webrtc-venv/bin/pip install -r examples/webrtc-sidecar/requirements.txt pytest
-/tmp/voice-webrtc-venv/bin/python examples/webrtc-sidecar/full_duplex_loopback_smoke.py --voice-bin /path/to/voice
+
+cd /path/to/hermes-agent
+VOICE_REPO=/path/to/voice \
+VOICE_WEBRTC_PYTHON=/tmp/voice-webrtc-venv/bin/python \
+  scripts/verify_voice_full_duplex_sidecar.py --voice-bin /path/to/voice
 ```
 
-The full-duplex smoke keeps everything local: it sends one `voice stream`
-utterance through a local WebRTC peer into the sidecar, drains the decoded PCM
-through `voice stream-transcribe`, and simultaneously queues outbound
-`voice stream` PCM back to the same peer. A passing run proves the sidecar,
-PCM contract, inbound STT bridge, and outbound TTS bridge agree before a real
-WhatsApp call is attempted.
+That wrapper runs `examples/webrtc-sidecar/full_duplex_loopback_smoke.py` from
+the `voice` checkout. The full-duplex smoke keeps everything local: it sends
+one `voice stream` utterance through a local WebRTC peer into the sidecar,
+drains the decoded PCM through `voice stream-transcribe`, and simultaneously
+queues outbound `voice stream` PCM back to the same peer. A passing run proves
+the sidecar, PCM contract, inbound STT bridge, and outbound TTS bridge agree
+before a real WhatsApp call is attempted.
 
 Supported stream-command placeholders:
 

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -325,8 +325,10 @@ scripts/verify_voice_local_stack.py \
 That aggregate check starts the local Hermes CLI, verifies command-provider
 Ogg/Opus output, runs the `voice` checkout's own WhatsApp contract verifier,
 verifies that the local Baileys bridge keeps `.ogg` / `.opus` audio as a
-native `audio/ogg; codecs=opus` voice note, verifies the raw `voice stream`
-PCM contract, and then runs the WhatsApp Calling control-plane smoke plus the
+native `audio/ogg; codecs=opus` voice note, verifies that the Cloud API adapter
+uploads direct and converted Ogg/Opus with that same MIME while falling back to
+MP3 only when conversion is unavailable, verifies the raw `voice stream` PCM
+contract, and then runs the WhatsApp Calling control-plane smoke plus the
 full-duplex sidecar smoke from the `voice` checkout. The voice contract step
 proves `voice stream-contract`, direct Ogg/Opus voice-note output, extension
 inference, misleading-extension rejection, raw PCM daemon streaming, and
@@ -334,8 +336,9 @@ streamed Ogg/Opus agree before Hermes adds its own routing. The control-plane
 smoke is synthetic and local: it feeds Hermes a representative Meta `calls`
 webhook and verifies the sidecar offer, Graph `pre_accept`, Graph `accept`,
 drain startup, and terminate cleanup without contacting Meta. Pass
-`--skip-whatsapp-bridge-media`, `--skip-calling-control-plane`, or
-`--skip-full-duplex` when you only want part of the preflight.
+`--skip-whatsapp-bridge-media`, `--skip-whatsapp-cloud-voice`,
+`--skip-calling-control-plane`, or `--skip-full-duplex` when you only want part
+of the preflight.
 
 After installing a local gateway service, verify the running process is using
 the expected voice-native checkout:

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -323,9 +323,13 @@ scripts/verify_voice_local_stack.py \
 ```
 
 That aggregate check starts the local Hermes CLI, verifies command-provider
-Ogg/Opus output, verifies the raw `voice stream` PCM contract, and then runs
-the WhatsApp Calling control-plane smoke plus the full-duplex sidecar smoke
-from the `voice` checkout. The control-plane smoke is synthetic and local: it
+Ogg/Opus output, runs the `voice` checkout's own WhatsApp contract verifier,
+verifies the raw `voice stream` PCM contract, and then runs the WhatsApp
+Calling control-plane smoke plus the full-duplex sidecar smoke from the `voice`
+checkout. The voice contract step proves `voice stream-contract`, direct
+Ogg/Opus voice-note output, extension inference, misleading-extension
+rejection, raw PCM daemon streaming, and streamed Ogg/Opus agree before Hermes
+adds its own routing. The control-plane smoke is synthetic and local: it
 feeds Hermes a representative Meta `calls` webhook and verifies the sidecar
 offer, Graph `pre_accept`, Graph `accept`, drain startup, and terminate cleanup
 without contacting Meta. Pass `--skip-calling-control-plane` or

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -405,6 +405,9 @@ WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND='voice stream --quiet --sample
 WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT=180
 ```
 
+Hermes posts that stdout PCM to the sidecar on the negotiated `frame_ms`
+cadence, so a fast TTS process does not build a large outbound playback queue.
+
 For a local Linux user-service deployment, let Hermes generate the sidecar unit
 and gateway drop-in first. The default is a dry run that prints the files and
 config it would write:

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -303,6 +303,16 @@ tts:
       timeout: 180
 ```
 
+Validate a live Hermes home before restarting the gateway:
+
+```bash
+scripts/verify_voice_command_tts.py --use-existing-config --hermes-home ~/.hermes
+```
+
+A passing run proves the configured provider returns a `[[audio_as_voice]]`
+media tag and real mono 48 kHz Ogg/Opus audio suitable for WhatsApp voice-note
+delivery.
+
 You can check whether the gateway found ffmpeg via the health endpoint:
 
 ```bash

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -342,6 +342,23 @@ Validate the installed command shape before a live call:
 scripts/verify_voice_stream_tts.py --voice-bin /path/to/voice
 ```
 
+Then validate the local WebRTC media bridge from a `voice` checkout before
+involving Meta's Graph API:
+
+```bash
+cd /path/to/voice
+python3 -m venv /tmp/voice-webrtc-venv
+/tmp/voice-webrtc-venv/bin/pip install -r examples/webrtc-sidecar/requirements.txt pytest
+/tmp/voice-webrtc-venv/bin/python examples/webrtc-sidecar/full_duplex_loopback_smoke.py --voice-bin /path/to/voice
+```
+
+The full-duplex smoke keeps everything local: it sends one `voice stream`
+utterance through a local WebRTC peer into the sidecar, drains the decoded PCM
+through `voice stream-transcribe`, and simultaneously queues outbound
+`voice stream` PCM back to the same peer. A passing run proves the sidecar,
+PCM contract, inbound STT bridge, and outbound TTS bridge agree before a real
+WhatsApp call is attempted.
+
 Supported stream-command placeholders:
 
 | Placeholder | Meaning |

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -352,6 +352,11 @@ Validate the installed command shape before a live call:
 scripts/verify_voice_stream_tts.py --voice-bin /path/to/voice
 ```
 
+The verifier reads `/path/to/voice stream-contract`, validates the advertised
+`raw_outbound_pcm` / `raw_inbound_pcm` `voice_surfaces`, then runs the rendered
+stream command and checks stdout for non-silent 48 kHz mono 20 ms `pcm_s16le`
+frames.
+
 Then validate the local WebRTC media bridge from a `voice` checkout before
 involving Meta's Graph API:
 

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -324,15 +324,17 @@ scripts/verify_voice_local_stack.py \
 
 That aggregate check starts the local Hermes CLI, verifies command-provider
 Ogg/Opus output, runs the `voice` checkout's own WhatsApp contract verifier,
-verifies the raw `voice stream` PCM contract, and then runs the WhatsApp
-Calling control-plane smoke plus the full-duplex sidecar smoke from the `voice`
-checkout. The voice contract step proves `voice stream-contract`, direct
-Ogg/Opus voice-note output, extension inference, misleading-extension
-rejection, raw PCM daemon streaming, and streamed Ogg/Opus agree before Hermes
-adds its own routing. The control-plane smoke is synthetic and local: it
-feeds Hermes a representative Meta `calls` webhook and verifies the sidecar
-offer, Graph `pre_accept`, Graph `accept`, drain startup, and terminate cleanup
-without contacting Meta. Pass `--skip-calling-control-plane` or
+verifies that the local Baileys bridge keeps `.ogg` / `.opus` audio as a
+native `audio/ogg; codecs=opus` voice note, verifies the raw `voice stream`
+PCM contract, and then runs the WhatsApp Calling control-plane smoke plus the
+full-duplex sidecar smoke from the `voice` checkout. The voice contract step
+proves `voice stream-contract`, direct Ogg/Opus voice-note output, extension
+inference, misleading-extension rejection, raw PCM daemon streaming, and
+streamed Ogg/Opus agree before Hermes adds its own routing. The control-plane
+smoke is synthetic and local: it feeds Hermes a representative Meta `calls`
+webhook and verifies the sidecar offer, Graph `pre_accept`, Graph `accept`,
+drain startup, and terminate cleanup without contacting Meta. Pass
+`--skip-whatsapp-bridge-media`, `--skip-calling-control-plane`, or
 `--skip-full-duplex` when you only want part of the preflight.
 
 After installing a local gateway service, verify the running process is using

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -450,16 +450,18 @@ The JSON plan also includes `verify_commands.local_stack`,
 `verify_commands.live_gateway_cloud_ready`. Run the emitted `local_stack`
 command before changing the live service; it includes an isolated Cloud webhook
 smoke that starts the adapter locally, checks `/health`, verifies the
-subscription challenge, and accepts a signed status-only POST without contacting
-Meta. Then run `live_gateway` after restart. Use the `cloud_only` variant when
-this host does not run the local Baileys bridge. Use the `cloud_ready` variant
-before routing real Meta webhooks to the host; it checks WhatsApp Cloud
-credential shape and recipient authorization, then probes the running local
-Cloud `/health` endpoint and local Meta subscription challenge handshake. It
-also sends a signed synthetic delivery-receipt POST to prove inbound HMAC
-verification accepts Meta-shaped webhook delivery without dispatching an agent
-message or printing secret values. If setup is incomplete, it reports every
-missing or malformed Cloud setting it can detect in one redacted failure.
+subscription challenge, accepts a signed status-only POST, and accepts a signed
+synthetic audio webhook that caches an Opus/Ogg voice note for downstream STT
+dispatch without contacting Meta. Then run `live_gateway` after restart. Use
+the `cloud_only` variant when this host does not run the local Baileys bridge.
+Use the `cloud_ready` variant before routing real Meta webhooks to the host; it
+checks WhatsApp Cloud credential shape and recipient authorization, then probes
+the running local Cloud `/health` endpoint and local Meta subscription challenge
+handshake. It also sends a signed synthetic delivery-receipt POST to prove
+inbound HMAC verification accepts Meta-shaped webhook delivery without
+dispatching an agent message or printing secret values. If setup is incomplete,
+it reports every missing or malformed Cloud setting it can detect in one
+redacted failure.
 
 The generated service files should look like this:
 

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -456,7 +456,8 @@ authorization, then probes the running local Cloud `/health` endpoint and local
 Meta subscription challenge handshake. It also sends a signed synthetic
 delivery-receipt POST to prove inbound HMAC verification accepts Meta-shaped
 webhook delivery without dispatching an agent message or printing secret
-values.
+values. If setup is incomplete, it reports every missing or malformed Cloud
+setting it can detect in one redacted failure.
 
 The generated service files should look like this:
 

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -453,7 +453,10 @@ restart. Use the `cloud_only` variant when this host does not run the local
 Baileys bridge. Use the `cloud_ready` variant before routing real Meta
 webhooks to the host; it checks WhatsApp Cloud credential shape and recipient
 authorization, then probes the running local Cloud `/health` endpoint and local
-Meta subscription challenge handshake without printing secret values.
+Meta subscription challenge handshake. It also sends a signed synthetic
+delivery-receipt POST to prove inbound HMAC verification accepts Meta-shaped
+webhook delivery without dispatching an agent message or printing secret
+values.
 
 The generated service files should look like this:
 

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -452,7 +452,8 @@ command before changing the live service, then run `live_gateway` after
 restart. Use the `cloud_only` variant when this host does not run the local
 Baileys bridge. Use the `cloud_ready` variant before routing real Meta
 webhooks to the host; it checks WhatsApp Cloud credential shape and recipient
-authorization without printing secret values.
+authorization, then probes the running local Cloud `/health` endpoint without
+printing secret values.
 
 The generated service files should look like this:
 

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -230,6 +230,10 @@ All settings live in `~/.hermes/.env`.  Required values are in **bold**.
 | `WHATSAPP_CLOUD_WEBHOOK_PATH` | `/whatsapp/webhook` | URL path Meta posts to. |
 | `WHATSAPP_CLOUD_API_VERSION` | `v20.0` | Meta Graph API version. Only override if a newer version is recommended in Meta's docs. |
 | `WHATSAPP_CLOUD_HOME_CHANNEL` | — | wa_id to use as the bot's home channel (for cron jobs etc). |
+| `WHATSAPP_CLOUD_CALLING_SIDECAR_URL` | — | Optional loopback URL for an experimental WhatsApp Calling / WebRTC sidecar. |
+| `WHATSAPP_CLOUD_CALLING_SIDECAR_TIMEOUT` | `10.0` | HTTP timeout in seconds for sidecar control-plane requests. |
+| `WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND` | — | Optional command that writes raw `pcm_s16le` TTS audio to stdout for live calls. |
+| `WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT` | `180.0` | Timeout in seconds for the live-call TTS stream command. |
 
 You can have **both** the Baileys (`whatsapp`) and Cloud (`whatsapp_cloud`) adapters enabled simultaneously, targeting different phone numbers.
 
@@ -277,13 +281,27 @@ This makes it obvious when the bot has seen your message versus when it's still 
 
 WhatsApp distinguishes between a "voice note" (the green waveform bubble) and a generic audio file attachment. The difference is purely codec: voice notes need to be `audio/ogg` with `opus` encoding.
 
-Hermes TTS produces MP3. Two paths:
+Hermes can use either direct Ogg/Opus output or a conversion fallback:
 
-- **With ffmpeg on PATH** (recommended) — outbound TTS is converted and arrives as a proper voice note. Install:
-  - Windows: `winget install Gyan.FFmpeg`
-  - macOS: `brew install ffmpeg`
-  - Linux: package manager
-- **Without ffmpeg** — outbound TTS arrives as an MP3 audio attachment. Plays fine, just doesn't look like a voice note. A one-time warning fires in the gateway log so you know.
+- **Direct Ogg/Opus** (preferred) — command TTS providers can produce WhatsApp-ready `.ogg` output directly. Set `output_format: ogg` and `voice_compatible: true`; Hermes uploads the file as `audio/ogg; codecs=opus` without ffmpeg conversion.
+- **With ffmpeg on PATH** — MP3/WAV outputs are converted and arrive as proper voice notes.
+- **Without ffmpeg** — MP3/WAV outputs arrive as generic audio attachments. They play fine, but do not render as voice-note bubbles. A one-time warning fires in the gateway log so you know.
+
+For a local `voice` / Kokoro command provider:
+
+```yaml
+tts:
+  provider: kokoro
+  providers:
+    kokoro:
+      type: command
+      command: /home/you/.local/bin/voice say --format ogg-opus --input-file {input_path} --output {output_path} --voice {voice} --speed {speed}
+      output_format: ogg
+      voice_compatible: true
+      voice: af_heart
+      speed: 1.0
+      timeout: 180
+```
 
 You can check whether the gateway found ffmpeg via the health endpoint:
 
@@ -291,6 +309,45 @@ You can check whether the gateway found ffmpeg via the health endpoint:
 curl http://localhost:8090/health
 # look for "ffmpeg_present": true
 ```
+
+### WhatsApp Calling / WebRTC sidecar (experimental)
+
+The Cloud API's live calling surface is a WebRTC media path, not a file-upload path. Hermes keeps that boundary separate from the normal Graph API adapter:
+
+1. Meta sends a `calls` webhook with an SDP offer.
+2. Hermes forwards the offer to a local sidecar at `WHATSAPP_CLOUD_CALLING_SIDECAR_URL`.
+3. The sidecar returns an SDP answer and exposes a fixed PCM contract.
+4. Hermes sends `pre_accept` and `accept` to Graph with that SDP answer.
+5. The sidecar bridges WebRTC RTP audio to local 48 kHz, mono, 20 ms `pcm_s16le` frames.
+6. Hermes drains inbound PCM from the sidecar, writes utterance WAV segments for the existing STT path, and sends outbound TTS frames back to the sidecar.
+
+The sidecar contract is identified as `voice.webrtc_sidecar`. Hermes fetches `GET /contract` when available and uses its endpoint paths and audio fields; older sidecars can omit `/contract` and use the legacy `/offer`, `/calls/{call_id}/audio`, and `/calls/{call_id}/close` paths.
+
+Minimal config:
+
+```bash
+WHATSAPP_CLOUD_CALLING_SIDECAR_URL=http://127.0.0.1:8787
+```
+
+For low-latency outbound speech, add a command that writes headerless `pcm_s16le` to stdout. With the `voice` daemon running, this uses `voice stream` directly instead of generating a file and decoding it with ffmpeg:
+
+```bash
+WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND='voice stream --quiet --sample-rate {sample_rate} --frame-ms {frame_ms} --raw-output - --input-file {input_path}'
+WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT=180
+```
+
+Supported stream-command placeholders:
+
+| Placeholder | Meaning |
+|---|---|
+| `{input_path}` / `{text_path}` | Temp UTF-8 file containing the reply text |
+| `{text}` | Reply text itself, shell-quoted for the command context |
+| `{sample_rate}` | Sidecar PCM sample rate, currently `48000` |
+| `{channels}` | Sidecar PCM channels, currently `1` |
+| `{frame_ms}` | Sidecar frame duration, currently `20` |
+| `{encoding}` | Sidecar PCM encoding, currently `pcm_s16le` |
+
+The health endpoint reports `calling_sidecar_configured`, `calling_sidecar_contract_loaded`, and `calling_sidecar_tts_stream_configured` booleans so you can confirm the live-call path is wired.
 
 ---
 
@@ -401,7 +458,7 @@ This uses your Nous Portal access token instead of needing a separate OpenAI key
 | Outbound | Local bridge → Baileys | HTTPS to graph.facebook.com |
 | Groups | Full support | DMs only (v1) |
 | 24h window | No restriction | Hard rule — templates required after |
-| Voice notes (out) | Native | Native with ffmpeg, MP3 fallback otherwise |
+| Voice notes (out) | Native with Ogg/Opus, ffmpeg fallback for MP3/WAV | Native with Ogg/Opus, ffmpeg fallback for MP3/WAV |
 | Read receipts | No | Yes (blue double-checkmarks) |
 | Typing indicator | No | Yes (auto-dismisses on response) |
 | Interactive buttons | Text fallback only | Native (clarify, approval, slash-confirm) |

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -327,6 +327,25 @@ Ogg/Opus output, verifies the raw `voice stream` PCM contract, and then runs
 the full-duplex sidecar smoke from the `voice` checkout. Pass
 `--skip-full-duplex` when the WebRTC sidecar dependencies are not installed yet.
 
+After installing a local gateway service, verify the running process is using
+the expected voice-native checkout:
+
+```bash
+scripts/verify_voice_live_gateway.py \
+  --live-hermes-root /path/to/hermes-agent \
+  --python-bin ~/.hermes/hermes-agent/venv/bin/python \
+  --hermes-home ~/.hermes \
+  --skip-bridge-health \
+  --run-tts-smoke
+```
+
+That live check inspects the systemd user service, verifies the running process
+environment, confirms imports resolve from the expected checkout, and can run
+one live-config TTS smoke that must produce mono 48 kHz Ogg/Opus. Omit
+`--skip-bridge-health` when the Baileys WhatsApp bridge is also enabled and you
+want the verifier to require the local bridge `/health` endpoint to be
+connected.
+
 You can check whether the gateway found ffmpeg via the health endpoint:
 
 ```bash

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -361,7 +361,8 @@ also compares the running sidecar `/contract` with `voice stream-contract` so
 PCM shape, endpoint paths, payload definitions, and advertised `voice`
 surfaces cannot drift silently. When `--sidecar-service` is included, it also
 checks the sidecar systemd user unit is active and points at the expected
-`VOICE_BIN`, `WorkingDirectory`, and `examples/webrtc-sidecar/sidecar.py`.
+`VOICE_BIN`, `WorkingDirectory`, `examples/webrtc-sidecar/sidecar.py`, and
+sidecar URL host/port.
 
 That live check inspects the systemd user service, verifies the running process
 environment, confirms imports resolve from the expected checkout, validates the

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -511,7 +511,10 @@ queues outbound `voice stream` PCM back to the same peer. A passing run proves
 the sidecar, PCM contract, inbound STT bridge, and outbound TTS bridge agree
 before a real WhatsApp call is attempted. It also enforces a default one-second
 outbound sidecar queue budget; adjust it with `--max-queued-tx-ms` on the
-wrapper or `--full-duplex-max-queued-tx-ms` on the aggregate verifier.
+wrapper or `--full-duplex-max-queued-tx-ms` on the aggregate verifier. Current
+sidecars report queue depth as both bytes and whole milliseconds
+(`queued_tx_bytes`/`queued_tx_ms`, `queued_rx_bytes`/`queued_rx_ms`) so Hermes
+can enforce latency budgets without duplicating PCM duration math.
 
 To validate just the Cloud Calling control plane without sidecar media
 dependencies, run:

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -418,7 +418,8 @@ scripts/install_voice_local_stack.py \
   --voice-repo /path/to/voice \
   --voice-bin /path/to/voice/target/release/voice \
   --webrtc-python-bin /tmp/voice-webrtc-venv/bin/python \
-  --configure-tts
+  --configure-tts \
+  --configure-stt
 ```
 
 When the JSON plan looks right, apply it and restart the gateway:
@@ -427,6 +428,7 @@ When the JSON plan looks right, apply it and restart the gateway:
 scripts/install_voice_local_stack.py \
   --apply \
   --configure-tts \
+  --configure-stt \
   --restart-hermes \
   --live-hermes-root /path/to/hermes-agent \
   --voice-repo /path/to/voice \
@@ -438,7 +440,10 @@ That writes `~/.config/systemd/user/voice-webrtc-sidecar.service`, writes
 `~/.config/systemd/user/hermes-gateway.service.d/voice-stack.conf`, updates
 `~/.hermes/config.yaml` so the Kokoro command provider emits Ogg/Opus through
 `voice say --format ogg-opus`, reloads systemd, starts the sidecar, and restarts
-`hermes-gateway.service`.
+`hermes-gateway.service`. With `--configure-stt`, it also sets
+`stt.provider: voice` with a command provider that runs
+`voice stream-transcribe --quiet {input_path}` for inbound voice messages and
+live-call WAV segments.
 
 The JSON plan also includes `verify_commands.local_stack`,
 `verify_commands.live_gateway`, and `verify_commands.live_gateway_cloud_only`.

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -313,6 +313,20 @@ A passing run proves the configured provider returns a `[[audio_as_voice]]`
 media tag and real mono 48 kHz Ogg/Opus audio suitable for WhatsApp voice-note
 delivery.
 
+For a single local preflight that uses an isolated Hermes home and leaves the
+live gateway untouched, run:
+
+```bash
+scripts/verify_voice_local_stack.py \
+  --voice-bin /path/to/voice \
+  --voice-repo /path/to/voice
+```
+
+That aggregate check starts the local Hermes CLI, verifies command-provider
+Ogg/Opus output, verifies the raw `voice stream` PCM contract, and then runs
+the full-duplex sidecar smoke from the `voice` checkout. Pass
+`--skip-full-duplex` when the WebRTC sidecar dependencies are not installed yet.
+
 You can check whether the gateway found ffmpeg via the health endpoint:
 
 ```bash

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -448,16 +448,18 @@ live-call WAV segments.
 The JSON plan also includes `verify_commands.local_stack`,
 `verify_commands.live_gateway`, `verify_commands.live_gateway_cloud_only`, and
 `verify_commands.live_gateway_cloud_ready`. Run the emitted `local_stack`
-command before changing the live service, then run `live_gateway` after
-restart. Use the `cloud_only` variant when this host does not run the local
-Baileys bridge. Use the `cloud_ready` variant before routing real Meta
-webhooks to the host; it checks WhatsApp Cloud credential shape and recipient
-authorization, then probes the running local Cloud `/health` endpoint and local
-Meta subscription challenge handshake. It also sends a signed synthetic
-delivery-receipt POST to prove inbound HMAC verification accepts Meta-shaped
-webhook delivery without dispatching an agent message or printing secret
-values. If setup is incomplete, it reports every missing or malformed Cloud
-setting it can detect in one redacted failure.
+command before changing the live service; it includes an isolated Cloud webhook
+smoke that starts the adapter locally, checks `/health`, verifies the
+subscription challenge, and accepts a signed status-only POST without contacting
+Meta. Then run `live_gateway` after restart. Use the `cloud_only` variant when
+this host does not run the local Baileys bridge. Use the `cloud_ready` variant
+before routing real Meta webhooks to the host; it checks WhatsApp Cloud
+credential shape and recipient authorization, then probes the running local
+Cloud `/health` endpoint and local Meta subscription challenge handshake. It
+also sends a signed synthetic delivery-receipt POST to prove inbound HMAC
+verification accepts Meta-shaped webhook delivery without dispatching an agent
+message or printing secret values. If setup is incomplete, it reports every
+missing or malformed Cloud setting it can detect in one redacted failure.
 
 The generated service files should look like this:
 

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -339,13 +339,15 @@ scripts/verify_voice_live_gateway.py \
   --live-hermes-root /path/to/hermes-agent \
   --python-bin ~/.hermes/hermes-agent/venv/bin/python \
   --hermes-home ~/.hermes \
+  --calling-sidecar-url http://127.0.0.1:8787 \
   --skip-bridge-health \
   --run-tts-smoke
 ```
 
 That live check inspects the systemd user service, verifies the running process
-environment, confirms imports resolve from the expected checkout, and can run
-one live-config TTS smoke that must produce mono 48 kHz Ogg/Opus. Omit
+environment, confirms imports resolve from the expected checkout, validates the
+configured Calling sidecar `/contract` and `/health`, and can run one
+live-config TTS smoke that must produce mono 48 kHz Ogg/Opus. Omit
 `--skip-bridge-health` when the Baileys WhatsApp bridge is also enabled and you
 want the verifier to require the local bridge `/health` endpoint to be
 connected.
@@ -381,6 +383,43 @@ For low-latency outbound speech, add a command that writes headerless `pcm_s16le
 ```bash
 WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND='voice stream --quiet --sample-rate {sample_rate} --frame-ms {frame_ms} --raw-output - --input-file {input_path}'
 WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT=180
+```
+
+For a local user-service deployment, run the sidecar on loopback and expose the
+same values to `hermes-gateway.service`:
+
+```ini
+# ~/.config/systemd/user/voice-webrtc-sidecar.service
+[Unit]
+Description=Voice WebRTC Sidecar
+After=network.target voice-daemon.service
+
+[Service]
+Type=simple
+WorkingDirectory=/path/to/voice
+Environment="VOICE_BIN=/path/to/voice"
+ExecStart=/tmp/voice-webrtc-venv/bin/python /path/to/voice/examples/webrtc-sidecar/sidecar.py --host 127.0.0.1 --port 8787 --rx-pcm %h/.hermes/voice-webrtc-sidecar/inbound.s16le --log-level INFO
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=default.target
+```
+
+```ini
+# ~/.config/systemd/user/hermes-gateway.service.d/voice-stack.conf
+[Service]
+Environment="WHATSAPP_CLOUD_CALLING_SIDECAR_URL=http://127.0.0.1:8787"
+Environment="WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND=/path/to/voice stream --quiet --sample-rate {sample_rate} --frame-ms {frame_ms} --raw-output - --input-file {input_path} --voice af_heart --speed 1.0"
+Environment="WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT=180"
+```
+
+Then reload and restart:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now voice-webrtc-sidecar.service
+systemctl --user restart hermes-gateway.service
 ```
 
 Validate the installed command shape before a live call:

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -509,7 +509,9 @@ one `voice stream` utterance through a local WebRTC peer into the sidecar,
 drains the decoded PCM through `voice stream-transcribe`, and simultaneously
 queues outbound `voice stream` PCM back to the same peer. A passing run proves
 the sidecar, PCM contract, inbound STT bridge, and outbound TTS bridge agree
-before a real WhatsApp call is attempted.
+before a real WhatsApp call is attempted. It also enforces a default one-second
+outbound sidecar queue budget; adjust it with `--max-queued-tx-ms` on the
+wrapper or `--full-duplex-max-queued-tx-ms` on the aggregate verifier.
 
 To validate just the Cloud Calling control plane without sidecar media
 dependencies, run:

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -390,7 +390,7 @@ The Cloud API's live calling surface is a WebRTC media path, not a file-upload p
 5. The sidecar bridges WebRTC RTP audio to local 48 kHz, mono, 20 ms `pcm_s16le` frames.
 6. Hermes drains inbound PCM from the sidecar, writes utterance WAV segments for the existing STT path, and sends outbound TTS frames back to the sidecar.
 
-The sidecar contract is identified as `voice.webrtc_sidecar`. Hermes fetches `GET /contract` when available and uses its endpoint paths and audio fields; older sidecars can omit `/contract` and use the legacy `/offer`, `/calls/{call_id}/audio`, and `/calls/{call_id}/close` paths.
+The sidecar contract is identified as `voice.webrtc_sidecar`. Hermes fetches `GET /contract` when available and uses its endpoint paths and audio fields; older sidecars can omit `/contract` and use the legacy `/offer`, `/calls/{call_id}/audio`, and `/calls/{call_id}/close` paths. When a newer sidecar advertises `clear_audio`, Hermes calls that endpoint at the start of a detected inbound speech segment so barge-in can discard stale queued outbound TTS without closing the call.
 
 Minimal config:
 

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -41,7 +41,7 @@ The rest of this page is the manual reference.
 1. **A Meta Business account**.  Create one at [business.facebook.com](https://business.facebook.com/).
 2. **A Meta app with WhatsApp enabled**.  See "Creating the Meta app" below.
 3. **A way to expose a local port to the public internet** with HTTPS.  Cloudflare Tunnel (`cloudflared`) is recommended — free, no port forwarding, no domain required.  ngrok, your own domain with a reverse proxy + TLS, or a VPS with the gateway directly bound to a public IP all work too.
-4. **Optional but recommended**: ffmpeg on `PATH` so outbound voice messages render as native WhatsApp voice-note bubbles (green waveform) instead of MP3 audio attachments. Hermes degrades gracefully if absent.
+4. **Optional for MP3/WAV providers**: ffmpeg on `PATH` lets Hermes convert non-Opus TTS output into native WhatsApp voice-note bubbles (green waveform). Command providers that emit Ogg/Opus directly do not need ffmpeg for outbound voice messages.
 
 ---
 
@@ -254,7 +254,7 @@ You can have **both** the Baileys (`whatsapp`) and Cloud (`whatsapp_cloud`) adap
 
 - **Text** — markdown is auto-converted to WhatsApp's flavored syntax (`**bold**` → `*bold*`, `~~strike~~` → `~strike~`, headers → bold, `[link](url)` → `link (url)`). Long messages split at 4096 chars per chunk.
 - **Images** — agent-generated images and local image files both supported, delivered as native photo attachments.
-- **Voice messages** — text-to-speech output is converted via ffmpeg into the native WhatsApp voice-note bubble (green waveform). Without ffmpeg installed, falls back to an MP3 audio attachment. See "Voice messages" below.
+- **Voice messages** — text-to-speech output can be sent directly as Ogg/Opus for native WhatsApp voice-note bubbles (green waveform). MP3/WAV output uses ffmpeg conversion when available and otherwise falls back to a regular audio attachment. See "Voice messages" below.
 - **Video / documents** — both supported, sent as native attachments.
 
 ### Interactive UX

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -336,6 +336,12 @@ WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_COMMAND='voice stream --quiet --sample
 WHATSAPP_CLOUD_CALLING_SIDECAR_TTS_STREAM_TIMEOUT=180
 ```
 
+Validate the installed command shape before a live call:
+
+```bash
+scripts/verify_voice_stream_tts.py --voice-bin /path/to/voice
+```
+
 Supported stream-command placeholders:
 
 | Placeholder | Meaning |

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -348,10 +348,16 @@ scripts/verify_voice_live_gateway.py \
   --live-hermes-root /path/to/hermes-agent \
   --python-bin ~/.hermes/hermes-agent/venv/bin/python \
   --hermes-home ~/.hermes \
+  --voice-bin /path/to/voice \
   --calling-sidecar-url http://127.0.0.1:8787 \
   --skip-bridge-health \
   --run-tts-smoke
 ```
+
+When `--voice-bin` is passed with `--calling-sidecar-url`, the live verifier
+also compares the running sidecar `/contract` with `voice stream-contract` so
+PCM shape, endpoint paths, payload definitions, and advertised `voice`
+surfaces cannot drift silently.
 
 That live check inspects the systemd user service, verifies the running process
 environment, confirms imports resolve from the expected checkout, validates the

--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -367,9 +367,12 @@ scripts/verify_voice_stream_tts.py --voice-bin /path/to/voice
 ```
 
 The verifier reads `/path/to/voice stream-contract`, validates the advertised
-`raw_outbound_pcm` / `raw_inbound_pcm` `voice_surfaces`, then runs the rendered
-stream command and checks stdout for non-silent 48 kHz mono 20 ms `pcm_s16le`
-frames.
+`streamed_voice_note`, `raw_outbound_pcm`, and `raw_inbound_pcm`
+`voice_surfaces`, then runs the rendered stream command and checks stdout for
+non-silent 48 kHz mono 20 ms `pcm_s16le` frames. It also runs
+`voice stream --output ... --format ogg-opus` and verifies the streamed file is
+real mono 48 kHz Ogg/Opus, so the low-latency daemon frame path and completed
+voice-note path are both covered without a WAV intermediate.
 
 Then validate the local WebRTC media bridge from a `voice` checkout before
 involving Meta's Graph API:

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -200,6 +200,17 @@ tts:
 
 With that shape Hermes asks `voice` for `.ogg` output up front, and the bridge sends it as a native voice note without a WAV or MP3 intermediate.
 
+To prove the local bridge behavior before sending a real message, run the local
+voice stack preflight from a Hermes checkout. It includes the Baileys bridge
+media-payload test that keeps `.ogg` / `.opus` audio as
+`audio/ogg; codecs=opus` with `ptt: true`.
+
+```bash
+scripts/verify_voice_local_stack.py \
+  --voice-bin /path/to/voice \
+  --voice-repo /path/to/voice
+```
+
 After installing a local gateway service, verify the running process is using
 the expected voice-native checkout before relying on WhatsApp delivery:
 

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -200,6 +200,41 @@ tts:
 
 With that shape Hermes asks `voice` for `.ogg` output up front, and the bridge sends it as a native voice note without a WAV or MP3 intermediate.
 
+After installing a local gateway service, verify the running process is using
+the expected voice-native checkout before relying on WhatsApp delivery:
+
+```bash
+scripts/verify_voice_live_gateway.py \
+  --live-hermes-root /path/to/hermes-agent \
+  --python-bin ~/.hermes/hermes-agent/venv/bin/python \
+  --hermes-home ~/.hermes \
+  --run-tts-smoke
+```
+
+The live verifier checks the systemd user service, confirms `PYTHONPATH` points
+at the expected checkout, confirms imports resolve from that checkout, checks
+the local bridge `/health` endpoint, and optionally generates one real
+WhatsApp-ready Ogg/Opus TTS file from the live config.
+
+For a temporary checkout-based deployment, add a systemd user-service drop-in
+that points the gateway at that checkout, then restart:
+
+```ini
+# ~/.config/systemd/user/hermes-gateway.service.d/voice-stack.conf
+[Service]
+Environment="PYTHONPATH=/path/to/hermes-agent"
+Environment="PATH=/path/to/hermes-agent/scripts/whatsapp-bridge/node_modules/.bin:/usr/bin:/home/you/.local/bin:/home/you/.cargo/bin:/usr/local/bin:/bin"
+```
+
+```bash
+systemctl --user daemon-reload
+systemctl --user restart hermes-gateway.service
+```
+
+Rollback is removing that drop-in, reloading systemd, and restarting the
+gateway. Run `verify_voice_live_gateway.py` after either deploy or rollback so
+you know which checkout the live process imported.
+
 ---
 
 ## Message Formatting & Delivery

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -172,7 +172,7 @@ with reconnection logic.
 Hermes supports voice on WhatsApp:
 
 - **Incoming:** Voice messages (`.ogg` opus) are automatically transcribed using the configured STT provider: local `faster-whisper`, Groq Whisper (`GROQ_API_KEY`), or OpenAI Whisper (`VOICE_TOOLS_OPENAI_KEY`)
-- **Outgoing:** TTS responses are sent as MP3 audio file attachments
+- **Outgoing:** TTS responses can be sent as native WhatsApp voice notes when the audio is Ogg/Opus. The bridge sends `.ogg` / `.opus` files with `ptt: true`; MP3/WAV outputs are converted with ffmpeg when possible and otherwise fall back to regular audio attachments.
 - Agent responses are prefixed with "⚕ **Hermes Agent**" by default. You can customize or disable this in `config.yaml`:
 
 ```yaml
@@ -181,6 +181,24 @@ whatsapp:
   reply_prefix: ""                          # Empty string disables the header
   # reply_prefix: "🤖 *My Bot*\n──────\n"  # Custom prefix (supports \n for newlines)
 ```
+
+For a local `voice` / Kokoro setup that writes WhatsApp-ready Ogg/Opus directly, configure a command TTS provider like this:
+
+```yaml
+tts:
+  provider: kokoro
+  providers:
+    kokoro:
+      type: command
+      command: /home/you/.local/bin/voice say --format ogg-opus --input-file {input_path} --output {output_path} --voice {voice} --speed {speed}
+      output_format: ogg
+      voice_compatible: true
+      voice: af_heart
+      speed: 1.0
+      timeout: 180
+```
+
+With that shape Hermes asks `voice` for `.ogg` output up front, and the bridge sends it as a native voice note without a WAV or MP3 intermediate.
 
 ---
 


### PR DESCRIPTION
## Summary

This combines the two voice-native WhatsApp branches into one integration PR:

- #45800: direct WhatsApp Ogg/Opus voice-note routing and Baileys media-payload hardening
- #45863: WhatsApp Cloud Calling sidecar client, voice stream contract validation, local/live verifiers, and docs

The branch is based on the current upstream `main` and excludes the unrelated live-machine Tirith allowlist preservation commit that exists only on the local deployment branch.

## Why combine

The voice-note and calling work are logically separable, but they now share the same operational goal: Hermes should consume `voice` outputs directly for WhatsApp voice notes today and use the same PCM/Opus contract for WebRTC-style calls later. The local machine is already running a combined checkout and the combined verifier path has passed.

## Validation

- `.venv/bin/python -m py_compile gateway/platforms/whatsapp_cloud.py tools/tts_tool.py scripts/verify_voice_command_tts.py scripts/verify_voice_stream_tts.py scripts/verify_voice_full_duplex_sidecar.py scripts/verify_voice_local_stack.py scripts/verify_voice_live_gateway.py tests/gateway/test_whatsapp_cloud.py tests/tools/test_tts_opus_routing.py tests/tools/test_verify_voice_command_tts_script.py tests/tools/test_verify_voice_stream_tts_script.py tests/tools/test_verify_voice_full_duplex_sidecar_script.py tests/tools/test_verify_voice_local_stack_script.py tests/tools/test_verify_voice_live_gateway_script.py`
- `.venv/bin/python -m ruff check gateway/platforms/whatsapp_cloud.py tools/tts_tool.py scripts/verify_voice_command_tts.py scripts/verify_voice_stream_tts.py scripts/verify_voice_full_duplex_sidecar.py scripts/verify_voice_local_stack.py scripts/verify_voice_live_gateway.py tests/gateway/test_whatsapp_cloud.py tests/tools/test_tts_opus_routing.py tests/tools/test_verify_voice_command_tts_script.py tests/tools/test_verify_voice_stream_tts_script.py tests/tools/test_verify_voice_full_duplex_sidecar_script.py tests/tools/test_verify_voice_local_stack_script.py tests/tools/test_verify_voice_live_gateway_script.py`
- `node --test scripts/whatsapp-bridge/media-payload.test.mjs scripts/whatsapp-bridge/allowlist.test.mjs` -> 10 passed
- `PYTHONPATH=. .venv/bin/python -m pytest -q tests/tools/test_tts_opus_routing.py tests/gateway/test_whatsapp_cloud.py tests/tools/test_verify_voice_command_tts_script.py tests/tools/test_verify_voice_stream_tts_script.py tests/tools/test_verify_voice_full_duplex_sidecar_script.py tests/tools/test_verify_voice_local_stack_script.py tests/tools/test_verify_voice_live_gateway_script.py` -> 211 passed
- `.venv/bin/python scripts/verify_voice_local_stack.py --live-hermes-root /home/ubuntu/.hermes/hermes-agent-voice-stack --voice-bin /home/ubuntu/.local/bin/voice --hermes-bin /home/ubuntu/.local/bin/hermes --voice-repo /home/ubuntu/projects/rgbkrk-voice --webrtc-python-bin /tmp/voice-webrtc-venv/bin/python` -> passed, including command-provider Ogg/Opus, raw PCM stream TTS, streamed Ogg/Opus, and full-duplex WebRTC sidecar loopback.
