### PR TITLE
fix: configure skill description truncation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -890,7 +890,8 @@ violate them.
    attention when many skills are loaded. State the capability, not
    the implementation. No marketing words ("powerful",
    "comprehensive", "seamless", "advanced"). Don't repeat the skill
-   name. Verify with:
+   name. `skills.description_max_length` may shorten prompt-index entries,
+   but it never relaxes this authoring limit. Verify with:
    ```python
    import re, pathlib
    m = re.search(r'^description: (.*)$',

--- a/agent/learn_prompt.py
+++ b/agent/learn_prompt.py
@@ -41,7 +41,9 @@ Frontmatter:
   skill index truncates the description to 60 chars and loads it every
   session, so anything past char 60 is silently cut and never routes. After
   you write the description, COUNT the characters; if it is over 60, cut it
-  down before saving — do not ship a sentence and hope.
+  down before saving — do not ship a sentence and hope. The optional
+  `skills.description_max_length` setting can shorten prompt-index entries;
+  it never permits descriptions longer than 60 characters.
     Good (<=60): `Search arXiv papers by keyword, author, or ID.`
     Bad (123):   `A comprehensive skill that lets the agent search arXiv for
                   academic papers using keywords, authors, and categories.`

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -24,6 +24,7 @@ from agent.skill_utils import (
     extract_skill_description,
     get_all_skills_dirs,
     get_disabled_skill_names,
+    get_skill_description_truncation_config,
     iter_skill_index_files,
     parse_frontmatter,
     skill_matches_environment,
@@ -1263,7 +1264,7 @@ def drain_truncation_warnings() -> list:
 _SKILLS_PROMPT_CACHE_MAX = 8
 _SKILLS_PROMPT_CACHE: OrderedDict[tuple, str] = OrderedDict()
 _SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
-_SKILLS_SNAPSHOT_VERSION = 1
+_SKILLS_SNAPSHOT_VERSION = 2
 
 
 def _skills_prompt_snapshot_path() -> Path:
@@ -1307,7 +1308,10 @@ def _build_skills_manifest(skills_dir: Path) -> dict[str, list[int]]:
     return manifest
 
 
-def _load_skills_snapshot(skills_dir: Path) -> Optional[dict]:
+def _load_skills_snapshot(
+    skills_dir: Path,
+    description_config: tuple[int, str],
+) -> Optional[dict]:
     """Load the disk snapshot if it exists and its manifest still matches."""
     snapshot_path = _skills_prompt_snapshot_path()
     if not snapshot_path.exists():
@@ -1320,6 +1324,8 @@ def _load_skills_snapshot(skills_dir: Path) -> Optional[dict]:
         return None
     if snapshot.get("version") != _SKILLS_SNAPSHOT_VERSION:
         return None
+    if snapshot.get("description_config") != list(description_config):
+        return None
     if snapshot.get("manifest") != _build_skills_manifest(skills_dir):
         return None
     return snapshot
@@ -1330,11 +1336,13 @@ def _write_skills_snapshot(
     manifest: dict[str, list[int]],
     skill_entries: list[dict],
     category_descriptions: dict[str, str],
+    description_config: tuple[int, str],
 ) -> None:
     """Persist skill metadata to disk for fast cold-start reuse."""
     payload = {
         "version": _SKILLS_SNAPSHOT_VERSION,
         "manifest": manifest,
+        "description_config": list(description_config),
         "skills": skill_entries,
         "category_descriptions": category_descriptions,
     }
@@ -1487,6 +1495,7 @@ def build_skills_system_prompt(
     # produce distinct cache entries (gateway serves multiple platforms).
     _platform_hint = _current_session_platform_hint()
     disabled = get_disabled_skill_names(_platform_hint or None)
+    description_config = get_skill_description_truncation_config()
     cache_key = (
         str(skills_dir),
         tuple(str(d) for d in external_dirs),
@@ -1495,6 +1504,7 @@ def build_skills_system_prompt(
         _platform_hint,
         tuple(sorted(disabled)),
         tuple(sorted(compact_categories or ())),
+        description_config,
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -1503,7 +1513,7 @@ def build_skills_system_prompt(
             return cached
 
     # ── Layer 2: disk snapshot ────────────────────────────────────────
-    snapshot = _load_skills_snapshot(skills_dir)
+    snapshot = _load_skills_snapshot(skills_dir, description_config)
 
     skills_by_category: dict[str, list[tuple[str, str]]] = {}
     category_descriptions: dict[str, str] = {}
@@ -1575,6 +1585,7 @@ def build_skills_system_prompt(
             _build_skills_manifest(skills_dir),
             skill_entries,
             category_descriptions,
+            description_config,
         )
 
     # ── External skill directories ─────────────────────────────────────

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -767,16 +767,68 @@ def resolve_skill_config_values(
 
 # ── Description extraction ────────────────────────────────────────────────
 
+DEFAULT_SKILL_DESCRIPTION_MAX_LENGTH = 60
+DEFAULT_SKILL_DESCRIPTION_TRUNCATION_SUFFIX = "..."
+
+def _coerce_description_max_length(value: Any) -> int:
+    if isinstance(value, bool):
+        return DEFAULT_SKILL_DESCRIPTION_MAX_LENGTH
+    try:
+        limit = int(value)
+    except (TypeError, ValueError):
+        return DEFAULT_SKILL_DESCRIPTION_MAX_LENGTH
+    if limit <= 0:
+        return DEFAULT_SKILL_DESCRIPTION_MAX_LENGTH
+    return min(limit, DEFAULT_SKILL_DESCRIPTION_MAX_LENGTH)
+
+
+def get_skill_description_truncation_config() -> Tuple[int, str]:
+    """Return the prompt-index description cap and truncation suffix.
+
+    The setting can reduce prompt usage but cannot relax the 60-character
+    skill-authoring contract. Raw config parsing shares this module's existing
+    mtime-aware cache with the other skill settings.
+    """
+    parsed = _load_raw_config()
+    skills_cfg = parsed.get("skills") if isinstance(parsed, dict) else None
+    if not isinstance(skills_cfg, dict):
+        return (
+            DEFAULT_SKILL_DESCRIPTION_MAX_LENGTH,
+            DEFAULT_SKILL_DESCRIPTION_TRUNCATION_SUFFIX,
+        )
+    return (
+        _coerce_description_max_length(
+            skills_cfg.get(
+                "description_max_length",
+                DEFAULT_SKILL_DESCRIPTION_MAX_LENGTH,
+            )
+        ),
+        str(
+            skills_cfg.get(
+                "description_truncation_suffix",
+                DEFAULT_SKILL_DESCRIPTION_TRUNCATION_SUFFIX,
+            )
+            or ""
+        ),
+    )
+
+
+def _truncate_skill_description(desc: str, max_length: int, suffix: str) -> str:
+    if len(desc) <= max_length:
+        return desc
+    if not suffix or len(suffix) >= max_length:
+        return desc[:max_length]
+    return desc[: max_length - len(suffix)] + suffix
+
 
 def extract_skill_description(frontmatter: Dict[str, Any]) -> str:
-    """Extract a truncated description from parsed frontmatter."""
+    """Extract a configured-length description from parsed frontmatter."""
     raw_desc = frontmatter.get("description", "")
     if not raw_desc:
         return ""
     desc = str(raw_desc).strip().strip("'\"")
-    if len(desc) > 60:
-        return desc[:57] + "..."
-    return desc
+    max_length, suffix = get_skill_description_truncation_config()
+    return _truncate_skill_description(desc, max_length, suffix)
 
 
 # ── File iteration ────────────────────────────────────────────────────────

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2350,6 +2350,11 @@ DEFAULT_CONFIG = {
     # always goes to ~/.hermes/skills/.
     "skills": {
         "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
+        # Skill frontmatter descriptions shown in the prompt skill index.
+        # This prompt-budget setting may shorten, but never exceed, the
+        # 60-character skill-authoring contract.
+        "description_max_length": 60,
+        "description_truncation_suffix": "...",
         # Substitute ${HERMES_SKILL_DIR} and ${HERMES_SESSION_ID} in SKILL.md
         # content with the absolute skill directory and the active session id
         # before the agent sees it.  Lets skill authors reference bundled

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -706,6 +706,17 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "description": "Context management engine",
         "options": ["default", "custom"],
     },
+    "skills.description_max_length": {
+        "type": "number",
+        "description": (
+            "Maximum characters from each skill description shown in the prompt "
+            "skill index (1-60; larger values are capped at 60)."
+        ),
+    },
+    "skills.description_truncation_suffix": {
+        "type": "string",
+        "description": "Suffix appended when a skill description is truncated.",
+    },
     "human_delay.mode": {
         "type": "select",
         "description": "Simulated typing delay mode",

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -415,6 +415,50 @@ class TestBuildSkillsSystemPrompt:
         assert "Debug Python scripts" in result
         assert "available_skills" in result
 
+    def test_description_config_invalidates_prompt_cache_and_snapshot(
+        self,
+        monkeypatch,
+        tmp_path,
+    ):
+        import json
+        import os
+
+        from agent import skill_utils
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "coding" / "long-description"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: long-description\ndescription: " + ("x" * 55) + "\n---\n",
+            encoding="utf-8",
+        )
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "skills:\n  description_max_length: 20\n",
+            encoding="utf-8",
+        )
+        skill_utils._raw_config_cache_clear()
+
+        first = build_skills_system_prompt()
+        snapshot_path = tmp_path / ".skills_prompt_snapshot.json"
+        first_snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+
+        assert ("x" * 17) + "..." in first
+        assert first_snapshot["description_config"] == [20, "..."]
+
+        previous_mtime = config_path.stat().st_mtime_ns
+        config_path.write_text(
+            "skills:\n  description_max_length: 40\n",
+            encoding="utf-8",
+        )
+        os.utime(config_path, ns=(previous_mtime + 1_000_000, previous_mtime + 1_000_000))
+
+        second = build_skills_system_prompt()
+        second_snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+
+        assert ("x" * 37) + "..." in second
+        assert second_snapshot["description_config"] == [40, "..."]
+
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         cat_dir = tmp_path / "skills" / "tools"
@@ -1651,5 +1695,4 @@ class TestParallelToolCallGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
 

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from agent.skill_utils import (
     extract_skill_conditions,
+    extract_skill_description,
     get_disabled_skill_names,
     get_external_skills_dirs,
     is_excluded_skill_path,
@@ -237,6 +238,75 @@ def test_iter_skill_index_files_keeps_support_named_categories(tmp_path):
     assert found == [scripts_skill / "SKILL.md", templates_skill / "SKILL.md"]
     assert is_skill_support_path(scripts_skill / "SKILL.md") is False
     assert is_excluded_skill_path(scripts_skill / "SKILL.md") is False
+
+
+def test_extract_skill_description_uses_default_limit(tmp_path, monkeypatch):
+    from agent import skill_utils
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    skill_utils._raw_config_cache_clear()
+    desc = "x" * 80
+
+    assert extract_skill_description({"description": desc}) == ("x" * 57) + "..."
+
+
+def test_extract_skill_description_uses_configured_limit(tmp_path, monkeypatch):
+    from agent import skill_utils
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "skills:\n"
+        "  description_max_length: 20\n",
+        encoding="utf-8",
+    )
+    skill_utils._raw_config_cache_clear()
+
+    assert extract_skill_description({"description": "abcdefghij" * 4}) == "abcdefghijabcdefg..."
+
+
+def test_extract_skill_description_uses_configured_suffix(tmp_path, monkeypatch):
+    from agent import skill_utils
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "skills:\n"
+        "  description_max_length: 12\n"
+        "  description_truncation_suffix: \" [more]\"\n",
+        encoding="utf-8",
+    )
+    skill_utils._raw_config_cache_clear()
+
+    assert extract_skill_description({"description": "abcdefghijklmnop"}) == "abcde [more]"
+
+
+def test_extract_skill_description_caps_config_at_authoring_limit(tmp_path, monkeypatch):
+    from agent import skill_utils
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "skills:\n"
+        "  description_max_length: 200\n",
+        encoding="utf-8",
+    )
+    skill_utils._raw_config_cache_clear()
+    desc = "x" * 200
+
+    assert extract_skill_description({"description": desc}) == ("x" * 57) + "..."
+
+
+def test_extract_skill_description_rejects_non_positive_limit(tmp_path, monkeypatch):
+    from agent import skill_utils
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text(
+        "skills:\n"
+        "  description_max_length: 0\n",
+        encoding="utf-8",
+    )
+    skill_utils._raw_config_cache_clear()
+    desc = "x" * 80
+
+    assert extract_skill_description({"description": desc}) == ("x" * 57) + "..."
 
 
 # ── skill_matches_platform on Termux ──────────────────────────────────────

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3776,6 +3776,18 @@ class TestBuildSchemaFromConfig:
         for cat, count in cats.items():
             assert count >= 2, f"Category '{cat}' has only {count} field(s) — should be merged"
 
+    def test_skill_description_truncation_config_in_schema(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+        from hermes_cli.web_server import CONFIG_SCHEMA
+
+        skills_cfg = DEFAULT_CONFIG["skills"]
+        assert skills_cfg["description_max_length"] == 60
+        assert skills_cfg["description_truncation_suffix"] == "..."
+        assert CONFIG_SCHEMA["skills.description_max_length"]["type"] == "number"
+        assert CONFIG_SCHEMA["skills.description_max_length"]["category"] == "agent"
+        assert CONFIG_SCHEMA["skills.description_truncation_suffix"]["type"] == "string"
+        assert CONFIG_SCHEMA["skills.description_truncation_suffix"]["category"] == "agent"
+
 
 # ---------------------------------------------------------------------------
 # Config round-trip tests


### PR DESCRIPTION
Summary:
- Add skills.description_max_length and skills.description_truncation_suffix config keys.
- Make the prompt skill-description extraction honor those keys while keeping the default 60-character behavior.
- Cache parsed truncation settings by config file mtime/size so scanning many skills does not reparse config repeatedly.

Tests:
- $HOME/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_skill_utils.py tests/hermes_cli/test_web_server.py::TestBuildSchemaFromConfig::test_skill_description_truncation_config_in_schema -q
- $HOME/.hermes/hermes-agent/venv/bin/python -m ruff check agent/skill_utils.py hermes_cli/config.py hermes_cli/web_server.py tests/agent/test_skill_utils.py tests/hermes_cli/test_web_server.py

Fixes #46024