### PR TITLE
fix(bedrock): honor explicit converse mode for Claude

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1675,10 +1675,17 @@ def resolve_runtime_provider(
             if _gr.get("trace"):
                 guardrail_config["trace"] = _gr["trace"]
         # Dual-path routing: Claude models use AnthropicBedrock SDK for full
-        # feature parity (prompt caching, thinking budgets, adaptive thinking).
-        # Non-Claude models use the Converse API for multi-model support.
+        # feature parity (prompt caching, thinking budgets, adaptive thinking)
+        # unless the user explicitly configured model.api_mode=bedrock_converse.
+        # That explicit escape hatch is required for Bedrock API-key / bearer
+        # token auth (AWS_BEARER_TOKEN_BEDROCK), which botocore supports but
+        # AnthropicBedrock currently does not resolve from the boto3 token
+        # provider chain. Non-Claude models use the Converse API for
+        # multi-model support.
         _current_model = str(model_cfg.get("default") or "").strip()
-        if is_anthropic_bedrock_model(_current_model):
+        configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
+        force_converse = configured_mode == "bedrock_converse"
+        if is_anthropic_bedrock_model(_current_model) and not force_converse:
             # Claude on Bedrock → AnthropicBedrock SDK → anthropic_messages path
             runtime = {
                 "provider": "bedrock",

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -173,6 +173,54 @@ def test_resolve_runtime_provider_qwen_oauth(monkeypatch):
     assert resolved["requested_provider"] == "qwen-oauth"
 
 
+def test_resolve_runtime_provider_bedrock_claude_honors_explicit_converse(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "bedrock")
+    monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "bedrock",
+            "default": "us.anthropic.claude-opus-4-7",
+            "api_mode": "bedrock_converse",
+        },
+    )
+    monkeypatch.setattr("agent.bedrock_adapter.resolve_bedrock_region", lambda: "us-east-1")
+    monkeypatch.setattr(
+        "agent.bedrock_adapter.resolve_aws_auth_env_var",
+        lambda: "AWS_BEARER_TOKEN_BEDROCK",
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="bedrock")
+
+    assert resolved["provider"] == "bedrock"
+    assert resolved["api_mode"] == "bedrock_converse"
+    assert resolved["base_url"] == "https://bedrock-runtime.us-east-1.amazonaws.com"
+    assert resolved["source"] == "AWS_BEARER_TOKEN_BEDROCK"
+    assert "bedrock_anthropic" not in resolved
+
+
+def test_resolve_runtime_provider_bedrock_claude_defaults_to_anthropic_sdk(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "bedrock")
+    monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "bedrock",
+            "default": "us.anthropic.claude-opus-4-7",
+        },
+    )
+    monkeypatch.setattr("agent.bedrock_adapter.resolve_bedrock_region", lambda: "us-east-1")
+    monkeypatch.setattr("agent.bedrock_adapter.resolve_aws_auth_env_var", lambda: "aws-sdk-default-chain")
+
+    resolved = rp.resolve_runtime_provider(requested="bedrock")
+
+    assert resolved["provider"] == "bedrock"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["bedrock_anthropic"] is True
+
+
 def test_resolve_runtime_provider_uses_qwen_pool_entry(monkeypatch):
     class _Entry:
         access_token = "pool-qwen-token"


### PR DESCRIPTION
## Summary
- honor explicit `model.api_mode: bedrock_converse` for Claude models on Bedrock
- keep the existing AnthropicBedrock SDK default when no explicit Converse mode is configured
- add runtime-provider regression tests for both paths

## Test Plan
- `uv run --extra dev pytest tests/hermes_cli/test_runtime_provider_resolution.py -q`
- `clod -z 'Reply exactly: OK'`