### PR TITLE
feat(tools): add validated feishu_request Open API gateway

### DIFF
--- a/plugins/platforms/feishu/feishu_comment.py
+++ b/plugins/platforms/feishu/feishu_comment.py
@@ -1057,8 +1057,10 @@ def _run_comment_agent(prompt: str, client: Any, session_key: str = "") -> str:
     logger.info("[Feishu-Comment] _run_comment_agent: injecting lark client into tool thread-locals")
     from tools.feishu_doc_tool import set_client as set_doc_client
     from tools.feishu_drive_tool import set_client as set_drive_client
+    from tools.feishu_request_tool import set_client as set_request_client
     set_doc_client(client)
     set_drive_client(client)
+    set_request_client(client)
 
     try:
         model, runtime_kwargs = _resolve_model_and_runtime()
@@ -1105,6 +1107,7 @@ def _run_comment_agent(prompt: str, client: Any, session_key: str = "") -> str:
     finally:
         set_doc_client(None)
         set_drive_client(None)
+        set_request_client(None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_feishu_request_tool.py
+++ b/tests/tools/test_feishu_request_tool.py
@@ -1,0 +1,180 @@
+"""Tests for feishu_request_tool -- endpoint validation ("navigation map")."""
+
+import importlib
+import json
+import unittest
+
+from tools.registry import registry
+
+importlib.import_module("tools.feishu_request_tool")
+from tools.feishu_request_tool import (  # noqa: E402
+    _handle_feishu_request,
+    set_client,
+    validate_endpoint,
+)
+
+
+class TestEndpointValidation(unittest.TestCase):
+    """The map accepts known-good paths and rejects guessed ones."""
+
+    def test_list_folder_correct_query_form_is_valid(self):
+        template, paths = validate_endpoint("GET", "/open-apis/drive/v1/files")
+        self.assertEqual(template, "/open-apis/drive/v1/files")
+        self.assertEqual(paths, {})
+
+    def test_list_folder_with_query_string_strips_and_validates(self):
+        template, paths = validate_endpoint(
+            "GET", "/open-apis/drive/v1/files?folder_token=fldcnABC123"
+        )
+        self.assertEqual(template, "/open-apis/drive/v1/files")
+        self.assertEqual(paths, {})
+
+    def test_wrong_children_path_is_rejected_with_suggestion(self):
+        # The exact mistake from the incident.
+        template, suggestions = validate_endpoint(
+            "GET", "/open-apis/drive/v1/files/fldcnK0sP9zb1TejQsaN0S54cHc/children"
+        )
+        self.assertIsNone(template)
+        self.assertIn("/open-apis/drive/v1/files", suggestions)
+
+    def test_token_segment_is_extracted_into_paths(self):
+        template, paths = validate_endpoint(
+            "GET", "/open-apis/drive/v1/files/Lv4SdXIhAou70nxGvwLc/comments"
+        )
+        self.assertEqual(template, "/open-apis/drive/v1/files/:file_token/comments")
+        self.assertEqual(paths, {"file_token": "Lv4SdXIhAou70nxGvwLc"})
+
+    def test_two_token_segments_extracted(self):
+        template, paths = validate_endpoint(
+            "PUT",
+            "/open-apis/bitable/v1/apps/APPTOKEN123456789/tables/tblXYZ/records/recABC",
+        )
+        self.assertEqual(
+            template,
+            "/open-apis/bitable/v1/apps/:app_token/tables/:table_id/records/:record_id",
+        )
+        self.assertEqual(paths["app_token"], "APPTOKEN123456789")
+        self.assertEqual(paths["table_id"], "tblXYZ")
+        self.assertEqual(paths["record_id"], "recABC")
+
+    def test_method_matters(self):
+        # The records collection is GET (list) and POST (create), not DELETE.
+        template, _ = validate_endpoint(
+            "DELETE",
+            "/open-apis/bitable/v1/apps/APPTOKEN123456789/tables/tblXYZ/records",
+        )
+        self.assertIsNone(template)
+
+    def test_unknown_root_returns_suggestions_list(self):
+        template, suggestions = validate_endpoint("GET", "/open-apis/totally/made/up")
+        self.assertIsNone(template)
+        self.assertIsInstance(suggestions, list)
+
+    def test_full_url_is_normalized_and_validated(self):
+        # The agent's actual mistake: pasting a full URL with scheme+host.
+        template, paths = validate_endpoint(
+            "GET", "https://open.feishu.cn/open-apis/drive/v1/files?page_size=50"
+        )
+        self.assertEqual(template, "/open-apis/drive/v1/files")
+        self.assertEqual(paths, {})
+
+    def test_bare_host_url_is_normalized(self):
+        template, _ = validate_endpoint(
+            "GET", "open.feishu.cn/open-apis/drive/v1/files"
+        )
+        self.assertEqual(template, "/open-apis/drive/v1/files")
+
+    def test_static_segment_wins_over_wildcard(self):
+        # create_folder is a literal segment, not a :file_token.
+        template, paths = validate_endpoint(
+            "POST", "/open-apis/drive/v1/files/create_folder"
+        )
+        self.assertEqual(template, "/open-apis/drive/v1/files/create_folder")
+        self.assertEqual(paths, {})
+
+
+class TestHandler(unittest.TestCase):
+    """Handler-level guards that don't need the lark SDK."""
+
+    def tearDown(self):
+        set_client(None)
+
+    def test_missing_args(self):
+        out = json.loads(_handle_feishu_request({"method": "GET"}))
+        self.assertIn("error", out)
+
+    def test_bad_method(self):
+        out = json.loads(
+            _handle_feishu_request({"method": "FETCH", "path": "/open-apis/drive/v1/files"})
+        )
+        self.assertIn("error", out)
+
+    def test_invalid_path_rejected_before_client_lookup(self):
+        # Even with no client set, an invalid path is rejected at validation.
+        out = json.loads(
+            _handle_feishu_request(
+                {"method": "GET", "path": "/open-apis/drive/v1/files/TOKEN123456789/children"}
+            )
+        )
+        self.assertIn("error", out)
+        self.assertIn("valid_suggestions", out)
+
+    def test_valid_path_without_client_reports_client_error(self):
+        # Valid path passes validation, then fails on missing client (not 404).
+        set_client(None)
+        out = json.loads(
+            _handle_feishu_request({"method": "GET", "path": "/open-apis/drive/v1/files"})
+        )
+        self.assertIn("error", out)
+        self.assertIn("client not available", out["error"])
+
+
+class TestToolsetWiring(unittest.TestCase):
+    """feishu_request must be reachable exactly where the lark client is injected.
+
+    resolve_toolset() reads the explicit ``tools`` list for statically-defined
+    toolsets (it does NOT merge registry toolset membership), so the name must
+    appear in toolsets.py to be reachable at all.
+
+    The client is only injected on the comment-agent path (feishu_comment.py),
+    which enables ["feishu_doc", "feishu_drive"]. So the tool belongs in
+    feishu_drive — but NOT in the general hermes-feishu platform set, where no
+    client is injected and the tool would only ever return "client not
+    available". This test locks that placement so the tool is never exposed
+    without a client behind it.
+    """
+
+    def test_resolves_via_feishu_drive(self):
+        from toolsets import resolve_toolset
+        self.assertIn("feishu_request", resolve_toolset("feishu_drive"))
+
+    def test_reachable_by_comment_agent_toolsets(self):
+        from toolsets import resolve_multiple_toolsets
+        self.assertIn(
+            "feishu_request",
+            resolve_multiple_toolsets(["feishu_doc", "feishu_drive"]),
+        )
+
+    def test_not_exposed_on_general_feishu_platform(self):
+        # hermes-feishu has no client injection — must not surface feishu_request.
+        from toolsets import resolve_toolset
+        self.assertNotIn("feishu_request", resolve_toolset("hermes-feishu"))
+
+
+class TestRegistration(unittest.TestCase):
+    def test_registered(self):
+        entry = registry.get_entry("feishu_request")
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry.toolset, "feishu_drive")
+        self.assertTrue(callable(entry.handler))
+
+    def test_schema_shape(self):
+        entry = registry.get_entry("feishu_request")
+        props = entry.schema["parameters"]["properties"]
+        self.assertIn("method", props)
+        self.assertIn("path", props)
+        self.assertEqual(entry.schema["parameters"]["required"], ["method", "path"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_feishu_request_tool.py
+++ b/tests/tools/test_feishu_request_tool.py
@@ -158,6 +158,33 @@ class TestHandler(unittest.TestCase):
         self.assertIn("client not available", out["error"])
 
 
+class TestNoWriteApprovalSurface(unittest.TestCase):
+    """Writes are not admitted — even with a client — so no approval path is needed.
+
+    Hermes' request_tool_approval / send_exec_approval stack is for shell
+    (and plugin escalate / ACP edits / memory write_approval). Platform API
+    mutators (e.g. Discord delete_message) do not use that stack. This tool
+    stays GET-only on the comment-agent path instead of inventing a new
+    Open-API write-approval product.
+    """
+
+    def tearDown(self):
+        set_client(None)
+
+    def test_schema_is_get_only(self):
+        entry = registry.get_entry("feishu_request")
+        self.assertEqual(
+            entry.schema["parameters"]["properties"]["method"]["enum"],
+            ["GET"],
+        )
+
+    def test_allowed_methods_constant_is_get_only(self):
+        from tools.feishu_request_tool import _ALLOWED_METHODS, _FEISHU_ENDPOINTS
+
+        self.assertEqual(_ALLOWED_METHODS, {"GET"})
+        self.assertTrue(all(m == "GET" for m, _ in _FEISHU_ENDPOINTS))
+
+
 class TestFakeClientDispatch(unittest.TestCase):
     """Prove canonical folder-list dispatch and write rejection without HTTP."""
 

--- a/tests/tools/test_feishu_request_tool.py
+++ b/tests/tools/test_feishu_request_tool.py
@@ -44,6 +44,14 @@ class TestEndpointValidation(unittest.TestCase):
         self.assertEqual(template, "/open-apis/drive/v1/files/:file_token/comments")
         self.assertEqual(paths, {"file_token": "Lv4SdXIhAou70nxGvwLc"})
 
+    def test_add_global_comment_official_path(self):
+        # Official docs: POST /open-apis/drive/v1/files/:file_token/comments
+        template, paths = validate_endpoint(
+            "POST", "/open-apis/drive/v1/files/Lv4SdXIhAou70nxGvwLc/comments"
+        )
+        self.assertEqual(template, "/open-apis/drive/v1/files/:file_token/comments")
+        self.assertEqual(paths, {"file_token": "Lv4SdXIhAou70nxGvwLc"})
+
     def test_two_token_segments_extracted(self):
         template, paths = validate_endpoint(
             "PUT",

--- a/tests/tools/test_feishu_request_tool.py
+++ b/tests/tools/test_feishu_request_tool.py
@@ -1,8 +1,9 @@
-"""Tests for feishu_request_tool -- endpoint validation ("navigation map")."""
+"""Tests for feishu_request_tool -- read-only endpoint validation + dispatch."""
 
 import importlib
 import json
 import unittest
+from unittest.mock import patch
 
 from tools.registry import registry
 
@@ -15,7 +16,7 @@ from tools.feishu_request_tool import (  # noqa: E402
 
 
 class TestEndpointValidation(unittest.TestCase):
-    """The map accepts known-good paths and rejects guessed ones."""
+    """The map accepts known-good GET paths and rejects guessed / write ones."""
 
     def test_list_folder_correct_query_form_is_valid(self):
         template, paths = validate_endpoint("GET", "/open-apis/drive/v1/files")
@@ -30,7 +31,7 @@ class TestEndpointValidation(unittest.TestCase):
         self.assertEqual(paths, {})
 
     def test_wrong_children_path_is_rejected_with_suggestion(self):
-        # The exact mistake from the incident.
+        # Exact mistake from the folder-listing incident.
         template, suggestions = validate_endpoint(
             "GET", "/open-apis/drive/v1/files/fldcnK0sP9zb1TejQsaN0S54cHc/children"
         )
@@ -44,34 +45,40 @@ class TestEndpointValidation(unittest.TestCase):
         self.assertEqual(template, "/open-apis/drive/v1/files/:file_token/comments")
         self.assertEqual(paths, {"file_token": "Lv4SdXIhAou70nxGvwLc"})
 
-    def test_add_global_comment_official_path(self):
-        # Official docs: POST /open-apis/drive/v1/files/:file_token/comments
-        template, paths = validate_endpoint(
-            "POST", "/open-apis/drive/v1/files/Lv4SdXIhAou70nxGvwLc/comments"
-        )
-        self.assertEqual(template, "/open-apis/drive/v1/files/:file_token/comments")
-        self.assertEqual(paths, {"file_token": "Lv4SdXIhAou70nxGvwLc"})
-
     def test_two_token_segments_extracted(self):
         template, paths = validate_endpoint(
-            "PUT",
-            "/open-apis/bitable/v1/apps/APPTOKEN123456789/tables/tblXYZ/records/recABC",
+            "GET",
+            "/open-apis/bitable/v1/apps/APPTOKEN123456789/tables/tblXYZ/records",
         )
         self.assertEqual(
             template,
-            "/open-apis/bitable/v1/apps/:app_token/tables/:table_id/records/:record_id",
+            "/open-apis/bitable/v1/apps/:app_token/tables/:table_id/records",
         )
         self.assertEqual(paths["app_token"], "APPTOKEN123456789")
         self.assertEqual(paths["table_id"], "tblXYZ")
-        self.assertEqual(paths["record_id"], "recABC")
 
-    def test_method_matters(self):
-        # The records collection is GET (list) and POST (create), not DELETE.
-        template, _ = validate_endpoint(
-            "DELETE",
-            "/open-apis/bitable/v1/apps/APPTOKEN123456789/tables/tblXYZ/records",
-        )
-        self.assertIsNone(template)
+    def test_write_methods_are_not_on_the_map(self):
+        # Read-only surface: comment POST / Bitable DELETE must not validate.
+        for method, path in (
+            ("POST", "/open-apis/drive/v1/files/Lv4SdXIhAou70nxGvwLc/comments"),
+            ("POST", "/open-apis/drive/v1/files/create_folder"),
+            (
+                "DELETE",
+                "/open-apis/bitable/v1/apps/APPTOKEN123456789/tables/tblXYZ"
+                "/records/recABC",
+            ),
+            (
+                "PUT",
+                "/open-apis/bitable/v1/apps/APPTOKEN123456789/tables/tblXYZ"
+                "/records/recABC",
+            ),
+            (
+                "POST",
+                "/open-apis/bitable/v1/apps/APPTOKEN123456789/tables/tblXYZ/records",
+            ),
+        ):
+            template, _ = validate_endpoint(method, path)
+            self.assertIsNone(template, msg=f"{method} {path} should be rejected")
 
     def test_unknown_root_returns_suggestions_list(self):
         template, suggestions = validate_endpoint("GET", "/open-apis/totally/made/up")
@@ -79,7 +86,6 @@ class TestEndpointValidation(unittest.TestCase):
         self.assertIsInstance(suggestions, list)
 
     def test_full_url_is_normalized_and_validated(self):
-        # The agent's actual mistake: pasting a full URL with scheme+host.
         template, paths = validate_endpoint(
             "GET", "https://open.feishu.cn/open-apis/drive/v1/files?page_size=50"
         )
@@ -93,12 +99,14 @@ class TestEndpointValidation(unittest.TestCase):
         self.assertEqual(template, "/open-apis/drive/v1/files")
 
     def test_static_segment_wins_over_wildcard(self):
-        # create_folder is a literal segment, not a :file_token.
+        # raw_content is a literal segment, not a :document_id-style capture.
         template, paths = validate_endpoint(
-            "POST", "/open-apis/drive/v1/files/create_folder"
+            "GET", "/open-apis/docx/v1/documents/DOCIDTOKEN12345/raw_content"
         )
-        self.assertEqual(template, "/open-apis/drive/v1/files/create_folder")
-        self.assertEqual(paths, {})
+        self.assertEqual(
+            template, "/open-apis/docx/v1/documents/:document_id/raw_content"
+        )
+        self.assertEqual(paths, {"document_id": "DOCIDTOKEN12345"})
 
 
 class TestHandler(unittest.TestCase):
@@ -117,8 +125,22 @@ class TestHandler(unittest.TestCase):
         )
         self.assertIn("error", out)
 
+    def test_write_method_rejected_before_dispatch(self):
+        out = json.loads(
+            _handle_feishu_request(
+                {
+                    "method": "DELETE",
+                    "path": (
+                        "/open-apis/bitable/v1/apps/APPTOKEN123456789"
+                        "/tables/tblXYZ/records/recABC"
+                    ),
+                }
+            )
+        )
+        self.assertIn("error", out)
+        self.assertIn("read-only", out["error"].lower())
+
     def test_invalid_path_rejected_before_client_lookup(self):
-        # Even with no client set, an invalid path is rejected at validation.
         out = json.loads(
             _handle_feishu_request(
                 {"method": "GET", "path": "/open-apis/drive/v1/files/TOKEN123456789/children"}
@@ -128,13 +150,84 @@ class TestHandler(unittest.TestCase):
         self.assertIn("valid_suggestions", out)
 
     def test_valid_path_without_client_reports_client_error(self):
-        # Valid path passes validation, then fails on missing client (not 404).
         set_client(None)
         out = json.loads(
             _handle_feishu_request({"method": "GET", "path": "/open-apis/drive/v1/files"})
         )
         self.assertIn("error", out)
         self.assertIn("client not available", out["error"])
+
+
+class TestFakeClientDispatch(unittest.TestCase):
+    """Prove canonical folder-list dispatch and write rejection without HTTP."""
+
+    def tearDown(self):
+        set_client(None)
+
+    def test_folder_list_dispatches_canonical_template(self):
+        set_client(object())  # any truthy client
+        with patch(
+            "tools.feishu_request_tool._do_request",
+            return_value=(0, "ok", {"files": [{"name": "a.docx"}]}),
+        ) as mock_req:
+            out = json.loads(
+                _handle_feishu_request(
+                    {
+                        "method": "GET",
+                        "path": "/open-apis/drive/v1/files",
+                        "query": {"folder_token": "fldcnABC123", "page_size": "50"},
+                    }
+                )
+            )
+        self.assertTrue(out.get("success"))
+        self.assertEqual(out["data"]["files"][0]["name"], "a.docx")
+        mock_req.assert_called_once()
+        args, kwargs = mock_req.call_args
+        # client, method, template (positional)
+        self.assertEqual(args[1], "GET")
+        self.assertEqual(args[2], "/open-apis/drive/v1/files")
+        self.assertFalse(kwargs.get("paths"))
+        queries = kwargs.get("queries")
+        self.assertIn(("folder_token", "fldcnABC123"), queries)
+        self.assertIn(("page_size", "50"), queries)
+
+    def test_write_delete_never_calls_client(self):
+        set_client(object())
+        with patch(
+            "tools.feishu_request_tool._do_request",
+            return_value=(0, "ok", {}),
+        ) as mock_req:
+            out = json.loads(
+                _handle_feishu_request(
+                    {
+                        "method": "DELETE",
+                        "path": (
+                            "/open-apis/bitable/v1/apps/APPTOKEN123456789"
+                            "/tables/tblXYZ/records/recABC"
+                        ),
+                    }
+                )
+            )
+        self.assertIn("error", out)
+        mock_req.assert_not_called()
+
+    def test_comment_post_never_calls_client(self):
+        set_client(object())
+        with patch(
+            "tools.feishu_request_tool._do_request",
+            return_value=(0, "ok", {}),
+        ) as mock_req:
+            out = json.loads(
+                _handle_feishu_request(
+                    {
+                        "method": "POST",
+                        "path": "/open-apis/drive/v1/files/Lv4SdXIhAou70nxGvwLc/comments",
+                        "body": {"content": "side effect"},
+                    }
+                )
+            )
+        self.assertIn("error", out)
+        mock_req.assert_not_called()
 
 
 class TestToolsetWiring(unittest.TestCase):
@@ -181,6 +274,7 @@ class TestRegistration(unittest.TestCase):
         props = entry.schema["parameters"]["properties"]
         self.assertIn("method", props)
         self.assertIn("path", props)
+        self.assertEqual(props["method"]["enum"], ["GET"])
         self.assertEqual(entry.schema["parameters"]["required"], ["method", "path"])
 
 

--- a/tools/feishu_drive_tool.py
+++ b/tools/feishu_drive_tool.py
@@ -43,7 +43,7 @@ def _do_request(client, method, uri, paths=None, queries=None, body=None):
     from lark_oapi.core.enum import HttpMethod
     from lark_oapi.core.model.base_request import BaseRequest
 
-    http_method = HttpMethod.GET if method == "GET" else HttpMethod.POST
+    http_method = getattr(HttpMethod, str(method).upper(), HttpMethod.GET)
 
     builder = (
         BaseRequest.builder()

--- a/tools/feishu_request_tool.py
+++ b/tools/feishu_request_tool.py
@@ -1,0 +1,308 @@
+"""Feishu generic request tool -- one validated entry point for the whole API.
+
+Rather than shipping one typed tool per Feishu endpoint (there are hundreds),
+this exposes a single ``feishu_request`` tool whose ``path`` is checked against a
+curated "navigation map" of known-good endpoint templates *before* the call is
+made.  An unknown path is rejected up front with a "did you mean ..." hint,
+instead of being sent to Feishu and bouncing back as a confusing 404.
+
+Why this exists: the agent has no folder-listing tool, so it used to fall back
+to the raw code sandbox and hand-craft URLs like
+``GET /open-apis/drive/v1/files/{folder_token}/children`` -- which does not
+exist (the correct call is ``GET /open-apis/drive/v1/files?folder_token=xxx``)
+and only failed at runtime.  Routing all ad-hoc calls through this tool turns
+that runtime 404 into a pre-flight rejection that names the correct endpoint.
+
+Validation is pure Python (no SDK import), so it is independently testable.
+Dispatch reuses ``feishu_drive_tool._do_request`` for response parsing.
+"""
+
+import difflib
+import logging
+import threading
+
+from tools.feishu_drive_tool import _do_request
+from tools.registry import registry, tool_error, tool_result
+
+logger = logging.getLogger(__name__)
+
+# Thread-local lark client, injected per-request by the feishu_comment handler.
+_local = threading.local()
+
+
+def set_client(client):
+    """Store a lark client for the current thread (called by feishu_comment)."""
+    _local.client = client
+
+
+def get_client():
+    """Return the lark client for the current thread, or None."""
+    return getattr(_local, "client", None)
+
+
+def _check_feishu():
+    # Mirror feishu_doc_tool._check_feishu -- find_spec keeps CLI startup fast.
+    import importlib.util
+    try:
+        return importlib.util.find_spec("lark_oapi") is not None
+    except (ImportError, ValueError):
+        return False
+
+
+# ---------------------------------------------------------------------------
+# The navigation map: (METHOD, path_template).
+#
+# A ``:segment`` matches any single concrete path segment (a token / id).
+# This list is the source of truth for what the agent is allowed to call --
+# fail-closed: anything not listed here is rejected.  It is intentionally
+# curated (not auto-generated) so every entry is a verified-correct endpoint.
+# Extend it as new endpoints are needed; keep templates exactly as Feishu
+# documents them (https://open.feishu.cn/document/server-docs).
+# ---------------------------------------------------------------------------
+_FEISHU_ENDPOINTS = [
+    # --- Drive: files & folders ---------------------------------------------
+    # List items in a folder == the call the agent kept getting wrong.
+    # It is a QUERY param (?folder_token=), NOT a /:token/children path.
+    ("GET", "/open-apis/drive/v1/files"),
+    ("POST", "/open-apis/drive/v1/files/create_folder"),
+    ("GET", "/open-apis/drive/v1/files/:file_token/statistics"),
+    ("POST", "/open-apis/drive/v1/metas/batch_query"),
+    # root_folder/meta is not in the typed lark SDK; verified against the
+    # official docs (GET .../drive/explorer/v2/root_folder/meta).
+    ("GET", "/open-apis/drive/explorer/v2/root_folder/meta"),
+    ("GET", "/open-apis/drive/v1/files/:file_token/comments"),
+    # new_comments mirrors feishu_drive_tool._ADD_COMMENT_URI (shipping code);
+    # it is the whole-document-comment endpoint, distinct from .../comments.
+    ("POST", "/open-apis/drive/v1/files/:file_token/new_comments"),
+    ("GET", "/open-apis/drive/v1/files/:file_token/comments/:comment_id/replies"),
+    ("POST", "/open-apis/drive/v1/files/:file_token/comments/:comment_id/replies"),
+    # --- Docx ----------------------------------------------------------------
+    ("GET", "/open-apis/docx/v1/documents/:document_id"),
+    ("GET", "/open-apis/docx/v1/documents/:document_id/raw_content"),
+    ("GET", "/open-apis/docx/v1/documents/:document_id/blocks"),
+    # --- Bitable (multi-dimensional tables) ----------------------------------
+    ("GET", "/open-apis/bitable/v1/apps/:app_token"),
+    ("GET", "/open-apis/bitable/v1/apps/:app_token/tables"),
+    ("GET", "/open-apis/bitable/v1/apps/:app_token/tables/:table_id/fields"),
+    ("GET", "/open-apis/bitable/v1/apps/:app_token/tables/:table_id/records"),
+    ("POST", "/open-apis/bitable/v1/apps/:app_token/tables/:table_id/records"),
+    ("POST", "/open-apis/bitable/v1/apps/:app_token/tables/:table_id/records/search"),
+    ("PUT", "/open-apis/bitable/v1/apps/:app_token/tables/:table_id/records/:record_id"),
+    ("DELETE", "/open-apis/bitable/v1/apps/:app_token/tables/:table_id/records/:record_id"),
+    # --- Sheets --------------------------------------------------------------
+    ("GET", "/open-apis/sheets/v3/spreadsheets/:spreadsheet_token"),
+    ("GET", "/open-apis/sheets/v3/spreadsheets/:spreadsheet_token/sheets/query"),
+    # --- Wiki ----------------------------------------------------------------
+    ("GET", "/open-apis/wiki/v2/spaces"),
+    ("GET", "/open-apis/wiki/v2/spaces/:space_id/nodes"),
+]
+
+_ALLOWED_METHODS = {"GET", "POST", "PUT", "DELETE", "PATCH"}
+
+
+def _normalize_path(path: str) -> str:
+    """Reduce any caller-supplied form to a bare ``/open-apis/...`` path.
+
+    The agent often pastes a full URL (the original incident used
+    ``https://open.feishu.cn/open-apis/drive/v1/files?page_size=50``). Slice
+    from ``/open-apis/`` so scheme+host don't get mistaken for path segments
+    and reject an otherwise-valid call.
+    """
+    path = (path or "").strip()
+    idx = path.find("/open-apis/")
+    return path[idx:] if idx > 0 else path
+
+
+def _split(path: str) -> list:
+    """Strip query string and slashes, return path segments."""
+    path = _normalize_path(path).split("?", 1)[0].strip("/")
+    return path.split("/") if path else []
+
+
+def _looks_like_token(seg: str) -> bool:
+    """Heuristic: is this segment a concrete id/token (vs a static path word)?"""
+    return len(seg) >= 16 or (len(seg) >= 10 and any(c.isdigit() for c in seg))
+
+
+def validate_endpoint(method: str, path: str):
+    """Check ``method``+``path`` against the navigation map.
+
+    Returns ``(template, paths)`` when valid -- ``template`` is the canonical
+    URI for the lark BaseRequest and ``paths`` maps each ``:param`` to the
+    concrete value pulled from *path*.  Returns ``(None, suggestions)`` when
+    invalid, where ``suggestions`` is a list of the closest valid templates.
+    """
+    method = str(method).upper()
+    segments = _split(path)
+
+    # Collect every structural match, then prefer the most specific one
+    # (fewest wildcards). This stops a literal segment like ``create_folder``
+    # or ``search`` from being captured as a ``:token`` by a looser template.
+    matches = []
+    for m, template in _FEISHU_ENDPOINTS:
+        if m != method:
+            continue
+        t_segs = template.strip("/").split("/")
+        if len(t_segs) != len(segments):
+            continue
+        paths, wildcards, ok = {}, 0, True
+        for tseg, seg in zip(t_segs, segments):
+            if tseg.startswith(":"):
+                paths[tseg[1:]] = seg
+                wildcards += 1
+            elif tseg != seg:
+                ok = False
+                break
+        if ok:
+            matches.append((wildcards, template, paths))
+    if matches:
+        matches.sort(key=lambda x: x[0])
+        return matches[0][1], matches[0][2]
+
+    # No match -> build "did you mean" suggestions. Normalise the caller's
+    # concrete tokens to ``:x`` so fuzzy matching compares shapes, not tokens.
+    norm = "/" + "/".join(":x" if _looks_like_token(s) else s for s in segments)
+    candidates = [t for (m, t) in _FEISHU_ENDPOINTS if m == method]
+    if not candidates:
+        candidates = [t for (_, t) in _FEISHU_ENDPOINTS]
+    norm_candidates = {
+        "/" + "/".join(":x" if s.startswith(":") else s for s in _split(t)): t
+        for t in candidates
+    }
+    close = difflib.get_close_matches(norm, list(norm_candidates), n=3, cutoff=0.5)
+    suggestions = [norm_candidates[c] for c in close]
+    if not suggestions:
+        # Fall back to longest shared path-prefix.
+        def _prefix_len(t):
+            ts = _split(t)
+            n = 0
+            for a, b in zip(ts, segments):
+                if a.startswith(":") or a == b:
+                    n += 1
+                else:
+                    break
+            return n
+        suggestions = sorted(candidates, key=_prefix_len, reverse=True)[:3]
+    return None, suggestions
+
+
+# ---------------------------------------------------------------------------
+# feishu_request
+# ---------------------------------------------------------------------------
+
+FEISHU_REQUEST_SCHEMA = {
+    "name": "feishu_request",
+    "description": (
+        "Call any Feishu/Lark Open API endpoint. The path is validated against "
+        "a map of known-good endpoints BEFORE the call -- an unknown path is "
+        "rejected with the correct one suggested, instead of 404ing. "
+        "Use this for Drive/Docx/Bitable/Sheets/Wiki reads and writes. "
+        "Note: list items in a folder is "
+        "GET /open-apis/drive/v1/files with query folder_token=xxx "
+        "(query param -- there is NO /files/{token}/children path)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "method": {
+                "type": "string",
+                "description": "HTTP method.",
+                "enum": ["GET", "POST", "PUT", "DELETE", "PATCH"],
+            },
+            "path": {
+                "type": "string",
+                "description": (
+                    "API path starting with /open-apis/, with concrete tokens "
+                    "inline, e.g. /open-apis/bitable/v1/apps/APP_TOKEN/tables."
+                ),
+            },
+            "query": {
+                "type": "object",
+                "description": "Optional query parameters as a flat object.",
+            },
+            "body": {
+                "type": "object",
+                "description": "Optional JSON body for POST/PUT/PATCH requests.",
+            },
+        },
+        "required": ["method", "path"],
+    },
+}
+
+
+def _handle_feishu_request(args: dict, **kwargs) -> str:
+    method = str(args.get("method", "")).strip().upper()
+    path = str(args.get("path", "")).strip()
+    query = args.get("query") or {}
+    body = args.get("body")
+
+    if not method or not path:
+        return tool_error("method and path are required")
+    if method not in _ALLOWED_METHODS:
+        return tool_error(
+            f"Unsupported method '{method}'. Use one of: "
+            f"{', '.join(sorted(_ALLOWED_METHODS))}."
+        )
+
+    template, result = validate_endpoint(method, path)
+    if template is None:
+        # Log the rejection so a guessed endpoint is auditable in agent.log
+        # rather than silently bounced — mirrors feishu_comment's API logging.
+        logger.warning(
+            "[Feishu-Request] REJECTED %s %s — not in endpoint map; suggesting %s",
+            method, path, result,
+        )
+        return tool_error(
+            f"Invalid Feishu endpoint: {method} {path}. This path is not in the "
+            f"validated endpoint map and would 404. Did you mean: {result}? "
+            f"(Reminder: list items in a folder is "
+            f"GET /open-apis/drive/v1/files?folder_token=xxx -- query param, "
+            f"NOT /files/{{token}}/children.)",
+            valid_suggestions=result,
+        )
+
+    client = get_client()
+    if client is None:
+        return tool_error("Feishu client not available (not in a Feishu context)")
+
+    # Expand list/tuple values into repeated key=value pairs (some Feishu
+    # endpoints take repeated query params); scalars stringify directly.
+    queries = []
+    for k, v in query.items():
+        if v is None:
+            continue
+        if isinstance(v, (list, tuple)):
+            queries.extend((k, str(x)) for x in v)
+        else:
+            queries.append((k, str(v)))
+
+    logger.info("[Feishu-Request] %s %s paths=%s", method, template, result or {})
+    code, msg, data = _do_request(
+        client, method, template,
+        paths=result or None,
+        queries=queries or None,
+        body=body,
+    )
+    if code != 0:
+        logger.warning("[Feishu-Request] %s %s failed: code=%s msg=%s",
+                       method, template, code, msg)
+        return tool_error(f"Feishu request failed: code={code} msg={msg}")
+
+    return tool_result(success=True, data=data)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+registry.register(
+    name="feishu_request",
+    toolset="feishu_drive",
+    schema=FEISHU_REQUEST_SCHEMA,
+    handler=_handle_feishu_request,
+    check_fn=_check_feishu,
+    requires_env=[],
+    is_async=False,
+    description="Call a validated Feishu Open API endpoint",
+    emoji="\U0001f5fa️",
+)

--- a/tools/feishu_request_tool.py
+++ b/tools/feishu_request_tool.py
@@ -1,20 +1,20 @@
-"""Feishu generic request tool -- one validated entry point for the whole API.
+"""Read-only Feishu Open API gateway with fail-closed path validation.
 
-Rather than shipping one typed tool per Feishu endpoint (there are hundreds),
-this exposes a single ``feishu_request`` tool whose ``path`` is checked against a
-curated "navigation map" of known-good endpoint templates *before* the call is
-made.  An unknown path is rejected up front with a "did you mean ..." hint,
-instead of being sent to Feishu and bouncing back as a confusing 404.
+Exposes a single ``feishu_request`` tool for ad-hoc Feishu/Lark reads. The
+path is checked against a curated GET-only endpoint map *before* dispatch;
+unknown paths are rejected with a "did you mean" hint instead of 404ing at
+Feishu (which the agent often misreads as a permissions problem).
 
-Why this exists: the agent has no folder-listing tool, so it used to fall back
-to the raw code sandbox and hand-craft URLs like
-``GET /open-apis/drive/v1/files/{folder_token}/children`` -- which does not
-exist (the correct call is ``GET /open-apis/drive/v1/files?folder_token=xxx``)
-and only failed at runtime.  Routing all ad-hoc calls through this tool turns
-that runtime 404 into a pre-flight rejection that names the correct endpoint.
+Why this exists: agents without a folder-listing tool invent paths like
+``GET /open-apis/drive/v1/files/{folder_token}/children`` (does not exist).
+The correct call is ``GET /open-apis/drive/v1/files?folder_token=xxx``.
 
-Validation is pure Python (no SDK import), so it is independently testable.
-Dispatch reuses ``feishu_drive_tool._do_request`` for response parsing.
+Scope: GET only. This tool is wired into ``feishu_drive`` (comment-agent
+path with lark client injection). Writes stay on typed tools and the
+handler's controlled ``deliver_comment_reply`` path — not this gateway.
+
+Validation is pure Python (no SDK import). Dispatch reuses
+``feishu_drive_tool._do_request``.
 """
 
 import difflib
@@ -50,64 +50,47 @@ def _check_feishu():
 
 
 # ---------------------------------------------------------------------------
-# The navigation map: (METHOD, path_template).
+# Read-only navigation map: (METHOD, path_template).
 #
-# A ``:segment`` matches any single concrete path segment (a token / id).
-# This list is the source of truth for what the agent is allowed to call --
-# fail-closed: anything not listed here is rejected.  It is intentionally
-# curated (not auto-generated) so every entry is a verified-correct endpoint.
-# Extend it as new endpoints are needed; keep templates exactly as Feishu
-# documents them (https://open.feishu.cn/document/server-docs).
+# ``:segment`` matches one concrete path segment (token / id).
+# Fail-closed: unlisted paths never leave the process. GET only — no
+# POST/PUT/DELETE (comment writes, Bitable mutations, create_folder, etc.).
+# Keep templates exactly as Feishu documents them
+# (https://open.feishu.cn/document/server-docs).
 # ---------------------------------------------------------------------------
 _FEISHU_ENDPOINTS = [
-    # --- Drive: files & folders ---------------------------------------------
-    # List items in a folder == the call the agent kept getting wrong.
-    # It is a QUERY param (?folder_token=), NOT a /:token/children path.
+    # Drive — folder list is ?folder_token=, NOT /:token/children.
     ("GET", "/open-apis/drive/v1/files"),
-    ("POST", "/open-apis/drive/v1/files/create_folder"),
     ("GET", "/open-apis/drive/v1/files/:file_token/statistics"),
-    ("POST", "/open-apis/drive/v1/metas/batch_query"),
-    # root_folder/meta is not in the typed lark SDK; verified against the
-    # official docs (GET .../drive/explorer/v2/root_folder/meta).
+    # Not in the typed lark SDK; verified against official docs.
     ("GET", "/open-apis/drive/explorer/v2/root_folder/meta"),
     ("GET", "/open-apis/drive/v1/files/:file_token/comments"),
-    # Official "Add a Global Comment" is POST .../comments (open.feishu.cn).
-    # new_comments is still used by tools/feishu_drive_tool._ADD_COMMENT_URI.
-    ("POST", "/open-apis/drive/v1/files/:file_token/comments"),
-    ("POST", "/open-apis/drive/v1/files/:file_token/new_comments"),
     ("GET", "/open-apis/drive/v1/files/:file_token/comments/:comment_id/replies"),
-    ("POST", "/open-apis/drive/v1/files/:file_token/comments/:comment_id/replies"),
-    # --- Docx ----------------------------------------------------------------
+    # Docx
     ("GET", "/open-apis/docx/v1/documents/:document_id"),
     ("GET", "/open-apis/docx/v1/documents/:document_id/raw_content"),
     ("GET", "/open-apis/docx/v1/documents/:document_id/blocks"),
-    # --- Bitable (multi-dimensional tables) ----------------------------------
+    # Bitable (reads only)
     ("GET", "/open-apis/bitable/v1/apps/:app_token"),
     ("GET", "/open-apis/bitable/v1/apps/:app_token/tables"),
     ("GET", "/open-apis/bitable/v1/apps/:app_token/tables/:table_id/fields"),
     ("GET", "/open-apis/bitable/v1/apps/:app_token/tables/:table_id/records"),
-    ("POST", "/open-apis/bitable/v1/apps/:app_token/tables/:table_id/records"),
-    ("POST", "/open-apis/bitable/v1/apps/:app_token/tables/:table_id/records/search"),
-    ("PUT", "/open-apis/bitable/v1/apps/:app_token/tables/:table_id/records/:record_id"),
-    ("DELETE", "/open-apis/bitable/v1/apps/:app_token/tables/:table_id/records/:record_id"),
-    # --- Sheets --------------------------------------------------------------
+    # Sheets
     ("GET", "/open-apis/sheets/v3/spreadsheets/:spreadsheet_token"),
     ("GET", "/open-apis/sheets/v3/spreadsheets/:spreadsheet_token/sheets/query"),
-    # --- Wiki ----------------------------------------------------------------
+    # Wiki
     ("GET", "/open-apis/wiki/v2/spaces"),
     ("GET", "/open-apis/wiki/v2/spaces/:space_id/nodes"),
 ]
 
-_ALLOWED_METHODS = {"GET", "POST", "PUT", "DELETE", "PATCH"}
+_ALLOWED_METHODS = {"GET"}
 
 
 def _normalize_path(path: str) -> str:
     """Reduce any caller-supplied form to a bare ``/open-apis/...`` path.
 
-    The agent often pastes a full URL (the original incident used
-    ``https://open.feishu.cn/open-apis/drive/v1/files?page_size=50``). Slice
-    from ``/open-apis/`` so scheme+host don't get mistaken for path segments
-    and reject an otherwise-valid call.
+    Agents often paste full URLs (scheme+host). Slice from ``/open-apis/`` so
+    the host is not treated as path segments.
     """
     path = (path or "").strip()
     idx = path.find("/open-apis/")
@@ -136,9 +119,9 @@ def validate_endpoint(method: str, path: str):
     method = str(method).upper()
     segments = _split(path)
 
-    # Collect every structural match, then prefer the most specific one
-    # (fewest wildcards). This stops a literal segment like ``create_folder``
-    # or ``search`` from being captured as a ``:token`` by a looser template.
+    # Prefer the most specific structural match (fewest wildcards) so a
+    # literal segment like ``raw_content`` or ``query`` is not captured as
+    # a ``:token`` by a looser template.
     matches = []
     for m, template in _FEISHU_ENDPOINTS:
         if m != method:
@@ -160,8 +143,8 @@ def validate_endpoint(method: str, path: str):
         matches.sort(key=lambda x: x[0])
         return matches[0][1], matches[0][2]
 
-    # No match -> build "did you mean" suggestions. Normalise the caller's
-    # concrete tokens to ``:x`` so fuzzy matching compares shapes, not tokens.
+    # No match -> "did you mean" suggestions. Normalize concrete tokens to
+    # ``:x`` so fuzzy matching compares shapes, not tokens.
     norm = "/" + "/".join(":x" if _looks_like_token(s) else s for s in segments)
     candidates = [t for (m, t) in _FEISHU_ENDPOINTS if m == method]
     if not candidates:
@@ -194,27 +177,28 @@ def validate_endpoint(method: str, path: str):
 FEISHU_REQUEST_SCHEMA = {
     "name": "feishu_request",
     "description": (
-        "Call any Feishu/Lark Open API endpoint. The path is validated against "
-        "a map of known-good endpoints BEFORE the call -- an unknown path is "
-        "rejected with the correct one suggested, instead of 404ing. "
-        "Use this for Drive/Docx/Bitable/Sheets/Wiki reads and writes. "
-        "Note: list items in a folder is "
-        "GET /open-apis/drive/v1/files with query folder_token=xxx "
-        "(query param -- there is NO /files/{token}/children path)."
+        "Call a validated Feishu/Lark Open API endpoint (GET / read-only). "
+        "The path is checked against a known-good map BEFORE the call — an "
+        "unknown path is rejected with the correct one suggested, instead of "
+        "404ing. Use for Drive/Docx/Bitable/Sheets/Wiki reads. "
+        "Writes are not supported here. "
+        "List items in a folder: GET /open-apis/drive/v1/files with query "
+        "folder_token=xxx (there is NO /files/{token}/children path)."
     ),
     "parameters": {
         "type": "object",
         "properties": {
             "method": {
                 "type": "string",
-                "description": "HTTP method.",
-                "enum": ["GET", "POST", "PUT", "DELETE", "PATCH"],
+                "description": "HTTP method (GET only — this tool is read-only).",
+                "enum": ["GET"],
             },
             "path": {
                 "type": "string",
                 "description": (
                     "API path starting with /open-apis/, with concrete tokens "
-                    "inline, e.g. /open-apis/bitable/v1/apps/APP_TOKEN/tables."
+                    "inline, e.g. /open-apis/drive/v1/files or "
+                    "/open-apis/docx/v1/documents/DOC_TOKEN/raw_content."
                 ),
             },
             "query": {
@@ -223,7 +207,7 @@ FEISHU_REQUEST_SCHEMA = {
             },
             "body": {
                 "type": "object",
-                "description": "Optional JSON body for POST/PUT/PATCH requests.",
+                "description": "Unused for GET; reserved for schema stability.",
             },
         },
         "required": ["method", "path"],
@@ -241,14 +225,12 @@ def _handle_feishu_request(args: dict, **kwargs) -> str:
         return tool_error("method and path are required")
     if method not in _ALLOWED_METHODS:
         return tool_error(
-            f"Unsupported method '{method}'. Use one of: "
-            f"{', '.join(sorted(_ALLOWED_METHODS))}."
+            f"Unsupported method '{method}'. feishu_request is read-only "
+            f"(GET only). Writes stay on typed Feishu tools / delivery path."
         )
 
     template, result = validate_endpoint(method, path)
     if template is None:
-        # Log the rejection so a guessed endpoint is auditable in agent.log
-        # rather than silently bounced — mirrors feishu_comment's API logging.
         logger.warning(
             "[Feishu-Request] REJECTED %s %s — not in endpoint map; suggesting %s",
             method, path, result,
@@ -289,7 +271,7 @@ def _handle_feishu_request(args: dict, **kwargs) -> str:
                        method, template, code, msg)
         return tool_error(f"Feishu request failed: code={code} msg={msg}")
 
-    return tool_result(success=True, data=data)
+    return tool_result({"success": True, "data": data})
 
 
 # ---------------------------------------------------------------------------
@@ -304,6 +286,6 @@ registry.register(
     check_fn=_check_feishu,
     requires_env=[],
     is_async=False,
-    description="Call a validated Feishu Open API endpoint",
+    description="Call a validated Feishu Open API endpoint (GET / read-only)",
     emoji="\U0001f5fa️",
 )

--- a/tools/feishu_request_tool.py
+++ b/tools/feishu_request_tool.py
@@ -71,8 +71,9 @@ _FEISHU_ENDPOINTS = [
     # official docs (GET .../drive/explorer/v2/root_folder/meta).
     ("GET", "/open-apis/drive/explorer/v2/root_folder/meta"),
     ("GET", "/open-apis/drive/v1/files/:file_token/comments"),
-    # new_comments mirrors feishu_drive_tool._ADD_COMMENT_URI (shipping code);
-    # it is the whole-document-comment endpoint, distinct from .../comments.
+    # Official "Add a Global Comment" is POST .../comments (open.feishu.cn).
+    # new_comments is still used by tools/feishu_drive_tool._ADD_COMMENT_URI.
+    ("POST", "/open-apis/drive/v1/files/:file_token/comments"),
     ("POST", "/open-apis/drive/v1/files/:file_token/new_comments"),
     ("GET", "/open-apis/drive/v1/files/:file_token/comments/:comment_id/replies"),
     ("POST", "/open-apis/drive/v1/files/:file_token/comments/:comment_id/replies"),

--- a/tools/feishu_request_tool.py
+++ b/tools/feishu_request_tool.py
@@ -13,6 +13,18 @@ Scope: GET only. This tool is wired into ``feishu_drive`` (comment-agent
 path with lark client injection). Writes stay on typed tools and the
 handler's controlled ``deliver_comment_reply`` path — not this gateway.
 
+Why not write+approval here?
+    Hermes approval is not a generic "Open API DELETE" gate. Existing
+    surfaces are: shell dangerous-command patterns (``tools.approval`` +
+    platform ``send_exec_approval`` on Feishu/WhatsApp/Teams/…), plugin
+    ``pre_tool_call`` → ``request_tool_approval``, ACP edit approval for
+    ``write_file``/``patch``, and optional ``write_approval`` for memory/
+    skills. Platform tools such as Discord ``delete_message`` do not go
+    through that gate. Comment-agent is output-only, so admitting writes
+    (even after a shell-style approval click) would still bypass
+    ``deliver_comment_reply``. Fail-closed GET-only is the matching
+    control for this toolset placement.
+
 Validation is pure Python (no SDK import). Dispatch reuses
 ``feishu_drive_tool._do_request``.
 """

--- a/tools/feishu_request_tool.py
+++ b/tools/feishu_request_tool.py
@@ -55,31 +55,45 @@ def _check_feishu():
 # ``:segment`` matches one concrete path segment (token / id).
 # Fail-closed: unlisted paths never leave the process. GET only — no
 # POST/PUT/DELETE (comment writes, Bitable mutations, create_folder, etc.).
-# Keep templates exactly as Feishu documents them
-# (https://open.feishu.cn/document/server-docs).
+# Templates match official Feishu HTTP URLs verbatim (open.feishu.cn).
 # ---------------------------------------------------------------------------
 _FEISHU_ENDPOINTS = [
-    # Drive — folder list is ?folder_token=, NOT /:token/children.
+    # Drive — list is ?folder_token=, NOT /:token/children
+    # https://open.feishu.cn/document/server-docs/docs/drive-v1/folder/list
     ("GET", "/open-apis/drive/v1/files"),
+    # https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/drive-v1/file-statistics/get
     ("GET", "/open-apis/drive/v1/files/:file_token/statistics"),
-    # Not in the typed lark SDK; verified against official docs.
+    # https://open.feishu.cn/document/server-docs/docs/drive-v1/folder/get-root-folder-meta
     ("GET", "/open-apis/drive/explorer/v2/root_folder/meta"),
+    # https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/drive-v1/file-comment/list
     ("GET", "/open-apis/drive/v1/files/:file_token/comments"),
+    # https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/drive-v1/file-comment-reply/list
     ("GET", "/open-apis/drive/v1/files/:file_token/comments/:comment_id/replies"),
     # Docx
+    # https://open.feishu.cn/document/server-docs/docs/docs/docx-v1/document/get
     ("GET", "/open-apis/docx/v1/documents/:document_id"),
+    # https://open.feishu.cn/document/server-docs/docs/docs/docx-v1/document/raw_content
     ("GET", "/open-apis/docx/v1/documents/:document_id/raw_content"),
+    # https://open.feishu.cn/document/ukTMukTMukTM/uUDN04SN0QjL1QDN/document-docx/docx-v1/document-block/list
     ("GET", "/open-apis/docx/v1/documents/:document_id/blocks"),
     # Bitable (reads only)
+    # https://open.feishu.cn/document/server-docs/docs/bitable-v1/app/get
     ("GET", "/open-apis/bitable/v1/apps/:app_token"),
+    # https://open.feishu.cn/document/server-docs/docs/bitable-v1/app-table/list
     ("GET", "/open-apis/bitable/v1/apps/:app_token/tables"),
+    # https://open.feishu.cn/document/server-docs/docs/bitable-v1/app-table-field/list
     ("GET", "/open-apis/bitable/v1/apps/:app_token/tables/:table_id/fields"),
+    # https://open.feishu.cn/document/server-docs/docs/bitable-v1/app-table-record/list
     ("GET", "/open-apis/bitable/v1/apps/:app_token/tables/:table_id/records"),
     # Sheets
+    # https://open.feishu.cn/document/server-docs/docs/sheets-v3/spreadsheet/get
     ("GET", "/open-apis/sheets/v3/spreadsheets/:spreadsheet_token"),
+    # https://open.feishu.cn/document/server-docs/docs/sheets-v3/spreadsheet-sheet/query
     ("GET", "/open-apis/sheets/v3/spreadsheets/:spreadsheet_token/sheets/query"),
     # Wiki
+    # https://open.feishu.cn/document/server-docs/docs/wiki-v2/space/list
     ("GET", "/open-apis/wiki/v2/spaces"),
+    # https://open.feishu.cn/document/server-docs/docs/wiki-v2/space-node/list
     ("GET", "/open-apis/wiki/v2/spaces/:space_id/nodes"),
 ]
 
@@ -205,10 +219,6 @@ FEISHU_REQUEST_SCHEMA = {
                 "type": "object",
                 "description": "Optional query parameters as a flat object.",
             },
-            "body": {
-                "type": "object",
-                "description": "Unused for GET; reserved for schema stability.",
-            },
         },
         "required": ["method", "path"],
     },
@@ -219,7 +229,6 @@ def _handle_feishu_request(args: dict, **kwargs) -> str:
     method = str(args.get("method", "")).strip().upper()
     path = str(args.get("path", "")).strip()
     query = args.get("query") or {}
-    body = args.get("body")
 
     if not method or not path:
         return tool_error("method and path are required")
@@ -264,7 +273,6 @@ def _handle_feishu_request(args: dict, **kwargs) -> str:
         client, method, template,
         paths=result or None,
         queries=queries or None,
-        body=body,
     )
     if code != 0:
         logger.warning("[Feishu-Request] %s %s failed: code=%s msg=%s",
@@ -287,5 +295,5 @@ registry.register(
     requires_env=[],
     is_async=False,
     description="Call a validated Feishu Open API endpoint (GET / read-only)",
-    emoji="\U0001f5fa️",
+    emoji="\U0001f5fa",
 )

--- a/toolsets.py
+++ b/toolsets.py
@@ -307,7 +307,7 @@ TOOLSETS = {
     },
 
     "feishu_drive": {
-        "description": "Feishu/Lark drive: document comments plus validated Open API access",
+        "description": "Feishu/Lark document comments plus read-only validated Open API reads",
         "tools": [
             "feishu_drive_list_comments", "feishu_drive_list_comment_replies",
             "feishu_drive_reply_comment", "feishu_drive_add_comment",

--- a/toolsets.py
+++ b/toolsets.py
@@ -307,10 +307,11 @@ TOOLSETS = {
     },
 
     "feishu_drive": {
-        "description": "Feishu/Lark document comment operations (list, reply, add)",
+        "description": "Feishu/Lark drive: document comments plus validated Open API access",
         "tools": [
             "feishu_drive_list_comments", "feishu_drive_list_comment_replies",
             "feishu_drive_reply_comment", "feishu_drive_add_comment",
+            "feishu_request",
         ],
         "includes": []
     },


### PR DESCRIPTION
## What does this PR do?

Adds `feishu_request`: a **read-only** Feishu/Lark Open API gateway. Paths are checked against a curated **GET-only** allowlist before dispatch. Unknown paths fail closed with a "did you mean" hint instead of 404ing at Feishu (which agents often misread as a permissions problem).

There's no folder-listing tool today, so the agent falls back to the code sandbox and guesses URLs. In one session it guessed `GET /open-apis/drive/v1/files/{folder_token}/children` (no such endpoint) and 404'd in a loop — the real call is `GET /open-apis/drive/v1/files?folder_token=xxx` ([official list API](https://open.feishu.cn/document/server-docs/docs/drive-v1/folder/list)). Typed Feishu tools hard-code their URIs and can't get this wrong, but they only cover a few endpoints. One generic **read** tool with an allowlist covers discovery without adding hundreds of typed tools, and without exposing writes on the comment-agent path.

**Security scope (review follow-up):** wired into `feishu_drive` only (comment-agent client injection). Surface is **GET only** — no Bitable write/delete, no comment POSTs, no create_folder. Writes stay on typed tools and the handler's controlled `deliver_comment_reply` path.

## Related Issue

N/A — no tracked issue. Surfaced from a live session (log under Screenshots / Logs).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/feishu_request_tool.py` (new): `feishu_request` tool + **GET-only** endpoint allowlist. Validation is pure Python — normalizes full URLs/bare hosts, prefers the most specific template over wildcards, expands list-valued query params, and logs rejected/dispatched calls. Official Feishu doc URLs cited on each template.
- `tools/feishu_drive_tool.py`: `_do_request` maps HTTP methods via `getattr(HttpMethod, ...)` so dispatch stays flexible. **GET/POST resolve identically to before** — backward compatible.
- `toolsets.py`: wire `feishu_request` into the `feishu_drive` toolset — the comment-agent path (`["feishu_doc", "feishu_drive"]`) where the lark client is injected. Deliberately **not** added to the general `hermes-feishu` set (no client injection).
- `plugins/platforms/feishu/feishu_comment.py`: inject the lark client into the new tool's thread-local (alongside existing doc/drive injections).
- `tests/tools/test_feishu_request_tool.py` (new): validation, normalization, handler guards, toolset wiring, fake-client dispatch (canonical folder list + write rejection).

## How to Test

1. `pytest tests/tools/test_feishu_request_tool.py tests/tools/test_feishu_tools.py tests/test_toolsets.py -q`
2. Validation rejects the incident path / writes, accepts the documented form:
   ```python
   from tools.feishu_request_tool import validate_endpoint
   validate_endpoint("GET", "/open-apis/drive/v1/files/FLDTOKEN/children")  # rejected + suggestions
   validate_endpoint("GET", "/open-apis/drive/v1/files")                    # ok
   validate_endpoint("DELETE", "/open-apis/bitable/v1/apps/A/tables/T/records/R")  # rejected (read-only)
   ```
3. Wiring: `feishu_request` in `resolve_toolset("feishu_drive")` → True; in `hermes-feishu` → False.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(tools):` / `fix(tools):` / `docs(tools):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run the affected tests and they pass (**25** in `test_feishu_request_tool.py`; sibling `test_feishu_tools` also green). Full-suite cloud CI awaits maintainer approval on this fork PR; local Docker Python 3.11 + ruff + windows-footguns on touched files are clean
- [x] I've added tests for my changes
- [x] I've tested on my platform: local Docker Python 3.11 (also developed against macOS/Python 3.11 earlier in the branch)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — module/tool docstrings + official URL comments on allowlist; no external docs needed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure stdlib + lazy SDK import; `scripts/check-windows-footguns.py` on touched files passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — new tool ships GET-only schema

## Screenshots / Logs

Original incident (session log) — guessed `/children` path 404s, documented query form works:

```
✗ 404: https://open.feishu.cn/open-apis/drive/v1/files/ROdLfcYwklAVgQduAn1cpNKRnFp/children
  Error: Not Found
✗ 404: https://open.feishu.cn/open-apis/drive/v1/files/root/children
  Error: Not Found
✓ SUCCESS: https://open.feishu.cn/open-apis/drive/v1/files?page_size=50
  { "code": 0, "data": { "files": [ ...3 docx... ] } }
```

CI gates (local, Docker Python 3.11):

```
### pytest (test_feishu_request_tool) ###
25 passed
### ruff check (touched files) ###
All checks passed!
### windows footguns (touched files) ###
✓ No Windows footguns found
```

Endpoint authenticity — all **16** GET allowlist templates matched against official `open.feishu.cn` HTTP URLs (see table below). Comment list/reply paths also match shipping `feishu_drive_tool` constants.

| Method | Path template | Official doc |
|--------|---------------|--------------|
| GET | `/open-apis/drive/v1/files` | [folder/list](https://open.feishu.cn/document/server-docs/docs/drive-v1/folder/list) |
| GET | `/open-apis/drive/v1/files/:file_token/statistics` | [file-statistics/get](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/drive-v1/file-statistics/get) |
| GET | `/open-apis/drive/explorer/v2/root_folder/meta` | [get-root-folder-meta](https://open.feishu.cn/document/server-docs/docs/drive-v1/folder/get-root-folder-meta) |
| GET | `/open-apis/drive/v1/files/:file_token/comments` | [file-comment/list](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/drive-v1/file-comment/list) |
| GET | `.../comments/:comment_id/replies` | [file-comment-reply/list](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/drive-v1/file-comment-reply/list) |
| GET | `/open-apis/docx/v1/documents/:document_id` | [docx get](https://open.feishu.cn/document/server-docs/docs/docs/docx-v1/document/get) |
| GET | `.../raw_content` | [raw_content](https://open.feishu.cn/document/server-docs/docs/docs/docx-v1/document/raw_content) |
| GET | `.../blocks` | [document-block/list](https://open.feishu.cn/document/ukTMukTMukTM/uUDN04SN0QjL1QDN/document-docx/docx-v1/document-block/list) |
| GET | `/open-apis/bitable/v1/apps/:app_token` (+ tables/fields/records) | [bitable docs](https://open.feishu.cn/document/server-docs/docs/bitable-v1/app/get) |
| GET | `/open-apis/sheets/v3/spreadsheets/:spreadsheet_token` (+ sheets/query) | [sheets docs](https://open.feishu.cn/document/server-docs/docs/sheets-v3/spreadsheet/get) |
| GET | `/open-apis/wiki/v2/spaces` (+ nodes) | [wiki docs](https://open.feishu.cn/document/server-docs/docs/wiki-v2/space/list) |

**Note:** Earlier draft of this PR listed 24 templates including writes; after review that surface was re-scoped to **16 GET-only** endpoints.