### PR TITLE
fix(desktop): recover remote gateway reconnects

### DIFF
--- a/apps/desktop/electron/connection-revalidate.cjs
+++ b/apps/desktop/electron/connection-revalidate.cjs
@@ -1,0 +1,42 @@
+/**
+ * Shared primary-backend revalidation logic for the Electron main process.
+ *
+ * Kept pure and dependency-injected so wake/reconnect behavior can be tested
+ * without loading Electron. A rejected cached connection promise is itself a
+ * stale descriptor: remote backends have no child-process exit handler to clear
+ * it, so callers must reset before the renderer retries.
+ */
+
+async function revalidatePrimaryConnection(connectionPromise, options = {}) {
+  const { probeStatus, resetConnection, rememberLog } = options
+
+  if (!connectionPromise) {
+    return { ok: true, rebuilt: false }
+  }
+
+  let conn = null
+  try {
+    conn = await connectionPromise
+  } catch {
+    resetConnection?.()
+    return { ok: true, rebuilt: true }
+  }
+
+  if (!conn || conn.mode !== 'remote' || !conn.baseUrl) {
+    return { ok: true, rebuilt: false }
+  }
+
+  const base = conn.baseUrl.replace(/\/+$/, '')
+  try {
+    await probeStatus?.(`${base}/api/status`)
+    return { ok: true, rebuilt: false }
+  } catch {
+    rememberLog?.('Cached remote Hermes backend failed liveness probe; dropping stale connection.')
+    resetConnection?.()
+    return { ok: true, rebuilt: true }
+  }
+}
+
+module.exports = {
+  revalidatePrimaryConnection
+}

--- a/apps/desktop/electron/connection-revalidate.test.cjs
+++ b/apps/desktop/electron/connection-revalidate.test.cjs
@@ -1,0 +1,73 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { revalidatePrimaryConnection } = require('./connection-revalidate.cjs')
+
+test('revalidatePrimaryConnection clears a rejected cached remote boot promise', async () => {
+  let resetCount = 0
+
+  const result = await revalidatePrimaryConnection(Promise.reject(new Error('session expired')), {
+    resetConnection: () => {
+      resetCount += 1
+    },
+    probeStatus: async () => {
+      throw new Error('should not probe after rejected boot')
+    }
+  })
+
+  assert.deepEqual(result, { ok: true, rebuilt: true })
+  assert.equal(resetCount, 1)
+})
+
+test('revalidatePrimaryConnection leaves healthy remote connections cached', async () => {
+  let resetCount = 0
+  const probed = []
+
+  const result = await revalidatePrimaryConnection(Promise.resolve({ mode: 'remote', baseUrl: 'https://box.example/' }), {
+    resetConnection: () => {
+      resetCount += 1
+    },
+    probeStatus: async url => {
+      probed.push(url)
+    }
+  })
+
+  assert.deepEqual(result, { ok: true, rebuilt: false })
+  assert.equal(resetCount, 0)
+  assert.deepEqual(probed, ['https://box.example/api/status'])
+})
+
+test('revalidatePrimaryConnection drops unreachable remote connection descriptors', async () => {
+  let resetCount = 0
+  const logs = []
+
+  const result = await revalidatePrimaryConnection(Promise.resolve({ mode: 'remote', baseUrl: 'http://box:9119' }), {
+    resetConnection: () => {
+      resetCount += 1
+    },
+    rememberLog: message => logs.push(message),
+    probeStatus: async () => {
+      throw new Error('offline')
+    }
+  })
+
+  assert.deepEqual(result, { ok: true, rebuilt: true })
+  assert.equal(resetCount, 1)
+  assert.match(logs.join('\n'), /failed liveness probe/i)
+})
+
+test('revalidatePrimaryConnection ignores local connection descriptors', async () => {
+  let resetCount = 0
+
+  const result = await revalidatePrimaryConnection(Promise.resolve({ mode: 'local', baseUrl: 'http://127.0.0.1:1234' }), {
+    resetConnection: () => {
+      resetCount += 1
+    },
+    probeStatus: async () => {
+      throw new Error('local should not be probed here')
+    }
+  })
+
+  assert.deepEqual(result, { ok: true, rebuilt: false })
+  assert.equal(resetCount, 0)
+})

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -36,6 +36,7 @@ const { canImportHermesCli, verifyHermesCli } = require('./backend-probes.cjs')
 const { probeGatewayWebSocket } = require('./gateway-ws-probe.cjs')
 const { adoptServedDashboardToken } = require('./dashboard-token.cjs')
 const { waitForDashboardPort } = require('./backend-ready.cjs')
+const { revalidatePrimaryConnection } = require('./connection-revalidate.cjs')
 const { serializeJsonBody, setJsonRequestHeaders } = require('./oauth-net-request.cjs')
 const { fetchMarketplaceThemes, searchMarketplaceThemes } = require('./vscode-marketplace.cjs')
 const { buildDesktopBackendEnv } = require('./backend-env.cjs')
@@ -5272,37 +5273,13 @@ ipcMain.handle('hermes:connection', async (_event, profile) => ensureBackend(pro
 // to confirm the cached PRIMARY backend is still reachable; if a remote one is
 // not, we drop the cache so the next getConnection() rebuilds it. Local backends
 // self-heal via their child 'exit' handler, so we never touch them here.
-ipcMain.handle('hermes:connection:revalidate', async () => {
-  if (!connectionPromise) {
-    return { ok: true, rebuilt: false }
-  }
-
-  let conn = null
-  try {
-    conn = await connectionPromise
-  } catch {
-    // The cached boot already rejected (its own catch nulls connectionPromise);
-    // nothing to revalidate — the next getConnection() builds fresh.
-    return { ok: true, rebuilt: false }
-  }
-
-  if (!conn || conn.mode !== 'remote' || !conn.baseUrl) {
-    return { ok: true, rebuilt: false }
-  }
-
-  const base = conn.baseUrl.replace(/\/+$/, '')
-  try {
-    await fetchPublicJson(`${base}/api/status`, { timeoutMs: 2_500 })
-    return { ok: true, rebuilt: false }
-  } catch {
-    // Unreachable remote: drop the stale cache so the renderer's next reconnect
-    // tick rebuilds a fresh, reachable descriptor. resetHermesConnection only
-    // nulls connectionPromise for a remote (no child to SIGTERM).
-    rememberLog('Cached remote Hermes backend failed liveness probe; dropping stale connection.')
-    resetHermesConnection()
-    return { ok: true, rebuilt: true }
-  }
-})
+ipcMain.handle('hermes:connection:revalidate', async () =>
+  revalidatePrimaryConnection(connectionPromise, {
+    probeStatus: url => fetchPublicJson(url, { timeoutMs: 2_500 }),
+    rememberLog,
+    resetConnection: resetHermesConnection
+  })
+)
 ipcMain.handle('hermes:backend:touch', async (_event, profile) => {
   touchPoolBackend(profile)
   return { ok: true }

--- a/apps/desktop/electron/windows-child-process.test.cjs
+++ b/apps/desktop/electron/windows-child-process.test.cjs
@@ -28,14 +28,13 @@ test('desktop background child processes opt into hidden Windows consoles', () =
   assert.match(source, /function hiddenWindowsChildOptions\(options = \{\}\)/)
 
   requireHiddenChildOptions(source, "execFileSync(\n          'reg'")
-  requireHiddenChildOptions(source, 'execFileSync(pyExe')
-  requireHiddenChildOptions(source, 'spawn(resolveGitBinary()')
+  requireHiddenChildOptions(source, "execFileSync(\n          pyExe")
+  requireHiddenChildOptions(source, "spawn(\n      resolveGitBinary()")
   requireHiddenChildOptions(source, "execFileSync('taskkill'")
-  requireHiddenChildOptions(source, 'spawn(command, args')
   requireHiddenChildOptions(source, "spawn('curl'")
-  requireHiddenChildOptions(source, 'spawn(backend.command, backend.args')
-  requireHiddenChildOptions(source, 'hermesProcess = spawn(backend.command, backend.args')
-  requireHiddenChildOptions(source, "spawn(py, ['-m', 'hermes_cli.main', 'uninstall', '--gui-summary']")
+  requireHiddenChildOptions(source, "spawn(\n      backend.command,\n      backend.args")
+  requireHiddenChildOptions(source, "hermesProcess = spawn(\n      backend.command,\n      backend.args")
+  requireHiddenChildOptions(source, "spawn(\n        py,\n        ['-m', 'hermes_cli.main', 'uninstall', '--gui-summary']")
 })
 
 test('intentional or interactive desktop child processes stay documented', () => {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -36,7 +36,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/connection-revalidate.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs",
     "typecheck": "tsc -p . --noEmit",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -101,6 +101,7 @@ export function useGatewayBoot({
     let reconnecting = false
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null
     let reconnectAttempt = 0
+    const RECONNECT_ESCALATION_THRESHOLD = 6
     // Surface "sign in again" once per disconnect episode, not on every backoff
     // tick — a stale OAuth ticket fails every attempt and would otherwise stack
     // identical error toasts (and their haptics). Reset on the next clean open.
@@ -179,6 +180,10 @@ export function useGatewayBoot({
     function scheduleReconnect() {
       if (cancelled || reconnecting || reconnectTimer !== null || gatewayOpen()) {
         return
+      }
+
+      if (reconnectAttempt >= RECONNECT_ESCALATION_THRESHOLD && !$desktopBoot.get().error) {
+        failDesktopBoot(translateNow('boot.errors.lostConnectionToGateway'))
       }
 
       // 1s, 2s, 4s … capped at 15s.

--- a/apps/desktop/src/components/boot-failure-overlay.tsx
+++ b/apps/desktop/src/components/boot-failure-overlay.tsx
@@ -80,7 +80,7 @@ export function BootFailureOverlay() {
         return
       }
 
-      if (cancelled || !isRemoteReauthFailure(config)) {
+      if (cancelled || !isRemoteReauthFailure(config, boot.error)) {
         return
       }
 
@@ -104,7 +104,7 @@ export function BootFailureOverlay() {
     return () => {
       cancelled = true
     }
-  }, [visible])
+  }, [visible, boot.error])
 
   if (!visible || suppressed) {
     return null

--- a/apps/desktop/src/components/boot-failure-reauth.test.ts
+++ b/apps/desktop/src/components/boot-failure-reauth.test.ts
@@ -23,8 +23,26 @@ describe('isRemoteReauthFailure', () => {
     expect(isRemoteReauthFailure(config())).toBe(true)
   })
 
-  it('false when the oauth session is still connected', () => {
+  it('false when the oauth session is still connected and the boot error is not auth-shaped', () => {
     expect(isRemoteReauthFailure(config({ remoteOauthConnected: true }))).toBe(false)
+  })
+
+  it('true for an auth-shaped remote boot error even when the cookie probe is stale-positive', () => {
+    expect(
+      isRemoteReauthFailure(
+        config({ remoteOauthConnected: true }),
+        'Your remote gateway session has expired. Open Settings → Gateway and click "Sign in" again.'
+      )
+    ).toBe(true)
+  })
+
+  it('false for prolonged connectivity loss copy that mentions sign in as one option', () => {
+    expect(
+      isRemoteReauthFailure(
+        config({ remoteOauthConnected: true }),
+        'Lost connection to Hermes gateway. Use Retry, sign in again, or switch to local gateway.'
+      )
+    ).toBe(false)
   })
 
   it('false for a local gateway', () => {

--- a/apps/desktop/src/components/boot-failure-reauth.ts
+++ b/apps/desktop/src/components/boot-failure-reauth.ts
@@ -32,16 +32,28 @@ const DEFAULT_SIGN_IN_COPY: SignInCopy = {
 // fix it — only re-establishing the remote session can. A connected oauth
 // session, or a token/local gateway, boots for some other reason the
 // local-recovery buttons address, so those return false here.
-export function isRemoteReauthFailure(config: DesktopConnectionConfig | null | undefined): boolean {
+export function isRemoteReauthFailure(
+  config: DesktopConnectionConfig | null | undefined,
+  bootError?: string | null
+): boolean {
   if (!config) {
     return false
   }
 
-  return (
-    config.mode === 'remote' &&
-    config.remoteAuthMode === 'oauth' &&
-    !config.remoteOauthConnected &&
-    Boolean(config.remoteUrl)
+  const remoteOauth = config.mode === 'remote' && config.remoteAuthMode === 'oauth' && Boolean(config.remoteUrl)
+
+  if (!remoteOauth) {
+    return false
+  }
+
+  if (!config.remoteOauthConnected) {
+    return true
+  }
+
+  const message = String(bootError ?? '')
+
+  return /remote gateway session has expired|gateway session has expired|oauth.*not signed in|sign in.*remote gateway/i.test(
+    message
   )
 }
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -58,6 +58,7 @@ export const en: Translations = {
       backendStopped: 'Backend stopped',
       desktopBootFailed: 'Desktop boot failed',
       gatewaySignInRequired: 'Gateway sign-in required',
+      lostConnectionToGateway: 'Lost connection to Hermes gateway. Use Retry, sign in again, or switch to local gateway.',
       ipcBridgeUnavailable: 'Desktop IPC bridge is unavailable.'
     },
     failure: {

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -58,6 +58,7 @@ export const ja = defineLocale({
       backendStopped: 'バックエンドが停止しました',
       desktopBootFailed: 'デスクトップの起動に失敗しました',
       gatewaySignInRequired: 'ゲートウェイへのサインインが必要です',
+      lostConnectionToGateway: 'Hermes ゲートウェイへの接続が失われました。再試行するか、再度サインインするか、ローカルゲートウェイに切り替えてください。',
       ipcBridgeUnavailable: 'デスクトップ IPC ブリッジが利用できません。'
     },
     failure: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -73,6 +73,7 @@ export interface Translations {
       backendStopped: string
       desktopBootFailed: string
       gatewaySignInRequired: string
+      lostConnectionToGateway: string
       ipcBridgeUnavailable: string
     }
     failure: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -58,6 +58,7 @@ export const zhHant = defineLocale({
       backendStopped: '後端已停止',
       desktopBootFailed: '桌面啟動失敗',
       gatewaySignInRequired: '需要閘道登入',
+      lostConnectionToGateway: '與 Hermes 閘道的連線已中斷。請重試、重新登入，或切換到本機閘道。',
       ipcBridgeUnavailable: '桌面 IPC 橋接器不可用。'
     },
     failure: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -58,6 +58,7 @@ export const zh: Translations = {
       backendStopped: '后端已停止',
       desktopBootFailed: '桌面启动失败',
       gatewaySignInRequired: '需要登录网关',
+      lostConnectionToGateway: '与 Hermes 网关的连接已断开。请重试、重新登录，或切换到本地网关。',
       ipcBridgeUnavailable: '桌面 IPC 桥不可用。'
     },
     failure: {


### PR DESCRIPTION
## Summary
- Extract primary connection revalidation into a pure tested helper and make rejected cached remote boot promises rebuild on the next retry.
- Classify auth-shaped remote OAuth boot failures using the boot error, so stale-positive cookie probes still show the remote sign-in recovery path.
- Escalate prolonged post-boot gateway reconnect loops to a recoverable boot error instead of leaving the Desktop stuck behind CONNECTING.
- Refresh brittle Windows child-process static tests to match multiline call sites while preserving the hidden-console guard.

## Test plan
- `node --test electron/connection-revalidate.test.cjs`
- `npm run test:desktop:platforms`
- `npm run test:ui -- src/components/boot-failure-reauth.test.ts src/app/gateway/hooks/use-gateway-boot.test.tsx`
- `npm run typecheck`
- `npm run build`

## Notes
This is intended to harden remote-thin-client Desktop mode after OAuth/ws-ticket failures and sleep/wake or remote outage reconnect loops.
