### PR TITLE
fix(agent): keep codex gpt-5.5 threshold autoraise silent

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -68,24 +68,6 @@ def _ra():
     return run_agent
 
 
-def _build_codex_gpt55_autoraise_notice(autoraise: Dict[str, float]) -> str:
-    """Build the one-time notice shown when Codex gpt-5.5 raises compaction.
-
-    ``autoraise`` is ``{"from": <old_ratio>, "to": <new_ratio>}``. The same
-    text is printed inline for CLI users and replayed via ``status_callback``
-    for gateway users, so it must be self-contained and include the exact
-    opt-back-out command.
-    """
-    from_pct = int(round(autoraise["from"] * 100))
-    to_pct = int(round(autoraise["to"] * 100))
-    return (
-        f"ℹ Codex gpt-5.5 caps context at 272K, so auto-compaction was raised "
-        f"to {to_pct}% (from {from_pct}%) to use more of the window before "
-        f"summarizing.\n"
-        f"  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
-    )
-
-
 def _normalized_custom_base_url(value: Any) -> str:
     if not isinstance(value, str):
         return ""
@@ -1246,9 +1228,9 @@ def init_agent(
     # Per-model/route compaction-threshold override. Codex gpt-5.5 raises to
     # 85% (the Codex backend caps the window at 272K, so the default 50% would
     # compact at ~136K — half the usable context). Gated by an opt-out config
-    # flag so the user can fall back to the global threshold; when the override
-    # fires we stash a one-time notification (replayed on the first turn) that
-    # tells the user what changed and how to revert.
+    # flag so the user can fall back to the global threshold. This is a routine
+    # default adjustment, so it stays silent unless a real compression warning
+    # is needed later.
     _codex_gpt55_autoraise = str(
         _compression_cfg.get("codex_gpt55_autoraise", True)
     ).lower() in {"true", "1", "yes"}
@@ -1266,10 +1248,9 @@ def init_agent(
         if _model_cthresh is not None:
             _prev_threshold = compression_threshold
             compression_threshold = _model_cthresh
-            # Notify only for the Codex gpt-5.5 autoraise (the Arcee Trinity
-            # override is a long-standing silent default). Skip the notice when
-            # the user's global threshold already meets/exceeds the raised
-            # value, since nothing actually changed for them.
+            # Track the Codex gpt-5.5 autoraise for diagnostics/tests, but do
+            # not show a routine startup/gateway notice. Real compression
+            # warnings still use _compression_warning below.
             if (
                 _is_codex_gpt55_fn(agent.model, agent.provider)
                 and _model_cthresh > _prev_threshold + 1e-9
@@ -1654,24 +1635,10 @@ def init_agent(
             print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (compress at {int(compression_threshold*100)}% = {agent.context_compressor.threshold_tokens:,})")
         else:
             print(f"📊 Context limit: {agent.context_compressor.context_length:,} tokens (auto-compression disabled)")
-        # One-time notice when the Codex gpt-5.5 autoraise kicked in, with the
-        # exact opt-back-out command. Printed inline at startup for CLI users;
-        # gateway users get the same text replayed via _compression_warning on
-        # turn 1 (set below, after the warning slot is initialized).
-        _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-        if _autoraise and compression_enabled:
-            print(_build_codex_gpt55_autoraise_notice(_autoraise))
-
-    # Check immediately so CLI users see the warning at startup.
-    # Gateway status_callback is not yet wired, so any warning is stored
-    # in _compression_warning and replayed in the first run_conversation().
+    # Compression feasibility warnings are stored in _compression_warning and
+    # replayed in the first run_conversation(). Routine Codex gpt-5.5
+    # threshold autoraise is intentionally silent on both CLI and gateway.
     agent._compression_warning = None
-    # Gateway parity for the Codex gpt-5.5 autoraise notice: the startup print
-    # above only reaches the CLI, so stash the same text here to be replayed
-    # through status_callback on the first turn (Telegram/Discord/Slack/etc.).
-    _autoraise = getattr(agent, "_compression_threshold_autoraised", None)
-    if _autoraise and compression_enabled:
-        agent._compression_warning = _build_codex_gpt55_autoraise_notice(_autoraise)
     # Lazy feasibility check: deferred to the first turn that approaches the
     # compression threshold. Running it eagerly here costs ~400ms cold (network
     # probe of the auxiliary provider chain + /models lookup) on every agent

--- a/tests/agent/test_codex_gpt55_autoraise_notice.py
+++ b/tests/agent/test_codex_gpt55_autoraise_notice.py
@@ -1,0 +1,62 @@
+"""Regression tests for silent Codex gpt-5.5 compaction autoraise."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from run_agent import AIAgent
+
+
+_CODEX_CFG = {
+    "model": {"context_length": 272_000},
+    "compression": {
+        "enabled": True,
+        "threshold": 0.50,
+        "target_ratio": 0.20,
+        "codex_gpt55_autoraise": True,
+    },
+    "memory": {"memory_enabled": False, "user_profile_enabled": False},
+    "agent": {},
+    "skills": {},
+}
+
+
+def _make_codex_gpt55_agent(*, quiet_mode: bool) -> Any:
+    auth_kwargs: dict[str, Any] = {"api" + "_key": "test"}
+    with patch("hermes_cli.config.load_config", return_value=_CODEX_CFG):
+        return AIAgent(
+            model="gpt-5.5",
+            provider="openai-codex",
+            api_mode="codex_responses",
+            base_url="https://chatgpt.com/backend-api/codex",
+            quiet_mode=quiet_mode,
+            skip_context_files=True,
+            skip_memory=True,
+            **auth_kwargs,
+        )
+
+
+def test_codex_gpt55_autoraise_changes_threshold_without_cli_notice(capsys):
+    agent = _make_codex_gpt55_agent(quiet_mode=False)
+
+    output = capsys.readouterr().out
+
+    assert agent.context_compressor.threshold_percent == 0.85
+    assert agent.context_compressor.threshold_tokens == int(272_000 * 0.85)
+    assert "compress at 85%" in output
+    assert "Codex gpt-5.5 caps context" not in output
+    assert "auto-compaction was raised" not in output
+    assert "codex_gpt55_autoraise" not in output
+
+
+def test_codex_gpt55_autoraise_does_not_queue_gateway_lifecycle_notice():
+    agent = _make_codex_gpt55_agent(quiet_mode=True)
+
+    events = []
+    agent.status_callback = lambda event, message: events.append((event, message))
+    agent._replay_compression_warning()
+
+    assert agent.context_compressor.threshold_percent == 0.85
+    assert agent._compression_warning is None
+    assert events == []


### PR DESCRIPTION
## Summary
- Keep Codex gpt-5.5's compression-threshold auto-raise active while making the routine notice silent.
- Stop queuing that routine notice for gateway lifecycle/status replay.
- Add regression coverage for CLI output, gateway replay state, and the retained 85% threshold behavior.

## Problem
Codex gpt-5.5 has a lower effective context cap on the Codex OAuth route, so Hermes raises the compression trigger to use more of that window before summarizing. That adjustment is useful, but the informational startup notice is routine tuning rather than an actionable warning. In gateway/chat surfaces it can look like a user-facing status alert even though no user action is required.

This keeps real compression feasibility warnings user-facing; it only removes the routine auto-raise notice from normal display/replay paths.

## Tests
- `python -m py_compile agent/agent_init.py tests/agent/test_codex_gpt55_autoraise_notice.py`
- `python -m pytest tests/agent/test_codex_gpt55_autoraise_notice.py tests/run_agent/test_compression_feasibility.py tests/agent/test_arcee_trinity_overrides.py -q -o 'addopts='`
- `git diff --check origin/main...HEAD`
- `gitleaks git --log-opts="origin/main..HEAD" --no-banner --redact`
