### PR TITLE
fix(auth): warn on duplicate Codex OAuth credentials

### DIFF
--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import math
 import sys
 import time
@@ -107,6 +108,33 @@ def _oauth_default_label(provider: str, count: int) -> str:
 
 def _api_key_default_label(count: int) -> str:
     return f"api-key-{count}"
+
+
+def _token_fingerprint(token: str) -> str:
+    """Return a short non-secret fingerprint for duplicate-token detection."""
+    if not token:
+        return ""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()[:12]
+
+
+def _find_duplicate_token_entry(entries, token: str):
+    """Find an existing pool entry with the exact same access token.
+
+    OAuth device-code flows can accidentally authorize the browser's current
+    account while the user supplies a different label.  If the resulting access
+    token is byte-for-byte identical to an existing pool entry, the new entry is
+    not an independent fallback account.  Return a 1-based index and entry so
+    the CLI can warn without printing token material.
+    """
+    if not token:
+        return None
+    for idx, existing in enumerate(entries, start=1):
+        # The public warning is about an exact duplicate credential.  Do not
+        # use the short fingerprint for the decision itself: it is only a
+        # non-secret display aid after byte-for-byte equality is established.
+        if (getattr(existing, "access_token", "") or "") == token:
+            return idx, existing, _token_fingerprint(token)
+    return None
 
 
 def _display_source(source: str) -> str:
@@ -334,7 +362,9 @@ def auth_add_command(args) -> None:
             base_url=creds.get("base_url"),
             last_refresh=creds.get("last_refresh"),
         )
-        first_credential = not pool.entries()
+        existing_entries = pool.entries()
+        duplicate = _find_duplicate_token_entry(existing_entries, entry.access_token)
+        first_credential = not existing_entries
         pool.add_entry(entry)
         # Adding the first Codex credential should make it the active provider
         # (the old singleton save path did this implicitly via
@@ -342,6 +372,15 @@ def auth_add_command(args) -> None:
         if first_credential:
             auth_mod.mark_provider_active_if_unset(provider)
         print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
+        if duplicate:
+            dup_index, dup_entry, dup_fp = duplicate
+            dup_label = getattr(dup_entry, "label", "") or f"credential #{dup_index}"
+            print(
+                f'Warning: this OAuth token matches existing {provider} credential '
+                f'#{dup_index} "{dup_label}" (fingerprint {dup_fp}). '
+                "If you intended to add a different account, switch browser "
+                "accounts and run auth add again."
+            )
         return
 
     if provider == "xai-oauth":

--- a/tests/hermes_cli/test_auth_commands_codex_duplicate.py
+++ b/tests/hermes_cli/test_auth_commands_codex_duplicate.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+def _args(label: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        provider="openai-codex",
+        auth_type="oauth",
+        label=label,
+        no_browser=True,
+        timeout=None,
+        api_key=None,
+    )
+
+
+def _seed_pool(tmp_path, token: str = "token-a") -> None:
+    home = tmp_path / "hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "auth.json").write_text(
+        '{"version":1,"credential_pool":{"openai-codex":[{"id":"cred1","label":"primary","auth_type":"oauth","priority":0,"source":"manual:device_code","access_token":"'
+        + token
+        + '","refresh_token":"refresh-a"}]}}\n'
+    )
+
+
+def test_codex_auth_add_warns_when_new_oauth_token_duplicates_existing_pool_entry(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _seed_pool(tmp_path, token="same-access-token")
+
+    import hermes_cli.auth_commands as auth_commands
+
+    monkeypatch.setattr(
+        auth_commands.auth_mod,
+        "_codex_device_code_login",
+        lambda: {
+            "tokens": {
+                "access_token": "same-access-token",
+                "refresh_token": "refresh-b",
+            },
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "last_refresh": "2026-01-01T00:00:00Z",
+        },
+    )
+
+    auth_commands.auth_add_command(_args("secondary"))
+
+    out = capsys.readouterr().out
+    assert 'Added openai-codex OAuth credential #2: "secondary"' in out
+    assert "Warning: this OAuth token matches existing openai-codex credential #1" in out
+    assert '"primary"' in out
+    assert "same-access-token" not in out
+    assert "switch browser accounts" in out.lower()
+
+
+def test_codex_auth_add_does_not_warn_for_distinct_oauth_token(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _seed_pool(tmp_path, token="access-token-a")
+
+    import hermes_cli.auth_commands as auth_commands
+
+    monkeypatch.setattr(
+        auth_commands.auth_mod,
+        "_codex_device_code_login",
+        lambda: {
+            "tokens": {
+                "access_token": "access-token-b",
+                "refresh_token": "refresh-b",
+            },
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "last_refresh": "2026-01-01T00:00:00Z",
+        },
+    )
+
+    auth_commands.auth_add_command(_args("secondary"))
+
+    out = capsys.readouterr().out
+    assert 'Added openai-codex OAuth credential #2: "secondary"' in out
+    assert "Warning: this OAuth token matches" not in out


### PR DESCRIPTION
## Summary
- Warn when `hermes auth add openai-codex` adds an OAuth credential whose access token exactly matches an existing pool credential.
- Keep duplicate detection non-blocking: the credential is still added, but the CLI tells the user to switch browser accounts and retry if they intended to add a different account.
- Add regression coverage for duplicate vs distinct Codex OAuth tokens and raw-token non-disclosure.

## Problem
When users maintain multiple Codex OAuth credentials, it is easy to approve the browser's currently signed-in account while supplying a label for a different account. That creates a pool entry that looks like an independent fallback credential, but actually carries the same access token as an existing entry.

This change detects exact duplicate access tokens and prints a warning using only a short non-secret fingerprint. The raw token is never printed, and the comparison remains byte-for-byte exact; the fingerprint is display-only.

## Tests
- `python -m pytest tests/hermes_cli/test_auth_commands_codex_duplicate.py tests/hermes_cli/test_auth_profile_fallback.py tests/agent/test_credential_pool.py -q -o 'addopts='`
- `git diff --check origin/main...HEAD`
- `gitleaks git --log-opts='origin/main..HEAD' --no-banner --redact`
- private/token marker scan over `git diff origin/main...HEAD`
- controller gate: `.pr-gate-runs/**/AUTO_PR_READY.json` → `ready_for_auto_pr`

Note: a full QualityGate MCP run was attempted on this worktree but timed out after 900s; focused regression tests and leak scans above passed.
