### PR TITLE
fix(kanban): default to rollback journal policy

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -58,14 +58,15 @@ worktrees so that research / ops / digital-twin workloads work alongside
 coding workloads.  See ``docs/hermes-kanban-v1-spec.pdf`` for the full
 design specification.
 
-Concurrency strategy: WAL mode + ``BEGIN IMMEDIATE`` for write
+Concurrency strategy: rollback journaling by default (override with
+``HERMES_KANBAN_JOURNAL=wal`` when desired) + ``BEGIN IMMEDIATE`` for write
 transactions + compare-and-swap (CAS) updates on ``tasks.status`` and
-``tasks.claim_lock``.  SQLite serializes writers via its WAL lock, so at
-most one claimer can win any given task.  Losers observe zero affected
-rows and move on -- no retry loops, no distributed-lock machinery.
-The CAS coordination is **per-board** — each board is a separate DB,
-so multi-board installs get the same atomicity guarantees without any
-new locking.
+``tasks.claim_lock``.  SQLite serializes writers behind the write
+transaction, so at most one claimer can win any given task.  Losers
+observe zero affected rows and move on -- no retry loops, no
+distributed-lock machinery.  The CAS coordination is **per-board** —
+each board is a separate DB, so multi-board installs get the same
+atomicity guarantees without any new locking.
 """
 
 from __future__ import annotations
@@ -1457,11 +1458,27 @@ def connect(
                 # sidecar files for a fresh database. Keep it in the same process-local
                 # critical section as schema initialization so concurrent gateway
                 # startup threads do not race before _INITIALIZED_PATHS is populated.
-                # WAL doesn't work on network filesystems (NFS/SMB/FUSE). Shared helper
-                # falls back to DELETE with one WARNING so kanban stays usable there.
-                # See hermes_state._WAL_INCOMPAT_MARKERS for detection logic.
-                from hermes_state import apply_wal_with_fallback
-                apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
+                # Some deployments intentionally force rollback journaling for kanban
+                # because several user services share the same DB and the watchdog
+                # checks for DELETE mode. Respect HERMES_KANBAN_JOURNAL before running
+                # the WAL helper; otherwise every kanban connection silently flips the
+                # DB back to WAL and the watchdog oscillates DELETE -> WAL -> DELETE.
+                journal_policy = os.getenv("HERMES_KANBAN_JOURNAL", "delete").strip().lower()
+                if journal_policy in {"delete", "persist", "truncate"}:
+                    result = conn.execute(
+                        f"PRAGMA journal_mode={journal_policy.upper()}"
+                    ).fetchone()
+                    actual = result[0].lower() if result else ""
+                    if actual != journal_policy:
+                        raise RuntimeError(
+                            f"Kanban DB journal_mode requested {journal_policy}, got {actual}"
+                        )
+                else:
+                    # WAL doesn't work on network filesystems (NFS/SMB/FUSE). Shared helper
+                    # falls back to DELETE with one WARNING so kanban stays usable there.
+                    # See hermes_state._WAL_INCOMPAT_MARKERS for detection logic.
+                    from hermes_state import apply_wal_with_fallback
+                    apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")
                 # FULL (was NORMAL): fsync before each checkpoint to narrow the
                 # crash window that can leave a b-tree page header torn.
                 conn.execute("PRAGMA synchronous=FULL")

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2664,6 +2664,7 @@ def test_connect_falls_back_to_delete_on_locking_protocol(tmp_path, monkeypatch,
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_JOURNAL", "wal")
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
 
     # Clear module cache so a fresh connect() is attempted
@@ -4119,9 +4120,10 @@ def test_write_txn_post_commit_check_fires_every_call(tmp_path):
     conn.close()
 
 
-def test_connect_sets_wal_autocheckpoint_100(tmp_path):
-    """connect() sets wal_autocheckpoint to 100."""
+def test_connect_sets_wal_autocheckpoint_100(tmp_path, monkeypatch):
+    """connect() sets wal_autocheckpoint to 100 when WAL is requested."""
     from hermes_cli.kanban_db import connect
+    monkeypatch.setenv("HERMES_KANBAN_JOURNAL", "wal")
     db = tmp_path / "test.db"
     conn = connect(db_path=db)
     val = conn.execute("PRAGMA wal_autocheckpoint").fetchone()[0]

--- a/tests/hermes_cli/test_kanban_db_journal_policy.py
+++ b/tests/hermes_cli/test_kanban_db_journal_policy.py
@@ -1,0 +1,37 @@
+import sqlite3
+
+from hermes_cli import kanban_db
+
+
+def _journal_mode(path):
+    conn = sqlite3.connect(str(path))
+    try:
+        return conn.execute("PRAGMA journal_mode").fetchone()[0]
+    finally:
+        conn.close()
+
+
+def test_connect_respects_delete_journal_policy(tmp_path, monkeypatch):
+    db_path = tmp_path / "kanban.db"
+    monkeypatch.setenv("HERMES_KANBAN_JOURNAL", "delete")
+
+    conn = kanban_db.connect(db_path=db_path)
+    try:
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0] == "delete"
+    finally:
+        conn.close()
+
+    assert _journal_mode(db_path) == "delete"
+
+
+def test_connect_defaults_to_delete_journal_policy(tmp_path, monkeypatch):
+    db_path = tmp_path / "kanban.db"
+    monkeypatch.delenv("HERMES_KANBAN_JOURNAL", raising=False)
+
+    conn = kanban_db.connect(db_path=db_path)
+    try:
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0] == "delete"
+    finally:
+        conn.close()
+
+    assert _journal_mode(db_path) == "delete"


### PR DESCRIPTION
## Bug Description

Kanban `connect()` unconditionally enabled WAL mode through `apply_wal_with_fallback()`. On deployments that intentionally require rollback journaling for the Kanban DB, every application connection could silently flip the DB back to WAL after a watchdog or post-update check restored DELETE mode.

## Root Cause

`HERMES_KANBAN_JOURNAL` was not treated as the default policy gate in `hermes_cli/kanban_db.py::connect()`. The live connection path always ran the WAL helper, so rollback-journal deployments oscillated:

`DELETE -> app reconnect -> WAL -> watchdog/check fails`

## Fix

- Default Kanban connections to `HERMES_KANBAN_JOURNAL=delete` when the env var is absent.
- Respect rollback modes: `delete`, `persist`, and `truncate` without invoking the WAL helper.
- Verify SQLite's returned `PRAGMA journal_mode` value and raise if the requested rollback mode was not actually applied.
- Keep WAL available when explicitly requested with `HERMES_KANBAN_JOURNAL=wal`.
- Add/adjust regression coverage for both default DELETE behavior and explicit WAL fallback behavior.

## How to Verify

1. Run `python -m pytest -q tests/hermes_cli/test_kanban_db_journal_policy.py tests/hermes_cli/test_kanban_db.py`.
2. Confirm a fresh `kanban_db.connect()` with no `HERMES_KANBAN_JOURNAL` env returns `PRAGMA journal_mode = delete`.
3. Confirm `HERMES_KANBAN_JOURNAL=wal` still exercises the WAL helper path.

## Test Plan

- [x] Added regression test for this bug
- [x] Existing Kanban DB tests still pass locally
- [x] Manual verification on a live deployment: post-update check now reports `journal=delete integrity=ok`

## Risk Assessment

Medium — this changes the default Kanban journal mode from WAL to rollback journaling. The change is intentional for deployments where WAL causes operational drift, but WAL remains opt-in via `HERMES_KANBAN_JOURNAL=wal` for environments that prefer it.
