### PR TITLE
fix(agent): allow read-only file tools in cron background review

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -470,7 +470,7 @@ def _run_review_in_thread(
             review_whitelist = {
                 t["function"]["name"]
                 for t in get_tool_definitions(
-                    enabled_toolsets=["memory", "skills"],
+                    enabled_toolsets=["memory", "skills", "file_read"],
                     quiet_mode=True,
                 )
             }
@@ -478,16 +478,17 @@ def _run_review_in_thread(
                 review_whitelist,
                 deny_msg_fmt=(
                     "Background review denied non-whitelisted tool: "
-                    "{tool_name}. Only memory/skill tools are allowed."
+                    "{tool_name}. Only memory/skill/read-only tools are allowed."
                 ),
             )
             try:
                 review_agent.run_conversation(
                     user_message=(
                         prompt
-                        + "\n\nYou can only call memory and skill "
-                        "management tools. Other tools will be denied "
-                        "at runtime — do not attempt them."
+                        + "\n\nYou can only call memory, skill management, "
+                        "and read-only file tools (read_file, search_files). "
+                        "Other tools will be denied at runtime — do not "
+                        "attempt them."
                     ),
                     conversation_history=messages_snapshot,
                 )

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -86,12 +86,12 @@ def test_background_review_matches_parent_toolset_config():
 
 
 def test_background_review_installs_thread_local_whitelist():
-    """The review fork must install a memory/skills-only thread-local whitelist.
+    """The review fork must install a memory/skills/read-only-file whitelist.
 
     The schema-level toolset narrowing was lifted (for prefix-cache parity),
     so #15204's safety contract now relies on the runtime whitelist gate to
     deny terminal/send_message/delegate_task at dispatch time. Verify the
-    whitelist is set with exactly the memory+skills tool names.
+    whitelist is set with exactly the memory+skills+file_read tool names.
     """
     import run_agent
     from hermes_cli import plugins as _plugins
@@ -127,16 +127,22 @@ def test_background_review_installs_thread_local_whitelist():
     assert "skill_manage" in whitelist
     assert "skill_view" in whitelist
     assert "skills_list" in whitelist
+    # read-only file tools must be allowed
+    assert "read_file" in whitelist
+    assert "search_files" in whitelist
     # dangerous tools must NOT be in the whitelist
     assert "terminal" not in whitelist
     assert "send_message" not in whitelist
     assert "delegate_task" not in whitelist
     assert "web_search" not in whitelist
     assert "execute_code" not in whitelist
+    # write file tools must NOT be in the whitelist
+    assert "write_file" not in whitelist
+    assert "patch" not in whitelist
 
 
 def test_background_review_agent_tools_are_limited():
-    """Verify the resolved memory+skills toolsets only contain memory and skill tools.
+    """Verify the resolved memory+skills+file_read toolsets contain only safe tools.
 
     Sanity check on the source of truth for what the runtime whitelist is
     derived from — if a future PR adds e.g. `terminal` to the `memory`
@@ -144,15 +150,19 @@ def test_background_review_agent_tools_are_limited():
     """
     from toolsets import resolve_multiple_toolsets
 
-    expected_tools = set(resolve_multiple_toolsets(["memory", "skills"]))
+    expected_tools = set(resolve_multiple_toolsets(["memory", "skills", "file_read"]))
 
     assert "memory" in expected_tools
     assert "skill_manage" in expected_tools
     assert "skill_view" in expected_tools
     assert "skills_list" in expected_tools
+    assert "read_file" in expected_tools
+    assert "search_files" in expected_tools
 
     assert "terminal" not in expected_tools
     assert "send_message" not in expected_tools
     assert "delegate_task" not in expected_tools
     assert "web_search" not in expected_tools
     assert "execute_code" not in expected_tools
+    assert "write_file" not in expected_tools
+    assert "patch" not in expected_tools

--- a/toolsets.py
+++ b/toolsets.py
@@ -200,7 +200,13 @@ TOOLSETS = {
         "tools": ["read_file", "write_file", "patch", "search_files"],
         "includes": []
     },
-    
+
+    "file_read": {
+        "description": "Read-only file tools: read files and search content/names without side effects",
+        "tools": ["read_file", "search_files"],
+        "includes": []
+    },
+
     "tts": {
         "description": "Text-to-speech: convert text to audio with Edge TTS (free), ElevenLabs, OpenAI, or xAI",
         "tools": ["text_to_speech"],


### PR DESCRIPTION
## Summary

The background review agent's tool whitelist only included `memory` and `skill` tools, blocking `read_file` and `search_files`. This forces cron agents to use `terminal(cat/grep)` workarounds or operate without reading relevant context.

This PR adds a `file_read` toolset (read-only: `read_file` + `search_files`) and includes it in the background review whitelist. Write tools (`write_file`, `patch`) remain blocked.

## Changes

- **`toolsets.py`**: Added `file_read` toolset with `read_file` and `search_files`
- **`agent/background_review.py`**: Added `file_read` to the whitelist toolsets, updated deny message and review prompt
- **`tests/run_agent/test_background_review_toolset_restriction.py`**: Updated tests to verify read-only tools are allowed and write tools are still blocked

## Test Plan

- [x] `test_background_review_matches_parent_toolset_config` — passes
- [x] `test_background_review_installs_thread_local_whitelist` — passes (now asserts `read_file` + `search_files` in whitelist, `write_file` + `patch` not in whitelist)
- [x] `test_background_review_agent_tools_are_limited` — passes (now verifies `file_read` toolset resolution)

Closes #45877