### PR TITLE
fix(session): smarter default reset — no daily wipe, guide agent to recover context

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -281,7 +281,7 @@ class SessionResetPolicy:
     - "both": Whichever triggers first (daily boundary OR idle timeout)
     - "none": Never auto-reset (context managed only by compression)
     """
-    mode: str = "both"  # "daily", "idle", "both", or "none"
+    mode: str = "idle"  # "daily", "idle", "both", or "none"
     at_hour: int = 4  # Hour for daily reset (0-23, local time)
     idle_minutes: int = 1440  # Minutes of inactivity before reset (24 hours)
     notify: bool = True  # Send a notification to the user when auto-reset occurs
@@ -305,7 +305,7 @@ class SessionResetPolicy:
         notify = data.get("notify")
         exclude = data.get("notify_exclude_platforms")
         return cls(
-            mode=mode if mode is not None else "both",
+            mode=mode if mode is not None else "idle",
             at_hour=at_hour if at_hour is not None else 4,
             idle_minutes=idle_minutes if idle_minutes is not None else 1440,
             notify=_coerce_bool(notify, True),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7869,9 +7869,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if reset_reason == "suspended":
                 context_note = "[System note: The user's previous session was stopped and suspended. This is a fresh conversation with no prior context.]"
             elif reset_reason == "daily":
-                context_note = "[System note: The user's session was automatically reset by the daily schedule. This is a fresh conversation with no prior context.]"
+                context_note = "[System note: The user's session was automatically reset by the daily schedule. Use session_search to look up what was discussed in the previous session, then naturally continue the conversation based on that context.]"
             else:
-                context_note = "[System note: The user's previous session expired due to inactivity. This is a fresh conversation with no prior context.]"
+                context_note = "[System note: The user's session expired due to inactivity. Use session_search to look up what was discussed in the previous session, then naturally continue the conversation based on that context.]"
             context_prompt = context_note + "\n\n" + context_prompt
 
             # Send a user-facing notification explaining the reset, unless:


### PR DESCRIPTION
## Summary

Two improvements to the default session reset behavior that make Hermes feel more intelligent out of the box:

### 1. Default `mode: "idle"` instead of `"both"`

The previous default (`mode: "both"`) forced a daily session reset at 4 AM, destroying all conversation context overnight. Users who chatted in the evening and returned the next morning would find Hermes with no memory of the previous conversation — asking "what are you asking about?" instead of continuing naturally.

**Change:** `SessionResetPolicy.mode` default changed from `"both"` to `"idle"`. The idle timeout remains at 1440 minutes (24 hours), so sessions still auto-clean on genuine disuse while surviving normal day-to-day usage.

### 2. Guide agent to recover context on auto-reset

When a session IS auto-reset (idle or daily), the previous context note told the agent: *"This is a fresh conversation with no prior context."* — which made the agent behave as if it had amnesia.

**Change:** The note now tells the agent to use `session_search` to look up what was discussed before and naturally continue the conversation. This makes even forced-reset scenarios feel intelligent.

### Files changed

- `gateway/config.py`: `SessionResetPolicy.mode` default and fallback: `"both"` → `"idle"`
- `gateway/run.py`: Auto-reset context notes: "no prior context" → "use session_search to recover context"

### Testing

- [ ] Manual: simulate daily reset and verify agent uses session_search to pick up previous conversation