### PR TITLE
fix(auxiliary): use glm-4.5v as Z.AI vision default (accessible on all coding plan tiers)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -326,7 +326,7 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = _API_KEY_PROVIDER_AUX_MODELS_FALL
 # "exotic provider" branch checks this before falling back to the main model.
 _PROVIDER_VISION_MODELS: Dict[str, str] = {
     "xiaomi": "mimo-v2.5",
-    "zai": "glm-5v-turbo",
+    "zai": "glm-4.5v",
 }
 
 # Providers whose endpoint does not accept image input, even though the
@@ -4175,7 +4175,7 @@ def resolve_vision_provider_client(
         #      _PROVIDER_VISION_MODELS provides per-provider vision model
         #      overrides when the provider has a dedicated multimodal model
         #      that differs from the chat model (e.g. xiaomi → mimo-v2-omni,
-        #      zai → glm-5v-turbo). Nous is the exception: it has a dedicated
+        #      zai → glm-4.5v). Nous is the exception: it has a dedicated
         #      strict vision backend with tier-aware defaults, so it must not
         #      fall through to the user's text chat model here.
         #   2. OpenRouter  (vision-capable aggregator fallback)

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -251,7 +251,7 @@ class TestResolveVisionProviderClientModelNormalization:
 
         assert provider == "zai"
         assert client is not None
-        assert model == "glm-5v-turbo"  # zai has dedicated vision model in _PROVIDER_VISION_MODELS
+        assert model == "glm-4.5v"  # zai has dedicated vision model in _PROVIDER_VISION_MODELS
 
 
 class TestVisionPathApiMode:


### PR DESCRIPTION
## What does this PR do?

Changes the hardcoded `_PROVIDER_VISION_MODELS["zai"]` default from `glm-5v-turbo` to `glm-4.5v`, which is the working vision model accessible on all Z.AI coding plan tiers (Lite/Pro/Max).

## Related Issue

Fixes #46050

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`: Changed `_PROVIDER_VISION_MODELS["zai"]` from `"glm-5v-turbo"` to `"glm-4.5v"` and updated the inline comment at line ~4196
- `tests/agent/test_auxiliary_named_custom_providers.py`: Updated assertion to expect `"glm-4.5v"` instead of `"glm-5v-turbo"`

## How to Test

1. Configure Hermes with Z.AI as the main provider on a coding plan tier
2. Send a message with an attached image (or use `vision_analyze` tool)
3. Verify vision works without errors (previously: `"Your current subscription plan does not yet include access to GLM-5V-Turbo"`)
4. Run `pytest tests/agent/test_auxiliary_named_custom_providers.py -q` — all 29 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_auxiliary_named_custom_providers.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_PROVIDER_VISION_MODELS` (usage: 5 call sites in `agent/auxiliary_client.py`)
- Blast radius: LOW — data-only change, no control flow modification
- Related patterns: `_PROVIDERS_WITHOUT_VISION` frozenset, `_main_model_supports_vision()` helper
