### PR TITLE
fix(gateway): re-send rich on unchanged-text streamed finalize (complements #45995)

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -1358,8 +1358,21 @@ class GatewayStreamConsumer:
                     # finalize=True edit even when content is unchanged, so
                     # their streaming UI can transition out of the in-
                     # progress state.  Everyone else short-circuits.
+                    # Adapters that prefer a fresh rich final (e.g. Telegram,
+                    # via ``prefers_fresh_final_streaming``) must also bypass
+                    # this skip on finalize.  The streamed preview was rendered
+                    # on the downgraded edit path; an unchanged-text finalize
+                    # would otherwise short-circuit here and never reach the
+                    # fresh rich re-send below, leaving rich constructs (tables,
+                    # task lists) collapsed to their legacy fallback.  Keyed on
+                    # the FINAL content's rich-eligibility (same predicate as the
+                    # fresh-final gate below), so it fires for any rich-capable
+                    # finalize, not only tables.
                     if text == self._last_sent_text and not (
-                        finalize and self._adapter_requires_finalize
+                        finalize and (
+                            self._adapter_requires_finalize
+                            or self._adapter_prefers_fresh_final(text)
+                        )
                     ):
                         return True
                     # Fresh-final for long-lived previews: when finalizing

--- a/tests/gateway/test_stream_consumer_fresh_final.py
+++ b/tests/gateway/test_stream_consumer_fresh_final.py
@@ -60,6 +60,86 @@ class TestFreshFinalForLongLivedPreviews:
         adapter.edit_message.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_unchanged_final_text_still_fresh_sends_when_adapter_prefers(self):
+        """Rich-preferring adapter must re-send the final fresh even when the
+        final text is unchanged.
+
+        Regression for the redundant-edit short-circuit pre-empting the
+        fresh-final path: the streamed preview is rendered on the downgraded
+        edit path, so an unchanged-text finalize that short-circuits to a
+        redundant-edit skip leaves rich constructs (tables, task lists)
+        collapsed.  ``prefers_fresh_final_streaming`` must override the skip on
+        finalize, independent of the time threshold.
+        """
+        adapter = _make_adapter()
+        adapter.prefers_fresh_final_streaming = MagicMock(return_value=True)
+        adapter.send.side_effect = [
+            SimpleNamespace(success=True, message_id="initial_preview"),
+            SimpleNamespace(success=True, message_id="fresh_final"),
+        ]
+        consumer = GatewayStreamConsumer(
+            adapter=adapter,
+            chat_id="chat",
+            # Time-threshold path disabled — exercise the adapter-prefers path.
+            config=StreamConsumerConfig(fresh_final_after_seconds=0.0),
+        )
+        await consumer._send_or_edit("same text")
+        # Finalize with identical text must NOT short-circuit to an edit.
+        await consumer._send_or_edit("same text", finalize=True)
+        assert adapter.send.call_count == 2  # preview + fresh final
+        adapter.edit_message.assert_not_called()
+        assert consumer._message_id == "fresh_final"
+        # Fresh-final cleanup contract: stale preview deleted, turn marked final.
+        adapter.delete_message.assert_awaited_once_with("chat", "initial_preview")
+        assert consumer._final_response_sent is True
+
+    @pytest.mark.asyncio
+    async def test_unchanged_text_fresh_sends_under_production_threshold(self):
+        """Under the default ``fresh_final_after_seconds=60``, a YOUNG preview
+        (time path inactive) with unchanged final text on a rich-preferring
+        adapter still fresh-sends — proving the adapter-prefers bypass, not the
+        time threshold, drives it.
+        """
+        adapter = _make_adapter()
+        adapter.prefers_fresh_final_streaming = MagicMock(return_value=True)
+        adapter.send.side_effect = [
+            SimpleNamespace(success=True, message_id="initial_preview"),
+            SimpleNamespace(success=True, message_id="fresh_final"),
+        ]
+        consumer = GatewayStreamConsumer(
+            adapter=adapter,
+            chat_id="chat",
+            config=StreamConsumerConfig(fresh_final_after_seconds=60.0),
+        )
+        await consumer._send_or_edit("same text")
+        # Preview is brand-new (< 60s), so the time path is inactive; only the
+        # adapter-prefers bypass can reach the fresh send here.
+        assert consumer._should_send_fresh_final() is False
+        await consumer._send_or_edit("same text", finalize=True)
+        assert adapter.send.call_count == 2
+        adapter.edit_message.assert_not_called()
+        assert consumer._message_id == "fresh_final"
+
+    @pytest.mark.asyncio
+    async def test_unchanged_text_still_edits_when_adapter_opts_out(self):
+        """Unchanged final text on an adapter that does NOT prefer a fresh final
+        (e.g. rich opted out / latched off) must still short-circuit to the
+        in-place edit — the bypass is opt-in via prefers_fresh_final_streaming.
+        """
+        adapter = _make_adapter()
+        adapter.prefers_fresh_final_streaming = MagicMock(return_value=False)
+        consumer = GatewayStreamConsumer(
+            adapter=adapter,
+            chat_id="chat",
+            config=StreamConsumerConfig(fresh_final_after_seconds=0.0),
+        )
+        await consumer._send_or_edit("same text")
+        await consumer._send_or_edit("same text", finalize=True)
+        # Redundant-edit skip holds: no fresh send, no edit.
+        assert adapter.send.call_count == 1
+        adapter.edit_message.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_short_lived_preview_edits_in_place(self):
         """Finalizing a preview younger than the threshold → normal edit."""
         adapter = _make_adapter()


### PR DESCRIPTION
Complements #45995 (relates to #45911). Best reviewed/merged **after** #45995.

## What & why
A narrow streamed-finalize corner. When a streamed Telegram turn finalizes with text byte-equal to the last streamed frame — e.g. the streaming cursor is empty/disabled, or a `got_done`/segment-break finalize frame that doesn't append the cursor — the redundant-edit short-circuit in `GatewayStreamConsumer._send_or_edit` returns **before** the fresh-final rich re-send. Since every preview send sets `expect_edits=True` (which disables `sendRichMessage`), the preview is on the downgraded MarkdownV2 edit path, so this corner leaves rich constructs (tables, task lists) collapsed to their legacy fallback.

**Fix:** let the redundant-edit skip yield to `prefers_fresh_final_streaming` on finalize — a sibling to the existing `_adapter_requires_finalize` exception — so a rich-preferring adapter reaches the fresh rich re-send. Reuses the `_adapter_prefers_fresh_final(text)` predicate already evaluated by the fresh-final gate just below.

## Scope & relationship to #45995 (please read)
- This is **not** the fix for #45911 (plain replies rendering heavier post-v16) — that's #45995.
- It's **not** required for the *default-config* table collapse either: with a non-empty streaming cursor (the default), the finalize frame differs from the last streamed frame, the short-circuit isn't hit, and the **pre-existing** fresh-final gate already re-sends the rich table. This PR closes the **unchanged-text corner** (cursor empty/disabled, or `got_done`/segment-break frames).
- The breadth of this bypass is governed by `prefers_fresh_final_streaming` → `_should_attempt_rich`. **#45995 narrows that to genuine rich constructs**, so the two compose cleanly (no file overlap, pure delegation). **Recommend landing after / together with #45995.** Standalone (pre-#45995) this widens fresh-send to any rich-eligible final including plain text — the #45911 surface; post-#45995 it fires only for tables / task lists / details / `$$`.

## Tests
`tests/gateway/test_stream_consumer_fresh_final.py`:
- `test_unchanged_final_text_still_fresh_sends_when_adapter_prefers` — fails without the fix (short-circuits to an edit, no rich re-send).
- `test_unchanged_text_fresh_sends_under_production_threshold` — `fresh_final_after_seconds=60`, young preview: proves the adapter-prefers bypass (not the time path) drives it.
- `test_unchanged_text_still_edits_when_adapter_opts_out` — opt-out adapter still edits in place. Post-#45995, plain text takes exactly this path automatically, jointly enforcing the #45995 narrowing contract.

Locally: 180 tests pass across `test_stream_consumer_fresh_final.py`, `test_telegram_rich_messages.py`, `test_stream_consumer_draft.py`, and `test_stream_consumer.py`. macOS / Python 3.11. Pure async control-flow change.
