### PR TITLE
fix(discord): mark outbound thread sends as participated

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1649,6 +1649,8 @@ class DiscordAdapter(BasePlatformAdapter):
             if message_ids:
                 _target_id = thread_id or chat_id
                 self._last_self_message_id[_target_id] = message_ids[-1]
+                if thread_id:
+                    self._threads.mark(str(thread_id))
 
             return SendResult(
                 success=True,
@@ -1709,6 +1711,8 @@ class DiscordAdapter(BasePlatformAdapter):
         raw_response: Dict[str, Any] = {"message_ids": message_ids, "thread_id": thread_id}
         if warnings:
             raw_response["warnings"] = warnings
+        if thread_id:
+            self._threads.mark(thread_id)
 
         return SendResult(
             success=True,
@@ -1769,6 +1773,8 @@ class DiscordAdapter(BasePlatformAdapter):
         thread_id = str(getattr(thread_channel, "id", getattr(thread, "id", "")))
         starter_msg = getattr(thread, "message", None)
         message_id = str(getattr(starter_msg, "id", thread_id)) if starter_msg else thread_id
+        if thread_id:
+            self._threads.mark(thread_id)
 
         return SendResult(
             success=True,

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -94,6 +94,11 @@ class FakeThread:
         return _iter()
 
 
+class SendableFakeThread(FakeThread):
+    async def send(self, content=None, reference=None, **kwargs):
+        return SimpleNamespace(id=444, content=content, reference=reference, **kwargs)
+
+
 @pytest.fixture
 def adapter(monkeypatch):
     monkeypatch.setattr(discord_platform.discord, "DMChannel", FakeDMChannel, raising=False)
@@ -581,6 +586,57 @@ async def test_discord_thread_default_keeps_responding_after_participation(adapt
     await adapter._handle_message(message)
 
     adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_discord_send_to_existing_thread_marks_participation(adapter):
+    """Outbound thread sends should make later no-mention replies eligible."""
+    thread = SendableFakeThread(channel_id=456, name="cron-created-thread")
+    adapter._client.get_channel = lambda channel_id: thread if channel_id == 456 else None
+
+    result = await adapter.send("123", "scheduled update", metadata={"thread_id": "456"})
+
+    assert result.success is True
+    assert "456" in adapter._threads
+
+
+@pytest.mark.asyncio
+async def test_discord_forum_thread_send_marks_participation(adapter):
+    """Forum posts create threads; those threads should accept follow-ups."""
+    forum = FakeForumChannel(channel_id=222, name="stock")
+
+    async def create_thread(*, name, content):
+        return SimpleNamespace(id=333, message=SimpleNamespace(id=444))
+
+    forum.create_thread = create_thread
+
+    result = await adapter._send_to_forum(forum, "scheduled update")
+
+    assert result.success is True
+    assert result.raw_response["thread_id"] == "333"
+    assert "333" in adapter._threads
+
+
+@pytest.mark.asyncio
+async def test_discord_forum_file_thread_send_marks_participation(adapter):
+    """Forum file posts create threads; those threads should accept follow-ups."""
+    forum = FakeForumChannel(channel_id=222, name="stock")
+
+    async def create_thread(**kwargs):
+        return SimpleNamespace(id=334, message=SimpleNamespace(id=445))
+
+    forum.create_thread = create_thread
+
+    result = await adapter._forum_post_file(
+        forum,
+        thread_name="scheduled chart",
+        content="scheduled update",
+        file=SimpleNamespace(filename="chart.png"),
+    )
+
+    assert result.success is True
+    assert result.raw_response["thread_id"] == "334"
+    assert "334" in adapter._threads
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Marks Discord threads as bot-participated when Hermes sends outbound messages into them or creates them as forum posts.

Hermes' Discord adapter intentionally allows no-mention follow-ups in threads where the bot has already participated, even when `discord.require_mention` / `DISCORD_REQUIRE_MENTION` is enabled. That works for inbound agent-triggered threads because `_handle_message()` records the thread id before dispatch.

Outbound-only paths missed the same bookkeeping. In particular, scheduled jobs and other gateway sends can create Discord forum threads or send into an existing thread without going through `_handle_message()`. Those threads visibly contain a Hermes bot message, but `discord_threads.json` did not record the thread id, so a user reply in that thread was silently ignored unless it explicitly mentioned the bot.

## Changes Made

- Mark participation after successful outbound sends when `metadata.thread_id` targets an existing thread.
- Mark participation after `_send_to_forum()` creates a text forum thread.
- Mark participation after `_forum_post_file()` creates a forum thread with an attachment.
- Add regression tests for existing-thread outbound sends and forum-created threads.

## Why

This keeps Discord's no-mention thread behavior consistent across inbound-created and outbound-created thread paths. Cron-created/forum-created threads should behave like threads Hermes has participated in because the bot just posted there.

## How to Test

```bash
python -m py_compile plugins/platforms/discord/adapter.py tests/gateway/test_discord_free_response.py
pytest tests/gateway/test_discord_free_response.py tests/gateway/test_discord_thread_persistence.py -q
```

Result: `47 passed`.

## Platforms tested

- macOS (Apple Silicon), Python 3.11