### PR TITLE
fix(email): use SMTP_SSL for port 465 and fall back to IPv4 on timeout

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -22,6 +22,7 @@ import logging
 import os
 import re
 import smtplib
+import socket
 import ssl
 import uuid
 from email.header import decode_header
@@ -293,6 +294,53 @@ class EmailAdapter(BasePlatformAdapter):
             # Fallback: just clear old entries if sort fails
             self._seen_uids = set(list(self._seen_uids)[-self._seen_uids_max // 2:])
 
+    def _connect_smtp(self) -> smtplib.SMTP:
+        """Create an SMTP connection, selecting the correct protocol for the port.
+
+        Port 465 uses implicit TLS (``SMTP_SSL``).  All other ports use
+        ``SMTP`` + ``STARTTLS``.
+
+        When the host resolves to an IPv6 address that is unreachable
+        (common on networks without IPv6 routing), the connection hangs
+        until the socket timeout expires.  To avoid this, we try the
+        default resolution first and fall back to IPv4-only on failure.
+
+        Returns a connected SMTP object with TLS established — callers
+        can proceed directly to ``login()``.
+        """
+        ctx = ssl.create_default_context()
+        host = self._smtp_host
+        port = self._smtp_port
+        timeout = 30
+
+        def _connect() -> smtplib.SMTP:
+            """Attempt one SMTP connection (default address family)."""
+            if port == 465:
+                return smtplib.SMTP_SSL(host, port, timeout=timeout, context=ctx)
+            s = smtplib.SMTP(host, port, timeout=timeout)
+            s.starttls(context=ctx)
+            return s
+
+        def _connect_ipv4() -> smtplib.SMTP:
+            """Fallback: force IPv4 via an AF_INET socket."""
+            sock = socket.create_connection(
+                (host, port), timeout=timeout, family=socket.AF_INET,
+            )
+            if port == 465:
+                return smtplib.SMTP_SSL(
+                    host, port, timeout=timeout, context=ctx, sock=sock,
+                )
+            s = smtplib.SMTP(host, port, timeout=timeout, sock=sock)
+            s.starttls(context=ctx)
+            return s
+
+        try:
+            return _connect()
+        except (socket.timeout, OSError):
+            # Connection-level failure (may be unreachable IPv6).
+            # Retry with IPv4 only.
+            return _connect_ipv4()
+
     async def connect(self) -> bool:
         """Connect to the IMAP server and start polling for new messages."""
         try:
@@ -316,10 +364,11 @@ class EmailAdapter(BasePlatformAdapter):
 
         try:
             # Test SMTP connection
-            smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
-            smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
-            smtp.quit()
+            smtp = self._connect_smtp()
+            try:
+                smtp.login(self._address, self._password)
+            finally:
+                smtp.quit()
             logger.info("[Email] SMTP connection test passed.")
         except Exception as e:
             logger.error("[Email] SMTP connection failed: %s", e)
@@ -555,9 +604,8 @@ class EmailAdapter(BasePlatformAdapter):
 
         msg.attach(MIMEText(body, "plain", "utf-8"))
 
-        smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
+        smtp = self._connect_smtp()
         try:
-            smtp.starttls(context=ssl.create_default_context())
             smtp.login(self._address, self._password)
             smtp.send_message(msg)
         finally:
@@ -677,9 +725,8 @@ class EmailAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[Email] Failed to attach %s: %s", file_path, e)
 
-        smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
+        smtp = self._connect_smtp()
         try:
-            smtp.starttls(context=ssl.create_default_context())
             smtp.login(self._address, self._password)
             smtp.send_message(msg)
         finally:
@@ -756,9 +803,8 @@ class EmailAdapter(BasePlatformAdapter):
             part.add_header("Content-Disposition", f"attachment; filename={fname}")
             msg.attach(part)
 
-        smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
+        smtp = self._connect_smtp()
         try:
-            smtp.starttls(context=ssl.create_default_context())
             smtp.login(self._address, self._password)
             smtp.send_message(msg)
         finally:

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1265,5 +1265,105 @@ class TestImapIdExtensionForNetEase(unittest.TestCase):
         mock_imap.xatom.assert_called_once()
 
 
+class TestConnectSmtp(unittest.TestCase):
+    """Test _connect_smtp() helper: protocol selection and IPv6 fallback."""
+
+    def _make_adapter(self, port="587"):
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+            "EMAIL_SMTP_PORT": port,
+        }):
+            from gateway.platforms.email import EmailAdapter
+            return EmailAdapter(PlatformConfig(enabled=True))
+
+    def test_port_587_uses_smtp_with_starttls(self):
+        """Port 587 should use smtplib.SMTP + STARTTLS."""
+        adapter = self._make_adapter("587")
+
+        with patch("smtplib.SMTP") as mock_smtp, \
+             patch("smtplib.SMTP_SSL") as mock_smtp_ssl:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            result = adapter._connect_smtp()
+
+            mock_smtp.assert_called_once()
+            mock_smtp_ssl.assert_not_called()
+            mock_server.starttls.assert_called_once()
+            self.assertIs(result, mock_server)
+
+    def test_port_465_uses_smtp_ssl(self):
+        """Port 465 should use smtplib.SMTP_SSL (implicit TLS)."""
+        adapter = self._make_adapter("465")
+
+        with patch("smtplib.SMTP") as mock_smtp, \
+             patch("smtplib.SMTP_SSL") as mock_smtp_ssl:
+            mock_server = MagicMock()
+            mock_smtp_ssl.return_value = mock_server
+
+            result = adapter._connect_smtp()
+
+            mock_smtp_ssl.assert_called_once()
+            mock_smtp.assert_not_called()
+            self.assertIs(result, mock_server)
+
+    def test_ipv6_timeout_falls_back_to_ipv4(self):
+        """When default connection times out, retry with AF_INET socket."""
+        import socket as _socket
+        adapter = self._make_adapter("587")
+
+        call_count = 0
+
+        def fake_smtp(host, port, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if "sock" not in kwargs:
+                raise _socket.timeout("timed out")
+            server = MagicMock()
+            return server
+
+        with patch("smtplib.SMTP", side_effect=fake_smtp), \
+             patch("socket.create_connection") as mock_create_conn:
+            mock_sock = MagicMock()
+            mock_create_conn.return_value = mock_sock
+
+            adapter._connect_smtp()
+
+            # First attempt without sock, then fallback with sock
+            self.assertEqual(call_count, 2)
+            mock_create_conn.assert_called_once_with(
+                ("smtp.test.com", 587), timeout=30, family=_socket.AF_INET,
+            )
+
+    def test_port_465_ipv6_fallback(self):
+        """Port 465 IPv6 timeout falls back to IPv4 with SMTP_SSL."""
+        import socket as _socket
+        adapter = self._make_adapter("465")
+
+        call_count = 0
+
+        def fake_smtp_ssl(host, port, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if "sock" not in kwargs:
+                raise _socket.timeout("timed out")
+            return MagicMock()
+
+        with patch("smtplib.SMTP_SSL", side_effect=fake_smtp_ssl), \
+             patch("socket.create_connection") as mock_create_conn:
+            mock_create_conn.return_value = MagicMock()
+
+            adapter._connect_smtp()
+
+            self.assertEqual(call_count, 2)
+            mock_create_conn.assert_called_once_with(
+                ("smtp.test.com", 465), timeout=30, family=_socket.AF_INET,
+            )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What does this PR do?

Fixes the Email gateway adapter to use `SMTP_SSL` (implicit TLS) for port 465 connections and adds IPv4 fallback when IPv6 is unreachable. Previously, the adapter always used `SMTP()` + `starttls()`, which is correct for port 587 but causes hangs/failures on port 465 providers.

## Related Issue

Fixes #46018

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/email.py`: Extracted `_connect_smtp()` helper that selects `SMTP_SSL` for port 465 and `SMTP` + `STARTTLS` for other ports. Added IPv4 fallback when the default connection times out (handles hosts with AAAA records on networks without IPv6 routing). Replaced 4 duplicate SMTP connection sites with calls to the helper.
- `tests/gateway/test_email.py`: Added `TestConnectSmtp` class with 4 tests: port 587 uses SMTP+STARTTLS, port 465 uses SMTP_SSL, IPv6 timeout falls back to IPv4 for port 587, and IPv6 timeout falls back to IPv4 for port 465.

## How to Test

1. Configure Email gateway with a port 465 provider (e.g., `EMAIL_SMTP_PORT=465`)
2. Start the gateway — SMTP connection should succeed using `SMTP_SSL`
3. Configure with a host that has AAAA records but no IPv6 routing — connection should fall back to IPv4 within the timeout
4. Run `pytest tests/gateway/test_email.py -x -q` — all 66 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_email.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/platforms/email.py` (`_connect_smtp`, `_send_email`, `_send_email_with_attachments`, `_send_email_with_attachment`, `connect`)
- Blast radius: LOW — changes are confined to SMTP connection establishment; send logic and message formatting are unchanged
- Related patterns: IMAP already uses `imaplib.IMAP4_SSL` (implicit TLS) — this fix brings SMTP to parity
