### PR TITLE
fix: keep desktop notifications background

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -20,7 +20,6 @@ const crypto = require('node:crypto')
 const fs = require('node:fs')
 const http = require('node:http')
 const https = require('node:https')
-const net = require('node:net')
 const path = require('node:path')
 const { pathToFileURL } = require('node:url')
 const { execFileSync, spawn } = require('node:child_process')
@@ -43,6 +42,7 @@ const { readDirForIpc } = require('./fs-read-dir.cjs')
 const { gitRootForIpc } = require('./git-root.cjs')
 const { worktreesForIpc } = require('./git-worktrees.cjs')
 const { OFFICIAL_REPO_HTTPS_URL, isOfficialSshRemote } = require('./update-remote.cjs')
+const { registerWindowsAppUserModelId } = require('./windows-app-id.cjs')
 const {
   buildPosixCleanupScript,
   buildWindowsCleanupScript,
@@ -118,6 +118,8 @@ const IS_MAC = process.platform === 'darwin'
 const IS_WINDOWS = process.platform === 'win32'
 const IS_WSL = isWslEnvironment()
 const APP_ROOT = app.getAppPath()
+
+registerWindowsAppUserModelId(app)
 
 function hiddenWindowsChildOptions(options = {}) {
   if (!IS_WINDOWS || Object.prototype.hasOwnProperty.call(options, 'windowsHide')) {

--- a/apps/desktop/electron/windows-app-id.cjs
+++ b/apps/desktop/electron/windows-app-id.cjs
@@ -1,0 +1,16 @@
+'use strict'
+
+const WINDOWS_APP_USER_MODEL_ID = 'com.nousresearch.hermes'
+
+function registerWindowsAppUserModelId(app, platform = process.platform) {
+  if (platform !== 'win32') return false
+  if (typeof app?.setAppUserModelId !== 'function') return false
+
+  app.setAppUserModelId(WINDOWS_APP_USER_MODEL_ID)
+  return true
+}
+
+module.exports = {
+  WINDOWS_APP_USER_MODEL_ID,
+  registerWindowsAppUserModelId
+}

--- a/apps/desktop/electron/windows-app-id.test.cjs
+++ b/apps/desktop/electron/windows-app-id.test.cjs
@@ -1,0 +1,41 @@
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const desktopPackage = require('../package.json')
+const {
+  WINDOWS_APP_USER_MODEL_ID,
+  registerWindowsAppUserModelId
+} = require('./windows-app-id.cjs')
+
+test('Windows app user model id matches the packaged desktop app id', () => {
+  assert.equal(WINDOWS_APP_USER_MODEL_ID, desktopPackage.build.appId)
+})
+
+test('registers the app user model id on Windows', () => {
+  const calls = []
+  const registered = registerWindowsAppUserModelId(
+    { setAppUserModelId: id => calls.push(id) },
+    'win32'
+  )
+
+  assert.equal(registered, true)
+  assert.deepEqual(calls, [WINDOWS_APP_USER_MODEL_ID])
+})
+
+test('does not register the app user model id outside Windows', () => {
+  const calls = []
+  const registered = registerWindowsAppUserModelId(
+    { setAppUserModelId: id => calls.push(id) },
+    'darwin'
+  )
+
+  assert.equal(registered, false)
+  assert.deepEqual(calls, [])
+})
+
+test('does not throw when the Electron app lacks the registration API', () => {
+  assert.equal(registerWindowsAppUserModelId({}, 'win32'), false)
+  assert.equal(registerWindowsAppUserModelId(null, 'win32'), false)
+})

--- a/apps/desktop/electron/windows-child-process.test.cjs
+++ b/apps/desktop/electron/windows-child-process.test.cjs
@@ -28,14 +28,14 @@ test('desktop background child processes opt into hidden Windows consoles', () =
   assert.match(source, /function hiddenWindowsChildOptions\(options = \{\}\)/)
 
   requireHiddenChildOptions(source, "execFileSync(\n          'reg'")
-  requireHiddenChildOptions(source, 'execFileSync(pyExe')
-  requireHiddenChildOptions(source, 'spawn(resolveGitBinary()')
+  requireHiddenChildOptions(source, 'execFileSync(\n          pyExe')
+  requireHiddenChildOptions(source, 'spawn(\n      resolveGitBinary()')
   requireHiddenChildOptions(source, "execFileSync('taskkill'")
-  requireHiddenChildOptions(source, 'spawn(command, args')
+  requireHiddenChildOptions(source, 'spawn(\n        command,\n        args')
   requireHiddenChildOptions(source, "spawn('curl'")
-  requireHiddenChildOptions(source, 'spawn(backend.command, backend.args')
-  requireHiddenChildOptions(source, 'hermesProcess = spawn(backend.command, backend.args')
-  requireHiddenChildOptions(source, "spawn(py, ['-m', 'hermes_cli.main', 'uninstall', '--gui-summary']")
+  requireHiddenChildOptions(source, 'spawn(\n    backend.command,\n    backend.args')
+  requireHiddenChildOptions(source, 'hermesProcess = spawn(\n      backend.command,\n      backend.args')
+  requireHiddenChildOptions(source, "spawn(\n        py,\n        ['-m', 'hermes_cli.main', 'uninstall', '--gui-summary']")
 })
 
 test('intentional or interactive desktop child processes stay documented', () => {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -36,7 +36,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-app-id.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs",
     "typecheck": "tsc -p . --noEmit",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",


### PR DESCRIPTION
Summary:
- Register the Windows app user model id during Electron startup so native notifications stay associated with the packaged desktop app.
- Keep toast click behavior unchanged; clicking a notification still focuses the session.
- Add focused tests and wire them into desktop platform tests; refresh stale Windows child-process source matchers.

Tests:
- npm run --workspace apps/desktop test:desktop:platforms
- npm exec --workspace apps/desktop -- eslint electron/windows-app-id.cjs electron/windows-app-id.test.cjs electron/windows-child-process.test.cjs electron/main.cjs
- git diff --check

Fixes #46037