### PR TITLE
fix(openrouter): surface router models in the picker and add Fusion

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -72,6 +72,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("nvidia/nemotron-3-super-120b-a12b",      ""),
     # OpenRouter routers
     ("openrouter/pareto-code",                 "auto-routes to cheapest coder meeting openrouter.min_coding_score"),
+    ("openrouter/fusion",                      "multi-model panel + judge deliberation (priced as sum of all calls)"),
     # Free tier
     ("openrouter/elephant-alpha",              "free"),
     ("openrouter/owl-alpha",                   "free"),
@@ -1287,6 +1288,21 @@ def _openrouter_model_is_free(pricing: Any) -> bool:
         return False
 
 
+# OpenRouter "router" model aliases (openrouter/<router>). These are not models
+# themselves - they dispatch each request to an underlying tool-capable model -
+# so the router alias advertises ``supported_parameters: []`` in /api/v1/models
+# even though the request that reaches the chosen model fully supports tools.
+# The plain tool-support filter below would therefore drop every router from the
+# picker (openrouter/pareto-code is already shipped and hits exactly this),
+# leaving the curated entry inert. Treat known routers as tool-capable so they
+# survive the filter. Keep this list explicit (not a prefix glob) so a future
+# non-router ``openrouter/*`` model that genuinely lacks tools is still filtered.
+_OPENROUTER_TOOL_CAPABLE_ROUTERS = frozenset({
+    "openrouter/pareto-code",
+    "openrouter/fusion",
+})
+
+
 def _openrouter_model_supports_tools(item: Any) -> bool:
     """Return True when the model's ``supported_parameters`` advertise tool calling.
 
@@ -1301,9 +1317,18 @@ def _openrouter_model_supports_tools(item: Any) -> bool:
     so the picker doesn't silently empty for those users. Only hide models
     whose ``supported_parameters`` is an explicit list that omits ``tools``.
 
+    **Router aliases are tool-capable.** OpenRouter router models
+    (``openrouter/pareto-code``, ``openrouter/fusion``) report an empty
+    ``supported_parameters`` because the alias itself isn't the executor - it
+    routes to an underlying tool-capable model. Without this allowance the
+    filter silently drops them from the picker. See
+    ``_OPENROUTER_TOOL_CAPABLE_ROUTERS`` above.
+
     Ported from Kilo-Org/kilocode#9068.
     """
     if not isinstance(item, dict):
+        return True
+    if str(item.get("id") or "").strip() in _OPENROUTER_TOOL_CAPABLE_ROUTERS:
         return True
     params = item.get("supported_parameters")
     if not isinstance(params, list):

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -211,6 +211,79 @@ class TestOpenRouterToolSupportHelper:
             {"id": "x", "supported_parameters": []}
         ) is False
 
+    def test_openrouter_router_aliases_are_tool_capable(self):
+        """OpenRouter router aliases advertise supported_parameters:[] but are
+        tool-capable (they route to a tool-capable model). They must survive the
+        filter even with an empty list - otherwise the curated picker entry is
+        inert. openrouter/pareto-code ships today and hits exactly this."""
+        from hermes_cli.models import _openrouter_model_supports_tools
+        for router_id in ("openrouter/pareto-code", "openrouter/fusion"):
+            assert _openrouter_model_supports_tools(
+                {"id": router_id, "supported_parameters": []}
+            ) is True, router_id
+
+    def test_non_router_openrouter_model_without_tools_still_dropped(self):
+        """The router allowance is an explicit allowlist, not an openrouter/* glob:
+        a non-router openrouter/* model that genuinely omits tools is still dropped."""
+        from hermes_cli.models import _openrouter_model_supports_tools
+        assert _openrouter_model_supports_tools(
+            {"id": "openrouter/some-image-model", "supported_parameters": []}
+        ) is False
+
+
+class TestOpenRouterFusionCurated:
+    """openrouter/fusion is a curated, selectable OpenRouter model."""
+
+    def test_fusion_in_openrouter_models_snapshot(self):
+        from hermes_cli.models import OPENROUTER_MODELS
+        ids = [mid for mid, _ in OPENROUTER_MODELS]
+        assert "openrouter/fusion" in ids
+
+    def test_fusion_survives_live_catalog_filter(self, monkeypatch):
+        """End-to-end picker path: even when the live /api/v1/models entry for
+        openrouter/fusion advertises supported_parameters:[] (its real shape
+        today), it must still appear in the curated picker output."""
+        import hermes_cli.models as _models_mod
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return (
+                    b'{"data":['
+                    b'{"id":"openrouter/fusion","pricing":{"prompt":"0","completion":"0"},'
+                    b'"supported_parameters":[]},'
+                    b'{"id":"anthropic/claude-opus-4.6","pricing":{"prompt":"0.000015","completion":"0.000075"},'
+                    b'"supported_parameters":["tools"]}'
+                    b']}'
+                )
+
+        monkeypatch.setattr(
+            _models_mod,
+            "OPENROUTER_MODELS",
+            [
+                ("anthropic/claude-opus-4.6", ""),
+                ("openrouter/fusion", "multi-model panel + judge deliberation"),
+            ],
+        )
+        monkeypatch.setattr(_models_mod, "_openrouter_catalog_cache", None)
+        # Force the in-repo fallback list (skip the remote curated manifest,
+        # which is imported lazily from hermes_cli.model_catalog inside the fn).
+        monkeypatch.setattr(
+            "hermes_cli.model_catalog.get_curated_openrouter_models",
+            lambda *a, **k: None,
+            raising=False,
+        )
+        with patch("hermes_cli.models.urllib.request.urlopen", return_value=_Resp()):
+            models = _models_mod.fetch_openrouter_models(force_refresh=True)
+
+        ids = [mid for mid, _ in models]
+        assert "openrouter/fusion" in ids
+
 
 class TestFindOpenrouterSlug:
     def test_exact_match(self):

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -113,6 +113,10 @@
           "description": "auto-routes to cheapest coder meeting openrouter.min_coding_score"
         },
         {
+          "id": "openrouter/fusion",
+          "description": "multi-model panel + judge deliberation (priced as sum of all calls)"
+        },
+        {
           "id": "openrouter/elephant-alpha",
           "description": "free"
         },


### PR DESCRIPTION
## Summary

Two changes, one root cause:

1. **Bug fix** - OpenRouter **router** models are silently dropped from `hermes model`. `openrouter/pareto-code` ships today (curated, documented, tested) but never appears in the picker, because the tool-support filter reads a router's `supported_parameters: []` as "no tool calling." This restores routers to the picker.
2. **New capability** - adds `openrouter/fusion` as a built-in selectable model.

The two belong together because the feature is impossible without the fix: `openrouter/fusion` is itself a router, so without fixing the filter it would be added and then immediately hidden - dead on arrival. Fixing the filter is the minimum required for the addition to work at all, and the same fix incidentally unblocks the already-shipped `pareto-code`. Keeping it one change avoids landing a fix and then a feature that re-touches the same five lines.

After this, `hermes model` / `/model` (TUI/CLI) and the desktop model picker list both router entries (today `openrouter/pareto-code` is silently absent):

```
openrouter/pareto-code   auto-routes to cheapest coder meeting openrouter.min_coding_score
openrouter/fusion        multi-model panel + judge deliberation (priced as sum of all calls)
```

Because the picker reads the hosted catalog manifest at runtime, the entry reaches existing installs without an app update.

## What Fusion is (OpenRouter docs)

A panel of 1-8 models answers in parallel (each with `openrouter:web_search` / `openrouter:web_fetch`), a judge compares them (it does not merge) and returns structured analysis - consensus, contradictions, blind spots - and a model writes the final answer. Useful when the cost of being wrong outweighs a few extra completions. Pricing, verbatim: "Because Fusion runs every panel member plus a judge call, your request is priced as the sum of those underlying completions rather than a single model."

## Changes

- `hermes_cli/models.py`: add `_OPENROUTER_TOOL_CAPABLE_ROUTERS` (`openrouter/pareto-code`, `openrouter/fusion`) and short-circuit `_openrouter_model_supports_tools()` to `True` for those ids. Explicit allowlist, not an `openrouter/*` glob, so a real non-router `openrouter/*` model lacking tools is still filtered. Add `openrouter/fusion` to the `OPENROUTER_MODELS` fallback snapshot.
- `website/static/api/model-catalog.json`: add `openrouter/fusion` to the hosted curated manifest - the source the picker prefers over the in-repo snapshot, so both are required for the entry to surface.
- `tests/hermes_cli/test_models.py`: router-survives-filter, allowlist-is-not-a-glob, fusion-curated, and an end-to-end picker test that keeps fusion when its catalog entry advertises `supported_parameters: []`.

## Tests

| Check | Result |
|---|---|
| `pytest tests/hermes_cli/test_models.py tests/hermes_cli/test_model_catalog.py tests/providers/test_provider_profiles.py` | 161 passed |
| `ruff check hermes_cli/models.py` | clean |
| E2E: `fetch_openrouter_models(force_refresh=True)` against live `/api/v1/models` with the updated manifest | `openrouter/fusion` and `openrouter/pareto-code` both present (both dropped before the fix) |

Tested on macOS, Python 3.11.

## Deliberately out of scope

A `fusion` config block (panel `analysis_models` + judge `model`) translated into the OpenRouter `plugins` array in `OpenRouterProfile.build_extra_body` - mirroring the existing `pareto-router` branch - is left out to keep this narrow: the bare alias already deliberates with server-side defaults, so wiring config now would be unused surface. A Fusion subsection for `website/docs/integrations/providers.md` (mirroring the Pareto Code section, with the verbatim pricing note) can be added here or as a follow-up - happy to include it in this PR if preferred.

Closes #46064