### PR TITLE
fix(desktop): keep profile homes out of bootstrap

### DIFF
--- a/apps/desktop/electron/backend-env.cjs
+++ b/apps/desktop/electron/backend-env.cjs
@@ -67,6 +67,16 @@ function buildDesktopBackendPath({
   )
 }
 
+function normalizeHermesHomeRoot(hermesHome, { pathModule = pathModuleForPlatform(process.platform) } = {}) {
+  if (!hermesHome) return hermesHome
+  const resolved = pathModule.resolve(String(hermesHome))
+  const parent = pathModule.dirname(resolved)
+  if (pathModule.basename(parent).toLowerCase() === 'profiles') {
+    return pathModule.dirname(parent)
+  }
+  return resolved
+}
+
 function buildDesktopBackendEnv({
   hermesHome,
   pythonPathEntries = [],
@@ -97,5 +107,6 @@ module.exports = {
   buildDesktopBackendEnv,
   buildDesktopBackendPath,
   delimiterForPlatform,
+  normalizeHermesHomeRoot,
   pathEnvKey
 }

--- a/apps/desktop/electron/backend-env.test.cjs
+++ b/apps/desktop/electron/backend-env.test.cjs
@@ -7,6 +7,7 @@ const {
   appendUniquePathEntries,
   buildDesktopBackendEnv,
   buildDesktopBackendPath,
+  normalizeHermesHomeRoot,
   pathEnvKey
 } = require('./backend-env.cjs')
 
@@ -64,6 +65,21 @@ test('buildDesktopBackendEnv extends PYTHONPATH and backend PATH together', () =
   assert.equal(env.PYTHONPATH, '/repo/hermes-agent:/existing/pythonpath')
   assert.ok(env.PATH.startsWith('/Users/test/.hermes/node/bin:/Users/test/.hermes/hermes-agent/venv/bin:'))
   assert.ok(env.PATH.includes('/opt/homebrew/bin'))
+})
+
+test('normalizeHermesHomeRoot maps profile homes back to the global Hermes root', () => {
+  assert.equal(
+    normalizeHermesHomeRoot('/Users/test/.hermes/profiles/oracle', { pathModule: path.posix }),
+    '/Users/test/.hermes'
+  )
+  assert.equal(
+    normalizeHermesHomeRoot('C:\\Users\\test\\AppData\\Local\\hermes\\profiles\\oracle', { pathModule: path.win32 }),
+    'C:\\Users\\test\\AppData\\Local\\hermes'
+  )
+  assert.equal(
+    normalizeHermesHomeRoot('/Users/test/.hermes', { pathModule: path.posix }),
+    '/Users/test/.hermes'
+  )
 })
 
 test('Windows PATH casing and delimiter are preserved without POSIX sane entries', () => {

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -38,7 +38,7 @@ const { adoptServedDashboardToken } = require('./dashboard-token.cjs')
 const { waitForDashboardPort } = require('./backend-ready.cjs')
 const { serializeJsonBody, setJsonRequestHeaders } = require('./oauth-net-request.cjs')
 const { fetchMarketplaceThemes, searchMarketplaceThemes } = require('./vscode-marketplace.cjs')
-const { buildDesktopBackendEnv } = require('./backend-env.cjs')
+const { buildDesktopBackendEnv, normalizeHermesHomeRoot } = require('./backend-env.cjs')
 const { readDirForIpc } = require('./fs-read-dir.cjs')
 const { gitRootForIpc } = require('./git-root.cjs')
 const { worktreesForIpc } = require('./git-worktrees.cjs')
@@ -240,7 +240,7 @@ if (INSTALL_STAMP) {
 // HERMES_HOME beneath the throwaway userData dir so a fresh-install run never
 // touches the user's real ~/.hermes / %LOCALAPPDATA%\hermes.
 function resolveHermesHome() {
-  if (process.env.HERMES_HOME) return path.resolve(process.env.HERMES_HOME)
+  if (process.env.HERMES_HOME) return normalizeHermesHomeRoot(process.env.HERMES_HOME)
   if (USER_DATA_OVERRIDE) return path.join(path.resolve(USER_DATA_OVERRIDE), 'hermes-home')
   if (IS_WINDOWS && process.env.LOCALAPPDATA) {
     const localappdata = path.join(process.env.LOCALAPPDATA, 'hermes')

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1655,13 +1655,18 @@ def _setup_telegram_auto_result():
 
     profile_name: str | None = None
     try:
-        hermes_home = str(get_hermes_home())
-        if "/profiles/" in hermes_home:
-            profile_name = hermes_home.rstrip("/").rsplit("/", 1)[-1]
+        profile_name = _profile_name_from_hermes_home(Path(get_hermes_home()))
     except Exception:
         pass
 
     return auto_setup_telegram_bot_result(profile_name=profile_name)
+
+
+def _profile_name_from_hermes_home(hermes_home) -> str | None:
+    """Return the active profile name when HERMES_HOME is a profile dir."""
+    if hermes_home.parent.name == "profiles":
+        return hermes_home.name
+    return None
 
 
 def _setup_telegram_auto() -> str | None:

--- a/tests/hermes_cli/test_telegram_managed_bot.py
+++ b/tests/hermes_cli/test_telegram_managed_bot.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import PureWindowsPath
 from unittest.mock import MagicMock, patch
 
 from hermes_cli.telegram_managed_bot import (
@@ -321,3 +322,34 @@ class TestSetupTelegramAuto:
         from hermes_cli.setup import _setup_telegram_auto
 
         assert callable(_setup_telegram_auto)
+
+    def test_setup_result_passes_profile_name_for_profile_home(self, monkeypatch, tmp_path):
+        from hermes_cli import setup
+
+        seen = {}
+        profile_home = tmp_path / ".hermes" / "profiles" / "oracle"
+        profile_home.mkdir(parents=True)
+
+        monkeypatch.setattr(setup, "get_hermes_home", lambda: profile_home)
+
+        def fake_auto_setup_telegram_bot_result(*, profile_name=None):
+            seen["profile_name"] = profile_name
+            return None
+
+        monkeypatch.setattr(
+            "hermes_cli.telegram_managed_bot.auto_setup_telegram_bot_result",
+            fake_auto_setup_telegram_bot_result,
+        )
+
+        assert setup._setup_telegram_auto_result() is None
+        assert seen["profile_name"] == "oracle"
+
+    def test_profile_name_from_home_path_handles_windows_separators(self):
+        from hermes_cli.setup import _profile_name_from_hermes_home
+
+        assert (
+            _profile_name_from_hermes_home(
+                PureWindowsPath(r"C:\Users\test\AppData\Local\hermes\profiles\oracle")
+            )
+            == "oracle"
+        )


### PR DESCRIPTION
## Summary
Desktop startup now treats an inherited profile-scoped `HERMES_HOME` as the machine Hermes root, so a crash/restart cannot bootstrap into `profiles/<name>` and overwrite that profile's config/env files.

Fixes #45758. Builds on the root-cause analysis in #45793, with the normalization in a tested Electron helper and the Windows profile-name setup check covered separately.

## Changes
- `apps/desktop/electron/backend-env.cjs`: add `normalizeHermesHomeRoot()` for profile-dir → root normalization.
- `apps/desktop/electron/main.cjs`: apply that normalization before deriving `ACTIVE_HERMES_ROOT`, bootstrap marker path, logs, and installer args.
- `hermes_cli/setup.py`: replace slash-string profile detection with path-based detection.
- Tests: cover POSIX + Windows path normalization and Windows profile-name extraction.

## Validation
| Check | Result |
|---|---|
| `node --check apps/desktop/electron/backend-env.cjs && node --check apps/desktop/electron/main.cjs` | pass |
| `node --test apps/desktop/electron/backend-env.test.cjs` | 6/6 pass |
| `scripts/run_tests.sh tests/hermes_cli/test_telegram_managed_bot.py` | 27/27 pass |
| `python3 -m py_compile hermes_cli/setup.py tests/hermes_cli/test_telegram_managed_bot.py` | pass |
| isolated Node E2E with `HERMES_HOME=<tmp>/hermes/profiles/oracle` | normalized to `<tmp>/hermes` |

## Infographic

![Profile Home Guard](https://v3b.fal.media/files/b/0a9e3f5c/cSbD1pcxR02jdNR2vdYGJ_Hoq3hFzC.png)
