### PR TITLE
fix(gemini): preserve native functionCall id round-trip for Gemini 3.x

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -299,12 +299,18 @@ def _translate_tool_call_to_gemini(tool_call: Dict[str, Any]) -> Dict[str, Any]:
     if not isinstance(args, dict):
         args = {"_value": args}
 
-    part: Dict[str, Any] = {
-        "functionCall": {
-            "name": str(fn.get("name") or ""),
-            "args": args,
-        }
+    function_call: Dict[str, Any] = {
+        "name": str(fn.get("name") or ""),
+        "args": args,
     }
+    # Replay Gemini 3's native functionCall id on the outgoing call so both
+    # halves of the pair carry the same value — the matching functionResponse
+    # echoes it in _translate_tool_result_to_gemini. Without this the model
+    # can't map results back to calls for parallel/compositional tool use.
+    call_id = str(tool_call.get("id") or "")
+    if call_id:
+        function_call["id"] = call_id
+    part: Dict[str, Any] = {"functionCall": function_call}
     thought_signature = _tool_call_extra_signature(tool_call)
     # Fallback sentinel for cross-provider tool_calls (e.g. fallback from
     # xAI/Anthropic to Gemini, where the original tool_call carries no
@@ -337,12 +343,15 @@ def _translate_tool_result_to_gemini(
     except json.JSONDecodeError:
         parsed = None
     response = parsed if isinstance(parsed, dict) else {"output": content}
-    return {
-        "functionResponse": {
-            "name": name,
-            "response": response,
-        }
-    }
+    function_response: Dict[str, Any] = {"name": name, "response": response}
+    # Gemini 3 always returns a unique id with every functionCall and requires
+    # that exact id to be echoed back on the matching functionResponse so the
+    # model can map results to calls (critical for parallel / compositional
+    # tool calls). Echo the id when we have one; older models that don't emit
+    # ids simply won't have a tool_call_id to forward.
+    if tool_call_id:
+        function_response["id"] = tool_call_id
+    return {"functionResponse": function_response}
 
 
 def _build_gemini_contents(messages: List[Dict[str, Any]]) -> tuple[List[Dict[str, Any]], Optional[Dict[str, Any]]]:
@@ -599,8 +608,13 @@ def translate_gemini_response(resp: Dict[str, Any], model: str) -> SimpleNamespa
                 args_str = json.dumps(fc.get("args") or {}, ensure_ascii=False)
             except (TypeError, ValueError):
                 args_str = "{}"
+            # Preserve Gemini 3's native functionCall id so it can be echoed
+            # back on the functionResponse; fall back to a generated id for
+            # models that don't emit one.
+            native_id = fc.get("id")
+            call_id = str(native_id) if native_id else f"call_{uuid.uuid4().hex[:12]}"
             tool_call = SimpleNamespace(
-                id=f"call_{uuid.uuid4().hex[:12]}",
+                id=call_id,
                 type="function",
                 index=index,
                 function=SimpleNamespace(name=str(fc["name"]), arguments=args_str),
@@ -749,9 +763,12 @@ def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices:
             )
             slot = tool_call_indices.get(call_key)
             if slot is None:
+                # Preserve Gemini 3's native functionCall id (echoed back on the
+                # functionResponse); fall back to a generated id for older models.
+                native_id = fc.get("id")
                 slot = {
                     "index": len(tool_call_indices),
-                    "id": f"call_{uuid.uuid4().hex[:12]}",
+                    "id": str(native_id) if native_id else f"call_{uuid.uuid4().hex[:12]}",
                     "last_arguments": "",
                 }
                 tool_call_indices[call_key] = slot

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -259,3 +259,108 @@ def test_stream_event_translation_emits_tool_call_delta_with_stable_index():
 
 
 
+def test_hermes_version_is_valid():
+    """_HERMES_VERSION should be a non-empty string."""
+    from agent.gemini_native_adapter import _HERMES_VERSION
+
+    assert isinstance(_HERMES_VERSION, str)
+    assert len(_HERMES_VERSION) > 0
+    assert _HERMES_VERSION != "0.0.0", (
+        "Version should resolve from hermes_cli.__version__, not the fallback"
+    )
+
+
+def test_translate_response_preserves_native_function_call_id():
+    """Gemini 3 returns a unique id per functionCall; it must become the tool_call id."""
+    from agent.gemini_native_adapter import translate_gemini_response
+
+    payload = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"functionCall": {"id": "fc_abc123", "name": "search", "args": {"q": "x"}}},
+                    ]
+                },
+                "finishReason": "STOP",
+            }
+        ],
+    }
+
+    response = translate_gemini_response(payload, model="gemini-3.5-flash")
+    assert response.choices[0].message.tool_calls[0].id == "fc_abc123"
+
+
+def test_translate_response_generates_id_when_absent():
+    """Older models without a functionCall id still get a generated tool_call id."""
+    from agent.gemini_native_adapter import translate_gemini_response
+
+    payload = {
+        "candidates": [
+            {
+                "content": {"parts": [{"functionCall": {"name": "search", "args": {}}}]},
+                "finishReason": "STOP",
+            }
+        ],
+    }
+
+    response = translate_gemini_response(payload, model="gemini-2.5-flash")
+    call_id = response.choices[0].message.tool_calls[0].id
+    assert call_id and call_id.startswith("call_")
+
+
+def test_tool_result_echoes_native_id_round_trip():
+    """The functionResponse must carry the id from the matching functionCall."""
+    from agent.gemini_native_adapter import build_gemini_request
+
+    request = build_gemini_request(
+        messages=[
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "fc_abc123",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "fc_abc123",
+                "content": '{"forecast": "sunny"}',
+            },
+        ],
+        tools=[],
+        tool_choice=None,
+    )
+
+    # Both halves of the pair must carry the same native id: the replayed
+    # functionCall and the functionResponse that echoes it.
+    function_call = request["contents"][0]["parts"][0]["functionCall"]
+    assert function_call["id"] == "fc_abc123"
+    function_response = request["contents"][1]["parts"][0]["functionResponse"]
+    assert function_response["id"] == "fc_abc123"
+    assert function_response["name"] == "get_weather"
+
+
+def test_stream_event_preserves_native_function_call_id():
+    """Streaming path must also surface Gemini's native functionCall id."""
+    from agent.gemini_native_adapter import translate_stream_event
+
+    event = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"functionCall": {"id": "fc_stream_9", "name": "search", "args": {"q": "abc"}}}
+                    ]
+                }
+            }
+        ]
+    }
+
+    chunks = translate_stream_event(event, model="gemini-3.5-flash", tool_call_indices={})
+    tool_chunks = [c for c in chunks if c.choices[0].delta.tool_calls]
+    assert tool_chunks[0].choices[0].delta.tool_calls[0].id == "fc_stream_9"


### PR DESCRIPTION
## Problem

Gemini 3 always returns a unique `id` with every `functionCall` and **requires that exact id to be echoed back** on the matching `functionResponse` so the model can map results to calls. This is essential for **parallel** and **compositional** tool calling, where matching by name/order alone is ambiguous.

Per the [official function-calling docs](https://ai.google.dev/gemini-api/docs/function-calling):

> **Always map function IDs:** Gemini 3 now always returns a unique `id` with every `functionCall`. Include this exact `id` in your `functionResponse` so the model can accurately map your result back to the original request.

The native `generateContent` REST example shows the shape directly:

```json
"functionResponse": {
  "name": "get_image",
  "id": "UNIQUE_CALL_ID_HERE",
  "response": { ... }
}
```

The native adapter previously **discarded** Gemini's returned id and generated its own UUID, so the id was never echoed back — silently breaking the round-trip for Gemini 3.x multi-tool turns.

## Fix

Three call sites in `agent/gemini_native_adapter.py`:

1. **`translate_gemini_response`** — use `fc["id"]` as the `tool_call` id when present.
2. **`translate_stream_event`** — same, in the streaming slot.
3. **`_translate_tool_result_to_gemini`** — echo `tool_call_id` back as `functionResponse.id`.

All three fall back to a generated `call_…` id for older models that don't emit one, so Gemini 2.x behavior is unchanged.

## Test plan

- [x] 4 new regression tests: native id preserved (non-stream + stream), generated fallback when absent, and full round-trip into `functionResponse.id`
- [x] `scripts/run_tests.sh tests/agent/test_gemini_native_adapter.py` — 24/24 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)