### PR TITLE
fix(email): use implicit TLS for port 465

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -22,6 +22,7 @@ import logging
 import os
 import re
 import smtplib
+import socket
 import ssl
 import uuid
 from email.header import decode_header
@@ -293,6 +294,53 @@ class EmailAdapter(BasePlatformAdapter):
             # Fallback: just clear old entries if sort fails
             self._seen_uids = set(list(self._seen_uids)[-self._seen_uids_max // 2:])
 
+    def _connect_smtp(self) -> smtplib.SMTP:
+        """Create an SMTP connection, selecting the correct protocol for the port.
+
+        Port 465 uses implicit TLS (``SMTP_SSL``).  All other ports use
+        ``SMTP`` + ``STARTTLS``.
+
+        When the host resolves to an IPv6 address that is unreachable
+        (common on networks without IPv6 routing), the connection hangs
+        until the socket timeout expires.  To avoid this, we try the
+        default resolution first and fall back to IPv4-only on failure.
+
+        Returns a connected SMTP object with TLS established — callers
+        can proceed directly to ``login()``.
+        """
+        ctx = ssl.create_default_context()
+        host = self._smtp_host
+        port = self._smtp_port
+        timeout = 30
+
+        def _connect() -> smtplib.SMTP:
+            """Attempt one SMTP connection (default address family)."""
+            if port == 465:
+                return smtplib.SMTP_SSL(host, port, timeout=timeout, context=ctx)
+            s = smtplib.SMTP(host, port, timeout=timeout)
+            s.starttls(context=ctx)
+            return s
+
+        def _connect_ipv4() -> smtplib.SMTP:
+            """Fallback: force IPv4 via an AF_INET socket."""
+            sock = socket.create_connection(
+                (host, port), timeout=timeout, family=socket.AF_INET,
+            )
+            if port == 465:
+                return smtplib.SMTP_SSL(
+                    host, port, timeout=timeout, context=ctx, sock=sock,
+                )
+            s = smtplib.SMTP(host, port, timeout=timeout, sock=sock)
+            s.starttls(context=ctx)
+            return s
+
+        try:
+            return _connect()
+        except (socket.timeout, OSError):
+            # Connection-level failure (may be unreachable IPv6).
+            # Retry with IPv4 only.
+            return _connect_ipv4()
+
     async def connect(self) -> bool:
         """Connect to the IMAP server and start polling for new messages."""
         try:
@@ -316,10 +364,11 @@ class EmailAdapter(BasePlatformAdapter):
 
         try:
             # Test SMTP connection
-            smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
-            smtp.starttls(context=ssl.create_default_context())
-            smtp.login(self._address, self._password)
-            smtp.quit()
+            smtp = self._connect_smtp()
+            try:
+                smtp.login(self._address, self._password)
+            finally:
+                smtp.quit()
             logger.info("[Email] SMTP connection test passed.")
         except Exception as e:
             logger.error("[Email] SMTP connection failed: %s", e)
@@ -555,9 +604,8 @@ class EmailAdapter(BasePlatformAdapter):
 
         msg.attach(MIMEText(body, "plain", "utf-8"))
 
-        smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
+        smtp = self._connect_smtp()
         try:
-            smtp.starttls(context=ssl.create_default_context())
             smtp.login(self._address, self._password)
             smtp.send_message(msg)
         finally:
@@ -677,9 +725,8 @@ class EmailAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[Email] Failed to attach %s: %s", file_path, e)
 
-        smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
+        smtp = self._connect_smtp()
         try:
-            smtp.starttls(context=ssl.create_default_context())
             smtp.login(self._address, self._password)
             smtp.send_message(msg)
         finally:
@@ -756,9 +803,8 @@ class EmailAdapter(BasePlatformAdapter):
             part.add_header("Content-Disposition", f"attachment; filename={fname}")
             msg.attach(part)
 
-        smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
+        smtp = self._connect_smtp()
         try:
-            smtp.starttls(context=ssl.create_default_context())
             smtp.login(self._address, self._password)
             smtp.send_message(msg)
         finally:

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -63,6 +63,63 @@ _AUTOMATED_HEADERS = {
 # Gmail-safe max length per email body
 MAX_MESSAGE_LENGTH = 50_000
 
+SMTP_CONNECT_TIMEOUT = 30
+
+
+def _create_ipv4_connection(
+    host: str,
+    port: int,
+    timeout: float,
+    source_address: Any = None,
+) -> socket.socket:
+    """Create a TCP connection using only IPv4 addresses.
+
+    This mirrors ``socket.create_connection`` but constrains DNS resolution to
+    ``AF_INET``.  It avoids mutating process-global socket functions, which
+    matters because email sends run in executor threads.
+    """
+    last_error: OSError | None = None
+    for family, socktype, proto, _canonname, sockaddr in socket.getaddrinfo(
+        host, port, socket.AF_INET, socket.SOCK_STREAM
+    ):
+        sock = socket.socket(family, socktype, proto)
+        sock.settimeout(timeout)
+        try:
+            if source_address:
+                sock.bind(source_address)
+            sock.connect(sockaddr)
+            return sock
+        except OSError as exc:
+            last_error = exc
+            sock.close()
+    if last_error is not None:
+        raise last_error
+    raise OSError(f"No IPv4 address found for {host}:{port}")
+
+
+class _IPv4SMTP(smtplib.SMTP):
+    def _get_socket(self, host, port, timeout):  # type: ignore[override]
+        return _create_ipv4_connection(
+            host,
+            port,
+            timeout,
+            source_address=self.source_address,
+        )
+
+
+class _IPv4SMTP_SSL(smtplib.SMTP_SSL):
+    def _get_socket(self, host, port, timeout):  # type: ignore[override]
+        raw_sock = _create_ipv4_connection(
+            host,
+            port,
+            timeout,
+            source_address=self.source_address,
+        )
+        return self.context.wrap_socket(
+            raw_sock,
+            server_hostname=getattr(self, "_host", host),
+        )
+
 # Supported image extensions for inline detection
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
 
@@ -301,9 +358,10 @@ class EmailAdapter(BasePlatformAdapter):
         ``SMTP`` + ``STARTTLS``.
 
         When the host resolves to an IPv6 address that is unreachable
-        (common on networks without IPv6 routing), the connection hangs
-        until the socket timeout expires.  To avoid this, we try the
-        default resolution first and fall back to IPv4-only on failure.
+        (common on networks without IPv6 routing), the default connection can
+        hang until the socket timeout expires.  We retry connection-level
+        failures through an IPv4-only socket path, without mutating global
+        resolver state.  TLS verification errors are not retried.
 
         Returns a connected SMTP object with TLS established — callers
         can proceed directly to ``login()``.
@@ -311,35 +369,29 @@ class EmailAdapter(BasePlatformAdapter):
         ctx = ssl.create_default_context()
         host = self._smtp_host
         port = self._smtp_port
-        timeout = 30
 
-        def _connect() -> smtplib.SMTP:
-            """Attempt one SMTP connection (default address family)."""
+        def _connect(*, ipv4_only: bool = False) -> smtplib.SMTP:
+            """Attempt one SMTP connection."""
+            smtp_cls = _IPv4SMTP if ipv4_only else smtplib.SMTP
+            smtp_ssl_cls = _IPv4SMTP_SSL if ipv4_only else smtplib.SMTP_SSL
             if port == 465:
-                return smtplib.SMTP_SSL(host, port, timeout=timeout, context=ctx)
-            s = smtplib.SMTP(host, port, timeout=timeout)
-            s.starttls(context=ctx)
-            return s
-
-        def _connect_ipv4() -> smtplib.SMTP:
-            """Fallback: force IPv4 via an AF_INET socket."""
-            sock = socket.create_connection(
-                (host, port), timeout=timeout, family=socket.AF_INET,
-            )
-            if port == 465:
-                return smtplib.SMTP_SSL(
-                    host, port, timeout=timeout, context=ctx, sock=sock,
-                )
-            s = smtplib.SMTP(host, port, timeout=timeout, sock=sock)
-            s.starttls(context=ctx)
-            return s
+                return smtp_ssl_cls(host, port, timeout=SMTP_CONNECT_TIMEOUT, context=ctx)
+            smtp = smtp_cls(host, port, timeout=SMTP_CONNECT_TIMEOUT)
+            try:
+                smtp.starttls(context=ctx)
+            except Exception:
+                smtp.close()
+                raise
+            return smtp
 
         try:
             return _connect()
-        except (socket.timeout, OSError):
+        except (socket.timeout, TimeoutError, ConnectionError, OSError) as exc:
+            if isinstance(exc, ssl.SSLError):
+                raise
             # Connection-level failure (may be unreachable IPv6).
             # Retry with IPv4 only.
-            return _connect_ipv4()
+            return _connect(ipv4_only=True)
 
     async def connect(self) -> bool:
         """Connect to the IMAP server and start polling for new messages."""

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1265,5 +1265,105 @@ class TestImapIdExtensionForNetEase(unittest.TestCase):
         mock_imap.xatom.assert_called_once()
 
 
+class TestConnectSmtp(unittest.TestCase):
+    """Test _connect_smtp() helper: protocol selection and IPv6 fallback."""
+
+    def _make_adapter(self, port="587"):
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+            "EMAIL_SMTP_PORT": port,
+        }):
+            from gateway.platforms.email import EmailAdapter
+            return EmailAdapter(PlatformConfig(enabled=True))
+
+    def test_port_587_uses_smtp_with_starttls(self):
+        """Port 587 should use smtplib.SMTP + STARTTLS."""
+        adapter = self._make_adapter("587")
+
+        with patch("smtplib.SMTP") as mock_smtp, \
+             patch("smtplib.SMTP_SSL") as mock_smtp_ssl:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            result = adapter._connect_smtp()
+
+            mock_smtp.assert_called_once()
+            mock_smtp_ssl.assert_not_called()
+            mock_server.starttls.assert_called_once()
+            self.assertIs(result, mock_server)
+
+    def test_port_465_uses_smtp_ssl(self):
+        """Port 465 should use smtplib.SMTP_SSL (implicit TLS)."""
+        adapter = self._make_adapter("465")
+
+        with patch("smtplib.SMTP") as mock_smtp, \
+             patch("smtplib.SMTP_SSL") as mock_smtp_ssl:
+            mock_server = MagicMock()
+            mock_smtp_ssl.return_value = mock_server
+
+            result = adapter._connect_smtp()
+
+            mock_smtp_ssl.assert_called_once()
+            mock_smtp.assert_not_called()
+            self.assertIs(result, mock_server)
+
+    def test_ipv6_timeout_falls_back_to_ipv4(self):
+        """When default connection times out, retry with AF_INET socket."""
+        import socket as _socket
+        adapter = self._make_adapter("587")
+
+        call_count = 0
+
+        def fake_smtp(host, port, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if "sock" not in kwargs:
+                raise _socket.timeout("timed out")
+            server = MagicMock()
+            return server
+
+        with patch("smtplib.SMTP", side_effect=fake_smtp), \
+             patch("socket.create_connection") as mock_create_conn:
+            mock_sock = MagicMock()
+            mock_create_conn.return_value = mock_sock
+
+            adapter._connect_smtp()
+
+            # First attempt without sock, then fallback with sock
+            self.assertEqual(call_count, 2)
+            mock_create_conn.assert_called_once_with(
+                ("smtp.test.com", 587), timeout=30, family=_socket.AF_INET,
+            )
+
+    def test_port_465_ipv6_fallback(self):
+        """Port 465 IPv6 timeout falls back to IPv4 with SMTP_SSL."""
+        import socket as _socket
+        adapter = self._make_adapter("465")
+
+        call_count = 0
+
+        def fake_smtp_ssl(host, port, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if "sock" not in kwargs:
+                raise _socket.timeout("timed out")
+            return MagicMock()
+
+        with patch("smtplib.SMTP_SSL", side_effect=fake_smtp_ssl), \
+             patch("socket.create_connection") as mock_create_conn:
+            mock_create_conn.return_value = MagicMock()
+
+            adapter._connect_smtp()
+
+            self.assertEqual(call_count, 2)
+            mock_create_conn.assert_called_once_with(
+                ("smtp.test.com", 465), timeout=30, family=_socket.AF_INET,
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -18,7 +18,7 @@ from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 from email.mime.base import MIMEBase
 from email import encoders
-from unittest.mock import patch, MagicMock, AsyncMock
+from unittest.mock import patch, MagicMock, AsyncMock, ANY
 
 from gateway.platforms.base import SendResult
 
@@ -1312,57 +1312,75 @@ class TestConnectSmtp(unittest.TestCase):
             self.assertIs(result, mock_server)
 
     def test_ipv6_timeout_falls_back_to_ipv4(self):
-        """When default connection times out, retry with AF_INET socket."""
+        """When default connection times out, retry with an IPv4-only SMTP path."""
         import socket as _socket
+        from gateway.platforms import email as email_mod
+
         adapter = self._make_adapter("587")
 
-        call_count = 0
+        with patch("smtplib.SMTP", side_effect=_socket.timeout("timed out")), \
+             patch.object(email_mod, "_IPv4SMTP") as mock_ipv4_smtp:
+            mock_server = MagicMock()
+            mock_ipv4_smtp.return_value = mock_server
 
-        def fake_smtp(host, port, **kwargs):
-            nonlocal call_count
-            call_count += 1
-            if "sock" not in kwargs:
-                raise _socket.timeout("timed out")
-            server = MagicMock()
-            return server
+            result = adapter._connect_smtp()
 
-        with patch("smtplib.SMTP", side_effect=fake_smtp), \
-             patch("socket.create_connection") as mock_create_conn:
-            mock_sock = MagicMock()
-            mock_create_conn.return_value = mock_sock
-
-            adapter._connect_smtp()
-
-            # First attempt without sock, then fallback with sock
-            self.assertEqual(call_count, 2)
-            mock_create_conn.assert_called_once_with(
-                ("smtp.test.com", 587), timeout=30, family=_socket.AF_INET,
-            )
+            self.assertIs(result, mock_server)
+            mock_ipv4_smtp.assert_called_once_with("smtp.test.com", 587, timeout=30)
+            mock_server.starttls.assert_called_once()
 
     def test_port_465_ipv6_fallback(self):
         """Port 465 IPv6 timeout falls back to IPv4 with SMTP_SSL."""
         import socket as _socket
+        from gateway.platforms import email as email_mod
+
         adapter = self._make_adapter("465")
 
-        call_count = 0
+        with patch("smtplib.SMTP_SSL", side_effect=_socket.timeout("timed out")), \
+             patch.object(email_mod, "_IPv4SMTP_SSL") as mock_ipv4_smtp_ssl:
+            mock_server = MagicMock()
+            mock_ipv4_smtp_ssl.return_value = mock_server
 
-        def fake_smtp_ssl(host, port, **kwargs):
-            nonlocal call_count
-            call_count += 1
-            if "sock" not in kwargs:
-                raise _socket.timeout("timed out")
-            return MagicMock()
+            result = adapter._connect_smtp()
 
-        with patch("smtplib.SMTP_SSL", side_effect=fake_smtp_ssl), \
-             patch("socket.create_connection") as mock_create_conn:
-            mock_create_conn.return_value = MagicMock()
-
-            adapter._connect_smtp()
-
-            self.assertEqual(call_count, 2)
-            mock_create_conn.assert_called_once_with(
-                ("smtp.test.com", 465), timeout=30, family=_socket.AF_INET,
+            self.assertIs(result, mock_server)
+            mock_ipv4_smtp_ssl.assert_called_once_with(
+                "smtp.test.com", 465, timeout=30, context=ANY,
             )
+
+    def test_tls_verification_error_does_not_retry_ipv4(self):
+        """Certificate failures are security errors, not IPv6 reachability failures."""
+        import ssl as _ssl
+        from gateway.platforms import email as email_mod
+
+        adapter = self._make_adapter("465")
+
+        with patch("smtplib.SMTP_SSL", side_effect=_ssl.SSLError("cert verify failed")), \
+             patch.object(email_mod, "_IPv4SMTP_SSL") as mock_ipv4_smtp_ssl:
+            with self.assertRaises(_ssl.SSLError):
+                adapter._connect_smtp()
+
+            mock_ipv4_smtp_ssl.assert_not_called()
+
+    def test_ipv4_connection_does_not_mutate_global_resolver(self):
+        """IPv4 fallback must not monkeypatch process-global socket state."""
+        import socket as _socket
+        from gateway.platforms.email import _create_ipv4_connection
+
+        original_getaddrinfo = _socket.getaddrinfo
+        fake_sock = MagicMock()
+
+        with patch(
+            "socket.getaddrinfo",
+            return_value=[(_socket.AF_INET, _socket.SOCK_STREAM, 6, "", ("192.0.2.1", 587))],
+        ) as mock_getaddrinfo, patch("socket.socket", return_value=fake_sock):
+            result = _create_ipv4_connection("smtp.test.com", 587, 30)
+
+        self.assertIs(result, fake_sock)
+        mock_getaddrinfo.assert_called_once_with(
+            "smtp.test.com", 587, _socket.AF_INET, _socket.SOCK_STREAM,
+        )
+        self.assertIs(_socket.getaddrinfo, original_getaddrinfo)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Email gateway SMTP connections now use the correct TLS mode for port 465 and a thread-safe IPv4 fallback for broken IPv6 routes.

Cherry-picks #46061 from @liuhao1024, then fixes the fallback path so it uses supported `smtplib` extension points instead of unsupported `sock=` kwargs. Also adds security-focused regressions: certificate/TLS verification errors are not retried through fallback, and the IPv4 path does not monkeypatch process-global socket resolution.

## Changes
- `gateway/platforms/email.py`: add `_connect_smtp()` with `SMTP_SSL` for port 465 and `SMTP` + `STARTTLS` elsewhere.
- `gateway/platforms/email.py`: add IPv4-only SMTP subclasses that override `_get_socket()` instead of passing unsupported `sock=` kwargs.
- `gateway/platforms/email.py`: close partially-open SMTP sessions if `STARTTLS` fails.
- `tests/gateway/test_email.py`: cover 465/587 protocol selection, IPv4 fallback, no TLS-error retry, and no global resolver mutation.

## Security notes
- TLS verification still uses `ssl.create_default_context()`.
- Certificate / TLS verification failures are treated as security failures and are not retried via IPv4.
- The IPv4 fallback is per-connection and thread-safe; it does not patch `socket.getaddrinfo` globally.

## Validation
| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/gateway/test_email.py` | 68 passed |
| `python -m py_compile gateway/platforms/email.py tests/gateway/test_email.py` | pass |
| `git diff --check` | pass |
| live Python signature smoke | verified `smtplib.SMTP`/`SMTP_SSL` have no `sock=` kwarg; fallback uses subclasses |

## Infographic
![SMTP TLS Pathfinder](https://v3b.fal.media/files/b/0a9e3ff0/XkW0eSd5R43FBMgCHNLjI_9nzxug1w.png)

Original PR: https://github.com/NousResearch/hermes-agent/pull/46061
Related duplicate: https://github.com/NousResearch/hermes-agent/pull/46019
Fixes: https://github.com/NousResearch/hermes-agent/issues/46018
