### PR TITLE
fix: desktop session delete/rename 404 when active profile differs from session's profile

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6546,11 +6546,34 @@ async def delete_session_endpoint(session_id: str, profile: Optional[str] = None
     # desktop routes their DELETE to the remote backend. Omit for current/default.
     db = _open_session_db_for_profile(profile)
     try:
-        if not db.delete_session(session_id):
-            raise HTTPException(status_code=404, detail="Session not found")
-        return {"ok": True}
+        if db.delete_session(session_id):
+            return {"ok": True}
     finally:
         db.close()
+
+    # Session not found in the requested/current profile's state.db.
+    # When the desktop active profile differs from the session's owning
+    # profile, the Electron router may send the request to the wrong backend
+    # (e.g. active=job but session lives in default).  Fall back to scanning
+    # every local profile so the delete still succeeds.
+    from hermes_state import SessionDB
+    from hermes_cli import profiles as profiles_mod
+    for info in profiles_mod.list_profiles():
+        home = info.path
+        db_path = home / "state.db"
+        if not db_path.exists():
+            continue
+        try:
+            db = SessionDB(db_path=db_path)
+        except Exception:
+            continue
+        try:
+            if db.delete_session(session_id):
+                return {"ok": True}
+        finally:
+            db.close()
+
+    raise HTTPException(status_code=404, detail="Session not found")
 
 
 class SessionRename(BaseModel):
@@ -6572,27 +6595,51 @@ async def rename_session_endpoint(session_id: str, body: SessionRename):
     db = _open_session_db_for_profile(body.profile)
     try:
         sid = db.resolve_session_id(session_id)
-        if not sid:
-            raise HTTPException(status_code=404, detail="Session not found")
-        if body.title is None and body.archived is None:
-            raise HTTPException(
-                status_code=400,
-                detail="Nothing to update; provide 'title' and/or 'archived'.",
-            )
-        if body.title is not None:
-            try:
-                db.set_session_title(sid, body.title or "")
-            except ValueError as e:
-                # Title too long, invalid characters, or already in use.
-                raise HTTPException(status_code=400, detail=str(e))
-        if body.archived is not None:
-            db.set_session_archived(sid, body.archived)
-        result = {"ok": True, "title": db.get_session_title(sid) or ""}
-        if body.archived is not None:
-            result["archived"] = bool(body.archived)
-        return result
+        if sid:
+            return _apply_session_update(db, sid, body)
     finally:
         db.close()
+
+    # Fallback: scan all profiles (same rationale as delete_session_endpoint).
+    from hermes_state import SessionDB
+    from hermes_cli import profiles as profiles_mod
+    for info in profiles_mod.list_profiles():
+        home = info.path
+        db_path = home / "state.db"
+        if not db_path.exists():
+            continue
+        try:
+            db = SessionDB(db_path=db_path)
+        except Exception:
+            continue
+        try:
+            sid = db.resolve_session_id(session_id)
+            if sid:
+                return _apply_session_update(db, sid, body)
+        finally:
+            db.close()
+
+    raise HTTPException(status_code=404, detail="Session not found")
+
+
+def _apply_session_update(db, sid: str, body: SessionRename):
+    """Apply title/archived mutations to an already-resolved session."""
+    if body.title is None and body.archived is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Nothing to update; provide 'title' and/or 'archived'.",
+        )
+    if body.title is not None:
+        try:
+            db.set_session_title(sid, body.title or "")
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+    if body.archived is not None:
+        db.set_session_archived(sid, body.archived)
+    result = {"ok": True, "title": db.get_session_title(sid) or ""}
+    if body.archived is not None:
+        result["archived"] = bool(body.archived)
+    return result
 
 
 @app.get("/api/sessions/{session_id}/export")


### PR DESCRIPTION
## Problem

When the Desktop app's active profile differs from the profile owning a session, delete and rename/archive operations fail with **404 "Session not found"**.

### Root cause

The Desktop has two independent profile resolution paths that diverge:

1. **Electron routing** (`ensureBackend`): uses `readActiveDesktopProfile()` which reads `active-profile.json` in Electron's `userData`. If absent, `primaryProfileKey()` returns `'default'`.
2. **Backend HERMES_HOME**: the spawned backend reads `~/.hermes/active_profile` to determine which profile's `state.db` to open.

When a user has `active_profile = job` (via `hermes profile use job`) but no `active-profile.json` (Desktop's own config):

- `readActiveDesktopProfile()` → `null` → `primaryProfileKey()` → `'default'`
- `ensureBackend('default')` → `key === primaryProfileKey()` → routes to main backend
- Main backend reads `active_profile` file → `'job'` → opens `~/.hermes/profiles/job/state.db`
- Session lives in `~/.hermes/state.db` (default profile) → **404**

The same issue affects `PATCH /api/sessions/{id}` (rename/archive).

### Reproduction

1. `hermes profile use job` (sets `~/.hermes/active_profile` to `job`)
2. Open Desktop (no `active-profile.json` in userData)
3. Create a session in the default profile (e.g. via CLI)
4. In Desktop sidebar, try to delete or rename that session → 404

## Fix

Both `delete_session_endpoint` and `rename_session_endpoint` now fall back to scanning all local profiles' `state.db` when the session is not found in the initially-targeted database. This is a best-effort fallback — it adds minimal overhead (one `SELECT COUNT(*)` per profile) only on the miss path.

Also extracted `_apply_session_update` helper to avoid duplicating the title/archived mutation logic in the rename fallback.

## Files changed

- `hermes_cli/web_server.py` — `delete_session_endpoint`, `rename_session_endpoint`, new `_apply_session_update` helper