### PR TITLE
fix(logging): tolerate rename failure during multi-process log rollover

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -467,7 +467,25 @@ class _ManagedRotatingFileHandler(RotatingFileHandler):
         return stream
 
     def doRollover(self):
-        super().doRollover()
+        try:
+            super().doRollover()
+        except OSError:
+            # Windows / multi-process: another Hermes process (gateway,
+            # dashboard, cron worker, CLI) holds the SAME log file open, so
+            # os.rename(base -> base.1) fails with WinError 32 (sharing
+            # violation). We cannot rotate while a peer has the file open.
+            # Recover gracefully instead of letting logging.handleError spam
+            # a traceback on every emit: ensure we still have a live stream on
+            # baseFilename and carry on. Whichever process eventually wins the
+            # rename performs the rotation; the inode-watch in emit() then
+            # reopens every other process onto the fresh file. Worst case the
+            # file grows past maxBytes until a rollover succeeds — acceptable
+            # versus crashing every log line with a "--- Logging error ---".
+            if self.stream is None:
+                try:
+                    self.stream = self._open()
+                except OSError:
+                    pass
         self._chmod_if_managed()
         # Our own rollover writes a new baseFilename; refresh the snapshot
         # so the next emit doesn't mistake it for external rotation.


### PR DESCRIPTION
## Problem

On Windows, multiple Hermes processes (gateway service, dashboard service, cron/profile workers, and the CLI) all write to the same log file (e.g. `agent.log`). When the file crosses `maxBytes`, whichever process emits next calls `doRollover()`, which does `os.rename(base -> base.1)`. On Windows you cannot rename a file that another process holds open, so the losing process raises:

```
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'agent.log' -> 'agent.log.1'
```

`logging.Handler.handleError` then dumps the full traceback to stderr (`--- Logging error ---`) on **every** emit until the file finally gets rotated. This is non-fatal but produces a wall of tracebacks attached to harmless INFO lines (e.g. model-switch / vision auto-detect logging).

`_ManagedRotatingFileHandler` already has `WatchedFileHandler`-style inode-watching in `emit()` to recover when a peer wins the rotation race — but `doRollover()` itself had no guard, so the losers crash instead of recovering.

## Fix

Wrap `_ManagedRotatingFileHandler.doRollover()` so an `OSError` on the rename is caught: the process re-opens its stream on `baseFilename` and carries on. Whichever process wins the rename performs the real rotation; the existing `emit()` inode-watch then reopens every other process onto the fresh inode. Worst case the file grows slightly past `maxBytes` until a rollover succeeds — far better than spamming a traceback per log line.

In stdlib `doRollover`, the stream is closed and set to `None` before the `os.rename`, and the final `_open()` never runs when the rename raises — so the `if self.stream is None: reopen` recovery path is correct (`baseFilename` still exists because the rename failed).

## Verification

- Reproduced the exact failure: stock stdlib `RotatingFileHandler.doRollover()` raises `PermissionError` WinError 32 when a peer holds the file open.
- Patched handler under the same conditions: `doRollover()` returns cleanly, the stream stays alive, writes keep working, and a later unblocked rollover correctly creates `agent.log.1`.
- `hermes_logging.py` imports cleanly; lint passes.

Scope: single file, `hermes_logging.py` (+19/-1).