### PR TITLE
fix(mcp): use encoding_error_handler='replace' for stdio transport

### DIFF
--- a/tests/tools/test_mcp_stdio_encoding_handler.py
+++ b/tests/tools/test_mcp_stdio_encoding_handler.py
@@ -1,0 +1,103 @@
+"""Tests for MCP stdio encoding error handler fix (issue #46099).
+
+On Windows, pipe I/O can produce non-UTF-8 bytes at chunk boundaries,
+causing UnicodeDecodeError when the MCP SDK's TextReceiveStream uses
+errors="strict". This test verifies that StdioServerParameters is created
+with encoding_error_handler="replace".
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tools.mcp_tool import MCPServerTask, _MCP_AVAILABLE
+
+pytestmark = pytest.mark.skipif(not _MCP_AVAILABLE, reason="MCP SDK not installed")
+
+
+class TestStdioEncodingErrorHandler:
+    """Verify that _run_stdio passes encoding_error_handler='replace'."""
+
+    def test_stdio_server_params_uses_replace_encoding_handler(self):
+        """StdioServerParameters must use encoding_error_handler='replace'.
+
+        On Windows, pipe chunk boundaries can split multi-byte UTF-8 sequences,
+        producing bytes that fail with errors='strict'. Using 'replace' ensures
+        undecodable bytes become U+FFFD instead of crashing.
+        """
+        mock_session = MagicMock()
+        mock_session.initialize = AsyncMock()
+        mock_session.list_tools = AsyncMock(return_value=SimpleNamespace(tools=[]))
+
+        mock_stdio_cm = MagicMock()
+        mock_stdio_cm.__aenter__ = AsyncMock(return_value=(object(), object()))
+        mock_stdio_cm.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session_cm = MagicMock()
+        mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_cm.__aexit__ = AsyncMock(return_value=False)
+
+        async def _test():
+            with (
+                patch("tools.mcp_tool.StdioServerParameters") as mock_params,
+                patch("tools.mcp_tool.stdio_client", return_value=mock_stdio_cm),
+                patch("tools.mcp_tool.ClientSession", return_value=mock_session_cm),
+                patch("tools.mcp_tool._snapshot_child_pids", return_value=set()),
+                patch("tools.mcp_tool._write_stderr_log_header"),
+                patch("tools.mcp_tool._get_mcp_stderr_log", return_value=None),
+            ):
+                server = MCPServerTask("test-encoding")
+                await server.start({
+                    "command": "echo",
+                    "args": ["hello"],
+                })
+
+                call_kwargs = mock_params.call_args.kwargs
+                assert call_kwargs["encoding_error_handler"] == "replace", (
+                    f"Expected encoding_error_handler='replace', "
+                    f"got '{call_kwargs.get('encoding_error_handler')}'"
+                )
+
+                await server.shutdown()
+
+        asyncio.run(_test())
+
+    def test_stdio_server_params_defaults_encoding_utf8(self):
+        """Verify that the default encoding (utf-8) is not overridden."""
+        mock_session = MagicMock()
+        mock_session.initialize = AsyncMock()
+        mock_session.list_tools = AsyncMock(return_value=SimpleNamespace(tools=[]))
+
+        mock_stdio_cm = MagicMock()
+        mock_stdio_cm.__aenter__ = AsyncMock(return_value=(object(), object()))
+        mock_stdio_cm.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session_cm = MagicMock()
+        mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_cm.__aexit__ = AsyncMock(return_value=False)
+
+        async def _test():
+            with (
+                patch("tools.mcp_tool.StdioServerParameters") as mock_params,
+                patch("tools.mcp_tool.stdio_client", return_value=mock_stdio_cm),
+                patch("tools.mcp_tool.ClientSession", return_value=mock_session_cm),
+                patch("tools.mcp_tool._snapshot_child_pids", return_value=set()),
+                patch("tools.mcp_tool._write_stderr_log_header"),
+                patch("tools.mcp_tool._get_mcp_stderr_log", return_value=None),
+            ):
+                server = MCPServerTask("test-encoding")
+                await server.start({
+                    "command": "echo",
+                    "args": ["hello"],
+                })
+
+                call_kwargs = mock_params.call_args.kwargs
+                # encoding is not explicitly set — StdioServerParameters defaults to utf-8
+                # We just verify we don't override it
+                assert "encoding" not in call_kwargs or call_kwargs.get("encoding") == "utf-8"
+
+                await server.shutdown()
+
+        asyncio.run(_test())

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1459,6 +1459,10 @@ class MCPServerTask:
             command=command,
             args=args,
             env=safe_env if safe_env else None,
+            # On Windows, pipe I/O can deliver non-UTF-8 bytes at chunk
+            # boundaries.  Use "replace" to substitute undecodable bytes
+            # with U+FFFD instead of crashing with UnicodeDecodeError.
+            encoding_error_handler="replace",
         )
 
         sampling_kwargs = self._sampling.session_kwargs() if self._sampling else {}


### PR DESCRIPTION
## What does this PR do?

Set `encoding_error_handler="replace"` on `StdioServerParameters` in `tools/mcp_tool.py` to prevent `UnicodeDecodeError` on Windows when pipe I/O delivers non-UTF-8 bytes at chunk boundaries.

## Related Issue

Fixes #46099

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py`: Add `encoding_error_handler="replace"` to `StdioServerParameters` construction in `_run_stdio()`, so the MCP SDK's `TextReceiveStream` substitutes undecodable bytes with U+FFFD instead of crashing with `UnicodeDecodeError`.
- `tests/tools/test_mcp_stdio_encoding_handler.py`: Two regression tests verifying the encoding error handler is set to `"replace"` and the default encoding remains `utf-8`.

## How to Test

1. On Windows, configure an MCP server (e.g., `npx @anthropic-ai/mcp-server-filesystem`) and send a message that triggers large stdout output
2. Verify no `UnicodeDecodeError` occurs during MCP tool execution
3. Run `pytest tests/tools/test_mcp_stdio_encoding_handler.py -v` — both tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tools/mcp_tool.py::_run_stdio()` (callers: `MCPServerTask.start()`)
- Blast radius: LOW — single parameter addition to `StdioServerParameters`, no control-flow change
- Related patterns: MCP SDK's `encoding_error_handler` field on `StdioServerParameters` (already supported, just not set by hermes-agent)
