### PR TITLE
fix: propagate plugin tool overrides to MCP bridge

### DIFF
--- a/agent/transports/hermes_tools_mcp_server.py
+++ b/agent/transports/hermes_tools_mcp_server.py
@@ -105,6 +105,60 @@ EXPOSED_TOOLS: tuple[str, ...] = (
 )
 
 
+def _resolve_exposed_tool_names() -> tuple[str, ...]:
+    """Return the registry-authoritative Hermes tool names to expose.
+
+    ``EXPOSED_TOOLS`` is the curated baseline. User plugins may intentionally
+    extend an already-exposed toolset (for example ``web_extract_raw`` in the
+    ``web`` toolset) or override a built-in tool name. The Codex MCP bridge
+    must export the post-plugin registry surface; otherwise Codex sessions can
+    keep seeing stale built-in schemas while normal Hermes dispatch uses the
+    plugin override.
+
+    Expansion is conservative: additional registered tools are included only
+    when their toolset is already represented by the curated baseline.
+    """
+    try:
+        from tools.registry import registry
+
+        tool_to_toolset = registry.get_tool_to_toolset_map()
+        exposed_toolsets = {
+            tool_to_toolset[name]
+            for name in EXPOSED_TOOLS
+            if name in tool_to_toolset
+        }
+        names = list(EXPOSED_TOOLS)
+        seen = set(names)
+        for name, toolset in sorted(tool_to_toolset.items()):
+            if name in seen:
+                continue
+            if toolset in exposed_toolsets:
+                names.append(name)
+                seen.add(name)
+        return tuple(names)
+    except Exception:
+        logger.debug("failed to resolve plugin-extended MCP tools", exc_info=True)
+        return EXPOSED_TOOLS
+
+
+def _apply_fastmcp_parameters_schema(mcp: Any, name: str, params_schema: dict) -> None:
+    """Patch FastMCP's inferred schema with Hermes' registry schema.
+
+    The mcp SDK version currently bundled here infers input schemas from Python
+    function signatures. Our generic dispatcher necessarily has a ``**kwargs``
+    signature, which would otherwise export ``{kwargs: ...}`` and hide the real
+    post-plugin Hermes schema from Codex. Mutating the created Tool object's
+    ``parameters`` field keeps the MCP bridge aligned with normal Hermes model
+    runtimes.
+    """
+    try:
+        tool_obj = mcp._tool_manager._tools.get(name)  # type: ignore[attr-defined]
+        if tool_obj is not None:
+            tool_obj.parameters = params_schema
+    except Exception:
+        logger.debug("failed to apply MCP input schema for %s", name, exc_info=True)
+
+
 def _build_server() -> Any:
     """Create the FastMCP server with Hermes tools attached. Lazy imports
     so the module can be imported without the mcp package installed
@@ -141,9 +195,10 @@ def _build_server() -> Any:
         if isinstance(td, dict) and td.get("type") == "function"
     }
 
+    exposed_names = _resolve_exposed_tool_names()
     exposed_count = 0
 
-    for name in EXPOSED_TOOLS:
+    for name in exposed_names:
         spec = all_defs.get(name)
         if spec is None:
             logger.debug(
@@ -156,9 +211,9 @@ def _build_server() -> Any:
 
         # FastMCP wants a Python callable. Build a closure that takes the
         # arguments dict, dispatches via handle_function_call, and returns
-        # the result string. We use add_tool() for full control over the
-        # input schema (FastMCP's @tool() decorator inspects type hints,
-        # which we can't get from a JSON schema at runtime).
+        # the result string. FastMCP introspects this generic callable as
+        # **kwargs, so after registration we patch the generated Tool object's
+        # parameters with the authoritative registry schema.
         def _make_handler(tool_name: str):
             def _dispatch(**kwargs: Any) -> str:
                 try:
@@ -175,21 +230,20 @@ def _build_server() -> Any:
                 _make_handler(name),
                 name=name,
                 description=description,
-                # FastMCP accepts JSON schema directly via the
-                # input_schema parameter on newer versions; older
-                # versions use parameters_schema. Try both for compat.
             )
+            _apply_fastmcp_parameters_schema(mcp, name, params_schema)
         except TypeError:
             # Older mcp SDK signature — fall back to decorator-style.
             handler = _make_handler(name)
             handler = mcp.tool(name=name, description=description)(handler)
+            _apply_fastmcp_parameters_schema(mcp, name, params_schema)
 
         exposed_count += 1
 
     logger.info(
         "hermes-tools MCP server registered %d/%d tools",
         exposed_count,
-        len(EXPOSED_TOOLS),
+        len(exposed_names),
     )
     return mcp
 

--- a/tests/agent/transports/test_hermes_tools_mcp_server.py
+++ b/tests/agent/transports/test_hermes_tools_mcp_server.py
@@ -1,14 +1,16 @@
 """Tests for the hermes-tools-as-MCP server module surface.
 
-We don't run a live MCP session in unit tests — that requires the codex
-subprocess + client + an event loop. These tests pin the static
-contract: the module imports, the EXPOSED_TOOLS list is sane, and the
-build helper assembles a server when the SDK is present.
+We don't run a live MCP session in most unit tests — that requires the codex
+subprocess + client + an event loop. These tests pin both the static contract
+and the plugin-override export contract for the bridge.
 """
 
 from __future__ import annotations
 
+import asyncio
+import json
 
+import pytest
 
 
 class TestModuleSurface:
@@ -95,6 +97,129 @@ class TestModuleSurface:
             assert orch_tool in EXPOSED_TOOLS, (
                 f"{orch_tool!r} missing from codex callback"
             )
+
+
+class TestPluginOverrideExport:
+    def _restore_entry(self, entry):
+        from tools.registry import registry
+
+        # Remove the protected override first so the original registration is
+        # restored as a normal built-in-style entry, not as another protected
+        # override that can leak into later tests.
+        registry.deregister(entry.name)
+        registry.register(
+            name=entry.name,
+            toolset=entry.toolset,
+            schema=entry.schema,
+            handler=entry.handler,
+            check_fn=entry.check_fn,
+            requires_env=entry.requires_env,
+            is_async=entry.is_async,
+            description=entry.description,
+            emoji=entry.emoji,
+            max_result_size_chars=entry.max_result_size_chars,
+            dynamic_schema_overrides=entry.dynamic_schema_overrides,
+        )
+
+    def test_resolve_exposed_tool_names_includes_plugin_tools_in_exposed_toolsets(self):
+        """Plugin tools in an exposed toolset are included by the bridge resolver."""
+        from agent.transports import hermes_tools_mcp_server as server_mod
+        from tools.registry import discover_builtin_tools, registry
+
+        discover_builtin_tools()
+        name = "web_mcp_plugin_probe_resolver"
+        registry.register(
+            name=name,
+            toolset="web",
+            schema={
+                "name": name,
+                "description": "Plugin probe tool in web toolset",
+                "parameters": {"type": "object", "properties": {}},
+            },
+            handler=lambda args, **kw: json.dumps({"ok": True}),
+            override=True,
+        )
+        try:
+            assert name in server_mod._resolve_exposed_tool_names()
+        finally:
+            registry.deregister(name)
+
+    def test_codex_mcp_bridge_exports_plugin_tools_in_exposed_toolsets(self):
+        """Plugin tools added to an already-exposed toolset should reach Codex MCP."""
+        pytest.importorskip("mcp.server.fastmcp")
+
+        from agent.transports import hermes_tools_mcp_server as server_mod
+        from tools.registry import discover_builtin_tools, registry
+
+        discover_builtin_tools()
+        name = "web_mcp_plugin_probe"
+        registry.register(
+            name=name,
+            toolset="web",
+            schema={
+                "name": name,
+                "description": "Plugin probe tool in web toolset",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"probe": {"type": "string"}},
+                    "required": ["probe"],
+                },
+            },
+            handler=lambda args, **kw: json.dumps({"ok": True}),
+            override=True,
+        )
+        try:
+            assert name in server_mod._resolve_exposed_tool_names()
+
+            async def _list():
+                mcp = server_mod._build_server()
+                return await mcp.list_tools()
+
+            tools = asyncio.run(_list())
+            tool = next(t for t in tools if t.name == name)
+            assert tool.inputSchema["properties"]["probe"]["type"] == "string"
+            assert tool.inputSchema["required"] == ["probe"]
+        finally:
+            registry.deregister(name)
+
+    def test_codex_mcp_bridge_exports_plugin_override_schema_for_builtin_tool(self):
+        """An override=True plugin registration should replace built-in schema in MCP."""
+        pytest.importorskip("mcp.server.fastmcp")
+
+        from agent.transports import hermes_tools_mcp_server as server_mod
+        from tools.registry import discover_builtin_tools, registry
+
+        discover_builtin_tools()
+        original = registry.get_entry("web_search")
+        assert original is not None
+
+        registry.register(
+            name="web_search",
+            toolset="web",
+            schema={
+                "name": "web_search",
+                "description": "OVERRIDE PROBE DESCRIPTION",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"override_probe": {"type": "boolean"}},
+                    "required": ["override_probe"],
+                },
+            },
+            handler=lambda args, **kw: json.dumps({"source": "override"}),
+            override=True,
+        )
+        try:
+            async def _list():
+                mcp = server_mod._build_server()
+                return await mcp.list_tools()
+
+            tools = asyncio.run(_list())
+            tool = next(t for t in tools if t.name == "web_search")
+            assert tool.description == "OVERRIDE PROBE DESCRIPTION"
+            assert "override_probe" in tool.inputSchema["properties"]
+            assert tool.inputSchema["required"] == ["override_probe"]
+        finally:
+            self._restore_entry(original)
 
 
 class TestMain:

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -112,6 +112,63 @@ class TestGetDefinitions:
         assert calls["count"] == 1
 
 
+class TestOverrideProtection:
+    def test_explicit_override_blocks_later_non_override_same_toolset_registration(self):
+        reg = ToolRegistry()
+
+        def override_handler(args, **kw):
+            return json.dumps({"source": "override"})
+
+        def builtin_handler(args, **kw):
+            return json.dumps({"source": "builtin"})
+
+        reg.register(
+            name="web_extract",
+            toolset="web",
+            schema={**_make_schema("web_extract"), "description": "override schema"},
+            handler=override_handler,
+            override=True,
+        )
+        reg.register(
+            name="web_extract",
+            toolset="web",
+            schema={**_make_schema("web_extract"), "description": "late builtin schema"},
+            handler=builtin_handler,
+        )
+
+        assert json.loads(reg.dispatch("web_extract", {})) == {"source": "override"}
+        defs = reg.get_definitions({"web_extract"})
+        assert defs[0]["function"]["description"] == "override schema"
+
+    def test_explicit_override_can_replace_protected_override(self):
+        reg = ToolRegistry()
+
+        def first_handler(args, **kw):
+            return json.dumps({"source": "first"})
+
+        def second_handler(args, **kw):
+            return json.dumps({"source": "second"})
+
+        reg.register(
+            name="web_extract",
+            toolset="web",
+            schema={**_make_schema("web_extract"), "description": "first override"},
+            handler=first_handler,
+            override=True,
+        )
+        reg.register(
+            name="web_extract",
+            toolset="web",
+            schema={**_make_schema("web_extract"), "description": "second override"},
+            handler=second_handler,
+            override=True,
+        )
+
+        assert json.loads(reg.dispatch("web_extract", {})) == {"source": "second"}
+        defs = reg.get_definitions({"web_extract"})
+        assert defs[0]["function"]["description"] == "second override"
+
+
 class TestUnknownToolDispatch:
     def test_returns_error_json(self):
         reg = ToolRegistry()

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -81,11 +81,13 @@ class ToolEntry:
         "name", "toolset", "schema", "handler", "check_fn",
         "requires_env", "is_async", "description", "emoji",
         "max_result_size_chars", "dynamic_schema_overrides",
+        "override_protected",
     )
 
     def __init__(self, name, toolset, schema, handler, check_fn,
                  requires_env, is_async, description, emoji,
-                 max_result_size_chars=None, dynamic_schema_overrides=None):
+                 max_result_size_chars=None, dynamic_schema_overrides=None,
+                 override_protected=False):
         self.name = name
         self.toolset = toolset
         self.schema = schema
@@ -104,6 +106,10 @@ class ToolEntry:
         # on every get_definitions() call; results are merged shallow on top
         # of the base schema before the {"type": "function", ...} wrap.
         self.dynamic_schema_overrides = dynamic_schema_overrides
+        # True for explicit plugin/user replacements.  Prevents a later
+        # built-in import from silently re-overwriting the override when plugin
+        # discovery happened first and builtin discovery runs afterward.
+        self.override_protected = bool(override_protected)
 
 
 # ---------------------------------------------------------------------------
@@ -252,10 +258,21 @@ class ToolRegistry:
         replace an existing built-in tool implementation (e.g. swap the
         default browser tool for a headed-Chrome CDP backend). Without it,
         registrations that would shadow an existing tool from a different
-        toolset are rejected to prevent accidental overwrites.
+        toolset are rejected to prevent accidental overwrites. Once an
+        explicit override lands, later non-override registrations for the same
+        name are rejected too; this preserves plugin override semantics even
+        when plugin discovery happens before built-in discovery.
         """
         with self._lock:
             existing = self._tools.get(name)
+            if existing and existing.override_protected and not override:
+                logger.warning(
+                    "Tool registration REJECTED: '%s' (toolset '%s') would "
+                    "overwrite protected override from toolset '%s'. Pass "
+                    "override=True to replace it intentionally.",
+                    name, toolset, existing.toolset,
+                )
+                return
             if existing and existing.toolset != toolset:
                 # Allow MCP-to-MCP overwrites (legitimate: server refresh,
                 # or two MCP servers with overlapping tool names).
@@ -299,6 +316,9 @@ class ToolRegistry:
                 emoji=emoji,
                 max_result_size_chars=max_result_size_chars,
                 dynamic_schema_overrides=dynamic_schema_overrides,
+                override_protected=override or (
+                    bool(existing.override_protected) if existing else False
+                ),
             )
             if check_fn and toolset not in self._toolset_checks:
                 self._toolset_checks[toolset] = check_fn


### PR DESCRIPTION
## Summary

Fixes the Hermes tool registry / Codex MCP export path so explicit plugin/user tool overrides stay authoritative everywhere they are supposed to surface.

## Why

Hermes supports replacing an existing tool through:

```python
registry.register(..., name="existing_tool", override=True)
```

That override could work in normal Hermes dispatch while still failing in two edge paths:

1. **Import-order overwrite:** if a plugin registered an override before later built-in discovery, a later non-override built-in registration could silently replace the protected override.
2. **Codex MCP export drift:** the hermes-tools MCP bridge could expose the stale/static surface to Codex instead of the post-plugin registry surface, and FastMCP could infer a generic `kwargs` schema from the dispatcher callable instead of exposing Hermes' real JSON schema.

Mechanically, that meant a normal Hermes session and a Codex/MCP session could disagree about the same tool name.

## Behavior after this PR

- `override=True` registrations are protected from later non-override registrations for the same tool name.
- A later explicit `override=True` still replaces the previous override, so deliberate replacement remains possible.
- The Codex hermes-tools MCP bridge resolves exposed tool names from the current registry, not only the static baseline list.
- Plugin tools in already-exposed toolsets are included conservatively in the MCP export.
- MCP-exported tools receive Hermes' authoritative JSON parameter schema instead of FastMCP's inferred `kwargs` schema.

## Files changed

- `tools/registry.py`
  - tracks override-protected entries
  - exposes registry maps used by export layers
  - prevents accidental late built-in overwrite of explicit overrides
- `agent/transports/hermes_tools_mcp_server.py`
  - resolves post-plugin exposed tools
  - applies Hermes registry schemas to FastMCP tool objects
- `tests/tools/test_registry.py`
  - covers override protection and explicit re-override behavior
- `tests/agent/transports/test_hermes_tools_mcp_server.py`
  - covers plugin tool export, plugin override schema export, and real schema propagation to MCP

## Test Plan

- `python3 -m py_compile tools/registry.py agent/transports/hermes_tools_mcp_server.py tests/tools/test_registry.py tests/agent/transports/test_hermes_tools_mcp_server.py`
- `uv run --python 3.11 --with pytest --with pytest-asyncio --with pytest-xdist --with pyyaml python -m pytest -q -o 'addopts=' tests/agent/transports/test_hermes_tools_mcp_server.py tests/tools/test_registry.py`

Result after rebasing onto current `origin/main`:

```text
43 passed, 2 skipped in 5.93s
```
