### PR TITLE
fix(gateway): scrub image attachment markers from replay

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -117,6 +117,15 @@ _INTERNAL_NOTE_RE = re.compile(
     r'\[System note:\s*The following is recalled memory context,\s*NOT new user input\.\s*Treat as (?:informational background data|authoritative reference data[^\]]*)\.\]\s*',
     re.IGNORECASE,
 )
+_IMAGE_ATTACHMENT_MARKER_RE = re.compile(
+    r'\s*\[Image attached(?: at)?:[^\]\n]+\]',
+    re.IGNORECASE,
+)
+_IMAGE_ATTACHMENT_PLACEHOLDER_RE = re.compile(
+    r'\s*\[(?:screenshot|inline image)\](?=\s|$)',
+    re.IGNORECASE,
+)
+_EXCESS_BLANK_LINES_RE = re.compile(r'\n{3,}')
 
 
 def sanitize_context(text: str) -> str:
@@ -125,6 +134,25 @@ def sanitize_context(text: str) -> str:
     text = _INTERNAL_NOTE_RE.sub('', text)
     text = _FENCE_TAG_RE.sub('', text)
     return text
+
+
+def sanitize_transcript_context(text: str) -> str:
+    """Strip internal context plus ephemeral attachment-routing metadata.
+
+    Native image routing appends text hints such as ``[Image attached at:
+    /.../image_cache/img_x.jpg]`` to the current multimodal user turn so the
+    model can reference the just-attached image in tools. Those hints are
+    transport metadata, not durable user text. If replayed from the session DB
+    on later turns, a plain follow-up can look like it still contains the old
+    screenshot.
+    """
+    cleaned = sanitize_context(text)
+    had_attachment_marker = _IMAGE_ATTACHMENT_MARKER_RE.search(cleaned) is not None
+    cleaned = _IMAGE_ATTACHMENT_MARKER_RE.sub('', cleaned)
+    if had_attachment_marker:
+        cleaned = _IMAGE_ATTACHMENT_PLACEHOLDER_RE.sub('', cleaned)
+        cleaned = _EXCESS_BLANK_LINES_RE.sub('\n\n', cleaned)
+    return cleaned
 
 
 class StreamingContextScrubber:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -23,7 +23,7 @@ import threading
 import time
 from pathlib import Path
 
-from agent.memory_manager import sanitize_context
+from agent.memory_manager import sanitize_transcript_context
 from hermes_constants import get_hermes_home
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
 
@@ -2872,7 +2872,7 @@ class SessionDB:
         for row in rows:
             content = self._decode_content(row["content"])
             if row["role"] in {"user", "assistant"} and isinstance(content, str):
-                content = sanitize_context(content).strip()
+                content = sanitize_transcript_context(content).strip()
             msg = {"role": row["role"], "content": content}
             if row["tool_call_id"]:
                 msg["tool_call_id"] = row["tool_call_id"]

--- a/run_agent.py
+++ b/run_agent.py
@@ -132,7 +132,7 @@ from tools.browser_tool import cleanup_browser
 
 
 # Agent internals extracted to agent/ package for modularity
-from agent.memory_manager import sanitize_context
+from agent.memory_manager import sanitize_context, sanitize_transcript_context
 from agent.error_classifier import FailoverReason
 from agent.redact import redact_sensitive_text
 from agent.model_metadata import (
@@ -1603,13 +1603,18 @@ class AIAgent:
                 if _is_multimodal_tool_result(content):
                     content = _multimodal_text_summary(content)
                 elif isinstance(content, list):
-                    # List of OpenAI-style content parts: strip images, keep text.
+                    # List of OpenAI-style content parts: strip images, keep
+                    # durable user text only. Native vision routing appends
+                    # ``[Image attached at: ...]`` hints to the current API
+                    # turn so tools can reference the just-attached image;
+                    # those hints (and synthetic ``[screenshot]`` placeholders)
+                    # must not persist into replayable transcript history.
                     _txt = []
                     for p in content:
                         if isinstance(p, dict) and p.get("type") == "text":
-                            _txt.append(str(p.get("text", "")))
-                        elif isinstance(p, dict) and p.get("type") in {"image", "image_url", "input_image"}:
-                            _txt.append("[screenshot]")
+                            _clean = sanitize_transcript_context(str(p.get("text", ""))).strip()
+                            if _clean:
+                                _txt.append(_clean)
                     content = "\n".join(_txt) if _txt else None
                 tool_calls_data = None
                 if hasattr(msg, "tool_calls") and isinstance(msg.tool_calls, list) and msg.tool_calls:

--- a/tests/test_image_attachment_marker_sanitization.py
+++ b/tests/test_image_attachment_marker_sanitization.py
@@ -43,7 +43,9 @@ def test_session_replay_strips_legacy_native_image_attachment_markers(tmp_path: 
 
     replay = db.get_messages_as_conversation(sid)
 
-    assert replay == [{"role": "user", "content": "Where do I scan this?"}]
+    assert len(replay) == 1
+    assert replay[0]["role"] == "user"
+    assert replay[0]["content"] == "Where do I scan this?"
 
 
 def test_transcript_sanitizer_strips_remote_image_attachment_markers():

--- a/tests/test_image_attachment_marker_sanitization.py
+++ b/tests/test_image_attachment_marker_sanitization.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+from agent.memory_manager import sanitize_context, sanitize_transcript_context
+from hermes_state import SessionDB
+from run_agent import AIAgent
+
+
+class _CaptureSessionDB:
+    def __init__(self) -> None:
+        self.rows: list[dict] = []
+
+    def append_message(self, **kwargs):
+        self.rows.append(kwargs)
+        return len(self.rows)
+
+
+def _agent_with_capture_db() -> tuple[AIAgent, _CaptureSessionDB]:
+    agent = cast(Any, AIAgent.__new__(AIAgent))
+    capture_db = _CaptureSessionDB()
+    agent._session_db = capture_db
+    agent._session_db_created = True
+    agent._last_flushed_db_idx = 0
+    agent.session_id = "native-image-session"
+    agent._apply_persist_user_message_override = lambda messages: None
+    return cast(AIAgent, agent), capture_db
+
+
+def test_session_replay_strips_legacy_native_image_attachment_markers(tmp_path: Path):
+    db = SessionDB(tmp_path / "state.db")
+    sid = db.create_session("legacy-native-image-session", source="gateway")
+    db.append_message(
+        session_id=sid,
+        role="user",
+        content=(
+            "Where do I scan this?\n\n"
+            "[Image attached at: /tmp/hermes-home/image_cache/img_ccf883cb57da.jpg]\n"
+            "[screenshot]"
+        ),
+    )
+
+    replay = db.get_messages_as_conversation(sid)
+
+    assert replay == [{"role": "user", "content": "Where do I scan this?"}]
+
+
+def test_transcript_sanitizer_strips_remote_image_attachment_markers():
+    content = (
+        "Please compare this.\n\n"
+        "[Image attached: https://example.com/image.png]\n"
+        "[inline image]"
+    )
+
+    assert sanitize_transcript_context(content).strip() == "Please compare this."
+
+
+def test_base_context_sanitizer_preserves_literal_screenshot_text():
+    content = "Please write the literal token [screenshot] in the docs."
+
+    assert sanitize_context(content) == content
+    assert sanitize_transcript_context(content) == content
+
+
+def test_flush_multimodal_user_message_does_not_persist_image_path_markers():
+    agent, capture_db = _agent_with_capture_db()
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        "Where do I scan this?\n\n"
+                        "[Image attached at: /tmp/hermes-home/image_cache/img_ccf883cb57da.jpg]"
+                    ),
+                },
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/jpeg;base64,AAAA"},
+                },
+            ],
+        }
+    ]
+
+    agent._flush_messages_to_session_db(messages)
+
+    assert capture_db.rows[0]["content"] == "Where do I scan this?"


### PR DESCRIPTION
## Summary

Fix native image attachment routing metadata leaking into replayed session history.

Native image turns intentionally append text hints like `[Image attached at: /path]` to the current multimodal API content so the model can reference the just-attached image in tools. However, that text part was also persisted into the SQLite session transcript, and the image part was persisted as a synthetic `[screenshot]` placeholder. Later gateway turns replayed those markers as ordinary user text, so a plain follow-up could look like it still contained the previous screenshot.

This PR keeps current-turn native image behavior intact while preventing attachment-routing metadata from becoming durable replay context.

## Changes

- Add `sanitize_transcript_context()` for transcript replay / persistence cleanup, leaving the existing `sanitize_context()` behavior unchanged for memory/streaming context cleanup.
- Use transcript sanitization when loading user/assistant messages from `SessionDB.get_messages_as_conversation()`.
- Sanitize multimodal user text before writing to the session DB, and stop persisting synthetic `[screenshot]` placeholders for image parts.
- Add regression tests for:
  - legacy DB rows with `[Image attached at: ...]` + `[screenshot]`;
  - remote image markers (`[Image attached: https://...]` + `[inline image]`);
  - preserving literal `[screenshot]` text when it is not attachment metadata;
  - new multimodal user turns not persisting local image paths.

## Verification

```bash
PYTHONPATH=/home/a/.tmp/hermes-native-image-marker-pr \
  /home/a/.hermes-yuheng/hermes-agent/venv/bin/python -m pytest -q -o addopts='' \
  tests/test_image_attachment_marker_sanitization.py \
  tests/test_hermes_state.py \
  tests/run_agent/test_860_dedup.py \
  tests/agent/test_image_routing.py \
  tests/gateway/test_native_image_buffer_isolation.py
# 356 passed in 20.82s

PYTHONPATH=/home/a/.tmp/hermes-native-image-marker-pr \
  /home/a/.hermes-yuheng/hermes-agent/venv/bin/ruff check \
  agent/memory_manager.py hermes_state.py run_agent.py tests/test_image_attachment_marker_sanitization.py
# All checks passed!
```
