### PR TITLE
fix(send_message_tool): add sendRichMessage fast-path for Telegram

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -123,6 +123,12 @@ async def _send_telegram_message_with_retry(bot, *, attempts: int = 3, **kwargs)
             await asyncio.sleep(delay)
 
 
+class _RichMsg:
+    """Minimal message-id carrier for sendRichMessage results."""
+    __slots__ = ("message_id",)
+    def __init__(self, mid: int): self.message_id = mid
+
+
 SEND_MESSAGE_SCHEMA = {
     "name": "send_message",
     "description": (
@@ -1032,7 +1038,40 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         last_msg = None
         warnings = []
 
-        if formatted.strip():
+        # ── Bot API 10.1 rich send fast-path ───────────────────────
+        # sendRichMessage preserves tables, task lists, math, etc.
+        # Falls through to legacy MarkdownV2 on any failure.
+        _rich_ok = False
+        if not _has_html and message.strip() and len(message) <= 32768:
+            try:
+                import inspect
+                if inspect.iscoroutinefunction(getattr(bot, "do_api_request", None)):
+                    rich_payload: dict = {
+                        "chat_id": int_chat_id,
+                        "rich_message": {"markdown": message},
+                    }
+                    rich_payload.update(
+                        {k: v for k, v in thread_kwargs.items() if v is not None}
+                    )
+                    if disable_link_previews:
+                        rich_payload["link_preview_options"] = {"is_disabled": True}
+                    rich_result = await bot.do_api_request(
+                        "sendRichMessage", api_kwargs=rich_payload
+                    )
+                    rich_msg_id = None
+                    if isinstance(rich_result, dict):
+                        rich_msg_id = rich_result.get("message_id") or (
+                            (rich_result.get("result") or {}).get("message_id")
+                        )
+                    else:
+                        rich_msg_id = getattr(rich_result, "message_id", None)
+                    if rich_msg_id is not None:
+                        last_msg = _RichMsg(rich_msg_id)
+                        _rich_ok = True
+            except Exception:
+                pass  # Fall through to legacy MarkdownV2
+
+        if not _rich_ok and formatted.strip():
             try:
                 last_msg = await _send_telegram_message_with_retry(
                     bot,

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -6,6 +6,7 @@ human-friendly channel names to IDs. Works in both CLI and gateway contexts.
 """
 
 import asyncio
+import inspect
 import json
 import logging
 import os
@@ -1044,7 +1045,6 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         _rich_ok = False
         if not _has_html and message.strip() and len(message) <= 32768:
             try:
-                import inspect
                 if inspect.iscoroutinefunction(getattr(bot, "do_api_request", None)):
                     rich_payload: dict = {
                         "chat_id": int_chat_id,


### PR DESCRIPTION
## Problem

The `send_message` tool's `_send_telegram` function creates a raw `Bot` object and calls `bot.sendMessage(parse_mode=MarkdownV2)`. It bypasses the gateway's rich message path entirely. Tables, task lists, math, and other rich constructs always degrade to bulleted lists when sent via the `send_message` tool.

Agent streaming responses work fine (they go through the gateway adapter's rich path), but any explicit `send_message` call — notifications, cron outputs, cross-channel messages — gets MarkdownV2 degradation.

## Fix

Two additions to `tools/send_message_tool.py`:

1. **`_RichMsg` helper class** — wraps the `message_id` from `sendRichMessage` responses so the return-value pipeline (which expects a message object) works unchanged.

2. **Rich fast-path in `_send_telegram`** — before the existing MarkdownV2 path, tries `bot.do_api_request("sendRichMessage", ...)` with `rich_message: {markdown: ...}`. On any failure, falls through to the existing MarkdownV2 path — purely additive, zero regression risk.

## Verification

Tested on a Hermes instance with Telegram PTB 22.6+:

```bash
grep "sendRichMessage" agent.log | tail -5
# Shows sendRichMessage calls with rich_message.blocks containing native table/list/heading blocks
```

Tables, task lists, blockquotes, and math expressions now render natively when sent via the `send_message` tool.

## Related

- \#45741 — original rich message implementation (gateway adapter streaming path)
- The gateway adapter already has rich send support — this PR extends it to the `send_message` tool path.