### PR TITLE
fix(stream_consumer): guard branch C against blocking fresh-final rich re-send

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -613,6 +613,9 @@ class GatewayStreamConsumer:
                                 not self._adapter_requires_finalize
                                 or self._last_edit_overflowed
                             )
+                            and not self._adapter_prefers_fresh_final(
+                                self._accumulated
+                            )
                         ):
                             # Mid-stream edit above already delivered the
                             # final accumulated content.  Skip the redundant


### PR DESCRIPTION
## Problem

In `gateway/stream_consumer.py`, the `got_done` handler evaluates branches in order:

| Branch | Condition | Action |
|--------|-----------|--------|
| A | `_fallback_final_send` | Fallback send |
| B | `_final_response_sent` | Already done |
| **C** | **`current_update_visible + !_adapter_requires_finalize`** | **Mid-stream edit was enough — skip** |
| D | `_message_id` | Fresh-final path (`_try_fresh_final`) |

The problem: on every tick before `got_done`, `_send_or_edit` runs with `finalize=False`, so `_adapter_prefers_fresh_final` is never checked (that gate only activates at `finalize=True`). Each mid-stream edit uses `editMessageText` — which has **no rich support** — destroying tables, task lists, and math.

When `got_done` arrives, `current_update_visible` is True from the last mid-stream MarkdownV2 edit. Branch C fires: "content already delivered, skip." The fresh `sendRichMessage` re-send that was supposed to restore rich formatting at finalize time **never runs**.

Result: agent streaming responses start with a beautiful rich draft, then degrade to bulleted lists after tool calls, and stay degraded permanently.

## Fix

One-line guard on branch C (line 612):

```python
and not self._adapter_prefers_fresh_final(self._accumulated)
```

When the adapter prefers fresh-final (Telegram with rich content), the shortcut is skipped and execution falls through to branch D, which triggers:

```
_send_or_edit(accumulated, finalize=True)
  → _try_fresh_final
    → fresh sendRichMessage + delete garbled preview
```

The full streaming flow with the fix:

1. **Draft preview:** `sendRichMessageDraft` — rich table ✅
2. **Tool call completes:** mid-stream `editMessageText` — table degrades ⚠️ (known: no rich edit support yet)
3. **got_done:** `_adapter_prefers_fresh_final` → True → branch C skipped → branch D → `_try_fresh_final` → fresh `sendRichMessage` → rich table restored ✅

## Verification

```bash
grep "_try_fresh_final\|sendRichMessage.*message_id" agent.log | tail -10
# Should show _try_fresh_final firing + final sendRichMessage with native table blocks
```

## Related

- #45741 — original fresh-final streaming design