### PR TITLE
fix(telegram): chunk long rich messages

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -931,15 +931,23 @@ class TelegramAdapter(BasePlatformAdapter):
     # preview until rich_message edit support is wired directly.
     # ------------------------------------------------------------------
     def _content_fits_rich_limits(self, content: str) -> bool:
-        """Cheap pre-check for the one hard rich limit we can count locally.
+        """Cheap pre-check for locally countable rich-message limits.
 
-        Only the 32,768 UTF-8 character text cap is enforced here. Other Bot API
-        rich limits (500 blocks, 16 nesting levels, 20 table columns, ...) are
-        not pre-counted; if exceeded Telegram returns a BadRequest, which
-        :meth:`_is_rich_fallback_error` classifies as permanent so the send
-        degrades to the legacy chunking path.
+        Keep persisted rich sends within Telegram's normal visible message
+        limit too. The raw rich endpoint accepts a larger 32,768-character
+        payload, but long bot messages are still poorly handled by clients and
+        can appear truncated. Content above the regular text limit falls back
+        to the legacy chunking path.
+
+        Other Bot API rich limits (500 blocks, 16 nesting levels, 20 table
+        columns, ...) are not pre-counted; if exceeded Telegram returns a
+        BadRequest, which :meth:`_is_rich_fallback_error` classifies as
+        permanent so the send degrades to the legacy chunking path.
         """
-        return len(content) <= self.RICH_MESSAGE_MAX_CHARS
+        return (
+            len(content) <= self.RICH_MESSAGE_MAX_CHARS
+            and utf16_len(content) <= self.MAX_MESSAGE_LENGTH
+        )
 
     def _bot_supports_rich(self) -> bool:
         """True when the bound bot can issue raw ``sendRichMessage`` calls.
@@ -1008,22 +1016,12 @@ class TelegramAdapter(BasePlatformAdapter):
         return False
 
     def streaming_overflow_limit(self) -> Optional[int]:
-        """Allow the stream consumer to accumulate up to the rich-message cap
-        before splitting, so a reply that fits one ``sendRichMessage`` /
-        ``sendRichMessageDraft`` isn't fragmented at the 4,096 MarkdownV2 limit.
+        """Return a platform-specific streaming overflow limit override.
 
-        Gated on the same rich capability as the send path (minus the
-        content-length check — raising that cap is the whole point): rich not
-        latched off and the bot exposes an async ``do_api_request``.  Returns
-        ``None`` (→ legacy 4,096 limit) when rich isn't available, so non-rich
-        streams split exactly as before.
+        Persisted rich sends deliberately stay at Telegram's normal
+        4,096-UTF-16-unit visible message limit, so the stream consumer should
+        use its default text chunking behavior.
         """
-        if (
-            getattr(self, "_rich_messages_enabled", False)
-            and not getattr(self, "_rich_send_disabled", False)
-            and self._bot_supports_rich()
-        ):
-            return self.RICH_MESSAGE_MAX_CHARS
         return None
 
     def _rich_message_payload(

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -237,20 +237,20 @@ async def test_oversized_content_skips_rich_and_chunks():
 
 
 @pytest.mark.asyncio
-async def test_rich_limit_is_characters_not_bytes():
-    """Telegram's rich limit is UTF-8 characters, not encoded bytes."""
+async def test_long_content_under_rich_cap_skips_rich_and_chunks():
+    """Long visible replies should be split instead of sent as one rich blob."""
     adapter = _make_adapter()
-    cjk = "测" * 20000  # 20k chars, 60k UTF-8 bytes
-    assert len(cjk.encode("utf-8")) > TelegramAdapter.RICH_MESSAGE_MAX_BYTES
-    assert len(cjk) <= TelegramAdapter.RICH_MESSAGE_MAX_CHARS
+    content = "测" * 5000
+    assert len(content) <= TelegramAdapter.RICH_MESSAGE_MAX_CHARS
+    assert adapter.message_len_fn(content) > TelegramAdapter.MAX_MESSAGE_LENGTH
 
-    result = await adapter.send("12345", cjk)
+    result = await adapter.send("12345", content)
 
     assert result.success is True
     bot = adapter._bot
     assert bot is not None
-    bot.do_api_request.assert_awaited_once()
-    bot.send_message.assert_not_called()
+    bot.do_api_request.assert_not_called()
+    assert bot.send_message.await_count > 1
 
 
 @pytest.mark.asyncio
@@ -544,13 +544,12 @@ def test_prefers_fresh_final_streaming_honors_rich_opt_out():
 
 
 # ----------------------------------------------------------------------
-# streaming_overflow_limit: with rich on, the stream consumer may accumulate up
-# to the 32,768-char rich cap before splitting, so a reply that fits one
-# sendRichMessage / sendRichMessageDraft isn't fragmented at the 4,096 limit.
+# streaming_overflow_limit: persisted rich sends use Telegram's regular visible
+# message limit, so streaming should keep the default chunking behavior.
 # ----------------------------------------------------------------------
-def test_streaming_overflow_limit_is_rich_cap_when_enabled():
+def test_streaming_overflow_limit_none_when_rich_enabled():
     adapter = _make_adapter()
-    assert adapter.streaming_overflow_limit() == TelegramAdapter.RICH_MESSAGE_MAX_CHARS
+    assert adapter.streaming_overflow_limit() is None
 
 
 def test_streaming_overflow_limit_none_when_rich_opted_out():


### PR DESCRIPTION
## Summary
- keep Telegram rich sends within the normal 4,096 UTF-16 visible message limit
- let longer rich-capable replies fall back to the existing MarkdownV2 chunking path
- keep streaming overflow on the default chunking behavior so final replies do not arrive as a single oversized rich blob

## Tests
- /home/alan/.hermes/hermes-agent/venv/bin/pytest tests/gateway/test_telegram_rich_messages.py tests/gateway/test_telegram_format.py