### PR TITLE
fix(slack): track assistant status per thread

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2199,6 +2199,7 @@ class BasePlatformAdapter(ABC):
         # Without the owner-task map, an old task's finally block could delete
         # a newer task's guard, leaving stale busy state.
         self._active_sessions: Dict[str, asyncio.Event] = {}
+        self._active_session_metadata: Dict[str, Optional[Dict[str, Any]]] = {}
         self._pending_messages: Dict[str, MessageEvent] = {}
         self._session_tasks: Dict[str, asyncio.Task] = {}
         # Legacy busy_text_mode env var; when unset the runner syncs the
@@ -3523,6 +3524,28 @@ class BasePlatformAdapter(ABC):
 
         return paths, cleaned
 
+    async def _stop_typing_with_metadata(self, chat_id: str, metadata=None) -> None:
+        """Stop typing, passing metadata only to adapters that accept it."""
+        stop_typing = getattr(self, "stop_typing", None)
+        if not callable(stop_typing):
+            return
+        try:
+            sig = inspect.signature(stop_typing)
+        except (TypeError, ValueError):
+            sig = None
+        params = sig.parameters if sig is not None else {}
+        accepts_metadata = (
+            sig is None
+            or "metadata" in params
+            or any(param.kind is inspect.Parameter.VAR_KEYWORD for param in params.values())
+        )
+        if accepts_metadata:
+            result = stop_typing(chat_id, metadata=metadata)
+        else:
+            result = stop_typing(chat_id)
+        if inspect.isawaitable(result):
+            await result
+
     async def _keep_typing(
         self,
         chat_id: str,
@@ -3600,7 +3623,7 @@ class BasePlatformAdapter(ABC):
             # Cancelling _keep_typing alone won't clean that up.
             if hasattr(self, "stop_typing"):
                 try:
-                    await self.stop_typing(chat_id)
+                    await self._stop_typing_with_metadata(chat_id, metadata=metadata)
                 except Exception:
                     pass
             self._typing_paused.discard(chat_id)
@@ -3610,6 +3633,7 @@ class BasePlatformAdapter(ABC):
         chat_id: str,
         typing_task: asyncio.Task | None = None,
         *,
+        metadata=None,
         timeout: float = 0.5,
         stop_attempts: int = 2,
     ) -> None:
@@ -3629,7 +3653,7 @@ class BasePlatformAdapter(ABC):
             attempts = max(1, stop_attempts)
             for attempt in range(attempts):
                 try:
-                    await self.stop_typing(chat_id)
+                    await self._stop_typing_with_metadata(chat_id, metadata=metadata)
                 except Exception:
                     pass
                 if attempt < attempts - 1:
@@ -3656,7 +3680,10 @@ class BasePlatformAdapter(ABC):
             if interrupt_event is not None:
                 interrupt_event.set()
         try:
-            await self.stop_typing(chat_id)
+            await self._stop_typing_with_metadata(
+                chat_id,
+                metadata=getattr(self, "_active_session_metadata", {}).get(session_key),
+            )
         except Exception:
             pass
 
@@ -4096,6 +4123,7 @@ class BasePlatformAdapter(ABC):
         if guard is not None and current_guard is not guard:
             return
         del self._active_sessions[session_key]
+        getattr(self, "_active_session_metadata", {}).pop(session_key, None)
 
     def _session_task_is_stale(self, session_key: str) -> bool:
         """Return True if the owner task for ``session_key`` is done/cancelled.
@@ -4136,6 +4164,7 @@ class BasePlatformAdapter(ABC):
             session_key,
         )
         self._active_sessions.pop(session_key, None)
+        getattr(self, "_active_session_metadata", {}).pop(session_key, None)
         self._pending_messages.pop(session_key, None)
         self._session_tasks.pop(session_key, None)
         self._discard_text_debounce(session_key)
@@ -4567,6 +4596,9 @@ class BasePlatformAdapter(ABC):
         # never spawned, so no "typing…" / "is thinking…" status is shown.
         # typing_task stays None; _stop_typing_refresh already no-ops on None.
         _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
+        if not hasattr(self, "_active_session_metadata"):
+            self._active_session_metadata = {}
+        self._active_session_metadata[session_key] = _thread_metadata
         typing_task: Optional[asyncio.Task] = None
         if getattr(self.config, "typing_indicator", True):
             _keep_typing_kwargs: Dict[str, Any] = {"metadata": _thread_metadata}
@@ -4587,6 +4619,7 @@ class BasePlatformAdapter(ABC):
             await self._stop_typing_refresh(
                 event.source.chat_id,
                 typing_task,
+                metadata=_thread_metadata,
             )
         
         try:
@@ -5010,6 +5043,7 @@ class BasePlatformAdapter(ABC):
             await self._stop_typing_refresh(
                 event.source.chat_id,
                 None,
+                metadata=_thread_metadata,
                 stop_attempts=1,
             )
             # Final drain/release boundary: force-flush any timer that missed
@@ -5153,6 +5187,9 @@ class BasePlatformAdapter(ABC):
         self._session_tasks.clear()
         self._pending_messages.clear()
         self._active_sessions.clear()
+        metadata_store = getattr(self, "_active_session_metadata", None)
+        if metadata_store is not None:
+            metadata_store.clear()
         for state in list(self._text_debounce_store().values()):
             if state.task is not None and not state.task.done():
                 state.task.cancel()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10398,11 +10398,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_timestamp=persist_user_timestamp,
             )
 
-            # Stop persistent typing indicator now that the agent is done
+            # Stop persistent typing indicator now that the agent is done.
+            # Thread-aware adapters (Slack Assistant status) need metadata so
+            # one completed thread does not clear a sibling thread in the same
+            # channel/DM.
             try:
                 _typing_adapter = self.adapters.get(source.platform)
                 if _typing_adapter and hasattr(_typing_adapter, "stop_typing"):
-                    await _typing_adapter.stop_typing(source.chat_id)
+                    _typing_metadata = self._thread_metadata_for_source(
+                        source,
+                        self._reply_anchor_for_event(event),
+                    )
+                    _stop_with_metadata = getattr(
+                        _typing_adapter,
+                        "_stop_typing_with_metadata",
+                        None,
+                    )
+                    if callable(_stop_with_metadata):
+                        _stop_result = _stop_with_metadata(
+                            source.chat_id,
+                            metadata=_typing_metadata,
+                        )
+                    else:
+                        _stop_result = _typing_adapter.stop_typing(source.chat_id)
+                    if inspect.isawaitable(_stop_result):
+                        await _stop_result
             except Exception:
                 pass
 
@@ -10905,11 +10925,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return response
             
         except Exception as e:
-            # Stop typing indicator on error too
+            # Stop typing indicator on error too.
             try:
                 _err_adapter = self.adapters.get(source.platform)
                 if _err_adapter and hasattr(_err_adapter, "stop_typing"):
-                    await _err_adapter.stop_typing(source.chat_id)
+                    _err_metadata = self._thread_metadata_for_source(
+                        source,
+                        self._reply_anchor_for_event(event),
+                    )
+                    _stop_with_metadata = getattr(
+                        _err_adapter,
+                        "_stop_typing_with_metadata",
+                        None,
+                    )
+                    if callable(_stop_with_metadata):
+                        _stop_result = _stop_with_metadata(
+                            source.chat_id,
+                            metadata=_err_metadata,
+                        )
+                    else:
+                        _stop_result = _err_adapter.stop_typing(source.chat_id)
+                    if inspect.isawaitable(_stop_result):
+                        await _stop_result
             except Exception:
                 pass
             logger.exception("Agent error in session %s", session_key)

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -459,8 +459,13 @@ class SlackAdapter(BasePlatformAdapter):
         # Track message IDs that should get reaction lifecycle (DMs / @mentions).
         self._reacting_message_ids: set = set()
         # Track active assistant thread status indicators so stop_typing can
-        # clear them (chat_id → thread_ts).
-        self._active_status_threads: Dict[str, str] = {}
+        # clear them. A single Slack channel/DM can have multiple assistant
+        # threads running concurrently, so this must be chat_id → thread_ts set
+        # instead of a single chat_id → thread_ts slot.
+        self._active_status_threads: Dict[str, set[str]] = {}
+        # Map bot reply message ts → parent thread ts so streaming final edits
+        # can clear the exact Slack Assistant status for the edited message.
+        self._message_thread_ts: Dict[str, str] = {}
         # Slash-command contexts: stash response_url + user_id so send()
         # can route the first reply ephemerally.  Keyed by
         # (channel_id, user_id) to avoid cross-user collisions.
@@ -1346,6 +1351,7 @@ class SlackAdapter(BasePlatformAdapter):
         if not self._app:
             return SendResult(success=False, error="Not connected")
 
+        thread_ts = None
         try:
             # Check for a pending slash-command context.  When the user ran a
             # native slash command (e.g. /q, /stop, /model), the initial ack
@@ -1388,7 +1394,7 @@ class SlackAdapter(BasePlatformAdapter):
 
             # Clear Slack Assistant status as soon as the final message is posted.
             if thread_ts:
-                await self.stop_typing(chat_id)
+                await self.stop_typing(chat_id, metadata={"thread_ts": thread_ts})
 
             # Track the sent message ts so we can auto-respond to thread
             # replies without requiring @mention.
@@ -1398,10 +1404,12 @@ class SlackAdapter(BasePlatformAdapter):
                 # Also register the thread root so replies-to-my-replies work
                 if thread_ts:
                     self._bot_message_ts.add(thread_ts)
+                    self._message_thread_ts[sent_ts] = thread_ts
                 if len(self._bot_message_ts) > self._BOT_TS_MAX:
                     excess = len(self._bot_message_ts) - self._BOT_TS_MAX // 2
                     for old_ts in list(self._bot_message_ts)[:excess]:
                         self._bot_message_ts.discard(old_ts)
+                        self._message_thread_ts.pop(old_ts, None)
 
             return SendResult(
                 success=True,
@@ -1410,6 +1418,14 @@ class SlackAdapter(BasePlatformAdapter):
             )
 
         except Exception as e:  # pragma: no cover - defensive logging
+            if thread_ts:
+                try:
+                    await self.stop_typing(chat_id, metadata={"thread_ts": thread_ts})
+                except Exception as clear_error:
+                    logger.debug(
+                        "[Slack] assistant.threads.setStatus clear after send error failed: %s",
+                        clear_error,
+                    )
             logger.error("[Slack] Send error: %s", e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
@@ -1468,7 +1484,9 @@ class SlackAdapter(BasePlatformAdapter):
                 text=formatted,
             )
             if finalize:
-                await self.stop_typing(chat_id)
+                thread_ts = self._message_thread_ts.get(message_id)
+                metadata = {"thread_ts": thread_ts} if thread_ts else None
+                await self.stop_typing(chat_id, metadata=metadata)
             return SendResult(success=True, message_id=message_id)
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error(
@@ -1497,13 +1515,13 @@ class SlackAdapter(BasePlatformAdapter):
         if not thread_ts:
             return  # Can only set status in a thread context
 
-        self._active_status_threads[chat_id] = thread_ts
         try:
             await self._get_client(chat_id).assistant_threads_setStatus(
                 channel_id=chat_id,
                 thread_ts=thread_ts,
                 status="is thinking...",
             )
+            self._active_status_threads.setdefault(chat_id, set()).add(thread_ts)
         except Exception as e:
             # Silently ignore — may lack assistant:write scope or not be
             # in an assistant-enabled context. Falls back to reactions.
@@ -1513,17 +1531,36 @@ class SlackAdapter(BasePlatformAdapter):
         """Clear the assistant thread status indicator."""
         if not self._app:
             return
-        thread_ts = self._active_status_threads.pop(chat_id, None)
-        if not thread_ts:
+
+        active_threads = self._active_status_threads.get(chat_id)
+        if not active_threads:
             return
-        try:
-            await self._get_client(chat_id).assistant_threads_setStatus(
-                channel_id=chat_id,
-                thread_ts=thread_ts,
-                status="",
-            )
-        except Exception as e:
-            logger.debug("[Slack] assistant.threads.setStatus clear failed: %s", e)
+
+        thread_ts = None
+        if metadata:
+            thread_ts = metadata.get("thread_id") or metadata.get("thread_ts")
+
+        if thread_ts:
+            targets = [thread_ts] if thread_ts in active_threads else []
+        else:
+            # Fallback for shutdown/interruption paths that predate metadata
+            # propagation. Normal send/final-edit paths pass metadata so one
+            # completed thread does not clear a sibling thread's status.
+            targets = list(active_threads)
+
+        for target_thread_ts in targets:
+            active_threads.discard(target_thread_ts)
+            try:
+                await self._get_client(chat_id).assistant_threads_setStatus(
+                    channel_id=chat_id,
+                    thread_ts=target_thread_ts,
+                    status="",
+                )
+            except Exception as e:
+                logger.debug("[Slack] assistant.threads.setStatus clear failed: %s", e)
+
+        if not active_threads:
+            self._active_status_threads.pop(chat_id, None)
 
     def _dm_top_level_threads_as_sessions(self) -> bool:
         """Whether top-level Slack DMs get per-message session threads.

--- a/tests/gateway/test_gateway_silence_tokens.py
+++ b/tests/gateway/test_gateway_silence_tokens.py
@@ -6,8 +6,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 import gateway.run as gateway_run
-from gateway.config import GatewayConfig, Platform
-from gateway.platforms.base import MessageEvent
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, SendResult
 from gateway.session import SessionEntry, SessionSource
 from gateway.response_filters import (
     is_intentional_silence_agent_result,
@@ -29,6 +29,46 @@ def _event():
         text="side chatter",
         source=_source(),
         message_id="msg-42",
+    )
+
+
+class _ThreadAwareStopAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.SLACK)
+        self.stopped = []
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        return SendResult(success=True, message_id="reply-1")
+
+    async def stop_typing(self, chat_id, metadata=None):
+        self.stopped.append({"chat_id": chat_id, "metadata": metadata})
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+
+def _slack_thread_source():
+    return SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C123",
+        chat_type="channel",
+        user_id="U123",
+        thread_id="111.222",
+    )
+
+
+def _slack_thread_event():
+    source = _slack_thread_source()
+    return MessageEvent(
+        text="thread question",
+        source=source,
+        message_id="111.333",
     )
 
 
@@ -163,3 +203,32 @@ async def test_prose_mentioning_silence_token_is_delivered(monkeypatch, tmp_path
     )
 
     assert response == text
+
+
+@pytest.mark.asyncio
+async def test_agent_done_stop_typing_preserves_thread_metadata(monkeypatch, tmp_path):
+    runner = _runner(monkeypatch, tmp_path)
+    adapter = _ThreadAwareStopAdapter()
+    runner.adapters[Platform.SLACK] = adapter
+    runner._run_agent = AsyncMock(return_value={
+        "final_response": "done",
+        "messages": [
+            {"role": "user", "content": "thread question"},
+            {"role": "assistant", "content": "done"},
+        ],
+        "tools": [],
+        "history_offset": 0,
+        "last_prompt_tokens": 0,
+        "api_calls": 1,
+        "failed": False,
+    })
+    source = _slack_thread_source()
+
+    response = await runner._handle_message_with_agent(
+        _slack_thread_event(), source, "agent:main:slack:channel:C123:111.222", 1
+    )
+
+    assert response == "done"
+    assert adapter.stopped == [
+        {"chat_id": "C123", "metadata": {"thread_id": "111.222"}}
+    ]

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2059,6 +2059,76 @@ class TestSendTyping:
         )
 
     @pytest.mark.asyncio
+    async def test_stop_typing_clears_only_requested_thread(self, adapter):
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+
+        await adapter.send_typing("C123", metadata={"thread_id": "thread_1"})
+        await adapter.send_typing("C123", metadata={"thread_id": "thread_2"})
+        await adapter.stop_typing("C123", metadata={"thread_id": "thread_1"})
+
+        assert adapter._app.client.assistant_threads_setStatus.call_args_list == [
+            call(channel_id="C123", thread_ts="thread_1", status="is thinking..."),
+            call(channel_id="C123", thread_ts="thread_2", status="is thinking..."),
+            call(channel_id="C123", thread_ts="thread_1", status=""),
+        ]
+        assert "thread_2" in adapter._active_status_threads["C123"]
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_without_metadata_clears_all_tracked_threads(self, adapter):
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        adapter._active_status_threads = {
+            "C123": {"thread_1", "thread_2"},
+        }
+
+        await adapter.stop_typing("C123")
+
+        calls = adapter._app.client.assistant_threads_setStatus.call_args_list
+        cleared_threads = {call.kwargs["thread_ts"] for call in calls}
+        assert cleared_threads == {"thread_1", "thread_2"}
+        assert all(call.kwargs["channel_id"] == "C123" for call in calls)
+        assert all(call.kwargs["status"] == "" for call in calls)
+        assert "C123" not in adapter._active_status_threads
+
+    @pytest.mark.asyncio
+    async def test_send_failure_clears_requested_thread_status(self, adapter):
+        adapter._app.client.chat_postMessage = AsyncMock(side_effect=Exception("boom"))
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        adapter._active_status_threads = {
+            "C123": {"thread_1", "thread_2"},
+        }
+
+        result = await adapter.send("C123", "done", metadata={"thread_id": "thread_1"})
+
+        assert not result.success
+        adapter._app.client.assistant_threads_setStatus.assert_called_once_with(
+            channel_id="C123",
+            thread_ts="thread_1",
+            status="",
+        )
+        assert adapter._active_status_threads["C123"] == {"thread_2"}
+
+    @pytest.mark.asyncio
+    async def test_typing_refresh_stop_uses_thread_metadata(self, adapter):
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        adapter._active_status_threads = {
+            "C123": {"thread_1", "thread_2"},
+        }
+
+        await adapter._stop_typing_refresh(
+            "C123",
+            None,
+            metadata={"thread_id": "thread_1"},
+            stop_attempts=1,
+        )
+
+        adapter._app.client.assistant_threads_setStatus.assert_called_once_with(
+            channel_id="C123",
+            thread_ts="thread_1",
+            status="",
+        )
+        assert adapter._active_status_threads["C123"] == {"thread_2"}
+
+    @pytest.mark.asyncio
     async def test_stop_typing_clears_tracked_thread(self, adapter):
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
         await adapter.send_typing("C123", metadata={"thread_id": "parent_ts"})
@@ -2084,7 +2154,7 @@ class TestSendTyping:
 
     @pytest.mark.asyncio
     async def test_stop_typing_handles_api_error_gracefully(self, adapter):
-        adapter._active_status_threads["C123"] = "parent_ts"
+        adapter._active_status_threads["C123"] = {"parent_ts"}
         adapter._app.client.assistant_threads_setStatus = AsyncMock(
             side_effect=Exception("missing_scope")
         )
@@ -2104,7 +2174,7 @@ class TestSendTyping:
             return_value={"ts": "reply_ts"}
         )
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
-        adapter._active_status_threads["C123"] = "parent_ts"
+        adapter._active_status_threads["C123"] = {"parent_ts"}
 
         result = await adapter.send("C123", "done", metadata={"thread_id": "parent_ts"})
 
@@ -2121,7 +2191,7 @@ class TestSendTyping:
     async def test_streaming_final_edit_clears_status(self, adapter):
         adapter._app.client.chat_update = AsyncMock()
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
-        adapter._active_status_threads["C123"] = "parent_ts"
+        adapter._active_status_threads["C123"] = {"parent_ts"}
 
         result = await adapter.edit_message(
             "C123",
@@ -2144,10 +2214,32 @@ class TestSendTyping:
         assert "C123" not in adapter._active_status_threads
 
     @pytest.mark.asyncio
+    async def test_streaming_final_edit_clears_mapped_thread_only(self, adapter):
+        adapter._app.client.chat_update = AsyncMock()
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        adapter._active_status_threads["C123"] = {"parent_ts", "sibling_ts"}
+        adapter._message_thread_ts["reply_ts"] = "parent_ts"
+
+        result = await adapter.edit_message(
+            "C123",
+            "reply_ts",
+            "done",
+            finalize=True,
+        )
+
+        assert result.success
+        adapter._app.client.assistant_threads_setStatus.assert_called_once_with(
+            channel_id="C123",
+            thread_ts="parent_ts",
+            status="",
+        )
+        assert adapter._active_status_threads["C123"] == {"sibling_ts"}
+
+    @pytest.mark.asyncio
     async def test_streaming_intermediate_edit_keeps_status(self, adapter):
         adapter._app.client.chat_update = AsyncMock()
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
-        adapter._active_status_threads["C123"] = "parent_ts"
+        adapter._active_status_threads["C123"] = {"parent_ts"}
 
         result = await adapter.edit_message(
             "C123",
@@ -2158,7 +2250,7 @@ class TestSendTyping:
 
         assert result.success
         adapter._app.client.assistant_threads_setStatus.assert_not_called()
-        assert adapter._active_status_threads["C123"] == "parent_ts"
+        assert adapter._active_status_threads["C123"] == {"parent_ts"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Track Slack Assistant `is thinking...` status per thread instead of one thread per channel/DM.
- Propagate thread metadata through typing cleanup paths so normal completion, errors, interrupts, and refresh cleanup clear the intended Slack thread only.
- Track Slack reply timestamps back to their parent thread for streaming final edits, and add regression coverage for sibling threads.

## Testing
- `scripts/run_tests.sh tests/gateway/test_slack.py tests/gateway/test_gateway_silence_tokens.py tests/gateway/test_keep_typing_timeout.py tests/gateway/test_pending_drain_no_recursion.py tests/gateway/test_run_progress_topics.py tests/gateway/test_active_session_text_merge.py` — 266 passed
- `/Users/akitani/.hermes/hermes-agent/venv/bin/python -m py_compile gateway/platforms/slack.py gateway/platforms/base.py gateway/run.py tests/gateway/test_slack.py tests/gateway/test_gateway_silence_tokens.py` — passed
- `/Users/akitani/.hermes/hermes-agent/venv/bin/python scripts/check-windows-footguns.py gateway/platforms/base.py gateway/platforms/slack.py gateway/run.py tests/gateway/test_slack.py tests/gateway/test_gateway_silence_tokens.py` — passed
- `git diff --check` — passed
- `scripts/run_tests.sh tests/gateway` — 6823 passed, 5 failed locally. Four failures were reproduced on detached `origin/main` (`test_background_command.py::TestRunBackgroundTask::test_media_files_routed_by_type`, `test_gateway_shutdown.py::test_gateway_stop_systemd_service_restart_exits_cleanly`, `test_matrix.py::TestMatrixMarkdownToHtml::test_matrix_markdown_preserves_table_structure`, `test_shutdown_forensics.py::TestSpawnAsyncDiagnostic::test_spawns_subprocess_and_writes_output`). The remaining `test_memory_monitor.py::test_periodic_timer_fires` failure is a timing-sensitive local test in an untouched file.
