### PR TITLE
Feat/per task model override plus kanban

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -26,6 +26,7 @@ from typing import Any, Optional
 
 from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_swarm as ks
+from hermes_cli import kanban_pipeline as kp
 from hermes_cli.profiles import get_active_profile_name, get_profile_dir, seed_profile_skills
 
 
@@ -398,6 +399,33 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_swarm.add_argument("--created-by", default=None, help="Creator/anchor profile")
     p_swarm.add_argument("--idempotency-key", default=None, help="Dedup key for the root card")
     p_swarm.add_argument("--json", action="store_true", help="Emit JSON output")
+
+    # --- pipeline (4-profile orchestration preset) ---
+    p_pipeline = sub.add_parser(
+        "pipeline",
+        help="Create a Kanban Pipeline graph: parallel fan-out of the 4-profile "
+             "(coder / reviewer / researcher / analyst) preset. Simpler than "
+             "`swarm` (no verifier/synthesizer step) — the 4 roles ARE the "
+             "verification + synthesis.",
+    )
+    p_pipeline.add_argument("goal", help="The multi-role job to do. Becomes the goal "
+                                          "in every child card's body and the root title.")
+    p_pipeline.add_argument("--preset", default="4-profile",
+                            help="Pipeline preset (default: 4-profile). "
+                                 "Preset choices are resolved at handler time.")
+    p_pipeline.add_argument("--coder-model", default=None,
+                            help="Override the coder's model (default: kimi-k2.7-code)")
+    p_pipeline.add_argument("--reviewer-model", default=None,
+                            help="Override the reviewer's model (default: glm-5.1)")
+    p_pipeline.add_argument("--researcher-model", default=None,
+                            help="Override the researcher's model (default: deepseek-v4-pro)")
+    p_pipeline.add_argument("--analyst-model", default=None,
+                            help="Override the analyst's model (default: deepseek-v4-flash)")
+    p_pipeline.add_argument("--tenant", default=None, help="Tenant namespace")
+    p_pipeline.add_argument("--priority", type=int, default=0, help="Priority tiebreaker")
+    p_pipeline.add_argument("--created-by", default=None, help="Author profile for the root card")
+    p_pipeline.add_argument("--idempotency-key", default=None, help="Dedup key for the root card")
+    p_pipeline.add_argument("--json", action="store_true", help="Emit JSON output")
 
     # --- list ---
     p_list = sub.add_parser("list", aliases=["ls"], help="List tasks")
@@ -939,6 +967,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "init":     _cmd_init,
             "create":   _cmd_create,
             "swarm":    _cmd_swarm,
+            "pipeline": _cmd_pipeline,
             "list":     _cmd_list,
             "ls":       _cmd_list,
             "show":     _cmd_show,
@@ -1411,6 +1440,54 @@ def _cmd_swarm(args: argparse.Namespace) -> int:
         print("Workers: " + ", ".join(created.worker_ids))
         print(f"Verifier: {created.verifier_id}")
         print(f"Synthesizer: {created.synthesizer_id}")
+    return 0
+
+
+def _cmd_pipeline(args: argparse.Namespace) -> int:
+    """Create a Kanban Pipeline graph from a registered preset.
+
+    Mirrors the structure of :func:`_cmd_swarm` but uses the preset
+    (4-profile by default) to fill in the worker spec list, so the user
+    does not need to know which model each role needs — the preset
+    encodes the validated model + skill mapping.
+
+    Per-role model overrides (``--coder-model``, ``--reviewer-model``,
+    ``--researcher-model``, ``--analyst-model``) win over the preset
+    defaults. Per-role skill overrides are not yet exposed on the CLI
+    (the 4-profile preset has fixed skills per role; future presets
+    with variable skills can add ``--coder-skill`` flags here).
+    """
+    overrides: dict[str, dict[str, Any]] = {}
+    if args.coder_model:
+        overrides.setdefault("coder", {})["model"] = args.coder_model
+    if args.reviewer_model:
+        overrides.setdefault("reviewer", {})["model"] = args.reviewer_model
+    if args.researcher_model:
+        overrides.setdefault("researcher", {})["model"] = args.researcher_model
+    if args.analyst_model:
+        overrides.setdefault("analyst", {})["model"] = args.analyst_model
+
+    try:
+        with kb.connect_closing() as conn:
+            created = kp.create_pipeline(
+                conn,
+                goal=args.goal,
+                preset=args.preset,
+                overrides=overrides or None,
+                tenant=args.tenant,
+                created_by=args.created_by or _profile_author(),
+                priority=args.priority,
+                idempotency_key=getattr(args, "idempotency_key", None),
+            )
+    except ValueError as exc:
+        print(f"kanban pipeline: {exc}", file=sys.stderr)
+        return 2
+    if getattr(args, "json", False):
+        print(json.dumps(created.as_dict(), indent=2, ensure_ascii=False))
+    else:
+        print(f"Pipeline root: {created.root_id}  (preset: {created.preset})")
+        for role, tid in created.worker_ids.items():
+            print(f"  {role:11s} {tid}")
     return 0
 
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -79,6 +79,13 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "session_id": t.session_id,
         "workflow_template_id": t.workflow_template_id,
         "current_step_key": t.current_step_key,
+        # Per-task model override (added in this branch to surface the
+        # column in `hermes kanban create --json` and `hermes kanban show
+        # --json`). The dispatcher uses this when spawning the worker;
+        # surfacing it lets callers verify the override without reading
+        # the SQLite DB directly. The dispatcher cmd's `-m <model>` is
+        # added at kanban_db.py:6843 when this field is truthy.
+        "model_override": t.model_override,
     }
 
 
@@ -307,6 +314,14 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_create.add_argument("title", help="Task title")
     p_create.add_argument("--body", default=None, help="Optional opening post")
     p_create.add_argument("--assignee", default=None, help="Profile name to assign")
+    p_create.add_argument("--model", dest="model_override", default=None,
+                          help="Override the assignee profile's default model for "
+                               "this task only. The dispatcher passes `-m <model>` "
+                               "to the spawned worker (so `hermes kanban show` and "
+                               "the worker log reflect the requested model id). "
+                               "Use this for one-off model swaps without creating a "
+                               "new profile; for stable routing, prefer a dedicated "
+                               "profile (e.g. --assignee coder for kimi-k2.7-code).")
     p_create.add_argument("--parent", action="append", default=[],
                           help="Parent task id (repeatable)")
     p_create.add_argument("--workspace", default="scratch",
@@ -1346,6 +1361,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
             initial_status=getattr(args, "initial_status", "running"),
+            model_override=getattr(args, "model_override", None),
         )
         task = kb.get_task(conn, task_id)
     if getattr(args, "json", False):

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5449,7 +5449,135 @@ def _error_fingerprint(error_text: str) -> str:
     return fp.lower().strip()
 
 
-def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
+def _classify_worker_error(
+    log_path: "Path | str | None",
+    *,
+    default_kind: str = "unknown",
+    default_message: str = "no worker log available",
+) -> "tuple[str, str]":
+    """Classify a worker crash by reading the tail of its log file.
+
+    Companion to :func:`_classify_worker_exit` (which is PID-based and
+    only knows the exit code). This helper reads the actual worker's
+    log to extract an operator-actionable error class, so the
+    ``last_failure_error`` column on the task tells the operator WHY the
+    worker died, not just "pid X not alive".
+
+    Returns ``(kind, message)`` where ``kind`` is one of:
+
+      * ``"rate_limited"`` — provider returned HTTP 429 / quota wall.
+        Worker hit a provider-side throttle; transient, retry after
+        the quota window clears.
+      * ``"auth_failed"`` — provider returned HTTP 401/403. The
+        configured API key is wrong or missing.
+      * ``"context_overflow"`` — provider returned HTTP 400 with
+        context-length / token-limit message. The prompt is too big
+        for this model.
+      * ``"model_unavailable"`` — provider returned HTTP 404/410 or
+        a "model not found" / "model deprecated" message.
+      * ``"rate_limited_sentence"`` — worker self-reported "rate
+        limited" / "quota" in its chat (e.g. the OLLAMA rate-limit
+        handler, the OpenAI retry-and-give-up path). Distinct from
+        ``rate_limited`` (which requires an explicit HTTP 429 in the
+        log); this one is the worker's own narrative.
+      * ``"unknown"`` — log was empty, missing, or had no recognizable
+        error pattern. ``message`` falls back to ``default_message``.
+
+    The function is intentionally tolerant: it never raises. A
+    malformed log line, a permissions error, or a missing file all
+    degrade to ``(default_kind, default_message)`` so the dispatcher's
+    crash path stays robust.
+    """
+    if not log_path:
+        return (default_kind, default_message)
+    path = Path(log_path)
+    if not path.exists():
+        return (default_kind, default_message)
+    try:
+        # Read the tail (last 16 KiB) — long enough to catch the final
+        # error line, short enough to be cheap on a hot loop over many
+        # crashed workers.
+        with open(path, "rb") as f:
+            try:
+                f.seek(-16384, 2)
+            except OSError:
+                f.seek(0)
+            raw = f.read().decode("utf-8", errors="replace")
+    except OSError as exc:
+        return (default_kind, f"{default_message} (read error: {exc})")
+
+    # Patterns are deliberately conservative: each one captures the
+    # HTTP class (or worker-narrated class) and the most informative
+    # detail line. Order matters — first match wins. More-specific
+    # patterns come before less-specific ones.
+    patterns: list[tuple[str, "re.Pattern[str]"]] = [
+        # HTTP 429 / quota / throttling. Match the most common shapes
+        # first, then fall through to "rate limited" prose.
+        ("rate_limited", re.compile(
+            r"HTTP\s*429[^\n]*?(?:rate|quota|throttl|usage)[^\n]*",
+            re.IGNORECASE,
+        )),
+        ("rate_limited", re.compile(
+            r"HTTP\s*429[^\n]{0,160}",
+            re.IGNORECASE,
+        )),
+        ("rate_limited", re.compile(
+            r"\brate[\s-]?limit(?:ed|ing)?\b[^\n]{0,160}",
+            re.IGNORECASE,
+        )),
+        ("rate_limited", re.compile(
+            r"\bquota\s+(?:exhausted|wall|exceeded|reached|max(?:ed)?)\b[^\n]{0,160}",
+            re.IGNORECASE,
+        )),
+        # HTTP 401/403 — bad credentials.
+        ("auth_failed", re.compile(
+            r"HTTP\s*(?:401|403)[^\n]{0,200}",
+            re.IGNORECASE,
+        )),
+        ("auth_failed", re.compile(
+            r"\b(?:invalid[_ ]api[_ ]key|incorrect[_ ]api[_ ]key|"
+            r"unauthorized|forbidden|authentication[_ ]failed|"
+            r"api[_ ]key[_ ]not[_ ]valid)\b[^\n]{0,160}",
+            re.IGNORECASE,
+        )),
+        # HTTP 400/413 — context overflow / token limit.
+        ("context_overflow", re.compile(
+            r"HTTP\s*(?:400|413|422)[^\n]*?(?:context|token|too[_ ]long|"
+            r"maximum[_ ]context|context[_ ]length|reduce[_ ]the[_ ]length)[^\n]{0,160}",
+            re.IGNORECASE,
+        )),
+        ("context_overflow", re.compile(
+            r"\b(?:context[_ ]length[_ ]exceeded|maximum[_ ]context[_ ]length|"
+            r"prompt[_ ]is[_ ]too[_ ]long|reduce[_ ]the[_ ]length)\b[^\n]{0,160}",
+            re.IGNORECASE,
+        )),
+        # HTTP 404/410 — model not found / deprecated.
+        ("model_unavailable", re.compile(
+            r"HTTP\s*(?:404|410)[^\n]{0,200}",
+            re.IGNORECASE,
+        )),
+        ("model_unavailable", re.compile(
+            r"\b(?:model[_ ]not[_ ]found|model[_ ](?:has[_ ]been[_ ])?deprecated|"
+            r"the[_ ]model[^\n]{0,40}does[_ ]not[_ ]exist)\b[^\n]{0,160}",
+            re.IGNORECASE,
+        )),
+    ]
+    for kind, pat in patterns:
+        m = pat.search(raw)
+        if m:
+            msg = m.group(0).strip()
+            # Truncate to a reasonable column width but keep the
+            # actionable tail.
+            if len(msg) > 240:
+                msg = msg[:237] + "..."
+            return (kind, msg)
+    return (default_kind, default_message)
+
+
+def detect_crashed_workers(
+    conn: sqlite3.Connection,
+    board: "Optional[str]" = None,
+) -> list[str]:
     """Reclaim ``running`` tasks whose worker PID is no longer alive.
 
     Appends a ``crashed`` event and drops the task back to ``ready``.
@@ -5550,16 +5678,43 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
             else:
                 protocol_violation = False
                 if kind == "nonzero_exit":
-                    error_text = f"pid {pid} exited with code {code}"
+                    base_error = f"pid {pid} exited with code {code}"
                 elif kind == "signaled":
-                    error_text = f"pid {pid} killed by signal {code}"
+                    base_error = f"pid {pid} killed by signal {code}"
                 else:
-                    error_text = f"pid {pid} not alive"
+                    base_error = f"pid {pid} not alive"
+                # K1: enrich error_text with the HTTP error class from
+                # the worker's log when one is available. The log is the
+                # source of truth for WHY the worker died (rate limit,
+                # bad auth, context overflow, etc); the pid-based
+                # ``_classify_worker_exit`` only knows the exit code.
+                # Read the log once per crashed task — cheap (last 16 KiB)
+                # and bounded.
+                log_kind, log_msg = _classify_worker_error(
+                    worker_log_path(row["id"], board=board),
+                    default_kind=kind,
+                    default_message=base_error,
+                )
+                # Prefix the operator-actionable class so the
+                # ``last_failure_error`` column reads as
+                # "rate_limited: HTTP 429 — extra usage auto reload..."
+                # in the dashboard. Falls back to the pid-based message
+                # when the log has no recognizable error pattern.
+                error_text = (
+                    f"{log_kind}: {log_msg}"
+                    if log_kind not in ("unknown", kind)
+                    else base_error
+                )
                 event_kind = "crashed"
                 event_payload = {"pid": pid, "claimer": row["claim_lock"]}
                 if code is not None and kind != "unknown":
                     event_payload["exit_kind"] = kind
                     event_payload["exit_code"] = code
+                # Also surface the log-based kind so future audit
+                # tooling can filter by it without re-parsing the
+                # error string.
+                if log_kind not in ("unknown", kind):
+                    event_payload["log_error_kind"] = log_kind
 
             cur = conn.execute(
                 "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
@@ -5605,32 +5760,30 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # ready → blocked with a ``gave_up`` event on top of the ``crashed``
     # event we already emitted.
     #
-    # Protocol-violation crashes force an immediate trip (failure_limit=1)
-    # because clean-exit-without-transition is deterministic: the next
-    # respawn will do exactly the same thing. Better to surface to a
-    # human with a clear reason than to loop ``DEFAULT_FAILURE_LIMIT``
-    # times first.
+    # We use a CONSISTENT 2-strike policy regardless of crash type:
+    # protocol-violation and systemic (3+ same-fingerprint in a tick)
+    # crashes no longer trip on the first occurrence. Reasoning: the
+    # user wants predictable, uniform retry behavior — a worker that
+    # exits cleanly without kanban_complete is just as likely to be a
+    # transient issue (lost network, model timeout, profile misconfig
+    # on first run) as it is to be a permanent bug. Surfacing after 2
+    # strikes instead of 1 gives the dispatcher one chance to retry
+    # under changed conditions before paging a human.
     auto_blocked: list[str] = []
     if crash_details:
-        # Fingerprint errors to detect systemic failures.
-        _fp_counts: dict[str, int] = {}
-        for _, _, _, _, err_text in crash_details:
-            fp = _error_fingerprint(err_text)
-            _fp_counts[fp] = _fp_counts.get(fp, 0) + 1
-        for tid, pid, claimer, protocol_violation, error_text in crash_details:
-            fp = _error_fingerprint(error_text)
-            is_systemic = (
-                not protocol_violation
-                and _fp_counts.get(fp, 0) >= 3
-            )
+        for tid, pid, claimer, _protocol_violation, error_text in crash_details:
             tripped = _record_task_failure(
                 conn, tid,
                 error=error_text,
                 outcome="crashed",
-                failure_limit=1 if (protocol_violation or is_systemic) else None,
+                failure_limit=None,  # K2: always fall through to DEFAULT_FAILURE_LIMIT
                 release_claim=False,
                 end_run=False,
-                event_payload_extra={"pid": pid, "claimer": claimer},
+                # _protocol_violation is preserved in the event payload
+                # for audit purposes even though it no longer affects
+                # the breaker trip (K2: consistent 2-strike).
+                event_payload_extra={"pid": pid, "claimer": claimer,
+                                     "protocol_violation": _protocol_violation},
             )
             if tripped:
                 auto_blocked.append(tid)
@@ -6827,21 +6980,34 @@ def _default_spawn(
     # many profile-scoped skills dirs; preloading a missing skill is
     # fatal at CLI startup). Only add when the per-task skills list
     # does not already ask for it (avoid duplicate --skills flags).
+    # Insert kanban-worker BEFORE the first ``--skills`` (i.e. as the
+    # leading skill) so argv reads ``--skills kanban-worker --skills
+    # <user-skill-1> ... chat``. Tests + dashboard both expect the
+    # built-in to come first.
     if (
         _kanban_worker_skill_available(env.get("HERMES_HOME"))
         and "kanban-worker" not in (task.skills or [])
     ):
-        # Inject before ``chat -q <prompt>`` (the helper appended those
-        # at the end). One ``--skills X`` pair, mirrors the original
-        # dispatcher shape.
-        idx = next(
-            (i for i, tok in enumerate(cmd) if tok == "chat"),
-            len(cmd) - 2,
+        first_skills_idx = next(
+            (i for i, tok in enumerate(cmd) if tok == "--skills"),
+            # Fall back to right before ``chat`` if no --skills yet.
+            next(
+                (i for i, tok in enumerate(cmd) if tok == "chat"),
+                len(cmd),
+            ),
         )
-        cmd = cmd[:idx] + ["--skills", "kanban-worker"] + cmd[idx:]
+        cmd = (
+            cmd[:first_skills_idx]
+            + ["--skills", "kanban-worker"]
+            + cmd[first_skills_idx:]
+        )
     # Worker toolsets come from the assigned profile's config.yaml; append
     # after the standard shape so a future change to the dispatcher's
     # per-profile toolset rules does not have to touch the public helper.
+    # The 62c85118d refactor moved the base cmd into
+    # ``spawn_worker.build_spawn_cmd`` but left the per-profile toolset
+    # injection here, which needs a local resolution to work.
+    worker_toolsets = _resolve_worker_cli_toolsets(env.get("HERMES_HOME"))
     if worker_toolsets:
         # Inject ``--toolsets X`` before ``chat -q <prompt>`` (which
         # build_spawn_cmd appended at the end). The kanban CLI accepts

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -90,6 +90,8 @@ from typing import Any, Iterable, Optional
 
 from toolsets import get_toolset_names
 
+from hermes_cli import spawn_worker
+
 _log = logging.getLogger(__name__)
 
 
@@ -6814,51 +6816,41 @@ def _default_spawn(
     # attributed correctly regardless of how the child loads config.
     env["HERMES_PROFILE"] = profile_arg
 
-    cmd = [
-        *_resolve_hermes_argv(),
-        "-p", profile_arg,
-        # Worker subprocesses switch to a profile-scoped HERMES_HOME above,
-        # so they see that profile's shell-hook allowlist instead of the
-        # dispatcher's root allowlist. Pass --accept-hooks explicitly so
-        # profile-local worker sessions still register configured hooks.
-        "--accept-hooks",
-    ]
-    # Auto-load the kanban-worker skill so every dispatched worker
-    # has the pattern library (good summary/metadata shapes, retry
-    # diagnostics, block-reason examples) in its context, even if
-    # the profile hasn't wired it into skills config. The MANDATORY
-    # lifecycle is already in the system prompt via KANBAN_GUIDANCE;
-    # this skill is the deeper reference. Users can point a profile
-    # at a different/additional skill via config if they want —
-    # --skills is additive to the profile's default skill set.
-    #
-    # Only add the flag when the skill actually resolves for the home
-    # the worker runs under: the bundled skill is absent from many
-    # profile-scoped skills dirs, and preloading a missing skill is
-    # fatal at CLI startup. Omitting it is safe — the lifecycle
-    # contract still ships via KANBAN_GUIDANCE.
-    if _kanban_worker_skill_available(env.get("HERMES_HOME")):
-        cmd.extend(["--skills", "kanban-worker"])
-    # Per-task force-loaded skills. Each name goes in its own
-    # `--skills X` pair rather than a single comma-joined arg: the CLI
-    # accepts both forms (action='append' + comma-split), but
-    # per-name pairs are easier to read in `ps` output and avoid any
-    # quoting ambiguity if a skill name ever contains unusual chars.
-    # Dedupe against the built-in so we don't double-load kanban-worker
-    # if a task author asks for it explicitly.
-    if task.skills:
-        for sk in task.skills:
-            if sk and sk != "kanban-worker":
-                cmd.extend(["--skills", sk])
-    if task.model_override:
-        cmd.extend(["-m", task.model_override])
-    worker_toolsets = _resolve_worker_cli_toolsets(env.get("HERMES_HOME"))
+    cmd = spawn_worker.build_spawn_cmd(
+        profile=profile_arg,
+        prompt=prompt,
+        model=task.model_override,
+        skills=task.skills,
+    )
+    # Auto-load the kanban-worker skill if the home under which the
+    # worker runs actually ships it (the bundled skill is missing from
+    # many profile-scoped skills dirs; preloading a missing skill is
+    # fatal at CLI startup). Only add when the per-task skills list
+    # does not already ask for it (avoid duplicate --skills flags).
+    if (
+        _kanban_worker_skill_available(env.get("HERMES_HOME"))
+        and "kanban-worker" not in (task.skills or [])
+    ):
+        # Inject before ``chat -q <prompt>`` (the helper appended those
+        # at the end). One ``--skills X`` pair, mirrors the original
+        # dispatcher shape.
+        idx = next(
+            (i for i, tok in enumerate(cmd) if tok == "chat"),
+            len(cmd) - 2,
+        )
+        cmd = cmd[:idx] + ["--skills", "kanban-worker"] + cmd[idx:]
+    # Worker toolsets come from the assigned profile's config.yaml; append
+    # after the standard shape so a future change to the dispatcher's
+    # per-profile toolset rules does not have to touch the public helper.
     if worker_toolsets:
-        cmd.extend(["--toolsets", ",".join(worker_toolsets)])
-    cmd.extend([
-        "chat",
-        "-q", prompt,
-    ])
+        # Inject ``--toolsets X`` before ``chat -q <prompt>`` (which
+        # build_spawn_cmd appended at the end). The kanban CLI accepts
+        # ``--toolsets`` anywhere in the flag region.
+        idx = next(
+            (i for i, tok in enumerate(cmd) if tok == "chat"),
+            len(cmd) - 2,
+        )
+        cmd = cmd[:idx] + ["--toolsets", ",".join(worker_toolsets)] + cmd[idx:]
     # Redirect output to a per-task log under <board-root>/logs/.
     # Anchored at the board root (not the shared kanban root), so
     # `hermes kanban log` on a specific board reads its own file and

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2072,6 +2072,7 @@ def create_task(
     initial_status: str = "running",
     session_id: Optional[str] = None,
     board: Optional[str] = None,
+    model_override: Optional[str] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -2104,6 +2105,13 @@ def create_task(
         raise ValueError(
             f"initial_status must be one of {sorted(VALID_INITIAL_STATUSES)}"
         )
+    # Normalise model_override: empty string is the same as None. The
+    # dispatcher treats None as "use the profile's default model"; an
+    # explicit empty string would currently produce `hermes -m ''` which
+    # the CLI rejects, so collapse to None here to keep the public API
+    # forgiving (matches how --max-retries etc. treat empty input).
+    if model_override is not None:
+        model_override = str(model_override).strip() or None
     if workspace_kind not in VALID_WORKSPACE_KINDS:
         raise ValueError(
             f"workspace_kind must be one of {sorted(VALID_WORKSPACE_KINDS)}, "
@@ -2236,8 +2244,9 @@ def create_task(
                         id, title, body, assignee, status, priority,
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, tenant, idempotency_key, max_runtime_seconds,
-                        skills, max_retries, goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        skills, max_retries, goal_mode, goal_max_turns, session_id,
+                        model_override
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -2259,6 +2268,7 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        model_override,
                     ),
                 )
                 for pid in parents:

--- a/hermes_cli/kanban_pipeline.py
+++ b/hermes_cli/kanban_pipeline.py
@@ -1,0 +1,358 @@
+"""Kanban Pipeline — the 4-profile orchestration pattern as a reusable helper.
+
+The pipeline pattern is the durable, board-persisted shape of the
+``coder + reviewer + researcher + analyst`` workflow validated on
+2026-06-13 (see ``hermes-multi-profile-orchestration`` skill). It writes
+a small task graph into the existing kanban kernel:
+
+    planning root (completed immediately, stays as the shared blackboard)
+        ├─ coder      (parallel)
+        ├─ reviewer   (parallel)
+        ├─ researcher (parallel)
+        └─ analyst    (parallel)
+
+This is deliberately simpler than ``kanban_swarm`` (no verifier, no
+synthesizer): the 4-profile pattern's verifier is the reviewer and the
+synthesizer is the analyst, baked in by role, so the topology collapses
+to one level of fan-out.
+
+Presets are pure data so new patterns (e.g. ``2-profile {coder, reviewer}``,
+``6-profile {coder, reviewer, researcher, analyst, security, perf}``)
+can be added without code changes — just register the preset in
+``PRESETS`` and the CLI auto-discovers it.
+
+Why a separate module (not folded into ``kanban_swarm.py``): the
+swarm module's contract is "parallel workers → verifier → synthesizer",
+which fits the LLM-judge pattern. The 4-profile pipeline has no
+separate verifier; the role IS the verification. Mixing the two
+shapes would force every swarm to declare a verifier that sometimes
+overlaps with a worker.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+import sqlite3
+from typing import Any, Iterable, Optional
+
+from hermes_cli import kanban_db as kb
+
+
+# ----- presets -----------------------------------------------------------
+
+@dataclass(frozen=True)
+class PipelineRoleSpec:
+    """One role in a pipeline preset."""
+
+    profile: str
+    """Profile name to assign (becomes the card's ``assignee``)."""
+
+    title_template: str
+    """Title template for the child card. ``{goal}`` is substituted; the
+    resulting title is what the dispatcher and the worker see."""
+
+    body_template: str
+    """Body template for the child card. ``{goal}`` is substituted."""
+
+    model: Optional[str] = None
+    """Per-task model override (becomes the card's ``model_override``).
+    Mirrors ``hermes kanban create --model``."""
+
+    skills: list[str] = field(default_factory=list)
+    """Skills to force-load into the worker (passed via ``--skills``)."""
+
+
+# 4-profile preset — the validated pattern.
+#
+# Each role's body embeds a directive shape and an output file path. The
+# body is the worker's contract: read it, do the work, write the artifact.
+# We deliberately keep the body templates in code (not in the caller's
+# CLI args) so the same preset produces the same body across every
+# invocation, and so a "swap the demo" change is a one-line edit here.
+FOUR_PROFILE_PRESET: dict[str, PipelineRoleSpec] = {
+    "coder": PipelineRoleSpec(
+        profile="coder",
+        title_template="Coder: {goal} (kimi-k2.7-code)",
+        body_template=(
+            "EXECUTE. No clarifying questions. Use the test-driven-development skill.\n\n"
+            "Goal: {goal}\n\n"
+            "Process (TDD per the test-driven-development skill):\n"
+            "1. Write a stub that raises NotImplementedError, plus at least 5 failing\n"
+            "   assert tests so `python <file>` exits non-zero on a red run.\n"
+            "2. Run the file; confirm it exits non-zero.\n"
+            "3. Replace the stub with a real implementation.\n"
+            "4. Run the file again; confirm it exits 0.\n"
+            "5. Return a 3-line summary: complexity, exit code, any deviations.\n"
+        ),
+        model="kimi-k2.7-code",
+        skills=["test-driven-development"],
+    ),
+    "reviewer": PipelineRoleSpec(
+        profile="reviewer",
+        title_template="Reviewer: code review for {goal} (glm-5.1)",
+        body_template=(
+            "EXECUTE. No questions. No interactive back-and-forth.\n\n"
+            "Goal: {goal}\n\n"
+            "Read the coder's artifact and write a numbered list of issues, each with\n"
+            "severity (blocker / major / minor / nit) and a one-line fix suggestion.\n"
+            "At least 3 items, under 400 words. If no issues, write a one-paragraph\n"
+            "'approved' justification explaining what you checked.\n\n"
+            "Do not modify the coder's source. Return a 2-line summary: form chosen\n"
+            "(numbered / approved) and word count.\n"
+        ),
+        model="glm-5.1",
+        skills=["requesting-code-review"],
+    ),
+    "researcher": PipelineRoleSpec(
+        profile="researcher",
+        title_template="Researcher: brief for {goal} (deepseek-v4-pro)",
+        body_template=(
+            "EXECUTE. No clarifying questions. Do the research and write the file.\n\n"
+            "Goal: {goal}\n\n"
+            "Use the web tool. Produce a brief in exactly 5 markdown bullets.\n"
+            "Each bullet <= 30 words. At least 3 bullets must include a URL\n"
+            "citation. No preamble, no conclusion.\n\n"
+            "Return a 2-line summary: bullet count and URL count.\n"
+        ),
+        model="deepseek-v4-pro",
+        skills=[],
+    ),
+    "analyst": PipelineRoleSpec(
+        profile="analyst",
+        title_template="Analyst: benchmark for {goal} (deepseek-v4-flash)",
+        body_template=(
+            "EXECUTE. No questions.\n\n"
+            "Goal: {goal}\n\n"
+            "After the coder's artifact exists:\n"
+            "1. Write a benchmark that imports the artifact, runs both the artifact's\n"
+            "   implementation and a baseline (e.g. heapq.nlargest, Counter.most_common),\n"
+            "   on (n=1_000,k=10), (n=100_000,k=10), (n=100_000,k=1_000). 5 reps per case.\n"
+            "   Report median ms in a markdown table.\n"
+            "2. Run the benchmark and confirm the table file exists.\n\n"
+            "Return a 3-line summary: impl strategy, n=100k,k=1000 medians, winner.\n"
+        ),
+        model="deepseek-v4-flash",
+        skills=[],
+    ),
+}
+
+
+PRESETS: dict[str, dict[str, PipelineRoleSpec]] = {
+    "4-profile": FOUR_PROFILE_PRESET,
+}
+
+
+# ----- outputs -----------------------------------------------------------
+
+@dataclass(frozen=True)
+class PipelineCreated:
+    """IDs produced by :func:`create_pipeline`."""
+
+    root_id: str
+    worker_ids: dict[str, str]
+    """``{role_name: task_id}`` — one per role in the preset."""
+
+    preset: str
+    goal: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "root_id": self.root_id,
+            "worker_ids": dict(self.worker_ids),
+            "preset": self.preset,
+            "goal": self.goal,
+        }
+
+
+# ----- helpers -----------------------------------------------------------
+
+def _require_text(value: str, field_name: str) -> str:
+    text = (value or "").strip()
+    if not text:
+        raise ValueError(f"{field_name} is required")
+    return text
+
+
+def _resolve_goal(goal: str) -> str:
+    """Normalize the goal string. The kanban task title and each child's
+    body embed ``{goal}``; collapse internal newlines so the title stays
+    a single readable line."""
+    g = _require_text(goal, "goal")
+    return " ".join(line.strip() for line in g.splitlines() if line.strip()) or g
+
+
+def _apply_overrides(
+    role_name: str,
+    spec: PipelineRoleSpec,
+    overrides: Optional[dict[str, dict[str, Any]]],
+) -> PipelineRoleSpec:
+    """Apply per-role overrides from the caller. Supported keys: ``model``,
+    ``skills`` (list), ``title_template``, ``body_template``. The
+    ``profile`` field is intentionally NOT overridable — the preset fixes
+    which profile handles which role, and re-pointing a role to a
+    different profile is what would make the preset a different preset.
+    """
+    if not overrides:
+        return spec
+    role_over = overrides.get(role_name) or {}
+    if not role_over:
+        return spec
+    return PipelineRoleSpec(
+        profile=spec.profile,
+        title_template=role_over.get("title_template", spec.title_template),
+        body_template=role_over.get("body_template", spec.body_template),
+        model=role_over.get("model", spec.model),
+        skills=list(role_over.get("skills", spec.skills)),
+    )
+
+
+def _pipeline_blackboard(root_id: str, goal: str, preset: str, role_specs: dict[str, PipelineRoleSpec]) -> str:
+    """Structured comment payload recorded on the root so a future reader
+    can reconstruct the topology without re-running the helper. Symmetric
+    with :func:`hermes_cli.kanban_swarm.latest_blackboard`."""
+    return json.dumps({
+        "kind": "kanban_pipeline_v1",
+        "preset": preset,
+        "root_id": root_id,
+        "goal": goal,
+        "roles": {
+            r: {
+                "profile": s.profile,
+                "model": s.model,
+                "skills": list(s.skills),
+            }
+            for r, s in role_specs.items()
+        },
+    }, ensure_ascii=False)
+
+
+def create_pipeline(
+    conn: sqlite3.Connection,
+    *,
+    goal: str,
+    preset: str = "4-profile",
+    overrides: Optional[dict[str, dict[str, Any]]] = None,
+    root_title: Optional[str] = None,
+    tenant: Optional[str] = None,
+    created_by: str = "pipeline-orchestrator",
+    workspace_kind: str = "scratch",
+    workspace_path: Optional[str] = None,
+    priority: int = 0,
+    idempotency_key: Optional[str] = None,
+) -> PipelineCreated:
+    """Create a durable Kanban pipeline graph for the given goal.
+
+    The graph is immediately dispatchable: the planning root is marked
+    ``done`` with topology metadata, the 4 children start in ``ready``
+    (the parent being ``done`` unblocks them), and the dispatcher picks
+    them up in parallel subject to
+    ``delegation.max_concurrent_children``.
+
+    Returns:
+      :class:`PipelineCreated` with the root id and the per-role
+      ``{role: task_id}`` map. The CLI surfaces this as JSON.
+
+    Raises:
+      ValueError: unknown preset, empty goal, or no roles in the preset.
+    """
+    if preset not in PRESETS:
+        raise ValueError(
+            f"unknown preset {preset!r}; available: {sorted(PRESETS.keys())}"
+        )
+    goal_text = _resolve_goal(goal)
+    base_specs = PRESETS[preset]
+    if not base_specs:
+        raise ValueError(f"preset {preset!r} has no roles")
+
+    final_specs: dict[str, PipelineRoleSpec] = {
+        role: _apply_overrides(role, spec, overrides)
+        for role, spec in base_specs.items()
+    }
+
+    # 1. Create the planning root. Marked ``done`` immediately so children
+    # can promote; it remains the shared blackboard for the duration of
+    # the pipeline.
+    root_title_final = root_title or f"Pipeline[{preset}]: {goal_text[:80]}"
+    root = kb.create_task(
+        conn,
+        title=root_title_final,
+        body=(
+            "Kanban Pipeline v1 planning/root card. This card is completed "
+            "immediately so the 4 child roles can start while it remains "
+            "the shared blackboard and audit anchor.\n\n"
+            f"Goal:\n{goal_text}\n\n"
+            f"Preset: {preset}\n"
+            f"Roles: {', '.join(final_specs.keys())}\n"
+        ),
+        assignee=created_by,
+        created_by=created_by,
+        tenant=tenant,
+        priority=priority,
+        idempotency_key=idempotency_key,
+        workspace_kind=workspace_kind,
+        workspace_path=workspace_path,
+        skills=["kanban-orchestrator"],
+    )
+
+    # 2. Build the 4 child cards in stable role order, each with a
+    # ``parents=[root]`` edge so it cannot start until the root is
+    # released (it already is, so it lands in ``ready``).
+    worker_ids: dict[str, str] = {}
+    for role_name in ("coder", "reviewer", "researcher", "analyst"):
+        if role_name not in final_specs:
+            continue
+        spec = final_specs[role_name]
+        title = spec.title_template.format(goal=goal_text)
+        body = spec.body_template.format(goal=goal_text)
+        tid = kb.create_task(
+            conn,
+            title=title,
+            body=body,
+            assignee=spec.profile,
+            created_by=created_by,
+            parents=[root],
+            tenant=tenant,
+            priority=priority,
+            workspace_kind=workspace_kind,
+            workspace_path=workspace_path,
+            skills=spec.skills or None,
+            model_override=spec.model,
+        )
+        worker_ids[role_name] = tid
+
+    # 3. Mark the root done with topology metadata so a later reader can
+    # reconstruct the graph from a single task id.
+    kb.complete_task(
+        conn,
+        root,
+        summary=f"Pipeline[{preset}] topology planned; {len(worker_ids)} roles ready.",
+        metadata={
+            "kind": "kanban_pipeline_v1",
+            "preset": preset,
+            "goal": goal_text,
+            "role_count": len(worker_ids),
+            "worker_ids": dict(worker_ids),
+        },
+    )
+
+    # 4. Record a structured blackboard comment for human readers. Kept
+    # separate from the metadata blob so the kanban UI's comment thread
+    # is the canonical human-readable log.
+    try:
+        kb.add_comment(
+            conn,
+            root,
+            created_by,
+            "[pipeline:blackboard] " + _pipeline_blackboard(root, goal_text, preset, final_specs),
+        )
+    except AttributeError:
+        # Older kanban_db without add_comment — best-effort, the
+        # topology is already in the task metadata.
+        pass
+
+    return PipelineCreated(
+        root_id=root,
+        worker_ids=worker_ids,
+        preset=preset,
+        goal=goal_text,
+    )

--- a/hermes_cli/kanban_swarm.py
+++ b/hermes_cli/kanban_swarm.py
@@ -36,6 +36,12 @@ class SwarmWorkerSpec:
     skills: list[str] = field(default_factory=list)
     priority: int = 0
     max_runtime_seconds: Optional[int] = None
+    model: Optional[str] = None
+    """Per-worker model override (mirrors ``kb.create_task``'s
+    ``model_override``). When set, the dispatcher spawns this worker
+    with ``hermes -m <model>`` so it uses the requested model instead
+    of ``profile``'s default. Symmetric with the single-task
+    ``hermes kanban create --model`` flag."""
 
 
 @dataclass(frozen=True)
@@ -170,6 +176,7 @@ def create_swarm(
             workspace_path=workspace_path,
             skills=spec.skills or None,
             max_runtime_seconds=spec.max_runtime_seconds,
+            model_override=spec.model,
         )
         worker_ids.append(worker_id)
 
@@ -268,12 +275,24 @@ def latest_blackboard(conn: sqlite3.Connection, root_id: str) -> dict[str, Any]:
 
 
 def parse_worker_arg(raw: str) -> SwarmWorkerSpec:
-    """Parse CLI ``--worker profile:title[:skill,skill]`` values."""
+    """Parse CLI ``--worker profile:title[:skill,skill][@model]`` values.
 
+    ``@model`` is an optional tail override (e.g. ``coder:Write tests@kimi-k2.7-code``).
+    Empty / missing ``@model`` means "use the profile's default", which
+    is encoded as ``model=None`` on the resulting :class:`SwarmWorkerSpec`.
+    """
+    # Split off optional @model first, then handle profile:title[:skills].
+    model: Optional[str] = None
+    if "@" in raw:
+        raw, _, model_part = raw.partition("@")
+        model = model_part.strip() or None
     parts = [p.strip() for p in raw.split(":", 2)]
     if len(parts) < 2:
         raise ValueError("worker must be profile:title or profile:title:skill,skill")
     skills: list[str] = []
     if len(parts) == 3 and parts[2]:
         skills = [s.strip() for s in parts[2].split(",") if s.strip()]
-    return SwarmWorkerSpec(profile=parts[0], title=parts[1], body=parts[1], skills=skills)
+    return SwarmWorkerSpec(
+        profile=parts[0], title=parts[1], body=parts[1],
+        skills=skills, model=model,
+    )

--- a/hermes_cli/spawn_worker.py
+++ b/hermes_cli/spawn_worker.py
@@ -1,0 +1,180 @@
+"""Public spawn helper for kanban workers.
+
+Thin, importable wrapper around the ``hermes -p <profile> chat -q ...`` cmd
+that the kanban dispatcher builds for every worker subprocess. Exposed so:
+
+  * ad-hoc scripts and tests can build the same argv the dispatcher would,
+    without copying the construction logic,
+  * the dispatcher's internal ``_default_spawn`` can share the canonical
+    builder, so a future change to the spawn shape (extra flag, new
+    placeholder for skill preload, etc.) lands in one place,
+  * downstream tooling that wants to invoke a profile the way the
+    dispatcher would (e.g. local rehearsals, scenario-runner helpers,
+    ``hermes-demo`` style manual fan-outs) has a single source of truth.
+
+The function is intentionally narrow: it returns the argv list, the same
+shape ``subprocess.Popen`` expects. It does NOT spawn the process, set up
+the per-task log, or pin the board — those are dispatch concerns and stay
+in ``hermes_cli.kanban_db._default_spawn``. The split is the same as
+``argparse`` building a parser and the CLI handler executing it: builders
+build, dispatchers dispatch.
+
+Why a separate module (not a helper in ``kanban_db``): ``kanban_db`` is the
+hot-path DB module imported at every CLI invocation; adding new public
+imports there tightens the import graph for everyone. Keeping the helper
+in its own file also lets the KPI tests assert against the public shape
+without touching the DB.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional, Sequence
+
+
+def _safe_which_no_cwd(name: str) -> Optional[str]:
+    """``shutil.which`` that ignores the current directory on Windows.
+
+    Background: on Windows, ``shutil.which`` will return a path with a
+    leading ``.\\`` when the command is found in CWD. That is unsafe as
+    ``argv[0]`` for ``Popen`` because it lets a same-directory file win
+    over a system-installed command. Mirrors the helper in
+    ``hermes_cli.kanban_db`` for the same reason.
+    """
+    import shutil
+    import sys
+
+    found = shutil.which(name)
+    if not found:
+        return None
+    if sys.platform.startswith("win") and (found.startswith(".\\") or found.startswith("./")):
+        return None
+    return found
+
+
+def _looks_like_path(value: str) -> bool:
+    """True if ``value`` is filesystem-path-shaped (has a separator or a
+    drive letter). Bare command names like ``"hermes"`` return False so the
+    PATH lookup still applies."""
+    if not value:
+        return False
+    if value[0] in ("\\", "/") or (len(value) >= 2 and value[1] == ":"):
+        return True
+    if "\\" in value or "/" in value:
+        return True
+    return False
+
+
+def _module_hermes_argv() -> list[str]:
+    """Fallback argv when no ``hermes`` shim is on PATH: launch the current
+    Python with ``-m hermes_cli.main`` so the result is independent of
+    ``$PATH`` (cron, systemd ``User=`` services, detached jobs, etc.)."""
+    import sys
+    return [sys.executable, "-m", "hermes_cli.main"]
+
+
+def _hermes_path_argv(path: str) -> list[str]:
+    """Normalize a resolved ``hermes`` shim path to an absolute argv.
+
+    Path-like values are passed through absolute. Bare command names keep
+    normal PATH semantics.
+    """
+    p = Path(path)
+    if p.is_absolute():
+        return [str(p)]
+    return [str(p)]
+
+
+def resolve_hermes_argv() -> list[str]:
+    """Resolve the ``hermes`` invocation as argv parts for ``Popen``.
+
+    Tries in order:
+      1. ``$HERMES_BIN`` — explicit operator override.
+      2. ``shutil.which("hermes")`` — the console-script shim.
+      3. ``sys.executable -m hermes_cli.main`` — fallback for setups
+         where the shim is not on PATH.
+
+    Mirrors ``hermes_cli.kanban_db._resolve_hermes_argv``; kept as a public
+    re-export so callers do not have to reach into the private module.
+    """
+    env_bin = os.environ.get("HERMES_BIN", "").strip()
+    if env_bin:
+        if _looks_like_path(env_bin):
+            return _hermes_path_argv(env_bin)
+        resolved_env_bin = _safe_which_no_cwd(env_bin)
+        if resolved_env_bin:
+            return _hermes_path_argv(resolved_env_bin)
+        return _module_hermes_argv()
+
+    hermes_bin = _safe_which_no_cwd("hermes")
+    if hermes_bin:
+        return _hermes_path_argv(hermes_bin)
+    return _module_hermes_argv()
+
+
+def build_spawn_cmd(
+    profile: str,
+    prompt: str,
+    *,
+    model: Optional[str] = None,
+    skills: Optional[Sequence[str]] = None,
+    accept_hooks: bool = True,
+    extra_args: Optional[Sequence[str]] = None,
+) -> list[str]:
+    """Build the argv list for ``hermes -p <profile> chat -q <prompt>``.
+
+    This is the canonical command shape used by the kanban dispatcher for
+    every worker subprocess, factored out so callers and tests can build
+    the same argv without going through the dispatcher.
+
+    Args:
+      profile: profile name (becomes the ``-p`` value).
+      prompt: the worker's opening prompt (becomes the ``-q`` value).
+      model: optional per-task model override. When set, ``-m <model>`` is
+        appended, and the dispatched worker uses that model id in place of
+        the profile's default. Mirrors ``hermes kanban create --model``.
+      skills: optional iterable of skill names to force-load into the
+        worker via repeated ``--skills <name>`` flags. ``kanban-worker``
+        is added automatically when the home under which the worker will
+        run actually ships the bundled skill (the dispatcher checks the
+        same precondition to avoid a fatal "Unknown skill" error).
+      accept_hooks: when True (default), pass ``--accept-hooks`` so
+        profile-local hook allowlists are honored. Profile-scoped workers
+        use the profile's allowlist, not the dispatcher's root allowlist,
+        so the flag is needed to register the hooks again.
+      extra_args: optional extra argv parts appended after the standard
+        shape (before ``chat -q <prompt>``). Escape hatch for one-off
+        flags; prefer the named kwargs for the supported ones.
+
+    Returns:
+      A list of argv strings, suitable for ``subprocess.Popen(cmd, ...)``.
+
+    Examples:
+      >>> cmd = build_spawn_cmd("coder", "work kanban task t_abc",
+      ...                       model="kimi-k2.7-code",
+      ...                       skills=["test-driven-development"])
+      >>> "coder" in cmd and "kimi-k2.7-code" in cmd
+      True
+    """
+    profile = (profile or "").strip()
+    if not profile:
+        raise ValueError("profile is required")
+    if prompt is None:
+        raise ValueError("prompt is required")
+
+    cmd: list[str] = list(resolve_hermes_argv())
+    cmd.extend(["-p", profile])
+    if accept_hooks:
+        cmd.append("--accept-hooks")
+    # Per-task force-loaded skills. Same shape as the dispatcher:
+    # one ``--skills X`` pair per name, easy to grep in ``ps`` output.
+    skill_list = list(skills or [])
+    for sk in skill_list:
+        if sk and sk != "kanban-worker":
+            cmd.extend(["--skills", sk])
+    if model and model.strip():
+        cmd.extend(["-m", model.strip()])
+    if extra_args:
+        cmd.extend(list(extra_args))
+    cmd.extend(["chat", "-q", prompt])
+    return cmd

--- a/hermes_cli/spawn_worker.py
+++ b/hermes_cli/spawn_worker.py
@@ -168,9 +168,14 @@ def build_spawn_cmd(
         cmd.append("--accept-hooks")
     # Per-task force-loaded skills. Same shape as the dispatcher:
     # one ``--skills X`` pair per name, easy to grep in ``ps`` output.
+    # We do NOT filter ``kanban-worker`` here — the caller's dispatcher
+    # (or test) decides whether to inject it. Filtering at this layer
+    # would cause a silent drop when the user explicitly listed it
+    # (e.g. via ``hermes kanban create --skill kanban-worker``), with
+    # no replacement downstream.
     skill_list = list(skills or [])
     for sk in skill_list:
-        if sk and sk != "kanban-worker":
+        if sk:
             cmd.extend(["--skills", sk])
     if model and model.strip():
         cmd.extend(["-m", model.strip()])

--- a/run_agent.py
+++ b/run_agent.py
@@ -5140,6 +5140,7 @@ class AIAgent:
             acp_command=function_args.get("acp_command"),
             acp_args=function_args.get("acp_args"),
             role=function_args.get("role"),
+            model=function_args.get("model"),
             parent_agent=self,
         )
 

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -4345,9 +4345,15 @@ def test_detect_crashed_workers_increments_counter(kanban_home):
 def test_detect_crashed_workers_protocol_violation_auto_blocks(kanban_home):
     """A worker that exited rc=0 while its task was still ``running``
     is a protocol violation (agent answered conversationally without
-    calling kanban_complete / kanban_block). Retrying will just loop,
-    so auto-block immediately instead of waiting for the breaker to
-    trip at ``DEFAULT_FAILURE_LIMIT``.
+    calling kanban_complete / kanban_block).
+
+    The user requested consistent 2-strike behavior for ALL crash
+    types (K2), even protocol violations. So instead of auto-blocking
+    on the first occurrence, the task now transitions
+    ``running → ready`` with counter=1, and a ``protocol_violation``
+    event is recorded for the operator. The second consecutive
+    protocol violation would then trip the breaker at
+    ``DEFAULT_FAILURE_LIMIT`` (2).
 
     Regression test for the respawn-loop-after-completion bug reported
     against small local models (gemma4-e2b q4) where the model writes
@@ -4376,10 +4382,15 @@ def test_detect_crashed_workers_protocol_violation_auto_blocks(kanban_home):
 
         assert tid in result_crashed, "should be detected as crashed"
         task = kb.get_task(conn, tid)
-        assert task.status == "blocked", (
-            f"protocol violation should auto-block on first occurrence, "
+        # K2: consistent 2-strike. 1st protocol violation -> ready,
+        # counter=1. The 2nd occurrence would block. This gives the
+        # dispatcher one retry under changed conditions before
+        # paging a human.
+        assert task.status == "ready", (
+            f"protocol violation should be ready (consistent 2-strike), "
             f"got status={task.status}"
         )
+        assert task.consecutive_failures == 1
         assert "kanban_complete" in (task.last_failure_error or ""), (
             f"expected protocol-violation message, got {task.last_failure_error!r}"
         )

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -546,7 +546,18 @@ def test_stale_claim_reclaim_event_records_diagnostic_payload(
 def test_detect_crashed_workers_systemic_failure_fast_block(
     kanban_home, monkeypatch,
 ):
-    """When many tasks crash with the same error, trip the breaker faster."""
+    """When many tasks crash with the same error, the breaker still
+    follows the consistent 2-strike policy.
+
+    The original implementation used a 1-strike shortcut for systemic
+    failures (3+ same-fingerprint crashes in a tick) and protocol
+    violations. The user requested consistent 2-strike behavior for
+    ALL crash types — even when the failure pattern is clearly
+    systemic. This test now verifies the new contract: 4 tasks with
+    the same crash each transition ``running → ready`` (not
+    ``running → blocked``), counter=1, and stay in the ready queue
+    for the dispatcher's normal 2-strike cycle.
+    """
     import hermes_cli.kanban_db as _kb
 
     monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
@@ -569,8 +580,14 @@ def test_detect_crashed_workers_systemic_failure_fast_block(
 
         for tid in task_ids:
             task = kb.get_task(conn, tid)
-            assert task.status == "blocked", (
-                f"task {tid} should be blocked (systemic), got {task.status}"
+            # K2: consistent 2-strike. 1st crash -> ready, counter=1.
+            assert task.status == "ready", (
+                f"task {tid} should be ready (consistent 2-strike), "
+                f"got {task.status}"
+            )
+            assert task.consecutive_failures == 1, (
+                f"task {tid} should have counter=1, got "
+                f"{task.consecutive_failures}"
             )
 
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -2795,5 +2795,135 @@ class TestFallbackModelInheritance(unittest.TestCase):
         self.assertIsNone(kwargs["fallback_model"])
 
 
+class TestDelegateModelOverride(unittest.TestCase):
+    """Coverage for the ``model`` parameter on ``delegate_task``.
+
+    Regression for #41821 (model param silently ignored) and #41814
+    (per-task model override). The contract:
+
+      1. Schema exposes ``model`` at the top level AND per-task.
+      2. Top-level ``model`` is forwarded to ``_build_child_agent``.
+      3. Per-task ``model`` (in ``tasks[]``) beats the top-level value.
+      4. When neither is set, the child uses the config-resolved
+         delegation model (``creds["model"]``) — existing behaviour.
+      5. Whitespace-only ``model`` is treated as omitted so it can't
+         silently override a real config value with an empty string.
+    """
+
+    def test_schema_exposes_model_top_level_and_per_task(self):
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        self.assertIn("model", props, "top-level 'model' missing from schema")
+        self.assertEqual(props["model"]["type"], "string")
+
+        task_props = props["tasks"]["items"]["properties"]
+        self.assertIn("model", task_props, "per-task 'model' missing from schema")
+        self.assertEqual(task_props["model"]["type"], "string")
+
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_top_level_model_forwarded_to_child(self, mock_build, mock_run):
+        mock_build.return_value = MagicMock()
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed", "summary": "ok",
+            "api_calls": 1, "duration_seconds": 0.1,
+        }
+        parent = _make_mock_parent()
+        override = "anthropic/claude-haiku-4"
+
+        delegate_task(goal="t", model=override, parent_agent=parent)
+
+        mock_build.assert_called_once()
+        _, kwargs = mock_build.call_args
+        self.assertEqual(
+            kwargs["model"], override,
+            "top-level model= must reach _build_child_agent",
+        )
+
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_per_task_model_beats_top_level(self, mock_build, mock_run):
+        mock_build.return_value = MagicMock()
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed", "summary": "ok",
+            "api_calls": 1, "duration_seconds": 0.1,
+        }
+        parent = _make_mock_parent()
+
+        delegate_task(
+            tasks=[{"goal": "g", "model": "openrouter/x-ai/grok-4"}],
+            model="anthropic/claude-haiku-4",
+            parent_agent=parent,
+        )
+
+        _, kwargs = mock_build.call_args
+        self.assertEqual(
+            kwargs["model"], "openrouter/x-ai/grok-4",
+            "per-task model must beat top-level model",
+        )
+
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_no_model_falls_back_to_creds(self, mock_build, mock_run):
+        """When neither top-level nor per-task model is set, the child
+        must receive the config-resolved delegation model — i.e. the
+        pre-existing behaviour is preserved.
+        """
+        mock_build.return_value = MagicMock()
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed", "summary": "ok",
+            "api_calls": 1, "duration_seconds": 0.1,
+        }
+        parent = _make_mock_parent()
+
+        with patch(
+            "tools.delegate_tool._resolve_delegation_credentials",
+            return_value={
+                "model": "configured/model",
+                "provider": None,
+                "base_url": None,
+                "api_key": None,
+                "api_mode": None,
+                "command": None,
+                "args": None,
+            },
+        ):
+            delegate_task(goal="g", parent_agent=parent)
+
+        _, kwargs = mock_build.call_args
+        self.assertEqual(kwargs["model"], "configured/model")
+
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._build_child_agent")
+    def test_whitespace_model_treated_as_omitted(self, mock_build, mock_run):
+        """A whitespace-only model string must NOT clobber the configured
+        delegation model. Otherwise a model-emitted ``"model": "  "`` would
+        silently break delegation for users who rely on config-resolved
+        credentials.
+        """
+        mock_build.return_value = MagicMock()
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed", "summary": "ok",
+            "api_calls": 1, "duration_seconds": 0.1,
+        }
+        parent = _make_mock_parent()
+
+        with patch(
+            "tools.delegate_tool._resolve_delegation_credentials",
+            return_value={
+                "model": "configured/model",
+                "provider": None,
+                "base_url": None,
+                "api_key": None,
+                "api_mode": None,
+                "command": None,
+                "args": None,
+            },
+        ):
+            delegate_task(goal="g", model="   ", parent_agent=parent)
+
+        _, kwargs = mock_build.call_args
+        self.assertEqual(kwargs["model"], "configured/model")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2018,6 +2018,7 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
+    model: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -2112,7 +2113,7 @@ def delegate_task(
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
         task_list = [
-            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role}
+            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role, "model": model}
         ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
@@ -2153,12 +2154,22 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            # Per-task model beats top-level model, which beats config-resolved
+            # delegation model. Whitespace-only strings are treated as omitted
+            # so the next level can supply a value.
+            task_model_raw = t.get("model") if isinstance(t.get("model"), str) else None
+            top_model_raw = model if isinstance(model, str) else None
+            effective_model = (
+                (task_model_raw.strip() if task_model_raw else None)
+                or (top_model_raw.strip() if top_model_raw else None)
+                or creds["model"]
+            )
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
+                model=effective_model,
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
@@ -2891,6 +2902,15 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "model": {
+                            "type": "string",
+                            "description": (
+                                "Per-task model override (e.g. 'anthropic/claude-haiku-4', "
+                                "'openrouter/x-ai/grok-4'). Overrides the top-level 'model' "
+                                "for this task only. When omitted, inherits the top-level "
+                                "model or the configured delegation model."
+                            ),
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -2903,6 +2923,17 @@ DELEGATE_TASK_SCHEMA = {
                 "type": "string",
                 "enum": ["leaf", "orchestrator"],
                 "description": "(rebuilt at get_definitions() time)",
+            },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Override the model used by child agents for this call "
+                    "(e.g. 'anthropic/claude-haiku-4', 'openrouter/x-ai/grok-4'). "
+                    "Overrides the configured delegation model. Per-task 'model' "
+                    "in 'tasks[]' beats this top-level value. When omitted, "
+                    "children use delegation.model from config.yaml (or inherit "
+                    "from the parent when no delegation model is configured)."
+                ),
             },
             "acp_command": {
                 "type": "string",
@@ -2948,6 +2979,7 @@ registry.register(
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         role=args.get("role"),
+        model=args.get("model"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,


### PR DESCRIPTION
## feat(delegate+kanban): per-task model_override end-to-end

Closes the v0.16.0 gap where per-task `model` on `delegate_task` was silently
dropped (subagents always inherited the parent's model) and where kanban's
`tasks.model_override` column existed in the schema but was unreachable from
the public write API.

### What this PR does

* **`tools/delegate_tool.py`** — accept and propagate per-task and top-level
  `model` on every leaf / orchestrator child (the symptom in issue #41814).
* **`hermes_cli/kanban_db.py`** — `create_task()` now accepts `model_override`;
  dispatcher passes `-m <model>` to the spawned worker when the column is
  set; schema migration already present for older DBs.
* **`hermes_cli/kanban.py`** — public `spawn_worker` helper extracted for the
  4-profile orchestration pipeline.
* **Operator-actionable `last_failure_error`** via `kb._classify_worker_error()`
  (HTTP 429 / 401 / 400 / 413 / 404 / 410 → `rate_limited` / `auth_failed` /
  `context_overflow` / `model_unavailable`); consistent 2-strike rule
  applied uniformly across the failure matrix.

### Why now

Local testing on v0.16.0 confirmed that all four `delegate_task` call sites
ignore `model`, forcing every subagent to use the parent's model. The
kanban-side `model_override` column was a read-only dead end. This PR makes
both paths work end-to-end and makes the dispatcher error readable in one
glance.

### How it was validated

* `kpi_test_per_task_model.py` and `kpi_test_per_task_model_live.py` — verify
  the patched `delegate_task` propagates `model` to the child subprocess.
* `kpi_test_kanban_failure_handling.py` — 11/11 pass, exercises
  `_classify_worker_error()` against the full HTTP-error matrix.
* `kpi_test_scenario_dashboard.py` — 7-subagent / 4-model dashboard DAG
  (minimax-m3 / kimi-k2.7-code / glm-5.1 / deepseek-v4) on Ollama Cloud.

### Open questions / follow-ups

* Cross-provider dict shape (`{"provider": ..., "model": ...}`) for routing
  across Anthropic / Ollama Cloud in a single task — out of scope here;
  see upstream issue #41814 / PR #41826 for the feature-shape discussion.
* The 2-strike rule now applies uniformly; if you want per-task
  `max_retries` override, the `Task` dataclass already supports it.

### Commits

```
38782c621 fix(kanban): operator-actionable last_failure_error + consistent 2-strike
a6434e211 kanban: add 4-profile pipeline + public spawn helper
441fb3eea feat(kanban): expose per-task model_override on the write side
178fb4d6f fix(delegate): honor per-task and top-level model override on delegate_task
```

### Test plan for reviewers

1. `python C:\Users\andre\kpi_test_per_task_model_live.py` — exit 0.
2. `python C:\Users\andre\kpi_test_kanban_failure_handling.py` — 11/11 PASS.
3. `python C:\Users\andre\kpi_test_scenario_dashboard.py` — 4-model DAG runs.
