### PR TITLE
feat(irc): IRCv3 capability negotiation, message tags, reactions & typing notifications

### DIFF
--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -10,6 +10,7 @@ import json
 import logging
 import re
 import time
+from html.parser import HTMLParser
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict
 
@@ -175,6 +176,149 @@ _RE_INLINE_CODE = re.compile(r"`(.+?)`")
 _RE_HEADING = re.compile(r"^#{1,6}\s+", re.MULTILINE)
 _RE_LINK = re.compile(r"\[([^\]]+)\]\([^\)]+\)")
 _RE_MULTI_NEWLINE = re.compile(r"\n{3,}")
+_RE_IMAGE = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
+_RE_LINK_WITH_URL = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+_RE_AUTOLINK = re.compile(r"<((?:https?|mailto):[^>\s]+)>")
+_RE_STRIKE = re.compile(r"~~(.+?)~~", re.DOTALL)
+_RE_BULLET = re.compile(r"^[ \t]*[-*+]\s+", re.MULTILINE)
+_RE_ORDERED_LIST = re.compile(r"^[ \t]*\d+[.)]\s+", re.MULTILINE)
+
+
+class _MarkdownPlainTextExtractor(HTMLParser):
+    """Extract readable plain text from Markdown-generated HTML."""
+
+    _BLOCK_TAGS = {
+        "address", "article", "aside", "blockquote", "br", "div", "dl",
+        "fieldset", "figcaption", "figure", "footer", "form", "h1", "h2",
+        "h3", "h4", "h5", "h6", "header", "hr", "li", "main", "nav", "ol",
+        "p", "pre", "section", "table", "tbody", "td", "tfoot", "th", "thead",
+        "tr", "ul",
+    }
+    _PARAGRAPH_TAGS = {"p", "pre"}
+
+    def __init__(self, *, preserve_urls: bool = False):
+        super().__init__(convert_charrefs=True)
+        self.preserve_urls = preserve_urls
+        self._parts: list[str] = []
+        self._skip_depth = 0
+        self._anchor_href: str | None = None
+        self._anchor_text: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs) -> None:
+        tag = tag.lower()
+        if tag in {"script", "style"}:
+            self._skip_depth += 1
+            return
+        if self._skip_depth:
+            return
+
+        attrs_dict = {str(k).lower(): str(v) for k, v in attrs if v is not None}
+        if tag in self._BLOCK_TAGS:
+            self._newline()
+        if tag == "li":
+            self._append("• ")
+        elif tag == "a":
+            self._anchor_href = attrs_dict.get("href")
+            self._anchor_text = []
+        elif tag == "img":
+            src = attrs_dict.get("src", "")
+            alt = attrs_dict.get("alt", "")
+            if self.preserve_urls and src:
+                self._append(src)
+            elif alt:
+                self._append(alt)
+
+    def handle_startendtag(self, tag: str, attrs) -> None:
+        self.handle_starttag(tag, attrs)
+
+    def handle_endtag(self, tag: str) -> None:
+        tag = tag.lower()
+        if tag in {"script", "style"} and self._skip_depth:
+            self._skip_depth -= 1
+            return
+        if self._skip_depth:
+            return
+
+        if tag == "a":
+            href = self._anchor_href
+            label = "".join(self._anchor_text).strip()
+            if (
+                self.preserve_urls
+                and href
+                and label
+                and href.strip() != label
+            ):
+                self._append(f" ({href.strip()})")
+            self._anchor_href = None
+            self._anchor_text = []
+        if tag in self._PARAGRAPH_TAGS:
+            self._newline(blank=True)
+        elif tag in self._BLOCK_TAGS:
+            self._newline()
+
+    def handle_data(self, data: str) -> None:
+        if self._skip_depth:
+            return
+        if not data.strip() and "\n" in data:
+            return
+        self._append(data)
+        if self._anchor_href is not None:
+            self._anchor_text.append(data)
+
+    def text(self) -> str:
+        text = "".join(self._parts)
+        text = re.sub(r"[ \t]+\n", "\n", text)
+        text = re.sub(r"\n[ \t]+", "\n", text)
+        text = re.sub(r"[ \t]{2,}", " ", text)
+        text = _RE_MULTI_NEWLINE.sub("\n\n", text)
+        return text.strip()
+
+    def _append(self, text: str) -> None:
+        if text:
+            self._parts.append(text)
+
+    def _newline(self, *, blank: bool = False) -> None:
+        if not self._parts:
+            return
+        current = "".join(self._parts)
+        if blank:
+            if current.endswith("\n\n"):
+                return
+            if current.endswith("\n"):
+                self._parts.append("\n")
+            else:
+                self._parts.append("\n\n")
+            return
+        if current.endswith("\n"):
+            return
+        self._parts.append("\n")
+
+
+def _regex_strip_markdown(text: str, *, preserve_urls: bool = False) -> str:
+    """Regex fallback for environments where Python-Markdown is unavailable."""
+    text = re.sub(
+        r"```[a-zA-Z0-9_+-]*\n?([\s\S]*?)```",
+        lambda m: m.group(1).rstrip("\n"),
+        text,
+    )
+    text = _RE_INLINE_CODE.sub(r"\1", text)
+    text = _RE_AUTOLINK.sub(r"\1", text)
+    if preserve_urls:
+        text = _RE_IMAGE.sub(lambda m: m.group(2), text)
+        text = _RE_LINK_WITH_URL.sub(lambda m: f"{m.group(1)} ({m.group(2)})", text)
+    else:
+        text = _RE_IMAGE.sub(lambda m: m.group(1) or m.group(2), text)
+        text = _RE_LINK_WITH_URL.sub(r"\1", text)
+    text = _RE_BOLD.sub(r"\1", text)
+    text = _RE_ITALIC_STAR.sub(r"\1", text)
+    text = _RE_BOLD_UNDER.sub(r"\1", text)
+    text = _RE_ITALIC_UNDER.sub(r"\1", text)
+    text = _RE_STRIKE.sub(r"\1", text)
+    text = _RE_HEADING.sub("", text)
+    text = _RE_BULLET.sub("• ", text)
+    text = _RE_ORDERED_LIST.sub("", text)
+    text = _RE_MULTI_NEWLINE.sub("\n\n", text)
+    return text.strip()
 
 
 def strip_markdown(text: str) -> str:
@@ -183,16 +327,36 @@ def strip_markdown(text: str) -> str:
     Replaces the identical ``_strip_markdown()`` functions previously
     duplicated in sms.py, bluebubbles.py, and feishu.py.
     """
-    text = _RE_BOLD.sub(r"\1", text)
-    text = _RE_ITALIC_STAR.sub(r"\1", text)
-    text = _RE_BOLD_UNDER.sub(r"\1", text)
-    text = _RE_ITALIC_UNDER.sub(r"\1", text)
-    text = _RE_CODE_BLOCK.sub("", text)
-    text = _RE_INLINE_CODE.sub(r"\1", text)
-    text = _RE_HEADING.sub("", text)
-    text = _RE_LINK.sub(r"\1", text)
-    text = _RE_MULTI_NEWLINE.sub("\n\n", text)
-    return text.strip()
+    return strip_markdown_preserving_urls(text, preserve_urls=False)
+
+
+def strip_markdown_preserving_urls(text: str, *, preserve_urls: bool = True) -> str:
+    """Convert Markdown to readable plain text.
+
+    Uses Python-Markdown plus a small HTML text extractor when available, so
+    fenced code blocks, tables, inline HTML, nested emphasis, images, and
+    links are handled by a real Markdown parser.  The regex path is only a
+    fallback for unusual runtime environments.
+    """
+    if not text:
+        return text
+
+    try:
+        import markdown as _markdown
+
+        text = _RE_STRIKE.sub(r"\1", text)
+        html = _markdown.markdown(
+            text,
+            extensions=["fenced_code", "sane_lists", "tables"],
+            output_format="html",
+        )
+        parser = _MarkdownPlainTextExtractor(preserve_urls=preserve_urls)
+        parser.feed(html)
+        parser.close()
+        return parser.text()
+    except Exception:
+        logger.debug("Markdown parser unavailable; using regex fallback", exc_info=True)
+        return _regex_strip_markdown(text, preserve_urls=preserve_urls)
 
 
 # ─── Thread Participation Tracking ───────────────────────────────────────────

--- a/plugins/platforms/irc/adapter.py
+++ b/plugins/platforms/irc/adapter.py
@@ -21,10 +21,13 @@ Configuration in config.yaml::
             nickserv_password: ""     # optional NickServ identification
             allowed_users: []         # empty = allow all, or list of nicks
             max_message_length: 450   # IRC line limit (safe default)
+            ircv3: true               # request IRCv3 capabilities
+            reactions: true           # send IRCv3 draft reactions when allowed
 
 Or via environment variables (overrides config.yaml):
     IRC_SERVER, IRC_PORT, IRC_NICKNAME, IRC_CHANNEL, IRC_USE_TLS,
-    IRC_SERVER_PASSWORD, IRC_NICKSERV_PASSWORD
+    IRC_SERVER_PASSWORD, IRC_NICKSERV_PASSWORD, IRC_IRCV3,
+    IRC_IRCV3_CAPS, IRC_REACTIONS
 """
 
 import asyncio
@@ -33,6 +36,8 @@ import os
 import re
 import ssl
 import time
+from collections import OrderedDict
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -48,21 +53,136 @@ from gateway.platforms.base import (
     SendResult,
     MessageEvent,
     MessageType,
+    ProcessingOutcome,
 )
 from gateway.config import Platform
+from gateway.platforms.helpers import strip_markdown_preserving_urls
 
 
 # ---------------------------------------------------------------------------
 # IRC protocol helpers
 # ---------------------------------------------------------------------------
 
+_DEFAULT_IRCV3_CAPS = (
+    "message-tags",
+    "server-time",
+    "batch",
+    "invite-notify",
+    "echo-message",
+)
+
+_TAG_UNESCAPE = {
+    ":": ";",
+    "s": " ",
+    "\\": "\\",
+    "r": "\r",
+    "n": "\n",
+}
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _coerce_bool(value: Any, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _split_words(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [item for item in re.split(r"[\s,]+", value.strip()) if item]
+    if isinstance(value, (list, tuple, set)):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return []
+
+
+def _unescape_tag_value(value: str) -> str:
+    """Decode IRCv3 message-tag escapes."""
+    out: list[str] = []
+    i = 0
+    while i < len(value):
+        ch = value[i]
+        if ch != "\\":
+            out.append(ch)
+            i += 1
+            continue
+        i += 1
+        if i >= len(value):
+            break
+        out.append(_TAG_UNESCAPE.get(value[i], value[i]))
+        i += 1
+    return "".join(out)
+
+
+def _escape_tag_value(value: str) -> str:
+    """Encode an IRCv3 message-tag value."""
+    return (
+        str(value)
+        .replace("\\", "\\\\")
+        .replace(";", "\\:")
+        .replace(" ", "\\s")
+        .replace("\r", "\\r")
+        .replace("\n", "\\n")
+    )
+
+
+def _parse_irc_tags(raw_tags: str) -> Dict[str, Optional[str]]:
+    """Parse an IRCv3 message-tag section into an opaque key/value mapping."""
+    tags: Dict[str, Optional[str]] = {}
+    for item in raw_tags.split(";"):
+        if not item:
+            continue
+        if "=" in item:
+            key, value = item.split("=", 1)
+            tags[key] = _unescape_tag_value(value) if value else None
+        else:
+            tags[item] = None
+    return tags
+
+
+def _format_irc_tags(tags: Dict[str, Optional[str]]) -> str:
+    """Format IRCv3 message tags without the leading ``@``."""
+    parts: list[str] = []
+    for key, value in tags.items():
+        if not key or any(ch in key for ch in " ;\r\n\x00"):
+            continue
+        if value is None:
+            parts.append(key)
+        else:
+            parts.append(f"{key}={_escape_tag_value(value)}")
+    return ";".join(parts)
+
+
+def _cap_name(token: str) -> str:
+    return token.split("=", 1)[0].lower()
+
+
 def _parse_irc_message(raw: str) -> dict:
     """Parse a raw IRC protocol line into components.
 
-    Returns dict with keys: prefix, command, params.
+    Returns dict with keys: tags, prefix, command, params.
     """
+    tags: Dict[str, Optional[str]] = {}
     prefix = ""
     trailing = ""
+
+    if raw.startswith("@"):
+        try:
+            raw_tags, raw = raw[1:].split(" ", 1)
+            tags = _parse_irc_tags(raw_tags)
+        except ValueError:
+            return {"tags": _parse_irc_tags(raw[1:]), "prefix": "", "command": "", "params": []}
 
     if raw.startswith(":"):
         try:
@@ -80,7 +200,7 @@ def _parse_irc_message(raw: str) -> dict:
     if trailing:
         params.append(trailing)
 
-    return {"prefix": prefix, "command": command, "params": params}
+    return {"tags": tags, "prefix": prefix, "command": command, "params": params}
 
 
 def _extract_nick(prefix: str) -> str:
@@ -116,10 +236,41 @@ class IRCAdapter(BasePlatformAdapter):
         self.use_tls = (
             os.getenv("IRC_USE_TLS", "").lower() in {"1", "true", "yes"}
             if os.getenv("IRC_USE_TLS")
-            else extra.get("use_tls", True)
+            else _coerce_bool(extra.get("use_tls"), True)
         )
         self.server_password = os.getenv("IRC_SERVER_PASSWORD") or extra.get("server_password", "")
         self.nickserv_password = os.getenv("IRC_NICKSERV_PASSWORD") or extra.get("nickserv_password", "")
+
+        # IRCv3 support.  Capabilities are requested opportunistically and
+        # every feature below checks the server's ACKs before sending tags.
+        self.ircv3_enabled = _env_bool("IRC_IRCV3", _coerce_bool(extra.get("ircv3"), True))
+        caps_override = os.getenv("IRC_IRCV3_CAPS")
+        if caps_override is not None:
+            self._desired_caps = tuple(_cap_name(cap) for cap in _split_words(caps_override))
+        else:
+            configured_caps = _split_words(extra.get("ircv3_caps"))
+            self._desired_caps = tuple(
+                _cap_name(cap) for cap in (configured_caps or _DEFAULT_IRCV3_CAPS)
+            )
+        if not self.ircv3_enabled:
+            self._desired_caps = ()
+
+        self._server_caps: Dict[str, Optional[str]] = {}
+        self._enabled_caps: set[str] = set()
+        self._cap_negotiating = False
+        self._cap_req_pending = False
+        self._clienttagdeny: Optional[str] = None
+
+        self.reactions_enabled = _env_bool(
+            "IRC_REACTIONS",
+            _coerce_bool(extra.get("reactions"), True),
+        )
+        try:
+            self._recent_message_limit = int(extra.get("recent_message_limit", 500))
+        except (TypeError, ValueError):
+            self._recent_message_limit = 500
+        self._recent_messages: OrderedDict[str, str] = OrderedDict()
+        self._last_typing_notice: Dict[str, float] = {}
 
         # Auth
         self.allowed_users: list = extra.get("allowed_users", [])
@@ -189,9 +340,14 @@ class IRCAdapter(BasePlatformAdapter):
             self._set_fatal_error("connect_failed", str(e), retryable=True)
             return False
 
-        # IRC registration sequence
+        # IRC registration sequence. PASS stays first for networks that
+        # require it, then IRCv3 capability negotiation starts before NICK/USER
+        # so servers can pause registration until CAP END.
         if self.server_password:
-            await self._send_raw(f"PASS {self.server_password}")
+            await self._send_raw(f"PASS {_strip_irc_control_chars(self.server_password)}")
+        if self._desired_caps:
+            self._cap_negotiating = True
+            await self._send_raw("CAP LS 302")
         await self._send_raw(f"NICK {self.nickname}")
         await self._send_raw(f"USER {self.nickname} 0 * :Hermes Agent")
 
@@ -209,7 +365,9 @@ class IRCAdapter(BasePlatformAdapter):
 
         # NickServ identification
         if self.nickserv_password:
-            await self._send_raw(f"PRIVMSG NickServ :IDENTIFY {self.nickserv_password}")
+            await self._send_raw(
+                f"PRIVMSG NickServ :IDENTIFY {_strip_irc_control_chars(self.nickserv_password)}"
+            )
             await asyncio.sleep(2)  # Give NickServ time to process
 
         # Join channel
@@ -252,6 +410,12 @@ class IRCAdapter(BasePlatformAdapter):
         self._writer = None
         self._registered = False
         self._registration_event.clear()
+        self._server_caps.clear()
+        self._enabled_caps.clear()
+        self._cap_negotiating = False
+        self._cap_req_pending = False
+        self._clienttagdeny = None
+        self._last_typing_notice.clear()
 
     # ── Sending ───────────────────────────────────────────────────────────
 
@@ -266,11 +430,15 @@ class IRCAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         target = chat_id  # channel name or nick for DMs
+        if not _is_safe_irc_target(target):
+            return SendResult(success=False, error="Invalid IRC target")
+
         lines = self._split_message(content, target)
+        base_tags = self._outbound_message_tags(reply_to=reply_to, metadata=metadata)
 
         for line in lines:
             try:
-                await self._send_raw(f"PRIVMSG {target} :{line}")
+                await self._send_tagged("PRIVMSG", target, trailing=line, tags=base_tags)
                 # Basic rate limiting to avoid excess flood
                 await asyncio.sleep(0.3)
             except Exception as e:
@@ -279,8 +447,8 @@ class IRCAdapter(BasePlatformAdapter):
         return SendResult(success=True, message_id=str(int(time.time() * 1000)))
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
-        """IRC has no typing indicator — no-op."""
-        pass
+        """Send an IRCv3 typing notification when negotiated."""
+        await self._send_typing_tag(chat_id, "active")
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         is_channel = chat_id.startswith("#") or chat_id.startswith("&")
@@ -288,6 +456,161 @@ class IRCAdapter(BasePlatformAdapter):
             "name": chat_id,
             "type": "group" if is_channel else "dm",
         }
+
+    async def on_processing_start(self, event: MessageEvent) -> None:
+        """React to the triggering message when IRCv3 reactions are available."""
+        await self._send_reaction(event, "👀")
+
+    async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
+        """Finalize typing/reaction state for IRCv3-aware clients."""
+        source = getattr(event, "source", None)
+        chat_id = getattr(source, "chat_id", None)
+        if chat_id:
+            await self._send_typing_tag(chat_id, "done", force=True)
+
+        if outcome == ProcessingOutcome.CANCELLED:
+            await self._send_reaction(event, "👀", unreact=True)
+        elif outcome == ProcessingOutcome.SUCCESS:
+            await self._send_reaction(event, "👀", unreact=True)
+            await self._send_reaction(event, "✅")
+        elif outcome == ProcessingOutcome.FAILURE:
+            await self._send_reaction(event, "👀", unreact=True)
+            await self._send_reaction(event, "❌")
+
+    # ── IRCv3 helpers ────────────────────────────────────────────────────
+
+    def _message_tags_enabled(self) -> bool:
+        return "message-tags" in self._enabled_caps
+
+    def _client_tag_allowed(self, tag_name: str) -> bool:
+        """Return True if CLIENTTAGDENY allows a client-only tag."""
+        name = tag_name[1:] if tag_name.startswith("+") else tag_name
+        deny = self._clienttagdeny
+        if deny is None or deny == "":
+            return True
+
+        parts = [part for part in deny.split(",") if part]
+        if not parts:
+            return True
+        if parts[0] == "*":
+            return f"-{name}" in parts
+        return name not in {part[1:] if part.startswith("-") else part for part in parts}
+
+    def _reply_tag_name(self) -> Optional[str]:
+        # +reply is the registered IRCv3 tag; +draft/reply is accepted for
+        # networks/clients experimenting with the draft name mentioned by
+        # Libera.Chat's 2026 feature note.
+        for tag in ("+reply", "+draft/reply"):
+            if self._client_tag_allowed(tag):
+                return tag
+        return None
+
+    def _outbound_message_tags(
+        self,
+        *,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Optional[str]]:
+        tags: Dict[str, Optional[str]] = {}
+        if not self._message_tags_enabled():
+            return tags
+
+        reply_id = reply_to or (metadata or {}).get("reply_to_message_id")
+        if reply_id:
+            reply_tag = self._reply_tag_name()
+            if reply_tag:
+                tags[reply_tag] = str(reply_id)
+
+        channel_context = (metadata or {}).get("irc_channel_context")
+        if (
+            channel_context
+            and _is_irc_channel(str(channel_context))
+            and self._client_tag_allowed("+draft/channel-context")
+        ):
+            tags["+draft/channel-context"] = str(channel_context)
+        return tags
+
+    def _reactions_available(self) -> bool:
+        return (
+            self.reactions_enabled
+            and self._message_tags_enabled()
+            and self._reply_tag_name() is not None
+            and self._client_tag_allowed("+draft/react")
+        )
+
+    async def _send_reaction(
+        self,
+        event: MessageEvent,
+        emoji: str,
+        *,
+        unreact: bool = False,
+    ) -> None:
+        if not self._reactions_available():
+            return
+        message_id = getattr(event, "message_id", None)
+        source = getattr(event, "source", None)
+        target = getattr(source, "chat_id", None)
+        if not message_id or not target or not _is_safe_irc_target(str(target)):
+            return
+
+        reaction_tag = "+draft/unreact" if unreact else "+draft/react"
+        if not self._client_tag_allowed(reaction_tag):
+            return
+        reply_tag = self._reply_tag_name()
+        if not reply_tag:
+            return
+        await self._send_tagged(
+            "TAGMSG",
+            str(target),
+            tags={reply_tag: str(message_id), reaction_tag: emoji},
+        )
+
+    async def _send_typing_tag(
+        self,
+        target: str,
+        state: str,
+        *,
+        force: bool = False,
+    ) -> None:
+        if (
+            not self._message_tags_enabled()
+            or not self._client_tag_allowed("+typing")
+            or not _is_safe_irc_target(target)
+        ):
+            return
+        if state not in {"active", "paused", "done"}:
+            return
+        now = time.monotonic()
+        last = self._last_typing_notice.get(target, 0.0)
+        if not force and now - last < 3.0:
+            return
+        self._last_typing_notice[target] = now
+        await self._send_tagged("TAGMSG", target, tags={"+typing": state})
+
+    async def _send_tagged(
+        self,
+        command: str,
+        target: str,
+        *,
+        trailing: Optional[str] = None,
+        tags: Optional[Dict[str, Optional[str]]] = None,
+    ) -> None:
+        line = f"{command} {target}"
+        if trailing is not None:
+            line += f" :{_strip_irc_control_chars(trailing)}"
+        if tags and self._message_tags_enabled():
+            tag_text = _format_irc_tags(tags)
+            if tag_text:
+                line = f"@{tag_text} {line}"
+        await self._send_raw(line)
+
+    def _remember_message(self, message_id: Optional[str], text: str) -> None:
+        if not message_id:
+            return
+        self._recent_messages[str(message_id)] = text
+        self._recent_messages.move_to_end(str(message_id))
+        while len(self._recent_messages) > self._recent_message_limit:
+            self._recent_messages.popitem(last=False)
 
     # ── Message splitting ─────────────────────────────────────────────────
 
@@ -306,6 +629,7 @@ class IRCAdapter(BasePlatformAdapter):
 
         lines: List[str] = []
         for paragraph in content.split("\n"):
+            paragraph = _strip_irc_control_chars(paragraph).rstrip()
             if not paragraph.strip():
                 continue
             while True:
@@ -337,22 +661,9 @@ class IRCAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _strip_markdown(text: str) -> str:
-        """Convert basic markdown to plain text for IRC."""
-        # Bold: **text** or __text__ → text
-        text = re.sub(r"\*\*(.+?)\*\*", r"\1", text)
-        text = re.sub(r"__(.+?)__", r"\1", text)
-        # Italic: *text* or _text_ → text
-        text = re.sub(r"\*(.+?)\*", r"\1", text)
-        text = re.sub(r"(?<!\w)_(.+?)_(?!\w)", r"\1", text)
-        # Inline code: `text` → text
-        text = re.sub(r"`(.+?)`", r"\1", text)
-        # Code blocks: ```...``` → content
-        text = re.sub(r"```\w*\n?", "", text)
-        # Images: ![alt](url) → url  (must come BEFORE links)
-        text = re.sub(r"!\[([^\]]*)\]\(([^)]+)\)", r"\2", text)
-        # Links: [text](url) → text (url)
-        text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"\1 (\2)", text)
-        return text
+        """Convert Markdown to plain text for IRC while keeping URLs visible."""
+        text = text.replace("\r", " ").replace("\x00", "")
+        return strip_markdown_preserving_urls(text, preserve_urls=True)
 
     # ── Raw IRC I/O ──────────────────────────────────────────────────────
 
@@ -360,6 +671,7 @@ class IRCAdapter(BasePlatformAdapter):
         """Send a raw IRC protocol line."""
         if not self._writer or self._writer.is_closing():
             return
+        line = _strip_irc_control_chars(line)
         encoded = (line + "\r\n").encode("utf-8")
         self._writer.write(encoded)
         await self._writer.drain()
@@ -393,8 +705,9 @@ class IRCAdapter(BasePlatformAdapter):
     async def _handle_line(self, raw: str) -> None:
         """Dispatch a single IRC protocol line."""
         msg = _parse_irc_message(raw)
-        command = msg["command"]
+        command = msg["command"].upper()
         params = msg["params"]
+        tags = msg.get("tags", {})
 
         # PING/PONG keepalive
         if command == "PING":
@@ -402,13 +715,29 @@ class IRCAdapter(BasePlatformAdapter):
             await self._send_raw(f"PONG :{payload}")
             return
 
+        if command == "CAP":
+            await self._handle_cap(msg)
+            return
+
+        # RPL_ISUPPORT — parse CLIENTTAGDENY so we only emit client tags the
+        # server says it will relay.
+        if command == "005":
+            self._handle_isupport(params)
+            return
+
         # RPL_WELCOME (001) — registration complete
         if command == "001":
             self._registered = True
+            self._cap_negotiating = False
             self._registration_event.set()
             if params:
                 # Server may confirm our nick in the first param
                 self._current_nick = params[0]
+            return
+
+        # IRCv3 batch/invite notifications are useful to clients with a UI, but
+        # they are not user text for Hermes.  Consume them quietly.
+        if command in {"BATCH", "INVITE", "TAGMSG"}:
             return
 
         # ERR_NICKNAMEINUSE (433) — nick collision during registration
@@ -431,6 +760,16 @@ class IRCAdapter(BasePlatformAdapter):
             sender_nick = _extract_nick(msg["prefix"])
             target = params[0]
             text = params[1]
+            message_id = tags.get("msgid") or str(int(time.time() * 1000))
+            reply_to_id = (
+                tags.get("+reply")
+                or tags.get("+draft/reply")
+                or tags.get("reply")
+                or tags.get("draft/reply")
+            )
+            timestamp = self._parse_server_time(tags.get("time"))
+
+            self._remember_message(message_id, text)
 
             # Ignore our own messages
             if sender_nick.lower() == self._current_nick.lower():
@@ -472,12 +811,101 @@ class IRCAdapter(BasePlatformAdapter):
                 chat_type=chat_type,
                 user_id=sender_nick,
                 user_name=sender_nick,
+                raw_message=msg,
+                message_id=message_id,
+                timestamp=timestamp,
+                reply_to_message_id=reply_to_id,
+                reply_to_text=self._recent_messages.get(str(reply_to_id)) if reply_to_id else None,
             )
 
         # NICK — track our own nick changes
         if command == "NICK" and _extract_nick(msg["prefix"]).lower() == self._current_nick.lower():
             if params:
                 self._current_nick = params[0]
+
+    async def _handle_cap(self, msg: dict) -> None:
+        params = msg.get("params", [])
+        if len(params) < 2:
+            return
+        subcmd = str(params[1]).upper()
+        rest = params[2:]
+
+        if subcmd == "LS":
+            continuation = bool(rest and rest[0] == "*")
+            cap_text = rest[-1] if rest else ""
+            for token in _split_words(cap_text):
+                name = _cap_name(token)
+                value = token.split("=", 1)[1] if "=" in token else None
+                self._server_caps[name] = value
+            if not continuation:
+                await self._finish_cap_ls()
+            return
+
+        if subcmd == "ACK":
+            for token in _split_words(rest[-1] if rest else ""):
+                self._enabled_caps.add(_cap_name(token))
+            self._cap_req_pending = False
+            if self._cap_negotiating:
+                await self._send_raw("CAP END")
+                self._cap_negotiating = False
+            return
+
+        if subcmd == "NAK":
+            self._cap_req_pending = False
+            if self._cap_negotiating:
+                await self._send_raw("CAP END")
+                self._cap_negotiating = False
+            return
+
+        if subcmd == "NEW":
+            newly_available: list[str] = []
+            for token in _split_words(rest[-1] if rest else ""):
+                name = _cap_name(token)
+                value = token.split("=", 1)[1] if "=" in token else None
+                self._server_caps[name] = value
+                if name in self._desired_caps and name not in self._enabled_caps:
+                    newly_available.append(name)
+            if newly_available and not self._cap_req_pending:
+                self._cap_req_pending = True
+                await self._send_raw(f"CAP REQ :{' '.join(sorted(newly_available))}")
+            return
+
+        if subcmd == "DEL":
+            for token in _split_words(rest[-1] if rest else ""):
+                self._enabled_caps.discard(_cap_name(token))
+
+    async def _finish_cap_ls(self) -> None:
+        requested = [
+            cap for cap in self._desired_caps
+            if cap in self._server_caps and cap not in self._enabled_caps
+        ]
+        if requested:
+            self._cap_req_pending = True
+            await self._send_raw(f"CAP REQ :{' '.join(requested)}")
+        else:
+            await self._send_raw("CAP END")
+            self._cap_negotiating = False
+
+    def _handle_isupport(self, params: list[str]) -> None:
+        for param in params[1:]:
+            if param == "CLIENTTAGDENY":
+                self._clienttagdeny = ""
+            elif param.startswith("CLIENTTAGDENY="):
+                self._clienttagdeny = param.split("=", 1)[1]
+
+    @staticmethod
+    def _parse_server_time(value: Optional[str]) -> datetime:
+        if not value:
+            return datetime.now()
+        try:
+            if value.endswith("Z"):
+                return datetime.fromisoformat(value[:-1] + "+00:00")
+            parsed = datetime.fromisoformat(value)
+            if parsed.tzinfo is None:
+                return parsed.replace(tzinfo=timezone.utc)
+            return parsed
+        except ValueError:
+            return datetime.now()
 
     async def _dispatch_message(
         self,
@@ -486,6 +914,11 @@ class IRCAdapter(BasePlatformAdapter):
         chat_type: str,
         user_id: str,
         user_name: str,
+        raw_message: Optional[dict] = None,
+        message_id: Optional[str] = None,
+        timestamp: Optional[datetime] = None,
+        reply_to_message_id: Optional[str] = None,
+        reply_to_text: Optional[str] = None,
     ) -> None:
         """Build a MessageEvent and hand it to the base class handler."""
         if not self._message_handler:
@@ -503,8 +936,11 @@ class IRCAdapter(BasePlatformAdapter):
             text=text,
             message_type=MessageType.TEXT,
             source=source,
-            message_id=str(int(time.time() * 1000)),
-            timestamp=__import__("datetime").datetime.now(),
+            raw_message=raw_message,
+            message_id=message_id or str(int(time.time() * 1000)),
+            reply_to_message_id=reply_to_message_id,
+            reply_to_text=reply_to_text,
+            timestamp=timestamp or datetime.now(),
         )
 
         await self.handle_message(event)
@@ -716,6 +1152,10 @@ def _is_irc_channel(target: str) -> bool:
     return bool(target) and target[0] in "#&+!"
 
 
+def _is_safe_irc_target(target: str) -> bool:
+    return bool(target) and not any(ch in target for ch in ("\r", "\n", "\x00", " ", "\t"))
+
+
 async def _standalone_send(
     pconfig,
     chat_id: str,
@@ -760,7 +1200,7 @@ async def _standalone_send(
     if use_tls_env is not None:
         use_tls = use_tls_env.lower() in {"1", "true", "yes"}
     else:
-        use_tls = bool(extra.get("use_tls", True))
+        use_tls = _coerce_bool(extra.get("use_tls"), True)
 
     server_password = os.getenv("IRC_SERVER_PASSWORD") or extra.get("server_password", "")
     nickserv_password = os.getenv("IRC_NICKSERV_PASSWORD") or extra.get("nickserv_password", "")

--- a/plugins/platforms/irc/plugin.yaml
+++ b/plugins/platforms/irc/plugin.yaml
@@ -52,3 +52,15 @@ optional_env:
     description: "Channel for cron / notification delivery (defaults to IRC_CHANNEL)"
     prompt: "Home channel (or empty)"
     password: false
+  - name: IRC_IRCV3
+    description: "Enable IRCv3 capability negotiation (default: true)"
+    prompt: "Enable IRCv3? (true/false)"
+    password: false
+  - name: IRC_IRCV3_CAPS
+    description: "Comma-separated IRCv3 capabilities to request (default: message-tags, server-time, batch, invite-notify, echo-message)"
+    prompt: "IRCv3 capabilities (or empty for default)"
+    password: false
+  - name: IRC_REACTIONS
+    description: "Send IRCv3 draft reactions for processing status when supported (default: true)"
+    prompt: "Enable IRCv3 reactions? (true/false)"
+    password: false

--- a/tests/gateway/test_irc_adapter.py
+++ b/tests/gateway/test_irc_adapter.py
@@ -12,8 +12,11 @@ from tests.gateway._plugin_adapter_loader import load_plugin_adapter
 _irc_mod = load_plugin_adapter("irc")
 
 _parse_irc_message = _irc_mod._parse_irc_message
+_format_irc_tags = _irc_mod._format_irc_tags
 _extract_nick = _irc_mod._extract_nick
 IRCAdapter = _irc_mod.IRCAdapter
+MessageEvent = _irc_mod.MessageEvent
+ProcessingOutcome = _irc_mod.ProcessingOutcome
 check_requirements = _irc_mod.check_requirements
 validate_config = _irc_mod.validate_config
 register = _irc_mod.register
@@ -49,6 +52,22 @@ class TestIRCProtocolHelpers:
 
     def test_extract_nick_bare(self):
         assert _extract_nick("server.example.com") == "server.example.com"
+
+    def test_parse_ircv3_tags(self):
+        msg = _parse_irc_message(
+            "@time=2026-02-11T10:20:30.123Z;msgid=abc\\:def;+reply=old\\sid "
+            ":nick!user@host PRIVMSG #channel :Hello world"
+        )
+        assert msg["tags"]["time"] == "2026-02-11T10:20:30.123Z"
+        assert msg["tags"]["msgid"] == "abc;def"
+        assert msg["tags"]["+reply"] == "old id"
+        assert msg["prefix"] == "nick!user@host"
+        assert msg["command"] == "PRIVMSG"
+
+    def test_format_ircv3_tags_escapes_values(self):
+        assert _format_irc_tags({"+reply": "old id", "+draft/react": "semi;colon"}) == (
+            "+reply=old\\sid;+draft/react=semi\\:colon"
+        )
 
 
 # ── IRC Adapter ──────────────────────────────────────────────────────────
@@ -151,6 +170,77 @@ class TestIRCAdapterSend:
         assert b"PRIVMSG #test :hello world" in sent_data
 
     @pytest.mark.asyncio
+    async def test_send_uses_reply_tag_when_message_tags_enabled(self, adapter):
+        writer = MagicMock()
+        writer.is_closing = MagicMock(return_value=False)
+        writer.write = MagicMock()
+        writer.drain = AsyncMock()
+        adapter._writer = writer
+        adapter._enabled_caps.add("message-tags")
+
+        result = await adapter.send("#test", "hello world", reply_to="msg 123")
+
+        assert result.success is True
+        sent_data = writer.write.call_args[0][0].decode("utf-8")
+        assert sent_data.startswith("@+reply=msg\\s123 PRIVMSG #test :hello world")
+
+    @pytest.mark.asyncio
+    async def test_send_skips_reply_tag_when_clienttagdeny_blocks_it(self, adapter):
+        writer = MagicMock()
+        writer.is_closing = MagicMock(return_value=False)
+        writer.write = MagicMock()
+        writer.drain = AsyncMock()
+        adapter._writer = writer
+        adapter._enabled_caps.add("message-tags")
+        adapter._clienttagdeny = "*,-typing"
+
+        result = await adapter.send("#test", "hello world", reply_to="msg123")
+
+        assert result.success is True
+        sent_data = writer.write.call_args[0][0].decode("utf-8")
+        assert sent_data == "PRIVMSG #test :hello world\r\n"
+
+    @pytest.mark.asyncio
+    async def test_send_typing_uses_ircv3_typing_tag(self, adapter):
+        writer = MagicMock()
+        writer.is_closing = MagicMock(return_value=False)
+        writer.write = MagicMock()
+        writer.drain = AsyncMock()
+        adapter._writer = writer
+        adapter._enabled_caps.add("message-tags")
+
+        await adapter.send_typing("#test")
+
+        sent_data = writer.write.call_args[0][0].decode("utf-8")
+        assert sent_data == "@+typing=active TAGMSG #test\r\n"
+
+    @pytest.mark.asyncio
+    async def test_processing_reactions_use_draft_react_tags(self, adapter):
+        writer = MagicMock()
+        writer.is_closing = MagicMock(return_value=False)
+        writer.write = MagicMock()
+        writer.drain = AsyncMock()
+        adapter._writer = writer
+        adapter._enabled_caps.add("message-tags")
+        source = adapter.build_source(
+            chat_id="#test",
+            chat_name="#test",
+            chat_type="group",
+            user_id="user",
+            user_name="user",
+        )
+        event = MessageEvent(text="hello", source=source, message_id="msg123")
+
+        await adapter.on_processing_start(event)
+        await adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+        sent_lines = b"".join(call.args[0] for call in writer.write.call_args_list).decode("utf-8").splitlines()
+        assert "@+reply=msg123;+draft/react=👀 TAGMSG #test" in sent_lines
+        assert "@+typing=done TAGMSG #test" in sent_lines
+        assert "@+reply=msg123;+draft/unreact=👀 TAGMSG #test" in sent_lines
+        assert "@+reply=msg123;+draft/react=✅ TAGMSG #test" in sent_lines
+
+    @pytest.mark.asyncio
     async def test_send_splits_long_messages(self, adapter):
         writer = MagicMock()
         writer.is_closing = MagicMock(return_value=False)
@@ -209,6 +299,46 @@ class TestIRCAdapterMessageParsing:
         assert adapter._registration_event.is_set()
 
     @pytest.mark.asyncio
+    async def test_cap_ls_requests_supported_ircv3_caps(self, adapter):
+        writer = MagicMock()
+        writer.is_closing = MagicMock(return_value=False)
+        writer.write = MagicMock()
+        writer.drain = AsyncMock()
+        adapter._writer = writer
+        adapter._cap_negotiating = True
+
+        await adapter._handle_line(
+            ":server CAP * LS :message-tags server-time batch echo-message unrelated"
+        )
+
+        sent = writer.write.call_args[0][0].decode("utf-8")
+        assert sent == "CAP REQ :message-tags server-time batch echo-message\r\n"
+        assert adapter._server_caps["message-tags"] is None
+
+    @pytest.mark.asyncio
+    async def test_cap_ack_enables_caps_and_ends_negotiation(self, adapter):
+        writer = MagicMock()
+        writer.is_closing = MagicMock(return_value=False)
+        writer.write = MagicMock()
+        writer.drain = AsyncMock()
+        adapter._writer = writer
+        adapter._cap_negotiating = True
+
+        await adapter._handle_line(":server CAP * ACK :message-tags server-time")
+
+        assert "message-tags" in adapter._enabled_caps
+        assert "server-time" in adapter._enabled_caps
+        sent = writer.write.call_args[0][0].decode("utf-8")
+        assert sent == "CAP END\r\n"
+
+    @pytest.mark.asyncio
+    async def test_isupport_parses_clienttagdeny(self, adapter):
+        await adapter._handle_line(":server 005 hermes CHANTYPES=# CLIENTTAGDENY=*,-typing :supported")
+        assert adapter._clienttagdeny == "*,-typing"
+        assert adapter._client_tag_allowed("+typing") is True
+        assert adapter._client_tag_allowed("+draft/react") is False
+
+    @pytest.mark.asyncio
     async def test_handle_nick_collision(self, adapter):
         writer = MagicMock()
         writer.is_closing = MagicMock(return_value=False)
@@ -240,6 +370,29 @@ class TestIRCAdapterMessageParsing:
         assert len(dispatched) == 1
         assert dispatched[0]["text"] == "hello there"
         assert dispatched[0]["chat_id"] == "#test"
+
+    @pytest.mark.asyncio
+    async def test_handle_ircv3_message_tags_are_dispatched(self, adapter):
+        dispatched = []
+        adapter._message_handler = AsyncMock()
+        adapter._recent_messages["parent1"] = "parent text"
+
+        async def capture_dispatch(**kwargs):
+            dispatched.append(kwargs)
+
+        adapter._dispatch_message = capture_dispatch
+
+        await adapter._handle_line(
+            "@time=2026-02-11T10:20:30.123Z;msgid=child1;+reply=parent1 "
+            ":user!u@host PRIVMSG #test :hermes: tagged hello"
+        )
+
+        assert len(dispatched) == 1
+        assert dispatched[0]["text"] == "tagged hello"
+        assert dispatched[0]["message_id"] == "child1"
+        assert dispatched[0]["reply_to_message_id"] == "parent1"
+        assert dispatched[0]["reply_to_text"] == "parent text"
+        assert dispatched[0]["timestamp"].isoformat() == "2026-02-11T10:20:30.123000+00:00"
 
     @pytest.mark.asyncio
     async def test_ignores_unaddressed_channel_message(self, adapter):
@@ -441,6 +594,19 @@ class TestIRCAdapterMarkdown:
     def test_strip_image(self):
         result = IRCAdapter._strip_markdown("![alt](https://example.com/img.png)")
         assert result == "https://example.com/img.png"
+
+    def test_strip_markdown_keeps_fenced_code_content(self):
+        result = IRCAdapter._strip_markdown("```python\nprint('hi')\n```")
+        assert result == "print('hi')"
+
+    def test_strip_markdown_handles_headings_lists_and_strikethrough(self):
+        result = IRCAdapter._strip_markdown("# Title\n- **done**\n~~old~~")
+        assert "Title" in result
+        assert "done" in result
+        assert "old" in result
+        assert "#" not in result
+        assert "**" not in result
+        assert "~~" not in result
 
 
 # ── Requirements / validation ────────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

<img width="190" height="95" alt="image" src="https://github.com/user-attachments/assets/19b19c2c-0373-4db2-9173-5ccf424c1f5e" />

<img width="427" height="108" alt="image" src="https://github.com/user-attachments/assets/8e738530-82c2-4eec-97d2-c72083a460b2" />

Adds IRCv3 capability negotiation and message-tag support to the IRC adapter. The adapter now performs a proper `CAP LS 302` handshake before registration, so servers that support IRCv3 can advertise and grant capabilities before the client sends `NICK`/`USER`.

With `message-tags` negotiated, inbound messages expose their `msgid`, `+reply`, and `server-time` tags on `MessageEvent`, enabling accurate threading and timestamps. Outbound messages carry `+reply` tags when replying, `+typing` state via `TAGMSG`, and `+draft/react`/`+draft/unreact` emoji reactions that track processing status (👀 while thinking, ✅ on success, ❌ on failure). All client tags are gated behind `CLIENTTAGDENY` parsing so only tags the server will relay are emitted.

Also replaces the hand-rolled markdown regex in `_strip_markdown` with a shared `strip_markdown_preserving_urls` helper (`gateway/platforms/helpers.py`) that uses `python-markdown` + a lightweight `HTMLParser` subclass, with a regex fallback for environments that don't have the library. URLs are kept visible in IRC output rather than being dropped.

Security: control characters (`\r`, `\n`, `\x00`) are now stripped from every outbound IRC line, and target names are validated before use to prevent CRLF injection.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/irc/adapter.py` — CAP negotiation state machine (`_handle_cap`, `_finish_cap_ls`); `_handle_isupport` for `CLIENTTAGDENY`; `_send_tagged` / `_send_reaction` / `_send_typing_tag` helpers; `on_processing_start` / `on_processing_complete` hooks; `_remember_message` LRU cache for reply-to text; control-char stripping on all outbound lines; `_is_safe_irc_target` guard
- `gateway/platforms/helpers.py` — `_MarkdownPlainTextExtractor` (HTMLParser subclass), `_regex_strip_markdown` fallback, `strip_markdown_preserving_urls` public function
- `plugins/platforms/irc/plugin.yaml` — added `IRC_IRCV3`, `IRC_IRCV3_CAPS`, `IRC_REACTIONS` optional env vars
- `tests/gateway/test_irc_adapter.py` — 10 new test cases covering tag parsing/formatting, reply tags, `CLIENTTAGDENY` filtering, typing TAGMSG, reaction lifecycle, CAP LS/ACK flow, ISUPPORT parsing, and tagged PRIVMSG dispatch

## How to Test

1. Point the IRC adapter at a server with IRCv3 support (e.g. Libera.Chat). Set `ircv3: true` in config (default).
2. Send a message to the bot and confirm it responds — check server logs or an IRCv3-aware client (e.g. Senpai, WeeChat with `irc.look.msgid_use`) to see `+reply` tags on responses and 👀/✅ reactions on the triggering message.
3. Set `IRC_IRCV3=false` and verify the adapter falls back to plain `PRIVMSG` with no tags.
4. Run `pytest tests/gateway/test_irc_adapter.py -q` — all tests should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform:

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<img width="190" height="95" alt="image" src="https://github.com/user-attachments/assets/19b19c2c-0373-4db2-9173-5ccf424c1f5e" />

<img width="427" height="108" alt="image" src="https://github.com/user-attachments/assets/8e738530-82c2-4eec-97d2-c72083a460b2" />
