### PR TITLE
fix(agent): decouple memory provider tool injection from memory toolset gate

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1197,7 +1197,9 @@ def init_agent(
             agent._memory_manager = None
 
     from agent.memory_manager import inject_memory_provider_tools as _inject_memory_provider_tools
-    _inject_memory_provider_tools(agent)
+    _disabled_ts_raw = (_agent_cfg.get("agent") or {}).get("disabled_toolsets") or []
+    _disabled_ts = {str(t) for t in _disabled_ts_raw} if _disabled_ts_raw else None
+    _inject_memory_provider_tools(agent, disabled_toolsets=_disabled_ts)
 
     # Skills config: nudge interval for skill creation reminders
     agent._skill_nudge_interval = 10

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -62,7 +62,9 @@ def memory_provider_tools_enabled(enabled_toolsets: Optional[List[str]]) -> bool
         return False
 
 
-def inject_memory_provider_tools(agent: Any) -> int:
+def inject_memory_provider_tools(
+    agent: Any, *, disabled_toolsets: set[str] | None = None,
+) -> int:
     """Append external memory-provider tool schemas to an agent tool surface."""
     memory_manager = getattr(agent, "_memory_manager", None)
     tools = getattr(agent, "tools", None)
@@ -74,9 +76,12 @@ def inject_memory_provider_tools(agent: Any) -> int:
         for tool in tools
         if isinstance(tool, dict)
     }
+    _has_providers = bool(getattr(memory_manager, "providers", None))
+    _mem_disabled = disabled_toolsets and "memory" in disabled_toolsets
     if (
         "memory" not in existing_tool_names
         and not memory_provider_tools_enabled(getattr(agent, "enabled_toolsets", None))
+        and not (_mem_disabled and _has_providers)
     ):
         return 0
 

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1330,7 +1330,7 @@ class TestMemoryToolToolsetGate:
     """
 
     @staticmethod
-    def _run_memory_injection(enabled_toolsets, memory_manager):
+    def _run_memory_injection(enabled_toolsets, memory_manager, *, disabled_toolsets=None):
         """Run the shared memory-tool injection helper against a fake agent."""
         fake_agent = SimpleNamespace(
             _memory_manager=memory_manager,
@@ -1338,7 +1338,7 @@ class TestMemoryToolToolsetGate:
             tools=[],
             valid_tool_names=set(),
         )
-        inject_memory_provider_tools(fake_agent)
+        inject_memory_provider_tools(fake_agent, disabled_toolsets=disabled_toolsets)
         return fake_agent.tools, fake_agent.valid_tool_names
 
     def _mgr_with_tools(self, *tool_names):
@@ -1375,6 +1375,32 @@ class TestMemoryToolToolsetGate:
         """`platform_toolsets: telegram: []` must suppress memory tools. (#5544)"""
         mgr = self._mgr_with_tools("fact_store")
         tools, names = self._run_memory_injection([], mgr)
+        assert tools == []
+        assert names == set()
+
+    def test_disabled_toolsets_with_provider_still_injects(self):
+        """`agent.disabled_toolsets: [memory]` must not suppress provider tools.
+
+        When the user explicitly configures a memory provider (e.g. Mnemosyne)
+        and also disables the legacy ``memory`` toolset, the provider tools
+        should still be injected.  The ``disabled_toolsets`` gate only removes
+        the legacy tool function; it must not block the independent provider
+        system.  (#46108)
+        """
+        mgr = self._mgr_with_tools("mnemosyne_remember", "mnemosyne_recall")
+        tools, names = self._run_memory_injection(
+            ["terminal", "web"], mgr, disabled_toolsets={"memory"},
+        )
+        assert "mnemosyne_remember" in names
+        assert "mnemosyne_recall" in names
+
+    def test_disabled_toolsets_without_provider_still_blocks(self):
+        """When no memory provider is configured, disabled_toolsets blocks."""
+        # MemoryManager with no providers — _has_providers is False
+        mgr = MemoryManager()
+        tools, names = self._run_memory_injection(
+            ["terminal"], mgr, disabled_toolsets={"memory"},
+        )
         assert tools == []
         assert names == set()
 


### PR DESCRIPTION
## What does this PR do?

Decouples memory provider tool injection from the `memory` toolset gate so that `agent.disabled_toolsets: [memory]` no longer silently suppresses external memory provider tools (e.g. Mnemosyne `mnemosyne_remember`, `mnemosyne_recall`).

## Related Issue

Fixes #46108

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/memory_manager.py`: Add `disabled_toolsets` keyword parameter to `inject_memory_provider_tools()`. When "memory" is in `disabled_toolsets` AND the memory manager has providers, bypass the toolset gate and allow provider tool injection.
- `agent/agent_init.py`: Read `agent.disabled_toolsets` from config and pass it to `inject_memory_provider_tools()`.
- `tests/agent/test_memory_provider.py`: Add 2 tests — (1) disabled memory toolset with configured provider still injects provider tools, (2) disabled memory toolset without provider still blocks injection. Update `_run_memory_injection` helper to forward `disabled_toolsets`.

## How to Test

1. Configure a memory provider in `config.yaml` (e.g. `memory.provider: mnemosyne`)
2. Set `agent.disabled_toolsets: [memory]` in `config.yaml`
3. Start a session — verify `mnemosyne_remember` / `mnemosyne_recall` tools are available
4. Remove the memory provider config — verify the legacy `memory` tool is gone and no provider tools leak
5. Run `pytest tests/agent/test_memory_provider.py -x -q` — all 95 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_memory_provider.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/memory_manager.py::inject_memory_provider_tools` (called from agent_init.py, acp_adapter/server.py × 2)
- Blast radius: LOW — additive bypass condition; existing gate behavior unchanged for all paths that don't pass `disabled_toolsets`
- Related patterns: #5544 (platform toolset restriction), `memory_provider_tools_enabled()` gate
