### PR TITLE
fix(gateway): stop typing before final stream flush

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25470,16 +25470,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             interrupt_monitor.cancel()
             _notify_task.cancel()
 
-            # Eagerly stop typing indicator when _run_agent exits.
-            # The caller (_handle_message_with_agent) and the base adapter's
-            # finally block also call stop_typing, but if the agent took a long
-            # time failing (e.g. retries with backoff), the typing indicator
-            # was visible throughout.  Stopping here ensures we don't leave a
-            # phantom typing indicator while the caller does post-processing
-            # (stream consumer flush, delivery, hooks, etc.).
+            # Stop typing before waiting for the stream consumer's final edit.
+            # The caller and base adapter also stop it, but only after this
+            # method returns; until then their refresh task can keep the
+            # indicator visible throughout the final stream flush.
             try:
-                _cleanup_adapter = self.adapters.get(source.platform)
-                if _cleanup_adapter and hasattr(_cleanup_adapter, "stop_typing"):
+                _cleanup_adapter = self._adapter_for_source(source)
+                _stop_with_metadata = getattr(
+                    type(_cleanup_adapter), "_stop_typing_with_metadata", None
+                )
+                _stop_typing = getattr(type(_cleanup_adapter), "stop_typing", None)
+                if _cleanup_adapter and callable(_stop_with_metadata):
+                    await _cleanup_adapter._stop_typing_with_metadata(
+                        source.chat_id, _status_thread_metadata
+                    )
+                elif _cleanup_adapter and callable(_stop_typing):
                     await _cleanup_adapter.stop_typing(source.chat_id)
             except Exception:
                 pass

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25470,6 +25470,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             interrupt_monitor.cancel()
             _notify_task.cancel()
 
+            # Eagerly stop typing indicator when _run_agent exits.
+            # The caller (_handle_message_with_agent) and the base adapter's
+            # finally block also call stop_typing, but if the agent took a long
+            # time failing (e.g. retries with backoff), the typing indicator
+            # was visible throughout.  Stopping here ensures we don't leave a
+            # phantom typing indicator while the caller does post-processing
+            # (stream consumer flush, delivery, hooks, etc.).
+            try:
+                _cleanup_adapter = self.adapters.get(source.platform)
+                if _cleanup_adapter and hasattr(_cleanup_adapter, "stop_typing"):
+                    await _cleanup_adapter.stop_typing(source.chat_id)
+            except Exception:
+                pass
+
             # Wait for stream consumer to finish its final edit
             if stream_task:
                 # If the agent never created a stream consumer (e.g. non-

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -433,7 +433,12 @@ async def test_run_agent_progress_uses_event_message_id_for_slack_dm(monkeypatch
         "message_id": "1234567890.000001",
     }
     assert adapter.sent[0]["metadata"] == expected_metadata
-    assert all(call["metadata"] == expected_metadata for call in adapter.typing)
+    typing_updates = [
+        call for call in adapter.typing if call["metadata"] != {"stopped": True}
+    ]
+    assert typing_updates
+    assert all(call["metadata"] == expected_metadata for call in typing_updates)
+    assert any(call["metadata"] == {"stopped": True} for call in adapter.typing)
 
 
 # ---------------------------------------------------------------------------
@@ -809,6 +814,154 @@ async def _run_with_agent(
         session_key=session_key,
     )
     return adapter, result
+
+
+@pytest.mark.asyncio
+async def test_run_agent_stops_profile_adapter_before_final_stream_flush(
+    monkeypatch, tmp_path
+):
+    """Cleanup must stop the routed profile's typing before stream flush ends."""
+    import yaml
+    import gateway.stream_consumer as stream_consumer_mod
+
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump({
+            "display": {"tool_progress": "off", "interim_assistant_messages": False},
+            "streaming": {"enabled": True, "edit_interval": 0.01, "buffer_threshold": 1},
+        }),
+        encoding="utf-8",
+    )
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    class StreamingAgent:
+        def __init__(self, **kwargs):
+            self.stream_delta_callback = kwargs.get("stream_delta_callback")
+            self.tools = []
+
+        def run_conversation(self, message, conversation_history=None, task_id=None):
+            if self.stream_delta_callback:
+                self.stream_delta_callback("final answer")
+            return {
+                "final_response": "final answer",
+                "messages": [],
+                "api_calls": 1,
+            }
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = StreamingAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    events = []
+    flush_started = asyncio.Event()
+    allow_flush = asyncio.Event()
+    profile_stopped = asyncio.Event()
+    default_stopped = asyncio.Event()
+
+    class DelayedFinalFlushConsumer:
+        def __init__(self, *, adapter, chat_id, **kwargs):
+            self.adapter = adapter
+            self.chat_id = chat_id
+            self.message_id = None
+            self.final_response_sent = False
+            self.final_content_delivered = False
+            self._finished = False
+
+        def on_delta(self, text):
+            return None
+
+        def finish(self):
+            self._finished = True
+
+        async def run(self):
+            while not self._finished:
+                await asyncio.sleep(0)
+            events.append("flush-started")
+            flush_started.set()
+            await allow_flush.wait()
+            events.append("flush-complete")
+            self.final_response_sent = True
+            self.final_content_delivered = True
+
+        def has_delivered_text(self, final_text):
+            return self.final_response_sent and final_text == "final answer"
+
+    monkeypatch.setattr(
+        stream_consumer_mod, "GatewayStreamConsumer", DelayedFinalFlushConsumer
+    )
+
+    class MetadataStopAdapter(ProgressCaptureAdapter):
+        def __init__(self, label, stopped_event):
+            super().__init__(platform=Platform.SLACK)
+            self.label = label
+            self.stopped_event = stopped_event
+            self.stop_metadata = []
+
+        async def stop_typing(self, chat_id, metadata=None):
+            events.append(f"{self.label}-stop")
+            self.stop_metadata.append(metadata)
+            self.stopped_event.set()
+
+    default_adapter = MetadataStopAdapter("default", default_stopped)
+    profile_adapter = MetadataStopAdapter("profile", profile_stopped)
+
+    runner = _make_runner(default_adapter)
+    runner._profile_adapters = {
+        "secondary": {Platform.SLACK: profile_adapter},
+    }
+    runner.config.streaming = StreamingConfig.from_dict({
+        "enabled": True,
+        "edit_interval": 0.01,
+        "buffer_threshold": 1,
+    })
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+    source = SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C123",
+        chat_type="channel",
+        thread_id="1700000000.000100",
+        scope_id="T-secondary",
+        profile="secondary",
+    )
+
+    run_task = asyncio.create_task(
+        runner._run_agent(
+            message="hello",
+            context_prompt="",
+            history=[],
+            source=source,
+            session_id="sess-profile-stream-flush",
+            session_key="agent:secondary:slack:channel:C123:1700000000.000100",
+            event_message_id="1700000000.000200",
+        )
+    )
+    try:
+        await asyncio.wait_for(flush_started.wait(), timeout=1.0)
+        try:
+            await asyncio.wait_for(profile_stopped.wait(), timeout=0.25)
+        except asyncio.TimeoutError:
+            pytest.fail(
+                "profile-specific adapter was not stopped before final stream flush"
+            )
+        assert not default_stopped.is_set()
+        assert profile_adapter.stop_metadata == [
+            {
+                "thread_id": "1700000000.000100",
+                "message_id": "1700000000.000200",
+                "slack_team_id": "T-secondary",
+            }
+        ]
+    finally:
+        allow_flush.set()
+        await asyncio.wait_for(run_task, timeout=1.0)
+
+    assert events.index("profile-stop") < events.index("flush-complete")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- stop the typing indicator immediately before waiting for the stream consumer's final edit
- resolve the adapter from the full session source so multiplexed profiles use their own adapter
- preserve Slack thread, message, and workspace routing metadata through the shared metadata-aware stop helper
- retain the later idempotent cleanup paths as fallbacks

## Why

`_run_agent_inner()` can wait for the stream consumer to finish its final delivery before returning to the caller. During that wait, the normal caller/base-adapter cleanup has not run yet, so a persistent typing/status refresh can remain visible after the model turn is already complete.

## Testing

- added an async delayed-final-flush regression that verifies stop-before-flush ordering
- verifies secondary-profile adapter selection and that the default adapter is untouched
- verifies exact Slack thread/message/workspace metadata
- `scripts/run_tests.sh tests/gateway/test_run_progress_topics.py tests/gateway/test_multiplex_adapter_registry.py tests/gateway/test_multiplex_profile_authz.py -q` (35 passed)
- Ruff and `git diff --check`