### PR TITLE
fix(desktop): check remote gateway before local media stream for audio/video

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.tsx
@@ -103,16 +103,18 @@ async function mediaSrc(path: string): Promise<string> {
     return path
   }
 
+  // Remote gateway: files live on the gateway machine, not this disk, so fetch
+  // them over the authenticated API.  Must come before the audio/video stream
+  // check because hermes-media:// only resolves local files — on a remote
+  // gateway it would produce a 0-second broken playback.
+  if (window.hermesDesktop && isRemoteGateway()) {
+    return gatewayMediaDataUrl(path)
+  }
+
   // Stream audio/video through the custom protocol: data URLs are capped and
   // load the whole file into memory, which broke playback for larger videos.
   if (window.hermesDesktop && ['audio', 'video'].includes(mediaKind(path))) {
     return mediaStreamUrl(path)
-  }
-
-  // Remote gateway: the image lives on the gateway machine, so read it over the
-  // authenticated API rather than this machine's disk.
-  if (window.hermesDesktop && isRemoteGateway()) {
-    return gatewayMediaDataUrl(path)
   }
 
   if (!window.hermesDesktop?.readFileDataUrl) {


### PR DESCRIPTION
## What does this PR do?

Reorders the `mediaSrc()` check priority in the Desktop app so that remote gateway sessions fetch audio/video media via the authenticated API instead of the local `hermes-media://` stream protocol, which produces 0-second broken playback when the file lives on the server.

## Related Issue

Fixes #46135

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/components/assistant-ui/markdown-text.tsx`: Moved the `isRemoteGateway()` check before the audio/video `mediaStreamUrl()` check in `mediaSrc()`. Remote gateways now always use `gatewayMediaDataUrl()` for all media types, while local gateways continue using the streaming protocol for audio/video.

## How to Test

1. Connect the Desktop app to a remote Hermes gateway (VPS/remote backend)
2. Ask the agent to generate TTS audio (e.g., "Generate an audio test saying hello")
3. Verify the audio attachment plays correctly (not 0-second/broken)
4. Connect the Desktop app to a local gateway
5. Verify audio/video still plays correctly via the local streaming protocol
6. Verify images still load correctly in both local and remote modes

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `mediaSrc()` in `apps/desktop/src/components/assistant-ui/markdown-text.tsx` (callers: 1 via `MediaAttachment` component)
- Blast radius: LOW — `mediaSrc` is a private function used only within the `MediaAttachment` component; the reorder only affects which code path runs first
- Related patterns: `isRemoteGateway()` is already used in `directive-text.tsx` (line 386) and `generated-image-result.tsx` (line 35) with the same "check remote first" pattern
