### PR TITLE
fix(desktop): prevent active session state reset when clicked in sidebar

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -148,6 +148,10 @@ export function SidebarSessionRow({
               return
             }
 
+            if (isSelected) {
+              return
+            }
+
             onResume()
           }}
           type="button"


### PR DESCRIPTION
Fixes an issue where clicking on the currently active session in the sidebar resets the session state and clears user inputs. Adds a guard check to return early if the clicked session is already selected.