### PR TITLE
fix: hide noncanonical slash aliases from discovery

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -294,6 +294,42 @@ for _cmd in COMMAND_REGISTRY:
         SUBCOMMANDS[key] = m.group(0).split("|")
 
 
+# Aliases in this allowlist are intentionally discoverable shortcuts. Other
+# aliases remain dispatchable for backwards compatibility but are hidden from
+# user-facing discovery surfaces to keep the command map canonical.
+_USER_VISIBLE_ALIASES: frozenset[str] = frozenset({"bg", "q", "exit", "reset", "sb"})
+
+
+def _is_internal_alias(alias: str, canonical: str) -> bool:
+    """Return True for spelling-only aliases kept for transport compatibility.
+
+    Some platform menus cannot display hyphenated slash commands, so Hermes
+    keeps underscore aliases such as ``reload_mcp`` for dispatch. Those aliases
+    are implementation details; user-facing surfaces should show the canonical
+    hyphenated command once, not a duplicate row.
+    """
+    return alias != canonical and alias.replace("-", "_") == canonical.replace("-", "_")
+
+
+def _is_hidden_alias(alias: str, canonical: str) -> bool:
+    """Return True when an alias should resolve but not be advertised.
+
+    Canonical commands define the public map. A small allowlist of ergonomic
+    shortcuts stays visible; spelling-only, legacy, and semantic duplicate
+    aliases stay working but disappear from autocomplete/help/menu surfaces.
+    """
+    return alias not in _USER_VISIBLE_ALIASES or _is_internal_alias(alias, canonical)
+
+
+def _is_hidden_alias_command(slash_command: str) -> bool:
+    """Return True if ``/name`` is a hidden alias of a registry command."""
+    name = slash_command.lstrip("/")
+    for cmd in COMMAND_REGISTRY:
+        if name in cmd.aliases and _is_hidden_alias(name, cmd.name):
+            return True
+    return False
+
+
 # ---------------------------------------------------------------------------
 # Gateway helpers
 # ---------------------------------------------------------------------------
@@ -436,8 +472,8 @@ def gateway_help_lines() -> list[str]:
         args = f" {cmd.args_hint}" if cmd.args_hint else ""
         alias_parts: list[str] = []
         for a in cmd.aliases:
-            # Skip internal aliases like reload_mcp (underscore variant)
-            if a.replace("-", "_") == cmd.name.replace("-", "_") and a != cmd.name:
+            # Skip hidden aliases like reload_mcp, /btw, /tasks, etc.
+            if _is_hidden_alias(a, cmd.name):
                 continue
             alias_parts.append(f"`/{a}`")
         alias_note = f" (alias: {', '.join(alias_parts)})" if alias_parts else ""
@@ -1191,10 +1227,14 @@ class SlashCommandCompleter(Completer):
         skill_commands_provider: Callable[[], Mapping[str, dict[str, Any]]] | None = None,
         command_filter: Callable[[str], bool] | None = None,
         skill_bundles_provider: Callable[[], Mapping[str, dict[str, Any]]] | None = None,
+        show_skill_commands: bool = True,
+        show_skill_bundles: bool = True,
     ) -> None:
         self._skill_commands_provider = skill_commands_provider
         self._command_filter = command_filter
         self._skill_bundles_provider = skill_bundles_provider
+        self._show_skill_commands = show_skill_commands
+        self._show_skill_bundles = show_skill_bundles
         # Cached project file list for fuzzy @ completions
         self._file_cache: list[str] = []
         self._file_cache_time: float = 0.0
@@ -1209,6 +1249,8 @@ class SlashCommandCompleter(Completer):
             return True
 
     def _iter_skill_commands(self) -> Mapping[str, dict[str, Any]]:
+        if not self._show_skill_commands:
+            return {}
         if self._skill_commands_provider is None:
             return {}
         try:
@@ -1217,6 +1259,8 @@ class SlashCommandCompleter(Completer):
             return {}
 
     def _iter_skill_bundles(self) -> Mapping[str, dict[str, Any]]:
+        if not self._show_skill_bundles:
+            return {}
         if self._skill_bundles_provider is None:
             return {}
         try:
@@ -1692,6 +1736,8 @@ class SlashCommandCompleter(Completer):
         word = text[1:]
 
         for cmd, desc in COMMANDS.items():
+            if _is_hidden_alias_command(cmd):
+                continue
             if not self._command_allowed(cmd):
                 continue
             cmd_name = cmd[1:]
@@ -1781,6 +1827,8 @@ class SlashCommandAutoSuggest(AutoSuggest):
             # Still typing the command name: /upd → suggest "ate"
             word = text[1:].lower()
             for cmd in COMMANDS:
+                if _is_hidden_alias_command(cmd):
+                    continue
                 if self._completer is not None and not self._completer._command_allowed(cmd):
                     continue
                 cmd_name = cmd[1:]  # strip leading /

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1767,6 +1767,103 @@ def test_complete_slash_drops_removed_provider_alias():
     assert any(item["text"] == "model" for item in resp_model["result"]["items"])
 
 
+def _slash_completion_displays(text: str) -> set[str]:
+    resp = server.handle_request(
+        {"id": "1", "method": "complete.slash", "params": {"text": text}}
+    )
+
+    assert resp is not None
+    result = resp["result"]
+    assert isinstance(result, dict)
+    return {item["display"] for item in result["items"]}
+
+
+def test_complete_slash_hides_internal_spelling_aliases():
+    # Keep underscore aliases dispatchable for platforms that cannot expose
+    # hyphenated commands, but do not show both spellings in the TUI picker.
+    texts = _slash_completion_displays("/reload")
+
+    assert "/reload-mcp" in texts
+    assert "/reload-skills" in texts
+    assert "/reload_mcp" not in texts
+    assert "/reload_skills" not in texts
+
+
+def test_complete_slash_hides_legacy_and_semantic_duplicate_aliases():
+    # Keep the public command map canonical: only ergonomic shortcuts from the
+    # allowlist are discoverable, while older/semantic aliases still dispatch.
+    background_texts = _slash_completion_displays("/b")
+    assert "/background" in background_texts
+    assert "/bg" in background_texts
+    assert "/btw" not in background_texts
+
+    assert "/fork" not in _slash_completion_displays("/f")
+    assert "/snap" not in _slash_completion_displays("/s")
+    assert "/tasks" not in _slash_completion_displays("/t")
+    assert "/gateway" not in _slash_completion_displays("/g")
+
+    # Intentionally visible shortcuts remain discoverable.
+    assert "/q" in _slash_completion_displays("/q")
+    assert "/reset" in _slash_completion_displays("/r")
+
+
+def test_tui_slash_completion_hides_individual_skill_commands(monkeypatch):
+    import agent.skill_bundles as skill_bundles
+    import agent.skill_commands as skill_commands
+
+    monkeypatch.setattr(
+        skill_commands,
+        "get_skill_commands",
+        lambda: {
+            "/grill-me": {"description": "Interview the user relentlessly"},
+        },
+    )
+    monkeypatch.setattr(
+        skill_bundles,
+        "get_skill_bundles",
+        lambda: {
+            "/hub-day": {"description": "Daily operating pipeline", "skills": ["hub-day"]},
+        },
+    )
+
+    # The top-level TUI slash menu should surface commands and curated bundles,
+    # not every individual skill command.
+    assert "/goal" in _slash_completion_displays("/g")
+    assert "/grill-me" not in _slash_completion_displays("/g")
+    assert "/hub-day" in _slash_completion_displays("/h")
+
+
+def test_hidden_aliases_still_resolve():
+    from hermes_cli.commands import resolve_command
+
+    expected = {
+        "reload_mcp": "reload-mcp",
+        "reload_skills": "reload-skills",
+        "btw": "background",
+        "fork": "branch",
+        "snap": "snapshot",
+        "tasks": "agents",
+        "gateway": "platforms",
+        "set-home": "sethome",
+    }
+    for alias, canonical in expected.items():
+        resolved = resolve_command(alias)
+        assert resolved is not None, alias
+        assert resolved.name == canonical
+
+
+def test_gateway_help_hides_non_visible_aliases():
+    from hermes_cli.commands import gateway_help_lines
+
+    help_text = "\n".join(gateway_help_lines())
+    assert "alias: `/q`" in help_text
+    assert "alias: `/bg`" in help_text
+    assert "alias: `/btw`" not in help_text
+    assert "alias: `/tasks`" not in help_text
+    assert "alias: `/set-home`" not in help_text
+    assert "alias: `/reload_mcp`" not in help_text
+
+
 def test_complete_slash_returns_plain_string_fields():
     # prompt_toolkit hands us FormattedText (a list subclass) for
     # display/display_meta; the TUI's CompletionItem contract is plain

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6533,6 +6533,11 @@ def _(rid, params: dict) -> dict:
         completer = SlashCommandCompleter(
             skill_commands_provider=lambda: get_skill_commands(),
             skill_bundles_provider=lambda: get_skill_bundles(),
+            # Keep TUI slash discovery focused on the command/pipeline layer.
+            # Individual skills remain invokable via their exact /skill-name
+            # commands and discoverable through /skills, but they no longer
+            # flood the top-level "/" menu.
+            show_skill_commands=False,
         )
         doc = Document(text, len(text))
         items = [


### PR DESCRIPTION
Closes #33211.\n\n## Summary\n- keep command aliases dispatchable while hiding noncanonical aliases from user-facing discovery\n- expose only intentional shortcuts such as /bg, /q, /reset, /exit, and /sb\n- hide spelling/legacy/semantic duplicates such as /reload_mcp, /btw, /fork, /snap, /tasks, /gateway, and /set-home from TUI autocomplete/autosuggest and gateway help\n\n## Validation\n- uv run python -m pytest tests/test_tui_gateway_server.py -k 'slash_hides or hidden_aliases or gateway_help_hides or complete_slash_returns_plain_string_fields' -q -o 'addopts='\n- uv run python -m pytest tests/test_tui_gateway_server.py tests/gateway/test_unknown_command.py tests/gateway/test_background_command.py tests/gateway/test_running_agent_session_toggles.py tests/gateway/test_title_command.py -q -o 'addopts=' *(1 unrelated browser.manage local-environment assertion failed; 249 passed)*\n