### PR TITLE
Scope TUI `/stop` to the active session's background processes

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1598,6 +1598,53 @@ def _session(agent=None, **extra):
     }
 
 
+def test_process_stop_only_kills_calling_session_processes(monkeypatch):
+    class _FakeProc:
+        def __init__(self, session_key, exited=False):
+            self.session_key = session_key
+            self.exited = exited
+
+    class _FakeRegistry:
+        def __init__(self):
+            self.procs = {
+                "own-1": _FakeProc("owner-key"),
+                "other-1": _FakeProc("other-key"),
+                "own-finished": _FakeProc("owner-key", exited=True),
+                "own-2": _FakeProc("owner-key"),
+            }
+            self.killed = []
+
+        def list_sessions(self):
+            return [{"session_id": sid} for sid in self.procs]
+
+        def get(self, sid):
+            return self.procs.get(sid)
+
+        def kill_process(self, sid):
+            self.killed.append(sid)
+            return {"status": "killed", "session_id": sid}
+
+        def kill_all(self):
+            raise AssertionError("process.stop must not kill every session")
+
+    fake_registry = _FakeRegistry()
+    fake_module = types.ModuleType("tools.process_registry")
+    fake_module.process_registry = fake_registry
+    monkeypatch.setitem(sys.modules, "tools.process_registry", fake_module)
+    server._sessions["stop-owner"] = _session(session_key="owner-key")
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "process.stop",
+            "params": {"session_id": "stop-owner"},
+        }
+    )
+
+    assert resp["result"] == {"killed": 2}
+    assert fake_registry.killed == ["own-1", "own-2"]
+
+
 def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
     calls = {"hooks": []}
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3886,6 +3886,62 @@ def test_snapshot_restore_is_blocked_from_tui_worker():
     )
 
 
+def test_slash_exec_stop_scoped_to_session(monkeypatch):
+    class _FakeProc:
+        def __init__(self, session_key, exited=False):
+            self.session_key = session_key
+            self.exited = exited
+
+    class _FakeRegistry:
+        def __init__(self):
+            self.procs = {
+                "own-1": _FakeProc("owner-key"),
+                "other-1": _FakeProc("other-key"),
+                "own-finished": _FakeProc("owner-key", exited=True),
+                "own-2": _FakeProc("owner-key"),
+            }
+            self.killed = []
+
+        def list_sessions(self):
+            return [{"session_id": sid} for sid in self.procs]
+
+        def get(self, sid):
+            return self.procs.get(sid)
+
+        def kill_process(self, sid):
+            self.killed.append(sid)
+            return {"status": "killed", "session_id": sid}
+
+    class _FakeWorker:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def run(self, cmd):
+            assert cmd == "stop"
+            return "stopped"
+
+        def close(self):
+            pass
+
+    fake_registry = _FakeRegistry()
+    fake_module = types.ModuleType("tools.process_registry")
+    fake_module.process_registry = fake_registry
+    monkeypatch.setitem(sys.modules, "tools.process_registry", fake_module)
+    monkeypatch.setattr(server, "_SlashWorker", _FakeWorker)
+    server._sessions["slash-owner"] = _session(session_key="owner-key")
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "slash.exec",
+            "params": {"session_id": "slash-owner", "command": "stop"},
+        }
+    )
+
+    assert resp["result"]["output"] == "stopped"
+    assert fake_registry.killed == ["own-1", "own-2"]
+
+
 def test_command_dispatch_exec_nonzero_surfaces_error(monkeypatch):
     monkeypatch.setattr(
         server,
@@ -4650,6 +4706,45 @@ def test_mirror_slash_side_effects_allowed_when_idle(monkeypatch):
     # Should NOT contain "session busy" — the switch went through.
     assert "session busy" not in warning
     assert applied["model"]
+
+
+def test_mirror_slash_side_effects_stop_scoped_to_session(monkeypatch):
+    class _FakeProc:
+        def __init__(self, session_key, exited=False):
+            self.session_key = session_key
+            self.exited = exited
+
+    class _FakeRegistry:
+        def __init__(self):
+            self.procs = {
+                "own-1": _FakeProc("owner-key"),
+                "other-1": _FakeProc("other-key"),
+                "own-finished": _FakeProc("owner-key", exited=True),
+                "own-2": _FakeProc("owner-key"),
+            }
+            self.killed = []
+
+        def list_sessions(self):
+            return [{"session_id": sid} for sid in self.procs]
+
+        def get(self, sid):
+            return self.procs.get(sid)
+
+        def kill_process(self, sid):
+            self.killed.append(sid)
+            return {"status": "killed", "session_id": sid}
+
+    fake_registry = _FakeRegistry()
+    fake_module = types.ModuleType("tools.process_registry")
+    fake_module.process_registry = fake_registry
+    monkeypatch.setitem(sys.modules, "tools.process_registry", fake_module)
+    session = _session()
+    session["session_key"] = "owner-key"
+
+    warning = server._mirror_slash_side_effects("sid", session, "/stop")
+
+    assert warning == ""
+    assert fake_registry.killed == ["own-1", "own-2"]
 
 
 def test_mirror_slash_compress_does_not_prelock_history(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7666,10 +7666,26 @@ def _(rid, params: dict) -> dict:
 
 @method("process.stop")
 def _(rid, params: dict) -> dict:
+    session, err = _sess(params, rid)
+    if err:
+        return err
     try:
         from tools.process_registry import process_registry
 
-        return _ok(rid, {"killed": process_registry.kill_all()})
+        session_key = str(session.get("session_key") or "")
+        killed = 0
+        for entry in process_registry.list_sessions():
+            proc = process_registry.get(entry["session_id"])
+            if (
+                proc is None
+                or str(getattr(proc, "session_key", "") or "") != session_key
+                or bool(getattr(proc, "exited", False))
+            ):
+                continue
+            result = process_registry.kill_process(entry["session_id"])
+            if result.get("status") in {"killed", "already_exited"}:
+                killed += 1
+        return _ok(rid, {"killed": killed})
     except Exception as e:
         return _err(rid, 5010, str(e))
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7664,28 +7664,32 @@ def _(rid, params: dict) -> dict:
 # ── Methods: tools & system ──────────────────────────────────────────
 
 
+def _stop_session_processes(session: dict) -> int:
+    from tools.process_registry import process_registry
+
+    session_key = str(session.get("session_key") or "")
+    killed = 0
+    for entry in process_registry.list_sessions():
+        proc = process_registry.get(entry["session_id"])
+        if (
+            proc is None
+            or str(getattr(proc, "session_key", "") or "") != session_key
+            or bool(getattr(proc, "exited", False))
+        ):
+            continue
+        result = process_registry.kill_process(entry["session_id"])
+        if result.get("status") in {"killed", "already_exited"}:
+            killed += 1
+    return killed
+
+
 @method("process.stop")
 def _(rid, params: dict) -> dict:
     session, err = _sess(params, rid)
     if err:
         return err
     try:
-        from tools.process_registry import process_registry
-
-        session_key = str(session.get("session_key") or "")
-        killed = 0
-        for entry in process_registry.list_sessions():
-            proc = process_registry.get(entry["session_id"])
-            if (
-                proc is None
-                or str(getattr(proc, "session_key", "") or "") != session_key
-                or bool(getattr(proc, "exited", False))
-            ):
-                continue
-            result = process_registry.kill_process(entry["session_id"])
-            if result.get("status") in {"killed", "already_exited"}:
-                killed += 1
-        return _ok(rid, {"killed": killed})
+        return _ok(rid, {"killed": _stop_session_processes(session)})
     except Exception as e:
         return _err(rid, 5010, str(e))
 
@@ -9115,9 +9119,7 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
         elif name == "reload-mcp" and agent and hasattr(agent, "reload_mcp_tools"):
             agent.reload_mcp_tools()
         elif name == "stop":
-            from tools.process_registry import process_registry
-
-            process_registry.kill_all()
+            _stop_session_processes(session)
     except Exception as e:
         return f"live session sync failed: {e}"
     return ""

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -421,7 +421,7 @@ describe('createSlashHandler', () => {
     ['/browser connect', 'browser.manage', { action: 'connect', session_id: null, url: 'http://127.0.0.1:9222' }],
     ['/reload-mcp', 'reload.mcp', { session_id: null }],
     ['/reload', 'reload.env', {}],
-    ['/stop', 'process.stop', {}],
+    ['/stop', 'process.stop', { session_id: null }],
     ['/fast status', 'config.get', { key: 'fast', session_id: null }],
     ['/busy status', 'config.get', { key: 'busy' }],
     ['/indicator', 'config.get', { key: 'indicator' }]

--- a/ui-tui/src/app/slash/commands/ops.ts
+++ b/ui-tui/src/app/slash/commands/ops.ts
@@ -67,7 +67,7 @@ export const opsCommands: SlashCommand[] = [
     name: 'stop',
     run: (_arg, ctx) => {
       ctx.gateway
-        .rpc<ProcessStopResponse>('process.stop', {})
+        .rpc<ProcessStopResponse>('process.stop', { session_id: ctx.sid })
         .then(
           ctx.guarded<ProcessStopResponse>(r => {
             const killed = Number(r.killed ?? 0)


### PR DESCRIPTION
## Summary

This makes TUI/Desktop `/stop` stop only the background processes owned by the active session. The gateway filters the process registry by that session's `session_key` before killing anything, and the slash-worker mirror path now uses the same scoped helper.

## Why

`process.list` and `process.kill` are already session-scoped, but `process.stop` still called `process_registry.kill_all()` with no session filter. The TUI slash command also sent `{}` for `/stop`, so one TUI/Desktop session could stop background terminal jobs that belonged to other live sessions sharing the same gateway process.

That is surprising in multi-session TUI/Desktop usage and breaks the isolation already enforced by `process.list` and `process.kill`.

## Changes

- Make `process.stop` resolve the caller session and kill only registry entries whose `session_key` matches that session.
- Make the slash-worker mirror path for `/stop` use the same session-scoped helper.
- Skip already-finished registry entries.
- Add a regression test that fails if `process.stop` falls back to `kill_all()` or kills another session's process.
- Add a regression test that exercises `slash.exec` with `/stop` end to end.

## Tests

```text
python -m pytest tests/test_tui_gateway_server.py -k "process_stop_only_kills_calling_session_processes or slash_exec_stop_scoped_to_session or mirror_slash_side_effects_stop_scoped_to_session" -q --timeout-method=thread
3 passed, 271 deselected
```

```text
git diff --check
```

Not run:

```text
npm run test -- createSlashHandler.test.ts
```

`npm run test -- createSlashHandler.test.ts` failed in this checkout because `vitest` is not installed/available in `ui-tui`.