### PR TITLE
fix(stt): preserve local language auto-detect

### DIFF
--- a/docs/plans/2026-06-14-001-fix-mixed-language-discord-stt-plan.md
+++ b/docs/plans/2026-06-14-001-fix-mixed-language-discord-stt-plan.md
@@ -1,0 +1,134 @@
+---
+title: "fix: Make Discord STT robust for mixed Estonian/English voice messages"
+type: fix
+status: completed
+date: 2026-06-14
+---
+
+# fix: Make Discord STT robust for mixed Estonian/English voice messages
+
+## Summary
+
+Make the inbound Discord audio transcription path preserve multilingual auto-detection end to end, with tests that protect Kadri-style mixed Estonian/English voice notes from being forced through an English-only local STT fallback.
+
+---
+
+## Problem Frame
+
+Kadri Hermes already caches Discord audio attachments into local audio cache paths and `gateway/run.py` feeds those paths to `tools.transcription_tools.transcribe_audio`. A cached Kadri Discord `.ogg` transcribed successfully with the local faster-whisper provider. The remaining robustness gap is configuration and fallback behavior: Kadri's intended mixed-language posture is `stt.local.language: ""` so faster-whisper can auto-detect Estonian or English, but the local command fallback currently treats a blank language as English and the auto-detected whisper CLI template always emits `--language {language}`. If faster-whisper becomes unavailable and Hermes falls back to a local CLI, mixed-language Discord messages can silently regress to English-biased transcription.
+
+---
+
+## Requirements
+
+**Mixed-language transcription**
+
+- R1. Blank `stt.local.language` must mean language auto-detection for local STT, not English.
+- R2. Explicit local language settings such as `et` or `en` must continue to force that language when configured.
+- R3. Discord audio attachment handling must continue to provide local paths and `audio/*` media types so gateway STT enrichment sees the attachments.
+
+**Fallback and compatibility**
+
+- R4. The faster-whisper path must keep its current auto-detect behavior when language is blank.
+- R5. The local command fallback must support auto-detect without forcing `--language en`, while preserving compatibility for user-provided command templates that include `{language}`.
+- R6. The change must not mutate Kadri's live profile config; deployment/config changes remain an operator step after code verification.
+
+---
+
+## Key Technical Decisions
+
+- KTD1. Treat blank local language as an explicit auto-detect signal: The code should distinguish “missing language” from “English default” for local STT. This matches Kadri's current config and faster-whisper's native behavior.
+- KTD2. Make the auto-detected whisper CLI template omit `--language` by default: Many Whisper CLIs auto-detect when the language flag is absent. Omitting the flag is safer for mixed Estonian/English than filling `{language}` with `en`.
+- KTD3. Preserve user template compatibility with a resolved language token: Custom `HERMES_LOCAL_STT_COMMAND` templates may already include `{language}`. For those, leave `{language}` available and only use the legacy English fallback when neither config nor env supplies a language.
+- KTD4. Verify through focused unit tests rather than live Discord: The Discord adapter already has attachment-path behavior in code; the risk here is STT language resolution. Unit tests on `tools/transcription_tools.py` are the smallest meaningful regression gate.
+
+---
+
+## Implementation Units
+
+### U1. Pin local STT language resolution semantics
+
+- **Goal:** Add a small helper or equivalent local logic that makes blank config/env language resolve to auto-detect for native faster-whisper and for auto-detected CLI commands.
+- **Requirements:** R1, R2, R4, R5.
+- **Dependencies:** None.
+- **Files:**
+  - `tools/transcription_tools.py`
+  - `tests/tools/test_transcription_tools.py`
+- **Approach:** Keep faster-whisper passing no `language` kwarg when config/env language is blank. Adjust the local command fallback so the built-in whisper CLI template can omit the language flag entirely when no language is configured. Preserve explicit language behavior for `et`, `en`, or other valid language codes.
+- **Patterns to follow:** Existing `_transcribe_local()` language resolution and `TestTranscribeLocalCommand` command-capture style in `tests/tools/test_transcription_tools.py`.
+- **Test scenarios:**
+  - Blank `stt.local.language` with faster-whisper calls model transcription without a `language` kwarg.
+  - Explicit `stt.local.language: et` with faster-whisper passes `language="et"`.
+  - Auto-detected local whisper CLI command with no configured language builds a command without `--language`.
+  - Auto-detected local whisper CLI command with `HERMES_LOCAL_STT_LANGUAGE=et` includes `--language et`.
+- **Verification:** Focused transcription tests show blank means auto-detect and explicit language still forces the requested language.
+
+### U2. Preserve custom local command template compatibility
+
+- **Goal:** Ensure existing `HERMES_LOCAL_STT_COMMAND` users do not break when their templates contain `{language}`.
+- **Requirements:** R2, R5.
+- **Dependencies:** U1.
+- **Files:**
+  - `tools/transcription_tools.py`
+  - `tests/tools/test_transcription_tools.py`
+- **Approach:** When a user-provided command template contains `{language}`, continue to substitute a concrete language token. If config/env has a non-empty language, use it; otherwise keep the previous English fallback for that compatibility path rather than failing template formatting.
+- **Patterns to follow:** Existing shell/list mode split in `_transcribe_local_command()` and `TestShellSafety`.
+- **Test scenarios:**
+  - Existing custom template containing `{language}` still receives `en` by default when no config/env language is set.
+  - Custom template receives `et` when `HERMES_LOCAL_STT_LANGUAGE=et`.
+  - Invalid custom templates still report the existing placeholder error path.
+- **Verification:** Local command tests pass without changing the shell-safety contract.
+
+### U3. Confirm Discord-to-STT path remains intact
+
+- **Goal:** Protect against accidental regression in the Discord attachment path while changing STT internals.
+- **Requirements:** R3, R6.
+- **Dependencies:** U1.
+- **Files:**
+  - `gateway/platforms/discord.py`
+  - `gateway/run.py`
+  - `tests/gateway/test_discord_document_handling.py` or a focused Discord attachment test if existing coverage lacks audio-path assertions.
+- **Approach:** Prefer inspection and existing tests if audio attachment coverage already proves cached path + `audio/*` media types. Add only a narrow regression test if there is no coverage for Discord audio attachments entering `event.media_urls`/`media_types`.
+- **Patterns to follow:** Existing Discord document and image attachment tests that construct fake attachments and call adapter message processing helpers.
+- **Test scenarios:**
+  - Discord audio attachment with `content_type="audio/ogg"` is cached to a local audio path and marked as `audio/ogg`.
+  - A no-text Discord audio message remains eligible for gateway transcription rather than being treated as a plain document.
+- **Verification:** Existing or added gateway tests show audio attachments still flow into STT enrichment.
+
+---
+
+## Scope Boundaries
+
+- Do not edit or deploy Kadri's live profile config in this code change.
+- Do not change provider selection priority, cloud STT providers, or Discord voice-channel live audio behavior.
+- Do not add a translation layer; this work is transcription language detection, not cross-language response policy.
+
+---
+
+## Risks & Dependencies
+
+- The local whisper CLI's exact option behavior varies by implementation. The safe default is to omit `--language` for auto-detect, but tests should validate command construction rather than invoking a real CLI.
+- Existing users with custom templates may rely on `{language}` always being non-empty; keeping a compatibility fallback avoids breaking them.
+- Mixed-language accuracy still depends on model size and audio quality. Code can preserve auto-detect, but Kadri's profile should still use a model such as `small` for better Estonian/English accuracy once code is verified.
+
+---
+
+## Documentation / Operational Notes
+
+After code verification, Kadri's runtime profile can be checked separately for:
+
+- `stt.enabled: true`
+- `stt.provider: local`
+- `stt.local.model: small`
+- `stt.local.language: ""`
+
+That runtime check is intentionally outside this repo mutation unless the operator explicitly asks to deploy config.
+
+---
+
+## Sources / Research
+
+- `gateway/platforms/discord.py` caches inbound `audio/*` Discord attachments with `cache_audio_from_bytes` / URL fallback and records local paths in `media_urls`.
+- `gateway/run.py` collects `audio_paths` from `audio/*` media and calls `tools.transcription_tools.transcribe_audio` during message enrichment.
+- `tools/transcription_tools.py` already lets faster-whisper auto-detect when `stt.local.language` is blank; the local command fallback is the weaker path because it defaults blank language to English.
+- `tests/tools/test_transcription_tools.py` contains existing provider selection, local command, shell-safety, and faster-whisper regression coverage to extend.

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -425,6 +425,169 @@ class TestTranscribeLocalCommand:
         assert result["transcript"] == "hello from local command"
         assert result["provider"] == "local_command"
 
+    def test_auto_detected_command_omits_language_when_blank(self, monkeypatch, sample_ogg, tmp_path):
+        out_dir = tmp_path / "local-out"
+        out_dir.mkdir()
+        captured_commands = []
+
+        monkeypatch.delenv("HERMES_LOCAL_STT_COMMAND", raising=False)
+        monkeypatch.delenv("HERMES_LOCAL_STT_LANGUAGE", raising=False)
+        monkeypatch.setattr("tools.transcription_tools._load_stt_config", lambda: {"local": {"language": ""}})
+        monkeypatch.setattr("tools.transcription_tools._find_whisper_binary", lambda: "/usr/bin/whisper")
+        monkeypatch.setattr("tools.transcription_tools._find_ffmpeg_binary", lambda: "/usr/bin/ffmpeg")
+
+        def fake_tempdir(prefix=None):
+            class _TempDir:
+                def __enter__(self_inner):
+                    return str(out_dir)
+
+                def __exit__(self_inner, exc_type, exc, tb):
+                    return False
+
+            return _TempDir()
+
+        def fake_run(cmd, *args, **kwargs):
+            captured_commands.append(cmd)
+            if isinstance(cmd, list) and cmd[0] == "/usr/bin/ffmpeg":
+                with open(cmd[-1], "wb") as handle:
+                    handle.write(b"RIFF....WAVEfmt ")
+            else:
+                (out_dir / "test.txt").write_text("tere hello\n", encoding="utf-8")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr("tools.transcription_tools.tempfile.TemporaryDirectory", fake_tempdir)
+        monkeypatch.setattr("tools.transcription_tools.subprocess.run", fake_run)
+
+        from tools.transcription_tools import _transcribe_local_command
+
+        result = _transcribe_local_command(sample_ogg, "base")
+
+        assert result["success"] is True
+        whisper_cmd = captured_commands[-1]
+        assert whisper_cmd[0] == "/usr/bin/whisper"
+        assert "--language" not in whisper_cmd
+
+    def test_auto_detected_command_includes_explicit_language(self, monkeypatch, sample_ogg, tmp_path):
+        out_dir = tmp_path / "local-out"
+        out_dir.mkdir()
+        captured_commands = []
+
+        monkeypatch.delenv("HERMES_LOCAL_STT_COMMAND", raising=False)
+        monkeypatch.setenv("HERMES_LOCAL_STT_LANGUAGE", "et")
+        monkeypatch.setattr("tools.transcription_tools._load_stt_config", lambda: {})
+        monkeypatch.setattr("tools.transcription_tools._find_whisper_binary", lambda: "/usr/bin/whisper")
+        monkeypatch.setattr("tools.transcription_tools._find_ffmpeg_binary", lambda: "/usr/bin/ffmpeg")
+
+        def fake_tempdir(prefix=None):
+            class _TempDir:
+                def __enter__(self_inner):
+                    return str(out_dir)
+
+                def __exit__(self_inner, exc_type, exc, tb):
+                    return False
+
+            return _TempDir()
+
+        def fake_run(cmd, *args, **kwargs):
+            captured_commands.append(cmd)
+            if isinstance(cmd, list) and cmd[0] == "/usr/bin/ffmpeg":
+                with open(cmd[-1], "wb") as handle:
+                    handle.write(b"RIFF....WAVEfmt ")
+            else:
+                (out_dir / "test.txt").write_text("tere\n", encoding="utf-8")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr("tools.transcription_tools.tempfile.TemporaryDirectory", fake_tempdir)
+        monkeypatch.setattr("tools.transcription_tools.subprocess.run", fake_run)
+
+        from tools.transcription_tools import _transcribe_local_command
+
+        result = _transcribe_local_command(sample_ogg, "base")
+
+        assert result["success"] is True
+        whisper_cmd = captured_commands[-1]
+        assert "--language" in whisper_cmd
+        assert "et" in whisper_cmd
+
+    def test_custom_command_template_keeps_default_language_token(self, monkeypatch, sample_ogg, tmp_path):
+        out_dir = tmp_path / "local-out"
+        out_dir.mkdir()
+        captured_commands = []
+
+        monkeypatch.setenv(
+            "HERMES_LOCAL_STT_COMMAND",
+            "whisper {input_path} --output_dir {output_dir} --language {language}",
+        )
+        monkeypatch.delenv("HERMES_LOCAL_STT_LANGUAGE", raising=False)
+        monkeypatch.setattr("tools.transcription_tools._load_stt_config", lambda: {"local": {"language": ""}})
+        monkeypatch.setattr("tools.transcription_tools._find_ffmpeg_binary", lambda: "/usr/bin/ffmpeg")
+
+        def fake_tempdir(prefix=None):
+            class _TempDir:
+                def __enter__(self_inner):
+                    return str(out_dir)
+
+                def __exit__(self_inner, exc_type, exc, tb):
+                    return False
+
+            return _TempDir()
+
+        def fake_run(cmd, *args, **kwargs):
+            captured_commands.append(cmd)
+            if isinstance(cmd, list):
+                with open(cmd[-1], "wb") as handle:
+                    handle.write(b"RIFF....WAVEfmt ")
+            else:
+                (out_dir / "test.txt").write_text("hello\n", encoding="utf-8")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr("tools.transcription_tools.tempfile.TemporaryDirectory", fake_tempdir)
+        monkeypatch.setattr("tools.transcription_tools.subprocess.run", fake_run)
+
+        from tools.transcription_tools import _transcribe_local_command
+
+        result = _transcribe_local_command(sample_ogg, "base")
+
+        assert result["success"] is True
+        assert captured_commands[-1].endswith("--language en")
+
+
+class TestTranscribeLocalLanguageSelection:
+    def test_blank_language_uses_faster_whisper_auto_detect(self, monkeypatch, sample_ogg):
+        segment = MagicMock()
+        segment.text = "tere hello"
+        info = MagicMock(language="et", duration=1.0)
+        model = MagicMock()
+        model.transcribe.return_value = ([segment], info)
+
+        monkeypatch.delenv("HERMES_LOCAL_STT_LANGUAGE", raising=False)
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("tools.transcription_tools._load_stt_config", return_value={"local": {"language": ""}}), \
+             patch("tools.transcription_tools._local_model", model), \
+             patch("tools.transcription_tools._local_model_name", "base"):
+            from tools.transcription_tools import _transcribe_local
+            result = _transcribe_local(sample_ogg, "base")
+
+        assert result["success"] is True
+        model.transcribe.assert_called_once_with(sample_ogg, beam_size=5)
+
+    def test_explicit_language_is_passed_to_faster_whisper(self, sample_ogg):
+        segment = MagicMock()
+        segment.text = "tere"
+        info = MagicMock(language="et", duration=1.0)
+        model = MagicMock()
+        model.transcribe.return_value = ([segment], info)
+
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("tools.transcription_tools._load_stt_config", return_value={"local": {"language": "et"}}), \
+             patch("tools.transcription_tools._local_model", model), \
+             patch("tools.transcription_tools._local_model_name", "base"):
+            from tools.transcription_tools import _transcribe_local
+            result = _transcribe_local(sample_ogg, "base")
+
+        assert result["success"] is True
+        model.transcribe.assert_called_once_with(sample_ogg, beam_size=5, language="et")
+
 
 # ============================================================================
 # _transcribe_local — additional tests
@@ -1557,6 +1720,7 @@ class TestShellSafety:
             input_path=shlex.quote("/tmp/test.wav"),
             output_dir=shlex.quote("/tmp/out"),
             language=shlex.quote("en"),
+            language_arg=" --language en",
             model=shlex.quote("base"),
         )
         parts = shlex.split(cmd)

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -170,9 +170,23 @@ def _get_local_command_template() -> Optional[str]:
         quoted_binary = shlex.quote(whisper_binary)
         return (
             f"{quoted_binary} {{input_path}} --model {{model}} --output_format txt "
-            "--output_dir {output_dir} --language {language}"
+            "--output_dir {output_dir}{language_arg}"
         )
     return None
+
+
+def _configured_local_stt_language() -> Optional[str]:
+    """Return the configured local STT language, or None for auto-detect.
+
+    A blank config/env value is intentional: local Whisper backends should
+    auto-detect the spoken language so mixed-language voice notes are not
+    silently forced through English.
+    """
+    configured = _load_stt_config().get("local", {}).get("language")
+    if configured is None:
+        configured = os.getenv(LOCAL_STT_LANGUAGE_ENV)
+    configured = str(configured or "").strip()
+    return configured or None
 
 
 def _has_local_command() -> bool:
@@ -1128,14 +1142,10 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
             _local_model_name = model_name
 
         # Language: config.yaml (stt.local.language) > env var > auto-detect.
-        _forced_lang = (
-            _load_stt_config().get("local", {}).get("language")
-            or os.getenv(LOCAL_STT_LANGUAGE_ENV)
-            or None
-        )
+        forced_lang = _configured_local_stt_language()
         transcribe_kwargs = {"beam_size": 5}
-        if _forced_lang:
-            transcribe_kwargs["language"] = _forced_lang
+        if forced_lang:
+            transcribe_kwargs["language"] = forced_lang
 
         try:
             segments, info = _local_model.transcribe(file_path, **transcribe_kwargs)
@@ -1210,12 +1220,12 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
             ),
         }
 
-    # Language: config.yaml (stt.local.language) > env var > "en" default.
-    language = (
-        _load_stt_config().get("local", {}).get("language")
-        or os.getenv(LOCAL_STT_LANGUAGE_ENV)
-        or DEFAULT_LOCAL_STT_LANGUAGE
-    )
+    # Language: config.yaml (stt.local.language) > env var > auto-detect.
+    configured_language = _configured_local_stt_language()
+    # Keep legacy custom-template behavior: templates that explicitly include
+    # {language} still receive a concrete token even when no language is set.
+    language = configured_language or DEFAULT_LOCAL_STT_LANGUAGE
+    language_arg = f" --language {shlex.quote(configured_language)}" if configured_language else ""
     normalized_model = _normalize_local_command_model(model_name)
 
     try:
@@ -1228,6 +1238,7 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
                 input_path=shlex.quote(prepared_input),
                 output_dir=shlex.quote(output_dir),
                 language=shlex.quote(language),
+                language_arg=language_arg,
                 model=shlex.quote(normalized_model),
             )
             # User-provided templates (env var) may contain shell syntax; auto-detected commands are safe for list mode.


### PR DESCRIPTION
## Summary

Local STT now treats a blank language setting as intentional auto-detection, so mixed Estonian/English Discord voice notes are no longer forced through English if Hermes falls back from faster-whisper to a local Whisper CLI. Explicit language choices still work, and custom command templates that already use `{language}` keep receiving a concrete default token for compatibility.

The plan artifact records the Kadri Discord audio path investigation and keeps runtime config deployment out of this code change.

## Test plan

- `pytest tests/tools/test_transcription_tools.py -q`
- `pytest tests/gateway/test_discord_document_handling.py tests/gateway/test_voice_command.py -q -k 'process_voice_input or document_handling or attachment'`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![openai--codex_gpt--5.5](https://img.shields.io/badge/openai--codex_gpt--5.5-000000)
