### PR TITLE
fix(bedrock): configure runtime client timeouts

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -95,8 +95,16 @@ def _get_bedrock_runtime_client(region: str):
     """
     if region not in _bedrock_runtime_client_cache:
         boto3 = _require_boto3()
+        from botocore.config import Config as BotoConfig
+        _read_timeout = int(os.getenv("BEDROCK_READ_TIMEOUT", "300"))
+        _connect_timeout = int(os.getenv("BEDROCK_CONNECT_TIMEOUT", "10"))
         _bedrock_runtime_client_cache[region] = boto3.client(
             "bedrock-runtime", region_name=region,
+            config=BotoConfig(
+                read_timeout=_read_timeout,
+                connect_timeout=_connect_timeout,
+                retries={"max_attempts": 0},  # Hermes handles retries at a higher level
+            ),
         )
     return _bedrock_runtime_client_cache[region]
 

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -29,6 +29,7 @@ Requires: ``boto3`` (optional dependency — only needed when using the Bedrock 
 
 import json
 import logging
+import math
 import os
 import re
 from types import SimpleNamespace
@@ -59,6 +60,8 @@ _bedrock_control_client_cache: Dict[str, Any] = {}
 
 
 _MIN_BOTO3_VERSION = (1, 34, 59)
+_DEFAULT_READ_TIMEOUT_SECONDS = 300.0
+_DEFAULT_CONNECT_TIMEOUT_SECONDS = 10.0
 
 
 def _require_boto3():
@@ -88,6 +91,38 @@ def _require_boto3():
     return boto3
 
 
+def _coerce_positive_timeout(raw: object, default: float) -> float:
+    if isinstance(raw, bool):
+        return default
+    try:
+        timeout = float(raw)
+    except (TypeError, ValueError, OverflowError):
+        return default
+    return timeout if math.isfinite(timeout) and timeout > 0 else default
+
+
+def _bedrock_client_timeouts() -> tuple[float, float]:
+    """Return validated read/connect timeouts from ``config.yaml``."""
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        config = load_config_readonly()
+        section = config.get("bedrock", {}) if isinstance(config, dict) else {}
+        if not isinstance(section, dict):
+            section = {}
+    except Exception:
+        section = {}
+
+    return (
+        _coerce_positive_timeout(
+            section.get("read_timeout_seconds"), _DEFAULT_READ_TIMEOUT_SECONDS
+        ),
+        _coerce_positive_timeout(
+            section.get("connect_timeout_seconds"), _DEFAULT_CONNECT_TIMEOUT_SECONDS
+        ),
+    )
+
+
 def _get_bedrock_runtime_client(region: str):
     """Get or create a cached ``bedrock-runtime`` client for the given region.
 
@@ -96,13 +131,12 @@ def _get_bedrock_runtime_client(region: str):
     if region not in _bedrock_runtime_client_cache:
         boto3 = _require_boto3()
         from botocore.config import Config as BotoConfig
-        _read_timeout = int(os.getenv("BEDROCK_READ_TIMEOUT", "300"))
-        _connect_timeout = int(os.getenv("BEDROCK_CONNECT_TIMEOUT", "10"))
+        read_timeout, connect_timeout = _bedrock_client_timeouts()
         _bedrock_runtime_client_cache[region] = boto3.client(
             "bedrock-runtime", region_name=region,
             config=BotoConfig(
-                read_timeout=_read_timeout,
-                connect_timeout=_connect_timeout,
+                read_timeout=read_timeout,
+                connect_timeout=connect_timeout,
                 retries={"max_attempts": 0},  # Hermes handles retries at a higher level
             ),
         )

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -139,8 +139,10 @@ model:
 # implicit non-stream stale detector is auto-disabled for local endpoints
 # and can scale upward for very large contexts.
 #
-# Not currently wired for AWS Bedrock (bedrock_converse + AnthropicBedrock
-# SDK paths) — those use boto3 with its own timeout configuration.
+# AWS Bedrock's native Converse client uses its own validated timeout settings:
+# bedrock:
+#   read_timeout_seconds: 300
+#   connect_timeout_seconds: 10
 #
 # providers:
 #   ollama-local:

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -538,6 +538,103 @@ class TestExtractProviderFromArn:
 # ---------------------------------------------------------------------------
 
 class TestClientCache:
+    @staticmethod
+    def _fake_botocore_config(config_ctor):
+        botocore_mod = ModuleType("botocore")
+        config_mod = ModuleType("botocore.config")
+        config_mod.Config = config_ctor
+        botocore_mod.config = config_mod
+        return {
+            "botocore": botocore_mod,
+            "botocore.config": config_mod,
+        }
+
+    def test_runtime_client_uses_configured_timeouts(self, monkeypatch):
+        from agent.bedrock_adapter import _get_bedrock_runtime_client, reset_client_cache
+
+        monkeypatch.delenv("BEDROCK_READ_TIMEOUT", raising=False)
+        monkeypatch.delenv("BEDROCK_CONNECT_TIMEOUT", raising=False)
+        reset_client_cache()
+        boto3 = MagicMock()
+        client = object()
+        boto3.client.return_value = client
+        boto_config = object()
+        config_ctor = MagicMock(return_value=boto_config)
+
+        try:
+            with (
+                patch("agent.bedrock_adapter._require_boto3", return_value=boto3),
+                patch(
+                    "hermes_cli.config.load_config_readonly",
+                    return_value={
+                        "bedrock": {
+                            "read_timeout_seconds": 45,
+                            "connect_timeout_seconds": 2.5,
+                        }
+                    },
+                ),
+                patch.dict("sys.modules", self._fake_botocore_config(config_ctor)),
+            ):
+                assert _get_bedrock_runtime_client("us-east-1") is client
+
+            config_ctor.assert_called_once_with(
+                read_timeout=45.0,
+                connect_timeout=2.5,
+                retries={"max_attempts": 0},
+            )
+            boto3.client.assert_called_once_with(
+                "bedrock-runtime",
+                region_name="us-east-1",
+                config=boto_config,
+            )
+        finally:
+            reset_client_cache()
+
+    @pytest.mark.parametrize(
+        ("read_timeout", "connect_timeout"),
+        [
+            ("not-a-number", "also-invalid"),
+            (0, -1),
+            (True, False),
+            (float("inf"), float("nan")),
+            (10**400, 10**400),
+        ],
+    )
+    def test_runtime_client_invalid_timeouts_fall_back_to_defaults(
+        self, monkeypatch, read_timeout, connect_timeout
+    ):
+        from agent.bedrock_adapter import _get_bedrock_runtime_client, reset_client_cache
+
+        monkeypatch.delenv("BEDROCK_READ_TIMEOUT", raising=False)
+        monkeypatch.delenv("BEDROCK_CONNECT_TIMEOUT", raising=False)
+        reset_client_cache()
+        boto3 = MagicMock()
+        config_ctor = MagicMock(return_value=object())
+
+        try:
+            with (
+                patch("agent.bedrock_adapter._require_boto3", return_value=boto3),
+                patch(
+                    "hermes_cli.config.load_config_readonly",
+                    return_value={
+                        "bedrock": {
+                            "read_timeout_seconds": read_timeout,
+                            "connect_timeout_seconds": connect_timeout,
+                        }
+                    },
+                ),
+                patch.dict("sys.modules", self._fake_botocore_config(config_ctor)),
+            ):
+                _get_bedrock_runtime_client("us-west-2")
+
+            config_ctor.assert_called_once_with(
+                read_timeout=300.0,
+                connect_timeout=10.0,
+                retries={"max_attempts": 0},
+            )
+        finally:
+            reset_client_cache()
+
     def test_reset_clears_caches(self):
         from agent.bedrock_adapter import (
             _bedrock_runtime_client_cache,

--- a/website/docs/guides/aws-bedrock.md
+++ b/website/docs/guides/aws-bedrock.md
@@ -62,6 +62,21 @@ Set the AWS region in any of these ways (highest priority first):
 3. `AWS_DEFAULT_REGION` environment variable
 4. Default: `us-east-1`
 
+### Client timeouts
+
+The native Converse client waits up to 300 seconds for a response and 10
+seconds to establish a connection. Override either positive numeric value in
+`config.yaml`:
+
+```yaml
+bedrock:
+  read_timeout_seconds: 600
+  connect_timeout_seconds: 15
+```
+
+Invalid, boolean, zero, and negative values fall back to the defaults instead
+of preventing the Bedrock client from starting.
+
 ### Guardrails
 
 To apply [Amazon Bedrock Guardrails](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html) to all model invocations:

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -95,7 +95,7 @@ You can set `providers.<id>.request_timeout_seconds` for a provider-wide request
 
 You can also set `providers.<id>.stale_timeout_seconds` for the non-streaming stale-call detector, plus `providers.<id>.models.<model>.stale_timeout_seconds` for a model-specific override. This wins over the legacy `HERMES_API_CALL_STALE_TIMEOUT` env var.
 
-Leaving these unset keeps the legacy defaults (`HERMES_API_TIMEOUT=1800`s, `HERMES_API_CALL_STALE_TIMEOUT=90`s, native Anthropic 900s). The non-streaming stale detector is auto-disabled for local endpoints when left implicit and can scale upward for very large contexts. Not currently wired for AWS Bedrock (both `bedrock_converse` and AnthropicBedrock SDK paths use boto3 with its own timeout configuration). See the commented example in [`cli-config.yaml.example`](https://github.com/NousResearch/hermes-agent/blob/main/cli-config.yaml.example).
+Leaving these unset keeps the legacy defaults (`HERMES_API_TIMEOUT=1800`s, `HERMES_API_CALL_STALE_TIMEOUT=90`s, native Anthropic 900s). The non-streaming stale detector is auto-disabled for local endpoints when left implicit and can scale upward for very large contexts. AWS Bedrock's native Converse client uses `bedrock.read_timeout_seconds` (default `300`) and `bedrock.connect_timeout_seconds` (default `10`) instead. See the commented example in [`cli-config.yaml.example`](https://github.com/NousResearch/hermes-agent/blob/main/cli-config.yaml.example).
 
 ## Update Behavior
 


### PR DESCRIPTION
## Summary

Configure explicit timeouts on the native AWS Bedrock Runtime client so large-context requests are not limited by boto3's 60-second read timeout.

## Changes

- Set a 300-second read timeout and 10-second connect timeout through `botocore.config.Config`.
- Read optional overrides from non-secret `config.yaml` settings:

  ```yaml
  bedrock:
    read_timeout_seconds: 600
    connect_timeout_seconds: 15
  ```

- Validate both values as positive finite numerics; malformed, boolean, non-positive, NaN/infinite, and oversized values fall back to the defaults instead of failing client construction.
- Set `retries={"max_attempts": 0}` because Hermes handles retries at the conversation-loop level.
- Document the settings in the Bedrock guide, configuration reference, and canonical config example.

The original Dashboard credential-probe bypass was removed after review: current Bedrock runtime resolution already supplies `api_key="aws-sdk"`, so the normal path does not reproduce an empty-key warning.

## Testing

- `scripts/run_tests.sh tests/agent/test_bedrock_adapter.py -q` — 68 passed
- `.venv/bin/ruff check agent/bedrock_adapter.py tests/agent/test_bedrock_adapter.py`
- `git diff --check`