### PR TITLE
Scope TUI config reads to session profile

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1854,6 +1854,60 @@ def _session(agent=None, **extra):
     }
 
 
+def test_config_get_full_uses_session_profile_home(monkeypatch, tmp_path):
+    launch_home = tmp_path / "launch-home"
+    profile_home = tmp_path / "profile-home"
+    launch_home.mkdir()
+    profile_home.mkdir()
+    (launch_home / "config.yaml").write_text(
+        "display:\n  tui_compact: false\n", encoding="utf-8"
+    )
+    (profile_home / "config.yaml").write_text(
+        "display:\n  tui_compact: true\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(server, "_hermes_home", launch_home)
+    server._cfg_cache = None
+    server._cfg_mtime = None
+    server._cfg_path = None
+    server._sessions["cfg-profile"] = _session(profile_home=str(profile_home))
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "config.get",
+            "params": {"key": "full", "session_id": "cfg-profile"},
+        }
+    )
+
+    assert resp["result"]["config"]["display"]["tui_compact"] is True
+
+
+def test_config_get_mtime_uses_session_profile_home(monkeypatch, tmp_path):
+    launch_home = tmp_path / "launch-home"
+    profile_home = tmp_path / "profile-home"
+    launch_home.mkdir()
+    profile_home.mkdir()
+    launch_cfg = launch_home / "config.yaml"
+    profile_cfg = profile_home / "config.yaml"
+    launch_cfg.write_text("display:\n  tui_compact: false\n", encoding="utf-8")
+    profile_cfg.write_text("display:\n  tui_compact: true\n", encoding="utf-8")
+    profile_mtime = launch_cfg.stat().st_mtime + 10
+    os.utime(profile_cfg, (profile_mtime, profile_mtime))
+    monkeypatch.setattr(server, "_hermes_home", launch_home)
+    server._sessions["cfg-mtime"] = _session(profile_home=str(profile_home))
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "config.get",
+            "params": {"key": "mtime", "session_id": "cfg-mtime"},
+        }
+    )
+
+    assert resp["result"]["mtime"] == profile_cfg.stat().st_mtime
+    assert resp["result"]["mtime"] != launch_cfg.stat().st_mtime
+
+
 def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
     calls = {"hooks": []}
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1971,6 +1971,24 @@ def _save_cfg(cfg: dict):
             _cfg_mtime = None
 
 
+def _config_home_for_params(params: dict | None = None) -> Path:
+    params = params or {}
+    session = _sessions.get(params.get("session_id") or "")
+    profile_home = session.get("profile_home") if session else None
+    return Path(profile_home) if profile_home else _hermes_home
+
+
+def _load_cfg_for_params(params: dict | None = None) -> dict:
+    home = _config_home_for_params(params)
+    if home == _hermes_home:
+        return _load_cfg()
+    token = set_hermes_home_override(str(home))
+    try:
+        return _load_cfg()
+    finally:
+        reset_hermes_home_override(token)
+
+
 def _cwd_for_session_key(session_key: str) -> str:
     """Reverse-map session_key to the session's logical cwd.
 
@@ -11305,7 +11323,7 @@ def _(rid, params: dict) -> dict:
         cwd = _completion_cwd({"cwd": raw} if raw else {})
         return _ok(rid, {"cwd": cwd, "branch": _git_branch_for_cwd(cwd)})
     if key == "full":
-        return _ok(rid, {"config": _load_cfg()})
+        return _ok(rid, {"config": _load_cfg_for_params(params)})
     if key == "prompt":
         return _ok(rid, {"prompt": _load_cfg().get("custom_prompt", "")})
     if key == "skin":
@@ -11423,7 +11441,7 @@ def _(rid, params: dict) -> dict:
         display = _load_cfg().get("display")
         return _ok(rid, {"value": _display_mouse_tracking(display)})
     if key == "mtime":
-        cfg_path = _hermes_home / "config.yaml"
+        cfg_path = _config_home_for_params(params) / "config.yaml"
         try:
             return _ok(
                 rid, {"mtime": cfg_path.stat().st_mtime if cfg_path.exists() else 0}

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -1142,6 +1142,55 @@ describe('createGatewayEventHandler', () => {
     expect(getTurnState().activity.filter(a => a.text.includes('/agents'))).toHaveLength(0)
   })
 
+  it('scopes the agents nudge config read to the active session profile', async () => {
+    const ctx = buildCtx([])
+    ctx.gateway.rpc = vi.fn(async (method: string) =>
+      method === 'config.get' ? { config: { display: { tui_agents_nudge: true } } } : null
+    )
+    const onEvent = createGatewayEventHandler(ctx)
+
+    patchUiState({ sid: 'sess-profile' })
+    onEvent({
+      payload: { goal: 'child a', subagent_id: 'sa-a', task_index: 0 },
+      type: 'subagent.start'
+    } as any)
+
+    await Promise.resolve()
+
+    expect(ctx.gateway.rpc).toHaveBeenCalledWith('config.get', {
+      key: 'full',
+      session_id: 'sess-profile'
+    })
+  })
+
+  it('refetches the agents nudge config after a launch-profile read when a session becomes active', async () => {
+    const ctx = buildCtx([])
+    ctx.gateway.rpc = vi.fn(async (method: string) =>
+      method === 'config.get' ? { config: { display: { tui_agents_nudge: true } } } : null
+    )
+    const onEvent = createGatewayEventHandler(ctx)
+
+    onEvent({
+      payload: { goal: 'child a', subagent_id: 'sa-a', task_index: 0 },
+      type: 'subagent.start'
+    } as any)
+    await Promise.resolve()
+
+    patchUiState({ sid: 'sess-profile' })
+    onEvent({ payload: {}, type: 'message.start' } as any)
+    onEvent({
+      payload: { goal: 'child b', subagent_id: 'sa-b', task_index: 1 },
+      type: 'subagent.start'
+    } as any)
+    await Promise.resolve()
+
+    expect(ctx.gateway.rpc).toHaveBeenNthCalledWith(1, 'config.get', { key: 'full' })
+    expect(ctx.gateway.rpc).toHaveBeenNthCalledWith(2, 'config.get', {
+      key: 'full',
+      session_id: 'sess-profile'
+    })
+  })
+
   it('drops stale reasoning/tool/todos events after ctrl-c until the next message starts', () => {
     // Repro for the discord report: ctrl-c interrupts, but late reasoning/tool
     // events from the still-winding-down agent loop kept populating the UI for

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -396,8 +396,13 @@ describe('hydrateFullConfig', () => {
 
     await hydrateFullConfig(gw, setBell, setVoiceRecordKey)
 
-    expect(gw.request).toHaveBeenCalledWith('config.get', { key: 'full' })
-    expect(setVoiceRecordKey).toHaveBeenCalledWith(expect.objectContaining({ ch: 'o', mod: 'ctrl', raw: 'ctrl+o' }))
+    expect(gw.request).toHaveBeenCalledWith('config.get', {
+      key: 'full',
+      session_id: null
+    })
+    expect(setVoiceRecordKey).toHaveBeenCalledWith(
+      expect.objectContaining({ ch: 'o', mod: 'ctrl', raw: 'ctrl+o' })
+    )
     expect(setBell).toHaveBeenCalledWith(false)
   })
 

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -164,9 +164,20 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
   // instead of one per concern.  Resolves to null on RPC failure; callers
   // treat null as "use defaults".
   let fullConfigPromise: null | Promise<ConfigFullResponse | null> = null
+  let fullConfigSessionId: null | string = null
 
   const getFullConfigOnce = (): Promise<ConfigFullResponse | null> => {
-    fullConfigPromise ??= rpc<ConfigFullResponse>('config.get', { key: 'full' }).catch(() => null)
+    const sessionId = getUiState().sid ?? null
+
+    if (fullConfigPromise && fullConfigSessionId === sessionId) {
+      return fullConfigPromise
+    }
+
+    fullConfigSessionId = sessionId
+    fullConfigPromise = rpc<ConfigFullResponse>('config.get', {
+      key: 'full',
+      ...(sessionId ? { session_id: sessionId } : {})
+    }).catch(() => null)
 
     return fullConfigPromise
   }
@@ -184,14 +195,19 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
   // until it resolves we assume the default (on).
   let agentsNudgeEnabled = true
   let agentsNudgeConfigFetched = false
+  let agentsNudgeConfigSessionId: null | string = null
   let agentsNudgedThisTurn = false
 
   const ensureAgentsNudgeConfig = () => {
-    if (agentsNudgeConfigFetched) {
+    const sessionId = getUiState().sid ?? null
+
+    if (agentsNudgeConfigFetched && agentsNudgeConfigSessionId === sessionId) {
       return
     }
 
     agentsNudgeConfigFetched = true
+    agentsNudgeConfigSessionId = sessionId
+    agentsNudgeEnabled = true
     getFullConfigOnce().then(cfg => {
       // Only an explicit `false` disables it; absent/unknown keeps default on.
       if (cfg?.config?.display?.tui_agents_nudge === false) {

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -188,9 +188,13 @@ const _pasteCollapseCharsFromConfig = (cfg: ConfigFullResponse | null): number =
 export async function hydrateFullConfig(
   gw: GatewayClient,
   setBell: (v: boolean) => void,
-  setVoiceRecordKey?: (v: ParsedVoiceRecordKey) => void
+  setVoiceRecordKey?: (v: ParsedVoiceRecordKey) => void,
+  sid?: string | null
 ): Promise<ConfigFullResponse | null> {
-  const cfg = await quietRpc<ConfigFullResponse>(gw, 'config.get', { key: 'full' })
+  const cfg = await quietRpc<ConfigFullResponse>(gw, 'config.get', {
+    key: 'full',
+    session_id: sid ?? null
+  })
   applyDisplay(cfg, setBell, setVoiceRecordKey)
 
   return cfg
@@ -252,10 +256,13 @@ export function useConfigSync({
     // Environment flags are enough to initialize the UI bit; the heavier status
     // check still runs when the user opens /voice.
     setVoiceEnabled(process.env.HERMES_VOICE === '1')
-    quietRpc<ConfigMtimeResponse>(gw, 'config.get', { key: 'mtime' }).then(r => {
+    quietRpc<ConfigMtimeResponse>(gw, 'config.get', {
+      key: 'mtime',
+      session_id: sid
+    }).then(r => {
       mtimeRef.current = Number(r?.mtime ?? 0)
     })
-    void hydrateFullConfig(gw, setBellOnComplete, setVoiceRecordKey)
+    void hydrateFullConfig(gw, setBellOnComplete, setVoiceRecordKey, sid)
   }, [gw, setBellOnComplete, setVoiceEnabled, setVoiceRecordKey, sid])
 
   useEffect(() => {
@@ -264,7 +271,10 @@ export function useConfigSync({
     }
 
     const id = setInterval(() => {
-      quietRpc<ConfigMtimeResponse>(gw, 'config.get', { key: 'mtime' }).then(r => {
+      quietRpc<ConfigMtimeResponse>(gw, 'config.get', {
+        key: 'mtime',
+        session_id: sid
+      }).then(r => {
         const next = Number(r?.mtime ?? 0)
 
         if (!mtimeRef.current) {
@@ -284,7 +294,7 @@ export function useConfigSync({
         quietRpc<ReloadMcpResponse>(gw, 'reload.mcp', { session_id: sid, confirm: true }).then(
           r => r && turnController.pushActivity('MCP reloaded after config change')
         )
-        void hydrateFullConfig(gw, setBellOnComplete, setVoiceRecordKey)
+        void hydrateFullConfig(gw, setBellOnComplete, setVoiceRecordKey, sid)
       })
     }, MTIME_POLL_MS)
 


### PR DESCRIPTION
## Summary

This scopes TUI config hydration and config mtime polling to the active session profile. The frontend now sends the active `session_id` with `config.get full` and `config.get mtime`, and the gateway uses the session's `profile_home` when reading those values.

## Why

Profile-bound TUI/Desktop sessions already track `profile_home`, and `_load_cfg()` can honor a Hermes home override. But the config sync path did not pass any session context:

- `hydrateFullConfig()` called `config.get { key: "full" }`.
- The mtime poller called `config.get { key: "mtime" }`.
- The gateway's `config.get full` read the launch profile config.
- The gateway's `config.get mtime` checked `_hermes_home/config.yaml`.

That means a resumed or profile-bound TUI session can hydrate display/paste/voice settings from the launch profile and miss config changes made in the active profile. In multi-profile TUI/Desktop usage, the UI can therefore render and reload against the wrong profile's config.

## Changes

- Add a small gateway helper that resolves the config home from `params.session_id` when the session has `profile_home`.
- Use that profile-aware helper for `config.get full`.
- Use that profile-aware home for `config.get mtime`.
- Send `session_id` from the TUI config hydration and mtime polling paths.
- Update the config sync unit expectation.
- Add regression tests proving `config.get full` and `config.get mtime` read the session profile home instead of the launch home.

## Tests

```text
python -m pytest tests/test_tui_gateway_server.py -k "config_get" -q --timeout-method=thread
8 passed, 265 deselected
```

```text
git diff --check
```

Not run:

```text
npm run test -- useConfigSync.test.ts
```

`npm run test -- useConfigSync.test.ts` failed in this checkout because `vitest` is not installed/available in `ui-tui`.