### PR TITLE
Store TUI artifacts under session profile home

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6952,6 +6952,68 @@ def test_image_attach_bytes_writes_to_gateway_dir(monkeypatch, tmp_path):
     assert res["bytes"] > 0
 
 
+def test_image_attach_bytes_uses_session_profile_home(monkeypatch, tmp_path):
+    """Profile-bound sessions keep uploaded images in that profile's home."""
+    _attach_bytes_cli(monkeypatch)
+    launch_home = tmp_path / "launch-home"
+    profile_home = tmp_path / "profile-home"
+    monkeypatch.setattr(server, "_hermes_home", launch_home)
+    server._sessions["profile-img"] = _session(profile_home=str(profile_home))
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "image.attach_bytes",
+            "params": {
+                "session_id": "profile-img",
+                "content_base64": _PNG_1X1_B64,
+                "filename": "shot.png",
+            },
+        }
+    )
+
+    res = resp["result"]
+    written = Path(res["path"])
+    assert written.is_file()
+    assert written.parent == profile_home / "images"
+    assert not (launch_home / "images").exists()
+    assert server._sessions["profile-img"]["attached_images"] == [str(written)]
+
+
+def test_clipboard_paste_uses_session_profile_home(monkeypatch, tmp_path):
+    """Clipboard image attach should not write into the launch profile."""
+    import base64 as _base64
+
+    fake_clipboard = types.ModuleType("hermes_cli.clipboard")
+
+    def save_clipboard_image(path):
+        path.write_bytes(_base64.b64decode(_PNG_1X1_B64))
+        return True
+
+    fake_clipboard.has_clipboard_image = lambda: True
+    fake_clipboard.save_clipboard_image = save_clipboard_image
+
+    launch_home = tmp_path / "launch-home"
+    profile_home = tmp_path / "profile-home"
+    monkeypatch.setitem(sys.modules, "hermes_cli.clipboard", fake_clipboard)
+    monkeypatch.setattr(server, "_hermes_home", launch_home)
+    server._sessions["profile-clip"] = _session(profile_home=str(profile_home))
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "clipboard.paste",
+            "params": {"session_id": "profile-clip"},
+        }
+    )
+
+    res = resp["result"]
+    written = Path(res["path"])
+    assert res["attached"] is True
+    assert written.parent == profile_home / "images"
+    assert not (launch_home / "images").exists()
+
+
 def test_image_attach_bytes_accepts_data_url_prefix(monkeypatch, tmp_path):
     _attach_bytes_cli(monkeypatch)
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
@@ -7043,6 +7105,27 @@ def test_image_attach_bytes_rejects_unsupported_extension(monkeypatch, tmp_path)
     )
     assert "error" in resp
     assert resp["error"]["code"] == 4016
+
+
+def test_paste_collapse_uses_session_profile_home(monkeypatch, tmp_path):
+    launch_home = tmp_path / "launch-home"
+    profile_home = tmp_path / "profile-home"
+    monkeypatch.setattr(server, "_hermes_home", launch_home)
+    server._sessions["profile-paste"] = _session(profile_home=str(profile_home))
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "paste.collapse",
+            "params": {"session_id": "profile-paste", "text": "a\nb\nc"},
+        }
+    )
+
+    res = resp["result"]
+    written = Path(res["path"])
+    assert written.is_file()
+    assert written.parent == profile_home / "pastes"
+    assert not (launch_home / "pastes").exists()
 
 
 def test_pdf_attach_requires_poppler(monkeypatch, tmp_path):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1125,6 +1125,12 @@ def _session_cwd(session: dict | None) -> str:
     return _completion_cwd()
 
 
+def _session_home(session: dict | None) -> Path:
+    if session and session.get("profile_home"):
+        return Path(str(session["profile_home"]))
+    return _hermes_home
+
+
 def _register_session_cwd(session: dict | None) -> None:
     if not session:
         return
@@ -6154,7 +6160,7 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5027, f"clipboard unavailable: {e}")
 
     session["image_counter"] = session.get("image_counter", 0) + 1
-    img_dir = _hermes_home / "images"
+    img_dir = _session_home(session) / "images"
     img_dir.mkdir(parents=True, exist_ok=True)
     img_path = (
         img_dir
@@ -6295,14 +6301,14 @@ def _allowed_image_extensions() -> frozenset[str]:
 
 
 def _queue_attached_image(session: dict, img_bytes: bytes, ext: str, *, prefix: str) -> Path:
-    """Write image bytes into the gateway's images dir and queue them.
+    """Write image bytes into the session's images dir and queue them.
 
     Mirrors what ``image.attach`` does for a local path: appends to
     ``session["attached_images"]`` so the next ``prompt.submit`` picks it up via
     the existing native-image-attach pipeline. Returns the written path.
     """
     session["image_counter"] = session.get("image_counter", 0) + 1
-    img_dir = _hermes_home / "images"
+    img_dir = _session_home(session) / "images"
     img_dir.mkdir(parents=True, exist_ok=True)
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
     img_path = img_dir / f"{prefix}_{ts}_{session['image_counter']}{ext}"
@@ -8387,10 +8393,15 @@ def _(rid, params: dict) -> dict:
     text = params.get("text", "")
     if not text:
         return _err(rid, 4004, "empty paste")
+    session = None
+    if params.get("session_id"):
+        session, err = _sess_nowait(params, rid)
+        if err:
+            return err
 
     _paste_counter += 1
     line_count = text.count("\n") + 1
-    paste_dir = _hermes_home / "pastes"
+    paste_dir = _session_home(session) / "pastes"
     paste_dir.mkdir(parents=True, exist_ok=True)
 
     from datetime import datetime

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -207,7 +207,10 @@ export function useComposerState({
       setPasteSnips(prev => trimSnips([...prev, { label, text: cleanedText }]))
 
       void gw
-        .request<{ path?: string }>('paste.collapse', { text: cleanedText })
+        .request<{ path?: string }>('paste.collapse', {
+          session_id: getUiState().sid,
+          text: cleanedText
+        })
         .then(r => {
           const path = r?.path
 


### PR DESCRIPTION
## Summary

This makes TUI-created session artifacts use the active session profile's Hermes home instead of the gateway process' launch Hermes home. Profile-bound sessions now store uploaded images, clipboard images, rendered PDF pages, and collapsed paste files under that profile.

## Why

The TUI gateway can host sessions bound to different Hermes profiles, and the normal session state already tracks `profile_home`. However, artifact-producing shortcuts still wrote to the process-global `_hermes_home`:

- `clipboard.paste` wrote clipboard screenshots to the launch profile's `images/`.
- `image.attach_bytes` and PDF page rendering used `_queue_attached_image()`, which also wrote to the launch profile's `images/`.
- `paste.collapse` wrote large paste files to the launch profile's `pastes/`.
- The TUI frontend did not send `session_id` with `paste.collapse`, so the backend could not scope collapsed paste files even if it wanted to.

In a multi-profile TUI/Desktop/dashboard session, that places user-provided artifacts in the wrong profile, breaks profile isolation, and can leave later prompts referencing files outside the active profile's artifact area.

## Changes

- Add a small `_session_home()` helper that prefers `session["profile_home"]` and falls back to `_hermes_home`.
- Use the session home for TUI clipboard image artifacts.
- Use the session home for byte-uploaded images and rendered PDF page images.
- Use the session home for collapsed paste files when a `session_id` is provided.
- Send the active `session_id` from the TUI frontend when calling `paste.collapse`.
- Add regression tests for profile-scoped image upload, clipboard paste, and paste collapse storage.

## Tests

```text
python -m pytest tests/test_tui_gateway_server.py -k "artifact_home or paste_collapse or attach_bytes" -q --timeout-method=thread
8 passed, 266 deselected
```

Not run:

```text
npm run typecheck
```

`npm run typecheck` failed in this checkout because `tsc` is not installed/available in `ui-tui`.
