### PR TITLE
Scope TUI spawn tree storage to session profile

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6924,6 +6924,59 @@ def _attach_bytes_cli(monkeypatch):
     monkeypatch.setitem(sys.modules, "cli", fake_cli)
 
 
+def test_spawn_tree_save_list_load_uses_session_profile_home(monkeypatch, tmp_path):
+    import hermes_constants
+
+    launch_home = tmp_path / "launch-home"
+    profile_home = tmp_path / "profile-home"
+    launch_home.mkdir()
+    profile_home.mkdir()
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: launch_home)
+    server._sessions["spawn-sid"] = _session(profile_home=str(profile_home))
+
+    subagents = [{"id": "sub-1", "goal": "inspect", "status": "done"}]
+    try:
+        save_resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "spawn_tree.save",
+                "params": {
+                    "session_id": "spawn-sid",
+                    "started_at": 1700000000.0,
+                    "finished_at": 1700000005.0,
+                    "label": "inspect",
+                    "subagents": subagents,
+                },
+            }
+        )
+
+        saved_path = Path(save_resp["result"]["path"])
+        assert saved_path.parent == profile_home / "spawn-trees" / "spawn-sid"
+        assert saved_path.exists()
+        assert not (launch_home / "spawn-trees").exists()
+
+        list_resp = server.handle_request(
+            {
+                "id": "2",
+                "method": "spawn_tree.list",
+                "params": {"session_id": "spawn-sid"},
+            }
+        )
+        entries = list_resp["result"]["entries"]
+        assert [entry["path"] for entry in entries] == [str(saved_path)]
+
+        load_resp = server.handle_request(
+            {
+                "id": "3",
+                "method": "spawn_tree.load",
+                "params": {"session_id": "spawn-sid", "path": str(saved_path)},
+            }
+        )
+        assert load_resp["result"]["subagents"] == subagents
+    finally:
+        server._sessions.pop("spawn-sid", None)
+
+
 def test_image_attach_bytes_writes_to_gateway_dir(monkeypatch, tmp_path):
     """Remote client uploads base64 bytes; gateway writes them to its own disk."""
     _attach_bytes_cli(monkeypatch)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5252,10 +5252,13 @@ def _(rid, params: dict) -> dict:
 # Each file contains { session_id, started_at, finished_at, subagents: [...] }.
 
 
-def _spawn_trees_root():
+def _spawn_trees_root(session_id: str = ""):
     from hermes_constants import get_hermes_home
 
-    root = get_hermes_home() / "spawn-trees"
+    session = _sessions.get(session_id or "")
+    profile_home = session.get("profile_home") if session else None
+    base = Path(str(profile_home)) if profile_home else get_hermes_home()
+    root = base / "spawn-trees"
     root.mkdir(parents=True, exist_ok=True)
     return root
 
@@ -5264,7 +5267,7 @@ def _spawn_tree_session_dir(session_id: str):
     safe = (
         "".join(c if c.isalnum() or c in "-_" else "_" for c in session_id) or "unknown"
     )
-    d = _spawn_trees_root() / safe
+    d = _spawn_trees_root(session_id) / safe
     d.mkdir(parents=True, exist_ok=True)
     return d
 
@@ -5355,7 +5358,7 @@ def _(rid, params: dict) -> dict:
     cross_session = bool(params.get("cross_session"))
 
     if cross_session:
-        root = _spawn_trees_root()
+        root = _spawn_trees_root(session_id)
         roots = [p for p in root.iterdir() if p.is_dir()]
     else:
         roots = [_spawn_tree_session_dir(session_id or "default")]
@@ -5408,7 +5411,7 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 4000, "path required")
 
     # Reject paths escaping the spawn-trees root.
-    root = _spawn_trees_root().resolve()
+    root = _spawn_trees_root(str(params.get("session_id") or "")).resolve()
     try:
         resolved = Path(raw_path).resolve()
         resolved.relative_to(root)

--- a/ui-tui/src/app/slash/commands/ops.ts
+++ b/ui-tui/src/app/slash/commands/ops.ts
@@ -366,7 +366,10 @@ export const opsCommands: SlashCommand[] = [
         }
 
         ctx.gateway
-          .rpc<SpawnTreeLoadResponse>('spawn_tree.load', { path })
+          .rpc<SpawnTreeLoadResponse>('spawn_tree.load', {
+            path,
+            session_id: ctx.sid ?? 'default'
+          })
           .then(
             ctx.guarded<SpawnTreeLoadResponse>(r => {
               if (!r.subagents?.length) {


### PR DESCRIPTION
## Summary

This scopes TUI spawn-tree snapshot storage to the active session profile. `spawn_tree.save`, `spawn_tree.list`, and `spawn_tree.load` now resolve their `spawn-trees/` root from the live session's `profile_home` when available, with the existing Hermes home fallback for legacy/global callers.

## Why

The TUI event stream sends completed subagent trees to `spawn_tree.save` with the active `session_id`, and `/replay list` already includes that same `session_id`. But the gateway stored and read snapshots under process-global `get_hermes_home()/spawn-trees`.

In a profile-bound TUI/Desktop session, that means completed subagent snapshots are persisted under the launch profile instead of the profile that owns the session. The `/replay` disk archive can then miss the active profile's snapshots or load/validate paths against the wrong `spawn-trees` root.

## Changes

- Resolve the spawn-tree root from `session["profile_home"]` when the request includes a live `session_id`.
- Use that profile-aware root for `spawn_tree.save`.
- Use that profile-aware root for `spawn_tree.list`, including cross-session listing within the active profile's root.
- Use that profile-aware root for `spawn_tree.load` path validation.
- Send `session_id` from the TUI `/replay load <path>` command.
- Add a regression test covering save -> list -> load under a profile-bound session.

## Tests

```text
python -m pytest tests/test_tui_gateway_server.py -k "spawn_tree" -q --timeout-method=thread
1 passed, 271 deselected
```

```text
git diff --check
```

Not run:

```text
npm run test -- createSlashHandler.test.ts
```

`npm run test -- createSlashHandler.test.ts` failed in this checkout because `vitest` is not installed/available in `ui-tui`.