### PR TITLE
fix(tui): resolve profile state.db import-order race

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -29,6 +29,69 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar
 
 logger = logging.getLogger(__name__)
 
+T = TypeVar("T")
+
+
+def _default_db_path() -> Path:
+    """Resolve the default state DB path against the current Hermes home.
+
+    ``HERMES_HOME`` can be corrected after import time by profile-aware
+    launchers. Deferring this lookup avoids pinning ``state.db`` to a stale
+    profile path during an early import race.
+    """
+    return get_hermes_home() / "state.db"
+
+
+class _LazyDefaultDBPath:
+    """Path-like wrapper that resolves the default state DB lazily."""
+
+    def _resolve(self) -> Path:
+        return _default_db_path()
+
+    def __fspath__(self) -> str:
+        return str(self._resolve())
+
+    def __str__(self) -> str:
+        return str(self._resolve())
+
+    def __repr__(self) -> str:
+        return repr(self._resolve())
+
+    def __truediv__(self, other):
+        return self._resolve() / other
+
+    def __rtruediv__(self, other):
+        return Path(other) / self._resolve()
+
+    def __eq__(self, other: object) -> bool:
+        return self._resolve() == other
+
+    def __hash__(self) -> int:
+        return hash(self._resolve())
+
+    @property
+    def parent(self) -> Path:
+        return self._resolve().parent
+
+    def exists(self, *args, **kwargs):
+        return self._resolve().exists(*args, **kwargs)
+
+    def mkdir(self, *args, **kwargs):
+        return self._resolve().mkdir(*args, **kwargs)
+
+    def unlink(self, *args, **kwargs):
+        return self._resolve().unlink(*args, **kwargs)
+
+    def stat(self, *args, **kwargs):
+        return self._resolve().stat(*args, **kwargs)
+
+    def read_text(self, *args, **kwargs):
+        return self._resolve().read_text(*args, **kwargs)
+
+    def write_text(self, *args, **kwargs):
+        return self._resolve().write_text(*args, **kwargs)
+
+
 def _delegate_from_json(col: str = "model_config") -> str:
     return f"json_extract(COALESCE({col}, '{{}}'), '$._delegate_from')"
 
@@ -102,10 +165,7 @@ def _delete_delegate_children(conn, parent_ids: List[str]) -> List[str]:
         )
         conn.execute(f"DELETE FROM sessions WHERE id IN ({ph})", ids)
     return ids
-
-T = TypeVar("T")
-
-DEFAULT_DB_PATH = get_hermes_home() / "state.db"
+DEFAULT_DB_PATH = _LazyDefaultDBPath()
 
 SCHEMA_VERSION = 16
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1,4 +1,5 @@
 import json
+import importlib
 import os
 import subprocess
 import sys
@@ -1844,6 +1845,48 @@ def test_session_create_does_not_persist_empty_row(monkeypatch):
         assert created == [], "session.create should not persist an empty DB row"
     finally:
         server._sessions.pop(sid, None)
+
+
+def test_tui_session_db_uses_effective_home_after_early_import_race(
+    monkeypatch, tmp_path
+):
+    """Late profile override must win even if hermes_state imported earlier."""
+    repo = Path(__file__).resolve().parents[1]
+    root = tmp_path / "hermes-root"
+    private_home = root / "profiles" / "private"
+    private_home.mkdir(parents=True)
+    (root / "active_profile").write_text("private\n")
+
+    import hermes_state
+
+    original_home = os.environ.get("HERMES_HOME")
+    try:
+        monkeypatch.setenv("HERMES_HOME", str(private_home))
+        hermes_state = importlib.reload(hermes_state)
+
+        monkeypatch.setenv("HERMES_HOME", str(root))
+        server._db = None
+        server._db_error = None
+        server._ensure_session_db_row(
+            {"session_key": "sess-race", "cwd": str(repo), "explicit_cwd": True}
+        )
+
+        default_db = hermes_state.SessionDB(db_path=root / "state.db")
+        private_db = hermes_state.SessionDB(db_path=private_home / "state.db")
+        try:
+            assert default_db.get_session("sess-race") is not None
+            assert private_db.get_session("sess-race") is None
+        finally:
+            default_db.close()
+            private_db.close()
+    finally:
+        server._db = None
+        server._db_error = None
+        if original_home is None:
+            monkeypatch.delenv("HERMES_HOME", raising=False)
+        else:
+            monkeypatch.setenv("HERMES_HOME", original_home)
+        importlib.reload(hermes_state)
 
 
 def test_ensure_session_db_row_persists_explicit_cwd(monkeypatch, tmp_path):


### PR DESCRIPTION
## What does this PR do?

Fixes a profile-scoping race where TUI session persistence could write into the wrong `state.db` when `hermes_state` was imported before a later `HERMES_HOME` override took effect. The change makes the default state DB path resolve lazily, so `hermes -p <profile> --tui` follows the effective launch profile even under early-import timing.

## Related Issue

Fixes #46144

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Defer `hermes_state.DEFAULT_DB_PATH` resolution until use instead of freezing it at module import time.
- Add a regression test that reproduces the early-import race and proves TUI session rows land in the launch profile's `state.db`.

## How to Test

1. `source .venv/bin/activate`
2. `pytest tests/test_tui_gateway_server.py -k "effective_home_after_early_import_race or session_resume_uses_profile_row_cwd or ensure_session_db_row" -q`
3. `pytest tests/test_hermes_state_wal_fallback.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5 via targeted pytest coverage and a direct import-order reproduction script

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable.
