### PR TITLE
feat(kanban): support dashboard task deep links

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -244,6 +244,69 @@
     return `${url}${sep}board=${encodeURIComponent(board)}`;
   }
 
+  function readKanbanUrlParam(name) {
+    try {
+      const qs = new URLSearchParams(window.location.search || "");
+      const value = qs.get(name);
+      return (value || "").trim() || null;
+    } catch (_e) { return null; }
+  }
+
+  function readKanbanUrlBoard() {
+    return readKanbanUrlParam("board");
+  }
+
+  function readKanbanUrlTask() {
+    return readKanbanUrlParam("task") || readKanbanUrlParam("task_id");
+  }
+
+  function buildKanbanTaskUrl(board, taskId) {
+    const url = new URL(window.location.href);
+    if (board) url.searchParams.set("board", board);
+    else url.searchParams.delete("board");
+    url.searchParams.delete("task_id");
+    if (taskId) url.searchParams.set("task", taskId);
+    else url.searchParams.delete("task");
+    return url;
+  }
+
+  function writeKanbanUrlState(board, taskId) {
+    try {
+      if (!window.history || !window.location) return;
+      const url = buildKanbanTaskUrl(board, taskId);
+      window.history.replaceState(window.history.state, "", url.toString());
+    } catch (_e) { /* ignore browser history quirks */ }
+  }
+
+  function copyTextWithTextarea(text) {
+    const el = document.createElement("textarea");
+    el.value = text;
+    el.setAttribute("readonly", "readonly");
+    el.style.position = "fixed";
+    el.style.left = "-9999px";
+    document.body.appendChild(el);
+    el.select();
+    try {
+      if (typeof document.execCommand !== "function") {
+        throw new Error("Copy command is not available");
+      }
+      const copied = document.execCommand("copy");
+      if (!copied) throw new Error("Copy command was not accepted");
+    } catch (e) {
+      return Promise.reject(e);
+    } finally { document.body.removeChild(el); }
+    return Promise.resolve();
+  }
+
+  function copyTextToClipboard(text) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      return navigator.clipboard.writeText(text).catch(function () {
+        return copyTextWithTextarea(text);
+      });
+    }
+    return copyTextWithTextarea(text);
+  }
+
   // The SDK's Select component fires ``onValueChange(value)`` directly
   // (it's a shadcn-style popup, not a native <select>). Older plugin
   // code calls ``onChange({target: {value}})`` which silently never
@@ -464,7 +527,14 @@
 
   function KanbanPage() {
     const { t } = useI18n();
-    const [board, setBoard] = useState(() => readSelectedBoard() || null);
+    const [board, setBoard] = useState(function () {
+      const urlBoard = readKanbanUrlBoard();
+      if (urlBoard) {
+        writeSelectedBoard(urlBoard);
+        return urlBoard;
+      }
+      return readSelectedBoard() || null;
+    });
     const [boardList, setBoardList] = useState([]);      // [{slug, name, counts, ...}]
     const [showNewBoard, setShowNewBoard] = useState(false);
 
@@ -488,7 +558,7 @@
     const [laneByProfile, setLaneByProfile] = useState(true);
     const [configApplied, setConfigApplied] = useState(false);
 
-    const [selectedTaskId, setSelectedTaskId] = useState(null);
+    const [selectedTaskId, setSelectedTaskId] = useState(() => readKanbanUrlTask());
     const [selectedIds, setSelectedIds] = useState(() => new Set());
     const [lastSelectedId, setLastSelectedId] = useState(null);
     const [failedIds, setFailedIds] = useState(() => new Set());
@@ -673,6 +743,17 @@
     }, [boardData, tenantFilter, assigneeFilter, search]);
 
     // --- actions ------------------------------------------------------------
+    const openTask = useCallback(function (taskId) {
+      if (!taskId) return;
+      setSelectedTaskId(taskId);
+      writeKanbanUrlState(board, taskId);
+    }, [board]);
+
+    const closeTask = useCallback(function () {
+      setSelectedTaskId(null);
+      writeKanbanUrlState(board, null);
+    }, [board]);
+
     const moveTask = useCallback(function (taskId, newStatus) {
       const confirmMsg = getDestructiveConfirm(t, newStatus);
       if (confirmMsg && !window.confirm(confirmMsg)) return;
@@ -709,6 +790,32 @@
       setLastSelectedId(null);
       setFailedIds(new Set());
     }, []);
+
+    // Keep browser back/forward deep-link navigation in sync while the SPA
+    // keeps this plugin mounted. Initial page loads are handled by the state
+    // initializers above; this handles later query-string changes.
+    useEffect(function () {
+      function syncFromUrl() {
+        const urlBoard = readKanbanUrlBoard();
+        const urlTask = readKanbanUrlTask();
+        if (urlBoard && urlBoard !== board) {
+          setBoardData(null);
+          cursorRef.current = 0;
+          setLoading(true);
+          setBoard(urlBoard);
+          writeSelectedBoard(urlBoard);
+          setSearch("");
+          setTenantFilter("");
+          setAssigneeFilter("");
+          setIncludeArchived(false);
+          clearSelected();
+        }
+        setSelectedTaskId(urlTask);
+      }
+      window.addEventListener("popstate", syncFromUrl);
+      return function () { window.removeEventListener("popstate", syncFromUrl); };
+    }, [board, clearSelected]);
+
     const moveSelected = useCallback(function (newStatus) {
       const confirmMsg = DESTRUCTIVE_TRANSITIONS[newStatus];
       if (confirmMsg && !window.confirm(confirmMsg)) return;
@@ -908,6 +1015,8 @@
       setLoading(true);
       setBoard(nextSlug);
       writeSelectedBoard(nextSlug);
+      setSelectedTaskId(null);
+      writeKanbanUrlState(nextSlug, null);
       // Reset filters so stale search/tenant/assignee don't persist across boards.
       setSearch("");
       setTenantFilter("");
@@ -1003,7 +1112,7 @@
         h(OrchestrationPanel, null),
         h(AttentionStrip, {
           boardData,
-          onOpen: setSelectedTaskId,
+          onOpen: openTask,
         }),
         h(BoardToolbar, {
           board: boardData,
@@ -1042,14 +1151,14 @@
           onMove: moveTask,
           onMoveSelected: moveSelected,
           onDelete: deleteTask,
-          onOpen: setSelectedTaskId,
+          onOpen: openTask,
           onCreate: createTask,
           allTasks: boardData.columns.reduce(function (acc, c) { return acc.concat(c.tasks); }, []),
         }),
         selectedTaskId ? h(TaskDrawer, {
           taskId: selectedTaskId,
           boardSlug: board,
-          onClose: function () { setSelectedTaskId(null); },
+          onClose: closeTask,
           onRefresh: loadBoard,
           renderMarkdown: renderMd,
           allTasks: boardData.columns.reduce(function (acc, c) { return acc.concat(c.tasks); }, []),
@@ -2800,6 +2909,7 @@
     const [homeChannels, setHomeChannels] = useState([]);
     const [homeBusy, setHomeBusy] = useState({});
     const boardSlug = props.boardSlug;
+    const [linkCopied, setLinkCopied] = useState(false);
 
     const load = useCallback(function () {
       return SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}`, boardSlug))
@@ -2826,6 +2936,16 @@
       window.addEventListener("keydown", onKey);
       return function () { window.removeEventListener("keydown", onKey); };
     }, [props.onClose, editing]);
+
+    const handleCopyLink = function () {
+      const link = buildKanbanTaskUrl(boardSlug, props.taskId).toString();
+      copyTextToClipboard(link)
+        .then(function () {
+          setLinkCopied(true);
+          setTimeout(function () { setLinkCopied(false); }, 1800);
+        })
+        .catch(function (e) { setErr(String(e.message || e)); });
+    };
 
     const handleComment = function () {
       const body = newComment.trim();
@@ -3016,12 +3136,20 @@
       },
         h("div", { className: "hermes-kanban-drawer-head" },
           h("span", { className: "text-xs text-muted-foreground" }, props.taskId),
-          h("button", {
-            type: "button",
-            onClick: props.onClose,
-            className: "hermes-kanban-drawer-close",
-            title: tx(t, "close", "Close (Esc)"),
-          }, "×"),
+          h("div", { className: "hermes-kanban-drawer-actions" },
+            h("button", {
+              type: "button",
+              onClick: handleCopyLink,
+              className: "hermes-kanban-drawer-linkcopy",
+              title: tx(t, "copyTaskLink", "Copy link to this task"),
+            }, linkCopied ? tx(t, "copied", "Copied") : tx(t, "copyLink", "Copy link")),
+            h("button", {
+              type: "button",
+              onClick: props.onClose,
+              className: "hermes-kanban-drawer-close",
+              title: tx(t, "close", "Close (Esc)"),
+            }, "×"),
+          ),
         ),
         loading ? h("div", { className: "p-4 text-sm text-muted-foreground" },
           tx(t, "loadingDetail", "Loading…")) :

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -386,6 +386,28 @@
 }
 .hermes-kanban-drawer-close:hover { color: var(--color-foreground); }
 
+.hermes-kanban-drawer-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.hermes-kanban-drawer-linkcopy {
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  color: var(--color-muted-foreground);
+  cursor: pointer;
+  font-size: 0.72rem;
+  line-height: 1;
+  padding: 0.25rem 0.5rem;
+}
+.hermes-kanban-drawer-linkcopy:hover {
+  color: var(--color-foreground);
+  border-color: var(--color-foreground);
+}
+
 /* Attachment download trigger — styled as a link, rendered as a <button>
    so the click handler can fetch with the session token (#35338). */
 .hermes-kanban-attachment-link {

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -240,11 +240,50 @@ def test_dashboard_initial_board_uses_backend_current_when_unpinned():
     bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
     js = bundle.read_text()
 
-    assert 'useState(() => readSelectedBoard() || null)' in js
+    assert "const urlBoard = readKanbanUrlBoard();" in js
+    assert "return readSelectedBoard() || null;" in js
     assert "const storedBoard = readSelectedBoard();" in js
     assert "if (!storedBoard && !board && data && data.current)" in js
     assert "setBoard(data.current);" in js
     assert 'readSelectedBoard() || "default"' not in js
+
+
+def test_dashboard_supports_task_deep_links():
+    """The dashboard should open and synchronize /kanban?board=...&task=... links."""
+
+    repo_root = Path(__file__).resolve().parents[2]
+    bundle = repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js"
+    js = bundle.read_text()
+
+    assert "function readKanbanUrlBoard()" in js
+    assert "function readKanbanUrlTask()" in js
+    assert 'readKanbanUrlParam("task") || readKanbanUrlParam("task_id")' in js
+    assert "writeSelectedBoard(urlBoard);" in js
+    assert "useState(() => readKanbanUrlTask())" in js
+    assert "writeKanbanUrlState(board, taskId);" in js
+    assert "writeKanbanUrlState(board, null);" in js
+    assert "writeKanbanUrlState(nextSlug, null);" in js
+    assert 'window.addEventListener("popstate", syncFromUrl);' in js
+    assert "setSelectedTaskId(urlTask);" in js
+
+
+def test_dashboard_task_drawer_has_copy_link_action():
+    """Task drawers need a visible affordance for canonical task links."""
+
+    repo_root = Path(__file__).resolve().parents[2]
+    js = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+    css = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css").read_text()
+
+    assert "function buildKanbanTaskUrl(board, taskId)" in js
+    assert "function copyTextToClipboard(text)" in js
+    assert "function copyTextWithTextarea(text)" in js
+    assert "return navigator.clipboard.writeText(text).catch(function ()" in js
+    assert 'new Error("Copy command is not available")' in js
+    assert 'new Error("Copy command was not accepted")' in js
+    assert "const handleCopyLink = function ()" in js
+    assert 'tx(t, "copyLink", "Copy link")' in js
+    assert "hermes-kanban-drawer-linkcopy" in js
+    assert "hermes-kanban-drawer-linkcopy" in css
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Adds task deep-link support to the Kanban dashboard.

Before this change, opening a URL like /kanban?board=default&task=t_123 loaded the Kanban dashboard but did not open the referenced task. This made links from external notifications/chat messages less useful because users still had to find the card manually.

This PR makes the dashboard read board + task query params, open the task drawer directly, keep the URL synchronized as the user opens/closes cards or switches boards, and adds a small "Copy link" action in the task drawer for sharing canonical task URLs.

The implementation stays inside the existing Kanban dashboard plugin bundle and follows the current project pattern for this plugin's frontend regression coverage.

## Related Issue

Fixes #33852

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- plugins/kanban/dashboard/dist/index.js
  - Reads board, task, and legacy task_id query params on dashboard load.
  - Opens the task drawer when a task id is present in the URL.
  - Keeps drawer open/close state synchronized with the URL.
  - Clears the task query param when switching boards.
  - Handles browser back/forward navigation via popstate.
  - Adds a task drawer "Copy link" action that copies the canonical /kanban?board=<slug>&task=<id> URL.
  - Adds clipboard fallback/error handling for browsers where the Clipboard API is unavailable or rejected.

- plugins/kanban/dashboard/dist/style.css
  - Adds styling for the task drawer link-copy action.

- tests/plugins/test_kanban_dashboard_plugin.py
  - Adds regression assertions for task deep-link support.
  - Adds regression assertions for the drawer copy-link action.
  - Updates the existing selected-board test to account for explicit board= URL handling.

## How to Test

1. Run the targeted dashboard plugin tests:
   - python -m pytest tests/plugins/test_kanban_dashboard_plugin.py -q

2. Run the JavaScript syntax check:
   - node --check plugins/kanban/dashboard/dist/index.js

3. Run whitespace/diff validation:
   - git diff --check

4. Start the Hermes dashboard and open a Kanban task deep link:
   - /kanban?board=default&task=<existing_task_id>

5. Verify:
   - The dashboard loads the requested board.
   - The referenced task drawer opens automatically.
   - Closing the drawer removes task from the URL.
   - Opening another task updates the URL.
   - Browser back/forward keeps the drawer state in sync.
   - The drawer "Copy link" button copies a URL containing both board and task.

Validation performed for this PR:

- git diff --check HEAD~1..HEAD
- node --check plugins/kanban/dashboard/dist/index.js
- python -m pytest tests/plugins/test_kanban_dashboard_plugin.py -q
  - Result: 97 passed, 1 warning
- python scripts/check-windows-footguns.py --diff HEAD~1
  - Result: no Windows footguns found

Local smoke test performed on Ubuntu:

- Restarted local hermes-dashboard.service.
- Opened /kanban?board=default&task=t_5765e994`.
- Confirmed the route returned HTTP 200.
- Confirmed the served Kanban plugin bundle included the new deep-link/copy-link markers.

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md) (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) (https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/Linux

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<img width="1174" height="112" alt="image" src="https://github.com/user-attachments/assets/b1c807b5-e892-4b70-97a5-76a96465fda4" />
<img width="639" height="103" alt="image" src="https://github.com/user-attachments/assets/78ebf642-46b5-46b1-9a5f-dcfc1e04cada" />


