### PR TITLE
fix(terminal): load passthrough env vars from dotenv locally

### DIFF
--- a/tests/tools/test_env_passthrough.py
+++ b/tests/tools/test_env_passthrough.py
@@ -228,3 +228,34 @@ class TestTerminalIntegration:
         # Arbitrary skill-specific var
         register_env_passthrough(["MY_SKILL_CUSTOM_CONFIG"])
         assert is_env_passthrough("MY_SKILL_CUSTOM_CONFIG")
+
+    def test_make_run_env_loads_passthrough_from_dotenv(self, monkeypatch):
+        """terminal.env_passthrough should work for vars loaded from .env only."""
+        import tools.environments.local as local
+
+        monkeypatch.delenv("TENOR_API_KEY", raising=False)
+        monkeypatch.setattr(
+            local,
+            "_load_hermes_env_vars",
+            lambda: {"TENOR_API_KEY": "dotenv-secret"},
+        )
+        register_env_passthrough(["TENOR_API_KEY"])
+
+        result = local._make_run_env({})
+
+        assert result["TENOR_API_KEY"] == "dotenv-secret"
+
+    def test_make_run_env_does_not_load_unregistered_dotenv_vars(self, monkeypatch):
+        """Unregistered .env secrets must not leak into local terminal runs."""
+        import tools.environments.local as local
+
+        monkeypatch.delenv("UNREGISTERED_DOTENV_TOKEN", raising=False)
+        monkeypatch.setattr(
+            local,
+            "_load_hermes_env_vars",
+            lambda: {"UNREGISTERED_DOTENV_TOKEN": "dotenv-secret"},
+        )
+
+        result = local._make_run_env({})
+
+        assert "UNREGISTERED_DOTENV_TOKEN" not in result

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -191,6 +191,14 @@ def _build_provider_env_blocklist() -> frozenset:
 _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
 
 
+def _load_hermes_env_vars() -> dict[str, str]:
+    try:
+        from hermes_cli.config import load_env
+        return load_env() or {}
+    except Exception:
+        return {}
+
+
 def _inject_context_hermes_home(env: dict) -> None:
     """Bridge the context-local Hermes home override into subprocess env."""
     try:
@@ -366,8 +374,12 @@ def _path_env_key(run_env: dict) -> str | None:
 def _make_run_env(env: dict) -> dict:
     """Build a run environment with a sane PATH and provider-var stripping."""
     try:
-        from tools.env_passthrough import is_env_passthrough as _is_passthrough
+        from tools.env_passthrough import (
+            get_all_passthrough as _get_all_passthrough,
+            is_env_passthrough as _is_passthrough,
+        )
     except Exception:
+        _get_all_passthrough = lambda: frozenset()  # noqa: E731
         _is_passthrough = lambda _: False  # noqa: E731
 
     merged = dict(os.environ | env)
@@ -378,6 +390,14 @@ def _make_run_env(env: dict) -> dict:
             run_env[real_key] = v
         elif k not in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_passthrough(k):
             run_env[k] = v
+
+    passthrough_keys = set(_get_all_passthrough())
+    if passthrough_keys:
+        hermes_env = _load_hermes_env_vars()
+        for key in sorted(passthrough_keys):
+            if key not in run_env and key in hermes_env:
+                run_env[key] = hermes_env[key]
+
     path_key = _path_env_key(run_env)
     if path_key is not None:
         run_env[path_key] = _append_missing_sane_path_entries(run_env.get(path_key, ""))


### PR DESCRIPTION
## Summary

- Load Hermes `.env` values in the local terminal backend for keys that are already registered via `terminal.env_passthrough` or skill passthrough.
- Keep `.env` secrets out of local terminal runs unless the key is explicitly allowlisted.
- Add regression coverage for `.env`-only passthrough values and non-allowlisted `.env` values.

## Root cause

The local backend built its child process environment from `os.environ | env`, then applied the existing provider-secret filter. That meant `terminal.env_passthrough` only worked when the variable was already in the parent process environment. Docker already falls back to `hermes_cli.config.load_env()` for passthrough keys, so variables that existed only in Hermes `.env` worked there but not with `terminal.backend: local`.

Fixes #46152.

## Tests

- `./.venv/bin/python -m pytest -o addopts='' tests/tools/test_env_passthrough.py -q`
- `./.venv/bin/python -m pytest -o addopts='' tests/tools/test_local_env_blocklist.py -q`
