### PR TITLE
feat(desktop): add reasoning level keybinds

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -665,6 +665,7 @@ export function DesktopController() {
   // Single global listener for every rebindable hotkey (incl. profile switching)
   // plus the on-screen keybind editor's capture mode.
   useKeybinds({
+    requestGateway,
     startFreshSession: startFreshSessionDraft,
     toggleCommandCenter,
     toggleSelectedPin

--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -4,8 +4,10 @@ import { useNavigate } from 'react-router-dom'
 import { $terminalTakeover, setTerminalTakeover } from '@/app/right-sidebar/store'
 import { PANE_TOGGLE_REVEAL_EVENT } from '@/components/pane-shell'
 import { matchesQuery } from '@/hooks/use-media-query'
-import { PROFILE_SLOT_COUNT, SESSION_SLOT_COUNT } from '@/lib/keybinds/actions'
+import { keybindActionAllowedInEditableTarget, PROFILE_SLOT_COUNT, SESSION_SLOT_COUNT } from '@/lib/keybinds/actions'
 import { comboAllowedInInput, comboFromEvent, isEditableTarget } from '@/lib/keybinds/combo'
+import { type ReasoningStepDirection, stepReasoningEffort, writeSessionReasoningEffort } from '@/lib/model-reasoning'
+import type { GatewayRequester } from '@/lib/yolo-session'
 import { toggleCommandPalette } from '@/store/command-palette'
 import { $capture, $comboIndex, endCapture, setBinding, toggleKeybindPanel } from '@/store/keybinds'
 import {
@@ -17,6 +19,7 @@ import {
   togglePanesFlipped,
   toggleSidebarOpen
 } from '@/store/layout'
+import { notifyError } from '@/store/notifications'
 import {
   $newChatProfile,
   cycleProfile,
@@ -25,7 +28,12 @@ import {
   switchToDefaultProfile,
   toggleShowAllProfiles
 } from '@/store/profile'
-import { setModelPickerOpen } from '@/store/session'
+import {
+  $activeSessionId,
+  $currentReasoningEffort,
+  setCurrentReasoningEffort,
+  setModelPickerOpen
+} from '@/store/session'
 import {
   $switcherOpen,
   closeSwitcher,
@@ -53,6 +61,8 @@ import {
 } from '../routes'
 
 export interface KeybindRuntimeDeps {
+  /** Gateway RPC requester for session-scoped model controls. */
+  requestGateway: GatewayRequester
   /** Open/close the command center overlay (sessions / system / usage). */
   toggleCommandCenter: () => void
   /** Drop to a fresh new-session draft. */
@@ -73,6 +83,7 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
   // Keep the latest closures without re-subscribing the listener.
   const handlersRef = useRef<HandlerMap>({})
   const commitSwitcherRef = useRef<() => void>(() => {})
+  const reasoningRequestSeqRef = useRef(0)
 
   const profileSwitchHandlers: HandlerMap = {}
 
@@ -108,11 +119,40 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
     setTerminalTakeover(false)
   }
 
+  const stepReasoning = (direction: ReasoningStepDirection) => {
+    const rollback = $currentReasoningEffort.get()
+    const next = stepReasoningEffort(rollback, direction)
+
+    if (next === rollback.trim().toLowerCase()) {
+      return
+    }
+
+    const requestSeq = reasoningRequestSeqRef.current + 1
+
+    reasoningRequestSeqRef.current = requestSeq
+    setCurrentReasoningEffort(next)
+
+    void writeSessionReasoningEffort(deps.requestGateway, $activeSessionId.get() ?? '', next)
+      .then(value => {
+        if (reasoningRequestSeqRef.current === requestSeq) {
+          setCurrentReasoningEffort(value)
+        }
+      })
+      .catch(error => {
+        if (reasoningRequestSeqRef.current === requestSeq) {
+          setCurrentReasoningEffort(rollback)
+          notifyError(error, 'Could not update reasoning level')
+        }
+      })
+  }
+
   handlersRef.current = {
     'keybinds.openPanel': toggleKeybindPanel,
 
     'composer.focus': () => requestComposerFocus('main'),
     'composer.modelPicker': () => setModelPickerOpen(true),
+    'composer.reasoningUp': () => stepReasoning(1),
+    'composer.reasoningDown': () => stepReasoning(-1),
 
     'nav.commandPalette': toggleCommandPalette,
     'nav.commandCenter': deps.toggleCommandCenter,
@@ -216,7 +256,11 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
         return
       }
 
-      if (isEditableTarget(event.target) && !comboAllowedInInput(combo)) {
+      if (
+        isEditableTarget(event.target) &&
+        !comboAllowedInInput(combo) &&
+        !keybindActionAllowedInEditableTarget(actionId, combo)
+      ) {
         return
       }
 

--- a/apps/desktop/src/app/shell/model-edit-submenu.tsx
+++ b/apps/desktop/src/app/shell/model-edit-submenu.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Switch } from '@/components/ui/switch'
 import { useI18n } from '@/i18n'
+import { REASONING_EFFORT_OPTIONS } from '@/lib/model-reasoning'
 import { notifyError } from '@/store/notifications'
 import {
   $activeSessionId,
@@ -20,15 +21,16 @@ import {
   setCurrentReasoningEffort
 } from '@/store/session'
 
-// Hermes' real reasoning levels (see VALID_REASONING_EFFORTS); `none` is owned
-// by the Thinking toggle, not the radio.
-const EFFORT_OPTIONS = [
-  { value: 'minimal', labelKey: 'minimal' },
-  { value: 'low', labelKey: 'low' },
-  { value: 'medium', labelKey: 'medium' },
-  { value: 'high', labelKey: 'high' },
-  { value: 'xhigh', labelKey: 'max' }
-] as const
+const EFFORT_LABEL_KEYS: Record<
+  (typeof REASONING_EFFORT_OPTIONS)[number],
+  'high' | 'low' | 'max' | 'medium' | 'minimal'
+> = {
+  minimal: 'minimal',
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+  xhigh: 'max'
+}
 
 /** How "fast" is achieved for a given model — two different mechanisms:
  *  - `param`: the Anthropic/OpenAI `speed=fast` request parameter.
@@ -209,14 +211,14 @@ export function ModelEditSubmenu({
                 onValueChange={value => void patchReasoning(value, currentReasoningEffort)}
                 value={effort}
               >
-                {EFFORT_OPTIONS.map(option => (
+                {REASONING_EFFORT_OPTIONS.map(value => (
                   <DropdownMenuRadioItem
                     className={dropdownMenuRow}
-                    key={option.value}
+                    key={value}
                     onSelect={event => event.preventDefault()}
-                    value={option.value}
+                    value={value}
                   >
-                    {copy[option.labelKey]}
+                    {copy[EFFORT_LABEL_KEYS[value]]}
                   </DropdownMenuRadioItem>
                 ))}
               </DropdownMenuRadioGroup>
@@ -241,5 +243,5 @@ function normalizeEffort(effort: string): string {
     return ''
   }
 
-  return EFFORT_OPTIONS.some(option => option.value === value) ? value : 'medium'
+  return REASONING_EFFORT_OPTIONS.some(option => option === value) ? value : 'medium'
 }

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -204,6 +204,8 @@ export const en: Translations = {
       'session.togglePin': 'Pin / unpin current session',
       'composer.focus': 'Focus composer',
       'composer.modelPicker': 'Open model picker',
+      'composer.reasoningUp': 'Reasoning level up',
+      'composer.reasoningDown': 'Reasoning level down',
       'view.toggleSidebar': 'Toggle sessions sidebar',
       'view.toggleRightSidebar': 'Toggle file browser',
       'view.showFiles': 'Show file browser',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -200,6 +200,8 @@ export const zh: Translations = {
       'session.togglePin': '固定/取消固定当前会话',
       'composer.focus': '聚焦输入框',
       'composer.modelPicker': '打开模型选择器',
+      'composer.reasoningUp': '提高推理等级',
+      'composer.reasoningDown': '降低推理等级',
       'view.toggleSidebar': '切换会话侧边栏',
       'view.toggleRightSidebar': '切换文件浏览器',
       'view.showFiles': '显示文件浏览器',

--- a/apps/desktop/src/lib/keybinds/actions.test.ts
+++ b/apps/desktop/src/lib/keybinds/actions.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultBindings, keybindAction, keybindActionAllowedInEditableTarget } from './actions'
+
+describe('desktop keybind actions', () => {
+  it('exposes unbound reasoning level actions for the keyboard shortcuts panel', () => {
+    expect(keybindAction('composer.reasoningUp')).toMatchObject({
+      category: 'composer',
+      defaults: [],
+      editableTargetPolicy: 'modified'
+    })
+    expect(keybindAction('composer.reasoningDown')).toMatchObject({
+      category: 'composer',
+      defaults: [],
+      editableTargetPolicy: 'modified'
+    })
+    expect(defaultBindings()['composer.reasoningUp']).toEqual([])
+    expect(defaultBindings()['composer.reasoningDown']).toEqual([])
+  })
+
+  it('allows reasoning level shortcuts to fire while the composer is focused', () => {
+    expect(keybindActionAllowedInEditableTarget('composer.reasoningUp', 'alt+]')).toBe(true)
+    expect(keybindActionAllowedInEditableTarget('composer.reasoningDown', 'mod+alt+[')).toBe(true)
+    expect(keybindActionAllowedInEditableTarget('composer.reasoningUp', ']')).toBe(false)
+    expect(keybindActionAllowedInEditableTarget('composer.reasoningUp', 'shift+]')).toBe(false)
+    expect(keybindActionAllowedInEditableTarget('appearance.toggleMode', 'alt+x')).toBe(false)
+  })
+})

--- a/apps/desktop/src/lib/keybinds/actions.ts
+++ b/apps/desktop/src/lib/keybinds/actions.ts
@@ -20,6 +20,8 @@ export interface KeybindActionMeta {
   category: KeybindCategory
   /** Default combos. Empty = shipped unbound (user can assign one). */
   defaults: readonly string[]
+  /** Extra allowance for editable targets beyond the global combo safety policy. */
+  editableTargetPolicy?: 'modified'
 }
 
 // Positional switch slots for *named* profiles: ⌘1…⌘9 for profiles 1-9, then
@@ -55,6 +57,8 @@ export const KEYBIND_ACTIONS: readonly KeybindActionMeta[] = [
   // ── Composer ─────────────────────────────────────────────────────────────
   { id: 'composer.focus', category: 'composer', defaults: [] },
   { id: 'composer.modelPicker', category: 'composer', defaults: [] },
+  { id: 'composer.reasoningUp', category: 'composer', defaults: [], editableTargetPolicy: 'modified' },
+  { id: 'composer.reasoningDown', category: 'composer', defaults: [], editableTargetPolicy: 'modified' },
 
   // ── Profiles ─────────────────────────────────────────────────────────────
   { id: 'profile.default', category: 'profiles', defaults: ['mod+d'] },
@@ -102,6 +106,16 @@ const ACTION_BY_ID = new Map(KEYBIND_ACTIONS.map(action => [action.id, action]))
 
 export function keybindAction(id: string): KeybindActionMeta | undefined {
   return ACTION_BY_ID.get(id)
+}
+
+function comboHasNonShiftModifier(combo: string): boolean {
+  const parts = combo.split('+')
+
+  return parts.slice(0, -1).some(part => part !== 'shift')
+}
+
+export function keybindActionAllowedInEditableTarget(id: string, combo: string): boolean {
+  return keybindAction(id)?.editableTargetPolicy === 'modified' && comboHasNonShiftModifier(combo)
 }
 
 export type KeybindBindings = Record<string, string[]>

--- a/apps/desktop/src/lib/model-reasoning.test.ts
+++ b/apps/desktop/src/lib/model-reasoning.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { $currentReasoningEffort, setCurrentReasoningEffort } from '@/store/session'
+
+import { stepReasoningEffort, writeSessionReasoningEffort } from './model-reasoning'
+
+afterEach(() => {
+  setCurrentReasoningEffort('')
+})
+
+describe('model reasoning shortcuts', () => {
+  it('steps reasoning effort through off and Hermes effort levels', () => {
+    expect(stepReasoningEffort('none', 1)).toBe('minimal')
+    expect(stepReasoningEffort('minimal', 1)).toBe('low')
+    expect(stepReasoningEffort('low', 1)).toBe('medium')
+    expect(stepReasoningEffort('medium', 1)).toBe('high')
+    expect(stepReasoningEffort('high', 1)).toBe('xhigh')
+    expect(stepReasoningEffort('xhigh', 1)).toBe('xhigh')
+
+    expect(stepReasoningEffort('xhigh', -1)).toBe('high')
+    expect(stepReasoningEffort('high', -1)).toBe('medium')
+    expect(stepReasoningEffort('medium', -1)).toBe('low')
+    expect(stepReasoningEffort('low', -1)).toBe('minimal')
+    expect(stepReasoningEffort('minimal', -1)).toBe('none')
+    expect(stepReasoningEffort('none', -1)).toBe('none')
+  })
+
+  it('treats empty or stale reasoning values as Hermes default medium before stepping', () => {
+    expect(stepReasoningEffort('', 1)).toBe('high')
+    expect(stepReasoningEffort('', -1)).toBe('low')
+    expect(stepReasoningEffort('banana', 1)).toBe('high')
+  })
+
+  it('persists a session-scoped reasoning effort and returns the normalized value', async () => {
+    setCurrentReasoningEffort('low')
+    const requestGateway = vi.fn().mockResolvedValue({ value: 'high' })
+
+    await expect(writeSessionReasoningEffort(requestGateway, 'session-1', 'xhigh')).resolves.toBe('high')
+
+    expect(requestGateway).toHaveBeenCalledWith('config.set', {
+      key: 'reasoning',
+      session_id: 'session-1',
+      value: 'xhigh'
+    })
+    expect($currentReasoningEffort.get()).toBe('low')
+  })
+})

--- a/apps/desktop/src/lib/model-reasoning.ts
+++ b/apps/desktop/src/lib/model-reasoning.ts
@@ -1,0 +1,41 @@
+import type { GatewayRequester } from './yolo-session'
+
+export const REASONING_EFFORT_OPTIONS = ['minimal', 'low', 'medium', 'high', 'xhigh'] as const
+export const REASONING_STEP_LEVELS = ['none', ...REASONING_EFFORT_OPTIONS] as const
+
+export type ReasoningEffort = (typeof REASONING_STEP_LEVELS)[number]
+export type ReasoningStepDirection = -1 | 1
+
+/** Empty means Hermes' default (medium); unknown stale values normalize there too. */
+export function normalizeReasoningEffort(effort: string): ReasoningEffort {
+  const value = effort.trim().toLowerCase()
+
+  if (REASONING_STEP_LEVELS.some(level => level === value)) {
+    return value as ReasoningEffort
+  }
+
+  return 'medium'
+}
+
+/** Move one notch through off → minimal → low → medium → high → xhigh. */
+export function stepReasoningEffort(effort: string, direction: ReasoningStepDirection): ReasoningEffort {
+  const current = normalizeReasoningEffort(effort)
+  const index = REASONING_STEP_LEVELS.indexOf(current)
+  const nextIndex = Math.min(Math.max(index + direction, 0), REASONING_STEP_LEVELS.length - 1)
+
+  return REASONING_STEP_LEVELS[nextIndex]
+}
+
+export async function writeSessionReasoningEffort(
+  requestGateway: GatewayRequester,
+  sessionId: string,
+  effort: ReasoningEffort
+): Promise<ReasoningEffort> {
+  const result = await requestGateway<{ value?: string }>('config.set', {
+    key: 'reasoning',
+    session_id: sessionId,
+    value: effort
+  })
+
+  return normalizeReasoningEffort(result?.value ?? effort)
+}


### PR DESCRIPTION
## Summary
- add unbound desktop keyboard-shortcut actions for reasoning level up/down in the Ctrl+/ shortcuts panel
- wire the shortcuts to session-scoped `config.set` reasoning updates with optimistic UI rollback on failure
- let modified reasoning shortcuts fire while the composer/input is focused without allowing bare/shift-only text keys to hijack typing
- guard rapid repeated reasoning shortcut presses against stale async responses clobbering the latest selected level
- share the desktop reasoning effort list between the model options menu and shortcut stepping

## Why
Hermes Desktop already lets users pick a reasoning effort in the model options UI, but there was no keyboard-shortcut action for stepping that level up or down. This adds the missing desktop shortcut actions without adding any new core model tools or backend API surface.

## How to test
1. Launch Hermes Desktop from this branch.
2. Open the keyboard shortcuts panel with Ctrl+/.
3. Under Composer, bind Reasoning level up and Reasoning level down to modified shortcuts, for example Alt+] / Alt+[ or Ctrl+Alt+] / Ctrl+Alt+[.
4. Focus the composer textbox.
5. Use the bindings and confirm the model/reasoning pill and model menu selection step through `none → minimal → low → medium → high → xhigh` and clamp at both ends.
6. Optional safety check: bind a bare key temporarily and confirm normal typing is not hijacked while the composer is focused.

## Platforms tested
- Linux / Arch-family desktop environment: manual Hermes Desktop smoke test from the PR working tree.

## Validation
- `npm run typecheck --workspace apps/desktop`
- `npx vitest run --environment jsdom src/lib/model-reasoning.test.ts src/lib/keybinds/actions.test.ts --config apps/desktop/vite.config.ts`
- `npx eslint src/app/hooks/use-keybinds.ts src/lib/keybinds/actions.ts src/lib/keybinds/actions.test.ts src/lib/model-reasoning.ts src/lib/model-reasoning.test.ts`
- Manual desktop smoke test from the PR working tree: opened Ctrl+/ keyboard shortcuts, confirmed Reasoning level up/down appear under Composer, bound shortcuts, focused the composer, and verified they step the reasoning level as intended.

`venv/bin/python -m pytest tests/ -v` was attempted, but this local checkout's linked venv does not have pytest installed. This PR only changes the Desktop TypeScript/Electron surface, so the focused desktop checks above cover the modified code path.

Note: full `npm run lint --workspace apps/desktop` still fails on pre-existing unrelated lint errors (for example `electron/main.cjs` unused `net` and existing import-order/curly warnings outside this change).

## Contribution-guide checklist
- Branch name follows the documented `feat/description` pattern: `feat/desktop-reasoning-shortcuts`.
- Commit message uses Conventional Commits: `feat(desktop): add reasoning level keybinds`.
- PR is focused on one logical Desktop feature.
- Description includes what changed, why, how to test, and tested platform.
- Cross-platform review: no Python process management, file path construction, shell interpolation, or platform-specific APIs were added.
- Security review: no user input is passed to shell commands, no paths/secrets/logging behavior changed, and no new core tools or backend API routes were added.
- Related issues: none.
