### PR TITLE
fix(cli): keep tool-spinner timer ticking and guard torn reads

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3890,6 +3890,15 @@ class HermesCLI:
         t0 = getattr(self, "_tool_start_time", 0) or 0
         if t0 > 0:
             elapsed = time.monotonic() - t0
+            # Guard against a torn read across the unlocked UI fields: _spinner_text
+            # and _tool_start_time are best-effort UI state updated by different
+            # events without a lock, so a render can briefly observe a fresh label
+            # paired with a stale start timestamp from a prior turn. A negative
+            # value (reset/clock-edge race) or an implausibly large one (>24h for a
+            # single tool) means the pairing is untrustworthy this frame; show the
+            # label without a timer rather than flashing an absurd number.
+            if elapsed < 0 or elapsed > 86400:
+                return f"  {txt}"
             if elapsed >= 60:
                 _m, _s = int(elapsed // 60), int(elapsed % 60)
                 # Fixed-width timer to avoid status-line wrap jitter while
@@ -15045,7 +15054,15 @@ class HermesCLI:
                 if not self._app:
                     time.sleep(0.1)
                     continue
-                if self._command_running:
+                # Repaint on a fixed cadence whenever a live timer is on screen:
+                # slow slash commands (_command_running) OR an agent turn with a
+                # running tool (_agent_running + non-empty _spinner_text). The old
+                # condition only checked _command_running, so during agent tool
+                # calls the elapsed timer was never repainted on a clock — it only
+                # advanced when an agent event happened to fire _invalidate(),
+                # which is why the seconds appeared to "jump" by whole tool
+                # durations instead of ticking smoothly.
+                if self._command_running or (self._agent_running and self._spinner_text):
                     self._invalidate(min_interval=0.1)
                     time.sleep(0.1)
                 else:

--- a/tests/cli/test_cli_spinner_timer.py
+++ b/tests/cli/test_cli_spinner_timer.py
@@ -1,0 +1,104 @@
+"""Regression tests for the inline tool spinner timer in the classic CLI.
+
+Covers two fixes:
+
+* ``_render_spinner_text`` torn-read guard — the live elapsed timer must never
+  render a negative or absurdly large number when a render observes a fresh
+  ``_spinner_text`` paired with a stale ``_tool_start_time`` (the two fields are
+  best-effort UI state updated by different events without a lock).
+
+* The ``spinner_loop`` repaint gate — the loop must repaint on a fixed cadence
+  while an agent turn is running a tool (``_agent_running`` + non-empty
+  ``_spinner_text``), not only while a slash command runs (``_command_running``).
+  Previously the agent-tool case was missed, so the timer only advanced when an
+  unrelated agent event happened to fire ``_invalidate()``, making the seconds
+  appear to jump by whole tool durations.
+"""
+
+import time
+
+from cli import HermesCLI
+
+
+def _make_cli():
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj._spinner_text = ""
+    cli_obj._tool_start_time = 0.0
+    return cli_obj
+
+
+class TestRenderSpinnerText:
+    def test_empty_spinner_returns_empty(self):
+        cli_obj = _make_cli()
+        assert cli_obj._render_spinner_text() == ""
+
+    def test_label_without_start_time_has_no_timer(self):
+        cli_obj = _make_cli()
+        cli_obj._spinner_text = "🔧 terminal"
+        cli_obj._tool_start_time = 0.0
+        out = cli_obj._render_spinner_text()
+        assert "terminal" in out
+        assert "(" not in out  # no timer parens
+
+    def test_normal_elapsed_renders_seconds(self):
+        cli_obj = _make_cli()
+        cli_obj._spinner_text = "🔧 terminal"
+        cli_obj._tool_start_time = time.monotonic() - 3.2
+        out = cli_obj._render_spinner_text()
+        assert "terminal" in out
+        assert "s)" in out
+        assert "3." in out
+
+    def test_rollover_past_60s_uses_fixed_width(self):
+        cli_obj = _make_cli()
+        cli_obj._spinner_text = "🔧 terminal"
+        cli_obj._tool_start_time = time.monotonic() - 125
+        out = cli_obj._render_spinner_text()
+        assert "02m05s" in out
+
+    def test_stale_start_time_does_not_flash_absurd_number(self):
+        """Torn read: fresh label, very old start timestamp from a prior turn."""
+        cli_obj = _make_cli()
+        cli_obj._spinner_text = "🔧 read_file"
+        cli_obj._tool_start_time = time.monotonic() - 999999  # ~11.5 days
+        out = cli_obj._render_spinner_text()
+        assert "read_file" in out
+        assert "(" not in out  # timer suppressed, no giant number
+
+    def test_negative_elapsed_does_not_render_negative_timer(self):
+        """Clock-edge / reset race producing a start time slightly in the future."""
+        cli_obj = _make_cli()
+        cli_obj._spinner_text = "🔧 patch"
+        cli_obj._tool_start_time = time.monotonic() + 50
+        out = cli_obj._render_spinner_text()
+        assert "patch" in out
+        assert "-" not in out
+
+
+def _repaint_gate(command_running: bool, agent_running: bool, spinner_text: str) -> bool:
+    """Mirror of the repaint condition in cli.py ``spinner_loop``.
+
+    Kept in sync with::
+
+        if self._command_running or (self._agent_running and self._spinner_text):
+
+    so the truth table is locked by a test even though the live condition lives
+    inside a thread closure that cannot be invoked directly.
+    """
+    return command_running or (agent_running and bool(spinner_text))
+
+
+class TestSpinnerLoopRepaintGate:
+    def test_idle_prompt_does_not_repaint(self):
+        assert _repaint_gate(False, False, "") is False
+
+    def test_slow_slash_command_repaints(self):
+        assert _repaint_gate(True, False, "") is True
+
+    def test_agent_running_tool_repaints(self):
+        # The regression: agent turn with a live tool must repaint the timer.
+        assert _repaint_gate(False, True, "🔧 terminal") is True
+
+    def test_agent_thinking_without_tool_does_not_repaint(self):
+        # No tool label => no live timer => keep idle prompt stable.
+        assert _repaint_gate(False, True, "") is False


### PR DESCRIPTION
## Summary
The inline tool-spinner elapsed timer in the classic CLI appeared to jump by whole tool durations and occasionally flashed an absurdly large number. This fixes both.

## Changes
- `spinner_loop` now repaints on a fixed cadence while an agent turn has a live tool label (`_agent_running` + non-empty `_spinner_text`), not only while a slash command runs. The timer ticks smoothly instead of advancing only when an unrelated agent event fires `_invalidate()`. Idle/thinking states still avoid background repaints to prevent the known tmux/Ghostty viewport fight.
- `_render_spinner_text` suppresses the timer for a frame when the computed elapsed is out of a plausible range (negative or > 24h), guarding the unlocked best-effort `_spinner_text` / `_tool_start_time` pair against a torn read. No locking is added, consistent with the existing best-effort UI design.

## Testing
- New `tests/cli/test_cli_spinner_timer.py` (10 tests): render guard (normal / rollover / stale / negative) + repaint-gate truth table. All pass.
- `pytest tests/cli/` shows no new failures versus the same-commit baseline (the pre-existing worktree-test errors and a flaky resume test reproduce identically on unmodified `main`).
- Note: verification is via unit tests; no interactive screen recording attached.

## Related
Closes #46175

## Checklist
- [x] Changes scoped to this fix only
- [x] Tests added
- [x] Considered cross-platform impact (monotonic/time behave consistently across macOS/Linux/Windows)
