### PR TITLE
fix(cli): drive per-prompt timer with monotonic clock

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3359,7 +3359,7 @@ class HermesCLI:
         self._resumed = False
         # Per-prompt elapsed timer — started at the beginning of each chat turn,
         # frozen when the agent thread completes, displayed in the status bar.
-        self._prompt_start_time: Optional[float] = None  # time.time() when turn started
+        self._prompt_start_time: Optional[float] = None  # time.monotonic() when turn started
         self._prompt_duration: float = 0.0  # frozen duration of last completed turn
         # Initialize SQLite session store early so /title works before first message
         self._session_db = None
@@ -3652,7 +3652,7 @@ class HermesCLI:
         """
         if prompt_start_time is None and prompt_duration == 0.0:
             return "⏲ 0s"
-        elapsed = time.time() - prompt_start_time if prompt_start_time is not None else prompt_duration
+        elapsed = time.monotonic() - prompt_start_time if prompt_start_time is not None else prompt_duration
         elapsed = max(0.0, elapsed)
 
         days = int(elapsed // 86400)
@@ -12425,7 +12425,7 @@ class HermesCLI:
             # exits the main thread and daemon threads are reaped automatically).
             # Start per-prompt elapsed timer — frozen after the agent thread
             # finishes; reset on the next turn.
-            self._prompt_start_time = time.time()
+            self._prompt_start_time = time.monotonic()
             self._prompt_duration = 0.0
             agent_thread = threading.Thread(target=run_agent, daemon=True)
             agent_thread.start()
@@ -12506,7 +12506,7 @@ class HermesCLI:
             # Freeze per-prompt elapsed timer once the agent thread has
             # exited (or been abandoned as a daemon after interrupt).
             if self._prompt_start_time is not None:
-                self._prompt_duration = max(0.0, time.time() - self._prompt_start_time)
+                self._prompt_duration = max(0.0, time.monotonic() - self._prompt_start_time)
                 self._prompt_start_time = None
 
             # Proactively clean up async clients whose event loop is dead.

--- a/tests/cli/test_cli_prompt_timer_clock.py
+++ b/tests/cli/test_cli_prompt_timer_clock.py
@@ -1,0 +1,48 @@
+"""Regression tests for the per-prompt status-bar timer formatter.
+
+The per-prompt elapsed timer is now driven by time.monotonic() instead of
+time.time(), so it no longer jumps when the wall clock is adjusted (NTP step,
+manual change) or across a suspend/resume. _format_prompt_elapsed therefore
+interprets a live prompt_start_time as a monotonic timestamp.
+"""
+
+import time
+
+from cli import HermesCLI
+
+fmt = HermesCLI._format_prompt_elapsed
+
+
+class TestFormatPromptElapsed:
+    def test_fresh_start_shows_zero(self):
+        assert fmt(None, 0.0) == "⏲ 0s"
+
+    def test_frozen_duration_seconds(self):
+        assert "5s" in fmt(None, 5.0)
+
+    def test_frozen_duration_minutes(self):
+        out = fmt(None, 65.0)
+        assert "1m" in out and "5s" in out
+
+    def test_frozen_duration_hours(self):
+        out = fmt(None, 3661.0)  # 1h 0m 1s
+        assert "1h" in out
+
+    def test_live_start_is_interpreted_as_monotonic(self):
+        # A live prompt with a start time 2s in the monotonic past must render
+        # ~2s elapsed. If the formatter still subtracted from time.time(), a
+        # monotonic start (a much smaller number than epoch seconds) would
+        # produce a huge bogus value.
+        start = time.monotonic() - 2.0
+        out = fmt(start, 0.0, live=True)
+        assert "2s" in out
+        # sanity: not an absurd wall-clock-vs-monotonic mismatch value
+        assert "h" not in out and "d" not in out
+
+    def test_negative_is_clamped_to_zero(self):
+        # Start slightly in the future (clock-edge race) clamps to 0s, never
+        # renders a negative timer.
+        start = time.monotonic() + 5.0
+        out = fmt(start, 0.0, live=True)
+        assert "0s" in out
+        assert "-" not in out


### PR DESCRIPTION
## Summary
The status-bar per-prompt elapsed timer measured wall-clock time via `time.time()`, so an NTP step, manual clock change, or suspend/resume during a turn could make it jump or briefly go backward. Switch it to `time.monotonic()`, matching the tool-spinner timer.

## Changes
- `_prompt_start_time` and the elapsed computation in `_format_prompt_elapsed` now use `time.monotonic()`.

## Behavior note (maintainer call)
With monotonic timing, suspend time is no longer counted toward the per-turn timer. This is arguably the correct semantics for a "how long did this turn work" timer, but it is a behavior change — flagging it explicitly.

## Testing
- New `tests/cli/test_cli_prompt_timer_clock.py` (6 tests): formatting at each scale + live monotonic interpretation + negative clamp. All pass.
- Existing `tests/cli/test_cli_status_bar.py` (37 tests) still pass.
- `pytest tests/cli/` shows no new failures versus the same-commit baseline.
- Note: verification is via unit tests; no interactive screen recording attached.

## Related
Closes #46177

## Checklist
- [x] Changes scoped to this fix only
- [x] Tests added
- [x] Considered cross-platform impact
