### PR TITLE
fix(gateway): reconcile stale running runtime state

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -550,9 +550,66 @@ def write_runtime_status(
     _write_json_file(path, payload)
 
 
+def read_runtime_status_raw(path: Optional[Path] = None) -> Optional[dict[str, Any]]:
+    """Read the persisted runtime health/status information verbatim.
+
+    This is the raw on-disk view, with no liveness reconciliation. Use it for
+    boot/recovery flows that need the last persisted intent rather than the
+    current effective state.
+    """
+    return _read_json_file(path or _get_runtime_status_path())
+
+
+def _reconcile_runtime_status(
+    payload: Optional[dict[str, Any]],
+    *,
+    path: Optional[Path] = None,
+    persist: bool = True,
+) -> Optional[dict[str, Any]]:
+    """Reconcile optimistic runtime status against current live-process truth."""
+    if not payload:
+        return payload
+
+    gateway_state = payload.get("gateway_state")
+    # Only reconcile states that imply a live gateway process should exist.
+    # Preserve explicit terminal/history states like "startup_failed" and
+    # "stopped" so operators still see the last real outcome.
+    if gateway_state != "running":
+        return payload
+
+    try:
+        running_pid = get_running_pid(cleanup_stale=False)
+    except Exception:
+        return payload
+
+    if running_pid is not None:
+        return payload
+
+    reconciled = dict(payload)
+    reconciled["gateway_state"] = "stopped"
+    if not persist:
+        return reconciled
+
+    persisted = dict(reconciled)
+    persisted["updated_at"] = _utc_now_iso()
+    try:
+        _write_json_file(path or _get_runtime_status_path(), persisted)
+    except Exception:
+        return reconciled
+    return persisted
+
+
 def read_runtime_status() -> Optional[dict[str, Any]]:
-    """Read the persisted gateway runtime health/status information."""
-    return _read_json_file(_get_runtime_status_path())
+    """Read the effective gateway runtime health/status information.
+
+    A leftover ``gateway_state='running'`` after an external kill or reboot is
+    stale state, not truth. Reconcile those optimistic runtime states against
+    the current profile's live PID guard so shared consumers do not each have
+    to rediscover the same mismatch independently. When that mismatch is found,
+    best-effort persist the corrected ``stopped`` state so later raw readers do
+    not keep inheriting the stale optimistic record.
+    """
+    return _reconcile_runtime_status(read_runtime_status_raw())
 
 
 def remove_pid_file() -> None:

--- a/hermes_cli/container_boot.py
+++ b/hermes_cli/container_boot.py
@@ -221,16 +221,17 @@ def _read_prior_state(profile_dir: Path) -> str | None:
     """Read gateway_state.json's ``gateway_state`` field, or None if
     missing or unparseable. Unparseable counts as "no prior state" so
     we don't bork the whole reconciliation on a corrupt file."""
+    from gateway.status import read_runtime_status_raw
+
     state_file = profile_dir / "gateway_state.json"
-    if not state_file.exists():
-        return None
-    try:
-        return json.loads(state_file.read_text()).get("gateway_state")
-    except (OSError, json.JSONDecodeError):
+    payload = read_runtime_status_raw(state_file)
+    if payload is not None:
+        return payload.get("gateway_state")
+    if state_file.exists():
         log.warning(
             "could not read %s; treating as no prior state", state_file,
         )
-        return None
+    return None
 
 
 def _cleanup_stale_runtime_files(profile_dir: Path) -> None:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -330,6 +330,81 @@ class TestGatewayRuntimeStatus:
         assert payload["platforms"]["telegram"]["error_code"] == "telegram_polling_conflict"
         assert payload["platforms"]["telegram"]["error_message"] == "another poller is active"
 
+    def test_read_runtime_status_reconciles_stale_running_state_to_stopped(self, tmp_path, monkeypatch):
+        """A stale runtime file must not keep reporting a running gateway.
+
+        Regression for #46133: desktop- and status-style consumers that only
+        read ``gateway_state.json`` should not trust a leftover
+        ``gateway_state='running'`` record when there is no matching live
+        gateway for this profile anymore.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        state_path = tmp_path / "gateway_state.json"
+        state_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": 111,
+            "kind": "hermes-gateway",
+            "gateway_state": "running",
+            "platforms": {"discord": {"state": "connected"}},
+            "updated_at": "2026-06-14T00:00:00+00:00",
+        }))
+
+        monkeypatch.setattr(status, "get_running_pid", lambda pid_path=None, cleanup_stale=False: None)
+
+        payload = status.read_runtime_status()
+        persisted = json.loads(state_path.read_text())
+
+        assert payload["gateway_state"] == "stopped"
+        assert payload["pid"] == 99999
+        assert payload["platforms"]["discord"]["state"] == "connected"
+        assert payload["updated_at"] != "2026-06-14T00:00:00+00:00"
+        assert persisted["gateway_state"] == "stopped"
+        assert persisted["pid"] == 99999
+        assert persisted["platforms"]["discord"]["state"] == "connected"
+        assert persisted["updated_at"] == payload["updated_at"]
+
+    def test_read_runtime_status_preserves_explicit_non_running_states(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        state_path = tmp_path / "gateway_state.json"
+        state_path.write_text(json.dumps({
+            "pid": 99999,
+            "gateway_state": "startup_failed",
+            "exit_reason": "discord token invalid",
+            "updated_at": "2026-06-14T00:00:00+00:00",
+        }))
+
+        monkeypatch.setattr(status, "get_running_pid", lambda pid_path=None, cleanup_stale=False: None)
+
+        payload = status.read_runtime_status()
+        persisted = json.loads(state_path.read_text())
+
+        assert payload["gateway_state"] == "startup_failed"
+        assert payload["exit_reason"] == "discord token invalid"
+        assert persisted["gateway_state"] == "startup_failed"
+        assert persisted["updated_at"] == "2026-06-14T00:00:00+00:00"
+
+    def test_read_runtime_status_best_effort_if_stale_correction_write_fails(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        state_path = tmp_path / "gateway_state.json"
+        state_path.write_text(json.dumps({
+            "pid": 99999,
+            "gateway_state": "running",
+            "updated_at": "2026-06-14T00:00:00+00:00",
+        }))
+
+        monkeypatch.setattr(status, "get_running_pid", lambda pid_path=None, cleanup_stale=False: None)
+        monkeypatch.setattr(status, "_write_json_file", lambda path, payload: (_ for _ in ()).throw(OSError("disk full")))
+
+        payload = status.read_runtime_status()
+        persisted = json.loads(state_path.read_text())
+
+        assert payload["gateway_state"] == "stopped"
+        assert payload["updated_at"] == "2026-06-14T00:00:00+00:00"
+        assert persisted["gateway_state"] == "running"
+
     def test_write_runtime_status_explicit_none_clears_stale_fields(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
@@ -351,7 +426,7 @@ class TestGatewayRuntimeStatus:
             error_message=None,
         )
 
-        payload = status.read_runtime_status()
+        payload = status.read_runtime_status_raw()
         assert payload["gateway_state"] == "running"
         assert payload["exit_reason"] is None
         assert payload["platforms"]["discord"]["state"] == "connected"


### PR DESCRIPTION
## What does this PR do?

Fixes the stale `gateway_state.json` read path behind a shared gateway-status helper instead of only patching individual consumers.

When the persisted runtime status says `gateway_state: "running"` but there is no live gateway PID for the current profile, `read_runtime_status()` now reconciles that optimistic state to `stopped` and best-effort writes the corrected state back to disk. This closes the underlying inconsistency that let desktop/status-style consumers keep inheriting stale `running` state after an external kill, reboot, or detached wrapper exit.

To avoid breaking restart-on-boot behavior, container boot recovery now explicitly reads the raw persisted state via `read_runtime_status_raw()` so it still follows the last stored intent instead of current live-PID truth.

## Related Issue

Fixes #46133

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `read_runtime_status_raw()` and split raw persisted reads from effective reconciled reads in `gateway/status.py`
- Reconcile stale persisted `gateway_state="running"` to `stopped` in the shared `read_runtime_status()` path, and best-effort persist that correction back to `gateway_state.json`
- Keep `hermes_cli/container_boot.py` on raw persisted-state semantics so container restart autostart behavior still follows the last stored state
- Add regression tests covering stale-running reconciliation, persisted correction, non-running state preservation, and best-effort fallback if the corrective write fails

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_status.py -- -q`
2. Run `scripts/run_tests.sh tests/hermes_cli/test_container_boot.py -- -q`
3. Run `scripts/run_tests.sh tests/hermes_cli/test_web_server.py -- -k "get_status_hides_stale_platforms_when_gateway_not_running or status_remote_probe_not_attempted_when_local_pid_found or status_falls_back_to_remote_probe" -q`
4. Run `scripts/run_tests.sh tests/hermes_cli/test_gateway_runtime_health.py -- -q`
5. Run `scripts/run_tests.sh tests/gateway/test_api_server.py -- -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Validation notes:
- The lower-level bug was still reproducible on that clean baseline: `gateway.status.read_runtime_status()` would return stale persisted `gateway_state="running"` unchanged when no live gateway PID existed.
- After this patch, a stale `running` record is reconciled to `stopped` through the shared read path and the corrected state is written back to disk.
