### PR TITLE
fix(gateway): refresh prompt policy in long-lived sessions

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1039,6 +1039,15 @@ class APIServerAdapter(BasePlatformAdapter):
         runtime_kwargs = _resolve_runtime_agent_kwargs()
         reasoning_config = GatewayRunner._load_reasoning_config()
         model = _resolve_gateway_model()
+        configured_ephemeral = GatewayRunner._load_ephemeral_system_prompt()
+        effective_ephemeral = "\n\n".join(
+            part
+            for part in (
+                configured_ephemeral.strip() if isinstance(configured_ephemeral, str) else "",
+                str(ephemeral_system_prompt or "").strip(),
+            )
+            if part
+        )
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
@@ -1055,7 +1064,7 @@ class APIServerAdapter(BasePlatformAdapter):
             max_iterations=max_iterations,
             quiet_mode=True,
             verbose_logging=False,
-            ephemeral_system_prompt=ephemeral_system_prompt or None,
+            ephemeral_system_prompt=effective_ephemeral,
             enabled_toolsets=enabled_toolsets,
             session_id=session_id,
             platform="api_server",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1828,6 +1828,34 @@ def _load_gateway_runtime_config() -> dict:
     return expanded if isinstance(expanded, dict) else {}
 
 
+def _resolve_personality_prompt(value: Any) -> str:
+    """Accept string or dict personality value; return system prompt string."""
+    if isinstance(value, dict):
+        parts = [value.get("system_prompt", "")]
+        if value.get("tone"):
+            parts.append(f'Tone: {value["tone"]}')
+        if value.get("style"):
+            parts.append(f'Style: {value["style"]}')
+        return "\n".join(str(p) for p in parts if p).strip()
+    return str(value or "").strip()
+
+
+def _resolve_display_personality_prompt(cfg: dict) -> str:
+    """Resolve display.personality to an agent.personalities prompt, if valid."""
+    name = str(cfg_get(cfg, "display", "personality", default="") or "").strip()
+    if not name or name.lower() in {"none", "default", "neutral"}:
+        return ""
+    personalities = cfg_get(cfg, "agent", "personalities", default={})
+    if not isinstance(personalities, dict):
+        return ""
+    value = personalities.get(name)
+    if value is None:
+        value = personalities.get(name.lower())
+    if value is None:
+        return ""
+    return _resolve_personality_prompt(value)
+
+
 def _resolve_gateway_model(config: dict | None = None) -> str:
     """Read model from config.yaml — single source of truth.
 
@@ -3389,15 +3417,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     @staticmethod
     def _load_ephemeral_system_prompt() -> str:
         """Load ephemeral system prompt from config or env var.
-        
-        Checks HERMES_EPHEMERAL_SYSTEM_PROMPT env var first, then falls back to
-        agent.system_prompt in ~/.hermes/config.yaml.
+
+        Precedence: HERMES_EPHEMERAL_SYSTEM_PROMPT, explicit agent.system_prompt,
+        then display.personality resolved through agent.personalities.
         """
         prompt = os.getenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", "")
         if prompt:
             return prompt
         cfg = _load_gateway_runtime_config()
-        return str(cfg_get(cfg, "agent", "system_prompt", default="") or "").strip()
+        prompt = str(cfg_get(cfg, "agent", "system_prompt", default="") or "").strip()
+        if prompt:
+            return prompt
+        return _resolve_display_personality_prompt(cfg)
 
     @staticmethod
     def _load_reasoning_config() -> dict | None:
@@ -10366,6 +10397,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
             turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+            background_ephemeral = self._load_ephemeral_system_prompt()
 
             # Enrich the prompt with image descriptions so the background
             # agent can see user-attached images (same as the main flow).
@@ -10393,6 +10425,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     verbose_logging=False,
                     enabled_toolsets=enabled_toolsets,
                     disabled_toolsets=disabled_toolsets,
+                    ephemeral_system_prompt=background_ephemeral,
                     reasoning_config=reasoning_config,
                     service_tier=self._service_tier,
                     request_overrides=turn_route.get("request_overrides"),
@@ -12432,7 +12465,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         ("compression", "threshold"),
         ("compression", "target_ratio"),
         ("compression", "protect_last_n"),
+        ("agent", "system_prompt"),
+        ("agent", "personalities"),
+        ("agent", "tool_use_enforcement"),
+        ("agent", "task_completion_guidance"),
         ("agent", "disabled_toolsets"),
+        ("display", "personality"),
         ("memory", "provider"),
     )
 
@@ -14147,6 +14185,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Platform.LOCAL ("local") maps to "cli"; others pass through as-is.
             platform_key = "cli" if source.platform == Platform.LOCAL else source.platform.value
             
+            # Re-read .env/config before resolving prompt-sensitive runtime
+            # settings. Gateway processes are long-lived, and manual edits to
+            # config.yaml / personalities should take effect on the next turn
+            # rather than waiting for a restart or cache eviction.
+            _reload_runtime_env_preserving_config_authority()
+            self._ephemeral_system_prompt = self._load_ephemeral_system_prompt()
+
             # Combine platform context, per-channel context, and the user-configured
             # ephemeral system prompt.
             combined_ephemeral = context_prompt or ""
@@ -14155,11 +14200,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 combined_ephemeral = (combined_ephemeral + "\n\n" + event_channel_prompt).strip()
             if self._ephemeral_system_prompt:
                 combined_ephemeral = (combined_ephemeral + "\n\n" + self._ephemeral_system_prompt).strip()
-
-            # Re-read .env and config for fresh credentials (gateway is long-lived,
-            # keys may change without restart). Keep config.yaml authoritative for
-            # runtime budget settings bridged into env vars.
-            _reload_runtime_env_preserving_config_authority()
 
             try:
                 model, runtime_kwargs = self._resolve_session_agent_runtime(

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -326,6 +326,10 @@ class TestAdapterInit:
             "gateway.run.GatewayRunner._load_reasoning_config",
             staticmethod(lambda: {"enabled": True, "effort": "xhigh"}),
         )
+        monkeypatch.setattr(
+            "gateway.run.GatewayRunner._load_ephemeral_system_prompt",
+            staticmethod(lambda: "delegation policy"),
+        )
         monkeypatch.setattr("gateway.run.GatewayRunner._load_fallback_model", staticmethod(lambda: None))
         monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
 
@@ -336,6 +340,31 @@ class TestAdapterInit:
 
         assert isinstance(agent, FakeAgent)
         assert captured["reasoning_config"] == {"enabled": True, "effort": "xhigh"}
+        assert captured["ephemeral_system_prompt"] == "delegation policy"
+
+    def test_create_agent_combines_config_prompt_before_request_instructions(self, monkeypatch):
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr("gateway.run._resolve_runtime_agent_kwargs", lambda: {})
+        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "gpt-5.5")
+        monkeypatch.setattr("gateway.run._load_gateway_config", lambda: {})
+        monkeypatch.setattr("gateway.run.GatewayRunner._load_reasoning_config", staticmethod(lambda: None))
+        monkeypatch.setattr("gateway.run.GatewayRunner._load_ephemeral_system_prompt", staticmethod(lambda: "delegation policy"))
+        monkeypatch.setattr("gateway.run.GatewayRunner._load_fallback_model", staticmethod(lambda: None))
+        monkeypatch.setattr("hermes_cli.tools_config._get_platform_tools", lambda *_: set())
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+
+        agent = adapter._create_agent(ephemeral_system_prompt="request instructions")
+
+        assert isinstance(agent, FakeAgent)
+        assert captured["ephemeral_system_prompt"] == "delegation policy\n\nrequest instructions"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_background_command.py
+++ b/tests/gateway/test_background_command.py
@@ -249,6 +249,7 @@ class TestRunBackgroundTask:
         mock_result = {"final_response": "Hello from background!", "messages": []}
 
         with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+             patch("gateway.run.GatewayRunner._load_ephemeral_system_prompt", return_value="delegate-first prompt"), \
              patch("run_agent.AIAgent") as MockAgent:
             mock_agent_instance = MagicMock()
             mock_agent_instance.shutdown_memory_provider = MagicMock()
@@ -264,6 +265,7 @@ class TestRunBackgroundTask:
         content = call_args[1].get("content", call_args[0][1] if len(call_args[0]) > 1 else "")
         assert "Background task complete" in content
         assert "Hello from background!" in content
+        assert MockAgent.call_args.kwargs["ephemeral_system_prompt"] == "delegate-first prompt"
         mock_agent_instance.shutdown_memory_provider.assert_called_once()
         mock_agent_instance.close.assert_called_once()
 

--- a/tests/gateway/test_discord_channel_prompts.py
+++ b/tests/gateway/test_discord_channel_prompts.py
@@ -218,7 +218,6 @@ async def test_run_agent_appends_channel_prompt_to_ephemeral_system_prompt(monke
     monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
     monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
     monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
-    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
     monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
     monkeypatch.setattr(
         gateway_run,

--- a/tests/gateway/test_runtime_config_env_expansion.py
+++ b/tests/gateway/test_runtime_config_env_expansion.py
@@ -118,3 +118,123 @@ def test_gateway_runtime_loaders_expand_env_var_templates(
     loader = getattr(gateway_run.GatewayRunner, loader_name)
 
     assert loader() == expected
+
+
+def test_ephemeral_system_prompt_uses_display_personality_fallback(gateway_home):
+    _write_config(
+        gateway_home,
+        "display:\n"
+        "  personality: orchestrator\n"
+        "agent:\n"
+        "  personalities:\n"
+        "    orchestrator:\n"
+        "      system_prompt: You are the orchestrator.\n"
+        "      tone: concise\n"
+        "      style: delegation-first\n",
+    )
+
+    assert gateway_run.GatewayRunner._load_ephemeral_system_prompt() == (
+        "You are the orchestrator.\nTone: concise\nStyle: delegation-first"
+    )
+
+
+def test_ephemeral_system_prompt_preserves_exact_personality_key_case(gateway_home):
+    _write_config(
+        gateway_home,
+        "display:\n"
+        "  personality: MixedCase\n"
+        "agent:\n"
+        "  personalities:\n"
+        "    MixedCase: exact case prompt\n"
+        "    mixedcase: lowercase prompt\n",
+    )
+
+    assert gateway_run.GatewayRunner._load_ephemeral_system_prompt() == "exact case prompt"
+
+
+def test_ephemeral_system_prompt_falls_back_to_lowercase_personality_key(gateway_home):
+    _write_config(
+        gateway_home,
+        "display:\n"
+        "  personality: MixedCase\n"
+        "agent:\n"
+        "  personalities:\n"
+        "    mixedcase: lowercase prompt\n",
+    )
+
+    assert gateway_run.GatewayRunner._load_ephemeral_system_prompt() == "lowercase prompt"
+
+
+def test_ephemeral_system_prompt_expands_env_inside_personality_prompt(monkeypatch, gateway_home):
+    _write_config(
+        gateway_home,
+        "display:\n"
+        "  personality: orchestrator\n"
+        "agent:\n"
+        "  personalities:\n"
+        "    orchestrator: ${PERSONALITY_PROMPT}\n",
+    )
+    monkeypatch.setenv("PERSONALITY_PROMPT", "expanded personality prompt")
+
+    assert gateway_run.GatewayRunner._load_ephemeral_system_prompt() == "expanded personality prompt"
+
+
+def test_ephemeral_system_prompt_prefers_agent_system_prompt_over_display_personality(
+    gateway_home,
+):
+    _write_config(
+        gateway_home,
+        "display:\n"
+        "  personality: orchestrator\n"
+        "agent:\n"
+        "  system_prompt: explicit prompt\n"
+        "  personalities:\n"
+        "    orchestrator: personality prompt\n",
+    )
+
+    assert gateway_run.GatewayRunner._load_ephemeral_system_prompt() == "explicit prompt"
+
+
+def test_ephemeral_system_prompt_prefers_env_over_config(monkeypatch, gateway_home):
+    _write_config(
+        gateway_home,
+        "display:\n"
+        "  personality: orchestrator\n"
+        "agent:\n"
+        "  system_prompt: explicit prompt\n"
+        "  personalities:\n"
+        "    orchestrator: personality prompt\n",
+    )
+    monkeypatch.setenv("HERMES_EPHEMERAL_SYSTEM_PROMPT", "env prompt")
+
+    assert gateway_run.GatewayRunner._load_ephemeral_system_prompt() == "env prompt"
+
+
+def test_agent_cache_signature_includes_prompt_policy_config_keys():
+    keys = set(gateway_run.GatewayRunner._CACHE_BUSTING_CONFIG_KEYS)
+
+    assert ("agent", "system_prompt") in keys
+    assert ("agent", "personalities") in keys
+    assert ("agent", "tool_use_enforcement") in keys
+    assert ("agent", "task_completion_guidance") in keys
+    assert ("display", "personality") in keys
+
+
+def test_extract_cache_busting_config_captures_prompt_policy_values():
+    extracted = gateway_run.GatewayRunner._extract_cache_busting_config(
+        {
+            "agent": {
+                "system_prompt": "prompt",
+                "personalities": {"delegator": "delegate first"},
+                "tool_use_enforcement": "strict",
+                "task_completion_guidance": "verify",
+            },
+            "display": {"personality": "delegator"},
+        }
+    )
+
+    assert extracted["agent.system_prompt"] == "prompt"
+    assert extracted["agent.personalities"] == {"delegator": "delegate first"}
+    assert extracted["agent.tool_use_enforcement"] == "strict"
+    assert extracted["agent.task_completion_guidance"] == "verify"
+    assert extracted["display.personality"] == "delegator"


### PR DESCRIPTION
## Summary
- refresh the gateway's configured prompt/personality policy before each normal turn in the long-lived runner
- include prompt-policy inputs in the gateway agent cache signature so agent construction state changes invalidate correctly
- propagate the configured prompt into background tasks and API-server-created agents
- add regression coverage for personality fallback, cache signature keys, background prompt propagation, and API prompt composition

## Notes
This intentionally keeps scope small and uses the local repair diff only for gateway prompt/cache/personality behavior. It does **not** include user-local SOUL/profile default changes, delegate result slimming/default behavior, auto-continue resume markers, or unrelated API profile/session/job routing changes.

Related/extends #32007. Also complements the cache-signature cluster: #37880, #39022, #39284, #39454, and #28078.

API server prompt ordering is configured/global prompt first, then request instructions, matching the normal gateway "platform/config first, request-specific last" composition and covered by test.

## Tests
- `uv run pytest tests/gateway/test_runtime_config_env_expansion.py tests/gateway/test_background_command.py::TestRunBackgroundTask::test_successful_task_sends_result tests/gateway/test_api_server.py::TestAdapterInit -q` — 24 passed
- `ulimit -n 4096; uv run pytest tests/gateway/test_runtime_config_env_expansion.py tests/gateway/test_background_command.py tests/gateway/test_api_server.py` — 196 passed, 1 failed: existing macOS `/var` vs `/private/var` temp path assertion in `test_media_files_routed_by_type` (unrelated to this prompt change)
- `python -m pytest tests/gateway/test_discord_channel_prompts.py -q` — 10 passed
- `python -m pytest tests/gateway/test_runtime_config_env_expansion.py -q` — 17 passed
- `python scripts/run_tests_parallel.py --slice 4/6` (local system env) — blocked by missing optional `acp`, missing `mcp.server.auth`, local kanban/test_run_agent timeouts; CI slice was re-run after the fixture fix
