### PR TITLE
fix(research): warn when trust_remote_code=True in trajectory compressor

### DIFF
--- a/tests/test_trajectory_compressor_async.py
+++ b/tests/test_trajectory_compressor_async.py
@@ -199,3 +199,44 @@ async def test_generate_summary_async_public_moonshot_cn_kimi_k2_5_omits_tempera
 
     assert result.startswith("[CONTEXT SUMMARY]:")
     assert "temperature" not in async_client.chat.completions.create.call_args.kwargs
+
+
+class TestTrustRemoteCodeWarning:
+    """trajectory_compressor.py — trust_remote_code security warning."""
+
+    def test_warning_logged_when_trust_remote_code_true(self):
+        """_init_tokenizer should log a warning when trust_remote_code=True."""
+        from trajectory_compressor import CompressionConfig, TrajectoryCompressor
+
+        config = CompressionConfig(trust_remote_code=True)
+        compressor = TrajectoryCompressor.__new__(TrajectoryCompressor)
+        compressor.config = config
+        compressor.logger = MagicMock()
+
+        mock_tokenizer_cls = MagicMock()
+        with patch.dict("sys.modules", {"transformers": MagicMock(
+            AutoTokenizer=mock_tokenizer_cls
+        )}):
+            compressor._init_tokenizer()
+
+        compressor.logger.warning.assert_called_once()
+        call_args = compressor.logger.warning.call_args
+        assert "trust_remote_code" in call_args[0][0]
+        assert config.tokenizer_name in call_args[0][1]
+
+    def test_no_warning_when_trust_remote_code_false(self):
+        """_init_tokenizer should NOT log a warning when trust_remote_code=False."""
+        from trajectory_compressor import CompressionConfig, TrajectoryCompressor
+
+        config = CompressionConfig(trust_remote_code=False)
+        compressor = TrajectoryCompressor.__new__(TrajectoryCompressor)
+        compressor.config = config
+        compressor.logger = MagicMock()
+
+        mock_tokenizer_cls = MagicMock()
+        with patch.dict("sys.modules", {"transformers": MagicMock(
+            AutoTokenizer=mock_tokenizer_cls
+        )}):
+            compressor._init_tokenizer()
+
+        compressor.logger.warning.assert_not_called()

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -84,6 +84,10 @@ class CompressionConfig:
     """Configuration for trajectory compression."""
     # Tokenizer
     tokenizer_name: str = "moonshotai/Kimi-K2-Thinking"
+    # SECURITY: When True, allows executing arbitrary Python code from the
+    # tokenizer repository.  Required for some tokenizers (e.g. Kimi-K2) but
+    # means an untrusted or compromised ``tokenizer_name`` repo can run code
+    # on the host.  Set to False when using a standard HuggingFace tokenizer.
     trust_remote_code: bool = True
     
     # Compression targets
@@ -363,6 +367,13 @@ class TrajectoryCompressor:
         """Initialize HuggingFace tokenizer for token counting."""
         try:
             from transformers import AutoTokenizer
+            if self.config.trust_remote_code:
+                self.logger.warning(
+                    "trust_remote_code=True for tokenizer '%s' — "
+                    "this allows the tokenizer repository to execute "
+                    "arbitrary code. Only use with trusted repos.",
+                    self.config.tokenizer_name,
+                )
             self.tokenizer = AutoTokenizer.from_pretrained(
                 self.config.tokenizer_name,
                 trust_remote_code=self.config.trust_remote_code


### PR DESCRIPTION
## What does this PR do?

Adds a security warning log when the trajectory compressor loads a HuggingFace tokenizer with `trust_remote_code=True`, and documents the security implications of the config field. This helps users understand that loading a tokenizer from an untrusted repository can execute arbitrary code on the host.

## Related Issue

Fixes #46170

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `trajectory_compressor.py`: Added security comment on `trust_remote_code` field in `CompressionConfig` explaining the code-execution risk. Added `logger.warning()` in `_init_tokenizer()` when `trust_remote_code=True` to surface the risk at runtime.
- `tests/test_trajectory_compressor_async.py`: Added `TestTrustRemoteCodeWarning` class with 2 tests — verifies warning is logged when `trust_remote_code=True` and not logged when `False`.

## How to Test

1. Run `pytest tests/test_trajectory_compressor_async.py -v` — all 10 tests should pass
2. Verify the new tests specifically: `pytest tests/test_trajectory_compressor_async.py::TestTrustRemoteCodeWarning -v`
3. Review the source: confirm `_init_tokenizer()` logs a warning before calling `AutoTokenizer.from_pretrained()` when `trust_remote_code=True`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `trajectory_compressor.py::CompressionConfig`, `trajectory_compressor.py::TrajectoryCompressor._init_tokenizer`
- Blast radius: LOW — standalone utility, no core runtime impact
- Related patterns: Security documentation, runtime warning logging
