### PR TITLE
fix(agent): persist recovered final responses

### DIFF
--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -140,6 +140,19 @@ def finalize_turn(
     # can replay assistant("(empty)") / recovery nudges and fall into the
     # same empty-response loop again.
     agent._drop_trailing_empty_response_scaffolding(messages)
+
+    # Some recovery/fallback paths return a real final_response without adding
+    # a closing assistant message to the transcript. If persisted as-is, the
+    # durable session can end at a tool/user message even though the caller saw
+    # a completed assistant response. Close the durable turn at the source.
+    if final_response and not interrupted:
+        try:
+            _tail_role = messages[-1].get("role") if messages else None
+        except Exception:
+            _tail_role = None
+        if _tail_role != "assistant":
+            messages.append({"role": "assistant", "content": final_response})
+
     agent._persist_session(messages, conversation_history)
 
     # ── Turn-exit diagnostic log ─────────────────────────────────────

--- a/tests/agent/test_turn_finalizer_final_response_persistence.py
+++ b/tests/agent/test_turn_finalizer_final_response_persistence.py
@@ -1,0 +1,112 @@
+from types import SimpleNamespace
+
+from agent.turn_finalizer import finalize_turn
+
+
+class FakeAgent:
+    def __init__(self):
+        self.max_iterations = 90
+        self.iteration_budget = SimpleNamespace(remaining=10, used=1, max_total=90)
+        self.quiet_mode = True
+        self.model = "test-model"
+        self.provider = "test-provider"
+        self.base_url = ""
+        self.session_id = "sess-test"
+        self.context_compressor = SimpleNamespace(last_prompt_tokens=0)
+        self.session_input_tokens = 0
+        self.session_output_tokens = 0
+        self.session_cache_read_tokens = 0
+        self.session_cache_write_tokens = 0
+        self.session_reasoning_tokens = 0
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.session_total_tokens = 0
+        self.session_estimated_cost_usd = 0
+        self.session_cost_status = "unknown"
+        self.session_cost_source = "test"
+        self._tool_guardrail_halt_decision = None
+        self._interrupt_message = None
+        self._response_was_previewed = True
+        self._skill_nudge_interval = 0
+        self._iters_since_skill = 0
+        self.valid_tool_names = []
+        self.persisted_messages = None
+
+    def _handle_max_iterations(self, messages, api_call_count):
+        raise AssertionError("not expected")
+
+    def _emit_status(self, *_args, **_kwargs):
+        pass
+
+    def _safe_print(self, *_args, **_kwargs):
+        pass
+
+    def _save_trajectory(self, *_args, **_kwargs):
+        pass
+
+    def _cleanup_task_resources(self, *_args, **_kwargs):
+        pass
+
+    def _drop_trailing_empty_response_scaffolding(self, messages):
+        pass
+
+    def _persist_session(self, messages, conversation_history):
+        self.persisted_messages = list(messages)
+
+    def _file_mutation_verifier_enabled(self):
+        return False
+
+    def _turn_completion_explainer_enabled(self):
+        return False
+
+    def _drain_pending_steer(self):
+        return None
+
+    def clear_interrupt(self):
+        pass
+
+    def _sync_external_memory_for_turn(self, **_kwargs):
+        pass
+
+
+def test_final_response_closes_tool_tail_before_persistence(monkeypatch):
+    """A recovered/previewed final response must be durable in session history.
+
+    Regression for turns where the caller receives a non-empty final_response,
+    but the message transcript still ends at a tool result. If persisted that
+    way, the next turn reloads a stale/malformed history and can appear to loop
+    because the assistant's visible final answer is missing from durable state.
+    """
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = FakeAgent()
+    messages = [
+        {"role": "user", "content": "do it"},
+        {
+            "role": "assistant",
+            "content": "I'll check.",
+            "tool_calls": [
+                {"id": "call-1", "function": {"name": "terminal", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call-1", "name": "terminal", "content": "ok"},
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response="Done.",
+        api_call_count=2,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task",
+        turn_id="turn",
+        user_message="do it",
+        original_user_message="do it",
+        _should_review_memory=False,
+        _turn_exit_reason="fallback_prior_turn_content",
+    )
+
+    assert result["messages"][-1] == {"role": "assistant", "content": "Done."}
+    assert agent.persisted_messages is not None
+    assert agent.persisted_messages[-1] == {"role": "assistant", "content": "Done."}


### PR DESCRIPTION
## Summary

Close non-interrupted recovered/fallback `final_response` turns with a durable assistant message before session persistence.

This prevents the persisted transcript from ending at a `tool` or `user` message after the caller has already received a completed assistant response. If that malformed tail is saved, the next turn can reload stale/incomplete history and appear to repeat or lose the visible final answer.

## Relation to #46071 / #46053

This is the same persistence-loop bug family as #46071 / #46053, but it is not the same root cause.

- #46071 fixed `_flush_messages_to_session_db()` losing newly appended assistant messages when `repair_message_sequence()` shortened `messages` below `conversation_history` length.
- This PR covers the adjacent path where `finalize_turn()` has a non-empty `final_response`, but no closing assistant message has been appended to `messages` before `_persist_session()`.

In other words, #46071 makes flushing robust once an assistant message exists. This PR ensures the recovered final response exists in the transcript before persistence.

## Changes

- `agent/turn_finalizer.py`: before `_persist_session()`, append `{role: "assistant", content: final_response}` when the turn is not interrupted, `final_response` is non-empty, and the transcript tail is not already assistant.
- `tests/agent/test_turn_finalizer_final_response_persistence.py`: regression for a transcript ending at a tool result while `final_response="Done."` is returned.

## Validation

| Check | Result |
|---|---|
| RED: `python -m pytest tests/agent/test_turn_finalizer_final_response_persistence.py::test_final_response_closes_tool_tail_before_persistence -q -o 'addopts='` on clean `origin/main` | failed as expected: tail persisted as `tool` |
| GREEN: same focused test after fix | pass |
| `python -m pytest tests/agent/test_turn_finalizer_final_response_persistence.py tests/run_agent/test_identity_flush.py tests/run_agent/test_compression_persistence.py tests/run_agent/test_860_dedup.py -q -o 'addopts='` | 19 passed, 1 warning |
| `python -m py_compile agent/turn_finalizer.py tests/agent/test_turn_finalizer_final_response_persistence.py` | pass |
| `git diff --check` | pass |

## Duplicate check

Searched existing issues/PRs and code for exact matches using terms including `turn_finalizer final_response`, `final_response assistant tail`, `final_response tool tail`, `pending tool result`, and exact code/test markers. Found #46071/#46053 as related persistence repair work, but no exact duplicate for closing a recovered `final_response` in `agent/turn_finalizer.py` before persistence.
