### PR TITLE
fix(agent): respect disabled_toolsets for memory provider tool injection (#46171)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,35 @@ source .venv/bin/activate   # or: source venv/bin/activate
 `$HOME/.hermes/hermes-agent/venv` (for worktrees that share a venv with the
 main checkout).
 
+**Python:** `>=3.11,<3.14` (pyproject.toml `requires-python`). The ceiling
+at <3.14 is load-bearing — Rust-backed transitives (pydantic-core) lack
+cp314 wheels. CI uses 3.11.
+
+## Before You Push
+
+CI runs these checks on every PR. Run them locally to avoid surprises:
+
+```bash
+# 1. Lint (blocking) — only PLW1514 (unspecified-encoding) enforced
+ruff check .
+
+# 2. Typecheck (advisory in CI, but fix warnings before PR)
+ty check
+
+# 3. Windows footguns (blocking) — catches os.kill(pid,0), os.killpg,
+#    bare open() without encoding=, signal.SIGKILL without getattr, etc.
+python scripts/check-windows-footguns.py --all
+
+# 4. Tests (blocking) — full suite with per-file subprocess isolation
+scripts/run_tests.sh
+```
+
+After changing `pyproject.toml` dependencies, regenerate the lockfile:
+```bash
+uv lock
+```
+CI has a required `uv-lockfile-check` that fails if `uv.lock` is stale.
+
 ## Project Structure
 
 File counts shift constantly — don't treat the tree below as exhaustive.
@@ -356,16 +385,22 @@ reinforced after the Mini Shai-Hulud worm campaign (May 2026).
 
 | Source type | Treatment | Example |
 |---|---|---|
-| PyPI package | `>=floor,<next_major` | `"httpx>=0.28.1,<1"` |
+| PyPI core dep | `==exact` | `"openai==2.24.0"` |
+| PyPI extra/lazy dep | `>=floor,<next_major` | `"httpx>=0.28.1,<1"` |
 | Git URL | Commit SHA | `git+https://...@<40-char-sha>` |
 | GitHub Actions | Commit SHA + comment | `uses: actions/checkout@<sha>  # v4` |
 | CI-only pip | `==exact` | `pyyaml==6.0.2` |
 
 **When adding a new dependency to `pyproject.toml`:**
-1. Pin to `>=current_version,<next_major` for post-1.0 (e.g. `>=1.5.0,<2`).
+1. Core deps (used by every session) use **exact pins**: `"package==X.Y.Z"`.
+   Extras/lazy-install deps use `>=current_version,<next_major`.
 2. For pre-1.0 packages, use `<0.(current_minor + 2)` (e.g. `>=0.29,<0.32`).
-3. Never commit a bare `>=X.Y.Z` without a ceiling — CI and reviewers will reject it.
+3. Never commit a bare `>=X.Y.Z` without a ceiling — CI's `dep-bounds` check
+   will reject it.
 4. Run `uv lock` to regenerate `uv.lock` with hashes.
+5. Scope rule: only packages used by EVERY hermes session belong in core
+   `dependencies`. Anything provider-specific belongs in an extra and gets
+   lazy-installed via `tools/lazy_deps.py`.
 
 Reference: #2810 (bounds pass), #9801 (SHA pinning + audit CI).
 
@@ -1053,7 +1088,7 @@ def profile_env(tmp_path, monkeypatch):
 
 **ALWAYS use `scripts/run_tests.sh`** — do not call `pytest` directly. The script enforces
 hermetic environment parity with CI (unset credential vars, TZ=UTC, LANG=C.UTF-8,
-`-n auto` xdist workers, in-tree subprocess-isolation plugin). Direct `pytest`
+per-file subprocess isolation via `run_tests_parallel.py`). Direct `pytest`
 on a 16+ core developer machine with API keys set diverges from CI in ways
 that have caused multiple "works locally, fails in CI" incidents (and the reverse).
 
@@ -1096,7 +1131,7 @@ Five real sources of local-vs-CI drift the script closes:
 | HOME / `~/.hermes/` | Your real config+auth.json | Temp dir per test |
 | Timezone | Local TZ (PDT etc.) | UTC |
 | Locale | Whatever is set | C.UTF-8 |
-| xdist workers | `-n auto` = all cores | `-n auto` (safe — subprocess isolation prevents cross-worker flakes) |
+| Parallelism | whatever your machine defaults to | Per-file subprocess isolation via `run_tests_parallel.py` (matches CI 6-slice matrix) |
 
 `tests/conftest.py` also enforces points 1-4 as an autouse fixture so ANY pytest
 invocation (including IDE integrations) gets hermetic behavior — but the wrapper

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1200,13 +1200,14 @@ def init_agent(
     #   enabled_toolsets is None        → no filter, inject (backward compat)
     #   "memory" in enabled_toolsets    → user opted in, inject
     #   otherwise (incl. [])            → user excluded memory, skip injection
+    #   disabled_toolsets has "memory"  → explicit deny, skip injection (#46171)
     #
     # Without this gate, `platform_toolsets: telegram: []` still leaks memory
     # provider tools (fact_store, etc.) into the tool surface — a 10x latency
     # penalty on local models and a frequent trigger of tool-call loops.
     if agent._memory_manager and agent.tools is not None and (
         agent.enabled_toolsets is None or "memory" in agent.enabled_toolsets
-    ):
+    ) and not (agent.disabled_toolsets and "memory" in agent.disabled_toolsets):
         _existing_tool_names = {
             t.get("function", {}).get("name")
             for t in agent.tools


### PR DESCRIPTION
## Summary

Fixes #46171

Memory provider tools (`fact_store`, `fact_feedback`) were re-injected into the tool surface after the deny filter because the guard only checked `enabled_toolsets` and ignored `disabled_toolsets`.

## Bug

At `agent/agent_init.py:1208`, the memory provider injection condition was:

```python
if agent._memory_manager and agent.tools is not None and (
    agent.enabled_toolsets is None or "memory" in agent.enabled_toolsets
):
```

When a caller passes `disabled_toolsets=["memory"]`, `enabled_toolsets` defaults to `None` (backward compat), so `agent.enabled_toolsets is None` evaluates to `True` — the deny policy is bypassed and memory provider tools are injected anyway.

## Fix

Added a `disabled_toolsets` check to the guard:

```python
if agent._memory_manager and agent.tools is not None and (
    agent.enabled_toolsets is None or "memory" in agent.enabled_toolsets
) and not (agent.disabled_toolsets and "memory" in agent.disabled_toolsets):
```

This ensures explicit deny via `disabled_toolsets` takes precedence over the default-allow `enabled_toolsets=None` behavior.