### PR TITLE
fix(zai): add glm-5.2 to coding plan endpoint probes

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -609,15 +609,15 @@ def _resolve_api_key_provider_secret(
 # endpoints.  A key that works on one may return "Insufficient balance" on
 # another.  We probe at setup time and store the working endpoint.
 # Each entry lists candidate models to try in order — newer coding plan accounts
-# may only have access to recent models (glm-5.1, glm-5v-turbo) while older
-# ones still use glm-4.7.
+# may only have access to recent models (glm-5.2, glm-5.1, glm-5v-turbo)
+# while older ones still use glm-4.7.
 
 ZAI_ENDPOINTS = [
     # (id, base_url, probe_models, label)
     ("global",        "https://api.z.ai/api/paas/v4",        ["glm-5"],   "Global"),
     ("cn",            "https://open.bigmodel.cn/api/paas/v4", ["glm-5"],   "China"),
-    ("coding-global", "https://api.z.ai/api/coding/paas/v4",  ["glm-5.1", "glm-5v-turbo", "glm-4.7"], "Global (Coding Plan)"),
-    ("coding-cn",     "https://open.bigmodel.cn/api/coding/paas/v4", ["glm-5.1", "glm-5v-turbo", "glm-4.7"], "China (Coding Plan)"),
+    ("coding-global", "https://api.z.ai/api/coding/paas/v4",  ["glm-5.2", "glm-5.1", "glm-5v-turbo", "glm-4.7"], "Global (Coding Plan)"),
+    ("coding-cn",     "https://open.bigmodel.cn/api/coding/paas/v4", ["glm-5.2", "glm-5.1", "glm-5v-turbo", "glm-4.7"], "China (Coding Plan)"),
 ]
 
 


### PR DESCRIPTION
## Summary

Add `glm-5.2` as the first probe model in the Z.AI Coding Plan endpoint entries so that endpoint auto-detection works for accounts provisioned with GLM-5.2.

## Context

Z.AI recently released GLM-5.2. Newer Coding Plan keys may only have access to this model, so the existing probe list (`glm-5.1`, `glm-5v-turbo`, `glm-4.7`) can fail to detect a working endpoint for these accounts.

## Changes

- Prepend `glm-5.2` to the probe models for both `coding-global` and `coding-cn` endpoints in `ZAI_ENDPOINTS`.

## Test Plan

- Existing `detect_zai_endpoint` tests continue to pass.
- Manual: a Coding Plan key with GLM-5.2 access will now auto-detect the coding endpoint correctly.