### PR TITLE
test(tui): scope session.create close_race orphan-cleanup assert to own session key

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5402,6 +5402,7 @@ def test_session_create_close_race_does_not_orphan_worker(monkeypatch):
     )
     assert resp.get("result"), f"got error: {resp.get('error')}"
     sid = resp["result"]["session_id"]
+    own_key = resp["result"]["stored_session_id"]
     assert build_entered.wait(timeout=1.0), "deferred build did not start"
 
     # Wait until the (deferred) build thread has actually entered
@@ -5440,12 +5441,15 @@ def test_session_create_close_race_does_not_orphan_worker(monkeypatch):
         len(closed_workers) == 1
     ), f"orphan worker was not cleaned up — closed_workers={closed_workers}"
     # Notify may be unregistered by both session.close (unconditional)
-    # and the orphan-cleanup path; the key guarantee is that the build
-    # thread does at least one unregister call (any prior close
-    # already popped the callback; the duplicate is a no-op).
-    assert len(unregistered_keys) >= 1, (
+    # and the orphan-cleanup path; the key guarantee is that THIS session's
+    # key gets unregistered (any prior close already popped the callback; the
+    # duplicate is a no-op). Match on our own key, not the global count: the
+    # registry is process-wide and a leaked _build thread from another
+    # session.create test can append a foreign key here and falsely satisfy
+    # a bare `>= 1`.
+    assert own_key in unregistered_keys, (
         f"orphan notify registration was not unregistered — "
-        f"unregistered_keys={unregistered_keys}"
+        f"{own_key} not in unregistered_keys={unregistered_keys}"
     )
 
 


### PR DESCRIPTION
Tightens the `close_race` orphan-cleanup assertion in `tests/test_tui_gateway_server.py::test_session_create_close_race_does_not_orphan_worker` to verify **this test's own** session key (`resp["result"]["stored_session_id"]`) appears in `unregistered_keys`, rather than accepting a bare process-global `len(unregistered_keys) >= 1`.

A leaked sibling `_build` thread can satisfy the global count with a foreign session key, so the old assertion could pass even when the real session's notify was never unregistered. Scoping the assert to the own key closes that gap while still catching a genuine missing-unregister regression.

**Scope note:** this PR originally also fixed a `no_race` flake from the same process-global-registry contamination, but that has since been fixed independently on `main` via session-state isolation. Rebased onto current `main`, this PR therefore narrows to the `close_race` assertion hardening above. Test-only; no production behavior changes.