### PR TITLE
feat(feishu): add render_mode for interactive card rendering

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -983,6 +983,8 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = channel_prompts
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
+                if "render_mode" in platform_cfg:
+                    bridged["render_mode"] = platform_cfg["render_mode"]
                 enabled_was_explicit = _cfg_toplevel and "enabled" in platform_cfg
                 if not bridged and not enabled_was_explicit:
                     continue

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -395,6 +395,11 @@ class FeishuAdapterSettings:
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
     allow_bots: str = "none"  # "none" | "mentions" | "all"
     require_mention: bool = True
+    # Render mode for outbound text messages:
+    #   "auto" — use interactive card when content has code blocks or tables (default)
+    #   "card" — always use interactive card
+    #   "raw"  — always use text/post (legacy behaviour)
+    render_mode: str = "auto"
 
 
 @dataclass
@@ -1575,6 +1580,9 @@ class FeishuAdapter(BasePlatformAdapter):
             require_mention=_to_boolean(
                 extra.get("require_mention", os.getenv("FEISHU_REQUIRE_MENTION", "true"))
             ),
+            render_mode=str(
+                extra.get("render_mode", os.getenv("FEISHU_RENDER_MODE", "auto"))
+            ).strip().lower(),
         )
 
     def _apply_settings(self, settings: FeishuAdapterSettings) -> None:
@@ -1607,6 +1615,13 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_ping_timeout = settings.ws_ping_timeout
         self._allow_bots = settings.allow_bots
         self._require_mention = settings.require_mention
+        self._render_mode = settings.render_mode
+        if self._render_mode not in {"auto", "card", "raw"}:
+            logger.warning(
+                "[Feishu] Unknown render_mode=%r, falling back to 'auto'. Valid: auto, card, raw.",
+                self._render_mode,
+            )
+            self._render_mode = "auto"
 
     def _build_event_handler(self) -> Any:
         if EventDispatcherHandler is None:
@@ -1798,15 +1813,40 @@ class FeishuAdapter(BasePlatformAdapter):
                         metadata=metadata,
                     )
                 except Exception as exc:
-                    if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
+                    # Interactive card send failed — fall back to post/text
+                    if msg_type == "interactive":
+                        logger.warning("[Feishu] Interactive card send failed: %s; falling back to post/text", exc)
+                        if _MARKDOWN_HINT_RE.search(chunk):
+                            fallback_msg_type, fallback_payload = "post", _build_markdown_post_payload(chunk)
+                        else:
+                            fallback_msg_type = "text"
+                            fallback_payload = json.dumps({"text": chunk}, ensure_ascii=False)
+                        response = await self._feishu_send_with_retry(
+                            chat_id=chat_id, msg_type=fallback_msg_type,
+                            payload=fallback_payload, reply_to=reply_to, metadata=metadata,
+                        )
+                    elif msg_type == "post" and _POST_CONTENT_INVALID_RE.search(str(exc)):
+                        logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
+                        response = await self._feishu_send_with_retry(
+                            chat_id=chat_id,
+                            msg_type="text",
+                            payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                            reply_to=reply_to,
+                            metadata=metadata,
+                        )
+                    else:
                         raise
-                    logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
+                # Interactive card silently rejected by API
+                if msg_type == "interactive" and not self._response_succeeded(response):
+                    logger.warning("[Feishu] Interactive card rejected by API; falling back to post/text")
+                    if _MARKDOWN_HINT_RE.search(chunk):
+                        fallback_msg_type, fallback_payload = "post", _build_markdown_post_payload(chunk)
+                    else:
+                        fallback_msg_type = "text"
+                        fallback_payload = json.dumps({"text": chunk}, ensure_ascii=False)
                     response = await self._feishu_send_with_retry(
-                        chat_id=chat_id,
-                        msg_type="text",
-                        payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
-                        reply_to=reply_to,
-                        metadata=metadata,
+                        chat_id=chat_id, msg_type=fallback_msg_type,
+                        payload=fallback_payload, reply_to=reply_to, metadata=metadata,
                     )
                 if (
                     msg_type == "post"
@@ -1836,26 +1876,44 @@ class FeishuAdapter(BasePlatformAdapter):
         *,
         finalize: bool = False,
     ) -> SendResult:
-        """Edit a previously sent Feishu text/post message."""
+        """Edit a previously sent Feishu text/post/interactive message."""
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
         content = self.format_message(content)
         try:
             msg_type, payload = self._build_outbound_payload(content)
-            body = self._build_update_message_body(msg_type=msg_type, content=payload)
-            request = self._build_update_message_request(message_id=message_id, request_body=body)
-            response = await asyncio.to_thread(self._client.im.v1.message.update, request)
-            result = self._finalize_send_result(response, "update failed")
-            if not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
-                logger.warning("[Feishu] Invalid post update payload rejected by API; falling back to plain text")
-                fallback_body = self._build_update_message_body(
-                    msg_type="text",
-                    content=json.dumps({"text": _strip_markdown_to_plain_text(content)}, ensure_ascii=False),
-                )
-                fallback_request = self._build_update_message_request(message_id=message_id, request_body=fallback_body)
-                fallback_response = await asyncio.to_thread(self._client.im.v1.message.update, fallback_request)
-                result = self._finalize_send_result(fallback_response, "update failed")
+
+            if msg_type == "interactive":
+                # Card messages must be edited via PATCH API, not UPDATE
+                try:
+                    from lark_oapi.api.im.v1 import PatchMessageRequest, PatchMessageRequestBody
+                except ImportError:
+                    PatchMessageRequest = PatchMessageRequestBody = None
+
+                if PatchMessageRequest and PatchMessageRequestBody:
+                    patch_body = PatchMessageRequestBody.builder().content(payload).build()
+                    patch_req = PatchMessageRequest.builder().message_id(message_id).request_body(patch_body).build()
+                    response = await asyncio.to_thread(self._client.im.v1.message.patch, patch_req)
+                else:
+                    body = self._build_update_message_body(msg_type=msg_type, content=payload)
+                    request = self._build_update_message_request(message_id=message_id, request_body=body)
+                    response = await asyncio.to_thread(self._client.im.v1.message.update, request)
+                result = self._finalize_send_result(response, "patch failed")
+            else:
+                body = self._build_update_message_body(msg_type=msg_type, content=payload)
+                request = self._build_update_message_request(message_id=message_id, request_body=body)
+                response = await asyncio.to_thread(self._client.im.v1.message.update, request)
+                result = self._finalize_send_result(response, "update failed")
+                if not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
+                    logger.warning("[Feishu] Invalid post update payload rejected by API; falling back to plain text")
+                    fallback_body = self._build_update_message_body(
+                        msg_type="text",
+                        content=json.dumps({"text": _strip_markdown_to_plain_text(content)}, ensure_ascii=False),
+                    )
+                    fallback_request = self._build_update_message_request(message_id=message_id, request_body=fallback_body)
+                    fallback_response = await asyncio.to_thread(self._client.im.v1.message.update, fallback_request)
+                    result = self._finalize_send_result(fallback_response, "update failed")
             if result.success:
                 result.message_id = message_id
             return result
@@ -4373,7 +4431,46 @@ class FeishuAdapter(BasePlatformAdapter):
     # Outbound payload construction and send pipeline
     # =========================================================================
 
+    @staticmethod
+    def _should_use_card(text: str) -> bool:
+        """Detect if text contains markdown elements that benefit from card rendering.
+
+        Interactive cards (schema 2.0) support full markdown including tables,
+        whereas Feishu post-type md elements cannot render tables.
+        """
+        return bool(re.search(r"```[\s\S]*?```", text) or _MARKDOWN_TABLE_RE.search(text))
+
+    @staticmethod
+    def _build_card_payload(content: str) -> str:
+        """Build a Feishu interactive card payload (schema 2.0) with markdown content.
+
+        Schema 2.0 format ensures markdown tables, code blocks, etc. render
+        properly.  Feishu post-type md elements do not render tables.
+        """
+        card = {
+            "schema": "2.0",
+            "config": {"width_mode": "fill"},
+            "body": {
+                "elements": [
+                    {
+                        "tag": "markdown",
+                        "content": content,
+                    }
+                ]
+            },
+        }
+        return json.dumps(card, ensure_ascii=False)
+
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
+        # render_mode == "raw" — legacy behaviour (never use cards)
+        if self._render_mode != "raw":
+            use_card = (
+                self._render_mode == "card"
+                or self._should_use_card(content)
+            )
+            if use_card:
+                return "interactive", self._build_card_payload(content)
+
         # Feishu post-type 'md' elements do not render markdown tables; sending
         # table content as post causes the message to appear blank on the client.
         # Force plain text for anything that looks like a markdown table.

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2584,7 +2584,9 @@ class TestAdapterBehavior(unittest.TestCase):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
 
-        adapter = FeishuAdapter(PlatformConfig())
+        # Use render_mode="raw" to test post-type row splitting (the default
+        # "auto" mode would render code blocks as interactive cards instead).
+        adapter = FeishuAdapter(PlatformConfig(enabled=True, extra={"render_mode": "raw"}))
         captured = {}
 
         class _MessageAPI:

--- a/tests/gateway/test_feishu_render_mode.py
+++ b/tests/gateway/test_feishu_render_mode.py
@@ -1,0 +1,320 @@
+"""Tests for Feishu render_mode (interactive card rendering)."""
+
+import asyncio
+import json
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+from gateway.config import PlatformConfig
+
+
+try:
+    import lark_oapi
+    _HAS_LARK = True
+except ImportError:
+    _HAS_LARK = False
+
+
+@unittest.skipUnless(_HAS_LARK, "lark_oapi not installed")
+class TestFeishuRenderModeSettings(unittest.TestCase):
+    """Test render_mode config loading and validation."""
+
+    def test_default_render_mode_is_auto(self):
+        """Default render_mode should be 'auto'."""
+        from gateway.platforms.feishu import FeishuAdapter, FeishuAdapterSettings
+        adapter = FeishuAdapter(PlatformConfig())
+        self.assertEqual(adapter._render_mode, "auto")
+
+    def test_render_mode_auto_from_config(self):
+        """render_mode='auto' loaded from config extra."""
+        from gateway.platforms.feishu import FeishuAdapter
+        pc = PlatformConfig(enabled=True, extra={"render_mode": "auto"})
+        adapter = FeishuAdapter(pc)
+        self.assertEqual(adapter._render_mode, "auto")
+
+    def test_render_mode_card_from_config(self):
+        """render_mode='card' loaded from config extra."""
+        from gateway.platforms.feishu import FeishuAdapter
+        pc = PlatformConfig(enabled=True, extra={"render_mode": "card"})
+        adapter = FeishuAdapter(pc)
+        self.assertEqual(adapter._render_mode, "card")
+
+    def test_render_mode_raw_from_config(self):
+        """render_mode='raw' loaded from config extra."""
+        from gateway.platforms.feishu import FeishuAdapter
+        pc = PlatformConfig(enabled=True, extra={"render_mode": "raw"})
+        adapter = FeishuAdapter(pc)
+        self.assertEqual(adapter._render_mode, "raw")
+
+    def test_invalid_render_mode_falls_back_to_auto(self):
+        """An invalid render_mode falls back to 'auto' with a warning."""
+        from gateway.platforms.feishu import FeishuAdapter
+        pc = PlatformConfig(enabled=True, extra={"render_mode": "invalid"})
+        with self.assertLogs("gateway.platforms.feishu", level="WARNING") as cm:
+            adapter = FeishuAdapter(pc)
+        self.assertEqual(adapter._render_mode, "auto")
+        self.assertTrue(any("Unknown render_mode" in msg for msg in cm.output))
+
+    @patch.dict(os.environ, {"FEISHU_RENDER_MODE": "card"})
+    def test_render_mode_from_env_var(self):
+        """render_mode can be set via FEISHU_RENDER_MODE env var."""
+        from gateway.platforms.feishu import FeishuAdapter
+        pc = PlatformConfig(enabled=True, extra={})
+        adapter = FeishuAdapter(pc)
+        self.assertEqual(adapter._render_mode, "card")
+
+    def test_config_extra_render_mode_case_insensitive(self):
+        """render_mode is case-insensitive (e.g. 'CARD' → 'card')."""
+        from gateway.platforms.feishu import FeishuAdapter
+        pc = PlatformConfig(enabled=True, extra={"render_mode": "CARD"})
+        adapter = FeishuAdapter(pc)
+        self.assertEqual(adapter._render_mode, "card")
+
+
+class TestFeishuShouldUseCard(unittest.TestCase):
+    """Test _should_use_card detection logic."""
+
+    def setUp(self):
+        from gateway.platforms.feishu import FeishuAdapter
+        self._should_use_card = FeishuAdapter._should_use_card
+
+    def test_code_fence_triggers_card(self):
+        """Content with fenced code blocks should use card."""
+        text = "Here is code:\n```python\nprint('hello')\n```\nDone."
+        self.assertTrue(self._should_use_card(text))
+
+    def test_markdown_table_triggers_card(self):
+        """Content with markdown tables should use card."""
+        text = "| Name | Value |\n|------|-------|\n| A    | 1     |"
+        self.assertTrue(self._should_use_card(text))
+
+    def test_plain_text_no_card(self):
+        """Plain text without code blocks or tables should not use card."""
+        text = "Just a simple message with no special formatting."
+        self.assertFalse(self._should_use_card(text))
+
+    def test_inline_code_no_card(self):
+        """Inline code (single backticks) should not trigger card."""
+        text = "Use the `pip install` command."
+        self.assertFalse(self._should_use_card(text))
+
+
+class TestFeishuBuildCardPayload(unittest.TestCase):
+    """Test _build_card_payload output format."""
+
+    def setUp(self):
+        from gateway.platforms.feishu import FeishuAdapter
+        self._build_card_payload = FeishuAdapter._build_card_payload
+
+    def test_card_payload_is_valid_json(self):
+        """Card payload should be valid JSON."""
+        result = self._build_card_payload("Hello world")
+        parsed = json.loads(result)
+        self.assertIsInstance(parsed, dict)
+
+    def test_card_payload_schema_2(self):
+        """Card payload should use schema 2.0."""
+        result = self._build_card_payload("Hello")
+        parsed = json.loads(result)
+        self.assertEqual(parsed["schema"], "2.0")
+
+    def test_card_payload_width_mode_fill(self):
+        """Card payload should set width_mode to fill."""
+        result = self._build_card_payload("Hello")
+        parsed = json.loads(result)
+        self.assertEqual(parsed["config"]["width_mode"], "fill")
+
+    def test_card_payload_markdown_element(self):
+        """Card payload should contain a markdown element with the content."""
+        result = self._build_card_payload("Test content")
+        parsed = json.loads(result)
+        elements = parsed["body"]["elements"]
+        self.assertEqual(len(elements), 1)
+        self.assertEqual(elements[0]["tag"], "markdown")
+        self.assertEqual(elements[0]["content"], "Test content")
+
+    def test_card_payload_preserves_unicode(self):
+        """Card payload should preserve non-ASCII characters."""
+        result = self._build_card_payload("中文测试 🎉")
+        parsed = json.loads(result)
+        self.assertEqual(parsed["body"]["elements"][0]["content"], "中文测试 🎉")
+
+
+@unittest.skipUnless(_HAS_LARK, "lark_oapi not installed")
+class TestFeishuBuildOutboundPayloadRenderMode(unittest.TestCase):
+    """Test _build_outbound_payload with different render_mode settings."""
+
+    def _make_adapter(self, render_mode="auto"):
+        from gateway.platforms.feishu import FeishuAdapter
+        pc = PlatformConfig(enabled=True, extra={"render_mode": render_mode})
+        return FeishuAdapter(pc)
+
+    def test_auto_mode_table_uses_interactive(self):
+        """In auto mode, markdown tables should trigger interactive card."""
+        adapter = self._make_adapter("auto")
+        text = "| Name | Value |\n|------|-------|\n| A    | 1     |"
+        msg_type, payload = adapter._build_outbound_payload(text)
+        self.assertEqual(msg_type, "interactive")
+
+    def test_auto_mode_code_block_uses_interactive(self):
+        """In auto mode, code blocks should trigger interactive card."""
+        adapter = self._make_adapter("auto")
+        text = "```python\nprint('hello')\n```"
+        msg_type, payload = adapter._build_outbound_payload(text)
+        self.assertEqual(msg_type, "interactive")
+
+    def test_auto_mode_plain_text_uses_text(self):
+        """In auto mode, plain text should use text type."""
+        adapter = self._make_adapter("auto")
+        msg_type, payload = adapter._build_outbound_payload("Hello world")
+        self.assertEqual(msg_type, "text")
+
+    def test_card_mode_always_uses_interactive(self):
+        """In card mode, even plain text should use interactive card."""
+        adapter = self._make_adapter("card")
+        msg_type, payload = adapter._build_outbound_payload("Hello world")
+        self.assertEqual(msg_type, "interactive")
+
+    def test_raw_mode_table_uses_text(self):
+        """In raw mode, even tables should use text (legacy behaviour)."""
+        adapter = self._make_adapter("raw")
+        text = "| Name | Value |\n|------|-------|\n| A    | 1     |"
+        msg_type, payload = adapter._build_outbound_payload(text)
+        self.assertEqual(msg_type, "text")
+
+    def test_raw_mode_plain_text_uses_text(self):
+        """In raw mode, plain text should use text type."""
+        adapter = self._make_adapter("raw")
+        msg_type, payload = adapter._build_outbound_payload("Hello world")
+        self.assertEqual(msg_type, "text")
+
+
+class TestFeishuRenderModeConfigBridge(unittest.TestCase):
+    """Test that render_mode is bridged from config.yaml to adapter extra."""
+
+    def test_render_mode_bridged_from_real_config_yaml(self):
+        """render_mode in feishu: config is loaded via load_gateway_config()."""
+        from gateway.config import Platform, load_gateway_config
+
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = os.path.join(tmp, "config.yaml")
+            with open(config_path, "w", encoding="utf-8") as f:
+                f.write(
+                    "feishu:\n"
+                    "  enabled: true\n"
+                    "  app_id: cli_test\n"
+                    "  app_secret: secret_test\n"
+                    "  render_mode: card\n"
+                )
+
+            with patch.dict(os.environ, {"HERMES_HOME": tmp}, clear=False):
+                config = load_gateway_config()
+
+        feishu_cfg = config.platforms.get(Platform.FEISHU)
+        if feishu_cfg is None:
+            self.fail("Feishu platform config was not loaded")
+        self.assertTrue(feishu_cfg.enabled)
+        self.assertEqual(feishu_cfg.extra.get("render_mode"), "card")
+
+
+@unittest.skipUnless(_HAS_LARK, "lark_oapi not installed")
+class TestFeishuRenderModeSendFallback(unittest.TestCase):
+    """Test send() fallback when interactive card delivery fails."""
+
+    def _make_adapter(self):
+        from gateway.platforms.feishu import FeishuAdapter
+        adapter = FeishuAdapter(PlatformConfig(enabled=True, extra={"render_mode": "auto"}))
+        adapter._client = Mock()
+        return adapter
+
+    @staticmethod
+    def _ok_response(message_id="om_fallback"):
+        return SimpleNamespace(success=lambda: True, data=SimpleNamespace(message_id=message_id))
+
+    @staticmethod
+    def _bad_response():
+        return SimpleNamespace(success=lambda: False, code=400, msg="card rejected")
+
+    def test_send_interactive_exception_falls_back_to_post(self):
+        adapter = self._make_adapter()
+        calls = []
+
+        async def _fake_send(**kwargs):
+            calls.append(kwargs)
+            if kwargs["msg_type"] == "interactive":
+                raise RuntimeError("interactive failed")
+            return self._ok_response("om_post_fallback")
+
+        adapter._feishu_send_with_retry = AsyncMock(side_effect=_fake_send)
+
+        result = asyncio.run(
+            adapter.send(
+                chat_id="oc_chat",
+                content="```python\nprint('hello')\n```",
+            )
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_post_fallback")
+        self.assertEqual(calls[0]["msg_type"], "interactive")
+        self.assertEqual(calls[1]["msg_type"], "post")
+
+    def test_send_interactive_rejection_falls_back_to_text_for_table(self):
+        adapter = self._make_adapter()
+        calls = []
+
+        async def _fake_send(**kwargs):
+            calls.append(kwargs)
+            if kwargs["msg_type"] == "interactive":
+                return self._bad_response()
+            return self._ok_response("om_text_fallback")
+
+        adapter._feishu_send_with_retry = AsyncMock(side_effect=_fake_send)
+
+        result = asyncio.run(
+            adapter.send(
+                chat_id="oc_chat",
+                content="| A | B |\n|---|---|\n| 1 | 2 |",
+            )
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_text_fallback")
+        self.assertEqual(calls[0]["msg_type"], "interactive")
+        self.assertEqual(calls[1]["msg_type"], "text")
+
+
+@unittest.skipUnless(_HAS_LARK, "lark_oapi not installed")
+class TestFeishuRenderModeEditPatch(unittest.TestCase):
+    """Test edit_message() uses Feishu patch API for interactive cards."""
+
+    def test_edit_interactive_card_uses_patch_not_update(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig(enabled=True, extra={"render_mode": "auto"}))
+        response = SimpleNamespace(success=lambda: True, data=SimpleNamespace(message_id="om_existing"))
+        message_api = SimpleNamespace(
+            patch=Mock(return_value=response),
+            update=Mock(return_value=response),
+        )
+        adapter._client = SimpleNamespace(im=SimpleNamespace(v1=SimpleNamespace(message=message_api)))
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.edit_message(
+                    chat_id="oc_chat",
+                    message_id="om_existing",
+                    content="| A | B |\n|---|---|\n| 1 | 2 |",
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_existing")
+        message_api.patch.assert_called_once()
+        message_api.update.assert_not_called()


### PR DESCRIPTION
Feishu post-type md elements cannot render markdown tables — sending table content as post causes blank messages.  Interactive cards (schema 2.0) support full markdown including tables and code blocks.

This commit adds a render_mode setting that controls how outbound text messages are rendered:

  - "auto" (default): use interactive card when content contains code blocks or markdown tables; plain text / post otherwise.
  - "card": always use interactive card.
  - "raw": always use text/post (legacy behaviour, no cards).

Changes:
- Add render_mode field to FeishuAdapterSettings with config/env loading.
- Add _should_use_card() to detect code blocks and tables.
- Add _build_card_payload() for schema 2.0 interactive card format.
- Modify _build_outbound_payload() to route through card when appropriate.
- Add interactive card fallback in send() (card → post → text).
- Modify edit_message() to use PATCH API for card messages.
- Bridge render_mode from config.yaml to adapter extra in config.py.
- Add test_feishu_render_mode.py (23 tests).
- Update existing post-row-splitting test to use render_mode=raw.

Config example:
  feishu:
    render_mode: auto   # auto | card | raw

Or via env: FEISHU_RENDER_MODE=card

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

