### PR TITLE
feat(pricing): add Xiaomi MiMo official pricing

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -534,6 +534,53 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
         source="official_docs_snapshot",
         pricing_version="minimax-pricing-2026-04",
     ),
+    # ── Xiaomi MiMo ──────────────────────────────────────────────────────────
+    # Source: https://platform.xiaomimimo.com/docs/en-US/pricing (overseas USD)
+    # Cache write is free (limited time) — not priced per token.
+    (
+        "xiaomi",
+        "mimo-v2.5-pro",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.435"),
+        output_cost_per_million=Decimal("0.87"),
+        cache_read_cost_per_million=Decimal("0.0036"),
+        source="official_docs_snapshot",
+        source_url="https://platform.xiaomimimo.com/docs/en-US/pricing",
+        pricing_version="xiaomi-pricing-2026-05-27",
+    ),
+    (
+        "xiaomi",
+        "mimo-v2.5",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.14"),
+        output_cost_per_million=Decimal("0.28"),
+        cache_read_cost_per_million=Decimal("0.0028"),
+        source="official_docs_snapshot",
+        source_url="https://platform.xiaomimimo.com/docs/en-US/pricing",
+        pricing_version="xiaomi-pricing-2026-05-27",
+    ),
+    (
+        "xiaomi",
+        "mimo-v2-pro",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.435"),
+        output_cost_per_million=Decimal("0.87"),
+        cache_read_cost_per_million=Decimal("0.0036"),
+        source="official_docs_snapshot",
+        source_url="https://platform.xiaomimimo.com/docs/en-US/pricing",
+        pricing_version="xiaomi-pricing-2026-05-27",
+    ),
+    (
+        "xiaomi",
+        "mimo-v2-flash",
+    ): PricingEntry(
+        input_cost_per_million=Decimal("0.10"),
+        output_cost_per_million=Decimal("0.30"),
+        cache_read_cost_per_million=Decimal("0.01"),
+        source="official_docs_snapshot",
+        source_url="https://platform.xiaomimimo.com/docs/en-US/pricing",
+        pricing_version="xiaomi-pricing-2026-05-27",
+    ),
 }
 
 
@@ -579,6 +626,8 @@ def resolve_billing_route(
         return BillingRoute(provider="openai", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name in {"minimax", "minimax-cn"}:
         return BillingRoute(provider=provider_name, model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
+    if provider_name == "xiaomi":
+        return BillingRoute(provider="xiaomi", model=model.split("/")[-1], base_url=base_url or "", billing_mode="official_docs_snapshot")
     if provider_name in {"custom", "local"} or (base and "localhost" in base):
         return BillingRoute(provider=provider_name or "custom", model=model, base_url=base_url or "", billing_mode="unknown")
     return BillingRoute(provider=provider_name or "unknown", model=model.split("/")[-1] if model else "", base_url=base_url or "", billing_mode="unknown")


### PR DESCRIPTION
## Summary

Add overseas USD pricing for Xiaomi MiMo V2.5 series models from the [official pricing page](https://platform.xiaomimimo.com/docs/en-US/pricing).

## Changes

- Add `xiaomi` provider routing in `resolve_billing_route()` so Hermes can look up pricing for direct Xiaomi API usage
- Add `_OFFICIAL_DOCS_PRICING` entries for all MiMo models:

| Model | Input | Output | Cache Read |
|-------|-------|--------|------------|
| mimo-v2.5-pro | $0.435/MTok | $0.87/MTok | $0.0036/MTok |
| mimo-v2.5 | $0.14/MTok | $0.28/MTok | $0.0028/MTok |
| mimo-v2-pro | $0.435/MTok | $0.87/MTok | $0.0036/MTok |
| mimo-v2-flash | $0.10/MTok | $0.30/MTok | $0.01/MTok |

Cache write is free (limited time) per Xiaomi docs.

## Motivation

Users of the Xiaomi MiMo provider see "unknown" cost status because Hermes has no pricing data for this provider. This adds the official pricing so cost estimates show correctly.