### PR TITLE
fix(desktop): limit thinking shimmer to the disclosure label

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread.tsx
@@ -588,10 +588,7 @@ const ReasoningTextPart: FC<{ text: string; status?: { type: string } }> = ({ te
 
   return (
     <MarkdownTextContent
-      containerClassName={cn(
-        'text-xs leading-snug text-muted-foreground/85',
-        isRunning && 'shimmer text-muted-foreground/55'
-      )}
+      containerClassName="text-xs leading-snug text-muted-foreground/85"
       containerProps={{ 'data-slot': 'aui_reasoning-text' } as ComponentProps<'div'>}
       isRunning={isRunning}
       text={displayText}


### PR DESCRIPTION
## Summary
- Remove `tw-shimmer` from streaming reasoning body text in the thinking disclosure
- Shimmer stays on the "Thinking" label only (already gated on `pending`)

## Test plan
- [x] `npm run test:ui -- src/components/assistant-ui/streaming.test.tsx`
- [ ] Manual: start a reasoning turn and confirm only the "Thinking" header shimmers, not the expanded text