### PR TITLE
fix(tui): normalize Hangul composer input to NFC

### DIFF
--- a/ui-tui/src/__tests__/textInputBurstInput.test.ts
+++ b/ui-tui/src/__tests__/textInputBurstInput.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { applyPrintableInsert, shouldRouteMultiCharInputAsPaste } from '../components/textInput.js'
+import { applyPrintableInsert, normalizeComposerInputState, shouldRouteMultiCharInputAsPaste } from '../components/textInput.js'
 
 describe('applyPrintableInsert', () => {
   it('applies non-bracketed multi-character bursts immediately', () => {
@@ -25,6 +25,27 @@ describe('applyPrintableInsert', () => {
   it('rejects control or escape-bearing input', () => {
     expect(applyPrintableInsert('abc', 3, '\x1b[200~pasted')).toBeNull()
     expect(applyPrintableInsert('abc', 3, '\t')).toBeNull()
+  })
+})
+
+describe('normalizeComposerInputState', () => {
+  it('normalizes decomposed Hangul jamo to NFC and preserves cursor position', () => {
+    const decomposed = '\u1112\u1161\u11AB\u1100\u1173\u11AF'
+    const result = normalizeComposerInputState(decomposed, decomposed.length)
+
+    expect(result).toEqual({ cursor: 2, value: '한글' })
+  })
+
+  it('keeps non-Hangul combining marks untouched', () => {
+    const value = 'Cafe\u0301'
+
+    expect(normalizeComposerInputState(value, value.length)).toEqual({ cursor: value.length, value })
+  })
+
+  it('updates cursor from the normalized prefix', () => {
+    const value = 'A\u1112\u1161B\u1102\u1161'
+
+    expect(normalizeComposerInputState(value, 3)).toEqual({ cursor: 2, value: 'A하B나' })
   })
 })
 

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -122,6 +122,21 @@ export function applyPrintableInsert(
 }
 
 export const shouldRouteMultiCharInputAsPaste = (text: string): boolean => text.includes('\n')
+const HANGUL_JAMO_RE = /[\u1100-\u11FF\u3130-\u318F\uA960-\uA97F\uD7B0-\uD7FF]/
+
+export function normalizeComposerInputState(value: string, cursor: number): TextInsertResult {
+  if (!HANGUL_JAMO_RE.test(value)) {
+    return { cursor, value }
+  }
+
+  const boundedCursor = Math.max(0, Math.min(cursor, value.length))
+  const normalizedValue = value.normalize('NFC')
+
+  return {
+    cursor: value.slice(0, boundedCursor).normalize('NFC').length,
+    value: normalizedValue
+  }
+}
 
 export function shouldPreserveCtrlJNewline(env: MinimalEnv = process.env): boolean {
   if (env.WT_SESSION) {
@@ -665,6 +680,9 @@ export function TextInput({
     nextLineWidth?: number
   ) => {
     const prev = vRef.current
+    const normalized = normalizeComposerInputState(next, nextCur)
+    next = normalized.value
+    nextCur = normalized.cursor
     const c = snapPos(next, nextCur)
     editVersionRef.current += 1
 


### PR DESCRIPTION
## Summary
- normalize decomposed Hangul jamo to NFC at the TUI composer input-state boundary
- preserve cursor position after normalization
- keep non-Hangul combining marks untouched when no Hangul jamo is present

## Tests
- /Users/leo/.hermes/hermes-agent/node_modules/.bin/vitest run src/__tests__/textInputBurstInput.test.ts
- python3 /Users/leo/.hermes/skills/devops/nightly-hermes-local-patch-maintenance/scripts/smoke_components.py --skill-dir /Users/leo/.hermes/skills/devops/nightly-hermes-local-patch-maintenance --repo-root /Users/leo/.hermes/worktrees/hermes-hangul-nfc-pr --component hangul-nfc-composer-input
