### PR TITLE
fix(gateway): suppress Codex autoraise status in Slack

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -87,6 +87,13 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 
+_SLACK_NOISY_STATUS_RE = re.compile(
+    r"codex\s+gpt-5\.5\s+caps\s+context\s+at\s+272k.*"
+    r"auto-compaction\s+was\s+raised.*"
+    r"compression\.codex_gpt55_autoraise\s+false",
+    re.IGNORECASE | re.DOTALL,
+)
+
 _GATEWAY_PROVIDER_ERROR_RE = re.compile(
     r"("  # infrastructure/provider error preambles, not ordinary assistant prose
     r"api\s+(?:call\s+)?failed"
@@ -363,7 +370,12 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
     text = str(message or "").strip()
     if not text:
         return None
-    if _gateway_platform_value(platform) != "telegram":
+
+    platform_value = _gateway_platform_value(platform)
+    if platform_value == "slack" and _SLACK_NOISY_STATUS_RE.search(text):
+        return None
+
+    if platform_value != "telegram":
         return text
 
     text = _redact_gateway_user_facing_secrets(text)

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -31,6 +31,19 @@ def test_non_telegram_status_is_unchanged():
     assert _prepare_gateway_status_message("local", "lifecycle", message) == message
 
 
+def test_slack_suppresses_codex_gpt55_autoraise_notice():
+    """Slack should not receive per-session Codex compression config notices."""
+    notice = (
+        "ℹ Codex gpt-5.5 caps context at 272K, so auto-compaction was raised "
+        "to 85% (from 50%) to use more of the window before summarizing.\n"
+        "  Opt back out: hermes config set compression.codex_gpt55_autoraise false"
+    )
+
+    assert _prepare_gateway_status_message(Platform.SLACK, "lifecycle", notice) is None
+    assert _prepare_gateway_status_message(Platform.DISCORD, "lifecycle", notice) == notice
+    assert _prepare_gateway_status_message("local", "lifecycle", notice) == notice
+
+
 def test_telegram_status_sanitizes_raw_provider_security_errors():
     """Provider policy/security bodies should be replaced before chat delivery."""
     raw = (


### PR DESCRIPTION
## Summary
- suppresses the Codex gpt-5.5 auto-compaction autoraise notice in Slack status delivery
- keeps the notice visible for non-Slack platforms such as Discord/local
- adds regression coverage for the Slack filter

## Test Plan
- venv/bin/python direct assertions for Slack/Discord/local status filtering
- venv/bin/python -m py_compile gateway/run.py tests/gateway/test_telegram_noise_filter.py agent/conversation_compression.py tests/run_agent/test_compression_feasibility.py

Note: pytest is not installed in this deployed Hermes venv, so full pytest could not be run locally.