### PR TITLE
fix(telegram): make Bot API 10.1 rich messages opt-in (default off)

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -421,9 +421,13 @@ class TelegramAdapter(BasePlatformAdapter):
         self._disable_link_previews: bool = self._coerce_bool_extra("disable_link_previews", False)
         # Bot API 10.1 Rich Messages: send final replies via sendRichMessage
         # with the raw agent markdown so tables/task lists/etc. render natively.
-        # Enabled by default; users can opt out for clients that accept but do
-        # not render rich messages via platforms.telegram.extra.rich_messages.
-        self._rich_messages_enabled: bool = self._coerce_bool_extra("rich_messages", True)
+        # Opt-in (default off): clients without Bot API 10.1 rich rendering
+        # (e.g. the Telegram macOS desktop app) accept the message but display a
+        # BLANK bubble. sendRichMessage carries no plaintext fallback and the
+        # Bot API exposes no recipient-client signal, so forcing it on silently
+        # breaks delivery for those users. Enable per bot when every client is
+        # known to render rich content: platforms.telegram.extra.rich_messages: true.
+        self._rich_messages_enabled: bool = self._coerce_bool_extra("rich_messages", False)
         # Latched off after a capability failure on sendRichMessage /
         # sendRichMessageDraft (e.g. older python-telegram-bot without the
         # endpoint) so later sends skip the doomed rich attempt entirely.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1990,7 +1990,7 @@ DEFAULT_CONFIG = {
         "channel_prompts": {},         # Per-chat/topic ephemeral system prompts (topics inherit from parent group)
         "allowed_chats": "",           # If set, bot ONLY responds in these group/supergroup chat IDs (whitelist)
         "extra": {
-            "rich_messages": True,      # Bot API 10.1 rich messages; set false to force legacy MarkdownV2
+            "rich_messages": False,     # Bot API 10.1 rich messages (opt-in: blank on clients that can't render them, e.g. macOS desktop)
         },
     },
 

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -832,7 +832,7 @@ class TestLoadGatewayConfig:
 
         assert config.platforms[Platform.TELEGRAM].extra["rich_messages"] is False
 
-    def test_load_config_default_includes_telegram_rich_messages(self, tmp_path, monkeypatch):
+    def test_load_config_default_telegram_rich_messages_opt_in(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
 
@@ -842,7 +842,9 @@ class TestLoadGatewayConfig:
 
         config = load_config()
 
-        assert config["telegram"]["extra"]["rich_messages"] is True
+        # Opt-in by default: rich messages render blank on clients that don't
+        # support Bot API 10.1 (e.g. macOS desktop), so the default is off.
+        assert config["telegram"]["extra"]["rich_messages"] is False
 
     def test_bridges_telegram_extra_base_url_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -46,9 +46,17 @@ PTB_INVALID_TOKEN_404 = InvalidToken(
 )
 
 
-def _make_adapter(extra=None):
-    """Build a TelegramAdapter with a mock bot wired for the rich path."""
-    config = PlatformConfig(enabled=True, token="fake-token", extra=extra or {})
+def _make_adapter(extra=None, enable_rich=True):
+    """Build a TelegramAdapter with a mock bot wired for the rich path.
+
+    Rich messages are opt-in in production (default off), but this harness
+    exists to exercise the rich path, so it enables them by default. Individual
+    tests override via ``extra`` (e.g. ``{"rich_messages": False}``) or disable
+    the injection entirely with ``enable_rich=False`` to assert the real default.
+    """
+    merged = {"rich_messages": True} if enable_rich else {}
+    merged.update(extra or {})
+    config = PlatformConfig(enabled=True, token="fake-token", extra=merged)
     adapter = TelegramAdapter(config)
     bot = MagicMock()
     # do_api_request as an AsyncMock makes inspect.iscoroutinefunction(...) True,
@@ -180,16 +188,19 @@ async def test_rich_messages_opt_out_accepts_string_false():
 
 
 @pytest.mark.asyncio
-async def test_rich_messages_default_is_enabled():
-    adapter = _make_adapter()
+async def test_rich_messages_default_is_opt_in():
+    # Rich messages are opt-in: with no explicit config the adapter must use
+    # the legacy MarkdownV2 send path, since clients that can't render Bot API
+    # 10.1 rich content (e.g. Telegram macOS desktop) would show a blank bubble.
+    adapter = _make_adapter(enable_rich=False)
 
     result = await adapter.send("12345", RICH_CONTENT)
 
     assert result.success is True
     bot = adapter._bot
     assert bot is not None
-    bot.do_api_request.assert_awaited_once()
-    bot.send_message.assert_not_called()
+    bot.do_api_request.assert_not_called()
+    bot.send_message.assert_awaited()
 
 
 @pytest.mark.asyncio

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -900,7 +900,7 @@ gateway:
 
 ## Rendering: Rich Messages, Tables and Link Previews
 
-**Rich Messages (Bot API 10.1).** Final replies are sent with Telegram's native [`sendRichMessage`](https://core.telegram.org/bots/api#sendrichmessage) using the agent's **raw markdown**, so tables, task lists, headings, nested blockquotes, collapsible `<details>`, footnotes/references, math/formulas, underline, sub/superscript, marked text, and anchors render natively — no client-side flattening. In DMs the live streaming preview also uses `sendRichMessageDraft`, so the animated draft matches the final rich message.
+**Rich Messages (Bot API 10.1).** When enabled, final replies are sent with Telegram's native [`sendRichMessage`](https://core.telegram.org/bots/api#sendrichmessage) using the agent's **raw markdown**, so tables, task lists, headings, nested blockquotes, collapsible `<details>`, footnotes/references, math/formulas, underline, sub/superscript, marked text, and anchors render natively — no client-side flattening. In DMs the live streaming preview also uses `sendRichMessageDraft`, so the animated draft matches the final rich message.
 
 The rich path is skipped automatically when content exceeds the 32,768-byte rich text limit, and any rejection from Telegram (unsupported endpoint on an older `python-telegram-bot`, parser error, oversized blocks/columns) **transparently falls back** to the MarkdownV2 path — your message is never lost. Transient/network errors are *not* silently re-sent (no duplicate final message).
 
@@ -909,17 +909,17 @@ The rich path is skipped automatically when content exceeds the 32,768-byte rich
 - **Small tables** are flattened into **row-group bullets** — each row becomes a readable bulleted list under the column headings. Good for 2–4 columns and short cells.
 - **Larger or wider tables** fall back to a **fenced code block** with aligned columns so nothing collapses.
 
-There's nothing to configure for the API fallback — the adapter picks the right rendering per message. If a Telegram client accepts but cannot render rich messages (for example, a watch client that shows them as opaque media blocks), opt out and force the MarkdownV2 path:
+There's nothing to configure for the API fallback — the adapter picks the right rendering per message. Rich messages are **opt-in (disabled by default)**: some clients (notably the Telegram **macOS desktop** app) accept `sendRichMessage` but render a **blank bubble**, and because the call returns success — with no plaintext fallback and no way for a bot to detect the recipient's client — forcing rich on silently breaks delivery for those users. Telegram only auto-falls-back when it *rejects* the API call, which the blank-render case does not. Enable rich messages only when you know every client you message renders them (e.g. iOS/Android):
 
 ```yaml
 gateway:
   platforms:
     telegram:
       extra:
-        rich_messages: false
+        rich_messages: true
 ```
 
-Rich messages are enabled by default (`rich_messages: true`). This setting is for client-rendering compatibility; Hermes already falls back automatically when Telegram rejects the rich API call. If you only want the legacy "always code-block" table behavior while keeping rich messages enabled, disable table normalization by setting `telegram.pretty_tables: false` in `config.yaml` (default: `true`).
+If you only want the legacy "always code-block" table behavior, disable table normalization by setting `telegram.pretty_tables: false` in `config.yaml` (default: `true`).
 
 **Link previews.** Telegram auto-generates link previews for URLs in bot messages. If you'd rather suppress those (long `/tools` output, agent reply that mentions ten links, etc.):
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/telegram.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/telegram.md
@@ -877,7 +877,7 @@ gateway:
 
 ## 渲染：富消息、表格和链接预览
 
-**富消息（Bot API 10.1）。** 最终回复通过 Telegram 原生的 [`sendRichMessage`](https://core.telegram.org/bots/api#sendrichmessage) 发送，使用 Agent 的**原始 markdown**，因此表格、任务列表、标题、嵌套引用块、可折叠的 `<details>`、脚注/引用、数学公式、下划线、上下标、高亮文本和锚点都能原生渲染——无需客户端展平。在私聊中，实时流式预览也使用 `sendRichMessageDraft`，因此动画草稿与最终的富消息保持一致。
+**富消息（Bot API 10.1）。** 启用后，最终回复通过 Telegram 原生的 [`sendRichMessage`](https://core.telegram.org/bots/api#sendrichmessage) 发送，使用 Agent 的**原始 markdown**，因此表格、任务列表、标题、嵌套引用块、可折叠的 `<details>`、脚注/引用、数学公式、下划线、上下标、高亮文本和锚点都能原生渲染——无需客户端展平。在私聊中，实时流式预览也使用 `sendRichMessageDraft`，因此动画草稿与最终的富消息保持一致。
 
 当内容超过 32,768 字节的富文本上限时，富消息路径会自动跳过；Telegram 的任何拒绝（较旧 `python-telegram-bot` 不支持该端点、解析错误、块/列过多）都会**透明回退**到 MarkdownV2 路径——消息绝不会丢失。瞬时/网络错误**不会**被静默重发（不会产生重复的最终消息）。
 
@@ -886,17 +886,17 @@ gateway:
 - **小表格**被展平为**行组项目符号**——每行在列标题下变为可读的项目符号列表。适合 2-4 列和短单元格。
 - **较大或较宽的表格**回退为带对齐列的**围栏代码块**，以防内容折叠。
 
-API 回退无需配置——适配器会为每条消息选择正确的渲染方式。如果某个 Telegram 客户端能接收但不能渲染富消息（例如手表客户端把它们显示为不透明媒体块），可以选择退出并强制使用 MarkdownV2 路径：
+API 回退无需配置——适配器会为每条消息选择正确的渲染方式。富消息为**可选启用（默认关闭）**：某些客户端（尤其是 Telegram **macOS 桌面版**）会接收 `sendRichMessage` 但渲染为**空白气泡**；由于该调用返回成功——既无纯文本回退，机器人也无法探测收件人的客户端——强制启用会静默破坏这些用户的消息送达。Telegram 仅在**拒绝** API 调用时才会自动回退，而空白渲染这种情况并不会触发回退。仅当你确定所发送的每个客户端都能渲染富消息时（例如 iOS/Android）才启用：
 
 ```yaml
 gateway:
   platforms:
     telegram:
       extra:
-        rich_messages: false
+        rich_messages: true
 ```
 
-富消息默认启用（`rich_messages: true`）。这个设置用于客户端渲染兼容性；当 Telegram 拒绝富消息 API 调用时，Hermes 已经会自动回退。如果你只是想在保持富消息启用的同时恢复旧版「始终使用代码块」表格行为，可在 `config.yaml` 中设置 `telegram.pretty_tables: false` 禁用表格规范化（默认：`true`）。
+如果你只是想恢复旧版「始终使用代码块」的表格行为，可在 `config.yaml` 中设置 `telegram.pretty_tables: false` 禁用表格规范化（默认：`true`）。
 
 **链接预览。** Telegram 会为机器人消息中的 URL 自动生成链接预览。如果你希望抑制这些预览（长 `/tools` 输出、提及十个链接的 Agent 回复等）：
 


### PR DESCRIPTION
## Summary

The Bot API 10.1 **rich message** path (`sendRichMessage`) was flipped to **always-on** in #45584. On clients that don't implement rich rendering — notably the **Telegram macOS desktop app** — the message is accepted but rendered as a **blank bubble**. This makes the bot appear to send empty replies after an update.

This is unrecoverable from the bot side:
- `sendRichMessage` returns `ok:true` even when the client shows nothing.
- It has **no plaintext fallback** field.
- The Bot API exposes **no recipient-client signal** — a bot cannot detect whether the user is on iOS (renders fine) or macOS desktop (blank), so per-client auto-detection is impossible.
- Telegram's existing transparent fallback only triggers when it *rejects* the call; the blank-render case is a silent success, so fallback never fires.

Real-world repro: same bot + same message → renders correctly on iPhone, blank on the macOS desktop client.

## Fix

Revert the default to **opt-in (off)** — the safe, universally-rendered MarkdownV2 path — in both:
- `gateway/platforms/telegram.py` (`_rich_messages_enabled` default)
- `hermes_cli/config.py` `DEFAULT_CONFIG` (`telegram.extra.rich_messages`)

The existing `platforms.telegram.extra.rich_messages` switch still lets users **enable** rich messages when they know every client they message renders them. Feature and code paths are untouched; only the default flips back to what shipped before #45584.

Docs (EN + zh-Hans) updated to describe rich messages as opt-in and explain the blank-bubble caveat.

## Test plan

- [x] `scripts/run_tests.sh tests/gateway/test_telegram_rich_messages.py tests/gateway/test_config.py` — 106 passed
- `test_rich_messages_default_is_opt_in` asserts the no-config default uses the legacy send path
- `test_load_config_default_telegram_rich_messages_opt_in` asserts `DEFAULT_CONFIG` ships `rich_messages: false`
- Rich-behavior tests opt into the feature explicitly via the `_make_adapter(enable_rich=True)` harness default (the harness exists to exercise the rich path)