### PR TITLE
fix(desktop): skip dashboard cron tick while the profile gateway is alive

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -115,16 +115,30 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
     Cross-process safe: ``cron.scheduler.tick`` takes the ``cron/.tick.lock``
     file lock, so this never double-fires alongside a real gateway on the same
     HERMES_HOME — whichever process grabs the lock first wins the tick.
+
+    Deference: when this profile's gateway is alive we skip the tick entirely
+    rather than race it for the lock. A dashboard claim delivers through the
+    standalone send path (no live adapters), losing threaded delivery — the
+    gateway should own the run whenever it can. Re-checked every iteration so
+    the ticker takes over if the gateway dies, and fails open (ticks) if the
+    health check itself errors.
     """
     from cron.scheduler import tick as cron_tick
+    from gateway.status import is_gateway_running
 
     _log.info("Desktop cron ticker started (interval=%ds)", interval)
     # Tick once up front (catches jobs due at launch), then on the interval.
     while not stop_event.is_set():
         try:
-            cron_tick(verbose=False, sync=False)
+            gateway_alive = is_gateway_running()
         except Exception as e:
-            _log.debug("Desktop cron tick error: %s", e)
+            _log.debug("Desktop cron ticker gateway check error: %s", e)
+            gateway_alive = False
+        if not gateway_alive:
+            try:
+                cron_tick(verbose=False, sync=False)
+            except Exception as e:
+                _log.debug("Desktop cron tick error: %s", e)
         stop_event.wait(interval)
 
 

--- a/tests/test_desktop_cron_ticker_gateway_guard.py
+++ b/tests/test_desktop_cron_ticker_gateway_guard.py
@@ -1,0 +1,67 @@
+"""Desktop dashboard cron ticker must not race a healthy gateway.
+
+The desktop-spawned dashboard backend runs its own cron ticker so jobs fire
+when no gateway exists. But when the profile's gateway IS running, the ticker
+races it for ``cron/.tick.lock`` — and dashboard claims use the standalone
+send path (no live adapters), bypassing threaded delivery. The ticker must
+skip its tick while a gateway is alive, re-checking every iteration, and
+fail open (tick anyway) if the gateway health check itself breaks.
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+from hermes_cli.web_server import _start_desktop_cron_ticker
+
+
+class _SelfStoppingEvent(threading.Event):
+    """Event whose wait() sets itself after N waits — bounds the ticker loop."""
+
+    def __init__(self, iterations: int = 1):
+        super().__init__()
+        self._remaining = iterations
+
+    def wait(self, timeout=None):  # noqa: ARG002 - signature matches Event
+        self._remaining -= 1
+        if self._remaining <= 0:
+            self.set()
+        return True
+
+
+def _run_one_iteration(gateway_running, iterations: int = 1):
+    """Run the ticker loop for N iterations with patched collaborators."""
+    cron_tick = MagicMock()
+    check = MagicMock(side_effect=gateway_running)
+    with (
+        patch("cron.scheduler.tick", cron_tick),
+        patch("gateway.status.is_gateway_running", check),
+    ):
+        _start_desktop_cron_ticker(_SelfStoppingEvent(iterations), interval=0)
+    return cron_tick, check
+
+
+class TestDesktopTickerGatewayGuard:
+    def test_skips_tick_while_gateway_running(self):
+        cron_tick, check = _run_one_iteration(gateway_running=[True])
+        cron_tick.assert_not_called()
+        check.assert_called()
+
+    def test_ticks_when_no_gateway_running(self):
+        cron_tick, _ = _run_one_iteration(gateway_running=[False])
+        cron_tick.assert_called_once()
+
+    def test_rechecks_gateway_every_iteration(self):
+        # Gateway dies between iterations: skip the first tick, fire the second.
+        cron_tick, check = _run_one_iteration(
+            gateway_running=[True, False], iterations=2
+        )
+        cron_tick.assert_called_once()
+        assert check.call_count == 2
+
+    def test_fails_open_when_gateway_check_raises(self):
+        # A broken health check must not silence cron entirely — flat
+        # delivery beats no delivery.
+        cron_tick, _ = _run_one_iteration(
+            gateway_running=RuntimeError("status unreadable")
+        )
+        cron_tick.assert_called_once()


### PR DESCRIPTION
## What does this PR do?

In a Hermes Desktop deployment, every desktop-spawned `hermes dashboard` backend runs its own cron ticker (gated on `HERMES_DESKTOP=1`). The `cron/.tick.lock` file lock prevents *double* delivery, but it doesn't decide *who* delivers: whichever process ticks first claims the run. Dashboard claims always use the standalone send path (no live adapters), so a job that should go through the gateway's adapters — e.g. threaded Slack delivery — instead posts flat when a dashboard backend wins the race.

This adds a guard so the gateway owns delivery whenever it's up:

- The desktop cron ticker checks `gateway.status.is_gateway_running()` on each iteration and **skips its tick while the profile's gateway is alive**.
- It **fails open**: if the health check itself errors, the ticker still ticks, so a wedged gateway never silently stops cron delivery.
- No behavior change when no gateway is running (dashboard-only setups tick exactly as before).

## Related Issue

N/A — surfaced operationally alongside #44537 (threaded cron delivery); a flat post from a dashboard claim is the symptom that motivated both.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/web_server.py`: in the desktop cron ticker loop, skip the tick when `gateway.status.is_gateway_running()` is true for the profile; tick normally (fail-open) if the check raises.
- `tests/test_desktop_cron_ticker_gateway_guard.py`: new tests covering gateway-alive (skip), gateway-down (tick), and health-check-error (fail-open) paths.

## How to Test

1. Start a profile gateway, then open Hermes Desktop for the same profile.
2. Trigger a cron job that delivers to Slack; confirm it posts via the gateway's live adapter (e.g. threaded), not flat.
3. Stop the gateway; confirm the dashboard ticker resumes delivering.
4. `pytest tests/test_desktop_cron_ticker_gateway_guard.py -q` — 4 tests pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.0

### Documentation & Housekeeping

- [x] Documentation — N/A (internal ticker behavior, no user-facing config)
- [x] `cli-config.yaml.example` — N/A (no new config keys)
- [x] `CONTRIBUTING.md`/`AGENTS.md` — N/A
- [x] Cross-platform impact considered — guard is OS-agnostic
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Running on a 4-profile deployment since 2026-06-12. After the guard, gateway-up cron runs consistently show `via live adapter` delivery rather than intermittent flat posts from dashboard claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
