### PR TITLE
fix(backup): exclude update-audits/ to stop 2x/day backup growth

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -42,6 +42,11 @@ _EXCLUDED_DIRS = {
     "backups",          # prior auto-backups — don't nest backups exponentially
     "checkpoints",      # session-local trajectory caches — regenerated per-session,
                         # session-hash-keyed so they don't port to another machine anyway
+    "update-audits",    # daily-update audit folders — same recursion hazard as
+                        # "backups"; the daily auto-update writes a pre-update
+                        # zip *inside* update-audits/daily-auto-*/, and if that
+                        # folder is scanned, each morning's backup includes all
+                        # previous mornings' zips (2×/day growth).
 }
 
 # File-name suffixes to skip

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -343,6 +343,38 @@ class TestBackup:
             pid_files = [n for n in names if n.endswith(".pid")]
             assert pid_files == []
 
+    def test_excludes_update_audits(self, tmp_path, monkeypatch):
+        """Backup does NOT include the daily auto-update audit folders.
+
+        Regression for 2x/day backup growth: the pre-update zip is written
+        *inside* update-audits/daily-auto-*/, so without this exclusion each
+        morning's backup bundles all previous mornings' zips.
+        """
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        _make_hermes_tree(hermes_home)
+
+        # Simulate yesterday's and today's pre-update zips
+        audits = hermes_home / "update-audits"
+        (audits / "daily-auto-2026-06-13").mkdir(parents=True)
+        (audits / "daily-auto-2026-06-13" / "pre-update.zip").write_bytes(b"x" * 64)
+        (audits / "daily-auto-2026-06-14").mkdir(parents=True)
+        (audits / "daily-auto-2026-06-14" / "pre-update.zip").write_bytes(b"y" * 64)
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        out_zip = tmp_path / "backup.zip"
+        args = Namespace(output=str(out_zip))
+
+        from hermes_cli.backup import run_backup
+        run_backup(args)
+
+        with zipfile.ZipFile(out_zip, "r") as zf:
+            names = zf.namelist()
+            audit_files = [n for n in names if "update-audits" in n]
+            assert audit_files == [], f"update-audits leaked into backup: {audit_files}"
+
     def test_default_output_path(self, tmp_path, monkeypatch):
         """When no output path given, zip goes to ~/hermes-backup-*.zip."""
         hermes_home = tmp_path / ".hermes"


### PR DESCRIPTION
## Problem

The daily auto-update writes a pre-update zip *inside* `update-audits/daily-auto-*/`. The backup scanner descended into that folder, so each morning's backup included all previous mornings' zips — roughly doubling the backup size every day.

## Fix

Add `update-audits` to `_EXCLUDED_DIRS` in `hermes_cli/backup.py`, alongside the existing `backups` exclusion. Same recursion-hazard pattern, same comment style.

## Test

New regression test `test_excludes_update_audits` in `tests/hermes_cli/test_backup.py` verifies the exclusion actually works (confirmed by stashing the source change and watching the test fail before passing again with the fix).

```
$ python -m pytest tests/hermes_cli/test_backup.py
110 passed in 28.89s
```

## Reproduction

Without this exclusion, `~/.hermes/update-audits/daily-auto-*/pre-update.zip` gets included in each morning's auto-backup, creating nested recursive growth.

## Context

Local-only patch surfaced by `hermes-audit-retention-watchdog` noticing the 2×/day growth. Follows the existing `backups` exclusion's pattern.