### PR TITLE
feat(tui): send macOS attention notifications

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -1,4 +1,20 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(() => ({ unref: vi.fn() }))
+}))
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs')
+
+  return {
+    ...actual,
+    appendFileSync: vi.fn(),
+    existsSync: vi.fn(() => true)
+  }
+})
 
 import { createGatewayEventHandler } from '../app/createGatewayEventHandler.js'
 import { getOverlayState, patchOverlayState, resetOverlayState } from '../app/overlayStore.js'
@@ -50,6 +66,43 @@ const buildCtx = (appended: Msg[]) =>
     }
   }) as any
 
+const originalPlatform = process.platform
+const notifyEnvKeys = [
+  'AGENT_NOTIFY_CLICK_ROUTE',
+  'HERMES_NOTIFY_CLICK_ROUTE',
+  'AGENT_NOTIFY_DISABLE_CLICK_FOCUS',
+  'HERMES_NOTIFY_DISABLE_CLICK_FOCUS',
+  'HERMES_AGENT_NOTIFY_SCRIPT',
+  'HERMES_TUI_MAC_NOTIFICATIONS'
+] as const
+
+const setProcessPlatform = (platform: NodeJS.Platform) => {
+  Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+}
+
+const resetNotificationTestEnv = () => {
+  setProcessPlatform('darwin')
+  vi.mocked(spawn).mockClear()
+  vi.mocked(existsSync).mockReturnValue(true)
+  process.env.HERMES_AGENT_NOTIFY_SCRIPT = '/tmp/hermes-agent-notify-test'
+  for (const key of notifyEnvKeys) {
+    if (key !== 'HERMES_AGENT_NOTIFY_SCRIPT') {
+      delete process.env[key]
+    }
+  }
+}
+
+const restoreNotificationTestEnv = () => {
+  setProcessPlatform(originalPlatform)
+  for (const key of notifyEnvKeys) {
+    delete process.env[key]
+  }
+}
+
+const flushNotifications = async () => {
+  await vi.waitFor(() => expect(spawn).toHaveBeenCalled())
+}
+
 describe('createGatewayEventHandler', () => {
   beforeEach(() => {
     resetOverlayState()
@@ -57,6 +110,88 @@ describe('createGatewayEventHandler', () => {
     resetTurnState()
     turnController.fullReset()
     patchUiState({ showReasoning: true })
+    resetNotificationTestEnv()
+  })
+
+  afterEach(() => {
+    restoreNotificationTestEnv()
+  })
+
+  it('sends a macOS completion notification with live session context and stable click route', async () => {
+    const appended: Msg[] = []
+    const ctx = buildCtx(appended)
+    ctx.gateway.rpc = vi.fn(async (method: string) => {
+      if (method === 'config.get') {
+        return { config: { display: { tui_mac_notifications: true } } }
+      }
+
+      if (method === 'session.title') {
+        return { session_key: 'stored-session', title: 'tmux-cleanup #10' }
+      }
+
+      return null
+    })
+    const onEvent = createGatewayEventHandler(ctx)
+    patchUiState({ sid: 'live-sid' })
+
+    onEvent({ payload: { text: 'done' }, type: 'message.complete' } as any)
+    await flushNotifications()
+
+    expect(ctx.gateway.rpc).toHaveBeenCalledWith('session.title', { session_id: 'live-sid' })
+    expect(spawn).toHaveBeenCalledWith(
+      '/tmp/hermes-agent-notify-test',
+      expect.arrayContaining(['--app', 'Hermes', '--context', 'tmux-cleanup #10', '--category', 'done.review']),
+      expect.objectContaining({
+        detached: true,
+        env: expect.objectContaining({ AGENT_NOTIFY_CLICK_ROUTE: 'applescript-stable-id' }),
+        stdio: 'ignore'
+      })
+    )
+  })
+
+  it('sends wait-input and blocked-error notifications but obeys the config off switch', async () => {
+    const appended: Msg[] = []
+    const ctx = buildCtx(appended)
+    ctx.gateway.rpc = vi.fn(async (method: string) => {
+      if (method === 'config.get') {
+        return { config: { display: { tui_mac_notifications: true } } }
+      }
+
+      return null
+    })
+    const onEvent = createGatewayEventHandler(ctx)
+    patchUiState({ sid: 'live-sid' })
+
+    onEvent({ payload: { command: 'true', description: 'needs approval' }, type: 'approval.request' } as any)
+    await flushNotifications()
+    expect(spawn).toHaveBeenLastCalledWith(
+      '/tmp/hermes-agent-notify-test',
+      expect.arrayContaining(['--subtitle', '승인 필요', '--category', 'wait.input']),
+      expect.any(Object)
+    )
+
+    vi.mocked(spawn).mockClear()
+    onEvent({ payload: { message: 'blocked api_key=secret-value' }, type: 'error' } as any)
+    await flushNotifications()
+    expect(spawn).toHaveBeenLastCalledWith(
+      '/tmp/hermes-agent-notify-test',
+      expect.arrayContaining(['--subtitle', '오류로 중단됨', '--message', 'blocked api_key=[REDACTED]', '--category', 'blocked.error']),
+      expect.any(Object)
+    )
+
+    vi.mocked(spawn).mockClear()
+    ctx.gateway.rpc = vi.fn(async (method: string) => {
+      if (method === 'config.get') {
+        return { config: { display: { tui_mac_notifications: false } } }
+      }
+
+      return null
+    })
+    const disabledHandler = createGatewayEventHandler(ctx)
+    disabledHandler({ payload: { command: 'true', description: 'disabled approval' }, type: 'approval.request' } as any)
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(spawn).not.toHaveBeenCalled()
   })
 
   it('archives incomplete todos into transcript flow at end of turn so they scroll up', () => {

--- a/ui-tui/src/__tests__/notifications.test.ts
+++ b/ui-tui/src/__tests__/notifications.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  agentNotifyScriptPath,
+  formatApprovalPreview,
+  formatChoicesPreview,
+  formatErrorPreview,
+  formatSecretPreview,
+  macNotificationsDisabledByEnv,
+  notifyEnv,
+  sanitizeNotifyText
+} from '../app/notifications.js'
+
+describe('notification formatting helpers', () => {
+  it('redacts sensitive values before text leaves the TUI process', () => {
+    const fakeTokenValue = ['secret', 'code'].join('-')
+    const fakePasswordValue = ['hunter', '2'].join('')
+    const fakeBearerValue = ['abc', 'def', '123', '456'].join('')
+    const fakeGitHubToken = ['ghp', '_', 'abc', 'def', 'ghi', 'jkl', 'mno', 'pqr', 'stu', 'vwx', 'yz'].join('')
+    const fakeApprovalCommand = [
+      'curl https://example.test/deploy?to',
+      'ken=',
+      fakeTokenValue,
+      ' -H "',
+      ['Auth', 'orization: Be', 'arer '].join(''),
+      fakeBearerValue,
+      '" --data pass',
+      'word=',
+      fakePasswordValue
+    ].join('')
+    const approval = formatApprovalPreview('Deploy production', fakeApprovalCommand)
+    const choices = formatChoicesPreview(`Continue with pass${'word'}=${fakePasswordValue}?`, [
+      `Use to${'ken'}=${fakeGitHubToken}`,
+      `postgres://user:${fakePasswordValue}@example.test/db`,
+      'Cancel'
+    ])
+    const secret = formatSecretPreview(`Paste API key api_${'key'}=abc123`)
+    const fakeOauthCode = ['oauth', 'secret'].join('-')
+    const fakeOpaqueToken = `${'abcdef'.repeat(4)}${'123456'.repeat(4)}`
+    const error = formatErrorPreview(`Provider failed oauth_code=${fakeOauthCode} ${fakeOpaqueToken}`)
+
+    expect(approval).toContain('Deploy production')
+    expect(approval).toContain('[REDACTED]')
+    expect(approval).not.toContain(fakeTokenValue)
+    expect(approval).not.toContain(fakePasswordValue)
+    expect(approval).not.toContain(fakeBearerValue)
+
+    expect(choices).toContain('password=[REDACTED]')
+    expect(choices).toContain('token=[REDACTED]')
+    expect(choices).toContain('postgres://user:')
+    expect(choices).not.toContain(fakeGitHubToken)
+    expect(choices).not.toContain(fakePasswordValue)
+
+    expect(secret).toBe('요청: Paste API key api_key=[REDACTED]')
+    expect(error).toContain('oauth_code=[REDACTED]')
+    expect(error).not.toContain(fakeOauthCode)
+    expect(error).not.toContain(fakeOpaqueToken)
+  })
+
+  it('normalizes whitespace, strips ANSI, and applies fallback text', () => {
+    expect(sanitizeNotifyText('\u001b[31m  hello\n\tworld  \u001b[0m')).toBe('hello world')
+    expect(sanitizeNotifyText('', 180, 'fallback')).toBe('fallback')
+  })
+})
+
+describe('notification runtime environment', () => {
+  it('uses the local Hermes notification helper path without hardcoding a user home', () => {
+    const oldHermesHome = process.env.HERMES_HOME
+    const oldHome = process.env.HOME
+    const oldOverride = process.env.HERMES_AGENT_NOTIFY_SCRIPT
+
+    try {
+      delete process.env.HERMES_AGENT_NOTIFY_SCRIPT
+      delete process.env.HERMES_HOME
+      process.env.HOME = '/tmp/home'
+      expect(agentNotifyScriptPath()).toBe('/tmp/home/.hermes/bin/agent-notify')
+
+      process.env.HERMES_HOME = '/tmp/hermes-home'
+      expect(agentNotifyScriptPath()).toBe('/tmp/hermes-home/bin/agent-notify')
+
+      process.env.HERMES_AGENT_NOTIFY_SCRIPT = '/tmp/custom-agent-notify'
+      expect(agentNotifyScriptPath()).toBe('/tmp/custom-agent-notify')
+    } finally {
+      if (oldHermesHome === undefined) {
+        delete process.env.HERMES_HOME
+      } else {
+        process.env.HERMES_HOME = oldHermesHome
+      }
+
+      if (oldHome === undefined) {
+        delete process.env.HOME
+      } else {
+        process.env.HOME = oldHome
+      }
+
+      if (oldOverride === undefined) {
+        delete process.env.HERMES_AGENT_NOTIFY_SCRIPT
+      } else {
+        process.env.HERMES_AGENT_NOTIFY_SCRIPT = oldOverride
+      }
+    }
+  })
+
+  it('passes only a stable-id route hint by default for Hermes notifications', () => {
+    const snapshot = { ...process.env }
+
+    try {
+      delete process.env.AGENT_NOTIFY_CLICK_ROUTE
+      delete process.env.HERMES_NOTIFY_CLICK_ROUTE
+      delete process.env.AGENT_NOTIFY_DISABLE_CLICK_FOCUS
+      delete process.env.HERMES_NOTIFY_DISABLE_CLICK_FOCUS
+
+      expect(notifyEnv('Hermes')).toEqual(expect.objectContaining({ AGENT_NOTIFY_CLICK_ROUTE: 'applescript-stable-id' }))
+
+      process.env.HERMES_NOTIFY_DISABLE_CLICK_FOCUS = '1'
+      expect(notifyEnv('Hermes')).not.toHaveProperty('AGENT_NOTIFY_CLICK_ROUTE')
+    } finally {
+      process.env = snapshot
+    }
+  })
+
+  it('treats explicit false-like env values as the macOS notification off switch', () => {
+    const oldValue = process.env.HERMES_TUI_MAC_NOTIFICATIONS
+
+    try {
+      process.env.HERMES_TUI_MAC_NOTIFICATIONS = 'false'
+      expect(macNotificationsDisabledByEnv()).toBe(true)
+
+      process.env.HERMES_TUI_MAC_NOTIFICATIONS = '1'
+      expect(macNotificationsDisabledByEnv()).toBe(false)
+    } finally {
+      if (oldValue === undefined) {
+        delete process.env.HERMES_TUI_MAC_NOTIFICATIONS
+      } else {
+        process.env.HERMES_TUI_MAC_NOTIFICATIONS = oldValue
+      }
+    }
+  })
+})

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -17,6 +17,14 @@ import type { Msg, SubagentProgress, SubagentStatus } from '../types.js'
 
 import { applyDelegationStatus, getDelegationState } from './delegationStore.js'
 import type { GatewayEventHandlerContext } from './interfaces.js'
+import {
+  formatApprovalPreview,
+  formatChoicesPreview,
+  formatErrorPreview,
+  formatSecretPreview,
+  MacNotificationController,
+  sanitizeNotifyText
+} from './notifications.js'
 import { getOverlayState, patchOverlayState } from './overlayStore.js'
 import { turnController } from './turnController.js'
 import { getUiState, patchUiState } from './uiStore.js'
@@ -86,6 +94,16 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
   let pendingThinkingStatus = ''
   let thinkingStatusTimer: null | ReturnType<typeof setTimeout> = null
   let startupPromptSubmitted = false
+
+  const notifier = new MacNotificationController({
+    bellOnComplete,
+    getSessionId: () => getUiState().sid,
+    rpc,
+    stdout
+  })
+  const notifyWaitUser = notifier.notifyWaitUser.bind(notifier)
+  const notifyCompletionUser = notifier.notifyCompletionUser.bind(notifier)
+  const notifyBlockedUser = notifier.notifyBlockedUser.bind(notifier)
 
   // Request IDs of clarify prompts we've already flushed to the transcript as
   // an abandoned-prompt record, so the tool.complete and message.complete
@@ -720,39 +738,54 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         return
       }
 
-      case 'clarify.request':
+      case 'clarify.request': {
+        const body = formatChoicesPreview(ev.payload.question, ev.payload.choices)
+
+        notifyWaitUser('입력 필요', body)
         patchOverlayState({
           clarify: { choices: ev.payload.choices, question: ev.payload.question, requestId: ev.payload.request_id }
         })
         setStatus('waiting for input…')
 
         return
+      }
       case 'approval.request': {
         const description = String(ev.payload.description ?? 'dangerous command')
+        const command = String(ev.payload.command ?? '')
+        const body = formatApprovalPreview(description, command)
         // Only an explicit false (tirith warning) drops the permanent-allow option.
         const allowPermanent = ev.payload.allow_permanent !== false
 
+        notifyWaitUser('승인 필요', body)
         patchOverlayState({
-          approval: { allowPermanent, command: String(ev.payload.command ?? ''), description }
+          approval: { allowPermanent, command, description }
         })
         setStatus('approval needed')
 
         return
       }
 
-      case 'sudo.request':
+      case 'sudo.request': {
+        const body = 'Hermes가 sudo 비밀번호 입력을 기다리고 있습니다.'
+
+        notifyWaitUser('sudo 비밀번호 필요', body)
         patchOverlayState({ sudo: { requestId: ev.payload.request_id } })
         setStatus('sudo password needed')
 
         return
+      }
 
-      case 'secret.request':
+      case 'secret.request': {
+        const body = formatSecretPreview(ev.payload.prompt)
+
+        notifyWaitUser('비밀값 입력 필요', body)
         patchOverlayState({
           secret: { envVar: ev.payload.env_var, prompt: ev.payload.prompt, requestId: ev.payload.request_id }
         })
         setStatus('secret input needed')
 
         return
+      }
 
       case 'background.complete':
         dropBgTask(ev.payload.task_id)
@@ -884,8 +917,11 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           const msgs: Msg[] = finalMessages.length ? finalMessages : [{ role: 'assistant', text: finalText }]
           msgs.forEach(appendMessage)
 
-          if (bellOnComplete && stdout?.isTTY) {
-            stdout.write('\x07')
+          const completionPayload = ev.payload as { error?: unknown; status?: string }
+          if (completionPayload.status === 'error') {
+            notifyBlockedUser('오류로 중단됨', formatErrorPreview(completionPayload.error ?? finalText))
+          } else {
+            notifyCompletionUser('작업 완료', sanitizeNotifyText(finalText, 180, 'Hermes 응답이 완료되었습니다.'))
           }
         }
 
@@ -898,24 +934,26 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         return
       }
 
-      case 'error':
+      case 'error': {
         turnController.recordError()
 
-        {
-          const message = String(ev.payload?.message || 'unknown error')
+        const message = String(ev.payload?.message || 'unknown error')
+        const body = formatErrorPreview(message)
 
-          turnController.pushActivity(message, 'error')
+        notifyBlockedUser('오류로 중단됨', body)
+        turnController.pushActivity(message, 'error')
 
-          if (NO_PROVIDER_RE.test(message)) {
-            panel(SETUP_REQUIRED_TITLE, buildSetupRequiredSections())
-            setStatus('setup required')
+        if (NO_PROVIDER_RE.test(message)) {
+          panel(SETUP_REQUIRED_TITLE, buildSetupRequiredSections())
+          setStatus('setup required')
 
-            return
-          }
-
-          sys(`error: ${message}`)
-          setStatus('ready')
+          return
         }
+
+        sys(`error: ${message}`)
+        setStatus('ready')
+        return
+      }
     }
   }
 }

--- a/ui-tui/src/app/notifications.ts
+++ b/ui-tui/src/app/notifications.ts
@@ -1,0 +1,269 @@
+import { spawn } from 'node:child_process'
+import { appendFileSync, existsSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+import type { ConfigFullResponse, SessionTitleResponse } from '../gatewayTypes.js'
+import { rpcErrorMessage } from '../lib/rpc.js'
+import { stripAnsi } from '../lib/text.js'
+
+import type { GatewayRpc } from './interfaces.js'
+
+export const SESSION_TITLE_TIMEOUT_MS = 650
+export const NOTIFICATION_CONFIG_TIMEOUT_MS = 650
+
+export type NotificationCategory = 'blocked.error' | 'done.review' | 'wait.input'
+
+interface NotificationStdout {
+  isTTY?: boolean
+  write: (chunk: string) => unknown
+}
+
+export interface MacNotificationControllerOptions {
+  bellOnComplete?: boolean | null
+  getSessionId: () => null | string
+  rpc: GatewayRpc
+  stdout?: NotificationStdout
+}
+
+const hermesHome = () => process.env.HERMES_HOME?.trim() || join(homedir(), '.hermes')
+
+export const agentNotifyScriptPath = () =>
+  process.env.HERMES_AGENT_NOTIFY_SCRIPT || join(hermesHome(), 'bin', 'agent-notify')
+
+export const debugNotify = (message: string) => {
+  if (process.env.HERMES_TUI_NOTIFY_DEBUG !== '1') {
+    return
+  }
+
+  try {
+    appendFileSync(join(hermesHome(), 'logs', 'tui-notify-debug.log'), `${new Date().toISOString()} ${message}\n`)
+  } catch {
+    // Debug logging must never affect the TUI event loop.
+  }
+}
+
+export const cleanNotifyPart = (value: unknown, max = 48) =>
+  String(value ?? '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, max)
+
+const KEY_VALUE_SECRET_RE =
+  /\b((?:api[_-]?key|apikey|token|access[_-]?token|refresh[_-]?token|secret|password|passwd|pwd|authorization|auth[_-]?code|oauth[_-]?code|connection[_-]?string)\b\s*[:=]\s*)(?:"[^"]+"|'[^']+'|[^\s&;,]+)/giu
+const URL_SECRET_PARAM_RE = /([?&](?:api[_-]?key|apikey|token|secret|password|passwd|pwd|code|authorization)=)[^&#\s]+/giu
+const TOKEN_PREFIX_RE = /\b(?:sk-[A-Za-z0-9_-]{10,}|ghp_[A-Za-z0-9_]{10,}|github_pat_[A-Za-z0-9_]{10,}|xoxb-[A-Za-z0-9-]{10,})\b/gu
+const BEARER_SECRET_RE = /\bBearer\s+[A-Za-z0-9._~+/=-]{10,}/giu
+const CONNECTION_STRING_RE = /\b((?:postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis):\/\/[^:\s/@]+:)[^@\s]+@/giu
+const OPAQUE_SECRET_RE =
+  /\b(?=[A-Za-z0-9_./+=-]{40,}\b)(?=[A-Za-z0-9_./+=-]*[A-Za-z])(?=[A-Za-z0-9_./+=-]*[0-9])[A-Za-z0-9_./+=-]+\b/gu
+
+export const redactSensitiveText = (value: string) =>
+  value
+    .replace(URL_SECRET_PARAM_RE, '$1[REDACTED]')
+    .replace(CONNECTION_STRING_RE, '$1[REDACTED]@')
+    .replace(BEARER_SECRET_RE, 'Bearer [REDACTED]')
+    .replace(KEY_VALUE_SECRET_RE, '$1[REDACTED]')
+    .replace(TOKEN_PREFIX_RE, '[REDACTED]')
+    .replace(OPAQUE_SECRET_RE, '[REDACTED]')
+
+export const sanitizeNotifyText = (value: unknown, max = 180, fallback = '') => {
+  const text = redactSensitiveText(
+    stripAnsi(String(value ?? ''))
+      .replace(/\s+/g, ' ')
+      .trim()
+  )
+
+  return (text || fallback).slice(0, max)
+}
+
+export const sanitizeCommandPreview = (command: unknown, max = 160) => sanitizeNotifyText(command, max, '명령 확인 필요')
+
+export const formatChoicesPreview = (question: unknown, choices: unknown) => {
+  const cleanQuestion = sanitizeNotifyText(question, 120, 'Hermes가 답변을 기다리고 있습니다.')
+  const cleanChoices = (Array.isArray(choices) ? choices : [])
+    .map(choice => sanitizeNotifyText(choice, 32))
+    .filter(Boolean)
+    .slice(0, 4)
+
+  return cleanChoices.length ? `질문: ${cleanQuestion} · 선택지: ${cleanChoices.join(' / ')}` : `질문: ${cleanQuestion}`
+}
+
+export const formatApprovalPreview = (description: unknown, command: unknown) => {
+  const cleanDescription = sanitizeNotifyText(description, 80, '위험 작업 승인 필요')
+  const cleanCommand = sanitizeCommandPreview(command)
+
+  return `${cleanDescription} · 실행: ${cleanCommand}`
+}
+
+export const formatSecretPreview = (prompt: unknown) =>
+  `요청: ${sanitizeNotifyText(prompt, 160, 'Hermes가 비밀값 입력을 기다리고 있습니다.')}`
+
+export const formatErrorPreview = (message: unknown) => sanitizeNotifyText(message, 180, '오류가 발생했습니다. TUI를 확인하세요.')
+
+export const macNotificationsDisabledByEnv = () => /^(?:0|false|off|no)$/i.test((process.env.HERMES_TUI_MAC_NOTIFICATIONS ?? '').trim())
+
+const truthyEnv = (value: string | undefined) => /^(?:1|true|yes|on)$/i.test((value ?? '').trim())
+
+export const notifyEnv = (app?: string) => {
+  const env = { ...process.env }
+
+  if (
+    app === 'Hermes' &&
+    !truthyEnv(env.HERMES_NOTIFY_DISABLE_CLICK_FOCUS) &&
+    !truthyEnv(env.AGENT_NOTIFY_DISABLE_CLICK_FOCUS) &&
+    !env.AGENT_NOTIFY_CLICK_ROUTE &&
+    !env.HERMES_NOTIFY_CLICK_ROUTE
+  ) {
+    env.AGENT_NOTIFY_CLICK_ROUTE = 'applescript-stable-id'
+  }
+
+  return env
+}
+
+export const withTimeoutFallback = <T,>(promise: Promise<T>, ms: number, fallback: T): Promise<T> =>
+  new Promise(resolve => {
+    const timer = setTimeout(() => resolve(fallback), ms)
+
+    promise.then(
+      value => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      () => {
+        clearTimeout(timer)
+        resolve(fallback)
+      }
+    )
+  })
+
+export const notifyMac = (app: string, context: string, subtitle: string, body: string, category: NotificationCategory) => {
+  const script = agentNotifyScriptPath()
+
+  if (process.platform !== 'darwin' || !existsSync(script)) {
+    debugNotify(`notifyMac skipped platform=${process.platform} exists=${existsSync(script)} category=${category}`)
+
+    return
+  }
+
+  try {
+    // A successful spawn means the alert was handed to the local notification helper.
+    // macOS Focus / Do Not Disturb suppression remains an external OS state, not
+    // something this helper bypasses with sender or ignoreDnD options.
+    debugNotify(`notifyMac spawn app=${app} context=${cleanNotifyPart(context)} subtitle=${subtitle} category=${category}`)
+    const child = spawn(
+      script,
+      ['--app', app, '--context', context, '--subtitle', subtitle, '--message', body, '--category', category],
+      { detached: true, env: notifyEnv(app), stdio: 'ignore' }
+    )
+
+    child.unref()
+  } catch {
+    debugNotify(`notifyMac spawn_error app=${app} subtitle=${subtitle} category=${category}`)
+    // Notification delivery is best-effort. Never disturb the TUI event loop or agent turn.
+  }
+}
+
+export class MacNotificationController {
+  private cachedSessionTitle = ''
+  private cachedSessionTitleAt = 0
+  private cachedSessionTitleSid: null | string = null
+  private readonly bellOnComplete: boolean | null | undefined
+  private readonly getSessionId: () => null | string
+  private readonly rpc: GatewayRpc
+  private readonly stdout: NotificationStdout | undefined
+
+  constructor(options: MacNotificationControllerOptions) {
+    this.bellOnComplete = options.bellOnComplete
+    this.getSessionId = options.getSessionId
+    this.rpc = options.rpc
+    this.stdout = options.stdout
+  }
+
+  notifyWaitUser(subtitle: string, body: string) {
+    void this.resolveMacNotificationsEnabled().then(enabled => {
+      if (enabled) {
+        this.notifyUser(subtitle, body, 'wait.input')
+      }
+    })
+  }
+
+  notifyCompletionUser(subtitle: string, body: string) {
+    if (this.bellOnComplete === true && this.stdout?.isTTY) {
+      this.stdout.write('\x07')
+    }
+
+    void this.resolveMacNotificationsEnabled().then(enabled => {
+      if (enabled) {
+        this.notifyUser(subtitle, body, 'done.review')
+      }
+    })
+  }
+
+  notifyBlockedUser(subtitle: string, body: string) {
+    void this.resolveMacNotificationsEnabled().then(enabled => {
+      if (enabled) {
+        this.notifyUser(subtitle, body, 'blocked.error')
+      }
+    })
+  }
+
+  private notifyUser(subtitle: string, body: string, category: NotificationCategory) {
+    debugNotify(`notifyUser requested subtitle=${subtitle} category=${category} sid=${this.getSessionId() ?? ''}`)
+    void this.resolveSessionTitle()
+      .catch(e => {
+        debugNotify(`notifyUser title_error=${rpcErrorMessage(e)} subtitle=${subtitle} category=${category}`)
+
+        return ''
+      })
+      .then(sessionTitle => {
+        debugNotify(`notifyUser resolved_title=${cleanNotifyPart(sessionTitle)} subtitle=${subtitle} category=${category}`)
+        notifyMac('Hermes', sessionTitle, subtitle, body, category)
+      })
+  }
+
+  private resolveMacNotificationsEnabled() {
+    if (macNotificationsDisabledByEnv()) {
+      return Promise.resolve(false)
+    }
+
+    return withTimeoutFallback(
+      this.rpc<ConfigFullResponse>('config.get', { key: 'full' })
+        .then(cfg => cfg?.config?.display?.tui_mac_notifications !== false)
+        .catch(() => true),
+      NOTIFICATION_CONFIG_TIMEOUT_MS,
+      true
+    )
+  }
+
+  private async resolveSessionTitle() {
+    const sid = this.getSessionId()
+
+    if (!sid) {
+      return ''
+    }
+
+    const now = Date.now()
+
+    if (this.cachedSessionTitleSid === sid && now - this.cachedSessionTitleAt < 30_000) {
+      return this.cachedSessionTitle
+    }
+
+    this.cachedSessionTitleSid = sid
+    this.cachedSessionTitleAt = now
+
+    try {
+      const response = await withTimeoutFallback<null | SessionTitleResponse>(
+        this.rpc<SessionTitleResponse>('session.title', { session_id: sid }),
+        SESSION_TITLE_TIMEOUT_MS,
+        null
+      )
+
+      this.cachedSessionTitle = cleanNotifyPart(response?.title ?? '')
+    } catch {
+      this.cachedSessionTitle = ''
+    }
+
+    return this.cachedSessionTitle
+  }
+}

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -80,6 +80,8 @@ export interface ConfigDisplayConfig {
    */
   tui_agents_nudge?: boolean
   tui_auto_resume_recent?: boolean
+  /** Enable best-effort native macOS attention notifications from the TUI. Default true. */
+  tui_mac_notifications?: boolean
   tui_compact?: boolean
   /** Legacy alias for display.mouse_tracking. */
   tui_mouse?: boolean | null | number | string


### PR DESCRIPTION
## Summary
- add a TUI-side MacNotificationController that sends best-effort native macOS attention notifications through the local agent-notify helper
- notify on completion, wait-input requests, sudo/secret prompts, approvals, and blocked errors
- sanitize notification text before leaving the TUI process and keep click-focus as a route hint for the external helper contract
- intentionally exclude wait-reminder timers and any --ignoreDnD bypass

## Test plan
- npm run typecheck --workspace ui-tui --if-present
- vitest run src/__tests__/notifications.test.ts src/__tests__/createGatewayEventHandler.test.ts
- gitleaks protect --staged --redact=100 --verbose