### PR TITLE
feat(web): add SEARXNG_API_KEY support for authenticated SearXNG instances

### DIFF
--- a/plugins/web/searxng/provider.py
+++ b/plugins/web/searxng/provider.py
@@ -18,6 +18,7 @@ Config keys this provider responds to::
 Env var::
 
     SEARXNG_URL=http://localhost:8080
+    SEARXNG_API_KEY=optional-api-key
 """
 
 from __future__ import annotations
@@ -41,6 +42,19 @@ def _searxng_url() -> str:
         val = None
     if val is None:
         val = os.getenv("SEARXNG_URL", "")
+    return (val or "").strip()
+
+
+def _searxng_api_key() -> str:
+    """Return SEARXNG_API_KEY from Hermes config-aware env, falling back to process env."""
+    try:
+        from hermes_cli.config import get_env_value
+
+        val = get_env_value("SEARXNG_API_KEY")
+    except Exception:
+        val = None
+    if val is None:
+        val = os.getenv("SEARXNG_API_KEY", "")
     return (val or "").strip()
 
 
@@ -80,11 +94,15 @@ class SearXNGWebSearchProvider(WebSearchProvider):
         }
 
         try:
+            headers: Dict[str, str] = {"Accept": "application/json"}
+            api_key = _searxng_api_key()
+            if api_key:
+                headers["X-API-Key"] = api_key
             resp = httpx.get(
                 f"{base_url}/search",
                 params=params,
                 timeout=15,
-                headers={"Accept": "application/json"},
+                headers=headers,
             )
             resp.raise_for_status()
         except httpx.HTTPStatusError as exc:
@@ -148,6 +166,11 @@ class SearXNGWebSearchProvider(WebSearchProvider):
                     "key": "SEARXNG_URL",
                     "prompt": "SearXNG instance URL (e.g. http://localhost:8080)",
                     "url": "https://searx.space/",
+                },
+                {
+                    "key": "SEARXNG_API_KEY",
+                    "prompt": "SearXNG API key (optional, for authenticated instances)",
+                    "optional": True,
                 },
             ],
         }


### PR DESCRIPTION
## What

Adds `SEARXNG_API_KEY` environment variable support to the SearXNG web search provider. When set, the key is passed as the `X-API-Key` header on search requests.

## Why

The SearXNG provider sent requests without authentication headers, which fails when the instance requires an API key — common for rate-limited public instances or private deployments behind auth.

Issue #5941 proposed API key support in the original feature request, but it was missed in the implementation (0d085d94).

## How

- Reads `SEARXNG_API_KEY` from the environment
- If set, adds `X-API-Key` header to the HTTP request
- Fully backward compatible — no key, no header (existing behavior preserved)

## Testing

Verified against a SearXNG instance with API key authentication enabled.

Closes #5941