### PR TITLE
fix(web): support image paste and drag-drop in WebUI chat

### DIFF
--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -72,16 +72,28 @@ const STATE_TONE: Record<
 interface ChatSidebarProps {
   channel: string;
   className?: string;
+  /** Pre-created GatewayClient. When omitted the sidebar creates its own. */
+  gw?: GatewayClient;
+  /** Called when the session_id changes (from session.info or session.create). */
+  onSessionInfo?: (sessionId: string) => void;
 }
 
-export function ChatSidebar({ channel, className }: ChatSidebarProps) {
+export function ChatSidebar({
+  channel,
+  className,
+  gw: externalGw,
+  onSessionInfo,
+}: ChatSidebarProps) {
   // `version` bumps on reconnect; gw is derived so we never call setState
   // for it inside an effect (React 19's set-state-in-effect rule). The
   // counter is the dependency on purpose — it's not read in the memo body,
   // it's the signal that says "rebuild the client".
   const [version, setVersion] = useState(0);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const gw = useMemo(() => new GatewayClient(), [version]);
+  const gw = useMemo(
+    () => externalGw ?? new GatewayClient(),
+    [version, externalGw],
+  );
 
   const [state, setState] = useState<ConnectionState>("idle");
   const [sessionId, setSessionId] = useState<string | null>(null);
@@ -97,6 +109,7 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
     const offSessionInfo = gw.on<SessionInfo>("session.info", (ev) => {
       if (ev.session_id) {
         setSessionId(ev.session_id);
+        onSessionInfo?.(ev.session_id);
       }
 
       if (ev.payload) {
@@ -143,9 +156,13 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
       offState();
       offSessionInfo();
       offError();
-      gw.close();
+      // Only close the GatewayClient if we created it ourselves.
+      // An externally-provided client is owned by the caller.
+      if (!externalGw) {
+        gw.close();
+      }
     };
-  }, [gw]);
+  }, [gw, externalGw, onSessionInfo]);
 
   // Event subscriber WebSocket — receives the rebroadcast of every
   // dispatcher emit from the PTY child's gateway.  See /api/pub +

--- a/web/src/hooks/useImageAttachment.ts
+++ b/web/src/hooks/useImageAttachment.ts
@@ -1,0 +1,205 @@
+/**
+ * useImageAttachment — intercepts clipboard paste and drag-and-drop of images
+ * on the terminal host, and forwards them to the gateway via `image.attach_bytes`
+ * so the agent can see them inline (native vision).
+ *
+ * The GatewayClient (from ChatSidebar's JSON-RPC sidecar) shares the same
+ * session_id as the PTY child — both receive `session.info` events on the
+ * same channel.  Calling `image.attach_bytes` appends to
+ * `session["attached_images"]`, which `_run_prompt_submit` picks up on the
+ * next prompt submission.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { GatewayClient } from "@/lib/gatewayClient";
+
+/** Accepted MIME prefixes for image clipboard data. */
+const IMAGE_MIME_RE = /^image\//;
+
+export interface AttachedImage {
+  /** Original filename or generated label. */
+  name: string;
+  /** Approximate dimensions if available. */
+  width?: number;
+  height?: number;
+}
+
+interface UseImageAttachmentOptions {
+  /** Terminal host element to listen on. */
+  hostRef: React.RefObject<HTMLDivElement | null>;
+  /** Sidebar's GatewayClient — must be connected. */
+  gw: GatewayClient | null;
+  /** PTY session id — from session.info events. */
+  sessionId: string | null;
+}
+
+interface UseImageAttachmentResult {
+  /** Currently attached images (pending next prompt submit). */
+  attachedImages: AttachedImage[];
+  /** Manually clear attached images (e.g. after submit). */
+  clearAttached: () => void;
+}
+
+export function useImageAttachment({
+  hostRef,
+  gw,
+  sessionId,
+}: UseImageAttachmentOptions): UseImageAttachmentResult {
+  const [attachedImages, setAttachedImages] = useState<AttachedImage[]>([]);
+  const gwRef = useRef(gw);
+  const sidRef = useRef(sessionId);
+
+  // Keep refs in sync so event handlers always see current values without
+  // re-registering listeners on every render.
+  useEffect(() => {
+    gwRef.current = gw;
+  }, [gw]);
+
+  useEffect(() => {
+    sidRef.current = sessionId;
+  }, [sessionId]);
+
+  const attachImage = useCallback(
+    async (dataUrl: string, filename: string) => {
+      const currentGw = gwRef.current;
+      const currentSid = sidRef.current;
+      if (!currentGw || currentGw.state !== "open" || !currentSid) {
+        console.warn(
+          "[image-attach] gateway not ready or session unknown — skipping",
+        );
+        return;
+      }
+
+      // Strip the data URL prefix to get raw base64.
+      const base64 = dataUrl.replace(/^data:[^;]+;base64,/, "");
+
+      try {
+        const result = await currentGw.request<{
+          attached?: boolean;
+          name?: string;
+          width?: number;
+          height?: number;
+        }>("image.attach_bytes", {
+          content_base64: base64,
+          filename,
+          session_id: currentSid,
+        });
+
+        if (result?.attached !== false) {
+          const info: AttachedImage = {
+            name: result?.name ?? filename,
+            width: result?.width,
+            height: result?.height,
+          };
+          setAttachedImages((prev) => [...prev, info]);
+          console.log("[image-attach] attached:", info.name);
+        }
+      } catch (err) {
+        console.warn("[image-attach] failed:", err);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+
+    // ---- Clipboard paste ----
+    const onPaste = (e: ClipboardEvent) => {
+      const items = e.clipboardData?.items;
+      if (!items) return;
+
+      for (const item of items) {
+        if (!IMAGE_MIME_RE.test(item.type)) continue;
+
+        e.preventDefault();
+        e.stopPropagation();
+
+        const blob = item.getAsFile();
+        if (!blob) continue;
+
+        const reader = new FileReader();
+        reader.onload = () => {
+          if (typeof reader.result === "string") {
+            const ext = extFromMime(blob.type);
+            attachImage(reader.result, `clipboard${ext}`);
+          }
+        };
+        reader.readAsDataURL(blob);
+        return; // handle first image only
+      }
+    };
+
+    // ---- Drag and drop ----
+    const onDragOver = (e: DragEvent) => {
+      if (e.dataTransfer?.types.includes("Files")) {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "copy";
+      }
+    };
+
+    const onDrop = (e: DragEvent) => {
+      const files = e.dataTransfer?.files;
+      if (!files?.length) return;
+
+      // Check if any file is an image.
+      const images = Array.from(files).filter((f) =>
+        IMAGE_MIME_RE.test(f.type),
+      );
+      if (!images.length) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+
+      for (const file of images) {
+        const reader = new FileReader();
+        reader.onload = () => {
+          if (typeof reader.result === "string") {
+            const ext = extFromMime(file.type) || extFromName(file.name);
+            const name = file.name || `dropped${ext}`;
+            attachImage(reader.result, name);
+          }
+        };
+        reader.readAsDataURL(file);
+      }
+    };
+
+    host.addEventListener("paste", onPaste, { capture: true });
+    host.addEventListener("dragover", onDragOver);
+    host.addEventListener("drop", onDrop);
+
+    return () => {
+      host.removeEventListener("paste", onPaste, { capture: true });
+      host.removeEventListener("dragover", onDragOver);
+      host.removeEventListener("drop", onDrop);
+    };
+  }, [hostRef, attachImage]);
+
+  // Clear attached images when session changes (new PTY child).
+  useEffect(() => {
+    setAttachedImages([]);
+  }, [sessionId]);
+
+  return {
+    attachedImages,
+    clearAttached: () => setAttachedImages([]),
+  };
+}
+
+function extFromMime(mime: string): string {
+  const map: Record<string, string> = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+    "image/bmp": ".bmp",
+    "image/svg+xml": ".svg",
+  };
+  return map[mime] ?? ".png";
+}
+
+function extFromName(name: string): string {
+  const dot = name.lastIndexOf(".");
+  return dot >= 0 ? name.slice(dot) : ".png";
+}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -35,6 +35,8 @@ import { ChatSidebar } from "@/components/ChatSidebar";
 import { usePageHeader } from "@/contexts/usePageHeader";
 import { useI18n } from "@/i18n";
 import { api } from "@/lib/api";
+import { GatewayClient } from "@/lib/gatewayClient";
+import { useImageAttachment } from "@/hooks/useImageAttachment";
 import { PluginSlot } from "@/plugins";
 import { useTheme } from "@/themes";
 import { useProfileScope } from "@/contexts/useProfileScope";
@@ -124,6 +126,26 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   // the moment `isActive` flips back to true (display:none → display:flex
   // collapses the host's box, so ResizeObserver never fires on return).
   const syncMetricsRef = useRef<(() => void) | null>(null);
+
+  // GatewayClient for image attachment — shared with ChatSidebar so both
+  // operate on the same JSON-RPC sidecar connection.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const gwRef = useRef(new GatewayClient());
+  const [sidebarSessionId, setSidebarSessionId] = useState<string | null>(null);
+
+  // Image paste / drop support — intercepts clipboard paste and drag-and-drop
+  // on the terminal host, then calls image.attach_bytes via the sidebar's
+  // GatewayClient so the agent can see images inline (native vision).
+  const { attachedImages, clearAttached } = useImageAttachment({
+    hostRef,
+    gw: gwRef.current,
+    sessionId: sidebarSessionId,
+  });
+
+  const handleSessionInfo = useCallback(
+    (sessionId: string) => setSidebarSessionId(sessionId),
+    [],
+  );
   const [searchParams, setSearchParams] = useSearchParams();
   // Lazy-init: the missing-token check happens at construction so the effect
   // body doesn't have to setState (React 19's set-state-in-effect rule).
@@ -726,6 +748,13 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     };
   }, [channel, resumeParam, scopedProfile]);
 
+  // Clean up the GatewayClient on unmount.
+  useEffect(() => {
+    return () => {
+      gwRef.current.close();
+    };
+  }, []);
+
   // When the user returns to the chat tab (isActive: false → true), the
   // terminal host just transitioned from display:none to display:flex.
   // ResizeObserver won't fire on that kind of style-driven box change —
@@ -861,7 +890,11 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
               "border-t border-current/10",
             )}
           >
-            <ChatSidebar channel={channel} />
+            <ChatSidebar
+              channel={channel}
+              gw={gwRef.current}
+              onSessionInfo={handleSessionInfo}
+            />
           </div>
         </div>
       </>,
@@ -919,6 +952,32 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
               </span>
             </span>
           </Button>
+
+          {attachedImages.length > 0 && (
+            <div
+              className={cn(
+                "absolute z-10",
+                "normal-case tracking-normal font-normal",
+                "rounded border border-current/30",
+                "bg-black/20 backdrop-blur-sm",
+                "opacity-90 hover:opacity-100",
+                "transition-opacity duration-150",
+                "bottom-2 left-2 px-2 py-1 text-xs sm:bottom-3 sm:left-3 sm:px-2.5 sm:py-1.5",
+                "lg:bottom-4 lg:left-4",
+                "cursor-pointer select-none",
+              )}
+              style={{ color: "#88cc88" }}
+              title={attachedImages.map((i) => i.name).join(", ")}
+              onClick={clearAttached}
+            >
+              <span className="inline-flex items-center gap-1.5">
+                📎 {attachedImages.length} image
+                {attachedImages.length > 1 ? "s" : ""} attached — will be
+                sent with next message
+                <span className="opacity-60 ml-1">(click to clear)</span>
+              </span>
+            </div>
+          )}
         </div>
 
         {!narrow && (
@@ -929,7 +988,11 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             className="flex min-h-0 shrink-0 flex-col overflow-hidden lg:h-full lg:w-80"
           >
             <div className="min-h-0 flex-1 overflow-hidden">
-              <ChatSidebar channel={channel} />
+              <ChatSidebar
+                channel={channel}
+                gw={gwRef.current}
+                onSessionInfo={handleSessionInfo}
+              />
             </div>
           </div>
         )}


### PR DESCRIPTION
## What does this PR do

Adds image paste and drag-and-drop support to the WebUI chat terminal, fixing the issue where images sent from the WebUI were invisible to the agent.

## Related Issue

WebUI images silently ignored — agent only received text path references like `[Attached files: /path/to/image.png]` but never saw actual image pixels. Telegram worked correctly; WebUI did not.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Security fix
- [ ] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] New skill

## Changes Made

### New file: `web/src/hooks/useImageAttachment.ts`
- Intercepts `paste` events on the terminal host `<div>` for `image/*` clipboard data
- Intercepts `drop` events for drag-and-dropped image files
- Converts images to base64 and calls `image.attach_bytes` via the existing JSON-RPC sidecar (`GatewayClient`)
- Tracks attached images with state, provides `clearAttached` method
- Handles session changes (clears attachments on new PTY child)

### Modified: `web/src/components/ChatSidebar.tsx`
- Added optional `gw` prop to accept an externally-provided `GatewayClient`
- Added optional `onSessionInfo` callback prop to notify parent of PTY session id changes
- When `gw` is provided externally, does NOT close it on unmount (owner manages lifecycle)

### Modified: `web/src/pages/ChatPage.tsx`
- Creates a `GatewayClient` (via ref) shared between `ChatSidebar` and `useImageAttachment`
- Tracks PTY session id via `onSessionInfo` callback from `ChatSidebar`
- Wires `useImageAttachment` hook to the terminal host `<div>`
- Shows a non-intrusive overlay badge indicating attached image count (with click-to-clear)

## How to Test

1. Open WebUI chat (`hermes dashboard`)
2. Paste an image from clipboard (Ctrl/Cmd+V) into the terminal area
3. Observe the "📎 N image(s) attached" badge appear at bottom-left
4. Send any text message — the agent should now see the image natively (requires model with `supports_vision: true`)
5. Also test drag-and-drop of image files onto the terminal area
6. Verify Telegram image paste still works (regression check)
7. Verify the badge click-to-clear functionality

## Root Cause Analysis

The WebUI's `ChatPage` uses an xterm.js PTY terminal — all input goes as raw bytes through a WebSocket to `hermes --tui`. The paste handler only called `navigator.clipboard.readText()`, which discards image data. The sidebar's `GatewayClient` (JSON-RPC sidecar) already maintained a session with the gateway and had full access to `image.attach_bytes` — it just was never used for image attachment.

The backend's `image.attach_bytes` → `session["attached_images"]` → `_run_prompt_submit` → `image_routing.py` → native content parts pipeline was fully functional. This fix is purely frontend — wiring the existing pieces together.

## Checklist

- [x] I have read `CONTRIBUTING.md`
- [x] Commit messages follow Conventional Commits format
- [x] TypeScript type check passes (`tsc -p . --noEmit`)
- [x] Production build succeeds (`npm run build`)
- [x] No backend changes required