### PR TITLE
fix: validate name at entry in skill_manage to prevent empty-name loops

### DIFF
--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -921,6 +921,9 @@ def skill_manage(
     if gate_result is not None:
         return gate_result
 
+    if not name:
+        return tool_error("name is required. Provide a skill name.", success=False)
+
     if action == "create":
         if not content:
             return tool_error("content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).", success=False)


### PR DESCRIPTION
## Summary

Add upfront `name` validation in `skill_manage()` before action dispatch. Prevents infinite retry loops when background review fork passes `name=""`.

## Root Cause

When a session ends and background review attempts to save learnings as a skill, it can pass `name=""` for complex/troubleshooting sessions where no class-level skill name is identified.

`skill_manage` had no guard for empty `name` at entry — only `_validate_name()` existed, called inside `_create_skill` but not at the top level. This caused:

1. `_find_skill("")` → returns `None`
2. "Skill '' not found" error
3. Fork retries same call → **infinite loop at ~18-19s intervals**
4. Tool guardrail fires after 6 attempts

## Fix

Single-line guard added after gate check, consistent with existing error-handling style:

```python
if not name:
    return tool_error("name is required. Provide a skill name.", success=False)
```

**File:** `tools/skill_manager_tool.py` — `skill_manage()` function, ~line 922

## Evidence

Error log from session `20260614_200302_90d096`:
```
2026-06-14 20:09:38,437 WARNING [...] Tool skill_manage returned error: {"success": false, "error": "Skill '' not found in active profile 'default'."}
2026-06-14 20:09:57,334 WARNING [...] Tool skill_manage returned error: {"success": false, "error": "Skill '' not found in active profile 'default'."}
... [14 identical errors over 4 minutes until guardrail fires]
```

See full issue: https://github.com/NousResearch/hermes-agent/issues/46217