### PR TITLE
fix(skills): filter platform-disabled skills from prompt (#46201)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1164,7 +1164,7 @@ def build_skills_system_prompt(
         or get_session_env("HERMES_SESSION_PLATFORM")
         or ""
     )
-    disabled = get_disabled_skill_names()
+    disabled = get_disabled_skill_names(_platform_hint or None)
     cache_key = (
         str(skills_dir.resolve()),
         tuple(str(d) for d in external_dirs),

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -305,13 +305,14 @@ def get_disabled_skill_names(platform: str | None = None) -> Set[str]:
         or os.getenv("HERMES_PLATFORM")
         or get_session_env("HERMES_SESSION_PLATFORM")
     )
+    global_disabled = _normalize_string_set(skills_cfg.get("disabled"))
     if resolved_platform:
         platform_disabled = (skills_cfg.get("platform_disabled") or {}).get(
             resolved_platform
         )
         if platform_disabled is not None:
-            return _normalize_string_set(platform_disabled)
-    return _normalize_string_set(skills_cfg.get("disabled"))
+            return global_disabled | _normalize_string_set(platform_disabled)
+    return global_disabled
 
 
 def _normalize_string_set(values) -> Set[str]:

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -419,6 +419,65 @@ class TestBuildSkillsSystemPrompt:
         second = build_skills_system_prompt()
         assert "cached-skill" not in second
 
+    def test_excludes_platform_disabled_skills(self, monkeypatch, tmp_path):
+        """Skills disabled for the active platform must not appear (#46201)."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_PLATFORM", "telegram")
+        skills_dir = tmp_path / "skills" / "tools"
+        skills_dir.mkdir(parents=True)
+
+        for name, desc in [("web-search", "Search the web"), ("xurl", "URL tool")]:
+            d = skills_dir / name
+            d.mkdir()
+            (d / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: {desc}\n---\n"
+            )
+
+        (tmp_path / "config.yaml").write_text(
+            "skills:\n  platform_disabled:\n    telegram: [xurl]\n"
+        )
+
+        result = build_skills_system_prompt()
+        assert "web-search" in result
+        assert "xurl" not in result
+
+    def test_global_disabled_merged_with_platform_disabled(self, monkeypatch, tmp_path):
+        """Globally disabled skills must stay hidden when platform_disabled exists (#46201).
+
+        Before the fix, platform_disabled REPLACED the global disabled set,
+        so globally disabled skills leaked back into the prompt for any
+        platform with a platform_disabled entry.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_PLATFORM", "telegram")
+        skills_dir = tmp_path / "skills" / "tools"
+        skills_dir.mkdir(parents=True)
+
+        for name, desc in [
+            ("global-bad", "Should be hidden everywhere"),
+            ("tg-bad", "Should be hidden on telegram"),
+            ("good-skill", "Always visible"),
+        ]:
+            d = skills_dir / name
+            d.mkdir()
+            (d / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: {desc}\n---\n"
+            )
+
+        (tmp_path / "config.yaml").write_text(
+            "skills:\n"
+            "  disabled: [global-bad]\n"
+            "  platform_disabled:\n"
+            "    telegram: [tg-bad]\n"
+        )
+
+        result = build_skills_system_prompt()
+        assert "global-bad" not in result, (
+            "Globally disabled skill leaked through platform_disabled entry"
+        )
+        assert "tg-bad" not in result
+        assert "good-skill" in result
+
     def test_includes_setup_needed_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         monkeypatch.delenv("MISSING_API_KEY_XYZ", raising=False)

--- a/tests/hermes_cli/test_skills_config.py
+++ b/tests/hermes_cli/test_skills_config.py
@@ -148,7 +148,7 @@ class TestGetDisabledSkillNames:
     """Tests for agent.skill_utils.get_disabled_skill_names."""
 
     def test_explicit_platform_param(self, tmp_path, monkeypatch):
-        """Explicit platform= parameter should resolve per-platform list."""
+        """Explicit platform= should merge per-platform list with global disabled."""
         config = tmp_path / "config.yaml"
         config.write_text(
             "skills:\n"
@@ -164,7 +164,7 @@ class TestGetDisabledSkillNames:
 
         from agent.skill_utils import get_disabled_skill_names
         result = get_disabled_skill_names(platform="telegram")
-        assert result == {"tg-only-skill"}
+        assert result == {"global-skill", "tg-only-skill"}
 
     def test_session_platform_env_var(self, tmp_path, monkeypatch):
         """HERMES_SESSION_PLATFORM should be used when HERMES_PLATFORM is unset."""
@@ -183,7 +183,7 @@ class TestGetDisabledSkillNames:
 
         from agent.skill_utils import get_disabled_skill_names
         result = get_disabled_skill_names()
-        assert result == {"discord-skill"}
+        assert result == {"global-skill", "discord-skill"}
 
     def test_hermes_platform_takes_precedence(self, tmp_path, monkeypatch):
         """HERMES_PLATFORM should win over HERMES_SESSION_PLATFORM."""


### PR DESCRIPTION
## Summary

Fixes #46201.

Disabled skills were still leaking into `<available_skills>` for active platforms because prompt construction did not pass the resolved platform into `get_disabled_skill_names()`. A second related bug meant platform-specific disables replaced the global `skills.disabled` set instead of merging with it.

This PR:
- threads the resolved platform hint into `build_skills_system_prompt()` disabled-skill filtering
- merges global and platform-specific disabled skill sets in `get_disabled_skill_names()`
- adds prompt-builder regression coverage for platform-disabled skills and global+platform merge behavior
- updates skill-config tests to assert the intended merged semantics

## Verification

Ran focused regression suite with the shared Hermes Python 3.11 venv:

```bash
/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest \
  tests/hermes_cli/test_skills_config.py \
  tests/agent/test_prompt_builder.py \
  -v -o "addopts=" --tb=short
```

Result: `164 passed, 1 skipped in 0.29s`.

## Competitor analysis

An existing PR, #46203, addresses the same issue and has green CI, but it includes unrelated desktop/shared TypeScript config changes, line-ending churn in `tests/hermes_cli/test_skills_config.py`, and weakens an existing prompt-builder test by removing an assertion. This PR keeps the fix focused to the Python prompt/skills paths and targeted tests only.

Auto-published by Moonsong via Path B automated pipeline.
