### PR TITLE
fix: honor unbounded goal turn budgets

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -29,6 +29,7 @@ from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
 from agent.error_classifier import FailoverReason
 from agent.model_metadata import is_local_endpoint
+from agent.iteration_budget import is_unbounded_iteration_limit
 from agent.message_sanitization import (
     _sanitize_surrogates,
     _repair_tool_call_arguments,
@@ -1304,6 +1305,15 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
 
 def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     """Request a summary when max iterations are reached. Returns the final response text."""
+    if is_unbounded_iteration_limit(getattr(agent, "max_iterations", 90)):
+        logger.warning(
+            "handle_max_iterations called while iteration budget is unbounded "
+            "(api_call_count=%s, max_iterations=%s); suppressing forced summary",
+            api_call_count,
+            getattr(agent, "max_iterations", None),
+        )
+        return ""
+
     print(f"⚠️  Reached maximum iterations ({agent.max_iterations}). Requesting summary...")
 
     summary_request = (

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -30,7 +30,7 @@ from typing import Any, Dict, List, Optional
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
-from agent.iteration_budget import IterationBudget
+from agent.iteration_budget import IterationBudget, is_unbounded_iteration_limit
 from agent.turn_context import build_turn_context
 from agent.turn_retry_state import TurnRetryState
 from agent.memory_manager import build_memory_context_block
@@ -508,6 +508,10 @@ def run_conversation(
     truncated_response_parts: List[str] = []
     compression_attempts = 0
     _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
+    _iterations_unbounded = is_unbounded_iteration_limit(agent.max_iterations) or bool(
+        getattr(agent.iteration_budget, "is_unbounded", False)
+    )
+    _iteration_limit_label = "∞" if _iterations_unbounded else str(agent.max_iterations)
 
     # Optional opt-in runtime: if api_mode == codex_app_server, hand the
     # turn to the codex app-server subprocess (terminal/file ops/patching
@@ -523,7 +527,11 @@ def run_conversation(
             should_review_memory=_should_review_memory,
         )
 
-    while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
+    while (
+        _iterations_unbounded
+        or (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0)
+        or agent._budget_grace_call
+    ):
         # Reset per-turn checkpoint dedup so each iteration can take one snapshot
         agent._checkpoint_mgr.new_turn()
 
@@ -547,7 +555,10 @@ def run_conversation(
         elif not agent.iteration_budget.consume():
             _turn_exit_reason = "budget_exhausted"
             if not agent.quiet_mode:
-                agent._safe_print(f"\n⚠️  Iteration budget exhausted ({agent.iteration_budget.used}/{agent.iteration_budget.max_total} iterations used)")
+                agent._safe_print(
+                    f"\n⚠️  Iteration budget exhausted "
+                    f"({agent.iteration_budget.used}/{agent.iteration_budget.max_total} iterations used)"
+                )
             break
 
         # Fire step_callback for gateway hooks (agent:step event)
@@ -844,7 +855,7 @@ def run_conversation(
         thinking_spinner = None
         
         if not agent.quiet_mode:
-            agent._vprint(f"\n{agent.log_prefix}🔄 Making API call #{api_call_count}/{agent.max_iterations}...")
+            agent._vprint(f"\n{agent.log_prefix}🔄 Making API call #{api_call_count}/{_iteration_limit_label}...")
             agent._vprint(f"{agent.log_prefix}   📊 Request size: {len(api_messages)} messages, ~{approx_tokens:,} tokens (~{total_chars:,} chars)")
             agent._vprint(f"{agent.log_prefix}   🔧 Available tools: {len(agent.tools) if agent.tools else 0}")
         else:
@@ -4388,7 +4399,7 @@ def run_conversation(
             # role-alternation invariants.
 
             # If we're near the limit, break to avoid infinite loops
-            if api_call_count >= agent.max_iterations - 1:
+            if not _iterations_unbounded and api_call_count >= agent.max_iterations - 1:
                 _turn_exit_reason = f"error_near_max_iterations({error_msg[:80]})"
                 final_response = f"I apologize, but I encountered repeated errors: {error_msg}"
                 # Append as assistant so the history stays valid for

--- a/agent/iteration_budget.py
+++ b/agent/iteration_budget.py
@@ -25,6 +25,10 @@ class IterationBudget:
     Users control the per-subagent limit via ``delegation.max_iterations``
     in config.yaml.
 
+    A non-positive max_total means "unbounded".  This is an explicit operator
+    escape hatch for long-running/durable sessions: usage is still counted for
+    observability, but ``consume()`` never denies an iteration.
+
     ``execute_code`` (programmatic tool calling) iterations are refunded via
     :meth:`refund` so they don't eat into the budget.
     """
@@ -34,10 +38,18 @@ class IterationBudget:
         self._used = 0
         self._lock = threading.Lock()
 
+    @property
+    def is_unbounded(self) -> bool:
+        """True when this budget has no hard iteration ceiling."""
+        try:
+            return int(self.max_total) <= 0
+        except (TypeError, ValueError):
+            return False
+
     def consume(self) -> bool:
         """Try to consume one iteration.  Returns True if allowed."""
         with self._lock:
-            if self._used >= self.max_total:
+            if not self.is_unbounded and self._used >= self.max_total:
                 return False
             self._used += 1
             return True
@@ -54,9 +66,19 @@ class IterationBudget:
             return self._used
 
     @property
-    def remaining(self) -> int:
+    def remaining(self):
         with self._lock:
+            if self.is_unbounded:
+                return float("inf")
             return max(0, self.max_total - self._used)
 
 
-__all__ = ["IterationBudget"]
+def is_unbounded_iteration_limit(max_iterations: int) -> bool:
+    """Return True when a configured max-iteration value disables the cap."""
+    try:
+        return int(max_iterations) <= 0
+    except (TypeError, ValueError):
+        return False
+
+
+__all__ = ["IterationBudget", "is_unbounded_iteration_limit"]

--- a/agent/iteration_budget.py
+++ b/agent/iteration_budget.py
@@ -41,6 +41,8 @@ class IterationBudget:
     @property
     def is_unbounded(self) -> bool:
         """True when this budget has no hard iteration ceiling."""
+        if isinstance(self.max_total, bool):
+            return False
         try:
             return int(self.max_total) <= 0
         except (TypeError, ValueError):
@@ -75,6 +77,8 @@ class IterationBudget:
 
 def is_unbounded_iteration_limit(max_iterations: int) -> bool:
     """Return True when a configured max-iteration value disables the cap."""
+    if isinstance(max_iterations, bool):
+        return False
     try:
         return int(max_iterations) <= 0
     except (TypeError, ValueError):

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import os
 
 from agent.codex_responses_adapter import _summarize_user_message_for_log
+from agent.iteration_budget import is_unbounded_iteration_limit
 
 
 def finalize_turn(
@@ -50,21 +51,31 @@ def finalize_turn(
     """
     from agent.conversation_loop import logger
 
-    if final_response is None and (
-        api_call_count >= agent.max_iterations
-        or agent.iteration_budget.remaining <= 0
-    ):
+    _budget_unbounded = is_unbounded_iteration_limit(agent.max_iterations) or bool(
+        getattr(agent.iteration_budget, "is_unbounded", False)
+    )
+    _iteration_limit_label = "∞" if _budget_unbounded else str(agent.max_iterations)
+    _budget_exhausted = (
+        not _budget_unbounded
+        and final_response is None
+        and (
+            api_call_count >= agent.max_iterations
+            or agent.iteration_budget.remaining <= 0
+        )
+    )
+
+    if _budget_exhausted:
         # Budget exhausted — ask the model for a summary via one extra
         # API call with tools stripped.  _handle_max_iterations injects a
         # user message and makes a single toolless request.
-        _turn_exit_reason = f"max_iterations_reached({api_call_count}/{agent.max_iterations})"
+        _turn_exit_reason = f"max_iterations_reached({api_call_count}/{_iteration_limit_label})"
         agent._emit_status(
-            f"⚠️ Iteration budget exhausted ({api_call_count}/{agent.max_iterations}) "
+            f"⚠️ Iteration budget exhausted ({api_call_count}/{_iteration_limit_label}) "
             "— asking model to summarise"
         )
         if not agent.quiet_mode:
             agent._safe_print(
-                f"\n⚠️  Iteration budget exhausted ({api_call_count}/{agent.max_iterations}) "
+                f"\n⚠️  Iteration budget exhausted ({api_call_count}/{_iteration_limit_label}) "
                 "— requesting summary..."
             )
         final_response = agent._handle_max_iterations(messages, api_call_count)
@@ -93,7 +104,7 @@ def finalize_turn(
                         _kanban_task,
                         error=(
                             f"Iteration budget exhausted "
-                            f"({api_call_count}/{agent.max_iterations}) — "
+                            f"({api_call_count}/{_iteration_limit_label}) — "
                             "task could not complete within the allowed "
                             "iterations"
                         ),
@@ -124,7 +135,7 @@ def finalize_turn(
     # Determine if conversation completed successfully
     completed = (
         final_response is not None
-        and api_call_count < agent.max_iterations
+        and (_budget_unbounded or api_call_count < agent.max_iterations)
         and not failed
     )
 
@@ -166,12 +177,12 @@ def finalize_turn(
     _budget_max = agent.iteration_budget.max_total if agent.iteration_budget else 0
 
     _diag_msg = (
-        "Turn ended: reason=%s model=%s api_calls=%d/%d budget=%d/%d "
+        "Turn ended: reason=%s model=%s api_calls=%d/%s budget=%d/%s "
         "tool_turns=%d last_msg_role=%s response_len=%d session=%s"
     )
     _diag_args = (
-        _turn_exit_reason, agent.model, api_call_count, agent.max_iterations,
-        _budget_used, _budget_max,
+        _turn_exit_reason, agent.model, api_call_count, _iteration_limit_label,
+        _budget_used, ("∞" if _budget_unbounded else _budget_max),
         _turn_tool_count, _last_msg_role, _resp_len,
         agent.session_id or "none",
     )

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getSessionMessages, listAllProfileSessions, listSessions } from './hermes'
+import { getSessionMessages, listAllProfileSessions, listSessions, transcribeAudio } from './hermes'
 
 const emptySessionsResponse = {
   limit: 0,
@@ -56,5 +56,23 @@ describe('Hermes REST session helpers', () => {
       path: '/api/sessions/session-1/messages?profile=xiaoxuxu',
       profile: 'xiaoxuxu'
     })
+  })
+
+  it('uses a longer timeout for desktop voice transcription', async () => {
+    api.mockResolvedValue({ ok: true, provider: 'test', transcript: 'hej' })
+
+    await transcribeAudio('data:audio/webm;base64,aGVsbG8=', 'audio/webm')
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: {
+          data_url: 'data:audio/webm;base64,aGVsbG8=',
+          mime_type: 'audio/webm'
+        },
+        method: 'POST',
+        path: '/api/audio/transcribe',
+        timeoutMs: 30 * 60_000
+      })
+    )
   })
 })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -44,6 +44,11 @@ import type {
 
 const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 30_000
 const SESSION_LIST_REQUEST_TIMEOUT_MS = 60_000
+// Local/remote STT can legitimately take far longer than the generic Electron
+// REST proxy default (15s), especially when the local CPU Whisper model is
+// warming up. Keep the generic default short, but give dictation enough room to
+// finish instead of surfacing a broken "Timed out ... 15000ms" notification.
+const AUDIO_TRANSCRIPTION_REQUEST_TIMEOUT_MS = 30 * 60_000
 
 export type {
   ActionResponse,
@@ -730,6 +735,7 @@ export function transcribeAudio(dataUrl: string, mimeType?: string): Promise<Aud
   return window.hermesDesktop.api<AudioTranscriptionResponse>({
     path: '/api/audio/transcribe',
     method: 'POST',
+    timeoutMs: AUDIO_TRANSCRIPTION_REQUEST_TIMEOUT_MS,
     body: {
       data_url: dataUrl,
       mime_type: mimeType

--- a/cli.py
+++ b/cli.py
@@ -7827,9 +7827,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             return existing
 
         try:
+            from hermes_cli.goals import resolve_goal_max_turns
+
             cfg = load_config() or {}
             goals_cfg = cfg.get("goals") or {}
-            max_turns = int(goals_cfg.get("max_turns", 20) or 20)
+            max_turns = resolve_goal_max_turns(goals_cfg)
         except Exception:
             max_turns = 20
 
@@ -13423,7 +13425,7 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
     if not goal_text:
         return
 
-    max_turns = task.goal_max_turns or _DEF_TURNS
+    max_turns = task.goal_max_turns if task.goal_max_turns is not None else _DEF_TURNS
 
     def _run_turn(prompt: str) -> str:
         result = cli.agent.run_conversation(

--- a/cli.py
+++ b/cli.py
@@ -3370,9 +3370,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         # Max turns priority: CLI arg > config file > env var > default
         if max_turns is not None:  # CLI arg was explicitly set
             self.max_turns = max_turns
-        elif CLI_CONFIG["agent"].get("max_turns"):
+        elif CLI_CONFIG["agent"].get("max_turns") is not None:
             self.max_turns = CLI_CONFIG["agent"]["max_turns"]
-        elif CLI_CONFIG.get("max_turns"):  # Backwards compat: root-level max_turns
+        elif CLI_CONFIG.get("max_turns") is not None:  # Backwards compat: root-level max_turns
             self.max_turns = CLI_CONFIG["max_turns"]
         elif os.getenv("HERMES_MAX_ITERATIONS"):
             try:

--- a/cli.py
+++ b/cli.py
@@ -10538,8 +10538,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # Notify when iteration budget was hit
             if result and not result.get("completed") and not result.get("interrupted"):
                 _api_calls = result.get("api_calls", 0)
-                if _api_calls >= getattr(self.agent, "max_iterations", 90):
-                    _max_iter = getattr(self.agent, "max_iterations", 90)
+                _max_iter = getattr(self.agent, "max_iterations", 90)
+                if _max_iter and _max_iter > 0 and _api_calls >= _max_iter:
                     _cprint(
                         f"\n{_DIM}⚠ Iteration budget reached "
                         f"({_api_calls}/{_max_iter}) — "

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -81,6 +81,16 @@ def _resolve_cron_disabled_toolsets(cfg: dict) -> list[str]:
     return disabled
 
 
+def _resolve_agent_max_iterations(cfg: dict, default: int = 90) -> int:
+    """Resolve agent max iterations while preserving explicit unbounded 0."""
+    agent_cfg = (cfg or {}).get("agent") or {}
+    if isinstance(agent_cfg, dict) and agent_cfg.get("max_turns") is not None:
+        return agent_cfg["max_turns"]
+    if (cfg or {}).get("max_turns") is not None:
+        return (cfg or {})["max_turns"]
+    return default
+
+
 def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
     """Resolve the toolset list for a cron job.
 
@@ -1636,7 +1646,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                     prefill_messages = None
 
         # Max iterations
-        max_iterations = _cfg.get("agent", {}).get("max_turns") or _cfg.get("max_turns") or 90
+        max_iterations = _resolve_agent_max_iterations(_cfg)
 
         # Provider routing
         pr = _cfg.get("provider_routing", {})

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9689,7 +9689,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 from hermes_cli.config import load_config
 
                 goals_cfg = (load_config() or {}).get("goals") or {}
-            return int(goals_cfg.get("max_turns", 20) or 20)
+            from hermes_cli.goals import resolve_goal_max_turns
+
+            return resolve_goal_max_turns(goals_cfg)
         except Exception:
             return 20
 

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -35,6 +35,11 @@ from gateway.config import HomeChannel, Platform, PlatformConfig
 from gateway.platforms.base import EphemeralReply, MessageEvent, MessageType
 from gateway.session import SessionSource, build_session_key
 from hermes_cli.config import cfg_get
+from hermes_cli.goals import (
+    format_goal_budget,
+    goal_completion_hint,
+    is_unbounded_goal_turns,
+)
 from utils import (
     atomic_json_write,
     atomic_yaml_write,
@@ -1626,6 +1631,12 @@ class GatewaySlashCommandsMixin:
             except Exception as exc:
                 logger.debug("goal kickoff enqueue failed: %s", exc)
 
+        if is_unbounded_goal_turns(state.max_turns):
+            return (
+                f"⊙ Goal set ({format_goal_budget(state.max_turns)}): {state.goal}\n"
+                f"{goal_completion_hint(state.max_turns)}\n"
+                "Controls: /goal status · /goal pause · /goal resume · /goal clear"
+            )
         return t("gateway.goal.set", budget=state.max_turns, goal=state.goal)
 
     async def _handle_subgoal_command(self, event: "MessageEvent") -> str:

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1844,11 +1844,15 @@ class CLICommandsMixin:
             _cprint(f"  Invalid goal: {exc}")
             return
 
-        _cprint(f"  ⊙ Goal set ({state.max_turns}-turn budget): {state.goal}")
+        from hermes_cli.goals import format_goal_budget, goal_completion_hint
+
+        goal_hint = goal_completion_hint(state.max_turns).replace(
+            "I'll keep working", "Hermes keeps working", 1
+        )
+        _cprint(f"  ⊙ Goal set ({format_goal_budget(state.max_turns)}): {state.goal}")
         _cprint(
             f"  {_DIM}After each turn, a judge model will check if the goal is done. "
-            f"Hermes keeps working until it is, you pause/clear it, or the budget is "
-            f"exhausted. Use /goal status, /goal pause, /goal resume, /goal clear.{_RST}"
+            f"{goal_hint} Use /goal status, /goal pause, /goal resume, /goal clear.{_RST}"
         )
         # Kick the loop off immediately so the user doesn't have to send a
         # separate message after setting the goal.

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -37,6 +37,7 @@ import shutil
 import subprocess
 import sys
 import time
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 # Short timeouts: schtasks occasionally wedges and we don't want to hang forever.
@@ -44,13 +45,19 @@ _SCHTASKS_TIMEOUT_S = 15
 _SCHTASKS_NO_OUTPUT_TIMEOUT_S = 30
 # Patterns in schtasks stderr that mean "fall back to the Startup folder".
 _FALLBACK_PATTERNS = re.compile(
-    r"(access is denied|acceso denegado|přístup byl odepřen|schtasks timed out|schtasks produced no output)",
+    r"(access is denied|acceso denegado|odmowa dost\S*pu|přístup byl odepřen|schtasks timed out|schtasks produced no output)",
     re.IGNORECASE,
 )
-_ACCESS_DENIED_PATTERN = re.compile(r"(access is denied|acceso denegado)", re.IGNORECASE)
+_ACCESS_DENIED_PATTERN = re.compile(
+    r"(access is denied|acceso denegado|odmowa dost\S*pu)",
+    re.IGNORECASE,
+)
 
 _TASK_NAME_DEFAULT = "Hermes_Gateway"
 _TASK_DESCRIPTION = "Hermes Agent Gateway - Messaging Platform Integration"
+_TASK_XML_NS = "http://schemas.microsoft.com/windows/2004/02/mit/task"
+
+ET.register_namespace("", _TASK_XML_NS)
 
 
 def _schtasks_encoding() -> str:
@@ -443,6 +450,76 @@ def _resolve_task_user() -> str | None:
     return f"{domain}\\{username}" if domain else username
 
 
+def _task_xml_tag(name: str) -> str:
+    return f"{{{_TASK_XML_NS}}}{name}"
+
+
+def _xml_text(parent: ET.Element, name: str, value: str) -> ET.Element:
+    child = ET.SubElement(parent, _task_xml_tag(name))
+    child.text = value
+    return child
+
+
+def _build_scheduled_task_xml(script_path: Path, user: str | None = None) -> str:
+    """Build Task Scheduler XML for the gateway daemon.
+
+    ``schtasks /Create /SC ONLOGON`` applies Windows' default 72-hour execution
+    limit.  Hermes gateway is a long-running daemon, so import XML and set
+    ``ExecutionTimeLimit`` to ``PT0S`` (unlimited) explicitly.
+    """
+    task = ET.Element(_task_xml_tag("Task"), {"version": "1.2"})
+
+    registration = ET.SubElement(task, _task_xml_tag("RegistrationInfo"))
+    _xml_text(registration, "Description", _TASK_DESCRIPTION)
+
+    triggers = ET.SubElement(task, _task_xml_tag("Triggers"))
+    logon_trigger = ET.SubElement(triggers, _task_xml_tag("LogonTrigger"))
+    _xml_text(logon_trigger, "Enabled", "true")
+    if user:
+        _xml_text(logon_trigger, "UserId", user)
+
+    principals = ET.SubElement(task, _task_xml_tag("Principals"))
+    principal = ET.SubElement(principals, _task_xml_tag("Principal"), {"id": "Author"})
+    if user:
+        _xml_text(principal, "UserId", user)
+    _xml_text(principal, "LogonType", "InteractiveToken")
+    _xml_text(principal, "RunLevel", "LeastPrivilege")
+
+    settings = ET.SubElement(task, _task_xml_tag("Settings"))
+    _xml_text(settings, "MultipleInstancesPolicy", "IgnoreNew")
+    _xml_text(settings, "DisallowStartIfOnBatteries", "true")
+    _xml_text(settings, "StopIfGoingOnBatteries", "true")
+    _xml_text(settings, "AllowHardTerminate", "true")
+    _xml_text(settings, "StartWhenAvailable", "false")
+    _xml_text(settings, "RunOnlyIfNetworkAvailable", "false")
+    idle = ET.SubElement(settings, _task_xml_tag("IdleSettings"))
+    _xml_text(idle, "StopOnIdleEnd", "true")
+    _xml_text(idle, "RestartOnIdle", "false")
+    _xml_text(settings, "AllowStartOnDemand", "true")
+    _xml_text(settings, "Enabled", "true")
+    _xml_text(settings, "Hidden", "false")
+    _xml_text(settings, "RunOnlyIfIdle", "false")
+    _xml_text(settings, "WakeToRun", "false")
+    _xml_text(settings, "ExecutionTimeLimit", "PT0S")
+    _xml_text(settings, "Priority", "7")
+
+    actions = ET.SubElement(task, _task_xml_tag("Actions"), {"Context": "Author"})
+    exec_action = ET.SubElement(actions, _task_xml_tag("Exec"))
+    _xml_text(exec_action, "Command", str(script_path))
+
+    return ET.tostring(task, encoding="unicode")
+
+
+def _write_scheduled_task_xml(task_name: str, script_path: Path, user: str | None) -> Path:
+    xml_path = script_path.with_name(f"{_sanitize_filename(task_name)}.xml")
+    xml_path.write_text(
+        _build_scheduled_task_xml(script_path, user),
+        encoding="utf-16",
+        newline="",
+    )
+    return xml_path
+
+
 def _install_scheduled_task(task_name: str, script_path: Path) -> tuple[bool, str]:
     """Create or replace the Scheduled Task. Returns (success, detail).
 
@@ -451,8 +528,6 @@ def _install_scheduled_task(task_name: str, script_path: Path) -> tuple[bool, st
     preserves those stale triggers and can make the gateway relaunch every
     minute. Delete+create gives us a clean ONLOGON task every install.
     """
-    quoted_script = _quote_schtasks_arg(str(script_path))
-
     delete_code, delete_out, delete_err = _exec_schtasks(["/Delete", "/F", "/TN", task_name])
     delete_detail = (delete_err or delete_out or "").strip()
     if delete_code != 0 and delete_detail and "cannot find" not in delete_detail.lower():
@@ -460,20 +535,9 @@ def _install_scheduled_task(task_name: str, script_path: Path) -> tuple[bool, st
             return (False, f"schtasks /Delete failed (code {delete_code}): {delete_detail}")
         # Non-fatal: /Create /F below may still replace it. Keep the detail in
         # the final error if creation also fails.
-    # password" variant; if that fails, retry without /RU /NP /IT.
-    base = [
-        "/Create",
-        "/F",
-        "/SC",
-        "ONLOGON",
-        "/RL",
-        "LIMITED",
-        "/TN",
-        task_name,
-        "/TR",
-        quoted_script,
-    ]
     user = _resolve_task_user()
+    xml_path = _write_scheduled_task_xml(task_name, script_path, user)
+    base = ["/Create", "/F", "/TN", task_name, "/XML", str(xml_path)]
     variants = []
     if user:
         variants.append([*base, "/RU", user, "/NP", "/IT"])
@@ -481,11 +545,17 @@ def _install_scheduled_task(task_name: str, script_path: Path) -> tuple[bool, st
 
     last_code = 1
     last_err = ""
-    for argv in variants:
-        code, out, err = _exec_schtasks(argv)
-        if code == 0:
-            return (True, f"Created Scheduled Task {task_name!r}")
-        last_code, last_err = code, (err or out or "")
+    try:
+        for argv in variants:
+            code, out, err = _exec_schtasks(argv)
+            if code == 0:
+                return (True, f"Created Scheduled Task {task_name!r}")
+            last_code, last_err = code, (err or out or "")
+    finally:
+        try:
+            xml_path.unlink(missing_ok=True)
+        except Exception:
+            pass
     if delete_detail and "cannot find" not in delete_detail.lower():
         last_err = f"{last_err.strip()} (delete detail: {delete_detail})"
     return (False, f"schtasks /Create failed (code {last_code}): {last_err.strip()}")

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -68,6 +68,52 @@ _JUDGE_RESPONSE_SNIPPET_CHARS = 4000
 DEFAULT_MAX_CONSECUTIVE_PARSE_FAILURES = 3
 
 
+def coerce_max_turns(value: Any, default: int = DEFAULT_MAX_TURNS) -> int:
+    """Parse a configured turn budget while preserving explicit 0 as unbounded."""
+    if value is None or isinstance(value, bool):
+        return int(default)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return int(default)
+
+
+def resolve_goal_max_turns(goals_cfg: Any, default: int = DEFAULT_MAX_TURNS) -> int:
+    """Resolve goals.max_turns from a config block without losing explicit 0."""
+    if isinstance(goals_cfg, dict) and "max_turns" in goals_cfg:
+        return coerce_max_turns(goals_cfg.get("max_turns"), default)
+    return int(default)
+
+
+def is_unbounded_goal_turns(max_turns: int) -> bool:
+    if isinstance(max_turns, bool):
+        return False
+    try:
+        return int(max_turns) <= 0
+    except (TypeError, ValueError):
+        return False
+
+
+def format_goal_budget(max_turns: int) -> str:
+    if isinstance(max_turns, bool):
+        max_turns = DEFAULT_MAX_TURNS
+    if is_unbounded_goal_turns(max_turns):
+        return "unbounded"
+    return f"{int(max_turns)}-turn budget"
+
+
+def goal_completion_hint(max_turns: int) -> str:
+    if is_unbounded_goal_turns(max_turns):
+        return "I'll keep working until the goal is done or you pause/clear it."
+    return "I'll keep working until the goal is done, you pause/clear it, or the budget is exhausted."
+
+
+def _format_goal_turns(turns_used: int, max_turns: int) -> str:
+    if is_unbounded_goal_turns(max_turns):
+        return f"unbounded ({int(turns_used)} turns used)"
+    return f"{int(turns_used)}/{int(max_turns)} turns"
+
+
 CONTINUATION_PROMPT_TEMPLATE = (
     "[Continuing toward your standing goal]\n"
     "Goal: {goal}\n\n"
@@ -174,7 +220,7 @@ class GoalState:
             goal=data.get("goal", ""),
             status=data.get("status", "active"),
             turns_used=int(data.get("turns_used", 0) or 0),
-            max_turns=int(data.get("max_turns", DEFAULT_MAX_TURNS) or DEFAULT_MAX_TURNS),
+            max_turns=coerce_max_turns(data.get("max_turns", DEFAULT_MAX_TURNS)),
             created_at=float(data.get("created_at", 0.0) or 0.0),
             last_turn_at=float(data.get("last_turn_at", 0.0) or 0.0),
             last_verdict=data.get("last_verdict"),
@@ -487,7 +533,7 @@ class GoalManager:
 
     def __init__(self, session_id: str, *, default_max_turns: int = DEFAULT_MAX_TURNS):
         self.session_id = session_id
-        self.default_max_turns = int(default_max_turns or DEFAULT_MAX_TURNS)
+        self.default_max_turns = coerce_max_turns(default_max_turns)
         self._state: Optional[GoalState] = load_goal(session_id)
 
     # --- introspection ------------------------------------------------
@@ -506,7 +552,7 @@ class GoalManager:
         s = self._state
         if s is None or s.status in {"cleared",}:
             return "No active goal. Set one with /goal <text>."
-        turns = f"{s.turns_used}/{s.max_turns} turns"
+        turns = _format_goal_turns(s.turns_used, s.max_turns)
         sub = f", {len(s.subgoals)} subgoal{'s' if len(s.subgoals) != 1 else ''}" if s.subgoals else ""
         if s.status == "active":
             return f"⊙ Goal (active, {turns}{sub}): {s.goal}"
@@ -527,7 +573,7 @@ class GoalManager:
             goal=goal,
             status="active",
             turns_used=0,
-            max_turns=int(max_turns) if max_turns else self.default_max_turns,
+            max_turns=coerce_max_turns(max_turns, self.default_max_turns),
             created_at=time.time(),
             last_turn_at=0.0,
         )
@@ -708,7 +754,7 @@ class GoalManager:
                 ),
             }
 
-        if state.turns_used >= state.max_turns:
+        if not is_unbounded_goal_turns(state.max_turns) and state.turns_used >= state.max_turns:
             state.status = "paused"
             state.paused_reason = f"turn budget exhausted ({state.turns_used}/{state.max_turns})"
             save_goal(self.session_id, state)
@@ -732,7 +778,7 @@ class GoalManager:
             "verdict": "continue",
             "reason": reason,
             "message": (
-                f"↻ Continuing toward goal ({state.turns_used}/{state.max_turns}): {reason}"
+                f"↻ Continuing toward goal ({_format_goal_turns(state.turns_used, state.max_turns)}): {reason}"
             ),
         }
 
@@ -822,9 +868,8 @@ def run_kanban_goal_loop(
             except Exception:
                 pass
 
-    max_turns = int(max_turns or DEFAULT_MAX_TURNS)
-    if max_turns < 1:
-        max_turns = DEFAULT_MAX_TURNS
+    max_turns = coerce_max_turns(max_turns)
+    budget_unbounded = is_unbounded_goal_turns(max_turns)
 
     last_response = first_response or ""
     # The first turn already consumed one unit of budget.
@@ -852,7 +897,7 @@ def run_kanban_goal_loop(
 
         # Still open — judge whether the latest response satisfies the card.
         verdict, reason, _parse_failed = judge_goal(goal_text, last_response)
-        _log(f"kanban goal loop: turn {turns_used}/{max_turns} verdict={verdict} reason={_truncate(reason, 120)}")
+        _log(f"kanban goal loop: turn {_format_goal_turns(turns_used, max_turns)} verdict={verdict} reason={_truncate(reason, 120)}")
 
         if verdict == "done":
             if nudged_to_finalize:
@@ -873,7 +918,7 @@ def run_kanban_goal_loop(
             prompt = KANBAN_GOAL_CONTINUATION_TEMPLATE.format(reason=_truncate(reason, 400))
 
         # Budget check BEFORE spending another turn.
-        if turns_used >= max_turns:
+        if not budget_unbounded and turns_used >= max_turns:
             _log(f"kanban goal loop: task {task_id} exhausted {turns_used}/{max_turns} turns; blocking")
             try:
                 block_fn(
@@ -904,6 +949,10 @@ __all__ = [
     "KANBAN_GOAL_CONTINUATION_TEMPLATE",
     "KANBAN_GOAL_FINALIZE_TEMPLATE",
     "DEFAULT_MAX_TURNS",
+    "coerce_max_turns",
+    "resolve_goal_max_turns",
+    "is_unbounded_goal_turns",
+    "format_goal_budget",
     "load_goal",
     "save_goal",
     "clear_goal",

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -871,7 +871,7 @@ class Task:
                 bool(row["goal_mode"]) if "goal_mode" in keys and row["goal_mode"] else False
             ),
             goal_max_turns=(
-                row["goal_max_turns"] if "goal_max_turns" in keys and row["goal_max_turns"] else None
+                row["goal_max_turns"] if "goal_max_turns" in keys else None
             ),
             session_id=(
                 row["session_id"] if "session_id" in keys else None
@@ -2193,6 +2193,15 @@ def create_task(
         if board_default:
             workspace_path = str(board_default)
 
+    # Normalize the per-card goal-loop budget once before any persistence.
+    # Explicit numeric 0 means "unbounded"; booleans are rejected so a
+    # model/tool caller cannot accidentally turn JSON false into 0 via
+    # Python's int(False) == 0.
+    if isinstance(goal_max_turns, bool):
+        raise ValueError("goal_max_turns must be an integer, not boolean")
+    if goal_max_turns is not None:
+        goal_max_turns = int(goal_max_turns)
+
     # Retry once on the extremely unlikely id collision.
     for attempt in range(2):
         task_id = _new_task_id()
@@ -2257,7 +2266,7 @@ def create_task(
                         json.dumps(skills_list) if skills_list is not None else None,
                         int(max_retries) if max_retries is not None else None,
                         1 if goal_mode else 0,
-                        int(goal_max_turns) if goal_max_turns is not None else None,
+                        goal_max_turns,
                         session_id,
                     ),
                 )

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -32,6 +32,7 @@ import logging
 import os
 import sys
 import threading
+import time
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Optional, Sequence
@@ -383,6 +384,7 @@ class _ManagedRotatingFileHandler(RotatingFileHandler):
     def __init__(self, *args, **kwargs):
         from hermes_cli.config import is_managed
         self._managed = is_managed()
+        self._rollover_deferred_until = 0.0
         super().__init__(*args, **kwargs)
         # Snapshot the inode of the currently open stream so emit() can
         # detect external rotation without an extra fstat per write.
@@ -466,8 +468,42 @@ class _ManagedRotatingFileHandler(RotatingFileHandler):
         self._chmod_if_managed()
         return stream
 
+    def shouldRollover(self, record: logging.LogRecord) -> bool:
+        """Skip retry storms after a cross-process Windows rollover lock.
+
+        ``RotatingFileHandler`` is process-local.  On Windows, a second Hermes
+        process holding the same agent.log handle makes ``os.rename`` fail with
+        ``PermissionError``.  If we immediately retry on every record, logging
+        emits multi-KB "--- Logging error ---" tracebacks forever because the
+        file is still above maxBytes.  Defer retries briefly and keep appending
+        instead; the next process that can acquire the file will rotate later.
+        """
+        if self._rollover_deferred_until:
+            if time.monotonic() < self._rollover_deferred_until:
+                return False
+            self._rollover_deferred_until = 0.0
+        return super().shouldRollover(record)
+
+    def _defer_locked_rollover(self) -> None:
+        self._rollover_deferred_until = time.monotonic() + 60.0
+        if self.stream is None:
+            try:
+                self.stream = self._open()
+            except Exception:
+                pass
+        self._record_stream_stat()
+
     def doRollover(self):
-        super().doRollover()
+        try:
+            super().doRollover()
+        except PermissionError:
+            self._defer_locked_rollover()
+            return
+        except OSError as exc:
+            if getattr(exc, "winerror", None) == 32:
+                self._defer_locked_rollover()
+                return
+            raise
         self._chmod_if_managed()
         # Our own rollover writes a new baseFilename; refresh the snapshot
         # so the next emit doesn't mistake it for external rotation.

--- a/tests/agent/test_iteration_budget.py
+++ b/tests/agent/test_iteration_budget.py
@@ -1,6 +1,6 @@
 """Regression tests for unbounded iteration budgets."""
 
-from agent.iteration_budget import IterationBudget
+from agent.iteration_budget import IterationBudget, is_unbounded_iteration_limit
 
 
 def test_non_positive_iteration_budget_is_unbounded_and_still_counts_usage():
@@ -22,3 +22,10 @@ def test_positive_iteration_budget_still_exhausts_at_limit():
     assert budget.consume() is True
     assert budget.consume() is False
     assert budget.remaining == 0
+
+
+def test_boolean_false_iteration_limit_is_not_unbounded():
+    budget = IterationBudget(False)
+
+    assert not budget.is_unbounded
+    assert not is_unbounded_iteration_limit(False)

--- a/tests/agent/test_iteration_budget.py
+++ b/tests/agent/test_iteration_budget.py
@@ -1,0 +1,24 @@
+"""Regression tests for unbounded iteration budgets."""
+
+from agent.iteration_budget import IterationBudget
+
+
+def test_non_positive_iteration_budget_is_unbounded_and_still_counts_usage():
+    budget = IterationBudget(0)
+
+    assert budget.is_unbounded
+    for _ in range(5):
+        assert budget.consume() is True
+
+    assert budget.used == 5
+    assert budget.remaining == float("inf")
+
+
+def test_positive_iteration_budget_still_exhausts_at_limit():
+    budget = IterationBudget(2)
+
+    assert not budget.is_unbounded
+    assert budget.consume() is True
+    assert budget.consume() is True
+    assert budget.consume() is False
+    assert budget.remaining == 0

--- a/tests/agent/test_turn_finalizer_unbounded.py
+++ b/tests/agent/test_turn_finalizer_unbounded.py
@@ -1,0 +1,81 @@
+"""Regression coverage for unbounded turn finalization."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from agent.iteration_budget import IterationBudget
+from agent.turn_finalizer import finalize_turn
+
+
+def _agent_for_finalizer(max_iterations=0):
+    agent = SimpleNamespace()
+    agent.max_iterations = max_iterations
+    agent.iteration_budget = IterationBudget(max_iterations)
+    agent.quiet_mode = True
+    agent.model = "test/model"
+    agent.provider = "test-provider"
+    agent.base_url = "https://example.test"
+    agent.session_id = "session-test"
+    agent.platform = "cli"
+    agent.context_compressor = SimpleNamespace(last_prompt_tokens=0)
+    agent.session_input_tokens = 0
+    agent.session_output_tokens = 0
+    agent.session_cache_read_tokens = 0
+    agent.session_cache_write_tokens = 0
+    agent.session_reasoning_tokens = 0
+    agent.session_prompt_tokens = 0
+    agent.session_completion_tokens = 0
+    agent.session_total_tokens = 0
+    agent.session_estimated_cost_usd = 0.0
+    agent.session_cost_status = "unknown"
+    agent.session_cost_source = "none"
+    agent._tool_guardrail_halt_decision = None
+    agent._response_was_previewed = False
+    agent._interrupt_message = None
+    agent._stream_callback = None
+    agent._skill_nudge_interval = 0
+    agent._iters_since_skill = 0
+    agent.valid_tool_names = set()
+    agent._emit_status = MagicMock()
+    agent._safe_print = MagicMock()
+    agent._handle_max_iterations = MagicMock(return_value="summary")
+    agent._save_trajectory = MagicMock()
+    agent._cleanup_task_resources = MagicMock()
+    agent._drop_trailing_empty_response_scaffolding = MagicMock()
+    agent._persist_session = MagicMock()
+    agent._file_mutation_verifier_enabled = MagicMock(return_value=False)
+    agent._turn_completion_explainer_enabled = MagicMock(return_value=False)
+    agent._format_turn_completion_explanation = MagicMock(return_value="")
+    agent._drain_pending_steer = MagicMock(return_value=None)
+    agent.clear_interrupt = MagicMock()
+    agent._sync_external_memory_for_turn = MagicMock()
+    agent._spawn_background_review = MagicMock()
+    return agent
+
+
+def test_unbounded_turn_finalizer_does_not_treat_high_api_count_as_exhausted():
+    agent = _agent_for_finalizer(max_iterations=0)
+    messages = [
+        {"role": "user", "content": "work"},
+        {"role": "assistant", "content": "done"},
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response="done",
+        api_call_count=999,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task-test",
+        turn_id="turn-test",
+        user_message="work",
+        original_user_message="work",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response(final)",
+    )
+
+    assert result["completed"] is True
+    assert result["final_response"] == "done"
+    agent._handle_max_iterations.assert_not_called()

--- a/tests/agent/test_turn_finalizer_unbounded.py
+++ b/tests/agent/test_turn_finalizer_unbounded.py
@@ -53,6 +53,35 @@ def _agent_for_finalizer(max_iterations=0):
     return agent
 
 
+def test_unbounded_turn_finalizer_does_not_treat_missing_response_as_exhausted():
+    agent = _agent_for_finalizer(max_iterations=0)
+    messages = [
+        {"role": "user", "content": "work"},
+        {"role": "assistant", "tool_calls": [{"function": {"name": "terminal"}}]},
+        {"role": "tool", "content": "still working"},
+    ]
+
+    result = finalize_turn(
+        agent,
+        final_response=None,
+        api_call_count=999,
+        interrupted=False,
+        failed=False,
+        messages=messages,
+        conversation_history=[],
+        effective_task_id="task-test",
+        turn_id="turn-test",
+        user_message="work",
+        original_user_message="work",
+        _should_review_memory=False,
+        _turn_exit_reason="loop_exited_without_final_response",
+    )
+
+    assert result["completed"] is False
+    assert result["final_response"] is None
+    agent._handle_max_iterations.assert_not_called()
+
+
 def test_unbounded_turn_finalizer_does_not_treat_high_api_count_as_exhausted():
     agent = _agent_for_finalizer(max_iterations=0)
     messages = [

--- a/tests/cli/test_cli_goal_max_turns.py
+++ b/tests/cli/test_cli_goal_max_turns.py
@@ -1,0 +1,98 @@
+"""Regression tests for classic CLI /goal max-turn parsing."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    from hermes_cli import goals
+
+    goals._DB_CACHE.clear()
+    yield home
+    goals._DB_CACHE.clear()
+
+
+def _make_cli(session_id: str = "cli-goal-max-turns"):
+    from cli import HermesCLI
+
+    shell = HermesCLI.__new__(HermesCLI)
+    shell.session_id = session_id
+    return shell
+
+
+def test_get_goal_manager_preserves_zero_max_turns(hermes_home, monkeypatch):
+    from hermes_cli import config
+
+    monkeypatch.setattr(config, "load_config", lambda: {"goals": {"max_turns": 0}})
+
+    mgr = _make_cli()._get_goal_manager()
+
+    assert mgr is not None
+    assert mgr.default_max_turns == 0
+
+
+def test_get_goal_manager_preserves_positive_max_turns(hermes_home, monkeypatch):
+    from hermes_cli import config
+
+    monkeypatch.setattr(config, "load_config", lambda: {"goals": {"max_turns": 7}})
+
+    mgr = _make_cli()._get_goal_manager()
+
+    assert mgr is not None
+    assert mgr.default_max_turns == 7
+
+
+def test_kanban_goal_loop_q_preserves_zero_task_max_turns(monkeypatch):
+    import cli as cli_mod
+    from hermes_cli import goals
+    from hermes_cli import kanban_db as kb
+
+    captured = {}
+    task = SimpleNamespace(title="open task", body="", goal_max_turns=0)
+
+    class _Conn:
+        def close(self):
+            pass
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-zero")
+    monkeypatch.setattr(kb, "connect", lambda: _Conn())
+    monkeypatch.setattr(kb, "get_task", lambda conn, task_id: task)
+    monkeypatch.setattr(goals, "run_kanban_goal_loop", lambda **kwargs: captured.update(kwargs))
+
+    shell = SimpleNamespace(agent=SimpleNamespace(), conversation_history=[], session_id="sid")
+
+    cli_mod._run_kanban_goal_loop_q(shell, "first response")
+
+    assert captured["max_turns"] == 0
+
+
+def test_kanban_goal_loop_q_uses_default_for_missing_task_max_turns(monkeypatch):
+    import cli as cli_mod
+    from hermes_cli import goals
+    from hermes_cli import kanban_db as kb
+
+    captured = {}
+    task = SimpleNamespace(title="default task", body="", goal_max_turns=None)
+
+    class _Conn:
+        def close(self):
+            pass
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-default")
+    monkeypatch.setattr(kb, "connect", lambda: _Conn())
+    monkeypatch.setattr(kb, "get_task", lambda conn, task_id: task)
+    monkeypatch.setattr(goals, "run_kanban_goal_loop", lambda **kwargs: captured.update(kwargs))
+
+    shell = SimpleNamespace(agent=SimpleNamespace(), conversation_history=[], session_id="sid")
+
+    cli_mod._run_kanban_goal_loop_q(shell, "first response")
+
+    assert captured["max_turns"] == goals.DEFAULT_MAX_TURNS

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -55,7 +55,7 @@ def _make_cli(env_overrides=None, config_overrides=None, **kwargs):
 
 
 class TestMaxTurnsResolution:
-    """max_turns must always resolve to a positive integer, never None."""
+    """max_turns must resolve deterministically, including explicit unbounded 0."""
 
     def test_default_max_turns_is_integer(self):
         cli = _make_cli()
@@ -65,6 +65,14 @@ class TestMaxTurnsResolution:
     def test_explicit_max_turns_honored(self):
         cli = _make_cli(max_turns=25)
         assert cli.max_turns == 25
+
+    def test_config_zero_max_turns_is_honored_as_unbounded(self):
+        cli = _make_cli(config_overrides={"agent": {"max_turns": 0}})
+        assert cli.max_turns == 0
+
+    def test_legacy_root_zero_max_turns_is_honored_as_unbounded(self):
+        cli = _make_cli(config_overrides={"agent": {}, "max_turns": 0})
+        assert cli.max_turns == 0
 
     def test_none_max_turns_gets_default(self):
         cli = _make_cli(max_turns=None)

--- a/tests/cron/test_cron_max_iterations.py
+++ b/tests/cron/test_cron_max_iterations.py
@@ -1,0 +1,15 @@
+"""Regression tests for cron agent max-iteration config resolution."""
+
+from cron.scheduler import _resolve_agent_max_iterations
+
+
+def test_cron_nested_zero_max_turns_is_unbounded_not_defaulted():
+    assert _resolve_agent_max_iterations({"agent": {"max_turns": 0}}) == 0
+
+
+def test_cron_root_zero_max_turns_is_unbounded_not_defaulted():
+    assert _resolve_agent_max_iterations({"agent": {}, "max_turns": 0}) == 0
+
+
+def test_cron_missing_max_turns_uses_default():
+    assert _resolve_agent_max_iterations({"agent": {}}) == 90

--- a/tests/gateway/test_goal_max_turns_config.py
+++ b/tests/gateway/test_goal_max_turns_config.py
@@ -60,3 +60,85 @@ async def test_gateway_goal_uses_goals_max_turns_from_full_config(tmp_path, monk
         assert state.max_turns == 7
     finally:
         goals._DB_CACHE.clear()
+
+
+@pytest.mark.asyncio
+async def test_gateway_goal_preserves_zero_max_turns_from_full_config(tmp_path, monkeypatch):
+    """Gateway /goal should preserve goals.max_turns=0 as unbounded."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("goals:\n  max_turns: 0\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    goals._DB_CACHE.clear()
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.DISCORD: PlatformConfig(enabled=True, token="token")}
+    )
+    runner.session_store = _FakeSessionStore()
+    runner.adapters = {}
+    runner._queued_events = {}
+
+    event = MessageEvent(
+        text="/goal ship without a turn ceiling",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="chat-goal-config",
+            chat_type="channel",
+            user_id="user-goal-config",
+        ),
+        message_id="msg-goal-config-zero",
+    )
+
+    response = await GatewayRunner._handle_goal_command(runner, event)
+
+    try:
+        assert "⊙ Goal set (unbounded): ship without a turn ceiling" in response
+        assert "budget is exhausted" not in response
+        state = goals.GoalManager("sid-gateway-goal-config").state
+        assert state is not None
+        assert state.max_turns == 0
+    finally:
+        goals._DB_CACHE.clear()
+
+
+@pytest.mark.asyncio
+async def test_gateway_goal_boolean_false_max_turns_falls_back_to_default(tmp_path, monkeypatch):
+    """YAML false must not silently become unbounded via int(False) == 0."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("goals:\n  max_turns: false\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    goals._DB_CACHE.clear()
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.DISCORD: PlatformConfig(enabled=True, token="token")}
+    )
+    runner.session_store = _FakeSessionStore()
+    runner.adapters = {}
+    runner._queued_events = {}
+
+    event = MessageEvent(
+        text="/goal stay bounded",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="chat-goal-config",
+            chat_type="channel",
+            user_id="user-goal-config",
+        ),
+        message_id="msg-goal-config-false",
+    )
+
+    response = await GatewayRunner._handle_goal_command(runner, event)
+
+    try:
+        assert "⊙ Goal set (20-turn budget): stay bounded" in response
+        assert "unbounded" not in response
+        state = goals.GoalManager("sid-gateway-goal-config").state
+        assert state is not None
+        assert state.max_turns == 20
+    finally:
+        goals._DB_CACHE.clear()

--- a/tests/hermes_cli/test_gateway_windows.py
+++ b/tests/hermes_cli/test_gateway_windows.py
@@ -12,6 +12,18 @@ import hermes_cli.setup as setup
 @pytest.mark.parametrize(
     "detail",
     [
+        "ERROR: Odmowa dost\u0119pu.",
+        "ERROR: Odmowa dost\ufffdpu.",
+    ],
+)
+def test_polish_schtasks_access_denied_uses_uac_or_fallback_path(detail):
+    assert gateway_windows._should_fall_back(1, detail) is True
+    assert gateway_windows._is_access_denied(detail) is True
+
+
+@pytest.mark.parametrize(
+    "detail",
+    [
         "ERROR: Access is denied.",
         "ERROR: Acceso denegado.",
         "ERROR: Přístup byl odepřen.",
@@ -247,6 +259,10 @@ def test_install_scheduled_task_recreates_instead_of_change(monkeypatch, tmp_pat
         if args[0] == "/Delete":
             return (0, "SUCCESS", "")
         if args[0] == "/Create":
+            xml_path = Path(args[args.index("/XML") + 1])
+            xml = xml_path.read_text(encoding="utf-16")
+            assert "<LogonTrigger>" in xml
+            assert "<Enabled>true</Enabled>" in xml
             return (0, "SUCCESS", "")
         raise AssertionError(f"unexpected schtasks args: {args}")
 
@@ -257,8 +273,43 @@ def test_install_scheduled_task_recreates_instead_of_change(monkeypatch, tmp_pat
     assert "/Change" not in [arg for call in calls for arg in call]
     assert calls[0][:4] == ("/Delete", "/F", "/TN", "Hermes_Gateway_alice")
     assert calls[1][0] == "/Create"
-    assert "/SC" in calls[1]
-    assert "ONLOGON" in calls[1]
+    assert "/XML" in calls[1]
+
+
+def test_install_scheduled_task_disables_windows_72h_runtime_cap(monkeypatch, tmp_path):
+    """Scheduled Task XML must set unlimited runtime for the daemon.
+
+    Windows' default Task Scheduler execution limit is 72h. Hermes gateway is a
+    daemon, so a freshly installed task must opt out instead of being killed
+    after three days.
+    """
+    calls = []
+    script_path = tmp_path / "Hermes_Gateway_alice.cmd"
+
+    monkeypatch.setattr(gateway_windows, "_assert_windows", lambda: None)
+    monkeypatch.setattr(gateway_windows, "_resolve_task_user", lambda: None)
+
+    def fake_schtasks(args):
+        calls.append(tuple(args))
+        if args[0] == "/Delete":
+            return (0, "SUCCESS", "")
+        if args[0] == "/Create":
+            xml_path = Path(args[args.index("/XML") + 1])
+            xml = xml_path.read_text(encoding="utf-16")
+            assert "<ExecutionTimeLimit>PT0S</ExecutionTimeLimit>" in xml
+            assert "<MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>" in xml
+            assert str(script_path) in xml
+            return (0, "SUCCESS", "")
+        raise AssertionError(f"unexpected schtasks args: {args}")
+
+    monkeypatch.setattr(gateway_windows, "_exec_schtasks", fake_schtasks)
+
+    ok, detail = gateway_windows._install_scheduled_task("Hermes_Gateway_alice", script_path)
+
+    assert ok is True
+    assert detail == "Created Scheduled Task 'Hermes_Gateway_alice'"
+    assert calls[1][0] == "/Create"
+    assert "/XML" in calls[1]
 
 
 def test_install_scheduled_task_success_start_now_uses_direct_spawn_not_task_run(monkeypatch, tmp_path, capsys):

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -32,6 +32,39 @@ def hermes_home(tmp_path, monkeypatch):
 
 
 # ──────────────────────────────────────────────────────────────────────
+# Budget parsing / formatting
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestGoalBudgetParsing:
+    def test_coerce_max_turns_preserves_numeric_zero(self):
+        from hermes_cli.goals import coerce_max_turns, is_unbounded_goal_turns
+
+        assert coerce_max_turns(0, default=20) == 0
+        assert coerce_max_turns("0", default=20) == 0
+        assert is_unbounded_goal_turns(0)
+
+    def test_boolean_max_turns_falls_back_instead_of_unbounded(self):
+        from hermes_cli.goals import (
+            coerce_max_turns,
+            format_goal_budget,
+            is_unbounded_goal_turns,
+            resolve_goal_max_turns,
+        )
+
+        assert coerce_max_turns(False, default=20) == 20
+        assert resolve_goal_max_turns({"max_turns": False}, default=20) == 20
+        assert not is_unbounded_goal_turns(False)
+        assert format_goal_budget(False) == "20-turn budget"
+
+    def test_unbounded_completion_hint_omits_budget_exhausted(self):
+        from hermes_cli.goals import goal_completion_hint
+
+        assert "budget is exhausted" not in goal_completion_hint(0)
+        assert "budget is exhausted" in goal_completion_hint(20)
+
+
+# ──────────────────────────────────────────────────────────────────────
 # _parse_judge_response
 # ──────────────────────────────────────────────────────────────────────
 
@@ -204,6 +237,25 @@ class TestGoalManager:
         assert "active" in mgr.status_line().lower()
         assert "port the thing" in mgr.status_line()
 
+    def test_set_preserves_zero_default_max_turns_as_unbounded(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="test-sid-zero-default", default_max_turns=0)
+        state = mgr.set("keep going")
+
+        assert state.max_turns == 0
+        assert "unbounded" in mgr.status_line()
+        assert "0/0" not in mgr.status_line()
+
+    def test_set_preserves_explicit_zero_max_turns_as_unbounded(self, hermes_home):
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="test-sid-zero-explicit", default_max_turns=5)
+        state = mgr.set("keep going", max_turns=0)
+
+        assert state.max_turns == 0
+        assert "unbounded" in mgr.status_line()
+
     def test_set_rejects_empty(self, hermes_home):
         from hermes_cli.goals import GoalManager
 
@@ -306,6 +358,26 @@ class TestGoalManager:
             assert mgr.state.status == "paused"
             assert mgr.state.turns_used == 2
             assert "budget" in (mgr.state.paused_reason or "").lower()
+
+    def test_evaluate_after_turn_zero_max_turns_does_not_pause_on_budget(
+        self, hermes_home
+    ):
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="eval-sid-unbounded", default_max_turns=0)
+        mgr.set("hard goal")
+
+        with patch.object(goals, "judge_goal", return_value=("continue", "not yet", False)):
+            for idx in range(3):
+                decision = mgr.evaluate_after_turn(f"step {idx}")
+                assert decision["should_continue"] is True
+                assert decision["verdict"] == "continue"
+                assert mgr.state.status == "active"
+
+        assert mgr.state.turns_used == 3
+        assert mgr.state.max_turns == 0
+        assert mgr.state.paused_reason is None
 
     def test_evaluate_after_turn_inactive(self, hermes_home):
         """evaluate_after_turn is a no-op when goal isn't active."""
@@ -539,6 +611,20 @@ class TestGoalStateSubgoalsBackcompat:
         state = GoalState.from_json(legacy)
         assert state.goal == "do a thing"
         assert state.subgoals == []
+
+    def test_zero_max_turns_round_trips_as_unbounded(self):
+        from hermes_cli.goals import GoalState
+
+        raw = json.dumps({
+            "goal": "do a thing",
+            "status": "active",
+            "turns_used": 1,
+            "max_turns": 0,
+        })
+
+        state = GoalState.from_json(raw)
+
+        assert state.max_turns == 0
 
     def test_subgoals_round_trip(self):
         from hermes_cli.goals import GoalState

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -57,6 +57,32 @@ def test_goal_mode_persists(kanban_home):
     assert task.goal_max_turns == 7
 
 
+def test_goal_mode_preserves_zero_max_turns(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="unbounded task",
+            assignee="worker",
+            goal_mode=True,
+            goal_max_turns=0,
+        )
+        task = kb.get_task(conn, tid)
+    assert task.goal_mode is True
+    assert task.goal_max_turns == 0
+
+
+def test_goal_mode_rejects_boolean_false_max_turns(kanban_home):
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="goal_max_turns must be an integer, not boolean"):
+            kb.create_task(
+                conn,
+                title="bad bool budget",
+                assignee="worker",
+                goal_mode=True,
+                goal_max_turns=False,
+            )
+
+
 def test_goal_mode_without_max_turns(kanban_home):
     with kb.connect() as conn:
         tid = kb.create_task(

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -145,6 +145,72 @@ class TestSetupLogging:
         assert agent_handlers[0].maxBytes == 10 * 1024 * 1024
         assert agent_handlers[0].backupCount == 5
 
+    def test_locked_windows_rollover_defers_without_losing_records(self, hermes_home):
+        """A locked log file must not spam stderr or drop the triggering record.
+
+        On Windows multiple Hermes processes can hold agent.log open. The stdlib
+        RotatingFileHandler raises PermissionError when one process tries to
+        rename a file another process still has open; without a guard every log
+        event after maxBytes emits a huge "--- Logging error ---" traceback.
+        """
+        log_path = hermes_home / "logs" / "agent.log"
+        root = logging.getLogger()
+        hermes_logging._add_rotating_handler(
+            root,
+            log_path,
+            level=logging.INFO,
+            max_bytes=1,
+            backup_count=1,
+            formatter=logging.Formatter("%(message)s"),
+        )
+        handler = next(
+            h
+            for h in root.handlers
+            if isinstance(h, RotatingFileHandler)
+            and getattr(h, "baseFilename", "") == str(log_path.resolve())
+        )
+
+        rollover_calls = {"count": 0}
+
+        def locked_rollover(self):
+            rollover_calls["count"] += 1
+            raise PermissionError(13, "file is locked", str(log_path))
+
+        with patch.object(RotatingFileHandler, "doRollover", locked_rollover):
+            with patch.object(
+                handler,
+                "handleError",
+                side_effect=AssertionError("handleError should not be called"),
+            ):
+                handler.emit(
+                    logging.LogRecord(
+                        "test.locked_rollover",
+                        logging.INFO,
+                        __file__,
+                        1,
+                        "first record survives locked rollover",
+                        (),
+                        None,
+                    )
+                )
+                handler.emit(
+                    logging.LogRecord(
+                        "test.locked_rollover",
+                        logging.INFO,
+                        __file__,
+                        1,
+                        "second record skips retry during cooldown",
+                        (),
+                        None,
+                    )
+                )
+
+        handler.flush()
+        content = log_path.read_text(encoding="utf-8")
+        assert "first record survives locked rollover" in content
+        assert "second record skips retry during cooldown" in content
+        assert rollover_calls["count"] == 1
+
     def test_suppresses_noisy_loggers(self, hermes_home):
         hermes_logging.setup_logging(hermes_home=hermes_home)
 
@@ -747,6 +813,10 @@ class TestAddRotatingHandler:
                 logger.removeHandler(h)
                 h.close()
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX mode bits are not enforced on NTFS by default",
+    )
     def test_managed_mode_initial_open_sets_group_writable(self, tmp_path):
         log_path = tmp_path / "managed-open.log"
         logger = logging.getLogger("_test_rotating_managed_open")
@@ -771,6 +841,10 @@ class TestAddRotatingHandler:
                 logger.removeHandler(h)
                 h.close()
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX mode bits are not enforced on NTFS by default",
+    )
     def test_managed_mode_rollover_sets_group_writable(self, tmp_path):
         log_path = tmp_path / "managed-rollover.log"
         logger = logging.getLogger("_test_rotating_managed_rollover")
@@ -859,6 +933,10 @@ class TestExternalRotationRecovery:
         handler.emit(record)
         handler.flush()
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Windows forbids renaming open log files; locked-rollover behavior is covered separately",
+    )
     def test_recovers_after_external_rename(self, tmp_path):
         """logrotate-style external rename: ``mv gateway.log gateway.log.1``.
 
@@ -887,6 +965,10 @@ class TestExternalRotationRecovery:
         finally:
             handler.close()
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Windows forbids unlinking open log files; locked-rollover behavior is covered separately",
+    )
     def test_recovers_after_external_unlink(self, tmp_path):
         """``rm gateway.log`` then keep writing — handler recreates the file."""
         log_path = tmp_path / "gateway.log"
@@ -957,6 +1039,10 @@ class TestExternalRotationRecovery:
         finally:
             handler.close()
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Windows forbids external rename of an open gateway.log handle",
+    )
     def test_gateway_log_attached_after_external_rotation_then_re_setup(
         self, hermes_home,
     ):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3861,6 +3861,36 @@ def test_command_dispatch_exec_nonzero_surfaces_error(monkeypatch):
     assert "failed" in resp["error"]["message"]
 
 
+def test_command_dispatch_exec_decodes_subprocess_output_lossily(monkeypatch):
+    """Gateway subprocess reads must tolerate non-UTF-8 tool output.
+
+    Python's subprocess.run(..., text=True) spawns _readerthread workers for
+    captured pipes on Windows.  Without errors="replace", one bad byte in a
+    child process stream surfaces through threading.excepthook as a scary
+    [gateway-crash] UnicodeDecodeError.
+    """
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"quick_commands": {"ok": {"type": "exec", "command": "ok"}}},
+    )
+    captured = {}
+
+    def fake_run(*args, **kwargs):
+        captured.update(kwargs)
+        return types.SimpleNamespace(returncode=0, stdout="decoded", stderr="")
+
+    monkeypatch.setattr(server.subprocess, "run", fake_run)
+
+    resp = server.handle_request(
+        {"id": "1", "method": "command.dispatch", "params": {"name": "ok"}}
+    )
+
+    assert resp["result"]["output"] == "decoded"
+    assert captured["encoding"] == "utf-8"
+    assert captured["errors"] == "replace"
+
+
 def test_plugins_list_surfaces_loader_error(monkeypatch):
     with patch("hermes_cli.plugins.get_plugin_manager", side_effect=Exception("boom")):
         resp = server.handle_request(
@@ -6457,6 +6487,71 @@ def test_make_agent_waits_for_shared_mcp_discovery(monkeypatch):
     assert waited == [0.75]
 
 
+def test_make_agent_preserves_nested_zero_max_turns(monkeypatch):
+    _setup_make_agent_mocks(monkeypatch, {"agent": {"max_turns": 0}})
+
+    with patch("run_agent.AIAgent") as mock_agent:
+        server._make_agent("sid1", "key1")
+
+    assert mock_agent.call_args.kwargs["max_iterations"] == 0
+
+
+def test_make_agent_preserves_root_zero_max_turns(monkeypatch):
+    _setup_make_agent_mocks(monkeypatch, {"max_turns": 0})
+
+    with patch("run_agent.AIAgent") as mock_agent:
+        server._make_agent("sid1", "key1")
+
+    assert mock_agent.call_args.kwargs["max_iterations"] == 0
+
+
+def test_make_agent_ignores_boolean_false_nested_max_turns(monkeypatch):
+    _setup_make_agent_mocks(monkeypatch, {"agent": {"max_turns": False}})
+
+    with patch("run_agent.AIAgent") as mock_agent:
+        server._make_agent("sid1", "key1")
+
+    assert mock_agent.call_args.kwargs["max_iterations"] == 90
+
+
+def test_make_agent_ignores_boolean_false_root_max_turns(monkeypatch):
+    _setup_make_agent_mocks(monkeypatch, {"max_turns": False})
+
+    with patch("run_agent.AIAgent") as mock_agent:
+        server._make_agent("sid1", "key1")
+
+    assert mock_agent.call_args.kwargs["max_iterations"] == 90
+
+
+def test_make_agent_nested_zero_takes_priority_over_root_max_turns(monkeypatch):
+    _setup_make_agent_mocks(monkeypatch, {"agent": {"max_turns": 0}, "max_turns": 100})
+
+    with patch("run_agent.AIAgent") as mock_agent:
+        server._make_agent("sid1", "key1")
+
+    assert mock_agent.call_args.kwargs["max_iterations"] == 0
+
+
+def test_make_agent_preserves_env_zero_max_turns(monkeypatch):
+    monkeypatch.setenv("HERMES_TUI_MAX_TURNS", "0")
+    _setup_make_agent_mocks(monkeypatch, {})
+
+    with patch("run_agent.AIAgent") as mock_agent:
+        server._make_agent("sid1", "key1")
+
+    assert mock_agent.call_args.kwargs["max_iterations"] == 0
+
+
+def test_make_agent_env_max_turns_takes_priority(monkeypatch):
+    monkeypatch.setenv("HERMES_TUI_MAX_TURNS", "40")
+    _setup_make_agent_mocks(monkeypatch, {"agent": {"max_turns": 20}, "max_turns": 30})
+
+    with patch("run_agent.AIAgent") as mock_agent:
+        server._make_agent("sid1", "key1")
+
+    assert mock_agent.call_args.kwargs["max_iterations"] == 40
+
+
 def test_make_agent_nested_max_turns_takes_priority(monkeypatch):
     _setup_make_agent_mocks(
         monkeypatch, {"agent": {"max_turns": 500}, "max_turns": 100}
@@ -6555,12 +6650,28 @@ def test_background_agent_kwargs_reads_nested_max_turns(monkeypatch):
     assert kwargs["max_iterations"] == 300
 
 
+def test_background_agent_kwargs_preserves_nested_zero_max_turns(monkeypatch):
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"agent": {"max_turns": 0}})
+
+    kwargs = server._background_agent_kwargs(_FakeAgentForBackground(), "task_1")
+
+    assert kwargs["max_iterations"] == 0
+
+
 def test_background_agent_kwargs_falls_back_to_root_max_turns(monkeypatch):
     monkeypatch.setattr(server, "_load_cfg", lambda: {"max_turns": 50})
 
     kwargs = server._background_agent_kwargs(_FakeAgentForBackground(), "task_1")
 
     assert kwargs["max_iterations"] == 50
+
+
+def test_background_agent_kwargs_preserves_root_zero_max_turns(monkeypatch):
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"max_turns": 0})
+
+    kwargs = server._background_agent_kwargs(_FakeAgentForBackground(), "task_1")
+
+    assert kwargs["max_iterations"] == 0
 
 
 def test_background_agent_kwargs_defaults_to_25(monkeypatch):
@@ -6594,6 +6705,23 @@ def test_config_show_displays_nested_max_turns(monkeypatch):
     )
 
     assert ["Max Turns", "120"] in agent_rows
+
+
+def test_config_show_displays_zero_max_turns(monkeypatch):
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"agent": {"max_turns": 0}, "enabled_toolsets": [], "verbose": False},
+    )
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+
+    resp = server.handle_request({"id": "1", "method": "config.show", "params": {}})
+    sections = resp["result"]["sections"]
+    agent_rows = next(
+        section["rows"] for section in sections if section["title"] == "Agent"
+    )
+
+    assert ["Max Turns", "0"] in agent_rows
 
 
 def test_notification_poller_delivers_completion(monkeypatch):

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -6,7 +6,7 @@ init_session() failure handling, and the CWD marker contract.
 
 from unittest.mock import MagicMock
 
-from tools.environments.base import BaseEnvironment
+from tools.environments.base import BaseEnvironment, _popen_bash
 
 
 class _TestableEnv(BaseEnvironment):
@@ -20,6 +20,26 @@ class _TestableEnv(BaseEnvironment):
 
     def cleanup(self):
         pass
+
+
+class TestPopenBash:
+    def test_uses_lossy_utf8_decoding_for_pipes(self, monkeypatch):
+        captured = {}
+
+        class FakeProc:
+            stdin = None
+
+        def fake_popen(*args, **kwargs):
+            captured.update(kwargs)
+            return FakeProc()
+
+        monkeypatch.setattr("tools.environments.base.subprocess.Popen", fake_popen)
+
+        _popen_bash(["bash", "-lc", "printf bad"])
+
+        assert captured["text"] is True
+        assert captured["encoding"] == "utf-8"
+        assert captured["errors"] == "replace"
 
 
 class TestWrapCommand:

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -45,6 +45,9 @@ from tools.code_execution_tool import (
     EXECUTE_CODE_SCHEMA,
     _TOOL_DOC_LINES,
     _execute_remote,
+    _is_unbounded_resource_limit,
+    _tool_call_limit_reached,
+    _timeout_or_none,
 )
 
 
@@ -137,6 +140,25 @@ class TestHermesToolsGeneration(unittest.TestCase):
         src = generate_hermes_tools_module(["terminal"], transport="file")
         self.assertIn("_seq_lock = threading.Lock()", src)
         self.assertIn("with _seq_lock:", src)
+
+
+class TestExecuteCodeResourceLimits(unittest.TestCase):
+    def test_non_positive_limits_are_unbounded(self):
+        for value in (0, -1, "0", "-5"):
+            self.assertTrue(_is_unbounded_resource_limit(value))
+            self.assertFalse(_tool_call_limit_reached(999, value))
+            self.assertIsNone(_timeout_or_none(value, default=300))
+
+    def test_positive_limits_still_apply(self):
+        self.assertFalse(_is_unbounded_resource_limit(1))
+        self.assertFalse(_tool_call_limit_reached(0, 1))
+        self.assertTrue(_tool_call_limit_reached(1, 1))
+        self.assertEqual(_timeout_or_none(30, default=300), 30)
+
+    def test_missing_limits_use_defaults(self):
+        self.assertFalse(_is_unbounded_resource_limit(None))
+        self.assertTrue(_tool_call_limit_reached(50, None, default=50))
+        self.assertEqual(_timeout_or_none(None, default=300), 300)
 
 
 class TestExecuteCodeRemoteTempDir(unittest.TestCase):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -163,6 +163,16 @@ class TestDelegateTask(unittest.TestCase):
         self.assertIn("error", result)
         self.assertIn("parent agent", result["error"])
 
+    def test_child_timeout_zero_disables_hard_wall_clock_timeout(self):
+        """Non-positive child_timeout_seconds means no delegate_task wall-clock cap."""
+        from tools import delegate_tool
+
+        with patch(
+            "tools.delegate_tool._load_config",
+            return_value={"child_timeout_seconds": 0},
+        ):
+            self.assertIsNone(delegate_tool._get_child_timeout())
+
     def test_depth_limit(self):
         parent = _make_mock_parent(depth=2)
         result = json.loads(delegate_task(goal="test", parent_agent=parent))

--- a/tests/tools/test_env_probe.py
+++ b/tests/tools/test_env_probe.py
@@ -155,3 +155,26 @@ class TestRobustness:
         result = env_probe.get_environment_probe_line()
         # Whatever the result is, it must be a string
         assert isinstance(result, str)
+
+    def test_run_decodes_non_utf8_subprocess_output_lossily(self, monkeypatch):
+        """Windows shims can emit localized cp1250 stderr while text=True is utf-8.
+
+        The probe must request replacement decoding so subprocess reader threads
+        don't crash the whole prompt build with UnicodeDecodeError.
+        """
+        seen = {}
+
+        def fake_run(cmd, **kwargs):
+            seen.update(kwargs)
+            return type("Result", (), {"returncode": 1, "stdout": "", "stderr": "błąd"})()
+
+        monkeypatch.setattr(env_probe.subprocess, "run", fake_run)
+
+        rc, out, err = env_probe._run(["python3", "-c", "print('x')"])
+
+        assert rc == 1
+        assert out == ""
+        assert err == "błąd"
+        assert seen["text"] is True
+        assert seen["encoding"] == "utf-8"
+        assert seen["errors"] == "replace"

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -768,6 +768,19 @@ def test_create_happy_path(worker_env):
         conn.close()
 
 
+def test_create_rejects_boolean_false_goal_max_turns(worker_env):
+    from tools import kanban_tools as kt
+
+    out = kt._handle_create({
+        "title": "bad goal budget",
+        "assignee": "peer",
+        "goal_mode": True,
+        "goal_max_turns": False,
+    })
+
+    assert "goal_max_turns must be an integer, not boolean" in json.loads(out).get("error", "")
+
+
 def test_create_inherits_worker_dir_workspace(monkeypatch, worker_env):
     """A worker scoped to a dir: task that spawns a child without a
     workspace arg inherits the dir, not scratch (so follow-up code-gen

--- a/tests/tui_gateway/test_goal_command.py
+++ b/tests/tui_gateway/test_goal_command.py
@@ -43,6 +43,17 @@ def server(hermes_home):
         },
     ):
         mod = importlib.import_module("tui_gateway.server")
+        # Other tests may import tui_gateway.server at collection time before this
+        # fixture sets HERMES_HOME. Keep these tests hermetic by forcing the
+        # module-level cached home/config to the temp Hermes home for each case.
+        old_home = getattr(mod, "_hermes_home", None)
+        old_cfg_cache = getattr(mod, "_cfg_cache", None)
+        old_cfg_mtime = getattr(mod, "_cfg_mtime", None)
+        old_cfg_path = getattr(mod, "_cfg_path", None)
+        mod._hermes_home = hermes_home
+        mod._cfg_cache = None
+        mod._cfg_mtime = None
+        mod._cfg_path = None
         yield mod
         # Reset module-level session state without re-importing. importlib.reload
         # would re-register the module's atexit hooks (ThreadPoolExecutor
@@ -55,6 +66,10 @@ def server(hermes_home):
         mod._sessions.clear()
         mod._pending.clear()
         mod._answers.clear()
+        mod._hermes_home = old_home
+        mod._cfg_cache = old_cfg_cache
+        mod._cfg_mtime = old_cfg_mtime
+        mod._cfg_path = old_cfg_path
 
 
 @pytest.fixture()
@@ -120,6 +135,43 @@ def test_goal_set_returns_send_with_notice(server, session):
     assert mgr.state is not None
     assert mgr.state.goal == "build a rocket"
     assert mgr.state.status == "active"
+
+
+def test_goal_set_preserves_zero_max_turns_from_config(server, session, monkeypatch):
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"goals": {"max_turns": 0}})
+    sid, session_key, _ = session
+
+    r = _call(server, "command.dispatch", name="goal", arg="build forever", session_id=sid)
+
+    result = r["result"]
+    assert result["type"] == "send"
+    assert "Goal set" in result["notice"]
+    assert "unbounded" in result["notice"]
+    assert "budget is exhausted" not in result["notice"]
+
+    from hermes_cli.goals import GoalManager
+
+    mgr = GoalManager(session_key)
+    assert mgr.state is not None
+    assert mgr.state.max_turns == 0
+
+
+def test_goal_set_boolean_false_max_turns_falls_back_to_default(server, session, monkeypatch):
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"goals": {"max_turns": False}})
+    sid, session_key, _ = session
+
+    r = _call(server, "command.dispatch", name="goal", arg="stay bounded", session_id=sid)
+
+    result = r["result"]
+    assert result["type"] == "send"
+    assert "20-turn budget" in result["notice"]
+    assert "unbounded" not in result["notice"]
+
+    from hermes_cli.goals import GoalManager
+
+    mgr = GoalManager(session_key)
+    assert mgr.state is not None
+    assert mgr.state.max_turns == 20
 
 
 def test_goal_pause_after_set(server, session):

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -68,11 +68,44 @@ SANDBOX_ALLOWED_TOOLS = frozenset([
     "terminal",
 ])
 
-# Resource limit defaults (overridable via config.yaml → code_execution.*)
+# Resource limit defaults (overridable via config.yaml → code_execution.*).
+# Non-positive configured values (0 / negative) explicitly disable that cap.
 DEFAULT_TIMEOUT = 300        # 5 minutes
 DEFAULT_MAX_TOOL_CALLS = 50
 MAX_STDOUT_BYTES = 50_000    # 50 KB
 MAX_STDERR_BYTES = 10_000    # 10 KB
+
+
+def _is_unbounded_resource_limit(value) -> bool:
+    """Return True when a configured execute_code resource limit is disabled."""
+    if value is None:
+        return False
+    try:
+        return int(value) <= 0
+    except (TypeError, ValueError):
+        return False
+
+
+def _tool_call_limit_reached(used: int, max_tool_calls, default: int = DEFAULT_MAX_TOOL_CALLS) -> bool:
+    """Return True if the execute_code RPC tool-call cap is exhausted."""
+    limit = default if max_tool_calls is None else max_tool_calls
+    if _is_unbounded_resource_limit(limit):
+        return False
+    try:
+        return used >= int(limit)
+    except (TypeError, ValueError):
+        return used >= default
+
+
+def _timeout_or_none(value, default: int = DEFAULT_TIMEOUT):
+    """Normalize execute_code timeout config; non-positive means no timeout."""
+    timeout = default if value is None else value
+    if _is_unbounded_resource_limit(timeout):
+        return None
+    try:
+        return int(timeout)
+    except (TypeError, ValueError):
+        return default
 
 # Environment variable scrubbing rules (shared between the local + remote
 # backends).  Secret-substring block is applied first; anything left must
@@ -533,8 +566,8 @@ def _rpc_server_loop(
                     conn.sendall((resp + "\n").encode())
                     continue
 
-                # Enforce tool call limit
-                if tool_call_counter[0] >= max_tool_calls:
+                # Enforce tool call limit unless explicitly unbounded.
+                if _tool_call_limit_reached(tool_call_counter[0], max_tool_calls):
                     resp = json.dumps({
                         "error": (
                             f"Tool call limit reached ({max_tool_calls}). "
@@ -810,8 +843,8 @@ def _rpc_poll_loop(
                             f"Available: {available}"
                         )
                     })
-                # Enforce tool call limit
-                elif tool_call_counter[0] >= max_tool_calls:
+                # Enforce tool call limit unless explicitly unbounded.
+                elif _tool_call_limit_reached(tool_call_counter[0], max_tool_calls):
                     tool_result = json.dumps({
                         "error": (
                             f"Tool call limit reached ({max_tool_calls}). "
@@ -887,7 +920,7 @@ def _execute_remote(
     """
 
     _cfg = _load_config()
-    timeout = _cfg.get("timeout", DEFAULT_TIMEOUT)
+    timeout = _timeout_or_none(_cfg.get("timeout"), DEFAULT_TIMEOUT)
     max_tool_calls = _cfg.get("max_tool_calls", DEFAULT_MAX_TOOL_CALLS)
 
     session_tools = set(enabled_tools) if enabled_tools else set()
@@ -1129,7 +1162,7 @@ def execute_code(
 
     # Resolve config
     _cfg = _load_config()
-    timeout = _cfg.get("timeout", DEFAULT_TIMEOUT)
+    timeout = _timeout_or_none(_cfg.get("timeout"), DEFAULT_TIMEOUT)
     max_tool_calls = _cfg.get("max_tool_calls", DEFAULT_MAX_TOOL_CALLS)
 
     # Determine which tools the sandbox can call
@@ -1295,7 +1328,7 @@ def execute_code(
         )
 
         # --- Poll loop: watch for exit, timeout, and interrupt ---
-        deadline = time.monotonic() + timeout
+        deadline = None if timeout is None else time.monotonic() + timeout
         stderr_chunks: list = []
 
         # Background readers to avoid pipe buffer deadlocks.
@@ -1385,7 +1418,7 @@ def execute_code(
                 status = "interrupted"
                 break
             now = time.monotonic()
-            if now > deadline:
+            if deadline is not None and now > deadline:
                 _kill_process_group(proc, escalate=True)
                 status = "timeout"
                 break
@@ -1397,7 +1430,12 @@ def execute_code(
                 except Exception:
                     pass
             try:
-                proc.wait(timeout=min(poll_interval, max(0.0, deadline - now)))
+                wait_timeout = (
+                    poll_interval
+                    if deadline is None
+                    else min(poll_interval, max(0.0, deadline - now))
+                )
+                proc.wait(timeout=wait_timeout)
             except subprocess.TimeoutExpired:
                 pass
             poll_interval = min(0.2, poll_interval * 1.5)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -404,38 +404,57 @@ def _get_child_timeout() -> Optional[float]:
     before being cut off, or ``None`` when no wall-clock cap applies.
 
     Default: ``None`` (no timeout). Subagents doing legitimate heavy work
-    (deep code review, large research fan-outs, slow reasoning models) were
-    routinely killed mid-task by the old blanket cap even though they were
-    making steady progress. Failures should come from what the child is
-    actually doing — API errors, tool errors, iteration budget — not from a
-    generic delegation-level stopwatch. Stuck-child protection is handled
-    separately by the heartbeat staleness monitor, which stops refreshing
-    parent activity so the gateway inactivity timeout can fire.
+    (deep code review, large research fan-outs, slow reasoning models) should
+    not be killed by a blanket delegation stopwatch. Stuck-child protection is
+    handled separately by the heartbeat staleness monitor.
 
     Set ``delegation.child_timeout_seconds`` to a positive number to opt back
-    in to a hard cap (floor 30 s); ``0`` or a negative value means disabled.
+    in to a hard cap (floor 30 s). Non-positive values and common sentinels
+    (``false``, ``off``, ``none``, ``unbounded``, ``infinite``) disable the
+    hard wall-clock timeout.
     """
+
+    def _parse_timeout(raw: Any) -> Optional[float]:
+        if isinstance(raw, str):
+            lowered = raw.strip().lower()
+            if lowered in {
+                "",
+                "0",
+                "false",
+                "no",
+                "off",
+                "none",
+                "null",
+                "unbounded",
+                "infinite",
+                "inf",
+            }:
+                return None
+        try:
+            seconds = float(raw)
+        except (TypeError, ValueError):
+            raise
+        if seconds <= 0:
+            return None
+        return max(30.0, seconds)
+
     cfg = _load_config()
     val = cfg.get("child_timeout_seconds")
     if val is not None:
         try:
-            parsed = float(val)
+            return _parse_timeout(val)
         except (TypeError, ValueError):
             logger.warning(
                 "delegation.child_timeout_seconds=%r is not a valid number; "
                 "using default (no timeout)",
                 val,
             )
-        else:
-            return None if parsed <= 0 else max(30.0, parsed)
     env_val = os.getenv("DELEGATION_CHILD_TIMEOUT_SECONDS")
-    if env_val:
+    if env_val is not None:
         try:
-            parsed = float(env_val)
+            return _parse_timeout(env_val)
         except (TypeError, ValueError):
             pass
-        else:
-            return None if parsed <= 0 else max(30.0, parsed)
     return DEFAULT_CHILD_TIMEOUT
 
 
@@ -1449,6 +1468,11 @@ def _run_single_child(
     # gateway inactivity timeout doesn't fire while the subagent is working.
     # Without this, the parent's _last_activity_ts freezes when delegate_task
     # starts and the gateway eventually kills the agent for "no activity".
+    # Read the wall-clock timeout before starting the heartbeat so the
+    # heartbeat policy can distinguish bounded children from explicit
+    # unbounded/infinite children (child_timeout_seconds <= 0).
+    child_timeout = _get_child_timeout()
+    _child_timeout_unbounded = child_timeout is None
     _heartbeat_stop = threading.Event()
     # Stale detection: track the child's (tool, iteration) pair across
     # heartbeat cycles. If neither advances, count the cycle as stale.
@@ -1458,11 +1482,15 @@ def _run_single_child(
     _stale_count = [0]
 
     def _heartbeat_loop():
-        while not _heartbeat_stop.wait(_HEARTBEAT_INTERVAL):
+        while not _heartbeat_stop.is_set():
             if parent_agent is None:
+                if _heartbeat_stop.wait(_HEARTBEAT_INTERVAL):
+                    break
                 continue
             touch = getattr(parent_agent, "_touch_activity", None)
             if not touch:
+                if _heartbeat_stop.wait(_HEARTBEAT_INTERVAL):
+                    break
                 continue
             # Pull detail from the child's own activity tracker
             desc = f"delegate_task: subagent {task_index} working"
@@ -1498,14 +1526,29 @@ def _run_single_child(
                     else _HEARTBEAT_STALE_CYCLES_IDLE
                 )
                 if _stale_count[0] >= stale_limit:
-                    logger.warning(
-                        "Subagent %d appears stale (no progress for %d "
-                        "heartbeat cycles, tool=%s) — stopping heartbeat",
-                        task_index,
-                        _stale_count[0],
-                        child_tool or "<none>",
-                    )
-                    break  # stop touching parent, let gateway timeout fire
+                    if _child_timeout_unbounded:
+                        # In explicit infinite mode, keep the parent alive even
+                        # if the child has not advanced for a long stretch.  A
+                        # human can still interrupt from the TUI; we just don't
+                        # let gateway inactivity be the hidden killer.
+                        if _stale_count[0] == stale_limit or _stale_count[0] % stale_limit == 0:
+                            logger.warning(
+                                "Subagent %d appears stale (no progress for %d "
+                                "heartbeat cycles, tool=%s) — continuing "
+                                "heartbeat because child_timeout_seconds is disabled",
+                                task_index,
+                                _stale_count[0],
+                                child_tool or "<none>",
+                            )
+                    else:
+                        logger.warning(
+                            "Subagent %d appears stale (no progress for %d "
+                            "heartbeat cycles, tool=%s) — stopping heartbeat",
+                            task_index,
+                            _stale_count[0],
+                            child_tool or "<none>",
+                        )
+                        break  # stop touching parent, let gateway timeout fire
 
                 if child_tool:
                     desc = (
@@ -1525,6 +1568,8 @@ def _run_single_child(
                 touch(desc)
             except Exception:
                 pass
+            if _heartbeat_stop.wait(_HEARTBEAT_INTERVAL):
+                break
 
     _heartbeat_thread = threading.Thread(target=_heartbeat_loop, daemon=True)
 

--- a/tools/env_probe.py
+++ b/tools/env_probe.py
@@ -63,6 +63,8 @@ def _run(cmd: list[str], timeout: float = 3.0) -> tuple[int, str, str]:
             cmd,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout,
             check=False,
             stdin=subprocess.DEVNULL,

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -147,6 +147,8 @@ def _popen_bash(
         stderr=subprocess.STDOUT,
         stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         **kwargs,
     )
     if stdin_data is not None:

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -773,6 +773,13 @@ def _handle_create(args: dict, **kw) -> str:
     if goal_bool_error:
         return tool_error(goal_bool_error)
     goal_max_turns = args.get("goal_max_turns")
+    if isinstance(goal_max_turns, bool):
+        return tool_error("goal_max_turns must be an integer, not boolean")
+    if goal_max_turns is not None:
+        try:
+            goal_max_turns = int(goal_max_turns)
+        except (TypeError, ValueError):
+            return tool_error("goal_max_turns must be an integer")
     if isinstance(parents, str):
         parents = [parents]
     if not isinstance(parents, (list, tuple)):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -252,6 +252,8 @@ class _SlashWorker:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             bufsize=1,
             cwd=os.getcwd(),
             env=os.environ.copy(),
@@ -1098,6 +1100,8 @@ def _git_branch_for_cwd(cwd: str) -> str:
             ["git", "-C", cwd, "branch", "--show-current"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=1.5,
             check=False,
             stdin=subprocess.DEVNULL,
@@ -1110,6 +1114,8 @@ def _git_branch_for_cwd(cwd: str) -> str:
             ["git", "-C", cwd, "rev-parse", "--short", "HEAD"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=1.5,
             check=False,
             stdin=subprocess.DEVNULL,
@@ -3032,15 +3038,34 @@ def _apply_personality_to_session(
     return False, None
 
 
-def _cfg_max_turns(cfg: dict, default: int) -> int:
+def _cfg_int_or_none(value: Any) -> Optional[int]:
+    if value is None or isinstance(value, bool):
+        return None
     try:
-        env_max = int(os.environ.get("HERMES_TUI_MAX_TURNS", "") or 0)
-        if env_max > 0:
-            return env_max
+        return int(value)
     except (TypeError, ValueError):
-        pass
+        return None
+
+
+def _cfg_max_turns(cfg: dict, default: int) -> int:
+    raw_env = os.environ.get("HERMES_TUI_MAX_TURNS")
+    if raw_env not in (None, ""):
+        env_max = _cfg_int_or_none(raw_env)
+        if env_max is not None:
+            return env_max
+
     agent_cfg = cfg.get("agent") or {}
-    return int(agent_cfg.get("max_turns") or cfg.get("max_turns") or default)
+    if isinstance(agent_cfg, dict) and "max_turns" in agent_cfg:
+        nested_max = _cfg_int_or_none(agent_cfg.get("max_turns"))
+        if nested_max is not None:
+            return nested_max
+
+    if "max_turns" in cfg:
+        root_max = _cfg_int_or_none(cfg.get("max_turns"))
+        if root_max is not None:
+            return root_max
+
+    return int(default)
 
 
 def _parse_tui_skills_env() -> list[str]:
@@ -5954,13 +5979,13 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
             # outcome. Mirrors gateway/run._post_turn_goal_continuation.
             if status == "complete" and isinstance(raw, str) and raw.strip():
                 try:
-                    from hermes_cli.goals import GoalManager
+                    from hermes_cli.goals import GoalManager, resolve_goal_max_turns
 
                     sid_key = session.get("session_key") or ""
                     if sid_key:
                         try:
                             goals_cfg = _load_cfg().get("goals") or {}
-                            goal_max_turns = int(goals_cfg.get("max_turns", 20) or 20)
+                            goal_max_turns = resolve_goal_max_turns(goals_cfg)
                         except Exception:
                             goal_max_turns = 20
                         goal_mgr = GoalManager(
@@ -6460,7 +6485,15 @@ def _(rid, params: dict) -> dict:
             str(pdf_path), str(out_prefix),
         ]
         try:
-            res = subprocess.run(argv, capture_output=True, text=True, timeout=120, stdin=subprocess.DEVNULL)
+            res = subprocess.run(
+                argv,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=120,
+                stdin=subprocess.DEVNULL,
+            )
         except subprocess.TimeoutExpired:
             return _err(rid, 5028, "pdftoppm timed out (>120s)")
         if res.returncode != 0:
@@ -8005,6 +8038,8 @@ def _(rid, params: dict) -> dict:
             [sys.executable, "-m", "hermes_cli.main", *argv],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=min(int(params.get("timeout", 240)), 600),
             cwd=os.getcwd(),
             env=os.environ.copy(),
@@ -8068,6 +8103,8 @@ def _(rid, params: dict) -> dict:
                 shell=True,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=30,
                 stdin=subprocess.DEVNULL,
             )
@@ -8190,7 +8227,12 @@ def _(rid, params: dict) -> dict:
         if not session:
             return _err(rid, 4001, "no active session")
         try:
-            from hermes_cli.goals import GoalManager
+            from hermes_cli.goals import (
+                GoalManager,
+                format_goal_budget,
+                goal_completion_hint,
+                resolve_goal_max_turns,
+            )
         except Exception as exc:
             return _err(rid, 5030, f"goals unavailable: {exc}")
 
@@ -8200,7 +8242,7 @@ def _(rid, params: dict) -> dict:
 
         try:
             goals_cfg = _load_cfg().get("goals") or {}
-            max_turns = int(goals_cfg.get("max_turns", 20) or 20)
+            max_turns = resolve_goal_max_turns(goals_cfg)
         except Exception:
             max_turns = 20
         mgr = GoalManager(session_id=sid_key, default_max_turns=max_turns)
@@ -8244,8 +8286,8 @@ def _(rid, params: dict) -> dict:
             return _err(rid, 4004, f"invalid goal: {exc}")
 
         notice = (
-            f"⊙ Goal set ({state.max_turns}-turn budget): {state.goal}\n"
-            "I'll keep working until the goal is done, you pause/clear it, or the budget is exhausted.\n"
+            f"⊙ Goal set ({format_goal_budget(state.max_turns)}): {state.goal}\n"
+            f"{goal_completion_hint(state.max_turns)}\n"
             "Controls: /goal status · /goal pause · /goal resume · /goal clear"
         )
         # Send the goal text as the kickoff prompt. The TUI client sees
@@ -10288,7 +10330,14 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5001, "shell.exec unavailable: approval safety module not importable")
     try:
         r = subprocess.run(
-            cmd, shell=True, capture_output=True, text=True, timeout=30, cwd=os.getcwd(),
+            cmd,
+            shell=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+            cwd=os.getcwd(),
             stdin=subprocess.DEVNULL,
         )
         return _ok(


### PR DESCRIPTION
## Summary
- Preserve numeric `0` as an explicit unbounded budget for agent/goal/kanban turn limits.
- Prevent YAML/JSON booleans (`false`) from being coerced through `int(False) == 0` into unbounded mode.
- Align CLI, gateway, and TUI `/goal` budget notices, including unbounded wording.
- Add Windows gateway/logging regressions, desktop audio-timeout coverage, and goal/max-turn regression coverage.

## Verification
- `uv run python -m py_compile` on modified Python source files
- `uv run python -m pytest -o addopts='' tests/test_tui_gateway_server.py tests/tui_gateway/test_goal_command.py tests/gateway/test_goal_max_turns_config.py tests/hermes_cli/test_goals.py tests/agent/test_iteration_budget.py tests/cli/test_cli_goal_max_turns.py tests/hermes_cli/test_kanban_goal_mode.py tests/tools/test_kanban_tools.py tests/hermes_cli/test_gateway_windows.py tests/test_hermes_logging.py tests/tools/test_base_environment.py tests/tools/test_delegate.py tests/tools/test_code_execution.py -q`
  - `755 passed, 37 skipped`
- `npm run test:ui -- src/hermes.test.ts` in `apps/desktop`
  - `4 passed`
- `git diff --check origin/main...HEAD`
- static added-line scan for hardcoded secrets, shell execution, eval/exec, pickle, and SQL formatting patterns
- independent pre-commit review passed before commit; rebase conflicts were resolved and the post-rebase gates above passed