### PR TITLE
Add Codex cockpit driver controls

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -217,6 +217,8 @@ def run_codex_app_server_turn(
         turn = agent._codex_session.run_turn(user_input=user_message)
     except Exception as exc:
         logger.exception("codex app-server turn failed")
+        agent._last_codex_error = str(exc)
+        agent._last_codex_completed_at = time.time()
         # Crash → unconditionally drop the session so the next turn
         # respawns from scratch instead of reusing a dead client.
         try:
@@ -251,6 +253,11 @@ def run_codex_app_server_turn(
         except Exception:
             pass
         agent._codex_session = None
+
+    agent._last_codex_thread_id = turn.thread_id
+    agent._last_codex_turn_id = turn.turn_id
+    agent._last_codex_error = turn.error or ""
+    agent._last_codex_completed_at = time.time()
 
     # Splice projected messages into the conversation. The projector emits
     # standard {role, content, tool_calls, tool_call_id} entries, which

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7069,6 +7069,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return ("Agent is running — wait or /stop first, then "
                         "change runtime.")
 
+            # /codex is a cockpit/readout surface and may also launch an
+            # independent Codex driver process in a clean worktree. It should
+            # not interrupt the active Hermes turn.
+            if _cmd_def_inner and _cmd_def_inner.name == "codex":
+                return await self._handle_codex_command(event)
+
             # /approve and /deny must bypass the running-agent interrupt path.
             # The agent thread is blocked on a threading.Event inside
             # tools/approval.py — sending an interrupt won't unblock it.
@@ -7445,6 +7451,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if canonical == "codex-runtime":
             return await self._handle_codex_runtime_command(event)
+
+        if canonical == "codex":
+            return await self._handle_codex_command(event)
 
         if canonical == "personality":
             return await self._handle_personality_command(event)

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1445,6 +1445,94 @@ class GatewaySlashCommandsMixin:
         prefix = "✓" if result.success else "✗"
         return f"{prefix} {result.message}"
 
+    async def _handle_codex_command(self, event: MessageEvent) -> str:
+        """Handle /codex cockpit commands.
+
+        `/codex-runtime` remains the low-level transport toggle. This command
+        is the operator-facing cockpit for readouts, staged context, and
+        launching Codex driver tasks in clean git worktrees.
+        """
+        from hermes_cli import codex_cockpit as cockpit
+        from hermes_cli.config import load_config
+
+        raw_args = event.get_command_args().strip() if event else ""
+        parsed = cockpit.parse_codex_command(raw_args)
+        if parsed.action == "error":
+            return f"Could not parse /codex arguments: {parsed.tokens[0]}"
+        if parsed.action == "help":
+            return cockpit.render_help()
+
+        try:
+            cfg = load_config()
+        except Exception as exc:
+            return f"Could not load config: {exc}"
+
+        source = event.source
+        session_key = self._session_key_for_source(source)
+        active_agent = self._running_agents.get(session_key)
+        cwd = os.environ.get("TERMINAL_CWD") or str(Path.home())
+
+        transcript: list[dict[str, Any]] = []
+        try:
+            session_entry = self.session_store.get_or_create_session(source)
+            transcript = self.session_store.load_transcript(session_entry.session_id)
+        except Exception:
+            logger.debug("could not load transcript for /codex", exc_info=True)
+
+        process_sessions: list[dict[str, Any]] = []
+        try:
+            from tools.process_registry import process_registry
+
+            process_sessions = process_registry.list_sessions()
+        except Exception:
+            logger.debug("could not list process registry for /codex", exc_info=True)
+
+        if parsed.action == "status":
+            return cockpit.render_status(
+                cfg,
+                active_agent=active_agent,
+                process_sessions=process_sessions,
+                transcript=transcript,
+                cwd=cwd,
+                session_key=session_key,
+            )
+        if parsed.action == "last":
+            return cockpit.render_last(transcript, active_agent=active_agent)
+        if parsed.action == "checks":
+            return cockpit.render_checks(process_sessions)
+        if parsed.action == "context":
+            return cockpit.render_context()
+        if parsed.action == "launch":
+            plan, error = cockpit.prepare_launch(raw_args, cfg, cwd=cwd)
+            if error:
+                return error
+            assert plan is not None
+            try:
+                from tools.process_registry import process_registry
+
+                proc = process_registry.spawn_local(
+                    plan.command,
+                    cwd=plan.repo_root,
+                    task_id=plan.task_id,
+                    session_key=session_key,
+                    use_pty=True,
+                )
+            except Exception as exc:
+                logger.warning("/codex launch failed", exc_info=True)
+                return f"Codex launch failed: {exc}"
+            return "\n".join(
+                [
+                    "Codex driver launched.",
+                    f"- Process: `{proc.id}`",
+                    f"- Branch: `{plan.branch}`",
+                    f"- Worktree: `{plan.worktree_path}`",
+                    f"- Prompt: {plan.prompt_preview}",
+                    "Use `/agents` or `/codex checks` to monitor background work.",
+                ]
+            )
+
+        return f"Unknown /codex action `{parsed.action}`.\n\n{cockpit.render_help()}"
+
     async def _handle_personality_command(self, event: MessageEvent) -> str:
         """Handle /personality command - list or set a personality."""
         from gateway.run import _hermes_home, _load_gateway_config

--- a/hermes_cli/codex_cockpit.py
+++ b/hermes_cli/codex_cockpit.py
@@ -1,0 +1,557 @@
+"""Codex cockpit helpers.
+
+This module keeps the Hermes/Codex integration split cleanly:
+
+* Hermes is the cockpit: status, launch orchestration, context review.
+* Codex is the driver: coding work runs in Codex app-server or codex exec.
+
+The functions here are intentionally gateway/CLI-neutral so slash commands,
+tests, and future UI surfaces can share the same parsing and rendering.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import subprocess
+import time
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+
+DEFAULT_READOUT = {
+    "include_git_status": True,
+    "include_recent_tool_events": True,
+    "include_checks": True,
+    "max_events": 25,
+}
+
+DEFAULT_CONTEXT_HELPER = {
+    "propose_memory": True,
+    "propose_skills": True,
+    "auto_promote": False,
+}
+
+
+@dataclass(frozen=True)
+class CodexCockpitConfig:
+    enabled: bool
+    driver: str
+    default_model: str
+    default_worktree_root: str
+    branch_prefix: str
+    repo_allowlist: tuple[str, ...]
+    readout: dict[str, Any]
+    context_helper: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class CodexCommand:
+    action: str
+    tokens: tuple[str, ...]
+    raw_args: str
+
+
+@dataclass(frozen=True)
+class LaunchPlan:
+    repo_root: str
+    worktree_path: str
+    branch: str
+    command: str
+    task_id: str
+    prompt_preview: str
+
+
+def _home_code_root() -> str:
+    return str(Path.home() / "Code")
+
+
+def load_cockpit_config(config: Mapping[str, Any] | None) -> CodexCockpitConfig:
+    """Return normalized cockpit config with conservative defaults."""
+    raw = {}
+    if isinstance(config, Mapping):
+        maybe = config.get("codex_cockpit", {})
+        if isinstance(maybe, Mapping):
+            raw = dict(maybe)
+
+    readout = dict(DEFAULT_READOUT)
+    if isinstance(raw.get("readout"), Mapping):
+        readout.update(raw["readout"])
+    context_helper = dict(DEFAULT_CONTEXT_HELPER)
+    if isinstance(raw.get("context_helper"), Mapping):
+        context_helper.update(raw["context_helper"])
+
+    allowlist_raw = raw.get("repo_allowlist")
+    if isinstance(allowlist_raw, str):
+        allowlist = [allowlist_raw]
+    elif isinstance(allowlist_raw, Iterable):
+        allowlist = [str(item) for item in allowlist_raw if str(item).strip()]
+    else:
+        allowlist = [_home_code_root()]
+
+    normalized_allowlist = tuple(
+        str(Path(os.path.expanduser(path)).resolve())
+        for path in allowlist
+        if str(path).strip()
+    )
+
+    return CodexCockpitConfig(
+        enabled=_as_bool(raw.get("enabled", True)),
+        driver=str(raw.get("driver") or "codex_app_server"),
+        default_model=str(raw.get("default_model") or "gpt-5.5"),
+        default_worktree_root=str(
+            raw.get("default_worktree_root") or "/private/tmp/hermes-codex"
+        ),
+        branch_prefix=str(raw.get("branch_prefix") or "codex/"),
+        repo_allowlist=normalized_allowlist,
+        readout=readout,
+        context_helper=context_helper,
+    )
+
+
+def parse_codex_command(raw_args: str) -> CodexCommand:
+    """Parse `/codex ...` into an action and shlex tokens."""
+    raw_args = raw_args or ""
+    try:
+        tokens = tuple(shlex.split(raw_args))
+    except ValueError as exc:
+        return CodexCommand("error", (str(exc),), raw_args)
+    if not tokens:
+        return CodexCommand("status", (), raw_args)
+    action = tokens[0].lower()
+    if action in {"?", "help"}:
+        return CodexCommand("help", tokens[1:], raw_args)
+    return CodexCommand(action, tokens[1:], raw_args)
+
+
+def render_help() -> str:
+    return "\n".join(
+        [
+            "**Codex Cockpit**",
+            "`/codex status` - show runtime, auth, active agent, git, and pending context",
+            "`/codex last` - show the latest assistant reply for this session",
+            "`/codex checks` - summarize recent validation-looking background processes",
+            "`/codex context` - show pending memory/skill promotions",
+            "`/codex launch <repo> <prompt>` - start Codex in a clean worktree",
+        ]
+    )
+
+
+def render_status(
+    config: Mapping[str, Any] | None,
+    *,
+    active_agent: Any = None,
+    process_sessions: Optional[list[dict[str, Any]]] = None,
+    transcript: Optional[list[dict[str, Any]]] = None,
+    cwd: Optional[str] = None,
+    session_key: Optional[str] = None,
+) -> str:
+    """Render a compact cockpit readout."""
+    cockpit = load_cockpit_config(config)
+    runtime = _current_runtime(config)
+    codex_ok, codex_version = _codex_binary_status()
+    auth_line = _codex_auth_line()
+
+    lines = [
+        "**Codex Cockpit**",
+        f"- Enabled: {_yes_no(cockpit.enabled)}",
+        f"- Driver: `{cockpit.driver}`",
+        f"- Hermes runtime: `{runtime}`",
+        f"- Codex CLI: {_format_binary(codex_ok, codex_version)}",
+        f"- Codex auth: {auth_line}",
+        f"- Default model: `{cockpit.default_model}`",
+        f"- Worktree root: `{cockpit.default_worktree_root}`",
+    ]
+    if session_key:
+        lines.append(f"- Session key: `{session_key}`")
+
+    lines.extend(_active_agent_lines(active_agent))
+
+    if cockpit.readout.get("include_recent_tool_events", True):
+        tool_names = _recent_tool_names(
+            transcript or [],
+            _positive_int(cockpit.readout.get("max_events"), 25),
+        )
+        if tool_names:
+            rendered_tools = ", ".join(f"`{name}`" for name in tool_names)
+            lines.append(f"- Recent tools: {rendered_tools}")
+        else:
+            lines.append("- Recent tools: none")
+
+    if cockpit.readout.get("include_git_status", True):
+        lines.extend(_git_lines(cwd))
+
+    if cockpit.readout.get("include_checks", True):
+        check_count = len(_validation_processes(process_sessions or []))
+        lines.append(f"- Recent checks: {check_count}")
+
+    mem_count, skill_count = _pending_context_counts()
+    lines.append(f"- Pending context: {mem_count} memory, {skill_count} skill")
+
+    last = latest_assistant_text(transcript or [])
+    if last:
+        lines.append(f"- Last reply: {_truncate_one_line(last, 140)}")
+    return "\n".join(lines)
+
+
+def render_last(
+    transcript: Optional[list[dict[str, Any]]],
+    *,
+    active_agent: Any = None,
+) -> str:
+    text = latest_assistant_text(transcript or [])
+    thread_id = _agent_attr(active_agent, "_last_codex_thread_id")
+    turn_id = _agent_attr(active_agent, "_last_codex_turn_id")
+    parts = ["**Codex Last**"]
+    if thread_id:
+        parts.append(f"- Thread: `{thread_id}`")
+    if turn_id:
+        parts.append(f"- Turn: `{turn_id}`")
+    if text:
+        parts.append("")
+        parts.append(text[-2500:])
+    else:
+        parts.append("- No assistant reply recorded for this session yet.")
+    return "\n".join(parts)
+
+
+def render_checks(process_sessions: Optional[list[dict[str, Any]]]) -> str:
+    checks = _validation_processes(process_sessions or [])[:8]
+    if not checks:
+        return "**Codex Checks**\nNo recent validation-looking background processes found."
+    lines = ["**Codex Checks**"]
+    for proc in checks:
+        status = str(proc.get("status") or "unknown")
+        exit_code = proc.get("exit_code")
+        suffix = f" exit={exit_code}" if exit_code is not None else ""
+        command = _truncate_one_line(str(proc.get("command") or ""), 120)
+        preview = _truncate_one_line(str(proc.get("output_preview") or ""), 160)
+        lines.append(f"- `{proc.get('session_id', 'process')}` {status}{suffix}: `{command}`")
+        if preview:
+            lines.append(f"  {preview}")
+    return "\n".join(lines)
+
+
+def render_context() -> str:
+    memory_pending, skill_pending = _pending_context_records()
+    lines = ["**Codex Context**"]
+    if not memory_pending and not skill_pending:
+        lines.append("No pending memory or skill promotions.")
+        return "\n".join(lines)
+
+    if memory_pending:
+        lines.append(f"Pending memory: {len(memory_pending)}")
+        for record in memory_pending[:5]:
+            lines.append(
+                f"- `{record.get('id', '?')}` {record.get('origin', 'foreground')}: "
+                f"{_truncate_one_line(str(record.get('summary') or ''), 140)}"
+            )
+    if skill_pending:
+        lines.append(f"Pending skills: {len(skill_pending)}")
+        for record in skill_pending[:5]:
+            lines.append(
+                f"- `{record.get('id', '?')}` {record.get('origin', 'foreground')}: "
+                f"{_truncate_one_line(str(record.get('summary') or ''), 140)}"
+            )
+    lines.append("Promote or discard staged items with the existing `/memory` and skill review flows.")
+    return "\n".join(lines)
+
+
+def prepare_launch(
+    raw_args: str,
+    config: Mapping[str, Any] | None,
+    *,
+    cwd: Optional[str] = None,
+    now: Optional[float] = None,
+) -> tuple[Optional[LaunchPlan], Optional[str]]:
+    """Validate `/codex launch` args and produce the background command."""
+    cockpit = load_cockpit_config(config)
+    if not cockpit.enabled:
+        return None, "Codex cockpit is disabled in `codex_cockpit.enabled`."
+
+    parsed = parse_codex_command(raw_args)
+    tokens = parsed.tokens if parsed.action == "launch" else tuple()
+    if len(tokens) < 2:
+        return None, "Usage: `/codex launch <repo> <prompt>`"
+
+    repo_arg = tokens[0]
+    prompt = " ".join(tokens[1:]).strip()
+    if not prompt:
+        return None, "Usage: `/codex launch <repo> <prompt>`"
+
+    repo_path = Path(os.path.expanduser(repo_arg))
+    if not repo_path.is_absolute():
+        repo_path = Path(cwd or os.getcwd()) / repo_path
+    repo_path = repo_path.resolve()
+
+    repo_root, error = resolve_git_root(str(repo_path))
+    if error:
+        return None, error
+    assert repo_root is not None
+
+    if not _path_allowed(repo_root, cockpit.repo_allowlist):
+        allowed = ", ".join(f"`{p}`" for p in cockpit.repo_allowlist) or "(none)"
+        return None, f"Repository `{repo_root}` is outside `codex_cockpit.repo_allowlist`: {allowed}"
+
+    timestamp = time.strftime("%Y%m%d-%H%M%S", time.localtime(now or time.time()))
+    slug = _slug(prompt)
+    branch_prefix = _safe_branch_prefix(cockpit.branch_prefix)
+    branch = f"{branch_prefix}{slug}-{timestamp}"
+    root = Path(os.path.expanduser(cockpit.default_worktree_root)).resolve()
+    worktree_path = root / f"{Path(repo_root).name}-{slug}-{timestamp}"
+    task_id = f"codex_{slug}_{timestamp}"
+
+    command = " && ".join(
+        [
+            f"mkdir -p {shlex.quote(str(root))}",
+            f"git -C {shlex.quote(repo_root)} fetch origin",
+            (
+                f"git -C {shlex.quote(repo_root)} worktree add "
+                f"-b {shlex.quote(branch)} {shlex.quote(str(worktree_path))} origin/main"
+            ),
+            (
+                "codex exec "
+                f"-C {shlex.quote(str(worktree_path))} "
+                f"--model {shlex.quote(cockpit.default_model)} "
+                "--sandbox workspace-write "
+                f"{shlex.quote(prompt)}"
+            ),
+        ]
+    )
+    return (
+        LaunchPlan(
+            repo_root=repo_root,
+            worktree_path=str(worktree_path),
+            branch=branch,
+            command=command,
+            task_id=task_id,
+            prompt_preview=_truncate_one_line(prompt, 120),
+        ),
+        None,
+    )
+
+
+def resolve_git_root(path: str) -> tuple[Optional[str], Optional[str]]:
+    try:
+        proc = subprocess.run(
+            ["git", "-C", path, "rev-parse", "--show-toplevel"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=10,
+        )
+    except Exception as exc:
+        return None, f"Could not inspect `{path}` as a git repo: {exc}"
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "not a git repository").strip()
+        return None, f"`{path}` is not a git repository: {detail}"
+    return str(Path(proc.stdout.strip()).resolve()), None
+
+
+def latest_assistant_text(transcript: list[dict[str, Any]]) -> str:
+    for msg in reversed(transcript):
+        if msg.get("role") != "assistant":
+            continue
+        content = msg.get("content")
+        if isinstance(content, str) and content.strip():
+            return content.strip()
+    return ""
+
+
+def _current_runtime(config: Mapping[str, Any] | None) -> str:
+    try:
+        from hermes_cli.codex_runtime_switch import get_current_runtime
+
+        return get_current_runtime(dict(config or {}))
+    except Exception:
+        return "unknown"
+
+
+def _codex_binary_status() -> tuple[bool, Optional[str]]:
+    try:
+        from hermes_cli.codex_runtime_switch import check_codex_binary_ok
+
+        return check_codex_binary_ok()
+    except Exception as exc:
+        return False, str(exc)
+
+
+def _codex_auth_line() -> str:
+    try:
+        from hermes_cli.auth import get_codex_auth_status
+
+        status = get_codex_auth_status()
+    except Exception as exc:
+        return f"unknown ({exc})"
+    if status.get("logged_in"):
+        source = status.get("source") or status.get("auth_mode") or "logged in"
+        return f"logged in ({source})"
+    error = status.get("error")
+    return f"not logged in ({error})" if error else "not logged in"
+
+
+def _active_agent_lines(active_agent: Any) -> list[str]:
+    if active_agent is None:
+        return ["- Active agent: no"]
+    lines = ["- Active agent: yes"]
+    for label, attr in (
+        ("Model", "model"),
+        ("Provider", "provider"),
+        ("API mode", "api_mode"),
+        ("CWD", "session_cwd"),
+        ("Codex thread", "_last_codex_thread_id"),
+        ("Codex turn", "_last_codex_turn_id"),
+        ("Codex error", "_last_codex_error"),
+    ):
+        value = _agent_attr(active_agent, attr)
+        if value:
+            lines.append(f"  {label}: `{value}`")
+    return lines
+
+
+def _agent_attr(active_agent: Any, attr: str) -> str:
+    if active_agent is None:
+        return ""
+    value = getattr(active_agent, attr, "")
+    if isinstance(value, (str, int, float)):
+        return str(value)
+    return ""
+
+
+def _git_lines(cwd: Optional[str]) -> list[str]:
+    if not cwd:
+        return ["- Git: no cwd"]
+    try:
+        proc = subprocess.run(
+            ["git", "-C", cwd, "status", "-sb"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=8,
+        )
+    except Exception as exc:
+        return [f"- Git: unavailable ({exc})"]
+    if proc.returncode != 0:
+        return ["- Git: not a git workspace"]
+    first = (proc.stdout or "").splitlines()[0] if proc.stdout else ""
+    return [f"- Git: `{first}`" if first else "- Git: clean/unknown"]
+
+
+def _validation_processes(process_sessions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    needles = (
+        "pytest",
+        "npm test",
+        "npm run test",
+        "npm run build",
+        "git diff --check",
+        "tsc",
+        "ruff",
+        "mypy",
+    )
+    filtered = []
+    for proc in process_sessions:
+        command = str(proc.get("command") or "").lower()
+        if any(needle in command for needle in needles):
+            filtered.append(proc)
+    return sorted(filtered, key=lambda item: str(item.get("started_at") or ""), reverse=True)
+
+
+def _recent_tool_names(transcript: list[dict[str, Any]], limit: int) -> list[str]:
+    names: list[str] = []
+    for msg in reversed(transcript):
+        tool_name = msg.get("tool_name")
+        if isinstance(tool_name, str) and tool_name.strip():
+            names.append(tool_name.strip())
+        calls = msg.get("tool_calls")
+        if isinstance(calls, list):
+            for call in reversed(calls):
+                if not isinstance(call, Mapping):
+                    continue
+                fn = call.get("function")
+                if isinstance(fn, Mapping):
+                    name = fn.get("name")
+                    if isinstance(name, str) and name.strip():
+                        names.append(name.strip())
+                if len(names) >= limit:
+                    return names
+        if len(names) >= limit:
+            return names
+    return names
+
+
+def _pending_context_counts() -> tuple[int, int]:
+    memory, skills = _pending_context_records()
+    return len(memory), len(skills)
+
+
+def _pending_context_records() -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    try:
+        from tools import write_approval
+
+        return (
+            write_approval.list_pending("memory"),
+            write_approval.list_pending("skills"),
+        )
+    except Exception:
+        return [], []
+
+
+def _path_allowed(path: str, allowlist: tuple[str, ...]) -> bool:
+    candidate = Path(path).resolve()
+    for root in allowlist:
+        try:
+            candidate.relative_to(Path(root).resolve())
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def _slug(text: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9]+", "-", text.strip().lower()).strip("-")
+    return (slug or "task")[:48].strip("-") or "task"
+
+
+def _safe_branch_prefix(prefix: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9._/-]+", "-", prefix.strip())
+    if not cleaned:
+        cleaned = "codex/"
+    return cleaned if cleaned.endswith("/") else f"{cleaned}/"
+
+
+def _truncate_one_line(text: str, limit: int) -> str:
+    one_line = " ".join(str(text).split())
+    if len(one_line) <= limit:
+        return one_line
+    return one_line[: max(0, limit - 3)].rstrip() + "..."
+
+
+def _format_binary(ok: bool, version: Optional[str]) -> str:
+    if ok:
+        return f"OK `{version or 'installed'}`"
+    return f"missing ({version or 'install codex'})"
+
+
+def _yes_no(value: bool) -> str:
+    return "yes" if value else "no"
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() not in {"0", "false", "no", "off", "disabled"}
+    return bool(value)
+
+
+def _positive_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -125,6 +125,10 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True),
     CommandDef("model", "Switch model for this session", "Configuration",
                args_hint="[model] [--provider name] [--global] [--refresh]"),
+    CommandDef("codex", "Codex cockpit readout and driver commands",
+               "Configuration",
+               args_hint="[status|launch|last|checks|context] ...",
+               subcommands=("status", "launch", "last", "checks", "context", "help")),
     CommandDef("codex-runtime", "Toggle codex app-server runtime for OpenAI/Codex models",
                "Configuration", aliases=("codex_runtime",),
                args_hint="[auto|codex_app_server]"),
@@ -1053,7 +1057,9 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 # the telegram-parity test reads it so an entry here is a deliberate
 # "Slack-via-/hermes" decision, not a silent clamp.
 #   - credits: the billing/top-up surface; reached via /hermes credits on Slack.
-_SLACK_VIA_HERMES_ONLY = frozenset({"credits"})
+#   - codex: cockpit subcommands can be long and remain reachable via
+#     /hermes codex ... without displacing existing native Slack commands.
+_SLACK_VIA_HERMES_ONLY = frozenset({"credits", "codex"})
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -811,6 +811,25 @@ DEFAULT_CONFIG = {
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
+    "codex_cockpit": {
+        "enabled": True,
+        "driver": "codex_app_server",
+        "default_model": "gpt-5.5",
+        "default_worktree_root": "/private/tmp/hermes-codex",
+        "branch_prefix": "codex/",
+        "repo_allowlist": [str(Path.home() / "Code")],
+        "readout": {
+            "include_git_status": True,
+            "include_recent_tool_events": True,
+            "include_checks": True,
+            "max_events": 25,
+        },
+        "context_helper": {
+            "propose_memory": True,
+            "propose_skills": True,
+            "auto_promote": False,
+        },
+    },
     # Global active chat session cap across CLI, TUI/dashboard, and messaging.
     # None/0 = unbounded.
     "max_concurrent_sessions": None,

--- a/skills/autonomous-ai-agents/codex/SKILL.md
+++ b/skills/autonomous-ai-agents/codex/SKILL.md
@@ -41,19 +41,26 @@ that Codex auth is missing.
 ## One-Shot Tasks
 
 ```
-terminal(command="codex exec 'Add dark mode toggle to settings'", workdir="~/project", pty=true)
+terminal(command="codex exec -C ~/project --sandbox workspace-write 'Add dark mode toggle to settings'", pty=true)
 ```
 
 For scratch work (Codex needs a git repo):
 ```
-terminal(command="cd $(mktemp -d) && git init && codex exec 'Build a snake game in Python'", pty=true)
+terminal(command="SCRATCH=$(mktemp -d) && git -C $SCRATCH init && codex exec -C $SCRATCH --sandbox workspace-write 'Build a snake game in Python'", pty=true)
 ```
 
 ## Background Mode (Long Tasks)
 
+Prefer the Hermes cockpit command when available:
+
 ```
-# Start in background with PTY
-terminal(command="codex exec --full-auto 'Refactor the auth module'", workdir="~/project", background=true, pty=true)
+/codex launch ~/project "Refactor the auth module"
+```
+
+Or start Codex manually in the background with a PTY:
+
+```
+terminal(command="codex exec -C ~/project --sandbox workspace-write 'Refactor the auth module'", background=true, pty=true)
 # Returns session_id
 
 # Monitor progress
@@ -72,8 +79,8 @@ process(action="kill", session_id="<id>")
 | Flag | Effect |
 |------|--------|
 | `exec "prompt"` | One-shot execution, exits when done |
-| `--full-auto` | Sandboxed but auto-approves file changes in workspace |
-| `--yolo` | No sandbox, no approvals (fastest, most dangerous) |
+| `-C <dir>` | Run Codex with a specific repository/worktree as cwd |
+| `--sandbox workspace-write` | Allow workspace writes while keeping Codex sandboxing on |
 | `--sandbox danger-full-access` | No Codex sandbox; useful when the host service context breaks bubblewrap |
 
 ## Hermes Gateway Caveat
@@ -110,8 +117,8 @@ terminal(command="git worktree add -b fix/issue-78 /tmp/issue-78 main", workdir=
 terminal(command="git worktree add -b fix/issue-99 /tmp/issue-99 main", workdir="~/project")
 
 # Launch Codex in each
-terminal(command="codex --yolo exec 'Fix issue #78: <description>. Commit when done.'", workdir="/tmp/issue-78", background=true, pty=true)
-terminal(command="codex --yolo exec 'Fix issue #99: <description>. Commit when done.'", workdir="/tmp/issue-99", background=true, pty=true)
+terminal(command="codex exec -C /tmp/issue-78 --sandbox workspace-write 'Fix issue #78: <description>. Commit when done.'", background=true, pty=true)
+terminal(command="codex exec -C /tmp/issue-99 --sandbox workspace-write 'Fix issue #99: <description>. Commit when done.'", background=true, pty=true)
 
 # Monitor
 process(action="list")
@@ -143,7 +150,7 @@ terminal(command="gh pr comment 86 --body '<review>'", workdir="~/project")
 1. **Always use `pty=true`** — Codex is an interactive terminal app and hangs without a PTY
 2. **Git repo required** — Codex won't run outside a git directory. Use `mktemp -d && git init` for scratch
 3. **Use `exec` for one-shots** — `codex exec "prompt"` runs and exits cleanly
-4. **`--full-auto` for building** — auto-approves changes within the sandbox
+4. **Prefer worktrees for feature work** — `/codex launch` creates a clean worktree and tracked background process
 5. **Background for long tasks** — use `background=true` and monitor with `process` tool
 6. **Don't interfere** — monitor with `poll`/`log`, be patient with long-running tasks
 7. **Parallel is fine** — run multiple Codex processes at once for batch work

--- a/tests/gateway/test_codex_cockpit_command.py
+++ b/tests/gateway/test_codex_cockpit_command.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    source = _make_source()
+    session_key = build_session_key(source)
+    session_entry = SessionEntry(
+        session_key=session_key,
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    runner.adapters = {Platform.TELEGRAM: MagicMock()}
+    runner._running_agents = {}
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = [
+        {"role": "assistant", "content": "latest answer"}
+    ]
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_codex_status_renders_cockpit(monkeypatch):
+    from hermes_cli import codex_cockpit as cc
+
+    runner = _make_runner()
+    agent = SimpleNamespace(
+        model="gpt-test",
+        provider="openai-codex",
+        api_mode="codex_app_server",
+        session_cwd="/tmp/repo",
+        _last_codex_thread_id="thread-1",
+        _last_codex_turn_id="turn-1",
+    )
+    runner._running_agents[build_session_key(_make_source())] = agent
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "model": {"openai_runtime": "codex_app_server"},
+            "codex_cockpit": {"readout": {"include_git_status": False}},
+        },
+    )
+    monkeypatch.setattr(cc, "_codex_binary_status", lambda: (True, "0.130.0"))
+    monkeypatch.setattr(cc, "_codex_auth_line", lambda: "logged in (test)")
+
+    result = await runner._handle_codex_command(_make_event("/codex status"))
+
+    assert "**Codex Cockpit**" in result
+    assert "codex_app_server" in result
+    assert "thread-1" in result
+    assert "latest answer" in result
+
+
+@pytest.mark.asyncio
+async def test_codex_launch_spawns_background_process(monkeypatch):
+    from hermes_cli import codex_cockpit as cc
+
+    runner = _make_runner()
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"codex_cockpit": {}})
+    plan = cc.LaunchPlan(
+        repo_root="/tmp/repo",
+        worktree_path="/tmp/worktree",
+        branch="codex/test",
+        command="codex exec -C /tmp/worktree test",
+        task_id="codex_test",
+        prompt_preview="test prompt",
+    )
+    monkeypatch.setattr(cc, "prepare_launch", lambda *args, **kwargs: (plan, None))
+
+    spawned = {}
+
+    class FakeRegistry:
+        def list_sessions(self):
+            return []
+
+        def spawn_local(self, command, **kwargs):
+            spawned["command"] = command
+            spawned.update(kwargs)
+            return SimpleNamespace(id="proc-1")
+
+    monkeypatch.setattr("tools.process_registry.process_registry", FakeRegistry())
+
+    result = await runner._handle_codex_command(
+        _make_event('/codex launch /tmp/repo "test prompt"')
+    )
+
+    assert "Codex driver launched" in result
+    assert "proc-1" in result
+    assert spawned["command"] == plan.command
+    assert spawned["cwd"] == plan.repo_root
+    assert spawned["task_id"] == plan.task_id
+    assert spawned["use_pty"] is True

--- a/tests/hermes_cli/test_codex_cockpit.py
+++ b/tests/hermes_cli/test_codex_cockpit.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from hermes_cli import codex_cockpit as cc
+
+
+def test_load_cockpit_config_defaults_to_home_code_allowlist():
+    cfg = cc.load_cockpit_config({})
+
+    assert cfg.enabled is True
+    assert cfg.driver == "codex_app_server"
+    assert cfg.default_model == "gpt-5.5"
+    assert cfg.branch_prefix == "codex/"
+    assert cfg.repo_allowlist
+
+
+def test_load_cockpit_config_normalizes_user_values(tmp_path):
+    allowed = tmp_path / "repos"
+    cfg = cc.load_cockpit_config(
+        {
+            "codex_cockpit": {
+                "enabled": "off",
+                "driver": "codex_exec",
+                "default_model": "gpt-test",
+                "default_worktree_root": str(tmp_path / "worktrees"),
+                "branch_prefix": "ai",
+                "repo_allowlist": [str(allowed)],
+                "readout": {"include_git_status": False},
+                "context_helper": {"auto_promote": True},
+            }
+        }
+    )
+
+    assert cfg.enabled is False
+    assert cfg.driver == "codex_exec"
+    assert cfg.default_model == "gpt-test"
+    assert cfg.branch_prefix == "ai"
+    assert cfg.repo_allowlist == (str(allowed.resolve()),)
+    assert cfg.readout["include_git_status"] is False
+    assert cfg.context_helper["auto_promote"] is True
+
+
+def test_prepare_launch_builds_safe_worktree_command(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    worktrees = tmp_path / "worktrees"
+    monkeypatch.setattr(
+        cc,
+        "resolve_git_root",
+        lambda path: (str(repo.resolve()), None),
+    )
+
+    plan, error = cc.prepare_launch(
+        'launch repo "Fix auth bug"',
+        {
+            "codex_cockpit": {
+                "repo_allowlist": [str(tmp_path)],
+                "default_worktree_root": str(worktrees),
+                "default_model": "gpt-test",
+                "branch_prefix": "codex/",
+            }
+        },
+        cwd=str(tmp_path),
+        now=1_800_000_000,
+    )
+
+    assert error is None
+    assert plan is not None
+    assert plan.repo_root == str(repo.resolve())
+    assert plan.branch.startswith("codex/fix-auth-bug-")
+    assert str(worktrees.resolve()) in plan.worktree_path
+    assert "git -C" in plan.command
+    assert "worktree add" in plan.command
+    assert "codex exec" in plan.command
+    assert "--model gpt-test" in plan.command
+    assert "--sandbox workspace-write" in plan.command
+
+
+def test_prepare_launch_rejects_repo_outside_allowlist(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    monkeypatch.setattr(
+        cc,
+        "resolve_git_root",
+        lambda path: (str(repo.resolve()), None),
+    )
+
+    plan, error = cc.prepare_launch(
+        "launch repo fix-things",
+        {"codex_cockpit": {"repo_allowlist": [str(allowed)]}},
+        cwd=str(tmp_path),
+    )
+
+    assert plan is None
+    assert error is not None
+    assert "outside `codex_cockpit.repo_allowlist`" in error
+
+
+def test_render_last_includes_codex_ids():
+    class Agent:
+        _last_codex_thread_id = "thread-1"
+        _last_codex_turn_id = "turn-2"
+
+    rendered = cc.render_last(
+        [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "done"},
+        ],
+        active_agent=Agent(),
+    )
+
+    assert "thread-1" in rendered
+    assert "turn-2" in rendered
+    assert "done" in rendered
+
+
+def test_render_checks_filters_validation_processes():
+    rendered = cc.render_checks(
+        [
+            {"session_id": "p1", "command": "sleep 1", "status": "running"},
+            {
+                "session_id": "p2",
+                "command": "npm run build",
+                "status": "exited",
+                "exit_code": 0,
+                "output_preview": "built",
+            },
+        ]
+    )
+
+    assert "p2" in rendered
+    assert "built" in rendered
+    assert "sleep 1" not in rendered
+
+
+def test_render_status_includes_recent_tool_events(monkeypatch):
+    monkeypatch.setattr(cc, "_codex_binary_status", lambda: (True, "test"))
+    monkeypatch.setattr(cc, "_codex_auth_line", lambda: "logged in (test)")
+    monkeypatch.setattr(cc, "_pending_context_counts", lambda: (0, 0))
+
+    rendered = cc.render_status(
+        {"codex_cockpit": {"readout": {"include_git_status": False, "max_events": 2}}},
+        transcript=[
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"function": {"name": "read_file"}},
+                    {"function": {"name": "terminal"}},
+                ],
+            },
+            {"role": "tool", "tool_name": "write_file", "content": "ok"},
+        ],
+    )
+
+    assert "- Recent tools: `write_file`, `terminal`" in rendered
+    assert "read_file" not in rendered


### PR DESCRIPTION
## Summary
- Add a configurable Codex cockpit helper with `/codex status`, `/codex last`, `/codex checks`, `/codex context`, and `/codex launch <repo> <prompt>`.
- Wire the gateway command so cockpit readouts can run during active Hermes turns and `launch` starts Codex in a clean worktree through the process registry.
- Track last Codex app-server thread/turn/error for readouts, add default `codex_cockpit` config, and refresh the bundled Codex skill examples to match the local `codex exec` CLI syntax.

## Tests
- `venv/bin/pytest tests/hermes_cli/test_codex_cockpit.py tests/gateway/test_codex_cockpit_command.py tests/hermes_cli/test_codex_runtime_switch.py tests/run_agent/test_codex_app_server_integration.py` — 55 passed
- `venv/bin/pytest tests/gateway/test_status_command.py tests/gateway/test_codex_cockpit_command.py tests/hermes_cli/test_config.py tests/hermes_cli/test_commands.py` — 272 passed
- `venv/bin/pytest tests/gateway/test_codex_cockpit_command.py` — 2 passed after the EOF cleanup
- `venv/bin/python -m compileall hermes_cli/codex_cockpit.py gateway/slash_commands.py gateway/run.py agent/codex_runtime.py hermes_cli/commands.py hermes_cli/config.py`
- `git diff --check` and `git diff --cached --check`
- `codex exec --help` verified that this installed Codex CLI supports `-C`/`--sandbox workspace-write` and does not support the older `--ask-for-approval` flag.

## Known Wall
- A broader macOS sweep hits pre-existing platform assumptions before this feature code: `venv/bin/pytest tests/hermes_cli/test_gateway_service.py -x` fails in `TestSystemdServiceRefresh.test_systemd_start_refreshes_outdated_unit` with `User D-Bus session is not available (not supported on this platform)`.