### PR TITLE
fix(gateway): deliver media before queued follow-ups

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12653,7 +12653,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # extract_local_files scanned text that still contained MEDIA: tags,
             # producing false-positive bare-path matches with the MEDIA: prefix
             # glued on. This matches the chain order in gateway/platforms/base.py.
-            _, cleaned = adapter.extract_images(cleaned)
+            remote_images, cleaned = adapter.extract_images(cleaned)
             local_files, _ = adapter.extract_local_files(cleaned)
             local_files = BasePlatformAdapter.filter_local_delivery_paths(local_files)
 
@@ -12685,12 +12685,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 else:
                     non_image_local.append(file_path)
 
-            if image_paths:
+            image_batch = list(remote_images or [])
+            image_batch.extend((f"file://{_quote(p)}", "") for p in image_paths)
+            if image_batch:
                 try:
-                    images = [(f"file://{_quote(p)}", "") for p in image_paths]
                     await adapter.send_multiple_images(
                         chat_id=event.source.chat_id,
-                        images=images,
+                        images=image_batch,
                         metadata=_thread_meta,
                     )
                 except Exception as e:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12742,6 +12742,50 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             logger.warning("Post-stream media extraction failed: %s", e)
 
 
+    async def _send_queued_first_response(
+        self,
+        response: str,
+        event: MessageEvent,
+        adapter,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Deliver a queued-turn first response with normal media handling.
+
+        The queued follow-up path cannot hand the response back to
+        ``BasePlatformAdapter._process_message_background()``, so sending the raw
+        text through ``adapter.send()`` would expose MEDIA directives and skip
+        attachments. Mirror the normal response pipeline: send only display text,
+        then deliver extracted MEDIA/local files separately.
+        """
+        if not response:
+            return
+
+        text_content = response
+        try:
+            from gateway.platforms.base import _strip_media_directives
+
+            _, text_content = adapter.extract_media(text_content)
+            _, text_content = adapter.extract_images(text_content)
+            _, text_content = adapter.extract_local_files(text_content)
+            text_content = _strip_media_directives(text_content).strip()
+        except Exception as exc:
+            logger.warning(
+                "[%s] Queued follow-up response media cleanup failed: %s",
+                getattr(adapter, "name", "adapter"),
+                exc,
+            )
+            text_content = response
+
+        if text_content:
+            await adapter.send(
+                event.source.chat_id,
+                text_content,
+                metadata=metadata,
+            )
+
+        await self._deliver_media_from_response(response, event, adapter)
+
+
 
     async def _run_background_task(
         self,
@@ -19057,9 +19101,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 "Queued follow-up for session %s: final stream delivery not confirmed; sending first response before continuing.",
                                 session_key or "?",
                             )
-                            await adapter.send(
-                                source.chat_id,
+                            response_event = MessageEvent(
+                                text="",
+                                message_type=MessageType.TEXT,
+                                source=source,
+                                message_id=event_message_id,
+                            )
+                            await self._send_queued_first_response(
                                 first_response,
+                                response_event,
+                                adapter,
                                 metadata=_status_thread_metadata,
                             )
                         except Exception as e:

--- a/tests/gateway/test_queued_followup_media_delivery.py
+++ b/tests/gateway/test_queued_followup_media_delivery.py
@@ -1,0 +1,91 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _runner() -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner._reply_anchor_for_event = lambda event: event.message_id
+    runner._thread_metadata_for_source = lambda source, _reply=None: (
+        {"thread_id": source.thread_id} if source.thread_id else None
+    )
+    return runner
+
+
+def _event() -> MessageEvent:
+    return MessageEvent(
+        text="next",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="273403055",
+            chat_type="dm",
+            user_id="273403055",
+            thread_id="374476",
+        ),
+        message_id="25741",
+    )
+
+
+def _adapter():
+    return SimpleNamespace(
+        name="Telegram",
+        extract_media=BasePlatformAdapter.extract_media,
+        extract_images=lambda text: ([], text),
+        extract_local_files=BasePlatformAdapter.extract_local_files,
+        send=AsyncMock(),
+        send_voice=AsyncMock(),
+        send_video=AsyncMock(),
+        send_document=AsyncMock(),
+        send_multiple_images=AsyncMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_queued_first_response_strips_media_and_sends_document(tmp_path):
+    html = tmp_path / "pivin-scenario.html"
+    html.write_text("<!doctype html><title>Pivin</title>", encoding="utf-8")
+
+    adapter = _adapter()
+    response = f"Done.\n\nMEDIA:{html}"
+
+    await _runner()._send_queued_first_response(
+        response,
+        _event(),
+        adapter,
+        metadata={"thread_id": "374476"},
+    )
+
+    adapter.send.assert_awaited_once_with(
+        "273403055",
+        "Done.",
+        metadata={"thread_id": "374476"},
+    )
+    adapter.send_document.assert_awaited_once()
+    assert adapter.send_document.await_args.kwargs["chat_id"] == "273403055"
+    assert adapter.send_document.await_args.kwargs["file_path"] == str(html)
+    assert adapter.send_document.await_args.kwargs["metadata"] == {"thread_id": "374476"}
+
+
+@pytest.mark.asyncio
+async def test_queued_first_response_all_media_sends_no_empty_text(tmp_path):
+    html = tmp_path / "handoff.html"
+    html.write_text("<!doctype html><title>Only media</title>", encoding="utf-8")
+
+    adapter = _adapter()
+
+    await _runner()._send_queued_first_response(
+        f"MEDIA:{html}",
+        _event(),
+        adapter,
+        metadata={"thread_id": "374476"},
+    )
+
+    adapter.send.assert_not_awaited()
+    adapter.send_document.assert_awaited_once()
+    assert adapter.send_document.await_args.kwargs["file_path"] == str(html)

--- a/tests/gateway/test_queued_followup_media_delivery.py
+++ b/tests/gateway/test_queued_followup_media_delivery.py
@@ -89,3 +89,27 @@ async def test_queued_first_response_all_media_sends_no_empty_text(tmp_path):
     adapter.send.assert_not_awaited()
     adapter.send_document.assert_awaited_once()
     assert adapter.send_document.await_args.kwargs["file_path"] == str(html)
+
+
+@pytest.mark.asyncio
+async def test_queued_first_response_preserves_remote_image_delivery():
+    adapter = _adapter()
+    adapter.extract_images = BasePlatformAdapter.extract_images
+
+    await _runner()._send_queued_first_response(
+        "Chart ready.\n\n![usage chart](https://example.com/usage.png)",
+        _event(),
+        adapter,
+        metadata={"thread_id": "374476"},
+    )
+
+    adapter.send.assert_awaited_once_with(
+        "273403055",
+        "Chart ready.",
+        metadata={"thread_id": "374476"},
+    )
+    adapter.send_multiple_images.assert_awaited_once_with(
+        chat_id="273403055",
+        images=[("https://example.com/usage.png", "usage chart")],
+        metadata={"thread_id": "374476"},
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes a gateway delivery path where a completed agent response is sent before draining a queued follow-up message. That path previously called the first-response delivery from inside `_run_agent`, where it could either bypass normal response media post-processing or, in the helper-based path, reference an out-of-scope `event` variable.

The change adds a small helper that mirrors normal response delivery for this queued path: send only displayable text, then deliver extracted `MEDIA:` / local files via the existing post-stream media delivery helper. The call site now builds a synthetic `MessageEvent` from the current `source` before invoking the helper, so queued first-response delivery has the chat/thread target it needs without relying on a non-existent local `event`.

This prevents raw `MEDIA:/path/to/file` text from leaking to users, preserves attachments when a user sends a follow-up while the first turn is completing, and avoids warnings like:

```text
Failed to send first response before queued message: name 'event' is not defined
```

## Related Issue

No related upstream issue or PR found. Searched PRs and issues for `MEDIA queued follow-up`, `final stream delivery`, `already_sent`, `MEDIA directive`, and `send_document MEDIA Telegram`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `gateway/run.py`
  - Add `_send_queued_first_response()` and use it in the queued follow-up first-response branch instead of raw `adapter.send()`.
  - Build a synthetic response `MessageEvent` from the current `source` at the queued call site so media delivery has chat/thread metadata and does not reference an undefined local `event`.
- `tests/gateway/test_queued_followup_media_delivery.py`
  - Cover mixed text plus `MEDIA:` and media-only queued first responses.

## How to Test

1. Reproduce by completing a response that includes `MEDIA:/path/to/file.html` while a follow-up message is already queued.
2. Before this fix, the queued branch can send the raw `MEDIA:` text and skip native attachment delivery, or fail the helper call with `name 'event' is not defined`.
3. After this fix, the display text is sent without `MEDIA:`, `send_document()` receives the referenced file, and the queued first-response branch has a valid response event.

Commands run:

```bash
/usr/local/lib/hermes-agent/venv/bin/python -m pytest -q -o addopts='' tests/gateway/test_queued_followup_media_delivery.py tests/gateway/test_media_extraction.py tests/gateway/test_duplicate_reply_suppression.py
/usr/local/lib/hermes-agent/venv/bin/python -m ruff check gateway/run.py tests/gateway/test_queued_followup_media_delivery.py
git diff --check
```

Results:

```text
39 passed, 1 warning
All checks passed!
git diff --check passed
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] Documentation update N/A
- [x] `cli-config.yaml.example` update N/A
- [x] `CONTRIBUTING.md` or `AGENTS.md` update N/A
- [x] Cross-platform impact considered; change is platform-neutral gateway response handling
- [x] Tool descriptions/schemas update N/A

## Screenshots / Logs

Observed live on Telegram: a queued first response containing text plus `MEDIA:/root/pivin-scenario.html` rendered the raw `MEDIA:` line instead of delivering the HTML attachment; a later media-only retry delivered the file.

A later live text-batch split also hit the same queued first-response branch and logged:

```text
Queued follow-up ... final stream delivery not confirmed; sending first response before continuing.
Failed to send first response before queued message: name 'event' is not defined
```

The regression tests encode the media delivery failure mode without depending on Telegram network state; the call-site fix removes the undefined `event` reference from the queued branch.
