### PR TITLE
fix(failover): multi-host fallback skipped same-provider/model on a different host

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -880,6 +880,38 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
 
 
 
+def _fallback_targets_current_backend(
+    fb_provider: str,
+    fb_model: str,
+    fb_base_url: str,
+    current_provider: str,
+    current_model: str,
+    current_base_url: str,
+) -> bool:
+    """True if a fallback entry resolves to the SAME backend that just failed.
+
+    "Same backend" = same model AND same endpoint, where the endpoint is the
+    fallback's explicit base_url when set, else the provider's default:
+
+      * same model + explicit base_url == current base_url  -> same backend
+      * same model + NO explicit base_url + same provider   -> same backend
+        (inherits the provider default == the current endpoint)
+
+    A same-provider/same-model entry with a DIFFERENT explicit base_url is a
+    DISTINCT backend (e.g. the same router type on ANOTHER HOST) and must NOT
+    be treated as the current backend — otherwise multi-host failover (primary
+    router host A, fallback router host B, identical provider+model) silently
+    skips the second host. This fixes the prior check that skipped on
+    provider+model alone, ignoring base_url. (Args are pre-normalised:
+    lower-cased, trailing slash stripped.)
+    """
+    if fb_model != current_model:
+        return False
+    if fb_base_url:
+        return fb_base_url == current_base_url
+    return fb_provider == current_provider
+
+
 def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool:
     """Switch to the next fallback model/provider in the chain.
 
@@ -919,21 +951,13 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
     current_model = (getattr(agent, "model", "") or "").strip()
     current_base_url = str(getattr(agent, "base_url", "") or "").rstrip("/").lower()
     fb_base_url_for_dedup = (fb.get("base_url") or "").strip().rstrip("/").lower()
-    if fb_provider == current_provider and fb_model == current_model:
-        logger.warning(
-            "Fallback skip: chain entry %s/%s matches current provider/model",
-            fb_provider, fb_model,
-        )
-        return agent._try_activate_fallback()
-    if (
-        fb_base_url_for_dedup
-        and current_base_url
-        and fb_base_url_for_dedup == current_base_url
-        and fb_model == current_model
+    if _fallback_targets_current_backend(
+        fb_provider, fb_model, fb_base_url_for_dedup,
+        current_provider, current_model, current_base_url,
     ):
         logger.warning(
-            "Fallback skip: chain entry base_url %s matches current backend",
-            fb_base_url_for_dedup,
+            "Fallback skip: chain entry %s/%s @ %s resolves to the current backend",
+            fb_provider, fb_model, fb_base_url_for_dedup or current_base_url,
         )
         return agent._try_activate_fallback()
 

--- a/tests/agent/test_fallback_multihost.py
+++ b/tests/agent/test_fallback_multihost.py
@@ -1,0 +1,73 @@
+"""Regression tests for multi-host fallback de-dup (_fallback_targets_current_backend).
+
+Bug: the prior skip logic in try_activate_fallback skipped any fallback whose
+provider+model matched the current backend, IGNORING base_url. That silently
+dropped a same-provider/same-model fallback pointing at a DIFFERENT HOST — i.e.
+multi-host failover (primary router on host A, fallback router on host B) never
+engaged; the chain jumped straight past the second host.
+
+The predicate must treat "same backend" as same model AND same endpoint, where
+the endpoint is the fallback's explicit base_url when set, else the provider
+default.
+"""
+
+from agent.chat_completion_helpers import _fallback_targets_current_backend as same_backend
+
+# All args are pre-normalised (lower-cased, trailing slash stripped) by the caller.
+PRIMARY_PROV = "nebius-tofa"
+PRIMARY_MODEL = "hermes/standard"
+PRIMARY_URL = "http://127.0.0.1:7831/v1"
+
+
+def test_multihost_same_provider_model_different_host_is_NOT_current_backend():
+    # THE FIX: rob-beast router — same provider+model as primary, different host.
+    assert (
+        same_backend(
+            "nebius-tofa", "hermes/standard", "http://100.74.162.102:7831/v1",
+            PRIMARY_PROV, PRIMARY_MODEL, PRIMARY_URL,
+        )
+        is False
+    )
+
+
+def test_same_provider_model_no_base_url_inherits_current_backend():
+    # No explicit base_url -> inherits the provider default == current endpoint -> skip.
+    assert (
+        same_backend("nebius-tofa", "hermes/standard", "", PRIMARY_PROV, PRIMARY_MODEL, PRIMARY_URL)
+        is True
+    )
+
+
+def test_same_base_url_same_model_is_current_backend_even_cross_provider():
+    # Two distinct providers pointing at the SAME shim/proxy URL + same model -> skip.
+    assert (
+        same_backend("custom", "hermes/standard", PRIMARY_URL, PRIMARY_PROV, PRIMARY_MODEL, PRIMARY_URL)
+        is True
+    )
+
+
+def test_exact_same_backend_is_skipped():
+    assert (
+        same_backend("nebius-tofa", "hermes/standard", PRIMARY_URL, PRIMARY_PROV, PRIMARY_MODEL, PRIMARY_URL)
+        is True
+    )
+
+
+def test_different_model_is_not_current_backend():
+    # The direct-ToFa seatbelt entry: different model -> always a distinct backend.
+    assert (
+        same_backend(
+            "nebius-tofa", "qwen/qwen3-235b-a22b-instruct-2507",
+            "https://api.tokenfactory.nebius.com/v1",
+            PRIMARY_PROV, PRIMARY_MODEL, PRIMARY_URL,
+        )
+        is False
+    )
+
+
+def test_different_host_different_model_not_current_backend():
+    assert (
+        same_backend("nebius-tofa", "other/model", "http://100.74.162.102:7831/v1",
+                     PRIMARY_PROV, PRIMARY_MODEL, PRIMARY_URL)
+        is False
+    )


### PR DESCRIPTION
## Bug
`try_activate_fallback` (`agent/chat_completion_helpers.py`) skipped any fallback chain entry whose **provider+model matched the current backend, ignoring base_url**. So a same-provider/same-model fallback pointing at a **different host/endpoint** (e.g. the same proxy/router type on another host for HA) was silently dropped — the chain jumped past it to the next distinct entry.

## Fix
Extract the skip decision into a pure predicate `_fallback_targets_current_backend` that treats "same backend" as **same model AND same endpoint** (the fallback's explicit base_url when set, else the provider default). A same-provider/model entry with a **different** base_url is a distinct backend and is no longer skipped. Both prior inline checks are subsumed correctly; loop-prevention is preserved (index advances before the skip; recursion terminates on chain exhaustion).

## Tests
6 new unit tests (`tests/agent/test_fallback_multihost.py`); 780 repo-wide fallback tests pass.

Found + verified in a multi-host LLM-router failover setup (primary router host A → fallback router host B → direct provider).