### PR TITLE
fix(docker): prevent CRLF in cont-init.d via .gitattributes + sed normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,8 +3,18 @@ web/package-lock.json linguist-generated=true
 
 # Enforce LF for scripts that run inside Linux containers.
 # Without this, Windows checkout converts to CRLF and breaks `exec` in the
-# container entrypoint with "no such file or directory".
+# container entrypoint with "no such file or directory". Three traps we
+# have hit so far:
+#   1. `*.sh`             — generic shell scripts
+#   2. `Dockerfile`       — RUN printf "..." + COPY chains
+#   3. `docker/cont-init.d/*` and `docker/s6-rc.d/**/type` — s6-overlay
+#      reads these via `with-contenv sh`; a stray \r makes it try to
+#      exec "sh\r" → "No such file or directory" at PID-1, cascading
+#      every service down (we have hit this twice: see
+#      hermes-docker-crlf-image-boot-failure.md).
 *.sh        text eol=lf
 Dockerfile  text eol=lf
 *.dockerfile text eol=lf
+docker/cont-init.d/*    text eol=lf
 docker/entrypoint.sh text eol=lf
+docker/s6-rc.d/**/type  text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -247,6 +247,16 @@ RUN if [ -n "${HERMES_GIT_SHA}" ]; then \
 # /etc/cont-init.d/02-reconcile-profiles (Phase 4 Task 4.0).
 COPY docker/s6-rc.d/ /etc/s6-overlay/s6-rc.d/
 
+# Defense in depth: strip any stray CR from the s6-rc tree after COPY.
+# `.gitattributes` (s6-rc.d/**/type) should already guarantee LF, but a
+# Windows checkout with core.autocrlf disabled (or a file added without
+# `git add --renormalize`) can still leak CRLF into the build context.
+# s6 strictly requires LF on `type`/contents.d files; a stray CR (e.g.
+# "longrun\r") is silently rejected as "invalid type: must be oneshot,
+# longrun, or bundle" and the whole bundle fails to start. See
+# hermes-docker-crlf-image-boot-failure.md.
+RUN find /etc/s6-overlay/s6-rc.d -type f -exec sed -i 's/\r$//' {} +
+
 # stage2-hook handles UID/GID remap, volume chown, config seeding,
 # skills sync — all the work the old entrypoint.sh did before
 # `exec hermes`. Wired in as cont-init.d/01- so it
@@ -261,6 +271,15 @@ RUN mkdir -p /etc/cont-init.d && \
     chmod +x /etc/cont-init.d/01-hermes-setup
 COPY --chmod=0755 docker/cont-init.d/015-supervise-perms /etc/cont-init.d/015-supervise-perms
 COPY --chmod=0755 docker/cont-init.d/02-reconcile-profiles /etc/cont-init.d/02-reconcile-profiles
+
+# Defense in depth: strip any stray CR from the cont-init scripts after
+# COPY. `.gitattributes` (docker/cont-init.d/*) should already guarantee
+# LF, but a Windows checkout with core.autocrlf disabled (or a file
+# added without `git add --renormalize`) can still leak CRLF into the
+# build context. s6-overlay's `with-contenv sh` then fails to exec
+# "sh\r" at container boot with "No such file or directory" and every
+# service cascades down. Mirrors the s6-rc.d normalization above.
+RUN find /etc/cont-init.d -type f -exec sed -i 's/\r$//' {} +
 
 # ---------- Runtime ----------
 ENV HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist


### PR DESCRIPTION
## Summary

Fix `exec: fatal: unable to exec sh` and `s6-rc-compile: invalid type` boot failures that occur when the image is built on Windows hosts with `core.autocrlf=true`.

## The bug

When the image is built from a Windows checkout (which is the default install path for this repo's contributor base), the `docker/cont-init.d/*` execlineb scripts and the `docker/s6-rc.d/**/type` marker files are delivered to the Docker daemon with **CRLF** line endings. Two cascading failures:

1. s6-overlay's PID-1 reads `02-reconcile-profiles` and `015-supervise-perms` via `with-contenv sh` and tries to `exec "sh\r"`, producing
   `exec: fatal: unable to exec sh : No such file or directory`
   followed by the script exiting with 127.
2. The same CRLF on `docker/s6-rc.d/<svc>/type` makes s6-rc-compile fail with `invalid type "longrun\r"`, taking the whole service tree down.

The net symptom from a user's perspective is: "the new image boots, every service is dead, and there is no obvious error in the dashboard."

## Root cause

`main`'s `.gitattributes` only protects `*.sh`, `Dockerfile`, `*.dockerfile`, and `docker/entrypoint.sh`. On a Windows host with the default `core.autocrlf=true`, the `docker/cont-init.d/*` and `docker/s6-rc.d/**/type` files slip through and get CRLF in the working tree. The Dockerfile's `COPY` then bakes CRLF into the image layer.

## Fix — two layers

**Layer 1 (root cause): `.gitattributes`**

Add two LF guards so the files never reach the build context with CRLF:

```
docker/cont-init.d/*    text eol=lf
docker/s6-rc.d/**/type  text eol=lf
```

**Layer 2 (defense in depth): `Dockerfile`**

Add two `RUN find … | sed -i 's/\r$//' {} +` blocks, one after `COPY docker/s6-rc.d/` and one after `COPY --chmod=0755 docker/cont-init.d/…`. These run unconditionally at image build time, so even if `.gitattributes` is bypassed (autocrlf disabled globally, file added without `git add --renormalize`, etc.) the image is still LF-only.

The combination is small (3 net lines of `text eol=lf` rules + 2 `RUN` blocks + comments) and matches the layering already in use elsewhere in this repo (`*.sh` → `RUN find … sed` in the build chain).

## Verification

End-to-end upgrade-chain test run on Windows 11 + Docker Desktop 29.4.3 (build context = the install clone at `D:\hermes-stack\data\hermes-agent\`):

| Step | Result |
| --- | --- |
| `hermes update --check` | passes |
| `hermes update --yes` (autostash + checkout main + pull + autostash pop) | clean, mirror diffs survive |
| `docker compose build` | 199.3s, mostly CACHED layers, new image `hermes-agent:latest` = `53f281476ce2` |
| `docker compose up -d --force-recreate` | both containers up, 11 gateway services registered |
| `curl http://127.0.0.1:8642/health` (work) | `HTTP 200` |
| `curl http://127.0.0.1:8643/health` (assistant) | `HTTP 200` |
| `docker restart hermes hermes-dashboard` → re-check | `HTTP 200` on both, no `exec: fatal` / `exited 127` / `invalid type` in logs |
| `gateway_state.json` for work + assistant | `gateway_state: "running"`, `api_server: connected` |

The `autostash` mechanism in `hermes_cli/main.py:cmd_update` is the load-bearing piece: it saves any local `.gitattributes` / `Dockerfile` mirror diffs, switches the install clone to `main`, pulls, switches back to the original branch, and pops the stash. As long as the working tree is restored before `docker compose build` runs, the build context picks up the fix.

## Test plan

A reviewer can verify on a Windows host with `core.autocrlf=true`:

1. `git clone` this branch into a fresh directory.
2. Confirm `docker/cont-init.d/02-reconcile-profiles` and `docker/s6-rc.d/gateway-default/type` are LF (not CRLF) in the working tree: `git ls-files --eol docker/cont-init.d/02-reconcile-profiles docker/s6-rc.d/gateway-default/type` → `w/-text w/-text attr/text eol=lf` for both.
3. `docker compose -f docker-compose.yml build` and confirm the build succeeds without any CR-related retries.
4. `docker compose up -d` and `docker logs hermes --tail 50` → no `exec: fatal` / `exited 127` / `invalid type`.
5. (Regression check) `find /etc/cont-init.d /etc/s6-overlay/s6-rc.d -type f -exec file {} +` inside a freshly-built container → all report `ASCII text` (not `ASCII text, with CRLF line terminators`).

## Out of scope

- The related issue where `hermes update` against an unmodified install clone rebuilds an image from `origin/main` (which currently lacks the `.gitattributes` guard) and reintroduces the bug. This PR is the root-cause fix; once it merges, that failure mode goes away.
- A follow-up commit could add a CI lint step that fails the build if any file under `docker/cont-init.d/` or `docker/s6-rc.d/` contains `\r`. Happy to send that as a separate PR if desired.
