### PR TITLE
fix(persistence): make identity flushing safe against id() reuse

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1574,26 +1574,33 @@ class AIAgent:
             # repair compacts the list around them.
             current_session_id = getattr(self, "session_id", None)
             flushed_session_id = getattr(self, "_flushed_db_message_session_id", None)
-            if flushed_session_id != current_session_id or self._last_flushed_db_idx == 0:
-                self._flushed_db_message_ids = set()
+            if (
+                not isinstance(getattr(self, "_flushed_db_messages", None), list)
+                or flushed_session_id != current_session_id
+                or self._last_flushed_db_idx == 0
+            ):
+                self._flushed_db_messages = []
                 self._flushed_db_message_session_id = current_session_id
-            flushed_ids = getattr(self, "_flushed_db_message_ids", None)
-            if not isinstance(flushed_ids, set):
-                flushed_ids = set()
-                self._flushed_db_message_ids = flushed_ids
-            history_ids = {
-                id(item) for item in (conversation_history or [])
-                if isinstance(item, dict)
-            }
+            # Track already-written messages by OBJECT IDENTITY, holding a strong
+            # reference to each. id()-based tracking is unsafe: repair can drop a
+            # this-turn message that was already flushed, after which CPython may
+            # recycle its id() onto a freshly-appended dict (the assistant reply),
+            # which an id()-set would then wrongly skip — silent transcript loss
+            # (#160). Pinning the objects stops their id()s from being recycled
+            # while still tracked; comparing with ``is`` is reuse-proof regardless.
+            # The pin is pruned to messages still present on each call, so memory
+            # stays bounded — a repair-removed message drops out and may then be
+            # garbage-collected safely.
+            flushed = self._flushed_db_messages
+            flushed[:] = [o for o in flushed if any(o is m for m in messages)]
+            history = conversation_history or []
 
             for msg in messages:
                 if not isinstance(msg, dict):
                     continue
-                msg_id = id(msg)
-                if msg_id in flushed_ids:
+                if any(msg is o for o in flushed):
                     continue
-                if msg_id in history_ids:
-                    flushed_ids.add(msg_id)
+                if any(msg is h for h in history):
                     continue
                 role = msg.get("role", "unknown")
                 content = msg.get("content")
@@ -1633,7 +1640,7 @@ class AIAgent:
                     codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
                     codex_message_items=msg.get("codex_message_items") if role == "assistant" else None,
                 )
-                flushed_ids.add(msg_id)
+                flushed.append(msg)
             self._last_flushed_db_idx = len(messages)
         except Exception as e:
             logger.warning("Session DB append_message failed: %s", e)

--- a/tests/run_agent/test_flush_id_reuse_regression.py
+++ b/tests/run_agent/test_flush_id_reuse_regression.py
@@ -1,0 +1,124 @@
+"""Regression: identity-based SQLite flushing must survive ``id()`` reuse.
+
+``_flush_messages_to_session_db`` tracks already-written messages so repeated
+flushes (the turn-start and turn-end persist paths both run) don't duplicate
+rows. When that tracking keys on ``id(msg)`` it is unsafe: ``repair_message_
+sequence`` can drop a this-turn message that was already flushed (e.g. merging
+consecutive user turns), after which CPython may recycle that freed dict's
+``id()`` onto the freshly-appended assistant reply. The reply then collides with
+a *retained* "already flushed" id and is silently skipped — the turn's answer
+never reaches ``state.db``. The loss is self-reinforcing: a missing assistant
+reply leaves a consecutive-user violation that makes the next repair shrink even
+more.
+
+Fix: track written messages by object identity while holding a strong reference
+(so a tracked message's ``id()`` cannot be recycled), compare with ``is``, and
+prune the pin to messages still present on each flush so memory stays bounded.
+"""
+import types
+
+from hermes_state import SessionDB
+from run_agent import AIAgent
+from agent.agent_runtime_helpers import repair_message_sequence
+
+
+def _make_flusher(db, session_id):
+    """A minimal stand-in exposing the real flush method against a real DB."""
+    stub = types.SimpleNamespace(
+        _session_db=db,
+        _session_db_created=True,
+        _last_flushed_db_idx=0,
+        session_id=session_id,
+    )
+    stub._apply_persist_user_message_override = lambda messages: None
+    stub._ensure_db_session = lambda: None
+    stub._flush_messages_to_session_db = types.MethodType(
+        AIAgent._flush_messages_to_session_db, stub
+    )
+    return stub
+
+
+def _assistant_texts(db, session_id):
+    return [
+        m.get("content")
+        for m in db.get_messages_as_conversation(session_id)
+        if m.get("role") == "assistant" and (m.get("content") or "").strip()
+    ]
+
+
+def test_assistant_reply_persists_when_repair_recycles_a_flushed_id(tmp_path):
+    """A repair-freed flushed message's recycled id() must not skip the reply."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = db.create_session(session_id="s1", source="test")
+
+    # Loaded history with a role-alternation violation already in the DB:
+    # two consecutive user turns (the shape interrupted/voice-burst turns leave).
+    loaded = [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "content": "a1"},
+        {"role": "user", "content": "q2a"},
+        {"role": "user", "content": "q2b"},  # consecutive-user violation
+    ]
+    for m in loaded:
+        db.append_message(sid, role=m["role"], content=m["content"])
+
+    conversation_history = [dict(m) for m in loaded]
+    messages = list(conversation_history)
+    messages.append({"role": "user", "content": "q3"})  # this turn's user input
+
+    flusher = _make_flusher(db, sid)
+
+    # Turn-start persist (mirrors the pre-loop session persist).
+    flusher._flush_messages_to_session_db(messages, conversation_history)
+
+    # Defensive role-alternation repair runs before the API call and shrinks
+    # `messages` in place (merges the consecutive user turns + q3), freeing the
+    # just-flushed q3 dict whose id() can then be recycled.
+    repaired = repair_message_sequence(flusher, messages)
+    assert repaired >= 1, "expected the consecutive-user violation to be repaired"
+
+    # Model produces its answer; appended to the live list (may reuse a freed id).
+    messages.append({"role": "assistant", "content": "THE_REPLY"})
+
+    # Turn-end persist.
+    flusher._flush_messages_to_session_db(messages, conversation_history)
+
+    texts = _assistant_texts(db, sid)
+    assert "THE_REPLY" in texts, (
+        "assistant reply was dropped — a recycled id() collided with a retained "
+        f"'already flushed' entry. assistant rows={texts}"
+    )
+
+
+def test_no_duplicate_writes_on_normal_turns(tmp_path):
+    """A clean turn (no repair) writes each new message exactly once across the
+    multiple persist calls of a turn."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    sid = db.create_session(session_id="s2", source="test")
+
+    loaded = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi there"},
+    ]
+    for m in loaded:
+        db.append_message(sid, role=m["role"], content=m["content"])
+
+    conversation_history = [dict(m) for m in loaded]
+    messages = list(conversation_history)
+
+    flusher = _make_flusher(db, sid)
+
+    # New user turn + assistant reply, persisted via two flush calls (as the
+    # turn-start and turn-end paths both do).
+    messages.append({"role": "user", "content": "how are you"})
+    flusher._flush_messages_to_session_db(messages, conversation_history)
+    messages.append({"role": "assistant", "content": "doing well"})
+    flusher._flush_messages_to_session_db(messages, conversation_history)
+    # An extra redundant flush must be a no-op.
+    flusher._flush_messages_to_session_db(messages, conversation_history)
+
+    rows = db.get_messages_as_conversation(sid)
+    contents = [m.get("content") for m in rows]
+    assert contents.count("how are you") == 1, contents
+    assert contents.count("doing well") == 1, contents
+    assert contents == ["hello", "hi there", "how are you", "doing well"], contents


### PR DESCRIPTION
## Problem

`AIAgent._flush_messages_to_session_db` tracks already-written messages by `id(msg)` (`_flushed_db_message_ids`) so the turn-start and turn-end persist paths don't write duplicate rows.

`id()` is not stable across object lifetimes. `repair_message_sequence` can drop a **this-turn** message that was already flushed (e.g. merging consecutive user turns), after which CPython may recycle that freed dict's `id()` onto the **freshly-appended assistant reply**. The reply's `id()` then collides with a retained "already flushed" entry and is silently skipped — the turn's answer never reaches `state.db`. The loss is self-reinforcing: a dropped assistant reply leaves a consecutive-user violation that makes the next `repair_message_sequence` shrink further.

## Fix

Track written messages **by object identity holding a strong reference** instead of by `id()`: pinning prevents the `id()` from being recycled while tracked, comparison uses `is`, and the pin is **pruned to messages still present each flush** so memory stays bounded. Existing dedup + the repair-shrink / stale-cursor / compression behaviour (`test_identity_flush.py`, `test_compression_persistence.py`) are preserved.

## Test

`tests/run_agent/test_flush_id_reuse_regression.py` — **fails** on the `id()`-set implementation, **passes** with the fix; also asserts no-duplicate-writes on a clean turn.

> Found running a long-lived headless deployment where a session stopped persisting assistant messages. Happy to adjust style/placement to your conventions.