### PR TITLE
refactor: remove local _openai_error from api_server, use shared ingress import

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -30,6 +30,7 @@ from typing import Any, Dict, List, Optional
 from agent.codex_responses_adapter import _summarize_user_message_for_log
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
+from agent.failure_policy import RecoveryAction, RecoveryDecision, decide_api_recovery
 from agent.iteration_budget import IterationBudget
 from agent.turn_context import build_turn_context
 from agent.turn_retry_state import TurnRetryState
@@ -69,6 +70,48 @@ logger = logging.getLogger(__name__)
 # cancelled while waiting on the provider. Surfaces (ACP, TUI) match on this
 # to treat it as cancellation metadata rather than assistant prose.
 INTERRUPT_WAITING_FOR_MODEL_PREFIX = "Operation interrupted: waiting for model response ("
+
+
+def _is_client_error_from_policy(
+    classified: Any,
+    recovery_decision: RecoveryDecision,
+    *,
+    is_local_validation_error: bool = False,
+    is_context_length_error: bool = False,
+) -> bool:
+    """Return True when the current failure should abort the generic retry path."""
+
+    if is_context_length_error:
+        return False
+    if is_local_validation_error:
+        return True
+    if classified.retryable:
+        return False
+    return recovery_decision.primary_action not in {
+        RecoveryAction.retry_same,
+        RecoveryAction.retry_smaller_scope,
+        RecoveryAction.compress_context,
+    }
+
+
+def _should_try_eager_fallback(
+    recovery_decision: RecoveryDecision,
+    *,
+    reason: FailoverReason,
+) -> bool:
+    """Whether to switch providers before burning more retries.
+
+    Keep this conservative while the policy layer is being threaded through the
+    runtime: today we only eager-fallback the same failure bucket as before
+    (rate-limit / quota exhaustion), but the decision object is now the source
+    of truth for why that switch is appropriate.
+    """
+
+    if reason == FailoverReason.rate_limit:
+        return recovery_decision.primary_action == RecoveryAction.fallback_provider
+    if reason == FailoverReason.billing:
+        return RecoveryAction.fallback_provider in recovery_decision.secondary_actions
+    return False
 
 
 def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str]:
@@ -2004,11 +2047,14 @@ def run_conversation(
                     context_length=_ctx_len,
                     num_messages=len(api_messages) if api_messages else 0,
                 )
+                recovery_decision = decide_api_recovery(classified)
                 logger.debug(
-                    "Error classified: reason=%s status=%s retryable=%s compress=%s rotate=%s fallback=%s",
+                    "Error classified: reason=%s status=%s retryable=%s compress=%s rotate=%s fallback=%s action=%s secondary=%s",
                     classified.reason.value, classified.status_code,
                     classified.retryable, classified.should_compress,
                     classified.should_rotate_credential, classified.should_fallback,
+                    recovery_decision.primary_action.value,
+                    [action.value for action in recovery_decision.secondary_actions],
                 )
                 agent._invoke_api_request_error_hook(
                     task_id=effective_task_id,
@@ -2552,7 +2598,11 @@ def run_conversation(
                     FailoverReason.rate_limit,
                     FailoverReason.billing,
                 }
-                if is_rate_limited and agent._fallback_index < len(agent._fallback_chain):
+                should_eager_fallback = _should_try_eager_fallback(
+                    recovery_decision,
+                    reason=classified.reason,
+                )
+                if should_eager_fallback and agent._fallback_index < len(agent._fallback_chain):
                     # Don't eagerly fallback if credential pool rotation may
                     # still recover.  See _pool_may_recover_from_rate_limit
                     # for the single-credential-pool and CloudCode-quota
@@ -2941,21 +2991,12 @@ def run_conversation(
                 # (real-world: ~$40 in 48h on a 24/7 gateway).  Aborting
                 # mirrors how 401/403 (also ``should_fallback=True``)
                 # already behave once their recovery paths have failed.
-                is_client_error = (
-                    is_local_validation_error
-                    or (
-                        not classified.retryable
-                        and not classified.should_compress
-                        and classified.reason not in {
-                            FailoverReason.rate_limit,
-                            FailoverReason.overloaded,
-                            FailoverReason.context_overflow,
-                            FailoverReason.payload_too_large,
-                            FailoverReason.long_context_tier,
-                            FailoverReason.thinking_signature,
-                        }
-                    )
-                ) and not is_context_length_error
+                is_client_error = _is_client_error_from_policy(
+                    classified,
+                    recovery_decision,
+                    is_local_validation_error=is_local_validation_error,
+                    is_context_length_error=is_context_length_error,
+                )
 
                 if is_client_error:
                     # Try fallback before aborting — a different provider may

--- a/agent/failure_policy.py
+++ b/agent/failure_policy.py
@@ -1,0 +1,343 @@
+"""Shared recovery-policy primitives for agent/runtime failures.
+
+This module is the first foundation block for the broader
+"autonomous operator" work:
+- normalize common failure shapes across API and tool paths
+- map them to explicit next actions
+- keep the policy data-first and easily testable before wiring it into
+  higher-level loops
+
+The existing ``agent.error_classifier`` already does deep provider/API
+classification.  This module sits one layer above it and answers the
+practical question: *what should Hermes try next?*
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional
+
+from agent.error_classifier import ClassifiedError, FailoverReason
+
+
+class FailureClass(enum.Enum):
+    """Cross-runtime failure buckets suitable for recovery policy."""
+
+    auth = "auth"
+    billing = "billing"
+    rate_limit = "rate_limit"
+    overloaded = "overloaded"
+    timeout = "timeout"
+    server_error = "server_error"
+    context_overflow = "context_overflow"
+    payload_too_large = "payload_too_large"
+    content_policy = "content_policy"
+    tool_unavailable = "tool_unavailable"
+    tool_failed = "tool_failed"
+    empty_result = "empty_result"
+    parse_error = "parse_error"
+    unsupported = "unsupported"
+    unknown = "unknown"
+
+
+class RecoveryAction(enum.Enum):
+    """Preferred next move after a classified failure."""
+
+    retry_same = "retry_same"
+    retry_smaller_scope = "retry_smaller_scope"
+    compress_context = "compress_context"
+    rotate_credential = "rotate_credential"
+    fallback_provider = "fallback_provider"
+    fallback_tool = "fallback_tool"
+    degrade_mode = "degrade_mode"
+    ask_user = "ask_user"
+    abort = "abort"
+
+
+@dataclass(frozen=True)
+class RecoveryDecision:
+    """A small, explicit recovery-plan object."""
+
+    failure_class: FailureClass
+    primary_action: RecoveryAction
+    reason: str
+    retryable: bool = False
+    secondary_actions: tuple[RecoveryAction, ...] = field(default_factory=tuple)
+
+
+_API_REASON_TO_FAILURE_CLASS: dict[FailoverReason, FailureClass] = {
+    FailoverReason.auth: FailureClass.auth,
+    FailoverReason.auth_permanent: FailureClass.auth,
+    FailoverReason.billing: FailureClass.billing,
+    FailoverReason.rate_limit: FailureClass.rate_limit,
+    FailoverReason.overloaded: FailureClass.overloaded,
+    FailoverReason.server_error: FailureClass.server_error,
+    FailoverReason.timeout: FailureClass.timeout,
+    FailoverReason.context_overflow: FailureClass.context_overflow,
+    FailoverReason.payload_too_large: FailureClass.payload_too_large,
+    FailoverReason.image_too_large: FailureClass.payload_too_large,
+    FailoverReason.provider_policy_blocked: FailureClass.unsupported,
+    FailoverReason.content_policy_blocked: FailureClass.content_policy,
+    FailoverReason.model_not_found: FailureClass.unsupported,
+    FailoverReason.format_error: FailureClass.parse_error,
+    FailoverReason.invalid_encrypted_content: FailureClass.parse_error,
+    FailoverReason.multimodal_tool_content_unsupported: FailureClass.unsupported,
+    FailoverReason.thinking_signature: FailureClass.parse_error,
+    FailoverReason.long_context_tier: FailureClass.unsupported,
+    FailoverReason.oauth_long_context_beta_forbidden: FailureClass.unsupported,
+    FailoverReason.llama_cpp_grammar_pattern: FailureClass.unsupported,
+    FailoverReason.unknown: FailureClass.unknown,
+}
+
+
+def decide_api_recovery(error: ClassifiedError) -> RecoveryDecision:
+    """Map a classified provider/API error to a concrete recovery decision."""
+
+    failure_class = _API_REASON_TO_FAILURE_CLASS.get(error.reason, FailureClass.unknown)
+
+    if error.reason == FailoverReason.context_overflow:
+        return RecoveryDecision(
+            failure_class=failure_class,
+            primary_action=RecoveryAction.compress_context,
+            secondary_actions=(RecoveryAction.retry_smaller_scope,),
+            retryable=True,
+            reason="Prompt/context exceeded the provider limit.",
+        )
+
+    if error.reason in {FailoverReason.payload_too_large, FailoverReason.image_too_large}:
+        return RecoveryDecision(
+            failure_class=failure_class,
+            primary_action=RecoveryAction.retry_smaller_scope,
+            secondary_actions=(RecoveryAction.compress_context,),
+            retryable=True,
+            reason="Request payload is too large; shrink the payload before retrying.",
+        )
+
+    if error.reason in {FailoverReason.auth, FailoverReason.billing}:
+        return RecoveryDecision(
+            failure_class=failure_class,
+            primary_action=RecoveryAction.rotate_credential,
+            secondary_actions=(RecoveryAction.fallback_provider,),
+            retryable=error.should_fallback,
+            reason="Credential/account path failed; rotate first, then fall back to another provider if needed.",
+        )
+
+    if error.reason == FailoverReason.rate_limit:
+        return RecoveryDecision(
+            failure_class=failure_class,
+            primary_action=RecoveryAction.fallback_provider,
+            secondary_actions=(RecoveryAction.retry_same,),
+            retryable=True,
+            reason="Provider is temporarily rate-limited; prefer another provider before retrying the same one.",
+        )
+
+    if error.reason in {FailoverReason.overloaded, FailoverReason.server_error, FailoverReason.timeout}:
+        return RecoveryDecision(
+            failure_class=failure_class,
+            primary_action=RecoveryAction.retry_same,
+            secondary_actions=(RecoveryAction.fallback_provider,),
+            retryable=True,
+            reason="Transient provider failure; retry once, then fall back if the path keeps failing.",
+        )
+
+    if error.reason in {
+        FailoverReason.provider_policy_blocked,
+        FailoverReason.model_not_found,
+        FailoverReason.multimodal_tool_content_unsupported,
+        FailoverReason.long_context_tier,
+        FailoverReason.oauth_long_context_beta_forbidden,
+        FailoverReason.llama_cpp_grammar_pattern,
+    }:
+        return RecoveryDecision(
+            failure_class=failure_class,
+            primary_action=RecoveryAction.degrade_mode,
+            secondary_actions=(RecoveryAction.fallback_provider,),
+            retryable=True,
+            reason="Current provider/path is unsupported for this request shape; degrade or switch paths.",
+        )
+
+    if error.reason in {
+        FailoverReason.format_error,
+        FailoverReason.invalid_encrypted_content,
+        FailoverReason.thinking_signature,
+    }:
+        return RecoveryDecision(
+            failure_class=failure_class,
+            primary_action=RecoveryAction.degrade_mode,
+            secondary_actions=(RecoveryAction.retry_same,),
+            retryable=True,
+            reason="Request/response formatting can often be repaired in-place before retrying.",
+        )
+
+    if error.reason == FailoverReason.content_policy_blocked:
+        return RecoveryDecision(
+            failure_class=failure_class,
+            primary_action=RecoveryAction.ask_user,
+            retryable=False,
+            reason="The provider blocked this request on policy grounds; do not retry unchanged.",
+        )
+
+    return RecoveryDecision(
+        failure_class=failure_class,
+        primary_action=RecoveryAction.retry_same if error.retryable else RecoveryAction.ask_user,
+        secondary_actions=(RecoveryAction.fallback_provider,) if error.should_fallback else tuple(),
+        retryable=error.retryable,
+        reason="Unknown provider failure; start with the least-destructive retry path.",
+    )
+
+
+_TOOL_UNAVAILABLE_PATTERNS = (
+    "not available",
+    "not enabled",
+    "unknown tool",
+    "missing required",
+    "requires",
+)
+
+_TOOL_PARSE_PATTERNS = (
+    "json",
+    "schema",
+    "parse",
+    "invalid arguments",
+)
+
+
+def decide_tool_recovery(tool_name: str, result: Optional[str]) -> RecoveryDecision:
+    """Classify a Hermes tool result into a conservative recovery decision.
+
+    The tool ecosystem is intentionally heterogeneous, so this function only
+    treats obviously structured failures as signals.  Ambiguous plain text is
+    left in the ``unknown`` bucket rather than over-classifying.
+    """
+
+    data = _parse_json_object(result)
+    if data is not None:
+        if data.get("success") is False:
+            message = _tool_message(data)
+            return _decision_from_tool_message(tool_name, message)
+        if _has_nonzero_exit_code(data):
+            return RecoveryDecision(
+                failure_class=FailureClass.tool_failed,
+                primary_action=RecoveryAction.degrade_mode,
+                secondary_actions=(RecoveryAction.fallback_tool,),
+                retryable=True,
+                reason=f"{tool_name} exited non-zero; prefer a safer variant or fallback tool.",
+            )
+        if _looks_empty(data):
+            return RecoveryDecision(
+                failure_class=FailureClass.empty_result,
+                primary_action=RecoveryAction.retry_smaller_scope,
+                secondary_actions=(RecoveryAction.fallback_tool,),
+                retryable=True,
+                reason=f"{tool_name} returned no useful payload; narrow the query or switch tools.",
+            )
+        return RecoveryDecision(
+            failure_class=FailureClass.unknown,
+            primary_action=RecoveryAction.retry_same,
+            retryable=True,
+            reason=f"{tool_name} produced structured output with no obvious failure marker.",
+        )
+
+    text = (result or "").strip()
+    if not text:
+        return RecoveryDecision(
+            failure_class=FailureClass.empty_result,
+            primary_action=RecoveryAction.retry_smaller_scope,
+            secondary_actions=(RecoveryAction.fallback_tool,),
+            retryable=True,
+            reason=f"{tool_name} returned an empty result.",
+        )
+
+    lowered = text.lower()
+    if any(p in lowered for p in _TOOL_UNAVAILABLE_PATTERNS):
+        return RecoveryDecision(
+            failure_class=FailureClass.tool_unavailable,
+            primary_action=RecoveryAction.fallback_tool,
+            secondary_actions=(RecoveryAction.ask_user,),
+            retryable=False,
+            reason=f"{tool_name} appears unavailable in this environment.",
+        )
+    if any(p in lowered for p in _TOOL_PARSE_PATTERNS):
+        return RecoveryDecision(
+            failure_class=FailureClass.parse_error,
+            primary_action=RecoveryAction.degrade_mode,
+            secondary_actions=(RecoveryAction.retry_same,),
+            retryable=True,
+            reason=f"{tool_name} failed because of argument/format issues that may be fixable.",
+        )
+
+    return RecoveryDecision(
+        failure_class=FailureClass.unknown,
+        primary_action=RecoveryAction.retry_same,
+        secondary_actions=(RecoveryAction.fallback_tool,),
+        retryable=True,
+        reason=f"{tool_name} returned unstructured output; retry once, then use a different tool path.",
+    )
+
+
+def _parse_json_object(result: Optional[str]) -> Optional[Mapping[str, Any]]:
+    if not isinstance(result, str) or not result.strip():
+        return None
+    try:
+        parsed = json.loads(result)
+    except Exception:
+        return None
+    return parsed if isinstance(parsed, Mapping) else None
+
+
+def _has_nonzero_exit_code(data: Mapping[str, Any]) -> bool:
+    code = data.get("exit_code")
+    return isinstance(code, int) and code != 0
+
+
+def _looks_empty(data: Mapping[str, Any]) -> bool:
+    if isinstance(data.get("results"), list) and len(data["results"]) == 0:
+        return True
+    if isinstance(data.get("matches"), list) and len(data["matches"]) == 0:
+        return True
+    if isinstance(data.get("files"), list) and len(data["files"]) == 0:
+        return True
+    content = data.get("content")
+    if isinstance(content, str) and not content.strip():
+        return True
+    output = data.get("output")
+    if isinstance(output, str) and not output.strip() and data.get("exit_code") == 0:
+        return True
+    return False
+
+
+def _tool_message(data: Mapping[str, Any]) -> str:
+    for key in ("error", "message", "detail", "output"):
+        value = data.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _decision_from_tool_message(tool_name: str, message: str) -> RecoveryDecision:
+    lowered = (message or "").lower()
+    if any(p in lowered for p in _TOOL_UNAVAILABLE_PATTERNS):
+        return RecoveryDecision(
+            failure_class=FailureClass.tool_unavailable,
+            primary_action=RecoveryAction.fallback_tool,
+            secondary_actions=(RecoveryAction.ask_user,),
+            retryable=False,
+            reason=f"{tool_name} is unavailable or misconfigured.",
+        )
+    if any(p in lowered for p in _TOOL_PARSE_PATTERNS):
+        return RecoveryDecision(
+            failure_class=FailureClass.parse_error,
+            primary_action=RecoveryAction.degrade_mode,
+            secondary_actions=(RecoveryAction.retry_same,),
+            retryable=True,
+            reason=f"{tool_name} rejected the request shape; adjust arguments and retry.",
+        )
+    return RecoveryDecision(
+        failure_class=FailureClass.tool_failed,
+        primary_action=RecoveryAction.degrade_mode,
+        secondary_actions=(RecoveryAction.fallback_tool,),
+        retryable=True,
+        reason=f"{tool_name} reported a structured failure.",
+    )

--- a/agent/job_lifecycle.py
+++ b/agent/job_lifecycle.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+"""Shared lifecycle-state helpers for long-running Hermes work.
+
+This is the first common state model spanning cron jobs, background
+processes, and future async task runners. It gives the runtime one stable
+vocabulary for "where is this work right now?" without forcing every legacy
+surface to give up its existing status strings immediately.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping, Optional
+
+
+AttemptRecord = dict[str, Any]
+RunnerMetadata = dict[str, Any]
+MAX_ATTEMPT_HISTORY = 10
+
+
+class JobLifecycleState(str, Enum):
+    queued = "queued"
+    running = "running"
+    retrying = "retrying"
+    failed = "failed"
+    completed = "completed"
+    cancelled = "cancelled"
+    paused = "paused"
+    unknown = "unknown"
+
+
+@dataclass(frozen=True)
+class LifecycleSnapshot:
+    state: JobLifecycleState
+    terminal: bool = False
+    retryable: bool = False
+    detail: str = ""
+
+
+def process_lifecycle_state(*, exited: bool, exit_code: Optional[int]) -> JobLifecycleState:
+    """Map background-process state to the shared lifecycle vocabulary."""
+    if not exited:
+        return JobLifecycleState.running
+    if exit_code in (-15, 130, 143):
+        return JobLifecycleState.cancelled
+    if exit_code == 0 or exit_code is None:
+        return JobLifecycleState.completed
+    return JobLifecycleState.failed
+
+
+def cron_lifecycle_state(job: Mapping[str, Any]) -> JobLifecycleState:
+    """Infer the shared lifecycle state for a cron job record.
+
+    Legacy cron jobs keep their existing ``state`` field (scheduled/paused/
+    completed/error). This helper projects that storage shape into the new
+    cross-runtime lifecycle vocabulary without breaking old readers.
+    """
+    raw_state = str(job.get("state") or "").strip().lower()
+    enabled = bool(job.get("enabled", True))
+    next_run_at = job.get("next_run_at")
+    last_status = str(job.get("last_status") or "").strip().lower()
+
+    if raw_state == "completed":
+        return JobLifecycleState.failed if last_status == "error" else JobLifecycleState.completed
+    if raw_state == "paused" or not enabled:
+        return JobLifecycleState.paused
+    if raw_state == "running":
+        return JobLifecycleState.running
+    if raw_state == "error":
+        return JobLifecycleState.failed
+    if next_run_at:
+        if last_status == "error":
+            return JobLifecycleState.retrying
+        return JobLifecycleState.queued
+    if last_status == "error":
+        return JobLifecycleState.failed
+    if last_status == "ok":
+        return JobLifecycleState.completed
+    return JobLifecycleState.unknown
+
+
+def lifecycle_snapshot_for_process(*, exited: bool, exit_code: Optional[int]) -> LifecycleSnapshot:
+    state = process_lifecycle_state(exited=exited, exit_code=exit_code)
+    return LifecycleSnapshot(
+        state=state,
+        terminal=state in {JobLifecycleState.completed, JobLifecycleState.failed, JobLifecycleState.cancelled},
+        retryable=False,
+    )
+
+
+def lifecycle_snapshot_for_cron(job: Mapping[str, Any]) -> LifecycleSnapshot:
+    state = cron_lifecycle_state(job)
+    retryable = state == JobLifecycleState.retrying
+    terminal = state in {JobLifecycleState.completed, JobLifecycleState.failed, JobLifecycleState.cancelled}
+    if state == JobLifecycleState.queued:
+        terminal = False
+    if state == JobLifecycleState.paused:
+        terminal = False
+    return LifecycleSnapshot(state=state, terminal=terminal, retryable=retryable)
+
+
+def make_attempt_record(
+    *,
+    attempt: int,
+    state: JobLifecycleState | str,
+    started_at: Optional[str],
+    finished_at: Optional[str] = None,
+    error: Optional[str] = None,
+    retry_count: int = 0,
+) -> AttemptRecord:
+    lifecycle_state = state.value if isinstance(state, JobLifecycleState) else str(state)
+    return {
+        "attempt": max(1, int(attempt)),
+        "lifecycle_state": lifecycle_state,
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "error": error,
+        "retry_count": max(0, int(retry_count)),
+    }
+
+
+def normalize_attempt_record(record: Any) -> Optional[AttemptRecord]:
+    if not isinstance(record, Mapping):
+        return None
+    try:
+        attempt = int(record.get("attempt", 1) or 1)
+    except Exception:
+        attempt = 1
+    try:
+        retry_count = int(record.get("retry_count", 0) or 0)
+    except Exception:
+        retry_count = 0
+    state = str(record.get("lifecycle_state") or JobLifecycleState.unknown.value).strip() or JobLifecycleState.unknown.value
+    started_at = record.get("started_at")
+    finished_at = record.get("finished_at")
+    error = record.get("error")
+    return make_attempt_record(
+        attempt=attempt,
+        state=state,
+        started_at=str(started_at) if started_at else None,
+        finished_at=str(finished_at) if finished_at else None,
+        error=str(error) if error is not None else None,
+        retry_count=retry_count,
+    )
+
+
+def default_queue_metadata(*, queued_at: Optional[str] = None) -> dict[str, Any]:
+    return {
+        "retry_count": 0,
+        "retry_backoff_seconds": 0,
+        "next_retry_at": None,
+        "current_attempt": None,
+        "last_attempt": None,
+        "attempt_history": [],
+        "last_queued_at": queued_at,
+        "runner": default_runner_metadata(kind="cron", queue_name="default"),
+    }
+
+
+def default_runner_metadata(
+    *,
+    kind: str = "cron",
+    queue_name: str = "default",
+    priority: int = 0,
+) -> RunnerMetadata:
+    return {
+        "kind": str(kind or "cron"),
+        "queue_name": str(queue_name or "default"),
+        "priority": int(priority or 0),
+        "active": False,
+        "claimed_at": None,
+        "lease_expires_at": None,
+        "worker_id": None,
+        "last_started_at": None,
+        "last_finished_at": None,
+    }
+
+
+def normalize_runner_metadata(
+    runner: Any,
+    *,
+    kind: str = "cron",
+    queue_name: str = "default",
+    priority: int = 0,
+) -> RunnerMetadata:
+    normalized = default_runner_metadata(kind=kind, queue_name=queue_name, priority=priority)
+    if not isinstance(runner, Mapping):
+        return normalized
+    normalized["kind"] = str(runner.get("kind") or normalized["kind"])
+    normalized["queue_name"] = str(runner.get("queue_name") or normalized["queue_name"])
+    try:
+        normalized["priority"] = int(runner.get("priority", normalized["priority"]) or 0)
+    except Exception:
+        normalized["priority"] = int(priority or 0)
+    normalized["active"] = bool(runner.get("active", False))
+    for key in ("claimed_at", "lease_expires_at", "worker_id", "last_started_at", "last_finished_at"):
+        value = runner.get(key)
+        normalized[key] = str(value) if value not in (None, "") else None
+    return normalized
+
+
+def append_attempt_history(history: Any, attempt: AttemptRecord, *, max_entries: int = MAX_ATTEMPT_HISTORY) -> list[AttemptRecord]:
+    normalized_history: list[AttemptRecord] = []
+    if isinstance(history, list):
+        for item in history:
+            normalized_item = normalize_attempt_record(item)
+            if normalized_item is not None:
+                normalized_history.append(normalized_item)
+    normalized_history.append(normalize_attempt_record(attempt) or attempt)
+    if max_entries > 0:
+        normalized_history = normalized_history[-max_entries:]
+    return normalized_history
+
+
+def normalize_queue_metadata(queue: Any, *, queued_at: Optional[str] = None) -> dict[str, Any]:
+    normalized = default_queue_metadata(queued_at=queued_at)
+    if isinstance(queue, Mapping):
+        try:
+            normalized["retry_count"] = max(0, int(queue.get("retry_count", 0) or 0))
+        except Exception:
+            normalized["retry_count"] = 0
+        try:
+            normalized["retry_backoff_seconds"] = max(0, int(queue.get("retry_backoff_seconds", 0) or 0))
+        except Exception:
+            normalized["retry_backoff_seconds"] = 0
+        normalized["next_retry_at"] = queue.get("next_retry_at")
+        normalized["current_attempt"] = normalize_attempt_record(queue.get("current_attempt"))
+        normalized["last_attempt"] = normalize_attempt_record(queue.get("last_attempt"))
+        history = queue.get("attempt_history")
+        if isinstance(history, list):
+            normalized["attempt_history"] = [
+                item for item in (normalize_attempt_record(entry) for entry in history) if item is not None
+            ][-MAX_ATTEMPT_HISTORY:]
+        last_queued_at = queue.get("last_queued_at")
+        if last_queued_at:
+            normalized["last_queued_at"] = str(last_queued_at)
+        normalized["runner"] = normalize_runner_metadata(queue.get("runner"))
+    return normalized

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -28,6 +28,7 @@ from agent.display import (
     get_tool_emoji as _get_tool_emoji,
     _detect_tool_failure,
 )
+from agent.failure_policy import FailureClass, RecoveryAction, decide_tool_recovery
 from agent.tool_guardrails import ToolGuardrailDecision
 from agent.tool_dispatch_helpers import (
     _is_destructive_command,
@@ -56,6 +57,20 @@ def _ra():
     """Lazy reference to ``run_agent`` so patches like ``run_agent._set_interrupt`` work."""
     import run_agent
     return run_agent
+
+
+def _tool_failure_recovery_decision(function_name: str, function_result: Any):
+    """Return a recovery decision when a tool result suggests corrective action."""
+
+    decision = decide_tool_recovery(function_name, function_result)
+    if (
+        decision.failure_class == FailureClass.unknown
+        and decision.primary_action == RecoveryAction.retry_same
+    ):
+        is_error_result, _ = _detect_tool_failure(function_name, function_result)
+        if not is_error_result:
+            return None
+    return decision
 
 
 def _emit_terminal_post_tool_call(
@@ -1284,7 +1299,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
 
         # Log tool errors to the persistent error log so [error] tags
         # in the UI always have a corresponding detailed entry on disk.
-        _is_error_result, _ = _detect_tool_failure(function_name, function_result)
+        _tool_recovery_decision = _tool_failure_recovery_decision(function_name, function_result)
+        _is_error_result = _tool_recovery_decision is not None
         # The agent-runtime tools above (todo, session_search, memory,
         # context-engine, memory-manager, clarify, delegate_task) are
         # dispatched inline — they never reach handle_function_call, so the
@@ -1318,7 +1334,15 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_result[:200] if len(function_result) > 200 else function_result
             )
         if _is_error_result:
-            logger.warning("Tool %s returned error (%.2fs): %s", function_name, tool_duration, result_preview)
+            logger.warning(
+                "Tool %s returned error (%.2fs): %s | recovery_action=%s failure_class=%s secondary=%s",
+                function_name,
+                tool_duration,
+                result_preview,
+                _tool_recovery_decision.primary_action.value,
+                _tool_recovery_decision.failure_class.value,
+                [action.value for action in _tool_recovery_decision.secondary_actions],
+            )
         else:
             logger.info("tool %s completed (%.2fs, %d chars)", function_name, tool_duration, _result_len)
 

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -19,6 +19,15 @@ from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Optional, Dict, List, Any, Union
 
+from agent.job_lifecycle import (
+    JobLifecycleState,
+    append_attempt_history,
+    cron_lifecycle_state,
+    default_queue_metadata,
+    make_attempt_record,
+    normalize_queue_metadata,
+)
+
 logger = logging.getLogger(__name__)
 
 from hermes_time import now as _hermes_now
@@ -149,6 +158,11 @@ def _normalize_job_record(job: Dict[str, Any]) -> Dict[str, Any]:
     if not state:
         state = "scheduled" if normalized.get("enabled", True) else "paused"
     normalized["state"] = state
+    normalized["queue"] = normalize_queue_metadata(
+        normalized.get("queue"),
+        queued_at=normalized.get("created_at") or normalized.get("last_run_at"),
+    )
+    normalized["lifecycle_state"] = cron_lifecycle_state(normalized).value
 
     return normalized
 
@@ -655,9 +669,11 @@ def create_job(
         },
         "enabled": True,
         "state": "scheduled",
+        "lifecycle_state": "queued",
         "paused_at": None,
         "paused_reason": None,
         "created_at": now,
+        "queue": default_queue_metadata(queued_at=now),
         "next_run_at": compute_next_run(parsed_schedule),
         "last_run_at": None,
         "last_status": None,
@@ -863,6 +879,48 @@ def remove_job(job_id: str) -> bool:
     return False
 
 
+def mark_job_started(job_id: str) -> bool:
+    """Persist that a cron job has started running and open a new attempt record."""
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        for job in jobs:
+            if job["id"] != job_id:
+                continue
+
+            normalized = _normalize_job_record(job)
+            queue = normalize_queue_metadata(
+                normalized.get("queue"),
+                queued_at=normalized.get("created_at") or normalized.get("last_run_at"),
+            )
+            last_attempt = queue.get("last_attempt") or {}
+            attempt_number = int(last_attempt.get("attempt", 0) or 0) + 1
+            retry_count = int(queue.get("retry_count", 0) or 0)
+            started_at = _hermes_now().isoformat()
+
+            queue["current_attempt"] = make_attempt_record(
+                attempt=attempt_number,
+                state=JobLifecycleState.running,
+                started_at=started_at,
+                retry_count=retry_count,
+            )
+            queue["next_retry_at"] = None
+            queue["last_queued_at"] = started_at
+            queue["runner"]["active"] = True
+            queue["runner"]["claimed_at"] = started_at
+            queue["runner"]["lease_expires_at"] = (_hermes_now() + timedelta(minutes=15)).isoformat()
+            queue["runner"]["worker_id"] = job_id
+            queue["runner"]["last_started_at"] = started_at
+            queue["runner"]["last_finished_at"] = None
+            job["queue"] = queue
+            job["state"] = "running"
+            job["lifecycle_state"] = JobLifecycleState.running.value
+            save_jobs(jobs)
+            return True
+
+        logger.warning("mark_job_started: job_id %s not found, skipping save", job_id)
+        return False
+
+
 def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                  delivery_error: Optional[str] = None):
     """
@@ -879,9 +937,51 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
         for i, job in enumerate(jobs):
             if job["id"] == job_id:
                 now = _hermes_now().isoformat()
+                queue = normalize_queue_metadata(
+                    job.get("queue"),
+                    queued_at=job.get("created_at") or job.get("last_run_at"),
+                )
+                current_attempt = queue.get("current_attempt")
+                if current_attempt is None:
+                    last_attempt = queue.get("last_attempt") or {}
+                    attempt_number = int(last_attempt.get("attempt", 0) or 0) + 1
+                    current_attempt = make_attempt_record(
+                        attempt=attempt_number,
+                        state=JobLifecycleState.running,
+                        started_at=job.get("last_run_at") or now,
+                        retry_count=int(queue.get("retry_count", 0) or 0),
+                    )
+                terminal_state = JobLifecycleState.completed if success else JobLifecycleState.failed
+                finished_attempt = make_attempt_record(
+                    attempt=current_attempt.get("attempt", 1),
+                    state=terminal_state,
+                    started_at=current_attempt.get("started_at") or now,
+                    finished_at=now,
+                    error=error if not success else None,
+                    retry_count=current_attempt.get("retry_count", queue.get("retry_count", 0)),
+                )
+                queue["current_attempt"] = None
+                queue["last_attempt"] = finished_attempt
+                queue["attempt_history"] = append_attempt_history(queue.get("attempt_history"), finished_attempt)
+                if success:
+                    queue["retry_count"] = 0
+                    queue["retry_backoff_seconds"] = 0
+                    queue["next_retry_at"] = None
+                else:
+                    queue["retry_count"] = int(queue.get("retry_count", 0) or 0) + 1
+                    queue["retry_backoff_seconds"] = 60 * queue["retry_count"]
+                    queue["next_retry_at"] = (_hermes_now() + timedelta(seconds=queue["retry_backoff_seconds"])).isoformat()
+                queue["last_queued_at"] = now if job.get("next_run_at") else queue.get("last_queued_at")
+                queue["runner"]["active"] = False
+                queue["runner"]["claimed_at"] = None
+                queue["runner"]["lease_expires_at"] = None
+                queue["runner"]["worker_id"] = job_id
+                queue["runner"]["last_finished_at"] = now
+                job["queue"] = queue
                 job["last_run_at"] = now
                 job["last_status"] = "ok" if success else "error"
                 job["last_error"] = error if not success else None
+                job["lifecycle_state"] = "completed" if success else "failed"
                 # Track delivery failures separately — cleared on successful delivery
                 job["last_delivery_error"] = delivery_error
                 
@@ -911,6 +1011,7 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                     kind = job.get("schedule", {}).get("kind")
                     if kind in {"cron", "interval"}:
                         job["state"] = "error"
+                        job["lifecycle_state"] = "failed"
                         if not job.get("last_error"):
                             job["last_error"] = (
                                 "Failed to compute next run for recurring "
@@ -927,8 +1028,11 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                     else:
                         job["enabled"] = False
                         job["state"] = "completed"
+                        job["lifecycle_state"] = "completed" if success else "failed"
                 elif job.get("state") != "paused":
                     job["state"] = "scheduled"
+                    job["lifecycle_state"] = "queued" if success else "retrying"
+                    job["queue"]["last_queued_at"] = job["next_run_at"]
 
                 save_jobs(jobs)
                 return
@@ -987,6 +1091,69 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
 
     for job in jobs:
         if not job.get("enabled", True):
+            continue
+
+        normalized = _normalize_job_record(job)
+        queue = normalize_queue_metadata(
+            normalized.get("queue"),
+            queued_at=normalized.get("created_at") or normalized.get("last_run_at"),
+        )
+        runner = queue.get("runner", {})
+
+        # 1. Handle stale leases
+        if runner.get("active"):
+            expires_at = runner.get("lease_expires_at")
+            if expires_at:
+                expires_dt = _ensure_aware(datetime.fromisoformat(expires_at))
+                if expires_dt <= now:
+                    logger.warning(
+                        "Job '%s' runner lease expired at %s. Marking attempt failed and scheduling retry.",
+                        job.get("name", job["id"]), expires_at
+                    )
+                    # For stale lease recovery, we do an in-place failure
+                    current_attempt = queue.get("current_attempt")
+                    if current_attempt:
+                        failed_attempt = make_attempt_record(
+                            attempt=current_attempt.get("attempt", 1),
+                            state=JobLifecycleState.failed,
+                            started_at=current_attempt.get("started_at"),
+                            finished_at=now.isoformat(),
+                            error="Runner lease expired (stale claim)",
+                            retry_count=current_attempt.get("retry_count", queue.get("retry_count", 0)),
+                        )
+                        queue["current_attempt"] = None
+                        queue["last_attempt"] = failed_attempt
+                        queue["attempt_history"] = append_attempt_history(queue.get("attempt_history"), failed_attempt)
+
+                    queue["retry_count"] = int(queue.get("retry_count", 0) or 0) + 1
+                    queue["retry_backoff_seconds"] = 60 * queue["retry_count"]
+                    queue["next_retry_at"] = (now + timedelta(seconds=queue["retry_backoff_seconds"])).isoformat()
+                    queue["runner"]["active"] = False
+                    queue["runner"]["claimed_at"] = None
+                    queue["runner"]["lease_expires_at"] = None
+                    queue["runner"]["last_finished_at"] = now.isoformat()
+                    job["queue"] = queue
+                    job["last_error"] = "Runner lease expired (stale claim)"
+                    job["lifecycle_state"] = JobLifecycleState.retrying.value
+
+                    # Write this recovery to disk immediately so we don't spam
+                    for rj in raw_jobs:
+                        if rj["id"] == job["id"]:
+                            rj["queue"] = queue
+                            rj["last_error"] = job["last_error"]
+                            needs_save = True
+                            break
+
+        # 2. Block if actively claimed
+        if queue.get("runner", {}).get("active"):
+            continue
+
+        # 3. Check backoff/retry scheduled time
+        next_retry_at = queue.get("next_retry_at")
+        if next_retry_at:
+            retry_dt = _ensure_aware(datetime.fromisoformat(next_retry_at))
+            if retry_dt <= now:
+                due.append(job)
             continue
 
         next_run = job.get("next_run_at")

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -148,7 +148,7 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run
+from cron.jobs import get_due_jobs, mark_job_started, mark_job_run, save_job_output, advance_next_run
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
@@ -2046,6 +2046,7 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
         def _process_job(job: dict) -> bool:
             """Run one due job end-to-end: execute, save, deliver, mark."""
             try:
+                mark_job_started(job["id"])
                 success, output, final_response, error = run_job(job)
 
                 output_file = save_job_output(job["id"], output)

--- a/cron/worker_daemon.py
+++ b/cron/worker_daemon.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""
+Queue Worker Daemon
+
+Standalone process that polls for due jobs and executes them, respecting
+runner leases and retry backoff. Designed to run independently of the
+gateway so job execution survives gateway restarts.
+
+Key design principles:
+- Uses the lease metadata from agent/job_lifecycle.py
+- Detects and recovers stale claims automatically  
+- Implements proper backoff on retries
+- Can run multiple workers with lease coordination
+- Graceful shutdown preserves running jobs
+
+Usage:
+    python -m cron.worker_daemon [--profile PROFILE] [--worker-id ID] [--poll-interval N]
+"""
+
+import os
+import sys
+import time
+import signal
+import logging
+import threading
+import concurrent.futures
+from pathlib import Path
+from typing import Optional, Set
+from datetime import datetime, timezone
+
+# Add the parent directory to sys.path so we can import from the hermes-agent modules
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from cron.jobs import get_due_jobs, mark_job_started, mark_job_run, save_job_output
+from cron.scheduler import run_job, _deliver_result, SILENT_MARKER
+from hermes_cli.config import load_config, get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+# Default worker configuration
+DEFAULT_POLL_INTERVAL = 30  # seconds
+DEFAULT_WORKER_ID = f"worker-{os.getpid()}"
+DEFAULT_MAX_CONCURRENT = 5
+
+# Global state for graceful shutdown
+_shutdown_event = threading.Event()
+_running_jobs: Set[str] = set()
+_running_lock = threading.Lock()
+
+
+class QueueWorker:
+    """
+    Standalone queue worker that polls for due jobs and executes them.
+    
+    Respects lease metadata to coordinate with other workers and recover
+    from stale claims when processes crash.
+    """
+    
+    def __init__(
+        self,
+        profile: Optional[str] = None,
+        worker_id: Optional[str] = None,
+        poll_interval: int = DEFAULT_POLL_INTERVAL,
+        max_concurrent: int = DEFAULT_MAX_CONCURRENT,
+    ):
+        self.profile = profile
+        self.worker_id = worker_id or DEFAULT_WORKER_ID
+        self.poll_interval = poll_interval
+        self.max_concurrent = max_concurrent
+        self.executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=max_concurrent,
+            thread_name_prefix=f"queue-worker-{self.worker_id}"
+        )
+        
+        logger.info(
+            "Queue worker initialized: worker_id=%s, poll_interval=%ds, max_concurrent=%d",
+            self.worker_id, self.poll_interval, self.max_concurrent
+        )
+    
+    def poll_and_execute(self) -> int:
+        """
+        Poll for due jobs and execute them.
+        
+        Returns:
+            Number of jobs started (not necessarily completed)
+        """
+        try:
+            due_jobs = get_due_jobs()
+            if not due_jobs:
+                return 0
+            
+            jobs_started = 0
+            
+            for job in due_jobs:
+                if _shutdown_event.is_set():
+                    logger.info("Shutdown requested, stopping job polling")
+                    break
+                
+                job_id = job["id"]
+                
+                # Check if we're already running this job in this worker
+                with _running_lock:
+                    if job_id in _running_jobs:
+                        logger.debug("Job '%s' already running in this worker", job_id)
+                        continue
+                    _running_jobs.add(job_id)
+                
+                # Submit job to thread pool
+                future = self.executor.submit(self._execute_job, job)
+                jobs_started += 1
+                
+                # Add completion callback to clean up running set
+                def cleanup_job(fut, jid=job_id):
+                    with _running_lock:
+                        _running_jobs.discard(jid)
+                        
+                future.add_done_callback(cleanup_job)
+            
+            if jobs_started > 0:
+                logger.info("Started %d job(s)", jobs_started)
+            
+            return jobs_started
+            
+        except Exception as e:
+            logger.error("Error polling for jobs: %s", e, exc_info=True)
+            return 0
+    
+    def _execute_job(self, job: dict) -> bool:
+        """
+        Execute a single job end-to-end.
+        
+        Args:
+            job: Job dictionary from get_due_jobs()
+            
+        Returns:
+            True if job completed successfully, False otherwise
+        """
+        job_id = job["id"]
+        job_name = job.get("name", job_id)
+        
+        try:
+            logger.info("Executing job '%s' (worker: %s)", job_name, self.worker_id)
+            
+            # Mark job as started (this will grant the lease to this worker)
+            mark_job_started(job_id)
+            
+            # Run the actual job
+            success, output, final_response, error = run_job(job)
+            
+            # Save output to file
+            output_file = save_job_output(job_id, output)
+            logger.debug("Job '%s' output saved to: %s", job_name, output_file)
+            
+            # Prepare content for delivery
+            deliver_content = final_response if success else f"⚠️ Cron job '{job_name}' failed:\n{error}"
+            
+            # Check if we should deliver (non-empty and not SILENT)
+            should_deliver = bool(deliver_content.strip())
+            if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
+                logger.info("Job '%s': agent returned %s — skipping delivery", job_id, SILENT_MARKER)
+                should_deliver = False
+            
+            # Deliver result if needed
+            delivery_error = None
+            if should_deliver:
+                try:
+                    delivery_error = _deliver_result(job, deliver_content, adapters=None, loop=None)
+                except Exception as de:
+                    delivery_error = str(de)
+                    logger.error("Delivery failed for job '%s': %s", job_id, de)
+            
+            # Treat empty final_response as a soft failure
+            if success and not final_response.strip():
+                success = False
+                error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
+            
+            # Mark job as completed
+            mark_job_run(job_id, success=success, error=error, delivery_error=delivery_error)
+            
+            if success:
+                logger.info("Job '%s' completed successfully", job_name)
+            else:
+                logger.warning("Job '%s' failed: %s", job_name, error)
+            
+            return success
+            
+        except Exception as e:
+            logger.error("Job '%s' execution failed: %s", job_name, e, exc_info=True)
+            
+            # Mark job as failed
+            try:
+                mark_job_run(job_id, success=False, error=f"Worker execution error: {e}")
+            except Exception as mark_error:
+                logger.error("Failed to mark job as failed: %s", mark_error)
+            
+            return False
+    
+    def run_forever(self):
+        """
+        Main worker loop - polls for jobs until shutdown is requested.
+        """
+        logger.info("Queue worker starting main loop")
+        
+        while not _shutdown_event.is_set():
+            try:
+                jobs_started = self.poll_and_execute()
+                
+                # Sleep for poll interval, but wake up on shutdown
+                if not _shutdown_event.wait(timeout=self.poll_interval):
+                    continue  # Timeout reached, continue polling
+                else:
+                    break  # Shutdown event set
+                    
+            except KeyboardInterrupt:
+                logger.info("KeyboardInterrupt received, shutting down")
+                break
+            except Exception as e:
+                logger.error("Unexpected error in worker loop: %s", e, exc_info=True)
+                # Sleep briefly to avoid tight error loops
+                time.sleep(5)
+        
+        logger.info("Worker loop ended, shutting down executor")
+        self.shutdown()
+    
+    def shutdown(self, wait_timeout: int = 30):
+        """
+        Graceful shutdown - wait for running jobs to complete.
+        
+        Args:
+            wait_timeout: Max seconds to wait for jobs to complete
+        """
+        logger.info("Shutting down queue worker (timeout=%ds)", wait_timeout)
+        
+        # Simple shutdown - wait for completion
+        self.executor.shutdown(wait=True)
+        
+        logger.info("Queue worker shutdown complete")
+
+
+def setup_signal_handlers():
+    """Set up signal handlers for graceful shutdown."""
+    def signal_handler(signum, frame):
+        logger.info("Received signal %d, requesting shutdown", signum)
+        _shutdown_event.set()
+    
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGINT, signal_handler)
+    if hasattr(signal, 'SIGHUP'):
+        signal.signal(signal.SIGHUP, signal_handler)
+
+
+def main():
+    """Main entry point for the queue worker daemon."""
+    import argparse
+    
+    parser = argparse.ArgumentParser(description="Hermes Queue Worker Daemon")
+    parser.add_argument("--profile", help="Hermes profile to use")
+    parser.add_argument("--worker-id", help="Unique worker ID")
+    parser.add_argument("--poll-interval", type=int, default=DEFAULT_POLL_INTERVAL,
+                       help="Poll interval in seconds")
+    parser.add_argument("--max-concurrent", type=int, default=DEFAULT_MAX_CONCURRENT,
+                       help="Max concurrent jobs")
+    parser.add_argument("--verbose", "-v", action="store_true",
+                       help="Enable verbose logging")
+    
+    args = parser.parse_args()
+    
+    # Setup logging
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S"
+    )
+    
+    # Setup signal handlers for graceful shutdown
+    setup_signal_handlers()
+    
+    # Create and run worker
+    worker = QueueWorker(
+        profile=args.profile,
+        worker_id=args.worker_id,
+        poll_interval=args.poll_interval,
+        max_concurrent=args.max_concurrent,
+    )
+    
+    try:
+        worker.run_forever()
+    except Exception as e:
+        logger.error("Fatal error in worker daemon: %s", e, exc_info=True)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/plans/2026-06-12-unified-api-webhook-router.md
+++ b/docs/plans/2026-06-12-unified-api-webhook-router.md
@@ -1,0 +1,302 @@
+# Unified API/Webhook Router Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Build a shared ingress seam for HTTP-driven agent entrypoints so API server runs, generic webhooks, and Graph-style webhooks can converge on one normalized request/event pipeline without changing public behavior.
+
+**Architecture:** Start with a narrow internal seam instead of a big-bang router rewrite. Introduce a small normalized ingress envelope/helper layer used by webhook-style adapters first, then progressively move API server request parsing and run/session orchestration onto the same primitives once the envelope and dispatch contracts are proven stable.
+
+**Tech Stack:** Python 3.11, aiohttp, Hermes gateway adapters, SessionDB/state.db, pytest
+
+---
+
+## Confirmed codebase context
+
+- Generic webhooks currently terminate in `gateway/platforms/webhook.py` and convert an HTTP POST directly into a `MessageEvent`, then call `self.handle_message(event)` in a background task.
+- Microsoft Graph webhook ingress in `gateway/platforms/msgraph_webhook.py` independently builds a `MessageEvent` and independently schedules `self.handle_message(event)`.
+- API server ingress in `gateway/platforms/api_server.py` does **not** use `MessageEvent` or `BasePlatformAdapter.handle_message()`. It parses HTTP bodies directly, creates an `AIAgent` directly via `_create_agent()`, and separately implements session continuity, SSE streaming, approval wiring, and run status/event plumbing.
+- The safest confirmed unification seam today is **before** agent execution but **after** request validation/parsing: a normalized internal ingress envelope plus shared dispatch helpers for HTTP-originated event sources.
+
+## Design constraints
+
+- Do **not** change public HTTP routes, response schemas, or authentication semantics in the first slice.
+- Do **not** push API server traffic through the gateway active-session queue until the session/approval/streaming semantics are explicitly mapped.
+- Preserve prompt-caching invariants: no mid-conversation toolset or system-prompt mutation.
+- Keep the first slice reversible and low-risk: internal-only helpers with immediate concrete consumers.
+
+---
+
+### Task 1: Add a shared ingress envelope module
+
+**Objective:** Create a single internal representation for HTTP-originated gateway events.
+
+**Files:**
+- Create: `gateway/ingress.py`
+- Test: `tests/gateway/test_ingress.py`
+
+**Step 1: Write failing tests**
+
+Add tests that expect:
+- an `IngressEnvelope` dataclass carrying normalized event fields
+- a helper that turns an envelope into a `MessageEvent` using a platform adapter
+- a helper that schedules `adapter.handle_message(event)` and tracks the background task set
+
+Example assertions to add:
+
+```python
+envelope = IngressEnvelope(
+    text="hello",
+    message_id="evt-1",
+    chat_id="webhook:route:evt-1",
+    chat_name="webhook/route",
+    chat_type="webhook",
+    user_id="webhook:route",
+    user_name="route",
+    raw_payload={"ok": True},
+)
+
+event = build_ingress_message_event(adapter, envelope)
+assert event.text == "hello"
+assert event.message_id == "evt-1"
+assert event.source.platform == Platform.WEBHOOK
+assert event.source.chat_id == "webhook:route:evt-1"
+```
+
+**Step 2: Run test to verify failure**
+
+Run: `python -m pytest tests/gateway/test_ingress.py -q -o 'addopts='`
+Expected: FAIL — module/functions do not exist yet
+
+**Step 3: Write minimal implementation**
+
+Create `gateway/ingress.py` with:
+- `IngressEnvelope` dataclass
+- `build_ingress_message_event(adapter, envelope)`
+- `schedule_ingress_envelope(adapter, envelope)`
+- `schedule_ingress_event(adapter, event)`
+
+Keep the module internal and dependency-light.
+
+**Step 4: Run test to verify pass**
+
+Run: `python -m pytest tests/gateway/test_ingress.py -q -o 'addopts='`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add gateway/ingress.py tests/gateway/test_ingress.py
+git commit -m "feat: add shared ingress envelope helpers"
+```
+
+---
+
+### Task 2: Move generic webhook agent-mode dispatch onto the shared seam
+
+**Objective:** Replace webhook-local event construction/dispatch boilerplate with the shared ingress helper.
+
+**Files:**
+- Modify: `gateway/platforms/webhook.py`
+- Test: `tests/gateway/test_webhook_adapter.py`
+
+**Step 1: Write failing test**
+
+Add or extend a test so it verifies the accepted webhook still:
+- returns HTTP 202
+- produces the same session-scoped `chat_id`
+- sends a `MessageEvent` with the route-derived identity fields
+- preserves `delivery_id` as `message_id`
+
+**Step 2: Run test to verify failure**
+
+Run: `python -m pytest tests/gateway/test_webhook_adapter.py -q -o 'addopts='`
+Expected: FAIL after the new expectations are added
+
+**Step 3: Write minimal implementation**
+
+In `gateway/platforms/webhook.py`:
+- import the new ingress helper(s)
+- replace the inline `build_source(...)`, `MessageEvent(...)`, `asyncio.create_task(...)`, and `_background_tasks` plumbing with one `IngressEnvelope` + `schedule_ingress_envelope(...)`
+- keep `deliver_only` untouched
+- keep response payloads/status codes untouched
+
+**Step 4: Run test to verify pass**
+
+Run: `python -m pytest tests/gateway/test_webhook_adapter.py -q -o 'addopts='`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add gateway/platforms/webhook.py tests/gateway/test_webhook_adapter.py
+git commit -m "refactor: route webhook ingress through shared envelope"
+```
+
+---
+
+### Task 3: Move MS Graph webhook dispatch onto the same seam
+
+**Objective:** Make the second webhook-like ingress source consume the same envelope helper.
+
+**Files:**
+- Modify: `gateway/platforms/msgraph_webhook.py`
+- Test: `tests/gateway/test_msgraph_webhook.py`
+
+**Step 1: Write failing test**
+
+Add or extend a test so it verifies accepted notifications still:
+- return HTTP 202
+- create a `MessageEvent` with `Platform.MSGRAPH_WEBHOOK`
+- preserve the receipt key as `message_id`
+- schedule through the shared path
+
+**Step 2: Run test to verify failure**
+
+Run: `python -m pytest tests/gateway/test_msgraph_webhook.py -q -o 'addopts='`
+Expected: FAIL after the new expectation is added
+
+**Step 3: Write minimal implementation**
+
+In `gateway/platforms/msgraph_webhook.py`:
+- import the new ingress helper(s)
+- replace `_build_message_event()` and the default scheduler branch with `IngressEnvelope` + `schedule_ingress_envelope(...)`
+- keep the custom scheduler extension point intact
+
+**Step 4: Run test to verify pass**
+
+Run: `python -m pytest tests/gateway/test_msgraph_webhook.py -q -o 'addopts='`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add gateway/platforms/msgraph_webhook.py tests/gateway/test_msgraph_webhook.py
+git commit -m "refactor: route msgraph webhook ingress through shared envelope"
+```
+
+---
+
+### Task 4: Add normalized HTTP request metadata helpers for API/webhook convergence
+
+**Objective:** Introduce shared request-metadata plumbing without changing wire behavior.
+
+**Files:**
+- Modify: `gateway/ingress.py`
+- Modify: `gateway/platforms/api_server.py`
+- Modify: `gateway/platforms/webhook.py`
+- Test: `tests/gateway/test_ingress.py`
+- Test: `tests/gateway/test_api_server_jobs.py`
+
+**Step 1: Write failing tests**
+
+Add tests for a small request-context helper that extracts sanitized:
+- `remote`
+- `peer_ip`
+- `forwarded_for`
+- `real_ip`
+- `user_agent`
+- `method`
+- `path`
+
+and keeps line breaks/control characters out of loggable values.
+
+**Step 2: Run test to verify failure**
+
+Run: `python -m pytest tests/gateway/test_ingress.py tests/gateway/test_api_server_jobs.py -q -o 'addopts='`
+Expected: FAIL
+
+**Step 3: Write minimal implementation**
+
+- move the generic request-audit extraction logic out of `api_server.py` into `gateway/ingress.py`
+- keep API server response behavior unchanged
+- optionally use the same helper for webhook logging/trace context, but do not alter webhook JSON responses
+
+**Step 4: Run test to verify pass**
+
+Run: `python -m pytest tests/gateway/test_ingress.py tests/gateway/test_api_server_jobs.py -q -o 'addopts='`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add gateway/ingress.py gateway/platforms/api_server.py gateway/platforms/webhook.py tests/gateway/test_ingress.py tests/gateway/test_api_server_jobs.py
+git commit -m "refactor: share ingress request metadata extraction"
+```
+
+---
+
+### Task 5: Document the next API-server migration seam
+
+**Objective:** Leave the next implementer with an exact, safe follow-on slice.
+
+**Files:**
+- Modify: `docs/plans/2026-06-12-unified-api-webhook-router.md`
+
+**Step 1: Add follow-on notes**
+
+Document the next migration target precisely:
+- extract API-server request parsing into pure helpers
+- normalize `chat_completions`, `session_chat`, and `runs` into one internal request model
+- only then consider a shared router/executor layer
+
+**Step 2: Verification**
+
+Read the updated plan and confirm it distinguishes:
+- current thin slice
+- next safe vertical slice
+- work explicitly deferred because it is higher risk
+
+**Step 3: Commit**
+
+```bash
+git add docs/plans/2026-06-12-unified-api-webhook-router.md
+git commit -m "docs: refine unified ingress follow-on slices"
+```
+
+---
+
+## Smallest safe vertical slice
+
+1. Add `gateway/ingress.py`.
+2. Route `gateway/platforms/webhook.py` through it.
+3. Route `gateway/platforms/msgraph_webhook.py` through it.
+4. Add tests proving event identity and scheduling semantics are unchanged.
+
+This is the minimum slice that creates a real unification seam with **two live ingress consumers** and no API contract changes.
+
+## Validation commands
+
+Run these from repo root:
+
+```bash
+python -m pytest tests/gateway/test_ingress.py -q -o 'addopts='
+python -m pytest tests/gateway/test_webhook_adapter.py -q -o 'addopts='
+python -m pytest tests/gateway/test_msgraph_webhook.py -q -o 'addopts='
+python -m pytest tests/gateway/test_api_server_jobs.py -q -o 'addopts='
+python -m pytest tests/gateway/test_webhook_adapter.py tests/gateway/test_msgraph_webhook.py tests/gateway/test_api_server_jobs.py tests/gateway/test_ingress.py -q -o 'addopts='
+```
+
+If broader time permits:
+
+```bash
+python -m pytest tests/gateway/ -q -o 'addopts='
+```
+
+## Risks
+
+- **API server is structurally different today.** Forcing it onto `MessageEvent` too early risks breaking SSE streams, approval waits, and session continuity headers.
+- **Webhook route semantics differ from chat semantics.** Route-specific delivery metadata must stay outside the generic envelope or be clearly marked optional.
+- **Background task lifecycle matters.** Any shared scheduler helper must preserve `_background_tasks` tracking so disconnect/cleanup behavior remains unchanged.
+
+## Rollback notes
+
+- The thin slice is fully reversible: revert `gateway/ingress.py` plus the adapter call sites in `gateway/platforms/webhook.py` and `gateway/platforms/msgraph_webhook.py`.
+- If a regression appears, roll back only the shared-dispatch adoption while keeping the plan document.
+- Do **not** partially roll back just one consumer after the helper lands unless tests prove the other consumer still exercises the helper correctly.
+
+## Explicitly deferred
+
+- No public route consolidation yet
+- No API server transport rewrite yet
+- No shared approval/session executor yet
+- No dashboard/control-plane contract changes yet

--- a/docs/plans/2026-06-12-unified-api-webhook-router.md
+++ b/docs/plans/2026-06-12-unified-api-webhook-router.md
@@ -300,3 +300,11 @@ python -m pytest tests/gateway/ -q -o 'addopts='
 - No API server transport rewrite yet
 - No shared approval/session executor yet
 - No dashboard/control-plane contract changes yet
+
+## Next Migration Seam (Phase 2)
+
+To safely continue the unified router migration without breaking SSE streams, approval waits, or session continuity headers, the next implementer must adhere to this strict sequence:
+
+1. **Extract API-server request parsing:** Move the parsing logic out of `_handle_chat_completions`, `_handle_session_chat`, and `_handle_runs` into pure, testable helpers (similar to the `/v1/responses` slice).
+2. **Normalize Request Models:** Converge `NormalizedSessionChatRequest`, `NormalizedRunRequest`, and `NormalizedChatCompletionsRequest` into a single, cohesive internal request model inside `gateway/ingress.py`.
+3. **Shared Executor Layer:** Only after parsing and normalization are fully shared and proven green, attempt to converge on a shared router/executor layer that safely handles the gateway's active-session queue.

--- a/gateway/ingress.py
+++ b/gateway/ingress.py
@@ -1,0 +1,94 @@
+"""Shared helpers for HTTP-style ingress sources.
+
+This module is intentionally narrow: it defines a small normalized envelope
+for gateway-style ingress events and the common boilerplate for turning those
+into ``MessageEvent`` objects and scheduling background dispatch.
+
+The first concrete consumers are webhook-like adapters.  API-server request
+handlers still own their direct ``AIAgent`` execution path for now, but can
+progressively reuse the request/envelope helpers added here as the ingress
+surfaces converge.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from gateway.platforms.base import MessageEvent, MessageType, SessionSource
+
+
+class IngressAdapter(Protocol):
+    """Minimal adapter surface required by the shared ingress helpers."""
+
+    _background_tasks: set[asyncio.Task]
+
+    def build_source(
+        self,
+        *,
+        chat_id: str,
+        chat_name: str | None = None,
+        chat_type: str = "dm",
+        user_id: str | None = None,
+        user_name: str | None = None,
+    ) -> SessionSource: ...
+
+    async def handle_message(self, event: MessageEvent): ...
+
+
+@dataclass(frozen=True)
+class IngressEnvelope:
+    """Normalized internal representation for HTTP-originated message ingress."""
+
+    text: str
+    message_id: str | None
+    chat_id: str
+    chat_name: str | None = None
+    chat_type: str = "webhook"
+    user_id: str | None = None
+    user_name: str | None = None
+    raw_payload: Any = None
+    internal: bool = False
+
+
+def build_ingress_message_event(adapter: IngressAdapter, envelope: IngressEnvelope) -> MessageEvent:
+    """Build a ``MessageEvent`` for an ingress envelope using an adapter's source factory."""
+
+    source = adapter.build_source(
+        chat_id=envelope.chat_id,
+        chat_name=envelope.chat_name,
+        chat_type=envelope.chat_type,
+        user_id=envelope.user_id,
+        user_name=envelope.user_name,
+    )
+    return MessageEvent(
+        text=envelope.text,
+        message_type=MessageType.TEXT,
+        source=source,
+        raw_message=envelope.raw_payload,
+        message_id=envelope.message_id,
+        internal=envelope.internal,
+    )
+
+
+def schedule_ingress_event(adapter: IngressAdapter, event: MessageEvent) -> asyncio.Task | None:
+    """Schedule a background ingress event and register it with the adapter."""
+
+    task = asyncio.create_task(adapter.handle_message(event))
+    try:
+        adapter._background_tasks.add(task)
+    except TypeError:
+        # Mirror the base adapter's test-friendly behavior: some tests stub
+        # task creation with lightweight sentinels that aren't hashable.
+        return None
+    if hasattr(task, "add_done_callback"):
+        task.add_done_callback(adapter._background_tasks.discard)
+    return task
+
+
+def schedule_ingress_envelope(adapter: IngressAdapter, envelope: IngressEnvelope) -> asyncio.Task | None:
+    """Build and schedule an ingress envelope in one step."""
+
+    event = build_ingress_message_event(adapter, envelope)
+    return schedule_ingress_event(adapter, event)

--- a/gateway/ingress.py
+++ b/gateway/ingress.py
@@ -1,22 +1,35 @@
 """Shared helpers for HTTP-style ingress sources.
 
-This module is intentionally narrow: it defines a small normalized envelope
-for gateway-style ingress events and the common boilerplate for turning those
-into ``MessageEvent`` objects and scheduling background dispatch.
+This module now holds two narrow families of ingress logic:
 
-The first concrete consumers are webhook-like adapters.  API-server request
-handlers still own their direct ``AIAgent`` execution path for now, but can
-progressively reuse the request/envelope helpers added here as the ingress
-surfaces converge.
+1. Webhook-style envelope helpers that build/schedule ``MessageEvent`` objects.
+2. Request-normalization helpers shared by HTTP API ingress surfaces.
+
+The goal is deliberately modest: provide a proven internal seam after parsing and
+before execution, without changing public handler behavior.
 """
 
 from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import Any, Dict, List, Optional, Protocol
+
+try:
+    from aiohttp import web
+except ImportError:  # pragma: no cover - import guard mirrors api_server optional dependency handling
+    web = None  # type: ignore[assignment]
 
 from gateway.platforms.base import MessageEvent, MessageType, SessionSource
+
+MAX_NORMALIZED_TEXT_LENGTH = 65_536
+MAX_CONTENT_LIST_SIZE = 1_000
+
+_TRUE_REQUEST_BOOL_STRINGS = frozenset({"1", "true", "yes", "on"})
+_FALSE_REQUEST_BOOL_STRINGS = frozenset({"0", "false", "no", "off"})
+_TEXT_PART_TYPES = frozenset({"text", "input_text", "output_text"})
+_IMAGE_PART_TYPES = frozenset({"image_url", "input_image"})
+_FILE_PART_TYPES = frozenset({"file", "input_file"})
 
 
 class IngressAdapter(Protocol):
@@ -51,6 +64,51 @@ class IngressEnvelope:
     user_name: str | None = None
     raw_payload: Any = None
     internal: bool = False
+
+
+@dataclass(frozen=True)
+class NormalizedSessionChatRequest:
+    """Normalized request payload shared by session chat sync + streaming endpoints."""
+
+    user_message: Any
+    system_prompt: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class NormalizedRunRequest:
+    """Normalized /v1/runs request body before response-store expansion."""
+
+    raw_input: Any
+    user_message: str
+    conversation_history: List[Dict[str, str]]
+    instructions: Optional[str] = None
+    previous_response_id: Optional[str] = None
+    session_id: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class NormalizedChatCompletionsRequest:
+    """Normalized /v1/chat/completions request body."""
+
+    user_message: Any
+    history: List[Dict[str, Any]]
+    conversation_messages: List[Dict[str, Any]]
+    system_prompt: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class NormalizedResponsesRequest:
+    """Normalized /v1/responses request body before response-store chaining."""
+
+    raw_input: Any
+    input_messages: List[Dict[str, Any]]
+    user_message: Any
+    conversation_history: List[Dict[str, Any]]
+    instructions: Optional[str] = None
+    previous_response_id: Optional[str] = None
+    conversation: Optional[str] = None
+    store: bool = True
+    history_from_input_messages: bool = False
 
 
 def build_ingress_message_event(adapter: IngressAdapter, envelope: IngressEnvelope) -> MessageEvent:
@@ -93,3 +151,419 @@ def schedule_ingress_envelope(adapter: IngressAdapter, envelope: IngressEnvelope
 
     event = build_ingress_message_event(adapter, envelope)
     return schedule_ingress_event(adapter, event)
+
+
+def _openai_error(
+    message: str,
+    err_type: str = "invalid_request_error",
+    param: Optional[str] = None,
+    code: Optional[str] = None,
+) -> Dict[str, Any]:
+    """OpenAI-style error envelope."""
+    return {
+        "error": {
+            "message": message,
+            "type": err_type,
+            "param": param,
+            "code": code,
+        }
+    }
+
+
+def _coerce_request_bool(value: Any, default: bool = False) -> bool:
+    """Normalize boolean-like API payload values."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in _TRUE_REQUEST_BOOL_STRINGS:
+            return True
+        if normalized in _FALSE_REQUEST_BOOL_STRINGS:
+            return False
+        return default
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return default
+
+
+def _normalize_chat_content(
+    content: Any, *, _max_depth: int = 10, _depth: int = 0,
+) -> str:
+    """Normalize OpenAI chat message content into a plain text string."""
+    if _depth > _max_depth:
+        return ""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content[:MAX_NORMALIZED_TEXT_LENGTH] if len(content) > MAX_NORMALIZED_TEXT_LENGTH else content
+
+    if isinstance(content, list):
+        parts: List[str] = []
+        items = content[:MAX_CONTENT_LIST_SIZE] if len(content) > MAX_CONTENT_LIST_SIZE else content
+        for item in items:
+            if isinstance(item, str):
+                if item:
+                    parts.append(item[:MAX_NORMALIZED_TEXT_LENGTH])
+            elif isinstance(item, dict):
+                item_type = str(item.get("type") or "").strip().lower()
+                if item_type in {"text", "input_text", "output_text"}:
+                    text = item.get("text", "")
+                    if text:
+                        try:
+                            parts.append(str(text)[:MAX_NORMALIZED_TEXT_LENGTH])
+                        except Exception:
+                            pass
+            elif isinstance(item, list):
+                nested = _normalize_chat_content(item, _max_depth=_max_depth, _depth=_depth + 1)
+                if nested:
+                    parts.append(nested)
+            if sum(len(p) for p in parts) >= MAX_NORMALIZED_TEXT_LENGTH:
+                break
+        result = "\n".join(parts)
+        return result[:MAX_NORMALIZED_TEXT_LENGTH] if len(result) > MAX_NORMALIZED_TEXT_LENGTH else result
+
+    try:
+        result = str(content)
+        return result[:MAX_NORMALIZED_TEXT_LENGTH] if len(result) > MAX_NORMALIZED_TEXT_LENGTH else result
+    except Exception:
+        return ""
+
+
+def _normalize_multimodal_content(content: Any) -> Any:
+    """Validate and normalize multimodal content for API-style ingress."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content[:MAX_NORMALIZED_TEXT_LENGTH] if len(content) > MAX_NORMALIZED_TEXT_LENGTH else content
+    if not isinstance(content, list):
+        return _normalize_chat_content(content)
+
+    items = content[:MAX_CONTENT_LIST_SIZE] if len(content) > MAX_CONTENT_LIST_SIZE else content
+    normalized_parts: List[Dict[str, Any]] = []
+
+    for part in items:
+        if isinstance(part, str):
+            if part:
+                trimmed = part[:MAX_NORMALIZED_TEXT_LENGTH]
+                normalized_parts.append({"type": "text", "text": trimmed})
+            continue
+
+        if not isinstance(part, dict):
+            continue
+
+        raw_type = part.get("type")
+        part_type = str(raw_type or "").strip().lower()
+
+        if part_type in _TEXT_PART_TYPES:
+            text = part.get("text")
+            if text is None:
+                continue
+            if not isinstance(text, str):
+                text = str(text)
+            if text:
+                trimmed = text[:MAX_NORMALIZED_TEXT_LENGTH]
+                normalized_parts.append({"type": "text", "text": trimmed})
+            continue
+
+        if part_type in _IMAGE_PART_TYPES:
+            detail = part.get("detail")
+            image_ref = part.get("image_url")
+            if isinstance(image_ref, dict):
+                url_value = image_ref.get("url")
+                detail = image_ref.get("detail", detail)
+            else:
+                url_value = image_ref
+            if not isinstance(url_value, str) or not url_value.strip():
+                raise ValueError("invalid_image_url:Image parts must include a non-empty image URL.")
+            url_value = url_value.strip()
+            lowered = url_value.lower()
+            if lowered.startswith("data:"):
+                if not lowered.startswith("data:image/") or "," not in url_value:
+                    raise ValueError(
+                        "unsupported_content_type:Only image data URLs are supported. "
+                        "Non-image data payloads are not supported."
+                    )
+            elif not (lowered.startswith("http://") or lowered.startswith("https://")):
+                raise ValueError(
+                    "invalid_image_url:Image inputs must use http(s) URLs or data:image/... URLs."
+                )
+            image_part: Dict[str, Any] = {"type": "image_url", "image_url": {"url": url_value}}
+            if detail is not None:
+                if not isinstance(detail, str) or not detail.strip():
+                    raise ValueError("invalid_content_part:Image detail must be a non-empty string when provided.")
+                image_part["image_url"]["detail"] = detail.strip()
+            normalized_parts.append(image_part)
+            continue
+
+        if part_type in _FILE_PART_TYPES:
+            raise ValueError(
+                "unsupported_content_type:Inline image inputs are supported, "
+                "but uploaded files and document inputs are not supported on this endpoint."
+            )
+
+        raise ValueError(
+            f"unsupported_content_type:Unsupported content part type {raw_type!r}. "
+            "Only text and image_url/input_image parts are supported."
+        )
+
+    if not normalized_parts:
+        return ""
+    if all(p.get("type") == "text" for p in normalized_parts):
+        return "\n".join(p["text"] for p in normalized_parts if p.get("text"))
+    return normalized_parts
+
+
+def _content_has_visible_payload(content: Any) -> bool:
+    """True when content has any text or image attachment."""
+    if isinstance(content, str):
+        return bool(content.strip())
+    if isinstance(content, list):
+        for part in content:
+            if isinstance(part, dict):
+                ptype = str(part.get("type") or "").strip().lower()
+                if ptype in _TEXT_PART_TYPES and str(part.get("text") or "").strip():
+                    return True
+                if ptype in _IMAGE_PART_TYPES:
+                    return True
+    return False
+
+
+def _multimodal_validation_error(exc: ValueError, *, param: str) -> Any:
+    """Translate a multimodal validation ``ValueError`` into a 400 response."""
+    raw = str(exc)
+    code, _, message = raw.partition(":")
+    if not message:
+        code, message = "invalid_content_part", raw
+    assert web is not None
+    return web.json_response(
+        _openai_error(message, code=code, param=param),
+        status=400,
+    )
+
+
+def _session_chat_user_message(body: Dict[str, Any], *, param: str = "message") -> tuple[Any, Any]:
+    """Parse and normalize session chat ``message`` / ``input`` like chat completions."""
+    user_message = body.get("message") or body.get("input")
+    if not _content_has_visible_payload(user_message):
+        assert web is not None
+        return None, web.json_response(
+            _openai_error("Missing 'message' field", code="missing_message"),
+            status=400,
+        )
+    try:
+        return _normalize_multimodal_content(user_message), None
+    except ValueError as exc:
+        return None, _multimodal_validation_error(exc, param=param)
+
+
+def _normalize_session_chat_request(
+    body: Dict[str, Any], *, message_param: str = "message"
+) -> tuple[Optional[NormalizedSessionChatRequest], Any]:
+    """Normalize shared session-chat request fields used by sync + SSE handlers."""
+    user_message, err = _session_chat_user_message(body, param=message_param)
+    if err is not None:
+        return None, err
+    system_prompt = body.get("system_message") or body.get("instructions")
+    if system_prompt is not None and not isinstance(system_prompt, str):
+        assert web is not None
+        return None, web.json_response(
+            _openai_error("system_message must be a string", code="invalid_system_message"),
+            status=400,
+        )
+    return NormalizedSessionChatRequest(
+        user_message=user_message,
+        system_prompt=system_prompt,
+    ), None
+
+
+def _normalize_run_request(
+    body: Dict[str, Any],
+) -> tuple[Optional[NormalizedRunRequest], Any]:
+    """Normalize /v1/runs body fields prior to previous_response expansion."""
+    raw_input = body.get("input")
+    if not raw_input:
+        assert web is not None
+        return None, web.json_response(_openai_error("Missing 'input' field"), status=400)
+
+    user_message = raw_input
+    conversation_history: List[Dict[str, str]] = []
+    if isinstance(raw_input, list):
+        last_message = raw_input[-1] if raw_input else None
+        if isinstance(last_message, dict):
+            user_message = _normalize_chat_content(last_message.get("content", ""))
+        else:
+            user_message = _normalize_chat_content(last_message)
+    elif not isinstance(raw_input, str):
+        user_message = _normalize_chat_content(raw_input)
+
+    if not user_message:
+        assert web is not None
+        return None, web.json_response(_openai_error("No user message found in input"), status=400)
+
+    raw_history = body.get("conversation_history")
+    if raw_history:
+        if not isinstance(raw_history, list):
+            assert web is not None
+            return None, web.json_response(
+                _openai_error("'conversation_history' must be an array of message objects"),
+                status=400,
+            )
+        for i, entry in enumerate(raw_history):
+            if not isinstance(entry, dict) or "role" not in entry or "content" not in entry:
+                assert web is not None
+                return None, web.json_response(
+                    _openai_error(f"conversation_history[{i}] must have 'role' and 'content' fields"),
+                    status=400,
+                )
+            conversation_history.append({"role": str(entry["role"]), "content": str(entry["content"])})
+    elif isinstance(raw_input, list) and len(raw_input) > 1:
+        for msg in raw_input[:-1]:
+            if isinstance(msg, dict) and msg.get("role") and msg.get("content"):
+                conversation_history.append(
+                    {
+                        "role": str(msg["role"]),
+                        "content": _normalize_chat_content(msg["content"]),
+                    }
+                )
+
+    return NormalizedRunRequest(
+        raw_input=raw_input,
+        user_message=str(user_message),
+        conversation_history=conversation_history,
+        instructions=body.get("instructions"),
+        previous_response_id=body.get("previous_response_id"),
+        session_id=body.get("session_id"),
+    ), None
+
+
+def _normalize_chat_completions_request(
+    body: Dict[str, Any],
+) -> tuple[Optional[NormalizedChatCompletionsRequest], Any]:
+    """Normalize /v1/chat/completions request fields prior to session handling."""
+    messages = body.get("messages")
+    if not messages or not isinstance(messages, list):
+        assert web is not None
+        return None, web.json_response(
+            {"error": {"message": "Missing or invalid 'messages' field", "type": "invalid_request_error"}},
+            status=400,
+        )
+
+    system_prompt = None
+    conversation_messages: List[Dict[str, Any]] = []
+    for idx, msg in enumerate(messages):
+        role = msg.get("role", "") if isinstance(msg, dict) else ""
+        raw_content = msg.get("content", "") if isinstance(msg, dict) else ""
+        if role == "system":
+            content = _normalize_chat_content(raw_content)
+            if system_prompt is None:
+                system_prompt = content
+            else:
+                system_prompt = system_prompt + "\n" + content
+        elif role in {"user", "assistant"}:
+            try:
+                content = _normalize_multimodal_content(raw_content)
+            except ValueError as exc:
+                return None, _multimodal_validation_error(exc, param=f"messages[{idx}].content")
+            conversation_messages.append({"role": role, "content": content})
+
+    user_message: Any = ""
+    history: List[Dict[str, Any]] = []
+    if conversation_messages:
+        user_message = conversation_messages[-1].get("content", "")
+        history = conversation_messages[:-1]
+
+    if not _content_has_visible_payload(user_message):
+        assert web is not None
+        return None, web.json_response(
+            {"error": {"message": "No user message found in messages", "type": "invalid_request_error"}},
+            status=400,
+        )
+
+    return NormalizedChatCompletionsRequest(
+        user_message=user_message,
+        history=history,
+        conversation_messages=conversation_messages,
+        system_prompt=system_prompt,
+    ), None
+
+
+def _normalize_responses_request(
+    body: Dict[str, Any],
+) -> tuple[Optional[NormalizedResponsesRequest], Any]:
+    """Normalize /v1/responses request fields before response-store chaining."""
+    raw_input = body.get("input")
+    if raw_input is None:
+        assert web is not None
+        return None, web.json_response(_openai_error("Missing 'input' field"), status=400)
+
+    instructions = body.get("instructions")
+    previous_response_id = body.get("previous_response_id")
+    conversation = body.get("conversation")
+    store = _coerce_request_bool(body.get("store"), default=True)
+
+    if conversation and previous_response_id:
+        assert web is not None
+        return None, web.json_response(_openai_error("Cannot use both 'conversation' and 'previous_response_id'"), status=400)
+
+    input_messages: List[Dict[str, Any]] = []
+    if isinstance(raw_input, str):
+        input_messages = [{"role": "user", "content": raw_input}]
+    elif isinstance(raw_input, list):
+        for idx, item in enumerate(raw_input):
+            if isinstance(item, str):
+                input_messages.append({"role": "user", "content": item})
+            elif isinstance(item, dict):
+                role = item.get("role", "user")
+                try:
+                    content = _normalize_multimodal_content(item.get("content", ""))
+                except ValueError as exc:
+                    return None, _multimodal_validation_error(exc, param=f"input[{idx}].content")
+                input_messages.append({"role": role, "content": content})
+    else:
+        assert web is not None
+        return None, web.json_response(_openai_error("'input' must be a string or array"), status=400)
+
+    conversation_history: List[Dict[str, Any]] = []
+    history_from_input_messages = False
+    raw_history = body.get("conversation_history")
+    if raw_history:
+        if not isinstance(raw_history, list):
+            assert web is not None
+            return None, web.json_response(
+                _openai_error("'conversation_history' must be an array of message objects"),
+                status=400,
+            )
+        for i, entry in enumerate(raw_history):
+            if not isinstance(entry, dict) or "role" not in entry or "content" not in entry:
+                assert web is not None
+                return None, web.json_response(
+                    _openai_error(f"conversation_history[{i}] must have 'role' and 'content' fields"),
+                    status=400,
+                )
+            try:
+                entry_content = _normalize_multimodal_content(entry["content"])
+            except ValueError as exc:
+                return None, _multimodal_validation_error(exc, param=f"conversation_history[{i}].content")
+            conversation_history.append({"role": str(entry["role"]), "content": entry_content})
+    else:
+        conversation_history = list(input_messages[:-1])
+        history_from_input_messages = True
+
+    user_message: Any = input_messages[-1].get("content", "") if input_messages else ""
+    if not _content_has_visible_payload(user_message):
+        assert web is not None
+        return None, web.json_response(_openai_error("No user message found in input"), status=400)
+
+    return NormalizedResponsesRequest(
+        raw_input=raw_input,
+        input_messages=input_messages,
+        user_message=user_message,
+        conversation_history=conversation_history,
+        instructions=instructions,
+        previous_response_id=previous_response_id,
+        conversation=conversation,
+        store=store,
+        history_from_input_messages=history_from_input_messages,
+    ), None

--- a/gateway/ingress.py
+++ b/gateway/ingress.py
@@ -32,6 +32,7 @@ class IngressAdapter(Protocol):
         chat_type: str = "dm",
         user_id: str | None = None,
         user_name: str | None = None,
+        **kwargs: Any,
     ) -> SessionSource: ...
 
     async def handle_message(self, event: MessageEvent): ...

--- a/gateway/ingress.py
+++ b/gateway/ingress.py
@@ -567,3 +567,37 @@ def _normalize_responses_request(
         store=store,
         history_from_input_messages=history_from_input_messages,
     ), None
+
+from typing import Any, Dict
+
+def clean_log_value(value: Any, *, max_len: int = 200) -> str:
+    """Sanitize request metadata before it reaches security logs."""
+    if value is None:
+        return ""
+    text = str(value).replace("\r", " ").replace("\n", " ").strip()
+    return text[:max_len]
+
+def extract_request_audit_context(request: Any) -> Dict[str, str]:
+    """Return non-secret source metadata for security/audit warnings."""
+    peer_ip = ""
+    try:
+        peer = request.transport.get_extra_info("peername") if request.transport else None
+        if isinstance(peer, (tuple, list)) and peer:
+            peer_ip = str(peer[0])
+    except Exception:
+        peer_ip = ""
+
+    return {
+        "remote": clean_log_value(getattr(request, "remote", "") or peer_ip),
+        "peer_ip": clean_log_value(peer_ip),
+        "forwarded_for": clean_log_value(request.headers.get("X-Forwarded-For", "")),
+        "real_ip": clean_log_value(request.headers.get("X-Real-IP", "")),
+        "method": clean_log_value(request.method, max_len=16),
+        "path": clean_log_value(getattr(request, "path_qs", ""), max_len=500),
+        "user_agent": clean_log_value(request.headers.get("User-Agent", ""), max_len=300),
+    }
+
+def extract_request_audit_log_suffix(request: Any) -> str:
+    ctx = extract_request_audit_context(request)
+    fields = [f"{key}={value!r}" for key, value in ctx.items() if value]
+    return " ".join(fields) if fields else "source='unknown'"

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -54,6 +54,8 @@ except ImportError:
 
 from gateway.config import Platform, PlatformConfig
 from gateway.ingress import (
+    extract_request_audit_context,
+    extract_request_audit_log_suffix,
     _coerce_request_bool,
     _content_has_visible_payload,
     _multimodal_validation_error,
@@ -616,13 +618,13 @@ class APIServerAdapter(BasePlatformAdapter):
         }
 
     def _request_audit_log_suffix(self, request: "web.Request") -> str:
-        ctx = self._request_audit_context(request)
+        ctx = extract_request_audit_context(request)
         fields = [f"{key}={value!r}" for key, value in ctx.items() if value]
         return " ".join(fields) if fields else "source='unknown'"
 
     def _cron_origin_from_request(self, request: "web.Request") -> Dict[str, str]:
         """Persist safe API source metadata on cron jobs created over HTTP."""
-        ctx = self._request_audit_context(request)
+        ctx = extract_request_audit_context(request)
         origin = {
             "platform": "api_server",
             "chat_id": "api",
@@ -662,7 +664,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         logger.warning(
             "API server rejected invalid API key: %s",
-            self._request_audit_log_suffix(request),
+            extract_request_audit_log_suffix(request),
         )
         return web.json_response(
             {"error": {"message": "Invalid API key", "type": "invalid_request_error", "code": "invalid_api_key"}},
@@ -2807,7 +2809,7 @@ class APIServerAdapter(BasePlatformAdapter):
             logger.warning(
                 "Cron jobs API rejected invalid job_id %r: %s",
                 job_id,
-                self._request_audit_log_suffix(request),
+                extract_request_audit_log_suffix(request),
             )
             return job_id, web.json_response(
                 {"error": "Invalid job ID format"}, status=400,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -53,6 +53,18 @@ except ImportError:
     web = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
+from gateway.ingress import (
+    _coerce_request_bool,
+    _content_has_visible_payload,
+    _multimodal_validation_error,
+    _normalize_chat_completions_request,
+    _normalize_chat_content,
+    _normalize_multimodal_content,
+    _normalize_responses_request,
+    _normalize_run_request,
+    _normalize_session_chat_request,
+    _openai_error,
+)
 from gateway.platforms.base import (
     BasePlatformAdapter,
     SendResult,
@@ -90,8 +102,6 @@ DEFAULT_PORT = 8642
 MAX_STORED_RESPONSES = 100
 MAX_REQUEST_BYTES = 10_000_000  # 10 MB — accommodates long agent conversations with tool calls
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
-MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
-MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
 
 
 def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
@@ -100,261 +110,6 @@ def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
         return int(value)
     except (TypeError, ValueError):
         return default
-
-
-_TRUE_REQUEST_BOOL_STRINGS = frozenset({"1", "true", "yes", "on"})
-_FALSE_REQUEST_BOOL_STRINGS = frozenset({"0", "false", "no", "off"})
-
-
-def _coerce_request_bool(value: Any, default: bool = False) -> bool:
-    """Normalize boolean-like API payload values.
-
-    External clients should send real JSON booleans, but some OpenAI-compatible
-    frontends and middleware serialize flags like ``stream`` as strings.  Using
-    Python truthiness on those values misroutes requests because ``"false"`` is
-    still truthy.  Treat only explicit bool-ish scalars as booleans; everything
-    else falls back to the caller's default.
-    """
-    if isinstance(value, bool):
-        return value
-    if value is None:
-        return default
-    if isinstance(value, str):
-        normalized = value.strip().lower()
-        if normalized in _TRUE_REQUEST_BOOL_STRINGS:
-            return True
-        if normalized in _FALSE_REQUEST_BOOL_STRINGS:
-            return False
-        return default
-    if isinstance(value, (int, float)):
-        return bool(value)
-    return default
-
-
-def _normalize_chat_content(
-    content: Any, *, _max_depth: int = 10, _depth: int = 0,
-) -> str:
-    """Normalize OpenAI chat message content into a plain text string.
-
-    Some clients (Open WebUI, LobeChat, etc.) send content as an array of
-    typed parts instead of a plain string::
-
-        [{"type": "text", "text": "hello"}, {"type": "input_text", "text": "..."}]
-
-    This function flattens those into a single string so the agent pipeline
-    (which expects strings) doesn't choke.
-
-    Defensive limits prevent abuse: recursion depth, list size, and output
-    length are all bounded.
-    """
-    if _depth > _max_depth:
-        return ""
-    if content is None:
-        return ""
-    if isinstance(content, str):
-        return content[:MAX_NORMALIZED_TEXT_LENGTH] if len(content) > MAX_NORMALIZED_TEXT_LENGTH else content
-
-    if isinstance(content, list):
-        parts: List[str] = []
-        items = content[:MAX_CONTENT_LIST_SIZE] if len(content) > MAX_CONTENT_LIST_SIZE else content
-        for item in items:
-            if isinstance(item, str):
-                if item:
-                    parts.append(item[:MAX_NORMALIZED_TEXT_LENGTH])
-            elif isinstance(item, dict):
-                item_type = str(item.get("type") or "").strip().lower()
-                if item_type in {"text", "input_text", "output_text"}:
-                    text = item.get("text", "")
-                    if text:
-                        try:
-                            parts.append(str(text)[:MAX_NORMALIZED_TEXT_LENGTH])
-                        except Exception:
-                            pass
-                # Silently skip image_url / other non-text parts
-            elif isinstance(item, list):
-                nested = _normalize_chat_content(item, _max_depth=_max_depth, _depth=_depth + 1)
-                if nested:
-                    parts.append(nested)
-            # Check accumulated size
-            if sum(len(p) for p in parts) >= MAX_NORMALIZED_TEXT_LENGTH:
-                break
-        result = "\n".join(parts)
-        return result[:MAX_NORMALIZED_TEXT_LENGTH] if len(result) > MAX_NORMALIZED_TEXT_LENGTH else result
-
-    # Fallback for unexpected types (int, float, bool, etc.)
-    try:
-        result = str(content)
-        return result[:MAX_NORMALIZED_TEXT_LENGTH] if len(result) > MAX_NORMALIZED_TEXT_LENGTH else result
-    except Exception:
-        return ""
-
-
-# Content part type aliases used by the OpenAI Chat Completions and Responses
-# APIs.  We accept both spellings on input and emit a single canonical internal
-# shape (``{"type": "text", ...}`` / ``{"type": "image_url", ...}``) that the
-# rest of the agent pipeline already understands.
-_TEXT_PART_TYPES = frozenset({"text", "input_text", "output_text"})
-_IMAGE_PART_TYPES = frozenset({"image_url", "input_image"})
-_FILE_PART_TYPES = frozenset({"file", "input_file"})
-
-
-def _normalize_multimodal_content(content: Any) -> Any:
-    """Validate and normalize multimodal content for the API server.
-
-    Returns a plain string when the content is text-only, or a list of
-    ``{"type": "text"|"image_url", ...}`` parts when images are present.
-    The output shape is the native OpenAI Chat Completions vision format,
-    which the agent pipeline accepts verbatim (OpenAI-wire providers) or
-    converts (``_preprocess_anthropic_content`` for Anthropic).
-
-    Raises ``ValueError`` with an OpenAI-style code on invalid input:
-      * ``unsupported_content_type`` — file/input_file/file_id parts, or
-        non-image ``data:`` URLs.
-      * ``invalid_image_url`` — missing URL or unsupported scheme.
-      * ``invalid_content_part`` — malformed text/image objects.
-
-    Callers translate the ValueError into a 400 response.
-    """
-    # Scalar passthrough mirrors ``_normalize_chat_content``.
-    if content is None:
-        return ""
-    if isinstance(content, str):
-        return content[:MAX_NORMALIZED_TEXT_LENGTH] if len(content) > MAX_NORMALIZED_TEXT_LENGTH else content
-    if not isinstance(content, list):
-        # Mirror the legacy text-normalizer's fallback so callers that
-        # pre-existed image support still get a string back.
-        return _normalize_chat_content(content)
-
-    items = content[:MAX_CONTENT_LIST_SIZE] if len(content) > MAX_CONTENT_LIST_SIZE else content
-    normalized_parts: List[Dict[str, Any]] = []
-    text_accum_len = 0
-
-    for part in items:
-        if isinstance(part, str):
-            if part:
-                trimmed = part[:MAX_NORMALIZED_TEXT_LENGTH]
-                normalized_parts.append({"type": "text", "text": trimmed})
-                text_accum_len += len(trimmed)
-            continue
-
-        if not isinstance(part, dict):
-            # Ignore unknown scalars for forward compatibility with future
-            # Responses API additions (e.g. ``refusal``).  The same policy
-            # the text normalizer applies.
-            continue
-
-        raw_type = part.get("type")
-        part_type = str(raw_type or "").strip().lower()
-
-        if part_type in _TEXT_PART_TYPES:
-            text = part.get("text")
-            if text is None:
-                continue
-            if not isinstance(text, str):
-                text = str(text)
-            if text:
-                trimmed = text[:MAX_NORMALIZED_TEXT_LENGTH]
-                normalized_parts.append({"type": "text", "text": trimmed})
-                text_accum_len += len(trimmed)
-            continue
-
-        if part_type in _IMAGE_PART_TYPES:
-            detail = part.get("detail")
-            image_ref = part.get("image_url")
-            # OpenAI Responses sends ``input_image`` with a top-level
-            # ``image_url`` string; Chat Completions sends ``image_url`` as
-            # ``{"url": "...", "detail": "..."}``.  Support both.
-            if isinstance(image_ref, dict):
-                url_value = image_ref.get("url")
-                detail = image_ref.get("detail", detail)
-            else:
-                url_value = image_ref
-            if not isinstance(url_value, str) or not url_value.strip():
-                raise ValueError("invalid_image_url:Image parts must include a non-empty image URL.")
-            url_value = url_value.strip()
-            lowered = url_value.lower()
-            if lowered.startswith("data:"):
-                if not lowered.startswith("data:image/") or "," not in url_value:
-                    raise ValueError(
-                        "unsupported_content_type:Only image data URLs are supported. "
-                        "Non-image data payloads are not supported."
-                    )
-            elif not (lowered.startswith("http://") or lowered.startswith("https://")):
-                raise ValueError(
-                    "invalid_image_url:Image inputs must use http(s) URLs or data:image/... URLs."
-                )
-            image_part: Dict[str, Any] = {"type": "image_url", "image_url": {"url": url_value}}
-            if detail is not None:
-                if not isinstance(detail, str) or not detail.strip():
-                    raise ValueError("invalid_content_part:Image detail must be a non-empty string when provided.")
-                image_part["image_url"]["detail"] = detail.strip()
-            normalized_parts.append(image_part)
-            continue
-
-        if part_type in _FILE_PART_TYPES:
-            raise ValueError(
-                "unsupported_content_type:Inline image inputs are supported, "
-                "but uploaded files and document inputs are not supported on this endpoint."
-            )
-
-        # Unknown part type — reject explicitly so clients get a clear error
-        # instead of a silently dropped turn.
-        raise ValueError(
-            f"unsupported_content_type:Unsupported content part type {raw_type!r}. "
-            "Only text and image_url/input_image parts are supported."
-        )
-
-    if not normalized_parts:
-        return ""
-
-    # Text-only: collapse to a plain string so downstream logging/trajectory
-    # code sees the native shape and prompt caching on text-only turns is
-    # unaffected.
-    if all(p.get("type") == "text" for p in normalized_parts):
-        return "\n".join(p["text"] for p in normalized_parts if p.get("text"))
-
-    return normalized_parts
-
-
-def _content_has_visible_payload(content: Any) -> bool:
-    """True when content has any text or image attachment.  Used to reject empty turns."""
-    if isinstance(content, str):
-        return bool(content.strip())
-    if isinstance(content, list):
-        for part in content:
-            if isinstance(part, dict):
-                ptype = str(part.get("type") or "").strip().lower()
-                if ptype in _TEXT_PART_TYPES and str(part.get("text") or "").strip():
-                    return True
-                if ptype in _IMAGE_PART_TYPES:
-                    return True
-    return False
-
-
-def _multimodal_validation_error(exc: ValueError, *, param: str) -> "web.Response":
-    """Translate a ``_normalize_multimodal_content`` ValueError into a 400 response."""
-    raw = str(exc)
-    code, _, message = raw.partition(":")
-    if not message:
-        code, message = "invalid_content_part", raw
-    return web.json_response(
-        _openai_error(message, code=code, param=param),
-        status=400,
-    )
-
-
-def _session_chat_user_message(body: Dict[str, Any], *, param: str = "message") -> tuple[Any, Optional["web.Response"]]:
-    """Parse and normalize session chat ``message`` / ``input`` like chat completions."""
-    user_message = body.get("message") or body.get("input")
-    if not _content_has_visible_payload(user_message):
-        return None, web.json_response(
-            _openai_error("Missing 'message' field", code="missing_message"),
-            status=400,
-        )
-    try:
-        return _normalize_multimodal_content(user_message), None
-    except ValueError as exc:
-        return None, _multimodal_validation_error(exc, param=param)
 
 
 def check_api_server_requirements() -> bool:
@@ -1550,17 +1305,15 @@ class APIServerAdapter(BasePlatformAdapter):
         body, err = await self._read_json_body(request)
         if err:
             return err
-        user_message, err = _session_chat_user_message(body)
+        normalized_request, err = _normalize_session_chat_request(body)
         if err is not None:
             return err
-        system_prompt = body.get("system_message") or body.get("instructions")
-        if system_prompt is not None and not isinstance(system_prompt, str):
-            return web.json_response(_openai_error("system_message must be a string", code="invalid_system_message"), status=400)
+        assert normalized_request is not None
         history = self._conversation_history_for_session(session_id)
         result, usage = await self._run_agent(
-            user_message=user_message,
+            user_message=normalized_request.user_message,
             conversation_history=history,
-            ephemeral_system_prompt=system_prompt,
+            ephemeral_system_prompt=normalized_request.system_prompt,
             session_id=session_id,
             gateway_session_key=gateway_session_key,
         )
@@ -1594,12 +1347,10 @@ class APIServerAdapter(BasePlatformAdapter):
         body, err = await self._read_json_body(request)
         if err:
             return err
-        user_message, err = _session_chat_user_message(body)
+        normalized_request, err = _normalize_session_chat_request(body)
         if err is not None:
             return err
-        system_prompt = body.get("system_message") or body.get("instructions")
-        if system_prompt is not None and not isinstance(system_prompt, str):
-            return web.json_response(_openai_error("system_message must be a string", code="invalid_system_message"), status=400)
+        assert normalized_request is not None
 
         loop = asyncio.get_running_loop()
         queue: "asyncio.Queue[Optional[tuple[str, Dict[str, Any]]]]" = asyncio.Queue()
@@ -1643,13 +1394,13 @@ class APIServerAdapter(BasePlatformAdapter):
 
         async def _run_and_signal() -> None:
             try:
-                await queue.put(_event_payload("run.started", {"user_message": {"role": "user", "content": user_message}}))
+                await queue.put(_event_payload("run.started", {"user_message": {"role": "user", "content": normalized_request.user_message}}))
                 await queue.put(_event_payload("message.started", {"message": {"id": message_id, "role": "assistant"}}))
                 history = self._conversation_history_for_session(session_id)
                 result, usage = await self._run_agent(
-                    user_message=user_message,
+                    user_message=normalized_request.user_message,
                     conversation_history=history,
-                    ephemeral_system_prompt=system_prompt,
+                    ephemeral_system_prompt=normalized_request.system_prompt,
                     session_id=session_id,
                     stream_delta_callback=_delta,
                     tool_progress_callback=_tool_progress,
@@ -1657,7 +1408,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
                 final_response = result.get("final_response", "") if isinstance(result, dict) else ""
                 effective_session_id = result.get("session_id", session_id) if isinstance(result, dict) else session_id
-                turn_messages = self._turn_transcript_messages(history, user_message, result) if isinstance(result, dict) else []
+                turn_messages = self._turn_transcript_messages(history, normalized_request.user_message, result) if isinstance(result, dict) else []
                 await queue.put(_event_payload("assistant.completed", {
                     "session_id": effective_session_id,
                     "message_id": message_id,
@@ -1732,49 +1483,16 @@ class APIServerAdapter(BasePlatformAdapter):
         except (json.JSONDecodeError, Exception):
             return web.json_response(_openai_error("Invalid JSON in request body"), status=400)
 
-        messages = body.get("messages")
-        if not messages or not isinstance(messages, list):
-            return web.json_response(
-                {"error": {"message": "Missing or invalid 'messages' field", "type": "invalid_request_error"}},
-                status=400,
-            )
+        normalized_request, err = _normalize_chat_completions_request(body)
+        if err is not None:
+            return err
+        assert normalized_request is not None
 
         stream = _coerce_request_bool(body.get("stream"), default=False)
-
-        # Extract system message (becomes ephemeral system prompt layered ON TOP of core)
-        system_prompt = None
-        conversation_messages: List[Dict[str, str]] = []
-
-        for idx, msg in enumerate(messages):
-            role = msg.get("role", "")
-            raw_content = msg.get("content", "")
-            if role == "system":
-                # System messages don't support images (Anthropic rejects, OpenAI
-                # text-model systems don't render them).  Flatten to text.
-                content = _normalize_chat_content(raw_content)
-                if system_prompt is None:
-                    system_prompt = content
-                else:
-                    system_prompt = system_prompt + "\n" + content
-            elif role in {"user", "assistant"}:
-                try:
-                    content = _normalize_multimodal_content(raw_content)
-                except ValueError as exc:
-                    return _multimodal_validation_error(exc, param=f"messages[{idx}].content")
-                conversation_messages.append({"role": role, "content": content})
-
-        # Extract the last user message as the primary input
-        user_message: Any = ""
-        history = []
-        if conversation_messages:
-            user_message = conversation_messages[-1].get("content", "")
-            history = conversation_messages[:-1]
-
-        if not _content_has_visible_payload(user_message):
-            return web.json_response(
-                {"error": {"message": "No user message found in messages", "type": "invalid_request_error"}},
-                status=400,
-            )
+        system_prompt = normalized_request.system_prompt
+        conversation_messages = list(normalized_request.conversation_messages)
+        user_message = normalized_request.user_message
+        history = list(normalized_request.history)
 
         # Allow caller to scope long-term memory (e.g. Honcho) with a
         # stable per-channel identifier via X-Hermes-Session-Key.  This
@@ -2809,67 +2527,27 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=400,
             )
 
-        raw_input = body.get("input")
-        if raw_input is None:
-            return web.json_response(_openai_error("Missing 'input' field"), status=400)
+        normalized_request, err = _normalize_responses_request(body)
+        if err is not None:
+            return err
+        assert normalized_request is not None
 
-        instructions = body.get("instructions")
-        previous_response_id = body.get("previous_response_id")
-        conversation = body.get("conversation")
-        store = _coerce_request_bool(body.get("store"), default=True)
-
-        # conversation and previous_response_id are mutually exclusive
-        if conversation and previous_response_id:
-            return web.json_response(_openai_error("Cannot use both 'conversation' and 'previous_response_id'"), status=400)
+        instructions = normalized_request.instructions
+        previous_response_id = normalized_request.previous_response_id
+        conversation = normalized_request.conversation
+        store = normalized_request.store
+        conversation_history = list(normalized_request.conversation_history)
+        input_messages = list(normalized_request.input_messages)
+        user_message = normalized_request.user_message
+        history_from_input_messages = normalized_request.history_from_input_messages
 
         # Resolve conversation name to latest response_id
         if conversation:
             previous_response_id = self._response_store.get_conversation(conversation)
             # No error if conversation doesn't exist yet — it's a new conversation
 
-        # Normalize input to message list
-        input_messages: List[Dict[str, Any]] = []
-        if isinstance(raw_input, str):
-            input_messages = [{"role": "user", "content": raw_input}]
-        elif isinstance(raw_input, list):
-            for idx, item in enumerate(raw_input):
-                if isinstance(item, str):
-                    input_messages.append({"role": "user", "content": item})
-                elif isinstance(item, dict):
-                    role = item.get("role", "user")
-                    try:
-                        content = _normalize_multimodal_content(item.get("content", ""))
-                    except ValueError as exc:
-                        return _multimodal_validation_error(exc, param=f"input[{idx}].content")
-                    input_messages.append({"role": role, "content": content})
-        else:
-            return web.json_response(_openai_error("'input' must be a string or array"), status=400)
-
-        # Accept explicit conversation_history from the request body.
-        # This lets stateless clients supply their own history instead of
-        # relying on server-side response chaining via previous_response_id.
-        # Precedence: explicit conversation_history > previous_response_id.
-        conversation_history: List[Dict[str, Any]] = []
-        raw_history = body.get("conversation_history")
-        if raw_history:
-            if not isinstance(raw_history, list):
-                return web.json_response(
-                    _openai_error("'conversation_history' must be an array of message objects"),
-                    status=400,
-                )
-            for i, entry in enumerate(raw_history):
-                if not isinstance(entry, dict) or "role" not in entry or "content" not in entry:
-                    return web.json_response(
-                        _openai_error(f"conversation_history[{i}] must have 'role' and 'content' fields"),
-                        status=400,
-                    )
-                try:
-                    entry_content = _normalize_multimodal_content(entry["content"])
-                except ValueError as exc:
-                    return _multimodal_validation_error(exc, param=f"conversation_history[{i}].content")
-                conversation_history.append({"role": str(entry["role"]), "content": entry_content})
-            if previous_response_id:
-                logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
+        if conversation_history and previous_response_id:
+            logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
 
         stored_session_id = None
         if not conversation_history and previous_response_id:
@@ -2883,11 +2561,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 instructions = stored.get("instructions")
 
         # Append new input messages to history (all but the last become history)
-        for msg in input_messages[:-1]:
-            conversation_history.append(msg)
+        if not history_from_input_messages:
+            for msg in input_messages[:-1]:
+                conversation_history.append(msg)
 
-        # Last input message is the user_message
-        user_message: Any = input_messages[-1].get("content", "") if input_messages else ""
+        # Last input message is the user_message, already normalized above.
         if not _content_has_visible_payload(user_message):
             return web.json_response(_openai_error("No user message found in input"), status=400)
 
@@ -3645,38 +3323,19 @@ class APIServerAdapter(BasePlatformAdapter):
         except Exception:
             return web.json_response(_openai_error("Invalid JSON"), status=400)
 
-        raw_input = body.get("input")
-        if not raw_input:
-            return web.json_response(_openai_error("Missing 'input' field"), status=400)
+        normalized_request, err = _normalize_run_request(body)
+        if err is not None:
+            return err
+        assert normalized_request is not None
 
-        user_message = raw_input if isinstance(raw_input, str) else (raw_input[-1].get("content", "") if isinstance(raw_input, list) else "")
-        if not user_message:
-            return web.json_response(_openai_error("No user message found in input"), status=400)
-
-        instructions = body.get("instructions")
-        previous_response_id = body.get("previous_response_id")
-
-        # Accept explicit conversation_history from the request body.
-        # Precedence: explicit conversation_history > previous_response_id.
-        conversation_history: List[Dict[str, str]] = []
-        raw_history = body.get("conversation_history")
-        if raw_history:
-            if not isinstance(raw_history, list):
-                return web.json_response(
-                    _openai_error("'conversation_history' must be an array of message objects"),
-                    status=400,
-                )
-            for i, entry in enumerate(raw_history):
-                if not isinstance(entry, dict) or "role" not in entry or "content" not in entry:
-                    return web.json_response(
-                        _openai_error(f"conversation_history[{i}] must have 'role' and 'content' fields"),
-                        status=400,
-                    )
-                conversation_history.append({"role": str(entry["role"]), "content": str(entry["content"])})
-            if previous_response_id:
-                logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
+        instructions = normalized_request.instructions
+        previous_response_id = normalized_request.previous_response_id
+        conversation_history: List[Dict[str, str]] = list(normalized_request.conversation_history)
+        user_message = normalized_request.user_message
 
         stored_session_id = None
+        if conversation_history and previous_response_id:
+            logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
         if not conversation_history and previous_response_id:
             stored = self._response_store.get(previous_response_id)
             if stored:
@@ -3687,21 +3346,10 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # When input is a multi-message array, extract all but the last
         # message as conversation history (the last becomes user_message).
-        # Only fires when no explicit history was provided.
-        if not conversation_history and isinstance(raw_input, list) and len(raw_input) > 1:
-            for msg in raw_input[:-1]:
-                if isinstance(msg, dict) and msg.get("role") and msg.get("content"):
-                    content = msg["content"]
-                    if isinstance(content, list):
-                        # Flatten multi-part content blocks to text
-                        content = " ".join(
-                            part.get("text", "") for part in content
-                            if isinstance(part, dict) and part.get("type") == "text"
-                        )
-                    conversation_history.append({"role": msg["role"], "content": str(content)})
+        # Done inside _normalize_run_request when no explicit history exists.
 
         run_id = f"run_{uuid.uuid4().hex}"
-        session_id = body.get("session_id") or stored_session_id or run_id
+        session_id = normalized_request.session_id or stored_session_id or run_id
         approval_session_key = gateway_session_key or session_id or run_id
         ephemeral_system_prompt = instructions
         loop = asyncio.get_running_loop()

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -322,18 +322,6 @@ else:
     cors_middleware = None  # type: ignore[assignment]
 
 
-def _openai_error(message: str, err_type: str = "invalid_request_error", param: str = None, code: str = None) -> Dict[str, Any]:
-    """OpenAI-style error envelope."""
-    return {
-        "error": {
-            "message": message,
-            "type": err_type,
-            "param": param,
-            "code": code,
-        }
-    }
-
-
 if AIOHTTP_AVAILABLE:
     @web.middleware
     async def body_limit_middleware(request, handler):

--- a/gateway/platforms/msgraph_webhook.py
+++ b/gateway/platforms/msgraph_webhook.py
@@ -20,13 +20,8 @@ except ImportError:
     web = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import (
-    BasePlatformAdapter,
-    MessageEvent,
-    MessageType,
-    SendResult,
-    is_network_accessible,
-)
+from gateway.ingress import build_ingress_message_event, IngressEnvelope, schedule_ingress_event
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, SendResult, is_network_accessible
 
 logger = logging.getLogger(__name__)
 
@@ -356,21 +351,18 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
         receipt_key: Optional[str],
     ) -> MessageEvent:
         message_id = receipt_key or f"sha1:{sha1(json.dumps(notification, sort_keys=True).encode('utf-8')).hexdigest()}"
-        source = self.build_source(
+        envelope = IngressEnvelope(
+            text=self._render_prompt(notification),
+            message_id=message_id,
             chat_id=f"msgraph:{notification.get('subscriptionId', 'unknown')}",
             chat_name="msgraph/webhook",
             chat_type="webhook",
             user_id="msgraph",
             user_name="Microsoft Graph",
-        )
-        return MessageEvent(
-            text=self._render_prompt(notification),
-            message_type=MessageType.TEXT,
-            source=source,
-            raw_message=notification,
-            message_id=message_id,
+            raw_payload=notification,
             internal=True,
         )
+        return build_ingress_message_event(self, envelope)
 
     def _render_prompt(self, notification: Dict[str, Any]) -> str:
         template = self.config.extra.get("prompt", "")
@@ -416,6 +408,4 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
                 task.add_done_callback(self._background_tasks.discard)
             return
 
-        task = asyncio.create_task(self.handle_message(event))
-        self._background_tasks.add(task)
-        task.add_done_callback(self._background_tasks.discard)
+        schedule_ingress_event(self, event)

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -47,12 +47,8 @@ except ImportError:
     web = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import (
-    BasePlatformAdapter,
-    MessageEvent,
-    MessageType,
-    SendResult,
-)
+from gateway.ingress import IngressEnvelope, schedule_ingress_envelope
+from gateway.platforms.base import BasePlatformAdapter, SendResult
 
 logger = logging.getLogger(__name__)
 
@@ -596,20 +592,15 @@ class WebhookAdapter(BasePlatformAdapter):
         self._delivery_info_created[session_chat_id] = now
         self._prune_delivery_info(now)
 
-        # Build source and event
-        source = self.build_source(
+        envelope = IngressEnvelope(
+            text=prompt,
+            message_id=delivery_id,
             chat_id=session_chat_id,
             chat_name=f"webhook/{route_name}",
             chat_type="webhook",
             user_id=f"webhook:{route_name}",
             user_name=route_name,
-        )
-        event = MessageEvent(
-            text=prompt,
-            message_type=MessageType.TEXT,
-            source=source,
-            raw_message=payload,
-            message_id=delivery_id,
+            raw_payload=payload,
         )
 
         logger.info(
@@ -622,9 +613,7 @@ class WebhookAdapter(BasePlatformAdapter):
         )
 
         # Non-blocking — return 202 Accepted immediately
-        task = asyncio.create_task(self.handle_message(event))
-        self._background_tasks.add(task)
-        task.add_done_callback(self._background_tasks.discard)
+        schedule_ingress_envelope(self, envelope)
 
         return web.json_response(
             {

--- a/hermes_cli/config.py.bak-20260610-151633
+++ b/hermes_cli/config.py.bak-20260610-151633
@@ -1,0 +1,6416 @@
+"""
+Configuration management for Hermes Agent.
+
+Config files are stored in ~/.hermes/ for easy access:
+- ~/.hermes/config.yaml  - All settings (model, toolsets, terminal, etc.)
+- ~/.hermes/.env         - API keys and secrets
+
+This module provides:
+- hermes config          - Show current configuration
+- hermes config edit     - Open config in editor
+- hermes config set      - Set a specific value
+- hermes config wizard   - Re-run setup wizard
+"""
+
+import copy
+import json
+import logging
+import os
+import platform
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Any, Optional, List, Tuple
+
+from hermes_cli.secret_prompt import masked_secret_prompt
+
+logger = logging.getLogger(__name__)
+
+# Track which (config_path, mtime_ns, size) tuples we've already warned about
+# so concurrent CLI/gateway loads of a broken config.yaml don't spam stderr
+# every time. Cleared automatically when the file changes (different mtime).
+_CONFIG_PARSE_WARNED: set = set()
+
+
+def _backup_corrupt_config(config_path: Path) -> Optional[Path]:
+    """Preserve a corrupted ``config.yaml`` by copying it to a timestamped ``.bak``.
+
+    When the YAML can't be parsed, ``load_config()`` silently falls back to
+    ``DEFAULT_CONFIG`` and the user's broken file stays on disk untouched.
+    That file is still the user's only copy of their intended overrides — if
+    they re-run the setup wizard or ``hermes config set`` (which rewrites
+    ``config.yaml``), the broken-but-recoverable content is gone for good.
+
+    This snapshots the corrupted file to ``config.yaml.corrupt.<ts>.bak`` so
+    the user can diff/repair it. Unlike Gemini CLI's policy-file recovery
+    (which resets the live file to a clean state), we deliberately leave
+    ``config.yaml`` in place: hermes never silently mutates the user's config,
+    and leaving it means a hand-fixed file is re-read on the next load. The
+    backup is best-effort — any failure (permissions, symlink, disk full) is
+    swallowed so config loading is never blocked by backup problems.
+
+    Returns the backup path on success, else ``None``. Symlinks are not
+    followed/copied (mirrors the Gemini #21541 lstat guard) to avoid
+    clobbering whatever a malicious/misconfigured symlink points at.
+    """
+    try:
+        if config_path.is_symlink():
+            return None
+        st = config_path.stat()
+        if st.st_size == 0:
+            # Empty file isn't worth preserving and yaml.safe_load returns {}
+            # for it anyway (so it wouldn't reach here), but guard regardless.
+            return None
+        ts = time.strftime("%Y%m%d-%H%M%S")
+        backup_path = config_path.with_name(f"{config_path.name}.corrupt.{ts}.bak")
+        # Don't clobber an existing backup from the same second; if there's
+        # already a corrupt backup for this exact mtime, assume we've snapshotted
+        # this corruption already and skip (the dedup cache normally prevents a
+        # second call, but a process restart can clear it).
+        sibling_baks = list(
+            config_path.parent.glob(f"{config_path.name}.corrupt.*.bak")
+        )
+        for existing in sibling_baks:
+            try:
+                if existing.stat().st_size == st.st_size:
+                    # Same size as the current broken file — likely the same
+                    # corruption already preserved. Avoid backup churn.
+                    return None
+            except OSError:
+                continue
+        if backup_path.exists():
+            return None
+        shutil.copy2(config_path, backup_path)
+        return backup_path
+    except Exception:
+        return None
+
+
+def _warn_config_parse_failure(config_path: Path, exc: Exception) -> None:
+    """Surface a config.yaml parse failure to user, log, and stderr.
+
+    A YAML parse error in ``~/.hermes/config.yaml`` causes ``load_config()``
+    to silently fall back to ``DEFAULT_CONFIG``, which means every user
+    override (auxiliary providers, fallback chain, model overrides, etc.)
+    is dropped. Before this helper that was a one-line ``print(...)`` that
+    scrolled off-screen on the first invocation and was never seen again.
+
+    Now: warn once per (path, mtime_ns, size) on stderr **and** in
+    ``agent.log`` / ``errors.log`` at WARNING level so ``hermes logs``
+    surfaces it. Re-warns automatically if the file changes (different
+    mtime/size), so users editing the config see the next failure. On the
+    first warning for a given broken file we also snapshot it to a
+    timestamped ``.bak`` (best-effort) so the user's recoverable content
+    survives any later rewrite of ``config.yaml`` by the setup wizard or
+    ``hermes config set``.
+    """
+    try:
+        st = config_path.stat()
+        key = (str(config_path), st.st_mtime_ns, st.st_size)
+    except OSError:
+        key = (str(config_path), 0, 0)
+    if key in _CONFIG_PARSE_WARNED:
+        return
+    _CONFIG_PARSE_WARNED.add(key)
+
+    backup_path = _backup_corrupt_config(config_path)
+
+    msg = (
+        f"Failed to parse {config_path}: {exc}. "
+        f"Falling back to default config — every user override "
+        f"(auxiliary providers, fallback chain, model settings) is being IGNORED. "
+        f"Fix the YAML and restart."
+    )
+    if backup_path is not None:
+        msg += f" A copy of the corrupted file was saved to {backup_path}."
+    logger.warning(msg)
+    try:
+        sys.stderr.write(f"⚠️  hermes config: {msg}\n")
+        sys.stderr.flush()
+    except Exception:
+        pass
+
+_IS_WINDOWS = platform.system() == "Windows"
+_ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+# Env var names that influence how the next subprocess executes —
+# never writable through ``save_env_value``. Anything that controls
+# the loader, interpreter, shell, or replacement editor counts:
+#
+# * ``LD_PRELOAD`` / ``LD_LIBRARY_PATH`` / ``LD_AUDIT`` — Linux dynamic
+#   loader. ``DYLD_*`` — macOS equivalent. Planting a path here means
+#   the next ``subprocess.run([...])`` Hermes makes loads attacker code
+#   before main().
+# * ``PYTHONPATH`` / ``PYTHONHOME`` / ``PYTHONSTARTUP`` /
+#   ``PYTHONUSERBASE`` — Python interpreter init. Hermes itself starts
+#   from one of these on every restart.
+# * ``NODE_OPTIONS`` / ``NODE_PATH`` — Node interpreter; affects npm,
+#   ``hermes update``, the TUI build.
+# * ``PATH`` — too broad to allow. The dashboard never needs to rewrite
+#   the operator's PATH; if a tool can't be found, the fix is to add an
+#   absolute path in the integration config, not to mutate PATH globally.
+# * ``GIT_SSH_COMMAND`` / ``GIT_EXEC_PATH`` — git rewrites that fire
+#   on every plugin install / ``hermes update``.
+# * ``BROWSER`` / ``EDITOR`` / ``VISUAL`` / ``PAGER`` — commands the
+#   shell or CLI invokes implicitly. Wrong values here = RCE on next
+#   ``$EDITOR``.
+# * ``SHELL`` — what subprocess uses with ``shell=True`` (we try to
+#   avoid that, but defense in depth).
+# * ``HERMES_HOME`` / ``HERMES_PROFILE`` / ``HERMES_CONFIG`` /
+#   ``HERMES_ENV`` — Hermes runtime location flags. Writing these into
+#   ``.env`` would relocate state in ways the user did not request from
+#   the dashboard. ``config.yaml`` is the supported surface for these.
+#
+# IMPORTANT: ``HERMES_*`` overall is NOT blocked. Many legitimate
+# integration credentials follow that prefix (HERMES_GEMINI_CLIENT_ID,
+# HERMES_LANGFUSE_PUBLIC_KEY, HERMES_SPOTIFY_CLIENT_ID, ...). The
+# denylist is name-by-name on purpose so the gate stays narrow and
+# doesn't accidentally break provider setup wizards.
+#
+# This is enforced on *write* only — values already in ``.env`` (set
+# by the operator out-of-band, or pre-existing) keep working. The
+# point is that the dashboard's writable surface cannot escalate by
+# planting them.
+_ENV_VAR_NAME_DENYLIST: frozenset[str] = frozenset({
+    # Loader / linker
+    "LD_PRELOAD", "LD_LIBRARY_PATH", "LD_AUDIT", "LD_DEBUG",
+    "DYLD_INSERT_LIBRARIES", "DYLD_LIBRARY_PATH", "DYLD_FRAMEWORK_PATH",
+    "DYLD_FALLBACK_LIBRARY_PATH", "DYLD_FALLBACK_FRAMEWORK_PATH",
+    # Python
+    "PYTHONPATH", "PYTHONHOME", "PYTHONSTARTUP", "PYTHONUSERBASE",
+    "PYTHONEXECUTABLE", "PYTHONNOUSERSITE",
+    # Node
+    "NODE_OPTIONS", "NODE_PATH",
+    # General
+    "PATH", "SHELL", "BROWSER", "EDITOR", "VISUAL", "PAGER",
+    # Git
+    "GIT_SSH_COMMAND", "GIT_EXEC_PATH", "GIT_SHELL",
+    # Hermes runtime location — never via dashboard env writer.
+    # NOT a HERMES_* blanket: integration credentials (HERMES_GEMINI_*,
+    # HERMES_LANGFUSE_*, HERMES_SPOTIFY_*, ...) ARE allowed.
+    "HERMES_HOME", "HERMES_PROFILE", "HERMES_CONFIG", "HERMES_ENV",
+})
+
+
+def _reject_denylisted_env_var(key: str) -> None:
+    """Raise if ``key`` is in :data:`_ENV_VAR_NAME_DENYLIST`.
+
+    Centralised so both the regular and "secure" env writers share the
+    same gate, and so the message is consistent for callers.
+    """
+    if key in _ENV_VAR_NAME_DENYLIST:
+        raise ValueError(
+            f"Environment variable {key!r} is on the writer denylist. "
+            "Names that influence subprocess execution (LD_PRELOAD, "
+            "PYTHONPATH, PATH, EDITOR, ...) or Hermes runtime location "
+            "(HERMES_HOME, HERMES_PROFILE, ...) cannot be persisted via "
+            "the env writer. If you really need this, edit "
+            "~/.hermes/.env directly."
+        )
+
+_LAST_EXPANDED_CONFIG_BY_PATH: Dict[str, Any] = {}
+# (path, mtime_ns, size) -> cached expanded config dict.
+# load_config() returns a deepcopy of the cached value when the file
+# hasn't changed since the last load, skipping yaml.safe_load +
+# _deep_merge + _normalize_* + _expand_env_vars (~13 ms/call).
+# save_config() + migrate_config() write via atomic_yaml_write which
+# produces a fresh inode, so stat() sees a new mtime_ns and the next
+# load repopulates automatically — no explicit invalidation hook.
+_LOAD_CONFIG_CACHE: Dict[str, Tuple[int, int, Dict[str, Any]]] = {}
+# (path, mtime_ns, size) -> cached raw yaml dict. Same pattern as
+# _LOAD_CONFIG_CACHE but for read_raw_config() — used when callers want
+# the user's on-disk values without defaults merged in.
+_RAW_CONFIG_CACHE: Dict[str, Tuple[int, int, Dict[str, Any]]] = {}
+# Serializes all config read/write paths. libyaml's C extension is not
+# thread-safe for concurrent safe_load() on the same file, and multiple
+# tool threads (approval.py, browser_tool.py, setup flows) hit
+# load_config / read_raw_config / save_config from different threads
+# during long agent runs. RLock (not Lock) because save_config internally
+# calls read_raw_config. Also covers mutation of the module-level cache
+# dicts above.
+_CONFIG_LOCK = threading.RLock()
+# Env var names written to .env that aren't in OPTIONAL_ENV_VARS
+# (managed by setup/provider flows directly).
+_EXTRA_ENV_KEYS = frozenset({
+    "OPENAI_API_KEY", "OPENAI_BASE_URL",
+    "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN",
+    "DISCORD_HOME_CHANNEL", "DISCORD_HOME_CHANNEL_NAME",
+    "TELEGRAM_HOME_CHANNEL", "TELEGRAM_HOME_CHANNEL_NAME",
+    "SLACK_HOME_CHANNEL", "SLACK_HOME_CHANNEL_NAME",
+    "SIGNAL_ACCOUNT", "SIGNAL_HTTP_URL",
+    "SIGNAL_ALLOWED_USERS", "SIGNAL_GROUP_ALLOWED_USERS",
+    "SIGNAL_HOME_CHANNEL", "SIGNAL_HOME_CHANNEL_NAME",
+    "SMS_HOME_CHANNEL", "SMS_HOME_CHANNEL_NAME",
+    "DINGTALK_CLIENT_ID", "DINGTALK_CLIENT_SECRET",
+    "DINGTALK_HOME_CHANNEL", "DINGTALK_HOME_CHANNEL_NAME",
+    "FEISHU_APP_ID", "FEISHU_APP_SECRET", "FEISHU_ENCRYPT_KEY", "FEISHU_VERIFICATION_TOKEN",
+    "FEISHU_HOME_CHANNEL", "FEISHU_HOME_CHANNEL_NAME",
+    "YUANBAO_HOME_CHANNEL", "YUANBAO_HOME_CHANNEL_NAME",
+    "WECOM_BOT_ID", "WECOM_SECRET",
+    "WECOM_CALLBACK_CORP_ID", "WECOM_CALLBACK_CORP_SECRET", "WECOM_CALLBACK_AGENT_ID",
+    "WECOM_CALLBACK_TOKEN", "WECOM_CALLBACK_ENCODING_AES_KEY",
+    "WECOM_CALLBACK_HOST", "WECOM_CALLBACK_PORT",
+    "WECOM_HOME_CHANNEL", "WECOM_HOME_CHANNEL_NAME",
+    "WEIXIN_ACCOUNT_ID", "WEIXIN_TOKEN", "WEIXIN_BASE_URL", "WEIXIN_CDN_BASE_URL",
+    "WEIXIN_HOME_CHANNEL", "WEIXIN_HOME_CHANNEL_NAME", "WEIXIN_DM_POLICY", "WEIXIN_GROUP_POLICY",
+    "WEIXIN_ALLOWED_USERS", "WEIXIN_GROUP_ALLOWED_USERS", "WEIXIN_ALLOW_ALL_USERS",
+    "BLUEBUBBLES_SERVER_URL", "BLUEBUBBLES_PASSWORD",
+    "BLUEBUBBLES_HOME_CHANNEL", "BLUEBUBBLES_HOME_CHANNEL_NAME",
+    "QQ_APP_ID", "QQ_CLIENT_SECRET", "QQBOT_HOME_CHANNEL", "QQBOT_HOME_CHANNEL_NAME",
+    "QQ_HOME_CHANNEL", "QQ_HOME_CHANNEL_NAME",  # legacy aliases (pre-rename, still read for back-compat)
+    "QQ_ALLOWED_USERS", "QQ_GROUP_ALLOWED_USERS", "QQ_ALLOW_ALL_USERS", "QQ_MARKDOWN_SUPPORT",
+    "QQ_STT_API_KEY", "QQ_STT_BASE_URL", "QQ_STT_MODEL",
+    "IRC_SERVER", "IRC_PORT", "IRC_NICKNAME", "IRC_CHANNEL",
+    "IRC_USE_TLS", "IRC_SERVER_PASSWORD", "IRC_NICKSERV_PASSWORD",
+    "TERMINAL_ENV", "TERMINAL_SSH_KEY", "TERMINAL_SSH_PORT",
+    "WHATSAPP_MODE", "WHATSAPP_ENABLED",
+    "MATTERMOST_HOME_CHANNEL", "MATTERMOST_HOME_CHANNEL_NAME", "MATTERMOST_REPLY_MODE",
+    "MATRIX_PASSWORD", "MATRIX_ENCRYPTION", "MATRIX_DEVICE_ID", "MATRIX_HOME_ROOM",
+    "MATRIX_REQUIRE_MENTION", "MATRIX_FREE_RESPONSE_ROOMS", "MATRIX_AUTO_THREAD", "MATRIX_DM_AUTO_THREAD",
+    "MATRIX_RECOVERY_KEY",
+    # Langfuse observability plugin — optional tuning keys + standard SDK vars.
+    # Activation is via plugins.enabled (opt-in through `hermes plugins enable
+    # observability/langfuse` or `hermes tools → Langfuse`); credentials gate
+    # the plugin at runtime.
+    "HERMES_LANGFUSE_ENV",
+    "HERMES_LANGFUSE_RELEASE",
+    "HERMES_LANGFUSE_SAMPLE_RATE",
+    "HERMES_LANGFUSE_MAX_CHARS",
+    "HERMES_LANGFUSE_DEBUG",
+    "LANGFUSE_PUBLIC_KEY",
+    "LANGFUSE_SECRET_KEY",
+    "LANGFUSE_BASE_URL",
+})
+import yaml
+
+from hermes_cli.colors import Colors, color
+from hermes_cli.default_soul import DEFAULT_SOUL_MD
+
+
+# =============================================================================
+# Managed mode (NixOS declarative config)
+# =============================================================================
+
+_MANAGED_TRUE_VALUES = ("true", "1", "yes")
+_MANAGED_SYSTEM_NAMES = {
+    "brew": "Homebrew",
+    "homebrew": "Homebrew",
+    "nix": "NixOS",
+    "nixos": "NixOS",
+}
+
+
+def get_managed_system() -> Optional[str]:
+    """Return the package manager owning this install, if any."""
+    raw = os.getenv("HERMES_MANAGED", "").strip()
+    if raw:
+        normalized = raw.lower()
+        if normalized in _MANAGED_TRUE_VALUES:
+            return "NixOS"
+        return _MANAGED_SYSTEM_NAMES.get(normalized, raw)
+
+    managed_marker = get_hermes_home() / ".managed"
+    if managed_marker.exists():
+        return "NixOS"
+    return None
+
+
+def is_managed() -> bool:
+    """Check if Hermes is running in package-manager-managed mode.
+
+    Two signals: the HERMES_MANAGED env var (set by the systemd service),
+    or a .managed marker file in HERMES_HOME (set by the NixOS activation
+    script, so interactive shells also see it).
+    """
+    return get_managed_system() is not None
+
+
+_NIX_UPDATE_MSG = "Update your Nix flake input and rebuild (e.g. nix flake update, nixos-rebuild, or home-manager switch)"
+
+
+def get_managed_update_command() -> Optional[str]:
+    """Return the preferred upgrade command for a managed install."""
+    managed_system = get_managed_system()
+    if managed_system == "Homebrew":
+        return "brew upgrade hermes-agent"
+    if managed_system == "NixOS":
+        return _NIX_UPDATE_MSG
+    return None
+
+
+def detect_install_method(project_root: Optional[Path] = None) -> str:
+    """Detect how Hermes was installed: 'docker', 'nixos', 'homebrew', 'git', or 'pip'.
+
+    Resolution order:
+    1. Stamped ``~/.hermes/.install_method`` file (written by installers)
+    2. HERMES_MANAGED env / .managed marker (NixOS, Homebrew)
+    3. .git directory presence -> 'git'
+    4. Fallback -> 'pip'
+
+    Note: running inside a container is NOT treated as "docker" on its own.
+    The two supported install paths both self-identify via the
+    ``.install_method`` stamp (caught by step 1), so neither relies on
+    container detection here:
+      - the curl installer (scripts/install.sh, the README/website install
+        command) git-clones the repo and stamps ``git``;
+      - the published ``nousresearch/hermes-agent`` image stamps ``docker``
+        at boot via ``docker/stage2-hook.sh``.
+    An unsupported manual install dropped into a container (no stamp) was
+    wrongly classified as the published image by bare container detection,
+    so ``hermes update`` bailed with "doesn't apply inside the Docker
+    container". Without that fallback such installs fall through to the
+    ``.git``/pip checks and behave like any off-path install. See issue #34397.
+    """
+    stamp = get_hermes_home() / ".install_method"
+    try:
+        method = stamp.read_text(encoding="utf-8").strip().lower()
+        if method:
+            return method
+    except OSError:
+        pass
+    managed = get_managed_system()
+    if managed:
+        return managed.lower().replace(" ", "-")
+    if project_root is None:
+        project_root = Path(__file__).parent.parent.resolve()
+    if (project_root / ".git").is_dir():
+        return "git"
+    return "pip"
+
+
+def stamp_install_method(method: str) -> None:
+    """Write the install method to ~/.hermes/.install_method."""
+    stamp = get_hermes_home() / ".install_method"
+    try:
+        stamp.parent.mkdir(parents=True, exist_ok=True)
+        stamp.write_text(method + "\n", encoding="utf-8")
+    except OSError:
+        pass
+
+
+def is_uv_tool_install() -> bool:
+    """Return True when the *running* Hermes lives in a ``uv tool`` layout.
+
+    ``uv tool install hermes-agent`` places the install at
+    ``.../uv/tools/hermes-agent/...`` (default ``~/.local/share/uv/tools``,
+    or ``$UV_TOOL_DIR/...``). Such installs live outside any virtualenv, so
+    ``uv pip install`` fails with ``No virtual environment found`` and the
+    update path must use ``uv tool upgrade`` instead.
+
+    Detection is intentionally restricted to properties of the running
+    interpreter (``sys.prefix`` / ``sys.executable``). We deliberately do
+    NOT consult ``uv tool list``: it would also return True when
+    ``hermes-agent`` happens to be uv-tool-installed on the machine while
+    the *active* Hermes is a regular pip/venv install, causing
+    ``hermes update`` to upgrade the wrong copy. It would also block on a
+    subprocess call (~seconds) just to compute a recommendation string.
+    """
+    def _has_uv_tool_marker(path: str) -> bool:
+        norm = os.path.normpath(path).replace(os.sep, "/").lower()
+        return "/uv/tools/hermes-agent/" in norm + "/"
+
+    if _has_uv_tool_marker(sys.prefix):
+        return True
+    if _has_uv_tool_marker(sys.executable or ""):
+        return True
+    return False
+
+
+def recommended_update_command_for_method(method: str) -> str:
+    """Return the update command or guidance for a given install method."""
+    if method == "nixos":
+        return _NIX_UPDATE_MSG
+    if method == "homebrew":
+        return "brew upgrade hermes-agent"
+    if method == "docker":
+        return "docker pull nousresearch/hermes-agent:latest"
+    if method == "pip":
+        if is_uv_tool_install():
+            return "uv tool upgrade hermes-agent"
+        import shutil
+        if shutil.which("uv"):
+            return "uv pip install --upgrade hermes-agent"
+        return "pip install --upgrade hermes-agent"
+    return "hermes update"
+
+
+def recommended_update_command() -> str:
+    """Return the best update command for the current installation."""
+    managed_cmd = get_managed_update_command()
+    if managed_cmd:
+        return managed_cmd
+    method = detect_install_method()
+    return recommended_update_command_for_method(method)
+
+
+# Long-form text for ``hermes update`` / ``--check`` when running inside the
+# Docker image.  Surfaced by ``cmd_update`` and ``_cmd_update_check`` in
+# hermes_cli/main.py; lives here so the wording stays consistent and we
+# don't grow two slightly-different copies.
+#
+# Why this matters:
+#   - The published image excludes ``.git`` (see .dockerignore), so the
+#     git-based update path can never succeed inside the container.
+#   - The pre-existing fallback message ("✗ Not a git repository. Please
+#     reinstall: curl ... install.sh") is actively misleading inside Docker
+#     — that script installs a *new* host-side Hermes, it doesn't update
+#     the running container.
+#   - The right action is ``docker pull`` + restart the container; this
+#     helper spells that out, with notes on tag pinning and config
+#     persistence so users don't get blindsided.
+_DOCKER_UPDATE_MESSAGE = """\
+✗ ``hermes update`` doesn't apply inside the Docker container.
+
+Hermes Agent runs as a published image (nousresearch/hermes-agent), not a
+git checkout — the container has no working tree to pull into.  Update by
+pulling a fresh image and restarting your container instead:
+
+  docker pull nousresearch/hermes-agent:latest
+  # then restart whatever started the container, e.g.:
+  docker compose up -d --force-recreate hermes-agent
+  # or, for ad-hoc runs, exit the current container and `docker run` again
+
+Verify the new version after restart:
+  docker run --rm nousresearch/hermes-agent:latest --version
+
+Notes:
+  • If you pinned a specific tag (e.g. ``:v0.14.0``) the ``:latest`` tag
+    won't move your container — pull the newer tag you actually want, or
+    switch to ``:latest`` / ``:main`` for rolling updates.  See available
+    tags at https://hub.docker.com/r/nousresearch/hermes-agent/tags
+  • Your config and session history live under ``$HERMES_HOME`` (``/opt/data``
+    in the container, typically bind-mounted from the host) and persist
+    across image upgrades — re-pulling doesn't lose any state.
+  • Running a fork?  Build your own image with this repo's ``Dockerfile``
+    and replace the ``docker pull`` step with your build/push pipeline."""
+
+
+def format_docker_update_message() -> str:
+    """Return the user-facing message for ``hermes update`` inside Docker.
+
+    Centralised so ``cmd_update`` (the apply path) and ``_cmd_update_check``
+    (the dry-run path) share the same wording.  See ``_DOCKER_UPDATE_MESSAGE``
+    above for the full rationale.
+    """
+    return _DOCKER_UPDATE_MESSAGE
+
+
+def format_managed_message(action: str = "modify this Hermes installation") -> str:
+    """Build a user-facing error for managed installs."""
+    managed_system = get_managed_system() or "a package manager"
+    raw = os.getenv("HERMES_MANAGED", "").strip().lower()
+
+    if managed_system == "NixOS":
+        env_hint = "true" if raw in _MANAGED_TRUE_VALUES else raw or "true"
+        return (
+            f"Cannot {action}: this Hermes installation is managed by NixOS "
+            f"(HERMES_MANAGED={env_hint}).\n"
+            "Edit services.hermes-agent.settings in your configuration.nix and run:\n"
+            "  sudo nixos-rebuild switch"
+        )
+
+    if managed_system == "Homebrew":
+        env_hint = raw or "homebrew"
+        return (
+            f"Cannot {action}: this Hermes installation is managed by Homebrew "
+            f"(HERMES_MANAGED={env_hint}).\n"
+            "Use:\n"
+            "  brew upgrade hermes-agent"
+        )
+
+    return (
+        f"Cannot {action}: this Hermes installation is managed by {managed_system}.\n"
+        "Use your package manager to upgrade or reinstall Hermes."
+    )
+
+def managed_error(action: str = "modify configuration"):
+    """Print user-friendly error for managed mode."""
+    print(format_managed_message(action), file=sys.stderr)
+
+
+# =============================================================================
+# Container-aware CLI (NixOS container mode)
+# =============================================================================
+
+def get_container_exec_info() -> Optional[dict]:
+    """Read container mode metadata from HERMES_HOME/.container-mode.
+
+    Returns a dict with keys: backend, container_name, exec_user, hermes_bin
+    or None if container mode is not active, we're already inside the
+    container, or HERMES_DEV=1 is set.
+
+    The .container-mode file is written by the NixOS activation script when
+    container.enable = true. It tells the host CLI to exec into the container
+    instead of running locally.
+    """
+    if os.environ.get("HERMES_DEV") == "1":
+        return None
+
+    from hermes_constants import is_container
+    if is_container():
+        return None
+
+    container_mode_file = get_hermes_home() / ".container-mode"
+
+    try:
+        info = {}
+        with open(container_mode_file, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if "=" in line and not line.startswith("#"):
+                    key, _, value = line.partition("=")
+                    info[key.strip()] = value.strip()
+    except FileNotFoundError:
+        return None
+    # All other exceptions (PermissionError, malformed data, etc.) propagate
+
+    backend = info.get("backend", "docker")
+    container_name = info.get("container_name", "hermes-agent")
+    exec_user = info.get("exec_user", "hermes")
+    hermes_bin = info.get("hermes_bin", "/data/current-package/bin/hermes")
+
+    return {
+        "backend": backend,
+        "container_name": container_name,
+        "exec_user": exec_user,
+        "hermes_bin": hermes_bin,
+    }
+
+
+# =============================================================================
+# Config paths
+# =============================================================================
+
+# Re-export from hermes_constants — canonical definition lives there.
+from hermes_constants import get_hermes_home  # noqa: F811,E402
+from utils import atomic_replace
+
+def get_config_path() -> Path:
+    """Get the main config file path."""
+    return get_hermes_home() / "config.yaml"
+
+def get_env_path() -> Path:
+    """Get the .env file path (for API keys)."""
+    return get_hermes_home() / ".env"
+
+def get_project_root() -> Path:
+    """Get the project installation directory."""
+    return Path(__file__).parent.parent.resolve()
+
+def _resolve_hermes_uid_gid() -> tuple[Optional[int], Optional[int]]:
+    """Read the HERMES_UID / HERMES_GID env vars set by Docker deployments.
+
+    Docker containers running Hermes commonly set these to map the in-container
+    user to a host user so volume-mounted state files end up with the right
+    ownership. The entrypoint chowns the top-level HERMES_HOME once, but
+    subdirectories created at runtime by ``ensure_hermes_home()`` (especially
+    for profile namespaces under ``profiles/<name>/``) need the same chown
+    or they land as ``root:root`` and block subsequent uid-mapped workers
+    with ``PermissionError [Errno 13]``. See #34107.
+
+    Returns ``(uid, gid)`` parsed from the env vars, or ``(None, None)``
+    when either is missing/invalid. Returns ``(None, None)`` on Windows
+    too (where chown is a no-op anyway).
+    """
+    if sys.platform == "win32":
+        return None, None
+    uid_str = os.environ.get("HERMES_UID", "").strip()
+    gid_str = os.environ.get("HERMES_GID", "").strip()
+    try:
+        uid = int(uid_str) if uid_str else None
+    except ValueError:
+        uid = None
+    try:
+        gid = int(gid_str) if gid_str else None
+    except ValueError:
+        gid = None
+    return uid, gid
+
+
+def _chown_to_hermes_uid(path) -> None:
+    """Chown ``path`` to ``HERMES_UID:HERMES_GID`` if those env vars are set.
+
+    No-op when:
+      - Either env var is unset/invalid
+      - The current process isn't root (chown will EPERM — silently ignored)
+      - On Windows (chown semantics don't apply)
+
+    Used by :func:`_secure_dir` to keep ownership consistent across all
+    directories created by :func:`ensure_hermes_home` on Docker deployments.
+    See #34107.
+    """
+    uid, gid = _resolve_hermes_uid_gid()
+    if uid is None and gid is None:
+        return
+    try:
+        # os.chown with -1 means "don't change" for that field.
+        os.chown(
+            path,
+            uid if uid is not None else -1,
+            gid if gid is not None else -1,
+        )
+    except (OSError, AttributeError, NotImplementedError):
+        # OSError covers EPERM (not running as root) and ENOENT (race),
+        # both of which are non-fatal — the dir is still created and
+        # the entrypoint's startup chown -R will fix it on next restart.
+        pass
+
+
+def _secure_dir(path):
+    """Set directory to owner-only access (0700 by default). No-op on Windows.
+
+    Skipped in managed mode — the NixOS module sets group-readable
+    permissions (0750) so interactive users in the hermes group can
+    share state with the gateway service.
+
+    The mode can be overridden via the HERMES_HOME_MODE environment variable
+    (e.g. HERMES_HOME_MODE=0701) for deployments where a web server (nginx,
+    caddy, etc.) needs to traverse HERMES_HOME to reach a served subdirectory.
+    The execute-only bit on a directory permits cd-through without exposing
+    directory listings.
+
+    Also applies ``HERMES_UID``/``HERMES_GID``-based ownership when those env
+    vars are set (#34107 — Docker deployments need this so profile subdirs
+    created at runtime by kanban workers don't land as root:root and block
+    subsequent uid-mapped workers).
+    """
+    if is_managed():
+        return
+    try:
+        mode_str = os.environ.get("HERMES_HOME_MODE", "").strip()
+        mode = int(mode_str, 8) if mode_str else 0o700
+    except ValueError:
+        mode = 0o700
+    try:
+        os.chmod(path, mode)
+    except (OSError, NotImplementedError):
+        pass
+    _chown_to_hermes_uid(path)
+
+
+def _is_container() -> bool:
+    """Detect if we're running inside a Docker/Podman/LXC container.
+
+    When Hermes runs in a container with volume-mounted config files, forcing
+    0o600 permissions breaks multi-process setups where the gateway and
+    dashboard run as different UIDs or the volume mount requires broader
+    permissions.
+    """
+    # Explicit opt-out
+    if os.environ.get("HERMES_CONTAINER") or os.environ.get("HERMES_SKIP_CHMOD"):
+        return True
+    # Docker / Podman marker file
+    if os.path.exists("/.dockerenv"):
+        return True
+    # LXC / cgroup-based detection
+    try:
+        with open("/proc/1/cgroup", "r", encoding="utf-8") as f:
+            cgroup_content = f.read()
+        if "docker" in cgroup_content or "lxc" in cgroup_content or "kubepods" in cgroup_content:
+            return True
+    except (OSError, IOError):
+        pass
+    return False
+
+
+def _secure_file(path):
+    """Set file to owner-only read/write (0600). No-op on Windows.
+
+    Skipped in managed mode — the NixOS activation script sets
+    group-readable permissions (0640) on config files.
+
+    Skipped in containers — Docker/Podman volume mounts often need broader
+    permissions.  Set HERMES_SKIP_CHMOD=1 to force-skip on other systems.
+    """
+    if is_managed() or _is_container():
+        return
+    try:
+        if os.path.exists(str(path)):
+            os.chmod(path, 0o600)
+    except (OSError, NotImplementedError):
+        pass
+
+
+def _ensure_default_soul_md(home: Path) -> None:
+    """Seed a default SOUL.md into HERMES_HOME if the user doesn't have one yet."""
+    soul_path = home / "SOUL.md"
+    if soul_path.exists():
+        return
+    soul_path.write_text(DEFAULT_SOUL_MD, encoding="utf-8")
+    _secure_file(soul_path)
+
+
+def ensure_hermes_home():
+    """Ensure ~/.hermes directory structure exists with secure permissions.
+
+    In managed mode (NixOS), dirs are created by the activation script with
+    setgid + group-writable (2770). We skip mkdir and set umask(0o007) so
+    any files created (e.g. SOUL.md) are group-writable (0660).
+    """
+    home = get_hermes_home()
+    if is_managed():
+        old_umask = os.umask(0o007)
+        try:
+            _ensure_hermes_home_managed(home)
+        finally:
+            os.umask(old_umask)
+    else:
+        home.mkdir(parents=True, exist_ok=True)
+        _secure_dir(home)
+        for subdir in (
+            "cron", "sessions", "logs", "logs/curator", "memories",
+            "pairing", "hooks", "image_cache", "audio_cache", "skills",
+        ):
+            d = home / subdir
+            d.mkdir(parents=True, exist_ok=True)
+            _secure_dir(d)
+        _ensure_default_soul_md(home)
+
+
+def _ensure_hermes_home_managed(home: Path):
+    """Managed-mode variant: verify dirs exist (activation creates them), seed SOUL.md."""
+    if not home.is_dir():
+        raise RuntimeError(
+            f"HERMES_HOME {home} does not exist. "
+            "Run 'sudo nixos-rebuild switch' first."
+        )
+    for subdir in ("cron", "sessions", "logs", "memories"):
+        d = home / subdir
+        if not d.is_dir():
+            raise RuntimeError(
+                f"{d} does not exist. "
+                "Run 'sudo nixos-rebuild switch' first."
+            )
+    # Curator reports dir is a sub-path of logs/; create it if missing.
+    # In managed mode the activation script may not know about this subdir,
+    # so we mkdir it ourselves (it's inside an already-secured logs/ dir).
+    (home / "logs" / "curator").mkdir(parents=True, exist_ok=True)
+    # Inside umask(0o007) scope — SOUL.md will be created as 0660
+    _ensure_default_soul_md(home)
+
+
+# =============================================================================
+# Config loading/saving
+# =============================================================================
+
+DEFAULT_CONFIG = {
+    "model": "",
+    "providers": {},
+    "fallback_providers": [],
+    "credential_pool_strategies": {},
+    "toolsets": ["hermes-cli"],
+    # Global active chat session cap across CLI, TUI/dashboard, and messaging.
+    # None/0 = unbounded.
+    "max_concurrent_sessions": None,
+    "agent": {
+        "max_turns": 90,
+        # Inactivity timeout for gateway agent execution (seconds).
+        # The agent can run indefinitely as long as it's actively calling
+        # tools or receiving API responses.  Only fires when the agent has
+        # been completely idle for this duration.  0 = unlimited.
+        "gateway_timeout": 1800,
+        # Graceful drain timeout for gateway stop/restart (seconds).
+        # The gateway stops accepting new work, waits for running agents
+        # to finish, then interrupts any remaining runs after the timeout.
+        # 0 = no drain, interrupt immediately.
+        #
+        # 180s is calibrated for realistic in-flight agent turns: a typical
+        # coding conversation mid-reasoning runs 60–150s per call, so a 60s
+        # budget routinely interrupted legitimate work on /restart. Raise
+        # further in config.yaml if you run very-long-reasoning models.
+        "restart_drain_timeout": 180,
+        # Max app-level retry attempts for API errors (connection drops,
+        # provider timeouts, 5xx, etc.) before the agent surfaces the
+        # failure.  The OpenAI SDK already does its own low-level retries
+        # (max_retries=2 default) for transient network errors; this is
+        # the Hermes-level retry loop that wraps the whole call.  Lower
+        # this to 1 if you use fallback providers and want fast failover
+        # on flaky primaries; raise it if you prefer to tolerate longer
+        # provider hiccups on a single provider.
+        "api_max_retries": 3,
+        "service_tier": "",
+        # Tool-use enforcement: injects system prompt guidance that tells the
+        # model to actually call tools instead of describing intended actions.
+        # Values: "auto" (default — applies to gpt/codex models), true/false
+        # (force on/off for all models), or a list of model-name substrings
+        # to match (e.g. ["gpt", "codex", "gemini", "qwen"]).
+        "tool_use_enforcement": "auto",
+        # Universal "finish the job" guidance — short prompt block applied to
+        # all models that targets two cross-family failure modes: (1) stopping
+        # after a stub instead of finishing the artifact, (2) fabricating
+        # plausible-looking output when a real path is blocked.  Costs ~80
+        # tokens in the cached system prompt.  Set False to disable globally.
+        "task_completion_guidance": True,
+        # Local-environment toolchain probe — surfaces Python/pip/uv/PEP-668
+        # state in the system prompt when something non-default is detected
+        # (e.g. python3 has no pip module, pip→python version mismatch, PEP
+        # 668 enforcement without uv).  Costs zero tokens when the env is
+        # clean (probe emits nothing).  Skipped for remote terminal backends
+        # (docker/modal/ssh — they have their own probe).  Set False to
+        # disable entirely.
+        "environment_probe": True,
+        # Embedder-supplied environment description appended to the system
+        # prompt's environment-hints block. Lets a host that wraps Hermes
+        # (sandbox runner, managed platform) explain the runtime environment
+        # — proxy, credential handling, mount layout — without editing the
+        # identity slot (SOUL.md). Empty by default. The HERMES_ENVIRONMENT_HINT
+        # env var overrides this (build-time/container mechanism).
+        "environment_hint": "",
+        # Staged inactivity warning: send a warning to the user at this
+        # threshold before escalating to a full timeout.  The warning fires
+        # once per run and does not interrupt the agent.  0 = disable warning.
+        "gateway_timeout_warning": 900,
+        # Maximum time (seconds) the gateway will block an agent waiting for
+        # a clarify-tool response from the user.  Hit this and the agent
+        # unblocks with "[user did not respond within Xm]" so it can adapt
+        # rather than pinning the running-agent guard forever.  CLI clarify
+        # blocks indefinitely (input() is synchronous) and ignores this.
+        "clarify_timeout": 600,
+        # Periodic "still working" notification interval (seconds).
+        # Sends a status message every N seconds so the user knows the
+        # agent hasn't died during long tasks.  0 = disable notifications.
+        # Lower values mean faster feedback on slow tasks but more chat
+        # noise; 180s is a compromise that catches spinning weak-model runs
+        # (60+ tool iterations with tiny output) before users assume the
+        # bot is dead and /restart.
+        "gateway_notify_interval": 180,
+        # Freshness window for the gateway auto-continue note (seconds).
+        # After a gateway crash/restart/SIGTERM mid-run, the next user
+        # message gets a "[System note: your previous turn was
+        # interrupted — process the unfinished tool result(s) first]"
+        # prepended so the model picks up where it left off.  That's the
+        # right behaviour while the interruption is fresh, but stale
+        # markers (transcript last touched hours or days ago) can revive
+        # an unrelated old task when the user's next message starts new
+        # work.  This window is the max age of the last persisted
+        # transcript row for which we still inject the continue note.
+        # Default 3600s comfortably covers a long turn (gateway_timeout
+        # default is 1800s) plus runtime slack.  Set to 0 to disable the
+        # gate and restore pre-fix behaviour (always inject).
+        "gateway_auto_continue_freshness": 3600,
+        # How user-attached images are presented to the main model on each turn.
+        #   "auto"   — attach natively when the active model reports
+        #              supports_vision=True AND the user hasn't explicitly
+        #              configured auxiliary.vision.provider.  Otherwise fall
+        #              back to text (vision_analyze pre-analysis).
+        #   "native" — always attach natively; non-vision models will either
+        #              error at the provider or get a last-chance text fallback
+        #              (see run_agent._prepare_messages_for_api).
+        #   "text"   — always pre-analyze with vision_analyze and prepend the
+        #              description as text; the main model never sees pixels.
+        # Affects gateway platforms, the TUI, and CLI /attach.  vision_analyze
+        # remains available as a tool regardless of this setting — the routing
+        # only controls how inbound user images are presented.
+        "image_input_mode": "auto",
+        "disabled_toolsets": [],
+    },
+    
+    "terminal": {
+        "backend": "local",
+        "modal_mode": "auto",
+        "cwd": ".",  # Use current directory
+        "timeout": 180,
+        # Environment variables to pass through to sandboxed execution
+        # (terminal and execute_code).  Skill-declared required_environment_variables
+        # are passed through automatically; this list is for non-skill use cases.
+        "env_passthrough": [],
+        # Extra files to source in the login shell when building the
+        # per-session environment snapshot.  Use this when tools like nvm,
+        # pyenv, asdf, or custom PATH entries are registered by files that
+        # a bash login shell would skip — most commonly ``~/.bashrc``
+        # (bash doesn't source bashrc in non-interactive login mode) or
+        # zsh-specific files like ``~/.zshrc`` / ``~/.zprofile``.
+        # Paths support ``~`` / ``${VAR}``. Missing files are silently
+        # skipped. When empty, Hermes auto-sources ``~/.profile``,
+        # ``~/.bash_profile``, and ``~/.bashrc`` (in that order) if the
+        # snapshot shell is bash (this is the ``auto_source_bashrc``
+        # behaviour — disable with that key if you want strict login-only
+        # semantics).
+        "shell_init_files": [],
+        # When true (default), Hermes sources the user's shell rc files
+        # (``~/.profile``, ``~/.bash_profile``, ``~/.bashrc``) in the
+        # login shell used to build the environment snapshot. This
+        # captures PATH additions, shell functions, and aliases — which a
+        # plain ``bash -l -c`` would otherwise miss because bash skips
+        # bashrc in non-interactive login mode, and because a default
+        # Debian/Ubuntu ``~/.bashrc`` short-circuits on non-interactive
+        # sources. ``~/.profile`` and ``~/.bash_profile`` are tried first
+        # because ``n`` / ``nvm`` / ``asdf`` installers typically write
+        # their PATH exports there without an interactivity guard. Turn
+        # this off if your rc files misbehave when sourced
+        # non-interactively (e.g. one that hard-exits on TTY checks).
+        "auto_source_bashrc": True,
+        "docker_image": "nikolaik/python-nodejs:python3.11-nodejs20",
+        "docker_forward_env": [],
+        # Explicit environment variables to set inside Docker containers.
+        # Unlike docker_forward_env (which reads values from the host process),
+        # docker_env lets you specify exact key-value pairs — useful when Hermes
+        # runs as a systemd service without access to the user's shell environment.
+        # Example: {"SSH_AUTH_SOCK": "/run/user/1000/ssh-agent.sock"}
+        "docker_env": {},
+        "singularity_image": "docker://nikolaik/python-nodejs:python3.11-nodejs20",
+        "modal_image": "nikolaik/python-nodejs:python3.11-nodejs20",
+        "daytona_image": "nikolaik/python-nodejs:python3.11-nodejs20",
+        # Container resource limits (docker, singularity, modal, daytona — ignored for local/ssh)
+        "container_cpu": 1,
+        "container_memory": 5120,       # MB (default 5GB)
+        "container_disk": 51200,        # MB (default 50GB)
+        "container_persistent": True,   # Persist filesystem across sessions
+        # Docker volume mounts — share host directories with the container.
+        # Each entry is "host_path:container_path" (standard Docker -v syntax).
+        # Example:
+        # ["/home/user/projects:/workspace/projects",
+        #  "/home/user/.hermes/cache/documents:/output"]
+        # For gateway MEDIA delivery, write inside Docker to /output/... and emit
+        # the host-visible path in MEDIA:, not the container path.
+        "docker_volumes": [],
+        # Explicit opt-in: mount the host cwd into /workspace for Docker sessions.
+        # Default off because passing host directories into a sandbox weakens isolation.
+        "docker_mount_cwd_to_workspace": False,
+        "docker_extra_args": [],        # Extra flags passed verbatim to docker run
+        # Explicit opt-in: run the Docker container as the host user's uid:gid
+        # (via `--user`).  When enabled, files written into bind-mounted dirs
+        # (docker_volumes, the persistent workspace, or the auto-mounted cwd)
+        # are owned by your host user instead of root, which avoids needing
+        # `sudo chown` after container runs. Default off to preserve behavior
+        # for images whose entrypoints expect to start as root (e.g. the
+        # bundled Hermes image, which drops to the `hermes` user via
+        # s6-setuidgid inside each supervised service).
+        # When on, SETUID/SETGID caps are omitted from the container since
+        # no privilege drop is needed.
+        "docker_run_as_host_user": False,
+        # Persistent shell — keep a long-lived bash shell across execute() calls
+        # so cwd/env vars/shell variables survive between commands.
+        # Enabled by default for non-local backends (SSH); local is always opt-in
+        # via TERMINAL_LOCAL_PERSISTENT env var.
+        "persistent_shell": True,
+    },
+
+    "web": {
+        "backend": "",           # shared fallback — applies to both search and extract
+        "search_backend": "",    # per-capability override for web_search (e.g. "searxng")
+        "extract_backend": "",   # per-capability override for web_extract (e.g. "native")
+    },
+
+    "browser": {
+        "inactivity_timeout": 120,
+        "command_timeout": 30,  # Timeout for browser commands in seconds (screenshot, navigate, etc.)
+        "record_sessions": False,  # Auto-record browser sessions as WebM videos
+        "allow_private_urls": False,  # Allow navigating to private/internal IPs (localhost, 192.168.x.x, etc.)
+        # Browser engine for local mode.  Passed as ``--engine <value>`` to
+        # agent-browser v0.25.3+.
+        # "auto"       — use Chrome (default, don't pass --engine at all)
+        # "lightpanda" — use Lightpanda (1.3-5.8x faster navigation, no screenshots)
+        # "chrome"     — explicitly request Chrome
+        # Also settable via AGENT_BROWSER_ENGINE env var.
+        "engine": "auto",
+        "auto_local_for_private_urls": True,  # When a cloud provider is set, auto-spawn local Chromium for LAN/localhost URLs instead of sending them to the cloud
+        "cdp_url": "",  # Optional persistent CDP endpoint for attaching to an existing Chromium/Chrome
+        # CDP supervisor — dialog + frame detection via a persistent WebSocket.
+        # Active only when a CDP-capable backend is attached (Browserbase or
+        # local Chrome via /browser connect). See
+        # website/docs/developer-guide/browser-supervisor.md.
+        "dialog_policy": "must_respond",  # must_respond | auto_dismiss | auto_accept
+        "dialog_timeout_s": 300,  # Safety auto-dismiss after N seconds under must_respond
+        "camofox": {
+            # When true, Hermes sends a stable profile-scoped userId to Camofox
+            # so the server maps it to a persistent Firefox profile automatically.
+            # When false (default), each session gets a random userId (ephemeral).
+            "managed_persistence": False,
+            # Optional externally managed Camofox identity. Useful when another
+            # app owns the visible browser and Hermes should operate in it.
+            "user_id": "",
+            "session_key": "",
+            # Rehydrate tab_id from Camofox before creating a new tab.
+            "adopt_existing_tab": False,
+            # Docker Camofox opens page URLs from inside the container. Enable
+            # this to rewrite loopback page URLs (localhost/127.0.0.1/::1) to a
+            # host alias while leaving CAMOFOX_URL itself unchanged.
+            "rewrite_loopback_urls": False,
+            "loopback_host_alias": "host.docker.internal",
+        },
+    },
+
+    # Filesystem checkpoints — automatic snapshots before destructive file ops.
+    # When enabled, the agent takes a snapshot of the working directory once
+    # per conversation turn (on first write_file/patch call).  Use /rollback
+    # to restore.
+    #
+    # Defaults changed in v2 (single shared shadow store, real pruning):
+    #   - enabled: True -> False   (opt-in; most users never use /rollback)
+    #   - max_snapshots: 50 -> 20  (now actually enforced via ref rewrite)
+    #   - auto_prune:   False -> True (orphans/stale pruned automatically)
+    # Opt in via ``hermes chat --checkpoints`` or set enabled=True here.
+    "checkpoints": {
+        "enabled": False,
+        # Max checkpoints to keep per working directory.  Pre-v2 this only
+        # limited the `/rollback` listing; v2 actually rewrites the ref and
+        # garbage-collects older commits.
+        "max_snapshots": 20,
+        # Hard ceiling on total ``~/.hermes/checkpoints/`` size (MB).  When
+        # exceeded, the oldest checkpoint per project is dropped in a
+        # round-robin pass until total size falls under the cap.
+        # 0 disables the size cap.
+        "max_total_size_mb": 500,
+        # Skip any single file larger than this when staging a checkpoint.
+        # Prevents accidental snapshotting of datasets, model weights, and
+        # other large generated assets.  0 disables the filter.
+        "max_file_size_mb": 10,
+        # Auto-maintenance: hermes sweeps the checkpoint base at startup
+        # (at most once per ``min_interval_hours``) and:
+        #   * deletes project entries whose workdir no longer exists (orphan)
+        #   * deletes project entries whose last_touch is older than
+        #     ``retention_days``
+        #   * GCs the single shared store to reclaim unreachable objects
+        #   * enforces ``max_total_size_mb`` across remaining projects
+        #   * deletes ``legacy-*`` archives older than ``retention_days``
+        "auto_prune": True,
+        "retention_days": 7,
+        "delete_orphans": True,
+        "min_interval_hours": 24,
+    },
+
+    # Maximum characters returned by a single read_file call.  Reads that
+    # exceed this are rejected with guidance to use offset+limit.
+    # 100K chars ≈ 25–35K tokens across typical tokenisers.
+    "file_read_max_chars": 100_000,
+
+    # Tool-output truncation thresholds. When terminal output or a
+    # single read_file page exceeds these limits, Hermes truncates the
+    # payload sent to the model (keeping head + tail for terminal,
+    # enforcing pagination for read_file). Tuning these trades context
+    # footprint against how much raw output the model can see in one
+    # shot. Ported from anomalyco/opencode PR #23770.
+    #
+    # - max_bytes:       terminal_tool output cap, in chars
+    #                    (default 50_000 ≈ 12-15K tokens).
+    # - max_lines:       read_file pagination cap — the maximum `limit`
+    #                    a single read_file call can request before
+    #                    being clamped (default 2000).
+    # - max_line_length: per-line cap applied when read_file emits a
+    #                    line-numbered view (default 2000 chars).
+    "tool_output": {
+        "max_bytes": 50_000,
+        "max_lines": 2000,
+        "max_line_length": 2000,
+    },
+
+    # Tool loop guardrails nudge models when they repeat failed or
+    # non-progressing tool calls. Soft warnings are always-on by default;
+    # hard stops are opt-in so interactive CLI/TUI sessions keep flowing.
+    "tool_loop_guardrails": {
+        "warnings_enabled": True,
+        "hard_stop_enabled": False,
+        "warn_after": {
+            "exact_failure": 2,
+            "same_tool_failure": 3,
+            "idempotent_no_progress": 2,
+        },
+        "hard_stop_after": {
+            "exact_failure": 5,
+            "same_tool_failure": 8,
+            "idempotent_no_progress": 5,
+        },
+    },
+
+    "compression": {
+        "enabled": True,
+        "threshold": 0.50,            # compress when context usage exceeds this ratio
+        "target_ratio": 0.20,         # fraction of threshold to preserve as recent tail
+        "protect_last_n": 20,         # minimum recent messages to keep uncompressed
+        "hygiene_hard_message_limit": 400,  # gateway session-hygiene force-compress threshold by message count
+        "protect_first_n": 3,         # non-system head messages always preserved
+                                      # verbatim, in ADDITION to the system prompt
+                                      # (which is always implicitly protected). Set to
+                                      # 0 for long-running rolling-compaction sessions
+                                      # where you want nothing pinned except the
+                                      # system prompt + rolling summary + recent tail.
+        "abort_on_summary_failure": False,  # When True, auto-compression that fails
+                                      # to generate a summary (aux LLM errored / returned
+                                      # non-JSON / timed out) aborts entirely instead of
+                                      # dropping the middle window with a static
+                                      # "summary unavailable" placeholder.  Messages are
+                                      # preserved unchanged and the session "freezes" at
+                                      # its current size until the user runs /compress
+                                      # (which bypasses the failure cooldown) or /new.
+                                      # Default False matches historical behavior; set to
+                                      # True if you'd rather pause than silently lose
+                                      # context turns when your aux model is flaky.
+        "codex_gpt55_autoraise": True,  # When True, gpt-5.5 on the ChatGPT Codex OAuth
+                                      # route raises its compaction trigger to 85% (vs the
+                                      # global `threshold` above). Codex hard-caps gpt-5.5
+                                      # at a 272K window, so the default 50% would compact
+                                      # at ~136K and waste half the usable context. Set to
+                                      # False to opt back down to the global threshold
+                                      # (e.g. 0.50) for Codex gpt-5.5 sessions. Only this
+                                      # exact route is affected — gpt-5.5 on OpenAI's
+                                      # direct API, OpenRouter, and Copilot keep the
+                                      # global threshold regardless.
+    },
+
+    # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).
+    # cache_ttl must be "5m" or "1h" (Anthropic-supported tiers); other values are ignored.
+    "prompt_caching": {
+        "cache_ttl": "5m",
+    },
+
+    # OpenRouter-specific settings.
+    # response_cache: enable OpenRouter response caching (X-OpenRouter-Cache header).
+    #   When enabled, identical requests return cached responses for free (zero billing).
+    #   This is separate from Anthropic prompt caching and works alongside it.
+    #   See: https://openrouter.ai/docs/guides/features/response-caching
+    # response_cache_ttl: how long cached responses remain valid, in seconds (1-86400).
+    #   Default 300 (5 minutes). Only used when response_cache is enabled.
+    # min_coding_score: knob for the openrouter/pareto-code router (0.0-1.0).
+    #   Only applied when model.model is "openrouter/pareto-code". Higher
+    #   values route to stronger (more expensive) coders; lower values open
+    #   up cheaper, faster options. Default 0.65 lands on the mid-tier
+    #   coder on the current Pareto frontier. Empty string = let OpenRouter
+    #   pick the strongest available coder (router's documented default
+    #   when the plugins block is omitted).
+    #   See: https://openrouter.ai/docs/guides/routing/routers/pareto-router
+    "openrouter": {
+        "response_cache": True,
+        "response_cache_ttl": 300,
+        "min_coding_score": 0.65,
+    },
+
+    # AWS Bedrock provider configuration.
+    # Only used when model.provider is "bedrock".
+    "bedrock": {
+        "region": "",  # AWS region for Bedrock API calls (empty = AWS_REGION env var → us-east-1)
+        "discovery": {
+            "enabled": True,           # Auto-discover models via ListFoundationModels
+            "provider_filter": [],     # Only show models from these providers (e.g. ["anthropic", "amazon"])
+            "refresh_interval": 3600,  # Cache discovery results for this many seconds
+        },
+        "guardrail": {
+            # Amazon Bedrock Guardrails — content filtering and safety policies.
+            # Create a guardrail in the Bedrock console, then set the ID and version here.
+            # See: https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html
+            "guardrail_identifier": "",  # e.g. "abc123def456"
+            "guardrail_version": "",     # e.g. "1" or "DRAFT"
+            "stream_processing_mode": "async",  # "sync" or "async"
+            "trace": "disabled",         # "enabled", "disabled", or "enabled_full"
+        },
+    },
+
+    # Auxiliary model config — provider:model for each side task.
+    # Format: provider is the provider name, model is the model slug.
+    # "auto" for provider = auto-detect best available provider.
+    # Empty model = use provider's default auxiliary model.
+    # All tasks fall back to openrouter:google/gemini-3-flash-preview if
+    # the configured provider is unavailable.
+    #
+    # extra_body: forwarded verbatim as request body fields on every aux call
+    # for that task. Use this to set provider-specific knobs (independent of
+    # main-agent settings). On OpenRouter you can set provider routing prefs
+    # and the Pareto Code coding-score floor here. Example:
+    #
+    #   auxiliary:
+    #     compression:
+    #       provider: openrouter
+    #       model: openrouter/pareto-code
+    #       extra_body:
+    #         provider:           # OpenRouter provider routing
+    #           order: [anthropic, google]
+    #           sort: throughput  # or price | latency
+    #         plugins:            # OpenRouter Pareto Code router
+    #           - id: pareto-router
+    #             min_coding_score: 0.5
+    #
+    # Each aux task is independent — main-agent provider_routing and
+    # openrouter.min_coding_score do NOT propagate to aux calls by design.
+    "auxiliary": {
+        "vision": {
+            "provider": "auto",    # auto | openrouter | nous | codex | custom
+            "model": "",           # e.g. "google/gemini-2.5-flash", "gpt-4o"
+            "base_url": "",        # direct OpenAI-compatible endpoint (takes precedence over provider)
+            "api_key": "",         # API key for base_url (falls back to OPENAI_API_KEY)
+            "timeout": 120,        # seconds — LLM API call timeout; vision payloads need generous timeout
+            "extra_body": {},      # OpenAI-compatible provider-specific request fields
+            "download_timeout": 30,  # seconds — image HTTP download timeout; increase for slow connections
+        },
+        "web_extract": {
+            "provider": "auto",
+            "model": "",
+            "base_url": "",
+            "api_key": "",
+            "timeout": 360,        # seconds (6min) — per-attempt LLM summarization timeout; increase for slow local models
+            "extra_body": {},
+        },
+        "compression": {
+            "provider": "auto",
+            "model": "",
+            "base_url": "",
+            "api_key": "",
+            "timeout": 120,        # seconds — compression summarises large contexts; increase for local models
+            "extra_body": {},
+        },
+        # Note: session_search no longer uses an auxiliary LLM (PR #27590 —
+        # single-shape tool returns DB content directly). The old
+        # ``auxiliary.session_search.*`` block was removed here. Existing
+        # values in user config.yaml files are harmless leftovers and ignored.
+        "skills_hub": {
+            "provider": "auto",
+            "model": "",
+            "base_url": "",
+            "api_key": "",
+            "timeout": 30,
+            "extra_body": {},
+        },
+        "approval": {
+            "provider": "auto",
+            "model": "",           # fast/cheap model recommended (e.g. gemini-flash, haiku)
+            "base_url": "",
+            "api_key": "",
+            "timeout": 30,
+            "extra_body": {},
+        },
+        "mcp": {
+            "provider": "auto",
+            "model": "",
+            "base_url": "",
+            "api_key": "",
+            "timeout": 30,
+            "extra_body": {},
+        },
+        "title_generation": {
+            "provider": "auto",
+            "model": "",
+            "base_url": "",
+            "api_key": "",
+            "timeout": 30,
+            "extra_body": {},
+        },
+        # Triage specifier — flesh out a rough one-liner in the Kanban
+        # Triage column into a concrete spec, then promote it to ``todo``.
+        # Invoked by ``hermes kanban specify`` (single id or --all). Set a
+        # cheap, capable model here (gemini-flash works well); the main
+        # model is overkill for short spec expansion.
+        "triage_specifier": {
+            "provider": "auto",
+            "model": "",
+            "base_url": "",
+            "api_key": "",
+            "timeout": 120,
+            "extra_body": {},
+        },
+        # Kanban decomposer — decomposes a triage task into a graph of
+        # child tasks routed to specialist profiles by description.
+        # Invoked by ``hermes kanban decompose`` and the kanban
+        # auto-decompose dispatcher tick. Returns a JSON task graph;
+        # uses more tokens than the specifier so allow more headroom.
+        "kanban_decomposer": {
+            "provider": "auto",
+            "model": "",
+            "base_url": "",
+            "api_key": "",
+            "timeout": 180,
+            "extra_body": {},
+        },
+        # Profile describer — auto-generates a 1-2 sentence description
+        # of what a profile is good at. Invoked by
+        # ``hermes profile describe <name> --auto`` and the dashboard's
+        # auto-generate button. Short, cheap call.
+        "profile_describer": {
+            "provider": "auto",
+            "model": "",
+            "base_url": "",
+            "api_key": "",
+            "timeout": 60,
+            "extra_body": {},
+        },
+        # Curator — skill-usage review fork. Timeout is generous because the
+        # review pass can take several minutes on reasoning models (umbrella
+        # building over hundreds of candidate skills). "auto" = use main chat
+        # model; override via `hermes model` → auxiliary → Curator to route
+        # to a cheaper aux model (e.g. openrouter google/gemini-3-flash-preview).
+        "curator": {
+            "provider": "auto",
+            "model": "",
+            "base_url": "",
+            "api_key": "",
+            "timeout": 600,
+            "extra_body": {},
+        },
+    },
+    
+    "display": {
+        "compact": False,
+        "personality": "",
+        "resume_display": "full",
+        # Recap tuning for /resume and startup resume. The defaults match the
+        # historical hardcoded values; expose them as config so power users can
+        # widen or tighten the snapshot to taste.
+        "resume_exchanges": 10,            # max user+assistant pairs to show
+        "resume_max_user_chars": 300,      # truncate user message text
+        "resume_max_assistant_chars": 200, # truncate non-last assistant text
+        "resume_max_assistant_lines": 3,   # truncate non-last assistant lines
+        # When True (default), assistant entries that are *only* tool calls
+        # (no visible text) are skipped in the recap. This prevents the recap
+        # from being dominated by `[2 tool calls: terminal, read_file]` lines
+        # when an exchange was tool-heavy. Set False to restore the legacy
+        # behavior of showing tool-call summaries inline.
+        "resume_skip_tool_only": True,
+        "busy_input_mode": "interrupt",  # interrupt | queue | steer
+        # Which interface bare `hermes` (and `hermes chat`) launches by default:
+        #   "cli" — the classic prompt_toolkit REPL (default, preserves prior behavior)
+        #   "tui" — the modern Ink TUI (same as passing `--tui`)
+        # Explicit flags always win over this setting: `--cli` forces the classic
+        # REPL and `--tui` (or HERMES_TUI=1) forces the TUI regardless of config.
+        "interface": "cli",
+        # When true, `hermes --tui` auto-resumes the most recent human-
+        # facing session on launch instead of forging a fresh one.
+        # Mirrors `hermes -c` muscle memory.  Default off so existing
+        # users aren't surprised.  HERMES_TUI_RESUME=<id> always wins.
+        "tui_auto_resume_recent": False,
+        # When true (default), `hermes --tui` drops a one-time hint
+        # ("subagents working · /agents to watch live") the first time a turn
+        # starts delegating, nudging the user toward the live spawn-tree
+        # dashboard. Set false to suppress the hint.
+        "tui_agents_nudge": True,
+        "bell_on_complete": False,
+        "show_reasoning": False,
+        "streaming": False,
+        "timestamps": False,      # Show [HH:MM] on user and assistant labels
+        "final_response_markdown": "strip",  # render | strip | raw
+        # Preserve recent classic CLI output across Ctrl+L, /redraw, and
+        # terminal resize full-screen clears. Disable if a terminal emulator
+        # behaves badly with replayed scrollback.
+        "persistent_output": True,
+        "persistent_output_max_lines": 200,
+        "inline_diffs": True,     # Show inline diff previews for write actions (write_file, patch, skill_manage)
+        # File-mutation verifier footer.  When true (default), the agent
+        # appends a one-line advisory to its final response whenever a
+        # write_file / patch call failed during the turn and was never
+        # superseded by a successful write to the same path.  This catches
+        # the "batch of parallel patches, half fail, model claims success"
+        # class of over-claim that otherwise forces users to run
+        # `git status` to verify edits landed.  Set false to suppress.
+        "file_mutation_verifier": True,
+        # Turn-completion explainer.  When true (default), the agent appends a
+        # one-line explanation to its final response whenever a turn ends
+        # abnormally with no usable reply — empty content after retries, a
+        # partial/truncated stream, a still-pending tool result, or an
+        # iteration/budget limit.  Replaces the bare "(empty)" sentinel so the
+        # failure isn't silent from the UI's perspective.  Set false to suppress.
+        "turn_completion_explainer": True,
+        "show_cost": False,       # Show $ cost in the status bar (off by default)
+        "skin": "default",
+        # UI language for static user-facing messages (approval prompts, a
+        # handful of gateway slash-command replies).  Does NOT affect agent
+        # responses, log lines, tool outputs, or slash-command descriptions.
+        # Supported: en, zh, ja, de, es, fr, tr, uk.  Unknown values fall back to en.
+        "language": "en",
+        # TUI busy indicator style: kaomoji (default), emoji, unicode (braille
+        # spinner), or ascii.  Live-swappable via `/indicator <style>`.
+        "tui_status_indicator": "kaomoji",
+        "user_message_preview": {  # CLI: how many submitted user-message lines to echo back in scrollback
+            "first_lines": 2,
+            "last_lines": 2,
+        },
+        "interim_assistant_messages": True,  # Gateway: show natural mid-turn assistant status messages
+        "tool_progress_command": False,  # Enable /verbose command in messaging gateway
+        "tool_progress_overrides": {},  # DEPRECATED — use display.platforms instead
+        "tool_preview_length": 0,  # Max chars for tool call previews (0 = no limit, show full paths/commands)
+        # Auto-delete system-notice replies (e.g. "✨ New session started!",
+        # "♻ Restarting gateway…", "⚡ Stopped…") after N seconds on platforms
+        # that support message deletion (currently Telegram; other platforms
+        # ignore and leave the message in place).  Only affects slash-command
+        # replies wrapped with gateway.platforms.base.EphemeralReply — agent
+        # responses and content messages are never touched.  Default 0
+        # (disabled) preserves prior behavior.
+        "ephemeral_system_ttl": 0,
+        # Per-platform display/streaming overrides. Each key is a gateway
+        # platform ("telegram", "discord", "slack", …) mapping to a dict of
+        # display settings that override the global value for that platform
+        # only. A setting left unset here falls through to the global default.
+        #
+        # Shipped defaults encode the streaming experience that works best
+        # per platform:
+        #   - Telegram has native animated draft streaming (sendMessageDraft),
+        #     which is smooth, so streaming is on by default there.
+        #   - Discord/Slack/etc. only have edit-based streaming (repeated
+        #     editMessage), which flickers and is noticeably jankier, so
+        #     streaming is off by default there.
+        # These are gap-fillers: a user who explicitly sets, e.g.,
+        # display.platforms.discord.streaming: true keeps their value
+        # (config deep-merge has user values win over defaults). The global
+        # streaming.enabled master switch still gates everything — these
+        # per-platform flags only take effect once streaming is enabled.
+        "platforms": {
+            "telegram": {"streaming": True},
+            "discord": {"streaming": False},
+        },
+        # Gateway runtime-metadata footer appended to the FINAL message of a turn
+        # (disabled by default to keep replies minimal). When enabled, renders
+        # e.g. `model · 68% · ~/projects/hermes`. Per-platform overrides go under
+        # display.platforms.<platform>.runtime_footer.
+        "runtime_footer": {
+            "enabled": False,
+            "fields": ["model", "context_pct", "cwd"],  # Order shown; drop any to hide
+        },
+        "copy_shortcut": "auto",  # "auto" (platform default) | "ctrl_c" | "ctrl_shift_c" | "disabled"
+    },
+
+    # Web dashboard settings
+    "dashboard": {
+        "theme": "default",  # Dashboard visual theme: "default", "midnight", "ember", "mono", "cyberpunk", "rose"
+        # Hide the token/cost analytics surfaces (Analytics page, token bars and
+        # cost figures on the Models page) by default.  The numbers shown there
+        # are a local debug estimate: they only count successful main-agent
+        # responses with a usable ``response.usage``, and silently exclude every
+        # auxiliary call (context compression, title generation, vision,
+        # session search, web extract, smart approval, MCP routing, plugin LLM
+        # access) plus provider-side retries, fallback attempts, and any call
+        # whose usage block didn't come back.  Cache writes are also missing
+        # from the API response.  On models with heavy auxiliary traffic
+        # (Kimi K2.6, MiniMax M2.7) the local total can be 10x-100x lower than
+        # the provider bill, which is worse than hiding the numbers entirely
+        # because they look precise enough to compare against the provider.
+        # Set this to True to re-enable the surfaces with the understanding
+        # that the numbers are a local lower-bound estimate, not billing.
+        "show_token_analytics": False,
+        # OAuth gate configuration (engaged when ``--host`` is set and
+        # ``--insecure`` is not). The bundled Nous Portal plugin reads
+        # both keys at startup; they are the canonical surface for these
+        # settings. Each can be overridden by an environment variable —
+        # ``HERMES_DASHBOARD_OAUTH_CLIENT_ID`` and
+        # ``HERMES_DASHBOARD_PORTAL_URL`` respectively — and the env var
+        # wins when set to a non-empty value. The override path is what
+        # Fly.io's platform-secret injection uses to push the per-deploy
+        # client_id at provisioning time without operators needing to
+        # touch config.yaml. Local dev / non-Fly deploys can set either
+        # surface; missing values fall through to the plugin's defaults
+        # (no provider registered when ``client_id`` is empty;
+        # ``portal_url`` defaults to https://portal.nousresearch.com).
+        "oauth": {
+            "client_id": "",  # agent:{instance_id} — Portal provisions this
+            "portal_url": "",  # blank → use plugin default (production Portal)
+        },
+        # Username/password gate configuration — read by the bundled
+        # ``dashboard_auth/basic`` plugin (a self-hosted "just put a
+        # password on my dashboard" provider that needs no OAuth IDP).
+        # The plugin registers a password provider when ``username`` plus
+        # either ``password_hash`` (preferred — no plaintext at rest) or
+        # ``password`` (plaintext, hashed in-memory at load) are set. Each
+        # key is overridable by an env var
+        # (``HERMES_DASHBOARD_BASIC_AUTH_USERNAME`` /
+        # ``_PASSWORD_HASH`` / ``_PASSWORD`` / ``_SECRET`` /
+        # ``_TTL_SECONDS``), env winning when non-empty. Leave ``username``
+        # empty (the default) to keep the plugin a no-op — loopback /
+        # ``--insecure`` operators and OAuth users are unaffected.
+        #
+        # ``secret`` is the HMAC key used to sign the stateless session
+        # tokens this provider mints. When empty, a random per-process key
+        # is generated — fine for a single process, but sessions then
+        # don't survive a restart or span multiple workers. Set an
+        # explicit ``secret`` (32+ random bytes, base64/hex/raw) for
+        # stable multi-worker / restart-surviving sessions. Compute a
+        # ``password_hash`` with
+        # ``python -c "from plugins.dashboard_auth.basic import hash_password; print(hash_password('PW'))"``.
+        "basic_auth": {
+            "username": "",  # blank → plugin no-op (no password provider)
+            "password_hash": "",  # scrypt$... (preferred — no plaintext at rest)
+            "password": "",  # plaintext fallback (hashed in-memory at load)
+            "secret": "",  # token-signing key; blank → random per-process
+            "session_ttl_seconds": 0,  # 0 → plugin default (12h)
+        },
+        # Public URL override (env: ``HERMES_DASHBOARD_PUBLIC_URL``).
+        # When set, this is the complete authority — scheme + host +
+        # optional path prefix (e.g. ``https://example.com/hermes``) —
+        # the OAuth ``redirect_uri`` is built from. Set this for deploys
+        # behind reverse proxies that don't reliably forward
+        # ``X-Forwarded-Host`` / ``X-Forwarded-Proto`` / ``X-Forwarded-Prefix``
+        # (manual nginx setups, on-prem ingresses, custom-domain Fly
+        # deploys without proper proxy headers). When set,
+        # ``X-Forwarded-Prefix`` is IGNORED on the OAuth path because
+        # the operator has declared the public URL — we no longer need
+        # to guess from proxy headers, and stacking the prefix on top
+        # would double-prefix the common case where the prefix is
+        # already baked into ``public_url``. Leave empty to use the
+        # existing proxy-header reconstruction (the default).
+        #
+        # Validation: rejects values without ``http(s)://`` scheme or
+        # without a host, and any string containing quote / angle /
+        # whitespace / control characters. A malformed value silently
+        # falls through to request reconstruction rather than breaking
+        # the login flow.
+        "public_url": "",
+    },
+
+    # Privacy settings
+    "privacy": {
+        "redact_pii": False,  # When True, hash user IDs and strip phone numbers from LLM context
+    },
+    
+    # Text-to-speech configuration
+    # Each provider supports an optional `max_text_length:` override for the
+    # per-request input-character cap. Omit it to use the provider's documented
+    # limit (OpenAI 4096, xAI 15000, MiniMax 10000, ElevenLabs 5k-40k model-aware,
+    # Gemini 5000, Edge 5000, Mistral 4000, NeuTTS/KittenTTS 2000).
+    "tts": {
+        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "gemini" | "neutts" (local) | "kittentts" (local) | "piper" (local)
+        "edge": {
+            "voice": "en-US-AriaNeural",
+            # Popular: AriaNeural, JennyNeural, AndrewNeural, BrianNeural, SoniaNeural
+        },
+        "elevenlabs": {
+            "voice_id": "pNInz6obpgDQGcFmaJgB",  # Adam
+            "model_id": "eleven_multilingual_v2",
+        },
+        "openai": {
+            "model": "gpt-4o-mini-tts",
+            "voice": "alloy",
+            # Voices: alloy, echo, fable, onyx, nova, shimmer
+        },
+        "xai": {
+            "voice_id": "eve",  # or custom voice ID — see https://docs.x.ai/developers/model-capabilities/audio/custom-voices
+            "language": "en",
+            "sample_rate": 24000,
+            "bit_rate": 128000,
+        },
+        "mistral": {
+            "model": "voxtral-mini-tts-2603",
+            "voice_id": "c69964a6-ab8b-4f8a-9465-ec0925096ec8",  # Paul - Neutral
+        },
+        "neutts": {
+            "ref_audio": "",  # Path to reference voice audio (empty = bundled default)
+            "ref_text": "",   # Path to reference voice transcript (empty = bundled default)
+            "model": "neuphonic/neutts-air-q4-gguf",  # HuggingFace model repo
+            "device": "cpu",  # cpu, cuda, or mps
+        },
+        "piper": {
+            # Voice name (e.g. "en_US-lessac-medium") downloaded on first
+            # use, OR an absolute path to a pre-downloaded .onnx file.
+            # Full voice list: https://github.com/OHF-Voice/piper1-gpl/blob/main/docs/VOICES.md
+            "voice": "en_US-lessac-medium",
+            # "voices_dir": "",        # Override voice cache dir; default = ~/.hermes/cache/piper-voices/
+            # "use_cuda": False,       # Requires onnxruntime-gpu
+            # "length_scale": 1.0,     # 2.0 = twice as slow
+            # "noise_scale": 0.667,
+            # "noise_w_scale": 0.8,
+            # "volume": 1.0,
+            # "normalize_audio": True,
+        },
+    },
+    
+    "stt": {
+        "enabled": True,
+        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe) | "elevenlabs" (Scribe)
+        "local": {
+            "model": "base",  # tiny, base, small, medium, large-v3
+            "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force
+        },
+        "openai": {
+            "model": "whisper-1",  # whisper-1, gpt-4o-mini-transcribe, gpt-4o-transcribe
+        },
+        "mistral": {
+            "model": "voxtral-mini-latest",  # voxtral-mini-latest, voxtral-mini-2602
+        },
+        "elevenlabs": {
+            "model_id": "scribe_v2",  # scribe_v2, scribe_v1
+            "language_code": "",  # auto-detect by default; set to "eng", "spa", "fra", etc. to force
+            "tag_audio_events": False,
+            "diarize": False,
+        },
+    },
+
+    "voice": {
+        "record_key": "ctrl+b",
+        "max_recording_seconds": 120,
+        "auto_tts": False,
+        "beep_enabled": True,         # Play record start/stop beeps in CLI voice mode
+        "silence_threshold": 200,     # RMS below this = silence (0-32767)
+        "silence_duration": 3.0,      # Seconds of silence before auto-stop
+    },
+    
+    "human_delay": {
+        "mode": "off",
+        "min_ms": 800,
+        "max_ms": 2500,
+    },
+    
+    # Context engine -- controls how the context window is managed when
+    # approaching the model's token limit.
+    # "compressor" = built-in lossy summarization (default).
+    # Set to a plugin name to activate an alternative engine (e.g. "lcm"
+    # for Lossless Context Management).  The engine must be installed as
+    # a plugin in plugins/context_engine/<name>/ or ~/.hermes/plugins/.
+    "context": {
+        "engine": "compressor",
+    },
+
+    # Persistent memory -- bounded curated memory injected into system prompt
+    "memory": {
+        "memory_enabled": True,
+        "user_profile_enabled": True,
+        "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
+        "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
+        # External memory provider plugin (empty = built-in only).
+        # Set to a provider name to activate: "openviking", "mem0",
+        # "hindsight", "holographic", "retaindb", "byterover".
+        # Only ONE external provider is allowed at a time.
+        "provider": "",
+    },
+
+    # Subagent delegation — override the provider:model used by delegate_task
+    # so child agents can run on a different (cheaper/faster) provider and model.
+    # Uses the same runtime provider resolution as CLI/gateway startup, so all
+    # configured providers (OpenRouter, Nous, Z.ai, Kimi, etc.) are supported.
+    "delegation": {
+        "model": "",       # e.g. "google/gemini-3-flash-preview" (empty = inherit parent model)
+        "provider": "",    # e.g. "openrouter" (empty = inherit parent provider + credentials)
+        "base_url": "",    # direct OpenAI-compatible endpoint for subagents
+        "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
+        "api_mode": "",    # wire protocol for delegation.base_url: "chat_completions",
+                           # "codex_responses", or "anthropic_messages". Empty = auto-detect
+                           # from URL (e.g. /anthropic suffix → anthropic_messages). Set this
+                           # explicitly for non-standard endpoints the heuristic can't detect.
+        # When delegate_task narrows child toolsets explicitly, preserve any
+        # MCP toolsets the parent already has enabled. On by default so
+        # narrowing (e.g. toolsets=["web","browser"]) expresses "I want these
+        # extras" without silently stripping MCP tools the parent already has.
+        # Set to false for strict intersection.
+        "inherit_mcp_toolsets": True,
+        "max_iterations": 50,  # per-subagent iteration cap (each subagent gets its own budget,
+                               # independent of the parent's max_iterations)
+        "child_timeout_seconds": 600,  # wall-clock timeout for each child agent (floor 30s,
+                                       # no ceiling). High-reasoning models on large tasks
+                                       # (e.g. gpt-5.5 xhigh, opus-4.6) need generous budgets;
+                                       # raise if children time out before producing output.
+        "reasoning_effort": "",  # reasoning effort for subagents: "xhigh", "high", "medium",
+                                 # "low", "minimal", "none" (empty = inherit parent's level)
+        "max_concurrent_children": 3,  # max parallel children per batch; floor of 1 enforced, no ceiling
+        # Orchestrator role controls (see tools/delegate_tool.py:_get_max_spawn_depth
+        # and _get_orchestrator_enabled).  Floored at 1, no upper ceiling —
+        # raise deliberately, each level multiplies API cost.
+        "max_spawn_depth": 1,        # depth (1 = flat [default], 2 = orchestrator→leaf, 3+ = deeper)
+        "orchestrator_enabled": True,  # kill switch for role="orchestrator"
+        # When a subagent hits a dangerous-command approval prompt, the parent's
+        # prompt_toolkit TUI owns stdin — a thread-local input() call from the
+        # subagent worker would deadlock the parent UI. To avoid the deadlock,
+        # subagent threads ALWAYS resolve approvals non-interactively:
+        #   false (default) → auto-deny with a logger.warning audit line (safe)
+        #   true             → auto-approve "once" with a logger.warning audit line
+        # Flip to true only if you trust delegated work to run dangerous cmds
+        # without human review (cron pipelines, batch automation, etc.).
+        "subagent_auto_approve": False,
+    },
+
+    # Ephemeral prefill messages file — JSON list of {role, content} dicts
+    # injected at the start of every API call for few-shot priming.
+    # Never saved to sessions, logs, or trajectories.
+    "prefill_messages_file": "",
+
+    # Goals — persistent cross-turn goals (Ralph-style loop).
+    # After every turn, a lightweight judge call asks the auxiliary model
+    # whether the active /goal is satisfied by the assistant's last
+    # response. If not, Hermes feeds a continuation prompt back into the
+    # same session and keeps working until the goal is done, the turn
+    # budget is exhausted, or the user pauses/clears it. Judge failures
+    # fail OPEN (continue) so a flaky judge never wedges progress — the
+    # turn budget is the real backstop.
+    "goals": {
+        # Max continuation turns before Hermes auto-pauses the goal and
+        # asks the user to /goal resume. Protects against judge false
+        # negatives (goal actually done but judge says continue) and
+        # unbounded model spend on fuzzy / unachievable goals.
+        "max_turns": 20,
+    },
+
+    # Skills — external skill directories for sharing skills across tools/agents.
+    # Each path is expanded (~, ${VAR}) and resolved.  Read-only — skill creation
+    # always goes to ~/.hermes/skills/.
+    "skills": {
+        "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
+        # Substitute ${HERMES_SKILL_DIR} and ${HERMES_SESSION_ID} in SKILL.md
+        # content with the absolute skill directory and the active session id
+        # before the agent sees it.  Lets skill authors reference bundled
+        # scripts without the agent having to join paths.
+        "template_vars": True,
+        # Pre-execute inline shell snippets written as !`cmd` in SKILL.md
+        # body.  Their stdout is inlined into the skill message before the
+        # agent reads it, so skills can inject dynamic context (dates, git
+        # state, detected tool versions, …).  Off by default because any
+        # content from the skill author runs on the host without approval;
+        # only enable for skill sources you trust.
+        "inline_shell": False,
+        # Timeout (seconds) for each !`cmd` snippet when inline_shell is on.
+        "inline_shell_timeout": 10,
+        # Run the keyword/pattern security scanner on skills the agent
+        # writes via skill_manage (create/edit/patch).  Off by default
+        # because the agent can already execute the same code paths via
+        # terminal() with no gate, so the scan adds friction (blocks
+        # skills that mention risky keywords in prose) without meaningful
+        # security.  Turn on if you want the belt-and-suspenders — a
+        # dangerous verdict will then surface as a tool error to the
+        # agent, which can retry with the flagged content removed.
+        # External hub installs (trusted/community sources) are always
+        # scanned regardless of this setting.
+        "guard_agent_created": False,
+    },
+
+    # Curator — background skill maintenance.
+    #
+    # Periodically reviews AGENT-CREATED skills (never bundled or
+    # hub-installed) and keeps the collection tidy: marks long-unused skills
+    # as stale, archives genuinely obsolete ones (archive only, never
+    # deletes), and spawns a forked aux-model agent to consolidate overlaps
+    # and patch drift. Runs inactivity-triggered from session start — no
+    # cron daemon.
+    #
+    # See `hermes curator status` for the last run summary.
+    "curator": {
+        "enabled": True,
+        # How long to wait between curator runs (hours).  Default: 7 days.
+        "interval_hours": 24 * 7,
+        # Only run when the agent has been idle at least this long (hours).
+        "min_idle_hours": 2,
+        # Mark a skill as "stale" after this many days without use.
+        "stale_after_days": 30,
+        # Archive a skill (move to skills/.archive/) after this many days
+        # without use. Archived skills are recoverable — no auto-deletion.
+        "archive_after_days": 90,
+        # Also prune (archive) bundled built-in skills after the inactivity
+        # period, not just agent-created ones. ON by default. Built-ins are
+        # normally restored on every `hermes update`, so pruning them only
+        # sticks because a suppression list tells the re-seeder to leave them
+        # archived. Hub-installed skills are NEVER pruned here — they have an
+        # external upstream owner. Built-ins accrue usage telemetry and their
+        # inactivity clock starts the first time the curator sees them, so a
+        # long-unused built-in is archived only after archive_after_days of
+        # genuine non-use (never a mass-prune on the first run). Set to false
+        # to keep all bundled built-ins permanently.
+        "prune_builtins": True,
+        # Pre-run backup: before every real curator pass (dry-run is
+        # skipped), snapshot ~/.hermes/skills/ into
+        # ~/.hermes/skills/.curator_backups/<utc-iso>/skills.tar.gz so the
+        # user can roll back with `hermes curator rollback`.
+        "backup": {
+            "enabled": True,
+            "keep": 5,  # retain last N regular snapshots
+        },
+    },
+
+    # Honcho AI-native memory -- reads ~/.honcho/config.json as single source of truth.
+    # This section is only needed for hermes-specific overrides; everything else
+    # (apiKey, workspace, peerName, sessions, enabled) comes from the global config.
+    "honcho": {},
+
+    # IANA timezone (e.g. "Asia/Kolkata", "America/New_York").
+    # Empty string means use server-local time.
+    "timezone": "",
+
+    # Slack platform settings (gateway mode)
+    "slack": {
+        "require_mention": True,       # Require @mention to respond in channels
+        "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
+        "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
+        "channel_prompts": {},         # Per-channel ephemeral system prompts
+    },
+
+    # Discord platform settings (gateway mode)
+    "discord": {
+        "require_mention": True,       # Require @mention to respond in server channels
+        "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
+        "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
+        "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)
+        "thread_require_mention": False,  # If True, require @mention in threads too (multi-bot threads)
+        "history_backfill": True,         # If True, prepend recent channel scrollback when bot is triggered (recovers messages missed while require_mention gated them out)
+        "history_backfill_limit": 50,     # Max number of recent messages to scan when assembling the backfill block
+        "reactions": True,             # Add 👀/✅/❌ reactions to messages during processing
+        "channel_prompts": {},         # Per-channel ephemeral system prompts (forum parents apply to child threads)
+        # Opt-in DM role-based auth (#12136). By default, DISCORD_ALLOWED_ROLES
+        # authorizes only guild messages in the role's own guild — DMs require
+        # DISCORD_ALLOWED_USERS. Set dm_role_auth_guild to a guild ID to also
+        # authorize DMs from members of that one trusted guild holding the
+        # allowed role. Unset / empty / 0 = secure default (DM role-auth off).
+        "dm_role_auth_guild": "",
+        # discord / discord_admin tools: restrict which actions the agent may call.
+        # Default (empty) = all actions allowed (subject to bot privileged intents).
+        # Accepts comma-separated string ("list_guilds,list_channels,fetch_messages")
+        # or YAML list. Unknown names are dropped with a warning at load time.
+        # Actions: list_guilds, server_info, list_channels, channel_info,
+        # list_roles, member_info, search_members, fetch_messages, list_pins,
+        # pin_message, unpin_message, create_thread, add_role, remove_role.
+        "server_actions": "",
+        # Accept arbitrary attachment file types (not just SUPPORTED_DOCUMENT_TYPES).
+        # When True, any uploaded file is cached to disk with mime
+        # application/octet-stream and the path is surfaced to the agent so it
+        # can use terminal/read_file/etc. against it. Default False preserves
+        # the historical allowlist behaviour.
+        # Env override: DISCORD_ALLOW_ANY_ATTACHMENT.
+        "allow_any_attachment": False,
+        # Maximum bytes per attachment the gateway will cache. The whole file
+        # is held in memory while being written, so unlimited uploads carry a
+        # real memory cost. Default 32 MiB matches the historical hardcoded
+        # cap. Set to 0 for no cap. Env override: DISCORD_MAX_ATTACHMENT_BYTES.
+        "max_attachment_bytes": 33554432,
+        # Voice-channel audio effects (the continuous mixer). OFF by default.
+        # When enabled, the bot installs a software mixer on the outgoing voice
+        # stream so a low ambient "thinking" bed, verbal acknowledgements, and
+        # TTS replies can OVERLAP (ducking the ambient under speech) instead of
+        # stop-and-swap — the Grok-voice-mode feel. discord.py ships no mixer;
+        # this is implemented in plugins/platforms/discord/voice_mixer.py.
+        "voice_fx": {
+            "enabled": False,         # master switch for the mixer subsystem
+            "ambient_enabled": True,  # play the idle "thinking" bed while tools run
+            "ambient_path": "",       # custom loop audio file; "" = synthesised pad
+            "ambient_gain": 0.18,     # idle bed loudness, 0.0–1.0
+            "duck_gain": 0.06,        # ambient loudness while speech plays
+            "speech_gain": 1.0,       # TTS / ack loudness, 0.0–1.0
+            "ack_enabled": True,      # speak a short phrase before the first tool call
+            "ack_phrases": [          # picked at random; set [] to disable phrases
+                "Let me look into that.",
+                "One moment.",
+                "Checking on that now.",
+                "Give me a sec.",
+                "On it.",
+            ],
+        },
+    },
+
+    # WhatsApp platform settings (gateway mode)
+    "whatsapp": {
+        # Reply prefix prepended to every outgoing WhatsApp message.
+        # Default (None) uses the built-in "⚕ *Hermes Agent*" header.
+        # Set to "" (empty string) to disable the header entirely.
+        # Supports \n for newlines, e.g. "🤖 *My Bot*\n──────\n"
+    },
+
+    # Telegram platform settings (gateway mode)
+    "telegram": {
+        "reactions": False,            # Add 👀/✅/❌ reactions to messages during processing
+        "channel_prompts": {},         # Per-chat/topic ephemeral system prompts (topics inherit from parent group)
+        "allowed_chats": "",           # If set, bot ONLY responds in these group/supergroup chat IDs (whitelist)
+    },
+
+    # Mattermost platform settings (gateway mode)
+    "mattermost": {
+        "require_mention": True,       # Require @mention to respond in channels
+        "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
+        "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
+        "channel_prompts": {},         # Per-channel ephemeral system prompts
+    },
+
+    # Matrix platform settings (gateway mode)
+    "matrix": {
+        "require_mention": True,       # Require @mention to respond in rooms
+        "free_response_rooms": "",     # Comma-separated room IDs where bot responds without mention
+        "allowed_rooms": "",           # If set, bot ONLY responds in these room IDs (whitelist)
+    },
+
+    # Approval mode for dangerous commands:
+    #   manual — always prompt the user (default)
+    #   smart  — use auxiliary LLM to auto-approve low-risk commands, prompt for high-risk
+    #   off    — skip all approval prompts (equivalent to --yolo)
+    #
+    # cron_mode — what to do when a cron job hits a dangerous command:
+    #   deny    — block the command and let the agent find another way (default, safe)
+    #   approve — auto-approve all dangerous commands in cron jobs
+    "approvals": {
+        "mode": "manual",
+        "timeout": 60,
+        "cron_mode": "deny",
+        # When true, /reload-mcp asks the user to confirm before rebuilding
+        # the MCP tool set for the active session.  Reloading invalidates
+        # the provider prompt cache (tool schemas are baked into the system
+        # prompt), so the next message re-sends full input tokens — this can
+        # be expensive on long-context or high-reasoning models.  Users click
+        # "Always Approve" to silence the prompt permanently; that flips
+        # this key to false.
+        "mcp_reload_confirm": True,
+        # When true, destructive session slash commands (/clear, /new, /reset,
+        # /undo) ask the user to confirm before discarding conversation state.
+        # Three-option prompt (Approve Once / Always Approve / Cancel) routed
+        # through tools.slash_confirm — native yes/no buttons on Telegram,
+        # Discord, and Slack; text fallback elsewhere.  Users click "Always
+        # Approve" to silence the prompt permanently; that flips this key to
+        # false.  TUI has its own modal overlay (HERMES_TUI_NO_CONFIRM=1 to
+        # opt out there).
+        "destructive_slash_confirm": True,
+    },
+
+    # Permanently allowed dangerous command patterns (added via "always" approval)
+    "command_allowlist": [],
+    # User-defined quick commands that bypass the agent loop (type: exec only)
+    "quick_commands": {},
+
+    # Shell-script hooks — declarative bridge that invokes shell scripts
+    # on plugin-hook events (pre_tool_call, post_tool_call, pre_llm_call,
+    # subagent_stop, etc.).  Each entry maps an event name to a list of
+    # {matcher, command, timeout} dicts.  First registration of a new
+    # command prompts the user for consent; subsequent runs reuse the
+    # stored approval from ~/.hermes/shell-hooks-allowlist.json.
+    # See `website/docs/user-guide/features/hooks.md` for schema + examples.
+    "hooks": {},
+
+    # Auto-accept shell-hook registrations without a TTY prompt.  Also
+    # toggleable per-invocation via --accept-hooks or HERMES_ACCEPT_HOOKS=1.
+    # Gateway / cron / non-interactive runs need this (or one of the other
+    # channels) to pick up newly-added hooks.
+    "hooks_auto_accept": False,
+    # Custom personalities — add your own entries here
+    # Supports string format: {"name": "system prompt"}
+    # Or dict format: {"name": {"description": "...", "system_prompt": "...", "tone": "...", "style": "..."}}
+    "personalities": {},
+
+    # Pre-exec security scanning via tirith
+    "security": {
+        "allow_private_urls": False,  # Allow requests to private/internal IPs (for OpenWrt, proxies, VPNs)
+        "redact_secrets": True,
+        "tirith_enabled": True,
+        "tirith_path": "tirith",
+        "tirith_timeout": 5,
+        "tirith_fail_open": True,
+        "website_blocklist": {
+            "enabled": False,
+            "domains": [],
+            "shared_files": [],
+        },
+        # Acknowledged supply-chain security advisories. Each entry is the
+        # ID of an advisory the user has read and acted on (uninstalled the
+        # compromised package, rotated credentials). Acked advisories no
+        # longer trigger the startup banner. Add via `hermes doctor --ack
+        # <id>`; remove by editing the list directly. See
+        # ``hermes_cli/security_advisories.py`` for the catalog.
+        "acked_advisories": [],
+        # Allow Hermes to lazy-install opt-in backend packages from PyPI
+        # the first time the user enables a backend that needs them
+        # (e.g. installing ``elevenlabs`` when the user picks ElevenLabs as
+        # their TTS provider). Set to false to require explicit
+        # ``pip install`` for everything beyond the base set — appropriate
+        # for restricted networks, audited environments, or air-gapped
+        # systems where any runtime install is unacceptable.
+        "allow_lazy_installs": True,
+    },
+
+    "cron": {
+        # Wrap delivered cron responses with a header (task name) and footer
+        # ("The agent cannot see this message").  Set to false for clean output.
+        "wrap_response": True,
+        # Maximum number of due jobs to run in parallel per tick.
+        # null/0 = unbounded (limited only by thread count).
+        # 1 = serial (pre-v0.9 behaviour).
+        # Also overridable via HERMES_CRON_MAX_PARALLEL env var.
+        "max_parallel_jobs": None,
+    },
+
+    # Kanban multi-agent coordination — controls the dispatcher loop that
+    # spawns workers for ready tasks. The dispatcher ticks every N seconds
+    # (default 60), reclaims stale claims, promotes dependency-satisfied
+    # todos to ready, and fires `hermes -p <assignee> chat -q ...` for
+    # each claimable ready task. One dispatcher per profile is sufficient;
+    # running more than one on the same kanban.db will race for claims.
+    "kanban": {
+        # Run the dispatcher inside the gateway process. On by default —
+        # the cost is ~300µs every `dispatch_interval_seconds` when idle,
+        # and gateway is the supervisor users already have. Set to false
+        # only if you run the dispatcher as a separate systemd unit or
+        # don't want the gateway to spawn workers.
+        "dispatch_in_gateway": True,
+        # Seconds between dispatcher ticks (idle or not). Lower = snappier
+        # pickup of newly-ready tasks; higher = less SQL pressure.
+        "dispatch_interval_seconds": 60,
+        # Auto-block after this many consecutive non-success attempts for the
+        # same task/profile (spawn_failed, timed_out, or crashed). Reassignment
+        # resets the streak for the new profile.
+        "failure_limit": 2,
+        # Worker stdout/stderr logs rotate at spawn time. Defaults preserve
+        # the historical 2 MiB + one-backup behavior; long-running workers can
+        # raise these to keep more early failure evidence.
+        "worker_log_rotate_bytes": 2 * 1024 * 1024,
+        "worker_log_backup_count": 1,
+        # Profile assigned to the root/orchestration task after Triage
+        # decomposition. When unset, falls back to the default profile (the
+        # one `hermes` launches with no -p flag). This does not control the
+        # decomposer prompt, model, or skills; configure that LLM path under
+        # auxiliary.kanban_decomposer.
+        "orchestrator_profile": "",
+        # Where a child task lands if the orchestrator can't match an
+        # assignee to any installed profile. When unset, falls back to the
+        # default profile. A task never ends up with assignee=None.
+        "default_assignee": "",
+        # Per-profile concurrency cap (#21582). When set to a positive int,
+        # no single profile can have more than N workers running at once,
+        # even if the global max_in_progress / max_spawn caps would allow
+        # it. Tasks blocked this way defer to the next dispatcher tick.
+        # Unset (None) means "no per-profile cap" — backward-compatible
+        # with existing installs. Useful for fan-out workflows that would
+        # otherwise saturate one profile's local model / API quota /
+        # browser pool while leaving other profiles idle.
+        "max_in_progress_per_profile": None,
+        # When true, the kanban dispatcher auto-runs the decomposer on
+        # tasks that land in Triage (every dispatcher tick). When false,
+        # decomposition is manual via `hermes kanban decompose <id>` or
+        # the dashboard's Decompose button.
+        "auto_decompose": True,
+        # Max triage tasks to decompose per dispatcher tick. Prevents a
+        # large bulk-load of triage tasks from spending a burst of aux
+        # LLM calls in one tick. Excess tasks defer to the next tick.
+        "auto_decompose_per_tick": 3,
+        # Stale detection: running tasks that have exceeded this many
+        # seconds without a heartbeat (since ``last_heartbeat_at``) are
+        # auto-reclaimed to ``ready`` on the next dispatcher tick. The
+        # worker process (if still running host-locally) is terminated
+        # before the reclaim.  0 disables stale detection entirely.
+        "dispatch_stale_timeout_seconds": 14400,
+    },
+
+    # execute_code settings — controls the tool used for programmatic tool calls.
+    "code_execution": {
+        # Execution mode:
+        #   project (default) — scripts run in the session's working directory
+        #     with the active virtualenv/conda env's python, so project deps
+        #     (pandas, torch, project packages) and relative paths resolve.
+        #   strict            — scripts run in an isolated temp directory with
+        #     hermes-agent's own python (sys.executable). Maximum isolation
+        #     and reproducibility; project deps and relative paths won't work.
+        # Env scrubbing (strips *_API_KEY, *_TOKEN, *_SECRET, ...) and the
+        # tool whitelist apply identically in both modes.
+        "mode": "project",
+    },
+
+    # Tool Search (progressive disclosure for large tool surfaces).
+    # When the model is connected to many MCP servers or non-core plugin
+    # tools, their JSON schemas can consume a substantial fraction of the
+    # context window on every turn. When enabled, those tools are replaced
+    # in the model-facing tools array with three bridge tools —
+    # tool_search / tool_describe / tool_call — and surfaced on demand.
+    #
+    # Core Hermes tools (terminal, read_file, write_file, patch,
+    # search_files, todo, memory, browser_*, etc.) are NEVER deferred.
+    # See tools/tool_search.py for full design notes and the
+    # openclaw-tool-search-report PDF in this PR for the rationale.
+    "tools": {
+        "tool_search": {
+            # "auto" (default) — activate only when deferrable tool schemas
+            #   exceed ``threshold_pct`` of the active model's context length,
+            #   so small toolsets pay no overhead.
+            # "on"  — always activate when there is at least one deferrable
+            #   tool. Use when you have many MCP servers and want maximum
+            #   token reduction unconditionally.
+            # "off" — disable entirely. Tools-array assembly is a pass-through.
+            "enabled": "auto",
+            # Percentage of context length at which "auto" mode kicks in.
+            # 10 matches the Claude Code default. Range 0..100.
+            "threshold_pct": 10,
+            # When the model calls tool_search without a ``limit`` argument,
+            # how many hits to return. Range 1..max_search_limit.
+            "search_default_limit": 5,
+            # Hard upper bound the model can request via ``limit``. Range 1..50.
+            "max_search_limit": 20,
+        },
+    },
+
+    # Logging — controls file logging to ~/.hermes/logs/.
+    # agent.log captures INFO+ (all agent activity); errors.log captures WARNING+.
+    "logging": {
+        "level": "INFO",       # Minimum level for agent.log: DEBUG, INFO, WARNING
+        "max_size_mb": 5,      # Max size per log file before rotation
+        "backup_count": 3,     # Number of rotated backup files to keep
+    },
+
+    # Remotely-hosted model catalog manifest.  When enabled, the CLI fetches
+    # curated model lists for OpenRouter and Nous Portal from this URL,
+    # falling back to the in-repo snapshot on network failure.  Lets us
+    # update model picker lists without shipping a hermes-agent release.
+    # The default URL is served by the docs site GitHub Pages deploy.
+    "model_catalog": {
+        "enabled": True,
+        "url": "https://hermes-agent.nousresearch.com/docs/api/model-catalog.json",
+        # Disk cache TTL in hours.  Beyond this, the CLI refetches on the
+        # next /model or `hermes model` invocation; network failures
+        # silently fall back to the stale cache.
+        "ttl_hours": 1,
+        # Optional per-provider override URLs for third parties that want
+        # to self-host their own curation list using the same schema.
+        # Example:
+        #   providers:
+        #     openrouter:
+        #       url: https://example.com/my-curation.json
+        "providers": {},
+    },
+
+    # Network settings — workarounds for connectivity issues.
+    "network": {
+        # Force IPv4 connections.  On servers with broken or unreachable IPv6,
+        # Python tries AAAA records first and hangs for the full TCP timeout
+        # before falling back to IPv4.  Set to true to skip IPv6 entirely.
+        "force_ipv4": False,
+    },
+
+    # Gateway settings — control how messaging platforms (Telegram, Discord,
+    # Slack, etc.) deliver agent-produced files as native attachments.
+    "gateway": {
+        # When false (default), any file path the agent emits is delivered
+        # as a native attachment as long as it isn't under the credential /
+        # system-path denylist (/etc, /proc, ~/.ssh, ~/.aws, ~/.hermes/.env,
+        # auth.json, etc.). This matches the symmetry of inbound delivery
+        # — we accept any document type the user uploads, and the agent
+        # can hand back any file that isn't a credential.
+        #
+        # When true, fall back to the older allowlist+recency-window
+        # behavior: files must live under the Hermes cache, under
+        # ``media_delivery_allow_dirs``, or be freshly produced inside the
+        # ``trust_recent_files_seconds`` window. Recommended for
+        # public-facing gateways where prompt injection from one user
+        # shouldn't be able to exfiltrate the host's secrets to that same
+        # user. Bridged to HERMES_MEDIA_DELIVERY_STRICT.
+        "strict": False,
+        # Extra directories from which model-emitted bare file paths may be
+        # uploaded as native gateway attachments. Files inside the Hermes
+        # cache (~/.hermes/cache/{documents,images,audio,video,screenshots})
+        # are always trusted; this list adds operator-controlled roots
+        # (project dirs, scratch dirs, mounted shares). Accepts a list of
+        # absolute paths or a single os.pathsep-separated string. Bridged
+        # to HERMES_MEDIA_ALLOW_DIRS at gateway startup. Tilde paths are
+        # expanded. Honored in both default and strict mode.
+        "media_delivery_allow_dirs": [],
+        # When true, files whose mtime is within ``trust_recent_files_seconds``
+        # of "now" are trusted for native delivery even outside the cache /
+        # operator allowlist — useful for ``pandoc -o /tmp/report.pdf`` or
+        # PDFs the agent writes into a working directory. System paths
+        # (/etc, /proc, ~/.ssh, ~/.aws, etc.) remain blocked regardless.
+        # Disable to fall back to pure-allowlist mode. Bridged to
+        # HERMES_MEDIA_TRUST_RECENT_FILES. Only consulted when ``strict``
+        # is true; in default mode the denylist alone gates delivery.
+        "trust_recent_files": True,
+        # Recency window in seconds. 600 (10 min) comfortably covers a
+        # multi-tool agent turn. Bridged to HERMES_MEDIA_TRUST_RECENT_SECONDS.
+        # Only consulted when ``strict`` is true.
+        "trust_recent_files_seconds": 600,
+    },
+
+    # Real-time token streaming to messaging platforms (Telegram, Discord,
+    # Slack, etc.). Read at the top level by the gateway; absent this block the
+    # gateway falls back to these same defaults, so adding it here only makes
+    # the feature discoverable in config.yaml — it does not change behavior.
+    #
+    # Disabled by default: streaming costs extra edit/draft API calls per
+    # response. Set ``enabled: true`` and restart the gateway to turn it on.
+    "streaming": {
+        # Master switch. When false, each response is delivered as a single
+        # final message (no progressive updates).
+        "enabled": False,
+        # Transport selection:
+        #   "auto"  — prefer native draft streaming where the platform
+        #             supports it (Telegram DMs via sendMessageDraft,
+        #             Bot API 9.5+) and fall back to edit-based elsewhere.
+        #             Safe global default: platforms without draft support
+        #             (Discord, Slack, Matrix, Telegram groups) transparently
+        #             use the edit path, so "auto" only upgrades chats that
+        #             can render the smoother native preview.
+        #   "draft" — explicitly request native drafts; falls back to edit
+        #             when the platform/chat doesn't support them.
+        #   "edit"  — progressive editMessageText only (legacy behavior).
+        #   "off"   — disable streaming entirely (same as enabled: false).
+        "transport": "auto",
+        # Minimum seconds between progressive edits — tuned for Telegram's
+        # ~1 edit/s flood envelope.
+        "edit_interval": 0.8,
+        # Flush the buffer to the platform once this many characters have
+        # accumulated, so short replies feel near-instant.
+        "buffer_threshold": 24,
+        # Cursor glyph appended to the in-progress message while streaming.
+        "cursor": " \u2589",
+        # When >0, the final edit for a long-running streamed response is
+        # delivered as a fresh message if the preview has been visible at
+        # least this many seconds, so the platform timestamp reflects
+        # completion time. Telegram only; other platforms ignore it.
+        "fresh_final_after_seconds": 60.0,
+    },
+
+    # Session storage — controls automatic cleanup of ~/.hermes/state.db.
+    # state.db accumulates every session, message, tool call, and FTS5 index
+    # entry forever.  Without auto-pruning, a heavy user (gateway + cron)
+    # reports 384MB+ databases with 68K+ messages, which slows down FTS5
+    # inserts, /resume listing, and insights queries.
+    "sessions": {
+        # When true, prune ended sessions older than retention_days once
+        # per (roughly) min_interval_hours at CLI/gateway/cron startup.
+        # Only touches ended sessions — active sessions are always preserved.
+        # Default false: session history is valuable for search recall, and
+        # silently deleting it could surprise users.  Opt in explicitly.
+        "auto_prune": False,
+        # How many days of ended-session history to keep.  Matches the
+        # default of ``hermes sessions prune``.
+        "retention_days": 90,
+        # VACUUM after a prune that actually deleted rows.  SQLite does not
+        # reclaim disk space on DELETE — freed pages are just reused on
+        # subsequent INSERTs — so without VACUUM the file stays bloated
+        # even after pruning.  VACUUM blocks writes for a few seconds per
+        # 100MB, so it only runs at startup, and only when prune deleted
+        # ≥1 session.
+        "vacuum_after_prune": True,
+        # Minimum hours between auto-maintenance runs (avoids repeating
+        # the sweep on every CLI invocation).  Tracked via state_meta in
+        # state.db itself, so it's shared across all processes.
+        "min_interval_hours": 24,
+        # Legacy per-session JSON snapshot writer.  When true, the agent
+        # rewrites ``~/.hermes/sessions/session_{sid}.json`` on every turn
+        # boundary with the full message list.  state.db is canonical and
+        # has every field the snapshot stored (plus per-message timestamps
+        # and token counts), so this is off by default — the snapshots had
+        # no consumer outside their own overwrite guard and accumulated
+        # GBs of disk on heavy users.  Opt in only if you have an external
+        # tool that consumes the JSON files directly.
+        "write_json_snapshots": False,
+    },
+
+    # Contextual first-touch onboarding hints (see agent/onboarding.py).
+    # Each hint is shown once per install and then latched here so it
+    # never fires again.  Users can wipe the section to re-see all hints.
+    "onboarding": {
+        "seen": {},
+        # Structured profile-build path offered on the very first gateway
+        # message ever. "ask" (default) -> offer to build a user profile
+        # (opt-in, consent-gated; the agent asks before any lookup and never
+        # reads connected accounts silently). "off" -> plain intro only.
+        # The offer fires at most once (latched under onboarding.seen).
+        "profile_build": "ask",
+    },
+
+    # ``hermes update`` behaviour.
+    "updates": {
+        # Run a full ``hermes backup``-style zip of HERMES_HOME before every
+        # ``hermes update``.  Backups land in ``<HERMES_HOME>/backups/`` and
+        # can be restored with ``hermes import <path>``.  Off by default —
+        # on large HERMES_HOME directories the zip can add minutes to every
+        # update.  Set to true to re-enable, or pass ``--backup`` to opt in
+        # for a single update run.
+        "pre_update_backup": False,
+        # How many pre-update backup zips to retain.  Older ones are pruned
+        # automatically after each successful backup.  Values below 1 are
+        # floored to 1 — the backup just created is always preserved.  To
+        # disable backups entirely, set ``pre_update_backup: false`` above
+        # rather than ``backup_keep: 0``.
+        "backup_keep": 5,
+        # What `hermes update` does with uncommitted local changes to the
+        # source tree when it runs NON-interactively — i.e. triggered from
+        # the desktop/chat app or the gateway, where there's no TTY to answer
+        # a restore prompt. Interactive (terminal) updates are unaffected:
+        # they always stash the changes and ask whether to restore, exactly
+        # as they always have.
+        #   "stash"   — auto-stash the changes, pull, then auto-restore them
+        #               on top of the updated code (the safe default; nothing
+        #               is ever lost — conflicts are preserved in a git stash).
+        #   "discard" — auto-stash the changes and throw the stash away after
+        #               the pull. Use this only if you never intend to keep
+        #               local edits to the source tree on this machine.
+        #               Stash-and-drop (not `reset --hard` + `clean -fd`) so
+        #               ignored paths — node_modules, venv, build outputs —
+        #               are never touched.
+        "non_interactive_local_changes": "stash",
+    },
+
+    # Language Server Protocol — semantic diagnostics from real
+    # language servers (pyright, gopls, rust-analyzer, etc.) wired
+    # into the post-write lint check used by ``write_file`` and
+    # ``patch``.
+    #
+    # LSP is gated on git-workspace detection: when the agent's
+    # cwd (or the file being edited) is inside a git worktree, LSP
+    # runs against that workspace.  When neither is in a git repo,
+    # LSP stays dormant and the in-process syntax check is the only
+    # tier — handy for Telegram/Discord chats where the cwd is the
+    # user's home directory.
+    "lsp": {
+        # Master toggle.  Setting this to false disables the entire
+        # subsystem — no servers spawn, no background event loop, no
+        # cost.
+        "enabled": True,
+
+        # Diagnostic-wait mode for the post-write check.
+        # ``"document"`` waits up to ``wait_timeout`` seconds for the
+        # current file's diagnostics; ``"full"`` additionally requests
+        # workspace-wide diagnostics (slower).
+        "wait_mode": "document",
+        "wait_timeout": 5.0,
+
+        # How to handle missing server binaries.
+        # ``"auto"`` — try to install via npm/go/pip into
+        #              ``<HERMES_HOME>/lsp/bin/`` on first use.
+        # ``"manual"`` — only use binaries already on PATH.
+        # ``"off"`` — alias for ``manual``.
+        "install_strategy": "auto",
+
+        # Per-server overrides.  Each key is a server_id from the
+        # registry (``pyright``, ``typescript``, ``gopls``,
+        # ``rust-analyzer``, etc.) and accepts:
+        #   disabled: true
+        #     — skip this server even when its extensions match
+        #   command: ["full/path/to/server", "--stdio"]
+        #     — pin a custom binary path; bypasses auto-install
+        #   env: {"KEY": "value"}
+        #     — extra env vars passed to the spawned process
+        #   initialization_options: {...}
+        #     — merged into the LSP ``initializationOptions``
+        # Empty by default; the registry defaults work for typical
+        # setups.
+        "servers": {},
+    },
+
+
+    # X (Twitter) Search via xAI's built-in x_search Responses tool.
+    # The tool registers when xAI credentials are available (SuperGrok
+    # OAuth or XAI_API_KEY) AND the x_search toolset is enabled in
+    # `hermes tools`. These settings tune the backing Responses API call.
+    "x_search": {
+        # xAI model used for the Responses call. grok-4.20-reasoning is
+        # the recommended default; any Grok model with x_search tool
+        # access works.
+        "model": "grok-4.20-reasoning",
+        # Request timeout in seconds (minimum 30). x_search can take
+        # 60-120s for complex queries — the default is generous.
+        "timeout_seconds": 180,
+        # Number of automatic retries on 5xx / ReadTimeout / ConnectionError.
+        # Each retry backs off (1.5x attempt seconds, capped at 5s).
+        "retries": 2,
+    },
+
+    # =========================================================================
+    # External secret sources
+    # =========================================================================
+    # Pull credentials from external secret managers at process startup
+    # rather than storing them in ~/.hermes/.env.
+    "secrets": {
+        "bitwarden": {
+            # Master switch.  When false, BSM is never contacted and the
+            # bws binary is never auto-installed — same as not having
+            # this section at all.
+            "enabled": False,
+            # Name of the env var that holds the Bitwarden machine-account
+            # access token.  This is the one bootstrap secret; it lives
+            # in ~/.hermes/.env (or your shell) and never in config.yaml.
+            "access_token_env": "BWS_ACCESS_TOKEN",
+            # UUID of the BSM project to sync from.
+            "project_id": "",
+            # Seconds to cache fetched secrets in-process.  0 disables.
+            "cache_ttl_seconds": 300,
+            # When True, BSM values overwrite existing env vars.  Default
+            # True because the point of using BSM is centralized rotation —
+            # if .env had the final say, rotating in Bitwarden wouldn't
+            # take effect until you also cleared the matching .env line.
+            "override_existing": True,
+            # When True, the bws binary is auto-downloaded into
+            # ~/.hermes/bin/ on first use.  When False you must install
+            # bws yourself and have it on PATH.
+            "auto_install": True,
+            # Bitwarden region / self-hosted endpoint.  Empty string
+            # means use the bws CLI default (US Cloud,
+            # https://vault.bitwarden.com).  Set to
+            # https://vault.bitwarden.eu for EU Cloud, or your own URL
+            # for self-hosted Bitwarden.  Plumbed into the bws subprocess
+            # as BWS_SERVER_URL.  Prompted for during
+            # `hermes secrets bitwarden setup`.
+            "server_url": "",
+        },
+    },
+
+    # Paste collapse thresholds (TUI + CLI).
+    #
+    # paste_collapse_threshold (default 5)
+    #   Bracketed-paste handler. Pastes with this many newlines or more
+    #   collapse to a file reference. Set 0 to disable.
+    #
+    # paste_collapse_threshold_fallback (default 5)
+    #   Fallback heuristic for terminals without bracketed paste support.
+    #   Same line count test but heuristically gated by chars-added /
+    #   newlines-added to avoid false positives from normal typing.
+    #   Set 0 to disable.
+    #
+    # paste_collapse_char_threshold (default 2000)
+    #   Long single-line paste guard. Pastes whose total char length
+    #   reaches this value collapse to a file reference even if line
+    #   count is below the line threshold. Catches the "8000 chars of
+    #   minified JSON / log output on one line" case. Set 0 to disable.
+    "paste_collapse_threshold": 5,
+    "paste_collapse_threshold_fallback": 5,
+    "paste_collapse_char_threshold": 2000,
+
+
+    # Config schema version - bump this when adding new required fields
+    "_config_version": 28,
+}
+
+# =============================================================================
+# Config Migration System
+# =============================================================================
+
+# Track which env vars were introduced in each config version.
+# Migration only mentions vars new since the user's previous version.
+ENV_VARS_BY_VERSION: Dict[int, List[str]] = {
+    3: ["FIRECRAWL_API_KEY", "BROWSERBASE_API_KEY", "BROWSERBASE_PROJECT_ID", "FAL_KEY"],
+    4: ["VOICE_TOOLS_OPENAI_KEY", "ELEVENLABS_API_KEY"],
+    5: ["WHATSAPP_ENABLED", "WHATSAPP_MODE", "WHATSAPP_ALLOWED_USERS",
+        "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"],
+    10: ["TAVILY_API_KEY"],
+    11: ["TERMINAL_MODAL_MODE"],
+}
+
+# Required environment variables with metadata for migration prompts.
+# LLM provider is required but handled in the setup wizard's provider
+# selection step (Nous Portal / OpenRouter / Custom endpoint), so this
+# dict is intentionally empty — no single env var is universally required.
+REQUIRED_ENV_VARS = {}
+
+# Optional environment variables that enhance functionality
+OPTIONAL_ENV_VARS = {
+    # ── Provider (handled in provider selection, not shown in checklists) ──
+    "NOUS_BASE_URL": {
+        "description": "Nous Portal base URL override",
+        "prompt": "Nous Portal base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "OPENROUTER_API_KEY": {
+        "description": "OpenRouter API key (for vision, web scraping helpers, and MoA)",
+        "prompt": "OpenRouter API key",
+        "url": "https://openrouter.ai/keys",
+        "password": True,
+        "tools": ["vision_analyze", "mixture_of_agents"],
+        "category": "provider",
+        "advanced": True,
+    },
+    "GOOGLE_API_KEY": {
+        "description": "Google AI Studio API key (also recognized as GEMINI_API_KEY)",
+        "prompt": "Google AI Studio API key",
+        "url": "https://aistudio.google.com/app/apikey",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "GEMINI_API_KEY": {
+        "description": "Google AI Studio API key (alias for GOOGLE_API_KEY)",
+        "prompt": "Gemini API key",
+        "url": "https://aistudio.google.com/app/apikey",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "GEMINI_BASE_URL": {
+        "description": "Google AI Studio base URL override",
+        "prompt": "Gemini base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "XAI_API_KEY": {
+        "description": "xAI API key",
+        "prompt": "xAI API key",
+        "url": "https://console.x.ai/",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "XAI_BASE_URL": {
+        "description": "xAI base URL override",
+        "prompt": "xAI base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "NVIDIA_API_KEY": {
+        "description": "NVIDIA NIM API key (build.nvidia.com or local NIM endpoint)",
+        "prompt": "NVIDIA NIM API key",
+        "url": "https://build.nvidia.com/",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "NVIDIA_BASE_URL": {
+        "description": "NVIDIA NIM base URL override (e.g. http://localhost:8000/v1 for local NIM)",
+        "prompt": "NVIDIA NIM base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "LM_API_KEY": {
+        "description": "LM Studio bearer token for auth-enabled local servers",
+        "prompt": "LM Studio API key / bearer token",
+        "url": None,
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "LM_BASE_URL": {
+        "description": "LM Studio base URL override",
+        "prompt": "LM Studio base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "GLM_API_KEY": {
+        "description": "Z.AI / GLM API key (also recognized as ZAI_API_KEY / Z_AI_API_KEY)",
+        "prompt": "Z.AI / GLM API key",
+        "url": "https://z.ai/",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "ZAI_API_KEY": {
+        "description": "Z.AI API key (alias for GLM_API_KEY)",
+        "prompt": "Z.AI API key",
+        "url": "https://z.ai/",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "Z_AI_API_KEY": {
+        "description": "Z.AI API key (alias for GLM_API_KEY)",
+        "prompt": "Z.AI API key",
+        "url": "https://z.ai/",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "GLM_BASE_URL": {
+        "description": "Z.AI / GLM base URL override",
+        "prompt": "Z.AI / GLM base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "KIMI_API_KEY": {
+        "description": "Kimi / Moonshot API key",
+        "prompt": "Kimi API key",
+        "url": "https://platform.moonshot.cn/",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "KIMI_BASE_URL": {
+        "description": "Kimi / Moonshot base URL override",
+        "prompt": "Kimi base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "KIMI_CN_API_KEY": {
+        "description": "Kimi / Moonshot China API key",
+        "prompt": "Kimi (China) API key",
+        "url": "https://platform.moonshot.cn/",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "STEPFUN_API_KEY": {
+        "description": "StepFun Step Plan API key",
+        "prompt": "StepFun Step Plan API key",
+        "url": "https://platform.stepfun.com/",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "STEPFUN_BASE_URL": {
+        "description": "StepFun Step Plan base URL override",
+        "prompt": "StepFun Step Plan base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "ARCEEAI_API_KEY": {
+        "description": "Arcee AI API key",
+        "prompt": "Arcee AI API key",
+        "url": "https://chat.arcee.ai/",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "ARCEE_BASE_URL": {
+        "description": "Arcee AI base URL override",
+        "prompt": "Arcee base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "GMI_API_KEY": {
+        "description": "GMI Cloud API key",
+        "prompt": "GMI Cloud API key",
+        "url": "https://www.gmicloud.ai/",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "GMI_BASE_URL": {
+        "description": "GMI Cloud base URL override",
+        "prompt": "GMI Cloud base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "MINIMAX_API_KEY": {
+        "description": "MiniMax API key (international)",
+        "prompt": "MiniMax API key",
+        "url": "https://www.minimax.io/",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "MINIMAX_BASE_URL": {
+        "description": "MiniMax base URL override",
+        "prompt": "MiniMax base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "MINIMAX_CN_API_KEY": {
+        "description": "MiniMax API key (China endpoint)",
+        "prompt": "MiniMax (China) API key",
+        "url": "https://www.minimaxi.com/",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "MINIMAX_CN_BASE_URL": {
+        "description": "MiniMax (China) base URL override",
+        "prompt": "MiniMax (China) base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "DEEPSEEK_API_KEY": {
+        "description": "DeepSeek API key for direct DeepSeek access",
+        "prompt": "DeepSeek API Key",
+        "url": "https://platform.deepseek.com/api_keys",
+        "password": True,
+        "category": "provider",
+    },
+    "DEEPSEEK_BASE_URL": {
+        "description": "Custom DeepSeek API base URL (advanced)",
+        "prompt": "DeepSeek Base URL",
+        "url": "",
+        "password": False,
+        "category": "provider",
+    },
+    "DASHSCOPE_API_KEY": {
+        "description": "Alibaba Cloud DashScope API key (Qwen + multi-provider models)",
+        "prompt": "DashScope API Key",
+        "url": "https://modelstudio.console.alibabacloud.com/",
+        "password": True,
+        "category": "provider",
+    },
+    "DASHSCOPE_BASE_URL": {
+        "description": "Custom DashScope base URL (default: coding-intl OpenAI-compat endpoint)",
+        "prompt": "DashScope Base URL",
+        "url": "",
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "HERMES_QWEN_BASE_URL": {
+        "description": "Qwen Portal base URL override (default: https://portal.qwen.ai/v1)",
+        "prompt": "Qwen Portal base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "HERMES_GEMINI_CLIENT_ID": {
+        "description": "Google OAuth client ID for google-gemini-cli (optional; defaults to Google's public gemini-cli client)",
+        "prompt": "Google OAuth client ID (optional — leave empty to use the public default)",
+        "url": "https://console.cloud.google.com/apis/credentials",
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "HERMES_GEMINI_CLIENT_SECRET": {
+        "description": "Google OAuth client secret for google-gemini-cli (optional)",
+        "prompt": "Google OAuth client secret (optional)",
+        "url": "https://console.cloud.google.com/apis/credentials",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "HERMES_GEMINI_PROJECT_ID": {
+        "description": "GCP project ID for paid Gemini tiers (free tier auto-provisions)",
+        "prompt": "GCP project ID for Gemini OAuth (leave empty for free tier)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "OPENCODE_ZEN_API_KEY": {
+        "description": "OpenCode Zen API key (pay-as-you-go access to curated models)",
+        "prompt": "OpenCode Zen API key",
+        "url": "https://opencode.ai/auth",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "OPENCODE_ZEN_BASE_URL": {
+        "description": "OpenCode Zen base URL override",
+        "prompt": "OpenCode Zen base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "OPENCODE_GO_API_KEY": {
+        "description": "OpenCode Go API key ($10/month subscription for open models)",
+        "prompt": "OpenCode Go API key",
+        "url": "https://opencode.ai/auth",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "OPENCODE_GO_BASE_URL": {
+        "description": "OpenCode Go base URL override",
+        "prompt": "OpenCode Go base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "HF_TOKEN": {
+        "description": "Hugging Face token for Inference Providers (20+ open models via router.huggingface.co)",
+        "prompt": "Hugging Face Token",
+        "url": "https://huggingface.co/settings/tokens",
+        "password": True,
+        "category": "provider",
+    },
+    "HF_BASE_URL": {
+        "description": "Hugging Face Inference Providers base URL override",
+        "prompt": "HF base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "OLLAMA_API_KEY": {
+        "description": "Ollama Cloud API key (ollama.com — cloud-hosted open models)",
+        "prompt": "Ollama Cloud API key",
+        "url": "https://ollama.com/settings",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "OLLAMA_BASE_URL": {
+        "description": "Ollama Cloud base URL override (default: https://ollama.com/v1)",
+        "prompt": "Ollama base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "XIAOMI_API_KEY": {
+        "description": "Xiaomi MiMo API key for MiMo models (mimo-v2.5-pro, mimo-v2.5, mimo-v2-pro, mimo-v2-omni, mimo-v2-flash)",
+        "prompt": "Xiaomi MiMo API Key",
+        "url": "https://platform.xiaomimimo.com",
+        "password": True,
+        "category": "provider",
+    },
+    "XIAOMI_BASE_URL": {
+        "description": "Xiaomi MiMo base URL override (default: https://api.xiaomimimo.com/v1)",
+        "prompt": "Xiaomi base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "AWS_REGION": {
+        "description": "AWS region for Bedrock API calls (e.g. us-east-1, eu-central-1)",
+        "prompt": "AWS Region",
+        "url": "https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-regions.html",
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "AWS_PROFILE": {
+        "description": "AWS named profile for Bedrock authentication (from ~/.aws/credentials)",
+        "prompt": "AWS Profile",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+    "AZURE_FOUNDRY_API_KEY": {
+        "description": "Azure Foundry API key for custom Azure endpoints",
+        "prompt": "Azure Foundry API Key",
+        "url": "https://ai.azure.com/",
+        "password": True,
+        "category": "provider",
+    },
+    "AZURE_FOUNDRY_BASE_URL": {
+        "description": "Azure Foundry base URL (set via 'hermes model' for endpoint-specific config)",
+        "prompt": "Azure Foundry base URL",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
+
+    # ── Tool API keys ──
+    "EXA_API_KEY": {
+        "description": "Exa API key for AI-native web search and contents",
+        "prompt": "Exa API key",
+        "url": "https://exa.ai/",
+        "tools": ["web_search", "web_extract"],
+        "password": True,
+        "category": "tool",
+    },
+    "PARALLEL_API_KEY": {
+        "description": "Parallel API key for AI-native web search and extract",
+        "prompt": "Parallel API key",
+        "url": "https://parallel.ai/",
+        "tools": ["web_search", "web_extract"],
+        "password": True,
+        "category": "tool",
+    },
+    "FIRECRAWL_API_KEY": {
+        "description": "Firecrawl API key for web search and scraping",
+        "prompt": "Firecrawl API key",
+        "url": "https://firecrawl.dev/",
+        "tools": ["web_search", "web_extract"],
+        "password": True,
+        "category": "tool",
+    },
+    "FIRECRAWL_API_URL": {
+        "description": "Firecrawl API URL for self-hosted instances (optional)",
+        "prompt": "Firecrawl API URL (leave empty for cloud)",
+        "url": None,
+        "password": False,
+        "category": "tool",
+        "advanced": True,
+    },
+    "FIRECRAWL_GATEWAY_URL": {
+        "description": "Exact Firecrawl tool-gateway origin override for Nous Subscribers only (optional)",
+        "prompt": "Firecrawl gateway URL (leave empty to derive from domain)",
+        "url": None,
+        "password": False,
+        "category": "tool",
+        "advanced": True,
+    },
+    "TOOL_GATEWAY_DOMAIN": {
+        "description": "Shared tool-gateway domain suffix for Nous Subscribers only, used to derive vendor hosts, e.g. nousresearch.com -> firecrawl-gateway.nousresearch.com",
+        "prompt": "Tool-gateway domain suffix",
+        "url": None,
+        "password": False,
+        "category": "tool",
+        "advanced": True,
+    },
+    "TOOL_GATEWAY_SCHEME": {
+        "description": "Shared tool-gateway URL scheme for Nous Subscribers only, used to derive vendor hosts (`https` by default, set `http` for local gateway testing)",
+        "prompt": "Tool-gateway URL scheme",
+        "url": None,
+        "password": False,
+        "category": "tool",
+        "advanced": True,
+    },
+    "TOOL_GATEWAY_USER_TOKEN": {
+        "description": "Explicit Nous Subscriber access token for tool-gateway requests (optional; otherwise read from the Hermes auth store)",
+        "prompt": "Tool-gateway user token",
+        "url": None,
+        "password": True,
+        "category": "tool",
+        "advanced": True,
+    },
+    "TAVILY_API_KEY": {
+        "description": "Tavily API key for AI-native web search and extract",
+        "prompt": "Tavily API key",
+        "url": "https://app.tavily.com/home",
+        "tools": ["web_search", "web_extract"],
+        "password": True,
+        "category": "tool",
+    },
+    "SEARXNG_URL": {
+        "description": "URL of your SearXNG instance for free self-hosted web search",
+        "prompt": "SearXNG URL (e.g. http://localhost:8080)",
+        "url": "https://searxng.github.io/searxng/",
+        "tools": ["web_search"],
+        "password": False,
+        "category": "tool",
+    },
+    "BRAVE_SEARCH_API_KEY": {
+        "description": "Brave Search API subscription token (free tier: 2,000 queries/mo)",
+        "prompt": "Brave Search subscription token",
+        "url": "https://brave.com/search/api/",
+        "tools": ["web_search"],
+        "password": True,
+        "category": "tool",
+    },
+    "BROWSERBASE_API_KEY": {
+        "description": "Browserbase API key for cloud browser (optional — local browser works without this)",
+        "prompt": "Browserbase API key",
+        "url": "https://browserbase.com/",
+        "tools": ["browser_navigate", "browser_click"],
+        "password": True,
+        "category": "tool",
+    },
+    "BROWSERBASE_PROJECT_ID": {
+        "description": "Browserbase project ID (optional — only needed for cloud browser)",
+        "prompt": "Browserbase project ID",
+        "url": "https://browserbase.com/",
+        "tools": ["browser_navigate", "browser_click"],
+        "password": False,
+        "category": "tool",
+    },
+    "BROWSER_USE_API_KEY": {
+        "description": "Browser Use API key for cloud browser (optional — local browser works without this)",
+        "prompt": "Browser Use API key",
+        "url": "https://browser-use.com/",
+        "tools": ["browser_navigate", "browser_click"],
+        "password": True,
+        "category": "tool",
+    },
+    "FIRECRAWL_BROWSER_TTL": {
+        "description": "Firecrawl browser session TTL in seconds (optional, default 300)",
+        "prompt": "Browser session TTL (seconds)",
+        "tools": ["browser_navigate", "browser_click"],
+        "password": False,
+        "category": "tool",
+    },
+    "AGENT_BROWSER_ENGINE": {
+        "description": "Browser engine for local mode: auto (default Chrome), lightpanda (faster, no screenshots), chrome",
+        "prompt": "Browser engine (auto/lightpanda/chrome)",
+        "url": "https://github.com/vercel-labs/agent-browser",
+        "tools": ["browser_navigate", "browser_snapshot", "browser_click", "browser_vision"],
+        "password": False,
+        "category": "tool",
+        "advanced": True,
+    },
+    "CAMOFOX_URL": {
+        "description": "Camofox browser server URL for local anti-detection browsing (e.g. http://localhost:9377)",
+        "prompt": "Camofox server URL",
+        "url": "https://github.com/jo-inc/camofox-browser",
+        "tools": ["browser_navigate", "browser_click"],
+        "password": False,
+        "category": "tool",
+    },
+    "FAL_KEY": {
+        "description": "FAL API key for image and video generation",
+        "prompt": "FAL API key",
+        "url": "https://fal.ai/",
+        "tools": ["image_generate", "video_generate"],
+        "password": True,
+        "category": "tool",
+    },
+    "KREA_API_KEY": {
+        "description": "Krea API key for Krea 2 image generation (Medium + Large)",
+        "prompt": "Krea API key",
+        "url": "https://www.krea.ai/settings/api-tokens",
+        "tools": ["image_generate"],
+        "password": True,
+        "category": "tool",
+    },
+    "VOICE_TOOLS_OPENAI_KEY": {
+        "description": "OpenAI API key for voice transcription (Whisper) and OpenAI TTS",
+        "prompt": "OpenAI API Key (for Whisper STT + TTS)",
+        "url": "https://platform.openai.com/api-keys",
+        "tools": ["voice_transcription", "openai_tts"],
+        "password": True,
+        "category": "tool",
+    },
+    "ELEVENLABS_API_KEY": {
+        "description": "ElevenLabs API key for premium text-to-speech voices and Scribe transcription",
+        "prompt": "ElevenLabs API key",
+        "url": "https://elevenlabs.io/",
+        "tools": ["elevenlabs_tts", "voice_transcription"],
+        "password": True,
+        "category": "tool",
+    },
+    "MISTRAL_API_KEY": {
+        "description": "Mistral API key for Voxtral TTS and transcription (STT)",
+        "prompt": "Mistral API key",
+        "url": "https://console.mistral.ai/",
+        "password": True,
+        "category": "tool",
+    },
+    "GITHUB_TOKEN": {
+        "description": "GitHub token for Skills Hub (higher API rate limits, skill publish)",
+        "prompt": "GitHub Token",
+        "url": "https://github.com/settings/tokens",
+        "password": True,
+        "category": "tool",
+    },
+
+    # ── Bundled skills (opt-in: only needed if the user uses that skill) ──
+    # These use category="skill" (distinct from "tool") so the sandbox
+    # env blocklist in tools/environments/local.py does NOT rewrite them —
+    # skills legitimately need these passed through to curl via
+    # tools/env_passthrough.py when the user's skill calls out.
+    "NOTION_API_KEY": {
+        "description": "Notion integration token (used by the `notion` skill)",
+        "prompt": "Notion API key",
+        "url": "https://www.notion.so/my-integrations",
+        "password": True,
+        "category": "skill",
+        "advanced": True,
+    },
+    "LINEAR_API_KEY": {
+        "description": "Linear personal API key (used by the `linear` skill)",
+        "prompt": "Linear API key",
+        "url": "https://linear.app/settings/account/security",
+        "password": True,
+        "category": "skill",
+        "advanced": True,
+    },
+    "AIRTABLE_API_KEY": {
+        "description": "Airtable personal access token (used by the `airtable` skill)",
+        "prompt": "Airtable API key",
+        "url": "https://airtable.com/create/tokens",
+        "password": True,
+        "category": "skill",
+        "advanced": True,
+    },
+    "TENOR_API_KEY": {
+        "description": "Tenor API key for GIF search (used by the `gif-search` skill)",
+        "prompt": "Tenor API key",
+        "url": "https://developers.google.com/tenor/guides/quickstart",
+        "password": True,
+        "category": "skill",
+        "advanced": True,
+    },
+
+    # ── Honcho ──
+    "HONCHO_API_KEY": {
+        "description": "Honcho API key for AI-native persistent memory",
+        "prompt": "Honcho API key",
+        "url": "https://app.honcho.dev",
+        "tools": ["honcho_context"],
+        "password": True,
+        "category": "tool",
+    },
+    "HONCHO_BASE_URL": {
+        "description": "Base URL for self-hosted Honcho instances (no API key needed)",
+        "prompt": "Honcho base URL (e.g. http://localhost:8000)",
+        "category": "tool",
+    },
+
+    # ── Langfuse observability ──
+    "HERMES_LANGFUSE_PUBLIC_KEY": {
+        "description": "Langfuse project public key (pk-lf-...)",
+        "prompt": "Langfuse public key",
+        "url": "https://cloud.langfuse.com",
+        "password": False,
+        "category": "tool",
+    },
+    "HERMES_LANGFUSE_SECRET_KEY": {
+        "description": "Langfuse project secret key (sk-lf-...)",
+        "prompt": "Langfuse secret key",
+        "url": "https://cloud.langfuse.com",
+        "password": True,
+        "category": "tool",
+    },
+    "HERMES_LANGFUSE_BASE_URL": {
+        "description": "Langfuse server URL (default: https://cloud.langfuse.com)",
+        "prompt": "Langfuse server URL (leave empty for cloud.langfuse.com)",
+        "url": None,
+        "password": False,
+        "category": "tool",
+        "advanced": True,
+    },
+
+    # ── Messaging platforms ──
+    "TELEGRAM_BOT_TOKEN": {
+        "description": "Telegram bot token from @BotFather",
+        "prompt": "Telegram bot token",
+        "url": "https://t.me/BotFather",
+        "password": True,
+        "category": "messaging",
+    },
+    "TELEGRAM_ALLOWED_USERS": {
+        "description": "Comma-separated Telegram user IDs allowed to use the bot (get ID from @userinfobot)",
+        "prompt": "Allowed Telegram user IDs (comma-separated)",
+        "url": "https://t.me/userinfobot",
+        "password": False,
+        "category": "messaging",
+    },
+    "TELEGRAM_PROXY": {
+        "description": "Proxy URL for Telegram connections (overrides HTTPS_PROXY). Supports http://, https://, socks5://",
+        "prompt": "Telegram proxy URL (optional)",
+        "password": False,
+        "category": "messaging",
+    },
+    "DISCORD_BOT_TOKEN": {
+        "description": "Discord bot token from Developer Portal",
+        "prompt": "Discord bot token",
+        "url": "https://discord.com/developers/applications",
+        "password": True,
+        "category": "messaging",
+    },
+    "DISCORD_ALLOWED_USERS": {
+        "description": "Comma-separated Discord user IDs allowed to use the bot",
+        "prompt": "Allowed Discord user IDs (comma-separated)",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+    },
+    "DISCORD_REPLY_TO_MODE": {
+        "description": "Discord reply threading mode: 'off' (no reply references), 'first' (reply on first message only, default), 'all' (reply on every chunk)",
+        "prompt": "Discord reply mode (off/first/all)",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+    },
+    "SLACK_BOT_TOKEN": {
+        "description": "Slack bot token (xoxb-). Get from OAuth & Permissions after installing your app. "
+                       "Required scopes: chat:write, app_mentions:read, channels:history, groups:history, "
+                       "im:history, im:read, im:write, users:read, files:read, files:write",
+        "prompt": "Slack Bot Token (xoxb-...)",
+        "url": "https://api.slack.com/apps",
+        "password": True,
+        "category": "messaging",
+    },
+    "SLACK_APP_TOKEN": {
+        "description": "Slack app-level token (xapp-) for Socket Mode. Get from Basic Information → "
+                       "App-Level Tokens. Also ensure Event Subscriptions include: message.im, "
+                       "message.channels, message.groups, app_mention",
+        "prompt": "Slack App Token (xapp-...)",
+        "url": "https://api.slack.com/apps",
+        "password": True,
+        "category": "messaging",
+    },
+    "MATTERMOST_URL": {
+        "description": "Mattermost server URL (e.g. https://mm.example.com)",
+        "prompt": "Mattermost server URL",
+        "url": "https://mattermost.com/deploy/",
+        "password": False,
+        "category": "messaging",
+    },
+    "MATTERMOST_TOKEN": {
+        "description": "Mattermost bot token or personal access token",
+        "prompt": "Mattermost bot token",
+        "url": None,
+        "password": True,
+        "category": "messaging",
+    },
+    "MATTERMOST_ALLOWED_USERS": {
+        "description": "Comma-separated Mattermost user IDs allowed to use the bot",
+        "prompt": "Allowed Mattermost user IDs (comma-separated)",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+    },
+    "MATTERMOST_REQUIRE_MENTION": {
+        "description": "Require @mention in Mattermost channels (default: true). Set to false to respond to all messages.",
+        "prompt": "Require @mention in channels",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+    },
+    "MATTERMOST_FREE_RESPONSE_CHANNELS": {
+        "description": "Comma-separated Mattermost channel IDs where bot responds without @mention",
+        "prompt": "Free-response channel IDs (comma-separated)",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+    },
+    "MATRIX_HOMESERVER": {
+        "description": "Matrix homeserver URL (e.g. https://matrix.example.org)",
+        "prompt": "Matrix homeserver URL",
+        "url": "https://matrix.org/ecosystem/servers/",
+        "password": False,
+        "category": "messaging",
+    },
+    "MATRIX_ACCESS_TOKEN": {
+        "description": "Matrix access token (preferred over password login)",
+        "prompt": "Matrix access token",
+        "url": None,
+        "password": True,
+        "category": "messaging",
+    },
+    "MATRIX_USER_ID": {
+        "description": "Matrix user ID (e.g. @hermes:example.org)",
+        "prompt": "Matrix user ID (@user:server)",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+    },
+    "MATRIX_ALLOWED_USERS": {
+        "description": "Comma-separated Matrix user IDs allowed to use the bot (@user:server format)",
+        "prompt": "Allowed Matrix user IDs (comma-separated)",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+    },
+    "MATRIX_REQUIRE_MENTION": {
+        "description": "Require @mention in Matrix rooms (default: true). Set to false to respond to all messages.",
+        "prompt": "Require @mention in rooms (true/false)",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+        "advanced": True,
+    },
+    "MATRIX_FREE_RESPONSE_ROOMS": {
+        "description": "Comma-separated Matrix room IDs where bot responds without @mention",
+        "prompt": "Free-response room IDs (comma-separated)",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+        "advanced": True,
+    },
+    "MATRIX_AUTO_THREAD": {
+        "description": "Auto-create threads for messages in Matrix rooms (default: true)",
+        "prompt": "Auto-create threads in rooms (true/false)",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+        "advanced": True,
+    },
+    "MATRIX_DM_AUTO_THREAD": {
+        "description": "Auto-create threads for DM messages in Matrix (default: false)",
+        "prompt": "Auto-create threads in DMs (true/false)",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+        "advanced": True,
+    },
+    "MATRIX_DEVICE_ID": {
+        "description": "Stable Matrix device ID for E2EE persistence across restarts (e.g. HERMES_BOT)",
+        "prompt": "Matrix device ID (stable across restarts)",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+        "advanced": True,
+    },
+    "MATRIX_RECOVERY_KEY": {
+        "description": "Matrix recovery key for cross-signing verification after device key rotation (from Element: Settings → Security → Recovery Key)",
+        "prompt": "Matrix recovery key",
+        "url": None,
+        "password": True,
+        "category": "messaging",
+        "advanced": True,
+    },
+    "BLUEBUBBLES_SERVER_URL": {
+        "description": "BlueBubbles server URL for iMessage integration (e.g. http://192.168.1.10:1234)",
+        "prompt": "BlueBubbles server URL",
+        "url": "https://bluebubbles.app/",
+        "password": False,
+        "category": "messaging",
+    },
+    "BLUEBUBBLES_PASSWORD": {
+        "description": "BlueBubbles server password (from BlueBubbles Server → Settings → API)",
+        "prompt": "BlueBubbles server password",
+        "url": None,
+        "password": True,
+        "category": "messaging",
+    },
+    "BLUEBUBBLES_ALLOWED_USERS": {
+        "description": "Comma-separated iMessage addresses (email or phone) allowed to use the bot",
+        "prompt": "Allowed iMessage addresses (comma-separated)",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+    },
+    "BLUEBUBBLES_ALLOW_ALL_USERS": {
+        "description": "Allow all BlueBubbles users without allowlist",
+        "prompt": "Allow All BlueBubbles Users",
+        "category": "messaging",
+    },
+    "QQ_APP_ID": {
+        "description": "QQ Bot App ID from QQ Open Platform (q.qq.com)",
+        "prompt": "QQ App ID",
+        "url": "https://q.qq.com",
+        "category": "messaging",
+    },
+    "QQ_CLIENT_SECRET": {
+        "description": "QQ Bot Client Secret from QQ Open Platform",
+        "prompt": "QQ Client Secret",
+        "password": True,
+        "category": "messaging",
+    },
+    "QQ_ALLOWED_USERS": {
+        "description": "Comma-separated QQ user IDs allowed to use the bot",
+        "prompt": "QQ Allowed Users",
+        "category": "messaging",
+    },
+    "QQ_GROUP_ALLOWED_USERS": {
+        "description": "Comma-separated QQ group IDs allowed to interact with the bot",
+        "prompt": "QQ Group Allowed Users",
+        "category": "messaging",
+    },
+    "QQ_ALLOW_ALL_USERS": {
+        "description": "Allow all QQ users without an allowlist (true/false)",
+        "prompt": "Allow All QQ Users",
+        "category": "messaging",
+    },
+    "QQBOT_HOME_CHANNEL": {
+        "description": "Default QQ channel/group for cron delivery and notifications",
+        "prompt": "QQ Home Channel",
+        "category": "messaging",
+    },
+    "QQBOT_HOME_CHANNEL_NAME": {
+        "description": "Display name for the QQ home channel",
+        "prompt": "QQ Home Channel Name",
+        "category": "messaging",
+    },
+    "QQ_SANDBOX": {
+        "description": "Enable QQ sandbox mode for development testing (true/false)",
+        "prompt": "QQ Sandbox Mode",
+        "category": "messaging",
+    },
+    "IRC_SERVER": {
+        "description": "IRC server hostname (e.g. irc.libera.chat)",
+        "prompt": "IRC server",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+    },
+    "IRC_CHANNEL": {
+        "description": "IRC channel to join (e.g. #hermes)",
+        "prompt": "IRC channel",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+    },
+    "IRC_NICKNAME": {
+        "description": "Bot nickname on IRC (default: hermes-bot)",
+        "prompt": "IRC nickname",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+    },
+    "IRC_SERVER_PASSWORD": {
+        "description": "IRC server password (if required)",
+        "prompt": "IRC server password",
+        "url": None,
+        "password": True,
+        "category": "messaging",
+        "advanced": True,
+    },
+    "IRC_NICKSERV_PASSWORD": {
+        "description": "NickServ password for nick identification",
+        "prompt": "NickServ password",
+        "url": None,
+        "password": True,
+        "category": "messaging",
+        "advanced": True,
+    },
+    "GATEWAY_ALLOW_ALL_USERS": {
+        "description": "Allow all users to interact with messaging bots (true/false). Default: false.",
+        "prompt": "Allow all users (true/false)",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+        "advanced": True,
+    },
+    "API_SERVER_ENABLED": {
+        "description": "Enable the OpenAI-compatible API server (true/false). Allows frontends like Open WebUI, LobeChat, etc. to connect.",
+        "prompt": "Enable API server (true/false)",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+        "advanced": True,
+    },
+    "API_SERVER_KEY": {
+        "description": "Bearer token for API server authentication. Required whenever the API server is enabled; server refuses to start without it.",
+        "prompt": "API server auth key",
+        "url": None,
+        "password": True,
+        "category": "messaging",
+        "advanced": True,
+    },
+    "API_SERVER_PORT": {
+        "description": "Port for the API server (default: 8642).",
+        "prompt": "API server port",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+        "advanced": True,
+    },
+    "API_SERVER_HOST": {
+        "description": "Host/bind address for the API server (default: 127.0.0.1). API_SERVER_KEY is still required even on loopback binds.",
+        "prompt": "API server host",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+        "advanced": True,
+    },
+    "API_SERVER_MODEL_NAME": {
+        "description": "Model name advertised on /v1/models. Defaults to the profile name (or 'hermes-agent' for the default profile). Useful for multi-user setups with OpenWebUI.",
+        "prompt": "API server model name",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+        "advanced": True,
+    },
+    "GATEWAY_PROXY_URL": {
+        "description": "URL of a remote Hermes API server to forward messages to (proxy mode). When set, the gateway handles platform I/O only — all agent work is delegated to the remote server. Use for Docker E2EE containers that relay to a host agent. Also configurable via gateway.proxy_url in config.yaml.",
+        "prompt": "Remote Hermes API server URL (e.g. http://192.168.1.100:8642)",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+        "advanced": True,
+    },
+    "GATEWAY_PROXY_KEY": {
+        "description": "Bearer token for authenticating with the remote Hermes API server (proxy mode). Must match the API_SERVER_KEY on the remote host.",
+        "prompt": "Remote API server auth key",
+        "url": None,
+        "password": True,
+        "category": "messaging",
+        "advanced": True,
+    },
+    "WEBHOOK_ENABLED": {
+        "description": "Enable the webhook platform adapter for receiving events from GitHub, GitLab, etc.",
+        "prompt": "Enable webhooks (true/false)",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+    },
+    "WEBHOOK_PORT": {
+        "description": "Port for the webhook HTTP server (default: 8644).",
+        "prompt": "Webhook port",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+    },
+    "WEBHOOK_SECRET": {
+        "description": "Global HMAC secret for webhook signature validation (overridable per route in config.yaml).",
+        "prompt": "Webhook secret",
+        "url": None,
+        "password": True,
+        "category": "messaging",
+    },
+
+    # ── Agent settings ──
+    # NOTE: MESSAGING_CWD was removed here — use terminal.cwd in config.yaml
+    # instead.  The gateway reads TERMINAL_CWD (bridged from terminal.cwd).
+    "SUDO_PASSWORD": {
+        "description": "Sudo password for terminal commands requiring root access; set to an explicit empty string to try empty without prompting",
+        "prompt": "Sudo password",
+        "url": None,
+        "password": True,
+        "category": "setting",
+    },
+    # HERMES_TOOL_PROGRESS and HERMES_TOOL_PROGRESS_MODE are deprecated —
+    # now configured via display.tool_progress in config.yaml (off|new|all|verbose).
+    # Gateway falls back to these env vars for backward compatibility.
+    "HERMES_TOOL_PROGRESS": {
+        "description": "(deprecated) Use display.tool_progress in config.yaml instead",
+        "prompt": "Tool progress (deprecated — use config.yaml)",
+        "url": None,
+        "password": False,
+        "category": "setting",
+    },
+    "HERMES_TOOL_PROGRESS_MODE": {
+        "description": "(deprecated) Use display.tool_progress in config.yaml instead",
+        "prompt": "Progress mode (deprecated — use config.yaml)",
+        "url": None,
+        "password": False,
+        "category": "setting",
+    },
+    "HERMES_PREFILL_MESSAGES_FILE": {
+        "description": "Path to JSON file with ephemeral prefill messages for few-shot priming",
+        "prompt": "Prefill messages file path",
+        "url": None,
+        "password": False,
+        "category": "setting",
+    },
+    "HERMES_EPHEMERAL_SYSTEM_PROMPT": {
+        "description": "Ephemeral system prompt injected at API-call time (never persisted to sessions)",
+        "prompt": "Ephemeral system prompt",
+        "url": None,
+        "password": False,
+        "category": "setting",
+    },
+}
+
+# Tool Gateway env vars are always visible — they're useful for
+# self-hosted / custom gateway setups regardless of subscription state.
+
+
+def get_missing_env_vars(required_only: bool = False) -> List[Dict[str, Any]]:
+    """
+    Check which environment variables are missing.
+    
+    Returns list of dicts with var info for missing variables.
+    """
+    missing = []
+    
+    # Check required vars
+    for var_name, info in REQUIRED_ENV_VARS.items():
+        if not get_env_value(var_name):
+            missing.append({"name": var_name, **info, "is_required": True})
+    
+    # Check optional vars (if not required_only)
+    if not required_only:
+        for var_name, info in OPTIONAL_ENV_VARS.items():
+            if not get_env_value(var_name):
+                missing.append({"name": var_name, **info, "is_required": False})
+    
+    return missing
+
+
+def _set_nested(config, dotted_key: str, value):
+    """Set a value at an arbitrarily nested dotted key path.
+
+    Supports both dict and list navigation:
+      _set_nested(c, "a.b.c", 1)     → c["a"]["b"]["c"] = 1
+      _set_nested(c, "a.0.b", 1)     → c["a"][0]["b"] = 1
+      _set_nested(c, "providers.1", "x") → c["providers"][1] = "x"
+
+    Intermediate dicts are created on demand.  List indices are parsed
+    from numeric path segments; the referenced index must already exist
+    (we do not grow lists — the user is navigating into structure they
+    wrote themselves).  If a segment targets a non-container leaf
+    (scalar), the leaf is replaced with a fresh dict so the write can
+    proceed — this preserves the pre-existing behavior for bare scalar
+    overrides (e.g. setting ``a.b.c`` where ``a.b`` was previously a
+    string).
+
+    Guards against #17876: before this fix the code unconditionally
+    replaced any non-dict value (including lists) with ``{}``, silently
+    destroying list-typed config like ``custom_providers`` whenever a
+    caller used an indexed path.
+    """
+    parts = dotted_key.split(".")
+    current = config
+    for part in parts[:-1]:
+        if isinstance(current, list):
+            try:
+                idx = int(part)
+            except (TypeError, ValueError):
+                raise TypeError(
+                    f"Cannot navigate into list at key {dotted_key!r}: "
+                    f"segment {part!r} is not a numeric index"
+                )
+            current = current[idx]
+        elif isinstance(current, dict):
+            existing = current.get(part)
+            # Preserve dicts and lists; replace missing/scalar with a fresh dict.
+            if part not in current or not isinstance(existing, (dict, list)):
+                current[part] = {}
+            current = current[part]
+        else:
+            raise TypeError(
+                f"Cannot navigate into {type(current).__name__} at key {dotted_key!r}"
+            )
+    last = parts[-1]
+    if isinstance(current, list):
+        current[int(last)] = value
+    else:
+        current[last] = value
+
+
+def get_missing_config_fields() -> List[Dict[str, Any]]:
+    """
+    Check which config fields are missing or outdated (recursive).
+    
+    Walks the DEFAULT_CONFIG tree at arbitrary depth and reports any keys
+    present in defaults but absent from the user's loaded config.
+    """
+    config = load_config()
+    missing = []
+
+    def _check(defaults: dict, current: dict, prefix: str = ""):
+        for key, default_value in defaults.items():
+            if key.startswith('_'):
+                continue
+            full_key = key if not prefix else f"{prefix}.{key}"
+            if key not in current:
+                missing.append({
+                    "key": full_key,
+                    "default": default_value,
+                    "description": f"New config option: {full_key}",
+                })
+            elif isinstance(default_value, dict) and isinstance(current.get(key), dict):
+                _check(default_value, current[key], full_key)
+
+    _check(DEFAULT_CONFIG, config)
+    return missing
+
+
+def get_missing_skill_config_vars() -> List[Dict[str, Any]]:
+    """Return skill-declared config vars that are missing or empty in config.yaml.
+
+    Scans all enabled skills for ``metadata.hermes.config`` entries, then checks
+    which ones are absent or empty under ``skills.config.<key>`` in the user's
+    config.yaml.  Returns a list of dicts suitable for prompting.
+    """
+    try:
+        from agent.skill_utils import discover_all_skill_config_vars, SKILL_CONFIG_PREFIX
+    except Exception:
+        return []
+
+    try:
+        all_vars = discover_all_skill_config_vars()
+    except Exception as e:
+        # A malformed SKILL.md, unreadable external skill dir, or similar
+        # should never break `hermes update`.  Skill-config prompting is a
+        # post-migration nicety, not a blocker.
+        import logging
+        logging.getLogger(__name__).debug(
+            "discover_all_skill_config_vars failed: %s", e
+        )
+        return []
+    if not all_vars:
+        return []
+
+    config = load_config()
+    missing: List[Dict[str, Any]] = []
+    for var in all_vars:
+        # Skill config is stored under skills.config.<logical_key>
+        storage_key = f"{SKILL_CONFIG_PREFIX}.{var['key']}"
+        parts = storage_key.split(".")
+        current = config
+        value = None
+        for part in parts:
+            if isinstance(current, dict) and part in current:
+                current = current[part]
+                value = current
+            else:
+                value = None
+                break
+        # Missing = key doesn't exist or is empty string
+        if value is None or (isinstance(value, str) and not value.strip()):
+            missing.append(var)
+    return missing
+
+
+def _normalize_custom_provider_entry(
+    entry: Any,
+    *,
+    provider_key: str = "",
+) -> Optional[Dict[str, Any]]:
+    """Return a runtime-compatible custom provider entry or ``None``."""
+    if not isinstance(entry, dict):
+        return None
+
+    # Accept camelCase aliases commonly used in hand-written configs.
+    _CAMEL_ALIASES: Dict[str, str] = {
+        "apiKey": "api_key",
+        "baseUrl": "base_url",
+        "apiMode": "api_mode",
+        "keyEnv": "key_env",
+        "apiKeyEnv": "key_env",  # alias — OpenClaw-compatible + docs variant
+        "defaultModel": "default_model",
+        "contextLength": "context_length",
+        "rateLimitDelay": "rate_limit_delay",
+    }
+    # api_key_env is a documented snake_case alias for key_env (see
+    # website/docs/guides/azure-foundry.md).  Normalize it up front so the
+    # rest of the normalizer treats it as the canonical field.
+    if "api_key_env" in entry and "key_env" not in entry:
+        entry["key_env"] = entry["api_key_env"]
+    _KNOWN_KEYS = {
+        "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
+        "api_mode", "transport", "model", "default_model", "models",
+        "context_length", "rate_limit_delay",
+        "request_timeout_seconds", "stale_timeout_seconds",
+        "discover_models", "extra_body",
+    }
+    for camel, snake in _CAMEL_ALIASES.items():
+        if camel in entry and snake not in entry:
+            logger.warning(
+                "providers.%s: camelCase key '%s' auto-mapped to '%s' "
+                "(use snake_case to avoid this warning)",
+                provider_key or "?", camel, snake,
+            )
+            entry[snake] = entry[camel]
+    unknown = set(entry.keys()) - _KNOWN_KEYS - set(_CAMEL_ALIASES.keys())
+    if unknown:
+        logger.warning(
+            "providers.%s: unknown config keys ignored: %s",
+            provider_key or "?", ", ".join(sorted(unknown)),
+        )
+
+    from urllib.parse import urlparse
+
+    base_url = ""
+    for url_key in ("base_url", "url", "api"):
+        raw_url = entry.get(url_key)
+        if isinstance(raw_url, str) and raw_url.strip():
+            candidate = raw_url.strip()
+            parsed = urlparse(candidate)
+            if parsed.scheme and parsed.netloc:
+                base_url = candidate
+                break
+            else:
+                logger.warning(
+                    "providers.%s: '%s' value '%s' is not a valid URL "
+                    "(no scheme or host) — skipped",
+                    provider_key or "?", url_key, candidate,
+                )
+    if not base_url:
+        return None
+
+    name = ""
+    raw_name = entry.get("name")
+    if isinstance(raw_name, str) and raw_name.strip():
+        name = raw_name.strip()
+    elif provider_key.strip():
+        name = provider_key.strip()
+    if not name:
+        return None
+
+    normalized: Dict[str, Any] = {
+        "name": name,
+        "base_url": base_url,
+    }
+
+    provider_key = provider_key.strip()
+    if provider_key:
+        normalized["provider_key"] = provider_key
+
+    api_key = entry.get("api_key")
+    if isinstance(api_key, str) and api_key.strip():
+        normalized["api_key"] = api_key.strip()
+
+    key_env = entry.get("key_env")
+    if isinstance(key_env, str) and key_env.strip():
+        normalized["key_env"] = key_env.strip()
+
+    api_mode = entry.get("api_mode") or entry.get("transport")
+    if isinstance(api_mode, str) and api_mode.strip():
+        normalized["api_mode"] = api_mode.strip()
+
+    model_name = entry.get("model") or entry.get("default_model")
+    if isinstance(model_name, str) and model_name.strip():
+        normalized["model"] = model_name.strip()
+
+    models = entry.get("models")
+    if isinstance(models, dict) and models:
+        normalized["models"] = models
+    elif isinstance(models, list) and models:
+        # Hand-edited configs (and older Hermes versions) write ``models`` as
+        # a plain list of model ids. Preserve them by converting to the dict
+        # shape downstream code expects; otherwise normalize silently drops
+        # the list and /model shows the provider with (0) models.
+        normalized["models"] = {
+            str(m): {} for m in models if isinstance(m, str) and m.strip()
+        }
+
+    context_length = entry.get("context_length")
+    if isinstance(context_length, int) and context_length > 0:
+        normalized["context_length"] = context_length
+
+    rate_limit_delay = entry.get("rate_limit_delay")
+    if isinstance(rate_limit_delay, (int, float)) and rate_limit_delay >= 0:
+        normalized["rate_limit_delay"] = rate_limit_delay
+
+    discover_models = entry.get("discover_models")
+    if isinstance(discover_models, bool):
+        normalized["discover_models"] = discover_models
+
+    extra_body = entry.get("extra_body")
+    if isinstance(extra_body, dict):
+        normalized["extra_body"] = dict(extra_body)
+
+    return normalized
+
+
+def _custom_provider_entry_to_provider_config(
+    entry: Any,
+    *,
+    provider_key: str = "",
+) -> Optional[Dict[str, Any]]:
+    """Translate a legacy custom provider entry to the v12 providers shape."""
+    normalized = _normalize_custom_provider_entry(
+        dict(entry) if isinstance(entry, dict) else entry,
+        provider_key=provider_key,
+    )
+    if normalized is None:
+        return None
+
+    provider_entry: Dict[str, Any] = {"api": normalized["base_url"]}
+
+    for field in (
+        "name",
+        "api_key",
+        "key_env",
+        "models",
+        "context_length",
+        "rate_limit_delay",
+        "discover_models",
+        "extra_body",
+    ):
+        if field in normalized:
+            provider_entry[field] = normalized[field]
+
+    if "model" in normalized:
+        provider_entry["default_model"] = normalized["model"]
+    if "api_mode" in normalized:
+        provider_entry["transport"] = normalized["api_mode"]
+
+    return provider_entry
+
+
+def providers_dict_to_custom_providers(providers_dict: Any) -> List[Dict[str, Any]]:
+    """Normalize ``providers`` config entries into the legacy custom-provider shape."""
+    if not isinstance(providers_dict, dict):
+        return []
+
+    custom_providers: List[Dict[str, Any]] = []
+    for key, entry in providers_dict.items():
+        normalized = _normalize_custom_provider_entry(entry, provider_key=str(key))
+        if normalized is not None:
+            custom_providers.append(normalized)
+
+    return custom_providers
+
+
+def get_compatible_custom_providers(
+    config: Optional[Dict[str, Any]] = None,
+) -> List[Dict[str, Any]]:
+    """Return a deduplicated custom-provider view across legacy and v12+ config.
+
+    ``custom_providers`` remains the on-disk legacy format, while ``providers``
+    is the newer keyed schema.  Runtime and picker flows still need a single
+    list-shaped view, but we should not materialise that compatibility layer
+    back into config.yaml because it duplicates entries in UIs.
+    """
+    if config is None:
+        config = load_config()
+
+    compatible: List[Dict[str, Any]] = []
+    seen_provider_keys: set = set()
+    seen_name_url_pairs: set = set()
+
+    def _append_if_new(entry: Optional[Dict[str, Any]]) -> None:
+        if entry is None:
+            return
+        provider_key = str(entry.get("provider_key", "") or "").strip().lower()
+        name = str(entry.get("name", "") or "").strip().lower()
+        base_url = str(entry.get("base_url", "") or "").strip().rstrip("/").lower()
+        model = str(entry.get("model", "") or "").strip().lower()
+        pair = (name, base_url, model)
+
+        if provider_key and provider_key in seen_provider_keys:
+            return
+        if name and base_url and pair in seen_name_url_pairs:
+            return
+
+        compatible.append(entry)
+        if provider_key:
+            seen_provider_keys.add(provider_key)
+        if name and base_url:
+            seen_name_url_pairs.add(pair)
+
+    custom_providers = config.get("custom_providers")
+    if custom_providers is not None:
+        if not isinstance(custom_providers, list):
+            return []
+        for entry in custom_providers:
+            _append_if_new(_normalize_custom_provider_entry(entry))
+
+    for entry in providers_dict_to_custom_providers(config.get("providers")):
+        _append_if_new(entry)
+
+    return compatible
+
+
+def get_custom_provider_context_length(
+    model: str,
+    base_url: str,
+    custom_providers: Optional[List[Dict[str, Any]]] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> Optional[int]:
+    """Look up a per-model ``context_length`` override from ``custom_providers``.
+
+    Matches any entry whose ``base_url`` equals ``base_url`` (trailing-slash
+    insensitive) and returns ``custom_providers[i].models.<model>.context_length``
+    if present and valid.  Returns ``None`` when no override applies.
+
+    This is the single source of truth for custom-provider context overrides,
+    used by:
+      * ``AIAgent.__init__`` (startup resolution)
+      * ``AIAgent.switch_model`` (mid-session ``/model`` switch)
+      * ``hermes_cli.model_switch.resolve_display_context_length`` (``/model`` confirmation display)
+      * ``gateway.run._format_session_info`` (``/info`` display)
+      * ``agent.model_metadata.get_model_context_length`` (when custom_providers is threaded through)
+
+    Before this helper existed, the lookup was duplicated in ``run_agent.py``'s
+    startup path only; every other path (notably ``/model`` switch) fell back
+    to the 128K default.  See #15779.
+    """
+    if not model or not base_url:
+        return None
+    if custom_providers is None:
+        try:
+            custom_providers = get_compatible_custom_providers(config)
+        except Exception:
+            if config is None:
+                return None
+            raw = config.get("custom_providers")
+            custom_providers = raw if isinstance(raw, list) else []
+    if not isinstance(custom_providers, list):
+        return None
+
+    target_url = (base_url or "").rstrip("/")
+    if not target_url:
+        return None
+
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+        entry_url = (entry.get("base_url") or "").rstrip("/")
+        if not entry_url or entry_url != target_url:
+            continue
+        models = entry.get("models")
+        if not isinstance(models, dict):
+            continue
+        model_cfg = models.get(model)
+        if not isinstance(model_cfg, dict):
+            continue
+        raw_ctx = model_cfg.get("context_length")
+        if raw_ctx is None:
+            continue
+        try:
+            ctx = int(raw_ctx)
+        except (TypeError, ValueError):
+            continue
+        if ctx > 0:
+            return ctx
+    return None
+
+
+def _coerce_config_version(value: Any) -> int:
+    """Return a safe integer config version, treating invalid values as legacy."""
+    if isinstance(value, bool):
+        return 0
+    try:
+        version = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return max(version, 0)
+
+
+def check_config_version() -> Tuple[int, int]:
+    """
+    Check the raw on-disk config schema version.
+
+    ``load_config()`` deliberately starts from ``DEFAULT_CONFIG`` and deep-merges
+    the user's file, which is correct for runtime reads but wrong for deciding
+    whether the user's persisted schema has been migrated. A config file with no
+    raw ``_config_version`` must remain visible as legacy instead of inheriting
+    the latest default version in memory.
+
+    Returns (current_version, latest_version).
+    """
+    latest = _coerce_config_version(DEFAULT_CONFIG.get("_config_version", 1)) or 1
+    config_path = get_config_path()
+    if not config_path.exists():
+        return latest, latest
+
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            config = yaml.safe_load(f) or {}
+    except Exception as e:
+        # Invalid YAML needs a parse warning, not an automatic schema rewrite
+        # that could replace the user's broken file with defaults.
+        _warn_config_parse_failure(config_path, e)
+        return latest, latest
+
+    if not isinstance(config, dict):
+        config = {}
+    current = _coerce_config_version(config.get("_config_version"))
+    return current, latest
+
+
+# =============================================================================
+# Config structure validation
+# =============================================================================
+
+# Fields that are valid at root level of config.yaml
+_KNOWN_ROOT_KEYS = {
+    "_config_version", "model", "providers", "fallback_model",
+    "fallback_providers", "credential_pool_strategies", "toolsets",
+    "agent", "terminal", "display", "compression", "delegation",
+    "auxiliary", "custom_providers", "context", "memory", "gateway",
+    "sessions", "streaming", "updates",
+}
+
+# Valid fields inside a custom_providers list entry
+_VALID_CUSTOM_PROVIDER_FIELDS = {
+    "name", "base_url", "api_key", "api_mode", "model", "models",
+    "context_length", "rate_limit_delay", "extra_body",
+    # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
+    # — include it here so the set accurately describes the supported schema.
+    "key_env",
+}
+
+# Fields that look like they should be inside custom_providers, not at root
+_CUSTOM_PROVIDER_LIKE_FIELDS = {"base_url", "api_key", "rate_limit_delay", "api_mode"}
+
+
+@dataclass
+class ConfigIssue:
+    """A detected config structure problem."""
+
+    severity: str  # "error", "warning"
+    message: str
+    hint: str
+
+
+def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["ConfigIssue"]:
+    """Validate config.yaml structure and return a list of detected issues.
+
+    Catches common YAML formatting mistakes that produce confusing runtime
+    errors (like "Unknown provider") instead of clear diagnostics.
+
+    Can be called with a pre-loaded config dict, or will load from disk.
+    """
+    if config is None:
+        try:
+            config = load_config()
+        except Exception:
+            return [ConfigIssue("error", "Could not load config.yaml", "Run 'hermes setup' to create a valid config")]
+
+    issues: List[ConfigIssue] = []
+
+    # ── custom_providers must be a list, not a dict ──────────────────────
+    cp = config.get("custom_providers")
+    if cp is not None:
+        if isinstance(cp, dict):
+            issues.append(ConfigIssue(
+                "error",
+                "custom_providers is a dict — it must be a YAML list (items prefixed with '-')",
+                "Change to:\n"
+                "  custom_providers:\n"
+                "    - name: my-provider\n"
+                "      base_url: https://...\n"
+                "      api_key: ...",
+            ))
+            # Check if dict keys look like they should be list-entry fields
+            cp_keys = set(cp.keys()) if isinstance(cp, dict) else set()
+            suspicious = cp_keys & _CUSTOM_PROVIDER_LIKE_FIELDS
+            if suspicious:
+                issues.append(ConfigIssue(
+                    "warning",
+                    f"Root-level keys {sorted(suspicious)} look like custom_providers entry fields",
+                    "These should be indented under a '- name: ...' list entry, not at root level",
+                ))
+        elif isinstance(cp, list):
+            # Validate each entry in the list
+            for i, entry in enumerate(cp):
+                if not isinstance(entry, dict):
+                    issues.append(ConfigIssue(
+                        "warning",
+                        f"custom_providers[{i}] is not a dict (got {type(entry).__name__})",
+                        "Each entry should have at minimum: name, base_url",
+                    ))
+                    continue
+                if not entry.get("name"):
+                    issues.append(ConfigIssue(
+                        "warning",
+                        f"custom_providers[{i}] is missing 'name' field",
+                        "Add a name, e.g.: name: my-provider",
+                    ))
+                if not entry.get("base_url"):
+                    issues.append(ConfigIssue(
+                        "warning",
+                        f"custom_providers[{i}] is missing 'base_url' field",
+                        "Add the API endpoint URL, e.g.: base_url: https://api.example.com/v1",
+                    ))
+
+    # ── fallback_model: single dict OR list of dicts (chain) ─────────────
+    fb = config.get("fallback_model")
+    if fb is not None:
+        if isinstance(fb, list):
+            # Chain fallback — validate each entry
+            for i, entry in enumerate(fb):
+                if not isinstance(entry, dict):
+                    issues.append(ConfigIssue(
+                        "error",
+                        f"fallback_model[{i}] should be a dict, got {type(entry).__name__}",
+                        "Each entry needs provider + model",
+                    ))
+                else:
+                    if not entry.get("provider"):
+                        issues.append(ConfigIssue(
+                            "warning",
+                            f"fallback_model[{i}] is missing 'provider' field",
+                            "Add: provider: openrouter (or another provider)",
+                        ))
+                    if not entry.get("model"):
+                        issues.append(ConfigIssue(
+                            "warning",
+                            f"fallback_model[{i}] is missing 'model' field",
+                            "Add: model: <model-name>",
+                        ))
+        elif not isinstance(fb, dict):
+            issues.append(ConfigIssue(
+                "error",
+                f"fallback_model should be a dict with 'provider' and 'model', got {type(fb).__name__}",
+                "Change to:\n"
+                "  fallback_model:\n"
+                "    provider: openrouter\n"
+                "    model: anthropic/claude-sonnet-4",
+            ))
+        elif fb:
+            if not fb.get("provider"):
+                issues.append(ConfigIssue(
+                    "warning",
+                    "fallback_model is missing 'provider' field — fallback will be disabled",
+                    "Add: provider: openrouter (or another provider)",
+                ))
+            if not fb.get("model"):
+                issues.append(ConfigIssue(
+                    "warning",
+                    "fallback_model is missing 'model' field — fallback will be disabled",
+                    "Add: model: anthropic/claude-sonnet-4 (or another model)",
+                ))
+
+    # ── Check for fallback_model accidentally nested inside custom_providers ──
+    if isinstance(cp, dict) and "fallback_model" not in config and "fallback_model" in (cp or {}):
+        issues.append(ConfigIssue(
+            "error",
+            "fallback_model appears inside custom_providers instead of at root level",
+            "Move fallback_model to the top level of config.yaml (no indentation)",
+        ))
+
+    # ── model section: should exist when custom_providers is configured ──
+    model_cfg = config.get("model")
+    if cp and not model_cfg:
+        issues.append(ConfigIssue(
+            "warning",
+            "custom_providers defined but no 'model' section — Hermes won't know which provider to use",
+            "Add a model section:\n"
+            "  model:\n"
+            "    provider: custom\n"
+            "    default: your-model-name\n"
+            "    base_url: https://...",
+        ))
+
+    # ── Root-level keys that look misplaced ──────────────────────────────
+    for key in config:
+        if key.startswith("_"):
+            continue
+        if key not in _KNOWN_ROOT_KEYS and key in _CUSTOM_PROVIDER_LIKE_FIELDS:
+            issues.append(ConfigIssue(
+                "warning",
+                f"Root-level key '{key}' looks misplaced — should it be under 'model:' or inside a 'custom_providers' entry?",
+                f"Move '{key}' under the appropriate section",
+            ))
+
+    return issues
+
+
+def print_config_warnings(config: Optional[Dict[str, Any]] = None) -> None:
+    """Print config structure warnings to stderr at startup.
+
+    Called early in CLI and gateway init so users see problems before
+    they hit cryptic "Unknown provider" errors.  Prints nothing if
+    config is healthy.
+    """
+    try:
+        issues = validate_config_structure(config)
+    except Exception:
+        return
+    if not issues:
+        return
+
+    lines = ["\033[33m⚠ Config issues detected in config.yaml:\033[0m"]
+    for ci in issues:
+        marker = "\033[31m✗\033[0m" if ci.severity == "error" else "\033[33m⚠\033[0m"
+        lines.append(f"  {marker} {ci.message}")
+    lines.append("  \033[2mRun 'hermes doctor' for fix suggestions.\033[0m")
+    sys.stderr.write("\n".join(lines) + "\n\n")
+
+
+def warn_deprecated_cwd_env_vars(config: Optional[Dict[str, Any]] = None) -> None:
+    """Warn if MESSAGING_CWD or TERMINAL_CWD is set in .env instead of config.yaml.
+
+    These env vars are deprecated — the canonical setting is terminal.cwd
+    in config.yaml.  Prints a migration hint to stderr.
+    """
+    messaging_cwd = os.environ.get("MESSAGING_CWD")
+    terminal_cwd_env = os.environ.get("TERMINAL_CWD")
+
+    if config is None:
+        try:
+            config = load_config()
+        except Exception:
+            return
+
+    terminal_cfg = config.get("terminal", {})
+    config_cwd = terminal_cfg.get("cwd", ".") if isinstance(terminal_cfg, dict) else "."
+    # Only warn if config.yaml doesn't have an explicit path
+    config_has_explicit_cwd = config_cwd not in {".", "auto", "cwd", ""}
+
+    lines: list[str] = []
+    if messaging_cwd:
+        lines.append(
+            f"  \033[33m⚠\033[0m MESSAGING_CWD={messaging_cwd} found in .env — "
+            f"this is deprecated."
+        )
+    if terminal_cwd_env and not config_has_explicit_cwd:
+        # TERMINAL_CWD in env but not from config bridge — likely from .env
+        lines.append(
+            f"  \033[33m⚠\033[0m TERMINAL_CWD={terminal_cwd_env} found in .env — "
+            f"this is deprecated."
+        )
+    if lines:
+        hint_path = os.environ.get("HERMES_HOME", "~/.hermes")
+        lines.insert(0, "\033[33m⚠ Deprecated .env settings detected:\033[0m")
+        lines.append(
+            f"  \033[2mMove to config.yaml instead:  "
+            f"terminal:\\n    cwd: /your/project/path\033[0m"
+        )
+        lines.append(
+            f"  \033[2mThen remove the old entries from {hint_path}/.env\033[0m"
+        )
+        sys.stderr.write("\n".join(lines) + "\n\n")
+
+
+def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, Any]:
+    """
+    Migrate config to latest version, prompting for new required fields.
+    
+    Args:
+        interactive: If True, prompt user for missing values
+        quiet: If True, suppress output
+        
+    Returns:
+        Dict with migration results: {"env_added": [...], "config_added": [...], "warnings": [...]}
+    """
+    results = {"env_added": [], "config_added": [], "warnings": []}
+
+    # ── Always: sanitize .env (split concatenated keys) ──
+    try:
+        fixes = sanitize_env_file()
+        if fixes and not quiet:
+            print(f"  ✓ Repaired .env file ({fixes} corrupted entries fixed)")
+    except Exception:
+        pass  # best-effort; don't block migration on sanitize failure
+
+    # Check config version
+    current_ver, latest_ver = check_config_version()
+    
+    # ── Version 3 → 4: migrate tool progress from .env to config.yaml ──
+    if current_ver < 4:
+        config = load_config()
+        display = config.get("display", {})
+        if not isinstance(display, dict):
+            display = {}
+        if "tool_progress" not in display:
+            old_enabled = get_env_value("HERMES_TOOL_PROGRESS")
+            old_mode = get_env_value("HERMES_TOOL_PROGRESS_MODE")
+            if old_enabled and old_enabled.lower() in {"false", "0", "no"}:
+                display["tool_progress"] = "off"
+                results["config_added"].append("display.tool_progress=off (from HERMES_TOOL_PROGRESS=false)")
+            elif old_mode and old_mode.lower() in {"new", "all"}:
+                display["tool_progress"] = old_mode.lower()
+                results["config_added"].append(f"display.tool_progress={old_mode.lower()} (from HERMES_TOOL_PROGRESS_MODE)")
+            else:
+                display["tool_progress"] = "all"
+                results["config_added"].append("display.tool_progress=all (default)")
+            config["display"] = display
+            save_config(config)
+            if not quiet:
+                print(f"  ✓ Migrated tool progress to config.yaml: {display['tool_progress']}")
+    
+    # ── Version 4 → 5: add timezone field ──
+    if current_ver < 5:
+        config = load_config()
+        if "timezone" not in config:
+            old_tz = os.getenv("HERMES_TIMEZONE", "")
+            if old_tz and old_tz.strip():
+                config["timezone"] = old_tz.strip()
+                results["config_added"].append(f"timezone={old_tz.strip()} (from HERMES_TIMEZONE)")
+            else:
+                config["timezone"] = ""
+                results["config_added"].append("timezone= (empty, uses server-local)")
+            save_config(config)
+            if not quiet:
+                tz_display = config["timezone"] or "(server-local)"
+                print(f"  ✓ Added timezone to config.yaml: {tz_display}")
+
+    # ── Version 8 → 9: clear ANTHROPIC_TOKEN from .env ──
+    # The new Anthropic auth flow no longer uses this env var.
+    if current_ver < 9:
+        try:
+            old_token = get_env_value("ANTHROPIC_TOKEN")
+            if old_token:
+                save_env_value("ANTHROPIC_TOKEN", "")
+                if not quiet:
+                    print("  ✓ Cleared ANTHROPIC_TOKEN from .env (no longer used)")
+        except Exception:
+            pass
+
+    # ── Version 11 → 12: migrate custom_providers list → providers dict ──
+    if current_ver < 12:
+        config = load_config()
+        custom_list = config.get("custom_providers")
+        if isinstance(custom_list, list) and custom_list:
+            providers_dict = config.get("providers", {})
+            if not isinstance(providers_dict, dict):
+                providers_dict = {}
+            migrated_count = 0
+            for entry in custom_list:
+                if not isinstance(entry, dict):
+                    continue
+                old_name = entry.get("name", "")
+                old_url = entry.get("base_url", "") or entry.get("url", "") or entry.get("api", "") or ""
+                if not old_url:
+                    continue  # skip entries with no URL
+
+                # Generate a kebab-case key from the display name
+                key = old_name.strip().lower().replace(" ", "-").replace("(", "").replace(")", "")
+                # Remove consecutive hyphens and trailing hyphens
+                while "--" in key:
+                    key = key.replace("--", "-")
+                key = key.strip("-")
+                if not key:
+                    # Fallback: derive from URL hostname
+                    try:
+                        from urllib.parse import urlparse
+                        parsed = urlparse(old_url)
+                        key = (parsed.hostname or "endpoint").replace(".", "-")
+                    except Exception:
+                        key = f"endpoint-{migrated_count}"
+
+                # Don't overwrite existing entries
+                base_key = key
+                suffix = migrated_count
+                while key in providers_dict:
+                    key = f"{base_key}-{suffix}"
+                    suffix += 1
+
+                new_entry = _custom_provider_entry_to_provider_config(
+                    entry,
+                    provider_key=key,
+                )
+                if new_entry is None:
+                    continue
+                if not old_name:
+                    new_entry.pop("name", None)
+                if new_entry.get("api_key") in {"no-key", "no-key-required", ""}:
+                    new_entry.pop("api_key", None)
+
+                providers_dict[key] = new_entry
+                migrated_count += 1
+
+            if migrated_count > 0:
+                config["providers"] = providers_dict
+                # Remove the old list — runtime reads via get_compatible_custom_providers()
+                config.pop("custom_providers", None)
+                save_config(config)
+                if not quiet:
+                    print(f"  ✓ Migrated {migrated_count} custom provider(s) to providers: section")
+                    for key in list(providers_dict.keys())[-migrated_count:]:
+                        ep = providers_dict[key]
+                        print(f"    → {key}: {ep.get('api', '')}")
+
+    # ── Version 12 → 13: clear dead LLM_MODEL / OPENAI_MODEL from .env ──
+    # These env vars were written by the old setup wizard but nothing reads
+    # them anymore (config.yaml is the sole source of truth since March 2026).
+    # Stale entries cause user confusion — see issue report.
+    if current_ver < 13:
+        for dead_var in ("LLM_MODEL", "OPENAI_MODEL"):
+            try:
+                old_val = get_env_value(dead_var)
+                if old_val:
+                    save_env_value(dead_var, "")
+                    if not quiet:
+                        print(f"  ✓ Cleared {dead_var} from .env (no longer used — config.yaml is source of truth)")
+            except Exception:
+                pass
+
+    # ── Version 13 → 14: migrate legacy flat stt.model to provider section ──
+    # Old configs (and cli-config.yaml.example) had a flat `stt.model` key
+    # that was provider-agnostic.  When the provider was "local" this caused
+    # OpenAI model names (e.g. "whisper-1") to be fed to faster-whisper,
+    # crashing with "Invalid model size".  Move the value into the correct
+    # provider-specific section and remove the flat key.
+    if current_ver < 14:
+        # Read raw config (no defaults merged) to check what the user actually
+        # wrote, then apply changes to the merged config for saving.
+        raw = read_raw_config()
+        raw_stt = raw.get("stt", {})
+        if isinstance(raw_stt, dict) and "model" in raw_stt:
+            legacy_model = raw_stt["model"]
+            provider = raw_stt.get("provider", "local")
+            config = load_config()
+            stt = config.get("stt", {})
+            # Remove the legacy flat key
+            stt.pop("model", None)
+            # Place it in the appropriate provider section only if the
+            # user didn't already set a model there
+            if provider in {"local", "local_command"}:
+                # Don't migrate an OpenAI model name into the local section
+                _local_models = {
+                    "tiny.en", "tiny", "base.en", "base", "small.en", "small",
+                    "medium.en", "medium", "large-v1", "large-v2", "large-v3",
+                    "large", "distil-large-v2", "distil-medium.en",
+                    "distil-small.en", "distil-large-v3", "distil-large-v3.5",
+                    "large-v3-turbo", "turbo",
+                }
+                if legacy_model in _local_models:
+                    # Check raw config — only set if user didn't already
+                    # have a nested local.model
+                    raw_local = raw_stt.get("local", {})
+                    if not isinstance(raw_local, dict) or "model" not in raw_local:
+                        local_cfg = stt.setdefault("local", {})
+                        local_cfg["model"] = legacy_model
+                # else: drop it — it was an OpenAI model name, local section
+                # already defaults to "base" via DEFAULT_CONFIG
+            else:
+                # Cloud provider — put it in that provider's section only
+                # if user didn't already set a nested model
+                raw_provider = raw_stt.get(provider, {})
+                if not isinstance(raw_provider, dict) or "model" not in raw_provider:
+                    provider_cfg = stt.setdefault(provider, {})
+                    provider_cfg["model"] = legacy_model
+            config["stt"] = stt
+            save_config(config)
+            if not quiet:
+                print(f"  ✓ Migrated legacy stt.model to provider-specific config")
+
+    # ── Version 14 → 15: add explicit gateway interim-message gate ──
+    if current_ver < 15:
+        config = read_raw_config()
+        display = config.get("display", {})
+        if not isinstance(display, dict):
+            display = {}
+        if "interim_assistant_messages" not in display:
+            display["interim_assistant_messages"] = True
+            config["display"] = display
+            results["config_added"].append("display.interim_assistant_messages=true (default)")
+            save_config(config)
+            if not quiet:
+                print("  ✓ Added display.interim_assistant_messages=true")
+
+    # ── Version 15 → 16: migrate tool_progress_overrides into display.platforms ──
+    if current_ver < 16:
+        config = read_raw_config()
+        display = config.get("display", {})
+        if not isinstance(display, dict):
+            display = {}
+        old_overrides = display.get("tool_progress_overrides")
+        if isinstance(old_overrides, dict) and old_overrides:
+            platforms = display.get("platforms", {})
+            if not isinstance(platforms, dict):
+                platforms = {}
+            for plat, mode in old_overrides.items():
+                if plat not in platforms:
+                    platforms[plat] = {}
+                if "tool_progress" not in platforms[plat]:
+                    platforms[plat]["tool_progress"] = mode
+            display["platforms"] = platforms
+            config["display"] = display
+            save_config(config)
+            if not quiet:
+                migrated = ", ".join(f"{p}={m}" for p, m in old_overrides.items())
+                print(f"  ✓ Migrated tool_progress_overrides → display.platforms: {migrated}")
+            results["config_added"].append("display.platforms (migrated from tool_progress_overrides)")
+
+    # ── Version 16 → 17: remove legacy compression.summary_* keys ──
+    if current_ver < 17:
+        config = read_raw_config()
+        comp = config.get("compression", {})
+        if isinstance(comp, dict):
+            s_model = comp.pop("summary_model", None)
+            s_provider = comp.pop("summary_provider", None)
+            s_base_url = comp.pop("summary_base_url", None)
+            migrated_keys = []
+            # Migrate non-empty, non-default values to auxiliary.compression
+            if s_model and str(s_model).strip():
+                aux = config.setdefault("auxiliary", {})
+                aux_comp = aux.setdefault("compression", {})
+                if not aux_comp.get("model"):
+                    aux_comp["model"] = str(s_model).strip()
+                    migrated_keys.append(f"model={s_model}")
+            if s_provider and str(s_provider).strip() not in {"", "auto"}:
+                aux = config.setdefault("auxiliary", {})
+                aux_comp = aux.setdefault("compression", {})
+                if not aux_comp.get("provider") or aux_comp.get("provider") == "auto":
+                    aux_comp["provider"] = str(s_provider).strip()
+                    migrated_keys.append(f"provider={s_provider}")
+            if s_base_url and str(s_base_url).strip():
+                aux = config.setdefault("auxiliary", {})
+                aux_comp = aux.setdefault("compression", {})
+                if not aux_comp.get("base_url"):
+                    aux_comp["base_url"] = str(s_base_url).strip()
+                    migrated_keys.append(f"base_url={s_base_url}")
+            if migrated_keys or s_model is not None or s_provider is not None or s_base_url is not None:
+                config["compression"] = comp
+                save_config(config)
+                if not quiet:
+                    if migrated_keys:
+                        print(f"  ✓ Migrated compression.summary_* → auxiliary.compression: {', '.join(migrated_keys)}")
+                    else:
+                        print("  ✓ Removed unused compression.summary_* keys")
+
+    # ── Version 20 → 21: plugins are now opt-in; grandfather existing user plugins ──
+    # The loader now requires plugins to appear in ``plugins.enabled`` before
+    # loading. Existing installs had all discovered plugins loading by default
+    # (minus anything in ``plugins.disabled``). To avoid silently breaking
+    # those setups on upgrade, populate ``plugins.enabled`` with the set of
+    # currently-installed user plugins that aren't already disabled.
+    #
+    # Bundled plugins (shipped in the repo itself) are NOT grandfathered —
+    # they ship off for everyone, including existing users, so any user who
+    # wants one has to opt in explicitly.
+    if current_ver < 21:
+        config = read_raw_config()
+        plugins_cfg = config.get("plugins")
+        if not isinstance(plugins_cfg, dict):
+            plugins_cfg = {}
+        # Only migrate if the enabled allow-list hasn't been set yet.
+        if "enabled" not in plugins_cfg:
+            disabled = plugins_cfg.get("disabled", []) or []
+            if not isinstance(disabled, list):
+                disabled = []
+            disabled_set = set(disabled)
+
+            # Scan ``$HERMES_HOME/plugins/`` for currently installed user plugins.
+            grandfathered: List[str] = []
+            try:
+                user_plugins_dir = get_hermes_home() / "plugins"
+                if user_plugins_dir.is_dir():
+                    for child in sorted(user_plugins_dir.iterdir()):
+                        if not child.is_dir():
+                            continue
+                        manifest_file = child / "plugin.yaml"
+                        if not manifest_file.exists():
+                            manifest_file = child / "plugin.yml"
+                        if not manifest_file.exists():
+                            continue
+                        try:
+                            with open(manifest_file, encoding="utf-8") as _mf:
+                                manifest = yaml.safe_load(_mf) or {}
+                        except Exception:
+                            manifest = {}
+                        name = manifest.get("name") or child.name
+                        if name in disabled_set:
+                            continue
+                        grandfathered.append(name)
+            except Exception:
+                grandfathered = []
+
+            plugins_cfg["enabled"] = grandfathered
+            config["plugins"] = plugins_cfg
+            save_config(config)
+            results["config_added"].append(
+                f"plugins.enabled (opt-in allow-list, {len(grandfathered)} grandfathered)"
+            )
+            if not quiet:
+                if grandfathered:
+                    print(
+                        f"  ✓ Plugins now opt-in: grandfathered "
+                        f"{len(grandfathered)} existing plugin(s) into plugins.enabled"
+                    )
+                else:
+                    print(
+                        "  ✓ Plugins now opt-in: no existing plugins to grandfather. "
+                        "Use `hermes plugins enable <name>` to activate."
+                    )
+
+    # ── Version 22 → 23: seed curator defaults + create logs/curator/ ──
+    # The curator (background skill maintenance) was added in PR #16049, but
+    # existing configs from before that PR (or before the April 2026
+    # unification under `auxiliary.curator`) never wrote the curator section
+    # to disk. The runtime deep-merge in `load_config()` fills defaults at
+    # read time, so the curator *functions*; but users can't see/edit the
+    # settings in their `config.yaml`, and `hermes curator status` has no
+    # stable logs dir to point at until the first run mkdir's it.
+    #
+    # This migration:
+    #   1. Writes the `curator` top-level section to config.yaml (enabled,
+    #      interval_hours, min_idle_hours, stale_after_days, archive_after_days)
+    #      — only keys the user hasn't already overridden.
+    #   2. Writes the `auxiliary.curator` aux-task slot (provider, model,
+    #      base_url, api_key, timeout, extra_body) — canonical slot for
+    #      routing the curator fork to a cheaper aux model.
+    #   3. Creates `~/.hermes/logs/curator/` if missing (belt-and-suspenders
+    #      on top of ensure_hermes_home() — old profiles that predate this
+    #      migration still benefit).
+    if current_ver < 23:
+        try:
+            curator_dir = get_hermes_home() / "logs" / "curator"
+            curator_dir.mkdir(parents=True, exist_ok=True)
+        except Exception as e:
+            results["warnings"].append(f"Could not create {curator_dir}: {e}")
+
+        config = read_raw_config()
+        touched = False
+
+        # (1) Top-level curator section — only add missing keys
+        _curator_defaults = DEFAULT_CONFIG.get("curator", {})
+        raw_curator = config.get("curator")
+        if not isinstance(raw_curator, dict):
+            raw_curator = {}
+        added_curator: List[str] = []
+        for k, v in _curator_defaults.items():
+            if k not in raw_curator:
+                raw_curator[k] = copy.deepcopy(v)
+                added_curator.append(k)
+        if added_curator:
+            config["curator"] = raw_curator
+            touched = True
+
+        # (2) auxiliary.curator task slot
+        _aux_curator_defaults = (
+            DEFAULT_CONFIG.get("auxiliary", {}).get("curator", {})
+        )
+        raw_aux = config.get("auxiliary")
+        if not isinstance(raw_aux, dict):
+            raw_aux = {}
+        raw_aux_curator = raw_aux.get("curator")
+        if not isinstance(raw_aux_curator, dict):
+            raw_aux_curator = {}
+        added_aux: List[str] = []
+        for k, v in _aux_curator_defaults.items():
+            if k not in raw_aux_curator:
+                raw_aux_curator[k] = copy.deepcopy(v)
+                added_aux.append(k)
+        if added_aux:
+            raw_aux["curator"] = raw_aux_curator
+            config["auxiliary"] = raw_aux
+            touched = True
+
+        if touched:
+            save_config(config)
+            if added_curator:
+                results["config_added"].append(
+                    f"curator ({len(added_curator)} default key(s))"
+                )
+                if not quiet:
+                    print(
+                        "  ✓ Seeded curator defaults in config.yaml: "
+                        f"{', '.join(added_curator)}"
+                    )
+            if added_aux:
+                results["config_added"].append(
+                    f"auxiliary.curator ({len(added_aux)} default key(s))"
+                )
+                if not quiet:
+                    print(
+                        "  ✓ Seeded auxiliary.curator defaults in config.yaml: "
+                        f"{', '.join(added_aux)}"
+                    )
+
+    # ── Version 24 → 25: lower model_catalog TTL 24h → 1h ──
+    # The model picker now refreshes its curated list hourly so freshly
+    # published model-catalog.json deploys reach users without a day-long
+    # stale window. Only rewrite the OLD default (24) — never clobber a
+    # value the user deliberately customized.
+    if current_ver < 25:
+        config = read_raw_config()
+        raw_mc = config.get("model_catalog")
+        if isinstance(raw_mc, dict) and raw_mc.get("ttl_hours") == 24:
+            raw_mc["ttl_hours"] = 1
+            config["model_catalog"] = raw_mc
+            save_config(config)
+            results["config_added"].append("model_catalog.ttl_hours 24→1")
+            if not quiet:
+                print("  ✓ Lowered model_catalog.ttl_hours to 1 (hourly picker refresh)")
+
+    if current_ver < latest_ver and not quiet:
+        print(f"Config version: {current_ver} → {latest_ver}")
+    
+    # Check for missing required env vars
+    missing_env = get_missing_env_vars(required_only=True)
+    
+    if missing_env and not quiet:
+        print("\n⚠️  Missing required environment variables:")
+        for var in missing_env:
+            print(f"   • {var['name']}: {var['description']}")
+    
+    if interactive and missing_env:
+        print("\nLet's configure them now:\n")
+        for var in missing_env:
+            if var.get("url"):
+                print(f"  Get your key at: {var['url']}")
+            
+            if var.get("password"):
+                value = masked_secret_prompt(f"  {var['prompt']}: ")
+            else:
+                value = input(f"  {var['prompt']}: ").strip()
+            
+            if value:
+                save_env_value(var["name"], value)
+                results["env_added"].append(var["name"])
+                print(f"  ✓ Saved {var['name']}")
+            else:
+                results["warnings"].append(f"Skipped {var['name']} - some features may not work")
+            print()
+    
+    # Check for missing optional env vars and offer to configure interactively
+    # Skip "advanced" vars (like OPENAI_BASE_URL) -- those are for power users
+    missing_optional = get_missing_env_vars(required_only=False)
+    required_names = {v["name"] for v in missing_env} if missing_env else set()
+    missing_optional = [
+        v for v in missing_optional
+        if v["name"] not in required_names and not v.get("advanced")
+    ]
+    
+    # Only offer to configure env vars that are NEW since the user's previous version
+    new_var_names = set()
+    for ver in range(current_ver + 1, latest_ver + 1):
+        new_var_names.update(ENV_VARS_BY_VERSION.get(ver, []))
+
+    if new_var_names and interactive and not quiet:
+        new_and_unset = [
+            (name, OPTIONAL_ENV_VARS[name])
+            for name in sorted(new_var_names)
+            if not get_env_value(name) and name in OPTIONAL_ENV_VARS
+        ]
+        if new_and_unset:
+            print(f"\n  {len(new_and_unset)} new optional key(s) in this update:")
+            for name, info in new_and_unset:
+                print(f"    • {name} — {info.get('description', '')}")
+            print()
+            try:
+                answer = input("  Configure new keys? [y/N]: ").strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                answer = "n"
+
+            if answer in {"y", "yes"}:
+                print()
+                for name, info in new_and_unset:
+                    if info.get("url"):
+                        print(f"  {info.get('description', name)}")
+                        print(f"  Get your key at: {info['url']}")
+                    else:
+                        print(f"  {info.get('description', name)}")
+                    if info.get("password"):
+                        value = masked_secret_prompt(
+                            f"  {info.get('prompt', name)} (Enter to skip): "
+                        )
+                    else:
+                        value = input(f"  {info.get('prompt', name)} (Enter to skip): ").strip()
+                    if value:
+                        save_env_value(name, value)
+                        results["env_added"].append(name)
+                        print(f"  ✓ Saved {name}")
+                    print()
+            else:
+                print("  Set later with: hermes config set <key> <value>")
+    
+    # Check for missing config fields
+    missing_config = get_missing_config_fields()
+    
+    if missing_config:
+        config = load_config()
+        
+        for field in missing_config:
+            key = field["key"]
+            default = field["default"]
+            
+            _set_nested(config, key, default)
+            results["config_added"].append(key)
+            if not quiet:
+                print(f"  ✓ Added {key} = {default}")
+        
+        # Update version and save
+        config["_config_version"] = latest_ver
+        save_config(config)
+    elif current_ver < latest_ver:
+        # Just update version
+        config = load_config()
+        config["_config_version"] = latest_ver
+        save_config(config)
+
+    # ── Skill-declared config vars ──────────────────────────────────────
+    # Skills can declare config.yaml settings they need via
+    # metadata.hermes.config in their SKILL.md frontmatter.
+    # Prompt for any that are missing/empty.
+    missing_skill_config = get_missing_skill_config_vars()
+    if missing_skill_config and interactive and not quiet:
+        print(f"\n  {len(missing_skill_config)} skill setting(s) not configured:")
+        for var in missing_skill_config:
+            skill_name = var.get("skill", "unknown")
+            print(f"    • {var['key']} — {var['description']} (from skill: {skill_name})")
+        print()
+        try:
+            answer = input("  Configure skill settings? [y/N]: ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            answer = "n"
+
+        if answer in {"y", "yes"}:
+            print()
+            config = load_config()
+            try:
+                from agent.skill_utils import SKILL_CONFIG_PREFIX
+            except Exception:
+                SKILL_CONFIG_PREFIX = "skills.config"
+            for var in missing_skill_config:
+                default = var.get("default", "")
+                default_hint = f" (default: {default})" if default else ""
+                value = input(f"  {var['prompt']}{default_hint}: ").strip()
+                if not value and default:
+                    value = str(default)
+                if value:
+                    storage_key = f"{SKILL_CONFIG_PREFIX}.{var['key']}"
+                    _set_nested(config, storage_key, value)
+                    results["config_added"].append(var["key"])
+                    print(f"  ✓ Saved {var['key']} = {value}")
+                else:
+                    results["warnings"].append(
+                        f"Skipped {var['key']} — skill '{var.get('skill', '?')}' may ask for it later"
+                    )
+                print()
+            save_config(config)
+        else:
+            print("  Set later with: hermes config set <key> <value>")
+
+    return results
+
+
+def _deep_merge(base: dict, override: dict) -> dict:
+    """Recursively merge *override* into *base*, preserving nested defaults.
+
+    Keys in *override* take precedence. If both values are dicts the merge
+    recurses, so a user who overrides only ``tts.elevenlabs.voice_id`` will
+    keep the default ``tts.elevenlabs.model_id`` intact.
+    """
+    result = base.copy()
+    for key, value in override.items():
+        if (
+            key in result
+            and isinstance(result[key], dict)
+            and isinstance(value, dict)
+        ):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def _expand_env_vars(obj):
+    """Recursively expand ``${VAR}`` references in config values.
+
+    Only string values are processed; dict keys, numbers, booleans, and
+    None are left untouched.  Unresolved references (variable not in
+    ``os.environ``) are kept verbatim so callers can detect them.
+    """
+    if isinstance(obj, str):
+        return re.sub(
+            r"\${([^}]+)}",
+            lambda m: os.environ.get(m.group(1), m.group(0)),
+            obj,
+        )
+    if isinstance(obj, dict):
+        return {k: _expand_env_vars(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_expand_env_vars(item) for item in obj]
+    return obj
+
+
+def _items_by_unique_name(items):
+    """Return a name-indexed dict only when all items have unique string names."""
+    if not isinstance(items, list):
+        return None
+    indexed = {}
+    for item in items:
+        if not isinstance(item, dict) or not isinstance(item.get("name"), str):
+            return None
+        name = item["name"]
+        if name in indexed:
+            return None
+        indexed[name] = item
+    return indexed
+
+
+def _preserve_env_ref_templates(current, raw, loaded_expanded=None):
+    """Restore raw ``${VAR}`` templates when a value is otherwise unchanged.
+
+    ``load_config()`` expands env refs for runtime use. When a caller later
+    persists that config after modifying some unrelated setting, keep the
+    original on-disk template instead of writing the expanded plaintext
+    secret back to ``config.yaml``.
+
+    Prefer preserving the raw template when ``current`` still matches either
+    the value previously returned by ``load_config()`` for this config path or
+    the current environment expansion of ``raw``. This handles env-var
+    rotation between load and save while still treating mixed literal/template
+    string edits as caller-owned once their rendered value diverges.
+    """
+    if isinstance(current, str) and isinstance(raw, str) and re.search(r"\${[^}]+}", raw):
+        if current == raw:
+            return raw
+        if isinstance(loaded_expanded, str) and current == loaded_expanded:
+            return raw
+        if _expand_env_vars(raw) == current:
+            return raw
+        return current
+
+    if isinstance(current, dict) and isinstance(raw, dict):
+        return {
+            key: _preserve_env_ref_templates(
+                value,
+                raw.get(key),
+                loaded_expanded.get(key) if isinstance(loaded_expanded, dict) else None,
+            )
+            for key, value in current.items()
+        }
+
+    if isinstance(current, list) and isinstance(raw, list):
+        # Prefer matching named config objects (e.g. custom_providers) by name
+        # so harmless reordering doesn't drop the original template. If names
+        # are duplicated, fall back to positional matching instead of silently
+        # shadowing one entry.
+        current_by_name = _items_by_unique_name(current)
+        raw_by_name = _items_by_unique_name(raw)
+        loaded_by_name = _items_by_unique_name(loaded_expanded)
+        if current_by_name is not None and raw_by_name is not None:
+            return [
+                _preserve_env_ref_templates(
+                    item,
+                    raw_by_name.get(item.get("name")),
+                    loaded_by_name.get(item.get("name")) if loaded_by_name is not None else None,
+                )
+                for item in current
+            ]
+        return [
+            _preserve_env_ref_templates(
+                item,
+                raw[index] if index < len(raw) else None,
+                loaded_expanded[index]
+                if isinstance(loaded_expanded, list) and index < len(loaded_expanded)
+                else None,
+            )
+            for index, item in enumerate(current)
+        ]
+
+    return current
+
+
+def _normalize_root_model_keys(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Move stale root-level provider/base_url/context_length into model section.
+
+    Some users (or older code) placed ``provider:``, ``base_url:``, or
+    ``context_length:`` at the config root instead of inside ``model:``.
+    These root-level keys are only used as a fallback when the corresponding
+    ``model.*`` key is empty — they never override an existing value.
+    After migration the root-level keys are removed so they can't cause
+    confusion on subsequent loads.
+    """
+    # Only act if there are root-level keys to migrate
+    has_root = any(config.get(k) for k in ("provider", "base_url", "context_length"))
+    if not has_root:
+        return config
+
+    config = dict(config)
+    model = config.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        config["model"] = model
+
+    for key in ("provider", "base_url", "context_length"):
+        root_val = config.get(key)
+        if root_val and not model.get(key):
+            model[key] = root_val
+        config.pop(key, None)
+
+    return config
+
+
+def _normalize_max_turns_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize legacy root-level max_turns into agent.max_turns."""
+    config = dict(config)
+    agent_config = dict(config.get("agent") or {})
+
+    if "max_turns" in config and "max_turns" not in agent_config:
+        agent_config["max_turns"] = config["max_turns"]
+
+    if "max_turns" not in agent_config:
+        agent_config["max_turns"] = DEFAULT_CONFIG["agent"]["max_turns"]
+
+    config["agent"] = agent_config
+    config.pop("max_turns", None)
+    return config
+
+
+def cfg_get(cfg: Optional[Dict[str, Any]], *keys: str, default: Any = None) -> Any:
+    """Traverse nested dict keys safely, returning ``default`` on any miss.
+
+    Canonical helper for the ``cfg.get("X", {}).get("Y", default)`` pattern
+    that appears 50+ times across the codebase. Handles three common gotchas
+    in one place:
+
+      1. Missing intermediate keys (returns ``default``, no KeyError).
+      2. An intermediate value that's not a dict (e.g. a user wrote a string
+         where a section was expected). Returns ``default`` instead of
+         AttributeError on ``.get()``.
+      3. ``cfg is None`` (callers sometimes pass ``load_config() or None``).
+
+    Named ``cfg_get`` rather than ``cfg_path`` to avoid shadowing the
+    ubiquitous ``cfg_path = _hermes_home / "config.yaml"`` local variable
+    that appears in gateway/run.py, cron/scheduler.py, main.py, etc.
+
+    Explicit ``None`` values are returned as-is (matches ``dict.get(key,
+    default)`` semantics — ``default`` is only returned when the key is
+    *absent*, not when it's present but set to ``None``).
+
+    Examples:
+        >>> cfg_get({"agent": {"reasoning_effort": "high"}}, "agent", "reasoning_effort")
+        'high'
+        >>> cfg_get({}, "agent", "reasoning_effort", default="medium")
+        'medium'
+        >>> cfg_get({"agent": "oops_a_string"}, "agent", "reasoning_effort", default="low")
+        'low'
+        >>> cfg_get(None, "anything", default=42)
+        42
+        >>> cfg_get({"a": {"b": None}}, "a", "b", default="def")  # explicit None preserved
+        >>> cfg_get({"a": {"b": False}}, "a", "b", default=True)  # falsy values preserved
+        False
+    """
+    if not isinstance(cfg, dict):
+        return default
+    node: Any = cfg
+    for key in keys:
+        if not isinstance(node, dict):
+            return default
+        if key not in node:
+            return default
+        node = node[key]
+    return node
+
+
+
+def read_raw_config() -> Dict[str, Any]:
+    """Read ~/.hermes/config.yaml as-is, without merging defaults or migrating.
+
+    Returns the raw YAML dict, or ``{}`` if the file doesn't exist or can't
+    be parsed.  Use this for lightweight config reads where you just need a
+    single value and don't want the overhead of ``load_config()``'s deep-merge
+    + migration pipeline.
+
+    Cached on the config file's (mtime_ns, size) — same strategy as
+    ``load_config()``. Returns a deepcopy on every call since some callers
+    mutate the result before passing to ``save_config()``.
+    """
+    with _CONFIG_LOCK:
+        try:
+            config_path = get_config_path()
+            st = config_path.stat()
+            cache_key = (st.st_mtime_ns, st.st_size)
+        except (FileNotFoundError, OSError):
+            return {}
+
+        path_key = str(config_path)
+        cached = _RAW_CONFIG_CACHE.get(path_key)
+        if cached is not None and cached[:2] == cache_key:
+            return copy.deepcopy(cached[2])
+
+        try:
+            with open(config_path, encoding="utf-8") as f:
+                data = yaml.safe_load(f) or {}
+        except Exception as e:
+            _warn_config_parse_failure(config_path, e)
+            return {}
+
+        if not isinstance(data, dict):
+            data = {}
+        _RAW_CONFIG_CACHE[path_key] = (cache_key[0], cache_key[1], copy.deepcopy(data))
+        return data
+
+
+def load_config() -> Dict[str, Any]:
+    """Load configuration from ~/.hermes/config.yaml.
+
+    Cached on the config file's (mtime_ns, size). Returns a deepcopy of
+    the cached value when unchanged, since most call sites mutate the
+    result (e.g. ``cfg["model"]["default"] = ...`` before ``save_config``).
+    The cache is keyed on ``str(config_path)`` so profile switches
+    (which change ``HERMES_HOME`` and therefore ``get_config_path()``)
+    don't collide.
+
+    Read-only callers should use ``load_config_readonly()`` to skip the
+    defensive deepcopy — that path matters in agent-loop hot spots like
+    ``get_provider_request_timeout`` which is called once per API turn.
+    """
+    return _load_config_impl(want_deepcopy=True)
+
+
+def load_config_readonly() -> Dict[str, Any]:
+    """Fast-path variant of ``load_config()`` for callers that ONLY READ.
+
+    Returns the cached config dict directly without the defensive deepcopy
+    that ``load_config()`` applies. **Mutating the returned dict (or any
+    nested structure) corrupts the in-process cache for every subsequent
+    caller** — only use this when you are absolutely sure your code path
+    will not write to the result. If you need to mutate or pass to
+    ``save_config``, call ``load_config()`` instead.
+
+    Why this exists: ``load_config()`` cache-hit cost is ~265us per call,
+    half of which (~135us) is the defensive deepcopy. The agent loop calls
+    into config reads (timeouts, thresholds, feature flags) ~20-50x per
+    conversation; skipping deepcopy here removes a measurable allocation
+    source and the GC pressure that comes with it.
+
+    Note: this returns a plain ``dict`` (not ``MappingProxyType``) so
+    existing ``isinstance(x, dict)`` guards downstream keep working. The
+    safety guarantee is purely documented, not enforced — be careful.
+    """
+    return _load_config_impl(want_deepcopy=False)
+
+
+TERMINAL_CONFIG_ENV_MAP = {
+    "backend": "TERMINAL_ENV",
+    "modal_mode": "TERMINAL_MODAL_MODE",
+    "cwd": "TERMINAL_CWD",
+    "timeout": "TERMINAL_TIMEOUT",
+    "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
+    "docker_image": "TERMINAL_DOCKER_IMAGE",
+    "docker_forward_env": "TERMINAL_DOCKER_FORWARD_ENV",
+    "singularity_image": "TERMINAL_SINGULARITY_IMAGE",
+    "modal_image": "TERMINAL_MODAL_IMAGE",
+    "daytona_image": "TERMINAL_DAYTONA_IMAGE",
+    "ssh_host": "TERMINAL_SSH_HOST",
+    "ssh_user": "TERMINAL_SSH_USER",
+    "ssh_port": "TERMINAL_SSH_PORT",
+    "ssh_key": "TERMINAL_SSH_KEY",
+    "container_cpu": "TERMINAL_CONTAINER_CPU",
+    "container_memory": "TERMINAL_CONTAINER_MEMORY",
+    "container_disk": "TERMINAL_CONTAINER_DISK",
+    "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
+    "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
+    "docker_env": "TERMINAL_DOCKER_ENV",
+    "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
+    "docker_extra_args": "TERMINAL_DOCKER_EXTRA_ARGS",
+    "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
+    "docker_persist_across_processes": "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES",
+    "docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",
+    "sandbox_dir": "TERMINAL_SANDBOX_DIR",
+    "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
+}
+
+
+def _terminal_env_value(value: Any) -> str:
+    if isinstance(value, (list, dict)):
+        return json.dumps(value)
+    return str(value)
+
+
+def terminal_config_env_var_for_key(key: str) -> Optional[str]:
+    """Return the env var mirrored by a ``terminal.*`` config key."""
+    prefix = "terminal."
+    if not key.startswith(prefix):
+        return None
+    return TERMINAL_CONFIG_ENV_MAP.get(key[len(prefix):])
+
+
+def apply_terminal_config_to_env(
+    *,
+    env: Optional[Dict[str, str]] = None,
+    config: Optional[Dict[str, Any]] = None,
+    override: Optional[bool] = None,
+) -> Dict[str, str]:
+    """Bridge ``terminal.*`` config into the env vars terminal tools read.
+
+    ``tools.terminal_tool`` is intentionally environment-driven because it also
+    runs in child processes (TUI, dashboard PTY, gateway workers).  This helper
+    gives those child-process launch paths the same config bridge as classic
+    CLI without importing ``cli.py`` and paying for its startup side effects.
+
+    When the user config contains a ``terminal`` section, config.yaml is
+    authoritative and overrides existing env values.  Otherwise defaults only
+    backfill missing env vars so exported/.env values keep working.
+    """
+    target = os.environ if env is None else env
+
+    raw_config = read_raw_config()
+    file_has_terminal_config = isinstance(raw_config.get("terminal"), dict)
+    should_override = file_has_terminal_config if override is None else override
+
+    cfg = config if config is not None else load_config_readonly()
+    terminal_cfg = cfg.get("terminal", {}) if isinstance(cfg, dict) else {}
+    if not isinstance(terminal_cfg, dict):
+        return target
+
+    for cfg_key, env_var in TERMINAL_CONFIG_ENV_MAP.items():
+        if cfg_key not in terminal_cfg:
+            continue
+        value = terminal_cfg[cfg_key]
+        if cfg_key == "cwd":
+            raw_cwd = str(value or "").strip()
+            if raw_cwd in {".", "auto", "cwd"}:
+                continue
+            if isinstance(value, str):
+                value = os.path.expanduser(value)
+        if should_override or env_var not in target:
+            target[env_var] = _terminal_env_value(value)
+    return target
+
+
+def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
+    with _CONFIG_LOCK:
+        ensure_hermes_home()
+        config_path = get_config_path()
+        path_key = str(config_path)
+
+        try:
+            st = config_path.stat()
+            cache_key: Optional[Tuple[int, int]] = (st.st_mtime_ns, st.st_size)
+        except FileNotFoundError:
+            cache_key = None
+
+        cached = _LOAD_CONFIG_CACHE.get(path_key)
+        if cached is not None and cache_key is not None and cached[:2] == cache_key:
+            return copy.deepcopy(cached[2]) if want_deepcopy else cached[2]
+
+        config = copy.deepcopy(DEFAULT_CONFIG)
+
+        if cache_key is not None:
+            try:
+                with open(config_path, encoding="utf-8") as f:
+                    user_config = yaml.safe_load(f) or {}
+
+                if "max_turns" in user_config:
+                    agent_user_config = dict(user_config.get("agent") or {})
+                    if agent_user_config.get("max_turns") is None:
+                        agent_user_config["max_turns"] = user_config["max_turns"]
+                    user_config["agent"] = agent_user_config
+                    user_config.pop("max_turns", None)
+
+                config = _deep_merge(config, user_config)
+            except Exception as e:
+                _warn_config_parse_failure(config_path, e)
+
+        normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
+        expanded = _expand_env_vars(normalized)
+        _LAST_EXPANDED_CONFIG_BY_PATH[path_key] = copy.deepcopy(expanded)
+        if cache_key is not None:
+            # Cache stores a separate deepcopy so subsequent ``load_config()``
+            # (deepcopy=True) callers can mutate freely without affecting the
+            # cached value, and ``load_config_readonly()`` (deepcopy=False)
+            # callers all see the same stable cached object.
+            cached_copy = copy.deepcopy(expanded)
+            _LOAD_CONFIG_CACHE[path_key] = (cache_key[0], cache_key[1], cached_copy)
+            # On the readonly path return the same cached object subsequent
+            # calls will see — keeps "two readonly calls return the same
+            # object" invariant that callers may rely on for identity checks.
+            if not want_deepcopy:
+                return cached_copy
+        else:
+            _LOAD_CONFIG_CACHE.pop(path_key, None)
+        # First-load result is a fresh dict (not aliased to the cache); safe
+        # to return directly. For the deepcopy=True path this is the
+        # canonical "freshly-built mutable result" the function has always
+        # returned. For the deepcopy=False path with no cache (e.g. config
+        # file missing), it's also fine — callers get an isolated object.
+        return expanded
+
+
+_SECURITY_COMMENT = """
+# ── Security ──────────────────────────────────────────────────────────
+# Secret redaction is ON by default — strings that look like API keys,
+# tokens, and passwords are masked in tool output, logs, and chat
+# responses before the model or user ever sees them. Set redact_secrets
+# to false to disable (e.g. when developing the redactor itself).
+# tirith pre-exec scanning is enabled by default when the tirith binary
+# is available. Configure via security.tirith_* keys or env vars
+# (TIRITH_ENABLED, TIRITH_BIN, TIRITH_TIMEOUT, TIRITH_FAIL_OPEN).
+#
+# security:
+#   redact_secrets: true
+#   tirith_enabled: true
+#   tirith_path: "tirith"
+#   tirith_timeout: 5
+#   tirith_fail_open: true
+"""
+
+_FALLBACK_COMMENT = """
+# ── Fallback Model ────────────────────────────────────────────────────
+# Automatic provider failover when primary is unavailable.
+# Uncomment and configure to enable. Triggers on rate limits (429),
+# overload (529), service errors (503), or connection failures.
+#
+# Supported providers:
+#   openrouter   (OPENROUTER_API_KEY)  — routes to any model
+#   openai-codex (OAuth — hermes auth) — OpenAI Codex
+#   nous         (OAuth — hermes auth) — Nous Portal
+#   zai          (ZAI_API_KEY)         — Z.AI / GLM
+#   kimi-coding  (KIMI_API_KEY)        — Kimi / Moonshot
+#   kimi-coding-cn (KIMI_CN_API_KEY)   — Kimi / Moonshot (China)
+#   minimax      (MINIMAX_API_KEY)     — MiniMax
+#   minimax-cn   (MINIMAX_CN_API_KEY)  — MiniMax (China)
+#   bedrock      (AWS IAM / boto3)     — AWS Bedrock (Converse API)
+#
+# For custom OpenAI-compatible endpoints, add base_url and key_env.
+#
+# fallback_model:
+#   provider: openrouter
+#   model: anthropic/claude-sonnet-4
+"""
+
+
+_COMMENTED_SECTIONS = """
+# ── Security ──────────────────────────────────────────────────────────
+# Secret redaction is ON by default. Set to false to pass tool output,
+# logs, and chat responses through unmodified (e.g. for redactor dev).
+#
+# security:
+#   redact_secrets: true
+
+# ── Fallback Model ────────────────────────────────────────────────────
+# Automatic provider failover when primary is unavailable.
+# Uncomment and configure to enable. Triggers on rate limits (429),
+# overload (529), service errors (503), or connection failures.
+#
+# Supported providers:
+#   openrouter   (OPENROUTER_API_KEY)  — routes to any model
+#   openai-codex (OAuth — hermes auth) — OpenAI Codex
+#   nous         (OAuth — hermes auth) — Nous Portal
+#   zai          (ZAI_API_KEY)         — Z.AI / GLM
+#   kimi-coding  (KIMI_API_KEY)        — Kimi / Moonshot
+#   kimi-coding-cn (KIMI_CN_API_KEY)   — Kimi / Moonshot (China)
+#   minimax      (MINIMAX_API_KEY)     — MiniMax
+#   minimax-cn   (MINIMAX_CN_API_KEY)  — MiniMax (China)
+#   bedrock      (AWS IAM / boto3)     — AWS Bedrock (Converse API)
+#
+# For custom OpenAI-compatible endpoints, add base_url and key_env.
+#
+# fallback_model:
+#   provider: openrouter
+#   model: anthropic/claude-sonnet-4
+"""
+
+
+def save_config(config: Dict[str, Any]):
+    """Save configuration to ~/.hermes/config.yaml."""
+    with _CONFIG_LOCK:
+        if is_managed():
+            managed_error("save configuration")
+            return
+        from utils import atomic_yaml_write
+
+        ensure_hermes_home()
+        config_path = get_config_path()
+        current_normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
+        normalized = current_normalized
+        raw_existing = _normalize_root_model_keys(_normalize_max_turns_config(read_raw_config()))
+        if raw_existing:
+            normalized = _preserve_env_ref_templates(
+                normalized,
+                raw_existing,
+                _LAST_EXPANDED_CONFIG_BY_PATH.get(str(config_path)),
+            )
+
+        # Build optional commented-out sections for features that are off by
+        # default or only relevant when explicitly configured.
+        parts = []
+        sec = normalized.get("security", {})
+        if not sec or sec.get("redact_secrets") is None:
+            parts.append(_SECURITY_COMMENT)
+        fb = normalized.get("fallback_model", {})
+        fb_is_valid = False
+        if isinstance(fb, list):
+            fb_is_valid = any(isinstance(e, dict) and e.get("provider") and e.get("model") for e in fb)
+        elif isinstance(fb, dict):
+            fb_is_valid = bool(fb.get("provider") and fb.get("model"))
+        if not fb_is_valid:
+            parts.append(_FALLBACK_COMMENT)
+
+        atomic_yaml_write(
+            config_path,
+            normalized,
+            extra_content="".join(parts) if parts else None,
+        )
+        _secure_file(config_path)
+        _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(current_normalized)
+
+
+def load_env() -> Dict[str, str]:
+    """Load environment variables from ~/.hermes/.env.
+
+    Sanitizes lines before parsing so that corrupted files (e.g.
+    concatenated KEY=VALUE pairs on a single line) are handled
+    gracefully instead of producing mangled values such as duplicated
+    bot tokens.  See #8908.
+
+    The parsed dict is memoised keyed on the .env file mtime, because
+    ``get_env_value()`` is called dozens-to-hundreds of times per
+    interactive menu render (`hermes tools`, `hermes setup`, status
+    panels). Sanitisation is O(lines × known-keys), so re-parsing the
+    same file on every call was burning ~300ms of CPU per `hermes tools`
+    menu paint on top of the OAuth-refresh slowness. The mtime check
+    invalidates the cache when the user edits .env mid-process.
+    """
+    global _env_cache
+    env_path = get_env_path()
+
+    try:
+        mtime = env_path.stat().st_mtime
+        size = env_path.stat().st_size
+        cache_key = (str(env_path), mtime, size)
+    except FileNotFoundError:
+        cache_key = (str(env_path), None, None)
+    except Exception:
+        cache_key = None
+
+    if cache_key is not None and _env_cache is not None:
+        cached_key, cached_vars = _env_cache
+        if cached_key == cache_key:
+            return dict(cached_vars)
+
+    env_vars: Dict[str, str] = {}
+
+    if env_path.exists():
+        # On Windows, open() defaults to the system locale (cp1252) which can
+        # fail on UTF-8 .env files. Always use explicit UTF-8; tolerate BOM
+        # via utf-8-sig since users may edit .env in Notepad which adds one.
+        open_kw = {"encoding": "utf-8-sig", "errors": "replace"}
+        with open(env_path, **open_kw) as f:
+            raw_lines = f.readlines()
+        # Sanitize before parsing: split concatenated lines & drop stale
+        # placeholders so corrupted .env files don't produce invalid tokens.
+        lines = _sanitize_env_lines(raw_lines)
+        for line in lines:
+            line = line.strip()
+            if line and not line.startswith('#') and '=' in line:
+                key, _, value = line.partition('=')
+                env_vars[key.strip()] = value.strip().strip('"\'')
+
+    if cache_key is not None:
+        _env_cache = (cache_key, dict(env_vars))
+
+    return env_vars
+
+
+# Module-level memo for load_env(), keyed on (path, mtime, size).
+# Editing .env bumps mtime → next load_env() rebuilds. invalidate_env_cache()
+# is the explicit knob for writers that update .env via this module
+# (set_env_value, save_env, etc.) without relying on filesystem mtime
+# resolution.
+_env_cache: Optional[Tuple[Tuple[str, Optional[float], Optional[int]], Dict[str, str]]] = None
+
+
+def invalidate_env_cache() -> None:
+    """Clear the load_env() process-level memo.
+
+    Writers that mutate .env (set_env_value, save_env, etc.) call this
+    to guarantee the next load_env() sees their change even on
+    filesystems with coarse mtime resolution. Reads invalidate naturally
+    via the mtime/size check.
+    """
+    global _env_cache
+    _env_cache = None
+
+
+def _sanitize_env_lines(lines: list) -> list:
+    """Fix corrupted .env lines before reading or writing.
+
+    Handles two known corruption patterns:
+    1. Concatenated KEY=VALUE pairs on a single line (missing newline between
+       entries, e.g. ``ANTHROPIC_API_KEY=sk-...OPENAI_BASE_URL=https://...``).
+    2. Stale ``KEY=***`` placeholder entries left by incomplete setup runs.
+
+    Uses a known-keys set (OPTIONAL_ENV_VARS + _EXTRA_ENV_KEYS) so we only
+    split on real Hermes env var names, avoiding false positives from values
+    that happen to contain uppercase text with ``=``.
+    """
+    # Build the known keys set lazily from OPTIONAL_ENV_VARS + extras.
+    # Done inside the function so OPTIONAL_ENV_VARS is guaranteed to be defined.
+    known_keys = set(OPTIONAL_ENV_VARS.keys()) | _EXTRA_ENV_KEYS
+
+    sanitized: list[str] = []
+    for line in lines:
+        raw = line.rstrip("\r\n")
+        stripped = raw.strip()
+
+        # Preserve blank lines and comments
+        if not stripped or stripped.startswith("#"):
+            sanitized.append(raw + "\n")
+            continue
+
+        # Detect concatenated KEY=VALUE pairs on one line.
+        # Search for known KEY= patterns at any position in the line.
+        # We collect full needle ranges so we can drop matches that are
+        # fully contained within a longer overlapping needle. Without this,
+        # suffix collisions corrupt the file: e.g. LM_API_KEY= inside
+        # GLM_API_KEY= would otherwise split the line into "G\nLM_API_KEY=...".
+        match_ranges: list[tuple[int, int]] = []
+        for key_name in known_keys:
+            needle = key_name + "="
+            idx = stripped.find(needle)
+            while idx >= 0:
+                match_ranges.append((idx, idx + len(needle)))
+                idx = stripped.find(needle, idx + len(needle))
+
+        split_positions = sorted({
+            s for s, e in match_ranges
+            if not any(
+                s2 <= s and e2 >= e and (s2, e2) != (s, e)
+                for s2, e2 in match_ranges
+            )
+        })
+
+        if len(split_positions) > 1:
+            for i, pos in enumerate(split_positions):
+                end = split_positions[i + 1] if i + 1 < len(split_positions) else len(stripped)
+                part = stripped[pos:end].strip()
+                if part:
+                    sanitized.append(part + "\n")
+        else:
+            sanitized.append(stripped + "\n")
+
+    return sanitized
+
+
+def sanitize_env_file() -> int:
+    """Read, sanitize, and rewrite ~/.hermes/.env in place.
+
+    Returns the number of lines that were fixed (concatenation splits +
+    placeholder removals).  Returns 0 when no changes are needed.
+    """
+    env_path = get_env_path()
+    if not env_path.exists():
+        return 0
+
+    read_kw = {"encoding": "utf-8-sig", "errors": "replace"}
+    write_kw = {"encoding": "utf-8"}
+
+    with open(env_path, **read_kw) as f:
+        original_lines = f.readlines()
+
+    sanitized = _sanitize_env_lines(original_lines)
+
+    if sanitized == original_lines:
+        return 0
+
+    # Count fixes: difference in line count (from splits) + removed lines
+    fixes = abs(len(sanitized) - len(original_lines))
+    if fixes == 0:
+        # Lines changed content (e.g. *** removal) even if count is same
+        fixes = sum(1 for a, b in zip(original_lines, sanitized) if a != b)
+        fixes += abs(len(sanitized) - len(original_lines))
+
+    fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix=".tmp", prefix=".env_")
+    try:
+        with os.fdopen(fd, "w", **write_kw) as f:
+            f.writelines(sanitized)
+            f.flush()
+            os.fsync(f.fileno())
+        atomic_replace(tmp_path, env_path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+    _secure_file(env_path)
+    invalidate_env_cache()
+    return fixes
+
+
+def _check_non_ascii_credential(key: str, value: str) -> str:
+    """Warn and strip non-ASCII characters from credential values.
+
+    API keys and tokens must be pure ASCII — they are sent as HTTP header
+    values which httpx/httpcore encode as ASCII.  Non-ASCII characters
+    (commonly introduced by copy-pasting from rich-text editors or PDFs
+    that substitute lookalike Unicode glyphs for ASCII letters) cause
+    ``UnicodeEncodeError: 'ascii' codec can't encode character`` at
+    request time.
+
+    Returns the sanitized (ASCII-only) value.  Prints a warning if any
+    non-ASCII characters were found and removed.
+    """
+    try:
+        value.encode("ascii")
+        return value  # all ASCII — nothing to do
+    except UnicodeEncodeError:
+        pass
+
+    # Build a readable list of the offending characters
+    bad_chars: list[str] = []
+    for i, ch in enumerate(value):
+        if ord(ch) > 127:
+            bad_chars.append(f"  position {i}: {ch!r} (U+{ord(ch):04X})")
+    sanitized = value.encode("ascii", errors="ignore").decode("ascii")
+
+    print(
+        f"\n  Warning: {key} contains non-ASCII characters that will break API requests.\n"
+        f"  This usually happens when copy-pasting from a PDF, rich-text editor,\n"
+        f"  or web page that substitutes lookalike Unicode glyphs for ASCII letters.\n"
+        f"\n"
+        + "\n".join(f"  {line}" for line in bad_chars[:5])
+        + ("\n  ... and more" if len(bad_chars) > 5 else "")
+        + f"\n\n  The non-ASCII characters have been stripped automatically.\n"
+        f"  If authentication fails, re-copy the key from the provider's dashboard.\n",
+        file=sys.stderr,
+    )
+    return sanitized
+
+
+def save_env_value(key: str, value: str):
+    """Save or update a value in ~/.hermes/.env."""
+    if is_managed():
+        managed_error(f"set {key}")
+        return
+    if not _ENV_VAR_NAME_RE.match(key):
+        raise ValueError(f"Invalid environment variable name: {key!r}")
+    _reject_denylisted_env_var(key)
+    value = value.replace("\n", "").replace("\r", "")
+    # API keys / tokens must be ASCII — strip non-ASCII with a warning.
+    value = _check_non_ascii_credential(key, value)
+    ensure_hermes_home()
+    env_path = get_env_path()
+
+    # On Windows, open() defaults to the system locale (cp1252) which can
+    # cause OSError errno 22 on UTF-8 .env files.
+    read_kw = {"encoding": "utf-8-sig", "errors": "replace"}
+    write_kw = {"encoding": "utf-8"}
+
+    lines = []
+    if env_path.exists():
+        with open(env_path, **read_kw) as f:
+            lines = f.readlines()
+        # Sanitize on every read: split concatenated keys, drop stale placeholders
+        lines = _sanitize_env_lines(lines)
+
+    # Find and update or append
+    found = False
+    for i, line in enumerate(lines):
+        if line.strip().startswith(f"{key}="):
+            lines[i] = f"{key}={value}\n"
+            found = True
+            break
+
+    if not found:
+        # Ensure there's a newline at the end of the file before appending
+        if lines and not lines[-1].endswith("\n"):
+            lines[-1] += "\n"
+        lines.append(f"{key}={value}\n")
+    
+    fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix='.tmp', prefix='.env_')
+    # Preserve original permissions so Docker volume mounts aren't clobbered.
+    original_mode = None
+    if env_path.exists():
+        try:
+            original_mode = stat.S_IMODE(env_path.stat().st_mode)
+        except OSError:
+            pass
+    try:
+        with os.fdopen(fd, 'w', **write_kw) as f:
+            f.writelines(lines)
+            f.flush()
+            os.fsync(f.fileno())
+        atomic_replace(tmp_path, env_path)
+        # Restore original permissions before _secure_file may tighten them.
+        if original_mode is not None:
+            try:
+                os.chmod(env_path, original_mode)
+            except OSError:
+                pass
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+    _secure_file(env_path)
+
+    os.environ[key] = value
+    invalidate_env_cache()
+
+
+def remove_env_value(key: str) -> bool:
+    """Remove a key from ~/.hermes/.env and os.environ.
+
+    Returns True if the key was found and removed, False otherwise.
+    """
+    if is_managed():
+        managed_error(f"remove {key}")
+        return False
+    if not _ENV_VAR_NAME_RE.match(key):
+        raise ValueError(f"Invalid environment variable name: {key!r}")
+    env_path = get_env_path()
+    if not env_path.exists():
+        os.environ.pop(key, None)
+        return False
+
+    read_kw = {"encoding": "utf-8-sig", "errors": "replace"}
+    write_kw = {"encoding": "utf-8"}
+
+    with open(env_path, **read_kw) as f:
+        lines = f.readlines()
+    lines = _sanitize_env_lines(lines)
+
+    new_lines = [line for line in lines if not line.strip().startswith(f"{key}=")]
+    found = len(new_lines) < len(lines)
+
+    if found:
+        fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix='.tmp', prefix='.env_')
+        # Preserve original permissions so Docker volume mounts aren't clobbered.
+        original_mode = None
+        try:
+            original_mode = stat.S_IMODE(env_path.stat().st_mode)
+        except OSError:
+            pass
+        try:
+            with os.fdopen(fd, 'w', **write_kw) as f:
+                f.writelines(new_lines)
+                f.flush()
+                os.fsync(f.fileno())
+            atomic_replace(tmp_path, env_path)
+            if original_mode is not None:
+                try:
+                    os.chmod(env_path, original_mode)
+                except OSError:
+                    pass
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+        _secure_file(env_path)
+
+    os.environ.pop(key, None)
+    invalidate_env_cache()
+    return found
+
+
+def save_anthropic_oauth_token(value: str, save_fn=None):
+    """Persist an Anthropic OAuth/setup token and clear the API-key slot."""
+    writer = save_fn or save_env_value
+    writer("ANTHROPIC_TOKEN", value)
+    writer("ANTHROPIC_API_KEY", "")
+
+
+def use_anthropic_claude_code_credentials(save_fn=None):
+    """Use Claude Code's own credential files instead of persisting env tokens."""
+    writer = save_fn or save_env_value
+    writer("ANTHROPIC_TOKEN", "")
+    writer("ANTHROPIC_API_KEY", "")
+
+
+def save_anthropic_api_key(value: str, save_fn=None):
+    """Persist an Anthropic API key and clear the OAuth/setup-token slot."""
+    writer = save_fn or save_env_value
+    writer("ANTHROPIC_API_KEY", value)
+    writer("ANTHROPIC_TOKEN", "")
+
+
+def save_env_value_secure(key: str, value: str) -> Dict[str, Any]:
+    save_env_value(key, value)
+    return {
+        "success": True,
+        "stored_as": key,
+        "validated": False,
+    }
+
+
+
+def reload_env() -> int:
+    """Re-read ~/.hermes/.env into os.environ. Returns count of vars updated.
+
+    Adds/updates vars that changed and removes vars that were deleted from
+    the .env file (but only vars known to Hermes — OPTIONAL_ENV_VARS and
+    _EXTRA_ENV_KEYS — to avoid clobbering unrelated environment).
+    """
+    env_vars = load_env()
+    known_keys = set(OPTIONAL_ENV_VARS.keys()) | _EXTRA_ENV_KEYS
+    count = 0
+    for key, value in env_vars.items():
+        if os.environ.get(key) != value:
+            os.environ[key] = value
+            count += 1
+    # Remove known Hermes vars that are no longer in .env
+    for key in known_keys:
+        if key not in env_vars and key in os.environ:
+            del os.environ[key]
+            count += 1
+    return count
+
+
+def get_env_value(key: str) -> Optional[str]:
+    """Get a value from ~/.hermes/.env or environment."""
+    # Check environment first
+    if key in os.environ:
+        return os.environ[key]
+    
+    # Then check .env file
+    env_vars = load_env()
+    return env_vars.get(key)
+
+
+# =============================================================================
+# Config display
+# =============================================================================
+
+def redact_key(key: str) -> str:
+    """Redact an API key for display.
+
+    Thin wrapper over :func:`agent.redact.mask_secret` — preserves the
+    "(not set)" placeholder in dim color for the empty case.
+    """
+    from agent.redact import mask_secret
+    return mask_secret(key, empty=color("(not set)", Colors.DIM))
+
+
+def show_config():
+    """Display current configuration."""
+    config = load_config()
+    
+    print()
+    print(color("┌─────────────────────────────────────────────────────────┐", Colors.CYAN))
+    print(color("│              ⚕ Hermes Configuration                    │", Colors.CYAN))
+    print(color("└─────────────────────────────────────────────────────────┘", Colors.CYAN))
+    
+    # Paths
+    print()
+    print(color("◆ Paths", Colors.CYAN, Colors.BOLD))
+    print(f"  Config:       {get_config_path()}")
+    print(f"  Secrets:      {get_env_path()}")
+    print(f"  Install:      {get_project_root()}")
+    
+    # API Keys
+    print()
+    print(color("◆ API Keys", Colors.CYAN, Colors.BOLD))
+    
+    keys = [
+        ("OPENROUTER_API_KEY", "OpenRouter"),
+        ("VOICE_TOOLS_OPENAI_KEY", "OpenAI (STT/TTS)"),
+        ("EXA_API_KEY", "Exa"),
+        ("PARALLEL_API_KEY", "Parallel"),
+        ("FIRECRAWL_API_KEY", "Firecrawl"),
+        ("TAVILY_API_KEY", "Tavily"),
+        ("BROWSERBASE_API_KEY", "Browserbase"),
+        ("BROWSER_USE_API_KEY", "Browser Use"),
+        ("FAL_KEY", "FAL"),
+    ]
+    
+    for env_key, name in keys:
+        value = get_env_value(env_key)
+        print(f"  {name:<14} {redact_key(value)}")
+    from hermes_cli.auth import get_anthropic_key
+    anthropic_value = get_anthropic_key()
+    print(f"  {'Anthropic':<14} {redact_key(anthropic_value)}")
+    
+    # Model settings
+    print()
+    print(color("◆ Model", Colors.CYAN, Colors.BOLD))
+    print(f"  Model:        {config.get('model', 'not set')}")
+    _cfg_max_turns = config.get('agent', {}).get('max_turns', DEFAULT_CONFIG['agent']['max_turns'])
+    print(f"  Max turns:    {_cfg_max_turns}")
+    # Warn on stale HERMES_MAX_ITERATIONS ghost in .env that disagrees with
+    # config.yaml (issue #17534). Read the .env FILE directly so we catch the
+    # ghost even when the gateway bridge already overrode os.environ.
+    try:
+        _env_ghost = load_env().get("HERMES_MAX_ITERATIONS")
+        if _env_ghost is not None and str(_env_ghost).strip() != str(_cfg_max_turns).strip():
+            print(color(
+                f"                ⚠ .env has stale HERMES_MAX_ITERATIONS={_env_ghost} "
+                f"(run 'hermes doctor --fix' to remove)",
+                Colors.YELLOW,
+            ))
+    except Exception:
+        pass
+    
+    # Display
+    print()
+    print(color("◆ Display", Colors.CYAN, Colors.BOLD))
+    display = config.get('display', {})
+    print(f"  Personality:  {display.get('personality') or 'none'}")
+    print(f"  Reasoning:    {'on' if display.get('show_reasoning', False) else 'off'}")
+    print(f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'}")
+    ump = display.get('user_message_preview', {}) if isinstance(display.get('user_message_preview', {}), dict) else {}
+    ump_first = ump.get('first_lines', 2)
+    ump_last = ump.get('last_lines', 2)
+    print(f"  User preview: first {ump_first} line(s), last {ump_last} line(s)")
+
+    # Terminal
+    print()
+    print(color("◆ Terminal", Colors.CYAN, Colors.BOLD))
+    terminal = config.get('terminal', {})
+    print(f"  Backend:      {terminal.get('backend', 'local')}")
+    print(f"  Working dir:  {terminal.get('cwd', '.')}")
+    print(f"  Timeout:      {terminal.get('timeout', 60)}s")
+    
+    if terminal.get('backend') == 'docker':
+        print(f"  Docker image: {terminal.get('docker_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}")
+    elif terminal.get('backend') == 'singularity':
+        print(f"  Image:        {terminal.get('singularity_image', 'docker://nikolaik/python-nodejs:python3.11-nodejs20')}")
+    elif terminal.get('backend') == 'modal':
+        print(f"  Modal image:  {terminal.get('modal_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}")
+        modal_token = get_env_value('MODAL_TOKEN_ID')
+        print(f"  Modal token:  {'configured' if modal_token else '(not set)'}")
+    elif terminal.get('backend') == 'daytona':
+        print(f"  Daytona image: {terminal.get('daytona_image', 'nikolaik/python-nodejs:python3.11-nodejs20')}")
+        daytona_key = get_env_value('DAYTONA_API_KEY')
+        print(f"  API key:      {'configured' if daytona_key else '(not set)'}")
+    elif terminal.get('backend') == 'ssh':
+        ssh_host = get_env_value('TERMINAL_SSH_HOST')
+        ssh_user = get_env_value('TERMINAL_SSH_USER')
+        print(f"  SSH host:     {ssh_host or '(not set)'}")
+        print(f"  SSH user:     {ssh_user or '(not set)'}")
+    
+    # Timezone
+    print()
+    print(color("◆ Timezone", Colors.CYAN, Colors.BOLD))
+    tz = config.get('timezone', '')
+    if tz:
+        print(f"  Timezone:     {tz}")
+    else:
+        print(f"  Timezone:     {color('(server-local)', Colors.DIM)}")
+
+    # Compression
+    print()
+    print(color("◆ Context Compression", Colors.CYAN, Colors.BOLD))
+    compression = config.get('compression', {})
+    enabled = compression.get('enabled', True)
+    print(f"  Enabled:      {'yes' if enabled else 'no'}")
+    if enabled:
+        print(f"  Threshold:    {compression.get('threshold', 0.50) * 100:.0f}%")
+        print(f"  Target ratio: {compression.get('target_ratio', 0.20) * 100:.0f}% of threshold preserved")
+        print(f"  Protect last: {compression.get('protect_last_n', 20)} messages")
+        print(f"  Protect first: {compression.get('protect_first_n', 3)} non-system head messages")
+        _aux_comp = config.get('auxiliary', {}).get('compression', {})
+        _sm = _aux_comp.get('model', '') or '(auto)'
+        print(f"  Model:        {_sm}")
+        comp_provider = _aux_comp.get('provider', 'auto')
+        if comp_provider and comp_provider != 'auto':
+            print(f"  Provider:     {comp_provider}")
+    
+    # Auxiliary models
+    auxiliary = config.get('auxiliary', {})
+    aux_tasks = {
+        "Vision":      auxiliary.get('vision', {}),
+        "Web extract": auxiliary.get('web_extract', {}),
+    }
+    has_overrides = any(
+        t.get('provider', 'auto') != 'auto' or t.get('model', '')
+        for t in aux_tasks.values()
+    )
+    if has_overrides:
+        print()
+        print(color("◆ Auxiliary Models (overrides)", Colors.CYAN, Colors.BOLD))
+        for label, task_cfg in aux_tasks.items():
+            prov = task_cfg.get('provider', 'auto')
+            mdl = task_cfg.get('model', '')
+            if prov != 'auto' or mdl:
+                parts = [f"provider={prov}"]
+                if mdl:
+                    parts.append(f"model={mdl}")
+                print(f"  {label:12s}  {', '.join(parts)}")
+    
+    # Messaging
+    print()
+    print(color("◆ Messaging Platforms", Colors.CYAN, Colors.BOLD))
+    
+    telegram_token = get_env_value('TELEGRAM_BOT_TOKEN')
+    discord_token = get_env_value('DISCORD_BOT_TOKEN')
+    
+    print(f"  Telegram:     {'configured' if telegram_token else color('not configured', Colors.DIM)}")
+    print(f"  Discord:      {'configured' if discord_token else color('not configured', Colors.DIM)}")
+    
+    # Skill config
+    try:
+        from agent.skill_utils import discover_all_skill_config_vars, resolve_skill_config_values
+        skill_vars = discover_all_skill_config_vars()
+        if skill_vars:
+            resolved = resolve_skill_config_values(skill_vars)
+            print()
+            print(color("◆ Skill Settings", Colors.CYAN, Colors.BOLD))
+            for var in skill_vars:
+                key = var["key"]
+                value = resolved.get(key, "")
+                skill_name = var.get("skill", "")
+                display_val = str(value) if value else color("(not set)", Colors.DIM)
+                print(f"  {key:<20s} {display_val}  {color(f'[{skill_name}]', Colors.DIM)}")
+    except Exception:
+        pass
+
+    print()
+    print(color("─" * 60, Colors.DIM))
+    print(color("  hermes config edit     # Edit config file", Colors.DIM))
+    print(color("  hermes config set <key> <value>", Colors.DIM))
+    print(color("  hermes setup           # Run setup wizard", Colors.DIM))
+    print()
+
+
+def edit_config():
+    """Open config file in user's editor."""
+    if is_managed():
+        managed_error("edit configuration")
+        return
+    config_path = get_config_path()
+    
+    # Ensure config exists
+    if not config_path.exists():
+        save_config(DEFAULT_CONFIG)
+        print(f"Created {config_path}")
+    
+    # Find editor
+    editor = os.getenv('EDITOR') or os.getenv('VISUAL')
+
+    if not editor:
+        # Try common editors — order is platform-aware so Windows users
+        # land on a working editor (notepad) even without Git Bash or nano
+        # installed.  On POSIX, prefer nano/vim over code/notepad because
+        # it's more likely to be present on headless / server systems.
+        import shutil
+        import sys as _sys
+        if _sys.platform == "win32":
+            candidates = ['notepad', 'code', 'vim', 'vi', 'nano']
+        else:
+            candidates = ['nano', 'vim', 'vi', 'code', 'notepad']
+        for cmd in candidates:
+            if shutil.which(cmd):
+                editor = cmd
+                break
+    
+    if not editor:
+        print("No editor found. Config file is at:")
+        print(f"  {config_path}")
+        return
+    
+    print(f"Opening {config_path} in {editor}...")
+    subprocess.run([editor, str(config_path)])
+
+
+def set_config_value(key: str, value: str):
+    """Set a configuration value."""
+    if is_managed():
+        managed_error("set configuration values")
+        return
+    # Check if it's an API key (goes to .env)
+    api_keys = [
+        'OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'VOICE_TOOLS_OPENAI_KEY',
+        'EXA_API_KEY', 'PARALLEL_API_KEY', 'FIRECRAWL_API_KEY', 'FIRECRAWL_API_URL',
+        'FIRECRAWL_GATEWAY_URL', 'TOOL_GATEWAY_DOMAIN', 'TOOL_GATEWAY_SCHEME',
+        'TOOL_GATEWAY_USER_TOKEN', 'TAVILY_API_KEY',
+        'BROWSERBASE_API_KEY', 'BROWSERBASE_PROJECT_ID', 'BROWSER_USE_API_KEY',
+        'FAL_KEY', 'TELEGRAM_BOT_TOKEN', 'DISCORD_BOT_TOKEN',
+        'TERMINAL_SSH_HOST', 'TERMINAL_SSH_USER', 'TERMINAL_SSH_KEY',
+        'SUDO_PASSWORD', 'SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN',
+        'GITHUB_TOKEN', 'HONCHO_API_KEY',
+    ]
+    
+    if key.upper() in api_keys or key.upper().endswith(('_API_KEY', '_TOKEN')) or key.upper().startswith('TERMINAL_SSH'):
+        save_env_value(key.upper(), value)
+        print(f"✓ Set {key} in {get_env_path()}")
+        return
+    
+    # Otherwise it goes to config.yaml
+    # Read the raw user config (not merged with defaults) to avoid
+    # dumping all default values back to the file
+    config_path = get_config_path()
+    user_config = {}
+    if config_path.exists():
+        try:
+            with open(config_path, encoding="utf-8") as f:
+                user_config = yaml.safe_load(f) or {}
+        except Exception:
+            user_config = {}
+    
+    # Handle nested keys (e.g., "tts.provider") including numeric list
+    # indices (e.g., "custom_providers.0.api_key").  Delegates to
+    # _set_nested which preserves list-typed nodes; before #17876 the
+    # inline navigation here silently overwrote lists with dicts.
+
+    # Convert value to appropriate type
+    if value.lower() in {'true', 'yes', 'on'}:
+        value = True
+    elif value.lower() in {'false', 'no', 'off'}:
+        value = False
+    elif value.isdigit():
+        value = int(value)
+    elif value.replace('.', '', 1).isdigit():
+        value = float(value)
+
+    _set_nested(user_config, key, value)
+    
+    # Write only user config back (not the full merged defaults)
+    ensure_hermes_home()
+    from utils import atomic_yaml_write
+    atomic_yaml_write(config_path, user_config, sort_keys=False)
+    
+    # Keep .env in sync for keys that terminal_tool reads directly from env vars.
+    # config.yaml is authoritative, but terminal_tool only reads TERMINAL_ENV etc.
+    env_var = terminal_config_env_var_for_key(key)
+    if env_var and key != "terminal.cwd":
+        save_env_value(env_var, _terminal_env_value(value))
+
+    print(f"✓ Set {key} = {value} in {config_path}")
+
+
+# =============================================================================
+# Command handler
+# =============================================================================
+
+def config_command(args):
+    """Handle config subcommands."""
+    subcmd = getattr(args, 'config_command', None)
+    
+    if subcmd is None or subcmd == "show":
+        show_config()
+    
+    elif subcmd == "edit":
+        edit_config()
+    
+    elif subcmd == "set":
+        key = getattr(args, 'key', None)
+        value = getattr(args, 'value', None)
+        if not key or value is None:
+            print("Usage: hermes config set <key> <value>")
+            print()
+            print("Examples:")
+            print("  hermes config set model anthropic/claude-sonnet-4")
+            print("  hermes config set terminal.backend docker")
+            print("  hermes config set OPENROUTER_API_KEY sk-or-...")
+            sys.exit(1)
+        set_config_value(key, value)
+    
+    elif subcmd == "path":
+        print(get_config_path())
+    
+    elif subcmd == "env-path":
+        print(get_env_path())
+    
+    elif subcmd == "migrate":
+        print()
+        print(color("🔄 Checking configuration for updates...", Colors.CYAN, Colors.BOLD))
+        print()
+        
+        # Check what's missing
+        missing_env = get_missing_env_vars(required_only=False)
+        missing_config = get_missing_config_fields()
+        current_ver, latest_ver = check_config_version()
+        
+        if not missing_env and not missing_config and current_ver >= latest_ver:
+            print(color("✓ Configuration is up to date!", Colors.GREEN))
+            print()
+            return
+        
+        # Show what needs to be updated
+        if current_ver < latest_ver:
+            print(f"  Config version: {current_ver} → {latest_ver}")
+        
+        if missing_config:
+            print(f"\n  {len(missing_config)} new config option(s) will be added with defaults")
+        
+        required_missing = [v for v in missing_env if v.get("is_required")]
+        optional_missing = [
+            v for v in missing_env
+            if not v.get("is_required") and not v.get("advanced")
+        ]
+        
+        if required_missing:
+            print(f"\n  ⚠️  {len(required_missing)} required API key(s) missing:")
+            for var in required_missing:
+                print(f"     • {var['name']}")
+        
+        if optional_missing:
+            print(f"\n  ℹ️  {len(optional_missing)} optional API key(s) not configured:")
+            for var in optional_missing:
+                tools = var.get("tools", [])
+                tools_str = f" (enables: {', '.join(tools[:2])})" if tools else ""
+                print(f"     • {var['name']}{tools_str}")
+        
+        print()
+        
+        # Run migration
+        results = migrate_config(interactive=True, quiet=False)
+        
+        print()
+        if results["env_added"] or results["config_added"]:
+            print(color("✓ Configuration updated!", Colors.GREEN))
+        
+        if results["warnings"]:
+            print()
+            for warning in results["warnings"]:
+                print(color(f"  ⚠️  {warning}", Colors.YELLOW))
+        
+        print()
+    
+    elif subcmd == "check":
+        # Non-interactive check for what's missing
+        print()
+        print(color("📋 Configuration Status", Colors.CYAN, Colors.BOLD))
+        print()
+        
+        current_ver, latest_ver = check_config_version()
+        if current_ver >= latest_ver:
+            print(f"  Config version: {current_ver} ✓")
+        else:
+            print(color(f"  Config version: {current_ver} → {latest_ver} (update available)", Colors.YELLOW))
+        
+        print()
+        print(color("  Required:", Colors.BOLD))
+        for var_name in REQUIRED_ENV_VARS:
+            if get_env_value(var_name):
+                print(f"    ✓ {var_name}")
+            else:
+                print(color(f"    ✗ {var_name} (missing)", Colors.RED))
+        
+        print()
+        print(color("  Optional:", Colors.BOLD))
+        for var_name, info in OPTIONAL_ENV_VARS.items():
+            if get_env_value(var_name):
+                print(f"    ✓ {var_name}")
+            else:
+                tools = info.get("tools", [])
+                tools_str = f" → {', '.join(tools[:2])}" if tools else ""
+                print(color(f"    ○ {var_name}{tools_str}", Colors.DIM))
+        
+        missing_config = get_missing_config_fields()
+        if missing_config:
+            print()
+            print(color(f"  {len(missing_config)} new config option(s) available", Colors.YELLOW))
+            print("    Run 'hermes config migrate' to add them")
+        
+        print()
+    
+    else:
+        print(f"Unknown config command: {subcmd}")
+        print()
+        print("Available commands:")
+        print("  hermes config           Show current configuration")
+        print("  hermes config edit      Open config in editor")
+        print("  hermes config set <key> <value>   Set a config value")
+        print("  hermes config check     Check for missing/outdated config")
+        print("  hermes config migrate   Update config with new options")
+        print("  hermes config path      Show config file path")
+        print("  hermes config env-path  Show .env file path")
+        sys.exit(1)
+
+
+# ── Profile-driven env var injection ─────────────────────────────────────────
+# Any provider registered in providers/ with auth_type="api_key" automatically
+# gets its env_vars exposed in OPTIONAL_ENV_VARS without editing this file.
+# Runs once at import time.
+
+_profile_env_vars_injected = False
+
+
+def _inject_profile_env_vars() -> None:
+    """Populate OPTIONAL_ENV_VARS from provider profiles not already listed.
+
+    Called once at module load time. Idempotent — repeated calls are no-ops.
+    """
+    global _profile_env_vars_injected
+    if _profile_env_vars_injected:
+        return
+    _profile_env_vars_injected = True
+    try:
+        from providers import list_providers
+        for _pp in list_providers():
+            if _pp.auth_type not in {"api_key",}:
+                continue
+            for _var in _pp.env_vars:
+                if _var in OPTIONAL_ENV_VARS:
+                    continue
+                _is_key = not _var.endswith("_BASE_URL") and not _var.endswith("_URL")
+                OPTIONAL_ENV_VARS[_var] = {
+                    "description": f"{_pp.display_name or _pp.name} {'API key' if _is_key else 'base URL override'}",
+                    "prompt": f"{_pp.display_name or _pp.name} {'API key' if _is_key else 'base URL (leave empty for default)'}",
+                    "url": _pp.signup_url or None,
+                    "password": _is_key,
+                    "category": "provider",
+                    "advanced": True,
+                }
+    except Exception:
+        pass
+
+
+# Eagerly inject so that OPTIONAL_ENV_VARS is fully populated at import time.
+_inject_profile_env_vars()
+
+
+# ── Platform-plugin env var injection ────────────────────────────────────────
+# Bundled platform plugins under ``plugins/platforms/*/plugin.yaml`` declare
+# their required env vars via ``requires_env``.  This mirror of
+# ``_inject_profile_env_vars`` surfaces them in ``hermes config`` UI so users
+# can configure Teams / IRC / Google Chat without the core repo ever needing
+# to know they exist.
+#
+# Each ``requires_env`` entry may be a bare string (name only) or a dict:
+#
+#   requires_env:
+#     - TEAMS_CLIENT_ID                          # minimal
+#     - name: TEAMS_CLIENT_SECRET                # rich
+#       description: "Teams bot client secret"
+#       url: "https://portal.azure.com/"
+#       password: true
+#       prompt: "Teams client secret"
+#
+# An optional ``optional_env`` block surfaces non-required vars the same way
+# (e.g. allowlist, home channel).
+
+_platform_plugin_env_vars_injected = False
+
+
+def _inject_platform_plugin_env_vars() -> None:
+    """Populate OPTIONAL_ENV_VARS from bundled platform plugin manifests.
+
+    Called once at module load time. Idempotent — repeated calls are no-ops.
+    Failures are swallowed so a malformed plugin.yaml can't break CLI import.
+    """
+    global _platform_plugin_env_vars_injected
+    if _platform_plugin_env_vars_injected:
+        return
+    _platform_plugin_env_vars_injected = True
+    try:
+        import yaml  # type: ignore
+
+        # Resolve the bundled plugins dir from this file's location so the
+        # injector works regardless of CWD.
+        repo_root = Path(__file__).resolve().parents[1]
+        platforms_dir = repo_root / "plugins" / "platforms"
+        if not platforms_dir.is_dir():
+            return
+        for child in platforms_dir.iterdir():
+            if not child.is_dir():
+                continue
+            manifest_path = child / "plugin.yaml"
+            if not manifest_path.exists():
+                manifest_path = child / "plugin.yml"
+            if not manifest_path.exists():
+                continue
+            try:
+                with open(manifest_path, "r", encoding="utf-8") as f:
+                    manifest = yaml.safe_load(f) or {}
+            except Exception:
+                continue
+            label = manifest.get("label") or manifest.get("name") or child.name
+            # Merge required + optional env var declarations.
+            entries = list(manifest.get("requires_env") or [])
+            entries.extend(manifest.get("optional_env") or [])
+            for entry in entries:
+                if isinstance(entry, str):
+                    name = entry
+                    meta: dict = {}
+                elif isinstance(entry, dict) and entry.get("name"):
+                    name = entry["name"]
+                    meta = entry
+                else:
+                    continue
+                if name in OPTIONAL_ENV_VARS:
+                    continue  # hardcoded entry wins (back-compat)
+                # Heuristic: anything named *TOKEN, *SECRET, *KEY, *PASSWORD
+                # is a password field unless explicitly overridden.
+                name_upper = name.upper()
+                is_secret = bool(meta.get("password") or meta.get("secret"))
+                if not is_secret and not meta.get("password") is False:
+                    is_secret = any(
+                        name_upper.endswith(suf)
+                        for suf in ("_TOKEN", "_SECRET", "_KEY", "_PASSWORD", "_JSON")
+                    )
+                OPTIONAL_ENV_VARS[name] = {
+                    "description": (
+                        meta.get("description")
+                        or f"{label} configuration"
+                    ),
+                    "prompt": meta.get("prompt") or name,
+                    "url": meta.get("url") or None,
+                    "password": is_secret,
+                    "category": meta.get("category") or "messaging",
+                }
+    except Exception:
+        pass
+
+
+# Eagerly inject so that platform plugin env vars show up in the setup wizard.
+_inject_platform_plugin_env_vars()

--- a/hermes_cli/worker_cli.py
+++ b/hermes_cli/worker_cli.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""
+Command-line interface for managing the Hermes queue worker daemon.
+
+This provides commands to start, stop, and manage standalone queue workers
+that execute cron jobs independently of the gateway process.
+"""
+
+import os
+import sys
+import json
+import signal
+import subprocess
+import argparse
+from pathlib import Path
+from typing import Optional
+
+# Add the parent directory to sys.path so we can import hermes modules
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from hermes_cli.config import get_hermes_home
+
+
+def get_worker_pid_file(worker_id: str = "default") -> Path:
+    """Get the path to the worker PID file."""
+    return get_hermes_home() / "workers" / f"{worker_id}.pid"
+
+
+def get_worker_log_file(worker_id: str = "default") -> Path:
+    """Get the path to the worker log file."""
+    return get_hermes_home() / "workers" / f"{worker_id}.log"
+
+
+def is_worker_running(worker_id: str = "default") -> bool:
+    """Check if a worker with the given ID is currently running."""
+    pid_file = get_worker_pid_file(worker_id)
+    
+    if not pid_file.exists():
+        return False
+    
+    try:
+        with open(pid_file, 'r') as f:
+            pid = int(f.read().strip())
+        
+        # Check if the process is actually running
+        os.kill(pid, 0)  # This will raise if process doesn't exist
+        return True
+        
+    except (ValueError, OSError, ProcessLookupError):
+        # PID file is invalid or process is dead
+        # Clean up stale PID file
+        try:
+            pid_file.unlink()
+        except OSError:
+            pass
+        return False
+
+
+def start_worker(
+    worker_id: str = "default",
+    profile: Optional[str] = None,
+    poll_interval: int = 30,
+    max_concurrent: int = 5,
+    daemon: bool = True,
+    verbose: bool = False
+) -> bool:
+    """
+    Start a queue worker daemon.
+    
+    Returns:
+        True if worker started successfully, False otherwise
+    """
+    if is_worker_running(worker_id):
+        print(f"Worker '{worker_id}' is already running")
+        return False
+    
+    # Prepare worker directories
+    worker_dir = get_hermes_home() / "workers"
+    worker_dir.mkdir(parents=True, exist_ok=True)
+    
+    pid_file = get_worker_pid_file(worker_id)
+    log_file = get_worker_log_file(worker_id)
+    
+    # Build command
+    worker_script = Path(__file__).parent / "worker_daemon.py"
+    cmd = [
+        sys.executable, "-m", "cron.worker_daemon",
+        "--worker-id", worker_id,
+        "--poll-interval", str(poll_interval),
+        "--max-concurrent", str(max_concurrent)
+    ]
+    
+    if profile:
+        cmd.extend(["--profile", profile])
+    
+    if verbose:
+        cmd.append("--verbose")
+    
+    try:
+        if daemon:
+            # Start as daemon process
+            with open(log_file, 'w') as log_f:
+                process = subprocess.Popen(
+                    cmd,
+                    stdout=log_f,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True,  # Detach from current session
+                    cwd=Path(__file__).parent.parent  # Run from hermes-agent root
+                )
+            
+            # Write PID file
+            with open(pid_file, 'w') as f:
+                f.write(str(process.pid))
+            
+            print(f"Worker '{worker_id}' started (PID: {process.pid})")
+            print(f"Logs: {log_file}")
+            
+        else:
+            # Run in foreground
+            print(f"Starting worker '{worker_id}' in foreground...")
+            os.chdir(Path(__file__).parent.parent)  # Run from hermes-agent root
+            subprocess.run(cmd)
+        
+        return True
+        
+    except Exception as e:
+        print(f"Failed to start worker '{worker_id}': {e}")
+        return False
+
+
+def stop_worker(worker_id: str = "default", timeout: int = 30) -> bool:
+    """
+    Stop a running queue worker.
+    
+    Args:
+        worker_id: Worker ID to stop
+        timeout: Seconds to wait for graceful shutdown
+        
+    Returns:
+        True if worker stopped successfully, False otherwise
+    """
+    pid_file = get_worker_pid_file(worker_id)
+    
+    if not is_worker_running(worker_id):
+        print(f"Worker '{worker_id}' is not running")
+        return True
+    
+    try:
+        with open(pid_file, 'r') as f:
+            pid = int(f.read().strip())
+        
+        print(f"Stopping worker '{worker_id}' (PID: {pid})")
+        
+        # Send SIGTERM for graceful shutdown
+        os.kill(pid, signal.SIGTERM)
+        
+        # Wait for process to exit
+        import time
+        for _ in range(timeout):
+            try:
+                os.kill(pid, 0)  # Check if still running
+                time.sleep(1)
+            except ProcessLookupError:
+                # Process is dead
+                break
+        else:
+            # Timeout reached, force kill
+            print(f"Worker '{worker_id}' didn't stop gracefully, forcing shutdown")
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+        
+        # Clean up PID file
+        try:
+            pid_file.unlink()
+        except OSError:
+            pass
+        
+        print(f"Worker '{worker_id}' stopped")
+        return True
+        
+    except Exception as e:
+        print(f"Failed to stop worker '{worker_id}': {e}")
+        return False
+
+
+def list_workers() -> None:
+    """List all registered workers and their status."""
+    worker_dir = get_hermes_home() / "workers"
+    
+    if not worker_dir.exists():
+        print("No workers directory found")
+        return
+    
+    pid_files = list(worker_dir.glob("*.pid"))
+    
+    if not pid_files:
+        print("No workers configured")
+        return
+    
+    print("Workers:")
+    print("-" * 50)
+    
+    for pid_file in pid_files:
+        worker_id = pid_file.stem
+        running = is_worker_running(worker_id)
+        status = "RUNNING" if running else "STOPPED"
+        
+        log_file = get_worker_log_file(worker_id)
+        log_size = ""
+        if log_file.exists():
+            size_bytes = log_file.stat().st_size
+            if size_bytes > 1024 * 1024:
+                log_size = f" ({size_bytes // (1024 * 1024)}MB)"
+            elif size_bytes > 1024:
+                log_size = f" ({size_bytes // 1024}KB)"
+        
+        print(f"  {worker_id:15} {status:8} {log_file}{log_size}")
+
+
+def show_worker_logs(worker_id: str = "default", tail_lines: int = 50) -> None:
+    """Show recent log entries for a worker."""
+    log_file = get_worker_log_file(worker_id)
+    
+    if not log_file.exists():
+        print(f"No log file found for worker '{worker_id}'")
+        return
+    
+    try:
+        with open(log_file, 'r') as f:
+            lines = f.readlines()
+        
+        # Show last N lines
+        recent_lines = lines[-tail_lines:] if len(lines) > tail_lines else lines
+        
+        print(f"Recent logs for worker '{worker_id}' ({len(recent_lines)} lines):")
+        print("-" * 60)
+        for line in recent_lines:
+            print(line.rstrip())
+            
+    except Exception as e:
+        print(f"Failed to read logs for worker '{worker_id}': {e}")
+
+
+def main():
+    """Main CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Hermes Queue Worker Management",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s start                    # Start default worker
+  %(prog)s start --worker-id bg     # Start background worker
+  %(prog)s start --foreground       # Run in foreground (no daemon)
+  %(prog)s stop                     # Stop default worker
+  %(prog)s list                     # List all workers
+  %(prog)s logs --worker-id bg      # Show logs for background worker
+        """
+    )
+    
+    subparsers = parser.add_subparsers(dest='command', help='Available commands')
+    
+    # Start command
+    start_parser = subparsers.add_parser('start', help='Start a queue worker')
+    start_parser.add_argument('--worker-id', default='default', help='Worker ID')
+    start_parser.add_argument('--profile', help='Hermes profile to use')
+    start_parser.add_argument('--poll-interval', type=int, default=30, help='Poll interval in seconds')
+    start_parser.add_argument('--max-concurrent', type=int, default=5, help='Max concurrent jobs')
+    start_parser.add_argument('--foreground', action='store_true', help='Run in foreground (not daemon)')
+    start_parser.add_argument('--verbose', '-v', action='store_true', help='Verbose logging')
+    
+    # Stop command
+    stop_parser = subparsers.add_parser('stop', help='Stop a queue worker')
+    stop_parser.add_argument('--worker-id', default='default', help='Worker ID')
+    stop_parser.add_argument('--timeout', type=int, default=30, help='Shutdown timeout in seconds')
+    
+    # List command
+    subparsers.add_parser('list', help='List all workers')
+    
+    # Logs command
+    logs_parser = subparsers.add_parser('logs', help='Show worker logs')
+    logs_parser.add_argument('--worker-id', default='default', help='Worker ID')
+    logs_parser.add_argument('--tail', type=int, default=50, help='Number of recent lines to show')
+    
+    args = parser.parse_args()
+    
+    if not args.command:
+        parser.print_help()
+        return
+    
+    if args.command == 'start':
+        success = start_worker(
+            worker_id=args.worker_id,
+            profile=args.profile,
+            poll_interval=args.poll_interval,
+            max_concurrent=args.max_concurrent,
+            daemon=not args.foreground,
+            verbose=args.verbose
+        )
+        sys.exit(0 if success else 1)
+        
+    elif args.command == 'stop':
+        success = stop_worker(args.worker_id, args.timeout)
+        sys.exit(0 if success else 1)
+        
+    elif args.command == 'list':
+        list_workers()
+        
+    elif args.command == 'logs':
+        show_worker_logs(args.worker_id, args.tail)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/agent/test_failure_policy.py
+++ b/tests/agent/test_failure_policy.py
@@ -1,0 +1,98 @@
+import json
+
+from agent.error_classifier import ClassifiedError, FailoverReason
+from agent.failure_policy import (
+    FailureClass,
+    RecoveryAction,
+    decide_api_recovery,
+    decide_tool_recovery,
+)
+
+
+def test_api_context_overflow_prefers_compression() -> None:
+    err = ClassifiedError(
+        reason=FailoverReason.context_overflow,
+        retryable=True,
+        should_compress=True,
+    )
+
+    decision = decide_api_recovery(err)
+
+    assert decision.failure_class == FailureClass.context_overflow
+    assert decision.primary_action == RecoveryAction.compress_context
+    assert decision.secondary_actions == (RecoveryAction.retry_smaller_scope,)
+    assert decision.retryable is True
+
+
+def test_api_auth_prefers_rotation_then_fallback() -> None:
+    err = ClassifiedError(
+        reason=FailoverReason.auth,
+        retryable=False,
+        should_fallback=True,
+        should_rotate_credential=True,
+    )
+
+    decision = decide_api_recovery(err)
+
+    assert decision.failure_class == FailureClass.auth
+    assert decision.primary_action == RecoveryAction.rotate_credential
+    assert decision.secondary_actions == (RecoveryAction.fallback_provider,)
+
+
+def test_api_content_policy_asks_user_not_retry() -> None:
+    err = ClassifiedError(reason=FailoverReason.content_policy_blocked, retryable=False)
+
+    decision = decide_api_recovery(err)
+
+    assert decision.failure_class == FailureClass.content_policy
+    assert decision.primary_action == RecoveryAction.ask_user
+    assert decision.retryable is False
+
+
+def test_tool_structured_nonzero_exit_prefers_degrade_then_fallback() -> None:
+    result = json.dumps({"exit_code": 2, "output": "Traceback: nope"})
+
+    decision = decide_tool_recovery("terminal", result)
+
+    assert decision.failure_class == FailureClass.tool_failed
+    assert decision.primary_action == RecoveryAction.degrade_mode
+    assert decision.secondary_actions == (RecoveryAction.fallback_tool,)
+    assert decision.retryable is True
+
+
+def test_tool_empty_results_prefers_narrower_scope() -> None:
+    result = json.dumps({"results": []})
+
+    decision = decide_tool_recovery("web_search", result)
+
+    assert decision.failure_class == FailureClass.empty_result
+    assert decision.primary_action == RecoveryAction.retry_smaller_scope
+    assert decision.secondary_actions == (RecoveryAction.fallback_tool,)
+
+
+def test_tool_missing_service_is_unavailable() -> None:
+    result = json.dumps({"success": False, "error": "Tool not available: Home Assistant token missing"})
+
+    decision = decide_tool_recovery("ha_get_state", result)
+
+    assert decision.failure_class == FailureClass.tool_unavailable
+    assert decision.primary_action == RecoveryAction.fallback_tool
+    assert decision.retryable is False
+
+
+def test_tool_invalid_json_args_becomes_parse_error() -> None:
+    result = "JSON parse error: expected object"
+
+    decision = decide_tool_recovery("execute_code", result)
+
+    assert decision.failure_class == FailureClass.parse_error
+    assert decision.primary_action == RecoveryAction.degrade_mode
+    assert decision.secondary_actions == (RecoveryAction.retry_same,)
+
+
+def test_tool_plain_unknown_text_retries_then_falls_back() -> None:
+    decision = decide_tool_recovery("browser_navigate", "unexpected upstream weirdness")
+
+    assert decision.failure_class == FailureClass.unknown
+    assert decision.primary_action == RecoveryAction.retry_same
+    assert decision.secondary_actions == (RecoveryAction.fallback_tool,)

--- a/tests/agent/test_job_lifecycle.py
+++ b/tests/agent/test_job_lifecycle.py
@@ -1,0 +1,95 @@
+from agent.job_lifecycle import (
+    JobLifecycleState,
+    cron_lifecycle_state,
+    default_queue_metadata,
+    make_attempt_record,
+    normalize_queue_metadata,
+    process_lifecycle_state,
+)
+
+
+def test_process_running_maps_to_running() -> None:
+    assert process_lifecycle_state(exited=False, exit_code=None) == JobLifecycleState.running
+
+
+def test_process_zero_exit_maps_to_completed() -> None:
+    assert process_lifecycle_state(exited=True, exit_code=0) == JobLifecycleState.completed
+
+
+def test_process_sigterm_maps_to_cancelled() -> None:
+    assert process_lifecycle_state(exited=True, exit_code=-15) == JobLifecycleState.cancelled
+
+
+def test_cron_scheduled_job_maps_to_queued() -> None:
+    state = cron_lifecycle_state({"state": "scheduled", "enabled": True, "next_run_at": "2030-01-01T00:00:00+00:00"})
+    assert state == JobLifecycleState.queued
+
+
+def test_cron_failed_recurring_job_maps_to_retrying() -> None:
+    state = cron_lifecycle_state(
+        {
+            "state": "scheduled",
+            "enabled": True,
+            "next_run_at": "2030-01-01T00:00:00+00:00",
+            "last_status": "error",
+        }
+    )
+    assert state == JobLifecycleState.retrying
+
+
+def test_cron_paused_job_maps_to_paused() -> None:
+    state = cron_lifecycle_state({"state": "paused", "enabled": False})
+    assert state == JobLifecycleState.paused
+
+
+def test_cron_terminal_error_maps_to_failed() -> None:
+    state = cron_lifecycle_state({"state": "completed", "enabled": False, "last_status": "error"})
+    assert state == JobLifecycleState.failed
+
+
+def test_default_queue_metadata_starts_empty() -> None:
+    queue = default_queue_metadata(queued_at="2030-01-01T00:00:00")
+    assert queue == {
+        "retry_count": 0,
+        "retry_backoff_seconds": 0,
+        "next_retry_at": None,
+        "current_attempt": None,
+        "last_attempt": None,
+        "attempt_history": [],
+        "last_queued_at": "2030-01-01T00:00:00",
+        "runner": {
+            "kind": "cron",
+            "queue_name": "default",
+            "priority": 0,
+            "active": False,
+            "claimed_at": None,
+            "lease_expires_at": None,
+            "worker_id": None,
+            "last_started_at": None,
+            "last_finished_at": None,
+        },
+    }
+
+
+def test_normalize_queue_metadata_preserves_attempt_records() -> None:
+    queue = normalize_queue_metadata(
+        {
+            "retry_count": "2",
+            "current_attempt": make_attempt_record(
+                attempt=3,
+                state=JobLifecycleState.running,
+                started_at="2030-01-01T00:00:00",
+                retry_count=2,
+            ),
+        },
+        queued_at="2030-01-01T00:00:00",
+    )
+    assert queue["retry_count"] == 2
+    assert queue["current_attempt"]["attempt"] == 3
+    assert queue["current_attempt"]["lifecycle_state"] == JobLifecycleState.running.value
+    assert queue["attempt_history"] == []
+    assert queue["next_retry_at"] is None
+    assert queue["retry_backoff_seconds"] == 0
+    assert queue["runner"]["kind"] == "cron"
+    assert queue["runner"]["queue_name"] == "default"
+    assert queue["runner"]["lease_expires_at"] is None

--- a/tests/agent/test_tool_executor_recovery_policy.py
+++ b/tests/agent/test_tool_executor_recovery_policy.py
@@ -1,0 +1,24 @@
+from agent.failure_policy import RecoveryAction
+from agent.tool_executor import _tool_failure_recovery_decision
+
+
+def test_tool_failure_recovery_decision_for_empty_search_result() -> None:
+    decision = _tool_failure_recovery_decision("web_search", '{"results": []}')
+
+    assert decision is not None
+    assert decision.primary_action == RecoveryAction.retry_smaller_scope
+
+
+def test_tool_failure_recovery_decision_for_unavailable_tool() -> None:
+    decision = _tool_failure_recovery_decision(
+        "ha_get_state",
+        '{"success": false, "error": "Tool not available: Home Assistant token missing"}',
+    )
+
+    assert decision is not None
+    assert decision.primary_action == RecoveryAction.fallback_tool
+    assert decision.retryable is False
+
+
+def test_tool_failure_recovery_decision_returns_none_for_success() -> None:
+    assert _tool_failure_recovery_decision("read_file", '{"content": "hello"}') is None

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -17,11 +17,13 @@ from cron.jobs import (
     pause_job,
     resume_job,
     remove_job,
+    mark_job_started,
     mark_job_run,
     advance_next_run,
     get_due_jobs,
     save_job_output,
 )
+from agent.job_lifecycle import JobLifecycleState
 
 
 # =========================================================================
@@ -193,10 +195,34 @@ class TestJobCRUD:
         assert job["prompt"] == "Check server status"
         assert job["enabled"] is True
         assert job["schedule"]["kind"] == "once"
+        assert job["lifecycle_state"] == JobLifecycleState.queued.value
 
         fetched = get_job(job["id"])
         assert fetched is not None
         assert fetched["prompt"] == "Check server status"
+        assert fetched["lifecycle_state"] == JobLifecycleState.queued.value
+
+    def test_create_initializes_queue_metadata(self, tmp_cron_dir):
+        job = create_job(prompt="Check queue", schedule="every 1h")
+
+        assert job["queue"]["retry_count"] == 0
+        assert job["queue"]["retry_backoff_seconds"] == 0
+        assert job["queue"]["next_retry_at"] is None
+        assert job["queue"]["current_attempt"] is None
+        assert job["queue"]["last_attempt"] is None
+        assert job["queue"]["attempt_history"] == []
+        assert job["queue"]["last_queued_at"] == job["created_at"]
+        assert job["queue"]["runner"] == {
+            "kind": "cron",
+            "queue_name": "default",
+            "priority": 0,
+            "active": False,
+            "claimed_at": None,
+            "lease_expires_at": None,
+            "worker_id": None,
+            "last_started_at": None,
+            "last_finished_at": None,
+        }
 
     def test_list_jobs(self, tmp_cron_dir):
         create_job(prompt="Job 1", schedule="every 1h")
@@ -434,12 +460,114 @@ class TestResolveJobRef:
 
 
 class TestMarkJobRun:
+    def test_mark_job_started_creates_running_attempt_record(self, tmp_cron_dir):
+        job = create_job(prompt="Test", schedule="every 1h")
+
+        assert mark_job_started(job["id"]) is True
+
+        updated = get_job(job["id"])
+        attempt = updated["queue"]["current_attempt"]
+        assert updated["state"] == "running"
+        assert updated["lifecycle_state"] == JobLifecycleState.running.value
+        assert attempt["attempt"] == 1
+        assert attempt["lifecycle_state"] == JobLifecycleState.running.value
+        assert attempt["started_at"]
+        assert attempt["finished_at"] is None
+        assert attempt["retry_count"] == 0
+        assert updated["queue"]["attempt_history"] == []
+        assert updated["queue"]["retry_backoff_seconds"] == 0
+        assert updated["queue"]["next_retry_at"] is None
+        assert updated["queue"]["runner"]["active"] is True
+        assert updated["queue"]["runner"]["claimed_at"] == attempt["started_at"]
+        assert updated["queue"]["runner"]["lease_expires_at"] is not None
+        assert updated["queue"]["runner"]["last_started_at"] == attempt["started_at"]
+        assert updated["queue"]["runner"]["last_finished_at"] is None
+
     def test_increments_completed(self, tmp_cron_dir):
         job = create_job(prompt="Test", schedule="every 1h")
+        mark_job_started(job["id"])
         mark_job_run(job["id"], success=True)
         updated = get_job(job["id"])
         assert updated["repeat"]["completed"] == 1
         assert updated["last_status"] == "ok"
+        assert updated["lifecycle_state"] == JobLifecycleState.queued.value
+        attempt = updated["queue"]["last_attempt"]
+        assert updated["queue"]["current_attempt"] is None
+        assert updated["queue"]["retry_count"] == 0
+        assert updated["queue"]["retry_backoff_seconds"] == 0
+        assert updated["queue"]["next_retry_at"] is None
+        assert attempt["attempt"] == 1
+        assert attempt["lifecycle_state"] == JobLifecycleState.completed.value
+        assert attempt["finished_at"]
+        assert attempt["error"] is None
+        assert updated["queue"]["attempt_history"] == [attempt]
+        assert updated["queue"]["runner"]["active"] is False
+        assert updated["queue"]["runner"]["claimed_at"] is None
+        assert updated["queue"]["runner"]["last_finished_at"] == attempt["finished_at"]
+
+    def test_failure_increments_retry_count_and_records_error(self, tmp_cron_dir):
+        job = create_job(prompt="Retry me", schedule="every 1h")
+        mark_job_started(job["id"])
+
+        mark_job_run(job["id"], success=False, error="boom")
+
+        updated = get_job(job["id"])
+        attempt = updated["queue"]["last_attempt"]
+        assert updated["queue"]["retry_count"] == 1
+        assert updated["queue"]["retry_backoff_seconds"] == 60
+        assert updated["queue"]["next_retry_at"] is not None
+        assert updated["lifecycle_state"] == JobLifecycleState.retrying.value
+        assert attempt["attempt"] == 1
+        assert attempt["lifecycle_state"] == JobLifecycleState.failed.value
+        assert attempt["error"] == "boom"
+        assert updated["queue"]["attempt_history"] == [attempt]
+        assert updated["queue"]["runner"]["active"] is False
+        assert updated["queue"]["runner"]["last_finished_at"] == attempt["finished_at"]
+
+    def test_next_start_increments_attempt_number(self, tmp_cron_dir):
+        job = create_job(prompt="Retry me", schedule="every 1h")
+        mark_job_started(job["id"])
+        mark_job_run(job["id"], success=False, error="boom")
+
+        assert mark_job_started(job["id"]) is True
+
+        updated = get_job(job["id"])
+        attempt = updated["queue"]["current_attempt"]
+        assert attempt["attempt"] == 2
+        assert attempt["retry_count"] == 1
+        assert attempt["lifecycle_state"] == JobLifecycleState.running.value
+        assert updated["queue"]["next_retry_at"] is None
+        assert updated["queue"]["retry_backoff_seconds"] == 60
+        assert len(updated["queue"]["attempt_history"]) == 1
+        assert updated["queue"]["runner"]["active"] is True
+        assert updated["queue"]["runner"]["last_started_at"] == attempt["started_at"]
+
+    def test_attempt_history_accumulates_across_runs(self, tmp_cron_dir):
+        job = create_job(prompt="History", schedule="every 1h")
+
+        mark_job_started(job["id"])
+        mark_job_run(job["id"], success=False, error="first")
+        mark_job_started(job["id"])
+        mark_job_run(job["id"], success=True)
+
+        updated = get_job(job["id"])
+        history = updated["queue"]["attempt_history"]
+        assert [item["attempt"] for item in history] == [1, 2]
+        assert history[0]["error"] == "first"
+        assert history[1]["lifecycle_state"] == JobLifecycleState.completed.value
+
+    def test_retry_backoff_escalates_on_second_failure(self, tmp_cron_dir):
+        job = create_job(prompt="Retry me", schedule="every 1h")
+        mark_job_started(job["id"])
+        mark_job_run(job["id"], success=False, error="first")
+        mark_job_started(job["id"])
+        mark_job_run(job["id"], success=False, error="second")
+
+        updated = get_job(job["id"])
+        assert updated["queue"]["retry_count"] == 2
+        assert updated["queue"]["retry_backoff_seconds"] == 120
+        assert updated["queue"]["next_retry_at"] is not None
+        assert updated["queue"]["last_attempt"]["attempt"] == 2
 
     def test_repeat_limit_removes_job(self, tmp_cron_dir):
         job = create_job(prompt="Once", schedule="30m", repeat=1)
@@ -471,6 +599,7 @@ class TestMarkJobRun:
         updated = get_job(job["id"])
         assert updated["last_status"] == "error"
         assert updated["last_error"] == "timeout"
+        assert updated["lifecycle_state"] == JobLifecycleState.retrying.value
 
     def test_delivery_error_tracked_separately(self, tmp_cron_dir):
         """Agent succeeds but delivery fails — both tracked independently."""
@@ -703,6 +832,60 @@ class TestGetDueJobs:
         from cron.jobs import _ensure_aware, _hermes_now
         next_dt = _ensure_aware(datetime.fromisoformat(updated["next_run_at"]))
         assert next_dt > _hermes_now()
+
+    def test_active_runner_claim_blocks_due_job_until_lease_expires(self, tmp_cron_dir, monkeypatch):
+        start = datetime(2026, 6, 12, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: start)
+        job = create_job(prompt="Claimed", schedule="every 1h")
+        jobs = load_jobs()
+        jobs[0]["next_run_at"] = (start - timedelta(minutes=5)).isoformat()
+        save_jobs(jobs)
+        mark_job_started(job["id"])
+
+        later = start + timedelta(minutes=5)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: later)
+        due = get_due_jobs()
+
+        assert due == []
+        updated = get_job(job["id"])
+        assert updated["queue"]["runner"]["active"] is True
+        assert updated["queue"]["current_attempt"] is not None
+
+    def test_stale_runner_claim_is_reclaimed_and_schedules_retry(self, tmp_cron_dir, monkeypatch):
+        start = datetime(2026, 6, 12, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: start)
+        job = create_job(prompt="Claimed", schedule="every 1h")
+        jobs = load_jobs()
+        jobs[0]["next_run_at"] = (start - timedelta(minutes=5)).isoformat()
+        save_jobs(jobs)
+        mark_job_started(job["id"])
+
+        stale_now = start + timedelta(minutes=16)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: stale_now)
+        due = get_due_jobs()
+
+        assert due == []
+        updated = get_job(job["id"])
+        assert updated["queue"]["runner"]["active"] is False
+        assert updated["queue"]["current_attempt"] is None
+        assert updated["queue"]["retry_count"] == 1
+        assert updated["queue"]["retry_backoff_seconds"] == 60
+        assert updated["queue"]["next_retry_at"] == (stale_now + timedelta(seconds=60)).isoformat()
+        assert "stale" in (updated["last_error"] or "").lower()
+        assert updated["queue"]["last_attempt"]["lifecycle_state"] == JobLifecycleState.failed.value
+
+    def test_retry_backoff_due_job_runs_before_next_schedule(self, tmp_cron_dir, monkeypatch):
+        start = datetime(2026, 6, 12, 12, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: start)
+        job = create_job(prompt="Retry due", schedule="every 1h")
+        mark_job_started(job["id"])
+        mark_job_run(job["id"], success=False, error="boom")
+
+        retry_due = start + timedelta(seconds=61)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: retry_due)
+        due = get_due_jobs()
+
+        assert [item["id"] for item in due] == [job["id"]]
 
     def test_future_not_returned(self, tmp_cron_dir):
         create_job(prompt="Not yet", schedule="every 1h")

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1329,12 +1329,14 @@ class TestRunJobSessionPersistence:
         with patch("cron.scheduler._hermes_home", tmp_path), \
              patch("cron.scheduler.get_due_jobs", return_value=[job]), \
              patch("cron.scheduler.advance_next_run"), \
+             patch("cron.scheduler.mark_job_started") as mock_started, \
              patch("cron.scheduler.mark_job_run") as mock_mark, \
              patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
              patch("cron.scheduler._resolve_origin", return_value=None), \
              patch("cron.scheduler.run_job", return_value=(True, "output", "", None)):
             tick(verbose=False)
 
+        mock_started.assert_called_once_with("empty-job")
         # Should be called with success=False because final_response is empty
         mock_mark.assert_called_once()
         call_args = mock_mark.call_args

--- a/tests/cron/test_worker_daemon.py
+++ b/tests/cron/test_worker_daemon.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""
+Tests for the queue worker daemon.
+
+Validates that the worker can poll for jobs, execute them, and handle
+lease coordination properly.
+"""
+
+import pytest
+import tempfile
+import os
+import sys
+import time
+import threading
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+# Add the parent directory to sys.path so we can import from the hermes-agent modules
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from cron.worker_daemon import QueueWorker, DEFAULT_WORKER_ID
+
+
+class TestQueueWorker:
+    """Test suite for the QueueWorker class."""
+    
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.worker = QueueWorker(
+            worker_id="test-worker",
+            poll_interval=1,
+            max_concurrent=2
+        )
+    
+    def teardown_method(self):
+        """Clean up after tests."""
+        self.worker.shutdown()
+    
+    def test_worker_initialization(self):
+        """Test that worker initializes correctly."""
+        assert self.worker.worker_id == "test-worker"
+        assert self.worker.poll_interval == 1
+        assert self.worker.max_concurrent == 2
+        assert self.worker.executor is not None
+    
+    @patch('cron.worker_daemon.get_due_jobs')
+    def test_poll_with_no_jobs(self, mock_get_due_jobs):
+        """Test polling when no jobs are due."""
+        mock_get_due_jobs.return_value = []
+        
+        jobs_started = self.worker.poll_and_execute()
+        
+        assert jobs_started == 0
+        mock_get_due_jobs.assert_called_once()
+    
+    @patch('cron.worker_daemon.get_due_jobs')
+    @patch('cron.worker_daemon.mark_job_started')
+    @patch('cron.worker_daemon.run_job')
+    @patch('cron.worker_daemon.save_job_output')
+    @patch('cron.worker_daemon._deliver_result')
+    @patch('cron.worker_daemon.mark_job_run')
+    def test_successful_job_execution(
+        self,
+        mock_mark_job_run,
+        mock_deliver_result,
+        mock_save_job_output,
+        mock_run_job,
+        mock_mark_job_started,
+        mock_get_due_jobs
+    ):
+        """Test successful execution of a single job."""
+        # Setup mocks
+        test_job = {"id": "test-job-1", "name": "Test Job"}
+        mock_get_due_jobs.return_value = [test_job]
+        mock_run_job.return_value = (True, "output content", "Job completed", None)
+        mock_save_job_output.return_value = "/tmp/output.md"
+        mock_deliver_result.return_value = None
+        
+        # Execute
+        jobs_started = self.worker.poll_and_execute()
+        
+        # Wait briefly for async execution
+        time.sleep(0.1)
+        
+        # Verify
+        assert jobs_started == 1
+        mock_get_due_jobs.assert_called_once()
+        mock_mark_job_started.assert_called_once_with("test-job-1")
+        mock_run_job.assert_called_once_with(test_job)
+        mock_save_job_output.assert_called_once_with("test-job-1", "output content")
+        mock_deliver_result.assert_called_once()
+        mock_mark_job_run.assert_called_once_with(
+            "test-job-1", success=True, error=None, delivery_error=None
+        )
+    
+    @patch('cron.worker_daemon.get_due_jobs')
+    @patch('cron.worker_daemon.mark_job_started')
+    @patch('cron.worker_daemon.run_job')
+    @patch('cron.worker_daemon.save_job_output')
+    @patch('cron.worker_daemon.mark_job_run')
+    def test_failed_job_execution(
+        self,
+        mock_mark_job_run,
+        mock_save_job_output,
+        mock_run_job,
+        mock_mark_job_started,
+        mock_get_due_jobs
+    ):
+        """Test handling of a failed job."""
+        # Setup mocks
+        test_job = {"id": "test-job-2", "name": "Failed Job"}
+        mock_get_due_jobs.return_value = [test_job]
+        mock_run_job.return_value = (False, "error output", "", "Something went wrong")
+        mock_save_job_output.return_value = "/tmp/error_output.md"
+        
+        # Execute
+        jobs_started = self.worker.poll_and_execute()
+        
+        # Wait briefly for async execution
+        time.sleep(0.1)
+        
+        # Verify
+        assert jobs_started == 1
+        mock_mark_job_run.assert_called_once_with(
+            "test-job-2", success=False, error="Something went wrong", delivery_error=None
+        )
+    
+    @patch('cron.worker_daemon.get_due_jobs')
+    @patch('cron.worker_daemon.mark_job_started')
+    @patch('cron.worker_daemon.run_job')
+    @patch('cron.worker_daemon.save_job_output')
+    @patch('cron.worker_daemon._deliver_result')
+    @patch('cron.worker_daemon.mark_job_run')
+    def test_silent_job_no_delivery(
+        self,
+        mock_mark_job_run,
+        mock_deliver_result,
+        mock_save_job_output,
+        mock_run_job,
+        mock_mark_job_started,
+        mock_get_due_jobs
+    ):
+        """Test that SILENT jobs don't trigger delivery."""
+        # Setup mocks
+        test_job = {"id": "test-job-3", "name": "Silent Job"}
+        mock_get_due_jobs.return_value = [test_job]
+        mock_run_job.return_value = (True, "output content", "[SILENT]", None)
+        mock_save_job_output.return_value = "/tmp/silent_output.md"
+        
+        # Execute
+        jobs_started = self.worker.poll_and_execute()
+        
+        # Wait briefly for async execution
+        time.sleep(0.1)
+        
+        # Verify no delivery was attempted
+        assert jobs_started == 1
+        mock_deliver_result.assert_not_called()
+        mock_mark_job_run.assert_called_once_with(
+            "test-job-3", success=True, error=None, delivery_error=None
+        )
+    
+    @patch('cron.worker_daemon.get_due_jobs')
+    def test_duplicate_job_prevention(self, mock_get_due_jobs):
+        """Test that the same job isn't started twice concurrently."""
+        # Setup
+        test_job = {"id": "test-job-4", "name": "Duplicate Test"}
+        mock_get_due_jobs.return_value = [test_job, test_job]  # Same job twice
+        
+        with patch('cron.worker_daemon.mark_job_started'), \
+             patch('cron.worker_daemon.run_job') as mock_run_job:
+            
+            # Make run_job slow so we can test concurrency
+            def slow_run_job(job):
+                time.sleep(0.2)
+                return (True, "output", "result", None)
+            mock_run_job.side_effect = slow_run_job
+            
+            # Execute - should only start one job even though two are "due"
+            jobs_started = self.worker.poll_and_execute()
+            
+            # Second poll while first is still running
+            jobs_started_2 = self.worker.poll_and_execute()
+            
+            # Wait for jobs to complete
+            time.sleep(0.5)
+            
+            # Verify only one job was actually started
+            assert jobs_started == 1
+            assert jobs_started_2 == 0
+    
+    def test_shutdown(self):
+        """Test graceful shutdown."""
+        # Worker should shutdown without hanging
+        self.worker.shutdown()
+        # Executor should be shut down
+        assert self.worker.executor._shutdown
+    
+    @patch('cron.worker_daemon.get_due_jobs')
+    def test_poll_exception_handling(self, mock_get_due_jobs):
+        """Test that polling exceptions are handled gracefully."""
+        mock_get_due_jobs.side_effect = Exception("Database error")
+        
+        # Should not raise, should return 0
+        jobs_started = self.worker.poll_and_execute()
+        assert jobs_started == 0
+
+
+class TestWorkerDaemonCLI:
+    """Test the CLI interface for the worker daemon."""
+    
+    def test_default_worker_id_generation(self):
+        """Test that default worker IDs are generated correctly."""
+        worker_id = DEFAULT_WORKER_ID
+        assert worker_id.startswith("worker-")
+        assert len(worker_id) > len("worker-")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/gateway/test_api_server_multimodal.py
+++ b/tests/gateway/test_api_server_multimodal.py
@@ -14,13 +14,8 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
 
 from gateway.config import PlatformConfig
-from gateway.platforms.api_server import (
-    APIServerAdapter,
-    _content_has_visible_payload,
-    _normalize_multimodal_content,
-    cors_middleware,
-    security_headers_middleware,
-)
+from gateway.ingress import _content_has_visible_payload, _normalize_multimodal_content
+from gateway.platforms.api_server import APIServerAdapter, cors_middleware, security_headers_middleware
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_api_server_normalize.py
+++ b/tests/gateway/test_api_server_normalize.py
@@ -1,6 +1,269 @@
-"""Tests for _normalize_chat_content in the API server adapter."""
+"""Tests for API server request/content normalization helpers."""
+from gateway.ingress import (
+    _normalize_chat_completions_request,
+    _normalize_chat_content,
+    _normalize_responses_request,
+    _normalize_run_request,
+    _normalize_session_chat_request,
+)
 
-from gateway.platforms.api_server import _normalize_chat_content
+
+class TestNormalizeSessionChatRequest:
+    """Session chat request normalization shared by sync + streaming endpoints."""
+
+    def test_uses_system_message_when_present(self):
+        normalized, err = _normalize_session_chat_request(
+            {"message": "hello", "system_message": "stay focused"}
+        )
+        assert err is None
+        assert normalized.user_message == "hello"
+        assert normalized.system_prompt == "stay focused"
+
+    def test_falls_back_to_instructions(self):
+        normalized, err = _normalize_session_chat_request(
+            {"message": "hello", "instructions": "be concise"}
+        )
+        assert err is None
+        assert normalized.user_message == "hello"
+        assert normalized.system_prompt == "be concise"
+
+    def test_accepts_multimodal_message(self):
+        normalized, err = _normalize_session_chat_request(
+            {
+                "message": [
+                    {"type": "input_text", "text": "What is this?"},
+                    {"type": "input_image", "image_url": "data:image/png;base64,AAAA"},
+                ]
+            }
+        )
+        assert err is None
+        assert normalized.user_message == [
+            {"type": "text", "text": "What is this?"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+        ]
+        assert normalized.system_prompt is None
+
+    def test_rejects_non_string_system_message(self):
+        normalized, err = _normalize_session_chat_request(
+            {"message": "hello", "system_message": ["not", "a", "string"]}
+        )
+        assert normalized is None
+        assert err is not None
+        assert err.status == 400
+
+
+class TestNormalizeRunRequest:
+    """/v1/runs request normalization shared by the runs handler."""
+
+    def test_accepts_string_input(self):
+        normalized, err = _normalize_run_request({"input": "hello"})
+        assert err is None
+        assert normalized.user_message == "hello"
+        assert normalized.instructions is None
+        assert normalized.previous_response_id is None
+        assert normalized.conversation_history == []
+        assert normalized.raw_input == "hello"
+
+    def test_extracts_history_from_multi_message_input(self):
+        normalized, err = _normalize_run_request(
+            {
+                "input": [
+                    {"role": "system", "content": "ignore me"},
+                    {"role": "user", "content": "first"},
+                    {"role": "assistant", "content": [{"type": "text", "text": "second"}]},
+                    {"role": "user", "content": "final"},
+                ]
+            }
+        )
+        assert err is None
+        assert normalized.user_message == "final"
+        assert normalized.conversation_history == [
+            {"role": "system", "content": "ignore me"},
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "second"},
+        ]
+
+    def test_preserves_explicit_conversation_history(self):
+        normalized, err = _normalize_run_request(
+            {
+                "input": [
+                    {"role": "user", "content": "first"},
+                    {"role": "user", "content": "final"},
+                ],
+                "conversation_history": [{"role": "assistant", "content": "from body"}],
+                "previous_response_id": "resp_123",
+                "instructions": "be concise",
+                "session_id": "sess_1",
+            }
+        )
+        assert err is None
+        assert normalized.user_message == "final"
+        assert normalized.conversation_history == [{"role": "assistant", "content": "from body"}]
+        assert normalized.previous_response_id == "resp_123"
+        assert normalized.instructions == "be concise"
+        assert normalized.session_id == "sess_1"
+
+    def test_rejects_missing_input(self):
+        normalized, err = _normalize_run_request({"model": "test"})
+        assert normalized is None
+        assert err is not None
+        assert err.status == 400
+
+    def test_rejects_invalid_conversation_history_shape(self):
+        normalized, err = _normalize_run_request(
+            {"input": "hello", "conversation_history": {"role": "user"}}
+        )
+        assert normalized is None
+        assert err is not None
+        assert err.status == 400
+
+
+class TestNormalizeResponsesRequest:
+    """/v1/responses request normalization prior to response-store chaining."""
+
+    def test_wraps_string_input_as_single_user_message(self):
+        normalized, err = _normalize_responses_request({"input": "hello"})
+        assert err is None
+        assert normalized.input_messages == [{"role": "user", "content": "hello"}]
+        assert normalized.user_message == "hello"
+        assert normalized.conversation_history == []
+        assert normalized.instructions is None
+        assert normalized.previous_response_id is None
+        assert normalized.conversation is None
+        assert normalized.store is True
+
+    def test_extracts_history_from_array_input_and_preserves_metadata(self):
+        normalized, err = _normalize_responses_request(
+            {
+                "input": [
+                    {"role": "user", "content": "first"},
+                    {"role": "assistant", "content": [{"type": "text", "text": "second"}]},
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "input_text", "text": "final"},
+                            {"type": "input_image", "image_url": "https://example.com/cat.png"},
+                        ],
+                    },
+                ],
+                "instructions": "be concise",
+                "previous_response_id": "resp_1",
+                "conversation": None,
+                "store": "false",
+            }
+        )
+        assert err is None
+        assert normalized.input_messages == [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "second"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "final"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+                ],
+            },
+        ]
+        assert normalized.conversation_history == [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "second"},
+        ]
+        assert normalized.user_message == [
+            {"type": "text", "text": "final"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+        ]
+        assert normalized.instructions == "be concise"
+        assert normalized.previous_response_id == "resp_1"
+        assert normalized.store is False
+
+    def test_explicit_conversation_history_takes_precedence(self):
+        normalized, err = _normalize_responses_request(
+            {
+                "input": [
+                    {"role": "user", "content": "first"},
+                    {"role": "user", "content": "final"},
+                ],
+                "conversation_history": [{"role": "assistant", "content": [{"type": "text", "text": "from body"}]}],
+                "previous_response_id": "resp_123",
+            }
+        )
+        assert err is None
+        assert normalized.conversation_history == [{"role": "assistant", "content": "from body"}]
+        assert normalized.previous_response_id == "resp_123"
+        assert normalized.user_message == "final"
+
+    def test_rejects_missing_input(self):
+        normalized, err = _normalize_responses_request({"model": "test"})
+        assert normalized is None
+        assert err is not None
+        assert err.status == 400
+
+    def test_rejects_conversation_and_previous_response_id_together(self):
+        normalized, err = _normalize_responses_request(
+            {"input": "hello", "conversation": "chat-1", "previous_response_id": "resp_1"}
+        )
+        assert normalized is None
+        assert err is not None
+        assert err.status == 400
+
+
+class TestNormalizeChatCompletionsRequest:
+    """/v1/chat/completions request normalization."""
+
+    def test_combines_system_messages_and_extracts_last_user_message(self):
+        normalized, err = _normalize_chat_completions_request(
+            {
+                "messages": [
+                    {"role": "system", "content": "be helpful"},
+                    {"role": "user", "content": "first"},
+                    {"role": "assistant", "content": "second"},
+                    {"role": "system", "content": [{"type": "text", "text": "stay concise"}]},
+                    {"role": "user", "content": "final"},
+                ]
+            }
+        )
+        assert err is None
+        assert normalized.system_prompt == "be helpful\nstay concise"
+        assert normalized.user_message == "final"
+        assert normalized.history == [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "second"},
+        ]
+
+    def test_preserves_multimodal_user_content(self):
+        normalized, err = _normalize_chat_completions_request(
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "what is this?"},
+                            {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+                        ],
+                    }
+                ]
+            }
+        )
+        assert err is None
+        assert normalized.user_message == [
+            {"type": "text", "text": "what is this?"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+        ]
+        assert normalized.history == []
+
+    def test_rejects_missing_messages(self):
+        normalized, err = _normalize_chat_completions_request({"model": "test"})
+        assert normalized is None
+        assert err is not None
+        assert err.status == 400
+
+    def test_rejects_missing_user_message(self):
+        normalized, err = _normalize_chat_completions_request(
+            {"messages": [{"role": "system", "content": "only system"}]}
+        )
+        assert normalized is None
+        assert err is not None
+        assert err.status == 400
 
 
 class TestNormalizeChatContent:

--- a/tests/gateway/test_ingress.py
+++ b/tests/gateway/test_ingress.py
@@ -1,0 +1,105 @@
+"""Tests for shared HTTP-ingress helpers."""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.ingress import (
+    IngressEnvelope,
+    build_ingress_message_event,
+    schedule_ingress_envelope,
+    schedule_ingress_event,
+)
+from gateway.platforms.webhook import WebhookAdapter
+
+
+def _make_adapter() -> WebhookAdapter:
+    config = PlatformConfig(enabled=True, extra={"host": "127.0.0.1", "port": 0, "routes": {}})
+    return WebhookAdapter(config)
+
+
+class TestBuildIngressMessageEvent:
+    def test_builds_message_event_with_route_identity(self):
+        adapter = _make_adapter()
+        envelope = IngressEnvelope(
+            text="hello from ingress",
+            message_id="evt-1",
+            chat_id="webhook:ci:evt-1",
+            chat_name="webhook/ci",
+            chat_type="webhook",
+            user_id="webhook:ci",
+            user_name="ci",
+            raw_payload={"ref": "main"},
+        )
+
+        event = build_ingress_message_event(adapter, envelope)
+
+        assert event.text == "hello from ingress"
+        assert event.message_id == "evt-1"
+        assert event.raw_message == {"ref": "main"}
+        assert event.source.platform == adapter.platform
+        assert event.source.chat_id == "webhook:ci:evt-1"
+        assert event.source.chat_name == "webhook/ci"
+        assert event.source.chat_type == "webhook"
+        assert event.source.user_id == "webhook:ci"
+        assert event.source.user_name == "ci"
+
+
+class TestScheduleIngressEvent:
+    @pytest.mark.asyncio
+    async def test_tracks_background_task_until_completion(self):
+        adapter = _make_adapter()
+        captured = []
+
+        async def _capture(event):
+            captured.append(event)
+
+        adapter.handle_message = _capture
+        event = build_ingress_message_event(
+            adapter,
+            IngressEnvelope(
+                text="hello",
+                message_id="evt-2",
+                chat_id="webhook:test:evt-2",
+                raw_payload={"ok": True},
+            ),
+        )
+
+        task = schedule_ingress_event(adapter, event)
+        assert task in adapter._background_tasks
+
+        await task
+        await asyncio.sleep(0)
+
+        assert captured == [event]
+        assert task not in adapter._background_tasks
+
+    @pytest.mark.asyncio
+    async def test_schedule_envelope_builds_and_dispatches_event(self):
+        adapter = _make_adapter()
+        adapter.handle_message = AsyncMock()
+        envelope = IngressEnvelope(
+            text="dispatch me",
+            message_id="evt-3",
+            chat_id="webhook:test:evt-3",
+            chat_name="webhook/test",
+            user_id="webhook:test",
+            user_name="test",
+            raw_payload={"value": 3},
+            internal=True,
+        )
+
+        task = schedule_ingress_envelope(adapter, envelope)
+        await task
+
+        adapter.handle_message.assert_awaited_once()
+        await_args = adapter.handle_message.await_args
+        assert await_args is not None
+        dispatched_event = await_args.args[0]
+        assert dispatched_event.text == "dispatch me"
+        assert dispatched_event.message_id == "evt-3"
+        assert dispatched_event.internal is True
+        assert dispatched_event.source.chat_id == "webhook:test:evt-3"
+        assert dispatched_event.raw_message == {"value": 3}

--- a/tests/gateway/test_msgraph_webhook.py
+++ b/tests/gateway/test_msgraph_webhook.py
@@ -1,10 +1,12 @@
 """Tests for the Microsoft Graph webhook adapter."""
 
 import asyncio
+from typing import cast
 
 import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig, _apply_env_overrides
+from gateway.platforms.base import MessageEvent
 from gateway.platforms.msgraph_webhook import AIOHTTP_AVAILABLE, MSGraphWebhookAdapter
 
 
@@ -177,11 +179,14 @@ class TestMSGraphNotifications:
         await asyncio.sleep(0.05)
 
         assert len(scheduled) == 1
-        notification, event = scheduled[0]
+        notification, event_obj = scheduled[0]
+        event = cast(MessageEvent, event_obj)
         assert notification["id"] == "notif-1"
         assert event.source.platform == Platform.MSGRAPH_WEBHOOK
         assert event.source.chat_type == "webhook"
         assert event.message_id == "id:notif-1"
+        assert event.internal is True
+        assert event.raw_message == payload["value"][0]
 
     @pytest.mark.anyio
     async def test_bad_client_state_rejected_as_auth_failure(self):

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -498,6 +498,41 @@ class TestHTTPHandling:
             assert data["status"] == "accepted"
             assert data["route"] == "test"
 
+        adapter.handle_message.assert_awaited_once()
+        await_args = adapter.handle_message.await_args
+        assert await_args is not None
+        event = await_args.args[0]
+        assert event.text == "hi"
+        assert event.message_id
+        assert event.source.platform == Platform.WEBHOOK
+        assert event.source.chat_id == f"webhook:test:{event.message_id}"
+        assert event.source.chat_name == "webhook/test"
+        assert event.source.user_id == "webhook:test"
+        assert event.source.user_name == "test"
+        assert event.raw_message == {"data": "value"}
+
+    @pytest.mark.asyncio
+    async def test_webhook_preserves_delivery_id_as_message_id(self):
+        """Accepted webhook events keep delivery_id as MessageEvent.message_id."""
+        routes = {"test": {"secret": _INSECURE_NO_AUTH, "prompt": "hi"}}
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/test",
+                json={"data": "value"},
+                headers={"X-GitHub-Delivery": "delivery-xyz"},
+            )
+            assert resp.status == 202
+
+        await_args = adapter.handle_message.await_args
+        assert await_args is not None
+        event = await_args.args[0]
+        assert event.message_id == "delivery-xyz"
+        assert event.source.chat_id == "webhook:test:delivery-xyz"
+
     @pytest.mark.asyncio
     async def test_route_without_secret_rejects_unsigned_request(self):
         """Missing HMAC secret must fail closed even if connect() was bypassed."""

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -534,6 +534,36 @@ class TestHTTPHandling:
         assert event.source.chat_id == "webhook:test:delivery-xyz"
 
     @pytest.mark.asyncio
+    async def test_webhook_handler_dispatches_shared_ingress_envelope(self):
+        """Webhook requests dispatch through the shared ingress envelope helper."""
+        routes = {"deploy": {"secret": _INSECURE_NO_AUTH, "prompt": "Deploy {branch}"}}
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/deploy",
+                json={"branch": "main"},
+                headers={"X-GitHub-Delivery": "delivery-42"},
+            )
+            assert resp.status == 202
+
+            await asyncio.sleep(0)
+
+        adapter.handle_message.assert_awaited_once()
+        dispatched_event = adapter.handle_message.await_args_list[0].args[0]
+        assert dispatched_event.text == "Deploy main"
+        assert dispatched_event.message_id == "delivery-42"
+        assert dispatched_event.raw_message == {"branch": "main"}
+        assert dispatched_event.source.chat_id == "webhook:deploy:delivery-42"
+        assert dispatched_event.source.chat_name == "webhook/deploy"
+        assert dispatched_event.source.chat_type == "webhook"
+        assert dispatched_event.source.user_id == "webhook:deploy"
+        assert dispatched_event.source.user_name == "deploy"
+        assert adapter._background_tasks == set()
+
+    @pytest.mark.asyncio
     async def test_route_without_secret_rejects_unsigned_request(self):
         """Missing HMAC secret must fail closed even if connect() was bypassed."""
         routes = {"test": {"prompt": "hi"}}

--- a/tests/run_agent/test_18028_content_policy_blocked.py
+++ b/tests/run_agent/test_18028_content_policy_blocked.py
@@ -15,6 +15,8 @@ was the problem.
 """
 from __future__ import annotations
 
+from agent.conversation_loop import _is_client_error_from_policy
+from agent.failure_policy import decide_api_recovery
 
 class TestContentPolicyBlockedClassification:
     """Verify classify_api_error returns the right shape so downstream
@@ -43,53 +45,22 @@ class TestContentPolicyBlockedClassification:
 
 
 class TestContentPolicyTriggersClientErrorAbort:
-    """Mirror the ``is_client_error`` predicate in
-    ``agent/conversation_loop.py`` and verify
-    ``FailoverReason.content_policy_blocked`` resolves to True so the loop
-    aborts (after attempting fallback) instead of falling into the
-    retry-backoff path.
-    """
-
-    def _mirror_is_client_error(
-        self,
-        *,
-        classified_retryable: bool,
-        classified_reason,
-        classified_should_compress: bool = False,
-        is_local_validation_error: bool = False,
-        is_context_length_error: bool = False,
-    ) -> bool:
-        """Exact shape of conversation_loop.py's is_client_error check.
-
-        Kept in lock-step with the source. If you change one, change both.
-        """
-        from agent.error_classifier import FailoverReason
-
-        return (
-            is_local_validation_error
-            or (
-                not classified_retryable
-                and not classified_should_compress
-                and classified_reason not in {
-                    FailoverReason.rate_limit,
-                    FailoverReason.overloaded,
-                    FailoverReason.context_overflow,
-                    FailoverReason.payload_too_large,
-                    FailoverReason.long_context_tier,
-                    FailoverReason.thinking_signature,
-                }
-            )
-        ) and not is_context_length_error
+    """Verify the live recovery-policy wiring takes the abort path."""
 
     def test_content_policy_blocked_triggers_abort(self):
         """Safety-filter block must reach is_client_error → fallback/abort."""
-        from agent.error_classifier import FailoverReason
+        from agent.error_classifier import ClassifiedError, FailoverReason
 
-        # What classify_api_error returns for a content-policy block:
-        #   reason=content_policy_blocked, retryable=False, should_compress=False
-        assert self._mirror_is_client_error(
-            classified_retryable=False,
-            classified_reason=FailoverReason.content_policy_blocked,
+        classified = ClassifiedError(
+            reason=FailoverReason.content_policy_blocked,
+            retryable=False,
+            should_compress=False,
+        )
+        recovery_decision = decide_api_recovery(classified)
+
+        assert _is_client_error_from_policy(
+            classified,
+            recovery_decision,
         ), (
             "FailoverReason.content_policy_blocked must trigger the "
             "is_client_error path so fallback fires immediately instead of "

--- a/tests/run_agent/test_conversation_loop_recovery_policy.py
+++ b/tests/run_agent/test_conversation_loop_recovery_policy.py
@@ -1,0 +1,67 @@
+from agent.conversation_loop import _is_client_error_from_policy, _should_try_eager_fallback
+from agent.error_classifier import ClassifiedError, FailoverReason
+from agent.failure_policy import RecoveryAction, decide_api_recovery
+
+
+def test_rate_limit_uses_policy_for_eager_fallback() -> None:
+    classified = ClassifiedError(
+        reason=FailoverReason.rate_limit,
+        retryable=True,
+        should_fallback=True,
+    )
+
+    decision = decide_api_recovery(classified)
+
+    assert decision.primary_action == RecoveryAction.fallback_provider
+    assert _should_try_eager_fallback(decision, reason=classified.reason) is True
+
+
+def test_billing_uses_secondary_fallback_action_for_eager_fallback() -> None:
+    classified = ClassifiedError(
+        reason=FailoverReason.billing,
+        retryable=False,
+        should_fallback=True,
+        should_rotate_credential=True,
+    )
+
+    decision = decide_api_recovery(classified)
+
+    assert decision.primary_action == RecoveryAction.rotate_credential
+    assert RecoveryAction.fallback_provider in decision.secondary_actions
+    assert _should_try_eager_fallback(decision, reason=classified.reason) is True
+
+
+def test_context_overflow_stays_on_recovery_path_not_client_abort() -> None:
+    classified = ClassifiedError(
+        reason=FailoverReason.context_overflow,
+        retryable=True,
+        should_compress=True,
+    )
+
+    decision = decide_api_recovery(classified)
+
+    assert _is_client_error_from_policy(classified, decision) is False
+
+
+def test_non_retryable_auth_is_client_error_after_recovery_paths_exhaust() -> None:
+    classified = ClassifiedError(
+        reason=FailoverReason.auth,
+        retryable=False,
+        should_fallback=True,
+        should_rotate_credential=True,
+    )
+
+    decision = decide_api_recovery(classified)
+
+    assert _is_client_error_from_policy(classified, decision) is True
+
+
+def test_local_validation_error_forces_client_error() -> None:
+    classified = ClassifiedError(reason=FailoverReason.unknown, retryable=True)
+    decision = decide_api_recovery(classified)
+
+    assert _is_client_error_from_policy(
+        classified,
+        decision,
+        is_local_validation_error=True,
+    ) is True

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -128,6 +128,7 @@ class TestGetAndPoll:
         registry._running[s.id] = s
         result = registry.poll(s.id)
         assert result["status"] == "running"
+        assert result["lifecycle_state"] == "running"
         assert "some output" in result["output_preview"]
         assert result["command"] == "echo hello"
 
@@ -136,6 +137,7 @@ class TestGetAndPoll:
         registry._finished[s.id] = s
         result = registry.poll(s.id)
         assert result["status"] == "exited"
+        assert result["lifecycle_state"] == "completed"
         assert result["exit_code"] == 0
 
 
@@ -398,6 +400,21 @@ class TestListSessions:
         assert "status" in entry
         assert "pid" in entry
         assert "output_preview" in entry
+        assert entry["retry_count"] == 0
+        assert entry["attempt"]["attempt"] == 1
+        assert entry["attempt"]["lifecycle_state"] == "running"
+        assert entry["attempt_history"] == [entry["attempt"]]
+        assert entry["runner"] == {
+            "kind": "background_process",
+            "queue_name": "interactive",
+            "priority": 0,
+            "active": True,
+            "claimed_at": entry["started_at"],
+            "lease_expires_at": None,
+            "worker_id": entry["session_id"],
+            "last_started_at": entry["started_at"],
+            "last_finished_at": None,
+        }
 
 
 # =========================================================================

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -46,6 +46,12 @@ from hermes_cli._subprocess_compat import windows_hide_flags
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+from agent.job_lifecycle import (
+    JobLifecycleState,
+    default_runner_metadata,
+    lifecycle_snapshot_for_process,
+    make_attempt_record,
+)
 from hermes_cli.config import get_hermes_home
 
 logger = logging.getLogger(__name__)
@@ -86,6 +92,35 @@ def format_uptime_short(seconds: int) -> str:
     return f"{hours}h {mins}m"
 
 
+def _iso_or_none(timestamp: Optional[float]) -> Optional[str]:
+    if timestamp is None:
+        return None
+    return time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime(timestamp))
+
+
+def _attempt_metadata_for_session(session: "ProcessSession") -> dict[str, Any]:
+    lifecycle = lifecycle_snapshot_for_process(exited=session.exited, exit_code=session.exit_code)
+    return make_attempt_record(
+        attempt=1,
+        state=lifecycle.state,
+        started_at=_iso_or_none(session.started_at),
+        finished_at=_iso_or_none(session.finished_at),
+        error=None if lifecycle.state in {JobLifecycleState.running, JobLifecycleState.completed} else session.output_buffer[-500:] or None,
+        retry_count=0,
+    )
+
+
+def _runner_metadata_for_session(session: "ProcessSession") -> dict[str, Any]:
+    runner = default_runner_metadata(kind="background_process", queue_name="interactive", priority=0)
+    started_at = _iso_or_none(session.started_at)
+    runner["active"] = not session.exited
+    runner["claimed_at"] = started_at if not session.exited else None
+    runner["worker_id"] = session.id
+    runner["last_started_at"] = started_at
+    runner["last_finished_at"] = _iso_or_none(session.finished_at)
+    return runner
+
+
 @dataclass
 class ProcessSession:
     """A tracked background process with output buffering."""
@@ -98,6 +133,7 @@ class ProcessSession:
     env_ref: Any = None                         # Reference to the environment object
     cwd: Optional[str] = None                   # Working directory
     started_at: float = 0.0                     # time.time() of spawn
+    finished_at: Optional[float] = None         # time.time() when process finished
     exited: bool = False                        # Whether the process has finished
     exit_code: Optional[int] = None             # Exit code (None if still running)
     output_buffer: str = ""                     # Rolling output (last MAX_OUTPUT_CHARS)
@@ -425,6 +461,7 @@ class ProcessRegistry:
             if session.exited:
                 return session
             session.exited = True
+            session.finished_at = time.time()
             # Recovered sessions no longer have a waitable handle, so the real
             # exit code is unavailable once the original process object is gone.
             session.exit_code = None
@@ -870,6 +907,8 @@ class ProcessRegistry:
         with self._lock:
             was_running = self._running.pop(session.id, None) is not None
             self._finished[session.id] = session
+        if session.finished_at is None:
+            session.finished_at = time.time()
         self._write_checkpoint()
 
         # Only enqueue completion notification on the FIRST move.  Without
@@ -1005,11 +1044,12 @@ class ProcessRegistry:
 
         with session._lock:
             output_preview = strip_ansi(session.output_buffer[-1000:]) if session.output_buffer else ""
-
+        lifecycle = lifecycle_snapshot_for_process(exited=session.exited, exit_code=session.exit_code)
         result = {
             "session_id": session.id,
             "command": session.command,
             "status": "exited" if session.exited else "running",
+            "lifecycle_state": lifecycle.state.value,
             "pid": session.pid,
             "uptime_seconds": int(time.time() - session.started_at),
             "output_preview": output_preview,
@@ -1045,6 +1085,7 @@ class ProcessRegistry:
         result = {
             "session_id": session.id,
             "status": "exited" if session.exited else "running",
+            "lifecycle_state": lifecycle_snapshot_for_process(exited=session.exited, exit_code=session.exit_code).state.value,
             "output": "\n".join(selected),
             "total_lines": total_lines,
             "showing": f"{len(selected)} lines",
@@ -1101,6 +1142,7 @@ class ProcessRegistry:
                 self._completion_consumed.add(session_id)
                 result = {
                     "status": "exited",
+                    "lifecycle_state": lifecycle_snapshot_for_process(exited=True, exit_code=session.exit_code).state.value,
                     "exit_code": session.exit_code,
                     "output": strip_ansi(session.output_buffer[-2000:]),
                 }
@@ -1283,14 +1325,24 @@ class ProcessRegistry:
 
         result = []
         for s in all_sessions:
+            if s is None:
+                continue
+            lifecycle = lifecycle_snapshot_for_process(exited=s.exited, exit_code=s.exit_code)
+            attempt = _attempt_metadata_for_session(s)
             entry = {
                 "session_id": s.id,
                 "command": s.command[:200],
                 "cwd": s.cwd,
                 "pid": s.pid,
-                "started_at": time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime(s.started_at)),
+                "started_at": _iso_or_none(s.started_at),
+                "finished_at": _iso_or_none(s.finished_at),
                 "uptime_seconds": int(time.time() - s.started_at),
                 "status": "exited" if s.exited else "running",
+                "lifecycle_state": lifecycle.state.value,
+                "retry_count": 0,
+                "attempt": attempt,
+                "attempt_history": [attempt],
+                "runner": _runner_metadata_for_session(s),
                 "output_preview": s.output_buffer[-200:] if s.output_buffer else "",
             }
             if s.exited:


### PR DESCRIPTION
Removes a duplicated _openai_error() helper from gateway/platforms/api_server.py that was functionally identical to the one already imported from gateway/ingress.py. 

 No behaviour change — 105 API server tests + 86 webhook/session tests pass. Verified live after restart.
