### PR TITLE
fix(skills): platform-disabled skills still appear in <available_skills> + unify all resolution sites (#46201)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1164,7 +1164,7 @@ def build_skills_system_prompt(
         or get_session_env("HERMES_SESSION_PLATFORM")
         or ""
     )
-    disabled = get_disabled_skill_names()
+    disabled = get_disabled_skill_names(_platform_hint or None)
     cache_key = (
         str(skills_dir.resolve()),
         tuple(str(d) for d in external_dirs),

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -305,13 +305,14 @@ def get_disabled_skill_names(platform: str | None = None) -> Set[str]:
         or os.getenv("HERMES_PLATFORM")
         or get_session_env("HERMES_SESSION_PLATFORM")
     )
+    global_disabled = _normalize_string_set(skills_cfg.get("disabled"))
     if resolved_platform:
         platform_disabled = (skills_cfg.get("platform_disabled") or {}).get(
             resolved_platform
         )
         if platform_disabled is not None:
-            return _normalize_string_set(platform_disabled)
-    return _normalize_string_set(skills_cfg.get("disabled"))
+            return global_disabled | _normalize_string_set(platform_disabled)
+    return global_disabled
 
 
 def _normalize_string_set(values) -> Set[str]:

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -278,8 +278,10 @@ def get_disabled_skill_names(platform: str | None = None) -> Set[str]:
     Args:
         platform: Explicit platform name (e.g. ``"telegram"``).  When
             *None*, resolves from ``HERMES_PLATFORM`` or
-            ``HERMES_SESSION_PLATFORM`` env vars.  Falls back to the
-            global disabled list when no platform is determined.
+            ``HERMES_SESSION_PLATFORM`` env vars.  Returns the global
+            disabled list, unioned with the platform-specific list when a
+            platform is resolved (a globally-disabled skill stays disabled
+            on every platform).
 
     Reads the config file directly (no CLI config imports) to stay
     lightweight.

--- a/hermes_cli/skills_config.py
+++ b/hermes_cli/skills_config.py
@@ -25,7 +25,13 @@ PLATFORMS = {k: info.label for k, info in _PLATFORMS.items() if k != "api_server
 # ─── Config Helpers ───────────────────────────────────────────────────────────
 
 def get_disabled_skills(config: dict, platform: Optional[str] = None) -> Set[str]:
-    """Return disabled skill names. Platform-specific list falls back to global."""
+    """Return disabled skill names: the global list unioned with the
+    platform-specific list when a platform is given.
+
+    A globally-disabled skill stays disabled on every platform, so the
+    platform list adds to the global list rather than replacing it. This
+    mirrors ``agent.skill_utils.get_disabled_skill_names``.
+    """
     skills_cfg = config.get("skills", {})
     global_disabled = set(skills_cfg.get("disabled", []))
     if platform is None:
@@ -33,7 +39,7 @@ def get_disabled_skills(config: dict, platform: Optional[str] = None) -> Set[str
     platform_disabled = cfg_get(skills_cfg, "platform_disabled", platform)
     if platform_disabled is None:
         return global_disabled
-    return set(platform_disabled)
+    return global_disabled | set(platform_disabled)
 
 
 def save_disabled_skills(config: dict, disabled: Set[str], platform: Optional[str] = None):

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -419,6 +419,7 @@ class TestBuildSkillsSystemPrompt:
         second = build_skills_system_prompt()
         assert "cached-skill" not in second
 
+
     def test_includes_setup_needed_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         monkeypatch.delenv("MISSING_API_KEY_XYZ", raising=False)

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -419,7 +419,6 @@ class TestBuildSkillsSystemPrompt:
         second = build_skills_system_prompt()
         assert "cached-skill" not in second
 
-
     def test_includes_setup_needed_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         monkeypatch.delenv("MISSING_API_KEY_XYZ", raising=False)

--- a/tests/hermes_cli/test_skills_config.py
+++ b/tests/hermes_cli/test_skills_config.py
@@ -22,7 +22,19 @@ class TestGetDisabledSkills:
             "disabled": ["skill-a"],
             "platform_disabled": {"telegram": ["skill-b"]}
         }}
-        assert get_disabled_skills(config, platform="telegram") == {"skill-b"}
+        # Union of global + platform: a globally-disabled skill stays disabled
+        # on every platform, and the platform list adds to it.
+        assert get_disabled_skills(config, platform="telegram") == {"skill-a", "skill-b"}
+
+    def test_platform_list_unions_with_global(self):
+        from hermes_cli.skills_config import get_disabled_skills
+        config = {"skills": {
+            "disabled": ["global-skill"],
+            "platform_disabled": {"telegram": []}
+        }}
+        # An explicit empty platform list does NOT re-enable a globally-disabled
+        # skill (matches issue #46201 — global disables hold everywhere).
+        assert get_disabled_skills(config, platform="telegram") == {"global-skill"}
 
     def test_platform_falls_back_to_global(self):
         from hermes_cli.skills_config import get_disabled_skills
@@ -102,14 +114,27 @@ class TestIsSkillDisabled:
         assert _is_skill_disabled("tg-skill", platform="telegram") is True
 
     @patch("hermes_cli.config.load_config")
-    def test_platform_enabled_overrides_global(self, mock_load):
+    def test_globally_disabled_stays_disabled_on_platform(self, mock_load):
+        mock_load.return_value = {"skills": {
+            "disabled": ["skill-a"],
+            "platform_disabled": {"telegram": ["tg-skill"]}
+        }}
+        from tools.skills_tool import _is_skill_disabled
+        # Union: a globally-disabled skill stays disabled on a platform that
+        # has its own platform_disabled list (matches issue #46201).
+        assert _is_skill_disabled("skill-a", platform="telegram") is True
+        assert _is_skill_disabled("tg-skill", platform="telegram") is True
+
+    @patch("hermes_cli.config.load_config")
+    def test_empty_platform_list_keeps_global_disabled(self, mock_load):
         mock_load.return_value = {"skills": {
             "disabled": ["skill-a"],
             "platform_disabled": {"telegram": []}
         }}
         from tools.skills_tool import _is_skill_disabled
-        # telegram has explicit empty list -> skill-a is NOT disabled for telegram
-        assert _is_skill_disabled("skill-a", platform="telegram") is False
+        # An explicit empty platform list does NOT re-enable a globally-disabled
+        # skill — global disables hold on every platform.
+        assert _is_skill_disabled("skill-a", platform="telegram") is True
 
     @patch("hermes_cli.config.load_config")
     def test_platform_falls_back_to_global(self, mock_load):

--- a/tests/hermes_cli/test_skills_config.py
+++ b/tests/hermes_cli/test_skills_config.py
@@ -164,7 +164,7 @@ class TestGetDisabledSkillNames:
 
         from agent.skill_utils import get_disabled_skill_names
         result = get_disabled_skill_names(platform="telegram")
-        assert result == {"tg-only-skill"}
+        assert result == {"tg-only-skill", "global-skill"}
 
     def test_session_platform_env_var(self, tmp_path, monkeypatch):
         """HERMES_SESSION_PLATFORM should be used when HERMES_PLATFORM is unset."""
@@ -183,7 +183,7 @@ class TestGetDisabledSkillNames:
 
         from agent.skill_utils import get_disabled_skill_names
         result = get_disabled_skill_names()
-        assert result == {"discord-skill"}
+        assert result == {"discord-skill", "global-skill"}
 
     def test_hermes_platform_takes_precedence(self, tmp_path, monkeypatch):
         """HERMES_PLATFORM should win over HERMES_SESSION_PLATFORM."""

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -583,11 +583,15 @@ def _is_skill_disabled(name: str, platform: str = None) -> bool:
         config = load_config()
         skills_cfg = config.get("skills", {})
         resolved_platform = platform or os.getenv("HERMES_PLATFORM") or _get_session_platform()
+        global_disabled = skills_cfg.get("disabled", [])
         if resolved_platform:
             platform_disabled = cfg_get(skills_cfg, "platform_disabled", resolved_platform)
             if platform_disabled is not None:
-                return name in platform_disabled
-        return name in skills_cfg.get("disabled", [])
+                # A globally-disabled skill stays disabled on every platform;
+                # the platform list adds to it rather than replacing it. Keep
+                # in sync with agent.skill_utils.get_disabled_skill_names.
+                return name in platform_disabled or name in global_disabled
+        return name in global_disabled
     except Exception:
         return False
 


### PR DESCRIPTION
Fixes #46201. Salvages the fix from #46203 by @iborazzi (authorship preserved as
commit 1) and completes it across all sibling resolution sites (commit 2).

## The bug
`hermes skills config` disables skills per-platform, but the platform config never
reached the `<available_skills>` prompt, so disabled skills still appeared and the
agent's "you MUST load it" rule tried to load them.

## Commit 1 (@iborazzi, salvaged from #46203)
- `build_skills_system_prompt()` resolved `_platform_hint` (and keyed the prompt
  cache on it) but called `get_disabled_skill_names()` with no argument, so the
  platform never reached the filter. → pass `_platform_hint or None`.
- `get_disabled_skill_names()` discarded the global `disabled` list once a
  platform-specific list existed. → return the union `global | platform`.

The unrelated `apps/shared/tsconfig.json` ES2023 bump bundled in #46203 is
intentionally dropped (one concern per PR).

## Commit 2 (follow-up) — fix the whole bug class
The same global-vs-platform resolution was duplicated in two more places that
#46203 left on the old replace-not-union semantics, leaving the codebase
inconsistent (a skill hidden from the prompt could still load / show enabled):
- `hermes_cli/skills_config.get_disabled_skills` — the `hermes skills config` UI
  showed a globally-disabled skill as enabled on any platform with a
  `platform_disabled` entry.
- `tools/skills_tool._is_skill_disabled` — the `skill_view` gate would still load
  a globally-disabled skill on such a platform.

Both now union with the global list, matching `get_disabled_skill_names`. An
explicit empty platform list no longer re-enables a globally-disabled skill —
global disables hold on every platform. Stale docstring fixed; regression tests
added for both sites (proven to fail on the old replace semantics).

## Verification
- `tests/{hermes_cli/test_skills_config,agent/test_prompt_builder,tools/test_skills_tool}.py` — 251 passed, 1 skipped.
- New union tests confirmed to fail on the old replace-semantics and pass with the fix.
- ruff clean on all touched files.
