### PR TITLE
feat(desktop): add composer.dictate rebindable keybind action (#11936)

### DIFF
--- a/apps/desktop/src/app/chat/composer/focus.test.ts
+++ b/apps/desktop/src/app/chat/composer/focus.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { markActiveComposer, onComposerDictateRequest, requestComposerDictate } from './focus'
+
+describe('requestComposerDictate / onComposerDictateRequest', () => {
+  beforeEach(() => {
+    // Reset module state: activeTarget defaults to 'main' on import; flip
+    // it explicitly so each test starts from a known place.
+    markActiveComposer('main')
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('publishes a dictate event with target=main by default', async () => {
+    vi.useFakeTimers()
+    const handler = vi.fn()
+    const off = onComposerDictateRequest(handler)
+
+    requestComposerDictate()
+    // dispatch defers to a macrotask; flush the timer.
+    await vi.runAllTimersAsync()
+
+    expect(handler).toHaveBeenCalledWith('main')
+    off()
+  })
+
+  it('routes target=active to whichever composer is currently active', async () => {
+    vi.useFakeTimers()
+    markActiveComposer('edit')
+
+    const handler = vi.fn()
+    const off = onComposerDictateRequest(handler)
+
+    requestComposerDictate('active')
+    await vi.runAllTimersAsync()
+
+    expect(handler).toHaveBeenCalledWith('edit')
+    off()
+  })
+
+  it('respects an explicit target override (ignores active)', async () => {
+    vi.useFakeTimers()
+    markActiveComposer('edit')
+
+    const handler = vi.fn()
+    const off = onComposerDictateRequest(handler)
+
+    requestComposerDictate('main')
+    await vi.runAllTimersAsync()
+
+    expect(handler).toHaveBeenCalledWith('main')
+    off()
+  })
+
+  it('only invokes the most recent subscriber when the same handler is re-registered', async () => {
+    vi.useFakeTimers()
+    const stale = vi.fn()
+    const fresh = vi.fn()
+
+    const offStale = onComposerDictateRequest(stale)
+    onComposerDictateRequest(fresh)
+
+    requestComposerDictate('main')
+    await vi.runAllTimersAsync()
+
+    // Both fire — every subscriber is a separate listener, so the test is
+    // that off() detaches the stale one without disturbing the fresh one.
+    expect(stale).toHaveBeenCalledTimes(1)
+    expect(fresh).toHaveBeenCalledTimes(1)
+
+    offStale()
+
+    requestComposerDictate('main')
+    await vi.runAllTimersAsync()
+
+    expect(stale).toHaveBeenCalledTimes(1)
+    expect(fresh).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/focus.ts
+++ b/apps/desktop/src/app/chat/composer/focus.ts
@@ -34,6 +34,7 @@ interface InsertRefsDetail {
 const FOCUS_EVENT = 'hermes:composer-focus'
 const INSERT_EVENT = 'hermes:composer-insert'
 const INSERT_REFS_EVENT = 'hermes:composer-insert-refs'
+const DICTATE_EVENT = 'hermes:composer-dictate'
 
 let activeTarget: ComposerTarget = 'main'
 
@@ -104,6 +105,15 @@ export const requestComposerInsertRefs = (
 
 export const onComposerInsertRefsRequest = (handler: (detail: InsertRefsDetail) => void) =>
   subscribe<InsertRefsDetail>(INSERT_REFS_EVENT, handler)
+
+/** Toggle dictation on the targeted composer. The composer owns the
+ * push-to-talk state machine (recording / transcribing / idle) — we just
+ * dispatch the intent and let the matching instance drive the recorder. */
+export const requestComposerDictate = (target: ComposerTarget | 'active' = 'active') =>
+  dispatch<FocusDetail>(DICTATE_EVENT, { target: resolve(target) })
+
+export const onComposerDictateRequest = (handler: (target: ComposerTarget) => void) =>
+  subscribe<FocusDetail>(DICTATE_EVENT, ({ target }) => handler(target))
 
 /**
  * Focus a composer input across React commit + browser focus restore.

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -67,6 +67,7 @@ import {
   type ComposerInsertMode,
   focusComposerInput,
   markActiveComposer,
+  onComposerDictateRequest,
   onComposerFocusRequest,
   onComposerInsertRefsRequest,
   onComposerInsertRequest
@@ -216,6 +217,10 @@ export function ChatBar({
   // can't spin-loop. Cleared on success; reset naturally on remount/reconnect.
   const drainFailuresRef = useRef(new Map<string, number>())
   const urlInputRef = useRef<HTMLInputElement | null>(null)
+  // Live closure from useVoiceRecorder — kept in a ref so the external-event
+  // subscription (set up before useVoiceRecorder) can call the latest version
+  // without re-subscribing on every render.
+  const dictateRef = useRef<() => void>(() => {})
 
   const [urlOpen, setUrlOpen] = useState(false)
   const [urlValue, setUrlValue] = useState('')
@@ -357,9 +362,18 @@ export function ChatBar({
       }
     })
 
+    // `dictate` is a fresh closure from useVoiceRecorder on every render; keep
+    // the subscription stable by reading through a ref the effect captures.
+    const offDictate = onComposerDictateRequest(target => {
+      if (target === 'main') {
+        dictateRef.current()
+      }
+    })
+
     return () => {
       offFocus()
       offInsert()
+      offDictate()
     }
   }, [appendExternalText, inputDisabled])
 
@@ -1647,6 +1661,13 @@ export function ChatBar({
     onTranscript: insertText,
     onTranscribeAudio
   })
+
+  // Keep the subscription's ref pointed at the latest dictate closure. The
+  // event listener reads through dictateRef, so this single-line bridge is all
+  // we need to wire a keybind (or any external caller) to the recorder.
+  useEffect(() => {
+    dictateRef.current = dictate
+  }, [dictate])
 
   const pendingResponse = () => {
     const messages = $messages.get()

--- a/apps/desktop/src/app/hooks/use-keybinds.ts
+++ b/apps/desktop/src/app/hooks/use-keybinds.ts
@@ -39,7 +39,7 @@ import {
 } from '@/store/session-switcher'
 import { useTheme } from '@/themes/context'
 
-import { requestComposerFocus } from '../chat/composer/focus'
+import { requestComposerDictate, requestComposerFocus } from '../chat/composer/focus'
 import { SIDEBAR_COLLAPSE_MEDIA_QUERY } from '../layout-constants'
 import {
   AGENTS_ROUTE,
@@ -113,6 +113,7 @@ export function useKeybinds(deps: KeybindRuntimeDeps): void {
 
     'composer.focus': () => requestComposerFocus('main'),
     'composer.modelPicker': () => setModelPickerOpen(true),
+    'composer.dictate': () => requestComposerDictate('active'),
 
     'nav.commandPalette': toggleCommandPalette,
     'nav.commandCenter': deps.toggleCommandCenter,

--- a/apps/desktop/src/lib/keybinds/actions.ts
+++ b/apps/desktop/src/lib/keybinds/actions.ts
@@ -55,6 +55,12 @@ export const KEYBIND_ACTIONS: readonly KeybindActionMeta[] = [
   // ── Composer ─────────────────────────────────────────────────────────────
   { id: 'composer.focus', category: 'composer', defaults: [] },
   { id: 'composer.modelPicker', category: 'composer', defaults: [] },
+  // Toggle push-to-talk dictation on the active composer. Shipped unbound
+  // (defaults:[]) — dictation lives behind a permission-gated mic state, and
+  // ⌘D is already taken by profile.default. The Shortcuts panel surfaces
+  // this row so the user can pick a chord (the row-11936 ask was for the
+  // *capability*, not a specific default).
+  { id: 'composer.dictate', category: 'composer', defaults: [] },
 
   // ── Profiles ─────────────────────────────────────────────────────────────
   { id: 'profile.default', category: 'profiles', defaults: ['mod+d'] },


### PR DESCRIPTION
## Summary

The dictation mic button in the composer was wired only to `onClick`. There was no keyboard shortcut to start/stop dictation, and `composer.dictate` was not a registered action — so the Shortcuts panel (Ctrl+/) couldn't even surface it for rebinding.

This adds the action through the same pattern as `composer.focus` / `composer.modelPicker`:

- `apps/desktop/src/app/chat/composer/focus.ts`: new `hermes:composer-dictate` event, exported `requestComposerDictate` / `onComposerDictateRequest`.
- `apps/desktop/src/lib/keybinds/actions.ts`: register `composer.dictate` in the `composer` category, shipped unbound (⌘D is `profile.default`).
- `apps/desktop/src/app/hooks/use-keybinds.ts`: dispatch `requestComposerDictate` on the active composer when the keybind fires.
- `apps/desktop/src/app/chat/composer/index.tsx`: `ChatBar` subscribes to the dictate request and calls the live `useVoiceRecorder` closure through a ref (so the subscription doesn't tear down on every render).

Once the user assigns a chord in the Shortcuts panel, the keybind toggles the dictation mic.

## Tests

- New `apps/desktop/src/app/chat/composer/focus.test.ts` (4 tests): event API default target, active-target routing, explicit-target override, and subscriber detachment.
- Existing composer tests still green: 33/33.

## Local checks

- `tsc -b --noEmit` — clean
- `eslint` on touched files — 0 new errors (1 pre-existing import-order issue at focus.ts:14 unrelated to this PR)
- `vitest run src/app/chat/composer/` — 7 files, 33 tests pass

## Closes

- rob.improvement_backlog #11936