### PR TITLE
fix(transport): handle None content in Anthropic normalize_response

### DIFF
--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -106,7 +106,7 @@ class AnthropicTransport(ProviderTransport):
         # tests/agent/test_anthropic_thinking_block_order.py.
         ordered_blocks = []
 
-        for block in response.content:
+        for block in (response.content or []):
             block_dict = _to_plain_data(block)
             clean_block = None
             if isinstance(block_dict, dict):

--- a/tests/agent/transports/test_transport.py
+++ b/tests/agent/transports/test_transport.py
@@ -165,6 +165,26 @@ class TestAnthropicTransport:
         r = SimpleNamespace(usage=usage)
         assert transport.extract_cache_stats(r) is None
 
+    def test_normalize_response_none_content(self, transport):
+        """Test normalization when response.content is None.
+
+        Anthropic can return content=None when the response is empty or
+        refused. Previously this crashed with:
+            TypeError: 'NoneType' object is not iterable
+        because normalize_response iterated response.content directly.
+        """
+        r = SimpleNamespace(
+            content=None,
+            stop_reason="end_turn",
+            usage=SimpleNamespace(input_tokens=10, output_tokens=0),
+            model="claude-sonnet-4-6",
+        )
+        nr = transport.normalize_response(r)
+        assert isinstance(nr, NormalizedResponse)
+        assert nr.content is None or nr.content == ""
+        assert nr.tool_calls is None or nr.tool_calls == []
+        assert nr.finish_reason == "stop"
+
     def test_normalize_response_text(self, transport):
         """Test normalization of a simple text response."""
         r = SimpleNamespace(


### PR DESCRIPTION
## Problem

`AnthropicTransport.normalize_response()` crashes with:

```
TypeError: 'NoneType' object is not iterable
```

when `response.content` is `None`. This happens when the Anthropic API returns an empty/refused response (e.g. overloaded, incomplete SSE stream, or model refusal without content blocks).

## Impact

Affects all profiles using the `anthropic_messages` api_mode (native Anthropic transport). Observed in:
- `vision_analyze` tool — auxiliary vision calls via Anthropic
- `browser_vision` tool — screenshot analysis
- `context_compressor` — compression summary generation

## Root Cause

`agent/transports/anthropic.py` line 109:

```python
for block in response.content:  # crashes when content is None
```

## Fix

Guard the iteration:

```python
for block in (response.content or []):
```

## Reproduction

```python
from types import SimpleNamespace
from agent.transports.anthropic import AnthropicTransport

transport = AnthropicTransport()
response = SimpleNamespace(
    content=None,
    stop_reason='end_turn',
    usage=SimpleNamespace(input_tokens=10, output_tokens=0),
    model='claude-sonnet-4-6',
)
# Before fix: TypeError: 'NoneType' object is not iterable
# After fix: returns NormalizedResponse with empty content
transport.normalize_response(response)
```

## Test

Added `test_normalize_response_none_content` in `tests/agent/transports/test_transport.py`.

## Error Logs (from production gateway)

```
2026-06-15 00:24:17 ERROR tools.vision_tools: Error analyzing image: 'NoneType' object is not iterable
Traceback:
  File "tools/vision_tools.py", line 978, in vision_analyze_tool
    response = await async_call_llm(**call_kwargs)
  File "agent/auxiliary_client.py", line 5661, in async_call_llm
    await client.chat.completions.create(**kwargs), task)
  File "agent/auxiliary_client.py", line 1109, in create
    return await asyncio.to_thread(self._sync.create, **kwargs)
  File "agent/auxiliary_client.py", line 1046, in create
    _nr = _transport.normalize_response(...)
  File "agent/transports/anthropic.py", line 98, in normalize_response
    for block in response.content:
TypeError: 'NoneType' object is not iterable
```
