### PR TITLE
fix(gateway): suppress routine compression statuses

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -68,6 +68,14 @@ _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
+_GATEWAY_ROUTINE_COMPRESSION_STATUS_RE = re.compile(
+    r"("
+    r"compacting\s+context\s+[—-]\s+summarizing\s+earlier\s+conversation"
+    r"|preflight\s+compression"
+    r")",
+    re.IGNORECASE | re.DOTALL,
+)
+
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not Telegram chat
     r"auxiliary\s+.+\s+failed"
@@ -363,7 +371,14 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
     text = str(message or "").strip()
     if not text:
         return None
-    if _gateway_platform_value(platform) != "telegram":
+    platform_value = _gateway_platform_value(platform)
+    if (
+        platform_value != "local"
+        and event_type in {"lifecycle", "status"}
+        and _GATEWAY_ROUTINE_COMPRESSION_STATUS_RE.search(text)
+    ):
+        return None
+    if platform_value != "telegram":
         return text
 
     text = _redact_gateway_user_facing_secrets(text)

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -31,6 +31,28 @@ def test_non_telegram_status_is_unchanged():
     assert _prepare_gateway_status_message("local", "lifecycle", message) == message
 
 
+def test_gateway_suppresses_routine_compression_status_on_messaging_platforms():
+    """Routine compaction chrome should stay in logs, not Slack/Discord chat."""
+    messages = [
+        "📦 Preflight compression: ~247,564 tokens >= 231,200 threshold. This may take a moment.",
+        "🗜️ Compacting context — summarizing earlier conversation so I can continue...",
+    ]
+
+    for message in messages:
+        assert _prepare_gateway_status_message(Platform.SLACK, "lifecycle", message) is None
+        assert _prepare_gateway_status_message(Platform.DISCORD, "lifecycle", message) is None
+        assert _prepare_gateway_status_message(Platform.TELEGRAM, "lifecycle", message) is None
+        assert _prepare_gateway_status_message("local", "lifecycle", message) == message
+
+
+def test_gateway_keeps_actionable_compression_warnings_visible_outside_telegram():
+    """Only routine start/status chrome is suppressed globally."""
+    warning = "⚠ Compression summary failed: upstream error. Inserted a fallback context marker."
+
+    assert _prepare_gateway_status_message(Platform.SLACK, "warn", warning) == warning
+    assert _prepare_gateway_status_message(Platform.DISCORD, "warn", warning) == warning
+
+
 def test_telegram_status_sanitizes_raw_provider_security_errors():
     """Provider policy/security bodies should be replaced before chat delivery."""
     raw = (


### PR DESCRIPTION
## Summary
- Suppress routine context-compression start/status messages for gateway messaging platforms.
- Keep local status output unchanged and keep actionable compression warnings visible.
- Add regression coverage for Slack, Discord, Telegram, and local behavior.

## Problem
Routine compression chrome such as “Preflight compression” or “Compacting context — summarizing earlier conversation” is useful in logs/local output, but it is not actionable user-facing content when delivered into messaging platform chats.

## Tests
- `python -m pytest tests/gateway/test_telegram_noise_filter.py -q -o 'addopts='`
- `gitleaks git --log-opts='HEAD~1..HEAD' --no-banner --redact`
- private path/token/NAS/private-context regex scan over the PR diff
