### PR TITLE
fix(auxiliary): avoid deadlock by skipping force-close on loop mismatch

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4608,7 +4608,10 @@ def _get_cached_client(
                     effective = _compat_model(cached_client, model, cached_default)
                     return cached_client, effective
                 # Stale — evict and fall through to create a new client.
-                _force_close_async_httpx(cached_client)
+                # Do not force-close the cached client here: _force_close_async_httpx
+                # can deadlock when called from sync-to-async bridging (e.g.
+                # session_search parallel summarization) because it may block on
+                # the wrong event loop.
                 del _client_cache[cache_key]
             else:
                 effective = _compat_model(cached_client, model, cached_default)


### PR DESCRIPTION
This PR fixes a deadlock that occurs during sync-to-async bridging (e.g., during session_search parallel summarization) when a stale async client is detected.

By removing the call to `_force_close_async_httpx` during cache eviction and relying on the garbage collector for cleanup, we avoid blocking on the wrong event loop.

Verified by running the full test suite.