### PR TITLE
fix(anthropic): use platform.claude.com for OAuth token exchange

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1349,18 +1349,34 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
             "code_verifier": verifier,
         }).encode()
 
-        req = urllib.request.Request(
+        # Anthropic migrated the OAuth token endpoint from console.anthropic.com
+        # to platform.claude.com; the old host now 404s for the authorization_code
+        # exchange. Try the new endpoint first and fall back to the legacy one,
+        # mirroring the multi-endpoint logic already used by the refresh path.
+        result = None
+        last_error = None
+        for endpoint in (
+            "https://platform.claude.com/v1/oauth/token",
             _OAUTH_TOKEN_URL,
-            data=exchange_data,
-            headers={
-                "Content-Type": "application/json",
-                "User-Agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
-            },
-            method="POST",
-        )
-
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            result = json.loads(resp.read().decode())
+        ):
+            req = urllib.request.Request(
+                endpoint,
+                data=exchange_data,
+                headers={
+                    "Content-Type": "application/json",
+                    "User-Agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
+                },
+                method="POST",
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=15) as resp:
+                    result = json.loads(resp.read().decode())
+                break
+            except Exception as exc:
+                last_error = exc
+                continue
+        if result is None:
+            raise last_error if last_error else RuntimeError("Token exchange failed")
     except Exception as e:
         print(f"Token exchange failed: {e}")
         return None


### PR DESCRIPTION
## Summary

Anthropic migrated the OAuth token endpoint from `console.anthropic.com` to `platform.claude.com`. The **initial authorization_code exchange** in `begin_anthropic_oauth()` (`agent/anthropic_adapter.py`) still POSTs only to `_OAUTH_TOKEN_URL` (`https://console.anthropic.com/v1/oauth/token`), which now returns **HTTP 404**. As a result, every `hermes auth add anthropic --type oauth` login fails with:

```
Token exchange failed: HTTP Error 404: Not Found
Anthropic OAuth login did not return credentials.
```

even though the browser authorization succeeds and a valid code is returned.

The **refresh** path (`refresh_anthropic_oauth_token`) was already updated to try `platform.claude.com` first with `console.anthropic.com` as fallback (see the `token_endpoints` list). The initial exchange was missed and never got the same treatment.

## Fix

Apply the same multi-endpoint pattern to the initial exchange: try `https://platform.claude.com/v1/oauth/token` first, fall back to the legacy `_OAUTH_TOKEN_URL`. Re-raises the last error if both fail, preserving the existing `Token exchange failed: ...` message.

## Test plan

- [x] Reproduced on current `main` (6c34088): OAuth login 404s at the exchange step.
- [x] With the patch applied, `hermes auth add anthropic --type oauth` completes (`Added anthropic OAuth credential`), `hermes auth status anthropic` reports `logged in`, and a live `hermes chat -q` call routes successfully through the OAuth credential.
- [x] `python3 -c "import ast; ast.parse(...)"` syntax check passes.

## Notes

Endpoint string is inlined to mirror the existing refresh-path list rather than introducing a new module constant; happy to hoist both into a shared tuple if preferred.