### PR TITLE
docs(skills): add hermes-agent verification rule

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -31,6 +31,16 @@ People use Hermes for software development, research, system administration, dat
 
 **Docs:** https://hermes-agent.nousresearch.com/docs/
 
+## Scope & Verification
+
+This skill is a concise operating guide, not the complete source of truth for every Hermes feature. If a Hermes feature, command, or setting is not mentioned here, do not treat that absence as evidence that it does not exist. Check the live repository and official docs before giving a negative answer.
+
+Good verification targets:
+
+- CLI commands: `hermes --help`, `hermes <command> --help`, and `hermes_cli/main.py`
+- User documentation: https://hermes-agent.nousresearch.com/docs/
+- Source tree: https://github.com/NousResearch/hermes-agent
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
Adds a short Scope & Verification section to the hermes-agent skill.

The issue was not just that one command was missing from the skill, but that silence in the skill could be treated as proof that a real Hermes feature does not exist. This adds a simple guardrail: check live CLI help, the repo, and official docs before giving a negative answer.

This is intentionally separate from the broader command-listing work in #41328.

Closes #46224

Checked with:
- git diff --check
- skill markdown/frontmatter smoke check