### PR TITLE
fix(gateway): suppress routine compression statuses

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -68,6 +68,15 @@ _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
+_GATEWAY_ROUTINE_COMPRESSION_STATUS_PATTERN = (
+    r"compacting\s+context\s+[—-]\s+summarizing\s+earlier\s+conversation"
+    r"|preflight\s+compression"
+)
+_GATEWAY_ROUTINE_COMPRESSION_STATUS_RE = re.compile(
+    rf"({_GATEWAY_ROUTINE_COMPRESSION_STATUS_PATTERN})",
+    re.IGNORECASE | re.DOTALL,
+)
+
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not Telegram chat
     r"auxiliary\s+.+\s+failed"
@@ -76,8 +85,7 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|configured\s+compression\s+model\s+.+\s+failed"
     r"|no\s+auxiliary\s+llm\s+provider\s+configured"
     r"|auto-lowered\s+compression\s+threshold"
-    r"|compacting\s+context\s+[—-]\s+summarizing\s+earlier\s+conversation"
-    r"|preflight\s+compression"
+    rf"|{_GATEWAY_ROUTINE_COMPRESSION_STATUS_PATTERN}"
     r"|rate\s+limited\.\s+waiting\s+\d"
     r"|retrying\s+in\s+\d"
     r"|max\s+retries\s+\(\d+\).*(?:trying\s+fallback|exhausted|invalid\s+responses)"
@@ -363,7 +371,14 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
     text = str(message or "").strip()
     if not text:
         return None
-    if _gateway_platform_value(platform) != "telegram":
+    platform_value = _gateway_platform_value(platform)
+    if (
+        platform_value != "local"
+        and event_type in {"lifecycle", "status"}
+        and _GATEWAY_ROUTINE_COMPRESSION_STATUS_RE.search(text)
+    ):
+        return None
+    if platform_value != "telegram":
         return text
 
     text = _redact_gateway_user_facing_secrets(text)

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -31,6 +31,28 @@ def test_non_telegram_status_is_unchanged():
     assert _prepare_gateway_status_message("local", "lifecycle", message) == message
 
 
+def test_gateway_suppresses_routine_compression_status_on_messaging_platforms():
+    """Routine compaction chrome should stay in logs, not Slack/Discord chat."""
+    messages = [
+        "📦 Preflight compression: ~247,564 tokens >= 231,200 threshold. This may take a moment.",
+        "🗜️ Compacting context — summarizing earlier conversation so I can continue...",
+    ]
+
+    for message in messages:
+        assert _prepare_gateway_status_message(Platform.SLACK, "lifecycle", message) is None
+        assert _prepare_gateway_status_message(Platform.DISCORD, "lifecycle", message) is None
+        assert _prepare_gateway_status_message(Platform.TELEGRAM, "lifecycle", message) is None
+        assert _prepare_gateway_status_message("local", "lifecycle", message) == message
+
+
+def test_gateway_keeps_actionable_compression_warnings_visible_outside_telegram():
+    """Only routine start/status chrome is suppressed globally."""
+    warning = "⚠ Compression summary failed: upstream error. Inserted a fallback context marker."
+
+    assert _prepare_gateway_status_message(Platform.SLACK, "warn", warning) == warning
+    assert _prepare_gateway_status_message(Platform.DISCORD, "warn", warning) == warning
+
+
 def test_telegram_status_sanitizes_raw_provider_security_errors():
     """Provider policy/security bodies should be replaced before chat delivery."""
     raw = (


### PR DESCRIPTION
## Summary
- Suppress routine context-compression lifecycle/status messages at the gateway delivery layer for messaging platforms.
- Keep local/CLI diagnostics unchanged.
- Preserve actionable compression warnings outside Telegram and existing Telegram sanitization/noise filtering.
- Add regression coverage for Slack, Discord, Telegram, and local behavior.

## Problem
Routine compression housekeeping messages such as preflight compression and compacting-context notices can be delivered into chat surfaces even though they are not actionable for end users.

This is a scoped gateway-layer fix for the routine compression-status examples in #39293. Related: #26956, which approaches compression status handling from a configuration/source-emission layer.

## Tests
- `python -m pytest tests/gateway/test_telegram_noise_filter.py tests/run_agent/test_413_compression.py::TestPreflightCompression::test_preflight_compresses_oversized_history tests/run_agent/test_413_compression.py::TestPreflightCompression::test_compress_context_emits_lifecycle_status_before_work -q -o 'addopts='`
- `python -m py_compile gateway/run.py tests/gateway/test_telegram_noise_filter.py`
- `ruff check gateway/run.py tests/gateway/test_telegram_noise_filter.py`
- `git diff --check`
- `gitleaks git --log-opts='origin/main..HEAD' --no-banner --redact`
