### PR TITLE
feat: add native skill eval and observation tools

### DIFF
--- a/tests/tools/test_observation_tool.py
+++ b/tests/tools/test_observation_tool.py
@@ -1,0 +1,224 @@
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from tools.observation_tool import (
+    MAX_LIST_ITEM_LENGTH,
+    MAX_SEARCH_TEXT_LENGTH,
+    MAX_TEXT_LENGTHS,
+    OBSERVATION_SAVE_SCHEMA,
+    OBSERVATION_SEARCH_SCHEMA,
+    observation_save,
+    observation_search,
+)
+
+
+@pytest.fixture
+def hermes_home(tmp_path):
+    token = set_hermes_home_override(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        reset_hermes_home_override(token)
+
+
+def _json_result(raw: str) -> dict:
+    return json.loads(raw)
+
+
+def _save(**overrides) -> dict:
+    payload = {
+        "type": "verification",
+        "title": "Unique observation title",
+        "narrative": "A concise evidence-linked observation narrative.",
+        "confidence": "medium",
+        "evidence_paths": ["/tmp/evidence.md"],
+    }
+    payload.update(overrides)
+    return _json_result(observation_save(payload))
+
+
+def _db_path(hermes_home: Path) -> Path:
+    return hermes_home / "aion" / "observations" / "aion_observations.db"
+
+
+def _stored_row(hermes_home: Path, observation_id: int) -> sqlite3.Row:
+    conn = sqlite3.connect(_db_path(hermes_home))
+    conn.row_factory = sqlite3.Row
+    try:
+        row = conn.execute("SELECT * FROM observations WHERE id = ?", (observation_id,)).fetchone()
+        assert row is not None
+        return row
+    finally:
+        conn.close()
+
+
+def test_observation_save_rejects_invalid_type(hermes_home):
+    result = _save(type="bad")
+
+    assert result["status"] == "error"
+    assert "invalid type" in result["error"].lower()
+
+
+def test_observation_save_requires_evidence_for_high_confidence(hermes_home):
+    result = _save(confidence="high", evidence_paths=[])
+
+    assert result["status"] == "error"
+    assert "evidence" in result["error"].lower()
+
+
+def test_observation_save_low_confidence_without_evidence_allowed_with_warning(hermes_home):
+    result = _save(confidence="low", evidence_paths=[])
+
+    assert result["status"] == "saved"
+    assert result["observation"]["confidence"] == "low"
+    assert any("evidence" in warning.lower() for warning in result["warnings"])
+
+
+def test_observation_save_rejects_importance_outside_range(hermes_home):
+    for importance in (0, 6):
+        result = _save(importance=importance)
+        assert result["status"] == "error"
+        assert "importance" in result["error"].lower()
+
+
+def test_observation_save_rejects_oversized_evidence_and_tags(hermes_home):
+    oversized = "x" * 5000
+
+    evidence_result = _save(evidence_paths=[oversized])
+    tag_result = _save(tags=[oversized])
+
+    assert evidence_result["status"] == "error"
+    assert "evidence_paths" in evidence_result["error"]
+    assert tag_result["status"] == "error"
+    assert "tags" in tag_result["error"]
+
+
+def test_observation_save_uses_hermes_home(hermes_home):
+    result = _save(title="Profile isolation observation")
+
+    expected_db = hermes_home / "aion" / "observations" / "aion_observations.db"
+    assert result["status"] == "saved"
+    assert Path(result["db_path"]) == expected_db
+    assert expected_db.exists()
+
+
+def test_observation_search_uses_same_profile_db(hermes_home):
+    _save(title="Searchable alpha observation")
+
+    result = _json_result(observation_search({"query": "alpha"}))
+
+    assert result["status"] == "ok"
+    assert result["count"] == 1
+    assert result["observations"][0]["title"] == "Searchable alpha observation"
+    assert Path(result["db_path"]) == hermes_home / "aion" / "observations" / "aion_observations.db"
+
+
+def test_observation_search_is_read_only_by_default(hermes_home):
+    saved = _save(title="Read only search observation")
+    obs_id = saved["observation"]["id"]
+    before = _stored_row(hermes_home, obs_id)
+
+    result = _json_result(observation_search({"query": "Read"}))
+    after = _stored_row(hermes_home, obs_id)
+
+    assert result["status"] == "ok"
+    assert after["access_count"] == before["access_count"]
+    assert after["updated_at"] == before["updated_at"]
+
+
+def test_observation_search_on_fresh_profile_does_not_create_database(hermes_home):
+    db_path = _db_path(hermes_home)
+
+    result = _json_result(observation_search({"query": "anything"}))
+
+    assert result["status"] == "ok"
+    assert result["count"] == 0
+    assert not db_path.exists()
+    assert not db_path.parent.exists()
+
+
+def test_observation_search_rejects_oversized_query(hermes_home):
+    result = _json_result(observation_search({"query": "x" * 1000}))
+
+    assert result["status"] == "error"
+    assert "query" in result["error"].lower()
+
+
+def test_observation_search_filters_by_domain_and_type(hermes_home):
+    _save(title="Network router verified", type="verification", domain="TECHNICAL")
+    _save(title="Network client decision", type="decision", domain="COMMERCIAL")
+
+    result = _json_result(
+        observation_search({"query": "Network", "domain": "TECHNICAL", "type": "verification"})
+    )
+
+    assert result["status"] == "ok"
+    assert result["count"] == 1
+    assert result["observations"][0]["domain"] == "TECHNICAL"
+    assert result["observations"][0]["type"] == "verification"
+
+
+def test_observation_search_limits_results(hermes_home):
+    for idx in range(30):
+        _save(title=f"Limit candidate {idx}", narrative="Repeated limit search narrative.")
+
+    result = _json_result(observation_search({"query": "candidate", "limit": 5}))
+
+    assert result["status"] == "ok"
+    assert result["count"] == 5
+    assert len(result["observations"]) == 5
+
+
+def test_observation_search_rejects_limit_above_cap(hermes_home):
+    result = _json_result(observation_search({"limit": 500}))
+
+    assert result["status"] == "error"
+    assert "limit" in result["error"].lower()
+
+
+def test_observation_search_query_does_not_inject_sql(hermes_home):
+    _save(title="Injection resistant observation", narrative="SQL safety evidence.")
+
+    result = _json_result(observation_search({"query": "' OR 1=1 --"}))
+
+    assert result["status"] == "ok"
+    assert isinstance(result["observations"], list)
+
+
+def test_observation_search_rejects_tokenless_non_empty_query(hermes_home):
+    _save(title="Tokenless query should not return everything")
+
+    result = _json_result(observation_search({"query": "!!! -- ..."}))
+
+    assert result["status"] == "error"
+    assert "search token" in result["error"].lower()
+
+
+def test_observation_save_schema_declares_runtime_text_caps():
+    properties = OBSERVATION_SAVE_SCHEMA["parameters"]["properties"]
+
+    for field, max_length in MAX_TEXT_LENGTHS.items():
+        assert properties[field]["maxLength"] == max_length
+
+    assert properties["evidence_paths"]["items"]["maxLength"] == MAX_LIST_ITEM_LENGTH
+    assert properties["tags"]["items"]["maxLength"] == MAX_LIST_ITEM_LENGTH
+
+
+def test_observation_search_schema_declares_runtime_query_cap():
+    properties = OBSERVATION_SEARCH_SCHEMA["parameters"]["properties"]
+
+    assert properties["query"]["maxLength"] == MAX_SEARCH_TEXT_LENGTH
+
+
+def test_observation_tools_are_in_skills_toolset():
+    import tools.observation_tool  # noqa: F401 - import registers tools
+    from toolsets import resolve_toolset
+
+    tools = resolve_toolset("skills")
+
+    assert "observation_save" in tools
+    assert "observation_search" in tools

--- a/tests/tools/test_skill_eval_tool.py
+++ b/tests/tools/test_skill_eval_tool.py
@@ -1,0 +1,500 @@
+"""Tests for the native skill_eval_run tool."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+def _write_eval_pack(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "skill_name": "demo-skill",
+                "skill_path": "/tmp/demo/SKILL.md",
+                "purpose": "Verify native tool wrapper behaviour.",
+                "cases": [
+                    {
+                        "id": "CASE-1",
+                        "title": "Dry run case",
+                        "prompt": "Do the thing",
+                        "expected_trigger": "user asks for thing",
+                        "required_behaviors": ["show required behavior"],
+                        "forbidden_behaviors": ["claim scored output during dry-run"],
+                        "evidence_requirements": ["report path exists"],
+                        "scoring_rubric": {"max_points": 5, "criteria": ["truthful"]},
+                    }
+                ],
+                "scoring": {
+                    "case_max_points": 5,
+                    "pass_threshold_percent": 80,
+                    "hard_fail_conditions": ["claims dry-run is scored"],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_dry_run_writes_unscored_report_under_reports_dir(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    eval_path = hermes_home / "aion-evolution" / "evals" / "demo.json"
+    _write_eval_pack(eval_path)
+
+    from tools.skill_eval_tool import skill_eval_run
+
+    result = json.loads(
+        skill_eval_run(
+            {
+                "eval_path": str(eval_path),
+                "mode": "dry_run",
+                "json_summary": True,
+            }
+        )
+    )
+
+    assert result["status"] == "ok"
+    assert result["mode"] == "dry_run"
+    assert result["scored"] is False
+    assert result["case_count"] == 1
+    report = Path(result["report"])
+    assert report.exists()
+    report_text = report.read_text(encoding="utf-8")
+    assert "Skill Eval Report — demo-skill" in report_text
+    assert "Dry-run: `true`" in report_text
+    assert "Scored: `false`" in report_text
+    assert "claim scored output during dry-run" in report_text
+
+
+def test_manual_score_hard_fail_overrides_numeric_pass(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    eval_path = hermes_home / "aion-evolution" / "evals" / "demo.json"
+    _write_eval_pack(eval_path)
+    score_path = hermes_home / "aion-evolution" / "evals" / "scores.json"
+    score_path.write_text(
+        json.dumps({"scores": {"CASE-1": {"score": 5, "notes": "good but unsafe", "hard_fail": True}}}),
+        encoding="utf-8",
+    )
+
+    from tools.skill_eval_tool import skill_eval_run
+
+    result = json.loads(
+        skill_eval_run(
+            {
+                "eval_path": str(eval_path),
+                "mode": "manual_score",
+                "score_file": str(score_path),
+                "json_summary": True,
+            }
+        )
+    )
+
+    assert result["status"] == "failed"
+    assert result["scored"] is True
+    assert result["hard_fail"] is True
+    assert result["score"] == 5
+    assert result["max_score"] == 5
+
+
+def test_eval_path_outside_allowed_roots_is_blocked(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    eval_path = tmp_path / "outside.json"
+    _write_eval_pack(eval_path)
+
+    from tools.skill_eval_tool import skill_eval_run
+
+    result = json.loads(skill_eval_run({"eval_path": str(eval_path), "mode": "dry_run"}))
+
+    assert result["status"] == "error"
+    assert "outside allowed roots" in result["error"]
+
+
+def test_report_path_outside_reports_dir_is_blocked(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    eval_path = hermes_home / "aion-evolution" / "evals" / "demo.json"
+    _write_eval_pack(eval_path)
+
+    from tools.skill_eval_tool import skill_eval_run
+
+    result = json.loads(
+        skill_eval_run(
+            {
+                "eval_path": str(eval_path),
+                "mode": "dry_run",
+                "report_path": str(tmp_path / "bad-report.md"),
+            }
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "report_path outside reports directory" in result["error"]
+
+
+def test_invalid_pack_missing_cases_returns_schema_error(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    eval_path = hermes_home / "aion-evolution" / "evals" / "bad.json"
+    eval_path.parent.mkdir(parents=True, exist_ok=True)
+    eval_path.write_text(json.dumps({"schema_version": "1.0"}), encoding="utf-8")
+
+    from tools.skill_eval_tool import skill_eval_run
+
+    result = json.loads(skill_eval_run({"eval_path": str(eval_path), "mode": "dry_run"}))
+
+    assert result["status"] == "error"
+    assert any("missing top-level field: cases" in err for err in result["errors"])
+
+
+def test_report_path_rejects_symlinked_reports_directory(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    eval_path = hermes_home / "aion-evolution" / "evals" / "demo.json"
+    _write_eval_pack(eval_path)
+    reports_dir = hermes_home / "aion-evolution" / "evals" / "reports"
+    outside = tmp_path / "outside-reports"
+    outside.mkdir(parents=True)
+    reports_dir.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        reports_dir.symlink_to(outside, target_is_directory=True)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlinks unavailable in test environment: {exc}")
+
+    from tools.skill_eval_tool import skill_eval_run
+
+    result = json.loads(skill_eval_run({"eval_path": str(eval_path), "mode": "dry_run"}))
+
+    assert result["status"] == "error"
+    assert "symlink" in result["error"]
+    assert not (outside / "demo-eval-report.md").exists()
+
+
+def test_eval_path_rejects_symlinked_evals_root(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    real_evals = tmp_path / "real-evals"
+    eval_path = real_evals / "demo.json"
+    _write_eval_pack(eval_path)
+    evals_root = hermes_home / "aion-evolution" / "evals"
+    evals_root.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        evals_root.symlink_to(real_evals, target_is_directory=True)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlinks unavailable in test environment: {exc}")
+
+    from tools.skill_eval_tool import skill_eval_run
+
+    result = json.loads(skill_eval_run({"eval_path": str(evals_root / "demo.json"), "mode": "dry_run"}))
+
+    assert result["status"] == "error"
+    assert "evals root contains symlink" in result["error"]
+
+
+def test_manual_score_with_unknown_case_id_is_error(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    eval_path = hermes_home / "aion-evolution" / "evals" / "demo.json"
+    _write_eval_pack(eval_path)
+    score_path = hermes_home / "aion-evolution" / "evals" / "scores.json"
+    score_path.write_text(json.dumps({"scores": {"UNKNOWN": {"score": 5}}}), encoding="utf-8")
+
+    from tools.skill_eval_tool import skill_eval_run
+
+    result = json.loads(
+        skill_eval_run({"eval_path": str(eval_path), "mode": "manual_score", "score_file": str(score_path)})
+    )
+
+    assert result["status"] == "error"
+    assert "unknown score case id" in result["error"]
+
+
+def test_manual_score_with_empty_score_file_is_error(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    eval_path = hermes_home / "aion-evolution" / "evals" / "demo.json"
+    _write_eval_pack(eval_path)
+    score_path = hermes_home / "aion-evolution" / "evals" / "scores.json"
+    score_path.write_text(json.dumps({"scores": {}}), encoding="utf-8")
+
+    from tools.skill_eval_tool import skill_eval_run
+
+    result = json.loads(
+        skill_eval_run({"eval_path": str(eval_path), "mode": "manual_score", "score_file": str(score_path)})
+    )
+
+    assert result["status"] == "error"
+    assert "at least one matching score" in result["error"]
+
+
+def test_partial_manual_score_is_incomplete_not_scored(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    eval_path = hermes_home / "aion-evolution" / "evals" / "demo.json"
+    _write_eval_pack(eval_path)
+    data = json.loads(eval_path.read_text(encoding="utf-8"))
+    second_case = dict(data["cases"][0])
+    second_case["id"] = "CASE-2"
+    data["cases"].append(second_case)
+    eval_path.write_text(json.dumps(data), encoding="utf-8")
+    score_path = hermes_home / "aion-evolution" / "evals" / "scores.json"
+    score_path.write_text(json.dumps({"scores": {"CASE-1": {"score": 5}}}), encoding="utf-8")
+
+    from tools.skill_eval_tool import skill_eval_run
+
+    result = json.loads(
+        skill_eval_run({"eval_path": str(eval_path), "mode": "manual_score", "score_file": str(score_path)})
+    )
+
+    assert result["status"] == "incomplete"
+    assert result["scored"] is False
+    assert result["scored_cases"] == 1
+    assert result["case_count"] == 2
+
+
+def test_report_path_rejects_symlink_leaf_file(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    eval_path = hermes_home / "aion-evolution" / "evals" / "demo.json"
+    _write_eval_pack(eval_path)
+    reports_dir = hermes_home / "aion-evolution" / "evals" / "reports"
+    reports_dir.mkdir(parents=True)
+    outside = tmp_path / "outside.md"
+    outside.write_text("do not overwrite", encoding="utf-8")
+    link = reports_dir / "linked-report.md"
+    try:
+        link.symlink_to(outside)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlinks unavailable in test environment: {exc}")
+
+    from tools.skill_eval_tool import skill_eval_run
+
+    result = json.loads(
+        skill_eval_run({"eval_path": str(eval_path), "mode": "dry_run", "report_path": str(link)})
+    )
+
+    assert result["status"] == "error"
+    assert "report_path contains symlink" in result["error"]
+    assert outside.read_text(encoding="utf-8") == "do not overwrite"
+
+
+def test_report_path_replaces_hardlink_without_overwriting_outside_target(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    eval_path = hermes_home / "aion-evolution" / "evals" / "demo.json"
+    _write_eval_pack(eval_path)
+    reports_dir = hermes_home / "aion-evolution" / "evals" / "reports"
+    reports_dir.mkdir(parents=True)
+    outside = tmp_path / "outside.md"
+    outside.write_text("do not overwrite", encoding="utf-8")
+    link = reports_dir / "hardlinked-report.md"
+    try:
+        os.link(outside, link)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"hardlinks unavailable in test environment: {exc}")
+
+    from tools.skill_eval_tool import skill_eval_run
+
+    result = json.loads(
+        skill_eval_run({"eval_path": str(eval_path), "mode": "dry_run", "report_path": str(link)})
+    )
+
+    assert result["status"] == "ok"
+    assert outside.read_text(encoding="utf-8") == "do not overwrite"
+    assert "Skill Eval Report" in link.read_text(encoding="utf-8")
+    assert os.stat(outside).st_ino != os.stat(link).st_ino
+
+
+def test_partial_manual_low_score_remains_incomplete_not_failed(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    eval_path = hermes_home / "aion-evolution" / "evals" / "demo.json"
+    _write_eval_pack(eval_path)
+    data = json.loads(eval_path.read_text(encoding="utf-8"))
+    second_case = dict(data["cases"][0])
+    second_case["id"] = "CASE-2"
+    data["cases"].append(second_case)
+    eval_path.write_text(json.dumps(data), encoding="utf-8")
+    score_path = hermes_home / "aion-evolution" / "evals" / "scores.json"
+    score_path.write_text(
+        json.dumps({"scores": {"CASE-1": {"score": 0, "hard_fail": True}}}),
+        encoding="utf-8",
+    )
+
+    from tools.skill_eval_tool import skill_eval_run
+
+    result = json.loads(
+        skill_eval_run({"eval_path": str(eval_path), "mode": "manual_score", "score_file": str(score_path)})
+    )
+
+    assert result["status"] == "incomplete"
+    assert result["scored"] is False
+    assert result["hard_fail"] is True
+
+
+def test_eval_path_rejects_parent_directory_traversal(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    outside = hermes_home / "aion-evolution" / "outside.json"
+    _write_eval_pack(outside)
+    traversal = hermes_home / "aion-evolution" / "evals" / ".." / "outside.json"
+
+    from tools.skill_eval_tool import skill_eval_run
+
+    result = json.loads(skill_eval_run({"eval_path": str(traversal), "mode": "dry_run"}))
+
+    assert result["status"] == "error"
+    assert "parent-directory traversal" in result["error"]
+
+
+def test_score_file_rejects_parent_directory_traversal(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    eval_path = hermes_home / "aion-evolution" / "evals" / "demo.json"
+    _write_eval_pack(eval_path)
+    outside_score = hermes_home / "aion-evolution" / "scores.json"
+    outside_score.write_text(json.dumps({"scores": {"CASE-1": {"score": 5}}}), encoding="utf-8")
+    traversal = hermes_home / "aion-evolution" / "evals" / ".." / "scores.json"
+
+    from tools.skill_eval_tool import skill_eval_run
+
+    result = json.loads(
+        skill_eval_run({"eval_path": str(eval_path), "mode": "manual_score", "score_file": str(traversal)})
+    )
+
+    assert result["status"] == "error"
+    assert "parent-directory traversal" in result["error"]
+
+
+def test_report_path_rejects_parent_directory_traversal(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    eval_path = hermes_home / "aion-evolution" / "evals" / "demo.json"
+    _write_eval_pack(eval_path)
+    traversal = hermes_home / "aion-evolution" / "evals" / "reports" / ".." / "escaped.md"
+
+    from tools.skill_eval_tool import skill_eval_run
+
+    result = json.loads(
+        skill_eval_run({"eval_path": str(eval_path), "mode": "dry_run", "report_path": str(traversal)})
+    )
+
+    assert result["status"] == "error"
+    assert "parent-directory traversal" in result["error"]
+    assert not (hermes_home / "aion-evolution" / "evals" / "escaped.md").exists()
+
+
+def test_invalid_numeric_pack_fields_return_schema_errors(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    eval_path = hermes_home / "aion-evolution" / "evals" / "bad-numeric.json"
+    _write_eval_pack(eval_path)
+    data = json.loads(eval_path.read_text(encoding="utf-8"))
+    data["cases"][0]["scoring_rubric"]["max_points"] = 0
+    data["scoring"]["case_max_points"] = True
+    data["scoring"]["pass_threshold_percent"] = None
+    eval_path.write_text(json.dumps(data), encoding="utf-8")
+
+    from tools.skill_eval_tool import skill_eval_run
+
+    result = json.loads(skill_eval_run({"eval_path": str(eval_path), "mode": "dry_run"}))
+
+    assert result["status"] == "error"
+    assert any("max_points must be a positive integer" in err for err in result["errors"])
+    assert any("case_max_points must be a positive integer" in err for err in result["errors"])
+    assert any("pass_threshold_percent must be a number" in err for err in result["errors"])
+
+
+def test_manual_score_rejects_non_integer_score(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    eval_path = hermes_home / "aion-evolution" / "evals" / "demo.json"
+    _write_eval_pack(eval_path)
+    score_path = hermes_home / "aion-evolution" / "evals" / "scores.json"
+    score_path.write_text(json.dumps({"scores": {"CASE-1": {"score": []}}}), encoding="utf-8")
+
+    from tools.skill_eval_tool import skill_eval_run
+
+    result = json.loads(
+        skill_eval_run({"eval_path": str(eval_path), "mode": "manual_score", "score_file": str(score_path)})
+    )
+
+    assert result["status"] == "error"
+    assert "Score for CASE-1 must be an integer" in result["error"]
+
+
+def test_manual_score_rejects_boolean_score(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    eval_path = hermes_home / "aion-evolution" / "evals" / "demo.json"
+    _write_eval_pack(eval_path)
+    score_path = hermes_home / "aion-evolution" / "evals" / "scores.json"
+    score_path.write_text(json.dumps({"scores": {"CASE-1": True}}), encoding="utf-8")
+
+    from tools.skill_eval_tool import skill_eval_run
+
+    result = json.loads(
+        skill_eval_run({"eval_path": str(eval_path), "mode": "manual_score", "score_file": str(score_path)})
+    )
+
+    assert result["status"] == "error"
+    assert "Invalid score value for CASE-1" in result["error"]
+
+
+def test_manual_score_rejects_non_boolean_hard_fail(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    eval_path = hermes_home / "aion-evolution" / "evals" / "demo.json"
+    _write_eval_pack(eval_path)
+    score_path = hermes_home / "aion-evolution" / "evals" / "scores.json"
+    score_path.write_text(
+        json.dumps({"scores": {"CASE-1": {"score": 5, "hard_fail": "false"}}}),
+        encoding="utf-8",
+    )
+
+    from tools.skill_eval_tool import skill_eval_run
+
+    result = json.loads(
+        skill_eval_run({"eval_path": str(eval_path), "mode": "manual_score", "score_file": str(score_path)})
+    )
+
+    assert result["status"] == "error"
+    assert "hard_fail for CASE-1 must be a boolean" in result["error"]
+
+
+def test_eval_pack_rejects_non_string_case_id(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    eval_path = hermes_home / "aion-evolution" / "evals" / "bad-case-id.json"
+    _write_eval_pack(eval_path)
+    data = json.loads(eval_path.read_text(encoding="utf-8"))
+    data["cases"][0]["id"] = 1
+    eval_path.write_text(json.dumps(data), encoding="utf-8")
+
+    from tools.skill_eval_tool import skill_eval_run
+
+    result = json.loads(skill_eval_run({"eval_path": str(eval_path), "mode": "dry_run"}))
+
+    assert result["status"] == "error"
+    assert any("id must be a non-empty string" in err for err in result["errors"])
+
+
+def test_tool_is_registered_in_skills_toolset():
+    import tools.skill_eval_tool  # noqa: F401
+    from tools.registry import registry
+
+    entry = registry.get_entry("skill_eval_run")
+    assert entry is not None
+    assert entry.toolset == "skills"

--- a/tools/observation_tool.py
+++ b/tools/observation_tool.py
@@ -1,0 +1,440 @@
+"""Native Aion structured observation tools.
+
+Minimal Phase 8 surface: save and search evidence-linked observations in the
+active Hermes profile. This intentionally does not write persistent memory,
+read raw source files, or inject observations into prompts.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+from tools.registry import registry
+
+ALLOWED_TYPES = {
+    "decision",
+    "bugfix",
+    "discovery",
+    "procedure",
+    "client_fact",
+    "person_fact",
+    "risk",
+    "verification",
+    "handoff",
+}
+ALLOWED_CONFIDENCE = {"low", "medium", "high"}
+ALLOWED_STATUS = {"active", "stale", "superseded", "archived"}
+MAX_LIMIT = 25
+DEFAULT_LIMIT = 10
+MAX_LIST_ITEM_LENGTH = 512
+MAX_LIST_SERIALIZED_LENGTH = 2000
+MAX_SEARCH_TEXT_LENGTH = 240
+MAX_TEXT_LENGTHS = {
+    "title": 240,
+    "narrative": 4000,
+    "lesson_learned": 2000,
+    "project": 200,
+    "client": 200,
+    "domain": 120,
+    "source_session_id": 200,
+    "stale_after": 120,
+}
+
+SCHEMA_SQL = """
+PRAGMA foreign_keys = ON;
+PRAGMA journal_mode = WAL;
+
+CREATE TABLE IF NOT EXISTS observations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    source_session_id TEXT,
+    project TEXT,
+    client TEXT,
+    domain TEXT,
+    type TEXT NOT NULL CHECK (type IN (
+        'decision', 'bugfix', 'discovery', 'procedure', 'client_fact',
+        'person_fact', 'risk', 'verification', 'handoff'
+    )),
+    title TEXT NOT NULL,
+    narrative TEXT NOT NULL,
+    lesson_learned TEXT,
+    evidence_paths TEXT,
+    tags TEXT,
+    importance INTEGER NOT NULL DEFAULT 3 CHECK (importance BETWEEN 1 AND 5),
+    confidence TEXT NOT NULL DEFAULT 'medium' CHECK (confidence IN ('low', 'medium', 'high')),
+    stale_after TEXT,
+    superseded_by INTEGER REFERENCES observations(id) ON DELETE SET NULL,
+    access_count INTEGER NOT NULL DEFAULT 0,
+    injection_count INTEGER NOT NULL DEFAULT 0,
+    use_feedback TEXT,
+    status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'stale', 'superseded', 'archived'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_observations_type ON observations(type);
+CREATE INDEX IF NOT EXISTS idx_observations_project ON observations(project);
+CREATE INDEX IF NOT EXISTS idx_observations_client ON observations(client);
+CREATE INDEX IF NOT EXISTS idx_observations_domain ON observations(domain);
+CREATE INDEX IF NOT EXISTS idx_observations_tags ON observations(tags);
+CREATE INDEX IF NOT EXISTS idx_observations_status ON observations(status);
+CREATE INDEX IF NOT EXISTS idx_observations_importance ON observations(importance);
+CREATE INDEX IF NOT EXISTS idx_observations_created_at ON observations(created_at);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS observation_fts USING fts5(
+    title,
+    narrative,
+    lesson_learned,
+    evidence_paths,
+    tags,
+    content='observations',
+    content_rowid='id'
+);
+
+CREATE TRIGGER IF NOT EXISTS observations_ai AFTER INSERT ON observations BEGIN
+    INSERT INTO observation_fts(rowid, title, narrative, lesson_learned, evidence_paths, tags)
+    VALUES (new.id, new.title, new.narrative, new.lesson_learned, new.evidence_paths, new.tags);
+END;
+
+CREATE TRIGGER IF NOT EXISTS observations_ad AFTER DELETE ON observations BEGIN
+    INSERT INTO observation_fts(observation_fts, rowid, title, narrative, lesson_learned, evidence_paths, tags)
+    VALUES('delete', old.id, old.title, old.narrative, old.lesson_learned, old.evidence_paths, old.tags);
+END;
+
+CREATE TRIGGER IF NOT EXISTS observations_au AFTER UPDATE ON observations BEGIN
+    INSERT INTO observation_fts(observation_fts, rowid, title, narrative, lesson_learned, evidence_paths, tags)
+    VALUES('delete', old.id, old.title, old.narrative, old.lesson_learned, old.evidence_paths, old.tags);
+    INSERT INTO observation_fts(rowid, title, narrative, lesson_learned, evidence_paths, tags)
+    VALUES (new.id, new.title, new.narrative, new.lesson_learned, new.evidence_paths, new.tags);
+END;
+
+CREATE TABLE IF NOT EXISTS schema_meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+INSERT OR REPLACE INTO schema_meta(key, value) VALUES
+    ('schema_name', 'aion_observations'),
+    ('schema_version', '1.0.0'),
+    ('created_for', 'Aion structured observation memory native tool');
+"""
+
+
+def _json_error(message: str, **extra: Any) -> str:
+    payload = {"status": "error", "error": message}
+    payload.update(extra)
+    return json.dumps(payload, indent=2)
+
+
+def _json_ok(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, indent=2)
+
+
+def _db_path() -> Path:
+    return get_hermes_home().expanduser().absolute() / "aion" / "observations" / "aion_observations.db"
+
+
+def _connect() -> sqlite3.Connection:
+    path = _db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.executescript(SCHEMA_SQL)
+    return conn
+
+
+def _connect_existing() -> sqlite3.Connection | None:
+    path = _db_path()
+    if not path.exists():
+        return None
+    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _coerce_optional_string(value: Any, field: str) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    max_len = MAX_TEXT_LENGTHS.get(field)
+    if max_len and len(text) > max_len:
+        raise ValueError(f"{field} exceeds {max_len} characters")
+    return text
+
+
+def _coerce_required_string(value: Any, field: str) -> str:
+    text = _coerce_optional_string(value, field)
+    if text is None:
+        raise ValueError(f"{field} is required")
+    return text
+
+
+def _coerce_list_text(value: Any, field: str) -> tuple[str | None, list[str]]:
+    if value is None or value == "":
+        return None, []
+    if isinstance(value, str):
+        parts = [part.strip() for part in re.split(r"[\n,]", value) if part.strip()]
+    elif isinstance(value, (list, tuple)):
+        parts = [str(part).strip() for part in value if str(part).strip()]
+    else:
+        raise ValueError(f"{field} must be a string or list of strings")
+    for part in parts:
+        if len(part) > MAX_LIST_ITEM_LENGTH:
+            raise ValueError(f"{field} item exceeds {MAX_LIST_ITEM_LENGTH} characters")
+    normalized = json.dumps(parts, ensure_ascii=False) if parts else None
+    if normalized is not None and len(normalized) > MAX_LIST_SERIALIZED_LENGTH:
+        raise ValueError(f"{field} exceeds {MAX_LIST_SERIALIZED_LENGTH} serialized characters")
+    return normalized, parts
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds")
+
+
+def _row_to_observation(row: sqlite3.Row) -> dict[str, Any]:
+    return {
+        "id": row["id"],
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+        "source_session_id": row["source_session_id"],
+        "project": row["project"],
+        "client": row["client"],
+        "domain": row["domain"],
+        "type": row["type"],
+        "title": row["title"],
+        "narrative": row["narrative"],
+        "lesson_learned": row["lesson_learned"],
+        "evidence_paths": json.loads(row["evidence_paths"] or "[]"),
+        "tags": json.loads(row["tags"] or "[]"),
+        "importance": row["importance"],
+        "confidence": row["confidence"],
+        "stale_after": row["stale_after"],
+        "access_count": row["access_count"],
+        "injection_count": row["injection_count"],
+        "status": row["status"],
+    }
+
+
+def _fts_query(query: str) -> str:
+    terms = re.findall(r"\b\w[\w.-]*\b", query, flags=re.UNICODE)
+    return " OR ".join(f'"{term.replace(chr(34), chr(34) + chr(34))}"' for term in terms[:12])
+
+
+def _string_schema(field: str) -> dict[str, Any]:
+    return {"type": "string", "maxLength": MAX_TEXT_LENGTHS[field]}
+
+
+def _list_schema(description: str) -> dict[str, Any]:
+    return {
+        "description": description,
+        "oneOf": [
+            {"type": "string", "maxLength": MAX_LIST_SERIALIZED_LENGTH},
+            {"type": "array", "items": {"type": "string", "maxLength": MAX_LIST_ITEM_LENGTH}},
+        ],
+        "items": {"type": "string", "maxLength": MAX_LIST_ITEM_LENGTH},
+    }
+
+
+def observation_save(args: dict[str, Any], **_: Any) -> str:
+    """Save one structured observation in the active Hermes profile."""
+    try:
+        obs_type = str(args.get("type", "")).strip()
+        if obs_type not in ALLOWED_TYPES:
+            return _json_error(f"invalid type: {obs_type!r}", allowed_types=sorted(ALLOWED_TYPES))
+
+        confidence = str(args.get("confidence", "medium")).strip() or "medium"
+        if confidence not in ALLOWED_CONFIDENCE:
+            return _json_error(f"invalid confidence: {confidence!r}", allowed_confidence=sorted(ALLOWED_CONFIDENCE))
+
+        importance = int(args.get("importance", 3))
+        if importance < 1 or importance > 5:
+            return _json_error("importance must be between 1 and 5")
+
+        title = _coerce_required_string(args.get("title"), "title")
+        narrative = _coerce_required_string(args.get("narrative"), "narrative")
+        lesson_learned = _coerce_optional_string(args.get("lesson_learned"), "lesson_learned")
+        project = _coerce_optional_string(args.get("project"), "project")
+        client = _coerce_optional_string(args.get("client"), "client")
+        domain = _coerce_optional_string(args.get("domain"), "domain")
+        stale_after = _coerce_optional_string(args.get("stale_after"), "stale_after")
+        source_session_id = _coerce_optional_string(args.get("source_session_id"), "source_session_id")
+        evidence_paths, evidence_items = _coerce_list_text(args.get("evidence_paths"), "evidence_paths")
+        tags_json, ignored_tags = _coerce_list_text(args.get("tags"), "tags")
+
+        warnings: list[str] = []
+        if confidence == "high" and not evidence_items:
+            return _json_error("evidence_paths is required when confidence is high")
+        if not evidence_items:
+            warnings.append("No evidence_paths supplied; observation should remain low-confidence unless independently verified.")
+        if confidence != "low" and not evidence_items:
+            confidence = "low"
+            warnings.append("confidence downgraded to low because evidence_paths was empty")
+
+        now = _now()
+        with _connect() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO observations (
+                    created_at, updated_at, source_session_id, project, client, domain,
+                    type, title, narrative, lesson_learned, evidence_paths, tags,
+                    importance, confidence, stale_after, status
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active')
+                """,
+                (
+                    now,
+                    now,
+                    source_session_id,
+                    project,
+                    client,
+                    domain,
+                    obs_type,
+                    title,
+                    narrative,
+                    lesson_learned,
+                    evidence_paths,
+                    tags_json,
+                    importance,
+                    confidence,
+                    stale_after,
+                ),
+            )
+            if cursor.lastrowid is None:
+                raise sqlite3.Error("observation insert did not return an id")
+            obs_id = int(cursor.lastrowid)
+            row = conn.execute("SELECT * FROM observations WHERE id = ?", (obs_id,)).fetchone()
+            if row is None:
+                raise sqlite3.Error("saved observation could not be reloaded")
+
+        return _json_ok(
+            {
+                "status": "saved",
+                "observation": _row_to_observation(row),
+                "warnings": warnings,
+                "db_path": str(_db_path()),
+            }
+        )
+    except (ValueError, TypeError, sqlite3.Error) as exc:
+        return _json_error(str(exc), db_path=str(_db_path()))
+
+
+def observation_search(args: dict[str, Any], **_: Any) -> str:
+    """Search active Hermes profile observations."""
+    try:
+        limit = int(args.get("limit", DEFAULT_LIMIT))
+        if limit < 1 or limit > MAX_LIMIT:
+            return _json_error(f"limit must be between 1 and {MAX_LIMIT}")
+
+        status = str(args.get("status", "active")).strip() or "active"
+        if status not in ALLOWED_STATUS:
+            return _json_error(f"invalid status: {status!r}", allowed_status=sorted(ALLOWED_STATUS))
+
+        obs_type = args.get("type")
+        if obs_type is not None:
+            obs_type = str(obs_type).strip()
+            if obs_type and obs_type not in ALLOWED_TYPES:
+                return _json_error(f"invalid type: {obs_type!r}", allowed_types=sorted(ALLOWED_TYPES))
+
+        clauses = ["o.status = ?"]
+        params: list[Any] = [status]
+        query = str(args.get("query", "")).strip()
+        if len(query) > MAX_SEARCH_TEXT_LENGTH:
+            return _json_error(f"query exceeds {MAX_SEARCH_TEXT_LENGTH} characters")
+        fts = _fts_query(query) if query else ""
+        if query and not fts:
+            return _json_error("query must include at least one search token")
+        if fts:
+            clauses.append("o.id IN (SELECT rowid FROM observation_fts WHERE observation_fts MATCH ?)")
+            params.append(fts)
+        if obs_type:
+            clauses.append("o.type = ?")
+            params.append(obs_type)
+        for field in ("project", "client", "domain"):
+            value = args.get(field)
+            if value is not None and str(value).strip():
+                clauses.append(f"o.{field} = ?")
+                params.append(str(value).strip())
+
+        sql = f"""
+            SELECT o.*
+            FROM observations o
+            WHERE {' AND '.join(clauses)}
+            ORDER BY o.importance DESC, o.created_at DESC, o.id DESC
+            LIMIT ?
+        """
+        params.append(limit)
+
+        conn = _connect_existing()
+        if conn is None:
+            return _json_ok({"status": "ok", "count": 0, "observations": [], "db_path": str(_db_path())})
+        with conn:
+            rows = conn.execute(sql, params).fetchall()
+
+        observations = [_row_to_observation(row) for row in rows]
+        return _json_ok({"status": "ok", "count": len(observations), "observations": observations, "db_path": str(_db_path())})
+    except (ValueError, TypeError, sqlite3.Error) as exc:
+        return _json_error(str(exc), db_path=str(_db_path()))
+
+
+OBSERVATION_SAVE_SCHEMA = {
+    "description": "Save one evidence-linked structured observation in the active Hermes profile.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "type": {"type": "string", "enum": sorted(ALLOWED_TYPES)},
+            "title": _string_schema("title"),
+            "narrative": _string_schema("narrative"),
+            "lesson_learned": _string_schema("lesson_learned"),
+            "evidence_paths": _list_schema("String or list of evidence path/reference strings."),
+            "tags": _list_schema("String or list of tag strings."),
+            "importance": {"type": "integer", "minimum": 1, "maximum": 5, "default": 3},
+            "confidence": {"type": "string", "enum": sorted(ALLOWED_CONFIDENCE), "default": "medium"},
+            "stale_after": _string_schema("stale_after"),
+            "project": _string_schema("project"),
+            "client": _string_schema("client"),
+            "domain": _string_schema("domain"),
+            "source_session_id": _string_schema("source_session_id"),
+        },
+        "required": ["type", "title", "narrative"],
+    },
+}
+
+OBSERVATION_SEARCH_SCHEMA = {
+    "description": "Search structured observations in the active Hermes profile without reading raw source files.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "maxLength": MAX_SEARCH_TEXT_LENGTH},
+            "type": {"type": "string", "enum": sorted(ALLOWED_TYPES)},
+            "project": _string_schema("project"),
+            "client": _string_schema("client"),
+            "domain": _string_schema("domain"),
+            "status": {"type": "string", "enum": sorted(ALLOWED_STATUS), "default": "active"},
+            "limit": {"type": "integer", "minimum": 1, "maximum": MAX_LIMIT, "default": DEFAULT_LIMIT},
+        },
+    },
+}
+
+registry.register(
+    name="observation_save",
+    toolset="skills",
+    schema=OBSERVATION_SAVE_SCHEMA,
+    handler=lambda args, **kwargs: observation_save(args, **kwargs),
+    description=OBSERVATION_SAVE_SCHEMA["description"],
+    emoji="🧠",
+)
+
+registry.register(
+    name="observation_search",
+    toolset="skills",
+    schema=OBSERVATION_SEARCH_SCHEMA,
+    handler=lambda args, **kwargs: observation_search(args, **kwargs),
+    description=OBSERVATION_SEARCH_SCHEMA["description"],
+    emoji="🔎",
+)

--- a/tools/skill_eval_tool.py
+++ b/tools/skill_eval_tool.py
@@ -1,0 +1,545 @@
+"""Native skill evaluation runner tool.
+
+This tool intentionally mirrors the Aion Phase 8 manual ``skill_eval_run``
+prototype without adding LLM judging, skill mutation, candidate promotion, or
+runtime config mutation. Dry-runs are always reported as unscored.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+from tools.registry import registry
+
+
+@dataclass
+class CaseResult:
+    case_id: str
+    title: str
+    score: int | None
+    max_points: int
+    notes: str
+    hard_fail: bool = False
+
+
+def _json_error(message: str, *, errors: list[str] | None = None) -> str:
+    payload: dict[str, Any] = {"status": "error", "error": message}
+    if errors is not None:
+        payload["errors"] = errors
+    return json.dumps(payload, indent=2)
+
+
+def _reject_traversal_segments(path: Path, field: str) -> None:
+    if any(part in {".", ".."} for part in path.parts):
+        raise ValueError(f"{field} contains parent-directory traversal segment")
+
+
+def _resolve_existing_path(value: str, field: str) -> Path:
+    if not value or not str(value).strip():
+        raise ValueError(f"{field} is required")
+    path = Path(value).expanduser()
+    _reject_traversal_segments(path, field)
+    absolute = path if path.is_absolute() else Path.cwd() / path
+    absolute = absolute.absolute()
+    if not absolute.exists():
+        raise ValueError(f"{field} does not exist: {path}")
+    if not absolute.is_file():
+        raise ValueError(f"{field} is not a file: {absolute}")
+    return absolute
+
+
+def _resolve_output_path(value: str | None, default: Path) -> Path:
+    path = Path(value).expanduser() if value else default
+    _reject_traversal_segments(path, "report_path")
+    absolute = path if path.is_absolute() else Path.cwd() / path
+    return absolute.absolute()
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _aion_evals_root() -> Path:
+    return (get_hermes_home().expanduser().absolute() / "aion-evolution" / "evals").absolute()
+
+
+def _reports_dir() -> Path:
+    return (_aion_evals_root() / "reports").absolute()
+
+
+def _reject_symlink_component(path: Path, label: str) -> None:
+    """Reject if any existing component of ``path`` is a symlink.
+
+    The tool's authorization boundary is the literal Hermes evals/reports tree,
+    not the canonical target of symlinks.  ``Path.resolve``-based checks would
+    authorize symlink targets outside that tree, so we fail closed instead.
+    """
+    current = Path(path.anchor) if path.is_absolute() else Path.cwd()
+    parts = path.parts[1:] if path.is_absolute() else path.parts
+    for part in parts:
+        current = current / part
+        try:
+            if current.is_symlink():
+                raise ValueError(f"{label} contains symlink component: {current}")
+        except OSError as exc:
+            raise ValueError(f"cannot inspect {label} path component: {current}") from exc
+
+
+def _ensure_eval_path_allowed(path: Path) -> None:
+    allowed = _aion_evals_root()
+    _reject_symlink_component(allowed, "evals root")
+    _reject_symlink_component(path, "eval_path")
+    if not _is_relative_to(path, allowed):
+        raise ValueError(f"eval_path outside allowed roots: {path}; allowed root: {allowed}")
+    if path.parent != allowed:
+        raise ValueError(f"eval_path and score_file must be direct children of evals root: {allowed}")
+
+
+def _ensure_report_path_allowed(path: Path) -> None:
+    reports = _reports_dir()
+    _reject_symlink_component(reports, "reports directory")
+    _reject_symlink_component(path, "report_path")
+    _reject_symlink_component(path.parent, "report_path")
+    if not _is_relative_to(path, reports):
+        raise ValueError(f"report_path outside reports directory: {path}; reports directory: {reports}")
+    if path.parent != reports:
+        raise ValueError(f"report_path must be a direct child of reports directory: {reports}")
+
+
+def _write_report_safely(path: Path, content: str) -> None:
+    reports = _reports_dir()
+    _ensure_report_path_allowed(path)
+
+    dir_fd = _open_dir_chain(reports, create_leaf=True)
+    file_fd: int | None = None
+    temp_name = f".{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp"
+    try:
+        file_fd = os.open(
+            temp_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+            dir_fd=dir_fd,
+        )
+        with os.fdopen(file_fd, "w", encoding="utf-8") as handle:
+            file_fd = None
+            handle.write(content)
+        os.replace(temp_name, path.name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
+    except OSError as exc:
+        try:
+            os.unlink(temp_name, dir_fd=dir_fd)
+        except OSError:
+            pass
+        raise ValueError(f"failed to safely write report_path: {exc}") from exc
+    finally:
+        if file_fd is not None:
+            os.close(file_fd)
+        if dir_fd is not None:
+            os.close(dir_fd)
+
+
+def _open_dir_chain(path: Path, *, create_leaf: bool = False) -> int:
+    """Open an absolute directory path component-by-component with O_NOFOLLOW.
+
+    Returns a directory file descriptor for ``path``.  Callers own the fd.
+    This avoids the pathname-check-then-open race for symlinked ancestors: every
+    component is opened relative to the previous trusted directory fd, and
+    ``O_NOFOLLOW`` is applied at each step.
+    """
+    if not path.is_absolute():
+        raise ValueError(f"directory path must be absolute: {path}")
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(Path(path.anchor), flags)
+    parts = path.parts[1:]
+    try:
+        for index, part in enumerate(parts):
+            is_leaf = index == len(parts) - 1
+            if create_leaf and is_leaf:
+                try:
+                    os.mkdir(part, 0o700, dir_fd=fd)
+                except FileExistsError:
+                    pass
+            next_fd = os.open(part, flags, dir_fd=fd)
+            os.close(fd)
+            fd = next_fd
+        return fd
+    except OSError as exc:
+        os.close(fd)
+        raise ValueError(f"failed to safely open directory path: {path}: {exc}") from exc
+
+
+def _is_int_not_bool(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    _ensure_eval_path_allowed(path)
+    evals_fd = _open_dir_chain(_aion_evals_root(), create_leaf=False)
+    file_fd: int | None = None
+    try:
+        file_fd = os.open(path.name, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0), dir_fd=evals_fd)
+        with os.fdopen(file_fd, "r", encoding="utf-8") as handle:
+            file_fd = None
+            data = json.load(handle)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in {path}: {exc}") from exc
+    except OSError as exc:
+        raise ValueError(f"failed to safely read eval JSON: {path}: {exc}") from exc
+    finally:
+        if file_fd is not None:
+            os.close(file_fd)
+        os.close(evals_fd)
+    if not isinstance(data, dict):
+        raise ValueError(f"JSON root must be an object: {path}")
+    return data
+
+
+def validate_pack(data: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    required_top = ["schema_version", "skill_name", "skill_path", "purpose", "cases", "scoring"]
+    for key in required_top:
+        if key not in data:
+            errors.append(f"missing top-level field: {key}")
+    if data.get("schema_version") != "1.0":
+        errors.append("schema_version must be 1.0")
+
+    cases = data.get("cases")
+    if not isinstance(cases, list) or not cases:
+        errors.append("cases must be a non-empty list")
+        return errors
+
+    required_case = [
+        "id",
+        "prompt",
+        "expected_trigger",
+        "required_behaviors",
+        "forbidden_behaviors",
+        "evidence_requirements",
+        "scoring_rubric",
+    ]
+    ids: set[str] = set()
+    for idx, case in enumerate(cases, start=1):
+        if not isinstance(case, dict):
+            errors.append(f"case {idx} is not an object")
+            continue
+        for key in required_case:
+            if key not in case:
+                errors.append(f"case {idx} missing field: {key}")
+        raw_cid = case.get("id", "")
+        if not isinstance(raw_cid, str) or not raw_cid:
+            cid = str(raw_cid)
+            errors.append(f"case {idx} id must be a non-empty string")
+        else:
+            cid = raw_cid
+        if cid and cid in ids:
+            errors.append(f"duplicate case id: {cid}")
+        if cid:
+            ids.add(cid)
+        rubric = case.get("scoring_rubric", {})
+        if not isinstance(rubric, dict) or "max_points" not in rubric or "criteria" not in rubric:
+            errors.append(f"case {cid or idx} has invalid scoring_rubric")
+        else:
+            if not _is_int_not_bool(rubric.get("max_points")) or rubric["max_points"] <= 0:
+                errors.append(f"case {cid or idx} scoring_rubric.max_points must be a positive integer")
+            if not isinstance(rubric.get("criteria"), list) or not rubric["criteria"]:
+                errors.append(f"case {cid or idx} scoring_rubric.criteria must be a non-empty list")
+        for list_key in ["required_behaviors", "forbidden_behaviors", "evidence_requirements"]:
+            if list_key in case and not isinstance(case[list_key], list):
+                errors.append(f"case {cid or idx} {list_key} must be a list")
+
+    scoring = data.get("scoring", {})
+    if not isinstance(scoring, dict):
+        errors.append("scoring must be an object")
+    else:
+        for key in ["case_max_points", "pass_threshold_percent", "hard_fail_conditions"]:
+            if key not in scoring:
+                errors.append(f"scoring missing field: {key}")
+        if "case_max_points" in scoring and (
+            not _is_int_not_bool(scoring["case_max_points"]) or scoring["case_max_points"] <= 0
+        ):
+            errors.append("scoring.case_max_points must be a positive integer")
+        threshold = scoring.get("pass_threshold_percent")
+        if not isinstance(threshold, (int, float)) or isinstance(threshold, bool) or not 0 <= threshold <= 100:
+            errors.append("scoring.pass_threshold_percent must be a number between 0 and 100")
+        if "hard_fail_conditions" in scoring and not isinstance(scoring["hard_fail_conditions"], list):
+            errors.append("scoring.hard_fail_conditions must be a list")
+    return errors
+
+
+def load_scores(path: Path | None) -> dict[str, dict[str, Any]]:
+    if path is None:
+        return {}
+    raw = load_json(path)
+    if "scores" in raw:
+        raw = raw["scores"]
+    if not isinstance(raw, dict):
+        raise ValueError('Score file must be an object keyed by case id, or {"scores": {...}}')
+
+    scores: dict[str, dict[str, Any]] = {}
+    for case_id, value in raw.items():
+        if _is_int_not_bool(value):
+            scores[str(case_id)] = {"score": value, "notes": "", "hard_fail": False}
+        elif isinstance(value, dict):
+            raw_score = value.get("score")
+            if not _is_int_not_bool(raw_score):
+                raise ValueError(f"Score for {case_id} must be an integer")
+            if "hard_fail" in value and not isinstance(value["hard_fail"], bool):
+                raise ValueError(f"hard_fail for {case_id} must be a boolean")
+            scores[str(case_id)] = {
+                "score": raw_score,
+                "notes": value.get("notes", ""),
+                "hard_fail": bool(value.get("hard_fail", False)),
+            }
+        else:
+            raise ValueError(f"Invalid score value for {case_id}")
+    return scores
+
+
+def render_case(case: dict[str, Any]) -> str:
+    lines = [f"### {case['id']} — {case.get('title', '').strip() or 'Untitled'}", ""]
+    lines.extend(["Prompt:", "", f"> {case['prompt']}", ""])
+    lines.append(f"Expected trigger: {case['expected_trigger']}")
+    if case.get("expected_decision"):
+        lines.append(f"Expected decision: `{case['expected_decision']}`")
+    lines.append("")
+    lines.append("Required behaviors:")
+    for item in case.get("required_behaviors", []):
+        lines.append(f"- {item}")
+    lines.append("")
+    lines.append("Forbidden behaviors:")
+    for item in case.get("forbidden_behaviors", []):
+        lines.append(f"- {item}")
+    lines.append("")
+    lines.append("Evidence requirements:")
+    for item in case.get("evidence_requirements", []):
+        lines.append(f"- {item}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_results(data: dict[str, Any], scores: dict[str, dict[str, Any]]) -> list[CaseResult]:
+    case_ids = {str(case["id"]) for case in data["cases"]}
+    unknown_ids = sorted(set(scores) - case_ids)
+    if unknown_ids:
+        raise ValueError(f"unknown score case id(s): {', '.join(unknown_ids)}")
+    if not scores:
+        raise ValueError("manual_score requires at least one matching score")
+    results: list[CaseResult] = []
+    for case in data["cases"]:
+        cid = case["id"]
+        max_points = int(case["scoring_rubric"]["max_points"])
+        score_entry = scores.get(cid)
+        if score_entry is None:
+            score = None
+            notes = "Not scored."
+            hard_fail = False
+        else:
+            raw_score = score_entry.get("score")
+            score = None if raw_score is None else int(raw_score)
+            if score is not None and (score < 0 or score > max_points):
+                raise ValueError(f"Score for {cid} must be between 0 and {max_points}")
+            notes = str(score_entry.get("notes", ""))
+            hard_fail = bool(score_entry.get("hard_fail", False))
+        results.append(CaseResult(cid, case.get("title", ""), score, max_points, notes, hard_fail))
+    return results
+
+
+def summarize_results(data: dict[str, Any], results: list[CaseResult] | None) -> dict[str, Any]:
+    if not results:
+        return {"status": "ok", "scored": False}
+    scored = [r for r in results if r.score is not None]
+    if not scored:
+        return {
+            "status": "incomplete",
+            "scored": False,
+            "scored_cases": 0,
+            "score": 0,
+            "max_score": 0,
+            "hard_fail": any(r.hard_fail for r in results),
+        }
+    max_total = sum(r.max_points for r in scored)
+    total = sum(r.score or 0 for r in scored)
+    hard_fail = any(r.hard_fail for r in results)
+    if len(scored) != len(results):
+        return {
+            "status": "incomplete",
+            "scored": False,
+            "scored_cases": len(scored),
+            "score": total,
+            "max_score": max_total,
+            "hard_fail": hard_fail,
+        }
+    percent = (total / max_total * 100) if max_total else None
+    threshold = float(data["scoring"]["pass_threshold_percent"])
+    status = "passed"
+    if hard_fail or (percent is not None and percent < threshold):
+        status = "failed"
+    return {
+        "status": status,
+        "scored": len(scored) == len(results) and status != "incomplete",
+        "scored_cases": len(scored),
+        "score": total,
+        "max_score": max_total,
+        "hard_fail": hard_fail,
+    }
+
+
+def render_report(data: dict[str, Any], eval_path: Path, mode: str, results: list[CaseResult] | None) -> str:
+    now = datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds")
+    summary = summarize_results(data, results)
+    scored = summary["scored"]
+    lines: list[str] = []
+    lines.append(f"# Skill Eval Report — {data['skill_name']}")
+    lines.append("")
+    lines.append(f"- Generated: `{now}`")
+    lines.append(f"- Eval pack: `{eval_path}`")
+    lines.append(f"- Skill path: `{data['skill_path']}`")
+    lines.append(f"- Mode: `{mode}`")
+    lines.append(f"- Dry-run: `{str(mode == 'dry_run').lower()}`")
+    lines.append(f"- Scored: `{str(scored).lower()}`")
+    lines.append(f"- Purpose: {data['purpose']}")
+    lines.append("")
+    lines.append("## Scoring")
+    scoring = data["scoring"]
+    lines.append(f"- Case max points: `{scoring['case_max_points']}`")
+    lines.append(f"- Pass threshold: `{scoring['pass_threshold_percent']}%`")
+    lines.append("- Hard fail conditions:")
+    for item in scoring.get("hard_fail_conditions", []):
+        lines.append(f"  - {item}")
+    lines.append("")
+
+    if results:
+        lines.append("## Manual Score Summary")
+        lines.append(f"- Scored cases: `{summary['scored_cases']}/{len(results)}`")
+        lines.append(f"- Score: `{summary['score']}/{summary['max_score']}`")
+        lines.append(f"- Hard fail: `{str(summary['hard_fail']).lower()}`")
+        lines.append(f"- Status: `{summary['status']}`")
+        lines.append("")
+        lines.append("### Case Scores")
+        for result in results:
+            score_txt = "not scored" if result.score is None else f"{result.score}/{result.max_points}"
+            lines.append(
+                f"- `{result.case_id}` {result.title}: {score_txt}; "
+                f"hard_fail={str(result.hard_fail).lower()}; notes={result.notes or ''}"
+            )
+        lines.append("")
+
+    lines.append("## Cases")
+    lines.append("")
+    for case in data["cases"]:
+        lines.append(render_case(case))
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def default_report_path(eval_path: Path) -> Path:
+    return _reports_dir() / f"{eval_path.stem}-eval-report.md"
+
+
+def skill_eval_run(args: dict, **_: Any) -> str:
+    """Run a local skill-eval pack and write a Markdown report.
+
+    Returns a JSON string because Hermes tool handlers use JSON-encoded results.
+    """
+    try:
+        mode = str(args.get("mode", "dry_run")).strip() or "dry_run"
+        if mode not in {"dry_run", "manual_score"}:
+            return _json_error("mode must be 'dry_run' or 'manual_score'")
+
+        eval_path = _resolve_existing_path(str(args.get("eval_path", "")), "eval_path")
+        _ensure_eval_path_allowed(eval_path)
+
+        score_file = None
+        if args.get("score_file"):
+            score_file = _resolve_existing_path(str(args.get("score_file")), "score_file")
+            _ensure_eval_path_allowed(score_file)
+        if mode == "manual_score" and score_file is None:
+            return _json_error("score_file is required when mode is manual_score")
+        if mode == "dry_run" and score_file is not None:
+            return _json_error("score_file is not allowed when mode is dry_run")
+
+        report_path = _resolve_output_path(args.get("report_path"), default_report_path(eval_path))
+        _ensure_report_path_allowed(report_path)
+
+        data = load_json(eval_path)
+        errors = validate_pack(data)
+        if errors:
+            return _json_error("eval pack schema validation failed", errors=errors)
+
+        scores = load_scores(score_file) if score_file else {}
+        results = build_results(data, scores) if mode == "manual_score" else None
+        report = render_report(data, eval_path, mode, results)
+        _write_report_safely(report_path, report)
+
+        summary = summarize_results(data, results)
+        payload: dict[str, Any] = {
+            "status": summary["status"],
+            "mode": mode,
+            "skill_name": data["skill_name"],
+            "eval": str(eval_path),
+            "report": str(report_path),
+            "case_count": len(data["cases"]),
+            "scored": summary["scored"],
+            "truthfulness_note": "dry_run reports are unscored and do not test model behavior" if mode == "dry_run" else "manual_score uses provided score_file evidence only",
+        }
+        for key in ("scored_cases", "score", "max_score", "hard_fail"):
+            if key in summary:
+                payload[key] = summary[key]
+        return json.dumps(payload, indent=2)
+    except (ValueError, OSError, TypeError, OverflowError) as exc:
+        return _json_error(str(exc))
+
+
+SKILL_EVAL_RUN_SCHEMA = {
+    "description": (
+        "Run a local skill evaluation pack and write a Markdown report. "
+        "Dry-run mode is unscored and never claims model behavior was tested."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "eval_path": {
+                "type": "string",
+                "description": "Absolute path to an eval JSON pack under $HERMES_HOME/aion-evolution/evals.",
+            },
+            "mode": {
+                "type": "string",
+                "enum": ["dry_run", "manual_score"],
+                "default": "dry_run",
+            },
+            "score_file": {
+                "type": "string",
+                "description": "Manual score JSON file under the evals root. Required for manual_score; forbidden for dry_run.",
+            },
+            "report_path": {
+                "type": "string",
+                "description": "Optional Markdown report path under $HERMES_HOME/aion-evolution/evals/reports.",
+            },
+            "json_summary": {
+                "type": "boolean",
+                "description": "Accepted for CLI parity; native tool always returns JSON.",
+                "default": True,
+            },
+        },
+        "required": ["eval_path"],
+    },
+}
+
+
+registry.register(
+    name="skill_eval_run",
+    toolset="skills",
+    schema=SKILL_EVAL_RUN_SCHEMA,
+    handler=lambda args, **kwargs: skill_eval_run(args, **kwargs),
+    description=SKILL_EVAL_RUN_SCHEMA["description"],
+    emoji="🧪",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -39,6 +39,7 @@ _HERMES_CORE_TOOLS = [
     "vision_analyze", "image_generate",
     # Skills
     "skills_list", "skill_view", "skill_manage", "skill_eval_run",
+    "observation_save", "observation_search",
     # Browser automation
     "browser_navigate", "browser_snapshot", "browser_click",
     "browser_type", "browser_scroll", "browser_back",
@@ -163,7 +164,10 @@ TOOLSETS = {
     
     "skills": {
         "description": "Access, create, edit, evaluate, and manage skill documents with specialized instructions and knowledge",
-        "tools": ["skills_list", "skill_view", "skill_manage", "skill_eval_run"],
+        "tools": [
+            "skills_list", "skill_view", "skill_manage", "skill_eval_run",
+            "observation_save", "observation_search",
+        ],
         "includes": []
     },
     

--- a/toolsets.py
+++ b/toolsets.py
@@ -38,7 +38,7 @@ _HERMES_CORE_TOOLS = [
     # Vision + image generation
     "vision_analyze", "image_generate",
     # Skills
-    "skills_list", "skill_view", "skill_manage",
+    "skills_list", "skill_view", "skill_manage", "skill_eval_run",
     # Browser automation
     "browser_navigate", "browser_snapshot", "browser_click",
     "browser_type", "browser_scroll", "browser_back",
@@ -162,8 +162,8 @@ TOOLSETS = {
     },
     
     "skills": {
-        "description": "Access, create, edit, and manage skill documents with specialized instructions and knowledge",
-        "tools": ["skills_list", "skill_view", "skill_manage"],
+        "description": "Access, create, edit, evaluate, and manage skill documents with specialized instructions and knowledge",
+        "tools": ["skills_list", "skill_view", "skill_manage", "skill_eval_run"],
         "includes": []
     },
     


### PR DESCRIPTION
## Summary
- Add native skill_eval_run tool with dry-run/manual-score evaluation support.
- Add native observation_save and observation_search tools backed by profile-scoped SQLite storage.
- Register the tools in Hermes toolsets with profile-safe pathing and validation.

## Test Plan
- python -m pytest tests/tools/test_observation_tool.py tests/tools/test_skill_eval_tool.py tests/test_toolsets.py -q -o 'addopts='

## Notes
- Local focused verification passed: 67 passed.
- Direct push to NousResearch/hermes-agent was denied for smartlight-maker, so this PR is opened from the smartlight-maker fork.
- Existing unrelated local dirty files were not included: gateway/platforms/telegram.py and daily-ops-log.md.