### PR TITLE
fix(provider): forward OPENROUTER_API_KEY through loopback custom proxy

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -911,10 +911,20 @@ def _resolve_openrouter_runtime(
     # Also treat explicitly-configured OpenRouter mirrors/proxies as OpenRouter
     # for key selection — if the user set OPENROUTER_BASE_URL or requested
     # provider=openrouter explicitly, OPENROUTER_API_KEY should still be used.
+    # Additionally, when provider is "custom" and the base_url is a loopback
+    # address that matches OPENROUTER_BASE_URL env var, treat it as an
+    # OpenRouter context — the local proxy (Headroom, LiteLLM, etc.) is
+    # forwarding to OpenRouter and needs the key.
+    _is_loopback = _loopback_hostname(base_url_hostname(base_url))
     _is_openrouter_context = _is_openrouter_url or (
         requested_norm == "openrouter"
         and (env_openrouter_base_url or base_url == env_openrouter_base_url)
         and base_url == (env_openrouter_base_url or "").rstrip("/")
+    ) or (
+        requested_norm == "custom"
+        and _is_loopback
+        and bool(env_openrouter_base_url)
+        and base_url == env_openrouter_base_url.rstrip("/")
     )
     if _is_openrouter_context:
         api_key_candidates = [


### PR DESCRIPTION
    When model.provider is custom and model.base_url points to a loopback
    proxy (e.g. Headroom on localhost:8787), the runtime resolver did not
    recognise the loopback as an OpenRouter context and excluded
    OPENROUTER_API_KEY from API key candidates. Requests arrived with
    Authorization: Bearer *** which Headroom forwarded verbatim
    to OpenRouter causing 401 failures.

    Fix: add a third leg to _is_openrouter_context — when provider is
    custom, base_url is loopback, AND OPENROUTER_BASE_URL env var is set
    and matches that URL, include OPENROUTER_API_KEY in the candidates.

    Security: gated on all three predicates. Loopback alone is not enough
    — existing host-gate from #28660 (GHSA-76xc-57q6-vm5m) is preserved.
    Existing tests pass unchanged.

    Change: +10 lines in hermes_cli/runtime_provider.py