### PR TITLE
fix(custom-provider): read max_tokens from custom_providers and auto-clamp to context_length

### DIFF
--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -15,6 +15,31 @@ from providers.base import ProviderProfile
 class CustomProfile(ProviderProfile):
     """Custom/Ollama local provider — think=false and num_ctx support."""
 
+    def get_max_tokens(self, model: str | None) -> int | None:
+        """Custom/Ollama: resolve max_tokens from custom_providers config when available."""
+        val = self.default_max_tokens
+        if not model:
+            return val
+        try:
+            from hermes_cli.config import load_config
+            config = load_config()
+            custom_providers = config.get("custom_providers") or []
+            for entry in custom_providers:
+                if isinstance(entry, dict) and entry.get("model") == model:
+                    # 1. Explicit max_tokens override under this custom_provider
+                    if "max_tokens" in entry:
+                        try:
+                            return int(entry["max_tokens"])
+                        except (TypeError, ValueError):
+                            pass
+                    # 2. Implicit auto-clamp to context_length if smaller than default_max_tokens
+                    ctx_len = entry.get("context_length")
+                    if isinstance(ctx_len, int) and ctx_len > 0 and ctx_len < val:
+                        return ctx_len
+        except Exception:
+            pass
+        return val
+
     def build_api_kwargs_extras(
         self,
         *,

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -487,3 +487,39 @@ class TestBaseProfile:
         eb, tl = p.build_api_kwargs_extras()
         assert eb == {}
         assert tl == {}
+
+
+class TestCustomProfile:
+    def test_get_max_tokens_default(self):
+        p = get_provider_profile("custom")
+        assert p.get_max_tokens("nonexistent_model") == 65536
+
+    def test_get_max_tokens_clamped_by_context_length(self, monkeypatch):
+        p = get_provider_profile("custom")
+        mock_config = {
+            "custom_providers": [
+                {
+                    "name": "aiase",
+                    "model": "aiase_model",
+                    "context_length": 32768
+                }
+            ]
+        }
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: mock_config)
+        assert p.get_max_tokens("aiase_model") == 32768
+
+    def test_get_max_tokens_override(self, monkeypatch):
+        p = get_provider_profile("custom")
+        mock_config = {
+            "custom_providers": [
+                {
+                    "name": "aiase",
+                    "model": "aiase_model",
+                    "context_length": 32768,
+                    "max_tokens": 8192
+                }
+            ]
+        }
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: mock_config)
+        assert p.get_max_tokens("aiase_model") == 8192
+


### PR DESCRIPTION
## Summary
This PR adds support for resolving `max_tokens` (and auto-clamping it to `context_length`) for the `custom` provider.

### Problem
When using custom model endpoints (e.g., LiteLLM serving small/mid models), the total context window size can be smaller than the `custom` provider's static default of `65536`. This causes the model initialization or subsequent chat completion calls to crash with a 400 BadRequestError (e.g., `max_tokens=65536 cannot be greater than max_model_len=max_total_tokens=32768`).

### Solution
1. **Model-specific `max_tokens` override**: Custom provider entries under `custom_providers` can now explicitly define a `max_tokens` property (e.g. `max_tokens: 8192`).
2. **Auto-clamp behavior**: If no explicit `max_tokens` is defined but the entry specifies a `context_length` less than `65536` (default), we automatically clamp the `max_tokens` to that `context_length`. This ensures that smaller models served via `custom` providers never crash on startup due to oversized output token requests.
3. Added unit tests under `tests/providers/test_provider_profiles.py` to cover all codepaths.