### PR TITLE
fix: match WhatsApp reply-to bot IDs without device suffix

### DIFF
--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -211,12 +211,30 @@ class WhatsAppBehaviorMixin:
             )
         return compiled
 
+    @staticmethod
+    def _whatsapp_id_variants(value: Optional[str]) -> set[str]:
+        """Return comparable WhatsApp JID variants for Baileys device IDs.
+
+        Baileys can surface the bot's own multi-device JID with a device
+        suffix (``15551230000:10@s.whatsapp.net`` / normalized here to
+        ``15551230000@10@s.whatsapp.net``), while quoted-message participants
+        often arrive without that suffix (``15551230000@s.whatsapp.net``).
+        Include both forms so reply-to-bot checks don't depend on which shape
+        a particular field used.
+        """
+        normalized = WhatsAppBehaviorMixin._normalize_whatsapp_id(value)
+        if not normalized:
+            return set()
+        variants = {normalized}
+        parts = normalized.split("@")
+        if len(parts) > 2 and parts[0] and parts[-1]:
+            variants.add(f"{parts[0]}@{parts[-1]}")
+        return variants
+
     def _bot_ids_from_message(self, data: Dict[str, Any]) -> set[str]:
         bot_ids = set()
         for candidate in data.get("botIds") or []:
-            normalized = self._normalize_whatsapp_id(candidate)
-            if normalized:
-                bot_ids.add(normalized)
+            bot_ids.update(self._whatsapp_id_variants(candidate))
         return bot_ids
 
     def _message_is_reply_to_bot(self, data: Dict[str, Any]) -> bool:

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -90,6 +90,18 @@ def test_group_messages_can_require_direct_trigger_via_config():
     assert adapter._should_process_message(_group_message("/status")) is True
 
 
+def test_reply_to_bot_matches_device_suffixed_bot_jid():
+    adapter = _make_adapter(require_mention=True)
+
+    assert adapter._should_process_message(
+        _group_message(
+            "replying to the bot",
+            botIds=["15551230000@10@s.whatsapp.net", "99999999999999@10@lid"],
+            quotedParticipant="15551230000@s.whatsapp.net",
+        )
+    ) is True
+
+
 def test_regex_mention_patterns_allow_custom_wake_words():
     adapter = _make_adapter(require_mention=True, mention_patterns=[r"^\s*chompy\b"])
 


### PR DESCRIPTION
## Summary
- add WhatsApp bot JID variants without Baileys multi-device suffixes
- keep legacy/non-device JIDs unchanged
- cover reply-to-bot gating when quotedParticipant is suffix-less

Fixes #29023

## Test Plan
- [x] python -m pytest tests/gateway/test_whatsapp_group_gating.py -q -o 'addopts='