### PR TITLE
fix(s6): register profile gateways without auto-starting

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1229,7 +1229,7 @@ def _maybe_register_gateway_service(profile_name: str) -> None:
     if not mgr.supports_runtime_registration():
         return  # host backend; no-op
     try:
-        mgr.register_profile_gateway(profile_name)
+        mgr.register_profile_gateway(profile_name, start_now=False)
     except ValueError:
         # Already registered (e.g. the container-boot reconciler ran
         # first and brought up a stale slot). That's fine.

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -77,6 +77,7 @@ class ServiceManager(Protocol):
         profile: str,
         *,
         extra_env: dict[str, str] | None = None,
+        start_now: bool = True,
     ) -> None: ...
     def unregister_profile_gateway(self, profile: str) -> None: ...
     def list_profile_gateways(self) -> list[str]: ...
@@ -175,6 +176,7 @@ class _RegistrationUnsupportedMixin:
         profile: str,
         *,
         extra_env: dict[str, str] | None = None,
+        start_now: bool = True,
     ) -> None:
         raise NotImplementedError(
             f"{type(self).__name__} does not support runtime profile "
@@ -823,15 +825,15 @@ class S6ServiceManager:
         profile: str,
         *,
         extra_env: dict[str, str] | None = None,
+        start_now: bool = True,
     ) -> None:
         """Create the s6 service directory for a profile gateway.
 
         Triggers ``s6-svscanctl -a`` so s6-svscan picks the new directory
-        up immediately. The service is created in the *up* state — to
-        register without auto-starting, follow up with ``stop(profile)``
-        (or pass the start flag via the future ``start_now=False`` arg,
-        which the Phase 4 reconciliation path uses via a ``down``
-        marker file written directly).
+        up immediately.  When *start_now* is ``True`` (the default) the
+        service starts immediately; when ``False`` a ``down`` marker file
+        is written so s6-supervise leaves the service stopped until the
+        user explicitly runs ``hermes -p <profile> gateway start``.
 
         Raises:
             ValueError: if the profile name is invalid or the service
@@ -878,6 +880,13 @@ class S6ServiceManager:
             # dirs. See ``_seed_supervise_skeleton`` for the full
             # rationale.
             _seed_supervise_skeleton(tmp_dir)
+
+            # When start_now is False, write a `down` marker so
+            # s6-supervise does not auto-start the service on rescan.
+            # Mirrors the same pattern in container_boot.py
+            # _register_gateway_slot when start=False.
+            if not start_now:
+                (tmp_dir / "down").touch()
 
             tmp_dir.rename(svc_dir)
         except Exception:

--- a/tests/docker/test_container_restart.py
+++ b/tests/docker/test_container_restart.py
@@ -296,7 +296,8 @@ def test_live_gateway_autostarts_after_real_restart_without_manual_state_stamp(
         )
         if r.returncode == 0 and '"gateway_state"' in r.stdout:
             state = r.stdout
-            break
+            if '"running"' in state:
+                break
         time.sleep(0.5)
     assert '"running"' in state, (
         f"gateway never persisted running state pre-restart: {state!r}"

--- a/tests/hermes_cli/test_profiles_s6_hooks.py
+++ b/tests/hermes_cli/test_profiles_s6_hooks.py
@@ -54,10 +54,12 @@ class _S6Manager:
     def register_profile_gateway(
         self, profile: str, *,
         extra_env: dict[str, str] | None = None,
+        start_now: bool = True,
     ) -> None:
         if self.raise_on_register is not None:
             raise self.raise_on_register
         self.registered.append(profile)
+        self.last_start_now = start_now
 
     def unregister_profile_gateway(self, profile: str) -> None:
         if self.raise_on_unregister is not None:
@@ -105,6 +107,21 @@ def test_register_calls_through_on_s6(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     _maybe_register_gateway_service("coder")
     assert mgr.registered == ["coder"]
+
+
+def test_register_passes_start_now_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_maybe_register_gateway_service must register with start_now=False
+    so that profile creation does not auto-start a gateway that may
+    conflict with the main gateway's bot-token lock."""
+    _patch_detect_s6(monkeypatch)
+    mgr = _S6Manager()
+    monkeypatch.setattr(
+        "hermes_cli.service_manager.get_service_manager", lambda: mgr,
+    )
+    _maybe_register_gateway_service("coder")
+    assert mgr.last_start_now is False, (
+        "profile creation must not auto-start the gateway service"
+    )
 
 
 def test_register_swallows_duplicate_value_error(

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -572,6 +572,35 @@ def test_s6_register_creates_service_dir_and_triggers_scan(
     ), f"s6-svscanctl -a not invoked; saw: {fake_subprocess_run}"
 
 
+def test_s6_register_start_now_false_writes_down_marker(
+    s6_scandir, fake_subprocess_run,
+) -> None:
+    """When start_now=False, a `down` marker must be written so
+    s6-supervise does not auto-start the service on rescan."""
+    mgr = S6ServiceManager(scandir=s6_scandir)
+    mgr.register_profile_gateway("coder", start_now=False)
+
+    svc_dir = s6_scandir / "gateway-coder"
+    assert svc_dir.is_dir()
+    assert (svc_dir / "down").is_file(), (
+        "start_now=False must write a `down` marker file"
+    )
+
+
+def test_s6_register_start_now_true_no_down_marker(
+    s6_scandir, fake_subprocess_run,
+) -> None:
+    """When start_now=True (default), no `down` marker should exist."""
+    mgr = S6ServiceManager(scandir=s6_scandir)
+    mgr.register_profile_gateway("coder")
+
+    svc_dir = s6_scandir / "gateway-coder"
+    assert svc_dir.is_dir()
+    assert not (svc_dir / "down").exists(), (
+        "start_now=True must NOT write a `down` marker file"
+    )
+
+
 def test_s6_register_extra_env_is_quoted(s6_scandir, fake_subprocess_run) -> None:
     mgr = S6ServiceManager(scandir=s6_scandir)
     mgr.register_profile_gateway(


### PR DESCRIPTION
## Summary
Profile creation in s6 containers now registers the profile gateway service in the down state instead of auto-starting it.

## Changes
- `hermes_cli/service_manager.py`: adds `start_now` to runtime gateway registration and writes an s6 `down` marker when false.
- `hermes_cli/profiles.py`: profile creation passes `start_now=False` so worker profiles do not spawn resident gateways immediately.
- `tests/hermes_cli/`: adds coverage for down-marker registration and the profile-create hook.

## Validation
| Check | Result |
|---|---|
| `python3 -m pytest tests/hermes_cli/test_service_manager.py tests/hermes_cli/test_profiles_s6_hooks.py -q -o addopts=''` | 68 passed |
| isolated s6 registration probe | `start_now=False` writes `down`; default `start_now=True` does not |
| `python3 -m py_compile hermes_cli/service_manager.py hermes_cli/profiles.py tests/hermes_cli/test_profiles_s6_hooks.py tests/hermes_cli/test_service_manager.py` | passed |
| `git diff --check` | passed |

Fixes #45963. Salvages #45968 with @liuhao1024's authorship preserved. PR #46020 implements the same core fix without tests and should be closed as duplicate after this lands.

## Infographic
![S6 Profile Gateways](https://v3b.fal.media/files/b/0a9e4b4e/sc1f_5spn4JRh8C5zFYfJ_QxR9w7VI.png)
