### PR TITLE
feat: add disabled-by-default gateway runtime guard

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -30,7 +30,7 @@ except ImportError:
     except ImportError:
         msvcrt = None
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, List, Optional
 
 # Add parent directory to path for imports BEFORE repo-level imports.
 # Without this, standalone invocations (e.g. after `hermes update` reloads
@@ -510,6 +510,37 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
     }
 
 
+def check_cron_delivery_runtime_guard(
+    config_source: Any,
+    target: dict,
+    *,
+    job: Optional[dict] = None,
+):
+    """Classify a cron delivery target against runtime_guard policy.
+
+    Pure helper only: no delivery, adapter lookup, job mutation, or network
+    access. Missing runtime_guard config is disabled/no-op.
+    """
+
+    from gateway.runtime_guard import check_delivery_surface_policy
+
+    metadata = {}
+    if job:
+        if job.get("id"):
+            metadata["job_id"] = job.get("id")
+        if job.get("name"):
+            metadata["job_name"] = job.get("name")
+
+    return check_delivery_surface_policy(
+        config_source,
+        "cron_delivery",
+        platform=(target or {}).get("platform"),
+        chat_id=(target or {}).get("chat_id"),
+        thread_id=(target or {}).get("thread_id"),
+        metadata=metadata or None,
+    )
+
+
 def _normalize_deliver_value(deliver) -> str:
     """Normalize a stored/submitted ``deliver`` value to its canonical string form.
 
@@ -748,6 +779,14 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         pconfig = config.platforms.get(platform)
         if not pconfig or not pconfig.enabled:
             msg = f"platform '{platform_name}' not configured/enabled"
+            logger.warning("Job '%s': %s", job["id"], msg)
+            delivery_errors.append(msg)
+            continue
+
+        runtime_guard_config = {"runtime_guard": (getattr(pconfig, "extra", {}) or {}).get("runtime_guard")}
+        guard_decision = check_cron_delivery_runtime_guard(runtime_guard_config, target, job=job)
+        if not guard_decision.allowed:
+            msg = f"cron delivery blocked by runtime_guard: {guard_decision.reason or guard_decision.status}"
             logger.warning("Job '%s': %s", job["id"], msg)
             delivery_errors.append(msg)
             continue

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -172,6 +172,31 @@ class DeliveryTarget:
         return self.platform.value
 
 
+def check_delivery_router_runtime_guard(
+    config_source: Any,
+    target: DeliveryTarget,
+    *,
+    metadata: Optional[Dict[str, Any]] = None,
+):
+    """Classify a delivery-router send against runtime_guard policy.
+
+    The helper is intentionally pure: it does not send, resolve, or mutate
+    router state. Live wiring can call it later without coupling tests to
+    adapters.
+    """
+
+    from gateway.runtime_guard import check_delivery_surface_policy
+
+    return check_delivery_surface_policy(
+        config_source,
+        "delivery_router",
+        platform=target.platform,
+        chat_id=target.chat_id,
+        thread_id=target.thread_id,
+        metadata=metadata,
+    )
+
+
 class DeliveryRouter:
     """
     Routes messages to appropriate destinations.
@@ -220,6 +245,21 @@ class DeliveryRouter:
                 if target.platform == Platform.LOCAL:
                     result = self._deliver_local(content, job_id, job_name, metadata)
                 else:
+                    pconfig = self.config.platforms.get(target.platform) if self.config else None
+                    runtime_guard_config = None
+                    if pconfig is not None:
+                        runtime_guard_config = {"runtime_guard": (getattr(pconfig, "extra", {}) or {}).get("runtime_guard")}
+                    decision = check_delivery_router_runtime_guard(
+                        runtime_guard_config,
+                        target,
+                        metadata=metadata,
+                    )
+                    if not decision.allowed:
+                        results[target.to_string()] = {
+                            "success": False,
+                            "error": decision.reason or decision.status,
+                        }
+                        continue
                     result = await self._deliver_to_platform(target, content, metadata)
                 
                 results[target.to_string()] = {
@@ -427,7 +467,6 @@ class DeliveryRouter:
             if _send_result_failed(result):
                 raise RuntimeError(_send_result_error(result) or f"{target.platform.value} delivery failed")
         return result
-
 
 
 

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -23,6 +23,40 @@ from typing import Any, Optional
 logger = logging.getLogger("gateway.run")
 
 
+def check_kanban_notification_runtime_guard(
+    config_source: Any,
+    subscription: dict,
+    *,
+    task_id: str | None = None,
+    event_kind: str | None = None,
+    board: str | None = None,
+):
+    """Classify a kanban notification against runtime_guard policy.
+
+    This does not open kanban databases or touch adapters; it only maps the
+    already-collected subscription/event metadata into a GuardContext.
+    """
+
+    from gateway.runtime_guard import check_delivery_surface_policy
+
+    metadata: dict[str, Any] = {}
+    if task_id:
+        metadata["task_id"] = task_id
+    if event_kind:
+        metadata["event_kind"] = event_kind
+    if board:
+        metadata["board"] = board
+
+    return check_delivery_surface_policy(
+        config_source,
+        "kanban_notification",
+        platform=(subscription or {}).get("platform"),
+        chat_id=(subscription or {}).get("chat_id"),
+        thread_id=(subscription or {}).get("thread_id"),
+        metadata=metadata or None,
+    )
+
+
 class GatewayKanbanWatchersMixin:
     """Kanban watcher / notifier / dispatcher loops for GatewayRunner."""
 
@@ -300,6 +334,25 @@ class GatewayKanbanWatchersMixin:
                             sub["chat_id"], sub.get("thread_id") or "",
                         )
                         try:
+                            pconfig = getattr(adapter, "config", None)
+                            runtime_guard_config = None
+                            if pconfig is not None:
+                                runtime_guard_config = {"runtime_guard": (getattr(pconfig, "extra", {}) or {}).get("runtime_guard")}
+                            guard_decision = check_kanban_notification_runtime_guard(
+                                runtime_guard_config,
+                                sub,
+                                task_id=sub.get("task_id"),
+                                event_kind=kind,
+                                board=board_slug,
+                            )
+                            if not guard_decision.allowed:
+                                logger.warning(
+                                    "kanban notifier: runtime_guard blocked %s event for %s on board %s: %s",
+                                    kind, sub["task_id"], board_slug,
+                                    guard_decision.reason or guard_decision.status,
+                                )
+                                sub_fail_counts.pop(sub_key, None)
+                                continue
                             await adapter.send(
                                 sub["chat_id"], msg, metadata=metadata,
                             )

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -18,6 +18,7 @@ import sys
 import time
 import uuid
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
 from urllib.parse import urlsplit
 
 from utils import normalize_proxy_url
@@ -66,6 +67,13 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
     if thread_id is None:
         return None
     metadata = {"thread_id": thread_id}
+    for attr in ("parent_chat_id", "guild_id", "chat_type"):
+        value = getattr(source, attr, None)
+        if value is not None:
+            metadata[attr] = str(value)
+    sender = getattr(source, "user_id_alt", None) or getattr(source, "user_id", None)
+    if sender is not None:
+        metadata["user_id"] = str(sender)
     if _platform_name(getattr(source, "platform", None)) == "telegram" and getattr(source, "chat_type", None) == "dm":
         metadata["telegram_dm_topic_reply_fallback"] = True
         tid = str(thread_id)
@@ -484,6 +492,7 @@ from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
 
 from gateway.config import Platform, PlatformConfig
+from gateway.runtime_guard import GuardContext, get_runtime_guard_manager
 from gateway.session import SessionSource, build_session_key
 from hermes_constants import get_default_hermes_root, get_hermes_dir, get_hermes_home
 
@@ -2274,6 +2283,80 @@ class BasePlatformAdapter(ABC):
         except Exception:
             logger.debug("topic recovery rewrite failed", exc_info=True)
 
+    def _runtime_guard_config_source(self) -> Any:
+        """Return the adapter-local runtime guard config mapping, if present."""
+        config = getattr(self, "config", None)
+        extra = getattr(config, "extra", None)
+        if isinstance(extra, Mapping):
+            runtime_guard = extra.get("runtime_guard")
+            return runtime_guard if isinstance(runtime_guard, Mapping) else None
+        if isinstance(config, Mapping):
+            runtime_guard = config.get("runtime_guard")
+            return runtime_guard if isinstance(runtime_guard, Mapping) else None
+        return None
+
+    def _build_runtime_guard_context(
+        self,
+        event: MessageEvent,
+        session_key: str,
+        *,
+        surface: str,
+    ) -> GuardContext:
+        source = getattr(event, "source", None)
+        get_command = getattr(event, "get_command", None)
+        try:
+            command = get_command() if callable(get_command) else None
+        except Exception:
+            command = None
+        message_id = (
+            getattr(event, "message_id", None)
+            or getattr(source, "message_id", None)
+        )
+        return GuardContext(
+            surface=surface,
+            platform=getattr(source, "platform", getattr(self, "platform", None)),
+            chat_id=getattr(source, "chat_id", None),
+            thread_id=getattr(source, "thread_id", None),
+            parent_chat_id=getattr(source, "parent_chat_id", None),
+            guild_id=getattr(source, "guild_id", None),
+            user_id=getattr(source, "user_id_alt", None) or getattr(source, "user_id", None),
+            message_id=message_id,
+            session_key=session_key,
+            chat_type=getattr(source, "chat_type", None),
+            is_internal=bool(getattr(event, "internal", False)),
+            command=command,
+            metadata={
+                "message_type": getattr(getattr(event, "message_type", None), "value", None),
+            },
+        )
+
+    def _runtime_guard_manager(self):
+        return get_runtime_guard_manager(self._runtime_guard_config_source())
+
+    def _check_runtime_guard_inbound(
+        self,
+        event: MessageEvent,
+        session_key: str,
+    ):
+        context = self._build_runtime_guard_context(
+            event,
+            session_key,
+            surface="inbound_message",
+        )
+        return self._runtime_guard_manager().check(context)
+
+    def _check_runtime_guard_assistant_final(
+        self,
+        event: MessageEvent,
+        session_key: str,
+    ):
+        context = self._build_runtime_guard_context(
+            event,
+            session_key,
+            surface="assistant_final",
+        )
+        return self._runtime_guard_manager().check_surface_policy(context)
+
     def set_busy_session_handler(self, handler: Optional[Callable[[MessageEvent, str], Awaitable[bool]]]) -> None:
         """Set an optional handler for messages arriving during active sessions."""
         self._busy_session_handler = handler
@@ -3940,6 +4023,16 @@ class BasePlatformAdapter(ABC):
             thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
         )
 
+        _runtime_guard_decision = self._check_runtime_guard_inbound(event, session_key)
+        if not _runtime_guard_decision.allowed:
+            logger.warning(
+                "[%s] Runtime guard blocked inbound message for %s: %s",
+                self.name,
+                session_key,
+                _runtime_guard_decision.reason,
+            )
+            return
+
         # On-entry self-heal: if the adapter still has an _active_sessions
         # entry for this key but the owner task has already exited (done or
         # cancelled), the lock is stale.  Clear it and fall through to
@@ -4157,6 +4250,9 @@ class BasePlatformAdapter(ABC):
         
         # Start continuous typing indicator (refreshes every 2 seconds)
         _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
+        if _thread_metadata is not None:
+            _thread_metadata = dict(_thread_metadata)
+            _thread_metadata["session_key"] = session_key
         _keep_typing_kwargs = {"metadata": _thread_metadata}
         try:
             _keep_typing_sig = inspect.signature(self._keep_typing)
@@ -4212,6 +4308,19 @@ class BasePlatformAdapter(ABC):
                     session_key,
                 )
                 response = None
+            if response:
+                _runtime_guard_decision = self._check_runtime_guard_assistant_final(
+                    event,
+                    session_key,
+                )
+                if not _runtime_guard_decision.allowed:
+                    logger.warning(
+                        "[%s] Runtime guard blocked assistant final for %s: %s",
+                        self.name,
+                        session_key,
+                        _runtime_guard_decision.reason,
+                    )
+                    response = None
             if not response:
                 logger.debug("[%s] Handler returned empty/None response for %s", self.name, event.source.chat_id)
             if response:
@@ -4545,6 +4654,15 @@ class BasePlatformAdapter(ABC):
             try:
                 error_type = type(e).__name__
                 error_detail = str(e)[:300] if str(e) else "no details available"
+                _runtime_guard_decision = self._check_runtime_guard_assistant_final(event, session_key)
+                if not _runtime_guard_decision.allowed:
+                    logger.warning(
+                        "[%s] Runtime guard blocked error response for %s: %s",
+                        self.name,
+                        session_key,
+                        _runtime_guard_decision.reason,
+                    )
+                    return
                 _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
                 await self.send(
                     chat_id=event.source.chat_id,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -68,6 +68,18 @@ _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
+
+def _stream_response_previewed(stream_consumer: Any, full_response: str) -> bool:
+    """Return True only when streaming actually delivered visible content.
+
+    A stream consumer can exist while runtime_guard suppresses all visible stream
+    sends. In that case the final send path must not treat the response as
+    previewed/already delivered, or the user can get a silent drop.
+    """
+    if stream_consumer is None or not bool(full_response):
+        return False
+    return bool(getattr(stream_consumer, "final_content_delivered", False))
+
 _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"("  # transient/auxiliary status that should stay in logs, not Telegram chat
     r"auxiliary\s+.+\s+failed"
@@ -13390,7 +13402,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "tools": [],
             "history_offset": len(history),
             "session_id": session_id,
-            "response_previewed": _stream_consumer is not None and bool(full_response),
+            "response_previewed": _stream_response_previewed(_stream_consumer, full_response),
         }
 
     # ------------------------------------------------------------------

--- a/gateway/runtime_guard.py
+++ b/gateway/runtime_guard.py
@@ -1,0 +1,660 @@
+"""Generic runtime guard interface for gateway delivery paths.
+
+The module is intentionally provider-neutral and disabled by default. It gives
+future gateway insertion points a single policy surface without changing any
+adapter behavior until a config explicitly enables a scoped provider.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping, Protocol, runtime_checkable
+
+
+_STREAMING_POLICIES = frozenset({"allow", "disable", "guard_first_visible"})
+_SURFACE_ACTIONS = frozenset({"allow", "guard", "disable", "block"})
+_SENSITIVE_AUDIT_KEY_PARTS = (
+    "authorization",
+    "credential",
+    "password",
+    "secret",
+    "token",
+)
+_MISSING = object()
+
+
+def _enum_value(value: Any) -> Any:
+    return getattr(value, "value", value)
+
+
+def _normalize_text(value: Any, *, lower: bool = False) -> str:
+    raw = _enum_value(value)
+    if raw is None:
+        return ""
+    text = str(raw).strip()
+    return text.lower() if lower else text
+
+
+def _normalize_tuple(values: Any, *, lower: bool = False) -> tuple[str, ...]:
+    if values is None:
+        return ()
+    if isinstance(values, str) or not isinstance(values, (list, tuple, set, frozenset)):
+        values = (values,)
+    normalized = []
+    for value in values:
+        text = _normalize_text(value, lower=lower)
+        if text:
+            normalized.append(text)
+    return tuple(normalized)
+
+
+def _coerce_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+        return default
+    return bool(value)
+
+
+def _coerce_decision_allowed(value: Any) -> bool | None:
+    if value is _MISSING:
+        return False
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    return None
+
+
+def _normalize_streaming_policy(value: Any) -> str:
+    policy = _normalize_text(value, lower=True)
+    return policy if policy in _STREAMING_POLICIES else "disable"
+
+
+def _normalize_surface_action(value: Any, default: str) -> str:
+    action = _normalize_text(value, lower=True)
+    return action if action in _SURFACE_ACTIONS else default
+
+
+def _mapping_from_config(config: Any) -> Mapping[str, Any]:
+    if config is None:
+        return {}
+    if isinstance(config, Mapping):
+        if isinstance(config.get("runtime_guard"), Mapping):
+            return config["runtime_guard"]
+        return config
+    runtime_guard = getattr(config, "runtime_guard", None)
+    if isinstance(runtime_guard, Mapping):
+        return runtime_guard
+    return {}
+
+
+def _sanitize_audit(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        sanitized = {}
+        for key, item in value.items():
+            key_text = str(key)
+            lowered = key_text.lower()
+            if any(part in lowered for part in _SENSITIVE_AUDIT_KEY_PARTS):
+                continue
+            sanitized[key_text] = _sanitize_audit(item)
+        return sanitized
+    if isinstance(value, list):
+        return [_sanitize_audit(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_sanitize_audit(item) for item in value)
+    return value
+
+
+@dataclass(frozen=True)
+class RuntimeGuardScope:
+    """Scope selector for guarded gateway sessions.
+
+    Empty dimensions are non-restrictive. Non-empty dimensions must all match.
+    """
+
+    platforms: tuple[str, ...] = ()
+    chat_ids: tuple[str, ...] = ()
+    thread_ids: tuple[str, ...] = ()
+    parent_chat_ids: tuple[str, ...] = ()
+    session_keys: tuple[str, ...] = ()
+    guild_ids: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "platforms", _normalize_tuple(self.platforms, lower=True))
+        object.__setattr__(self, "chat_ids", _normalize_tuple(self.chat_ids))
+        object.__setattr__(self, "thread_ids", _normalize_tuple(self.thread_ids))
+        object.__setattr__(self, "parent_chat_ids", _normalize_tuple(self.parent_chat_ids))
+        object.__setattr__(self, "session_keys", _normalize_tuple(self.session_keys))
+        object.__setattr__(self, "guild_ids", _normalize_tuple(self.guild_ids))
+
+    @classmethod
+    def from_mapping(cls, data: Any) -> "RuntimeGuardScope":
+        if isinstance(data, RuntimeGuardScope):
+            return data
+        if not isinstance(data, Mapping):
+            return cls()
+        return cls(
+            platforms=_normalize_tuple(data.get("platforms"), lower=True),
+            chat_ids=_normalize_tuple(data.get("chat_ids")),
+            thread_ids=_normalize_tuple(data.get("thread_ids")),
+            parent_chat_ids=_normalize_tuple(data.get("parent_chat_ids")),
+            session_keys=_normalize_tuple(data.get("session_keys")),
+            guild_ids=_normalize_tuple(data.get("guild_ids")),
+        )
+
+    def matches(self, context: "GuardContext") -> bool:
+        checks = (
+            (self.platforms, context.normalized_platform),
+            (self.chat_ids, _normalize_text(context.chat_id)),
+            (self.thread_ids, _normalize_text(context.thread_id)),
+            (self.parent_chat_ids, _normalize_text(context.parent_chat_id)),
+            (self.session_keys, _normalize_text(context.session_key)),
+            (self.guild_ids, _normalize_text(context.guild_id)),
+        )
+        return all(not allowed or value in allowed for allowed, value in checks)
+
+
+@dataclass(frozen=True)
+class RuntimeGuardStreamingConfig:
+    policy: str = "disable"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "policy", _normalize_streaming_policy(self.policy))
+
+    @classmethod
+    def from_mapping(cls, data: Any) -> "RuntimeGuardStreamingConfig":
+        if isinstance(data, RuntimeGuardStreamingConfig):
+            return data
+        if not isinstance(data, Mapping):
+            return cls()
+        return cls(policy=data.get("policy", "disable"))
+
+
+@dataclass(frozen=True)
+class RuntimeGuardDeliveryPolicy:
+    assistant_final: str = "guard"
+    assistant_stream: str = "disable"
+    assistant_interim: str = "disable"
+    delivery_router: str = "allow"
+    tool_progress: str = "disable"
+    command_ack: str = "allow"
+    interaction_ack: str = "allow"
+    send_message_tool: str = "block"
+    send_message_reaction: str = "block"
+    cron_delivery: str = "allow"
+    kanban_notification: str = "allow"
+    process_notification: str = "allow"
+
+    def __post_init__(self) -> None:
+        for field_info in dataclasses.fields(self):
+            default = field_info.default
+            value = getattr(self, field_info.name)
+            object.__setattr__(
+                self,
+                field_info.name,
+                _normalize_surface_action(value, str(default)),
+            )
+
+    @classmethod
+    def from_mapping(cls, data: Any) -> "RuntimeGuardDeliveryPolicy":
+        if isinstance(data, RuntimeGuardDeliveryPolicy):
+            return data
+        if not isinstance(data, Mapping):
+            return cls()
+        defaults = cls()
+        values = {}
+        for field_info in dataclasses.fields(cls):
+            default = getattr(defaults, field_info.name)
+            values[field_info.name] = _normalize_surface_action(
+                data.get(field_info.name, default),
+                default,
+            )
+        return cls(**values)
+
+    def policy_for(self, surface: str) -> str:
+        normalized = _normalize_text(surface, lower=True)
+        if not normalized:
+            return "allow"
+        return getattr(self, normalized, "allow")
+
+
+@dataclass(frozen=True)
+class RuntimeGuardConfig:
+    enabled: bool = False
+    provider: str = "noop"
+    dry_run: bool = True
+    fail_closed: bool = True
+    scope: RuntimeGuardScope = field(default_factory=RuntimeGuardScope)
+    streaming: RuntimeGuardStreamingConfig = field(default_factory=RuntimeGuardStreamingConfig)
+    delivery_surfaces: RuntimeGuardDeliveryPolicy = field(default_factory=RuntimeGuardDeliveryPolicy)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "enabled", _coerce_bool(self.enabled, False))
+        object.__setattr__(self, "provider", _normalize_text(self.provider, lower=True) or "noop")
+        object.__setattr__(self, "dry_run", _coerce_bool(self.dry_run, True))
+        object.__setattr__(self, "fail_closed", _coerce_bool(self.fail_closed, True))
+        object.__setattr__(self, "scope", RuntimeGuardScope.from_mapping(self.scope))
+        object.__setattr__(
+            self,
+            "streaming",
+            RuntimeGuardStreamingConfig.from_mapping(self.streaming),
+        )
+        object.__setattr__(
+            self,
+            "delivery_surfaces",
+            RuntimeGuardDeliveryPolicy.from_mapping(self.delivery_surfaces),
+        )
+
+    @classmethod
+    def from_mapping(cls, data: Any) -> "RuntimeGuardConfig":
+        if isinstance(data, RuntimeGuardConfig):
+            return data
+        config = _mapping_from_config(data)
+        return cls(
+            enabled=_coerce_bool(config.get("enabled"), False),
+            provider=config.get("provider", "noop"),
+            dry_run=_coerce_bool(config.get("dry_run"), True),
+            fail_closed=_coerce_bool(config.get("fail_closed"), True),
+            scope=RuntimeGuardScope.from_mapping(config.get("scope")),
+            streaming=RuntimeGuardStreamingConfig.from_mapping(config.get("streaming")),
+            delivery_surfaces=RuntimeGuardDeliveryPolicy.from_mapping(
+                config.get("delivery_surfaces"),
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class GuardContext:
+    surface: str
+    platform: Any = None
+    chat_id: Any = None
+    thread_id: Any = None
+    parent_chat_id: Any = None
+    guild_id: Any = None
+    user_id: Any = None
+    message_id: Any = None
+    session_key: Any = None
+    chat_type: str | None = None
+    is_internal: bool = False
+    command: str | None = None
+    metadata: Mapping[str, Any] | None = None
+    idempotency_key: str | None = None
+
+    @property
+    def normalized_surface(self) -> str:
+        return _normalize_text(self.surface, lower=True)
+
+    @property
+    def normalized_platform(self) -> str:
+        return _normalize_text(self.platform, lower=True)
+
+    def with_surface(self, surface: str) -> "GuardContext":
+        return dataclasses.replace(self, surface=surface)
+
+
+@dataclass
+class GuardDecision:
+    allowed: bool
+    reason: str = ""
+    status: str = "allowed"
+    dry_run: bool = False
+    fail_closed: bool = False
+    provider: str = ""
+    surface: str = ""
+    audit: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.audit = _sanitize_audit(self.audit or {})
+
+    @classmethod
+    def allow(
+        cls,
+        *,
+        reason: str = "allowed",
+        status: str = "allowed",
+        provider: str = "",
+        surface: str = "",
+        dry_run: bool = False,
+        fail_closed: bool = False,
+        audit: Mapping[str, Any] | None = None,
+    ) -> "GuardDecision":
+        return cls(
+            allowed=True,
+            reason=reason,
+            status=status,
+            provider=provider,
+            surface=surface,
+            dry_run=dry_run,
+            fail_closed=fail_closed,
+            audit=dict(audit or {}),
+        )
+
+    @classmethod
+    def block(
+        cls,
+        *,
+        reason: str = "blocked",
+        status: str = "blocked",
+        provider: str = "",
+        surface: str = "",
+        fail_closed: bool = False,
+        audit: Mapping[str, Any] | None = None,
+    ) -> "GuardDecision":
+        return cls(
+            allowed=False,
+            reason=reason,
+            status=status,
+            provider=provider,
+            surface=surface,
+            fail_closed=fail_closed,
+            audit=dict(audit or {}),
+        )
+
+
+@runtime_checkable
+class RuntimeLeaseGuard(Protocol):
+    def check(self, context: GuardContext) -> GuardDecision:
+        ...
+
+
+class NoopRuntimeLeaseGuard:
+    """Provider used when the runtime guard is disabled or unconfigured."""
+
+    def check(self, context: GuardContext) -> GuardDecision:
+        return GuardDecision.allow(
+            reason="noop_runtime_guard",
+            status="allowed",
+            provider="noop",
+            surface=context.normalized_surface,
+        )
+
+
+RuntimeGuardProviderFactory = Callable[[RuntimeGuardConfig], RuntimeLeaseGuard]
+_runtime_guard_providers: dict[str, RuntimeLeaseGuard | RuntimeGuardProviderFactory | Any] = {
+    "noop": NoopRuntimeLeaseGuard(),
+}
+
+
+def register_runtime_guard_provider(name: str, provider_factory_or_instance: Any) -> None:
+    """Register a runtime guard provider by name.
+
+    Providers are process-local and intentionally generic: a value may be an
+    object with ``check(context)`` or a factory returning such an object.
+    """
+
+    normalized = _normalize_text(name, lower=True)
+    if not normalized:
+        raise ValueError("runtime guard provider name is required")
+    if provider_factory_or_instance is None:
+        raise ValueError("runtime guard provider is required")
+    _runtime_guard_providers[normalized] = provider_factory_or_instance
+
+
+class RuntimeGuardManager:
+    def __init__(self, config: RuntimeGuardConfig | Mapping[str, Any] | Any | None = None):
+        self.config = RuntimeGuardConfig.from_mapping(config)
+
+    def is_scoped(self, context: GuardContext) -> bool:
+        if not self.config.enabled:
+            return False
+        return self.config.scope.matches(context)
+
+    def check(self, context: GuardContext) -> GuardDecision:
+        if not self.config.enabled:
+            return self._allow(context, reason="runtime_guard_disabled", status="disabled")
+        if not self.is_scoped(context):
+            return self._allow(context, reason="runtime_guard_out_of_scope", status="out_of_scope")
+
+        try:
+            provider = self._resolve_provider()
+            raw_decision = provider.check(context)
+            decision = self._coerce_decision(raw_decision, context)
+        except Exception as exc:
+            return self._provider_error_decision(context, exc)
+
+        if decision.allowed:
+            return decision
+        if self.config.dry_run:
+            return self._dry_run_allow(context, decision)
+        return decision
+
+    def should_disable_streaming(self, context: GuardContext) -> bool:
+        if not self.config.enabled or self.config.dry_run or not self.is_scoped(context):
+            return False
+        return self.config.streaming.policy == "disable"
+
+    def requires_first_visible_stream_guard(self, context: GuardContext) -> bool:
+        if not self.config.enabled or not self.is_scoped(context):
+            return False
+        return self.config.streaming.policy == "guard_first_visible"
+
+    def check_first_visible_stream(self, context: GuardContext) -> GuardDecision:
+        stream_context = context.with_surface("assistant_stream")
+        if not self.requires_first_visible_stream_guard(stream_context):
+            return self._allow(
+                stream_context,
+                reason="stream_guard_not_required",
+                status="stream_guard_not_required",
+            )
+        return self.check(stream_context)
+
+    def surface_action(self, context_or_surface: GuardContext | str) -> str:
+        surface = (
+            context_or_surface.surface
+            if isinstance(context_or_surface, GuardContext)
+            else context_or_surface
+        )
+        return self.config.delivery_surfaces.policy_for(str(surface))
+
+    def should_guard_surface(self, context: GuardContext) -> bool:
+        return self.config.enabled and self.is_scoped(context) and self.surface_action(context) == "guard"
+
+    def should_block_surface(self, context: GuardContext) -> bool:
+        if not self.config.enabled or not self.is_scoped(context):
+            return False
+        return self.surface_action(context) == "block"
+
+    def should_disable_surface(self, context: GuardContext) -> bool:
+        if not self.config.enabled or not self.is_scoped(context):
+            return False
+        return self.surface_action(context) == "disable"
+
+    def check_surface_policy(self, context: GuardContext) -> GuardDecision:
+        if not self.config.enabled:
+            return self._allow(context, reason="runtime_guard_disabled", status="disabled")
+        if not self.is_scoped(context):
+            return self._allow(context, reason="runtime_guard_out_of_scope", status="out_of_scope")
+
+        action = self.surface_action(context)
+        if action == "allow":
+            return self._allow(context, reason="surface_policy_allow", status="surface_allowed")
+        if action == "guard":
+            return self.check(context)
+        if action in {"block", "disable"}:
+            decision = GuardDecision.block(
+                reason=f"surface_policy_{action}",
+                status="surface_blocked" if action == "block" else "surface_disabled",
+                provider=self.config.provider,
+                surface=context.normalized_surface,
+                fail_closed=self.config.fail_closed,
+            )
+            if self.config.dry_run:
+                return self._dry_run_allow(context, decision)
+            return decision
+        return self._allow(context, reason="surface_policy_allow", status="surface_allowed")
+
+    def _resolve_provider(self) -> RuntimeLeaseGuard:
+        entry = _runtime_guard_providers.get(self.config.provider)
+        if entry is None:
+            raise RuntimeError(f"runtime guard provider unavailable: {self.config.provider}")
+        if not isinstance(entry, type) and hasattr(entry, "check"):
+            return entry
+        if callable(entry):
+            provider = self._call_provider_factory(entry)
+            if hasattr(provider, "check"):
+                return provider
+        raise RuntimeError(f"runtime guard provider invalid: {self.config.provider}")
+
+    def _call_provider_factory(self, factory: Callable[..., Any]) -> Any:
+        try:
+            signature = inspect.signature(factory)
+        except (TypeError, ValueError):
+            return factory(self.config)
+
+        required_positional = [
+            param
+            for param in signature.parameters.values()
+            if param.default is inspect.Parameter.empty
+            and param.kind
+            in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+        ]
+        if required_positional:
+            return factory(self.config)
+        return factory()
+
+    def _coerce_decision(self, raw_decision: Any, context: GuardContext) -> GuardDecision:
+        if isinstance(raw_decision, GuardDecision):
+            return GuardDecision(
+                allowed=raw_decision.allowed,
+                reason=raw_decision.reason,
+                status=raw_decision.status,
+                dry_run=raw_decision.dry_run,
+                fail_closed=raw_decision.fail_closed,
+                provider=raw_decision.provider or self.config.provider,
+                surface=raw_decision.surface or context.normalized_surface,
+                audit=raw_decision.audit,
+            )
+        if isinstance(raw_decision, Mapping):
+            allowed = _coerce_decision_allowed(raw_decision.get("allowed", _MISSING))
+            if allowed is None:
+                raise RuntimeError(
+                    f"provider_invalid_allowed: {type(raw_decision.get('allowed')).__name__}"
+                )
+            return GuardDecision(
+                allowed=allowed,
+                reason=str(raw_decision.get("reason", "")),
+                status=str(raw_decision.get("status", "allowed")),
+                dry_run=_coerce_bool(raw_decision.get("dry_run"), False),
+                fail_closed=_coerce_bool(raw_decision.get("fail_closed"), False),
+                provider=str(raw_decision.get("provider") or self.config.provider),
+                surface=str(raw_decision.get("surface") or context.normalized_surface),
+                audit=dict(raw_decision.get("audit") or {}),
+            )
+        if isinstance(raw_decision, bool):
+            if raw_decision:
+                return self._allow(context, reason="provider_allowed", status="allowed")
+            return GuardDecision.block(
+                reason="provider_denied",
+                status="denied",
+                provider=self.config.provider,
+                surface=context.normalized_surface,
+            )
+        if raw_decision is None:
+            return self._allow(context, reason="provider_no_decision", status="allowed")
+        raise RuntimeError(f"runtime guard provider returned unsupported decision: {type(raw_decision)!r}")
+
+    def _provider_error_decision(self, context: GuardContext, exc: Exception) -> GuardDecision:
+        reason = f"runtime_guard_provider_error: {exc}"
+        if self.config.fail_closed:
+            return GuardDecision.block(
+                reason=reason,
+                status="provider_error",
+                provider=self.config.provider,
+                surface=context.normalized_surface,
+                fail_closed=True,
+            )
+        return GuardDecision.allow(
+            reason=reason,
+            status="provider_error_allowed",
+            provider=self.config.provider,
+            surface=context.normalized_surface,
+            fail_closed=False,
+        )
+
+    def _allow(self, context: GuardContext, *, reason: str, status: str) -> GuardDecision:
+        return GuardDecision.allow(
+            reason=reason,
+            status=status,
+            provider=self.config.provider,
+            surface=context.normalized_surface,
+            fail_closed=self.config.fail_closed,
+        )
+
+    def _dry_run_allow(self, context: GuardContext, blocked: GuardDecision) -> GuardDecision:
+        return GuardDecision.allow(
+            reason=f"dry_run_would_block: {blocked.reason}",
+            status="dry_run_allowed",
+            provider=blocked.provider or self.config.provider,
+            surface=blocked.surface or context.normalized_surface,
+            dry_run=True,
+            fail_closed=blocked.fail_closed or self.config.fail_closed,
+            audit={
+                "would_block": True,
+                "original_allowed": blocked.allowed,
+                "original_status": blocked.status,
+                "original_reason": blocked.reason,
+                "original_audit": blocked.audit,
+            },
+        )
+
+
+def get_runtime_guard_manager(config: RuntimeGuardConfig | Mapping[str, Any] | Any | None = None) -> RuntimeGuardManager:
+    return RuntimeGuardManager(config)
+
+
+def check_delivery_surface_policy(
+    config: RuntimeGuardConfig | Mapping[str, Any] | Any | None,
+    surface: str,
+    *,
+    platform: Any = None,
+    chat_id: Any = None,
+    thread_id: Any = None,
+    parent_chat_id: Any = None,
+    guild_id: Any = None,
+    user_id: Any = None,
+    message_id: Any = None,
+    session_key: Any = None,
+    chat_type: str | None = None,
+    is_internal: bool = False,
+    command: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+    idempotency_key: str | None = None,
+) -> GuardDecision:
+    """Evaluate a delivery surface without depending on live adapters.
+
+    This is a pure policy/classification helper for local delivery paths such
+    as the send_message tool, cron delivery, the delivery router, and kanban
+    notifications. A missing or disabled runtime_guard config remains a no-op.
+    """
+
+    context = GuardContext(
+        surface=surface,
+        platform=platform,
+        chat_id=chat_id,
+        thread_id=thread_id,
+        parent_chat_id=parent_chat_id,
+        guild_id=guild_id,
+        user_id=user_id,
+        message_id=message_id,
+        session_key=session_key,
+        chat_type=chat_type,
+        is_internal=is_internal,
+        command=command,
+        metadata=metadata,
+        idempotency_key=idempotency_key,
+    )
+    return get_runtime_guard_manager(config).check_surface_policy(context)

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -21,12 +21,14 @@ import logging
 import queue
 import re
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Callable, Optional
 
 from gateway.platforms.base import BasePlatformAdapter as _BasePlatformAdapter
 from gateway.platforms.base import _custom_unit_to_cp
 from gateway.platforms.base import MEDIA_TAG_CLEANUP_RE
+from gateway.runtime_guard import GuardContext, get_runtime_guard_manager
 from gateway.config import (
     DEFAULT_STREAMING_EDIT_INTERVAL as _DEFAULT_STREAMING_EDIT_INTERVAL,
     DEFAULT_STREAMING_BUFFER_THRESHOLD as _DEFAULT_STREAMING_BUFFER_THRESHOLD,
@@ -178,6 +180,8 @@ class GatewayStreamConsumer:
         self._adapter_requires_finalize: bool = (
             getattr(adapter, "REQUIRES_EDIT_FINALIZE", False) is True
         )
+        self._runtime_guard_first_visible_checked = False
+        self._runtime_guard_stream_blocked = False
 
         # Think-block filter state (mirrors CLI's _stream_delta tag suppression)
         self._in_think_block = False
@@ -211,6 +215,71 @@ class GatewayStreamConsumer:
     def message_id(self) -> str | None:
         """The Discord/chat message ID of the last-sent or edited message."""
         return self._message_id
+
+    def _runtime_guard_config_source(self) -> Any:
+        config = getattr(self.adapter, "config", None)
+        extra = getattr(config, "extra", None)
+        if isinstance(extra, Mapping):
+            runtime_guard = extra.get("runtime_guard")
+            return runtime_guard if isinstance(runtime_guard, Mapping) else None
+        if isinstance(config, Mapping):
+            runtime_guard = config.get("runtime_guard")
+            return runtime_guard if isinstance(runtime_guard, Mapping) else None
+        return None
+
+    def _build_runtime_guard_context(self, surface: str = "assistant_stream") -> GuardContext:
+        metadata = self.metadata if isinstance(self.metadata, Mapping) else {}
+        return GuardContext(
+            surface=surface,
+            platform=getattr(self.adapter, "platform", None),
+            chat_id=self.chat_id,
+            thread_id=metadata.get("thread_id"),
+            parent_chat_id=metadata.get("parent_chat_id"),
+            guild_id=metadata.get("guild_id"),
+            user_id=metadata.get("user_id"),
+            session_key=metadata.get("session_key"),
+            chat_type=self.cfg.chat_type or metadata.get("chat_type"),
+            metadata=metadata,
+        )
+
+    def _runtime_guard_manager(self):
+        return get_runtime_guard_manager(self._runtime_guard_config_source())
+
+    def runtime_guard_disables_streaming(
+        self,
+        context: Optional[GuardContext] = None,
+    ) -> bool:
+        return self._runtime_guard_manager().should_disable_streaming(
+            context or self._build_runtime_guard_context("assistant_stream")
+        )
+
+    def _runtime_guard_allows_visible_stream_send(
+        self,
+        context: Optional[GuardContext] = None,
+    ) -> bool:
+        if self._runtime_guard_stream_blocked:
+            return False
+
+        stream_context = context or self._build_runtime_guard_context("assistant_stream")
+        manager = self._runtime_guard_manager()
+        if manager.should_disable_streaming(stream_context):
+            self._runtime_guard_stream_blocked = True
+            self._edit_supported = False
+            return False
+
+        if self._runtime_guard_first_visible_checked:
+            return True
+        if not manager.requires_first_visible_stream_guard(stream_context):
+            return True
+
+        decision = manager.check_first_visible_stream(stream_context)
+        self._runtime_guard_first_visible_checked = True
+        if decision.allowed:
+            return True
+
+        self._runtime_guard_stream_blocked = True
+        self._edit_supported = False
+        return False
 
     @property
     def final_content_delivered(self) -> bool:
@@ -757,6 +826,8 @@ class GatewayStreamConsumer:
         text = self._clean_for_display(text)
         if not text.strip():
             return reply_to_id
+        if not self._runtime_guard_allows_visible_stream_send():
+            return reply_to_id
         try:
             meta = dict(self.metadata) if self.metadata else {}
             # This chunk becomes the next edit target — adapters that support
@@ -827,6 +898,8 @@ class GatewayStreamConsumer:
         final_text = self._clean_for_display(text)
         continuation = self._continuation_text(final_text)
         self._fallback_final_send = False
+        if not self._runtime_guard_allows_visible_stream_send():
+            return
         if not continuation.strip():
             # Nothing new to send — the visible partial already matches final text.
             # BUT: if final_text itself has meaningful content (e.g. a timeout
@@ -1021,6 +1094,9 @@ class GatewayStreamConsumer:
             # set in tandem with _draft_id in run().  Disable to be safe.
             self._use_draft_streaming = False
             return False
+        if not self._runtime_guard_allows_visible_stream_send():
+            self._use_draft_streaming = False
+            return False
         try:
             result = await self.adapter.send_draft(
                 chat_id=self.chat_id,
@@ -1069,6 +1145,8 @@ class GatewayStreamConsumer:
         tail = self._clean_for_display(tail)
         if not tail.strip():
             return
+        if not self._runtime_guard_allows_visible_stream_send():
+            return
         try:
             result = await self.adapter.send(
                 chat_id=self.chat_id,
@@ -1104,6 +1182,8 @@ class GatewayStreamConsumer:
         """Send a completed interim assistant commentary message."""
         text = self._clean_for_display(text)
         if not text.strip():
+            return False
+        if not self._runtime_guard_allows_visible_stream_send():
             return False
         try:
             result = await self.adapter.send(
@@ -1238,6 +1318,8 @@ class GatewayStreamConsumer:
         stale_ids = set(self._preview_message_ids)
         if self._message_id and self._message_id != "__no_edit__":
             stale_ids.add(self._message_id)
+        if not self._runtime_guard_allows_visible_stream_send():
+            return False
         try:
             result = await self.adapter.send(
                 chat_id=self.chat_id,
@@ -1328,6 +1410,8 @@ class GatewayStreamConsumer:
                 and self.cfg.cursor in text
                 and len(_visible_stripped) < _MIN_NEW_MSG_CHARS):
             return True  # too short for a standalone message — accumulate more
+        if not self._runtime_guard_allows_visible_stream_send():
+            return False
 
         # Native draft streaming: route mid-stream frames through send_draft.
         # The final answer is delivered via the regular sendMessage path

--- a/tests/cron/test_runtime_guard_cron_policy.py
+++ b/tests/cron/test_runtime_guard_cron_policy.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from cron.scheduler import _deliver_result, check_cron_delivery_runtime_guard
+from gateway.config import Platform, PlatformConfig
+
+
+def test_delivery_surface_policy_can_block_scoped_cron_delivery():
+    config = {
+        "runtime_guard": {
+            "enabled": True,
+            "dry_run": False,
+            "scope": {"platforms": ["telegram"], "chat_ids": ["chat-1"]},
+            "delivery_surfaces": {"cron_delivery": "block"},
+        }
+    }
+
+    decision = check_cron_delivery_runtime_guard(
+        config,
+        {"platform": "telegram", "chat_id": "chat-1", "thread_id": "topic-1"},
+        job={"id": "job-1", "name": "Nightly"},
+    )
+
+    assert decision.allowed is False
+    assert decision.surface == "cron_delivery"
+    assert decision.status == "surface_blocked"
+    assert decision.reason == "surface_policy_block"
+
+
+def test_cron_delivery_policy_disabled_is_noop():
+    decision = check_cron_delivery_runtime_guard(
+        {},
+        {"platform": "telegram", "chat_id": "chat-1"},
+        job={"id": "job-1"},
+    )
+
+    assert decision.allowed is True
+    assert decision.status == "disabled"
+
+
+def test_cron_delivery_block_policy_skips_standalone_send():
+    pconfig = PlatformConfig(
+        enabled=True,
+        token="***",
+        extra={
+            "runtime_guard": {
+                "enabled": True,
+                "dry_run": False,
+                "scope": {"platforms": ["telegram"], "chat_ids": ["chat-1"]},
+                "delivery_surfaces": {"cron_delivery": "block"},
+            }
+        },
+    )
+    mock_cfg = SimpleNamespace(platforms={Platform.TELEGRAM: pconfig})
+    job = {"id": "job-1", "name": "Nightly", "deliver": "telegram:chat-1"}
+
+    with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+         patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+        error = _deliver_result(job, "visible cron output")
+
+    assert error is not None
+    assert "cron delivery blocked by runtime_guard" in error
+    send_mock.assert_not_called()

--- a/tests/gateway/test_runtime_guard.py
+++ b/tests/gateway/test_runtime_guard.py
@@ -1,0 +1,214 @@
+from gateway.runtime_guard import (
+    GuardContext,
+    GuardDecision,
+    RuntimeGuardConfig,
+    RuntimeGuardScope,
+    get_runtime_guard_manager,
+    register_runtime_guard_provider,
+)
+
+
+def test_runtime_guard_config_defaults_disabled():
+    cfg = RuntimeGuardConfig()
+
+    assert cfg.enabled is False
+    assert cfg.provider == "noop"
+    assert cfg.dry_run is True
+    assert cfg.fail_closed is True
+    assert cfg.streaming.policy == "disable"
+    assert cfg.delivery_surfaces.policy_for("assistant_final") == "guard"
+    assert cfg.delivery_surfaces.policy_for("assistant_stream") == "disable"
+    assert cfg.delivery_surfaces.policy_for("send_message_tool") == "block"
+    assert cfg.delivery_surfaces.policy_for("command_ack") == "allow"
+
+    manager = get_runtime_guard_manager(cfg)
+    ctx = GuardContext(surface="assistant_final", platform="discord", chat_id="chat-1")
+
+    assert manager.is_scoped(ctx) is False
+    decision = manager.check(ctx)
+    assert decision.allowed is True
+    assert decision.status == "disabled"
+    assert decision.provider == "noop"
+
+
+def test_noop_guard_allows_disabled_context():
+    cfg = RuntimeGuardConfig(
+        enabled=False,
+        scope=RuntimeGuardScope(platforms=("discord",), chat_ids=("guarded-chat",)),
+    )
+    manager = get_runtime_guard_manager(cfg)
+    ctx = GuardContext(
+        surface="assistant_final",
+        platform="discord",
+        chat_id="guarded-chat",
+        session_key="discord:guarded-chat",
+    )
+
+    assert manager.check(ctx).allowed is True
+    assert manager.check_surface_policy(ctx).allowed is True
+
+
+def test_scope_matches_discord_thread_and_session():
+    cfg = RuntimeGuardConfig(
+        enabled=True,
+        scope=RuntimeGuardScope(
+            platforms=("discord",),
+            guild_ids=("guild-1",),
+            chat_ids=("channel-1",),
+            parent_chat_ids=("channel-1",),
+            thread_ids=("thread-1",),
+            session_keys=("discord:guild-1:channel-1:thread-1:user-1",),
+        ),
+    )
+    manager = get_runtime_guard_manager(cfg)
+    matching = GuardContext(
+        surface="assistant_final",
+        platform="discord",
+        guild_id="guild-1",
+        chat_id="channel-1",
+        parent_chat_id="channel-1",
+        thread_id="thread-1",
+        session_key="discord:guild-1:channel-1:thread-1:user-1",
+    )
+    wrong_thread = GuardContext(
+        surface="assistant_final",
+        platform="discord",
+        guild_id="guild-1",
+        chat_id="channel-1",
+        parent_chat_id="channel-1",
+        thread_id="thread-2",
+        session_key="discord:guild-1:channel-1:thread-1:user-1",
+    )
+
+    assert manager.is_scoped(matching) is True
+    assert manager.is_scoped(wrong_thread) is False
+
+
+def test_enabled_scoped_provider_exception_fails_closed():
+    class ExplodingGuard:
+        def check(self, context):
+            raise RuntimeError("provider unavailable")
+
+    register_runtime_guard_provider("explode_for_test", ExplodingGuard())
+    manager = get_runtime_guard_manager(
+        RuntimeGuardConfig(
+            enabled=True,
+            provider="explode_for_test",
+            dry_run=False,
+            fail_closed=True,
+            scope=RuntimeGuardScope(platforms=("discord",)),
+        )
+    )
+    ctx = GuardContext(surface="assistant_final", platform="discord", chat_id="chat-1")
+
+    decision = manager.check(ctx)
+
+    assert decision.allowed is False
+    assert decision.status == "provider_error"
+    assert decision.fail_closed is True
+    assert "provider unavailable" in decision.reason
+
+
+def test_mapping_decision_string_false_does_not_allow():
+    class StringFalseGuard:
+        def check(self, context):
+            return {"allowed": "false", "reason": "string_false", "status": "denied"}
+
+    register_runtime_guard_provider("string_false_for_test", StringFalseGuard())
+    manager = get_runtime_guard_manager(
+        RuntimeGuardConfig(
+            enabled=True,
+            provider="string_false_for_test",
+            dry_run=False,
+            scope=RuntimeGuardScope(platforms=("discord",)),
+        )
+    )
+
+    decision = manager.check(GuardContext(surface="assistant_final", platform="discord"))
+
+    assert decision.allowed is False
+    assert decision.status == "denied"
+    assert decision.reason == "string_false"
+
+
+def test_invalid_provider_return_fails_closed_without_raising():
+    class InvalidGuard:
+        def check(self, context):
+            return object()
+
+    register_runtime_guard_provider("invalid_return_for_test", InvalidGuard())
+    manager = get_runtime_guard_manager(
+        RuntimeGuardConfig(
+            enabled=True,
+            provider="invalid_return_for_test",
+            dry_run=False,
+            fail_closed=True,
+            scope=RuntimeGuardScope(platforms=("discord",)),
+        )
+    )
+
+    decision = manager.check(GuardContext(surface="assistant_final", platform="discord"))
+
+    assert decision.allowed is False
+    assert decision.status == "provider_error"
+    assert decision.fail_closed is True
+    assert "unsupported decision" in decision.reason
+
+
+def test_invalid_mapping_allowed_value_fails_closed_without_dry_run_allow():
+    class InvalidMappingGuard:
+        def check(self, context):
+            return {"allowed": ["not", "a", "bool"]}
+
+    register_runtime_guard_provider("invalid_mapping_for_test", InvalidMappingGuard())
+    manager = get_runtime_guard_manager(
+        RuntimeGuardConfig(
+            enabled=True,
+            provider="invalid_mapping_for_test",
+            dry_run=True,
+            fail_closed=True,
+            scope=RuntimeGuardScope(platforms=("discord",)),
+        )
+    )
+
+    decision = manager.check(GuardContext(surface="assistant_final", platform="discord"))
+
+    assert decision.allowed is False
+    assert decision.status == "provider_error"
+    assert decision.fail_closed is True
+    assert "provider_invalid_allowed" in decision.reason
+
+
+def test_dry_run_denial_allows_but_records_block():
+    class DenyingGuard:
+        def check(self, context):
+            return GuardDecision(
+                allowed=False,
+                reason="lease_conflict",
+                status="denied",
+                audit={"safe": "kept", "lease_token": "raw-secret"},
+            )
+
+    register_runtime_guard_provider("deny_for_dry_run_test", DenyingGuard())
+    manager = get_runtime_guard_manager(
+        RuntimeGuardConfig(
+            enabled=True,
+            provider="deny_for_dry_run_test",
+            dry_run=True,
+            fail_closed=True,
+            scope=RuntimeGuardScope(platforms=("discord",)),
+        )
+    )
+    ctx = GuardContext(surface="assistant_final", platform="discord", chat_id="chat-1")
+
+    decision = manager.check(ctx)
+
+    assert decision.allowed is True
+    assert decision.dry_run is True
+    assert decision.status == "dry_run_allowed"
+    assert "lease_conflict" in decision.reason
+    assert decision.audit["would_block"] is True
+    assert decision.audit["original_status"] == "denied"
+    assert decision.audit["original_reason"] == "lease_conflict"
+    assert decision.audit["original_audit"] == {"safe": "kept"}
+    assert "lease_token" not in decision.audit

--- a/tests/gateway/test_runtime_guard_delivery_surfaces.py
+++ b/tests/gateway/test_runtime_guard_delivery_surfaces.py
@@ -1,0 +1,99 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.delivery import DeliveryRouter, DeliveryTarget, check_delivery_router_runtime_guard
+from gateway.kanban_watchers import check_kanban_notification_runtime_guard
+from gateway.runtime_guard import check_delivery_surface_policy
+
+
+def test_delivery_surface_policy_allows_cron_and_kanban_by_default():
+    config = {
+        "runtime_guard": {
+            "enabled": True,
+            "dry_run": False,
+            "scope": {"platforms": ["telegram"], "chat_ids": ["chat-1"]},
+        }
+    }
+
+    cron_decision = check_delivery_surface_policy(
+        config,
+        "cron_delivery",
+        platform="telegram",
+        chat_id="chat-1",
+    )
+    kanban_decision = check_kanban_notification_runtime_guard(
+        config,
+        {"platform": "telegram", "chat_id": "chat-1", "thread_id": ""},
+        task_id="task-1",
+        event_kind="completed",
+    )
+
+    assert cron_decision.allowed is True
+    assert cron_decision.status == "surface_allowed"
+    assert kanban_decision.allowed is True
+    assert kanban_decision.status == "surface_allowed"
+
+
+def test_delivery_router_surface_policy_disabled_is_noop():
+    decision = check_delivery_router_runtime_guard(
+        None,
+        DeliveryTarget(platform=Platform.TELEGRAM, chat_id="chat-1"),
+        metadata={"job_id": "job-1"},
+    )
+
+    assert decision.allowed is True
+    assert decision.status == "disabled"
+    assert decision.surface == "delivery_router"
+
+
+def test_delivery_router_surface_policy_can_block_when_scoped():
+    config = {
+        "runtime_guard": {
+            "enabled": True,
+            "dry_run": False,
+            "scope": {"platforms": ["telegram"], "chat_ids": ["chat-1"]},
+            "delivery_surfaces": {"delivery_router": "block"},
+        }
+    }
+
+    decision = check_delivery_router_runtime_guard(
+        config,
+        DeliveryTarget(platform=Platform.TELEGRAM, chat_id="chat-1"),
+    )
+
+    assert decision.allowed is False
+    assert decision.reason == "surface_policy_block"
+    assert decision.status == "surface_blocked"
+
+
+@pytest.mark.asyncio
+async def test_delivery_router_live_delivery_blocks_before_adapter_send():
+    adapter = AsyncMock()
+    config = GatewayConfig(
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True,
+                token="***",
+                extra={
+                    "runtime_guard": {
+                        "enabled": True,
+                        "dry_run": False,
+                        "scope": {"platforms": ["telegram"], "chat_ids": ["chat-1"]},
+                        "delivery_surfaces": {"delivery_router": "block"},
+                    }
+                },
+            )
+        }
+    )
+    router = DeliveryRouter(config, adapters={Platform.TELEGRAM: adapter})
+
+    results = await router.deliver(
+        "visible output",
+        [DeliveryTarget(platform=Platform.TELEGRAM, chat_id="chat-1")],
+    )
+
+    assert results["telegram:chat-1"]["success"] is False
+    assert "surface_policy_block" in results["telegram:chat-1"]["error"]
+    adapter.send.assert_not_called()

--- a/tests/gateway/test_runtime_guard_gateway_wiring.py
+++ b/tests/gateway/test_runtime_guard_gateway_wiring.py
@@ -1,0 +1,233 @@
+import asyncio
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.runtime_guard import GuardDecision, register_runtime_guard_provider
+from gateway.session import SessionSource, build_session_key
+
+
+class _RecordingAdapter(BasePlatformAdapter):
+    def __init__(self, config: PlatformConfig | None = None):
+        super().__init__(config or PlatformConfig(enabled=True), Platform.TELEGRAM)
+        self.started: list[tuple[MessageEvent, str]] = []
+        self.sent: list[dict] = []
+
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, content="", reply_to=None, metadata=None, **kwargs):
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id=f"sent-{len(self.sent)}")
+
+    async def send_typing(self, chat_id, metadata=None):
+        pass
+
+    async def stop_typing(self, chat_id):
+        pass
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id, "type": "dm"}
+
+    def _start_session_processing(
+        self,
+        event: MessageEvent,
+        session_key: str,
+        *,
+        interrupt_event: asyncio.Event | None = None,
+    ) -> bool:
+        self.started.append((event, session_key))
+        return True
+
+
+def _event(text: str = "hello") -> MessageEvent:
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="chat-1",
+        chat_type="dm",
+        user_id="user-1",
+        thread_id="thread-1",
+        parent_chat_id="parent-1",
+        guild_id="guild-1",
+    )
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="message-1",
+    )
+
+
+def _blocking_runtime_guard_extra(provider: str) -> dict:
+    return {
+        "runtime_guard": {
+            "enabled": True,
+            "provider": provider,
+            "dry_run": False,
+            "fail_closed": True,
+            "scope": {"platforms": ["telegram"], "chat_ids": ["chat-1"]},
+        }
+    }
+
+
+def test_runtime_guard_disabled_allows_inbound_processing():
+    adapter = _RecordingAdapter()
+    adapter._message_handler = lambda event: None
+    event = _event()
+
+    asyncio.run(adapter.handle_message(event))
+
+    assert adapter.started == [
+        (
+            event,
+            build_session_key(
+                event.source,
+                group_sessions_per_user=True,
+                thread_sessions_per_user=False,
+            ),
+        )
+    ]
+
+
+def test_runtime_guard_enabled_blocks_inbound_before_processing():
+    seen = []
+
+    class DenyingGuard:
+        def check(self, context):
+            seen.append(context)
+            return GuardDecision.block(reason="lease_conflict", status="denied")
+
+    register_runtime_guard_provider("phase26_inbound_deny", DenyingGuard())
+    adapter = _RecordingAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra=_blocking_runtime_guard_extra("phase26_inbound_deny"),
+        )
+    )
+    adapter._message_handler = lambda event: None
+    event = _event()
+
+    asyncio.run(adapter.handle_message(event))
+
+    assert adapter.started == []
+    assert len(seen) == 1
+    assert seen[0].surface == "inbound_message"
+    assert seen[0].platform == Platform.TELEGRAM
+    assert seen[0].chat_id == "chat-1"
+    assert seen[0].thread_id == "thread-1"
+    assert seen[0].parent_chat_id == "parent-1"
+    assert seen[0].guild_id == "guild-1"
+    assert seen[0].user_id == "user-1"
+    assert seen[0].message_id == "message-1"
+    assert seen[0].session_key == build_session_key(event.source)
+
+
+@pytest.mark.asyncio
+async def test_runtime_guard_disabled_allows_outbound_send():
+    adapter = _RecordingAdapter()
+
+    async def handler(event):
+        return "visible response"
+
+    adapter._message_handler = handler
+    event = _event()
+    session_key = build_session_key(event.source)
+
+    await adapter._process_message_background(event, session_key)
+
+    assert [call["content"] for call in adapter.sent] == ["visible response"]
+
+
+@pytest.mark.asyncio
+async def test_runtime_guard_enabled_blocks_outbound_final_send():
+    seen = []
+
+    class DenyingGuard:
+        def check(self, context):
+            seen.append(context)
+            return GuardDecision.block(reason="lease_conflict", status="denied")
+
+    register_runtime_guard_provider("phase26_outbound_deny", DenyingGuard())
+    adapter = _RecordingAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra=_blocking_runtime_guard_extra("phase26_outbound_deny"),
+        )
+    )
+
+    async def handler(event):
+        return "blocked response"
+
+    adapter._message_handler = handler
+    event = _event()
+    session_key = build_session_key(event.source)
+
+    await adapter._process_message_background(event, session_key)
+
+    assert adapter.sent == []
+    assert len(seen) == 1
+    assert seen[0].surface == "assistant_final"
+    assert seen[0].session_key == session_key
+
+
+@pytest.mark.asyncio
+async def test_runtime_guard_invalid_outbound_provider_decision_blocks_without_error_send():
+    class InvalidGuard:
+        def check(self, context):
+            return object()
+
+    register_runtime_guard_provider("phase28_invalid_outbound", InvalidGuard())
+    adapter = _RecordingAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra=_blocking_runtime_guard_extra("phase28_invalid_outbound"),
+        )
+    )
+
+    async def handler(event):
+        return "should not send"
+
+    adapter._message_handler = handler
+    event = _event()
+    session_key = build_session_key(event.source)
+
+    await adapter._process_message_background(event, session_key)
+
+    assert adapter.sent == []
+
+
+@pytest.mark.asyncio
+async def test_runtime_guard_blocks_handler_error_fallback_send():
+    class DenyingGuard:
+        def check(self, context):
+            return GuardDecision.block(reason="lease_conflict", status="denied")
+
+    register_runtime_guard_provider("phase28_error_fallback_deny", DenyingGuard())
+    adapter = _RecordingAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra=_blocking_runtime_guard_extra("phase28_error_fallback_deny"),
+        )
+    )
+
+    async def handler(event):
+        raise RuntimeError("boom")
+
+    adapter._message_handler = handler
+    event = _event()
+    session_key = build_session_key(event.source)
+
+    await adapter._process_message_background(event, session_key)
+
+    assert adapter.sent == []

--- a/tests/gateway/test_runtime_guard_platform_base.py
+++ b/tests/gateway/test_runtime_guard_platform_base.py
@@ -1,0 +1,44 @@
+from gateway.runtime_guard import (
+    GuardContext,
+    RuntimeGuardConfig,
+    RuntimeGuardScope,
+    get_runtime_guard_manager,
+)
+
+
+def test_surface_policy_blocks_scoped_send_message_tool():
+    manager = get_runtime_guard_manager(
+        RuntimeGuardConfig(
+            enabled=True,
+            dry_run=False,
+            scope=RuntimeGuardScope(platforms=("discord",)),
+        )
+    )
+    ctx = GuardContext(surface="send_message_tool", platform="discord", chat_id="chat-1")
+    final_ctx = GuardContext(surface="assistant_final", platform="discord", chat_id="chat-1")
+
+    assert manager.surface_action(final_ctx) == "guard"
+    assert manager.should_guard_surface(final_ctx) is True
+    assert manager.surface_action(ctx) == "block"
+    assert manager.should_block_surface(ctx) is True
+
+    decision = manager.check_surface_policy(ctx)
+
+    assert decision.allowed is False
+    assert decision.status == "surface_blocked"
+    assert decision.reason == "surface_policy_block"
+
+
+def test_command_ack_surface_allowed():
+    manager = get_runtime_guard_manager(
+        RuntimeGuardConfig(
+            enabled=True,
+            dry_run=False,
+            scope=RuntimeGuardScope(platforms=("discord",)),
+        )
+    )
+    ctx = GuardContext(surface="command_ack", platform="discord", chat_id="chat-1")
+
+    assert manager.surface_action(ctx) == "allow"
+    assert manager.should_block_surface(ctx) is False
+    assert manager.check_surface_policy(ctx).allowed is True

--- a/tests/gateway/test_runtime_guard_stream_consumer_wiring.py
+++ b/tests/gateway/test_runtime_guard_stream_consumer_wiring.py
@@ -1,0 +1,221 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import SendResult
+from gateway.runtime_guard import GuardContext, GuardDecision, register_runtime_guard_provider
+from gateway.run import _stream_response_previewed
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+
+def _adapter(extra: dict | None = None):
+    adapter = MagicMock()
+    adapter.config = PlatformConfig(enabled=True, extra=extra or {})
+    adapter.platform = Platform.DISCORD
+    adapter.MAX_MESSAGE_LENGTH = 4096
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="msg-1"))
+    return adapter
+
+
+def test_stream_consumer_runtime_guard_disabled_does_not_disable_streaming():
+    consumer = GatewayStreamConsumer(_adapter(), "chat-1")
+    context = GuardContext(surface="assistant_stream", platform=Platform.DISCORD, chat_id="chat-1")
+
+    assert consumer.runtime_guard_disables_streaming(context) is False
+
+
+def test_stream_consumer_ignores_unrelated_platform_extra_enabled_key():
+    consumer = GatewayStreamConsumer(_adapter({"enabled": True}), "chat-1")
+    context = GuardContext(surface="assistant_stream", platform=Platform.DISCORD, chat_id="chat-1")
+
+    assert consumer.runtime_guard_disables_streaming(context) is False
+
+
+@pytest.mark.asyncio
+async def test_stream_consumer_runtime_guard_enabled_disable_policy_blocks_visible_stream():
+    adapter = _adapter(
+        {
+            "runtime_guard": {
+                "enabled": True,
+                "dry_run": False,
+                "scope": {"platforms": ["discord"], "chat_ids": ["chat-1"]},
+                "streaming": {"policy": "disable"},
+            }
+        }
+    )
+    consumer = GatewayStreamConsumer(adapter, "chat-1")
+    context = GuardContext(surface="assistant_stream", platform=Platform.DISCORD, chat_id="chat-1")
+
+    assert consumer.runtime_guard_disables_streaming(context) is True
+    assert await consumer._send_or_edit("visible streaming text") is False
+    adapter.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_stream_consumer_guard_first_visible_provider_deny_blocks_before_send():
+    seen = []
+
+    class DenyingGuard:
+        def check(self, context):
+            seen.append(context)
+            return GuardDecision.block(reason="lease_conflict", status="denied")
+
+    register_runtime_guard_provider("deny_first_visible_stream_test", DenyingGuard())
+    adapter = _adapter(
+        {
+            "runtime_guard": {
+                "enabled": True,
+                "provider": "deny_first_visible_stream_test",
+                "dry_run": False,
+                "scope": {"platforms": ["discord"], "chat_ids": ["chat-1"]},
+                "streaming": {"policy": "guard_first_visible"},
+            }
+        }
+    )
+    consumer = GatewayStreamConsumer(adapter, "chat-1")
+
+    assert await consumer._send_or_edit("visible streaming text") is False
+    adapter.send.assert_not_called()
+    assert seen
+    assert seen[0].surface == "assistant_stream"
+
+
+@pytest.mark.asyncio
+async def test_stream_consumer_guard_first_visible_provider_error_blocks_before_send():
+    class ExplodingGuard:
+        def check(self, context):
+            raise RuntimeError("lease provider unavailable")
+
+    register_runtime_guard_provider("explode_first_visible_stream_test", ExplodingGuard())
+    adapter = _adapter(
+        {
+            "runtime_guard": {
+                "enabled": True,
+                "provider": "explode_first_visible_stream_test",
+                "dry_run": False,
+                "fail_closed": True,
+                "scope": {"platforms": ["discord"], "chat_ids": ["chat-1"]},
+                "streaming": {"policy": "guard_first_visible"},
+            }
+        }
+    )
+    consumer = GatewayStreamConsumer(adapter, "chat-1")
+
+    assert await consumer._send_or_edit("visible streaming text") is False
+    adapter.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_stream_consumer_disable_policy_blocks_direct_new_chunk_send():
+    adapter = _adapter(
+        {
+            "runtime_guard": {
+                "enabled": True,
+                "dry_run": False,
+                "scope": {"platforms": ["discord"], "chat_ids": ["chat-1"]},
+                "streaming": {"policy": "disable"},
+            }
+        }
+    )
+    consumer = GatewayStreamConsumer(adapter, "chat-1")
+
+    assert await consumer._send_new_chunk("visible chunk", "reply-1") == "reply-1"
+    adapter.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_stream_consumer_disable_policy_blocks_oversized_first_visible_send():
+    adapter = _adapter(
+        {
+            "runtime_guard": {
+                "enabled": True,
+                "dry_run": False,
+                "scope": {"platforms": ["discord"], "chat_ids": ["chat-1"]},
+                "streaming": {"policy": "disable"},
+            }
+        }
+    )
+    adapter.MAX_MESSAGE_LENGTH = 550
+    adapter.truncate_message.side_effect = (
+        lambda text, limit, len_fn=None: [text[:limit], text[limit:]]
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat-1",
+        StreamConsumerConfig(buffer_threshold=1),
+    )
+    consumer.on_delta("x" * 700)
+    consumer.finish()
+
+    await consumer.run()
+
+    adapter.send.assert_not_called()
+    assert consumer.final_response_sent is False
+    assert consumer.final_content_delivered is False
+    assert _stream_response_previewed(consumer, "x" * 700) is False
+
+
+@pytest.mark.asyncio
+async def test_stream_response_previewed_requires_actual_delivery_confirmation():
+    adapter = _adapter()
+    consumer = GatewayStreamConsumer(adapter, "chat-1")
+
+    assert _stream_response_previewed(consumer, "model text") is False
+
+    consumer._final_content_delivered = True
+    assert _stream_response_previewed(consumer, "model text") is True
+
+
+@pytest.mark.asyncio
+async def test_stream_consumer_runtime_guard_can_scope_on_session_and_parent_metadata():
+    adapter = _adapter(
+        {
+            "runtime_guard": {
+                "enabled": True,
+                "dry_run": False,
+                "scope": {
+                    "platforms": ["discord"],
+                    "chat_ids": ["chat-1"],
+                    "thread_ids": ["thread-1"],
+                    "parent_chat_ids": ["parent-1"],
+                    "guild_ids": ["guild-1"],
+                    "user_ids": [],
+                    "session_keys": ["session-1"],
+                },
+                "streaming": {"policy": "disable"},
+            }
+        }
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat-1",
+        metadata={
+            "thread_id": "thread-1",
+            "parent_chat_id": "parent-1",
+            "guild_id": "guild-1",
+            "user_id": "user-1",
+            "session_key": "session-1",
+        },
+    )
+
+    assert await consumer._send_or_edit("visible streaming text") is False
+    adapter.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_stream_consumer_runtime_guard_dry_run_disable_policy_does_not_block_streaming():
+    adapter = _adapter(
+        {
+            "runtime_guard": {
+                "enabled": True,
+                "dry_run": True,
+                "scope": {"platforms": ["discord"], "chat_ids": ["chat-1"]},
+                "streaming": {"policy": "disable"},
+            }
+        }
+    )
+    consumer = GatewayStreamConsumer(adapter, "chat-1")
+
+    assert await consumer._send_or_edit("visible streaming text") is True
+    adapter.send.assert_awaited_once()

--- a/tests/gateway/test_runtime_guard_streaming.py
+++ b/tests/gateway/test_runtime_guard_streaming.py
@@ -1,0 +1,75 @@
+from gateway.runtime_guard import (
+    GuardContext,
+    GuardDecision,
+    RuntimeGuardConfig,
+    RuntimeGuardScope,
+    RuntimeGuardStreamingConfig,
+    get_runtime_guard_manager,
+    register_runtime_guard_provider,
+)
+
+
+def test_disabled_config_does_not_disable_streaming():
+    manager = get_runtime_guard_manager(RuntimeGuardConfig())
+    ctx = GuardContext(surface="assistant_stream", platform="discord", chat_id="chat-1")
+
+    assert manager.should_disable_streaming(ctx) is False
+    assert manager.requires_first_visible_stream_guard(ctx) is False
+
+
+def test_dry_run_config_does_not_disable_streaming():
+    manager = get_runtime_guard_manager(
+        RuntimeGuardConfig(
+            enabled=True,
+            dry_run=True,
+            scope=RuntimeGuardScope(platforms=("discord",), chat_ids=("chat-1",)),
+            streaming=RuntimeGuardStreamingConfig(policy="disable"),
+        )
+    )
+    ctx = GuardContext(surface="assistant_stream", platform="discord", chat_id="chat-1")
+
+    assert manager.should_disable_streaming(ctx) is False
+
+
+def test_enabled_scoped_disable_policy_disables_streaming():
+    manager = get_runtime_guard_manager(
+        RuntimeGuardConfig(
+            enabled=True,
+            dry_run=False,
+            scope=RuntimeGuardScope(platforms=("discord",)),
+            streaming=RuntimeGuardStreamingConfig(policy="disable"),
+        )
+    )
+    ctx = GuardContext(surface="assistant_stream", platform="discord", chat_id="chat-1")
+
+    assert manager.should_disable_streaming(ctx) is True
+    assert manager.requires_first_visible_stream_guard(ctx) is False
+
+
+def test_guard_first_visible_policy_keeps_streaming_but_requires_guard():
+    seen = []
+
+    class RecordingGuard:
+        def check(self, context):
+            seen.append(context)
+            return GuardDecision(allowed=True, reason="ok", status="allowed")
+
+    register_runtime_guard_provider("record_stream_guard_test", RecordingGuard())
+    manager = get_runtime_guard_manager(
+        RuntimeGuardConfig(
+            enabled=True,
+            provider="record_stream_guard_test",
+            dry_run=False,
+            scope=RuntimeGuardScope(platforms=("discord",)),
+            streaming=RuntimeGuardStreamingConfig(policy="guard_first_visible"),
+        )
+    )
+    ctx = GuardContext(surface="assistant_final", platform="discord", chat_id="chat-1")
+
+    assert manager.should_disable_streaming(ctx) is False
+    assert manager.requires_first_visible_stream_guard(ctx) is True
+
+    decision = manager.check_first_visible_stream(ctx)
+
+    assert decision.allowed is True
+    assert seen[0].surface == "assistant_stream"

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -163,6 +163,200 @@ def _ensure_slack_mock(monkeypatch):
 
 
 class TestSendMessageTool:
+    def test_runtime_guard_disabled_allows_send_message_policy(self):
+        config, telegram_cfg = _make_config()
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=False):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram:-1001",
+                        "message": "hello",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        send_mock.assert_awaited_once_with(
+            Platform.TELEGRAM,
+            telegram_cfg,
+            "-1001",
+            "hello",
+            thread_id=None,
+            media_files=[],
+            force_document=False,
+        )
+
+    def test_runtime_guard_enabled_blocks_scoped_send_message_before_platform_send(self):
+        telegram_cfg = SimpleNamespace(
+            enabled=True,
+            token_value="redacted-test-token",
+            extra={
+                "runtime_guard": {
+                    "enabled": True,
+                    "dry_run": False,
+                    "scope": {
+                        "platforms": ["telegram"],
+                        "chat_ids": ["-1001"],
+                    },
+                },
+            },
+        )
+        config = SimpleNamespace(
+            platforms={Platform.TELEGRAM: telegram_cfg},
+            get_home_channel=lambda _platform: None,
+        )
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram:-1001",
+                        "message": "blocked before send",
+                    }
+                )
+            )
+
+        assert result["blocked"] is True
+        assert result["surface"] == "send_message_tool"
+        assert result["reason"] == "surface_policy_block"
+        assert "Runtime guard blocked" in result["error"]
+        send_mock.assert_not_awaited()
+
+    def test_runtime_guard_enabled_blocks_scoped_reaction_before_adapter_call(self, monkeypatch):
+        telegram_cfg = SimpleNamespace(
+            enabled=True,
+            token_value="redacted-test-token",
+            extra={
+                "runtime_guard": {
+                    "enabled": True,
+                    "dry_run": False,
+                    "scope": {
+                        "platforms": ["telegram"],
+                        "chat_ids": ["-1001"],
+                    },
+                },
+            },
+        )
+        config = SimpleNamespace(
+            platforms={Platform.TELEGRAM: telegram_cfg},
+            get_home_channel=lambda _platform: None,
+        )
+        adapter = SimpleNamespace(add_reaction=AsyncMock(return_value={"success": True}))
+        runner = SimpleNamespace(adapters={Platform.TELEGRAM: adapter})
+        monkeypatch.setitem(
+            sys.modules,
+            "gateway.run",
+            SimpleNamespace(_gateway_runner_ref=lambda: runner),
+        )
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "react",
+                        "target": "telegram:-1001",
+                        "emoji": "👍",
+                        "message_id": "msg-1",
+                    }
+                )
+            )
+
+        assert result["blocked"] is True
+        assert result["surface"] == "send_message_reaction"
+        assert result["reason"] == "surface_policy_block"
+        assert "Runtime guard blocked" in result["error"]
+        adapter.add_reaction.assert_not_called()
+
+    def test_runtime_guard_reaction_uses_live_adapter_config_when_config_load_fails(self, monkeypatch):
+        telegram_cfg = SimpleNamespace(
+            enabled=True,
+            token_value="redacted-test-token",
+            extra={
+                "runtime_guard": {
+                    "enabled": True,
+                    "dry_run": False,
+                    "scope": {
+                        "platforms": ["telegram"],
+                        "chat_ids": ["-1001"],
+                    },
+                },
+            },
+        )
+        adapter = SimpleNamespace(
+            config=telegram_cfg,
+            add_reaction=AsyncMock(return_value={"success": True}),
+        )
+        runner = SimpleNamespace(adapters={Platform.TELEGRAM: adapter})
+        monkeypatch.setitem(
+            sys.modules,
+            "gateway.run",
+            SimpleNamespace(_gateway_runner_ref=lambda: runner),
+        )
+
+        with patch("gateway.config.load_gateway_config", side_effect=RuntimeError("config unavailable")), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "react",
+                        "target": "telegram:-1001",
+                        "emoji": "👍",
+                        "message_id": "msg-1",
+                    }
+                )
+            )
+
+        assert result["blocked"] is True
+        assert result["surface"] == "send_message_reaction"
+        adapter.add_reaction.assert_not_called()
+
+    def test_runtime_guard_disabled_allows_unreact_existing_behavior(self, monkeypatch):
+        telegram_cfg = SimpleNamespace(
+            enabled=True,
+            token_value="redacted-test-token",
+            extra={},
+        )
+        config = SimpleNamespace(
+            platforms={Platform.TELEGRAM: telegram_cfg},
+            get_home_channel=lambda _platform: None,
+        )
+        adapter = SimpleNamespace(remove_reaction=AsyncMock(return_value={"success": True}))
+        runner = SimpleNamespace(adapters={Platform.TELEGRAM: adapter})
+        monkeypatch.setitem(
+            sys.modules,
+            "gateway.run",
+            SimpleNamespace(_gateway_runner_ref=lambda: runner),
+        )
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "unreact",
+                        "target": "telegram:-1001",
+                        "message_id": "msg-1",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        adapter.remove_reaction.assert_awaited_once_with(
+            chat_id="-1001",
+            message_id="msg-1",
+        )
+
     def test_ntfy_topic_target_is_explicit(self):
         chat_id, thread_id, is_explicit = _parse_target_ref("ntfy", "alerts-channel")
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -212,8 +212,9 @@ def _handle_react(args, remove=False):
     platform_name = parts[0].strip().lower()
     target_ref = parts[1].strip() if len(parts) > 1 else None
     chat_id = None
+    thread_id = None
     if target_ref:
-        chat_id, _thread_id, _ = _parse_target_ref(platform_name, target_ref)
+        chat_id, thread_id, _ = _parse_target_ref(platform_name, target_ref)
         if not chat_id:
             try:
                 from gateway.channel_directory import resolve_channel_name
@@ -223,7 +224,11 @@ def _handle_react(args, remove=False):
             # Opaque platform-native ids (e.g. photon space GUIDs like
             # 'any;-;+1555...') match no parser pattern and no directory
             # entry — pass them through verbatim; the adapter validates.
-            chat_id = resolved or target_ref
+            if resolved:
+                chat_id, thread_id, _ = _parse_target_ref(platform_name, resolved)
+                chat_id = chat_id or resolved
+            else:
+                chat_id = target_ref
 
     try:
         from gateway.config import Platform, load_gateway_config
@@ -231,10 +236,30 @@ def _handle_react(args, remove=False):
     except (ValueError, KeyError):
         return tool_error(f"Unknown platform: {platform_name}")
 
+    config = None
+    pconfig = None
+    try:
+        config = load_gateway_config()
+        pconfig = config.platforms.get(platform)
+    except Exception:
+        config = None
+
+    runner = None
+    adapter = None
+    try:
+        from gateway.run import _gateway_runner_ref
+        runner = _gateway_runner_ref()
+        adapter = runner.adapters.get(platform) if runner is not None else None
+        if pconfig is None and adapter is not None:
+            pconfig = getattr(adapter, "config", None)
+    except Exception:
+        runner = None
+        adapter = None
+
+    used_home_channel = False
     if not chat_id:
         try:
-            config = load_gateway_config()
-            home = config.get_home_channel(platform)
+            home = config.get_home_channel(platform) if config is not None else None
         except Exception:
             home = None
         if not home:
@@ -243,14 +268,28 @@ def _handle_react(args, remove=False):
                 f"Use '{platform_name}:chat_id'."
             )
         chat_id = home.chat_id
+        thread_id = getattr(home, "thread_id", None) or thread_id
+        used_home_channel = True
 
-    runner = None
-    try:
-        from gateway.run import _gateway_runner_ref
-        runner = _gateway_runner_ref()
-    except Exception:
-        runner = None
-    adapter = runner.adapters.get(platform) if runner is not None else None
+    runtime_guard_decision = _check_send_message_runtime_guard(
+        pconfig,
+        platform,
+        chat_id,
+        thread_id,
+        target_ref=target_ref,
+        used_home_channel=used_home_channel,
+        surface="send_message_reaction",
+        extra_metadata={"action": "unreact" if remove else "react"},
+    )
+    if not runtime_guard_decision.allowed:
+        return tool_error(
+            "Runtime guard blocked send_message reaction",
+            blocked=True,
+            reason=runtime_guard_decision.reason,
+            status=runtime_guard_decision.status,
+            surface=runtime_guard_decision.surface,
+        )
+
     if adapter is None:
         return tool_error(
             f"Reactions require a live {platform_name} adapter in the running "
@@ -392,6 +431,23 @@ def _handle_send(args):
     duplicate_skip = _maybe_skip_cron_duplicate_send(platform_name, chat_id, thread_id)
     if duplicate_skip:
         return json.dumps(duplicate_skip)
+
+    runtime_guard_decision = _check_send_message_runtime_guard(
+        pconfig,
+        platform,
+        chat_id,
+        thread_id,
+        target_ref=target_ref,
+        used_home_channel=used_home_channel,
+    )
+    if not runtime_guard_decision.allowed:
+        return tool_error(
+            "Runtime guard blocked send_message delivery",
+            blocked=True,
+            reason=runtime_guard_decision.reason,
+            status=runtime_guard_decision.status,
+            surface=runtime_guard_decision.surface,
+        )
 
     # Slack: resolve user IDs (U...) to DM channel IDs via conversations.open
     if platform_name == "slack" and chat_id and chat_id.startswith("U"):
@@ -589,6 +645,72 @@ def _maybe_skip_cron_duplicate_send(platform_name: str, chat_id: str, thread_id:
             "your final response instead, or use a different target if you want an additional message."
         ),
     }
+
+
+def _send_message_runtime_guard_config_source(pconfig):
+    extra = getattr(pconfig, "extra", None)
+    if isinstance(extra, dict):
+        runtime_guard = extra.get("runtime_guard")
+        return runtime_guard if isinstance(runtime_guard, dict) else None
+    if isinstance(pconfig, dict):
+        runtime_guard = pconfig.get("runtime_guard")
+        return runtime_guard if isinstance(runtime_guard, dict) else None
+    return None
+
+
+def _check_send_message_runtime_guard(
+    pconfig,
+    platform,
+    chat_id,
+    thread_id,
+    *,
+    target_ref=None,
+    used_home_channel=False,
+    surface="send_message_tool",
+    extra_metadata=None,
+):
+    from gateway.runtime_guard import check_delivery_surface_policy
+
+    try:
+        from gateway.session_context import get_session_env
+    except Exception:
+        get_session_env = None
+
+    def _session_env(name):
+        if get_session_env is None:
+            return ""
+        try:
+            return get_session_env(name, "")
+        except Exception:
+            return ""
+
+    source_platform = _session_env("HERMES_SESSION_PLATFORM")
+    source_chat_id = _session_env("HERMES_SESSION_CHAT_ID")
+    source_thread_id = _session_env("HERMES_SESSION_THREAD_ID")
+    metadata = {
+        "target_ref": target_ref,
+        "used_home_channel": used_home_channel,
+    }
+    if isinstance(extra_metadata, dict):
+        metadata.update(extra_metadata)
+    if source_platform:
+        metadata["source_platform"] = source_platform
+    if source_chat_id:
+        metadata["source_chat_id"] = source_chat_id
+    if source_thread_id:
+        metadata["source_thread_id"] = source_thread_id
+
+    return check_delivery_surface_policy(
+        _send_message_runtime_guard_config_source(pconfig),
+        surface,
+        platform=platform,
+        chat_id=chat_id,
+        thread_id=thread_id,
+        user_id=_session_env("HERMES_SESSION_USER_ID") or None,
+        message_id=_session_env("HERMES_SESSION_MESSAGE_ID") or None,
+        session_key=_session_env("HERMES_SESSION_KEY") or None,
+        metadata=metadata,
+    )
 
 
 async def _send_via_adapter(


### PR DESCRIPTION
# Draft PR / Commit Text — Runtime Guard Local Package

## Suggested commit title

```text
feat: add disabled-by-default gateway runtime guard
```

## Suggested PR title

```text
Add disabled-by-default runtime guard for gateway delivery surfaces
```

## Summary

- Adds `gateway/runtime_guard.py`, a disabled-by-default runtime guard interface/config/manager with scope matching, streaming policy, delivery-surface policy, dry-run, and fail-closed provider behavior.
- Wires no-op-by-default guard checks into gateway inbound/outbound/platform paths, stream consumer visible-send paths, send_message send/react/unreact, delivery router, cron delivery, and kanban notifications.
- Fixes streaming accounting so a blocked stream cannot be treated as already previewed/final-delivered unless `final_content_delivered` is confirmed.
- Adds focused tests for runtime guard config/manager, streaming behavior, platform/base wiring, gateway wiring, delivery surfaces, cron policy, and send_message surfaces.

## Validation

```text
python -m pytest tests/gateway/test_runtime_guard.py tests/gateway/test_runtime_guard_streaming.py tests/gateway/test_runtime_guard_platform_base.py tests/gateway/test_runtime_guard_gateway_wiring.py tests/gateway/test_runtime_guard_stream_consumer_wiring.py tests/gateway/test_runtime_guard_delivery_surfaces.py tests/tools/test_send_message_tool.py tests/cron/test_runtime_guard_cron_policy.py tests/gateway/test_stream_consumer_draft.py tests/gateway/test_auto_voice_reply_format.py tests/cron/test_scheduler.py -q -o 'addopts='
331 passed, 2 warnings in 11.32s

python -m py_compile gateway/runtime_guard.py gateway/platforms/base.py gateway/stream_consumer.py gateway/run.py tools/send_message_tool.py gateway/delivery.py cron/scheduler.py gateway/kanban_watchers.py tests/gateway/test_runtime_guard.py tests/gateway/test_runtime_guard_streaming.py tests/gateway/test_runtime_guard_platform_base.py tests/gateway/test_runtime_guard_gateway_wiring.py tests/gateway/test_runtime_guard_stream_consumer_wiring.py tests/gateway/test_runtime_guard_delivery_surfaces.py tests/tools/test_send_message_tool.py tests/cron/test_runtime_guard_cron_policy.py
PASS

git diff --check
PASS

ADDED_LINE_SECRET_SCAN_STRICT_MATCHES 0
PACKAGE_JSON_DIFF_BYTES 0
PACKAGE_LOCK_DIFF_BYTES 0
```

## Safety notes

- Disabled/no-op by default.
- No gateway restart/start/stop performed.
- No live Redis/Postgres/cloud/OAuth/live Discord/API calls performed.
- No package.json/package-lock.json changes.
- No commit/stage/push/PR/deploy performed in local validation phase.
