### PR TITLE
FAD-724 Fix local terminal Python hook bootstrap

### DIFF
--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -201,6 +201,77 @@ class TestProviderEnvBlocklist:
         assert "USER" in result_env
         assert "PATH" in result_env
 
+    def test_hermes_python_bootstrap_vars_are_stripped(self):
+        """Hermes' own Python bootstrap vars must not leak into subprocesses.
+
+        Local terminal commands execute user/project tooling. If Hermes was
+        launched through a bootstrapped interpreter (for example uv or a venv),
+        leaking these variables makes child Python commands mix Hermes' stdlib
+        with the wrong source tree. A concrete regression: a Git pre-commit
+        hook with ``language: system`` and ``entry: python ...`` could resolve
+        to a different interpreter while inheriting Hermes' Python bootstrap,
+        failing before importing project packages such as PyYAML.
+        """
+        bootstrap_vars = {
+            "PYTHONHOME": r"C:\Users\Matth\AppData\Roaming\uv\python\cpython-3.11-windows-x86_64-none",
+            "PYTHONPATH": r"C:\Users\Matth\AppData\Local\hermes\hermes-agent",
+            "UV_INTERNAL__PYTHONHOME": r"C:\Users\Matth\AppData\Roaming\uv\python\cpython-3.11-windows-x86_64-none",
+        }
+        result_env = _run_with_env(extra_os_env=bootstrap_vars)
+
+        for var in bootstrap_vars:
+            assert var not in result_env, f"{var} leaked into subprocess env"
+
+    def test_virtualenv_path_is_preferred_for_system_python_hooks(self, monkeypatch):
+        """VIRTUAL_ENV's executable directory is moved ahead of other Pythons."""
+        from tools.environments import local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        result_env = _run_with_env(extra_os_env={
+            "PATH": r"C:\Python310;C:\Users\Matth\AppData\Local\hermes\hermes-agent\venv\Scripts;C:\Windows",
+            "VIRTUAL_ENV": r"C:\Users\Matth\AppData\Local\hermes\hermes-agent\venv",
+        })
+
+        assert result_env["VIRTUAL_ENV"] == r"C:\Users\Matth\AppData\Local\hermes\hermes-agent\venv"
+        assert result_env["PATH"].split(";")[0] == (
+            r"C:\Users\Matth\AppData\Local\hermes\hermes-agent\venv\Scripts"
+        )
+        assert result_env["PATH"].split(";").count(
+            r"C:\Users\Matth\AppData\Local\hermes\hermes-agent\venv\Scripts"
+        ) == 1
+
+    def test_virtualenv_path_is_preferred_for_posix_system_python_hooks(self, monkeypatch):
+        """POSIX VIRTUAL_ENV/bin is also moved ahead of other Pythons."""
+        from tools.environments import local as local_mod
+        from tools.environments.local import _make_run_env
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+        posix_env = {
+            "PATH": "/usr/bin:/home/user/.venv/bin:/bin",
+            "HOME": "/home/user",
+            "USER": "testuser",
+            "VIRTUAL_ENV": "/home/user/.venv",
+        }
+        with patch.dict(os.environ, posix_env, clear=True):
+            result_env = _make_run_env({})
+
+        assert result_env["VIRTUAL_ENV"] == "/home/user/.venv"
+        assert result_env["PATH"].split(":")[0] == "/home/user/.venv/bin"
+        assert result_env["PATH"].split(":").count("/home/user/.venv/bin") == 1
+
+    def test_self_env_python_bootstrap_vars_also_stripped(self):
+        """Blocked Python bootstrap vars in self.env are stripped too."""
+        result_env = _run_with_env(self_env={
+            "PYTHONHOME": "/hermes/pythonhome",
+            "PYTHONPATH": "/hermes/src",
+            "UV_INTERNAL__PYTHONHOME": "/hermes/uv-pythonhome",
+            "MY_CUSTOM_VAR": "keep-this",
+        })
+
+        for var in ("PYTHONHOME", "PYTHONPATH", "UV_INTERNAL__PYTHONHOME"):
+            assert var not in result_env, f"{var} leaked into subprocess env"
+        assert result_env["MY_CUSTOM_VAR"] == "keep-this"
+
     def test_self_env_blocked_vars_also_stripped(self):
         """Blocked vars in self.env are stripped; non-blocked vars pass through."""
         result_env = _run_with_env(self_env={
@@ -372,6 +443,15 @@ class TestBlocklistCoverage:
             "MODAL_TOKEN_ID",
             "MODAL_TOKEN_SECRET",
             "DAYTONA_API_KEY",
+        }
+        assert extras.issubset(_HERMES_PROVIDER_ENV_BLOCKLIST)
+
+    def test_python_bootstrap_vars_are_in_blocklist(self):
+        """Hermes bootstrap Python vars must stay blocked from user commands."""
+        extras = {
+            "PYTHONHOME",
+            "PYTHONPATH",
+            "UV_INTERNAL__PYTHONHOME",
         }
         assert extras.issubset(_HERMES_PROVIDER_ENV_BLOCKLIST)
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -124,6 +124,16 @@ def _build_provider_env_blocklist() -> frozenset:
         pass
 
     blocked.update({
+        # Hermes may be launched through a bootstrapped Python interpreter
+        # (uv-managed Python, an in-repo venv, or a source checkout with
+        # PYTHONPATH pointed at the Hermes tree). Those variables describe the
+        # agent process, not the user's project shell. Leaking them into
+        # terminal subprocesses makes Python-based project tooling mix the
+        # wrong stdlib/site-packages and breaks system hooks such as
+        # pre-commit `language: system` entries.
+        "PYTHONHOME",
+        "PYTHONPATH",
+        "UV_INTERNAL__PYTHONHOME",
         "OPENAI_BASE_URL",
         "OPENAI_API_KEY",
         "OPENAI_API_BASE",
@@ -363,6 +373,44 @@ def _path_env_key(run_env: dict) -> str | None:
     return None
 
 
+def _virtualenv_bin_dir(venv: str) -> str:
+    """Return the executable directory for a virtualenv path."""
+    trimmed = venv.rstrip("/\\")
+    return f"{trimmed}\\Scripts" if _IS_WINDOWS else f"{trimmed}/bin"
+
+
+def _prepend_virtualenv_to_path(run_env: dict, path_key: str | None) -> None:
+    """Make PATH agree with VIRTUAL_ENV when one is inherited.
+
+    Python virtualenv activation is defined by two coupled variables:
+    ``VIRTUAL_ENV`` points at the environment and PATH is prepended with its
+    executable directory. Some Hermes launch paths preserve VIRTUAL_ENV while
+    PATH later puts that directory behind unrelated Python installs. In that
+    shape, project tools such as pre-commit ``language: system`` hooks resolve
+    bare ``python`` to a different interpreter but still inherit Python
+    bootstrap env. Move the active virtualenv's executable directory to the
+    front so ``python`` and ``VIRTUAL_ENV`` describe the same environment.
+    """
+    if path_key is None:
+        return
+    venv = run_env.get("VIRTUAL_ENV")
+    if not venv:
+        return
+
+    bin_dir = _virtualenv_bin_dir(venv)
+    existing = run_env.get(path_key, "")
+    sep = ";" if _IS_WINDOWS else ":"
+
+    def _same_path(a: str, b: str) -> bool:
+        if _IS_WINDOWS:
+            return os.path.normcase(os.path.normpath(a)) == os.path.normcase(os.path.normpath(b))
+        return os.path.normpath(a) == os.path.normpath(b)
+
+    entries = [entry for entry in existing.split(sep) if entry]
+    entries = [entry for entry in entries if not _same_path(entry, bin_dir)]
+    run_env[path_key] = sep.join([bin_dir, *entries]) if entries else bin_dir
+
+
 def _make_run_env(env: dict) -> dict:
     """Build a run environment with a sane PATH and provider-var stripping."""
     try:
@@ -381,6 +429,7 @@ def _make_run_env(env: dict) -> dict:
     path_key = _path_env_key(run_env)
     if path_key is not None:
         run_env[path_key] = _append_missing_sane_path_entries(run_env.get(path_key, ""))
+        _prepend_virtualenv_to_path(run_env, path_key)
 
     _inject_context_hermes_home(run_env)
 


### PR DESCRIPTION
## Summary
- Strip Hermes Python bootstrap vars (`PYTHONHOME`, `PYTHONPATH`, `UV_INTERNAL__PYTHONHOME`) from local terminal subprocess environments.
- Keep inherited `VIRTUAL_ENV`, but move its executable directory to the front of `PATH` so `language: system` pre-commit hooks resolve the matching Python interpreter/site-packages.
- Add Windows and POSIX regression coverage for the hook bootstrap/path behavior.

## Validation
- `PYTHONHOME= PYTHONPATH= VIRTUAL_ENV= uv run --python 3.11.9 pytest tests/tools/test_local_env_blocklist.py::TestProviderEnvBlocklist::test_hermes_python_bootstrap_vars_are_stripped tests/tools/test_local_env_blocklist.py::TestProviderEnvBlocklist::test_virtualenv_path_is_preferred_for_system_python_hooks tests/tools/test_local_env_blocklist.py::TestProviderEnvBlocklist::test_virtualenv_path_is_preferred_for_posix_system_python_hooks tests/tools/test_local_env_blocklist.py::TestProviderEnvBlocklist::test_self_env_python_bootstrap_vars_also_stripped tests/tools/test_local_env_blocklist.py::TestBlocklistCoverage::test_python_bootstrap_vars_are_in_blocklist -q --no-cov`
- `PYTHONHOME= PYTHONPATH= VIRTUAL_ENV= uv run --python 3.11.9 ruff check tools/environments/local.py tests/tools/test_local_env_blocklist.py`
- Real repro validation via `LocalEnvironment` against `C:/fine/fine-shared`: `pre-commit run check-action-descriptions --files $(find .github/actions -name action.yml | head -1) -v` passed without clearing `core.hooksPath`.

## Review
- Independent Hermes subagent review passed after platform-specific test fix.

FAD-724
