### PR TITLE
fix: promote active PR handoffs to review

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6148,6 +6148,7 @@ def dispatch_once(
             "GROUP BY assignee"
         ):
             _per_profile_running[prow["assignee"]] = int(prow["n"])
+    active_pr_handoffs: set[str] = set()
     # Normalize default_assignee once: empty/whitespace string → None so the
     # rest of the loop can use ``if default_assignee:`` as a single check.
     # We also resolve profile_exists once here for the same reason.
@@ -6257,6 +6258,22 @@ def dispatch_once(
         # blocks via the normal path rather than on first occurrence.
         guard_reason = check_respawn_guard(conn, row["id"])
         if guard_reason is not None:
+            if guard_reason == "active_pr":
+                if not dry_run:
+                    with write_txn(conn):
+                        cur = conn.execute(
+                            "UPDATE tasks SET status = 'review' "
+                            "WHERE id = ? AND status = 'ready' "
+                            "AND claim_lock IS NULL",
+                            (row["id"],),
+                        )
+                        if cur.rowcount == 1:
+                            _append_event(
+                                conn, row["id"], "promoted_to_review",
+                                {"reason": "active_pr_handoff"},
+                            )
+                            active_pr_handoffs.add(row["id"])
+                continue
             result.respawn_guarded.append((row["id"], guard_reason))
             # Emit an event so operators can see why the task was
             # skipped when reading `hermes kanban tail` — without
@@ -6352,6 +6369,8 @@ def dispatch_once(
     for row in review_rows:
         if max_spawn is not None and running_count + spawned >= max_spawn:
             break
+        if row["id"] in active_pr_handoffs:
+            continue
         if not row["assignee"]:
             result.skipped_unassigned.append(row["id"])
             continue

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1808,10 +1808,9 @@ def test_dispatch_respawn_guard_skips_recent_success(
         assert kb.get_task(conn, t).status == "ready"  # not blocked, just skipped
 
 
-def test_dispatch_respawn_guard_skips_active_pr(
+def test_dispatch_respawn_guard_promotes_active_pr_to_review(
     kanban_home, all_assignees_spawnable
 ):
-    """dispatch_once skips (but does not block) a task with an active PR comment."""
     spawned_ids = []
 
     def fake_spawn(task, workspace):
@@ -1824,12 +1823,18 @@ def test_dispatch_respawn_guard_skips_active_pr(
             "Opened https://github.com/totemx-AI/subsidysmart/pull/99",
         )
         res = kb.dispatch_once(conn, spawn_fn=fake_spawn)
+        events = kb.list_events(conn, t)
 
-    assert (t, "active_pr") in res.respawn_guarded
+    assert (t, "active_pr") not in res.respawn_guarded
     assert t not in spawned_ids
     assert t not in res.auto_blocked
+    assert any(
+        event.kind == "promoted_to_review"
+        and event.payload == {"reason": "active_pr_handoff"}
+        for event in events
+    )
     with kb.connect() as conn:
-        assert kb.get_task(conn, t).status == "ready"
+        assert kb.get_task(conn, t).status == "review"
 
 
 def test_dispatch_respawn_guard_dry_run_no_auto_block(

--- a/tests/hermes_cli/test_kanban_respawn_guard_active_pr.py
+++ b/tests/hermes_cli/test_kanban_respawn_guard_active_pr.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Protocol
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_db import dispatch_once as run_dispatch_once
+
+
+class MonkeyPatchLike(Protocol):
+    def setenv(
+        self,
+        name: str,
+        value: str,
+        prepend: str | None = None,
+    ) -> None: ...
+
+    def setattr(
+        self,
+        target: object,
+        name: str,
+        value: object,
+        raising: bool = True,
+    ) -> None: ...
+
+
+class SpawnFn(Protocol):
+    def __call__(self, task: kb.Task, workspace: str) -> None: ...
+
+
+class DispatchOnceFn(Protocol):
+    def __call__(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        spawn_fn: SpawnFn,
+    ) -> kb.DispatchResult: ...
+
+
+def _init_kanban_home(tmp_path: Path, monkeypatch: MonkeyPatchLike) -> None:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    _ = kb.init_db()
+
+
+def test_ready_task_with_active_pr_promotes_to_review_without_respawn_guard(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatchLike,
+    all_assignees_spawnable: None,
+) -> None:
+    _ = all_assignees_spawnable
+    _init_kanban_home(tmp_path, monkeypatch)
+    spawned_ids: list[str] = []
+    dispatch_once: DispatchOnceFn = run_dispatch_once
+
+    def fake_spawn(task: kb.Task, _workspace: str) -> None:
+        spawned_ids.append(task.id)
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="active-pr", assignee="reviewer")
+        _ = kb.add_comment(
+            conn,
+            task_id,
+            "worker",
+            "Opened https://github.com/totemx-AI/hermes-agent/pull/123",
+        )
+
+        first = dispatch_once(conn, spawn_fn=fake_spawn)
+        task_after_first = kb.get_task(conn, task_id)
+        assert task_after_first is not None
+        spawned_after_first = list(spawned_ids)
+        second = dispatch_once(conn, spawn_fn=fake_spawn)
+        promoted_event_rows = conn.execute(
+            "SELECT id FROM task_events WHERE task_id = ? AND kind = "
+            + "'promoted_to_review' AND payload = ?",
+            (task_id, '{"reason": "active_pr_handoff"}'),
+        ).fetchall()
+        promoted_event_count = len(promoted_event_rows)
+        second_tick_guarded_event_rows = conn.execute(
+            "SELECT id FROM task_events WHERE task_id = ? AND kind = "
+            + "'respawn_guarded'",
+            (task_id,),
+        ).fetchall()
+        events = kb.list_events(conn, task_id)
+
+    assert task_after_first.status == "review"
+    assert first.respawn_guarded == []
+    assert second.respawn_guarded == []
+    assert first.spawned == []
+    assert spawned_after_first == []
+    assert promoted_event_count == 1
+    assert second_tick_guarded_event_rows == []
+    assert not any(
+        event.kind == "respawn_guarded" for event in events
+    )


### PR DESCRIPTION
## Summary
- Promote ready tasks with an active GitHub PR handoff comment to `review` on the first dispatcher tick.
- Emit `promoted_to_review` with `{ "reason": "active_pr_handoff" }` instead of repeatedly emitting `respawn_guarded`.
- Preserve existing defer behavior for other respawn-guard reasons.

## Behavior
A ready task with an active PR handoff now moves to `review` on the first dispatcher tick; the next tick does not emit another `respawn_guarded` event for that task.

## Test Plan
- `pytest tests/hermes_cli/test_kanban_respawn_guard_active_pr.py -q -o 'addopts='` — passed (`1 passed`)
- `pytest tests/hermes_cli/test_kanban_respawn_guard_active_pr.py tests/hermes_cli/test_kanban_db.py::test_dispatch_respawn_guard_promotes_active_pr_to_review tests/hermes_cli/test_kanban_db.py::test_dispatch_respawn_guard_skips_recent_success tests/hermes_cli/test_kanban_db.py::test_dispatch_respawn_guard_dry_run_no_auto_block tests/hermes_cli/test_kanban_db.py::test_dispatch_respawn_guard_emits_event_for_skipped_task -q -o 'addopts='` — passed (`5 passed`)
- `python3 -m py_compile hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_respawn_guard_active_pr.py tests/hermes_cli/test_kanban_db.py` — passed
- `pytest tests/hermes_cli/test_kanban_*.py -q -o 'addopts='` — failed with unrelated existing failures in PID live-system guard tests and kanban decompose default-assignee tests (`640 passed, 26 failed`)
