### PR TITLE
fix(kanban): preserve initial blocked approval gates

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2280,6 +2280,17 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                     },
                 )
+                if task_status == "blocked":
+                    # ``--initial-status blocked`` is an explicit operator
+                    # gate, not a dependency wait. Emit the same sticky
+                    # signal as ``block_task`` so recompute_ready/dispatch
+                    # never auto-promote it before an explicit unblock.
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {"reason": "initial_status=blocked"},
+                    )
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -49,6 +49,61 @@ def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 
 # ---------------------------------------------------------------------------
+# Initial operator blocks must be sticky
+# ---------------------------------------------------------------------------
+
+
+def test_initial_status_blocked_is_sticky(kanban_home: Path) -> None:
+    """A task created directly in ``blocked`` is an operator/human gate,
+    not a dependency wait. It must not be promoted just because its
+    parents are already complete or because it has no parents.
+
+    This pins the CLI contract for ``hermes kanban create --initial-status
+    blocked``: approval-gated cards should skip worker dispatch until an
+    explicit unblock.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="requires oauth approval",
+            initial_status="blocked",
+        )
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
+
+        for _ in range(5):
+            promoted = kb.recompute_ready(conn)
+            assert promoted == 0, "initial blocked task must not auto-promote"
+            task = kb.get_task(conn, tid)
+            assert task is not None
+            assert task.status == "blocked"
+
+
+def test_initial_status_blocked_child_with_done_parent_is_sticky(kanban_home: Path) -> None:
+    """The parent-completion path must not auto-dispatch approval-gated
+    children created with ``initial_status='blocked'``."""
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent")
+        kb.complete_task(conn, parent, result="parent ok")
+        child = kb.create_task(
+            conn,
+            title="requires ads api approval",
+            parents=[parent],
+            initial_status="blocked",
+        )
+        task = kb.get_task(conn, child)
+        assert task is not None
+        assert task.status == "blocked"
+
+        promoted = kb.recompute_ready(conn)
+        assert promoted == 0
+        task = kb.get_task(conn, child)
+        assert task is not None
+        assert task.status == "blocked"
+
+
+# ---------------------------------------------------------------------------
 # Worker-initiated kanban_block must be sticky
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- emit a sticky `blocked` event when a Kanban task is created with `initial_status="blocked"`
- prevent `recompute_ready()` / dispatcher ticks from auto-promoting approval-gated blocked tasks before an explicit unblock
- add regressions for both parentless and parent-done initial blocked tasks

Fixes #39609.

## Why

`create_task(initial_status="blocked")` wrote `tasks.status='blocked'` but did not emit a `blocked` event. The sticky-block guard only checks `blocked` / `unblocked` events, so a newly created blocked task could be treated like a transient recoverable block and promoted to `ready` on the next recompute/dispatcher pass.

`--initial-status blocked` is documented as a human/operator gate. It should stay inert until an explicit unblock.

## Testing

- `python -m pytest tests/hermes_cli/test_kanban_blocked_sticky.py tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_db.py tests/tools/test_kanban_tools.py -q -o 'addopts='` → 353 passed, 1 warning
- manual isolated smoke: initial blocked child with completed parent stayed `blocked`, `recompute_ready()` returned `0`, events were `['created', 'blocked']`
- `gitleaks git --log-opts='origin/main..HEAD' --no-banner --redact` → no leaks found
