### PR TITLE
fix(desktop): refresh sidebar sessions on focus

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -38,6 +38,7 @@ import { Tip } from '@/components/ui/tooltip'
 import { searchSessions, type SessionInfo, type SessionSearchResult } from '@/hermes'
 import { useWorktreeInfo } from '@/hooks/use-worktree-info'
 import { useI18n } from '@/i18n'
+import { RefreshCw } from '@/lib/icons'
 import { comboTokens } from '@/lib/keybinds/combo'
 import { profileColor } from '@/lib/profile-color'
 import { sessionMatchesSearch } from '@/lib/session-search'
@@ -303,6 +304,7 @@ interface ChatSidebarProps extends React.ComponentProps<typeof Sidebar> {
   onLoadMoreSessions: () => void
   onLoadMoreProfileSessions?: (profile: string) => Promise<void> | void
   onLoadMoreMessaging?: (platform: string) => Promise<void> | void
+  onRefreshSessions: () => Promise<void> | void
   onResumeSession: (sessionId: string) => void
   onDeleteSession: (sessionId: string) => void
   onArchiveSession: (sessionId: string) => void
@@ -317,6 +319,7 @@ export function ChatSidebar({
   onLoadMoreSessions,
   onLoadMoreProfileSessions,
   onLoadMoreMessaging,
+  onRefreshSessions,
   onResumeSession,
   onDeleteSession,
   onArchiveSession,
@@ -874,14 +877,28 @@ export function ChatSidebar({
         </SidebarGroup>
 
         {contentVisible && showSessionSections && (
-          <div className="shrink-0 px-2 pb-1 pt-1">
+          <div className="flex shrink-0 items-center gap-1 px-2 pb-1 pt-1">
             <SearchField
               aria-label={s.searchAria}
+              containerClassName="min-w-0 flex-1"
               inputRef={searchInputRef}
               onChange={setSearchQuery}
               placeholder={s.searchPlaceholder}
               value={searchQuery}
             />
+            <Tip label={sessionsLoading ? s.refreshing : s.refresh}>
+              <Button
+                aria-label={sessionsLoading ? s.refreshing : s.refresh}
+                className="size-7 shrink-0 rounded-md text-(--ui-text-secondary) hover:text-foreground"
+                disabled={sessionsLoading}
+                onClick={() => void onRefreshSessions()}
+                size="icon"
+                type="button"
+                variant="ghost"
+              >
+                <RefreshCw className={cn('size-3.5', sessionsLoading && 'animate-spin')} />
+              </Button>
+            </Tip>
           </div>
         )}
 

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -193,6 +193,7 @@ export function DesktopController() {
   const busyRef = useRef(false)
   const creatingSessionRef = useRef(false)
   const refreshSessionsRequestRef = useRef(0)
+  const lastFocusRefreshAtRef = useRef(0)
 
   const gatewayState = useStore($gatewayState)
   const activeSessionId = useStore($activeSessionId)
@@ -792,6 +793,40 @@ export function DesktopController() {
     }
   }, [gatewayState, refreshCurrentModel, refreshSessions])
 
+  // Gateway sessions can change while Desktop is sitting idle (for example, a
+  // Telegram/Discord conversation receives new messages). Refresh the sidebar
+  // when the user returns to the window so messaging sessions appear without a
+  // full app restart. Keep this focus-driven instead of polling: session lists
+  // can span profiles/remotes, and a short throttle absorbs duplicate
+  // focus+visibility events from Chromium/Electron.
+  useEffect(() => {
+    if (gatewayState !== 'open') {
+      return
+    }
+
+    const refreshOnFocus = () => {
+      if (document.visibilityState !== 'visible') {
+        return
+      }
+
+      const now = Date.now()
+      if (now - lastFocusRefreshAtRef.current < 10_000) {
+        return
+      }
+
+      lastFocusRefreshAtRef.current = now
+      void refreshSessions().catch(() => undefined)
+    }
+
+    window.addEventListener('focus', refreshOnFocus)
+    document.addEventListener('visibilitychange', refreshOnFocus)
+
+    return () => {
+      window.removeEventListener('focus', refreshOnFocus)
+      document.removeEventListener('visibilitychange', refreshOnFocus)
+    }
+  }, [gatewayState, refreshSessions])
+
   // Keep the cron jobs section live without a user action: the scheduler ticks
   // in the background (advancing next-run/state and creating runs), so poll the
   // job list on an interval (and on tab re-focus) while connected.
@@ -870,6 +905,7 @@ export function DesktopController() {
       }}
       onNavigate={selectSidebarItem}
       onNewSessionInWorkspace={startSessionInWorkspace}
+      onRefreshSessions={refreshSessions}
       onResumeSession={sessionId => navigate(sessionRoute(sessionId))}
       onTriggerCronJob={jobId => {
         void triggerCronJob(jobId)

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1142,6 +1142,8 @@ export const en: Translations = {
     },
     searchAria: 'Search sessions',
     searchPlaceholder: 'Search sessions…',
+    refresh: 'Refresh sessions',
+    refreshing: 'Refreshing sessions…',
     clearSearch: 'Clear search',
     noMatch: query => `No sessions match “${query}”.`,
     results: 'Results',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1282,6 +1282,8 @@ export const ja = defineLocale({
     },
     searchAria: 'セッションを検索',
     searchPlaceholder: 'セッションを検索…',
+    refresh: 'セッションを更新',
+    refreshing: 'セッションを更新中…',
     clearSearch: '検索をクリア',
     noMatch: query => `"${query}" に一致するセッションがありません。`,
     results: '結果',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -872,6 +872,8 @@ export interface Translations {
     nav: Record<string, string>
     searchAria: string
     searchPlaceholder: string
+    refresh: string
+    refreshing: string
     clearSearch: string
     noMatch: (query: string) => string
     results: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1236,6 +1236,8 @@ export const zhHant = defineLocale({
     },
     searchAria: '搜尋工作階段',
     searchPlaceholder: '搜尋工作階段…',
+    refresh: '重新整理工作階段',
+    refreshing: '正在重新整理工作階段…',
     clearSearch: '清除搜尋',
     noMatch: query => `沒有工作階段符合「${query}」。`,
     results: '結果',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1330,6 +1330,8 @@ export const zh: Translations = {
     },
     searchAria: '搜索会话',
     searchPlaceholder: '搜索会话…',
+    refresh: '刷新会话',
+    refreshing: '正在刷新会话…',
     clearSearch: '清除搜索',
     noMatch: query => `没有会话匹配"${query}"。`,
     results: '结果',


### PR DESCRIPTION
## Summary
- Refresh Desktop sidebar sessions when the app regains focus/visibility so messaging-origin sessions appear without restarting Desktop.
- Add a manual refresh button next to session search.
- Add localized refresh labels for supported Desktop locales.

## Test Plan
- npm run typecheck
- npx eslint src/app/chat/sidebar/index.tsx src/app/desktop-controller.tsx src/i18n/en.ts src/i18n/types.ts src/i18n/zh.ts src/i18n/zh-hant.ts src/i18n/ja.ts --quiet
- npm run build
