### PR TITLE
fix(desktop): stop voice status leaking across session switch (#46194)

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-session-reset.test.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-session-reset.test.ts
@@ -1,0 +1,107 @@
+import { cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { stopVoicePlayback } from '@/lib/voice-playback'
+
+import { useEndVoiceOnSessionSwitch, useStopVoicePlaybackOnUnmount } from './use-voice-session-reset'
+
+vi.mock('@/lib/voice-playback', () => ({
+  stopVoicePlayback: vi.fn()
+}))
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+function setup(initial: string | null) {
+  const onSwitch = vi.fn()
+
+  const view = renderHook(
+    ({ id }: { id: string | null }) => useEndVoiceOnSessionSwitch(id, onSwitch),
+    { initialProps: { id: initial } }
+  )
+
+  return { onSwitch, ...view }
+}
+
+describe('useEndVoiceOnSessionSwitch', () => {
+  it('does not fire on initial mount', () => {
+    const { onSwitch } = setup('A')
+    expect(onSwitch).not.toHaveBeenCalled()
+  })
+
+  it('does not fire when the session id is unchanged across re-renders', () => {
+    const { onSwitch, rerender } = setup('A')
+    rerender({ id: 'A' })
+    rerender({ id: 'A' })
+    expect(onSwitch).not.toHaveBeenCalled()
+  })
+
+  it('fires once per switch between two real sessions', () => {
+    const { onSwitch, rerender } = setup('A')
+    rerender({ id: 'B' })
+    expect(onSwitch).toHaveBeenCalledTimes(1)
+    rerender({ id: 'C' })
+    expect(onSwitch).toHaveBeenCalledTimes(2)
+    // Switching back is still a switch.
+    rerender({ id: 'A' })
+    expect(onSwitch).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not fire on the null→id persist of the session already in view', () => {
+    const { onSwitch, rerender } = setup(null)
+    rerender({ id: 'A' })
+    expect(onSwitch).not.toHaveBeenCalled()
+  })
+
+  it('treats undefined and null as the same "no session"', () => {
+    const onSwitch = vi.fn()
+
+    const { rerender } = renderHook(
+      ({ id }: { id: string | null | undefined }) => useEndVoiceOnSessionSwitch(id, onSwitch),
+      { initialProps: { id: undefined as string | null | undefined } }
+    )
+
+    // undefined → null is not a switch (both are "no session")…
+    rerender({ id: null })
+    expect(onSwitch).not.toHaveBeenCalled()
+    // …and undefined-seeded → first real id is the initial persist, not a switch.
+    rerender({ id: 'A' })
+    expect(onSwitch).not.toHaveBeenCalled()
+  })
+
+  it('fires when leaving a session (id→null)', () => {
+    const { onSwitch, rerender } = setup('A')
+    rerender({ id: null })
+    expect(onSwitch).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses the latest onSwitch callback', () => {
+    const first = vi.fn()
+    const second = vi.fn()
+
+    const { rerender } = renderHook(
+      ({ id, cb }: { id: string | null; cb: () => void }) => useEndVoiceOnSessionSwitch(id, cb),
+      { initialProps: { id: 'A' as string | null, cb: first } }
+    )
+
+    rerender({ id: 'B', cb: second })
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useStopVoicePlaybackOnUnmount', () => {
+  it('does not stop playback while mounted', () => {
+    renderHook(() => useStopVoicePlaybackOnUnmount())
+    expect(stopVoicePlayback).not.toHaveBeenCalled()
+  })
+
+  it('stops global read-aloud playback once on unmount (cold-switch teardown)', () => {
+    const { unmount } = renderHook(() => useStopVoicePlaybackOnUnmount())
+    expect(stopVoicePlayback).not.toHaveBeenCalled()
+    unmount()
+    expect(stopVoicePlayback).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-session-reset.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-session-reset.ts
@@ -1,0 +1,57 @@
+import { useEffect, useRef } from 'react'
+
+import { stopVoicePlayback } from '@/lib/voice-playback'
+
+/**
+ * Invoke `onSwitch` whenever the active session id changes to a *different*
+ * session, so session-scoped voice state (an in-flight voice conversation and
+ * the global read-aloud / `Preparing audio` / `Speaking` playback status) can
+ * be torn down instead of leaking into the newly selected session (#46194).
+ *
+ * This covers a **warm** switch, where the composer stays mounted and its voice
+ * state would otherwise persist across the switch. A **cold** switch (resuming a
+ * session with no warm runtime) unmounts the composer instead — the
+ * component-local conversation state dies with it, but the module-level
+ * read-aloud playback survives, so pair this with
+ * {@link useStopVoicePlaybackOnUnmount}.
+ *
+ * Skips two non-switches, mirroring the composer's placeholder-reset guard:
+ *  - the initial mount (no previous session), and
+ *  - the `null → id` transition where the brand-new session we're already in
+ *    just gets persisted.
+ * Leaving a session (`id → null`) and moving between two real sessions both
+ * count as a switch.
+ */
+export function useEndVoiceOnSessionSwitch(sessionId: string | null | undefined, onSwitch: () => void) {
+  const lastSessionIdRef = useRef(sessionId)
+
+  useEffect(() => {
+    // Treat `undefined` and `null` as the same "no session" so a transient
+    // undefined→null at startup isn't mistaken for a switch.
+    const previousSessionId = lastSessionIdRef.current ?? null
+    const currentSessionId = sessionId ?? null
+    lastSessionIdRef.current = sessionId
+
+    if (previousSessionId === currentSessionId || (previousSessionId === null && currentSessionId !== null)) {
+      return
+    }
+
+    onSwitch()
+  }, [onSwitch, sessionId])
+}
+
+/**
+ * Stop global read-aloud playback when the host component unmounts. On a cold
+ * session switch the composer is torn down (see {@link useEndVoiceOnSessionSwitch}),
+ * so the module-level `$voicePlayback` singleton would otherwise keep its
+ * `Preparing audio` / `Speaking` status and bleed into the resumed session's
+ * composer once it remounts (#46194).
+ */
+export function useStopVoicePlaybackOnUnmount() {
+  useEffect(
+    () => () => {
+      stopVoicePlayback()
+    },
+    []
+  )
+}

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -42,6 +42,7 @@ import { useComposerUrlDialog } from './hooks/use-composer-url-dialog'
 import { useComposerVoice } from './hooks/use-composer-voice'
 import { useSlashCompletions } from './hooks/use-slash-completions'
 import { useSessionStatusPresence } from './hooks/use-status-presence'
+import { useEndVoiceOnSessionSwitch, useStopVoicePlaybackOnUnmount } from './hooks/use-voice-session-reset'
 import { QueuePanel } from './queue-panel'
 import {
   composerPlainText,
@@ -665,6 +666,17 @@ export function ChatBar({
     onTranscribeAudio,
     sessionId
   })
+
+  // Tear down voice state when the user switches sessions so the prior
+  // session's listening + read-aloud playback status doesn't leak into the
+  // newly selected session's composer (#46194). The voice engine's
+  // `endConversation` clears the active conversation and stops recording /
+  // playback, including the read-aloud-only path.
+  useEndVoiceOnSessionSwitch(sessionId, endConversation)
+  // Cold switch unmounts the composer instead of re-rendering it, so the
+  // hook above never runs on that path; stop the surviving module-level
+  // read-aloud playback on unmount.
+  useStopVoicePlaybackOnUnmount()
 
   const contextMenu = (
     <ContextMenu


### PR DESCRIPTION
## What does this PR do?

Stops the desktop composer's **voice status** from leaking across a session switch. After switching sessions, the prior session's in-flight voice conversation (listening) and the global read-aloud playback status (`$voicePlayback` → `Preparing audio` / `Speaking`) were not reset, so session B's status area showed session A's carried-over voice state.

Both switch paths are handled:

- **Warm switch** (composer stays mounted): a colocated hook, `useEndVoiceOnSessionSwitch`, fires on a real session change and tears the voice state down — it disables the conversation (so the idle effect can't auto-restart listening under the new session) and calls `conversation.end()` (cancels recording, stops playback). The direct `end()` is load-bearing for the read-aloud-only case, where flipping `voiceConversationActive` is a no-op and won't trigger the conversation hook's own `enabled→false` teardown.
- **Cold switch** (resuming a session with no warm runtime unmounts the composer): the component-local conversation state dies with the unmount, but the module-level read-aloud singleton survives, so `useStopVoicePlaybackOnUnmount` stops it on teardown.

The switch guard skips the initial mount and the `null→id` persist of the session already in view (mirrors the composer's existing placeholder-reset), treating `undefined` and `null` as the same "no session". Leaving a session (`id→null`) and moving between two real sessions both count as a switch.

## Related Issue

#46194 (scoped — see below; the issue should stay **open** for the remaining async leak).

This fixes the **displayed voice-status** slice only. The other symptoms named in the issue are already handled or out of scope here:
- Queued follow-up state is already keyed per session on `main` (`$queuedPromptsBySession`, #45414/#43959).
- The transcript path is already session-keyed (`use-message-stream.ts`); the second-hand "both sessions show the same content" report is not reproducible on current `main`.
- **Remaining (follow-up):** a dictation or in-flight voice turn whose transcribe/submit resolves *after* the switch can still land in the newly active session (the stale-submit cross-binding via `ensureSessionState → rewriteOptimistic`). That needs epoch-guarding the async voice continuations and is intentionally left out of this focused fix.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- New `apps/desktop/src/app/chat/composer/hooks/use-voice-session-reset.ts` — `useEndVoiceOnSessionSwitch` (warm) + `useStopVoicePlaybackOnUnmount` (cold).
- Wired both into `apps/desktop/src/app/chat/composer/index.tsx` (the `ChatBar` composer).
- `use-voice-session-reset.test.ts` — 9 cases.

## How to Test

`npm --workspace apps/desktop run test:ui -- src/app/chat/composer/hooks/use-voice-session-reset.test.ts`

Manual: start a read-aloud (or voice conversation) in session A, switch to session B before it settles — B's composer no longer shows A's `Preparing audio`/`Speaking`/listening state. Repeat with a cold resume of B (no warm runtime) to exercise the unmount path.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally (`tsc` + `eslint` clean; only the pre-existing `trigger-popover.test.tsx` `@assistant-ui/tap` packaging failure is unrelated)
- [x] Tested on platform: macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)