### PR TITLE
fix(proxy): require opt-in for network binds

### DIFF
--- a/hermes_cli/proxy/cli.py
+++ b/hermes_cli/proxy/cli.py
@@ -144,7 +144,7 @@ def cmd_proxy(args: Any) -> int:
         "OAuth-authenticated provider credentials to outbound requests.\n"
         "\n"
         "Subcommands:\n"
-        "  hermes proxy start [--provider nous|xai] [--host 127.0.0.1] [--port 8645]\n"
+        "  hermes proxy start [--provider nous|xai] [--host 127.0.0.1] [--port 8645] [--allow-network]\n"
         "      Run the proxy in the foreground.\n"
         "  hermes proxy status\n"
         "      Show which upstream adapters are ready.\n"

--- a/hermes_cli/proxy/cli.py
+++ b/hermes_cli/proxy/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import logging
 import sys
 from typing import Any
@@ -16,6 +17,16 @@ from hermes_cli.proxy.server import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _is_loopback_bind_host(host: str) -> bool:
+    normalized = host.strip().lower().strip("[]")
+    if normalized in {"localhost"}:
+        return True
+    try:
+        return ipaddress.ip_address(normalized).is_loopback
+    except ValueError:
+        return False
 
 
 def _print_aiohttp_missing() -> None:
@@ -54,6 +65,16 @@ def cmd_proxy_start(args: Any) -> int:
 
     host = getattr(args, "host", None) or DEFAULT_HOST
     port = getattr(args, "port", None) or DEFAULT_PORT
+    allow_network = bool(getattr(args, "allow_network", False))
+
+    if not allow_network and not _is_loopback_bind_host(host):
+        print(
+            "Refusing to expose the credential-attaching proxy on a non-loopback "
+            f"address ({host}). Use --allow-network only if you intend to make "
+            "your authenticated provider proxy reachable from this network.",
+            file=sys.stderr,
+        )
+        return 2
 
     print(
         f"Starting Hermes proxy for {adapter.display_name}\n"

--- a/hermes_cli/subcommands/gateway.py
+++ b/hermes_cli/subcommands/gateway.py
@@ -265,13 +265,24 @@ def build_gateway_parser(subparsers, *, cmd_gateway: Callable, cmd_proxy: Callab
     proxy_start.add_argument(
         "--host",
         default=None,
-        help="Bind address (default: 127.0.0.1). Use 0.0.0.0 to expose on LAN.",
+        help=(
+            "Bind address (default: 127.0.0.1). Non-loopback addresses require "
+            "--allow-network."
+        ),
     )
     proxy_start.add_argument(
         "--port",
         type=int,
         default=None,
         help="Bind port (default: 8645)",
+    )
+    proxy_start.add_argument(
+        "--allow-network",
+        action="store_true",
+        help=(
+            "Allow binding the credential-attaching proxy to a non-loopback "
+            "address such as 0.0.0.0."
+        ),
     )
 
     proxy_subparsers.add_parser(

--- a/tests/hermes_cli/test_proxy.py
+++ b/tests/hermes_cli/test_proxy.py
@@ -899,3 +899,61 @@ def test_cmd_proxy_start_refuses_when_unauthenticated(capsys, tmp_path, monkeypa
     assert rc == 2
     err = capsys.readouterr().err
     assert "hermes auth add nous" in err
+
+
+def test_cmd_proxy_start_refuses_network_bind_without_opt_in(capsys, monkeypatch):
+    from hermes_cli.proxy import cli
+    from hermes_cli.proxy.cli import cmd_proxy_start
+
+    class FakeAdapter:
+        name = "fake"
+        display_name = "Fake Provider"
+
+        def is_authenticated(self):
+            return True
+
+    monkeypatch.setattr(cli, "get_adapter", lambda provider: FakeAdapter())
+
+    args = MagicMock()
+    args.provider = "fake"
+    args.host = "0.0.0.0"
+    args.port = 8645
+    args.allow_network = False
+
+    rc = cmd_proxy_start(args)
+
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "Refusing to expose" in err
+    assert "--allow-network" in err
+
+
+def test_cmd_proxy_start_allows_network_bind_with_opt_in(monkeypatch):
+    from hermes_cli.proxy import cli
+    from hermes_cli.proxy.cli import cmd_proxy_start
+
+    class FakeAdapter:
+        name = "fake"
+        display_name = "Fake Provider"
+
+        def is_authenticated(self):
+            return True
+
+    calls = []
+
+    async def fake_run_server(adapter, *, host, port):
+        calls.append((adapter.display_name, host, port))
+
+    monkeypatch.setattr(cli, "get_adapter", lambda provider: FakeAdapter())
+    monkeypatch.setattr(cli, "run_server", fake_run_server)
+
+    args = MagicMock()
+    args.provider = "fake"
+    args.host = "0.0.0.0"
+    args.port = 8645
+    args.allow_network = True
+
+    rc = cmd_proxy_start(args)
+
+    assert rc == 0
+    assert calls == [("Fake Provider", "0.0.0.0", 8645)]

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -451,7 +451,7 @@ Run a local OpenAI-compatible HTTP server that forwards requests to an OAuth-aut
 
 | Subcommand | Description |
 |------------|-------------|
-| `start` | Run the proxy in the foreground. Flags: `--provider <nous\|xai>` (default `nous`), `--host <addr>` (default `127.0.0.1`; use `0.0.0.0` to expose on LAN), `--port <int>` (default `8645`). |
+| `start` | Run the proxy in the foreground. Flags: `--provider <nous\|xai>` (default `nous`), `--host <addr>` (default `127.0.0.1`; use `0.0.0.0 --allow-network` to expose on LAN), `--port <int>` (default `8645`), `--allow-network` (required for non-loopback binds). |
 | `status` | Show which proxy upstreams are ready (credentials present, OAuth valid). |
 | `providers` | List available proxy upstream providers. |
 

--- a/website/docs/user-guide/features/subscription-proxy.md
+++ b/website/docs/user-guide/features/subscription-proxy.md
@@ -165,8 +165,12 @@ By default the proxy binds `127.0.0.1` (localhost only). To let other
 machines on your network use it:
 
 ```bash
-hermes proxy start --host 0.0.0.0 --port 8645
+hermes proxy start --host 0.0.0.0 --port 8645 --allow-network
 ```
+
+The `--allow-network` flag is required for non-loopback binds because this
+proxy does not authenticate clients; it attaches your upstream credentials to
+accepted requests.
 
 ⚠ **Be aware:** anyone on your network can now use your Portal
 subscription. The proxy has no auth of its own — it accepts any bearer.


### PR DESCRIPTION
## Summary

This makes `hermes proxy start` refuse non-loopback bind addresses unless the user passes `--allow-network`. The proxy is a credential-attaching forwarder: it discards the client's `Authorization` header and attaches the user's real provider credential upstream. Keeping the default loopback-only behavior is safe, but binding it to `0.0.0.0` without an explicit danger acknowledgement can expose authenticated model access to the local network.

## Why

`hermes proxy` is intentionally convenient for local tools: clients can send any bearer token while the proxy resolves the user's real OAuth/provider credential. That means an exposed proxy is also an exposed credential bridge. The CLI help previously advertised `--host 0.0.0.0` as the LAN exposure path with no extra confirmation or guard.

The safe default should be fail-closed for non-loopback binds, while preserving an explicit opt-in for users who knowingly want LAN access.

## Changes

- Add loopback bind detection for `hermes proxy start`.
- Refuse `0.0.0.0`, `::`, and other non-loopback bind hosts unless `--allow-network` is provided.
- Add the `--allow-network` CLI flag and update help text.
- Add regression tests for both refusal and explicit opt-in behavior.

## Tests

```text
python -m pytest tests/hermes_cli/test_proxy.py -k "cmd_proxy_start" -q --timeout-method=thread
4 passed, 37 deselected

python -m pytest tests/hermes_cli/test_proxy.py -q --timeout-method=thread
41 passed
```

## Branch

```text
fix/proxy-network-bind-requires-opt-in
```