### PR TITLE
feat: add side project triage helper

### DIFF
--- a/docs/nightly-side-project-triage-spec.md
+++ b/docs/nightly-side-project-triage-spec.md
@@ -1,0 +1,31 @@
+# Nightly Side Project Triage Spec
+
+## Goal
+
+Provide a small offline helper that turns Joe's hand-maintained side-project idea notes into a ranked review queue. The helper must not fetch external services or contact anyone; it only reads a Markdown file and prints Markdown or JSON for Joe to review.
+
+## Input contract
+
+- Markdown headings define sections.
+- Top-level bullets define candidate ideas.
+- Optional leading priority tag: `[high]`, `[medium]`, or `[low]`.
+- Optional metadata can appear as `key: value` fragments separated by semicolons, pipes, or em dashes.
+- Supported metadata: `effort`, `leverage`, `reuse`, `next`, `status`, `audience`.
+- Guidance/safety/template sections are ignored.
+
+## Output contract
+
+- Markdown output includes:
+  - total idea count
+  - ranked top picks
+  - parking lot for blocked/low scoring items
+  - missing next-action checklist
+- JSON output includes normalized entries and scores for automation.
+
+## Scoring contract
+
+Favor Joe's operating principles: high leverage, low effort, and reuse of existing tools. Penalize blocked items and high-effort ideas. The exact score is an implementation detail, but ordering must be deterministic.
+
+## Verification
+
+- Unit tests cover parsing, scoring/order, guidance-section skipping, missing-next-action reporting, and CLI JSON smoke.

--- a/scripts/side_project_triage.py
+++ b/scripts/side_project_triage.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Rank side-project ideas from a Markdown note into a compact review brief.
+
+The script is intentionally offline: it does not fetch services, create tasks,
+or contact anyone. It converts a human-maintained idea dump into a deterministic
+queue for manual review.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+URL_RE = re.compile(r"https?://[^\s)>,;|]+")
+BULLET_RE = re.compile(r"^[-*+]\s+(?P<body>.+?)\s*$")
+HEADING_RE = re.compile(r"^\s*#{1,6}\s+(?P<title>.+?)\s*$")
+PRIORITY_RE = re.compile(r"^\[(?P<priority>high|medium|low)\]\s*", re.IGNORECASE)
+GUIDANCE_SECTION_RE = re.compile(
+    r"\b(format|instructions?|notes?|safety|permission|template|output|example|contract|verification|goal)\b",
+    re.IGNORECASE,
+)
+FIELD_RE = re.compile(
+    r"(?:^|\s)(?P<key>effort|leverage|reuse|next|status|audience)\s*:\s*(?P<value>.*?)(?=\s*(?:[;|]|\s+—\s+|\s+-\s+|\s+--\s+|$))",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class SideProjectIdea:
+    """One side-project candidate extracted from a Markdown bullet."""
+
+    title: str
+    section: str
+    priority: str
+    effort: str | None
+    leverage: str | None
+    reuse: str | None
+    next_action: str | None
+    status: str | None
+    audience: str | None
+    urls: list[str]
+    raw: str
+    score: int
+
+
+def _normalize_field(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = re.sub(r"\s+", " ", value).strip(" -—;|,.")
+    return cleaned or None
+
+
+def _extract_fields(body: str) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    for match in FIELD_RE.finditer(body):
+        key = match.group("key").lower()
+        value = _normalize_field(match.group("value"))
+        if value:
+            fields[key] = value
+    return fields
+
+
+def _title_from_body(body: str, urls: Sequence[str]) -> str:
+    title_source = body
+    priority_match = PRIORITY_RE.match(title_source)
+    if priority_match:
+        title_source = title_source[priority_match.end() :].strip()
+
+    # Strip URLs before splitting, so a URL colon does not become a title separator.
+    for url in urls:
+        title_source = title_source.replace(url, "")
+
+    # The first field marker usually starts the metadata area; keep text before it.
+    field_match = re.search(r"(?:^|[;|]|\s+—\s+|\s+-\s+|\s+--\s+)\s*(effort|leverage|reuse|next|status|audience)\s*:", title_source, re.IGNORECASE)
+    if field_match:
+        title_source = title_source[: field_match.start()]
+
+    candidate = re.split(r"\s*(?:—|--|\|)\s*", title_source, maxsplit=1)[0]
+    candidate = re.sub(r"\s+", " ", candidate).strip(" -—:;|")
+    return candidate or "Untitled idea"
+
+
+def _score_idea(priority: str, fields: dict[str, str]) -> int:
+    score = {"high": 3, "medium": 1, "normal": 0, "low": -1}.get(priority, 0)
+
+    effort = (fields.get("effort") or "").lower()
+    if effort in {"low", "small", "easy", "quick"}:
+        score += 2
+    elif effort in {"medium", "moderate"}:
+        score += 0
+    elif effort in {"high", "large", "hard"}:
+        score -= 2
+
+    leverage = (fields.get("leverage") or "").lower()
+    if leverage in {"high", "large", "strong"}:
+        score += 3
+    elif leverage in {"medium", "moderate"}:
+        score += 1
+    elif leverage in {"low", "small"}:
+        score -= 1
+
+    reuse = (fields.get("reuse") or "").lower()
+    if reuse and reuse not in {"none", "no", "n/a", "na"}:
+        score += 1
+
+    status = (fields.get("status") or "").lower()
+    if any(term in status for term in ("blocked", "waiting", "parked")):
+        score -= 3
+    elif any(term in status for term in ("ready", "active")):
+        score += 1
+
+    if fields.get("next"):
+        score += 1
+    return score
+
+
+def parse_ideas(path: str | Path) -> list[SideProjectIdea]:
+    """Parse top-level Markdown bullets into normalized side-project ideas."""
+
+    idea_path = Path(path).expanduser()
+    text = idea_path.read_text(encoding="utf-8")
+    entries: list[SideProjectIdea] = []
+    section = "Unsectioned"
+
+    for line in text.splitlines():
+        heading = HEADING_RE.match(line)
+        if heading:
+            section = heading.group("title").strip()
+            continue
+
+        bullet = BULLET_RE.match(line)
+        if not bullet or GUIDANCE_SECTION_RE.search(section):
+            continue
+
+        raw = bullet.group("body").strip()
+        priority = "normal"
+        priority_match = PRIORITY_RE.match(raw)
+        if priority_match:
+            priority = priority_match.group("priority").lower()
+
+        urls = URL_RE.findall(raw)
+        fields = _extract_fields(raw)
+        title = _title_from_body(raw, urls)
+        score = _score_idea(priority, fields)
+        entries.append(
+            SideProjectIdea(
+                title=title,
+                section=section,
+                priority=priority,
+                effort=fields.get("effort"),
+                leverage=fields.get("leverage"),
+                reuse=fields.get("reuse"),
+                next_action=fields.get("next"),
+                status=fields.get("status"),
+                audience=fields.get("audience"),
+                urls=urls,
+                raw=raw,
+                score=score,
+            )
+        )
+
+    return entries
+
+
+def rank_ideas(entries: Iterable[SideProjectIdea]) -> list[SideProjectIdea]:
+    """Return ideas in deterministic review order."""
+
+    return sorted(entries, key=lambda entry: (-entry.score, entry.section.lower(), entry.title.lower()))
+
+
+def _format_idea(entry: SideProjectIdea) -> str:
+    bits = [f"score {entry.score}", entry.section]
+    if entry.priority != "normal":
+        bits.append(f"priority {entry.priority}")
+    if entry.effort:
+        bits.append(f"effort {entry.effort}")
+    if entry.leverage:
+        bits.append(f"leverage {entry.leverage}")
+    if entry.reuse:
+        bits.append(f"reuse {entry.reuse}")
+    if entry.status:
+        bits.append(f"status {entry.status}")
+    next_label = f" — next: {entry.next_action}" if entry.next_action else ""
+    url_label = f" — {entry.urls[0]}" if entry.urls else ""
+    return f"- {entry.title} ({'; '.join(bits)}){next_label}{url_label}"
+
+
+def build_markdown_brief(entries: Iterable[SideProjectIdea], *, limit: int = 5) -> str:
+    """Render a compact Markdown triage brief for manual review."""
+
+    ranked = rank_ideas(entries)
+    top = ranked[:limit]
+    parking_lot = [entry for entry in ranked if entry.score < 3 or (entry.status and "blocked" in entry.status.lower())]
+    missing_next = [entry for entry in ranked if not entry.next_action]
+
+    lines = ["# Side Project Triage", "", f"Ideas: {len(ranked)}", "", "## Top picks"]
+    if top:
+        lines.extend(_format_idea(entry) for entry in top)
+    else:
+        lines.append("- No side-project ideas found.")
+
+    lines.extend(["", "## Parking lot"])
+    if parking_lot:
+        lines.extend(_format_idea(entry) for entry in parking_lot)
+    else:
+        lines.append("- None")
+
+    lines.extend(["", "## Missing next actions"])
+    if missing_next:
+        for entry in missing_next:
+            lines.append(f"- {entry.title} ({entry.section})")
+    else:
+        lines.append("- None")
+
+    return "\n".join(lines) + "\n"
+
+
+def build_json_payload(entries: Iterable[SideProjectIdea], *, limit: int | None = None) -> dict[str, object]:
+    ranked = rank_ideas(entries)
+    if limit is not None:
+        ranked = ranked[:limit]
+    return {"count": len(ranked), "ideas": [asdict(entry) for entry in ranked]}
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("ideas", help="Markdown side-project ideas path")
+    parser.add_argument("--format", choices=("markdown", "json"), default="markdown")
+    parser.add_argument("--limit", type=int, default=5, help="Maximum top picks to include")
+    args = parser.parse_args(argv)
+
+    entries = parse_ideas(args.ideas)
+    if args.format == "json":
+        print(json.dumps(build_json_payload(entries, limit=args.limit), indent=2, sort_keys=True))
+    else:
+        print(build_markdown_brief(entries, limit=args.limit), end="")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised by CLI smoke test
+    raise SystemExit(main())

--- a/tests/scripts/test_side_project_triage.py
+++ b/tests/scripts/test_side_project_triage.py
@@ -1,0 +1,130 @@
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "side_project_triage.py"
+
+spec = importlib.util.spec_from_file_location("side_project_triage", SCRIPT_PATH)
+assert spec is not None
+assert spec.loader is not None
+side_project_triage = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = side_project_triage
+spec.loader.exec_module(side_project_triage)
+
+
+def test_parse_ideas_extracts_metadata_priority_and_urls(tmp_path):
+    ideas = tmp_path / "ideas.md"
+    ideas.write_text(
+        """
+# Side Projects
+
+## Life ops
+- [high] Fridge cadence helper — effort: low; leverage: medium; reuse: Apple Reminders; next: draft recurring reminder
+- AI tools radar | effort: medium | leverage: high | audience: Joe | https://github.com/example/radar
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    entries = side_project_triage.parse_ideas(ideas)
+
+    assert [entry.title for entry in entries] == ["Fridge cadence helper", "AI tools radar"]
+    assert entries[0].section == "Life ops"
+    assert entries[0].priority == "high"
+    assert entries[0].effort == "low"
+    assert entries[0].leverage == "medium"
+    assert entries[0].reuse == "Apple Reminders"
+    assert entries[0].next_action == "draft recurring reminder"
+    assert entries[1].urls == ["https://github.com/example/radar"]
+
+
+def test_ranked_brief_favors_low_effort_high_leverage_reuse(tmp_path):
+    ideas = tmp_path / "ideas.md"
+    ideas.write_text(
+        """
+# Ideas
+- Giant app rewrite — effort: high; leverage: medium; next: write RFC
+- [medium] Existing-tool dashboard — effort: low; leverage: high; reuse: Notion; next: build tiny template
+- Blocked experiment — effort: low; leverage: high; status: blocked; next: wait for API access
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    entries = side_project_triage.parse_ideas(ideas)
+    ranked = side_project_triage.rank_ideas(entries)
+    brief = side_project_triage.build_markdown_brief(entries)
+
+    assert [entry.title for entry in ranked] == ["Existing-tool dashboard", "Blocked experiment", "Giant app rewrite"]
+    assert "## Top picks" in brief
+    assert brief.index("Existing-tool dashboard") < brief.index("Giant app rewrite")
+    assert "## Parking lot" in brief
+    assert "Blocked experiment" in brief
+
+
+def test_parse_ideas_skips_guidance_sections(tmp_path):
+    ideas = tmp_path / "ideas.md"
+    ideas.write_text(
+        """
+# Ideas
+
+## Product candidates
+- Real candidate — effort: low; leverage: high
+
+## Output template
+- Title — effort: low; leverage: high; next: do something
+
+## Safety notes
+- Never send messages automatically
+
+## Scoring contract
+- This instruction should not become an idea
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    entries = side_project_triage.parse_ideas(ideas)
+
+    assert [entry.title for entry in entries] == ["Real candidate"]
+
+
+def test_brief_reports_missing_next_actions(tmp_path):
+    ideas = tmp_path / "ideas.md"
+    ideas.write_text(
+        """
+# Ideas
+- Ready idea — effort: low; leverage: high; next: ship a script
+- Vague idea — effort: low; leverage: high
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    brief = side_project_triage.build_markdown_brief(side_project_triage.parse_ideas(ideas))
+
+    assert "## Missing next actions" in brief
+    assert "Vague idea" in brief
+    assert "Ready idea" not in brief.split("## Missing next actions", maxsplit=1)[1]
+
+
+def test_cli_outputs_json(tmp_path):
+    ideas = tmp_path / "ideas.md"
+    ideas.write_text("- Quick win — effort: low; leverage: high; next: test it\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), str(ideas), "--format", "json"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["count"] == 1
+    assert payload["ideas"][0]["title"] == "Quick win"
+    assert payload["ideas"][0]["score"] > 0


### PR DESCRIPTION
## Summary

- add an offline `scripts/side_project_triage.py` helper that parses Markdown side-project idea bullets into a ranked review queue
- include a small spec documenting the input/output/scoring contract
- cover parsing, ranking, guidance-section skipping, missing next actions, and CLI JSON output

## Why

Joe's nightly Hermes workflow needs small, reversible tooling around personal side projects and life/system improvements. This helper turns a rough idea dump into an actionable morning queue without fetching external services or contacting anyone.

## Tests

- `scripts/run_tests.sh tests/scripts/test_side_project_triage.py`
- `python -m py_compile scripts/side_project_triage.py tests/scripts/test_side_project_triage.py`
- `python -m ruff check scripts/side_project_triage.py tests/scripts/test_side_project_triage.py`
- `python scripts/side_project_triage.py /tmp/side_project_ideas_sample.md --limit 2`

## Notes

`python -m black --check ...` was attempted but the local venv does not have `black` installed; `ruff` and py_compile passed.
