### PR TITLE
feat: add ponytail-minimal-code skill

### DIFF
--- a/skills/software-development/ponytail-minimal-code/SKILL.md
+++ b/skills/software-development/ponytail-minimal-code/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: ponytail-minimal-code
+description: "Use when writing or reviewing code. Forces the lazy-senior-dev decision ladder: question if code is needed, use stdlib/platform/existing deps first, write the minimum that works. Inspired by Ponytail (YAGNI for AI agents)."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [coding, yagni, minimal-code, code-review, best-practices, ponytail]
+    related_skills: [simplify-code, requesting-code-review, test-driven-development]
+---
+
+# Ponytail — Write Less Code
+
+Makes you think like the laziest senior dev in the room. The best code is
+the code you never wrote.
+
+> He says nothing. He writes one line. It works.
+
+## The Decision Ladder
+
+Before writing ANY code, run through this ladder **in order**. Stop at the
+first step that satisfies the requirement:
+
+```
+1. Does this need to exist?   → NO: skip it entirely (YAGNI)
+2. Stdlib does it?            → USE IT — don't reinvent
+3. Native platform feature?   → USE IT — browser/OS/framework built-ins
+4. Installed dependency?      → USE IT — check what's already in the project
+5. One-liner?                 → WRITE ONE LINE
+6. Only then:                 → Write the MINIMUM that works
+```
+
+### 1. Question everything
+
+- "Do we actually need this feature / file / abstraction?" — if unsure, don't create it.
+- Don't pre-build for hypothetical future requirements.
+- Don't create utility files "just in case".
+- Don't add config files nobody asked for.
+
+### 2. Stdlib first
+
+If the standard library can do it, never write a custom implementation.
+
+| Language | Prefer |
+|----------|--------|
+| Python | `collections`, `itertools`, `pathlib`, `dataclasses`, `json`, `csv`, `hashlib`, `unittest.mock` |
+| JavaScript / TypeScript | `Array.prototype.*`, `Object.*`, `Intl`, `URL`, `fetch`, `crypto.subtle` |
+| Go | `strings`, `slices`, `maps`, `encoding/json`, `net/http` |
+| Rust | `std::collections`, `std::fs`, `std::process` |
+
+### 3. Platform features
+
+- `<input type="date">` not a date-picker library.
+- `<dialog>` not a modal library.
+- CSS `grid` / `flexbox` not a layout framework.
+- Python `venv` + `pip` when a full dependency manager isn't needed.
+- React `useState` / `useReducer` not a global state library for local state.
+
+### 4. Existing dependencies
+
+- Check `package.json`, `requirements.txt`, `pyproject.toml`, `go.mod` before adding new deps.
+- Don't install `lodash` if native array methods suffice.
+- Don't install `axios` if `fetch` is available.
+- Don't install `moment` / `dayjs` if `Intl.DateTimeFormat` works.
+
+### 5. One-liners
+
+- If a task is a single expression, write a single expression.
+- Don't wrap a one-liner in a class with a factory pattern.
+- Don't add error handling to a line that can't fail.
+
+### 6. Minimum viable code
+
+- Write the smallest implementation that passes tests and handles **real** edge cases.
+- Inline small functions rather than creating util files.
+- Skip the interface / abstract base class if there's one implementation.
+- Skip the factory if there's one product.
+
+## What NOT to do
+
+- ❌ Install a package for something the stdlib does.
+- ❌ Create an abstraction layer with one concrete implementation.
+- ❌ Write a config system when constants work.
+- ❌ Add a wrapper class around a function call.
+- ❌ Build a plugin architecture nobody will extend.
+- ❌ Create separate files for 3-line utilities.
+- ❌ Add error handling that swallows errors silently.
+- ❌ Write retry logic for non-transient failures.
+
+## Lazy, not negligent
+
+This philosophy is **not** about cutting corners on:
+
+- ✅ Trust-boundary validation (auth, input sanitization, SQL parameterization).
+- ✅ Data-loss prevention (transactions, backups, atomic writes).
+- ✅ Security (sanitization, CSRF, parameterized queries).
+- ✅ Accessibility (semantic HTML, ARIA, keyboard nav).
+- ✅ Error handling for **real** failure modes.
+
+It **is** about:
+
+- ✅ Not building infrastructure for features that don't exist yet.
+- ✅ Not abstracting code that has one caller.
+- ✅ Not importing libraries for trivial operations.
+- ✅ Not writing boilerplate the framework already handles.
+
+## Code review with Ponytail
+
+When reviewing code — yours, a teammate's, or subagent output — ask:
+
+1. *Could this entire file be deleted?* → Delete it.
+2. *Could this function be a stdlib call?* → Replace it.
+3. *Could this class be a function?* → Simplify it.
+4. *Could this abstraction be inlined?* → Inline it.
+5. *Is this dependency necessary?* → Remove it if stdlib works.
+6. *Is this handling a real edge case or an imaginary one?* → Remove imaginary handling.
+
+## When delegating to subagents
+
+Include this directive in the delegation `context`:
+
+> Follow Ponytail rules: use stdlib first, existing deps second, write the
+> minimum code that works. Don't create unnecessary abstractions, files,
+> or dependencies. Question whether each piece of code needs to exist.
+
+## Attribution
+
+Inspired by [Ponytail](https://github.com/DietrichGebert/ponytail) by
+Dietrich Gebert — "Makes your AI agent think like the laziest senior dev
+in the room." This skill adapts Ponytail's decision ladder and YAGNI
+principles for the Hermes Agent skill system.

--- a/skills/software-development/ponytail-minimal-code/SKILL.md
+++ b/skills/software-development/ponytail-minimal-code/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: ponytail-minimal-code
-description: "Use when writing or reviewing code. Forces the lazy-senior-dev decision ladder: question if code is needed, use stdlib/platform/existing deps first, write the minimum that works. Inspired by Ponytail (YAGNI for AI agents)."
+description: "Use when writing or reviewing code to minimize complexity."
 version: 1.0.0
-author: Hermes Agent
+author: Het / @hetdev, Hermes Agent
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
@@ -11,123 +11,84 @@ metadata:
     related_skills: [simplify-code, requesting-code-review, test-driven-development]
 ---
 
-# Ponytail — Write Less Code
+# Ponytail Minimal Code Skill
 
-Makes you think like the laziest senior dev in the room. The best code is
-the code you never wrote.
+Ponytail makes implementation deliberately smaller by questioning whether
+code is needed before choosing how to write it. It applies YAGNI and a
+decision ladder while keeping validation, security, accessibility, and data
+safety intact. This skill adapts
+[Ponytail](https://github.com/DietrichGebert/ponytail) by Dietrich Gebert for
+the Hermes Agent skill system.
 
-> He says nothing. He writes one line. It works.
+## When to Use
 
-## The Decision Ladder
+- Use before implementing, refactoring, or reviewing code.
+- Use when choosing between a standard-library feature, a platform feature,
+  an installed dependency, or new code.
+- Do not use minimalism to skip a real security, validation, accessibility,
+  error-handling, or data-loss requirement.
 
-Before writing ANY code, run through this ladder **in order**. Stop at the
-first step that satisfies the requirement:
+## Prerequisites
 
-```
-1. Does this need to exist?   → NO: skip it entirely (YAGNI)
-2. Stdlib does it?            → USE IT — don't reinvent
-3. Native platform feature?   → USE IT — browser/OS/framework built-ins
-4. Installed dependency?      → USE IT — check what's already in the project
-5. One-liner?                 → WRITE ONE LINE
-6. Only then:                 → Write the MINIMUM that works
-```
+- No setup or external runtime dependency is required.
+- Read the relevant code with `read_file` and locate existing solutions with
+  `search_files`.
+- Check the project’s existing dependencies and platform capabilities before
+  proposing a new dependency.
+- Use `terminal` for commands and tests; use `patch` for focused edits.
 
-### 1. Question everything
+## How to Run
 
-- "Do we actually need this feature / file / abstraction?" — if unsure, don't create it.
-- Don't pre-build for hypothetical future requirements.
-- Don't create utility files "just in case".
-- Don't add config files nobody asked for.
+Apply the decision ladder in order before writing code. Stop at the first step
+that satisfies the requirement, then use `terminal` to run the relevant tests.
 
-### 2. Stdlib first
+## Quick Reference
 
-If the standard library can do it, never write a custom implementation.
+| Step | Question | Action |
+| --- | --- | --- |
+| 1 | Does this need to exist? | Skip it when the answer is no. |
+| 2 | Does the standard library do it? | Use the standard library. |
+| 3 | Does the native platform feature do it? | Use the platform feature. |
+| 4 | Does an installed dependency do it? | Reuse the dependency. |
+| 5 | Is it a one-liner? | Write one line. |
+| 6 | Is new code still required? | Write the minimum that works. |
 
-| Language | Prefer |
-|----------|--------|
-| Python | `collections`, `itertools`, `pathlib`, `dataclasses`, `json`, `csv`, `hashlib`, `unittest.mock` |
-| JavaScript / TypeScript | `Array.prototype.*`, `Object.*`, `Intl`, `URL`, `fetch`, `crypto.subtle` |
-| Go | `strings`, `slices`, `maps`, `encoding/json`, `net/http` |
-| Rust | `std::collections`, `std::fs`, `std::process` |
+## Procedure
 
-### 3. Platform features
+1. Question the requirement. Remove hypothetical features, abstractions,
+   utility files, and configuration that no real requirement needs.
+2. Check the standard library before writing a custom implementation.
+3. Check native platform features before adding a library.
+4. Check installed dependencies before adding a new dependency.
+5. Prefer a one-liner when it remains clear and correct.
+6. Write the minimum implementation that handles real edge cases.
+7. Inline small functions, and avoid a class, factory, interface, or plugin
+   architecture when one implementation or caller is sufficient.
+8. Preserve trust-boundary validation, data-loss prevention, security,
+   accessibility, and error handling for real failure modes.
+9. During review, ask whether the file can be deleted, the function replaced
+   by a standard-library call, the class made a function, the abstraction
+   inlined, or the dependency removed.
+10. When delegating through `delegate_task`, include the rule to use the
+    standard library first, existing dependencies second, and the minimum code
+    that works.
 
-- `<input type="date">` not a date-picker library.
-- `<dialog>` not a modal library.
-- CSS `grid` / `flexbox` not a layout framework.
-- Python `venv` + `pip` when a full dependency manager isn't needed.
-- React `useState` / `useReducer` not a global state library for local state.
+## Pitfalls
 
-### 4. Existing dependencies
+- Do not install a package for a standard-library operation.
+- Do not create an abstraction layer with one concrete implementation.
+- Do not build infrastructure for hypothetical future requirements.
+- Do not add error handling that silently hides failures.
+- Do not confuse “lazy” with skipping validation, security, accessibility, or
+  data-loss safeguards.
 
-- Check `package.json`, `requirements.txt`, `pyproject.toml`, `go.mod` before adding new deps.
-- Don't install `lodash` if native array methods suffice.
-- Don't install `axios` if `fetch` is available.
-- Don't install `moment` / `dayjs` if `Intl.DateTimeFormat` works.
+## Verification
 
-### 5. One-liners
-
-- If a task is a single expression, write a single expression.
-- Don't wrap a one-liner in a class with a factory pattern.
-- Don't add error handling to a line that can't fail.
-
-### 6. Minimum viable code
-
-- Write the smallest implementation that passes tests and handles **real** edge cases.
-- Inline small functions rather than creating util files.
-- Skip the interface / abstract base class if there's one implementation.
-- Skip the factory if there's one product.
-
-## What NOT to do
-
-- ❌ Install a package for something the stdlib does.
-- ❌ Create an abstraction layer with one concrete implementation.
-- ❌ Write a config system when constants work.
-- ❌ Add a wrapper class around a function call.
-- ❌ Build a plugin architecture nobody will extend.
-- ❌ Create separate files for 3-line utilities.
-- ❌ Add error handling that swallows errors silently.
-- ❌ Write retry logic for non-transient failures.
-
-## Lazy, not negligent
-
-This philosophy is **not** about cutting corners on:
-
-- ✅ Trust-boundary validation (auth, input sanitization, SQL parameterization).
-- ✅ Data-loss prevention (transactions, backups, atomic writes).
-- ✅ Security (sanitization, CSRF, parameterized queries).
-- ✅ Accessibility (semantic HTML, ARIA, keyboard nav).
-- ✅ Error handling for **real** failure modes.
-
-It **is** about:
-
-- ✅ Not building infrastructure for features that don't exist yet.
-- ✅ Not abstracting code that has one caller.
-- ✅ Not importing libraries for trivial operations.
-- ✅ Not writing boilerplate the framework already handles.
-
-## Code review with Ponytail
-
-When reviewing code — yours, a teammate's, or subagent output — ask:
-
-1. *Could this entire file be deleted?* → Delete it.
-2. *Could this function be a stdlib call?* → Replace it.
-3. *Could this class be a function?* → Simplify it.
-4. *Could this abstraction be inlined?* → Inline it.
-5. *Is this dependency necessary?* → Remove it if stdlib works.
-6. *Is this handling a real edge case or an imaginary one?* → Remove imaginary handling.
-
-## When delegating to subagents
-
-Include this directive in the delegation `context`:
-
-> Follow Ponytail rules: use stdlib first, existing deps second, write the
-> minimum code that works. Don't create unnecessary abstractions, files,
-> or dependencies. Question whether each piece of code needs to exist.
-
-## Attribution
-
-Inspired by [Ponytail](https://github.com/DietrichGebert/ponytail) by
-Dietrich Gebert — "Makes your AI agent think like the laziest senior dev
-in the room." This skill adapts Ponytail's decision ladder and YAGNI
-principles for the Hermes Agent skill system.
+- Confirm that every new file, abstraction, dependency, and configuration value
+  answers a current requirement.
+- Confirm that standard-library, platform, and installed-dependency options
+  were considered in that order.
+- Run the focused tests with `terminal` and confirm that real edge cases and
+  safety requirements remain covered.
+- Confirm that the final implementation is the smallest clear solution that
+  satisfies the requirement.

--- a/skills/software-development/ponytail-minimal-code/SKILL.md
+++ b/skills/software-development/ponytail-minimal-code/SKILL.md
@@ -16,9 +16,12 @@ metadata:
 Ponytail makes implementation deliberately smaller by questioning whether
 code is needed before choosing how to write it. It applies YAGNI and a
 decision ladder while keeping validation, security, accessibility, and data
-safety intact. This skill adapts
-[Ponytail](https://github.com/DietrichGebert/ponytail) by Dietrich Gebert for
-the Hermes Agent skill system.
+safety intact.
+
+**Credits:** This skill adapts the MIT-licensed
+[Ponytail project](https://github.com/DietrichGebert/ponytail) by
+[Dietrich Gebert](https://github.com/DietrichGebert) for the Hermes Agent skill
+system.
 
 ## When to Use
 

--- a/tests/skills/test_ponytail_minimal_code_skill.py
+++ b/tests/skills/test_ponytail_minimal_code_skill.py
@@ -1,0 +1,97 @@
+"""Contract tests for the in-repository Ponytail minimal-code skill."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+SKILL_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "software-development"
+    / "ponytail-minimal-code"
+    / "SKILL.md"
+)
+REQUIRED_SECTIONS = [
+    "When to Use",
+    "Prerequisites",
+    "How to Run",
+    "Quick Reference",
+    "Procedure",
+    "Pitfalls",
+    "Verification",
+]
+
+
+def _read_skill() -> str:
+    return SKILL_PATH.read_text(encoding="utf-8")
+
+
+def _frontmatter(content: str) -> dict[str, object]:
+    match = re.match(r"\A---\n(.*?)\n---\n", content, re.DOTALL)
+    assert match, "SKILL.md must begin with YAML frontmatter"
+    fields: dict[str, object] = {}
+    for line in match.group(1).splitlines():
+        if not line or line.startswith(" ") or ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        value = value.strip()
+        if value.startswith('"') and value.endswith('"'):
+            value = value[1:-1]
+        elif value.startswith("["):
+            value = [
+                item.strip().strip("'\"")
+                for item in value[1:-1].split(",")
+                if item.strip()
+            ]
+        fields[key] = value
+    return fields
+
+
+def test_skill_path_exists() -> None:
+    assert SKILL_PATH.is_file()
+
+
+def test_frontmatter_contract() -> None:
+    frontmatter = _frontmatter(_read_skill())
+
+    assert frontmatter["name"] == "ponytail-minimal-code"
+    description = frontmatter["description"]
+    assert isinstance(description, str)
+    assert description.startswith("Use when ")
+    assert len(description) <= 60
+    assert re.fullmatch(r"[^.!?]+\.", description)
+    assert frontmatter["author"] == "Het / @hetdev, Hermes Agent"
+    assert frontmatter["version"] == "1.0.0"
+    assert frontmatter["license"] == "MIT"
+    assert frontmatter["platforms"] == ["linux", "macos", "windows"]
+
+
+def test_exact_title_and_section_order() -> None:
+    content = _read_skill()
+    body = content.split("---\n", 2)[-1]
+    assert body.startswith("\n# Ponytail Minimal Code Skill\n")
+    headings = re.findall(r"^## (.+)$", content, re.MULTILINE)
+    assert headings == REQUIRED_SECTIONS
+
+
+def test_decision_ladder_and_attribution_are_preserved() -> None:
+    content = _read_skill()
+    for marker in (
+        "Does this need to exist?",
+        "Does the standard library do it?",
+        "Does the native platform feature do it?",
+        "Does an installed dependency do it?",
+        "Is it a one-liner?",
+        "Is new code still required?",
+    ):
+        assert marker in content
+    assert "Dietrich Gebert" in content
+    assert "github.com/DietrichGebert/ponytail" in content
+
+
+def test_skill_has_no_external_runtime_dependency() -> None:
+    content = _read_skill().lower()
+    assert "no setup or external runtime dependency is required" in content
+    for marker in ("pip install", "npm install", "brew install", "third-party runtime"):
+        assert marker not in content

--- a/tests/skills/test_ponytail_minimal_code_skill.py
+++ b/tests/skills/test_ponytail_minimal_code_skill.py
@@ -86,8 +86,12 @@ def test_decision_ladder_and_attribution_are_preserved() -> None:
         "Is new code still required?",
     ):
         assert marker in content
-    assert "Dietrich Gebert" in content
-    assert "github.com/DietrichGebert/ponytail" in content
+    assert "**Credits:**" in content
+    assert (
+        "[Ponytail project](https://github.com/DietrichGebert/ponytail)" in content
+    )
+    assert "[Dietrich Gebert](https://github.com/DietrichGebert)" in content
+    assert "MIT-licensed" in content
 
 
 def test_skill_has_no_external_runtime_dependency() -> None:


### PR DESCRIPTION
## Summary

Adds a new skill under `skills/software-development/` based on the [Ponytail](https://github.com/DietrichGebert/ponytail) philosophy — "Makes your AI agent think like the laziest senior dev in the room."

## What it does

The skill injects a **YAGNI decision ladder** that the agent follows before writing any code:

1. **Does this need to exist?** → Skip if not (YAGNI)
2. **Stdlib does it?** → Use it
3. **Native platform feature?** → Use it (`<input type="date">` not a library)
4. **Installed dependency?** → Use it (check before adding new deps)
5. **One-liner?** → Write one line
6. **Only then:** Write the minimum that works

## Why

AI agents tend to over-engineer: unnecessary abstractions, redundant utility files, extra dependencies for trivial operations. This skill counters that by forcing the agent to justify every line of code against the decision ladder.

**Lazy, not negligent** — the skill explicitly preserves trust-boundary validation, data-loss prevention, security, and accessibility.

## Placement

Placed under `software-development/` alongside the existing `simplify-code` (post-change cleanup) and `requesting-code-review` skills. No overlap — `simplify-code` is reactive cleanup, Ponytail is proactive minimalism at write time.

## Credits

This skill is adapted from the MIT-licensed [Ponytail project](https://github.com/DietrichGebert/ponytail) by [Dietrich Gebert (@DietrichGebert)](https://github.com/DietrichGebert). It brings Ponytail's decision ladder and YAGNI principles into the Hermes Agent skill system.