### PR TITLE
fix(gateway): serialize stale slash worker lifecycle

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3620,6 +3620,52 @@ def test_config_set_model_uses_live_switch_path(monkeypatch):
     assert seen["args"] == ("sid", "session-key", "new/model")
 
 
+def test_apply_model_switch_marks_slash_worker_stale_without_inline_restart(monkeypatch):
+    class _Agent:
+        model = "old/model"
+        provider = "old-provider"
+        base_url = ""
+        api_key = ""
+
+        def switch_model(self, **kwargs):
+            self.model = kwargs["new_model"]
+            self.provider = kwargs["new_provider"]
+
+    result = types.SimpleNamespace(
+        success=True,
+        new_model="anthropic/claude-sonnet-4.6",
+        target_provider="anthropic",
+        api_key="key",
+        base_url="https://api.anthropic.com",
+        api_mode="anthropic_messages",
+        warning_message="",
+        model_info=None,
+    )
+    restart_calls = []
+    session = _session(agent=_Agent())
+    session["slash_worker"] = types.SimpleNamespace(model="old/model")
+
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", lambda **_kwargs: result)
+    monkeypatch.setattr(
+        server, "_restart_slash_worker", lambda sid, target: restart_calls.append((sid, target))
+    )
+    monkeypatch.setattr(server, "_persist_live_session_runtime", lambda _session: None)
+    monkeypatch.setattr(server, "_persist_live_session_system_prompt", lambda _session: None)
+    monkeypatch.setattr(server, "_append_model_switch_marker", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_emit", lambda *_args, **_kwargs: None)
+
+    response = server._apply_model_switch(
+        "sid",
+        session,
+        "anthropic/claude-sonnet-4.6 --provider anthropic",
+        confirm_expensive_model=True,
+    )
+
+    assert response["value"] == "anthropic/claude-sonnet-4.6"
+    assert session["slash_worker_stale"] is True
+    assert restart_calls == []
+
+
 def test_config_set_model_requires_confirmation_for_expensive_model(monkeypatch):
     class _Agent:
         provider = "openrouter"
@@ -8499,6 +8545,82 @@ def test_restart_slash_worker_stores_on_live_session(monkeypatch):
         assert isinstance(live["slash_worker"], _FakeWorker)
     finally:
         server._sessions.pop("live-restart", None)
+
+
+def test_concurrent_slash_exec_replaces_stale_worker_once_and_serializes_runs(monkeypatch):
+    state_lock = threading.Lock()
+    run_state = {"active": 0, "max_active": 0}
+    created_workers = []
+
+    class _FakeWorker:
+        def __init__(self, session_key, model, profile_home=None):
+            self.session_key = session_key
+            self.model = model
+            self.closed = False
+            self.runs = []
+            created_workers.append(self)
+
+        def run(self, command):
+            with state_lock:
+                run_state["active"] += 1
+                run_state["max_active"] = max(
+                    run_state["max_active"], run_state["active"]
+                )
+            time.sleep(0.05)
+            self.runs.append(command)
+            with state_lock:
+                run_state["active"] -= 1
+            return f"ran:{self.model}:{command}"
+
+        def close(self):
+            time.sleep(0.05)
+            self.closed = True
+
+    stale_worker = _FakeWorker("session-key", "old/model")
+    created_workers.clear()
+    session = _session(agent=types.SimpleNamespace(model="new/model"))
+    session["slash_worker"] = stale_worker
+    session["slash_worker_stale"] = True
+    server._sessions["concurrent-slash"] = session
+    monkeypatch.setattr(server, "_SlashWorker", _FakeWorker)
+
+    requests = [
+        {
+            "id": str(index),
+            "method": "slash.exec",
+            "params": {
+                "session_id": "concurrent-slash",
+                "command": f"help-{index}",
+            },
+        }
+        for index in range(2)
+    ]
+    start = threading.Barrier(3)
+    responses = []
+
+    def _run(request):
+        start.wait()
+        responses.append(server.handle_request(request))
+
+    threads = [threading.Thread(target=_run, args=(request,)) for request in requests]
+    try:
+        for thread in threads:
+            thread.start()
+        start.wait()
+        for thread in threads:
+            thread.join(timeout=2)
+
+        assert all(not thread.is_alive() for thread in threads)
+        assert len(responses) == 2
+        assert all("result" in response for response in responses)
+        assert stale_worker.closed is True
+        assert len(created_workers) == 1
+        assert session["slash_worker"] is created_workers[0]
+        assert session["slash_worker"].model == "new/model"
+        assert session["slash_worker_stale"] is False
+        assert run_state["max_active"] == 1
+    finally:
+        server._sessions.pop("concurrent-slash", None)
 
 
 def test_session_close_rpc_delegates_to_close_session_by_id(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -278,6 +278,7 @@ class _SlashWorker:
     def __init__(self, session_key: str, model: str, profile_home: str | None = None):
         self._lock = threading.Lock()
         self._seq = 0
+        self.model = model or ""
         self.stderr_tail: list[str] = []
         self.stdout_queue: queue.Queue[dict | None] = queue.Queue()
 
@@ -2810,27 +2811,36 @@ def _tool_progress_enabled(sid: str) -> bool:
     return _session_tool_progress_mode(sid) != "off"
 
 
+def _slash_worker_lifecycle_lock(session: dict) -> threading.RLock:
+    lock = session.get("slash_worker_lifecycle_lock")
+    if lock is not None:
+        return lock
+    with _sessions_lock:
+        return session.setdefault("slash_worker_lifecycle_lock", threading.RLock())
+
+
 def _restart_slash_worker(sid: str, session: dict):
-    worker = session.get("slash_worker")
-    if worker:
+    with _slash_worker_lifecycle_lock(session):
+        worker = session.get("slash_worker")
+        if worker:
+            try:
+                worker.close()
+            except Exception:
+                pass
         try:
-            worker.close()
+            new_worker = _SlashWorker(
+                session["session_key"],
+                getattr(session.get("agent"), "model", _resolve_model()),
+                profile_home=session.get("profile_home"),
+            )
         except Exception:
-            pass
-    try:
-        new_worker = _SlashWorker(
-            session["session_key"],
-            getattr(session.get("agent"), "model", _resolve_model()),
-            profile_home=session.get("profile_home"),
-        )
-    except Exception:
-        session["slash_worker"] = None
-        return
-    # Route through the same store-iff-still-mapped guard as the spawn sites:
-    # the post-turn restart runs as `running` flips false, exactly when a
-    # close_on_disconnect reap can pop this session — a bare store would orphan
-    # the fresh worker (it self-heals only on gateway exit via the watchdog).
-    _attach_worker(sid, session, new_worker)
+            session["slash_worker"] = None
+            return
+        # Route through the same store-iff-still-mapped guard as the spawn sites:
+        # the post-turn restart runs as `running` flips false, exactly when a
+        # close_on_disconnect reap can pop this session — a bare store would orphan
+        # the fresh worker (it self-heals only on gateway exit via the watchdog).
+        _attach_worker(sid, session, new_worker)
 
 
 def _persist_model_switch(result) -> None:
@@ -3005,7 +3015,10 @@ def _apply_model_switch(
                 f"Model switch to {result.new_model} failed ({exc}); "
                 f"staying on {getattr(agent, 'model', current_model)}."
             ) from exc
-        _restart_slash_worker(sid, session)
+        # A model switch can race a pooled slash.exec request. Closing the
+        # persistent worker here can break its transport mid-command, so defer
+        # replacement until the next slash.exec lifecycle lock is held.
+        session["slash_worker_stale"] = True
         _persist_live_session_runtime(session)
         _persist_live_session_system_prompt(session)
         _append_model_switch_marker(
@@ -13315,32 +13328,48 @@ def _(rid, params: dict) -> dict:
         except Exception as e:
             return _ok(rid, {"output": f"Plugin command error: {e}"})
 
-    worker = session.get("slash_worker")
-    if not worker:
-        try:
-            worker = _SlashWorker(
-                session["session_key"],
-                getattr(session.get("agent"), "model", _resolve_model()),
-                profile_home=session.get("profile_home"),
-            )
-            _attach_worker(params.get("session_id", ""), session, worker)
-        except Exception as e:
-            return _err(rid, 5030, f"slash worker start failed: {e}")
+    with _slash_worker_lifecycle_lock(session):
+        worker = session.get("slash_worker")
+        target_model = getattr(session.get("agent"), "model", _resolve_model()) or ""
+        worker_model = getattr(worker, "model", "") if worker else ""
+        if worker and (
+            session.get("slash_worker_stale") or worker_model != target_model
+        ):
+            try:
+                worker.close()
+            except Exception:
+                pass
+            session["slash_worker"] = None
+            worker = None
 
-    try:
-        output = worker.run(cmd)
-        warning = _mirror_slash_side_effects(params.get("session_id", ""), session, cmd)
-        payload = {"output": output or "(no output)"}
-        if warning:
-            payload["warning"] = warning
-        return _ok(rid, payload)
-    except Exception as e:
+        if not worker:
+            try:
+                worker = _SlashWorker(
+                    session["session_key"],
+                    target_model,
+                    profile_home=session.get("profile_home"),
+                )
+                _attach_worker(params.get("session_id", ""), session, worker)
+                session["slash_worker_stale"] = False
+            except Exception as e:
+                return _err(rid, 5030, f"slash worker start failed: {e}")
+
         try:
-            worker.close()
-        except Exception:
-            pass
-        session["slash_worker"] = None
-        return _err(rid, 5030, str(e))
+            output = worker.run(cmd)
+            warning = _mirror_slash_side_effects(
+                params.get("session_id", ""), session, cmd
+            )
+            payload = {"output": output or "(no output)"}
+            if warning:
+                payload["warning"] = warning
+            return _ok(rid, payload)
+        except Exception as e:
+            try:
+                worker.close()
+            except Exception:
+                pass
+            session["slash_worker"] = None
+            return _err(rid, 5030, str(e))
 
 
 # ── Methods: voice ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- serialize slash-worker lifecycle operations per session
- mark the worker stale on model changes and replace it on the next `slash.exec`
- keep close, create, run, and mirror-state work inside the same session lock so concurrent commands cannot overwrite workers
- add a concurrent regression test proving one replacement and serialized execution

## Testing

- `uv run pytest -q tests/test_tui_gateway_server.py` (325 passed)
- `uv run ruff check tui_gateway/server.py tests/test_tui_gateway_server.py`
- `git diff --check`