### PR TITLE
feat(kanban): add bounded aux coordinator launcher

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -24,6 +24,7 @@ import time
 from pathlib import Path
 from typing import Any, Optional
 
+from hermes_cli import kanban_aux as ka
 from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_swarm as ks
 from hermes_cli.profiles import get_active_profile_name, get_profile_dir, seed_profile_skills
@@ -362,6 +363,48 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "that require immediate human ops (R3 gate) "
                                "to skip the brief running-to-blocked transition.")
     p_create.add_argument("--json", action="store_true", help="Emit JSON output")
+
+    # --- aux ---
+    p_aux = sub.add_parser(
+        "aux",
+        aliases=["launch-aux"],
+        help="Launch one bounded auxiliary Kanban coordinator card",
+        description=(
+            "Create or reuse a single idempotent coordination card for an "
+            "existing Hermes profile lane. This is a thin launcher on top of "
+            "the normal Kanban dispatcher — it does not start a second "
+            "dispatcher or recursively create helper agents."
+        ),
+    )
+    p_aux.add_argument("--source-task", default=None,
+                       help="Task id that motivated this aux pass (context/comment only)")
+    p_aux.add_argument("--parent", action="append", default=[],
+                       help="Parent dependency for the aux card (repeatable)")
+    p_aux.add_argument("--project", default=None,
+                       help="Project/fixture path or slug for dedupe context")
+    p_aux.add_argument("--micro-goal", default=None,
+                       help="Bounded coordination goal (default: board triage)")
+    p_aux.add_argument("--assignee", default=None,
+                       help="Existing profile to run the pass. Defaults to kanban-aux, autopilot, then default if present.")
+    p_aux.add_argument("--tenant", default=None, help="Tenant namespace")
+    p_aux.add_argument("--priority", type=int, default=0, help="Priority tiebreaker")
+    p_aux.add_argument("--max-runtime", default="30m",
+                       help="Runtime cap for the aux worker (default: 30m)")
+    p_aux.add_argument("--max-created", type=int, default=ka.DEFAULT_MAX_CREATED_CARDS,
+                       help="Instructional cap for cards the aux worker may create in one pass (default: 3)")
+    p_aux.add_argument("--evidence-root", default=None,
+                       help="Local evidence root. Defaults to ~/.omo/evidence/kanban-aux when ~/.omo exists, else Hermes home.")
+    p_aux.add_argument("--steward-plan", default=None,
+                       help="Path to a .omo Project Steward plan to reference in the aux card")
+    p_aux.add_argument("--no-steward-plan", action="store_true",
+                       help="Do not auto-detect/reference ~/.omo/plans/hermes-project-steward-runtime.md")
+    p_aux.add_argument("--idempotency-key", default=None,
+                       help="Override the deterministic kanban-aux:<...>:v1 key")
+    p_aux.add_argument("--created-by", default=ka.AUX_CREATED_BY,
+                       help="Author recorded on the task/comments")
+    p_aux.add_argument("--dry-run", action="store_true",
+                       help="Print the planned card/key/body without writing the board or evidence")
+    p_aux.add_argument("--json", action="store_true", help="Emit JSON output")
 
     # --- swarm ---
     p_swarm = sub.add_parser(
@@ -923,6 +966,8 @@ def kanban_command(args: argparse.Namespace) -> int:
         handlers = {
             "init":     _cmd_init,
             "create":   _cmd_create,
+            "aux":      _cmd_aux,
+            "launch-aux": _cmd_aux,
             "swarm":    _cmd_swarm,
             "list":     _cmd_list,
             "ls":       _cmd_list,
@@ -1364,6 +1409,61 @@ def _cmd_create(args: argparse.Namespace) -> int:
             running, message = _check_dispatcher_presence()
             if not running and message:
                 print(f"\n⚠  {message}", file=sys.stderr)
+    return 0
+
+
+def _cmd_aux(args: argparse.Namespace) -> int:
+    try:
+        max_runtime = _parse_duration(getattr(args, "max_runtime", None))
+    except ValueError as exc:
+        print(f"kanban aux: --max-runtime: {exc}", file=sys.stderr)
+        return 2
+    if getattr(args, "max_created", 0) < 0:
+        print("kanban aux: --max-created must be >= 0", file=sys.stderr)
+        return 2
+    with kb.connect_closing() as conn:
+        result = ka.launch_auxiliary_agent(
+            conn,
+            source_task_id=getattr(args, "source_task", None),
+            project=getattr(args, "project", None),
+            micro_goal=getattr(args, "micro_goal", None),
+            assignee=getattr(args, "assignee", None),
+            parents=tuple(getattr(args, "parent", None) or ()),
+            tenant=getattr(args, "tenant", None),
+            priority=getattr(args, "priority", 0),
+            max_runtime_seconds=max_runtime,
+            max_created_cards=getattr(args, "max_created", ka.DEFAULT_MAX_CREATED_CARDS),
+            evidence_root=getattr(args, "evidence_root", None),
+            steward_plan=getattr(args, "steward_plan", None),
+            include_steward_plan=not bool(getattr(args, "no_steward_plan", False)),
+            created_by=getattr(args, "created_by", None) or ka.AUX_CREATED_BY,
+            idempotency_key=getattr(args, "idempotency_key", None),
+            dry_run=bool(getattr(args, "dry_run", False)),
+        )
+    if getattr(args, "json", False):
+        print(json.dumps(result.as_dict(), indent=2, ensure_ascii=False))
+        return 0
+
+    if result.dry_run:
+        verb = "Would reuse" if result.reused else "Would create"
+    else:
+        verb = "Reused" if result.reused else "Created"
+    task_ref = result.task_id or "(dry-run)"
+    print(f"{verb} {task_ref}  ({result.status}, assignee={result.assignee})")
+    print(f"Idempotency: {result.idempotency_key}")
+    if result.parent_ids:
+        print("Parents: " + ", ".join(result.parent_ids))
+    evidence = result.evidence.as_dict()
+    print(
+        f"Evidence: {evidence.get('path')}, "
+        f"sha256={evidence.get('sha256') or '(not written)'}"
+    )
+    if result.steward_plan_path:
+        print(f"Steward plan: {result.steward_plan_path}")
+    if not result.dry_run and result.status == "ready" and result.assignee:
+        running, message = _check_dispatcher_presence()
+        if not running and message:
+            print(f"\n⚠  {message}", file=sys.stderr)
     return 0
 
 
@@ -2737,6 +2837,7 @@ Common subcommands:
   `show <id>`           Task details + comments + events
   `stats`               Per-status / per-assignee counts
   `create <title>…`     Create a task (auto-subscribes you to events)
+  `aux`                 Launch/reuse one bounded auxiliary coordinator card
   `comment <id> <msg>`  Append a comment
   `complete <id>…`      Mark task(s) done
   `block <id> [reason]` Mark blocked; `schedule <id> [reason]` parks time-delay work; `unblock <id>` to revive

--- a/hermes_cli/kanban_aux.py
+++ b/hermes_cli/kanban_aux.py
@@ -1,0 +1,439 @@
+"""Kanban auxiliary coordinator launcher.
+
+This module is deliberately a thin edge helper on top of the existing Kanban
+kernel.  It does not add a second dispatcher or spawn path; it writes one
+idempotent coordinator card that the normal gateway dispatcher can pick up as a
+regular Hermes profile-lane task.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+import re
+import sqlite3
+import time
+from typing import Any, Iterable, Optional
+
+from hermes_cli import kanban_db as kb
+
+DEFAULT_AUX_ASSIGNEE_CANDIDATES = ("kanban-aux", "autopilot", "default")
+AUX_CREATED_BY = "kanban-aux-launcher"
+DEFAULT_MAX_CREATED_CARDS = 3
+DEFAULT_LANE = "coordination"
+
+
+@dataclass(frozen=True)
+class EvidencePointer:
+    path: Optional[Path]
+    sha256: Optional[str]
+
+    def as_dict(self) -> dict[str, Optional[str]]:
+        return {
+            "path": str(self.path) if self.path else None,
+            "sha256": self.sha256,
+        }
+
+
+@dataclass(frozen=True)
+class AuxiliaryLaunch:
+    """Result returned by :func:`launch_auxiliary_agent`."""
+
+    task_id: Optional[str]
+    title: str
+    status: str
+    assignee: str
+    idempotency_key: str
+    reused: bool
+    dry_run: bool
+    round_id: str
+    source_task_id: Optional[str]
+    parent_ids: list[str]
+    evidence: EvidencePointer
+    steward_plan_path: Optional[str]
+    body: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "task_id": self.task_id,
+            "title": self.title,
+            "status": self.status,
+            "assignee": self.assignee,
+            "idempotency_key": self.idempotency_key,
+            "reused": self.reused,
+            "dry_run": self.dry_run,
+            "round_id": self.round_id,
+            "source_task_id": self.source_task_id,
+            "parent_ids": list(self.parent_ids),
+            "evidence": self.evidence.as_dict(),
+            "steward_plan_path": self.steward_plan_path,
+            "body": self.body,
+        }
+
+
+def _compact_slug(value: Optional[str], fallback: str) -> str:
+    text = (value or "").strip()
+    if not text:
+        return fallback
+    base = Path(text).name if any(sep in text for sep in ("/", "\\")) else text
+    slug = re.sub(r"[^a-z0-9]+", "-", base.casefold()).strip("-") or fallback
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:8]
+    return f"{slug[:48]}-{digest}"
+
+
+def _dedupe_preserve_order(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for raw in values:
+        value = (raw or "").strip()
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result
+
+
+def _parent_context_key(parent_ids: Iterable[str]) -> str:
+    parents = _dedupe_preserve_order(parent_ids)
+    if not parents:
+        return "root"
+    if len(parents) == 1:
+        return parents[0]
+    canonical = "\n".join(sorted(parents))
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:12]
+    return f"parents-{digest}"
+
+
+def build_auxiliary_idempotency_key(
+    *,
+    source_task_id: Optional[str] = None,
+    parent_ids: Iterable[str] = (),
+    project: Optional[str] = None,
+    micro_goal: Optional[str] = None,
+    lane: str = DEFAULT_LANE,
+) -> str:
+    """Return the stable key used to prevent duplicate aux-card launches.
+
+    ``--source-task`` is context/comment metadata only.  Dependency context is
+    the first key segment so identical project/micro-goal launches under
+    different parents produce distinct coordinator cards.
+    """
+
+    _ = source_task_id
+    parent_context = _parent_context_key(parent_ids)
+    project_key = _compact_slug(project, "none")
+    goal_key = _compact_slug(micro_goal, "board-triage")
+    lane_key = _compact_slug(lane, DEFAULT_LANE)
+    return f"kanban-aux:{parent_context}:{project_key}:{lane_key}:{goal_key}:v1"
+
+
+def _existing_task_id_for_key(conn: sqlite3.Connection, key: str) -> Optional[str]:
+    row = conn.execute(
+        "SELECT id FROM tasks WHERE idempotency_key = ? "
+        "AND status != 'archived' ORDER BY created_at DESC LIMIT 1",
+        (key,),
+    ).fetchone()
+    return str(row["id"]) if row else None
+
+
+def _select_assignee(requested: Optional[str]) -> str:
+    available = set(kb.list_profiles_on_disk())
+    if requested:
+        candidate = requested.strip()
+        if not candidate:
+            raise ValueError("--assignee requires a non-empty profile name")
+        if candidate not in available:
+            known = ", ".join(sorted(available)) or "(none)"
+            raise ValueError(
+                f"auxiliary assignee profile {candidate!r} does not exist on disk; "
+                f"known profiles: {known}"
+            )
+        return candidate
+
+    for candidate in DEFAULT_AUX_ASSIGNEE_CANDIDATES:
+        if candidate in available:
+            return candidate
+    known = ", ".join(sorted(available)) or "(none)"
+    raise ValueError(
+        "no auxiliary assignee profile is available. Create or choose an existing "
+        "profile with `--assignee <profile>`; known profiles: " + known
+    )
+
+
+def _default_evidence_root() -> Path:
+    """Pick a local evidence root without creating user-specific surface.
+
+    Gustavo's `.omo` workspace is preferred when present because the auxiliary
+    agent spec stores detailed evidence there.  Generic installs fall back to
+    the Hermes home so the command remains useful outside that workspace.
+    """
+
+    omo = Path.home() / ".omo"
+    if omo.is_dir():
+        return omo / "evidence" / "kanban-aux"
+    try:
+        from hermes_constants import get_hermes_home
+
+        return get_hermes_home() / "kanban" / "evidence" / "kanban-aux"
+    except Exception:
+        return Path.home() / ".hermes" / "kanban" / "evidence" / "kanban-aux"
+
+
+def _default_steward_plan_path() -> Optional[Path]:
+    candidate = Path.home() / ".omo" / "plans" / "hermes-project-steward-runtime.md"
+    return candidate if candidate.is_file() else None
+
+
+def _resolve_steward_plan(
+    *,
+    steward_plan: Optional[str],
+    include_steward_plan: bool,
+) -> Optional[Path]:
+    if not include_steward_plan:
+        return None
+    if steward_plan:
+        path = Path(steward_plan).expanduser()
+        if not path.is_file():
+            raise ValueError(f"steward plan not found: {path}")
+        return path
+    return _default_steward_plan_path()
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _round_id(key: str) -> str:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    nonce = hashlib.sha256(f"{key}:{time.time_ns()}".encode("utf-8")).hexdigest()[:8]
+    return f"kbaux-{stamp}-{nonce}"
+
+
+def build_auxiliary_task_body(
+    *,
+    source_task_id: Optional[str],
+    project: Optional[str],
+    micro_goal: Optional[str],
+    max_created_cards: int,
+    evidence_root: Path,
+    round_id: str,
+    idempotency_key: str,
+    steward_plan_path: Optional[Path],
+) -> str:
+    goal = (micro_goal or "board triage / evidence cleanup").strip()
+    source = source_task_id or "board-scan"
+    project_text = project or "not specified"
+    steward_section = ""
+    if steward_plan_path:
+        steward_section = f"""
+## Project Steward/.omo integration
+Detected plan: `{steward_plan_path}`.
+
+Explicit pending work to preserve while routing:
+- MVP remains local-only, foreground, one selected project/fixture, one card, one micro-goal, one serial cycle.
+- Do not create new profiles/skills for the Steward MVP; use existing profile lanes and Kanban summary-level state.
+- Detailed evidence belongs under `.omo/evidence/hermes-steward/` or `.omo/evidence/kanban-aux/` by local path + sha256, not pasted into Kanban.
+- Pending Steward artifacts are operator runbook, `steward doctor/run/status/tail/stop/resume/qa-final` command contract, append-only state, project lock, evidence manifest, optional visual manifest, review pack, and final executable QA gate.
+- If this board only has a single Steward MVP card/micro-goal, record `no_action_needed` instead of fanning out.
+""".strip()
+    else:
+        steward_section = """
+## Optional .omo/Steward integration
+No `~/.omo/plans/hermes-project-steward-runtime.md` plan was detected or supplied. Run the generic Kanban auxiliary pass only; keep evidence local and summary-level.
+""".strip()
+
+    return f"""
+Kanban auxiliary coordination pass. This card is a regular Hermes profile-lane task; the existing gateway dispatcher spawns it. It is not a new dispatcher, daemon, cron job, or recursive agent factory.
+
+## Inputs
+- source: `{source}`
+- project/fixture: `{project_text}`
+- micro-goal: `{goal}`
+- round id: `{round_id}`
+- launcher idempotency key: `{idempotency_key}`
+- evidence root: `{evidence_root}`
+
+## Operating contract
+1. Call `kanban_show()` first and read parent handoffs/comments.
+2. Run exactly one coordination pass: snapshot board pressure, dedupe similar cards, repair obvious parent links, and create only small follow-up cards with clear acceptance/evidence.
+3. Hard cap: create at most {max_created_cards} new cards in this pass. If more are needed, complete/block with a prioritized recommendation instead of launching another auxiliary card.
+4. Use existing profile assignees only. Block if the target profile does not exist or the next step requires credentials, 2FA/captcha, production mutation, external egress, destructive operations, or a human scope decision.
+5. Do not call `hermes kanban aux`, do not create another auxiliary coordinator card, and do not create profiles, skills, cron jobs, gateways, or a Steward foreground runner from this pass.
+6. Use deterministic child idempotency keys shaped like `kanban-aux:<parent_id|root>:<project>:<lane>:<normalized_micro_goal>:v1`.
+7. Keep raw stdout, screenshots, browser payloads, tokens, cookies, PHI, and full logs out of Kanban. Store detailed evidence locally and cite only path + sha256 + run_id.
+
+{steward_section}
+
+## Completion contract
+Complete with metadata containing `created_task_ids`, `reused_task_ids`, `dedupe_decisions`, `evidence_manifest_path`, `evidence_sha256`, and `no_action_needed` when applicable. Block with a specific one-line reason if a human decision is genuinely required.
+""".strip()
+
+
+def _write_evidence(
+    *,
+    evidence_root: Path,
+    round_id: str,
+    event: dict[str, Any],
+) -> EvidencePointer:
+    round_dir = evidence_root.expanduser() / round_id
+    round_dir.mkdir(parents=True, exist_ok=True)
+    path = round_dir / "events.jsonl"
+    path.write_text(json.dumps(event, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    return EvidencePointer(path=path, sha256=digest)
+
+
+def _launch_comment(result: AuxiliaryLaunch) -> str:
+    action = "reused" if result.reused else "created"
+    evidence = result.evidence.as_dict()
+    return (
+        f"kanban-aux {result.round_id}: {action} auxiliary coordinator\n"
+        f"- source: {result.source_task_id or 'board-scan'}\n"
+        f"- task: {result.task_id}\n"
+        f"- assignee: {result.assignee}\n"
+        f"- idempotency_key: {result.idempotency_key}\n"
+        f"- evidence: {evidence.get('path')}, sha256={evidence.get('sha256')}\n"
+        "- omitted: raw stdout/screenshots/secrets/PHI kept out of Kanban\n"
+        "- next: dispatcher runs the regular Hermes profile lane; do not launch a recursive aux card"
+    )
+
+
+def launch_auxiliary_agent(
+    conn: sqlite3.Connection,
+    *,
+    source_task_id: Optional[str] = None,
+    project: Optional[str] = None,
+    micro_goal: Optional[str] = None,
+    assignee: Optional[str] = None,
+    parents: Iterable[str] = (),
+    tenant: Optional[str] = None,
+    priority: int = 0,
+    max_runtime_seconds: Optional[int] = None,
+    max_created_cards: int = DEFAULT_MAX_CREATED_CARDS,
+    evidence_root: Optional[str | Path] = None,
+    steward_plan: Optional[str] = None,
+    include_steward_plan: bool = True,
+    created_by: str = AUX_CREATED_BY,
+    idempotency_key: Optional[str] = None,
+    dry_run: bool = False,
+) -> AuxiliaryLaunch:
+    if max_created_cards < 0:
+        raise ValueError("--max-created must be >= 0")
+
+    source_task_id = (source_task_id or "").strip() or None
+    if source_task_id and not kb.get_task(conn, source_task_id):
+        raise ValueError(f"unknown source task: {source_task_id}")
+
+    parent_ids = _dedupe_preserve_order(parents)
+    for parent_id in parent_ids:
+        if not kb.get_task(conn, parent_id):
+            raise ValueError(f"unknown parent task: {parent_id}")
+
+    chosen_assignee = _select_assignee(assignee)
+    evidence_root_path = Path(evidence_root).expanduser() if evidence_root else _default_evidence_root()
+    steward_plan_path = _resolve_steward_plan(
+        steward_plan=steward_plan,
+        include_steward_plan=include_steward_plan,
+    )
+    key = idempotency_key or build_auxiliary_idempotency_key(
+        source_task_id=source_task_id,
+        parent_ids=parent_ids,
+        project=project,
+        micro_goal=micro_goal,
+    )
+    round_id = _round_id(key)
+    title_goal = (micro_goal or "board triage").strip().splitlines()[0]
+    title = f"Kanban auxiliary: {title_goal[:80]}"
+    body = build_auxiliary_task_body(
+        source_task_id=source_task_id,
+        project=project,
+        micro_goal=micro_goal,
+        max_created_cards=max_created_cards,
+        evidence_root=evidence_root_path,
+        round_id=round_id,
+        idempotency_key=key,
+        steward_plan_path=steward_plan_path,
+    )
+
+    existing_id = _existing_task_id_for_key(conn, key)
+    if dry_run:
+        dry_parent_ids = kb.parent_ids(conn, existing_id) if existing_id else parent_ids
+        return AuxiliaryLaunch(
+            task_id=existing_id,
+            title=title,
+            status="dry-run",
+            assignee=chosen_assignee,
+            idempotency_key=key,
+            reused=bool(existing_id),
+            dry_run=True,
+            round_id=round_id,
+            source_task_id=source_task_id,
+            parent_ids=dry_parent_ids,
+            evidence=EvidencePointer(path=evidence_root_path / round_id / "events.jsonl", sha256=None),
+            steward_plan_path=str(steward_plan_path) if steward_plan_path else None,
+            body=body,
+        )
+
+    task_id = kb.create_task(
+        conn,
+        title=title,
+        body=body,
+        assignee=chosen_assignee,
+        created_by=created_by or AUX_CREATED_BY,
+        tenant=tenant,
+        priority=priority,
+        parents=parent_ids,
+        idempotency_key=key,
+        max_runtime_seconds=max_runtime_seconds,
+        skills=["kanban-orchestrator"],
+    )
+    task = kb.get_task(conn, task_id)
+    if not task:
+        raise RuntimeError(f"created auxiliary task disappeared: {task_id}")
+    reused = bool(existing_id and existing_id == task_id)
+    actual_parent_ids = kb.parent_ids(conn, task_id)
+
+    event = {
+        "ts": _iso_now(),
+        "agent": "kanban-aux-launcher",
+        "round_id": round_id,
+        "source_task_id": source_task_id,
+        "event": "launch",
+        "decision": "reuse_auxiliary_task" if reused else "create_auxiliary_task",
+        "reason": "idempotent launcher for one bounded Kanban coordination pass",
+        "created_task_ids": [] if reused else [task_id],
+        "reused_task_ids": [task_id] if reused else [],
+        "parents": actual_parent_ids,
+        "assignee": chosen_assignee,
+        "idempotency_key": key,
+        "project": project,
+        "micro_goal": micro_goal,
+        "steward_plan_path": str(steward_plan_path) if steward_plan_path else None,
+        "redaction": "pass",
+        "next_step": "wait_for_dispatcher_profile_lane",
+    }
+    evidence = _write_evidence(evidence_root=evidence_root_path, round_id=round_id, event=event)
+    result = AuxiliaryLaunch(
+        task_id=task_id,
+        title=task.title,
+        status=task.status,
+        assignee=task.assignee or chosen_assignee,
+        idempotency_key=key,
+        reused=reused,
+        dry_run=False,
+        round_id=round_id,
+        source_task_id=source_task_id,
+        parent_ids=actual_parent_ids,
+        evidence=evidence,
+        steward_plan_path=str(steward_plan_path) if steward_plan_path else None,
+        body=task.body or body,
+    )
+
+    comment = _launch_comment(result)
+    kb.add_comment(conn, task_id, author=created_by or AUX_CREATED_BY, body=comment)
+    if source_task_id and source_task_id != task_id:
+        kb.add_comment(conn, source_task_id, author=created_by or AUX_CREATED_BY, body=comment)
+    return result

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12444,9 +12444,13 @@ def main():
         cmd_chat(args)
         return
 
-    # Execute the command
+    # Execute the command. Subcommand handlers conventionally return a
+    # shell-style integer status on validation/runtime errors; propagate that
+    # instead of silently exiting 0 after printing stderr.
     if hasattr(args, "func"):
-        args.func(args)
+        exit_code = args.func(args)
+        if type(exit_code) is int:
+            sys.exit(exit_code)
     else:
         parser.print_help()
 

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import subprocess
+import sys
 import threading
 from pathlib import Path
 
@@ -165,6 +167,163 @@ def test_run_slash_json_output(kanban_home):
     assert payload["title"] == "jsontask"
     assert payload["assignee"] == "alice"
     assert payload["status"] == "ready"
+
+
+def test_run_slash_aux_creates_idempotent_card_with_evidence(kanban_home, tmp_path):
+    evidence_root = tmp_path / ".omo" / "evidence" / "kanban-aux"
+    command = (
+        "aux --micro-goal 'dedupe backlog' "
+        f"--project {tmp_path / 'project'} "
+        "--assignee default "
+        f"--evidence-root {evidence_root} "
+        "--no-steward-plan --json"
+    )
+
+    first = json.loads(kc.run_slash(command))
+
+    assert first["task_id"].startswith("t_")
+    assert first["status"] == "ready"
+    assert first["assignee"] == "default"
+    assert first["idempotency_key"].startswith("kanban-aux:root:")
+    assert first["reused"] is False
+    evidence_path = Path(first["evidence"]["path"])
+    assert evidence_path.is_file()
+    assert len(first["evidence"]["sha256"]) == 64
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, first["task_id"])
+        assert task is not None
+        assert "Do not call `hermes kanban aux`" in (task.body or "")
+        comments = kb.list_comments(conn, first["task_id"])
+        assert any("do not launch a recursive aux card" in c.body for c in comments)
+
+    second = json.loads(kc.run_slash(command))
+    assert second["task_id"] == first["task_id"]
+    assert second["reused"] is True
+    with kb.connect() as conn:
+        assert len(kb.list_tasks(conn)) == 1
+
+
+def test_run_slash_aux_references_detected_steward_plan(kanban_home, tmp_path):
+    plan = tmp_path / ".omo" / "plans" / "hermes-project-steward-runtime.md"
+    plan.parent.mkdir(parents=True)
+    plan.write_text("# local steward plan\n", encoding="utf-8")
+
+    out = kc.run_slash(
+        "aux --micro-goal 'preserve steward mvp' --assignee default "
+        f"--evidence-root {tmp_path / 'evidence'} --json"
+    )
+    payload = json.loads(out)
+
+    assert payload["steward_plan_path"] == str(plan)
+    with kb.connect() as conn:
+        task = kb.get_task(conn, payload["task_id"])
+        assert task is not None
+        assert "Project Steward/.omo integration" in (task.body or "")
+        assert "one selected project/fixture" in (task.body or "")
+
+
+def test_run_slash_aux_links_parent_and_comments_source(kanban_home, tmp_path):
+    with kb.connect() as conn:
+        source = kb.create_task(conn, title="source", assignee="default")
+        parent = kb.create_task(conn, title="parent", assignee="default")
+
+    out = kc.run_slash(
+        "aux --micro-goal 'route validation' "
+        f"--source-task {source} --parent {parent} "
+        "--assignee default "
+        f"--evidence-root {tmp_path / 'evidence'} "
+        "--no-steward-plan --json"
+    )
+    payload = json.loads(out)
+
+    assert payload["parent_ids"] == [parent]
+    assert payload["status"] == "todo"
+    with kb.connect() as conn:
+        assert kb.parent_ids(conn, payload["task_id"]) == [parent]
+        source_comments = kb.list_comments(conn, source)
+        assert any(payload["task_id"] in c.body for c in source_comments)
+
+
+def test_run_slash_aux_parent_context_disambiguates_idempotency_key(kanban_home, tmp_path):
+    with kb.connect() as conn:
+        parent_a = kb.create_task(conn, title="parent a", assignee="default")
+        parent_b = kb.create_task(conn, title="parent b", assignee="default")
+
+    base_command = (
+        "aux --micro-goal 'same goal' "
+        f"--project {tmp_path / 'project'} "
+        "--assignee default "
+        f"--evidence-root {tmp_path / 'evidence'} "
+        "--no-steward-plan --json"
+    )
+    first = json.loads(kc.run_slash(f"{base_command} --parent {parent_a}"))
+    second = json.loads(kc.run_slash(f"{base_command} --parent {parent_b}"))
+
+    assert first["idempotency_key"].startswith(f"kanban-aux:{parent_a}:")
+    assert second["idempotency_key"].startswith(f"kanban-aux:{parent_b}:")
+    assert second["idempotency_key"] != first["idempotency_key"]
+    assert first["task_id"] != second["task_id"]
+    assert first["reused"] is False
+    assert second["reused"] is False
+    assert first["parent_ids"] == [parent_a]
+    assert second["parent_ids"] == [parent_b]
+    with kb.connect() as conn:
+        assert kb.parent_ids(conn, first["task_id"]) == [parent_a]
+        assert kb.parent_ids(conn, second["task_id"]) == [parent_b]
+        assert len(kb.list_tasks(conn)) == 4
+
+
+def test_run_slash_aux_dry_run_and_missing_assignee(kanban_home, tmp_path):
+    dry = json.loads(
+        kc.run_slash(
+            "aux --micro-goal 'inspect board pressure' --assignee default "
+            f"--evidence-root {tmp_path / 'evidence'} "
+            "--no-steward-plan --dry-run --json"
+        )
+    )
+
+    assert dry["dry_run"] is True
+    assert dry["task_id"] is None
+    assert not Path(dry["evidence"]["path"]).exists()
+    with kb.connect() as conn:
+        assert kb.list_tasks(conn) == []
+
+    missing = kc.run_slash("aux --assignee no-such-profile --no-steward-plan")
+    assert "no-such-profile" in missing
+    assert "does not exist" in missing
+
+
+def test_cli_process_propagates_aux_error_exit_code(tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+    env["HERMES_HOME"] = str(home)
+    for key in ("HERMES_PROFILE", "HERMES_KANBAN_BOARD", "HERMES_KANBAN_DB"):
+        env.pop(key, None)
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "hermes_cli.main",
+            "kanban",
+            "aux",
+            "--assignee",
+            "no-such-profile",
+            "--no-steward-plan",
+        ],
+        cwd=Path(__file__).parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert proc.returncode != 0
+    assert "no-such-profile" in proc.stderr
+    assert "does not exist" in proc.stderr
 
 
 def test_run_slash_dispatch_dry_run_counts(kanban_home):

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -247,6 +247,41 @@ hermes kanban create "nightly ops review" \
     --json
 ```
 
+### Auxiliary coordinator launcher
+
+When a board needs a light coordination pass — dedupe, parent repair,
+evidence pointers, or routing follow-up cards to existing profiles — use
+`hermes kanban aux` instead of adding another dispatcher or hand-writing a
+swarm. The launcher creates (or reuses) exactly one idempotent coordinator
+card assigned to an existing profile lane (`kanban-aux`, `autopilot`, or
+`default` by default; override with `--assignee`).
+
+```bash
+hermes kanban aux \
+    --micro-goal "dedupe the release board and route missing validation" \
+    --project ~/code/my-project \
+    --assignee autopilot \
+    --max-created 3 \
+    --json
+```
+
+The generated card explicitly tells the auxiliary worker not to call
+`hermes kanban aux` recursively, not to create profiles/skills/cron/gateways,
+and to cap itself to one coordination pass. It uses a deterministic
+`kanban-aux:<parent_id|root>:<project>:<lane>:<micro_goal>:v1` idempotency key
+(single-parent launches use that parent id; multi-parent launches use a stable
+hash of the parent set), writes a redacted local evidence event
+(`~/.omo/evidence/kanban-aux/` when a `.omo` workspace exists, otherwise under
+Hermes home), and comments only the path + sha256 back onto Kanban.
+
+If a Project Steward plan is present at
+`~/.omo/plans/hermes-project-steward-runtime.md`, the launcher references it in
+the card body and preserves its MVP boundaries: local-only, one selected
+project/fixture, one card, one micro-goal, serial foreground runner, Kanban as
+summary-level state, and detailed evidence stored locally. Use
+`--no-steward-plan` to suppress that section or `--steward-plan <path>` to pin a
+different plan.
+
 ### Bulk CLI verbs
 
 All the lifecycle verbs accept multiple ids so you can clean up a batch
@@ -651,6 +686,10 @@ hermes kanban create "<title>" [--body ...] [--assignee <profile>]
                                 [--goal] [--goal-max-turns N]
                                 [--skill <name>]...
                                 [--json]
+hermes kanban aux [--source-task <id>] [--parent <id>]... [--project <path|slug>]
+                   [--micro-goal "..."] [--assignee <profile>] [--max-created N]
+                   [--evidence-root <path>] [--steward-plan <path>|--no-steward-plan]
+                   [--dry-run] [--json]
 hermes kanban list [--mine] [--assignee P] [--status S] [--tenant T] [--archived]
         [--workflow-template-id <id>] [--current-step-key <key>]
         [--sort created|created-desc|priority|priority-desc|status|assignee|title|updated]


### PR DESCRIPTION
## Summary
- Add `hermes kanban aux` / `launch-aux`, a thin idempotent launcher that creates or reuses one bounded auxiliary coordinator card through the existing Kanban DB/dispatcher flow.
- Scope the default aux idempotency key by parent context (`root`, single parent id, or stable multi-parent digest) so identical project/micro-goal launches under different dependencies do not reuse the wrong card.
- Report DB parent links after create/reuse, write local redacted evidence pointers, document the operational flow, and propagate integer CLI return codes so validation errors exit non-zero.

## Test plan
- `uv run --extra dev ruff check hermes_cli/main.py hermes_cli/kanban_aux.py hermes_cli/kanban.py tests/hermes_cli/test_kanban_cli.py`
- `git diff --check`
- `uv run --extra dev pytest tests/hermes_cli/test_kanban_cli.py -q -o 'addopts='`
- `uv run --extra dev pytest tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_kanban_core_functionality.py tests/tools/test_kanban_tools.py -q -o 'addopts='`
- `uv run --extra dev pytest tests/hermes_cli/test_subparser_routing_fallback.py tests/hermes_cli/test_slack_cli.py -q -o 'addopts='`
- Isolated temp-`HERMES_HOME` smoke: aux dry-run JSON succeeds without writing a card; invalid assignee/max-created/max-runtime commands return non-zero.
