### PR TITLE
fix(bedrock): add prompt-cache pricing to Claude Bedrock entries

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -451,6 +451,8 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
     ): PricingEntry(
         input_cost_per_million=Decimal("15.00"),
         output_cost_per_million=Decimal("75.00"),
+        cache_read_cost_per_million=Decimal("1.50"),
+        cache_write_cost_per_million=Decimal("18.75"),
         source="official_docs_snapshot",
         source_url="https://aws.amazon.com/bedrock/pricing/",
         pricing_version="bedrock-pricing-2026-04",
@@ -461,6 +463,8 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
     ): PricingEntry(
         input_cost_per_million=Decimal("3.00"),
         output_cost_per_million=Decimal("15.00"),
+        cache_read_cost_per_million=Decimal("0.30"),
+        cache_write_cost_per_million=Decimal("3.75"),
         source="official_docs_snapshot",
         source_url="https://aws.amazon.com/bedrock/pricing/",
         pricing_version="bedrock-pricing-2026-04",
@@ -471,6 +475,8 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
     ): PricingEntry(
         input_cost_per_million=Decimal("3.00"),
         output_cost_per_million=Decimal("15.00"),
+        cache_read_cost_per_million=Decimal("0.30"),
+        cache_write_cost_per_million=Decimal("3.75"),
         source="official_docs_snapshot",
         source_url="https://aws.amazon.com/bedrock/pricing/",
         pricing_version="bedrock-pricing-2026-04",
@@ -481,6 +487,8 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
     ): PricingEntry(
         input_cost_per_million=Decimal("0.80"),
         output_cost_per_million=Decimal("4.00"),
+        cache_read_cost_per_million=Decimal("0.08"),
+        cache_write_cost_per_million=Decimal("1.00"),
         source="official_docs_snapshot",
         source_url="https://aws.amazon.com/bedrock/pricing/",
         pricing_version="bedrock-pricing-2026-04",


### PR DESCRIPTION
## Problem

The Bedrock Claude pricing entries (added in `bedrock-pricing-2026-04`) set `input_cost_per_million` and `output_cost_per_million` but omit cache rates. As a result, `cache_read_tokens` and `cache_write_tokens` are billed at **$0** in cost estimates — so a cached agentic session (where the cached system+tools prefix is usually the *majority* of input) reports a cost far below reality.

## Fix

Add the standard Anthropic prompt-cache multipliers to the four Claude Bedrock entries (same rates apply on Bedrock):

- cache **read** = `0.1×` base input
- 5-minute cache **write** = `1.25×` base input

| model | input | cache_read | cache_write |
|---|--:|--:|--:|
| claude-opus-4-6 | 15.00 | 1.50 | 18.75 |
| claude-sonnet-4-6 | 3.00 | 0.30 | 3.75 |
| claude-sonnet-4-5 | 3.00 | 0.30 | 3.75 |
| claude-haiku-4-5 | 0.80 | 0.08 | 1.00 |

Input/output rates are unchanged. (Nova/other Bedrock models also support caching with different multipliers and could be added separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
