### PR TITLE
fix(gateway): normalize PATH in systemd unit staleness check

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2544,6 +2544,31 @@ def _normalize_launchd_plist_for_comparison(text: str) -> str:
     )
 
 
+def _normalize_systemd_unit_for_comparison(text: str) -> str:
+    """Normalize systemd unit text for staleness checks.
+
+    ``generate_systemd_unit()`` uses ``shutil.which("node")`` to locate the
+    node binary, which depends on the ambient ``PATH`` of the calling
+    process.  When called from different CLI contexts (e.g. ``gateway
+    restart`` vs ``gateway status``), the resolved node directory can differ —
+    the restart context may include ``~/.hermes/node/bin`` while the status
+    context does not — causing the PATH line to differ even though the
+    service definition is functionally identical.
+
+    Mirror the launchd approach: replace the ``Environment="PATH=…"``
+    payload with a stable placeholder so PATH differences that are purely
+    environmental don't trigger perpetual "outdated" warnings.
+    """
+    import re
+
+    normalized = _normalize_service_definition(text)
+    return re.sub(
+        r'(Environment="PATH=)(.*?)(")',
+        r"\1__HERMES_PATH__\3",
+        normalized,
+    )
+
+
 def systemd_unit_is_current(system: bool = False) -> bool:
     unit_path = get_systemd_unit_path(system=system)
     if not unit_path.exists():
@@ -2555,11 +2580,18 @@ def systemd_unit_is_current(system: bool = False) -> bool:
     # Normalize out directives that older systemd versions silently drop
     # (RestartMaxDelaySec, RestartSteps) so a unit that differs only by
     # those directives is not perpetually flagged as outdated.
+    # Also normalize the PATH payload — generate_systemd_unit() uses
+    # shutil.which("node") which depends on the ambient environment, so
+    # the PATH line can differ between CLI contexts (restart vs status).
     norm_installed = _normalize_service_definition(
-        _strip_optional_systemd_directives(installed)
+        _strip_optional_systemd_directives(
+            _normalize_systemd_unit_for_comparison(installed)
+        )
     )
     norm_expected = _normalize_service_definition(
-        _strip_optional_systemd_directives(expected)
+        _strip_optional_systemd_directives(
+            _normalize_systemd_unit_for_comparison(expected)
+        )
     )
     return norm_installed == norm_expected
 

--- a/tests/hermes_cli/test_systemd_optional_directives.py
+++ b/tests/hermes_cli/test_systemd_optional_directives.py
@@ -139,6 +139,93 @@ WantedBy=default.target
 
 
 class TestSystemdUnitIsCurrent:
+    def test_unit_with_different_path_is_current(self, tmp_path, monkeypatch):
+        """Units differing only in the Environment="PATH=…" line should be
+        considered current, since the PATH payload depends on the ambient
+        environment of the generating process (issue #46276)."""
+        from hermes_cli import gateway as gw
+
+        installed = """[Unit]
+Description=Hermes Gateway
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python gateway run
+Environment="PATH=/home/user/.hermes/node/bin:/usr/local/bin:/usr/bin:/bin"
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+"""
+        expected = """[Unit]
+Description=Hermes Gateway
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python gateway run
+Environment="PATH=/usr/local/bin:/usr/bin:/bin"
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+"""
+        unit_file = tmp_path / "hermes-gateway.service"
+        unit_file.write_text(installed)
+
+        monkeypatch.setattr(gw, "get_systemd_unit_path", lambda system=False: unit_file)
+        monkeypatch.setattr(
+            gw,
+            "generate_systemd_unit",
+            lambda system=False, run_as_user=None: expected,
+        )
+
+        assert gw.systemd_unit_is_current(system=False) is True
+
+    def test_unit_with_different_exec_is_not_current(self, tmp_path, monkeypatch):
+        """Units differing in non-PATH fields should still be outdated
+        even after PATH normalization."""
+        from hermes_cli import gateway as gw
+
+        installed = """[Unit]
+Description=Hermes Gateway
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python gateway run
+Environment="PATH=/usr/local/bin:/usr/bin:/bin"
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=default.target
+"""
+        expected = """[Unit]
+Description=Hermes Gateway
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python -m hermes_cli.main gateway run
+Environment="PATH=/usr/local/bin:/usr/bin:/bin"
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+"""
+        unit_file = tmp_path / "hermes-gateway.service"
+        unit_file.write_text(installed)
+
+        monkeypatch.setattr(gw, "get_systemd_unit_path", lambda system=False: unit_file)
+        monkeypatch.setattr(
+            gw,
+            "generate_systemd_unit",
+            lambda system=False, run_as_user=None: expected,
+        )
+
+        assert gw.systemd_unit_is_current(system=False) is False
+
     def test_unit_without_optional_directives_is_current(self, tmp_path, monkeypatch):
         """Installed unit missing RestartMaxDelaySec/RestartSteps should be
         considered current when the generated unit includes them."""
@@ -245,3 +332,74 @@ WantedBy=default.target
         unit_file = tmp_path / "nonexistent.service"
         monkeypatch.setattr(gw, "get_systemd_unit_path", lambda system=False: unit_file)
         assert gw.systemd_unit_is_current(system=False) is False
+
+
+# ---------------------------------------------------------------------------
+# _normalize_systemd_unit_for_comparison
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeSystemdUnitForComparison:
+    def test_replaces_path_payload(self):
+        from hermes_cli.gateway import _normalize_systemd_unit_for_comparison
+        text = 'Environment="PATH=/home/user/.hermes/node/bin:/usr/bin:/bin"'
+        result = _normalize_systemd_unit_for_comparison(text)
+        assert "__HERMES_PATH__" in result
+        assert ".hermes/node/bin" not in result
+        assert "/usr/bin" not in result
+
+    def test_preserves_non_path_environment(self):
+        from hermes_cli.gateway import _normalize_systemd_unit_for_comparison
+        text = 'Environment="HERMES_HOME=/home/user/.hermes"\nEnvironment="PATH=/usr/bin"'
+        result = _normalize_systemd_unit_for_comparison(text)
+        assert "HERMES_HOME=/home/user/.hermes" in result
+        assert "__HERMES_PATH__" in result
+
+    def test_no_path_line_unchanged(self):
+        from hermes_cli.gateway import _normalize_systemd_unit_for_comparison
+        text = "[Service]\nType=simple\nRestart=always\n"
+        result = _normalize_systemd_unit_for_comparison(text)
+        # _normalize_service_definition strips trailing whitespace, so
+        # compare content semantically rather than byte-for-byte.
+        assert "Type=simple" in result
+        assert "Restart=always" in result
+        assert "PATH" not in result
+
+    def test_full_unit_path_normalization(self):
+        """Full systemd unit with different PATH lines should normalize
+        to the same text for comparison."""
+        from hermes_cli.gateway import _normalize_systemd_unit_for_comparison
+        installed = """[Unit]
+Description=Hermes Gateway
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python gateway run
+Environment="PATH=/home/user/.hermes/node/bin:/usr/local/bin:/usr/bin:/bin"
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+"""
+        expected = """[Unit]
+Description=Hermes Gateway
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python gateway run
+Environment="PATH=/usr/local/bin:/usr/bin:/bin"
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+"""
+        norm_installed = _normalize_systemd_unit_for_comparison(installed)
+        norm_expected = _normalize_systemd_unit_for_comparison(expected)
+        assert norm_installed == norm_expected
+
+
+# ---------------------------------------------------------------------------
+# systemd_unit_is_current integration
+# ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Normalize the `Environment="PATH=…"` line in systemd unit staleness checks so that PATH differences caused by the ambient environment (e.g. `shutil.which("node")` resolving differently across CLI contexts) don't cause perpetual "outdated" warnings for per-profile gateway services.

## Related Issue

Fixes #46276

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py`: Added `_normalize_systemd_unit_for_comparison()` that replaces the `Environment="PATH=…"` payload with a stable `__HERMES_PATH__` placeholder (mirroring the existing `_normalize_launchd_plist_for_comparison()` pattern). Integrated it into `systemd_unit_is_current()` so PATH differences don't trigger false staleness.
- `tests/hermes_cli/test_systemd_optional_directives.py`: Added `TestNormalizeSystemdUnitForComparison` (4 unit tests) and 2 integration tests for `systemd_unit_is_current()` covering PATH-only differences and non-PATH differences.

## How to Test

1. `pytest tests/hermes_cli/test_systemd_optional_directives.py -v` — all 17 tests pass
2. On a Linux system with systemd user services and a named profile:
   - `hermes -p <profile> gateway restart`
   - `hermes -p <profile> gateway status` — should NOT show "outdated" warning
3. Verify that genuinely different service definitions (e.g. changed ExecStart) still trigger the outdated warning

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/gateway.py::_normalize_systemd_unit_for_comparison`, `systemd_unit_is_current`
- Blast radius: LOW — only affects systemd unit staleness comparison, no runtime behavior change
- Related patterns: Mirrors existing `_normalize_launchd_plist_for_comparison()` for launchd plist staleness checks
