### PR TITLE
feat(whatsapp): support opt-in multi-bubble replies

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -428,6 +428,20 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             get_hermes_dir("platforms/whatsapp/session", "whatsapp/session")
         ))
         self._reply_prefix: Optional[str] = config.extra.get("reply_prefix")
+        self._split_outgoing_on_blank_lines = str(
+            config.extra.get("split_outgoing_on_blank_lines", "false")
+        ).strip().lower() in {"true", "1", "yes", "on"}
+        self._split_outgoing_delay_seconds = self._coerce_float_extra(
+            "split_outgoing_delay_seconds", 0.6
+        )
+        try:
+            self._split_outgoing_max_parts = int(
+                config.extra.get("split_outgoing_max_parts", 4)
+            )
+        except (TypeError, ValueError):
+            self._split_outgoing_max_parts = 4
+        if self._split_outgoing_max_parts < 1:
+            self._split_outgoing_max_parts = 4
         self._dm_policy = str(config.extra.get("dm_policy") or _wenv("WHATSAPP_DM_POLICY", "pairing")).strip().lower()
         # Prefer config.extra, then the documented WHATSAPP_ALLOWED_USERS env
         # (setup wizard / pairing mirror). Select by key *presence* so an
@@ -939,9 +953,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         try:
             import aiohttp
 
-            # Format and chunk the message
+            # Format, optionally split into conversational bubbles, then apply
+            # the existing code-block-aware length chunking to every part.
             formatted = self.format_message(content)
-            chunks = self.truncate_message(formatted, self._outgoing_chunk_limit())
+            chunks = []
+            for part in self._outgoing_message_parts(formatted):
+                chunks.extend(self.truncate_message(part, self._outgoing_chunk_limit()))
 
             sent_message_ids: list[str] = []
             last_message_id = None
@@ -971,7 +988,10 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
                 # Small delay between chunks to avoid rate limiting
                 if len(chunks) > 1:
-                    await asyncio.sleep(0.3)
+                    delay = 0.3
+                    if getattr(self, "_split_outgoing_on_blank_lines", False):
+                        delay = getattr(self, "_split_outgoing_delay_seconds", 0.6)
+                    await asyncio.sleep(delay)
 
             return SendResult(
                 success=True,
@@ -981,6 +1001,46 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             )
         except Exception as e:
             return SendResult(success=False, error=str(e))
+
+    def _outgoing_message_parts(self, formatted: str) -> list[str]:
+        """Split on blank lines outside triple-backtick fenced code blocks."""
+        if not getattr(self, "_split_outgoing_on_blank_lines", False):
+            return [formatted]
+
+        parts: list[str] = []
+        current: list[str] = []
+        in_fence = False
+
+        for line in formatted.split("\n"):
+            stripped = line.lstrip()
+            indent = len(line) - len(stripped)
+
+            if indent <= 3 and re.match(r"```(?!`)", stripped):
+                if in_fence:
+                    if re.fullmatch(r"[ \t]{0,3}```[ \t]*", line):
+                        in_fence = False
+                else:
+                    in_fence = True
+
+            if not line.strip() and not in_fence:
+                part = "\n".join(current).strip()
+                if part:
+                    parts.append(part)
+                current = []
+                continue
+
+            current.append(line)
+
+        final_part = "\n".join(current).strip()
+        if final_part:
+            parts.append(final_part)
+        if len(parts) <= 1:
+            return [formatted]
+
+        max_parts = getattr(self, "_split_outgoing_max_parts", 4)
+        if max_parts > 0 and len(parts) > max_parts:
+            return parts[: max_parts - 1] + ["\n\n".join(parts[max_parts - 1 :])]
+        return parts
 
     async def edit_message(
         self,

--- a/tests/gateway/test_whatsapp_formatting.py
+++ b/tests/gateway/test_whatsapp_formatting.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.config import Platform
+from gateway.config import Platform, PlatformConfig
 
 
 @pytest.fixture(autouse=True)
@@ -44,6 +44,9 @@ def _make_adapter():
     adapter._bridge_log = None
     adapter._bridge_process = None
     adapter._reply_prefix = None
+    adapter._split_outgoing_on_blank_lines = False
+    adapter._split_outgoing_delay_seconds = 0.6
+    adapter._split_outgoing_max_parts = 4
     adapter._running = True
     adapter._message_handler = None
     adapter._fatal_error_code = None
@@ -129,6 +132,55 @@ class TestMessageLimits:
         )
 
 
+class TestOutgoingSplitConfig:
+    def test_defaults_are_opt_out_with_documented_values(self):
+        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+        adapter = WhatsAppAdapter(PlatformConfig(enabled=True))
+
+        assert adapter._split_outgoing_on_blank_lines is False
+        assert adapter._split_outgoing_delay_seconds == 0.6
+        assert adapter._split_outgoing_max_parts == 4
+
+    def test_values_are_config_backed_and_invalid_values_fall_back_safely(self):
+        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+        configured = WhatsAppAdapter(
+            PlatformConfig(
+                enabled=True,
+                extra={
+                    "split_outgoing_on_blank_lines": "yes",
+                    "split_outgoing_delay_seconds": "1.25",
+                    "split_outgoing_max_parts": "7",
+                },
+            )
+        )
+        invalid = WhatsAppAdapter(
+            PlatformConfig(
+                enabled=True,
+                extra={
+                    "split_outgoing_on_blank_lines": "sometimes",
+                    "split_outgoing_delay_seconds": "nan",
+                    "split_outgoing_max_parts": -2,
+                },
+            )
+        )
+        malformed_max = WhatsAppAdapter(
+            PlatformConfig(
+                enabled=True,
+                extra={"split_outgoing_max_parts": "many"},
+            )
+        )
+
+        assert configured._split_outgoing_on_blank_lines is True
+        assert configured._split_outgoing_delay_seconds == 1.25
+        assert configured._split_outgoing_max_parts == 7
+        assert invalid._split_outgoing_on_blank_lines is False
+        assert invalid._split_outgoing_delay_seconds == 0.6
+        assert invalid._split_outgoing_max_parts == 4
+        assert malformed_max._split_outgoing_max_parts == 4
+
+
 # ---------------------------------------------------------------------------
 # send() chunking tests
 # ---------------------------------------------------------------------------
@@ -180,6 +232,119 @@ class TestSendChunking:
             payload = call.kwargs.get("json") or call[1].get("json")
             final_text = adapter.DEFAULT_REPLY_PREFIX + payload["message"]
             assert len(final_text) <= adapter.MAX_MESSAGE_LENGTH
+
+    @pytest.mark.asyncio
+    async def test_blank_line_split_is_opt_in(self):
+        adapter = _make_adapter()
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        await adapter.send("chat1", "one\n\ntwo")
+
+        payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
+        assert [payload["message"] for payload in payloads] == ["one\n\ntwo"]
+
+    @pytest.mark.asyncio
+    async def test_blank_lines_split_bubbles_but_single_newlines_do_not(self):
+        adapter = _make_adapter()
+        adapter._split_outgoing_on_blank_lines = True
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        await adapter.send("chat1", "one\n\ntwo\nthree")
+
+        payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
+        assert [payload["message"] for payload in payloads] == ["one", "two\nthree"]
+
+    @pytest.mark.asyncio
+    async def test_blank_line_split_merges_remainder_at_max_parts(self):
+        adapter = _make_adapter()
+        adapter._split_outgoing_on_blank_lines = True
+        adapter._split_outgoing_max_parts = 3
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+
+        await adapter.send("chat1", "one\n\ntwo\n\nthree\n\nfour")
+
+        payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
+        assert [payload["message"] for payload in payloads] == [
+            "one",
+            "two",
+            "three\n\nfour",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_legacy_chunk_delay_remains_point_three_when_opted_out(self, monkeypatch):
+        adapter = _make_adapter()
+        adapter._split_outgoing_delay_seconds = 1.25
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+        sleep = AsyncMock()
+        monkeypatch.setattr(asyncio, "sleep", sleep)
+
+        await adapter.send("chat1", "a " * 3000)
+
+        assert adapter._http_session.post.call_count > 1
+        sleep.assert_awaited()
+        assert {call.args[0] for call in sleep.await_args_list} == {0.3}
+
+    @pytest.mark.asyncio
+    async def test_configured_split_delay_is_used_when_opted_in(self, monkeypatch):
+        adapter = _make_adapter()
+        adapter._split_outgoing_on_blank_lines = True
+        adapter._split_outgoing_delay_seconds = 1.25
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+        sleep = AsyncMock()
+        monkeypatch.setattr(asyncio, "sleep", sleep)
+
+        await adapter.send("chat1", "one\n\ntwo")
+
+        sleep.assert_awaited()
+        assert {call.args[0] for call in sleep.await_args_list} == {1.25}
+
+    @pytest.mark.asyncio
+    async def test_blank_lines_inside_fenced_code_stay_in_one_bubble(self):
+        adapter = _make_adapter()
+        adapter._split_outgoing_on_blank_lines = True
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+        content = "intro\n\n```python\nfirst()\n\nsecond()\n```\n\noutro"
+
+        await adapter.send("chat1", content)
+
+        payloads = [call.kwargs["json"] for call in adapter._http_session.post.call_args_list]
+        assert [payload["message"] for payload in payloads] == [
+            "intro",
+            "```python\nfirst()\n\nsecond()\n```",
+            "outro",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_length_chunking_still_balances_fences_after_bubble_split(self):
+        adapter = _make_adapter()
+        adapter._split_outgoing_on_blank_lines = True
+        resp = MagicMock(status=200)
+        resp.json = AsyncMock(return_value={"messageId": "msg1"})
+        adapter._http_session.post = MagicMock(return_value=_AsyncCM(resp))
+        code = "```python\n" + ("print('hello')\n" * 400) + "\nprint('done')\n```"
+
+        await adapter.send("chat1", f"intro\n\n{code}")
+
+        messages = [
+            call.kwargs["json"]["message"]
+            for call in adapter._http_session.post.call_args_list
+        ]
+        assert messages[0] == "intro"
+        assert len(messages) > 2
+        assert all(message.startswith("```python\n") for message in messages[1:])
+        assert all("```" in message.removeprefix("```python\n") for message in messages[1:])
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -195,6 +195,25 @@ WhatsApp supports **streaming (progressive) responses** — the bot edits its me
 
 Long responses are automatically split into multiple messages at **4,096 characters** per chunk (WhatsApp's practical display limit). You don't need to configure anything — the gateway handles splitting and sends chunks sequentially.
 
+### Optional Multi-Bubble Replies
+
+By default, Hermes sends one formatted reply and only creates additional messages when the reply exceeds the length limit. You can opt into splitting a reply at blank lines so separate paragraphs arrive as separate WhatsApp bubbles:
+
+```yaml
+# ~/.hermes/config.yaml
+gateway:
+  platforms:
+    whatsapp:
+      extra:
+        split_outgoing_on_blank_lines: true
+        split_outgoing_delay_seconds: 0.6
+        split_outgoing_max_parts: 4
+```
+
+With this option enabled, `First paragraph.\n\nSecond paragraph.` sends two bubbles. A single newline stays within one bubble. Blank lines inside triple-backtick fenced code blocks do not split the code block.
+
+`split_outgoing_max_parts` limits the number of paragraph-based parts (default `4`); any remaining paragraphs are merged into the final part rather than discarded. `split_outgoing_delay_seconds` controls the delay between sends while this mode is enabled (default `0.6`). Length-based chunking still applies to every resulting part and preserves fenced code blocks across chunks.
+
 ### WhatsApp-Compatible Markdown
 
 Standard Markdown in AI responses is automatically converted to WhatsApp's native formatting:


### PR DESCRIPTION
## Summary

WhatsApp profiles can opt into sending one assistant reply as several short message bubbles. When enabled, blank lines outside fenced code blocks become bubble boundaries. The default remains unchanged.

## Changes

- Add config-backed outgoing splitting to `plugins/platforms/whatsapp/adapter.py`:
  - `split_outgoing_on_blank_lines` (default `false`)
  - `split_outgoing_delay_seconds` (default `0.6`)
  - `split_outgoing_max_parts` (default `4`)
- Preserve existing opt-out behavior, including length-based chunking and the existing `0.3s` inter-chunk delay.
- Keep single newlines within one bubble.
- Keep blank lines inside native triple-backtick fenced code blocks within the same bubble.
- Merge overflow paragraphs into the final configured part without dropping content.
- Apply existing code-aware length truncation after paragraph splitting.
- Preserve `replyTo` only on the first outgoing chunk.
- Document the opt-in configuration in the current WhatsApp guide.

## Validation

```text
19 passed  — focused formatting suite with strict runtime warnings
127 passed — complete tests/gateway/test_whatsapp*.py suite
Ruff passed
Python compile check passed
git diff --check passed
```

The complete WhatsApp run emitted one existing `AsyncMock` cleanup warning from an unchanged group-gating test; the focused formatting suite was clean.
