### PR TITLE
fix(gateway): deterministic systemd unit PATH for named profiles (#46276)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2390,12 +2390,12 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
     detected_venv = _detect_venv_dir()
     venv_dir = str(detected_venv) if detected_venv else str(PROJECT_ROOT / "venv")
 
+    # _build_service_path_dirs() deterministically includes hermes_home/node/bin
+    # and project_root/node_modules/.bin when they exist, so avoid
+    # shutil.which("node") here — it is environment-sensitive and can
+    # produce different PATH entries across gateway/context invocations,
+    # causing per-profile user units to appear perpetually outdated (#46276).
     path_entries = _build_service_path_dirs()
-    resolved_node = shutil.which("node")
-    if resolved_node:
-        resolved_node_dir = str(Path(resolved_node).resolve().parent)
-        if resolved_node_dir not in path_entries:
-            path_entries.append(resolved_node_dir)
 
     common_bin_paths = [
         "/usr/local/sbin",

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -433,11 +433,17 @@ class TestGeneratedSystemdUnits:
         assert self._expected_timeout_stop_sec() in unit
 
     def test_user_unit_includes_resolved_node_directory_in_path(self, monkeypatch):
+        # shutil.which("node") is no longer used to build the service PATH
+        # to avoid environment-dependent non-determinism (#46276). The node
+        # path is added deterministically by _build_service_path_dirs() when
+        # hermes_home/node/bin exists.
         monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: "/home/test/.nvm/versions/node/v24.14.0/bin/node" if cmd == "node" else None)
 
         unit = gateway_cli.generate_systemd_unit(system=False)
 
-        assert "/home/test/.nvm/versions/node/v24.14.0/bin" in unit
+        # The nvm node path should NOT appear — only deterministic paths
+        # from _build_service_path_dirs() are included.
+        assert "/home/test/.nvm/versions/node/v24.14.0/bin" not in unit
 
     def test_user_unit_includes_wsl_windows_interop_paths(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "is_wsl", lambda: True)


### PR DESCRIPTION
Fixes #46276. _build_service_path_dirs() now includes the base hermes root node/bin and node_modules/.bin alongside the profile-specific ones, so the PATH in generated service units is stable regardless of whether the calling context is a named profile or the base home. Removed the environment-dependent shutil.which('node') fallback from generate_systemd_unit() and generate_launchd_unit() that was the root cause of the PATH drift between restart/install and status checks.