### PR TITLE
fix(deps): resolve npm audit vulnerabilities via overrides (esbuild, joi)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1356,7 +1356,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1373,7 +1372,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1390,7 +1388,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1407,7 +1404,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1424,7 +1420,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1441,7 +1436,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1458,7 +1452,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1475,7 +1468,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1492,7 +1484,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1509,7 +1500,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1526,7 +1516,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1543,7 +1532,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1560,7 +1548,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1577,7 +1564,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1594,7 +1580,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1611,7 +1596,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1628,7 +1612,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1645,7 +1628,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1662,7 +1644,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1679,7 +1660,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1696,7 +1676,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1713,7 +1692,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1730,7 +1708,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1747,7 +1724,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1764,7 +1740,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1781,7 +1756,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
   },
   "overrides": {
     "lodash": "4.18.1",
-    "@assistant-ui/store": "0.2.13"
+    "@assistant-ui/store": "0.2.13",
+    "esbuild": "^0.28.1",
+    "joi": "^18.2.1"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
## What changed

Adds two entries to the root `package.json` `overrides` block to force fixed transitive dependency versions:

- **`esbuild ^0.28.1`** — fixes [GHSA-gv7w-rqvm-qjhr](https://github.com/advisories/GHSA-gv7w-rqvm-qjhr) (RCE via `NPM_CONFIG_REGISTRY`) and [GHSA-g7r4-m6w7-qqqr](https://github.com/advisories/GHSA-g7r4-m6w7-qqqr) (arbitrary file read in the dev server on Windows). Vulnerable range `0.17.0–0.28.0`, pulled in transitively via `tsx`/vite tooling in `apps/desktop`.
- **`joi ^18.2.1`** — fixes [GHSA-q7cg-457f-vx79](https://github.com/advisories/GHSA-q7cg-457f-vx79) (uncaught `RangeError` on deeply nested input through recursive `link()` schemas). Vulnerable range `18.0.0–18.2.0`, pulled in via `wait-on`.

`package-lock.json` is regenerated to match.

## Why overrides instead of `npm audit fix --force`

`npm audit fix --force` is not usable in this workspace: it triggers an npm 11 bug (`Cannot read properties of null (reading 'edgesOut')`) and rewrites unrelated workspace `package.json` files (`apps/bootstrap-installer`, `ui-tui`, `web`) — adding `esbuild` as a *direct* dependency and bumping `vite` — without ever completing. Root `overrides` is the clean, monorepo-wide mechanism that forces every nested copy to the patched version without per-workspace churn.

## Verification

- `npm audit` → **0 vulnerabilities** (was 1 moderate + 2 high)
- Desktop app rebuilt successfully via `npm run pack` — `tsc -b` + `vite build` (vite 8.0.16, esbuild 0.28.1) + `electron-builder`; `Hermes.exe` packaged and asset assertions pass.

## Notes for reviewers

- The high-severity esbuild advisories are dev-server-only and do not affect the shipped (prebuilt) desktop bundle — this is hardening, not an active runtime hole.
- The lockfile diff is large because the reconciling `npm install` also deduped/flattened the tree (net reduction in lockfile size); no intended version changes beyond esbuild, joi, and the vite 8.0.10→8.0.16 patch they pulled along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)