### PR TITLE
fix(telegram): make Bot API 10.1 rich messages opt-in (default off)

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -421,6 +421,14 @@ class TelegramAdapter(BasePlatformAdapter):
         self._disable_link_previews: bool = self._coerce_bool_extra("disable_link_previews", False)
         # Bot API 10.1 Rich Messages: send final replies via sendRichMessage
         # with the raw agent markdown so tables/task lists/etc. render natively.
+        # Opt-in (default off): clients without Bot API 10.1 rich rendering
+        # (e.g. the Telegram macOS desktop app, AyuGram) accept the message
+        # but display a BLANK bubble or "not supported" error. sendRichMessage
+        # carries no plaintext fallback and the Bot API exposes no
+        # recipient-client signal, so forcing it on silently breaks delivery.
+        # Enable per bot when every client is known to render rich content:
+        # platforms.telegram.extra.rich_messages: true
+        self._rich_messages_enabled: bool = self._coerce_bool_extra("rich_messages", False)
         # Latched off after a capability failure on sendRichMessage /
         # sendRichMessageDraft (e.g. older python-telegram-bot without the
         # endpoint) so later sends skip the doomed rich attempt entirely.
@@ -954,7 +962,8 @@ class TelegramAdapter(BasePlatformAdapter):
         self, content: str, metadata: Optional[Dict[str, Any]] = None
     ) -> bool:
         return bool(
-            not getattr(self, "_rich_send_disabled", False)
+            self._rich_messages_enabled
+            and not getattr(self, "_rich_send_disabled", False)
             and not (metadata or {}).get("expect_edits")
             and content
             and content.strip()
@@ -995,7 +1004,8 @@ class TelegramAdapter(BasePlatformAdapter):
         streams split exactly as before.
         """
         if (
-            not getattr(self, "_rich_send_disabled", False)
+            self._rich_messages_enabled
+            and not getattr(self, "_rich_send_disabled", False)
             and self._bot_supports_rich()
         ):
             return self.RICH_MESSAGE_MAX_CHARS
@@ -1184,7 +1194,8 @@ class TelegramAdapter(BasePlatformAdapter):
 
     def _should_attempt_rich_draft(self, content: str) -> bool:
         return bool(
-            not getattr(self, "_rich_send_disabled", False)
+            self._rich_messages_enabled
+            and not getattr(self, "_rich_send_disabled", False)
             and not getattr(self, "_rich_draft_disabled", False)
             and content
             and content.strip()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1982,6 +1982,9 @@ DEFAULT_CONFIG = {
         "reactions": False,            # Add 👀/✅/❌ reactions to messages during processing
         "channel_prompts": {},         # Per-chat/topic ephemeral system prompts (topics inherit from parent group)
         "allowed_chats": "",           # If set, bot ONLY responds in these group/supergroup chat IDs (whitelist)
+        "extra": {
+            "rich_messages": False,     # Bot API 10.1 rich messages (opt-in: blank on clients that can't render them, e.g. AyuGram)
+        },
     },
 
     # Mattermost platform settings (gateway mode)


### PR DESCRIPTION
## Problem

Rich messages (`sendRichMessage` Bot API 10.1) are always enabled by default. Clients without Bot API 10.1 rich rendering — notably **AyuGram**, **Telegram Web**, and the **macOS desktop app** — accept the message but display either a BLANK bubble or a "This message is not supported" error. `sendRichMessage` carries no plaintext fallback and the Bot API exposes no recipient-client signal, so forcing it on silently breaks delivery for those users.

Fixes #46098, #45785

## Changes

- **`gateway/platforms/telegram.py`**: Added `_rich_messages_enabled` flag that reads from `platforms.telegram.extra.rich_messages` (default `False`). Gates `_should_attempt_rich`, `prefers_fresh_final_streaming`, `streaming_overflow_limit`, and `_should_attempt_rich_draft`.
- **`hermes_cli/config.py`**: Added `extra.rich_messages: False` to `DEFAULT_CONFIG` for the telegram section.

## Behavior

- Default: rich messages OFF (legacy MarkdownV2/sendMessage path)
- Opt-in: `platforms.telegram.extra.rich_messages: true` in config.yaml
- Existing `_rich_send_disabled` / `_rich_draft_disabled` latch mechanisms still apply on top

## Testing

Verified locally on AyuGram — replies render correctly with `rich_messages: false`. Gateway restarted and confirmed working.