### PR TITLE
[codex] Fix desktop image data URL extraction

### DIFF
--- a/apps/desktop/src/lib/embedded-images.test.ts
+++ b/apps/desktop/src/lib/embedded-images.test.ts
@@ -32,4 +32,35 @@ describe('extractEmbeddedImages', () => {
     expect(result.cleanedText).toBe('first  mid  tail')
     expect(result.images).toEqual([SAMPLE_PNG_DATA_URL, second])
   })
+
+  it('caps extracted images and removes overflow data URLs from visible text', () => {
+    const urls = Array.from({ length: 4 }, (_, index) => `data:image/png;base64,${String(index).repeat(96)}`)
+    const result = extractEmbeddedImages(urls.join(' '), { maxImages: 2 })
+
+    expect(result.images).toEqual(urls.slice(0, 2))
+    expect(result.cleanedText).toBe('')
+  })
+
+  it('leaves short invalid data:image URLs untouched', () => {
+    const short = 'data:image/png;base64,AAAA'
+
+    expect(extractEmbeddedImages(`show ${short}`)).toEqual({ cleanedText: `show ${short}`, images: [] })
+  })
+
+  it('handles multi-megabyte image data URLs without recursive regex overflow', () => {
+    const large = 'data:image/jpeg;base64,' + 'A'.repeat(6_000_000)
+    const result = extractEmbeddedImages(`before ${large} after`)
+
+    expect(result.cleanedText).toBe('before  after')
+    expect(result.images).toHaveLength(1)
+    expect(result.images[0]).toHaveLength(large.length)
+  })
+
+  it('handles multi-megabyte JSON-wrapped image_url data URLs', () => {
+    const large = 'data:image/jpeg;base64,' + 'A'.repeat(6_000_000)
+    const result = extractEmbeddedImages(`before {"type":"image_url","image_url":{"url":"${large}"}} after`)
+
+    expect(result.cleanedText).toBe('before  after')
+    expect(result.images).toEqual([large])
+  })
 })

--- a/apps/desktop/src/lib/embedded-images.ts
+++ b/apps/desktop/src/lib/embedded-images.ts
@@ -1,6 +1,3 @@
-const EMBEDDED_IMAGE_RE =
-  /(\{\s*"type"\s*:\s*"image_url"\s*,\s*"image_url"\s*:\s*\{\s*"url"\s*:\s*")?(data:image\/[\w.+-]+;base64,[A-Za-z0-9+/=]{64,})("\s*\}\s*\})?/g
-
 const DATA_URL_RE = /^data:([\w./+-]+);base64,(.*)$/i
 
 export const DATA_IMAGE_URL_RE = /^data:image\/[\w.+-]+;base64,/i
@@ -8,6 +5,112 @@ export const DATA_IMAGE_URL_RE = /^data:image\/[\w.+-]+;base64,/i
 export interface EmbeddedImageExtraction {
   cleanedText: string
   images: string[]
+}
+
+const DEFAULT_MAX_EMBEDDED_IMAGES = 24
+const DATA_IMAGE_PREFIX = 'data:image/'
+const BASE64_MARKER = ';base64,'
+const MIN_EMBEDDED_IMAGE_BASE64_CHARS = 64
+const JSON_IMAGE_URL_OPEN_RE =
+  /^\{\s*"type"\s*:\s*"image_url"\s*,\s*"image_url"\s*:\s*\{\s*"url"\s*:\s*"$/i
+const JSON_IMAGE_URL_OPEN_LOOKBEHIND = 2_048
+
+function isMimeSubtypeChar(code: number): boolean {
+  return (
+    (code >= 48 && code <= 57) ||
+    (code >= 65 && code <= 90) ||
+    (code >= 97 && code <= 122) ||
+    code === 43 ||
+    code === 45 ||
+    code === 46 ||
+    code === 95
+  )
+}
+
+function isBase64Char(code: number): boolean {
+  return (
+    (code >= 48 && code <= 57) ||
+    (code >= 65 && code <= 90) ||
+    (code >= 97 && code <= 122) ||
+    code === 43 ||
+    code === 47 ||
+    code === 61
+  )
+}
+
+function isJsonWhitespace(code: number): boolean {
+  return code === 9 || code === 10 || code === 13 || code === 32
+}
+
+function startsWithIgnoreCase(text: string, value: string, index: number): boolean {
+  return text.slice(index, index + value.length).toLowerCase() === value
+}
+
+function parseDataImageUrlAt(text: string, start: number): { end: number } | null {
+  let index = start + DATA_IMAGE_PREFIX.length
+  const subtypeStart = index
+
+  while (index < text.length && isMimeSubtypeChar(text.charCodeAt(index))) {
+    index += 1
+  }
+
+  if (index === subtypeStart || !startsWithIgnoreCase(text, BASE64_MARKER, index)) {
+    return null
+  }
+
+  index += BASE64_MARKER.length
+  const base64Start = index
+
+  while (index < text.length && isBase64Char(text.charCodeAt(index))) {
+    index += 1
+  }
+
+  return index - base64Start >= MIN_EMBEDDED_IMAGE_BASE64_CHARS ? { end: index } : null
+}
+
+function jsonImageEnvelopeStart(text: string, cursor: number, dataUrlStart: number): number {
+  const lookbehindStart = Math.max(cursor, dataUrlStart - JSON_IMAGE_URL_OPEN_LOOKBEHIND)
+  let candidateStart = text.indexOf('{', lookbehindStart)
+
+  while (candidateStart !== -1 && candidateStart < dataUrlStart) {
+    if (JSON_IMAGE_URL_OPEN_RE.test(text.slice(candidateStart, dataUrlStart))) {
+      return candidateStart
+    }
+
+    candidateStart = text.indexOf('{', candidateStart + 1)
+  }
+
+  return dataUrlStart
+}
+
+function consumeJsonImageEnvelopeClose(text: string, start: number): number {
+  let index = start
+
+  if (text.charCodeAt(index) !== 34) {
+    return start
+  }
+
+  index += 1
+
+  while (index < text.length && isJsonWhitespace(text.charCodeAt(index))) {
+    index += 1
+  }
+
+  if (text.charCodeAt(index) !== 125) {
+    return start
+  }
+
+  index += 1
+
+  while (index < text.length && isJsonWhitespace(text.charCodeAt(index))) {
+    index += 1
+  }
+
+  return text.charCodeAt(index) === 125 ? index + 1 : start
+}
+
+function normalizeCleanedText(text: string): string {
+  return text.replace(/[ \t]+\n/g, '\n').replace(/\n{3,}/g, '\n\n').trim()
 }
 
 export function dataUrlToBlob(dataUrl: string): Blob | null {
@@ -31,22 +134,52 @@ export function dataUrlToBlob(dataUrl: string): Blob | null {
   }
 }
 
-export function extractEmbeddedImages(text: string): EmbeddedImageExtraction {
+export function extractEmbeddedImages(
+  text: string,
+  { maxImages = DEFAULT_MAX_EMBEDDED_IMAGES }: { maxImages?: number } = {}
+): EmbeddedImageExtraction {
   if (!text || !text.includes('data:image/')) {
     return { cleanedText: text, images: [] }
   }
 
   const images: string[] = []
+  const cleanedChunks: string[] = []
+  let cursor = 0
+  let searchFrom = 0
 
-  const cleanedText = text
-    .replace(EMBEDDED_IMAGE_RE, (_match, _open, dataUrl: string) => {
-      images.push(dataUrl)
+  // Avoid running a global regex over multi-megabyte base64 strings; V8 can
+  // overflow the renderer stack before React gets a chance to paint an error.
+  while (searchFrom < text.length) {
+    const dataUrlStart = text.indexOf(DATA_IMAGE_PREFIX, searchFrom)
 
-      return ''
-    })
-    .replace(/[ \t]+\n/g, '\n')
-    .replace(/\n{3,}/g, '\n\n')
-    .trim()
+    if (dataUrlStart === -1) {
+      break
+    }
+
+    const parsed = parseDataImageUrlAt(text, dataUrlStart)
+
+    if (!parsed) {
+      searchFrom = dataUrlStart + DATA_IMAGE_PREFIX.length
+      continue
+    }
+
+    const matchStart = jsonImageEnvelopeStart(text, cursor, dataUrlStart)
+    const matchEnd =
+      matchStart === dataUrlStart ? parsed.end : consumeJsonImageEnvelopeClose(text, parsed.end)
+
+    cleanedChunks.push(text.slice(cursor, matchStart))
+
+    if (images.length < maxImages) {
+      images.push(text.slice(dataUrlStart, parsed.end))
+    }
+
+    cursor = matchEnd
+    searchFrom = matchEnd
+  }
+
+  cleanedChunks.push(text.slice(cursor))
+
+  const cleanedText = normalizeCleanedText(cleanedChunks.join(''))
 
   return { cleanedText, images }
 }


### PR DESCRIPTION
## Summary

Fixes the Desktop renderer crash when a large uploaded image is embedded as a `data:image/...;base64,...` URL in a user message.

The previous implementation used one global regex over the whole message body. Multi-megabyte base64 image previews can overflow the renderer stack before the error boundary can recover. This replaces the regex extraction with a bounded scanner that:

- finds `data:image/*;base64,` URLs iteratively
- preserves support for JSON-wrapped `image_url` envelopes
- removes overflow image URLs from visible text even when `maxImages` is reached
- leaves short invalid `data:image` strings alone

Closes #44785.

## Validation

- `npx vitest run src/lib/embedded-images.test.ts`
- `npm run typecheck`
