### PR TITLE
[codex] Add Codex learning harvester and curator integration

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -217,6 +217,8 @@ def run_codex_app_server_turn(
         turn = agent._codex_session.run_turn(user_input=user_message)
     except Exception as exc:
         logger.exception("codex app-server turn failed")
+        agent._last_codex_error = str(exc)
+        agent._last_codex_completed_at = time.time()
         # Crash → unconditionally drop the session so the next turn
         # respawns from scratch instead of reusing a dead client.
         try:
@@ -251,6 +253,11 @@ def run_codex_app_server_turn(
         except Exception:
             pass
         agent._codex_session = None
+
+    agent._last_codex_thread_id = turn.thread_id
+    agent._last_codex_turn_id = turn.turn_id
+    agent._last_codex_error = turn.error or ""
+    agent._last_codex_completed_at = time.time()
 
     # Splice projected messages into the conversation. The projector emits
     # standard {role, content, tool_calls, tool_call_id} entries, which

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1,19 +1,20 @@
 """Curator — background skill maintenance orchestrator.
 
-The curator is an auxiliary-model task that periodically reviews agent-created
-skills and maintains the collection. It runs inactivity-triggered (no cron
-daemon): when the agent is idle and the last curator run was longer than
+The curator is an auxiliary-model task that periodically reviews
+curator-managed skills and maintains the collection. It runs
+inactivity-triggered (no cron daemon): when the agent is idle and the last
+curator run was longer than
 ``interval_hours`` ago, ``maybe_run_curator()`` spawns a forked AIAgent to do
 the review.
 
 Responsibilities:
   - Auto-transition lifecycle states based on derived skill activity timestamps
   - Spawn a background review agent that can pin / archive / consolidate /
-    patch agent-created skills via skill_manage
+    patch curator-managed skills via skill_manage
   - Persist curator state (last_run_at, paused, etc.) in .curator_state
 
 Strict invariants:
-  - Only touches agent-created skills (see tools/skill_usage.is_agent_created)
+  - Only touches scope-filtered skills from tools.skill_usage
   - Never auto-deletes — only archives. Archive is recoverable.
   - Pinned skills bypass all auto-transitions
   - Uses the auxiliary client; never touches the main session's prompt cache
@@ -170,11 +171,15 @@ def get_archive_after_days() -> int:
         return DEFAULT_ARCHIVE_AFTER_DAYS
 
 
+def get_scope() -> str:
+    return skill_usage.curator_scope()
+
+
 def get_prune_builtins() -> bool:
     """Whether the curator may prune (archive) bundled built-in skills too.
 
     ON by default. When on, built-ins become curation candidates and are
-    archived after the same inactivity period as agent-created skills, with a
+    archived after the same inactivity period as other managed skills, with a
     suppression list keeping them archived across `hermes update` re-seeds.
     Hub-installed skills are never pruned regardless of this flag.
     """
@@ -356,8 +361,8 @@ CURATOR_REVIEW_PROMPT = (
     "bodies + `references/`, `templates/`, and `scripts/` subfiles for "
     "session-specific detail — not one-session-one-skill micro-entries.\n\n"
     "Hard rules — do not violate:\n"
-    "1. DO NOT touch bundled or hub-installed skills. The candidate list "
-    "below is already filtered to agent-created skills only.\n"
+    "1. DO NOT touch hub-installed skills. The candidate list below is "
+    "already filtered to curator-managed candidates only.\n"
     "2. DO NOT delete any skill. Archiving (moving the skill's directory "
     "into ~/.hermes/skills/.archive/) is the maximum destructive action. "
     "Archives are recoverable; deletion is not.\n"
@@ -1211,7 +1216,7 @@ def _render_report_markdown(p: Dict[str, Any]) -> str:
     counts = p.get("counts") or {}
     lines.append(
         f"Model: `{model}` via `{prov}`  ·  Duration: {dur_label}  ·  "
-        f"Agent-created skills: {counts.get('before', 0)} → {counts.get('after', 0)} "
+        f"Curator-managed skills: {counts.get('before', 0)} → {counts.get('after', 0)} "
         f"({counts.get('delta', 0):+d})\n"
     )
 
@@ -1385,11 +1390,11 @@ def _render_report_markdown(p: Dict[str, Any]) -> str:
 # ---------------------------------------------------------------------------
 
 def _render_candidate_list() -> str:
-    """Human/agent-readable list of agent-created skills with usage stats."""
+    """Human/agent-readable list of curator-managed skills with usage stats."""
     rows = skill_usage.agent_created_report()
     if not rows:
-        return "No agent-created skills to review."
-    lines = [f"Agent-created skills ({len(rows)}):\n"]
+        return "No curator-managed skills to review."
+    lines = [f"Curator-managed skills ({len(rows)}; scope={get_scope()}):\n"]
     for r in rows:
         lines.append(
             f"- {r['name']}  "
@@ -1413,7 +1418,7 @@ def run_curator_review(
 
     Steps:
       1. Apply automatic state transitions (pure, no LLM).
-      2. If there are agent-created skills, spawn a forked AIAgent that runs
+      2. If there are curator-managed skills, spawn a forked AIAgent that runs
          the LLM review prompt against the current candidate list.
       3. Update .curator_state with last_run_at and a one-line summary.
       4. Invoke *on_summary* with a user-visible description.
@@ -1492,7 +1497,7 @@ def run_curator_review(
         llm_meta: Dict[str, Any] = {}
         try:
             candidate_list = _render_candidate_list()
-            if "No agent-created skills" in candidate_list:
+            if "No curator-managed skills" in candidate_list:
                 final_summary = f"{prefix}{auto_summary}; llm: skipped (no candidates)"
                 llm_meta = {
                     "final": "",
@@ -1512,10 +1517,9 @@ def run_curator_review(
                     builtins_note = (
                         "\n\nPRUNE-BUILTINS MODE IS ON: bundled built-in skills "
                         "ARE included in the candidate list below and MAY be "
-                        "archived for staleness/irrelevance, overriding hard "
-                        "rule #1 for bundled skills ONLY. Hub-installed skills "
-                        "remain strictly off-limits. Treat a stale built-in the "
-                        "same as a stale agent-created skill: archive it (never "
+                        "archived for staleness/irrelevance. Hub-installed "
+                        "skills remain strictly off-limits. Treat a stale built-in the "
+                        "same as a stale managed skill: archive it (never "
                         "delete). It will be restored on `hermes update` only if "
                         "the user explicitly restores it."
                     )

--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -1,12 +1,13 @@
 """Curator snapshot + rollback.
 
-A pre-run snapshot of ``~/.hermes/skills/`` (excluding ``.curator_backups/``
-itself) is taken before any mutating curator pass. Snapshots are tar.gz
-files under ``~/.hermes/skills/.curator_backups/<utc-iso>/`` with a
-companion ``manifest.json`` describing the snapshot (reason, time, size,
-counted skill files). Rollback picks a snapshot, moves the current
-``skills/`` tree aside into another snapshot so even the rollback itself
-is undoable, then extracts the chosen snapshot into place.
+A pre-run snapshot of every managed skills root (``~/.hermes/skills/`` plus
+configured ``skills.external_dirs``) is taken before any mutating curator pass.
+Snapshots are tar.gz files under
+``~/.hermes/skills/.curator_backups/<utc-iso>/`` with a companion
+``manifest.json`` describing the roots, reason, time, size, and counted skill
+files. Rollback picks a snapshot, takes a safety snapshot of current roots so
+even the rollback itself is undoable, then extracts each root archive back
+into the same configured root.
 
 The snapshot does NOT include:
   - ``.curator_backups/`` (would recurse)
@@ -49,7 +50,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_constants import get_hermes_home
-from agent.skill_utils import is_excluded_skill_path
+from agent.skill_utils import get_all_skills_dirs, is_excluded_skill_path
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +74,22 @@ def _backups_dir() -> Path:
 
 def _skills_dir() -> Path:
     return get_hermes_home() / "skills"
+
+
+def _skill_roots() -> List[Path]:
+    """Return existing managed skill roots in runtime resolution order."""
+    roots: List[Path] = []
+    seen = set()
+    for root in get_all_skills_dirs():
+        try:
+            resolved = root.resolve()
+        except OSError:
+            resolved = root
+        if resolved in seen or not root.exists() or not root.is_dir():
+            continue
+        seen.add(resolved)
+        roots.append(root)
+    return roots
 
 
 def _cron_jobs_file() -> Path:
@@ -185,15 +202,27 @@ def _count_skill_files(base: Path) -> int:
 
 def _write_manifest(dest: Path, reason: str, archive_path: Path,
                     skills_counted: int,
-                    cron_info: Optional[Dict[str, Any]] = None) -> None:
+                    cron_info: Optional[Dict[str, Any]] = None,
+                    skill_roots: Optional[List[Dict[str, Any]]] = None) -> None:
+    archive_bytes = 0
+    if skill_roots:
+        for root_info in skill_roots:
+            try:
+                archive_bytes += int(root_info.get("archive_bytes") or 0)
+            except (TypeError, ValueError):
+                continue
+    else:
+        archive_bytes = archive_path.stat().st_size
     manifest = {
         "id": dest.name,
         "reason": reason,
         "created_at": datetime.now(timezone.utc).isoformat(),
         "archive": archive_path.name,
-        "archive_bytes": archive_path.stat().st_size,
+        "archive_bytes": archive_bytes,
         "skill_files": skills_counted,
     }
+    if skill_roots is not None:
+        manifest["skill_roots"] = skill_roots
     if cron_info is not None:
         manifest["cron_jobs"] = {
             "backed_up": bool(cron_info.get("backed_up", False)),
@@ -249,23 +278,41 @@ def snapshot_skills(reason: str = "manual") -> Optional[Path]:
         logger.debug("Failed to create snapshot dir %s: %s", dest, e)
         return None
 
-    archive = dest / "skills.tar.gz"
+    roots = _skill_roots()
+    if not roots:
+        logger.debug("No managed skills directories — nothing to back up")
+        return None
+
+    primary_archive = dest / "skills.tar.gz"
     try:
-        # Stream into the tarball — no tempdir copy needed.
-        with tarfile.open(archive, "w:gz", compresslevel=6) as tf:
-            for entry in sorted(skills.iterdir()):
-                if entry.name in _EXCLUDE_TOP_LEVEL:
-                    continue
-                # arcname: store paths relative to skills/ so extraction
-                # drops cleanly back into the skills dir.
-                tf.add(str(entry), arcname=entry.name, recursive=True)
+        skill_roots: List[Dict[str, Any]] = []
+        for idx, root in enumerate(roots):
+            root_id = "local" if idx == 0 else f"external-{idx}"
+            archive_name = "skills.tar.gz" if idx == 0 else f"skills-{root_id}.tar.gz"
+            archive = dest / archive_name
+            # Stream into the tarball — no tempdir copy needed.
+            with tarfile.open(archive, "w:gz", compresslevel=6) as tf:
+                for entry in sorted(root.iterdir()):
+                    if entry.name in _EXCLUDE_TOP_LEVEL:
+                        continue
+                    # arcname: store paths relative to the root so extraction
+                    # drops cleanly back into that same skills dir.
+                    tf.add(str(entry), arcname=entry.name, recursive=True)
+            skill_roots.append({
+                "id": root_id,
+                "path": str(root),
+                "archive": archive.name,
+                "archive_bytes": archive.stat().st_size,
+                "skill_files": _count_skill_files(root),
+            })
         # Capture cron/jobs.json alongside the tarball. Never fails the
         # snapshot — the skills side is the core guarantee; cron is
         # additive. We still record in the manifest whether it was
         # captured so rollback can surface "no cron data in this snapshot".
         cron_info = _backup_cron_jobs_into(dest)
-        _write_manifest(dest, reason, archive,
-                        _count_skill_files(skills),
+        _write_manifest(dest, reason, primary_archive,
+                        sum(int(r.get("skill_files") or 0) for r in skill_roots),
+                        skill_roots=skill_roots,
                         cron_info=cron_info)
     except (OSError, tarfile.TarError) as e:
         logger.debug("Curator snapshot failed: %s", e, exc_info=True)
@@ -381,6 +428,114 @@ def _resolve_backup(backup_id: Optional[str]) -> Optional[Path]:
         if c.is_dir() and _ID_RE.match(c.name) and (c / "skills.tar.gz").exists()
     ]
     return candidates[0] if candidates else None
+
+
+def _configured_root_map() -> Dict[str, Path]:
+    roots: Dict[str, Path] = {}
+    for root in _skill_roots():
+        try:
+            roots[str(root.resolve())] = root
+        except OSError:
+            roots[str(root)] = root
+    return roots
+
+
+def _manifest_root_specs(target: Path, manifest: Dict[str, Any]) -> List[Dict[str, Any]]:
+    raw = manifest.get("skill_roots")
+    if isinstance(raw, list) and raw:
+        specs: List[Dict[str, Any]] = []
+        for idx, item in enumerate(raw):
+            if not isinstance(item, dict):
+                continue
+            archive_name = str(item.get("archive") or "").strip()
+            root_path = str(item.get("path") or "").strip()
+            if not archive_name or not root_path:
+                continue
+            specs.append({
+                "id": str(item.get("id") or f"root-{idx}"),
+                "path": root_path,
+                "archive": archive_name,
+            })
+        if specs:
+            return specs
+    # Backward compatibility for snapshots created before multi-root support.
+    return [{
+        "id": "local",
+        "path": str(_skills_dir()),
+        "archive": str(manifest.get("archive") or "skills.tar.gz"),
+    }]
+
+
+def _resolve_root_specs(target: Path, manifest: Dict[str, Any]) -> Tuple[bool, str, List[Dict[str, Any]]]:
+    configured = _configured_root_map()
+    resolved_specs: List[Dict[str, Any]] = []
+    for spec in _manifest_root_specs(target, manifest):
+        root_path = Path(spec["path"])
+        try:
+            root_key = str(root_path.resolve())
+        except OSError:
+            root_key = str(root_path)
+        root = configured.get(root_key)
+        if root is None:
+            return (
+                False,
+                f"snapshot root {root_path} is no longer configured as a skills root",
+                [],
+            )
+        archive = target / spec["archive"]
+        if not archive.exists():
+            return False, f"snapshot {target.name} is missing {archive.name}", []
+        resolved_specs.append({
+            "id": spec["id"],
+            "root": root,
+            "archive": archive,
+        })
+    if not resolved_specs:
+        return False, f"snapshot {target.name} has no restorable skill roots", []
+    return True, "", resolved_specs
+
+
+def _safe_extract_archive(archive: Path, dest: Path) -> None:
+    with tarfile.open(archive, "r:gz") as tf:
+        # Python 3.12+ supports filter='data' for safer extraction.
+        # Fall back to the unfiltered call for older interpreters but still
+        # reject absolute paths and .. components defensively.
+        for member in tf.getmembers():
+            name = member.name
+            if name.startswith("/") or ".." in Path(name).parts:
+                raise tarfile.TarError(f"refusing to extract unsafe path: {name!r}")
+        try:
+            tf.extractall(str(dest), filter="data")  # type: ignore[call-arg]
+        except TypeError:
+            # Python < 3.12 — no filter kwarg
+            tf.extractall(str(dest))
+
+
+def _restore_moved(moved: List[Tuple[Path, Path]]) -> None:
+    for orig, staged in reversed(moved):
+        try:
+            if orig.exists():
+                continue
+            shutil.move(str(staged), str(orig))
+        except OSError:
+            pass
+
+
+def _clear_restorable_entries(root_specs: List[Dict[str, Any]]) -> None:
+    for spec in root_specs:
+        root: Path = spec["root"]
+        if not root.exists():
+            continue
+        for entry in list(root.iterdir()):
+            if entry.name in _EXCLUDE_TOP_LEVEL:
+                continue
+            try:
+                if entry.is_dir() and not entry.is_symlink():
+                    shutil.rmtree(entry)
+                else:
+                    entry.unlink()
+            except OSError:
+                pass
 
 
 def _restore_cron_skill_links(snapshot_dir: Path) -> Dict[str, Any]:
@@ -527,16 +682,16 @@ def _restore_cron_skill_links(snapshot_dir: Path) -> Dict[str, Any]:
 
 
 def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]]:
-    """Restore ``~/.hermes/skills/`` from a snapshot.
+    """Restore managed skill roots from a snapshot.
 
     Strategy:
       1. Resolve the target snapshot (explicit id or newest regular).
       2. Take a safety snapshot of the CURRENT skills tree under
          ``.curator_backups/pre-rollback-<ts>/`` so the rollback itself is
          undoable.
-      3. Move all current top-level entries (except ``.curator_backups``
+      3. Move each current root's top-level entries (except ``.curator_backups``
          and ``.hub``) into a tempdir.
-      4. Extract the chosen snapshot into ``~/.hermes/skills/``.
+      4. Extract each chosen root snapshot back into that same root.
       5. On failure during 4, move the tempdir contents back (best-effort)
          and return failure.
 
@@ -551,9 +706,10 @@ def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]
             + " (use `hermes curator rollback --list` to see available snapshots)",
             None,
         )
-    archive = target / "skills.tar.gz"
-    if not archive.exists():
-        return (False, f"snapshot {target.name} has no skills.tar.gz — corrupted?", None)
+    manifest = _read_manifest(target)
+    ok, msg, root_specs = _resolve_root_specs(target, manifest)
+    if not ok:
+        return (False, msg, None)
 
     skills = _skills_dir()
     skills.mkdir(parents=True, exist_ok=True)
@@ -580,49 +736,34 @@ def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]
 
     moved: List[Tuple[Path, Path]] = []
     try:
-        for entry in list(skills.iterdir()):
-            if entry.name in _EXCLUDE_TOP_LEVEL:
-                continue
-            dest = staged / entry.name
-            shutil.move(str(entry), str(dest))
-            moved.append((entry, dest))
+        for spec in root_specs:
+            root: Path = spec["root"]
+            root.mkdir(parents=True, exist_ok=True)
+            stage_root = staged / str(spec["id"]).replace("/", "_")
+            stage_root.mkdir(parents=True, exist_ok=True)
+            for entry in list(root.iterdir()):
+                if entry.name in _EXCLUDE_TOP_LEVEL:
+                    continue
+                dest = stage_root / entry.name
+                shutil.move(str(entry), str(dest))
+                moved.append((entry, dest))
     except OSError as e:
         # Best-effort rollback of the move
-        for orig, dest in moved:
-            try:
-                shutil.move(str(dest), str(orig))
-            except OSError:
-                pass
+        _restore_moved(moved)
         try:
             shutil.rmtree(staged, ignore_errors=True)
         except OSError:
             pass
         return (False, f"failed to stage current skills: {e}", None)
 
-    # Step 4: extract the snapshot into skills/
+    # Step 4: extract each root snapshot into its configured root.
     try:
-        with tarfile.open(archive, "r:gz") as tf:
-            # Python 3.12+ supports filter='data' for safer extraction.
-            # Fall back to the unfiltered call for older interpreters but
-            # still reject absolute paths and .. components defensively.
-            for member in tf.getmembers():
-                name = member.name
-                if name.startswith("/") or ".." in Path(name).parts:
-                    raise tarfile.TarError(
-                        f"refusing to extract unsafe path: {name!r}"
-                    )
-            try:
-                tf.extractall(str(skills), filter="data")  # type: ignore[call-arg]
-            except TypeError:
-                # Python < 3.12 — no filter kwarg
-                tf.extractall(str(skills))
+        for spec in root_specs:
+            _safe_extract_archive(spec["archive"], spec["root"])
     except (OSError, tarfile.TarError) as e:
         # Best-effort recover: move staged contents back
-        for orig, dest in moved:
-            try:
-                shutil.move(str(dest), str(orig))
-            except OSError:
-                pass
+        _clear_restorable_entries(root_specs)
+        _restore_moved(moved)
         try:
             shutil.rmtree(staged, ignore_errors=True)
         except OSError:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7069,6 +7069,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return ("Agent is running — wait or /stop first, then "
                         "change runtime.")
 
+            # /codex is a cockpit/readout surface and may also launch an
+            # independent Codex driver process in a clean worktree. It should
+            # not interrupt the active Hermes turn.
+            if _cmd_def_inner and _cmd_def_inner.name == "codex":
+                return await self._handle_codex_command(event)
+
             # /approve and /deny must bypass the running-agent interrupt path.
             # The agent thread is blocked on a threading.Event inside
             # tools/approval.py — sending an interrupt won't unblock it.
@@ -7445,6 +7451,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         if canonical == "codex-runtime":
             return await self._handle_codex_runtime_command(event)
+
+        if canonical == "codex":
+            return await self._handle_codex_command(event)
 
         if canonical == "personality":
             return await self._handle_personality_command(event)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1921,6 +1921,9 @@ def _format_gateway_process_notification(evt: dict) -> "str | None":
         text += "]"
         return text
 
+    if evt_type == "codex_learning_staged":
+        return f"[IMPORTANT: {evt.get('message', '')}]"
+
     return None
 
 
@@ -9010,7 +9013,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 while not _pr.completion_queue.empty():
                     evt = _pr.completion_queue.get_nowait()
                     evt_type = evt.get("type", "completion")
-                    if evt_type in {"watch_match", "watch_disabled"}:
+                    if evt_type in {"watch_match", "watch_disabled", "codex_learning_staged"}:
                         _watch_events.append(evt)
                     # else: completion events are handled by the watcher task
                 for evt in _watch_events:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1445,6 +1445,94 @@ class GatewaySlashCommandsMixin:
         prefix = "✓" if result.success else "✗"
         return f"{prefix} {result.message}"
 
+    async def _handle_codex_command(self, event: MessageEvent) -> str:
+        """Handle /codex cockpit commands.
+
+        `/codex-runtime` remains the low-level transport toggle. This command
+        is the operator-facing cockpit for readouts, staged context, and
+        launching Codex driver tasks in clean git worktrees.
+        """
+        from hermes_cli import codex_cockpit as cockpit
+        from hermes_cli.config import load_config
+
+        raw_args = event.get_command_args().strip() if event else ""
+        parsed = cockpit.parse_codex_command(raw_args)
+        if parsed.action == "error":
+            return f"Could not parse /codex arguments: {parsed.tokens[0]}"
+        if parsed.action == "help":
+            return cockpit.render_help()
+
+        try:
+            cfg = load_config()
+        except Exception as exc:
+            return f"Could not load config: {exc}"
+
+        source = event.source
+        session_key = self._session_key_for_source(source)
+        active_agent = self._running_agents.get(session_key)
+        cwd = os.environ.get("TERMINAL_CWD") or str(Path.home())
+
+        transcript: list[dict[str, Any]] = []
+        try:
+            session_entry = self.session_store.get_or_create_session(source)
+            transcript = self.session_store.load_transcript(session_entry.session_id)
+        except Exception:
+            logger.debug("could not load transcript for /codex", exc_info=True)
+
+        process_sessions: list[dict[str, Any]] = []
+        try:
+            from tools.process_registry import process_registry
+
+            process_sessions = process_registry.list_sessions()
+        except Exception:
+            logger.debug("could not list process registry for /codex", exc_info=True)
+
+        if parsed.action == "status":
+            return cockpit.render_status(
+                cfg,
+                active_agent=active_agent,
+                process_sessions=process_sessions,
+                transcript=transcript,
+                cwd=cwd,
+                session_key=session_key,
+            )
+        if parsed.action == "last":
+            return cockpit.render_last(transcript, active_agent=active_agent)
+        if parsed.action == "checks":
+            return cockpit.render_checks(process_sessions)
+        if parsed.action == "context":
+            return cockpit.render_context()
+        if parsed.action == "launch":
+            plan, error = cockpit.prepare_launch(raw_args, cfg, cwd=cwd)
+            if error:
+                return error
+            assert plan is not None
+            try:
+                from tools.process_registry import process_registry
+
+                proc = process_registry.spawn_local(
+                    plan.command,
+                    cwd=plan.repo_root,
+                    task_id=plan.task_id,
+                    session_key=session_key,
+                    use_pty=True,
+                )
+            except Exception as exc:
+                logger.warning("/codex launch failed", exc_info=True)
+                return f"Codex launch failed: {exc}"
+            return "\n".join(
+                [
+                    "Codex driver launched.",
+                    f"- Process: `{proc.id}`",
+                    f"- Branch: `{plan.branch}`",
+                    f"- Worktree: `{plan.worktree_path}`",
+                    f"- Prompt: {plan.prompt_preview}",
+                    "Use `/agents` or `/codex checks` to monitor background work.",
+                ]
+            )
+
+        return f"Unknown /codex action `{parsed.action}`.\n\n{cockpit.render_help()}"
+
     async def _handle_personality_command(self, event: MessageEvent) -> str:
         """Handle /personality command - list or set a personality."""
         from gateway.run import _hermes_home, _load_gateway_config

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1502,6 +1502,8 @@ class GatewaySlashCommandsMixin:
             return cockpit.render_checks(process_sessions)
         if parsed.action == "context":
             return cockpit.render_context()
+        if parsed.action == "learn":
+            return cockpit.render_learn(parsed.tokens, cfg)
         if parsed.action == "launch":
             plan, error = cockpit.prepare_launch(raw_args, cfg, cwd=cwd)
             if error:

--- a/hermes_cli/codex_cockpit.py
+++ b/hermes_cli/codex_cockpit.py
@@ -30,6 +30,14 @@ DEFAULT_READOUT = {
 }
 
 DEFAULT_CONTEXT_HELPER = {
+    "enabled": False,
+    "harvest_launches": True,
+    "review_model": "",
+    "max_output_chars": 8000,
+    "auto_promote_memory": True,
+    "auto_promote_skills": True,
+    "min_confidence": 0.75,
+    "notify_on_stage": True,
     "propose_memory": True,
     "propose_skills": True,
     "auto_promote": False,
@@ -135,6 +143,7 @@ def render_help() -> str:
             "`/codex last` - show the latest assistant reply for this session",
             "`/codex checks` - summarize recent validation-looking background processes",
             "`/codex context` - show pending memory/skill promotions",
+            "`/codex learn status|pending|apply|discard` - review Codex learning proposals",
             "`/codex launch <repo> <prompt>` - start Codex in a clean worktree",
         ]
     )
@@ -190,6 +199,9 @@ def render_status(
 
     mem_count, skill_count = _pending_context_counts()
     lines.append(f"- Pending context: {mem_count} memory, {skill_count} skill")
+    learning_count = _pending_learning_count()
+    if learning_count:
+        lines.append(f"- Pending Codex learning: {learning_count}")
 
     last = latest_assistant_text(transcript or [])
     if last:
@@ -258,6 +270,27 @@ def render_context() -> str:
             )
     lines.append("Promote or discard staged items with the existing `/memory` and skill review flows.")
     return "\n".join(lines)
+
+
+def render_learn(tokens: tuple[str, ...], config: Mapping[str, Any] | None) -> str:
+    """Render or apply `/codex learn ...` commands."""
+    from hermes_cli import codex_learning
+
+    action = (tokens[0].lower() if tokens else "status")
+    if action == "status":
+        return codex_learning.render_learn_status(config)
+    if action == "pending":
+        return codex_learning.render_learn_pending()
+    if action == "apply":
+        target = tokens[1] if len(tokens) > 1 else ""
+        return codex_learning.apply_learning(target, config)
+    if action in {"discard", "reject", "drop"}:
+        target = tokens[1] if len(tokens) > 1 else ""
+        return codex_learning.discard_learning(target)
+    return (
+        "Unknown `/codex learn` action. Use: "
+        "`/codex learn status|pending|apply <id|all>|discard <id|all>`."
+    )
 
 
 def prepare_launch(
@@ -499,6 +532,15 @@ def _pending_context_records() -> tuple[list[dict[str, Any]], list[dict[str, Any
         )
     except Exception:
         return [], []
+
+
+def _pending_learning_count() -> int:
+    try:
+        from hermes_cli import codex_learning
+
+        return codex_learning.count_pending_proposals()
+    except Exception:
+        return 0
 
 
 def _path_allowed(path: str, allowlist: tuple[str, ...]) -> bool:

--- a/hermes_cli/codex_cockpit.py
+++ b/hermes_cli/codex_cockpit.py
@@ -1,0 +1,557 @@
+"""Codex cockpit helpers.
+
+This module keeps the Hermes/Codex integration split cleanly:
+
+* Hermes is the cockpit: status, launch orchestration, context review.
+* Codex is the driver: coding work runs in Codex app-server or codex exec.
+
+The functions here are intentionally gateway/CLI-neutral so slash commands,
+tests, and future UI surfaces can share the same parsing and rendering.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import subprocess
+import time
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+
+DEFAULT_READOUT = {
+    "include_git_status": True,
+    "include_recent_tool_events": True,
+    "include_checks": True,
+    "max_events": 25,
+}
+
+DEFAULT_CONTEXT_HELPER = {
+    "propose_memory": True,
+    "propose_skills": True,
+    "auto_promote": False,
+}
+
+
+@dataclass(frozen=True)
+class CodexCockpitConfig:
+    enabled: bool
+    driver: str
+    default_model: str
+    default_worktree_root: str
+    branch_prefix: str
+    repo_allowlist: tuple[str, ...]
+    readout: dict[str, Any]
+    context_helper: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class CodexCommand:
+    action: str
+    tokens: tuple[str, ...]
+    raw_args: str
+
+
+@dataclass(frozen=True)
+class LaunchPlan:
+    repo_root: str
+    worktree_path: str
+    branch: str
+    command: str
+    task_id: str
+    prompt_preview: str
+
+
+def _home_code_root() -> str:
+    return str(Path.home() / "Code")
+
+
+def load_cockpit_config(config: Mapping[str, Any] | None) -> CodexCockpitConfig:
+    """Return normalized cockpit config with conservative defaults."""
+    raw = {}
+    if isinstance(config, Mapping):
+        maybe = config.get("codex_cockpit", {})
+        if isinstance(maybe, Mapping):
+            raw = dict(maybe)
+
+    readout = dict(DEFAULT_READOUT)
+    if isinstance(raw.get("readout"), Mapping):
+        readout.update(raw["readout"])
+    context_helper = dict(DEFAULT_CONTEXT_HELPER)
+    if isinstance(raw.get("context_helper"), Mapping):
+        context_helper.update(raw["context_helper"])
+
+    allowlist_raw = raw.get("repo_allowlist")
+    if isinstance(allowlist_raw, str):
+        allowlist = [allowlist_raw]
+    elif isinstance(allowlist_raw, Iterable):
+        allowlist = [str(item) for item in allowlist_raw if str(item).strip()]
+    else:
+        allowlist = [_home_code_root()]
+
+    normalized_allowlist = tuple(
+        str(Path(os.path.expanduser(path)).resolve())
+        for path in allowlist
+        if str(path).strip()
+    )
+
+    return CodexCockpitConfig(
+        enabled=_as_bool(raw.get("enabled", True)),
+        driver=str(raw.get("driver") or "codex_app_server"),
+        default_model=str(raw.get("default_model") or "gpt-5.5"),
+        default_worktree_root=str(
+            raw.get("default_worktree_root") or "/private/tmp/hermes-codex"
+        ),
+        branch_prefix=str(raw.get("branch_prefix") or "codex/"),
+        repo_allowlist=normalized_allowlist,
+        readout=readout,
+        context_helper=context_helper,
+    )
+
+
+def parse_codex_command(raw_args: str) -> CodexCommand:
+    """Parse `/codex ...` into an action and shlex tokens."""
+    raw_args = raw_args or ""
+    try:
+        tokens = tuple(shlex.split(raw_args))
+    except ValueError as exc:
+        return CodexCommand("error", (str(exc),), raw_args)
+    if not tokens:
+        return CodexCommand("status", (), raw_args)
+    action = tokens[0].lower()
+    if action in {"?", "help"}:
+        return CodexCommand("help", tokens[1:], raw_args)
+    return CodexCommand(action, tokens[1:], raw_args)
+
+
+def render_help() -> str:
+    return "\n".join(
+        [
+            "**Codex Cockpit**",
+            "`/codex status` - show runtime, auth, active agent, git, and pending context",
+            "`/codex last` - show the latest assistant reply for this session",
+            "`/codex checks` - summarize recent validation-looking background processes",
+            "`/codex context` - show pending memory/skill promotions",
+            "`/codex launch <repo> <prompt>` - start Codex in a clean worktree",
+        ]
+    )
+
+
+def render_status(
+    config: Mapping[str, Any] | None,
+    *,
+    active_agent: Any = None,
+    process_sessions: Optional[list[dict[str, Any]]] = None,
+    transcript: Optional[list[dict[str, Any]]] = None,
+    cwd: Optional[str] = None,
+    session_key: Optional[str] = None,
+) -> str:
+    """Render a compact cockpit readout."""
+    cockpit = load_cockpit_config(config)
+    runtime = _current_runtime(config)
+    codex_ok, codex_version = _codex_binary_status()
+    auth_line = _codex_auth_line()
+
+    lines = [
+        "**Codex Cockpit**",
+        f"- Enabled: {_yes_no(cockpit.enabled)}",
+        f"- Driver: `{cockpit.driver}`",
+        f"- Hermes runtime: `{runtime}`",
+        f"- Codex CLI: {_format_binary(codex_ok, codex_version)}",
+        f"- Codex auth: {auth_line}",
+        f"- Default model: `{cockpit.default_model}`",
+        f"- Worktree root: `{cockpit.default_worktree_root}`",
+    ]
+    if session_key:
+        lines.append(f"- Session key: `{session_key}`")
+
+    lines.extend(_active_agent_lines(active_agent))
+
+    if cockpit.readout.get("include_recent_tool_events", True):
+        tool_names = _recent_tool_names(
+            transcript or [],
+            _positive_int(cockpit.readout.get("max_events"), 25),
+        )
+        if tool_names:
+            rendered_tools = ", ".join(f"`{name}`" for name in tool_names)
+            lines.append(f"- Recent tools: {rendered_tools}")
+        else:
+            lines.append("- Recent tools: none")
+
+    if cockpit.readout.get("include_git_status", True):
+        lines.extend(_git_lines(cwd))
+
+    if cockpit.readout.get("include_checks", True):
+        check_count = len(_validation_processes(process_sessions or []))
+        lines.append(f"- Recent checks: {check_count}")
+
+    mem_count, skill_count = _pending_context_counts()
+    lines.append(f"- Pending context: {mem_count} memory, {skill_count} skill")
+
+    last = latest_assistant_text(transcript or [])
+    if last:
+        lines.append(f"- Last reply: {_truncate_one_line(last, 140)}")
+    return "\n".join(lines)
+
+
+def render_last(
+    transcript: Optional[list[dict[str, Any]]],
+    *,
+    active_agent: Any = None,
+) -> str:
+    text = latest_assistant_text(transcript or [])
+    thread_id = _agent_attr(active_agent, "_last_codex_thread_id")
+    turn_id = _agent_attr(active_agent, "_last_codex_turn_id")
+    parts = ["**Codex Last**"]
+    if thread_id:
+        parts.append(f"- Thread: `{thread_id}`")
+    if turn_id:
+        parts.append(f"- Turn: `{turn_id}`")
+    if text:
+        parts.append("")
+        parts.append(text[-2500:])
+    else:
+        parts.append("- No assistant reply recorded for this session yet.")
+    return "\n".join(parts)
+
+
+def render_checks(process_sessions: Optional[list[dict[str, Any]]]) -> str:
+    checks = _validation_processes(process_sessions or [])[:8]
+    if not checks:
+        return "**Codex Checks**\nNo recent validation-looking background processes found."
+    lines = ["**Codex Checks**"]
+    for proc in checks:
+        status = str(proc.get("status") or "unknown")
+        exit_code = proc.get("exit_code")
+        suffix = f" exit={exit_code}" if exit_code is not None else ""
+        command = _truncate_one_line(str(proc.get("command") or ""), 120)
+        preview = _truncate_one_line(str(proc.get("output_preview") or ""), 160)
+        lines.append(f"- `{proc.get('session_id', 'process')}` {status}{suffix}: `{command}`")
+        if preview:
+            lines.append(f"  {preview}")
+    return "\n".join(lines)
+
+
+def render_context() -> str:
+    memory_pending, skill_pending = _pending_context_records()
+    lines = ["**Codex Context**"]
+    if not memory_pending and not skill_pending:
+        lines.append("No pending memory or skill promotions.")
+        return "\n".join(lines)
+
+    if memory_pending:
+        lines.append(f"Pending memory: {len(memory_pending)}")
+        for record in memory_pending[:5]:
+            lines.append(
+                f"- `{record.get('id', '?')}` {record.get('origin', 'foreground')}: "
+                f"{_truncate_one_line(str(record.get('summary') or ''), 140)}"
+            )
+    if skill_pending:
+        lines.append(f"Pending skills: {len(skill_pending)}")
+        for record in skill_pending[:5]:
+            lines.append(
+                f"- `{record.get('id', '?')}` {record.get('origin', 'foreground')}: "
+                f"{_truncate_one_line(str(record.get('summary') or ''), 140)}"
+            )
+    lines.append("Promote or discard staged items with the existing `/memory` and skill review flows.")
+    return "\n".join(lines)
+
+
+def prepare_launch(
+    raw_args: str,
+    config: Mapping[str, Any] | None,
+    *,
+    cwd: Optional[str] = None,
+    now: Optional[float] = None,
+) -> tuple[Optional[LaunchPlan], Optional[str]]:
+    """Validate `/codex launch` args and produce the background command."""
+    cockpit = load_cockpit_config(config)
+    if not cockpit.enabled:
+        return None, "Codex cockpit is disabled in `codex_cockpit.enabled`."
+
+    parsed = parse_codex_command(raw_args)
+    tokens = parsed.tokens if parsed.action == "launch" else tuple()
+    if len(tokens) < 2:
+        return None, "Usage: `/codex launch <repo> <prompt>`"
+
+    repo_arg = tokens[0]
+    prompt = " ".join(tokens[1:]).strip()
+    if not prompt:
+        return None, "Usage: `/codex launch <repo> <prompt>`"
+
+    repo_path = Path(os.path.expanduser(repo_arg))
+    if not repo_path.is_absolute():
+        repo_path = Path(cwd or os.getcwd()) / repo_path
+    repo_path = repo_path.resolve()
+
+    repo_root, error = resolve_git_root(str(repo_path))
+    if error:
+        return None, error
+    assert repo_root is not None
+
+    if not _path_allowed(repo_root, cockpit.repo_allowlist):
+        allowed = ", ".join(f"`{p}`" for p in cockpit.repo_allowlist) or "(none)"
+        return None, f"Repository `{repo_root}` is outside `codex_cockpit.repo_allowlist`: {allowed}"
+
+    timestamp = time.strftime("%Y%m%d-%H%M%S", time.localtime(now or time.time()))
+    slug = _slug(prompt)
+    branch_prefix = _safe_branch_prefix(cockpit.branch_prefix)
+    branch = f"{branch_prefix}{slug}-{timestamp}"
+    root = Path(os.path.expanduser(cockpit.default_worktree_root)).resolve()
+    worktree_path = root / f"{Path(repo_root).name}-{slug}-{timestamp}"
+    task_id = f"codex_{slug}_{timestamp}"
+
+    command = " && ".join(
+        [
+            f"mkdir -p {shlex.quote(str(root))}",
+            f"git -C {shlex.quote(repo_root)} fetch origin",
+            (
+                f"git -C {shlex.quote(repo_root)} worktree add "
+                f"-b {shlex.quote(branch)} {shlex.quote(str(worktree_path))} origin/main"
+            ),
+            (
+                "codex exec "
+                f"-C {shlex.quote(str(worktree_path))} "
+                f"--model {shlex.quote(cockpit.default_model)} "
+                "--sandbox workspace-write "
+                f"{shlex.quote(prompt)}"
+            ),
+        ]
+    )
+    return (
+        LaunchPlan(
+            repo_root=repo_root,
+            worktree_path=str(worktree_path),
+            branch=branch,
+            command=command,
+            task_id=task_id,
+            prompt_preview=_truncate_one_line(prompt, 120),
+        ),
+        None,
+    )
+
+
+def resolve_git_root(path: str) -> tuple[Optional[str], Optional[str]]:
+    try:
+        proc = subprocess.run(
+            ["git", "-C", path, "rev-parse", "--show-toplevel"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=10,
+        )
+    except Exception as exc:
+        return None, f"Could not inspect `{path}` as a git repo: {exc}"
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "not a git repository").strip()
+        return None, f"`{path}` is not a git repository: {detail}"
+    return str(Path(proc.stdout.strip()).resolve()), None
+
+
+def latest_assistant_text(transcript: list[dict[str, Any]]) -> str:
+    for msg in reversed(transcript):
+        if msg.get("role") != "assistant":
+            continue
+        content = msg.get("content")
+        if isinstance(content, str) and content.strip():
+            return content.strip()
+    return ""
+
+
+def _current_runtime(config: Mapping[str, Any] | None) -> str:
+    try:
+        from hermes_cli.codex_runtime_switch import get_current_runtime
+
+        return get_current_runtime(dict(config or {}))
+    except Exception:
+        return "unknown"
+
+
+def _codex_binary_status() -> tuple[bool, Optional[str]]:
+    try:
+        from hermes_cli.codex_runtime_switch import check_codex_binary_ok
+
+        return check_codex_binary_ok()
+    except Exception as exc:
+        return False, str(exc)
+
+
+def _codex_auth_line() -> str:
+    try:
+        from hermes_cli.auth import get_codex_auth_status
+
+        status = get_codex_auth_status()
+    except Exception as exc:
+        return f"unknown ({exc})"
+    if status.get("logged_in"):
+        source = status.get("source") or status.get("auth_mode") or "logged in"
+        return f"logged in ({source})"
+    error = status.get("error")
+    return f"not logged in ({error})" if error else "not logged in"
+
+
+def _active_agent_lines(active_agent: Any) -> list[str]:
+    if active_agent is None:
+        return ["- Active agent: no"]
+    lines = ["- Active agent: yes"]
+    for label, attr in (
+        ("Model", "model"),
+        ("Provider", "provider"),
+        ("API mode", "api_mode"),
+        ("CWD", "session_cwd"),
+        ("Codex thread", "_last_codex_thread_id"),
+        ("Codex turn", "_last_codex_turn_id"),
+        ("Codex error", "_last_codex_error"),
+    ):
+        value = _agent_attr(active_agent, attr)
+        if value:
+            lines.append(f"  {label}: `{value}`")
+    return lines
+
+
+def _agent_attr(active_agent: Any, attr: str) -> str:
+    if active_agent is None:
+        return ""
+    value = getattr(active_agent, attr, "")
+    if isinstance(value, (str, int, float)):
+        return str(value)
+    return ""
+
+
+def _git_lines(cwd: Optional[str]) -> list[str]:
+    if not cwd:
+        return ["- Git: no cwd"]
+    try:
+        proc = subprocess.run(
+            ["git", "-C", cwd, "status", "-sb"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=8,
+        )
+    except Exception as exc:
+        return [f"- Git: unavailable ({exc})"]
+    if proc.returncode != 0:
+        return ["- Git: not a git workspace"]
+    first = (proc.stdout or "").splitlines()[0] if proc.stdout else ""
+    return [f"- Git: `{first}`" if first else "- Git: clean/unknown"]
+
+
+def _validation_processes(process_sessions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    needles = (
+        "pytest",
+        "npm test",
+        "npm run test",
+        "npm run build",
+        "git diff --check",
+        "tsc",
+        "ruff",
+        "mypy",
+    )
+    filtered = []
+    for proc in process_sessions:
+        command = str(proc.get("command") or "").lower()
+        if any(needle in command for needle in needles):
+            filtered.append(proc)
+    return sorted(filtered, key=lambda item: str(item.get("started_at") or ""), reverse=True)
+
+
+def _recent_tool_names(transcript: list[dict[str, Any]], limit: int) -> list[str]:
+    names: list[str] = []
+    for msg in reversed(transcript):
+        tool_name = msg.get("tool_name")
+        if isinstance(tool_name, str) and tool_name.strip():
+            names.append(tool_name.strip())
+        calls = msg.get("tool_calls")
+        if isinstance(calls, list):
+            for call in reversed(calls):
+                if not isinstance(call, Mapping):
+                    continue
+                fn = call.get("function")
+                if isinstance(fn, Mapping):
+                    name = fn.get("name")
+                    if isinstance(name, str) and name.strip():
+                        names.append(name.strip())
+                if len(names) >= limit:
+                    return names
+        if len(names) >= limit:
+            return names
+    return names
+
+
+def _pending_context_counts() -> tuple[int, int]:
+    memory, skills = _pending_context_records()
+    return len(memory), len(skills)
+
+
+def _pending_context_records() -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    try:
+        from tools import write_approval
+
+        return (
+            write_approval.list_pending("memory"),
+            write_approval.list_pending("skills"),
+        )
+    except Exception:
+        return [], []
+
+
+def _path_allowed(path: str, allowlist: tuple[str, ...]) -> bool:
+    candidate = Path(path).resolve()
+    for root in allowlist:
+        try:
+            candidate.relative_to(Path(root).resolve())
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def _slug(text: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9]+", "-", text.strip().lower()).strip("-")
+    return (slug or "task")[:48].strip("-") or "task"
+
+
+def _safe_branch_prefix(prefix: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9._/-]+", "-", prefix.strip())
+    if not cleaned:
+        cleaned = "codex/"
+    return cleaned if cleaned.endswith("/") else f"{cleaned}/"
+
+
+def _truncate_one_line(text: str, limit: int) -> str:
+    one_line = " ".join(str(text).split())
+    if len(one_line) <= limit:
+        return one_line
+    return one_line[: max(0, limit - 3)].rstrip() + "..."
+
+
+def _format_binary(ok: bool, version: Optional[str]) -> str:
+    if ok:
+        return f"OK `{version or 'installed'}`"
+    return f"missing ({version or 'install codex'})"
+
+
+def _yes_no(value: bool) -> str:
+    return "yes" if value else "no"
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() not in {"0", "false", "no", "off", "disabled"}
+    return bool(value)
+
+
+def _positive_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default

--- a/hermes_cli/codex_learning.py
+++ b/hermes_cli/codex_learning.py
@@ -1,0 +1,813 @@
+"""Codex cockpit learning harvester.
+
+This module is intentionally CLI/gateway neutral. The process registry calls
+``handle_process_completed`` when a background process exits; this module
+filters for `/codex launch` processes, builds a compact learning packet, runs
+a memory/skill-only Hermes review, and records links to the staged approval
+records created by ``tools.write_approval``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import re
+import shlex
+import subprocess
+import threading
+import time
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_LEARNING = {
+    "enabled": False,
+    "harvest_launches": True,
+    "review_model": "",
+    "max_output_chars": 8000,
+    "auto_promote_memory": True,
+    "auto_promote_skills": True,
+    "min_confidence": 0.75,
+    "notify_on_stage": True,
+}
+
+
+@dataclass(frozen=True)
+class LearningConfig:
+    enabled: bool
+    harvest_launches: bool
+    review_model: str
+    max_output_chars: int
+    auto_promote_memory: bool
+    auto_promote_skills: bool
+    min_confidence: float
+    notify_on_stage: bool
+
+
+def load_learning_config(config: Mapping[str, Any] | None) -> LearningConfig:
+    """Return normalized ``codex_cockpit.context_helper`` learning settings."""
+    raw: dict[str, Any] = {}
+    if isinstance(config, Mapping):
+        cockpit = config.get("codex_cockpit", {})
+        if isinstance(cockpit, Mapping):
+            helper = cockpit.get("context_helper", {})
+            if isinstance(helper, Mapping):
+                raw = dict(helper)
+
+    merged = dict(DEFAULT_LEARNING)
+    merged.update(raw)
+    return LearningConfig(
+        enabled=_as_bool(merged.get("enabled")),
+        harvest_launches=_as_bool(merged.get("harvest_launches")),
+        review_model=str(merged.get("review_model") or "").strip(),
+        max_output_chars=_positive_int(merged.get("max_output_chars"), 8000),
+        auto_promote_memory=_as_bool(merged.get("auto_promote_memory")),
+        auto_promote_skills=_as_bool(merged.get("auto_promote_skills")),
+        min_confidence=_confidence(merged.get("min_confidence"), 0.75),
+        notify_on_stage=_as_bool(merged.get("notify_on_stage")),
+    )
+
+
+def is_codex_launch_session(session: Any) -> bool:
+    """True when a process registry session looks like `/codex launch` output."""
+    task_id = str(getattr(session, "task_id", "") or "")
+    command = str(getattr(session, "command", "") or "")
+    if not task_id.startswith("codex_"):
+        return False
+    lowered = command.lower()
+    return "codex exec" in lowered and "worktree add" in lowered
+
+
+def handle_process_completed(session: Any) -> Optional[dict[str, Any]]:
+    """Harvest and review a completed process registry session if configured."""
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config()
+    except Exception as exc:
+        logger.debug("codex learning: could not load config: %s", exc)
+        return None
+
+    learning = load_learning_config(config)
+    if not learning.enabled or not learning.harvest_launches:
+        return None
+    if not is_codex_launch_session(session):
+        return None
+
+    packet = build_learning_packet(session, config)
+    if packet_exists(packet["id"]):
+        return load_packet(packet["id"])
+    save_packet(packet)
+    start_review_thread(packet["id"], config)
+    return packet
+
+
+def build_learning_packet(session: Any, config: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Build the bounded, durable packet used by the Hermes reviewer."""
+    learning = load_learning_config(config)
+    command = str(getattr(session, "command", "") or "")
+    cwd = str(getattr(session, "cwd", "") or "")
+    process_id = str(getattr(session, "id", "") or uuid.uuid4().hex[:12])
+    output = str(getattr(session, "output_buffer", "") or "")
+    try:
+        from tools.ansi_strip import strip_ansi
+
+        output = strip_ansi(output)
+    except Exception:
+        pass
+    output_tail = output[-learning.max_output_chars:] if output else ""
+
+    repo = _resolve_repo_root(cwd) or _extract_git_repo_from_command(command) or cwd
+    worktree = _extract_codex_worktree(command)
+    branch = _extract_branch_from_command(command) or _git_branch(worktree or cwd)
+    now = time.time()
+
+    return {
+        "id": _packet_id(process_id),
+        "status": "harvested",
+        "source": "process_registry",
+        "process_id": process_id,
+        "task_id": str(getattr(session, "task_id", "") or ""),
+        "session_key": str(getattr(session, "session_key", "") or ""),
+        "pid": getattr(session, "pid", None),
+        "command": command,
+        "cwd": cwd,
+        "repo": repo,
+        "branch": branch,
+        "worktree": worktree,
+        "exit_code": getattr(session, "exit_code", None),
+        "started_at": getattr(session, "started_at", None),
+        "completed_at": now,
+        "output_tail": output_tail,
+        "output_tail_chars": len(output_tail),
+        "cockpit_status": _cockpit_status_snapshot(config),
+        "proposal_ids": [],
+        "created_at": now,
+        "updated_at": now,
+    }
+
+
+def start_review_thread(packet_id: str, config: Mapping[str, Any] | None) -> threading.Thread:
+    """Start the background Hermes reviewer for a harvested packet."""
+    thread = threading.Thread(
+        target=review_packet,
+        args=(packet_id, dict(config or {})),
+        daemon=True,
+        name=f"codex-learning-review-{packet_id}",
+    )
+    thread.start()
+    return thread
+
+
+def review_packet(packet_id: str, config: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    """Run Hermes review for a packet and record staged proposal links."""
+    packet = load_packet(packet_id)
+    if not packet:
+        raise ValueError(f"No Codex learning packet with id {packet_id!r}")
+
+    learning = load_learning_config(config)
+    packet["status"] = "reviewing"
+    packet["updated_at"] = time.time()
+    save_packet(packet)
+
+    before = _pending_id_snapshot()
+    try:
+        _run_hermes_reviewer(packet, learning)
+    except Exception as exc:
+        logger.warning("Codex learning review failed for %s: %s", packet_id, exc)
+        packet["status"] = "failed"
+        packet["error"] = str(exc)
+        packet["updated_at"] = time.time()
+        save_packet(packet)
+        return packet
+
+    after = _pending_id_snapshot()
+    proposal_ids = []
+    for subsystem in ("memory", "skills"):
+        for pending_id in sorted(after[subsystem] - before[subsystem]):
+            pending = _get_pending(subsystem, pending_id)
+            proposal = _proposal_from_pending(packet, subsystem, pending_id, pending)
+            save_proposal(proposal)
+            proposal_ids.append(proposal["id"])
+
+    packet["proposal_ids"] = proposal_ids
+    packet["reviewed_at"] = time.time()
+    packet["status"] = "staged" if proposal_ids else "reviewed"
+    packet["updated_at"] = time.time()
+    save_packet(packet)
+
+    if proposal_ids:
+        _auto_promote_if_configured(proposal_ids, learning)
+        pending_after = [
+            proposal_id
+            for proposal_id in proposal_ids
+            if (load_proposal(proposal_id) or {}).get("approval_state") == "pending"
+        ]
+        packet["status"] = "staged" if pending_after else "applied"
+        packet["updated_at"] = time.time()
+        save_packet(packet)
+        if pending_after and learning.notify_on_stage:
+            _queue_stage_notification(packet, pending_after)
+    return packet
+
+
+def render_learn_status(config: Mapping[str, Any] | None) -> str:
+    learning = load_learning_config(config)
+    packets = list_packets()
+    proposals = list_proposals()
+    pending = [p for p in proposals if p.get("approval_state") == "pending"]
+    lines = [
+        "**Codex Learn**",
+        f"- Enabled: {_yes_no(learning.enabled)}",
+        f"- Harvest launches: {_yes_no(learning.harvest_launches)}",
+        f"- Review model: `{learning.review_model or 'default Hermes model'}`",
+        f"- Max output chars: {learning.max_output_chars}",
+        f"- Min confidence: {learning.min_confidence:.2f}",
+        (
+            "- Auto promote: "
+            f"memory={_yes_no(learning.auto_promote_memory)}, "
+            f"skills={_yes_no(learning.auto_promote_skills)}"
+        ),
+        f"- Curator scope: `{_curator_scope()}`",
+        f"- Pending proposals: {len(pending)}",
+    ]
+    if packets:
+        latest = packets[-1]
+        lines.append(
+            "- Last harvest: "
+            f"`{latest.get('id')}` {latest.get('status')} "
+            f"repo=`{latest.get('repo') or '?'}` branch=`{latest.get('branch') or '?'}`"
+        )
+    else:
+        lines.append("- Last harvest: none")
+    return "\n".join(lines)
+
+
+def render_learn_pending() -> str:
+    pending = [p for p in list_proposals() if p.get("approval_state") == "pending"]
+    if not pending:
+        return "**Codex Learn Pending**\nNo pending Codex learning proposals."
+    lines = [f"**Codex Learn Pending** ({len(pending)})"]
+    for proposal in pending:
+        lines.append(
+            "- "
+            f"`{proposal['id']}` {proposal.get('subsystem')} "
+            f"confidence={float(proposal.get('confidence') or 0):.2f} "
+            f"approval={proposal.get('approval_state')} "
+            f"repo=`{proposal.get('repo') or '?'}` branch=`{proposal.get('branch') or '?'}`"
+        )
+        summary = str(proposal.get("summary") or "")
+        if summary:
+            lines.append(f"  {summary[:180]}")
+        command = str(proposal.get("source_command") or "")
+        if command:
+            lines.append(f"  command: `{_one_line(command, 180)}`")
+    lines.append("")
+    lines.append("Apply: `/codex learn apply <id|all>`   Discard: `/codex learn discard <id|all>`")
+    return "\n".join(lines)
+
+
+def apply_learning(target: str, config: Mapping[str, Any] | None = None) -> str:
+    target = (target or "").strip()
+    if not target:
+        return "Usage: `/codex learn apply <id|all>`"
+    learning = load_learning_config(config)
+    proposals = _select_proposals(target)
+    if not proposals:
+        return f"No pending Codex learning proposal with id `{target}`."
+
+    applied = 0
+    failed: list[str] = []
+    for proposal in proposals:
+        ok, message = _apply_one_proposal(proposal, learning)
+        if ok:
+            applied += 1
+        else:
+            failed.append(f"{proposal['id']}: {message}")
+
+    lines = [f"Applied {applied} Codex learning proposal(s)."]
+    if failed:
+        lines.append("Failed:")
+        lines.extend(f"  {item}" for item in failed)
+    return "\n".join(lines)
+
+
+def discard_learning(target: str) -> str:
+    target = (target or "").strip()
+    if not target:
+        return "Usage: `/codex learn discard <id|all>`"
+    proposals = _select_proposals(target)
+    if not proposals:
+        return f"No pending Codex learning proposal with id `{target}`."
+
+    discarded = 0
+    for proposal in proposals:
+        subsystem = str(proposal.get("subsystem") or "")
+        pending_id = str(proposal.get("pending_id") or "")
+        try:
+            from tools import write_approval as wa
+
+            wa.discard_pending(subsystem, pending_id)
+        except Exception:
+            pass
+        proposal["status"] = "discarded"
+        proposal["approval_state"] = "discarded"
+        proposal["discarded_at"] = time.time()
+        proposal["updated_at"] = time.time()
+        save_proposal(proposal)
+        discarded += 1
+    return f"Discarded {discarded} Codex learning proposal(s)."
+
+
+def count_pending_proposals() -> int:
+    return sum(1 for proposal in list_proposals() if proposal.get("approval_state") == "pending")
+
+
+def list_packets() -> list[dict[str, Any]]:
+    packets = _read_records(_packets_dir())
+    packets.sort(key=lambda p: float(p.get("created_at") or 0))
+    return packets
+
+
+def list_proposals() -> list[dict[str, Any]]:
+    proposals = [_with_approval_state(p) for p in _read_records(_proposals_dir())]
+    proposals.sort(key=lambda p: float(p.get("created_at") or 0))
+    return proposals
+
+
+def load_packet(packet_id: str) -> Optional[dict[str, Any]]:
+    return _read_json(_packets_dir() / f"{packet_id}.json")
+
+
+def save_packet(packet: dict[str, Any]) -> None:
+    _write_json(_packets_dir() / f"{packet['id']}.json", packet)
+
+
+def packet_exists(packet_id: str) -> bool:
+    return (_packets_dir() / f"{packet_id}.json").exists()
+
+
+def save_proposal(proposal: dict[str, Any]) -> None:
+    _write_json(_proposals_dir() / f"{proposal['id']}.json", proposal)
+
+
+def load_proposal(proposal_id: str) -> Optional[dict[str, Any]]:
+    return _read_json(_proposals_dir() / f"{proposal_id}.json")
+
+
+def _run_hermes_reviewer(packet: dict[str, Any], learning: LearningConfig) -> None:
+    """Run a standalone Hermes agent with only memory/skills writes available."""
+    from run_agent import AIAgent
+    from tools import write_approval as wa
+    from tools.memory_tool import MemoryStore
+    from tools.terminal_tool import set_approval_callback
+
+    def _auto_deny(command: str, description: str, **_kwargs: Any) -> str:
+        logger.warning(
+            "Codex learning review auto-denied dangerous command: %s (%s)",
+            command,
+            description,
+        )
+        return "deny"
+
+    review_agent = None
+    try:
+        set_approval_callback(_auto_deny)
+        with open(os.devnull, "w", encoding="utf-8") as devnull, (
+            contextlib.redirect_stdout(devnull)
+        ), contextlib.redirect_stderr(devnull):
+            store = MemoryStore()
+            store.load_from_disk()
+            review_agent = AIAgent(
+                model=learning.review_model,
+                max_iterations=12,
+                quiet_mode=True,
+                enabled_toolsets=["memory", "skills"],
+                skip_memory=True,
+            )
+            review_agent._memory_write_origin = "codex_learning"
+            review_agent._memory_write_context = "codex_learning"
+            review_agent._memory_store = store
+            review_agent._memory_enabled = True
+            review_agent._user_profile_enabled = True
+            review_agent.suppress_status_output = True
+
+            from hermes_cli.plugins import (
+                clear_thread_tool_whitelist,
+                set_thread_tool_whitelist,
+            )
+            from model_tools import get_tool_definitions
+
+            whitelist = {
+                tool["function"]["name"]
+                for tool in get_tool_definitions(
+                    enabled_toolsets=["memory", "skills"],
+                    quiet_mode=True,
+                )
+            }
+            set_thread_tool_whitelist(
+                whitelist,
+                deny_msg_fmt=(
+                    "Codex learning review denied non-whitelisted tool: "
+                    "{tool_name}. Only memory/skill tools are allowed."
+                ),
+            )
+            try:
+                with wa.force_write_approval(wa.MEMORY, wa.SKILLS):
+                    review_agent.run_conversation(
+                        user_message=_review_prompt(packet, learning),
+                        conversation_history=[],
+                    )
+            finally:
+                clear_thread_tool_whitelist()
+    finally:
+        if review_agent is not None:
+            with contextlib.suppress(Exception):
+                review_agent.shutdown_memory_provider()
+            with contextlib.suppress(Exception):
+                review_agent.close()
+        with contextlib.suppress(Exception):
+            set_approval_callback(None)
+
+
+def _review_prompt(packet: dict[str, Any], learning: LearningConfig) -> str:
+    compact = {
+        "command": packet.get("command"),
+        "cwd": packet.get("cwd"),
+        "repo": packet.get("repo"),
+        "branch": packet.get("branch"),
+        "exit_code": packet.get("exit_code"),
+        "output_tail": packet.get("output_tail"),
+        "cockpit_status": packet.get("cockpit_status"),
+    }
+    return (
+        "You are Hermes' Codex completion learning reviewer.\n\n"
+        "Review this completed `/codex launch` packet and decide whether any "
+        "durable memory or skill update is justified. Only save stable lessons "
+        "that should affect future work. Do not save transient environment "
+        "failures, one-off task narrative, or negative claims that a tool is "
+        "broken. If there is nothing durable, reply exactly `Nothing to save.`\n\n"
+        "If a user or workflow preference should persist, use the memory tool. "
+        "If a reusable procedure, pitfall, verification pattern, or skill "
+        "improvement should persist, use skill_manage. You can only use memory "
+        "and skill-management tools, and every write will be staged for human "
+        "approval. Only call a write tool when your confidence is at least "
+        f"{learning.min_confidence:.2f}.\n\n"
+        "Learning packet JSON:\n"
+        f"{json.dumps(compact, ensure_ascii=False, indent=2)}"
+    )
+
+
+def _proposal_from_pending(
+    packet: dict[str, Any],
+    subsystem: str,
+    pending_id: str,
+    pending: Optional[dict[str, Any]],
+) -> dict[str, Any]:
+    now = time.time()
+    return {
+        "id": f"learn_{uuid.uuid4().hex[:8]}",
+        "packet_id": packet["id"],
+        "process_id": packet.get("process_id"),
+        "subsystem": subsystem,
+        "pending_id": pending_id,
+        "status": "staged",
+        "approval_state": "pending",
+        "confidence": 1.0,
+        "rationale": "Hermes staged this write during Codex completion review.",
+        "summary": (pending or {}).get("summary", ""),
+        "repo": packet.get("repo", ""),
+        "branch": packet.get("branch", ""),
+        "source_command": packet.get("command", ""),
+        "created_at": now,
+        "updated_at": now,
+    }
+
+
+def _apply_one_proposal(
+    proposal: dict[str, Any],
+    learning: LearningConfig,
+) -> tuple[bool, str]:
+    proposal = _with_approval_state(proposal)
+    if proposal.get("approval_state") != "pending":
+        return False, f"approval state is {proposal.get('approval_state')}"
+
+    confidence = float(proposal.get("confidence") or 0)
+    if confidence < learning.min_confidence:
+        return False, (
+            f"confidence {confidence:.2f} is below min_confidence "
+            f"{learning.min_confidence:.2f}"
+        )
+
+    subsystem = str(proposal.get("subsystem") or "")
+    pending_id = str(proposal.get("pending_id") or "")
+    try:
+        from hermes_cli.write_approval_commands import handle_pending_subcommand
+        from tools import write_approval as wa
+
+        if wa.get_pending(subsystem, pending_id) is None:
+            return False, f"pending {subsystem} write {pending_id!r} is missing"
+        memory_store = None
+        if subsystem == wa.MEMORY:
+            from tools.memory_tool import MemoryStore
+
+            memory_store = MemoryStore()
+            memory_store.load_from_disk()
+        handle_pending_subcommand(
+            subsystem,
+            ["approve", pending_id],
+            memory_store=memory_store,
+        )
+        if wa.get_pending(subsystem, pending_id) is not None:
+            return False, "approval did not remove the pending write"
+    except Exception as exc:
+        return False, str(exc)
+
+    proposal["status"] = "applied"
+    proposal["approval_state"] = "applied"
+    proposal["applied_at"] = time.time()
+    proposal["updated_at"] = time.time()
+    save_proposal(proposal)
+    return True, "applied"
+
+
+def _auto_promote_if_configured(proposal_ids: list[str], learning: LearningConfig) -> None:
+    for proposal_id in proposal_ids:
+        proposal = load_proposal(proposal_id)
+        if not proposal:
+            continue
+        subsystem = proposal.get("subsystem")
+        enabled = (
+            subsystem == "memory"
+            and learning.auto_promote_memory
+            or subsystem == "skills"
+            and learning.auto_promote_skills
+        )
+        if not enabled:
+            continue
+        ok, message = _apply_one_proposal(proposal, learning)
+        if not ok:
+            proposal["auto_promote_error"] = message
+            proposal["updated_at"] = time.time()
+            save_proposal(proposal)
+
+
+def _curator_scope() -> str:
+    try:
+        from tools.skill_usage import curator_scope
+
+        return curator_scope()
+    except Exception:
+        return "all_usable"
+
+
+def _select_proposals(target: str) -> list[dict[str, Any]]:
+    proposals = [p for p in list_proposals() if p.get("approval_state") == "pending"]
+    if target.lower() == "all":
+        return proposals
+    return [p for p in proposals if p.get("id") == target]
+
+
+def _pending_id_snapshot() -> dict[str, set[str]]:
+    return {
+        "memory": {r.get("id") for r in _list_pending("memory") if r.get("id")},
+        "skills": {r.get("id") for r in _list_pending("skills") if r.get("id")},
+    }
+
+
+def _list_pending(subsystem: str) -> list[dict[str, Any]]:
+    try:
+        from tools import write_approval as wa
+
+        return wa.list_pending(subsystem)
+    except Exception:
+        return []
+
+
+def _get_pending(subsystem: str, pending_id: str) -> Optional[dict[str, Any]]:
+    try:
+        from tools import write_approval as wa
+
+        return wa.get_pending(subsystem, pending_id)
+    except Exception:
+        return None
+
+
+def _with_approval_state(proposal: dict[str, Any]) -> dict[str, Any]:
+    proposal = dict(proposal)
+    if proposal.get("status") in {"applied", "discarded", "failed"}:
+        proposal["approval_state"] = proposal.get("status")
+        return proposal
+    pending = _get_pending(
+        str(proposal.get("subsystem") or ""),
+        str(proposal.get("pending_id") or ""),
+    )
+    proposal["approval_state"] = "pending" if pending else "missing"
+    return proposal
+
+
+def _queue_stage_notification(packet: dict[str, Any], proposal_ids: list[str]) -> None:
+    message = (
+        f"Codex learning staged {len(proposal_ids)} proposal(s) from "
+        f"{packet.get('process_id')}. Review with `/codex learn pending`."
+    )
+    try:
+        from tools.process_registry import process_registry
+
+        process_registry.completion_queue.put(
+            {
+                "type": "codex_learning_staged",
+                "session_id": packet.get("process_id", ""),
+                "session_key": packet.get("session_key", ""),
+                "command": packet.get("command", ""),
+                "message": message,
+                "proposal_ids": proposal_ids,
+            }
+        )
+    except Exception:
+        logger.info(message)
+
+
+def _cockpit_status_snapshot(config: Mapping[str, Any] | None) -> dict[str, Any]:
+    cockpit = config.get("codex_cockpit", {}) if isinstance(config, Mapping) else {}
+    if not isinstance(cockpit, Mapping):
+        cockpit = {}
+    helper = cockpit.get("context_helper", {})
+    if not isinstance(helper, Mapping):
+        helper = {}
+    return {
+        "enabled": _as_bool(cockpit.get("enabled", True)),
+        "driver": str(cockpit.get("driver") or "codex_app_server"),
+        "default_model": str(cockpit.get("default_model") or "gpt-5.5"),
+        "context_helper_enabled": _as_bool(helper.get("enabled", False)),
+        "pending_learning": count_pending_proposals(),
+    }
+
+
+def _resolve_repo_root(cwd: str) -> str:
+    if not cwd:
+        return ""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", cwd, "rev-parse", "--show-toplevel"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=5,
+        )
+    except Exception:
+        return ""
+    if proc.returncode != 0:
+        return ""
+    return str(Path(proc.stdout.strip()).resolve())
+
+
+def _git_branch(cwd: str) -> str:
+    if not cwd:
+        return ""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", cwd, "rev-parse", "--abbrev-ref", "HEAD"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=5,
+        )
+    except Exception:
+        return ""
+    if proc.returncode != 0:
+        return ""
+    branch = proc.stdout.strip()
+    return "" if branch == "HEAD" else branch
+
+
+def _extract_git_repo_from_command(command: str) -> str:
+    tokens = _shell_tokens(command)
+    for idx, token in enumerate(tokens[:-2]):
+        if token == "git" and tokens[idx + 1] == "-C":
+            return tokens[idx + 2]
+    return ""
+
+
+def _extract_branch_from_command(command: str) -> str:
+    tokens = _shell_tokens(command)
+    for idx, token in enumerate(tokens):
+        if token != "worktree":
+            continue
+        if idx + 1 >= len(tokens) or tokens[idx + 1] != "add":
+            continue
+        for j in range(idx + 2, len(tokens) - 1):
+            if tokens[j] == "&&":
+                break
+            if tokens[j] == "-b":
+                return tokens[j + 1]
+    return ""
+
+
+def _extract_codex_worktree(command: str) -> str:
+    tokens = _shell_tokens(command)
+    for idx, token in enumerate(tokens):
+        if token == "codex" and idx + 1 < len(tokens) and tokens[idx + 1] == "exec":
+            for j in range(idx + 2, len(tokens) - 1):
+                if tokens[j] == "-C":
+                    return tokens[j + 1]
+    return ""
+
+
+def _shell_tokens(command: str) -> list[str]:
+    try:
+        return shlex.split(command)
+    except ValueError:
+        return []
+
+
+def _packet_id(process_id: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "-", process_id).strip("-")
+    return f"pkt_{safe or uuid.uuid4().hex[:12]}"
+
+
+def _store_root() -> Path:
+    return get_hermes_home() / "codex_learning"
+
+
+def _packets_dir() -> Path:
+    return _store_root() / "packets"
+
+
+def _proposals_dir() -> Path:
+    return _store_root() / "proposals"
+
+
+def _read_records(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    records = []
+    for item in path.glob("*.json"):
+        record = _read_json(item)
+        if isinstance(record, dict):
+            records.append(record)
+    return records
+
+
+def _read_json(path: Path) -> Optional[dict[str, Any]]:
+    try:
+        if not path.exists():
+            return None
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else None
+    except Exception:
+        logger.warning("Could not read Codex learning JSON: %s", path)
+        return None
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() not in {"0", "false", "no", "off", "disabled"}
+    return bool(value)
+
+
+def _positive_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _confidence(value: Any, default: float) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return min(1.0, max(0.0, parsed))
+
+
+def _yes_no(value: bool) -> str:
+    return "yes" if value else "no"
+
+
+def _one_line(text: str, limit: int) -> str:
+    text = " ".join(text.split())
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 3)].rstrip() + "..."

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -125,6 +125,10 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True),
     CommandDef("model", "Switch model for this session", "Configuration",
                args_hint="[model] [--provider name] [--global] [--refresh]"),
+    CommandDef("codex", "Codex cockpit readout and driver commands",
+               "Configuration",
+               args_hint="[status|launch|last|checks|context] ...",
+               subcommands=("status", "launch", "last", "checks", "context", "help")),
     CommandDef("codex-runtime", "Toggle codex app-server runtime for OpenAI/Codex models",
                "Configuration", aliases=("codex_runtime",),
                args_hint="[auto|codex_app_server]"),
@@ -1053,7 +1057,9 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 # the telegram-parity test reads it so an entry here is a deliberate
 # "Slack-via-/hermes" decision, not a silent clamp.
 #   - credits: the billing/top-up surface; reached via /hermes credits on Slack.
-_SLACK_VIA_HERMES_ONLY = frozenset({"credits"})
+#   - codex: cockpit subcommands can be long and remain reachable via
+#     /hermes codex ... without displacing existing native Slack commands.
+_SLACK_VIA_HERMES_ONLY = frozenset({"credits", "codex"})
 
 
 def _sanitize_slack_name(raw: str) -> str:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -825,6 +825,14 @@ DEFAULT_CONFIG = {
             "max_events": 25,
         },
         "context_helper": {
+            "enabled": False,
+            "harvest_launches": True,
+            "review_model": "",
+            "max_output_chars": 8000,
+            "auto_promote_memory": True,
+            "auto_promote_skills": True,
+            "min_confidence": 0.75,
+            "notify_on_stage": True,
             "propose_memory": True,
             "propose_skills": True,
             "auto_promote": False,
@@ -1877,16 +1885,20 @@ DEFAULT_CONFIG = {
 
     # Curator — background skill maintenance.
     #
-    # Periodically reviews AGENT-CREATED skills (never bundled or
-    # hub-installed) and keeps the collection tidy: marks long-unused skills
-    # as stale, archives genuinely obsolete ones (archive only, never
-    # deletes), and spawns a forked aux-model agent to consolidate overlaps
-    # and patch drift. Runs inactivity-triggered from session start — no
-    # cron daemon.
+    # Periodically reviews curator-managed skills and keeps the collection
+    # tidy: marks long-unused skills as stale, archives genuinely obsolete
+    # ones (archive only, never deletes), and spawns a forked aux-model agent
+    # to consolidate overlaps and patch drift. Runs inactivity-triggered from
+    # session start — no cron daemon.
     #
     # See `hermes curator status` for the last run summary.
     "curator": {
         "enabled": True,
+        # all_usable = manage every loadable local/external skill except hub
+        # installs, hidden/quarantined paths, and protected built-ins.
+        # agent_created = legacy mode; only generated skills explicitly marked
+        # in usage telemetry participate.
+        "scope": "all_usable",
         # How long to wait between curator runs (hours).  Default: 7 days.
         "interval_hours": 24 * 7,
         # Only run when the agent has been idle at least this long (hours).
@@ -1897,7 +1909,8 @@ DEFAULT_CONFIG = {
         # without use. Archived skills are recoverable — no auto-deletion.
         "archive_after_days": 90,
         # Also prune (archive) bundled built-in skills after the inactivity
-        # period, not just agent-created ones. ON by default. Built-ins are
+        # period, not just generated/manual profile skills. ON by default.
+        # Built-ins are
         # normally restored on every `hermes update`, so pruning them only
         # sticks because a suppression list tells the re-seeder to leave them
         # archived. Hub-installed skills are NEVER pruned here — they have an
@@ -1908,9 +1921,10 @@ DEFAULT_CONFIG = {
         # to keep all bundled built-ins permanently.
         "prune_builtins": True,
         # Pre-run backup: before every real curator pass (dry-run is
-        # skipped), snapshot ~/.hermes/skills/ into
-        # ~/.hermes/skills/.curator_backups/<utc-iso>/skills.tar.gz so the
-        # user can roll back with `hermes curator rollback`.
+        # skipped), snapshot ~/.hermes/skills/ and configured
+        # skills.external_dirs roots into
+        # ~/.hermes/skills/.curator_backups/<utc-iso>/ so the user can roll
+        # back with `hermes curator rollback`.
         "backup": {
             "enabled": True,
             "keep": 5,  # retain last N regular snapshots

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -811,6 +811,25 @@ DEFAULT_CONFIG = {
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
+    "codex_cockpit": {
+        "enabled": True,
+        "driver": "codex_app_server",
+        "default_model": "gpt-5.5",
+        "default_worktree_root": "/private/tmp/hermes-codex",
+        "branch_prefix": "codex/",
+        "repo_allowlist": [str(Path.home() / "Code")],
+        "readout": {
+            "include_git_status": True,
+            "include_recent_tool_events": True,
+            "include_checks": True,
+            "max_events": 25,
+        },
+        "context_helper": {
+            "propose_memory": True,
+            "propose_skills": True,
+            "auto_promote": False,
+        },
+    },
     # Global active chat session cap across CLI, TUI/dashboard, and messaging.
     # None/0 = unbounded.
     "max_concurrent_sessions": None,

--- a/hermes_cli/curator.py
+++ b/hermes_cli/curator.py
@@ -75,12 +75,13 @@ def _cmd_status(args) -> int:
         else f"{_ih}h"
     )
     print(f"  interval:       every {_interval_label}")
+    print(f"  scope:          {curator.get_scope()}")
     print(f"  stale after:    {curator.get_stale_after_days()}d unused")
     print(f"  archive after:  {curator.get_archive_after_days()}d unused")
 
     rows = skill_usage.agent_created_report()
     if not rows:
-        print("\nno agent-created skills")
+        print("\nno curator-managed skills")
         return 0
 
     by_state = {"active": [], "stale": [], "archived": []}
@@ -91,7 +92,7 @@ def _cmd_status(args) -> int:
         if r.get("pinned"):
             pinned.append(r["name"])
 
-    print(f"\nagent-created skills: {len(rows)} total")
+    print(f"\ncurator-managed skills: {len(rows)} total")
     for state_name in ("active", "stale", "archived"):
         bucket = by_state.get(state_name, [])
         print(f"  {state_name:10s} {len(bucket)}")
@@ -233,10 +234,10 @@ def _cmd_resume(args) -> int:
 
 def _cmd_pin(args) -> int:
     from tools import skill_usage
-    if not skill_usage.is_agent_created(args.skill):
+    if not skill_usage.is_curation_eligible(args.skill):
         print(
-            f"curator: '{args.skill}' is bundled or hub-installed — cannot pin "
-            "(only agent-created skills participate in curation)"
+            f"curator: '{args.skill}' is hub-installed, protected, or otherwise "
+            "outside curator scope — cannot pin"
         )
         return 1
     skill_usage.set_pinned(args.skill, True)
@@ -246,10 +247,10 @@ def _cmd_pin(args) -> int:
 
 def _cmd_unpin(args) -> int:
     from tools import skill_usage
-    if not skill_usage.is_agent_created(args.skill):
+    if not skill_usage.is_curation_eligible(args.skill):
         print(
-            f"curator: '{args.skill}' is bundled or hub-installed — "
-            "there's nothing to unpin (curator only tracks agent-created skills)"
+            f"curator: '{args.skill}' is hub-installed, protected, or otherwise "
+            "outside curator scope — there's nothing to unpin"
         )
         return 1
     skill_usage.set_pinned(args.skill, False)
@@ -265,7 +266,7 @@ def _cmd_restore(args) -> int:
 
 
 def _cmd_archive(args) -> int:
-    """Manually archive an agent-created skill. Refuses if pinned.
+    """Manually archive a curator-managed skill. Refuses if pinned.
 
     The auto-curator archives stale skills on its own schedule; this verb is
     for the user who wants to archive *now* without waiting for a run.
@@ -302,7 +303,7 @@ def _idle_days(record: dict) -> Optional[int]:
 
 
 def _cmd_prune(args) -> int:
-    """Bulk-archive agent-created skills idle for >= N days.
+    """Bulk-archive curator-managed skills idle for >= N days.
 
     Pinned skills are exempt. Already-archived skills are skipped. Default
     ``--days 90`` matches a conservative read of the curator's own archive
@@ -535,7 +536,7 @@ def register_cli(parent: argparse.ArgumentParser) -> None:
 
     p_prune = subs.add_parser(
         "prune",
-        help="Bulk-archive agent-created skills idle for >= N days (default 90)",
+        help="Bulk-archive curator-managed skills idle for >= N days (default 90)",
     )
     p_prune.add_argument(
         "--days", type=int, default=90,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5573,8 +5573,8 @@ def _print_curator_first_run_notice() -> None:
     print("ℹ Skill curator")
     print(
         f"  Background skill maintenance is enabled. First pass is deferred "
-        f"~{days}d after installation; only agent-created skills are in "
-        f"scope and nothing is ever auto-deleted (archive is recoverable)."
+        f"~{days}d after installation; curator-managed skills are in scope "
+        f"and nothing is ever auto-deleted (archive is recoverable)."
     )
     print("  Preview now:  hermes curator run --dry-run")
     print("  Pause it:     hermes curator pause")
@@ -11802,9 +11802,9 @@ def main():
         help="Background skill maintenance (curator) — status, run, pause, pin",
         description=(
             "The curator is an auxiliary-model background task that "
-            "periodically reviews agent-created skills, prunes stale ones, "
+            "periodically reviews curator-managed skills, prunes stale ones, "
             "consolidates overlaps, and archives obsolete skills. "
-            "Bundled and hub-installed skills are never touched. "
+            "Hub-installed and protected skills are never touched. "
             "Archives are recoverable; auto-deletion never happens."
         ),
     )

--- a/hermes_cli/write_approval_commands.py
+++ b/hermes_cli/write_approval_commands.py
@@ -37,7 +37,7 @@ def _fmt_pending_list(subsystem: str) -> str:
     lines = [f"Pending {subsystem} writes ({len(records)}):"]
     for r in records:
         origin = r.get("origin", "foreground")
-        tag = " [auto]" if origin == "background_review" else ""
+        tag = " [auto]" if origin in {"background_review", "codex_learning"} else ""
         lines.append(f"  {r['id']}{tag}  {r.get('summary', '')}")
     where = "/{s} approve <id>".format(s=subsystem)
     lines.append("")
@@ -140,7 +140,15 @@ def _approve(subsystem: str, rest: List[str], memory_store) -> str:
 
 def _apply_one(subsystem: str, rec, memory_store):
     payload = rec.get("payload", {})
+    origin = str(rec.get("origin") or "foreground")
+    token = None
     try:
+        from tools.skill_provenance import (
+            reset_current_write_origin,
+            set_current_write_origin,
+        )
+
+        token = set_current_write_origin(origin)
         if subsystem == wa.MEMORY:
             if memory_store is None:
                 return False, "memory store unavailable"
@@ -153,6 +161,12 @@ def _apply_one(subsystem: str, rec, memory_store):
             return bool(result.get("success")), result.get("error", "")
     except Exception as e:
         return False, str(e)
+    finally:
+        if token is not None:
+            try:
+                reset_current_write_origin(token)
+            except Exception:
+                pass
 
 
 def _reject(subsystem: str, rest: List[str]) -> str:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "nick@nickwalther.me": "nwalther02",
     "kenmege@yahoo.com": "Kenmege",
     "dkobi16@gmail.com": "Diyoncrz18",
     "arnaud@nolimitdevelopment.com": "ali-nld",

--- a/skills/autonomous-ai-agents/codex/SKILL.md
+++ b/skills/autonomous-ai-agents/codex/SKILL.md
@@ -41,19 +41,26 @@ that Codex auth is missing.
 ## One-Shot Tasks
 
 ```
-terminal(command="codex exec 'Add dark mode toggle to settings'", workdir="~/project", pty=true)
+terminal(command="codex exec -C ~/project --sandbox workspace-write 'Add dark mode toggle to settings'", pty=true)
 ```
 
 For scratch work (Codex needs a git repo):
 ```
-terminal(command="cd $(mktemp -d) && git init && codex exec 'Build a snake game in Python'", pty=true)
+terminal(command="SCRATCH=$(mktemp -d) && git -C $SCRATCH init && codex exec -C $SCRATCH --sandbox workspace-write 'Build a snake game in Python'", pty=true)
 ```
 
 ## Background Mode (Long Tasks)
 
+Prefer the Hermes cockpit command when available:
+
 ```
-# Start in background with PTY
-terminal(command="codex exec --full-auto 'Refactor the auth module'", workdir="~/project", background=true, pty=true)
+/codex launch ~/project "Refactor the auth module"
+```
+
+Or start Codex manually in the background with a PTY:
+
+```
+terminal(command="codex exec -C ~/project --sandbox workspace-write 'Refactor the auth module'", background=true, pty=true)
 # Returns session_id
 
 # Monitor progress
@@ -72,8 +79,8 @@ process(action="kill", session_id="<id>")
 | Flag | Effect |
 |------|--------|
 | `exec "prompt"` | One-shot execution, exits when done |
-| `--full-auto` | Sandboxed but auto-approves file changes in workspace |
-| `--yolo` | No sandbox, no approvals (fastest, most dangerous) |
+| `-C <dir>` | Run Codex with a specific repository/worktree as cwd |
+| `--sandbox workspace-write` | Allow workspace writes while keeping Codex sandboxing on |
 | `--sandbox danger-full-access` | No Codex sandbox; useful when the host service context breaks bubblewrap |
 
 ## Hermes Gateway Caveat
@@ -110,8 +117,8 @@ terminal(command="git worktree add -b fix/issue-78 /tmp/issue-78 main", workdir=
 terminal(command="git worktree add -b fix/issue-99 /tmp/issue-99 main", workdir="~/project")
 
 # Launch Codex in each
-terminal(command="codex --yolo exec 'Fix issue #78: <description>. Commit when done.'", workdir="/tmp/issue-78", background=true, pty=true)
-terminal(command="codex --yolo exec 'Fix issue #99: <description>. Commit when done.'", workdir="/tmp/issue-99", background=true, pty=true)
+terminal(command="codex exec -C /tmp/issue-78 --sandbox workspace-write 'Fix issue #78: <description>. Commit when done.'", background=true, pty=true)
+terminal(command="codex exec -C /tmp/issue-99 --sandbox workspace-write 'Fix issue #99: <description>. Commit when done.'", background=true, pty=true)
 
 # Monitor
 process(action="list")
@@ -143,7 +150,7 @@ terminal(command="gh pr comment 86 --body '<review>'", workdir="~/project")
 1. **Always use `pty=true`** — Codex is an interactive terminal app and hangs without a PTY
 2. **Git repo required** — Codex won't run outside a git directory. Use `mktemp -d && git init` for scratch
 3. **Use `exec` for one-shots** — `codex exec "prompt"` runs and exits cleanly
-4. **`--full-auto` for building** — auto-approves changes within the sandbox
+4. **Prefer worktrees for feature work** — `/codex launch` creates a clean worktree and tracked background process
 5. **Background for long tasks** — use `background=true` and monitor with `process` tool
 6. **Don't interfere** — monitor with `poll`/`log`, be patient with long-running tasks
 7. **Parallel is fine** — run multiple Codex processes at once for batch work

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -243,18 +243,21 @@ def test_new_skill_without_last_used_not_immediately_archived(curator_env):
     # Bump nothing — record doesn't exist yet. Curator should create it
     # and fall back to created_at which is ~now.
     counts = c.apply_automatic_transitions()
+    assert counts["checked"] == 1
+    assert counts["seeded"] == 1
     assert counts["archived"] == 0
     assert counts["marked_stale"] == 0
     assert (skills_dir / "fresh").exists()
+    assert isinstance(u.load_usage().get("fresh"), dict)
 
 
-def test_manual_skill_is_not_auto_archived(curator_env):
-    """Manual skills can have usage records, but without the agent-created
-    marker they must stay out of curator transitions."""
+def test_manual_skill_is_ignored_in_legacy_agent_created_scope(curator_env, monkeypatch):
+    """Legacy scope preserves the old generated-only curation behavior."""
     c = curator_env["curator"]
     u = curator_env["usage"]
     skills_dir = curator_env["home"] / "skills"
     skill_dir = _write_skill(skills_dir, "manual")
+    monkeypatch.setattr(u, "curator_scope", lambda: u.SCOPE_AGENT_CREATED)
 
     super_old = (datetime.now(timezone.utc) - timedelta(days=365)).isoformat()
     data = u.load_usage()
@@ -267,6 +270,25 @@ def test_manual_skill_is_not_auto_archived(curator_env):
     assert counts["checked"] == 0
     assert counts["archived"] == 0
     assert skill_dir.exists()
+
+
+def test_external_skill_first_sight_is_seeded_not_archived(curator_env, monkeypatch, tmp_path):
+    """Broad all_usable scope must not mass-archive old untracked external skills."""
+    c = curator_env["curator"]
+    u = curator_env["usage"]
+    skills_dir = curator_env["home"] / "skills"
+    external = tmp_path / "external-skills"
+    external.mkdir()
+    external_skill = _write_skill(external, "external-old")
+    monkeypatch.setattr(u, "get_all_skills_dirs", lambda: [skills_dir, external])
+
+    counts = c.apply_automatic_transitions()
+
+    assert counts["checked"] == 1
+    assert counts["seeded"] == 1
+    assert counts["archived"] == 0
+    assert external_skill.exists()
+    assert isinstance(u.load_usage().get("external-old"), dict)
 
 
 def test_bundled_skill_not_touched_by_transitions(curator_env):
@@ -689,7 +711,8 @@ def test_curator_review_prompt_has_invariants():
     """Core invariants must be in the review prompt text."""
     from agent.curator import CURATOR_REVIEW_PROMPT
     assert "MUST NOT" in CURATOR_REVIEW_PROMPT or "DO NOT" in CURATOR_REVIEW_PROMPT
-    assert "bundled" in CURATOR_REVIEW_PROMPT.lower()
+    assert "hub-installed" in CURATOR_REVIEW_PROMPT.lower()
+    assert "protected built-ins" in CURATOR_REVIEW_PROMPT.lower()
     assert "delete" in CURATOR_REVIEW_PROMPT.lower()
     assert "pinned" in CURATOR_REVIEW_PROMPT.lower()
     # Must describe the actions the reviewer can take. The exact vocabulary

--- a/tests/agent/test_curator_backup.py
+++ b/tests/agent/test_curator_backup.py
@@ -89,6 +89,28 @@ def test_snapshot_excludes_hub_dir(backup_env):
     assert not any(n.startswith(".hub") for n in names)
 
 
+def test_snapshot_includes_external_skill_roots(backup_env, monkeypatch, tmp_path):
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+    external = tmp_path / "external-skills"
+    external.mkdir()
+    _write_skill(skills, "alpha")
+    _write_skill(external, "external-alpha")
+    monkeypatch.setattr(cb, "get_all_skills_dirs", lambda: [skills, external])
+
+    snap = cb.snapshot_skills(reason="multi-root")
+
+    assert snap is not None
+    manifest = json.loads((snap / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["skill_files"] == 2
+    roots = manifest["skill_roots"]
+    assert [r["id"] for r in roots] == ["local", "external-1"]
+    assert (snap / roots[1]["archive"]).exists()
+    with tarfile.open(snap / roots[1]["archive"]) as tf:
+        names = tf.getnames()
+    assert "external-alpha/SKILL.md" in names
+
+
 def test_snapshot_disabled_returns_none(backup_env, monkeypatch):
     cb = backup_env["cb"]
     monkeypatch.setattr(cb, "is_enabled", lambda: False)
@@ -257,6 +279,30 @@ def test_rollback_rejects_unsafe_tarball(backup_env, monkeypatch):
     ok, msg, _ = cb.rollback()
     assert not ok
     assert "unsafe" in msg.lower() or "refus" in msg.lower() or "extract" in msg.lower()
+
+
+def test_rollback_restores_external_skill_root(backup_env, monkeypatch, tmp_path):
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+    external = tmp_path / "external-skills"
+    external.mkdir()
+    _write_skill(skills, "local-skill", body="local v1")
+    external_skill = _write_skill(external, "external-skill", body="external v1")
+    monkeypatch.setattr(cb, "get_all_skills_dirs", lambda: [skills, external])
+    snap = cb.snapshot_skills(reason="pre-external-change")
+    assert snap is not None
+
+    import shutil as _sh
+    _sh.rmtree(external_skill)
+    _write_skill(external, "new-external", body="new state")
+
+    ok, msg, _ = cb.rollback(backup_id=snap.name)
+
+    assert ok, msg
+    assert (external / "external-skill" / "SKILL.md").exists()
+    assert "external v1" in (external / "external-skill" / "SKILL.md").read_text()
+    assert not (external / "new-external").exists()
+    assert (skills / "local-skill" / "SKILL.md").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_codex_cockpit_command.py
+++ b/tests/gateway/test_codex_cockpit_command.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    source = _make_source()
+    session_key = build_session_key(source)
+    session_entry = SessionEntry(
+        session_key=session_key,
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    runner.adapters = {Platform.TELEGRAM: MagicMock()}
+    runner._running_agents = {}
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = [
+        {"role": "assistant", "content": "latest answer"}
+    ]
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_codex_status_renders_cockpit(monkeypatch):
+    from hermes_cli import codex_cockpit as cc
+
+    runner = _make_runner()
+    agent = SimpleNamespace(
+        model="gpt-test",
+        provider="openai-codex",
+        api_mode="codex_app_server",
+        session_cwd="/tmp/repo",
+        _last_codex_thread_id="thread-1",
+        _last_codex_turn_id="turn-1",
+    )
+    runner._running_agents[build_session_key(_make_source())] = agent
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "model": {"openai_runtime": "codex_app_server"},
+            "codex_cockpit": {"readout": {"include_git_status": False}},
+        },
+    )
+    monkeypatch.setattr(cc, "_codex_binary_status", lambda: (True, "0.130.0"))
+    monkeypatch.setattr(cc, "_codex_auth_line", lambda: "logged in (test)")
+
+    result = await runner._handle_codex_command(_make_event("/codex status"))
+
+    assert "**Codex Cockpit**" in result
+    assert "codex_app_server" in result
+    assert "thread-1" in result
+    assert "latest answer" in result
+
+
+@pytest.mark.asyncio
+async def test_codex_launch_spawns_background_process(monkeypatch):
+    from hermes_cli import codex_cockpit as cc
+
+    runner = _make_runner()
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"codex_cockpit": {}})
+    plan = cc.LaunchPlan(
+        repo_root="/tmp/repo",
+        worktree_path="/tmp/worktree",
+        branch="codex/test",
+        command="codex exec -C /tmp/worktree test",
+        task_id="codex_test",
+        prompt_preview="test prompt",
+    )
+    monkeypatch.setattr(cc, "prepare_launch", lambda *args, **kwargs: (plan, None))
+
+    spawned = {}
+
+    class FakeRegistry:
+        def list_sessions(self):
+            return []
+
+        def spawn_local(self, command, **kwargs):
+            spawned["command"] = command
+            spawned.update(kwargs)
+            return SimpleNamespace(id="proc-1")
+
+    monkeypatch.setattr("tools.process_registry.process_registry", FakeRegistry())
+
+    result = await runner._handle_codex_command(
+        _make_event('/codex launch /tmp/repo "test prompt"')
+    )
+
+    assert "Codex driver launched" in result
+    assert "proc-1" in result
+    assert spawned["command"] == plan.command
+    assert spawned["cwd"] == plan.repo_root
+    assert spawned["task_id"] == plan.task_id
+    assert spawned["use_pty"] is True

--- a/tests/gateway/test_codex_cockpit_command.py
+++ b/tests/gateway/test_codex_cockpit_command.py
@@ -124,3 +124,16 @@ async def test_codex_launch_spawns_background_process(monkeypatch):
     assert spawned["cwd"] == plan.repo_root
     assert spawned["task_id"] == plan.task_id
     assert spawned["use_pty"] is True
+
+
+@pytest.mark.asyncio
+async def test_codex_learn_dispatches_to_cockpit(monkeypatch):
+    from hermes_cli import codex_cockpit as cc
+
+    runner = _make_runner()
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"codex_cockpit": {}})
+    monkeypatch.setattr(cc, "render_learn", lambda tokens, cfg: f"learn:{tokens[0]}")
+
+    result = await runner._handle_codex_command(_make_event("/codex learn pending"))
+
+    assert result == "learn:pending"

--- a/tests/hermes_cli/test_codex_cockpit.py
+++ b/tests/hermes_cli/test_codex_cockpit.py
@@ -11,6 +11,10 @@ def test_load_cockpit_config_defaults_to_home_code_allowlist():
     assert cfg.default_model == "gpt-5.5"
     assert cfg.branch_prefix == "codex/"
     assert cfg.repo_allowlist
+    assert cfg.context_helper["enabled"] is False
+    assert cfg.context_helper["harvest_launches"] is True
+    assert cfg.context_helper["auto_promote_memory"] is True
+    assert cfg.context_helper["auto_promote_skills"] is True
 
 
 def test_load_cockpit_config_normalizes_user_values(tmp_path):
@@ -25,7 +29,7 @@ def test_load_cockpit_config_normalizes_user_values(tmp_path):
                 "branch_prefix": "ai",
                 "repo_allowlist": [str(allowed)],
                 "readout": {"include_git_status": False},
-                "context_helper": {"auto_promote": True},
+                "context_helper": {"enabled": True, "auto_promote_memory": True},
             }
         }
     )
@@ -36,7 +40,8 @@ def test_load_cockpit_config_normalizes_user_values(tmp_path):
     assert cfg.branch_prefix == "ai"
     assert cfg.repo_allowlist == (str(allowed.resolve()),)
     assert cfg.readout["include_git_status"] is False
-    assert cfg.context_helper["auto_promote"] is True
+    assert cfg.context_helper["enabled"] is True
+    assert cfg.context_helper["auto_promote_memory"] is True
 
 
 def test_prepare_launch_builds_safe_worktree_command(monkeypatch, tmp_path):
@@ -155,3 +160,25 @@ def test_render_status_includes_recent_tool_events(monkeypatch):
 
     assert "- Recent tools: `write_file`, `terminal`" in rendered
     assert "read_file" not in rendered
+
+
+def test_render_status_includes_pending_learning(monkeypatch):
+    monkeypatch.setattr(cc, "_codex_binary_status", lambda: (True, "test"))
+    monkeypatch.setattr(cc, "_codex_auth_line", lambda: "logged in (test)")
+    monkeypatch.setattr(cc, "_pending_context_counts", lambda: (0, 0))
+    monkeypatch.setattr(cc, "_pending_learning_count", lambda: 2)
+
+    rendered = cc.render_status(
+        {"codex_cockpit": {"readout": {"include_git_status": False}}},
+        transcript=[],
+    )
+
+    assert "- Pending Codex learning: 2" in rendered
+
+
+def test_render_learn_dispatches_status(monkeypatch):
+    from hermes_cli import codex_learning
+
+    monkeypatch.setattr(codex_learning, "render_learn_status", lambda _cfg: "learn status")
+
+    assert cc.render_learn(("status",), {}) == "learn status"

--- a/tests/hermes_cli/test_codex_cockpit.py
+++ b/tests/hermes_cli/test_codex_cockpit.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from hermes_cli import codex_cockpit as cc
+
+
+def test_load_cockpit_config_defaults_to_home_code_allowlist():
+    cfg = cc.load_cockpit_config({})
+
+    assert cfg.enabled is True
+    assert cfg.driver == "codex_app_server"
+    assert cfg.default_model == "gpt-5.5"
+    assert cfg.branch_prefix == "codex/"
+    assert cfg.repo_allowlist
+
+
+def test_load_cockpit_config_normalizes_user_values(tmp_path):
+    allowed = tmp_path / "repos"
+    cfg = cc.load_cockpit_config(
+        {
+            "codex_cockpit": {
+                "enabled": "off",
+                "driver": "codex_exec",
+                "default_model": "gpt-test",
+                "default_worktree_root": str(tmp_path / "worktrees"),
+                "branch_prefix": "ai",
+                "repo_allowlist": [str(allowed)],
+                "readout": {"include_git_status": False},
+                "context_helper": {"auto_promote": True},
+            }
+        }
+    )
+
+    assert cfg.enabled is False
+    assert cfg.driver == "codex_exec"
+    assert cfg.default_model == "gpt-test"
+    assert cfg.branch_prefix == "ai"
+    assert cfg.repo_allowlist == (str(allowed.resolve()),)
+    assert cfg.readout["include_git_status"] is False
+    assert cfg.context_helper["auto_promote"] is True
+
+
+def test_prepare_launch_builds_safe_worktree_command(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    worktrees = tmp_path / "worktrees"
+    monkeypatch.setattr(
+        cc,
+        "resolve_git_root",
+        lambda path: (str(repo.resolve()), None),
+    )
+
+    plan, error = cc.prepare_launch(
+        'launch repo "Fix auth bug"',
+        {
+            "codex_cockpit": {
+                "repo_allowlist": [str(tmp_path)],
+                "default_worktree_root": str(worktrees),
+                "default_model": "gpt-test",
+                "branch_prefix": "codex/",
+            }
+        },
+        cwd=str(tmp_path),
+        now=1_800_000_000,
+    )
+
+    assert error is None
+    assert plan is not None
+    assert plan.repo_root == str(repo.resolve())
+    assert plan.branch.startswith("codex/fix-auth-bug-")
+    assert str(worktrees.resolve()) in plan.worktree_path
+    assert "git -C" in plan.command
+    assert "worktree add" in plan.command
+    assert "codex exec" in plan.command
+    assert "--model gpt-test" in plan.command
+    assert "--sandbox workspace-write" in plan.command
+
+
+def test_prepare_launch_rejects_repo_outside_allowlist(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    allowed = tmp_path / "allowed"
+    allowed.mkdir()
+    monkeypatch.setattr(
+        cc,
+        "resolve_git_root",
+        lambda path: (str(repo.resolve()), None),
+    )
+
+    plan, error = cc.prepare_launch(
+        "launch repo fix-things",
+        {"codex_cockpit": {"repo_allowlist": [str(allowed)]}},
+        cwd=str(tmp_path),
+    )
+
+    assert plan is None
+    assert error is not None
+    assert "outside `codex_cockpit.repo_allowlist`" in error
+
+
+def test_render_last_includes_codex_ids():
+    class Agent:
+        _last_codex_thread_id = "thread-1"
+        _last_codex_turn_id = "turn-2"
+
+    rendered = cc.render_last(
+        [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "done"},
+        ],
+        active_agent=Agent(),
+    )
+
+    assert "thread-1" in rendered
+    assert "turn-2" in rendered
+    assert "done" in rendered
+
+
+def test_render_checks_filters_validation_processes():
+    rendered = cc.render_checks(
+        [
+            {"session_id": "p1", "command": "sleep 1", "status": "running"},
+            {
+                "session_id": "p2",
+                "command": "npm run build",
+                "status": "exited",
+                "exit_code": 0,
+                "output_preview": "built",
+            },
+        ]
+    )
+
+    assert "p2" in rendered
+    assert "built" in rendered
+    assert "sleep 1" not in rendered
+
+
+def test_render_status_includes_recent_tool_events(monkeypatch):
+    monkeypatch.setattr(cc, "_codex_binary_status", lambda: (True, "test"))
+    monkeypatch.setattr(cc, "_codex_auth_line", lambda: "logged in (test)")
+    monkeypatch.setattr(cc, "_pending_context_counts", lambda: (0, 0))
+
+    rendered = cc.render_status(
+        {"codex_cockpit": {"readout": {"include_git_status": False, "max_events": 2}}},
+        transcript=[
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"function": {"name": "read_file"}},
+                    {"function": {"name": "terminal"}},
+                ],
+            },
+            {"role": "tool", "tool_name": "write_file", "content": "ok"},
+        ],
+    )
+
+    assert "- Recent tools: `write_file`, `terminal`" in rendered
+    assert "read_file" not in rendered

--- a/tests/hermes_cli/test_codex_learning.py
+++ b/tests/hermes_cli/test_codex_learning.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from hermes_cli import codex_learning as cl
+
+
+def _session(**overrides):
+    command = (
+        "mkdir -p /tmp/root && "
+        "git -C /tmp/repo worktree add -b codex/fix-thing /tmp/wt origin/main && "
+        "codex exec -C /tmp/wt --model gpt-test --sandbox workspace-write 'fix thing'"
+    )
+    values = {
+        "id": "proc_123",
+        "task_id": "codex_fix_thing",
+        "session_key": "session-1",
+        "pid": 1234,
+        "command": command,
+        "cwd": "/tmp/repo",
+        "started_at": 10.0,
+        "exit_code": 0,
+        "output_buffer": "0123456789abcdef",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_learning_config_defaults_auto_promote():
+    cfg = cl.load_learning_config({})
+
+    assert cfg.enabled is False
+    assert cfg.harvest_launches is True
+    assert cfg.auto_promote_memory is True
+    assert cfg.auto_promote_skills is True
+    assert cfg.min_confidence == 0.75
+
+
+def test_build_learning_packet_extracts_codex_launch_metadata(monkeypatch):
+    monkeypatch.setattr(cl, "_resolve_repo_root", lambda _cwd: "/tmp/repo")
+    packet = cl.build_learning_packet(
+        _session(),
+        {"codex_cockpit": {"context_helper": {"max_output_chars": 6}}},
+    )
+
+    assert packet["id"] == "pkt_proc_123"
+    assert packet["process_id"] == "proc_123"
+    assert packet["repo"] == "/tmp/repo"
+    assert packet["branch"] == "codex/fix-thing"
+    assert packet["worktree"] == "/tmp/wt"
+    assert packet["exit_code"] == 0
+    assert packet["output_tail"] == "abcdef"
+    assert packet["cockpit_status"]["context_helper_enabled"] is False
+
+
+def test_review_packet_links_new_pending_memory_write(monkeypatch):
+    from tools import write_approval as wa
+
+    packet = cl.build_learning_packet(
+        _session(),
+        {"codex_cockpit": {"context_helper": {"enabled": True}}},
+    )
+    cl.save_packet(packet)
+
+    def fake_reviewer(_packet, _learning):
+        wa.stage_write(
+            wa.MEMORY,
+            {"action": "add", "target": "memory", "content": "Codex learned x"},
+            summary="add to memory: Codex learned x",
+            origin="codex_learning",
+        )
+
+    monkeypatch.setattr(cl, "_run_hermes_reviewer", fake_reviewer)
+
+    reviewed = cl.review_packet(
+        packet["id"],
+        {
+            "codex_cockpit": {
+                "context_helper": {
+                    "auto_promote_memory": False,
+                    "auto_promote_skills": False,
+                }
+            }
+        },
+    )
+    proposals = cl.list_proposals()
+
+    assert reviewed["status"] == "staged"
+    assert len(reviewed["proposal_ids"]) == 1
+    assert len(proposals) == 1
+    assert proposals[0]["subsystem"] == "memory"
+    assert proposals[0]["approval_state"] == "pending"
+    assert proposals[0]["repo"] == packet["repo"]
+
+
+def test_review_packet_auto_promotes_memory_by_default(monkeypatch):
+    from tools import write_approval as wa
+    from tools.memory_tool import MemoryStore
+
+    packet = cl.build_learning_packet(_session(id="proc_mem"), {})
+    cl.save_packet(packet)
+
+    def fake_reviewer(_packet, _learning):
+        wa.stage_write(
+            wa.MEMORY,
+            {"action": "add", "target": "memory", "content": "Codex auto memory"},
+            summary="add to memory: Codex auto memory",
+            origin="codex_learning",
+        )
+
+    monkeypatch.setattr(cl, "_run_hermes_reviewer", fake_reviewer)
+
+    reviewed = cl.review_packet(packet["id"], {"codex_cockpit": {"context_helper": {}}})
+    proposals = cl.list_proposals()
+
+    assert reviewed["status"] == "applied"
+    assert len(proposals) == 1
+    assert proposals[0]["subsystem"] == wa.MEMORY
+    assert proposals[0]["approval_state"] == "applied"
+    assert wa.pending_count(wa.MEMORY) == 0
+    store = MemoryStore()
+    store.load_from_disk()
+    assert "Codex auto memory" in store.memory_entries
+
+
+def test_review_packet_auto_promotes_skill_and_seeds_curator(monkeypatch):
+    from tools import write_approval as wa
+    from tools import skill_usage
+
+    skill_content = (
+        "---\n"
+        "name: codex-auto-skill\n"
+        "description: Codex auto skill\n"
+        "version: 1.0.0\n"
+        "---\n"
+        "# Codex Auto Skill\n"
+    )
+    packet = cl.build_learning_packet(_session(id="proc_skill"), {})
+    cl.save_packet(packet)
+
+    def fake_reviewer(_packet, _learning):
+        wa.stage_write(
+            wa.SKILLS,
+            {
+                "action": "create",
+                "name": "codex-auto-skill",
+                "content": skill_content,
+            },
+            summary="create skill: codex-auto-skill",
+            origin="codex_learning",
+        )
+
+    monkeypatch.setattr(cl, "_run_hermes_reviewer", fake_reviewer)
+
+    reviewed = cl.review_packet(packet["id"], {"codex_cockpit": {"context_helper": {}}})
+    proposals = cl.list_proposals()
+
+    assert reviewed["status"] == "applied"
+    assert proposals[0]["subsystem"] == wa.SKILLS
+    assert proposals[0]["approval_state"] == "applied"
+    assert wa.pending_count(wa.SKILLS) == 0
+    assert skill_usage.get_record("codex-auto-skill")["created_by"] == "agent"
+    assert "codex-auto-skill" in skill_usage.list_agent_created_skill_names()
+
+
+def test_apply_and_discard_learning_proposals(monkeypatch):
+    from tools import write_approval as wa
+
+    memory_rec = wa.stage_write(
+        wa.MEMORY,
+        {"action": "add", "target": "memory", "content": "Apply me"},
+        summary="add to memory: Apply me",
+        origin="codex_learning",
+    )
+    memory_proposal = {
+        "id": "learn_apply",
+        "packet_id": "pkt_proc",
+        "process_id": "proc",
+        "subsystem": wa.MEMORY,
+        "pending_id": memory_rec["id"],
+        "status": "staged",
+        "approval_state": "pending",
+        "confidence": 1.0,
+        "summary": memory_rec["summary"],
+        "repo": "/tmp/repo",
+        "branch": "codex/test",
+        "source_command": "codex exec",
+        "created_at": 1.0,
+        "updated_at": 1.0,
+    }
+    cl.save_proposal(memory_proposal)
+
+    out = cl.apply_learning("learn_apply", {"codex_cockpit": {"context_helper": {}}})
+
+    assert "Applied 1" in out
+    assert wa.get_pending(wa.MEMORY, memory_rec["id"]) is None
+    assert cl.load_proposal("learn_apply")["status"] == "applied"
+
+    discard_rec = wa.stage_write(
+        wa.MEMORY,
+        {"action": "add", "target": "memory", "content": "Discard me"},
+        summary="add to memory: Discard me",
+        origin="codex_learning",
+    )
+    discard_proposal = dict(memory_proposal)
+    discard_proposal.update(
+        {
+            "id": "learn_discard",
+            "pending_id": discard_rec["id"],
+            "status": "staged",
+            "approval_state": "pending",
+        }
+    )
+    cl.save_proposal(discard_proposal)
+
+    out = cl.discard_learning("learn_discard")
+
+    assert "Discarded 1" in out
+    assert wa.get_pending(wa.MEMORY, discard_rec["id"]) is None
+    assert cl.load_proposal("learn_discard")["status"] == "discarded"
+
+
+def test_handle_process_completed_honors_enabled_flag(monkeypatch):
+    started = []
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"codex_cockpit": {"context_helper": {"enabled": True}}},
+    )
+    monkeypatch.setattr(cl, "start_review_thread", lambda packet_id, cfg: started.append(packet_id))
+    monkeypatch.setattr(cl, "_resolve_repo_root", lambda _cwd: "/tmp/repo")
+
+    packet = cl.handle_process_completed(_session())
+
+    assert packet is not None
+    assert packet["id"] == "pkt_proc_123"
+    assert started == ["pkt_proc_123"]
+
+
+def test_render_pending_lists_control_commands():
+    from tools import write_approval as wa
+
+    pending = wa.stage_write(
+        wa.MEMORY,
+        {"action": "add", "target": "memory", "content": "Pending"},
+        summary="add to memory: Pending",
+        origin="codex_learning",
+    )
+    cl.save_proposal(
+        {
+            "id": "learn_pending",
+            "packet_id": "pkt_proc",
+            "process_id": "proc",
+            "subsystem": wa.MEMORY,
+            "pending_id": pending["id"],
+            "status": "staged",
+            "approval_state": "pending",
+            "confidence": 1.0,
+            "summary": pending["summary"],
+            "repo": "/tmp/repo",
+            "branch": "codex/test",
+            "source_command": "codex exec -C /tmp/wt test",
+            "created_at": 1.0,
+            "updated_at": 1.0,
+        }
+    )
+
+    rendered = cl.render_learn_pending()
+
+    assert "learn_pending" in rendered
+    assert "/codex learn apply <id|all>" in rendered
+    assert "codex/test" in rendered

--- a/tests/hermes_cli/test_curator_status.py
+++ b/tests/hermes_cli/test_curator_status.py
@@ -59,7 +59,7 @@ def test_status_uses_last_activity_not_only_last_used(monkeypatch, capsys):
 
 @pytest.fixture
 def curator_status_env(tmp_path, monkeypatch):
-    """Isolated HERMES_HOME with real agent-created skills on disk."""
+    """Isolated HERMES_HOME with real curator-managed skills on disk."""
     home = tmp_path / ".hermes"
     skills = home / "skills"
     skills.mkdir(parents=True)
@@ -171,7 +171,7 @@ def test_status_hides_most_active_when_all_zero(curator_status_env):
 def test_status_no_skills_produces_clean_empty_output(curator_status_env):
     env = curator_status_env
     out = _capture_status(env["curator_cli"])
-    assert "no agent-created skills" in out
+    assert "no curator-managed skills" in out
     # None of the ranking sections render
     assert "most active" not in out
     assert "least active" not in out

--- a/tests/tools/test_codex_learning_notification.py
+++ b/tests/tools/test_codex_learning_notification.py
@@ -1,0 +1,12 @@
+from tools.process_registry import format_process_notification
+
+
+def test_format_codex_learning_staged_event():
+    evt = {
+        "type": "codex_learning_staged",
+        "message": "Codex learning staged 1 proposal.",
+    }
+
+    result = format_process_notification(evt)
+
+    assert result == "[IMPORTANT: Codex learning staged 1 proposal.]"

--- a/tests/tools/test_skill_usage.py
+++ b/tests/tools/test_skill_usage.py
@@ -474,15 +474,83 @@ def test_agent_created_report_includes_marked_skills_with_defaults(skills_home):
     assert by_name["b"]["state"] == "active"
 
 
-def test_manual_skill_with_usage_is_not_curator_managed(skills_home):
+def test_manual_skill_is_curator_managed_by_default(skills_home):
     from tools.skill_usage import agent_created_report, bump_view, list_agent_created_skill_names
     skills_dir = skills_home / "skills"
     _write_skill(skills_dir, "manual-skill")
 
     bump_view("manual-skill")
 
-    assert "manual-skill" not in list_agent_created_skill_names()
-    assert "manual-skill" not in {r["name"] for r in agent_created_report()}
+    assert "manual-skill" in list_agent_created_skill_names()
+    assert "manual-skill" in {r["name"] for r in agent_created_report()}
+
+
+def test_agent_created_scope_excludes_unmarked_manual_skill(skills_home, monkeypatch):
+    import tools.skill_usage as skill_usage
+
+    skills_dir = skills_home / "skills"
+    _write_skill(skills_dir, "manual-skill")
+    skill_usage.bump_view("manual-skill")
+    monkeypatch.setattr(skill_usage, "curator_scope", lambda: skill_usage.SCOPE_AGENT_CREATED)
+
+    assert "manual-skill" not in skill_usage.list_agent_created_skill_names()
+    assert "manual-skill" not in {r["name"] for r in skill_usage.agent_created_report()}
+
+
+def test_all_usable_scope_includes_external_skills(skills_home):
+    from agent.skill_utils import _external_dirs_cache_clear
+    from tools.skill_usage import list_agent_created_skill_names
+
+    external = skills_home / "external-skills"
+    external.mkdir()
+    _write_skill(external, "external-skill")
+    _write_skill(skills_home / "skills", "local-skill")
+    (skills_home / "config.yaml").write_text(
+        f"skills:\n  external_dirs:\n    - {external}\n",
+        encoding="utf-8",
+    )
+    _external_dirs_cache_clear()
+
+    names = list_agent_created_skill_names()
+    assert "local-skill" in names
+    assert "external-skill" in names
+
+
+def test_all_usable_scope_excludes_disabled_skills(skills_home):
+    from tools.skill_usage import list_agent_created_skill_names
+
+    skills_dir = skills_home / "skills"
+    _write_skill(skills_dir, "enabled-skill")
+    _write_skill(skills_dir, "disabled-skill")
+    (skills_home / "config.yaml").write_text(
+        "skills:\n  disabled:\n    - disabled-skill\n",
+        encoding="utf-8",
+    )
+
+    names = list_agent_created_skill_names()
+    assert "enabled-skill" in names
+    assert "disabled-skill" not in names
+
+
+def test_all_usable_scope_excludes_protected_and_hub(skills_home):
+    import tools.skill_usage as skill_usage
+
+    skills_dir = skills_home / "skills"
+    protected = next(iter(skill_usage.PROTECTED_BUILTIN_SKILLS))
+    _write_skill(skills_dir, protected)
+    _write_skill(skills_dir, "hub-skill")
+    _write_skill(skills_dir, "manual-skill")
+    hub_dir = skills_dir / ".hub"
+    hub_dir.mkdir()
+    (hub_dir / "lock.json").write_text(
+        json.dumps({"version": 1, "installed": {"hub-skill": {"source": "taps/main"}}}),
+        encoding="utf-8",
+    )
+
+    names = skill_usage.list_agent_created_skill_names()
+    assert "manual-skill" in names
+    assert protected not in names
+    assert "hub-skill" not in names
 
 
 def test_agent_created_report_excludes_bundled_and_hub(skills_home):

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -48,6 +48,28 @@ def test_invalid_subsystem_is_off(hermes_home):
     assert wa.write_approval_enabled("bogus") is False
 
 
+def test_force_write_approval_is_scoped(hermes_home):
+    from tools import write_approval as wa
+
+    assert wa.write_approval_enabled("memory") is False
+    assert wa.write_approval_enabled("skills") is False
+    with wa.force_write_approval(wa.MEMORY):
+        assert wa.write_approval_enabled("memory") is True
+        assert wa.write_approval_enabled("skills") is False
+    assert wa.write_approval_enabled("memory") is False
+
+
+def test_codex_learning_origin_is_background_for_approval(hermes_home):
+    from tools import write_approval as wa
+    from tools.skill_provenance import reset_current_write_origin, set_current_write_origin
+
+    token = set_current_write_origin("codex_learning")
+    try:
+        assert wa.is_background() is True
+    finally:
+        reset_current_write_origin(token)
+
+
 def test_normalize_enabled_coerces_values():
     from tools import write_approval as wa
     # Real bools pass through.
@@ -152,6 +174,38 @@ def test_skill_gate_on_then_apply_writes_file(hermes_home):
     res = json.loads(smt.apply_skill_pending(rec["payload"]))
     assert res["success"] is True
     assert smt._find_skill("applied-skill") is not None
+
+
+def test_skill_approval_replays_codex_origin_for_curator_usage(hermes_home):
+    import importlib
+    import tools.skill_manager_tool as smt
+    import tools.skill_usage as skill_usage
+    importlib.reload(smt)
+    importlib.reload(skill_usage)
+    from hermes_cli.write_approval_commands import handle_pending_subcommand
+    from tools import write_approval as wa
+
+    content = (
+        "---\n"
+        "name: codex-origin-skill\n"
+        "description: Created from Codex learning\n"
+        "version: 1.0.0\n"
+        "---\n"
+        "# Codex Origin Skill\n"
+    )
+    rec = wa.stage_write(
+        wa.SKILLS,
+        {"action": "create", "name": "codex-origin-skill", "content": content},
+        summary="create codex-origin-skill",
+        origin="codex_learning",
+    )
+
+    out = handle_pending_subcommand(wa.SKILLS, ["approve", rec["id"]])
+
+    assert "Approved 1" in out
+    assert wa.get_pending(wa.SKILLS, rec["id"]) is None
+    assert smt._find_skill("codex-origin-skill") is not None
+    assert skill_usage.get_record("codex-origin-skill")["created_by"] == "agent"
 
 
 def test_skill_create_diff_is_full_content(hermes_home):

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -888,6 +888,13 @@ class ProcessRegistry:
                 "exit_code": session.exit_code,
                 "output": output_tail,
             })
+        if was_running and str(session.task_id or "").startswith("codex_"):
+            try:
+                from hermes_cli import codex_learning
+
+                codex_learning.handle_process_completed(session)
+            except Exception:
+                logger.debug("Codex learning harvester failed for %s", session.id, exc_info=True)
 
     # ----- Query Methods -----
 
@@ -1529,6 +1536,9 @@ def format_process_notification(evt: dict) -> "str | None":
             text += f"\n({_sup} earlier matches were suppressed by rate limit)"
         text += "]"
         return text
+
+    if evt_type == "codex_learning_staged":
+        return f"[IMPORTANT: {evt.get('message', '')}]"
 
     _exit = evt.get("exit_code", "?")
     _out = evt.get("output", "")

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -964,15 +964,15 @@ def skill_manage(
             pass
         # Curator telemetry: bump patch_count on edit/patch/write_file (the actions
         # that mutate an existing skill's guidance), drop the record on delete.
-        # Only mark a skill as agent-created when the background self-improvement
-        # review fork creates it — foreground `skill_manage(create)` calls are
-        # user-directed, and those skills belong to the user (the curator must
-        # not touch them). Best-effort; telemetry failures never break the tool.
+        # Mark generated skills for curator provenance when an automated
+        # learning/review loop creates them. Foreground `skill_manage(create)`
+        # calls remain user-directed. Best-effort; telemetry failures never
+        # break the tool.
         try:
             from tools.skill_usage import bump_patch, forget, mark_agent_created
-            from tools.skill_provenance import is_background_review
+            from tools.skill_provenance import is_curator_managed_origin
             if action == "create":
-                if is_background_review():
+                if is_curator_managed_origin():
                     mark_agent_created(name)
             elif action in {"patch", "edit", "write_file", "remove_file"}:
                 bump_patch(name)

--- a/tools/skill_provenance.py
+++ b/tools/skill_provenance.py
@@ -1,8 +1,9 @@
-"""Skill write-origin provenance — ContextVar for distinguishing agent-sediment skill writes from foreground user-directed writes.
+"""Skill write-origin provenance — ContextVar for generated skill writes.
 
-The curator only consolidates/prunes skills it autonomously created via the
-background self-improvement review fork. Skills a user asks a foreground
-agent to write belong to the user and must never be auto-curated.
+The curator treats generated skills as system-managed sediment. Skills a user
+asks a foreground agent to write still belong to the user, but automated
+review loops such as background review and Codex learning need durable origin
+provenance so generated skills can be audited and curated.
 
 This module exposes a ContextVar that run_agent.py sets before each tool
 loop so tool handlers (e.g. skill_manage create) can check whether they
@@ -27,7 +28,7 @@ Usage:
         reset_current_write_origin(token)
 
     # inside a tool:
-    if get_current_write_origin() == "background_review":
+    if is_curator_managed_origin():
         mark_agent_created(skill_name)
 """
 
@@ -43,6 +44,8 @@ _write_origin: contextvars.ContextVar[str] = contextvars.ContextVar(
 # run_agent.py's AIAgent._memory_write_origin override in
 # _spawn_background_review().
 BACKGROUND_REVIEW = "background_review"
+CODEX_LEARNING = "codex_learning"
+CURATOR_MANAGED_ORIGINS = frozenset({BACKGROUND_REVIEW, CODEX_LEARNING})
 
 
 def set_current_write_origin(origin: str) -> contextvars.Token[str]:
@@ -65,9 +68,11 @@ def get_current_write_origin() -> str:
     Default: "foreground" — any tool call made by a regular (non-review)
     agent, from the CLI, the gateway, cron, or a subagent.
 
-    "background_review" — the self-improvement review fork; only skills
-    created under this origin should be marked agent-created for curator
-    management.
+    "background_review" — the self-improvement review fork.
+    "codex_learning" — the automated Codex completion learning reviewer.
+
+    Skills created under generated origins should be marked for curator
+    management and audit provenance.
     """
     return _write_origin.get()
 
@@ -76,3 +81,8 @@ def is_background_review() -> bool:
     """Convenience: True iff the current write origin is the background
     review fork."""
     return get_current_write_origin() == BACKGROUND_REVIEW
+
+
+def is_curator_managed_origin() -> bool:
+    """True when the active write origin is an automated learning/review loop."""
+    return get_current_write_origin() in CURATOR_MANAGED_ORIGINS

--- a/tools/skill_usage.py
+++ b/tools/skill_usage.py
@@ -11,9 +11,9 @@ Design notes:
   - Atomic writes via tempfile + os.replace (same pattern as .bundled_manifest).
   - All counter bumps are best-effort: failures log at DEBUG and return silently.
     A broken sidecar never breaks the underlying tool call.
-  - Provenance filter: curator-managed skills are explicitly marked when
-    created through skill_manage. Bundled / hub-installed skills stay
-    off-limits, and manually authored skills are not inferred from location.
+  - Scope filter: by default the curator manages every usable local skill
+    (profile skills + external_dirs) while hub-installed/protected skills stay
+    off-limits. The legacy agent-created-only scope remains config-selectable.
 
 Lifecycle states:
     active    -> default
@@ -34,7 +34,15 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import get_hermes_home
-from agent.skill_utils import is_excluded_skill_path
+from agent.skill_utils import (
+    get_all_skills_dirs,
+    get_disabled_skill_names,
+    is_excluded_skill_path,
+    iter_skill_index_files,
+    parse_frontmatter,
+    skill_matches_environment,
+    skill_matches_platform,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +62,9 @@ STATE_ACTIVE = "active"
 STATE_STALE = "stale"
 STATE_ARCHIVED = "archived"
 _VALID_STATES = {STATE_ACTIVE, STATE_STALE, STATE_ARCHIVED}
+SCOPE_AGENT_CREATED = "agent_created"
+SCOPE_ALL_USABLE = "all_usable"
+_VALID_SCOPES = {SCOPE_AGENT_CREATED, SCOPE_ALL_USABLE}
 
 # Load-bearing bundled built-ins the curator must NEVER archive or consolidate,
 # regardless of ``curator.prune_builtins``, pin state, or LLM judgment. These
@@ -122,8 +133,8 @@ def _usage_file_lock():
         fd.close()
 
 
-def _archive_dir() -> Path:
-    return _skills_dir() / ".archive"
+def _archive_dir(root: Optional[Path] = None) -> Path:
+    return (root or _skills_dir()) / ".archive"
 
 
 def _now_iso() -> str:
@@ -175,7 +186,7 @@ def activity_count(record: Dict[str, Any]) -> int:
 
 
 # ---------------------------------------------------------------------------
-# Provenance — which skills are agent-created (and thus eligible for curation)
+# Provenance + eligibility filters for curator-managed skills.
 # ---------------------------------------------------------------------------
 
 def _read_bundled_manifest_names() -> Set[str]:
@@ -260,6 +271,28 @@ def _prune_builtins_enabled() -> bool:
     return True
 
 
+def curator_scope() -> str:
+    """Return the configured curator scope.
+
+    ``all_usable`` is the new default: any skill Hermes can load from the local
+    profile skills dir or configured external_dirs is eligible, subject to the
+    existing hub/protected/bundled fences. ``agent_created`` preserves the older
+    explicit-provenance behavior for users who opt back into it.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        cur = cfg.get("curator") if isinstance(cfg, dict) else None
+        if isinstance(cur, dict):
+            scope = str(cur.get("scope") or SCOPE_ALL_USABLE).strip().lower()
+            if scope in _VALID_SCOPES:
+                return scope
+    except Exception as e:  # pragma: no cover - best-effort config read
+        logger.debug("Failed to read curator.scope: %s", e)
+    return SCOPE_ALL_USABLE
+
+
 def _suppressed_file() -> Path:
     return _skills_dir() / ".curator_suppressed"
 
@@ -330,32 +363,20 @@ def remove_suppressed_name(skill_name: str) -> None:
 def list_agent_created_skill_names() -> List[str]:
     """Enumerate skills the curator may manage.
 
-    Always includes agent-authored skills (those marked in ``.usage.json`` via
-    ``skill_manage(action="create")``). When ``curator.prune_builtins`` is
-    enabled, bundled built-in skills are ALSO included even though they have no
-    agent-created usage record — their inactivity clock is anchored on first
-    sight (see ``apply_automatic_transitions``). Hub-installed skills are never
-    included; manually authored skills are not inferred from filesystem
-    location.
+    In the default ``all_usable`` scope, this is every loadable local/external
+    skill after the normal skill-scan exclusions, minus hub-installed and
+    protected skills. In legacy ``agent_created`` scope, non-bundled skills must
+    still opt in via their usage record.
     """
-    base = _skills_dir()
-    if not base.exists():
-        return []
     hub = _read_hub_installed_names()
     bundled = _read_bundled_manifest_names()
     prune_builtins = _prune_builtins_enabled()
+    scope = curator_scope()
     usage = load_usage()
 
     names: List[str] = []
     # Top-level SKILL.md files (flat layout) AND nested category/skill/SKILL.md
-    for skill_md in base.rglob("SKILL.md"):
-        # Skip Hermes metadata, VCS, virtualenv/dependency, and cache dirs
-        if is_excluded_skill_path(skill_md):
-            continue
-        try:
-            skill_md.relative_to(base)
-        except ValueError:
-            continue
+    for _root, skill_md in _iter_skill_files():
         name = _read_skill_name(skill_md, fallback=skill_md.parent.name)
         # Hub-installed skills are always off-limits.
         if name in hub:
@@ -371,24 +392,26 @@ def list_agent_created_skill_names() -> List[str]:
                 continue
             names.append(name)
             continue
-        # Agent-authored (or local-manual) skills must opt in via their record.
-        if not _is_curator_managed_record(usage.get(name)):
+        if scope == SCOPE_AGENT_CREATED and not _is_curator_managed_record(usage.get(name)):
             continue
         names.append(name)
     return sorted(set(names))
 
 
 def list_archived_skill_names() -> List[str]:
-    """Enumerate skills in ``~/.hermes/skills/.archive/``.
+    """Enumerate skills in every managed root's ``.archive/`` directory.
 
-    Archive layout is flat (``.archive/<skill>/``) as set by ``archive_skill``,
-    so the directory name is the skill name. Used by ``hermes curator
-    list-archived`` to help users pass a name to ``hermes curator restore``.
+    Archive layout is flat (``<root>/.archive/<skill>/``) as set by
+    ``archive_skill``, so the directory name is the skill name. Used by
+    ``hermes curator list-archived`` to help users pass a name to
+    ``hermes curator restore``.
     """
-    archive_root = _archive_dir()
-    if not archive_root.exists():
-        return []
-    return sorted({p.name for p in archive_root.iterdir() if p.is_dir()})
+    names: set[str] = set()
+    for root in _skill_roots():
+        archive_root = _archive_dir(root)
+        if archive_root.exists():
+            names.update({p.name for p in archive_root.iterdir() if p.is_dir()})
+    return sorted(names)
 
 
 def _read_skill_name(skill_md: Path, fallback: str) -> str:
@@ -431,11 +454,11 @@ def is_bundled(skill_name: str) -> bool:
 def is_curation_eligible(skill_name: str) -> bool:
     """Whether the curator may track/archive *skill_name*.
 
-    Agent-created skills are always eligible. Bundled built-ins become eligible
-    only when ``curator.prune_builtins`` is enabled. Hub-installed skills are
-    NEVER eligible — they have an external upstream owner. Protected built-ins
-    (``PROTECTED_BUILTIN_SKILLS``) are NEVER eligible regardless of any flag —
-    they back load-bearing UX and must never be archived or consolidated.
+    In ``all_usable`` scope, manual and foreground-created local skills are
+    eligible too. Bundled built-ins become eligible only when
+    ``curator.prune_builtins`` is enabled. Hub-installed skills are NEVER
+    eligible — they have an external upstream owner. Protected built-ins are
+    NEVER eligible regardless of any flag.
     """
     if is_protected_builtin(skill_name):
         return False
@@ -556,7 +579,7 @@ def _mutate(skill_name: str, mutator, *, require_curation_eligible: bool = False
     """Load, apply *mutator(record)* in place, save. Best-effort.
 
     By default this records telemetry for ANY skill — bundled, hub-installed,
-    or agent-created — because usage tracking is pure observability and is
+    or generated — because usage tracking is pure observability and is
     orthogonal to whether a skill is ever curated. Lifecycle mutators
     (``set_state``, ``set_pinned``, ``mark_agent_created``) pass
     ``require_curation_eligible=True`` so they never write meaningless state
@@ -620,10 +643,11 @@ def bump_patch(skill_name: str) -> None:
 
 
 def mark_agent_created(skill_name: str) -> None:
-    """Opt a skill created by skill_manage into curator management.
+    """Mark a skill created by an automated loop for audit/curator provenance.
 
-    Viewing or invoking a manually authored skill may still create telemetry,
-    but only this explicit marker makes it eligible for automatic curation.
+    In the default all_usable scope, manual skills are also eligible for
+    curation; this marker is still preserved so generated skills remain
+    distinguishable in reports and audit trails.
     """
     def _apply(rec: Dict[str, Any]) -> None:
         rec["created_by"] = "agent"
@@ -670,7 +694,7 @@ def forget(skill_name: str) -> None:
 # ---------------------------------------------------------------------------
 
 def archive_skill(skill_name: str) -> Tuple[bool, str]:
-    """Move a curator-eligible skill directory to ~/.hermes/skills/.archive/.
+    """Move a curator-eligible skill directory to its root's ``.archive/``.
 
     Returns (ok, message). Never archives hub-installed skills. Bundled
     built-ins are only archivable when ``curator.prune_builtins`` is enabled;
@@ -690,11 +714,13 @@ def archive_skill(skill_name: str) -> Tuple[bool, str]:
             "curator.prune_builtins to allow pruning it"
         )
 
-    skill_dir = _find_skill_dir(skill_name)
-    if skill_dir is None:
+    found = _find_skill_info(skill_name)
+    if found is None:
         return False, f"skill '{skill_name}' not found"
+    skill_dir = found["path"]
+    root = found["root"]
 
-    archive_root = _archive_dir()
+    archive_root = _archive_dir(root)
     try:
         archive_root.mkdir(parents=True, exist_ok=True)
     except OSError as e:
@@ -725,8 +751,10 @@ def archive_skill(skill_name: str) -> Tuple[bool, str]:
 
 
 def restore_skill(skill_name: str) -> Tuple[bool, str]:
-    """Move an archived skill back to ~/.hermes/skills/. Restores to the flat
-    top-level layout; original category nesting is NOT reconstructed.
+    """Move an archived skill back to the same skill root it was archived from.
+
+    Restores to that root's flat top-level layout; original category nesting is
+    NOT reconstructed.
 
     Refuses to restore under a name that now collides with a hub-installed
     skill — that would shadow the upstream version. Also refuses to restore
@@ -748,25 +776,34 @@ def restore_skill(skill_name: str) -> Tuple[bool, str]:
             f"skill '{skill_name}' is now bundled; "
             "restore would shadow the upstream version"
         )
-    archive_root = _archive_dir()
-    if not archive_root.exists():
-        return False, "no archive directory"
-
     # Try exact name match first, then any prefix match (for timestamped dupes).
     # Recursive walk handles nested archive layouts (e.g. .archive/<category>/<skill>/)
     # left behind by older archive paths or external imports.
-    candidates = [p for p in archive_root.rglob("*") if p.is_dir() and p.name == skill_name]
-    if not candidates:
-        candidates = sorted(
-            [p for p in archive_root.rglob("*")
-             if p.is_dir() and p.name.startswith(f"{skill_name}-")],
-            reverse=True,
+    candidates: List[Tuple[Path, Path]] = []
+    for root in _skill_roots():
+        archive_root = _archive_dir(root)
+        if not archive_root.exists():
+            continue
+        exact = [(root, p) for p in archive_root.rglob("*") if p.is_dir() and p.name == skill_name]
+        if exact:
+            candidates.extend(exact)
+            continue
+        candidates.extend(
+            sorted(
+                [
+                    (root, p)
+                    for p in archive_root.rglob("*")
+                    if p.is_dir() and p.name.startswith(f"{skill_name}-")
+                ],
+                key=lambda item: str(item[1]),
+                reverse=True,
+            )
         )
     if not candidates:
         return False, f"skill '{skill_name}' not found in archive"
 
-    src = candidates[0]
-    dest = _skills_dir() / skill_name
+    root, src = candidates[0]
+    dest = root / skill_name
     if dest.exists():
         return False, f"destination already exists: {dest}"
 
@@ -786,21 +823,70 @@ def restore_skill(skill_name: str) -> Tuple[bool, str]:
     return True, f"restored to {dest}"
 
 
-def _find_skill_dir(skill_name: str) -> Optional[Path]:
+def _find_skill_info(skill_name: str) -> Optional[Dict[str, Path]]:
     """Locate the directory for a skill by its frontmatter `name:` field.
 
-    Handles both flat (~/.hermes/skills/<skill>/SKILL.md) and category-nested
-    (~/.hermes/skills/<category>/<skill>/SKILL.md) layouts.
+    Handles both flat (``<root>/<skill>/SKILL.md``) and category-nested
+    (``<root>/<category>/<skill>/SKILL.md``) layouts across local and external
+    skill roots. Root order mirrors runtime skill resolution: local first.
     """
-    base = _skills_dir()
-    if not base.exists():
-        return None
-    for skill_md in base.rglob("SKILL.md"):
-        if is_excluded_skill_path(skill_md):
-            continue
+    for root, skill_md in _iter_skill_files():
         if _read_skill_name(skill_md, fallback=skill_md.parent.name) == skill_name:
-            return skill_md.parent
+            return {"path": skill_md.parent, "root": root}
     return None
+
+
+def _find_skill_dir(skill_name: str) -> Optional[Path]:
+    found = _find_skill_info(skill_name)
+    return found["path"] if found else None
+
+
+def _skill_roots() -> List[Path]:
+    """Return existing skill roots in runtime resolution order."""
+    roots: List[Path] = []
+    seen: Set[Path] = set()
+    for root in get_all_skills_dirs():
+        try:
+            resolved = root.resolve()
+        except OSError:
+            resolved = root
+        if resolved in seen or not resolved.exists():
+            continue
+        seen.add(resolved)
+        roots.append(resolved)
+    return roots
+
+
+def _iter_skill_files() -> List[Tuple[Path, Path]]:
+    """Return ``(root, SKILL.md)`` pairs for loadable local/external skills."""
+    files: List[Tuple[Path, Path]] = []
+    disabled = get_disabled_skill_names()
+    seen_names: Set[str] = set()
+    for root in _skill_roots():
+        for skill_md in iter_skill_index_files(root, "SKILL.md"):
+            if is_excluded_skill_path(skill_md):
+                continue
+            try:
+                skill_md.relative_to(root)
+            except ValueError:
+                continue
+            try:
+                content = skill_md.read_text(encoding="utf-8", errors="replace")[:4000]
+                frontmatter, _body = parse_frontmatter(content)
+                if not skill_matches_platform(frontmatter):
+                    continue
+                if not skill_matches_environment(frontmatter):
+                    continue
+                name = str(frontmatter.get("name") or skill_md.parent.name)
+            except Exception:
+                name = _read_skill_name(skill_md, fallback=skill_md.parent.name)
+            if name in disabled:
+                continue
+            if name in seen_names:
+                continue
+            seen_names.add(name)
+            files.append((root, skill_md))
+    return files
 
 
 # ---------------------------------------------------------------------------
@@ -856,15 +942,10 @@ def usage_report() -> List[Dict[str, Any]]:
     ``provenance`` field ('agent' | 'bundled' | 'hub') and ``_persisted``
     (whether a real ``.usage.json`` record backs the row).
     """
-    base = _skills_dir()
-    if not base.exists():
-        return []
     data = load_usage()
     rows: List[Dict[str, Any]] = []
     seen: set = set()
-    for skill_md in base.rglob("SKILL.md"):
-        if is_excluded_skill_path(skill_md):
-            continue
+    for root, skill_md in _iter_skill_files():
         name = _read_skill_name(skill_md, fallback=skill_md.parent.name)
         if name in seen:
             continue
@@ -879,6 +960,7 @@ def usage_report() -> List[Dict[str, Any]]:
             "name": name,
             **rec,
             "provenance": provenance(name),
+            "root": str(root),
             "_persisted": persisted,
         }
         row["last_activity_at"] = latest_activity_at(row)

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -14,6 +14,8 @@ Both stores are written from two origins:
   * **background_review** — the self-improvement review fork that runs after a
     turn and autonomously decides what to save (the source of the
     "wrong assumptions" users complained about)
+  * **codex_learning** — the automated reviewer that learns from completed
+    `/codex launch` work
 
 This module lets the user gate those writes per-subsystem with a boolean
 ``write_approval``:
@@ -47,8 +49,10 @@ import logging
 import os
 import time
 import uuid
+import contextlib
+import contextvars
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 
 from hermes_constants import get_hermes_home
 
@@ -65,6 +69,10 @@ _SUBSYSTEMS = (MEMORY, SKILLS)
 # "block all writes" state — to disable a subsystem entirely use its own
 # enable flag (e.g. ``memory.memory_enabled: false``).
 CONFIG_KEY = "write_approval"
+_forced_approval_subsystems: contextvars.ContextVar[frozenset[str]] = contextvars.ContextVar(
+    "forced_write_approval_subsystems",
+    default=frozenset(),
+)
 
 
 # ---------------------------------------------------------------------------
@@ -80,6 +88,8 @@ def write_approval_enabled(subsystem: str) -> bool:
     """
     if subsystem not in _SUBSYSTEMS:
         return False
+    if subsystem in _forced_approval_subsystems.get():
+        return True
     try:
         from hermes_cli.config import load_config, cfg_get
         cfg = load_config()
@@ -103,6 +113,27 @@ def _normalize_enabled(value: Any) -> bool:
     return False
 
 
+@contextlib.contextmanager
+def force_write_approval(*subsystems: str) -> Iterator[None]:
+    """Temporarily require approval for selected durable-write subsystems.
+
+    This is for autonomous review loops that must stage proposed writes even
+    when the user's global memory/skills gate is off. It affects only the
+    current ContextVar context, so normal foreground writes keep their config
+    semantics.
+    """
+    selected = {s for s in subsystems if s in _SUBSYSTEMS}
+    if not selected:
+        yield
+        return
+    current = set(_forced_approval_subsystems.get())
+    token = _forced_approval_subsystems.set(frozenset(current | selected))
+    try:
+        yield
+    finally:
+        _forced_approval_subsystems.reset(token)
+
+
 # ---------------------------------------------------------------------------
 # Pending store (file-backed)
 # ---------------------------------------------------------------------------
@@ -123,7 +154,8 @@ def stage_write(subsystem: str, payload: Dict[str, Any],
         summary: a one-line human-readable description shown in pending lists.
             For skills this is the LLM/heuristic gist; for memory it can be the
             entry text itself.
-        origin: ``foreground`` or ``background_review`` — recorded for audit.
+        origin: ``foreground``, ``background_review``, or ``codex_learning`` —
+            recorded for audit.
 
     Returns a dict with ``id`` and metadata. Best-effort: on disk failure it
     logs and still returns a record (the write is simply lost, which is the
@@ -205,7 +237,7 @@ def pending_count(subsystem: str) -> int:
 # ---------------------------------------------------------------------------
 
 def current_origin() -> str:
-    """Return the active write origin: ``foreground`` or ``background_review``.
+    """Return the active write origin.
 
     Reuses the skill-provenance ContextVar, which the background review fork
     already sets (see ``agent.background_review`` /
@@ -220,7 +252,7 @@ def current_origin() -> str:
 
 
 def is_background() -> bool:
-    return current_origin() == "background_review"
+    return current_origin() in {"background_review", "codex_learning"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a Codex completion learning harvester with `/codex learn status|pending|apply|discard` controls
- auto-promote high-confidence memory and skill proposals through staged approval replay while preserving `codex_learning` / `background_review` provenance
- make Hermes Curator manage all usable local and external-dir skills by default, with hub/protected exclusions, first-sight seeding, and multi-root archive/restore backups

## Validation
- `PYTHONDONTWRITEBYTECODE=1 TZ=UTC LANG=C.UTF-8 LC_ALL=C.UTF-8 PYTHONHASHSEED=0 venv/bin/python -m pytest -o cache_dir=/private/tmp/hermes-pytest-cache tests/hermes_cli/test_codex_learning.py tests/hermes_cli/test_codex_cockpit.py tests/gateway/test_codex_cockpit_command.py tests/tools/test_write_approval.py tests/tools/test_codex_learning_notification.py tests/tools/test_skill_usage.py tests/agent/test_curator.py tests/agent/test_curator_backup.py tests/hermes_cli/test_curator_status.py -q`
- `RUFF_CACHE_DIR=/private/tmp/hermes-ruff-cache venv/bin/ruff check tools/skill_usage.py tools/skill_provenance.py tools/skill_manager_tool.py tools/write_approval.py hermes_cli/write_approval_commands.py hermes_cli/codex_learning.py hermes_cli/codex_cockpit.py hermes_cli/config.py hermes_cli/curator.py agent/curator.py agent/curator_backup.py tests/hermes_cli/test_codex_learning.py tests/hermes_cli/test_codex_cockpit.py tests/tools/test_write_approval.py tests/tools/test_skill_usage.py tests/agent/test_curator.py tests/agent/test_curator_backup.py tests/hermes_cli/test_curator_status.py`
- `git diff --check origin/main...HEAD`