### PR TITLE
fix(simplex): use structured /_send for DMs to fix silent message drops

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -811,12 +811,12 @@ class SimplexAdapter(BasePlatformAdapter):
         tools to signal file attachments), they are stripped from the text
         body and sent as native voice notes or documents.
 
-        Groups use the structured ``/_send #<id> json [...]`` form
-        because the bracket chat-command syntax (``#[<id>] text``) is
-        parsed by the daemon as a display-name lookup, which silently
-        drops when the group's display name isn't the literal ID. DMs
-        use the simple ``@<id> text`` form which has always worked in
-        production.
+        Both groups and DMs use the structured ``/_send <id> json [...]``
+        form because the bracket chat-command syntax (``@<id> text``
+        for DMs, ``#[<id>] text`` for groups) resolves ``<id>`` as a
+        display name rather than a numeric contactId. When ``chat_id``
+        is a numeric ID (the common case for DMs), the bare form
+        silently fails with ``contactNotFound``.
 
         The call is fire-and-forget at the WebSocket level: the daemon
         doesn't always return a corrId reply for chat commands, and
@@ -831,14 +831,15 @@ class SimplexAdapter(BasePlatformAdapter):
         if content:
             corr_id = self._make_corr_id()
             if chat_id.startswith("group:"):
-                # Structured form: addresses by numeric ID, and json.dumps
-                # escapes newlines + special chars correctly.
-                composed = json.dumps(
-                    [{"msgContent": {"type": "text", "text": content}}]
-                )
-                cmd_str = f"/_send #{chat_id[6:]} json {composed}"
+                target = f"#{chat_id[6:]}"
             else:
-                cmd_str = f"@{chat_id} {content}"
+                target = f"@{chat_id}"
+            # Structured form: addresses by numeric ID, and json.dumps
+            # escapes newlines + special chars correctly.
+            composed = json.dumps(
+                [{"msgContent": {"type": "text", "text": content}}]
+            )
+            cmd_str = f"/_send {target} json {composed}"
 
             await self._send_ws({"corrId": corr_id, "cmd": cmd_str})
 
@@ -1192,14 +1193,13 @@ async def _standalone_send(
 
     try:
         if chat_id.startswith("group:"):
-            group_id = chat_id[6:]
-            composed = json.dumps(
-                [{"msgContent": {"type": "text", "text": message}}]
-            )
-            cmd_str = f"/_send #{group_id} json {composed}"
+            target = f"#{chat_id[6:]}"
         else:
-            # Direct contacts are addressed by display name without brackets.
-            cmd_str = f"@{chat_id} {message}"
+            target = f"@{chat_id}"
+        composed = json.dumps(
+            [{"msgContent": {"type": "text", "text": message}}]
+        )
+        cmd_str = f"/_send {target} json {composed}"
 
         payload = {
             "corrId": f"{_CORR_PREFIX}snd-{int(time.time() * 1000)}",

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -205,12 +205,13 @@ def test_corr_id_pending_set_self_trims():
 
 @pytest.mark.asyncio
 async def test_send_dm():
-    """DMs use the bare ``@<id> text`` chat-command form.
+    """DMs use the structured ``/_send @<id> json [...]`` form.
 
-    The bracketed form ``@[<id>] text`` is what the daemon's man page
-    documents, but in practice both addressing styles route through
-    the same chat-command parser; bare ``@<id>`` matches what every
-    Hermes deployment has been using in production for months.
+    The bare ``@<id> text`` chat-command syntax resolves ``<id>`` as a
+    display name, silently failing with ``contactNotFound`` when
+    ``chat_id`` is a numeric contactId. The structured ``/_send`` form
+    addresses by contactId and survives special characters via
+    ``json.dumps``.
     """
     from gateway.config import PlatformConfig
     cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
@@ -222,7 +223,11 @@ async def test_send_dm():
     result = await adapter.send("contact-42", "Hello, SimpleX!")
     mock_ws.send.assert_called_once()
     payload = json.loads(mock_ws.send.call_args[0][0])
-    assert payload["cmd"] == "@contact-42 Hello, SimpleX!"
+    assert payload["cmd"].startswith("/_send @contact-42 json ")
+    msg_content = json.loads(payload["cmd"].split(" json ", 1)[1])[0][
+        "msgContent"
+    ]
+    assert msg_content == {"type": "text", "text": "Hello, SimpleX!"}
     assert payload["corrId"].startswith(_CORR_PREFIX)
     assert result.success is True
 
@@ -349,7 +354,11 @@ async def test_standalone_send_defaults_to_local_daemon(monkeypatch):
 
     result = await _standalone_send(pconfig, "contact-42", "hi")
     assert result == {"success": True, "platform": "simplex", "chat_id": "contact-42"}
-    assert sent_payloads[0]["cmd"] == "@contact-42 hi"
+    assert sent_payloads[0]["cmd"].startswith("/_send @contact-42 json ")
+    msg_content = json.loads(
+        sent_payloads[0]["cmd"].split(" json ", 1)[1]
+    )[0]["msgContent"]
+    assert msg_content == {"type": "text", "text": "hi"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Fixes silent DM message drops in the SimpleX gateway adapter. Outbound text DMs used the bare `@<id> text` chat-command syntax, which resolves `<id>` as a display name rather than a numeric contactId. When `chat_id` is a numeric ID (the common case for DMs), the daemon returns `contactNotFound` and the message is silently lost because the send is fire-and-forget at the WebSocket layer.

The fix uses the structured `/_send @<id> json [...]` form for DMs, matching what image, document, voice, and group sends already do.

## Related Issue

Fixes #46265

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/simplex/adapter.py`: Unified DM and group send paths to both use the structured `/_send` form. Updated `send()` and `_standalone_send()`. Updated docstring to reflect the actual daemon behavior.
- `tests/gateway/test_simplex_plugin.py`: Updated `test_send_dm` and `test_standalone_send_defaults_to_local_daemon` assertions to match the new structured command format.

## How to Test

1. Set up SimpleX gateway with `simplex-chat -p 5225`
2. Approve a contact and send a message to Hermes
3. Verify the reply arrives in the SimpleX app (previously it was silently dropped)
4. Run `pytest tests/gateway/test_simplex_plugin.py -v` — all 30 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `SimplexAdapter.send`, `_standalone_send` (callers: gateway dispatch + cron standalone)
- Blast radius: LOW — SimpleX plugin only, no cross-platform impact
- Related patterns: Structured `/_send` form already used by `send_image`, `send_document`, `send_voice`, and group sends. This change unifies the DM path with the existing pattern.
