### PR TITLE
Support client-side Harmony format parsing and stateful streaming scrubbing

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -41,6 +41,7 @@ from agent.model_metadata import (
 )
 from agent.process_bootstrap import _install_safe_stdio
 from agent.subdirectory_hints import SubdirectoryHintTracker
+from agent.harmony_scrubber import StreamingHarmonyScrubber
 from agent.think_scrubber import StreamingThinkScrubber
 from agent.tool_guardrails import (
     ToolCallGuardrailConfig,
@@ -578,6 +579,8 @@ def init_agent(
     # deltas (#5719).  sanitize_context() alone can't survive chunk
     # boundaries because the block regex needs both tags in one string.
     agent._stream_context_scrubber = StreamingContextScrubber()
+    # Stateful scrubber for Harmony tags in streamed deltas.
+    agent._stream_harmony_scrubber = StreamingHarmonyScrubber()
     # Stateful scrubber for reasoning/thinking tags in streamed deltas
     # (#17924).  Replaces the per-delta _strip_think_blocks regex that
     # destroyed downstream state (e.g. MiniMax-M2.7 streaming

--- a/agent/harmony_scrubber.py
+++ b/agent/harmony_scrubber.py
@@ -1,0 +1,185 @@
+"""Stateful scrubber for Harmony tags in streamed assistant text.
+
+Allows only content in the 'final' channel to pass through, stripping the surrounding
+Harmony tags (<|channel|>final<|message|>, <|end|>, <|endoftext|>). For all other channels,
+both the tags and the payloads are suppressed entirely to avoid leaking tool calls, thoughts,
+or formatting instructions in real-time.
+
+Usage:
+    scrubber = StreamingHarmonyScrubber()
+    for delta in stream:
+        visible = scrubber.feed(delta)
+        if visible:
+            emit(visible)
+    tail = scrubber.flush()
+    if tail:
+        emit(tail)
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = ["StreamingHarmonyScrubber"]
+
+
+class StreamingHarmonyScrubber:
+    """Stateful scrubber for Harmony tags.
+
+    State machine states:
+      - "SCANNING": Outside any channel. Searching for '<|channel|>' or orphan '<|end|>'/'<|endoftext|>'.
+      - "IN_HEADER": Found '<|channel|>' but haven't resolved '<|message|>' yet.
+      - "IN_CHANNEL_FINAL": Inside a 'final' channel. Emitting all content until '<|end|>' or '<|endoftext|>'.
+      - "IN_CHANNEL_SUPPRESSED": Inside a non-final channel (e.g. commentary, analysis, thought). Discarding content.
+    """
+
+    def __init__(self) -> None:
+        self._state: str = "SCANNING"
+        self._buf: str = ""
+        self._channel_name: str | None = None
+
+    def reset(self) -> None:
+        """Reset all state. Call at the top of every new turn."""
+        self._state = "SCANNING"
+        self._buf = ""
+        self._channel_name = None
+
+    def feed(self, text: str) -> str:
+        """Feed one delta; return the scrubbed visible portion of the stream."""
+        if not text:
+            return ""
+
+        buf = self._buf + text
+        self._buf = ""
+        out: list[str] = []
+
+        while buf:
+            if self._state == "SCANNING":
+                # Find the earliest occurrence of any relevant tag in SCANNING state
+                tags = ("<|channel|>", "<|end|>", "<|endoftext|>")
+                earliest_idx = -1
+                matched_tag = None
+                buf_lower = buf.lower()
+
+                for tag in tags:
+                    idx = buf_lower.find(tag)
+                    if idx != -1:
+                        if earliest_idx == -1 or idx < earliest_idx:
+                            earliest_idx = idx
+                            matched_tag = tag
+
+                if matched_tag is not None:
+                    # Emit everything before the tag
+                    pre = buf[:earliest_idx]
+                    if pre:
+                        out.append(pre)
+
+                    if matched_tag == "<|channel|>":
+                        self._state = "IN_HEADER"
+                        buf = buf[earliest_idx:]
+                    else:
+                        # Orphan close tag: discard it
+                        buf = buf[earliest_idx + len(matched_tag):]
+                else:
+                    # No tag matched. Hold back any partial suffix at the tail
+                    partial_len = 0
+                    for tag in tags:
+                        for l in range(min(len(buf), len(tag) - 1), 0, -1):
+                            suffix = buf_lower[-l:]
+                            if tag.startswith(suffix):
+                                if l > partial_len:
+                                    partial_len = l
+
+                    if partial_len > 0:
+                        self._buf = buf[-partial_len:]
+                        emit_text = buf[:-partial_len]
+                    else:
+                        emit_text = buf
+
+                    if emit_text:
+                        out.append(emit_text)
+                    buf = ""
+
+            elif self._state == "IN_HEADER":
+                # Search for '<|message|>' to complete the header
+                idx = buf.lower().find("<|message|>")
+                if idx != -1:
+                    header_content = buf[:idx]
+                    header_payload = header_content[len("<|channel|>"):].strip()
+                    parts = header_payload.split(None, 1)
+                    channel_name = parts[0].lower() if parts else ""
+
+                    self._channel_name = channel_name
+                    if channel_name == "final":
+                        self._state = "IN_CHANNEL_FINAL"
+                    else:
+                        self._state = "IN_CHANNEL_SUPPRESSED"
+
+                    # Discard header and the '<|message|>' tag
+                    buf = buf[idx + len("<|message|>"):]
+                else:
+                    # Keep buffering until we find '<|message|>'
+                    if len(buf) > 1000:
+                        # Fallback for abnormally long pseudo-headers
+                        out.append(buf)
+                        self._state = "SCANNING"
+                        buf = ""
+                    else:
+                        self._buf = buf
+                        buf = ""
+
+            elif self._state in ("IN_CHANNEL_FINAL", "IN_CHANNEL_SUPPRESSED"):
+                # Search for end tags
+                close_tags = ("<|end|>", "<|endoftext|>")
+                close_idx = -1
+                close_len = 0
+                buf_lower = buf.lower()
+
+                for tag in close_tags:
+                    idx = buf_lower.find(tag)
+                    if idx != -1:
+                        if close_idx == -1 or idx < close_idx:
+                            close_idx = idx
+                            close_len = len(tag)
+
+                if close_idx != -1:
+                    content = buf[:close_idx]
+                    if self._state == "IN_CHANNEL_FINAL" and content:
+                        out.append(content)
+
+                    self._state = "SCANNING"
+                    self._channel_name = None
+                    buf = buf[close_idx + close_len:]
+                else:
+                    # Hold back partial suffix
+                    partial_len = 0
+                    for tag in close_tags:
+                        for l in range(min(len(buf), len(tag) - 1), 0, -1):
+                            suffix = buf_lower[-l:]
+                            if tag.startswith(suffix):
+                                if l > partial_len:
+                                    partial_len = l
+
+                    if partial_len > 0:
+                        self._buf = buf[-partial_len:]
+                        content = buf[:-partial_len]
+                    else:
+                        content = buf
+
+                    if self._state == "IN_CHANNEL_FINAL" and content:
+                        out.append(content)
+                    buf = ""
+
+        return "".join(out)
+
+    def flush(self) -> str:
+        """End-of-stream flush."""
+        tail = self._buf
+        self._buf = ""
+        state = self._state
+        self._state = "SCANNING"
+        self._channel_name = None
+
+        if state in ("IN_CHANNEL_FINAL", "SCANNING"):
+            return tail
+        return ""

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -10,6 +10,9 @@ reasoning configuration, temperature handling, and extra_body assembly.
 """
 
 import copy
+import hashlib
+import json
+import re
 from typing import Any, Dict
 
 from agent.lmstudio_reasoning import resolve_lmstudio_effort
@@ -113,6 +116,144 @@ def _model_consumes_thought_signature(model: Any) -> bool:
     """
     m = str(model or "").lower()
     return "gemini" in m or "gemma" in m
+
+
+def _extract_json_object(s: str, start_idx: int) -> tuple[str, int] | None:
+    """Finds the matching closing brace for a JSON object starting at start_idx.
+    Returns (json_substring, end_idx) or None if no valid match is found.
+    """
+    brace_count = 0
+    in_string = False
+    escape = False
+    
+    idx = s.find('{', start_idx)
+    if idx == -1:
+        return None
+        
+    start_pos = idx
+    for i in range(idx, len(s)):
+        char = s[i]
+        if in_string:
+            if escape:
+                escape = False
+            elif char == '\\':
+                escape = True
+            elif char == '"':
+                in_string = False
+        else:
+            if char == '"':
+                in_string = True
+            elif char == '{':
+                brace_count += 1
+            elif char == '}':
+                brace_count -= 1
+                if brace_count == 0:
+                    return s[start_pos:i+1], i + 1
+    return None
+
+
+def _clean_harmony_control_tags(text: str) -> str:
+    """Strip any remaining control tags (e.g. <|channel|>final<|message|>, <|end|>, etc.)
+    to avoid showing raw Harmony tags to the user.
+    """
+    if not isinstance(text, str):
+        return text
+    text = re.sub(r"<\|channel\|>(?:commentary|analysis|final)(?:\s*<\|message\|>)?\s*", "", text, flags=re.IGNORECASE)
+    text = re.sub(r"<\|.*?\|>", "", text)
+    return text
+
+
+def _parse_harmony_tool_calls(content: str) -> tuple[str, list[ToolCall]]:
+    """Parse Harmony format tool calls from content string.
+    
+    Returns (cleaned_content, tool_calls_list).
+    """
+    if not isinstance(content, str) or not content.strip():
+        return content, []
+
+    # Tag style. e.g., <|channel|>commentary to=skill_view <|constrain|>json<|message|>{"name":"hermes-agent"}
+    pattern_tag = re.compile(
+        r"<\|channel\|>(?:commentary|analysis|final)\s+to=(?:functions\.)?([A-Za-z0-9_.-]+)(?:\s+<\|constrain\|>[a-z]+)?\s*<\|message\|>\s*",
+        re.IGNORECASE
+    )
+    
+    # Text style. e.g., to=functions.exec_command or to=exec_command
+    pattern_text = re.compile(
+        r"(?:^|[\s>|])to=(?:functions\.)?([A-Za-z_][\w.-]*)\s*",
+        re.IGNORECASE
+    )
+
+    tool_calls: list[ToolCall] = []
+    current_idx = 0
+    new_content_parts = []
+    
+    while current_idx < len(content):
+        match_tag = pattern_tag.search(content, current_idx)
+        match_text = pattern_text.search(content, current_idx)
+        
+        match = None
+        if match_tag and match_text:
+            if match_tag.start() <= match_text.start():
+                match = match_tag
+            else:
+                match = match_text
+        elif match_tag:
+            match = match_tag
+        elif match_text:
+            match = match_text
+            
+        if not match:
+            new_content_parts.append(content[current_idx:])
+            break
+            
+        # Append text before the matched tool call header
+        new_content_parts.append(content[current_idx:match.start()])
+        
+        # Look for the JSON args object starting after the matched header
+        search_start = match.end()
+        json_res = _extract_json_object(content, search_start)
+        
+        if json_res:
+            json_str, json_end_idx = json_res
+            try:
+                args = json.loads(json_str)
+                if not isinstance(args, dict):
+                    raise ValueError("JSON must be an object")
+                
+                tool_name = match.group(1)
+                
+                # Check for an optional <|end|> immediately following the JSON object
+                after_json = content[json_end_idx:]
+                end_tag_match = re.match(r"^\s*<\|end\|>", after_json, re.IGNORECASE)
+                if end_tag_match:
+                    json_end_idx += end_tag_match.end()
+                
+                # Generate deterministic call_id
+                seed = f"{tool_name}:{json_str}:{len(tool_calls)}"
+                digest = hashlib.sha256(seed.encode("utf-8", errors="replace")).hexdigest()[:12]
+                call_id = f"call_{digest}"
+                
+                tool_calls.append(
+                    ToolCall(
+                        id=call_id,
+                        name=tool_name,
+                        arguments=json_str,
+                        provider_data={"call_id": call_id}
+                    )
+                )
+                current_idx = json_end_idx
+                continue
+            except Exception:
+                pass
+                
+        # If parsing failed, keep the header match text as normal content
+        new_content_parts.append(content[match.start():match.end()])
+        current_idx = match.end()
+        
+    parsed_content = "".join(new_content_parts)
+    parsed_content = _clean_harmony_control_tags(parsed_content)
+    
+    return parsed_content, tool_calls
 
 
 class ChatCompletionsTransport(ProviderTransport):
@@ -676,6 +817,17 @@ class ChatCompletionsTransport(ProviderTransport):
         # loop's refusal handler surfaces it clearly and stops. ``refusal`` is
         # ``None`` for normal responses, so this is a no-op in the common case.
         content = msg.content
+        if not tool_calls and isinstance(content, str) and content.strip():
+            parsed_content, parsed_tool_calls = _parse_harmony_tool_calls(content)
+            if parsed_tool_calls:
+                tool_calls = parsed_tool_calls
+                content = parsed_content
+                finish_reason = "tool_calls"
+            else:
+                cleaned_content = _clean_harmony_control_tags(content).strip()
+                if cleaned_content != content.strip():
+                    content = cleaned_content
+
         refusal = getattr(msg, "refusal", None)
         if refusal is None and hasattr(msg, "model_extra"):
             _msg_extra = getattr(msg, "model_extra", None) or {}

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -202,6 +202,10 @@ def build_turn_context(
     think_scrubber = getattr(agent, "_stream_think_scrubber", None)
     if think_scrubber is not None:
         think_scrubber.reset()
+    # Reset the Harmony scrubber for the same reason.
+    harmony_scrubber = getattr(agent, "_stream_harmony_scrubber", None)
+    if harmony_scrubber is not None:
+        harmony_scrubber.reset()
 
     # Preserve the original user message (no nudge injection).
     original_user_message = persist_user_message if persist_user_message is not None else user_message

--- a/run_agent.py
+++ b/run_agent.py
@@ -4066,6 +4066,26 @@ class AIAgent:
 
     def _reset_stream_delivery_tracking(self) -> None:
         """Reset tracking for text delivered during the current model response."""
+        harmony_scrubber = getattr(self, "_stream_harmony_scrubber", None)
+        if harmony_scrubber is not None:
+            harmony_tail = harmony_scrubber.flush()
+            if harmony_tail:
+                think_scrubber = getattr(self, "_stream_think_scrubber", None)
+                if think_scrubber is not None:
+                    harmony_tail = think_scrubber.feed(harmony_tail)
+                if harmony_tail:
+                    ctx_scrubber = getattr(self, "_stream_context_scrubber", None)
+                    if ctx_scrubber is not None:
+                        harmony_tail = ctx_scrubber.feed(harmony_tail)
+                    if harmony_tail:
+                        callbacks = [cb for cb in (self.stream_delta_callback, self._stream_callback) if cb is not None]
+                        for cb in callbacks:
+                            try:
+                                cb(harmony_tail)
+                            except Exception:
+                                pass
+                        self._record_streamed_assistant_text(harmony_tail)
+
         # Flush any benign partial-tag tail held by the think scrubber
         # first (#17924): an innocent '<' at the end of the stream that
         # turned out not to be a tag prefix should reach the UI.  Then
@@ -4157,6 +4177,11 @@ class AIAgent:
         else:
             prepended_break = False
         if isinstance(text, str):
+            # Suppress Harmony tags (e.g. <|channel|>commentary to=...) statefully.
+            harmony_scrubber = getattr(self, "_stream_harmony_scrubber", None)
+            if harmony_scrubber is not None:
+                text = harmony_scrubber.feed(text or "")
+
             # Suppress reasoning/thinking blocks via the stateful
             # scrubber (#17924).  Earlier versions ran _strip_think_blocks
             # per-delta here, which destroyed downstream state machines

--- a/tests/agent/test_harmony_scrubber.py
+++ b/tests/agent/test_harmony_scrubber.py
@@ -1,0 +1,136 @@
+"""Tests for StreamingHarmonyScrubber.
+
+Verifies the stateful suppression of Harmony tags during streaming.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.harmony_scrubber import StreamingHarmonyScrubber
+
+
+def _drive(scrubber: StreamingHarmonyScrubber, deltas: list[str]) -> str:
+    """Feed a sequence of deltas and return the concatenated visible output."""
+    out = [scrubber.feed(d) for d in deltas]
+    out.append(scrubber.flush())
+    return "".join(out)
+
+
+class TestHarmonyScrubber:
+    def test_passthrough_normal_text(self) -> None:
+        s = StreamingHarmonyScrubber()
+        assert _drive(s, ["Hello ", "world!"]) == "Hello world!"
+
+    def test_single_final_channel(self) -> None:
+        s = StreamingHarmonyScrubber()
+        deltas = ["<|channel|>final<|message|>Hello world!<|end|>"]
+        assert _drive(s, deltas) == "Hello world!"
+
+    def test_final_channel_split(self) -> None:
+        s = StreamingHarmonyScrubber()
+        deltas = ["<|chan", "nel|>fi", "nal<|me", "ssage|>Hello ", "world!", "<|e", "nd|>"]
+        assert _drive(s, deltas) == "Hello world!"
+
+    def test_suppress_non_final_channel(self) -> None:
+        s = StreamingHarmonyScrubber()
+        deltas = ["<|channel|>commentary to=skill_view <|constrain|>json<|message|>{\"name\":\"hermes-agent\"}<|end|>"]
+        assert _drive(s, deltas) == ""
+
+    def test_suppress_non_final_channel_split(self) -> None:
+        s = StreamingHarmonyScrubber()
+        deltas = ["<|channel|>com", "mentary to=skill_view<|message|>", "{\"name\":", "\"hermes\"}", "<|end|>"]
+        assert _drive(s, deltas) == ""
+
+    def test_sequence_of_channels(self) -> None:
+        s = StreamingHarmonyScrubber()
+        deltas = [
+            "<|channel|>commentary to=skill_view<|message|>{\"name\":\"hermes\"}<|end|>",
+            "<|channel|>final<|message|>Done!<|end|>"
+        ]
+        assert _drive(s, deltas) == "Done!"
+
+    def test_sequence_of_channels_split(self) -> None:
+        s = StreamingHarmonyScrubber()
+        deltas = [
+            "<|channel|>commentary",
+            " to=skill_view<|message|>",
+            "{\"name\": \"hermes\"}<|e",
+            "nd|><|channel|>final<|message|>Done!",
+            "<|endoftext|>"
+        ]
+        assert _drive(s, deltas) == "Done!"
+
+    def test_orphan_close_tags_stripped(self) -> None:
+        s = StreamingHarmonyScrubber()
+        deltas = ["Hello<|end|> world<|endoftext|>"]
+        assert _drive(s, deltas) == "Hello world"
+
+    def test_orphan_close_tags_split(self) -> None:
+        s = StreamingHarmonyScrubber()
+        deltas = ["Hello<|e", "nd|> world<|endof", "text|>"]
+        assert _drive(s, deltas) == "Hello world"
+
+    def test_partial_tag_flush(self) -> None:
+        s = StreamingHarmonyScrubber()
+        # Stream ends while holding back a partial tag prefix
+        assert _drive(s, ["Hello <|chan"]) == "Hello <|chan"
+
+    def test_case_insensitivity(self) -> None:
+        s = StreamingHarmonyScrubber()
+        deltas = ["<|CHANNEL|>FINAL<|MESSAGE|>Hello<|END|>"]
+        assert _drive(s, deltas) == "Hello"
+
+    def test_reset(self) -> None:
+        s = StreamingHarmonyScrubber()
+        s.feed("<|channel|>commentary<|message|>abc")
+        assert s._state == "IN_CHANNEL_SUPPRESSED"
+        s.reset()
+        assert s._state == "SCANNING"
+        assert _drive(s, ["hello"]) == "hello"
+
+
+class TestAgentIntegration:
+    class FakeAgent:
+        def __init__(self):
+            self._stream_harmony_scrubber = StreamingHarmonyScrubber()
+            self._stream_think_scrubber = None
+            self._stream_context_scrubber = None
+            self._current_streamed_assistant_text = ""
+            self.stream_delta_callback = self._cb
+            self._stream_callback = None
+            self.fired_deltas = []
+
+        def _cb(self, text: str):
+            self.fired_deltas.append(text)
+
+        def _record_streamed_assistant_text(self, text: str):
+            self._current_streamed_assistant_text += text
+
+        def _strip_think_blocks(self, text: str) -> str:
+            return text
+
+        # Re-use the real _fire_stream_delta and _reset_stream_delivery_tracking
+        from run_agent import AIAgent
+        _fire_stream_delta = AIAgent._fire_stream_delta
+        _reset_stream_delivery_tracking = AIAgent._reset_stream_delivery_tracking
+
+    def test_agent_fire_stream_delta(self) -> None:
+        agent = self.FakeAgent()
+        agent._fire_stream_delta("<|channel|>commentary to=skill_view<|message|>{\"name\":\"hermes\"}<|end|>")
+        agent._fire_stream_delta("<|channel|>final<|message|>Hello world!<|end|>")
+        assert "".join(agent.fired_deltas) == "Hello world!"
+
+    def test_agent_reset_stream_delivery_tracking(self) -> None:
+        agent = self.FakeAgent()
+        agent._fire_stream_delta("<|channel|>final<|message|>Hello ")
+        # Stream finishes leaving "<|end" at the tail (partial end tag)
+        agent._fire_stream_delta("world!<|end")
+        assert "".join(agent.fired_deltas) == "Hello world!"
+        
+        # Now reset tracking which should flush the scrubber
+        agent._reset_stream_delivery_tracking()
+        # "<|end" is an end tag prefix. In flush, it is returned, routed and emitted.
+        # So it should be present in fired_deltas now.
+        assert "".join(agent.fired_deltas) == "Hello world!<|end"
+

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -64,6 +64,7 @@ class _FakeAgent:
         self._memory_write_origin = "assistant_tool"
         self._stream_context_scrubber = None
         self._stream_think_scrubber = None
+        self._stream_harmony_scrubber = None
         # Attributes the prologue assigns; recorded for assertions.
         self._invalid_tool_retries = -1
         self._vision_supported = None
@@ -185,3 +186,12 @@ def test_no_review_when_memory_disabled():
     agent = _FakeAgent()
     ctx = _build(agent)
     assert ctx.should_review_memory is False
+
+
+def test_harmony_scrubber_reset():
+    from unittest.mock import MagicMock
+    agent = _FakeAgent()
+    scrubber = MagicMock()
+    agent._stream_harmony_scrubber = scrubber
+    _build(agent)
+    scrubber.reset.assert_called_once()

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -1033,3 +1033,56 @@ class TestChatCompletionsGeminiNativeExtraBodyStrip:
         )
         eb = kw.get("extra_body")
         assert eb and "tags" in eb
+
+    def test_normalize_harmony_tag_style_tool_call(self, transport):
+        content = (
+            "Let me search the files first.\n"
+            "<|channel|>commentary to=skill_view <|constrain|>json<|message|>{\"name\":\"hermes-agent\"}\n"
+            "Here is the rest of the text."
+        )
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(content=content, tool_calls=None),
+                finish_reason="stop",
+            )],
+        )
+        nr = transport.normalize_response(r)
+        assert len(nr.tool_calls) == 1
+        assert nr.tool_calls[0].name == "skill_view"
+        assert nr.tool_calls[0].arguments == '{"name":"hermes-agent"}'
+        assert nr.finish_reason == "tool_calls"
+        assert nr.content == "Let me search the files first.\n\nHere is the rest of the text."
+
+    def test_normalize_harmony_text_style_tool_call(self, transport):
+        content = (
+            "I will execute the command.\n"
+            "to=functions.exec_command {\"cmd\": \"ls\"}\n"
+            "Done."
+        )
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(content=content, tool_calls=None),
+                finish_reason="stop",
+            )],
+        )
+        nr = transport.normalize_response(r)
+        assert len(nr.tool_calls) == 1
+        assert nr.tool_calls[0].name == "exec_command"
+        assert nr.tool_calls[0].arguments == '{"cmd": "ls"}'
+        assert nr.finish_reason == "tool_calls"
+        assert nr.content == "I will execute the command.\nDone."
+
+    def test_normalize_harmony_clean_tags_without_tool_call(self, transport):
+        content = "<|channel|>final<|message|>Hello there!<|end|>"
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(content=content, tool_calls=None),
+                finish_reason="stop",
+            )],
+        )
+        nr = transport.normalize_response(r)
+        assert nr.tool_calls is None
+        assert nr.finish_reason == "stop"
+        assert nr.content == "Hello there!"
+
+


### PR DESCRIPTION
### Support Client-Side Harmony Format Parsing & Stateful Streaming Scrubbing

This pull request implements support for client-side Harmony format parsing and stateful streaming scrubbing for standard OpenAI-compatible endpoints under the `chat_completions` transport.

#### The Problem
When running local/custom models (such as `gpt-oss-120b` via LM Studio) that generate standard Harmony tag schemas under the permissive `chat_completions` transport:
1. **At the end of a response** (non-streaming): Raw XML-like control tags (e.g. `<|channel|>` and `<|end|>`) remained in the user-visible content, and tool calls were not extracted if the model returned them as plain text rather than native structured `tool_calls`.
2. **During streaming** (real-time generation): Raw control tags, internal channel headers, and JSON payloads for tool calls leaked directly into the terminal stream, causing a messy user experience.

#### The Solution

1. **Client-Side Non-Streaming Parser**:
   - Implemented `_parse_harmony_tool_calls` in `ChatCompletionsTransport` (`chat_completions.py`) using a brace-matching parser (`_extract_json_object`).
   - Supports both tag-style (XML-like `<|channel|>`) and text-style (leaked `to=functions.tool_name`) formats.
   - Normalizes these to structured `ToolCall` objects and cleans the visible text response, setting `finish_reason = "tool_calls"`.

2. **Stateful Streaming Scrubber**:
   - Introduced `StreamingHarmonyScrubber` (`agent/harmony_scrubber.py`) using a state machine (`SCANNING` -> `IN_HEADER` -> `IN_CHANNEL_FINAL` / `IN_CHANNEL_SUPPRESSED`) to parse streaming tokens incrementally.
   - Suppresses internal channels (e.g., `commentary`, `analysis`, `thought`) entirely from real-time terminal output, preventing leaked JSON payloads and internal headers from flashing in the terminal.
   - Gracefully handles character-by-character token boundaries and partial tags across delta limits.
   - Integrates the scrubber into agent initialization (`agent_init.py`), turn context resetting (`turn_context.py`), and stream callbacks/flushing (`run_agent.py`).

3. **Robust Test Suite**:
   - Added 12 unit tests and 2 agent integration tests in `test_harmony_scrubber.py`.
   - Added tests in `test_turn_context.py` and `test_chat_completions.py` (totaling 136 passing tests).
