### PR TITLE
fix(whatsapp): bypass text batching for slash commands

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -971,10 +971,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         for msg_data in messages:
                             event = await self._build_message_event(msg_data)
                             if event:
-                                if event.message_type == MessageType.TEXT:
-                                    self._enqueue_text_event(event)
-                                else:
-                                    await self.handle_message(event)
+                                await self._dispatch_message_event(event)
             except asyncio.CancelledError:
                 break
             except Exception as e:
@@ -990,6 +987,23 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     # ── Text debounce batching ──────────────────────────────────────
 
     _SPLIT_THRESHOLD = 6000  # WhatsApp supports ~65K chars; generous threshold
+
+    @staticmethod
+    def _should_bypass_text_batch(event: MessageEvent) -> bool:
+        """Return True when a text event must dispatch immediately."""
+        if event.message_type != MessageType.TEXT:
+            return False
+        return bool((event.text or "").strip().startswith("/"))
+
+    async def _dispatch_message_event(self, event: MessageEvent) -> None:
+        """Dispatch a bridge event, debouncing only ordinary text."""
+        if event.message_type == MessageType.TEXT:
+            if self._should_bypass_text_batch(event):
+                await self.handle_message(event)
+            else:
+                self._enqueue_text_event(event)
+            return
+        await self.handle_message(event)
 
     def _text_batch_key(self, event: MessageEvent) -> str:
         """Session-scoped key for text message batching."""

--- a/tests/gateway/test_whatsapp_text_batching.py
+++ b/tests/gateway/test_whatsapp_text_batching.py
@@ -105,3 +105,43 @@ def test_lone_message_dispatched_alone():
 
     asyncio.run(_drive())
     assert dispatched == ["solo"]
+
+
+def test_slash_command_bypasses_text_batch():
+    adapter = _make_adapter()
+    dispatched = []
+    enqueued = []
+
+    async def _capture(event):
+        dispatched.append(event.text)
+
+    def _capture_enqueue(event):
+        enqueued.append(event.text)
+
+    adapter.handle_message = _capture
+    adapter._enqueue_text_event = _capture_enqueue
+
+    asyncio.run(adapter._dispatch_message_event(_event("/new")))
+
+    assert dispatched == ["/new"]
+    assert enqueued == []
+
+
+def test_ordinary_text_still_uses_text_batch():
+    adapter = _make_adapter()
+    dispatched = []
+    enqueued = []
+
+    async def _capture(event):
+        dispatched.append(event.text)
+
+    def _capture_enqueue(event):
+        enqueued.append(event.text)
+
+    adapter.handle_message = _capture
+    adapter._enqueue_text_event = _capture_enqueue
+
+    asyncio.run(adapter._dispatch_message_event(_event("hello")))
+
+    assert dispatched == []
+    assert enqueued == ["hello"]


### PR DESCRIPTION
## Summary
WhatsApp text batching should collapse ordinary rapid-fire messages, but gateway slash commands need immediate handling. This keeps commands like `/new`, `/reset`, and `/stop` out of the debounce queue so control-plane actions are not delayed or merged with follow-up text.

## Changes
- Route polled WhatsApp events through a small dispatch helper.
- Bypass text debounce for text events whose stripped content starts with `/`.
- Keep ordinary text batching behavior unchanged.
- Add focused tests for slash-command bypass and normal text enqueueing.

## Validation
| Check | Result |
|---|---|
| Targeted tests | `8 passed` via `python -m pytest tests/gateway/test_whatsapp_text_batching.py -q -o 'addopts='` |
| Compile check | `python -m py_compile gateway/platforms/whatsapp.py` passed |
| Whitespace | `git diff --check` passed |
