### PR TITLE
docs(teams): note Teams SDK Python requirement

### DIFF
--- a/website/docs/user-guide/messaging/teams.md
+++ b/website/docs/user-guide/messaging/teams.md
@@ -12,6 +12,10 @@ Need meeting summaries from Microsoft Graph events rather than normal bot conver
 
 > Run `hermes gateway setup` and pick **Microsoft Teams** for a guided walk-through.
 
+:::note Python requirement
+The Teams bot adapter depends on `microsoft-teams-apps`, which requires Python 3.12 or newer. If your Hermes environment uses Python 3.11, recreate it with Python 3.12+ before enabling Teams.
+:::
+
 ## How the Bot Responds
 
 | Context | Behavior |


### PR DESCRIPTION
## Summary

- Adds a short Teams setup note for the `microsoft-teams-apps` Python requirement.
- Documents that Teams bot setup requires Python 3.12+.
- Notes that users on Python 3.11 should recreate the Hermes environment with Python 3.12+ before enabling Teams.

## Validation

- Manually checked the edited file for trailing whitespace.

Docs-only change; runtime behavior is unchanged.

References #26083
