### PR TITLE
feat(local): discover local runtime models

### DIFF
--- a/hermes_cli/local_runtime.py
+++ b/hermes_cli/local_runtime.py
@@ -1,0 +1,396 @@
+"""Local model runtime discovery helpers.
+
+This module is intentionally read-only: it discovers local models exposed by
+common desktop/local runtimes, but it never starts a server or loads a model.
+Side-effectful bootstrap belongs behind an explicit opt-in config in a later
+feature layer.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, Literal, Optional
+
+Backend = Literal["lmstudio", "ollama", "openai-compatible"]
+
+
+@dataclass(frozen=True)
+class LocalModel:
+    """A model discovered from a local runtime."""
+
+    backend: str
+    id: str
+    source: str
+    kind: str = "llm"
+    status: str = "available"
+    name: str = ""
+    params: str = ""
+    architecture: str = ""
+    size: str = ""
+    device: str = ""
+    digest: str = ""
+    modified: str = ""
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class LocalRuntimeReport:
+    """Discovery result for one backend."""
+
+    backend: str
+    available: bool
+    models: list[LocalModel]
+    source: str = ""
+    error: str = ""
+
+    def to_dict(self) -> dict:
+        data = asdict(self)
+        data["models"] = [m.to_dict() for m in self.models]
+        return data
+
+
+_LMSTUDIO_VARIANT_SUFFIX = re.compile(r"\s+\(\d+\s+variants?\)\s*$", re.I)
+
+
+def _run(argv: list[str], timeout: float) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        argv,
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+        shell=False,
+    )
+
+
+def _split_table_row(line: str) -> list[str]:
+    return [part.strip() for part in re.split(r"\s{2,}", line.strip()) if part.strip()]
+
+
+def _clean_lmstudio_model_id(raw: str) -> str:
+    return _LMSTUDIO_VARIANT_SUFFIX.sub("", raw).strip()
+
+
+def parse_lmstudio_ls_output(output: str, *, include_embeddings: bool = False) -> list[LocalModel]:
+    """Parse `lms ls` table output.
+
+    LM Studio prints section headers (LLM / EMBEDDING) followed by a whitespace
+    table. We split on 2+ spaces so model IDs containing slashes or hyphens are
+    preserved.
+    """
+
+    models: list[LocalModel] = []
+    section = ""
+    for raw_line in (output or "").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        upper = line.upper()
+        if upper in {"LLM", "EMBEDDING"}:
+            section = upper.lower()
+            continue
+        if line.startswith("You have ") or set(line) <= {"─", "-", " "}:
+            continue
+        if upper.startswith("LLM "):
+            # Header row: LLM PARAMS ARCH SIZE DEVICE
+            section = "llm"
+            continue
+        if upper.startswith("EMBEDDING "):
+            section = "embedding"
+            continue
+
+        if section not in {"llm", "embedding"}:
+            continue
+        if section == "embedding" and not include_embeddings:
+            continue
+
+        cols = _split_table_row(line)
+        if not cols:
+            continue
+        model_id = _clean_lmstudio_model_id(cols[0])
+        if not model_id:
+            continue
+        models.append(
+            LocalModel(
+                backend="lmstudio",
+                id=model_id,
+                source="lms ls",
+                kind=section,
+                name=model_id,
+                params=cols[1] if len(cols) > 1 else "",
+                architecture=cols[2] if len(cols) > 2 else "",
+                size=cols[3] if len(cols) > 3 else "",
+                device=cols[4] if len(cols) > 4 else "",
+            )
+        )
+    return models
+
+
+def discover_lmstudio_models(*, include_embeddings: bool = False, timeout: float = 10.0) -> LocalRuntimeReport:
+    """Discover models installed in LM Studio via `lms ls`.
+
+    This does not require the LM Studio OpenAI-compatible server to be running.
+    """
+
+    lms = shutil.which("lms") or shutil.which("lms.exe")
+    if not lms:
+        return LocalRuntimeReport(
+            backend="lmstudio",
+            available=False,
+            models=[],
+            error="lms CLI not found on PATH",
+        )
+    try:
+        proc = _run([lms, "ls"], timeout)
+    except Exception as exc:  # noqa: BLE001 - CLI discovery is best-effort
+        return LocalRuntimeReport(
+            backend="lmstudio",
+            available=False,
+            models=[],
+            source=lms,
+            error=str(exc),
+        )
+    if proc.returncode != 0:
+        return LocalRuntimeReport(
+            backend="lmstudio",
+            available=True,
+            models=[],
+            source=lms,
+            error=(proc.stderr or proc.stdout or "lms ls failed").strip(),
+        )
+    return LocalRuntimeReport(
+        backend="lmstudio",
+        available=True,
+        models=parse_lmstudio_ls_output(proc.stdout, include_embeddings=include_embeddings),
+        source=lms,
+    )
+
+
+def parse_ollama_list_output(output: str) -> list[LocalModel]:
+    """Parse `ollama list` table output."""
+
+    models: list[LocalModel] = []
+    for raw_line in (output or "").splitlines():
+        line = raw_line.strip()
+        if not line or line.upper().startswith("NAME"):
+            continue
+        cols = _split_table_row(line)
+        if not cols:
+            continue
+        model_id = cols[0]
+        models.append(
+            LocalModel(
+                backend="ollama",
+                id=model_id,
+                source="ollama list",
+                name=model_id,
+                digest=cols[1] if len(cols) > 1 else "",
+                size=cols[2] if len(cols) > 2 else "",
+                modified=cols[3] if len(cols) > 3 else "",
+                detail="  ".join(cols[4:]) if len(cols) > 4 else "",
+            )
+        )
+    return models
+
+
+def _ollama_manifest_name(manifest: Path, manifests_root: Path) -> Optional[str]:
+    try:
+        rel = manifest.relative_to(manifests_root)
+    except ValueError:
+        return None
+    parts = rel.parts
+    if len(parts) < 3:
+        return None
+    tag = parts[-1]
+    namespace_parts = list(parts[1:-1])  # drop registry host
+    if namespace_parts and namespace_parts[0] == "library":
+        namespace_parts = namespace_parts[1:]
+    if not namespace_parts:
+        return None
+    return f"{'/'.join(namespace_parts)}:{tag}"
+
+
+def discover_ollama_manifest_models(manifests_root: Optional[Path] = None) -> list[LocalModel]:
+    """Discover Ollama models by reading manifest paths without the daemon."""
+
+    root = manifests_root or Path(os.getenv("OLLAMA_MODELS", str(Path.home() / ".ollama" / "models"))) / "manifests"
+    if not root.exists():
+        return []
+    models: list[LocalModel] = []
+    for manifest in sorted(p for p in root.rglob("*") if p.is_file()):
+        model_id = _ollama_manifest_name(manifest, root)
+        if not model_id:
+            continue
+        models.append(
+            LocalModel(
+                backend="ollama",
+                id=model_id,
+                source="ollama manifest",
+                name=model_id,
+                detail=str(manifest),
+            )
+        )
+    return models
+
+
+def _dedupe_models(models: Iterable[LocalModel]) -> list[LocalModel]:
+    seen: set[tuple[str, str]] = set()
+    out: list[LocalModel] = []
+    for model in models:
+        key = (model.backend, model.id)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(model)
+    return out
+
+
+def discover_ollama_models(*, timeout: float = 10.0) -> LocalRuntimeReport:
+    """Discover local Ollama models via `ollama list`, with manifest fallback."""
+
+    ollama = shutil.which("ollama") or shutil.which("ollama.exe")
+    manifest_models = discover_ollama_manifest_models()
+    if not ollama:
+        return LocalRuntimeReport(
+            backend="ollama",
+            available=bool(manifest_models),
+            models=manifest_models,
+            source="manifest" if manifest_models else "",
+            error="ollama CLI not found on PATH" if not manifest_models else "",
+        )
+    try:
+        proc = _run([ollama, "list"], timeout)
+    except Exception as exc:  # noqa: BLE001
+        return LocalRuntimeReport(
+            backend="ollama",
+            available=bool(manifest_models),
+            models=manifest_models,
+            source=ollama if not manifest_models else "manifest",
+            error=str(exc),
+        )
+    if proc.returncode == 0:
+        live = parse_ollama_list_output(proc.stdout)
+        return LocalRuntimeReport(
+            backend="ollama",
+            available=True,
+            models=_dedupe_models([*live, *manifest_models]),
+            source=ollama,
+        )
+    return LocalRuntimeReport(
+        backend="ollama",
+        available=bool(manifest_models),
+        models=manifest_models,
+        source=ollama if not manifest_models else "manifest",
+        error=(proc.stderr or proc.stdout or "ollama list failed").strip(),
+    )
+
+
+def _models_endpoint(base_url: str) -> str:
+    root = (base_url or "").strip().rstrip("/")
+    if not root:
+        return ""
+    return root + "/models"
+
+
+def discover_openai_compatible_models(
+    *,
+    base_url: str,
+    api_key: str = "",
+    timeout: float = 5.0,
+) -> LocalRuntimeReport:
+    """Discover models from a local OpenAI-compatible `/v1/models` endpoint."""
+
+    url = _models_endpoint(base_url)
+    if not url:
+        return LocalRuntimeReport(
+            backend="openai-compatible",
+            available=False,
+            models=[],
+            error="base URL is required",
+        )
+    headers = {"User-Agent": "Hermes-Agent/local-runtime-discovery"}
+    token = api_key.strip()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as resp:
+            payload = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        return LocalRuntimeReport(
+            backend="openai-compatible",
+            available=False,
+            models=[],
+            source=url,
+            error=f"HTTP {exc.code}",
+        )
+    except Exception as exc:  # noqa: BLE001
+        return LocalRuntimeReport(
+            backend="openai-compatible",
+            available=False,
+            models=[],
+            source=url,
+            error=str(exc),
+        )
+    data = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(data, list):
+        return LocalRuntimeReport(
+            backend="openai-compatible",
+            available=False,
+            models=[],
+            source=url,
+            error="malformed /models response",
+        )
+    models = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        model_id = str(item.get("id") or "").strip()
+        if not model_id:
+            continue
+        models.append(
+            LocalModel(
+                backend="openai-compatible",
+                id=model_id,
+                source=url,
+                name=model_id,
+                detail=str(item.get("owned_by") or ""),
+            )
+        )
+    return LocalRuntimeReport(
+        backend="openai-compatible",
+        available=True,
+        models=_dedupe_models(models),
+        source=url,
+    )
+
+
+def discover_local_models(
+    *,
+    backend: str = "all",
+    base_url: str = "",
+    api_key: str = "",
+    include_embeddings: bool = False,
+    timeout: float = 10.0,
+) -> list[LocalRuntimeReport]:
+    """Discover local models across selected backends."""
+
+    normalized = (backend or "all").strip().lower()
+    reports: list[LocalRuntimeReport] = []
+    if normalized in {"all", "lmstudio"}:
+        reports.append(discover_lmstudio_models(include_embeddings=include_embeddings, timeout=timeout))
+    if normalized in {"all", "ollama"}:
+        reports.append(discover_ollama_models(timeout=timeout))
+    if normalized in {"openai", "openai-compatible"} or (normalized == "all" and base_url):
+        reports.append(discover_openai_compatible_models(base_url=base_url, api_key=api_key, timeout=timeout))
+    return reports

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -266,6 +266,7 @@ from hermes_cli.subcommands._shared import add_accept_hooks_flag as _add_accept_
 from hermes_cli.subcommands.cron import build_cron_parser
 from hermes_cli.subcommands.gateway import build_gateway_parser
 from hermes_cli.subcommands.profile import build_profile_parser
+from hermes_cli.subcommands.local import build_local_parser
 from hermes_cli.subcommands.model import build_model_parser
 from hermes_cli.subcommands.setup import build_setup_parser
 from hermes_cli.subcommands.postinstall import build_postinstall_parser
@@ -4167,6 +4168,62 @@ def cmd_kanban(args):
     from hermes_cli.kanban import kanban_command
 
     return kanban_command(args)
+
+
+def _print_local_models_table(reports) -> None:
+    any_models = False
+    for report in reports:
+        status = "available" if report.available else "unavailable"
+        print(f"\n[{report.backend}] {status}")
+        if report.source:
+            print(f"  source: {report.source}")
+        if report.error:
+            print(f"  warning: {report.error}")
+        if not report.models:
+            print("  no models found")
+            continue
+        any_models = True
+        for model in report.models:
+            bits = [model.id]
+            extras = []
+            if model.kind and model.kind != "llm":
+                extras.append(model.kind)
+            if model.params:
+                extras.append(model.params)
+            if model.architecture:
+                extras.append(model.architecture)
+            if model.size:
+                extras.append(model.size)
+            if model.device:
+                extras.append(model.device)
+            if extras:
+                bits.append("(" + ", ".join(extras) + ")")
+            print("  - " + " ".join(bits))
+    if not any_models:
+        print("\nNo local models discovered.")
+
+
+def cmd_local(args):
+    """Inspect local model runtimes."""
+    import json
+    from hermes_cli.local_runtime import discover_local_models
+
+    action = getattr(args, "local_action", None)
+    if action in {"models", "ls", "list"}:
+        reports = discover_local_models(
+            backend=getattr(args, "backend", "all"),
+            base_url=getattr(args, "base_url", ""),
+            api_key=getattr(args, "api_key", ""),
+            include_embeddings=bool(getattr(args, "include_embeddings", False)),
+            timeout=float(getattr(args, "timeout", 10.0)),
+        )
+        if getattr(args, "json", False):
+            print(json.dumps([r.to_dict() for r in reports], indent=2, ensure_ascii=False))
+        else:
+            _print_local_models_table(reports)
+        return 0
+    print("Usage: hermes local models [--backend ...]", file=sys.stderr)
+    return 2
 
 
 def cmd_hooks(args):
@@ -10924,7 +10981,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "computer-use",
         "config", "cron", "curator", "dashboard", "debug", "doctor",
         "dump", "fallback", "gateway", "hooks", "import", "insights",
-        "gui", "desktop", "kanban", "login", "logout", "logs", "lsp", "mcp", "memory", "migrate",
+        "gui", "desktop", "kanban", "local", "login", "logout", "logs", "lsp", "mcp", "memory", "migrate",
         "model", "pairing", "plugins", "portal", "postinstall", "profile", "proxy",
         "prompt-size",
         "send", "sessions", "setup",
@@ -11563,6 +11620,11 @@ def main():
     # gateway + proxy commands  (parsers built in hermes_cli/subcommands/gateway.py)
     # =========================================================================
     build_gateway_parser(subparsers, cmd_gateway=cmd_gateway, cmd_proxy=cmd_proxy)
+
+    # =========================================================================
+    # local command  (parser built in hermes_cli/subcommands/local.py)
+    # =========================================================================
+    build_local_parser(subparsers, cmd_local=cmd_local)
 
     # =========================================================================
     # lsp command

--- a/hermes_cli/subcommands/local.py
+++ b/hermes_cli/subcommands/local.py
@@ -1,0 +1,60 @@
+"""``hermes local`` subcommand parser."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+
+def build_local_parser(subparsers, *, cmd_local: Callable) -> None:
+    """Attach the ``local`` subcommand to ``subparsers``."""
+
+    local_parser = subparsers.add_parser(
+        "local",
+        help="Inspect local model runtimes (LM Studio, Ollama, OpenAI-compatible)",
+    )
+    local_subparsers = local_parser.add_subparsers(dest="local_action")
+
+    models = local_subparsers.add_parser(
+        "models",
+        aliases=["ls", "list"],
+        help="List models installed in local runtimes",
+        description=(
+            "Discover local models without changing configuration or starting "
+            "servers. LM Studio is queried via `lms ls`; Ollama uses `ollama "
+            "list` with a manifest fallback when the daemon is stopped."
+        ),
+    )
+    models.add_argument(
+        "--backend",
+        choices=["all", "lmstudio", "ollama", "openai-compatible", "openai"],
+        default="all",
+        help="Runtime backend to inspect (default: all)",
+    )
+    models.add_argument(
+        "--base-url",
+        default="",
+        help="OpenAI-compatible base URL to probe, e.g. http://127.0.0.1:1234/v1",
+    )
+    models.add_argument(
+        "--api-key",
+        default="",
+        help="Optional bearer token for --base-url",
+    )
+    models.add_argument(
+        "--include-embeddings",
+        action="store_true",
+        help="Include embedding models when a runtime reports them",
+    )
+    models.add_argument(
+        "--timeout",
+        type=float,
+        default=10.0,
+        help="Per-backend probe timeout in seconds (default: 10)",
+    )
+    models.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON",
+    )
+
+    local_parser.set_defaults(func=cmd_local)

--- a/tests/hermes_cli/test_local_runtime.py
+++ b/tests/hermes_cli/test_local_runtime.py
@@ -1,0 +1,73 @@
+from hermes_cli.local_runtime import (
+    discover_ollama_manifest_models,
+    parse_lmstudio_ls_output,
+    parse_ollama_list_output,
+)
+
+
+def test_parse_lmstudio_ls_filters_embeddings_by_default():
+    output = """
+You have 3 models, taking up 25.04 GB of disk space.
+
+LLM                                 PARAMS     ARCH        SIZE        DEVICE
+qwen/qwen3-coder-30b (1 variant)    30B-A3B    qwen3moe    18.63 GB    Local
+
+EMBEDDING                               PARAMS    ARCH          SIZE        DEVICE
+text-embedding-nomic-embed-text-v1.5              Nomic BERT    84.11 MB    Local
+"""
+
+    models = parse_lmstudio_ls_output(output)
+
+    assert [m.id for m in models] == ["qwen/qwen3-coder-30b"]
+    assert models[0].backend == "lmstudio"
+    assert models[0].params == "30B-A3B"
+    assert models[0].architecture == "qwen3moe"
+    assert models[0].size == "18.63 GB"
+
+
+def test_parse_lmstudio_ls_can_include_embeddings():
+    output = """
+LLM                                 PARAMS     ARCH        SIZE        DEVICE
+google/gemma-4-e4b (1 variant)      7.5B       gemma4      6.33 GB     Local
+
+EMBEDDING                               PARAMS    ARCH          SIZE        DEVICE
+text-embedding-nomic-embed-text-v1.5              Nomic BERT    84.11 MB    Local
+"""
+
+    models = parse_lmstudio_ls_output(output, include_embeddings=True)
+
+    assert [m.id for m in models] == [
+        "google/gemma-4-e4b",
+        "text-embedding-nomic-embed-text-v1.5",
+    ]
+    assert models[1].kind == "embedding"
+
+
+def test_parse_ollama_list_output():
+    output = """
+NAME              ID              SIZE      MODIFIED
+qwen3:14b         abcdef123456    9.3 GB    2 days ago
+llama3.2:latest   123456abcdef    2.0 GB    1 week ago
+"""
+
+    models = parse_ollama_list_output(output)
+
+    assert [m.id for m in models] == ["qwen3:14b", "llama3.2:latest"]
+    assert models[0].digest == "abcdef123456"
+    assert models[0].size == "9.3 GB"
+
+
+def test_discover_ollama_manifest_models_without_daemon(tmp_path):
+    manifests = tmp_path / "models" / "manifests"
+    manifest = manifests / "registry.ollama.ai" / "library" / "qwen3" / "14b"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text('{"schemaVersion": 2}', encoding="utf-8")
+
+    namespaced = manifests / "registry.ollama.ai" / "someuser" / "custom-model" / "latest"
+    namespaced.parent.mkdir(parents=True)
+    namespaced.write_text('{"schemaVersion": 2}', encoding="utf-8")
+
+    models = discover_ollama_manifest_models(manifests)
+
+    assert [m.id for m in models] == ["qwen3:14b", "someuser/custom-model:latest"]
+    assert all(m.source == "ollama manifest" for m in models)

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -103,6 +103,23 @@ Hermes has **two** model commands that serve different purposes:
 
 If you're trying to switch to a provider you haven't set up yet (e.g. you only have OpenRouter configured and want to use Anthropic), you need `hermes model`, not `/model`. Exit your session first (`Ctrl+C` or `/quit`), run `hermes model`, complete the provider setup, then start a new session.
 
+### Discover Local Models
+
+Use `hermes local models` to inspect local runtimes before configuring a profile or provider. The command is read-only: it does not start LM Studio/Ollama, load a model, or edit `config.yaml`.
+
+```bash
+hermes local models
+hermes local models --backend lmstudio
+hermes local models --backend ollama --json
+hermes local models --backend openai-compatible --base-url http://127.0.0.1:1234/v1
+```
+
+Discovery sources:
+
+- LM Studio: `lms ls` (works even when the OpenAI-compatible server is stopped)
+- Ollama: `ollama list`, with a manifest fallback when the daemon is stopped
+- OpenAI-compatible endpoints: `GET /models` from the supplied `--base-url`
+
 
 ### Anthropic (Native)
 


### PR DESCRIPTION
## Summary

Adds a read-only `hermes local models` command for discovering models available from local runtimes before configuring a provider/profile.

Supported discovery sources:
- LM Studio via `lms ls` (does not require the OpenAI-compatible server to be running)
- Ollama via `ollama list`, with a manifest fallback when the daemon is stopped
- OpenAI-compatible endpoints via `GET /models` when `--base-url` is supplied

This PR intentionally does **not** start any local runtime, load models, or edit config. It keeps the first step side-effect free so later local-profile bootstrap work can build on a tested discovery layer.

## Usage

```bash
hermes local models
hermes local models --backend lmstudio
hermes local models --backend ollama --json
hermes local models --backend openai-compatible --base-url http://127.0.0.1:1234/v1
```

## Tests

- `python -m pytest tests/hermes_cli/test_local_runtime.py tests/hermes_cli/test_commands.py`
- `python -m ruff check hermes_cli/local_runtime.py hermes_cli/subcommands/local.py hermes_cli/main.py tests/hermes_cli/test_local_runtime.py`
- `python -m hermes_cli.main local models --backend lmstudio --timeout 3`
