### PR TITLE
fix(security): add DNS resolution timeout to async_is_safe_url

### DIFF
--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -1,9 +1,11 @@
 """Tests for SSRF protection in url_safety module."""
 
 import socket
+import time
 from unittest.mock import patch
 
 from tools.url_safety import (
+    ASYNC_SAFETY_CHECK_TIMEOUT_SECONDS,
     is_safe_url,
     async_is_safe_url,
     is_always_blocked_url,
@@ -239,6 +241,26 @@ class TestAsyncIsSafeUrl:
             (2, 1, 6, "", ("127.0.0.1", 0)),
         ]):
             assert await async_is_safe_url("http://localhost:8080/") is False
+
+    @pytest.mark.asyncio
+    async def test_dns_timeout_fails_closed(self, monkeypatch):
+        """If the DNS lookup exceeds the timeout, treat the URL as unsafe
+        instead of hanging the awaiting coroutine indefinitely."""
+        monkeypatch.setattr(
+            "tools.url_safety.ASYNC_SAFETY_CHECK_TIMEOUT_SECONDS", 0.05
+        )
+
+        def slow_getaddrinfo(*args, **kwargs):
+            time.sleep(0.5)
+            return [(2, 1, 6, "", ("93.184.216.34", 0))]
+
+        with patch("socket.getaddrinfo", side_effect=slow_getaddrinfo):
+            assert await async_is_safe_url("https://example.com/x") is False
+
+    def test_timeout_constant_is_reasonable(self):
+        """Sanity check the bound itself: short enough to avoid hangs,
+        long enough not to false-positive on normal DNS latency."""
+        assert 0 < ASYNC_SAFETY_CHECK_TIMEOUT_SECONDS <= 10
 
 
 class TestIsBlockedIp:

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -34,6 +34,12 @@ from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
 
+# Upper bound for the off-thread DNS/socket work performed by
+# async_is_safe_url(). Without this, a slow or non-responsive DNS
+# server can leave the awaiting coroutine blocked indefinitely,
+# stalling gateway SSRF checks and web/vision tool calls.
+ASYNC_SAFETY_CHECK_TIMEOUT_SECONDS = 5.0
+
 
 def normalize_url_for_request(url: str) -> str:
     """Return an ASCII-safe HTTP URL for Hermes-owned URL tools.
@@ -398,5 +404,21 @@ async def async_is_safe_url(url: str) -> bool:
 
     ``socket.getaddrinfo`` can block; call this from async code paths (gateway,
     ``web_extract_tool``, vision download hooks) instead of ``is_safe_url``.
+
+    The underlying DNS resolution is bounded by
+    :data:`ASYNC_SAFETY_CHECK_TIMEOUT_SECONDS`. If resolution doesn't complete
+    in time, the URL is treated as unsafe (fail closed) rather than letting
+    the caller hang indefinitely.
     """
-    return await asyncio.to_thread(is_safe_url, url)
+    try:
+        return await asyncio.wait_for(
+            asyncio.to_thread(is_safe_url, url),
+            timeout=ASYNC_SAFETY_CHECK_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "async_is_safe_url: DNS resolution timed out after %.1fs for %s",
+            ASYNC_SAFETY_CHECK_TIMEOUT_SECONDS,
+            url,
+        )
+        return False


### PR DESCRIPTION
## What does this PR do?
`async_is_safe_url` ran `is_safe_url`'s `socket.getaddrinfo` call in a thread via `asyncio.to_thread`, but with no timeout. A slow or unresponsive DNS server could leave the awaiting coroutine blocked indefinitely. This function is on the hot path for gateway SSRF checks and every web/vision tool call (`web_tools.py`, and `vision_tools.py` ×3).

This PR wraps the call in `asyncio.wait_for` bounded by a new `ASYNC_SAFETY_CHECK_TIMEOUT_SECONDS` (5s) constant, and fails closed (returns `False`, with a warning log) on timeout — consistent with the existing fail-closed behavior in `is_safe_url`'s exception handler.

## Related Issue


## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🔒 Security fix
- [ ] 📝 Documentation
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made
- `tools/url_safety.py`: added `ASYNC_SAFETY_CHECK_TIMEOUT_SECONDS = 5.0` constant; wrapped `async_is_safe_url`'s body in `asyncio.wait_for`, returning `False` and logging a warning on `asyncio.TimeoutError`.
- `tests/tools/test_url_safety.py`: added `test_dns_timeout_fails_closed` (verifies fail-closed behavior when DNS resolution exceeds the timeout) and `test_timeout_constant_is_reasonable` (sanity-checks the bound's range).

## How to Test
1. `python3 -m pytest tests/tools/test_url_safety.py::TestAsyncIsSafeUrl -v`
2. All 4 tests should pass (including the new timeout test).
3. Manual: with `socket.getaddrinfo` mocked to sleep 0.5s and the timeout monkeypatched to 0.05s, `async_is_safe_url` returns `False` without blocking the event loop.

## Checklist
- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Checked for duplicate PRs (filename, function name, topic keyword, issues, git log)
- [x] PR contains only related changes
- [x] `pytest tests/ -q` passes
- [x] Tests added
- [x] Platform specified: Windows 11 + WSL2 Ubuntu

- README/docs update: N/A
- cli-config.yaml.example: N/A
- CONTRIBUTING.md/AGENTS.md: N/A
- Cross-platform impact considered: N/A
- Tool description/schema: N/A
