### PR TITLE
fix(cli): use time.monotonic() for per-prompt status bar timer

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3475,9 +3475,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         self._resumed = False
         # Per-prompt elapsed timer — started at the beginning of each chat turn,
         # frozen when the agent thread completes, displayed in the status bar.
-        self._prompt_start_time: Optional[float] = None  # time.time() when turn started
+        self._prompt_start_time: Optional[float] = None  # time.monotonic() when turn started
         self._prompt_duration: float = 0.0  # frozen duration of last completed turn
-        self._last_turn_finished_at: Optional[float] = None  # time.time() when the last agent loop finished
+        self._last_turn_finished_at: Optional[float] = None  # time.monotonic() when the last agent loop finished
         # Initialize SQLite session store early so /title works before first message
         self._session_db = None
         try:
@@ -3841,7 +3841,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         """
         if prompt_start_time is None and prompt_duration == 0.0:
             return "⏲ 0s"
-        elapsed = time.time() - prompt_start_time if prompt_start_time is not None else prompt_duration
+        elapsed = time.monotonic() - prompt_start_time if prompt_start_time is not None else prompt_duration
         elapsed = max(0.0, elapsed)
 
         days = int(elapsed // 86400)
@@ -3873,7 +3873,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         """
         if turn_live or last_finished_at is None:
             return ""
-        idle = max(0.0, time.time() - last_finished_at)
+        idle = max(0.0, time.monotonic() - last_finished_at)
         return f"✓ {format_duration_compact(idle)}"
 
     def _get_status_bar_snapshot(self) -> Dict[str, Any]:
@@ -10279,7 +10279,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # exits the main thread and daemon threads are reaped automatically).
             # Start per-prompt elapsed timer — frozen after the agent thread
             # finishes; reset on the next turn.
-            self._prompt_start_time = time.time()
+            self._prompt_start_time = time.monotonic()
             self._prompt_duration = 0.0
             agent_thread = threading.Thread(target=run_agent, daemon=True)
             agent_thread.start()
@@ -10360,11 +10360,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             # Freeze per-prompt elapsed timer once the agent thread has
             # exited (or been abandoned as a daemon after interrupt).
             if self._prompt_start_time is not None:
-                self._prompt_duration = max(0.0, time.time() - self._prompt_start_time)
+                self._prompt_duration = max(0.0, time.monotonic() - self._prompt_start_time)
                 self._prompt_start_time = None
             # Record when this agent loop finished so the status bar can show
             # idle time since the last final response.
-            self._last_turn_finished_at = time.time()
+            self._last_turn_finished_at = time.monotonic()
 
             # Proactively clean up async clients whose event loop is dead.
             # The agent thread may have created AsyncOpenAI clients bound

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -619,20 +619,20 @@ class TestIdleSinceLastTurn:
         assert HermesCLI._format_idle_since(None, turn_live=False) == ""
 
     def test_hidden_while_turn_is_live(self):
-        assert HermesCLI._format_idle_since(time.time() - 30, turn_live=True) == ""
+        assert HermesCLI._format_idle_since(time.monotonic() - 30, turn_live=True) == ""
 
     def test_shows_compact_idle_time_after_turn(self):
-        label = HermesCLI._format_idle_since(time.time() - 42, turn_live=False)
+        label = HermesCLI._format_idle_since(time.monotonic() - 42, turn_live=False)
         assert label.startswith("✓ ")
         assert label == "✓ 42s"
 
     def test_scales_to_minutes(self):
-        label = HermesCLI._format_idle_since(time.time() - 3 * 60, turn_live=False)
+        label = HermesCLI._format_idle_since(time.monotonic() - 3 * 60, turn_live=False)
         assert label == "✓ 3m"
 
     def test_snapshot_carries_idle_since(self):
         cli_obj = _make_cli()
-        cli_obj._last_turn_finished_at = time.time() - 10
+        cli_obj._last_turn_finished_at = time.monotonic() - 10
         cli_obj._prompt_start_time = None
         cli_obj._prompt_duration = 5.0
         snapshot = cli_obj._get_status_bar_snapshot()
@@ -640,8 +640,8 @@ class TestIdleSinceLastTurn:
 
     def test_snapshot_idle_empty_during_live_turn(self):
         cli_obj = _make_cli()
-        cli_obj._last_turn_finished_at = time.time() - 10
-        cli_obj._prompt_start_time = time.time()
+        cli_obj._last_turn_finished_at = time.monotonic() - 10
+        cli_obj._prompt_start_time = time.monotonic()
         cli_obj._prompt_duration = 0.0
         snapshot = cli_obj._get_status_bar_snapshot()
         assert snapshot["idle_since"] == ""
@@ -656,8 +656,26 @@ class TestIdleSinceLastTurn:
             context_tokens=12_450,
             context_length=200_000,
         )
-        cli_obj._last_turn_finished_at = time.time() - 42
+        cli_obj._last_turn_finished_at = time.monotonic() - 42
         cli_obj._prompt_start_time = None
         cli_obj._prompt_duration = 7.0
         text = cli_obj._build_status_bar_text(width=160)
         assert "✓ 42s" in text
+
+    def test_timer_uses_monotonic_clock_not_wall_clock(self):
+        """Regression: per-prompt timer must use time.monotonic() so that
+        NTP step adjustments or system suspend/resume don't cause the
+        elapsed display to jump or go backwards (issue #46177)."""
+        import time as _time
+        # _format_prompt_elapsed receives a start time from time.monotonic()
+        start = _time.monotonic()
+        # Simulate 5 seconds of elapsed time
+        elapsed_str = HermesCLI._format_prompt_elapsed(start - 5.0, 0.0, live=True)
+        assert "5s" in elapsed_str
+
+        # Verify the function uses monotonic: if we pass a monotonic base,
+        # the result should be consistent regardless of wall-clock state.
+        # time.monotonic() is always less than time.time() on most systems,
+        # so if the function accidentally used time.time(), the result would
+        # be a huge number, not 5s.
+        assert "5s" in elapsed_str


### PR DESCRIPTION
## What does this PR do?

Switches the per-prompt elapsed timer and idle-since timer in the CLI status bar from `time.time()` (wall clock) to `time.monotonic()`, preventing display jumps or backward readings when NTP adjusts the system clock or the machine suspends/resumes.

## Related Issue

Fixes #46177

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py`: Changed 5 `time.time()` calls to `time.monotonic()` in timer-related code (`_prompt_start_time`, `_last_turn_finished_at`, `_format_prompt_elapsed`, `_format_idle_since`) and updated 2 inline comments
- `tests/cli/test_cli_status_bar.py`: Updated 7 test calls from `time.time()` to `time.monotonic()` to match the production code, and added a regression test verifying monotonic clock usage

## How to Test

1. `pytest tests/cli/test_cli_status_bar.py -x -q` — all 46 tests pass
2. Start a CLI session and observe the status bar timer (`⏱` during a turn, `✓` idle after)
3. During a turn, adjust system clock by a few seconds — the timer should not jump or go backward
4. Suspend/resume the machine during a turn — elapsed time should freeze during suspend and resume counting after wake

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (time.monotonic is cross-platform)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `cli.py:_format_prompt_elapsed`, `cli.py:_format_idle_since`, `cli.py:HermesCLI.__init__`, `cli.py:chat` (timer start/freeze)
- Blast radius: LOW — changes only affect status bar display timing, no control flow changes
- Related patterns: Tool-spinner timer already uses `time.monotonic()` (line 4098); this change aligns the per-prompt timer with that precedent
