### PR TITLE
fix(tui): preserve composer draft on prompt overlay

### DIFF
--- a/ui-tui/src/__tests__/textInputCursorSourceOfTruth.test.ts
+++ b/ui-tui/src/__tests__/textInputCursorSourceOfTruth.test.ts
@@ -47,4 +47,11 @@ describe('textInput cursor-layout source of truth', () => {
     const appendPattern = /stdout!\.write\(text\)[\s\S]{0,1000}?noteCursorAdvance\(text\.length\)/
     expect(source).toMatch(appendPattern)
   })
+
+  it('flushes deferred parent changes before TextInput unmount cleanup drops timers', () => {
+    const cleanupPattern =
+      /useEffect\(\s*\(\)\s*=>\s*\(\)\s*=>\s*{[\s\S]{0,500}?clearTimeout\(keyBurstTimer\.current\)[\s\S]{0,500}?keyBurstTimer\.current = null[\s\S]{0,500}?flushParentChange\(\)[\s\S]{0,500}?clearTimeout\(localRenderTimer\.current\)/
+
+    expect(source).toMatch(cleanupPattern)
+  })
 })

--- a/ui-tui/src/__tests__/textInputUnmountFlush.test.ts
+++ b/ui-tui/src/__tests__/textInputUnmountFlush.test.ts
@@ -1,0 +1,152 @@
+import { EventEmitter } from 'node:events'
+
+import { renderSync } from '@hermes/ink'
+import React from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { TextInput } from '../components/textInput.js'
+
+class FakeTty extends EventEmitter {
+  chunks: string[] = []
+  columns = 80
+  isRaw = false
+  isTTY = true
+  readableLength = 0
+  rows = 24
+
+  private buffered: string[] = []
+
+  pushInput(chunk: string): void {
+    this.buffered.push(chunk)
+    this.readableLength += chunk.length
+    this.emit('readable')
+  }
+
+  read(): null | string {
+    const next = this.buffered.shift() ?? null
+    this.readableLength = this.buffered.reduce((sum, chunk) => sum + chunk.length, 0)
+
+    return next
+  }
+
+  ref(): this {
+    return this
+  }
+
+  setEncoding(): this {
+    return this
+  }
+
+  setRawMode(mode: boolean): this {
+    this.isRaw = mode
+
+    return this
+  }
+
+  unref(): this {
+    return this
+  }
+
+  write(chunk: string | Uint8Array, cb?: (err?: Error | null) => void): boolean {
+    this.chunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'))
+    cb?.()
+
+    return true
+  }
+}
+
+const tick = () => new Promise<void>(resolve => setImmediate(resolve))
+
+function stubProcessStdout(writes: string[]): () => void {
+  const originalWrite = process.stdout.write
+  const originalIsTty = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+
+  Object.defineProperty(process.stdout, 'isTTY', {
+    configurable: true,
+    value: true
+  })
+
+  process.stdout.write = ((
+    chunk: string | Uint8Array,
+    encodingOrCb?: BufferEncoding | ((err?: Error | null) => void),
+    cb?: (err?: Error | null) => void
+  ) => {
+    writes.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'))
+    const callback = typeof encodingOrCb === 'function' ? encodingOrCb : cb
+    callback?.()
+
+    return true
+  }) as typeof process.stdout.write
+
+  return () => {
+    process.stdout.write = originalWrite
+
+    if (originalIsTty) {
+      Object.defineProperty(process.stdout, 'isTTY', originalIsTty)
+    } else {
+      Reflect.deleteProperty(process.stdout, 'isTTY')
+    }
+  }
+}
+
+describe('TextInput unmount cleanup', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('flushes a deferred fast-echo parent change before unmount', async () => {
+    vi.stubEnv('TERM_PROGRAM', 'vscode')
+    vi.stubEnv('TERMUX_VERSION', '')
+    vi.stubEnv('PREFIX', '')
+
+    const stdout = new FakeTty()
+    stdout.isTTY = false
+    const stdin = new FakeTty()
+    const stderr = new FakeTty()
+    const changes: string[] = []
+    const directWrites: string[] = []
+    const restoreStdout = stubProcessStdout(directWrites)
+    let didUnmount = false
+
+    const instance = renderSync(
+      React.createElement(TextInput, {
+        columns: 80,
+        onChange: value => changes.push(value),
+        value: 'hel'
+      }),
+      {
+        exitOnCtrlC: false,
+        patchConsole: false,
+        stderr: stderr as unknown as NodeJS.WriteStream,
+        stdin: stdin as unknown as NodeJS.ReadStream,
+        stdout: stdout as unknown as NodeJS.WriteStream
+      }
+    )
+
+    try {
+      await tick()
+      await tick()
+
+      expect(stdin.isRaw).toBe(true)
+      expect(stdin.listenerCount('readable')).toBeGreaterThan(0)
+
+      stdin.pushInput('p')
+
+      expect(directWrites).toContain('p')
+      expect(changes).toEqual([])
+
+      instance.unmount()
+      instance.cleanup()
+      didUnmount = true
+
+      expect(changes).toEqual(['help'])
+    } finally {
+      if (!didUnmount) {
+        instance.unmount()
+        instance.cleanup()
+      }
+
+      restoreStdout()
+    }
+  })
+})

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -1,6 +1,6 @@
 import type { InputEvent, Key } from '@hermes/ink'
 import * as Ink from '@hermes/ink'
-import { type MutableRefObject, useEffect, useMemo, useRef, useState } from 'react'
+import { type MutableRefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { setInputSelection } from '../app/inputSelectionStore.js'
 import { readClipboardText, writeClipboardText } from '../lib/clipboard.js'
@@ -609,24 +609,7 @@ export function TextInput({
     return () => setInputSelection(null)
   }, [cur, focus, selected])
 
-  useEffect(
-    () => () => {
-      if (keyBurstTimer.current) {
-        clearTimeout(keyBurstTimer.current)
-      }
-
-      if (parentChangeTimer.current) {
-        clearTimeout(parentChangeTimer.current)
-      }
-
-      if (localRenderTimer.current) {
-        clearTimeout(localRenderTimer.current)
-      }
-    },
-    []
-  )
-
-  const flushParentChange = () => {
+  const flushParentChange = useCallback(() => {
     if (parentChangeTimer.current) {
       clearTimeout(parentChangeTimer.current)
       parentChangeTimer.current = null
@@ -639,7 +622,26 @@ export function TextInput({
       self.current = true
       cbChange.current(next)
     }
-  }
+  }, [])
+
+  useEffect(
+    () => () => {
+      if (keyBurstTimer.current) {
+        clearTimeout(keyBurstTimer.current)
+        keyBurstTimer.current = null
+      }
+
+      // Prompt overlays can unmount the composer before the fast-echo parent
+      // sync fires; flush now so the user's draft survives the handoff.
+      flushParentChange()
+
+      if (localRenderTimer.current) {
+        clearTimeout(localRenderTimer.current)
+        localRenderTimer.current = null
+      }
+    },
+    [flushParentChange]
+  )
 
   const scheduleParentChange = (next: string) => {
     pendingParentValue.current = next

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -1,6 +1,6 @@
 import type { InputEvent, Key } from '@hermes/ink'
 import * as Ink from '@hermes/ink'
-import { type MutableRefObject, useEffect, useMemo, useRef, useState } from 'react'
+import { type MutableRefObject, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { setInputSelection } from '../app/inputSelectionStore.js'
 import { highlightMask, highlightsStable } from '../domain/composerHighlights.js'
@@ -992,28 +992,7 @@ export function TextInput({
     return () => setInputSelection(null)
   }, [cur, focus, selected])
 
-  useEffect(
-    () => () => {
-      if (keyBurstTimer.current) {
-        clearTimeout(keyBurstTimer.current)
-      }
-
-      if (parentChangeTimer.current) {
-        clearTimeout(parentChangeTimer.current)
-      }
-
-      if (localRenderTimer.current) {
-        clearTimeout(localRenderTimer.current)
-      }
-
-      if (inkRepaintResetTimer.current) {
-        clearTimeout(inkRepaintResetTimer.current)
-      }
-    },
-    []
-  )
-
-  const flushParentChange = () => {
+  const flushParentChange = useCallback(() => {
     if (parentChangeTimer.current) {
       clearTimeout(parentChangeTimer.current)
       parentChangeTimer.current = null
@@ -1026,7 +1005,30 @@ export function TextInput({
       self.current = true
       cbChange.current(next)
     }
-  }
+  }, [])
+
+  useEffect(
+    () => () => {
+      if (keyBurstTimer.current) {
+        clearTimeout(keyBurstTimer.current)
+        keyBurstTimer.current = null
+      }
+
+      // Prompt overlays can unmount the composer before the fast-echo parent
+      // sync fires; flush now so the user's draft survives the handoff.
+      flushParentChange()
+
+      if (localRenderTimer.current) {
+        clearTimeout(localRenderTimer.current)
+        localRenderTimer.current = null
+      }
+
+      if (inkRepaintResetTimer.current) {
+        clearTimeout(inkRepaintResetTimer.current)
+      }
+    },
+    [flushParentChange]
+  )
 
   const scheduleParentChange = (next: string) => {
     pendingParentValue.current = next


### PR DESCRIPTION
## Summary

Fixes #46278.

This preserves an in-progress TUI composer draft when a clarify/approval prompt overlay blocks and unmounts `TextInput` before the deferred fast-echo parent sync fires.

The bug is in the fast-echo path: simple ASCII input can update local refs immediately while deferring `onChange` for a frame. The old unmount cleanup cleared the parent-change timer without flushing the pending value, so prompt overlays could drop the newest draft text. The fix makes `flushParentChange` stable and calls it during unmount cleanup before timer state is discarded.

Blast radius is limited to `ui-tui/src/components/textInput.tsx` cleanup behavior plus focused tests.

## Verification

```bash
node /Users/harjothk/Documents/cowork/hermes-agent/node_modules/vitest/vitest.mjs run ui-tui/src/__tests__/textInputUnmountFlush.test.ts
```

Result: 1 file passed, 1 test passed.

```bash
node /Users/harjothk/Documents/cowork/hermes-agent/node_modules/vitest/vitest.mjs run ui-tui/src/__tests__/textInputCursorSourceOfTruth.test.ts ui-tui/src/__tests__/textInputFastEcho.test.ts ui-tui/src/__tests__/textInputBurstInput.test.ts ui-tui/src/__tests__/textInputUnmountFlush.test.ts
```

Result: 4 files passed, 38 tests passed.

```bash
node /Users/harjothk/Documents/cowork/hermes-agent/node_modules/typescript/bin/tsc --noEmit -p ui-tui/tsconfig.json
```

Result: passed.

```bash
node /Users/harjothk/Documents/cowork/hermes-agent/node_modules/eslint/bin/eslint.js src/components/textInput.tsx src/__tests__/textInputCursorSourceOfTruth.test.ts src/__tests__/textInputUnmountFlush.test.ts
```

Result: passed.

## Real behavior proof

Behavior addressed  
TUI prompt overlays could unmount the composer before `TextInput`'s deferred fast-echo parent sync fired, losing the latest draft text.

Real environment tested  
Real `TextInput` mounted through Ink's renderer with stdin driven through the Ink input path.

Exact steps or command run after this patch  
`node /Users/harjothk/Documents/cowork/hermes-agent/node_modules/vitest/vitest.mjs run ui-tui/src/__tests__/textInputUnmountFlush.test.ts`

Evidence after fix  
The regression test confirms `onChange` does not fire immediately for the fast-echo key, then unmount cleanup flushes the pending value.

Observed result after fix  
The parent receives `help` after unmount when the user had typed `p` into an existing `hel` draft.

What was not tested  
I did not run a live model session that opens a real clarify/approval modal, and I did not run the full TUI suite.

## Current-main revalidation

Rebased the two original human-authored commits onto current `main` on 2026-07-10 (head `6165a0fc3`), preserving main’s newer tmux fast-echo safeguards. Current duplicate searches for #46278 and `TUI composer draft prompt overlay unmount fast echo` remain empty.

```bash
node node_modules/vitest/vitest.mjs run \
  ui-tui/src/__tests__/textInputCursorSourceOfTruth.test.ts \
  ui-tui/src/__tests__/textInputFastEcho.test.ts \
  ui-tui/src/__tests__/textInputBurstInput.test.ts \
  ui-tui/src/__tests__/textInputUnmountFlush.test.ts
# 4 files, 43 tests passed

node node_modules/typescript/bin/tsc --noEmit -p ui-tui/tsconfig.json
# passed

cd ui-tui
node ../node_modules/eslint/bin/eslint.js \
  src/components/textInput.tsx \
  src/__tests__/textInputCursorSourceOfTruth.test.ts \
  src/__tests__/textInputUnmountFlush.test.ts
# passed

git diff --check origin/main...HEAD
# passed
```