### PR TITLE
fix(whatsapp): stop typing presence after responses

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1267,6 +1267,14 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Send typing indicator via bridge."""
+        await self._send_typing_state(chat_id, "composing")
+
+    async def stop_typing(self, chat_id: str) -> None:
+        """Stop the typing indicator via bridge."""
+        await self._send_typing_state(chat_id, "paused")
+
+    async def _send_typing_state(self, chat_id: str, state: str) -> None:
+        """Send a best-effort WhatsApp presence update via bridge."""
         if not self._running or not self._http_session:
             return
         if await self._check_managed_bridge_exit():
@@ -1280,8 +1288,8 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # socket in CLOSE_WAIT. See #18451.
             async with self._http_session.post(
                 f"http://127.0.0.1:{self._bridge_port}/typing",
-                json={"chatId": to_whatsapp_jid(chat_id)},
-                timeout=aiohttp.ClientTimeout(total=5)
+                json={"chatId": to_whatsapp_jid(chat_id), "state": state},
+                timeout=aiohttp.ClientTimeout(total=5),
             ):
                 pass
         except Exception:

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -11,7 +11,7 @@
  *   POST /edit           - Edit a sent message { chatId, messageId, message }
  *   POST /send-media     - Send media natively { chatId, filePath, mediaType?, caption?, fileName? }
  *   POST /send-location  - Send location pin { chatId, latitude, longitude, name?, address? }
- *   POST /typing         - Send typing indicator { chatId }
+ *   POST /typing         - Update typing indicator { chatId, state? }
  *   GET  /chat/:id       - Get chat info
  *   GET  /health         - Health check
  *
@@ -46,6 +46,7 @@ import {
   mediaPayloadForFile,
   pollCreationMessageFromPayload,
   pollUpdateForAggregation,
+  sendTypingPresence,
 } from './bridge_helpers.js';
 
 // Parse CLI args
@@ -1043,12 +1044,12 @@ app.post('/typing', async (req, res) => {
     return res.status(503).json({ error: 'Not connected' });
   }
 
-  const { chatId } = req.body;
+  const { chatId, state } = req.body;
   if (!chatId) return res.status(400).json({ error: 'chatId required' });
 
   try {
-    await sock.sendPresenceUpdate('composing', chatId);
-    res.json({ success: true });
+    const presence = await sendTypingPresence(sock, chatId, state);
+    res.json({ success: true, state: presence });
   } catch (err) {
     res.json({ success: false });
   }

--- a/scripts/whatsapp-bridge/bridge.typing.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.typing.test.mjs
@@ -1,0 +1,41 @@
+/**
+ * Unit tests for WhatsApp typing presence forwarding.
+ */
+
+import { strict as assert } from 'node:assert';
+
+import { sendTypingPresence } from './bridge_helpers.js';
+
+{
+  const calls = [];
+  const sock = {
+    sendPresenceUpdate: async (...args) => calls.push(args),
+  };
+
+  const presence = await sendTypingPresence(
+    sock,
+    '15551234567@s.whatsapp.net',
+    'paused',
+  );
+
+  assert.equal(presence, 'paused');
+  assert.deepEqual(calls, [['paused', '15551234567@s.whatsapp.net']]);
+}
+
+{
+  const calls = [];
+  const sock = {
+    sendPresenceUpdate: async (...args) => calls.push(args),
+  };
+
+  const presence = await sendTypingPresence(
+    sock,
+    '15551234567@s.whatsapp.net',
+    'unexpected',
+  );
+
+  assert.equal(presence, 'composing');
+  assert.deepEqual(calls, [['composing', '15551234567@s.whatsapp.net']]);
+}
+
+console.log('bridge.typing.test.mjs: all assertions passed');

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -18,6 +18,12 @@ export function normalizeWhatsAppId(value) {
   return String(value).replace(':', '@');
 }
 
+export async function sendTypingPresence(sock, chatId, state) {
+  const presence = state === 'paused' ? 'paused' : 'composing';
+  await sock.sendPresenceUpdate(presence, chatId);
+  return presence;
+}
+
 export function getMessageContent(msg) {
   const content = msg?.message || {};
   if (content.ephemeralMessage?.message) return content.ephemeralMessage.message;

--- a/scripts/whatsapp-bridge/package.json
+++ b/scripts/whatsapp-bridge/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "start": "node bridge.js"
+    "start": "node bridge.js",
+    "test": "node --test *.test.mjs"
   },
   "dependencies": {
     "@whiskeysockets/baileys": "7.0.0-rc13",

--- a/tests/gateway/test_whatsapp_typing.py
+++ b/tests/gateway/test_whatsapp_typing.py
@@ -1,0 +1,79 @@
+"""Tests for WhatsApp typing presence lifecycle."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+
+class _AsyncResponse:
+    async def __aenter__(self):
+        return MagicMock(status=200)
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+@pytest.fixture
+def adapter():
+    instance: Any = WhatsAppAdapter(
+        PlatformConfig(enabled=True, extra={"session_name": "test"})
+    )
+    instance._running = True
+    instance._check_managed_bridge_exit = AsyncMock(return_value=False)
+    instance._http_session = MagicMock()
+    instance._http_session.post = MagicMock(return_value=_AsyncResponse())
+    return instance
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method_name", "state"),
+    [("send_typing", "composing"), ("stop_typing", "paused")],
+)
+async def test_typing_presence_posts_explicit_state_and_normalized_jid(
+    adapter, method_name, state
+):
+    await getattr(adapter, method_name)("15551234567")
+
+    call = adapter._http_session.post.call_args
+    assert call.args[0] == "http://127.0.0.1:3000/typing"
+    assert call.kwargs["json"] == {
+        "chatId": "15551234567@s.whatsapp.net",
+        "state": state,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method_name", ["send_typing", "stop_typing"])
+@pytest.mark.parametrize("guard", ["not_running", "no_session"])
+async def test_typing_presence_respects_adapter_guards(adapter, method_name, guard):
+    post = adapter._http_session.post
+    if guard == "not_running":
+        adapter._running = False
+    else:
+        adapter._http_session = None
+
+    await getattr(adapter, method_name)("15551234567")
+
+    post.assert_not_called()
+    adapter._check_managed_bridge_exit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stop_typing_respects_managed_bridge_exit(adapter):
+    adapter._check_managed_bridge_exit.return_value = "bridge exited"
+
+    await adapter.stop_typing("15551234567")
+
+    adapter._http_session.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_stop_typing_failure_is_best_effort(adapter):
+    adapter._http_session.post.side_effect = RuntimeError("bridge unavailable")
+
+    await adapter.stop_typing("15551234567")


### PR DESCRIPTION
## Summary

WhatsApp typing presence was started with `composing`, but the gateway did not send the matching `paused` state after a response completed. This can leave clients showing a stale typing indicator until WhatsApp expires it.

## Changes

- Update the current plugin adapter in `plugins/platforms/whatsapp/adapter.py`:
  - `send_typing()` explicitly sends `composing`
  - `stop_typing()` sends `paused`
  - both paths retain adapter/session guards, managed-bridge checks, JID normalization, and best-effort failure handling
- Update the bridge `/typing` endpoint to accept a bounded presence state and forward only `composing` or `paused`.
- Add focused Python adapter tests and a real Node bridge test proving that `paused` reaches `sock.sendPresenceUpdate()`.
- Add a bridge package test command so the bridge suite can be run directly.

## Validation

```text
29 passed  — focused Python typing/connect/JID tests
23 passed  — WhatsApp bridge Node tests
126 passed — complete tests/gateway/test_whatsapp*.py suite
Ruff passed
Python compile check passed
Node syntax checks passed
git diff --check passed
```

The complete WhatsApp run emitted one existing `AsyncMock` cleanup warning from an unchanged connect test; the focused typing suite was clean under strict runtime-warning handling.
