### PR TITLE
fix: refresh OpenCode Go model catalog

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -407,19 +407,19 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "big-pickle",
     ],
     "opencode-go": [
-        "kimi-k2.6",
-        "kimi-k2.5",
         "glm-5.1",
         "glm-5",
+        "kimi-k2.7-code",
+        "kimi-k2.6",
         "mimo-v2.5-pro",
         "mimo-v2.5",
-        "mimo-v2-pro",
-        "mimo-v2-omni",
+        "minimax-m3",
         "minimax-m2.7",
-        "minimax-m2.5",
         "qwen3.7-max",
+        "qwen3.7-plus",
         "qwen3.6-plus",
-        "qwen3.5-plus",
+        "deepseek-v4-pro",
+        "deepseek-v4-flash",
     ],
     "kilocode": [
         "anthropic/claude-opus-4.6",
@@ -3274,8 +3274,8 @@ def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str])
 
     - GPT-5 / Codex models on Zen use ``/v1/responses``
     - Claude models on Zen use ``/v1/messages``
-    - MiniMax models on Go use ``/v1/messages``
-    - GLM / Kimi on Go use ``/v1/chat/completions``
+    - MiniMax models and Qwen3.7 Max/Plus on Go use ``/v1/messages``
+    - GLM / Kimi / DeepSeek / MiMo on Go use ``/v1/chat/completions``
     - Other Zen models (Gemini, GLM, Kimi, MiniMax, Qwen, etc.) use
       ``/v1/chat/completions``
 
@@ -3289,7 +3289,7 @@ def opencode_model_api_mode(provider_id: Optional[str], model_id: Optional[str])
     if provider == "opencode-go":
         if normalized.startswith("minimax-"):
             return "anthropic_messages"
-        if normalized.startswith("qwen3.7-max"):
+        if normalized.startswith(("qwen3.7-max", "qwen3.7-plus")):
             return "anthropic_messages"
         return "chat_completions"
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -102,7 +102,7 @@ _DEFAULT_PROVIDER_MODELS = {
     "minimax-cn": ["MiniMax-M2.7", "MiniMax-M2.5", "MiniMax-M2.1", "MiniMax-M2"],
     "kilocode": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5.4", "google/gemini-3-pro-preview", "google/gemini-3-flash-preview"],
     "opencode-zen": ["gpt-5.4", "gpt-5.3-codex", "claude-sonnet-4-6", "gemini-3-flash", "glm-5", "kimi-k2.5", "minimax-m2.7"],
-    "opencode-go": ["kimi-k2.6", "kimi-k2.5", "glm-5.1", "glm-5", "mimo-v2.5-pro", "mimo-v2.5", "mimo-v2-pro", "mimo-v2-omni", "minimax-m2.7", "minimax-m2.5", "qwen3.7-max", "qwen3.6-plus", "qwen3.5-plus"],
+    "opencode-go": ["glm-5.1", "glm-5", "kimi-k2.7-code", "kimi-k2.6", "mimo-v2.5-pro", "mimo-v2.5", "minimax-m3", "minimax-m2.7", "qwen3.7-max", "qwen3.7-plus", "qwen3.6-plus", "deepseek-v4-pro", "deepseek-v4-flash"],
     "huggingface": [
         "Qwen/Qwen3.5-397B-A17B", "Qwen/Qwen3-235B-A22B-Thinking-2507",
         "Qwen/Qwen3-Coder-480B-A35B-Instruct", "deepseek-ai/DeepSeek-R1-0528",

--- a/tests/hermes_cli/test_models_dev_preferred_merge.py
+++ b/tests/hermes_cli/test_models_dev_preferred_merge.py
@@ -85,7 +85,7 @@ class TestProviderModelIdsPreferred:
         with patch("agent.models_dev.list_agentic_models", return_value=[]):
             out = provider_model_ids("opencode-go")
         # Curated floor (see hermes_cli/models.py _PROVIDER_MODELS["opencode-go"])
-        assert "mimo-v2-pro" in out
+        assert "mimo-v2.5-pro" in out
         assert "kimi-k2.6" in out
 
     def test_opencode_zen_includes_fresh_models(self):

--- a/tests/hermes_cli/test_opencode_go_in_model_list.py
+++ b/tests/hermes_cli/test_opencode_go_in_model_list.py
@@ -11,14 +11,19 @@ from hermes_cli.model_switch import list_authenticated_providers
 # The curated list in hermes_cli/models.py defines the floor; models.dev only
 # ever adds names on top of it via _merge_with_models_dev.
 _OPENCODE_GO_REQUIRED = {
-    "kimi-k2.6",
-    "kimi-k2.5",
     "glm-5.1",
     "glm-5",
-    "mimo-v2-pro",
-    "mimo-v2-omni",
+    "kimi-k2.7-code",
+    "kimi-k2.6",
+    "mimo-v2.5-pro",
+    "mimo-v2.5",
+    "minimax-m3",
     "minimax-m2.7",
-    "minimax-m2.5",
+    "qwen3.7-max",
+    "qwen3.7-plus",
+    "qwen3.6-plus",
+    "deepseek-v4-pro",
+    "deepseek-v4-flash",
 }
 
 

--- a/tests/hermes_cli/test_opencode_go_validation_fallback.py
+++ b/tests/hermes_cli/test_opencode_go_validation_fallback.py
@@ -53,6 +53,17 @@ def test_opencode_go_known_model_accepted():
     assert result["message"] is None
 
 
+
+
+@_patched
+def test_opencode_go_current_docs_model_accepted():
+    """Newer OpenCode Go docs models must be in the curated fallback."""
+    result = validate_requested_model("deepseek-v4-flash", "opencode-go")
+    assert result["accepted"] is True
+    assert result["persist"] is True
+    assert result["recognized"] is True
+    assert result["message"] is None
+
 @_patched
 def test_opencode_go_known_model_case_insensitive():
     """Catalog lookup is case-insensitive."""

--- a/tests/hermes_cli/test_opencode_model_api_mode.py
+++ b/tests/hermes_cli/test_opencode_model_api_mode.py
@@ -1,0 +1,12 @@
+"""Tests for OpenCode per-model API mode routing."""
+
+from hermes_cli.models import opencode_model_api_mode
+
+
+
+def test_opencode_go_qwen37_plus_uses_anthropic_messages():
+    assert opencode_model_api_mode("opencode-go", "qwen3.7-plus") == "anthropic_messages"
+
+
+def test_opencode_go_deepseek_v4_flash_uses_chat_completions():
+    assert opencode_model_api_mode("opencode-go", "deepseek-v4-flash") == "chat_completions"


### PR DESCRIPTION
## What does this PR do?

Refreshes the built-in OpenCode Go curated fallback model catalog to match the current OpenCode Go docs, and updates the per-model API-mode routing for the new Qwen model.

This fixes the model picker / validation fallback path when OpenCode Go's live `/models` probe is unavailable or stale: current Go models like `deepseek-v4-flash`, `deepseek-v4-pro`, `kimi-k2.7-code`, `minimax-m3`, and `qwen3.7-plus` should be recognized by Hermes without requiring users to type them as unknown custom models.

Why this approach:
- OpenCode Go's documented model set changed faster than Hermes' baked-in fallback list.
- Hermes already soft-accepts unknown OpenCode models, but the picker and validation UX should still know the current curated floor.
- The change stays within existing provider catalog/routing code; no new provider/tooling surface is added.

## Related Issue

No issue filed. Found while using OpenCode Go after updating Hermes; the bundled fallback list did not include current OpenCode Go docs models.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/models.py`
  - Updated `_PROVIDER_MODELS["opencode-go"]` to the current OpenCode Go docs list.
  - Added `kimi-k2.7-code`, `minimax-m3`, `qwen3.7-plus`, `deepseek-v4-pro`, and `deepseek-v4-flash`.
  - Removed stale fallback entries no longer listed in current OpenCode Go docs: `kimi-k2.5`, `mimo-v2-pro`, `mimo-v2-omni`, `minimax-m2.5`, and `qwen3.5-plus`.
  - Routes `qwen3.7-plus` through `anthropic_messages`, matching the existing `qwen3.7-max` behavior.
- `hermes_cli/setup.py`
  - Updated the setup wizard's OpenCode Go fallback list to match `hermes_cli/models.py`.
- `tests/hermes_cli/test_opencode_go_in_model_list.py`
  - Updated the required curated floor assertions.
- `tests/hermes_cli/test_opencode_go_validation_fallback.py`
  - Added coverage proving a current docs model is accepted through the unreachable-`/models` fallback path.
- `tests/hermes_cli/test_opencode_model_api_mode.py`
  - Added coverage for `qwen3.7-plus` and `deepseek-v4-flash` OpenCode Go routing.

## How to Test

1. Run the targeted tests:

   ```bash
   uv run --with pytest --with pyyaml python -m pytest \
     tests/hermes_cli/test_models_dev_preferred_merge.py \
     tests/hermes_cli/test_opencode_go_in_model_list.py \
     tests/hermes_cli/test_opencode_go_validation_fallback.py \
     tests/hermes_cli/test_opencode_model_api_mode.py \
     -q -o 'addopts='
   ```

   Result: `26 passed in 7.09s`

2. Verify the provider catalog contains the new current docs models and the API-mode routing is correct:

   ```bash
   uv run --with pyyaml python - <<'PY'
   from hermes_cli.models import provider_model_ids, opencode_model_api_mode
   models = provider_model_ids('opencode-go')
   required = {'kimi-k2.7-code','minimax-m3','qwen3.7-plus','deepseek-v4-pro','deepseek-v4-flash'}
   print('missing', sorted(required - set(models)))
   print('qwen3.7-plus api_mode', opencode_model_api_mode('opencode-go','qwen3.7-plus'))
   print('deepseek-v4-flash api_mode', opencode_model_api_mode('opencode-go','deepseek-v4-flash'))
   PY
   ```

   Result:

   ```text
   missing []
   qwen3.7-plus api_mode anthropic_messages
   deepseek-v4-flash api_mode chat_completions
   ```

3. Live smoke check performed before opening this PR:

   ```bash
   hermes chat -q 'Return exactly: OK_MODEL_TEST' \
     --provider opencode-go \
     --model deepseek-v4-flash \
     --toolsets safe \
     --quiet
   ```

   Result: `OK_MODEL_TEST`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/Linux via Hermes local environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted test output:

```text
............                                                             [100%]
26 passed in 7.09s
```

Provider catalog/routing verification:

```text
missing []
qwen3.7-plus api_mode anthropic_messages
deepseek-v4-flash api_mode chat_completions
```

