### PR TITLE
docs: fix incorrect gif-search skill path in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -473,7 +473,7 @@ Gateway and messaging sessions never collect secrets in-band; they instruct the 
 - The skill relies on a CLI tool that may not be installed (e.g., `himalaya`, `openhue`, `ddgs`)
 - Treat command checks as guidance, not discovery-time hiding
 
-See `skills/gifs/gif-search/` and `skills/email/himalaya/` for examples.
+See `skills/media/gif-search/` and `skills/email/himalaya/` for examples.
 
 ### Skill authoring standards (HARDLINE)
 


### PR DESCRIPTION
CONTRIBUTING.md referenced `skills/gifs/gif-search/` as a skill example, but that path does not exist.

The actual skill lives at:

`skills/media/gif-search/`

This PR makes a one-line documentation path correction.

No code changes, no config changes, and no behavior changes.
