### PR TITLE
docs(.env.example): add missing ELEVENLABS_API_KEY placeholder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -411,6 +411,9 @@ IMAGE_TOOLS_DEBUG=false
 # Groq API key (free tier — used for Whisper STT in voice mode)
 # GROQ_API_KEY=
 
+# ElevenLabs API key (cloud STT/TTS — Scribe transcription)
+# ELEVENLABS_API_KEY=
+
 # =============================================================================
 # STT PROVIDER SELECTION
 # =============================================================================


### PR DESCRIPTION
The .env.example comment instructs users to set ELEVENLABS_API_KEY above, but no placeholder existed for it.

Its sibling environment variables, such as GROQ_API_KEY and VOICE_TOOLS_OPENAI_KEY, already have commented placeholders.

ELEVENLABS_API_KEY is a supported env var for ElevenLabs STT/TTS usage, so this PR adds the missing commented placeholder for consistency.

Docs/example only. Both new lines are commented, so there are no runtime, config, or behavior changes.