### PR TITLE
fix(memory): default null target to memory store

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -422,6 +422,26 @@ class TestMemoryToolDispatcher:
         result = json.loads(memory_tool(action="add", target="invalid", content="x", store=store))
         assert result["success"] is False
 
+    def test_null_target_defaults_to_memory_store(self, store):
+        result = json.loads(
+            memory_tool(
+                action="add",
+                target=None,
+                content="Project uses pytest with xdist.",
+                store=store,
+            )
+        )
+        assert result["success"] is True
+        assert store.memory_entries == ["Project uses pytest with xdist."]
+        assert store.user_entries == []
+
+    def test_invalid_non_string_target_still_rejected(self, store):
+        result = json.loads(
+            memory_tool(action="add", target=42, content="via tool", store=store)
+        )
+        assert result["success"] is False
+        assert "Invalid target" in result["error"]
+
     def test_unknown_action(self, store):
         result = json.loads(memory_tool(action="unknown", store=store))
         assert result["success"] is False

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -678,6 +678,12 @@ def memory_tool(
     if store is None:
         return tool_error("Memory is not available. It may be disabled in config or this environment.", success=False)
 
+    # Some strict providers fill optional schema fields with JSON null rather
+    # than omitting them.  Treat ``target: null`` as omitted so memory writes
+    # still use the documented default store instead of failing validation.
+    if target is None:
+        target = "memory"
+
     if target not in {"memory", "user"}:
         return tool_error(f"Invalid target '{target}'. Use 'memory' or 'user'.", success=False)
 


### PR DESCRIPTION
## Summary
`memory(action="add", target=null, ...)` now behaves like an omitted target and writes to the default memory store.

Source: nearai/ironclaw#4547 fixed the same strict-provider shape for IronClaw's `memory_write` capability. Hermes adapts the invariant at the Python tool dispatcher boundary instead of adding provider-specific schema plumbing.

## Changes
- `tools/memory_tool.py`: normalize `target is None` to `"memory"` before target validation.
- `tests/tools/test_memory_tool.py`: add regression coverage for `target=None` and keep non-string targets rejected.

## Validation
| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/tools/test_memory_tool.py` | 71/71 passed |
| E2E | real `MemoryStore`, temp memory dir, `target=None` writes `MEMORY.md`; `target=42` still rejected |

## Source adaptation
- IronClaw source PR: https://github.com/nearai/ironclaw/pull/4547
- Architectural difference: IronClaw strips optional null sentinels in first-party capability normalization; Hermes can fix this narrowly because the memory tool already has a documented default target.

## Infographic

![Memory null target fallback](https://v3b.fal.media/files/b/0a9e5368/GzR6ChyQ0oJKB8NtxkwxF_fIsSr5JK.png)
