### PR TITLE
fix: preserve chat type for process notifications

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11874,6 +11874,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             platform=context.source.platform.value,
             chat_id=context.source.chat_id,
             chat_name=context.source.chat_name or "",
+            chat_type=context.source.chat_type or "",
             thread_id=str(context.source.thread_id) if context.source.thread_id else "",
             user_id=str(context.source.user_id) if context.source.user_id else "",
             user_name=str(context.source.user_name) if context.source.user_name else "",
@@ -12282,6 +12283,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         session_key = watcher.get("session_key", "")
         platform_name = watcher.get("platform", "")
         chat_id = watcher.get("chat_id", "")
+        chat_type = watcher.get("chat_type", "")
         thread_id = watcher.get("thread_id", "")
         user_id = watcher.get("user_id", "")
         user_name = watcher.get("user_name", "")
@@ -12345,6 +12347,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "session_key": session_key,
                         "platform": platform_name,
                         "chat_id": chat_id,
+                        "chat_type": chat_type,
                         "thread_id": thread_id,
                         "user_id": user_id,
                         "user_name": user_name,

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -51,6 +51,7 @@ _UNSET: Any = object()
 _SESSION_PLATFORM: ContextVar = ContextVar("HERMES_SESSION_PLATFORM", default=_UNSET)
 _SESSION_CHAT_ID: ContextVar = ContextVar("HERMES_SESSION_CHAT_ID", default=_UNSET)
 _SESSION_CHAT_NAME: ContextVar = ContextVar("HERMES_SESSION_CHAT_NAME", default=_UNSET)
+_SESSION_CHAT_TYPE: ContextVar = ContextVar("HERMES_SESSION_CHAT_TYPE", default=_UNSET)
 _SESSION_THREAD_ID: ContextVar = ContextVar("HERMES_SESSION_THREAD_ID", default=_UNSET)
 _SESSION_USER_ID: ContextVar = ContextVar("HERMES_SESSION_USER_ID", default=_UNSET)
 _SESSION_USER_NAME: ContextVar = ContextVar("HERMES_SESSION_USER_NAME", default=_UNSET)
@@ -71,6 +72,7 @@ _VAR_MAP = {
     "HERMES_SESSION_PLATFORM": _SESSION_PLATFORM,
     "HERMES_SESSION_CHAT_ID": _SESSION_CHAT_ID,
     "HERMES_SESSION_CHAT_NAME": _SESSION_CHAT_NAME,
+    "HERMES_SESSION_CHAT_TYPE": _SESSION_CHAT_TYPE,
     "HERMES_SESSION_THREAD_ID": _SESSION_THREAD_ID,
     "HERMES_SESSION_USER_ID": _SESSION_USER_ID,
     "HERMES_SESSION_USER_NAME": _SESSION_USER_NAME,
@@ -109,6 +111,7 @@ def set_session_vars(
     session_id: str = "",
     message_id: str = "",
     cwd: str = "",
+    chat_type: str = "",
 ) -> list:
     """Set all session context variables and return reset tokens.
 
@@ -124,6 +127,7 @@ def set_session_vars(
         _SESSION_PLATFORM.set(platform),
         _SESSION_CHAT_ID.set(chat_id),
         _SESSION_CHAT_NAME.set(chat_name),
+        _SESSION_CHAT_TYPE.set(chat_type),
         _SESSION_THREAD_ID.set(thread_id),
         _SESSION_USER_ID.set(user_id),
         _SESSION_USER_NAME.set(user_name),
@@ -155,6 +159,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_PLATFORM,
         _SESSION_CHAT_ID,
         _SESSION_CHAT_NAME,
+        _SESSION_CHAT_TYPE,
         _SESSION_THREAD_ID,
         _SESSION_USER_ID,
         _SESSION_USER_NAME,

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -47,6 +47,7 @@ def test_set_session_env_sets_contextvars(monkeypatch):
     monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
     monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
     monkeypatch.delenv("HERMES_SESSION_CHAT_NAME", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_CHAT_TYPE", raising=False)
     monkeypatch.delenv("HERMES_SESSION_USER_ID", raising=False)
     monkeypatch.delenv("HERMES_SESSION_USER_NAME", raising=False)
     monkeypatch.delenv("HERMES_SESSION_THREAD_ID", raising=False)
@@ -57,12 +58,14 @@ def test_set_session_env_sets_contextvars(monkeypatch):
     assert get_session_env("HERMES_SESSION_PLATFORM") == "telegram"
     assert get_session_env("HERMES_SESSION_CHAT_ID") == "-1001"
     assert get_session_env("HERMES_SESSION_CHAT_NAME") == "Group"
+    assert get_session_env("HERMES_SESSION_CHAT_TYPE") == "group"
     assert get_session_env("HERMES_SESSION_USER_ID") == "123456"
     assert get_session_env("HERMES_SESSION_USER_NAME") == "alice"
     assert get_session_env("HERMES_SESSION_THREAD_ID") == "17585"
 
     # os.environ should NOT be touched
     assert os.getenv("HERMES_SESSION_PLATFORM") is None
+    assert os.getenv("HERMES_SESSION_CHAT_TYPE") is None
     assert os.getenv("HERMES_SESSION_THREAD_ID") is None
 
     # Clean up
@@ -76,6 +79,7 @@ def test_clear_session_env_restores_previous_state(monkeypatch):
     monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
     monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
     monkeypatch.delenv("HERMES_SESSION_CHAT_NAME", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_CHAT_TYPE", raising=False)
     monkeypatch.delenv("HERMES_SESSION_USER_ID", raising=False)
     monkeypatch.delenv("HERMES_SESSION_USER_NAME", raising=False)
     monkeypatch.delenv("HERMES_SESSION_THREAD_ID", raising=False)
@@ -94,6 +98,7 @@ def test_clear_session_env_restores_previous_state(monkeypatch):
     tokens = runner._set_session_env(context)
     assert get_session_env("HERMES_SESSION_PLATFORM") == "telegram"
     assert get_session_env("HERMES_SESSION_USER_ID") == "123456"
+    assert get_session_env("HERMES_SESSION_CHAT_TYPE") == "group"
 
     runner._clear_session_env(tokens)
 
@@ -101,6 +106,7 @@ def test_clear_session_env_restores_previous_state(monkeypatch):
     assert get_session_env("HERMES_SESSION_PLATFORM") == ""
     assert get_session_env("HERMES_SESSION_CHAT_ID") == ""
     assert get_session_env("HERMES_SESSION_CHAT_NAME") == ""
+    assert get_session_env("HERMES_SESSION_CHAT_TYPE") == ""
     assert get_session_env("HERMES_SESSION_USER_ID") == ""
     assert get_session_env("HERMES_SESSION_USER_NAME") == ""
     assert get_session_env("HERMES_SESSION_THREAD_ID") == ""
@@ -149,6 +155,7 @@ def test_set_session_env_handles_missing_optional_fields():
     assert get_session_env("HERMES_SESSION_PLATFORM") == "telegram"
     assert get_session_env("HERMES_SESSION_CHAT_ID") == "-1001"
     assert get_session_env("HERMES_SESSION_CHAT_NAME") == ""
+    assert get_session_env("HERMES_SESSION_CHAT_TYPE") == "private"
     assert get_session_env("HERMES_SESSION_THREAD_ID") == ""
 
     runner._clear_session_env(tokens)
@@ -333,3 +340,59 @@ async def test_run_in_executor_with_context_propagates_exceptions():
 
     with pytest.raises(ValueError, match="boom"):
         await runner._run_in_executor_with_context(blow_up)
+
+
+def test_build_process_event_source_uses_event_chat_type_without_session_cache():
+    """Recovered process watchers should carry chat_type without relying on cache."""
+    from gateway.config import Platform
+
+    runner = object.__new__(GatewayRunner)
+    runner.session_store = None
+    runner._session_sources = {}
+
+    source = runner._build_process_event_source({
+        "platform": "telegram",
+        "chat_id": "2144471399",
+        "chat_type": "dm",
+        "thread_id": "17585",
+        "user_id": "123456",
+        "user_name": "alice",
+    })
+
+    assert source is not None
+    assert source.platform == Platform.TELEGRAM
+    assert source.chat_id == "2144471399"
+    assert source.chat_type == "dm"
+    assert source.thread_id == "17585"
+    assert source.user_id == "123456"
+    assert source.user_name == "alice"
+
+
+def test_set_session_vars_chat_type_keyword_does_not_shift_existing_callers():
+    """Adding chat_type must not shift existing positional callers."""
+    tokens = set_session_vars(
+        "telegram",
+        "-1001",
+        "Group",
+        "17585",
+        "123456",
+        "alice",
+        "telegram:group:-1001:17585:123456",
+        "session-1",
+        "msg-1",
+        "/tmp/work",
+        chat_type="group",
+    )
+    try:
+        assert get_session_env("HERMES_SESSION_PLATFORM") == "telegram"
+        assert get_session_env("HERMES_SESSION_CHAT_ID") == "-1001"
+        assert get_session_env("HERMES_SESSION_CHAT_NAME") == "Group"
+        assert get_session_env("HERMES_SESSION_THREAD_ID") == "17585"
+        assert get_session_env("HERMES_SESSION_USER_ID") == "123456"
+        assert get_session_env("HERMES_SESSION_USER_NAME") == "alice"
+        assert get_session_env("HERMES_SESSION_KEY") == "telegram:group:-1001:17585:123456"
+        assert get_session_env("HERMES_SESSION_ID") == "session-1"
+        assert get_session_env("HERMES_SESSION_MESSAGE_ID") == "msg-1"
+        assert get_session_env("HERMES_SESSION_CHAT_TYPE") == "group"
+    finally:
+        clear_session_vars(tokens)

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -785,6 +785,7 @@ class TestCheckpoint:
             s = _make_session()
             s.watcher_platform = "telegram"
             s.watcher_chat_id = "999"
+            s.watcher_chat_type = "group"
             s.watcher_user_id = "u123"
             s.watcher_user_name = "alice"
             s.watcher_thread_id = "42"
@@ -796,6 +797,7 @@ class TestCheckpoint:
             assert len(data) == 1
             assert data[0]["watcher_platform"] == "telegram"
             assert data[0]["watcher_chat_id"] == "999"
+            assert data[0]["watcher_chat_type"] == "group"
             assert data[0]["watcher_user_id"] == "u123"
             assert data[0]["watcher_user_name"] == "alice"
             assert data[0]["watcher_thread_id"] == "42"
@@ -811,6 +813,7 @@ class TestCheckpoint:
             "session_key": "sk1",
             "watcher_platform": "telegram",
             "watcher_chat_id": "123",
+            "watcher_chat_type": "private",
             "watcher_user_id": "u123",
             "watcher_user_name": "alice",
             "watcher_thread_id": "42",
@@ -824,6 +827,7 @@ class TestCheckpoint:
             assert w["session_id"] == "proc_live"
             assert w["platform"] == "telegram"
             assert w["chat_id"] == "123"
+            assert w["chat_type"] == "private"
             assert w["user_id"] == "u123"
             assert w["user_name"] == "alice"
             assert w["thread_id"] == "42"

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -107,6 +107,7 @@ class ProcessSession:
     # Watcher/notification metadata (persisted for crash recovery)
     watcher_platform: str = ""
     watcher_chat_id: str = ""
+    watcher_chat_type: str = ""
     watcher_user_id: str = ""
     watcher_user_name: str = ""
     watcher_thread_id: str = ""
@@ -278,6 +279,7 @@ class ProcessRegistry:
                     "suppressed": session._watch_suppressed,
                     "platform": session.watcher_platform,
                     "chat_id": session.watcher_chat_id,
+                    "chat_type": session.watcher_chat_type,
                     "user_id": session.watcher_user_id,
                     "user_name": session.watcher_user_name,
                     "thread_id": session.watcher_thread_id,
@@ -311,6 +313,7 @@ class ProcessRegistry:
             "suppressed": suppressed,
             "platform": session.watcher_platform,
             "chat_id": session.watcher_chat_id,
+            "chat_type": session.watcher_chat_type,
             "user_id": session.watcher_user_id,
             "user_name": session.watcher_user_name,
             "thread_id": session.watcher_thread_id,
@@ -1401,6 +1404,7 @@ class ProcessRegistry:
                             "session_key": s.session_key,
                             "watcher_platform": s.watcher_platform,
                             "watcher_chat_id": s.watcher_chat_id,
+                            "watcher_chat_type": s.watcher_chat_type,
                             "watcher_user_id": s.watcher_user_id,
                             "watcher_user_name": s.watcher_user_name,
                             "watcher_thread_id": s.watcher_thread_id,
@@ -1465,6 +1469,7 @@ class ProcessRegistry:
                     detached=True,  # Can't read output, but can report status + kill
                     watcher_platform=entry.get("watcher_platform", ""),
                     watcher_chat_id=entry.get("watcher_chat_id", ""),
+                    watcher_chat_type=entry.get("watcher_chat_type", ""),
                     watcher_user_id=entry.get("watcher_user_id", ""),
                     watcher_user_name=entry.get("watcher_user_name", ""),
                     watcher_thread_id=entry.get("watcher_thread_id", ""),
@@ -1486,6 +1491,7 @@ class ProcessRegistry:
                         "session_key": session.session_key,
                         "platform": session.watcher_platform,
                         "chat_id": session.watcher_chat_id,
+                        "chat_type": session.watcher_chat_type,
                         "user_id": session.watcher_user_id,
                         "user_name": session.watcher_user_name,
                         "thread_id": session.watcher_thread_id,

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2266,12 +2266,14 @@ def terminal_tool(
                     _gw_platform = _gse("HERMES_SESSION_PLATFORM", "")
                     if _gw_platform:
                         _gw_chat_id = _gse("HERMES_SESSION_CHAT_ID", "")
+                        _gw_chat_type = _gse("HERMES_SESSION_CHAT_TYPE", "")
                         _gw_thread_id = _gse("HERMES_SESSION_THREAD_ID", "")
                         _gw_user_id = _gse("HERMES_SESSION_USER_ID", "")
                         _gw_user_name = _gse("HERMES_SESSION_USER_NAME", "")
                         _gw_message_id = _gse("HERMES_SESSION_MESSAGE_ID", "")
                         proc_session.watcher_platform = _gw_platform
                         proc_session.watcher_chat_id = _gw_chat_id
+                        proc_session.watcher_chat_type = _gw_chat_type
                         proc_session.watcher_user_id = _gw_user_id
                         proc_session.watcher_user_name = _gw_user_name
                         proc_session.watcher_thread_id = _gw_thread_id
@@ -2309,6 +2311,7 @@ def terminal_tool(
                             "session_key": session_key,
                             "platform": proc_session.watcher_platform,
                             "chat_id": proc_session.watcher_chat_id,
+                            "chat_type": proc_session.watcher_chat_type,
                             "user_id": proc_session.watcher_user_id,
                             "user_name": proc_session.watcher_user_name,
                             "thread_id": proc_session.watcher_thread_id,


### PR DESCRIPTION
## Summary
- Carry gateway `chat_type` through session context for background process notifications.
- Persist and restore watcher `chat_type` metadata in the process registry.
- Add regression coverage for context propagation, recovered watcher routing, and checkpoint restore metadata.

## Test Plan
- `python -m pytest tests/gateway/test_session_env.py tests/tools/test_process_registry.py tests/tools/test_terminal_tool.py -q -o 'addopts='`
- `python -m py_compile gateway/run.py gateway/session_context.py tools/process_registry.py tools/terminal_tool.py tests/gateway/test_session_env.py tests/tools/test_process_registry.py tests/tools/test_terminal_tool.py`
- `git diff --check HEAD~1 HEAD`
- static scan of added lines for obvious secrets/injection patterns