### PR TITLE
fix(cron): prefer Git Bash and POSIX paths on Windows (#46332)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2398,21 +2398,29 @@ def _run_job_script(
     # choice explicit here keeps the allowed surface small and auditable.
     suffix = path.suffix.lower()
     if suffix in {".sh", ".bash"}:
-        # Resolve bash dynamically so Windows (Git Bash) and Linux/macOS
-        # all work.  On native Windows without Git for Windows installed
-        # shutil.which returns None — fall back to a clear error rather
-        # than a FileNotFoundError with a confusing "[WinError 2]"
-        # traceback.
-        _bash = shutil.which("bash") or (
-            "/bin/bash" if os.path.isfile("/bin/bash") else None
-        )
+        script_arg = str(path)
+        try:
+            from tools.environments.local import _bash_safe_path, _find_bash
+
+            script_arg = _bash_safe_path(script_arg)
+            _bash = _find_bash()
+        except RuntimeError:
+            # Windows with no usable Git Bash: surface the clear setup error
+            # below instead of spawning the WSL launcher from System32.
+            _bash = None
+        except Exception:
+            # Keep the historical POSIX fallback if the shared helper cannot
+            # be imported in an embedded/minimal environment.
+            _bash = shutil.which("bash") or (
+                "/bin/bash" if os.path.isfile("/bin/bash") else None
+            )
         if _bash is None:
             return False, (
-                f"Cannot run .sh/.bash script {path.name!r}: bash not found on PATH. "
+                f"Cannot run .sh/.bash script {path.name!r}: bash not found. "
                 "On Windows, install Git for Windows (which ships Git Bash) "
                 "or rewrite the script as Python (.py)."
-        )
-        argv = [_bash, str(path)]
+            )
+        argv = [_bash, script_arg]
         env_overlay: dict[str, str] = {}
     else:
         python_exe, env_overlay = _windows_cron_python_invocation(sys.executable)

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -131,3 +131,62 @@ def test_run_job_script_nul_path_fails_cleanly(hermes_env):
     ok, output = _run_job_script("~user\x00bad.sh")
     assert ok is False
     assert "Blocked" in output
+
+
+def test_run_job_script_uses_shared_bash_resolver_and_safe_path(hermes_env, monkeypatch):
+    """Cron .sh execution must not pick WSL bash or pass raw Windows paths."""
+    from cron.scheduler import _run_job_script
+    import tools.environments.local as local_mod
+
+    script = hermes_env / "scripts" / "watch.sh"
+    script.write_text("#!/bin/bash\necho ok\n")
+    git_bash = "C:/Program Files/Git/bin/bash.exe"
+    captured = {}
+
+    class Result:
+        returncode = 0
+        stdout = "ok\n"
+        stderr = ""
+
+    monkeypatch.setattr(
+        "cron.scheduler.shutil.which",
+        lambda _name: r"C:\Windows\System32\bash.exe",
+    )
+    monkeypatch.setattr(local_mod, "_find_bash", lambda: git_bash)
+    monkeypatch.setattr(local_mod, "_bash_safe_path", lambda path: f"SAFE:{path}")
+
+    def fake_run(argv, **_kwargs):
+        captured["argv"] = argv
+        return Result()
+
+    monkeypatch.setattr("cron.scheduler.subprocess.run", fake_run)
+
+    ok, output = _run_job_script(str(script))
+
+    assert ok is True
+    assert output == "ok"
+    assert captured["argv"] == [git_bash, f"SAFE:{script}"]
+
+
+def test_run_job_script_reports_unusable_bash_without_spawning(
+    hermes_env, monkeypatch
+):
+    from cron.scheduler import _run_job_script
+    import tools.environments.local as local_mod
+
+    script = hermes_env / "scripts" / "watch.sh"
+    script.write_text("#!/bin/bash\necho ok\n")
+
+    def no_bash():
+        raise RuntimeError("no git bash")
+
+    def unexpected_spawn(*_args, **_kwargs):
+        raise AssertionError("must not spawn WSL bash")
+
+    monkeypatch.setattr(local_mod, "_find_bash", no_bash)
+    monkeypatch.setattr("cron.scheduler.subprocess.run", unexpected_spawn)
+
+    ok, output = _run_job_script(str(script))
+
+    assert ok is False
+    assert "bash not found" in output

--- a/tests/tools/test_blocked_command_guidance.py
+++ b/tests/tools/test_blocked_command_guidance.py
@@ -25,6 +25,21 @@ class TestParserLimitRecovery:
         assert body.startswith("#!/bin/bash")
         assert f"bash {saved}" in r["message"]
 
+    def test_saved_payload_hint_uses_bash_safe_path(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+        monkeypatch.setattr(
+            "tools.environments.local._bash_safe_path",
+            lambda path: f"SAFE:{path}",
+        )
+
+        r = _hardline_block_result(_PARSER_LIMIT_DESCRIPTION, "python3 -c 'x'")
+
+        assert "saved to SAFE:" in r["message"]
+        assert "run: terminal(command=\"bash SAFE:" in r["message"]
+        saved_dir = tmp_path / ".hermes" / "cache" / "blocked-scripts"
+        saved = next(saved_dir.glob("*.sh"))
+        assert "# then run it via: bash SAFE:" in saved.read_text()
+
     def test_save_failure_falls_back_to_manual_recipe(self, monkeypatch):
         import tools.approval as ap
         monkeypatch.setattr(ap, "_save_blocked_payload", lambda c: None)

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -616,16 +616,22 @@ def _save_blocked_payload(command: str) -> Optional[str]:
             except OSError:
                 pass
         path = script_dir / f"blocked-{int(_time.time())}-{_uuid.uuid4().hex[:8]}.sh"
+        try:
+            from tools.environments.local import _bash_safe_path
+
+            hint_path = _bash_safe_path(str(path))
+        except Exception:
+            hint_path = str(path)
         path.write_text(
             "#!/bin/bash\n"
             "# Auto-saved by Hermes: this command exceeded the inline command\n"
             "# parser limit and was blocked from direct execution. Review it,\n"
-            "# then run it via: bash " + str(path) + "\n"
+            "# then run it via: bash " + hint_path + "\n"
             + command
             + ("\n" if not command.endswith("\n") else ""),
             encoding="utf-8", errors="replace",
         )
-        return str(path)
+        return hint_path
     except Exception:
         logger.debug("failed to save blocked payload", exc_info=True)
         return None


### PR DESCRIPTION
Fixes #46332.

## Summary
- Prefer Git for Windows bash over WSL `bash.exe` when running `.sh`/`.bash` cron scripts on native Windows.
- Pass shell script paths to bash in forward-slash form on Windows so MSYS/Git Bash does not treat backslashes as escape characters.
- Preserve existing fallback behavior when Git Bash is not installed and preserve non-Windows path behavior.

## Why
Issue #46332 reports two separate Windows-only root causes:
1. `shutil.which("bash")` may resolve to WSL bash before Git Bash; WSL bash cannot execute Windows paths even when they use forward slashes.
2. Git Bash/MSYS mangles backslash-separated Windows paths such as `C:\Users\...` into `C:Users...`.

This PR covers both layers. Existing open PRs I found (#23405, #23489, #43076, #44350) only address the POSIX/forward-slash path layer and do not resolve the WSL bash preference layer.

## Verification
- `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/cron/test_cron_no_agent.py -v -o "addopts=" --tb=short`
  - Result: `26 passed, 1 warning in 0.48s`
- Branch verification after rebase: `git rev-list --left-right --count upstream/main...HEAD` → `0 1`

## Notes
Auto-published by Moonsong via Path B automated pipeline.
