### PR TITLE
fix(send_message): reuse live gateway adapter for Matrix media sends (#46310)

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -841,6 +841,145 @@ class TestSendToPlatformChunking:
         ]
 
 
+class TestMatrixMediaLiveAdapterReuse:
+    """Verify _send_matrix_via_adapter reuses the live gateway adapter
+    when available, avoiding per-message E2EE re-init storms (#46310)."""
+
+    def test_live_adapter_skips_connect_disconnect(self, tmp_path):
+        """When a live gateway adapter exists, no connect() or disconnect()
+        should be called — the persistent E2EE session is reused."""
+        img_path = tmp_path / "photo.png"
+        img_path.write_bytes(b"\x89PNG\r\n")
+
+        calls = []
+
+        class LiveAdapter:
+            async def send(self, chat_id, message, metadata=None):
+                calls.append(("send", chat_id, message))
+                return SimpleNamespace(success=True, message_id="$text")
+
+            async def send_image_file(self, chat_id, path, metadata=None):
+                calls.append(("send_image_file", chat_id, path))
+                return SimpleNamespace(success=True, message_id="$img")
+
+        live_adapter = LiveAdapter()
+        fake_runner = SimpleNamespace(
+            adapters={Platform.MATRIX: live_adapter}
+        )
+
+        with patch(
+            "gateway.run._gateway_runner_ref",
+            return_value=fake_runner,
+        ), patch.dict(
+            sys.modules, {"gateway.platforms.matrix": SimpleNamespace()}
+        ):
+            result = asyncio.run(
+                _send_matrix_via_adapter(
+                    SimpleNamespace(enabled=True, token="tok", extra={}),
+                    "!room:example.com",
+                    "here is an image",
+                    media_files=[(str(img_path), False)],
+                )
+            )
+
+        assert result["success"] is True
+        assert result["message_id"] == "$img"
+        # Only send + send_image_file; no connect / disconnect
+        assert calls == [
+            ("send", "!room:example.com", "here is an image"),
+            ("send_image_file", "!room:example.com", str(img_path)),
+        ]
+
+    def test_live_adapter_not_available_falls_back_to_ephemeral(self, tmp_path):
+        """When _gateway_runner_ref returns None, the ephemeral adapter
+        path (connect + disconnect) is used as before."""
+        doc_path = tmp_path / "doc.pdf"
+        doc_path.write_bytes(b"%PDF-1.4")
+
+        calls = []
+
+        class EphemeralAdapter:
+            def __init__(self, _config):
+                pass
+
+            async def connect(self):
+                calls.append(("connect",))
+                return True
+
+            async def send(self, chat_id, message, metadata=None):
+                calls.append(("send", chat_id, message))
+                return SimpleNamespace(success=True, message_id="$txt")
+
+            async def send_document(self, chat_id, path, metadata=None):
+                calls.append(("send_document", chat_id, path))
+                return SimpleNamespace(success=True, message_id="$doc")
+
+            async def disconnect(self):
+                calls.append(("disconnect",))
+
+        fake_module = SimpleNamespace(MatrixAdapter=EphemeralAdapter)
+
+        with patch(
+            "gateway.run._gateway_runner_ref", return_value=None
+        ), patch.dict(sys.modules, {"gateway.platforms.matrix": fake_module}):
+            result = asyncio.run(
+                _send_matrix_via_adapter(
+                    SimpleNamespace(enabled=True, token="tok", extra={}),
+                    "!room:example.com",
+                    "report attached",
+                    media_files=[(str(doc_path), False)],
+                )
+            )
+
+        assert result["success"] is True
+        assert calls == [
+            ("connect",),
+            ("send", "!room:example.com", "report attached"),
+            ("send_document", "!room:example.com", str(doc_path)),
+            ("disconnect",),
+        ]
+
+    def test_live_adapter_no_matrix_adapter_falls_back(self):
+        """When the runner exists but has no Matrix adapter registered,
+        fall back to ephemeral."""
+        calls = []
+
+        class EphemeralAdapter:
+            def __init__(self, _config):
+                pass
+
+            async def connect(self):
+                calls.append(("connect",))
+                return True
+
+            async def send(self, chat_id, message, metadata=None):
+                calls.append(("send",))
+                return SimpleNamespace(success=True, message_id="$txt")
+
+            async def disconnect(self):
+                calls.append(("disconnect",))
+
+        # Runner exists but adapters dict has no MATRIX key
+        fake_runner = SimpleNamespace(adapters={})
+        fake_module = SimpleNamespace(MatrixAdapter=EphemeralAdapter)
+
+        with patch(
+            "gateway.run._gateway_runner_ref",
+            return_value=fake_runner,
+        ), patch.dict(sys.modules, {"gateway.platforms.matrix": fake_module}):
+            result = asyncio.run(
+                _send_matrix_via_adapter(
+                    SimpleNamespace(enabled=True, token="tok", extra={}),
+                    "!room:example.com",
+                    "hello",
+                )
+            )
+
+        assert result["success"] is True
+        assert ("connect",) in calls
+        assert ("disconnect",) in calls
+
+
 # ---------------------------------------------------------------------------
 # HTML auto-detection in Telegram send
 # ---------------------------------------------------------------------------

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1535,56 +1535,50 @@ async def _send_matrix(token, extra, chat_id, message):
 
 
 async def _send_matrix_via_adapter(pconfig, chat_id, message, media_files=None, thread_id=None):
-    """Send via the Matrix adapter so native Matrix media uploads are preserved."""
+    """Send via the Matrix adapter so native Matrix media uploads are preserved.
+
+    When a live gateway adapter is available (i.e. the tool runs inside a
+    running gateway), the persistent connection is reused — one olm/megolm
+    session for all sends.  This avoids per-message E2EE re-init storms
+    that exhaust recipient OTKs and silently drop messages (issue #46310).
+
+    Falls back to an ephemeral connect/disconnect cycle only when no gateway
+    is running (standalone cron, ``hermes send`` CLI).
+    """
+    media_files = media_files or []
+    metadata = {"thread_id": thread_id} if thread_id else None
+
+    # --- Try the live gateway adapter first (persistent E2EE session) ---
+    live_adapter = None
+    try:
+        from gateway.config import Platform
+        from gateway.run import _gateway_runner_ref
+
+        runner = _gateway_runner_ref()
+        if runner is not None:
+            live_adapter = runner.adapters.get(Platform.MATRIX)
+    except Exception:
+        live_adapter = None
+
+    if live_adapter is not None:
+        return await _send_via_matrix_adapter(
+            live_adapter, chat_id, message, media_files, metadata
+        )
+
+    # --- Fallback: ephemeral adapter (standalone / cron context) ---
     try:
         from gateway.platforms.matrix import MatrixAdapter
     except ImportError:
         return {"error": "Matrix dependencies not installed. Run: pip install 'mautrix[encryption]'"}
 
-    media_files = media_files or []
-
+    adapter = MatrixAdapter(pconfig)
     try:
-        adapter = MatrixAdapter(pconfig)
         connected = await adapter.connect()
         if not connected:
             return _error("Matrix connect failed")
-
-        metadata = {"thread_id": thread_id} if thread_id else None
-        last_result = None
-
-        if message.strip():
-            last_result = await adapter.send(chat_id, message, metadata=metadata)
-            if not last_result.success:
-                return _error(f"Matrix send failed: {last_result.error}")
-
-        for media_path, is_voice in media_files:
-            if not os.path.exists(media_path):
-                return _error(f"Media file not found: {media_path}")
-
-            ext = os.path.splitext(media_path)[1].lower()
-            if ext in _IMAGE_EXTS:
-                last_result = await adapter.send_image_file(chat_id, media_path, metadata=metadata)
-            elif ext in _VIDEO_EXTS:
-                last_result = await adapter.send_video(chat_id, media_path, metadata=metadata)
-            elif ext in _VOICE_EXTS and is_voice:
-                last_result = await adapter.send_voice(chat_id, media_path, metadata=metadata)
-            elif ext in _AUDIO_EXTS:
-                last_result = await adapter.send_voice(chat_id, media_path, metadata=metadata)
-            else:
-                last_result = await adapter.send_document(chat_id, media_path, metadata=metadata)
-
-            if not last_result.success:
-                return _error(f"Matrix media send failed: {last_result.error}")
-
-        if last_result is None:
-            return {"error": "No deliverable text or media remained after processing MEDIA tags"}
-
-        return {
-            "success": True,
-            "platform": "matrix",
-            "chat_id": chat_id,
-            "message_id": last_result.message_id,
-        }
+        return await _send_via_matrix_adapter(
+            adapter, chat_id, message, media_files, metadata
+        )
     except Exception as e:
         return _error(f"Matrix send failed: {e}")
     finally:
@@ -1592,6 +1586,45 @@ async def _send_matrix_via_adapter(pconfig, chat_id, message, media_files=None, 
             await adapter.disconnect()
         except Exception:
             pass
+
+
+async def _send_via_matrix_adapter(adapter, chat_id, message, media_files, metadata):
+    """Core send logic shared by live and ephemeral Matrix adapters."""
+    last_result = None
+
+    if message.strip():
+        last_result = await adapter.send(chat_id, message, metadata=metadata)
+        if not last_result.success:
+            return _error(f"Matrix send failed: {last_result.error}")
+
+    for media_path, is_voice in media_files:
+        if not os.path.exists(media_path):
+            return _error(f"Media file not found: {media_path}")
+
+        ext = os.path.splitext(media_path)[1].lower()
+        if ext in _IMAGE_EXTS:
+            last_result = await adapter.send_image_file(chat_id, media_path, metadata=metadata)
+        elif ext in _VIDEO_EXTS:
+            last_result = await adapter.send_video(chat_id, media_path, metadata=metadata)
+        elif ext in _VOICE_EXTS and is_voice:
+            last_result = await adapter.send_voice(chat_id, media_path, metadata=metadata)
+        elif ext in _AUDIO_EXTS:
+            last_result = await adapter.send_voice(chat_id, media_path, metadata=metadata)
+        else:
+            last_result = await adapter.send_document(chat_id, media_path, metadata=metadata)
+
+        if not last_result.success:
+            return _error(f"Matrix media send failed: {last_result.error}")
+
+    if last_result is None:
+        return {"error": "No deliverable text or media remained after processing MEDIA tags"}
+
+    return {
+        "success": True,
+        "platform": "matrix",
+        "chat_id": chat_id,
+        "message_id": last_result.message_id,
+    }
 
 
 async def _send_dingtalk(extra, chat_id, message):


### PR DESCRIPTION
## What does this PR do?

Reuse the live gateway adapter for Matrix media sends in `send_message`, eliminating per-message E2EE re-init storms that exhaust recipient one-time keys (OTKs) and silently drop messages.

## Related Issue

Fixes #46310

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/send_message_tool.py`: `_send_matrix_via_adapter()` now checks for a live gateway adapter via `_gateway_runner_ref()` before creating an ephemeral one. Extracted shared send logic into `_send_via_matrix_adapter()` to avoid code duplication between the two paths.
- `tests/tools/test_send_message_tool.py`: Added `TestMatrixMediaLiveAdapterReuse` with 3 tests covering: live adapter reuse (no connect/disconnect), ephemeral fallback when no gateway, and fallback when runner exists but has no Matrix adapter.

## How to Test

1. Run `pytest tests/tools/test_send_message_tool.py::TestMatrixMediaLiveAdapterReuse -xvs` — all 3 tests pass
2. Run `pytest tests/tools/test_send_message_tool.py -x` — all 136 tests pass (no regressions)
3. Functional: with a running Matrix gateway, have the agent send multiple media messages in quick succession. Verify no "No one-time keys" warnings in `agent.log` and all messages reach the recipient.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tools/send_message_tool.py::_send_matrix_via_adapter`, `gateway/run.py::_gateway_runner_ref`
- Blast radius: LOW — changes only affect the Matrix media send path; text-only sends and other platforms are unaffected
- Related patterns: Same live-adapter reuse pattern used by `_send_to_platform` (line 618) and cron delivery after #31165 (Telegram reconnect storm fix)
