### PR TITLE
feat(dashboard): add mobile remote access bootstrap

### DIFF
--- a/docs/design/mobile-remote-access.md
+++ b/docs/design/mobile-remote-access.md
@@ -1,0 +1,145 @@
+# Mobile Remote Access
+
+## Goal
+
+Hermes Desktop should be able to act as a local host for first-class remote
+clients, including a future Flutter mobile app. The mobile client should drive
+the user's own Hermes instance directly, keep sessions cleanly scoped to that
+instance, and support multiple saved Hermes hosts without requiring a hosted
+relay.
+
+This document describes the upstream-friendly direction and the first backend
+contract now exposed by the dashboard:
+
+```http
+GET /api/mobile/bootstrap
+```
+
+The endpoint is read-only and public by design. It lets a client confirm that a
+reachable HTTP server is a Hermes dashboard host and choose the correct auth
+flow before attempting authenticated API or WebSocket calls.
+
+## Host and Client Model
+
+- **Host:** a `hermes dashboard` process. Hermes Desktop can launch this process
+  locally, and server installs can run it under `systemd`, `tmux`, or another
+  supervisor.
+- **Remote client:** a mobile app or another desktop app that talks to the host
+  over the existing dashboard HTTP and WebSocket surface.
+- **Session owner:** the host. Conversation storage, memory, skills, tools,
+  cron jobs, and profiles remain on the Hermes machine. The remote client is a
+  controller and display surface, not a second agent runtime.
+- **No relay:** Hermes should not require a hosted middlebox for mobile access.
+  A hosted relay may be a separate product decision later, but it is not part
+  of this design.
+
+## Connectivity
+
+Supported connection paths should all terminate at the same dashboard host:
+
+- **Local network or direct IP:** run `hermes dashboard --host 0.0.0.0 --port
+  9119 --no-open` with dashboard auth enabled.
+- **Tailscale or similar private overlay:** use the MagicDNS name or tailnet IP
+  as the saved host URL. The dashboard's Host-header and peer guards still
+  apply.
+- **Cloudflare Tunnel or equivalent reverse proxy:** terminate TLS at the tunnel
+  and forward to the dashboard. The public URL should preserve the dashboard
+  prefix and WebSocket upgrade paths.
+
+The mobile app should store a list of host records, for example:
+
+- display name
+- base URL
+- last seen server version
+- auth mode and provider names from `/api/mobile/bootstrap`
+- user-selected profile or instance label, once supported by authenticated APIs
+
+## Bootstrap Contract
+
+`GET /api/mobile/bootstrap` returns:
+
+```json
+{
+  "server_version": "x.y.z",
+  "api_version": 1,
+  "auth_required": true,
+  "auth_providers": ["basic"],
+  "features": {
+    "dashboard_status": true,
+    "desktop_gateway_ws": true,
+    "pty_chat": true,
+    "ws_ticket_auth": true,
+    "device_pairing": false,
+    "hosted_relay": false
+  }
+}
+```
+
+The response intentionally excludes host paths, PIDs, session counts, tokens,
+user ids, profile names, and config. Public callers should only learn the
+coarse capability and auth shape needed to continue safely.
+
+`api_version` is the mobile bootstrap contract version, not the Hermes package
+version. Additive fields may be introduced under the same version; incompatible
+changes require a version bump.
+
+## Auth and Security Model
+
+The dashboard keeps its existing split:
+
+- loopback binds use the ephemeral dashboard session token injected into the
+  local web UI;
+- non-loopback binds require the dashboard auth gate and a registered provider.
+
+Remote clients should treat `/api/mobile/bootstrap` as discovery only. All
+state-changing APIs, session APIs, and chat WebSockets must continue through the
+existing authenticated dashboard paths. In gated mode, clients should sign in
+through an advertised provider, then use the existing WebSocket-ticket flow for
+live chat sockets.
+
+Security requirements:
+
+- no secrets in bootstrap responses;
+- no weakening of dashboard auth or Host-header validation;
+- no unauthenticated session lists, profile details, config, memory, or logs;
+- no new core model tools;
+- no prompt or toolset mutation in existing conversations.
+
+## Pairing Direction
+
+Device pairing should be an authenticated setup flow layered on top of the
+dashboard, not a relay service. The expected direction:
+
+1. A logged-in dashboard operator opens a pairing screen.
+2. The host creates a short-lived, single-purpose pairing code.
+3. The dashboard renders a QR code containing the base URL and pairing code.
+4. The mobile app scans it, calls a pairing endpoint, and receives a scoped
+   device credential.
+5. The host stores device records under `get_hermes_home()` and lets the user
+   revoke them from the dashboard.
+
+This first slice deliberately does not add pairing persistence. The bootstrap
+endpoint advertises `"device_pairing": false` until the full flow exists and is
+tested.
+
+## Multi-Instance Behavior
+
+The mobile app should model each dashboard host as a separate instance. A user
+may save several hosts, such as "Laptop", "Workstation", and "Homelab". Each
+host owns its own Hermes home, profiles, sessions, credentials, and tools.
+
+Within one host, profile selection should follow the existing dashboard profile
+model instead of inventing a mobile-only session namespace. Remote clients
+should display the active instance and profile clearly before sending prompts.
+
+## Non-Goals
+
+- Building a Flutter app in this repository slice.
+- Adding a hosted relay.
+- Adding pairing persistence before the endpoint and revocation model are
+  designed and tested.
+- Adding new core model tools.
+- Exposing secrets, config, paths, sessions, memory, logs, or profile details
+  through unauthenticated APIs.
+- Replacing the existing dashboard auth, WebSocket-ticket, or Host-header
+  protections.

--- a/hermes_cli/dashboard_auth/public_paths.py
+++ b/hermes_cli/dashboard_auth/public_paths.py
@@ -37,6 +37,10 @@ PUBLIC_API_PATHS: frozenset[str] = frozenset({
     # liveness probe in
     # ``docs/agent-dashboard-public-url-contract.md`` (NAS side).
     "/api/status",
+    # Read-only mobile/remote-client discovery. Returns only version,
+    # auth-gate shape, and coarse feature flags so a client can decide
+    # whether to continue into the normal dashboard auth flow.
+    "/api/mobile/bootstrap",
     # Read-only config-defaults / schema feeds for the SPA's Config page.
     "/api/config/defaults",
     "/api/config/schema",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1686,6 +1686,42 @@ async def get_status():
     return status
 
 
+def _dashboard_auth_bootstrap_shape() -> Dict[str, Any]:
+    auth_required = bool(getattr(app.state, "auth_required", False))
+    auth_providers: list[str] = []
+    try:
+        from hermes_cli.dashboard_auth import list_providers as _list_providers
+        auth_providers = [p.name for p in _list_providers()]
+    except Exception:
+        pass
+
+    return {
+        "server_version": __version__,
+        "api_version": 1,
+        "auth_required": auth_required,
+        "auth_providers": auth_providers,
+        "features": {
+            "dashboard_status": True,
+            "desktop_gateway_ws": True,
+            "pty_chat": _DASHBOARD_EMBEDDED_CHAT_ENABLED,
+            "ws_ticket_auth": auth_required,
+            "device_pairing": False,
+            "hosted_relay": False,
+        },
+    }
+
+
+@app.get("/api/mobile/bootstrap")
+async def get_mobile_bootstrap():
+    """Read-only discovery contract for first-class remote clients.
+
+    Keep this shape intentionally coarse. The route is public so mobile apps
+    can identify a Hermes dashboard host before choosing an auth flow; it must
+    not expose host paths, PIDs, session data, tokens, user ids, or config.
+    """
+    return _dashboard_auth_bootstrap_shape()
+
+
 _WINDOWS_11_MIN_BUILD = 22000
 
 

--- a/tests/hermes_cli/test_dashboard_mobile_bootstrap.py
+++ b/tests/hermes_cli/test_dashboard_mobile_bootstrap.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hermes_cli import __version__, web_server
+from hermes_cli.dashboard_auth import clear_providers, register_provider
+from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+
+pytestmark = pytest.mark.xdist_group("dashboard_auth_app_state")
+
+
+@pytest.fixture
+def loopback_client():
+    clear_providers()
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.bound_host = "127.0.0.1"
+    web_server.app.state.bound_port = 9119
+    web_server.app.state.auth_required = False
+    client = TestClient(web_server.app, base_url="http://127.0.0.1:9119")
+    yield client
+    clear_providers()
+    web_server.app.state.bound_host = prev_host
+    web_server.app.state.bound_port = prev_port
+    web_server.app.state.auth_required = prev_required
+
+
+@pytest.fixture
+def gated_client():
+    clear_providers()
+    register_provider(StubAuthProvider())
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.bound_host = "hermes.example.test"
+    web_server.app.state.bound_port = 443
+    web_server.app.state.auth_required = True
+    client = TestClient(web_server.app, base_url="https://hermes.example.test")
+    yield client
+    clear_providers()
+    web_server.app.state.bound_host = prev_host
+    web_server.app.state.bound_port = prev_port
+    web_server.app.state.auth_required = prev_required
+
+
+def test_mobile_bootstrap_is_public_in_loopback_mode(loopback_client):
+    response = loopback_client.get("/api/mobile/bootstrap")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body == {
+        "server_version": __version__,
+        "api_version": 1,
+        "auth_required": False,
+        "auth_providers": [],
+        "features": {
+            "dashboard_status": True,
+            "desktop_gateway_ws": True,
+            "pty_chat": True,
+            "ws_ticket_auth": False,
+            "device_pairing": False,
+            "hosted_relay": False,
+        },
+    }
+
+
+def test_mobile_bootstrap_reports_gated_auth_without_login(gated_client):
+    response = gated_client.get("/api/mobile/bootstrap")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["server_version"] == __version__
+    assert body["api_version"] == 1
+    assert body["auth_required"] is True
+    assert body["auth_providers"] == ["stub"]
+    assert body["features"]["ws_ticket_auth"] is True
+    assert body["features"]["device_pairing"] is False
+    assert body["features"]["hosted_relay"] is False
+
+
+def test_mobile_bootstrap_does_not_expose_host_or_session_detail(gated_client):
+    response = gated_client.get("/api/mobile/bootstrap")
+
+    assert response.status_code == 200
+    body = response.json()
+    forbidden = {
+        "hermes_home",
+        "config_path",
+        "env_path",
+        "gateway_pid",
+        "gateway_health_url",
+        "active_sessions",
+        "session_id",
+        "token",
+        "user_id",
+    }
+    assert forbidden.isdisjoint(body)

--- a/website/docs/user-guide/features/web-dashboard.md
+++ b/website/docs/user-guide/features/web-dashboard.md
@@ -179,6 +179,27 @@ curl -s http://VM_IP:9119/api/status | jq '.auth_required, .auth_providers'
 
 If `/api/status` shows the gate is on with the `"basic"` provider and Desktop *still* fails to connect after signing in, the issue is past basic setup — grab a fresh `desktop.log` (Settings → Gateway → Open logs) plus the dashboard's logs from the same retry window and look for the `/api/ws` close code (4403 = chat WS rejected by the request guard, e.g. Host/peer mismatch; 4401 = the WS ticket didn't authenticate).
 
+### Mobile and remote-client bootstrap
+
+The dashboard also exposes a small read-only discovery endpoint for future
+first-class mobile and remote clients:
+
+```bash
+curl -s http://VM_IP:9119/api/mobile/bootstrap | jq
+```
+
+It returns the Hermes server version, a mobile bootstrap API version, whether
+dashboard auth is required, the advertised auth providers, and coarse feature
+flags such as WebSocket chat support. It does **not** return tokens, session
+lists, profile names, host paths, config, memory, logs, or API keys.
+
+Use this endpoint only to identify a Hermes dashboard host and choose the next
+auth step. All live chat, session, config, and management calls still go
+through the existing authenticated dashboard APIs and WebSocket-ticket flow.
+Pairing and QR/device registration are planned follow-up work; there is no
+hosted relay in this contract. See `docs/design/mobile-remote-access.md` in the
+repository for the design notes.
+
 ### Config
 
 A form-based editor for `config.yaml`. All 150+ configuration fields are auto-discovered from `DEFAULT_CONFIG` and organized into tabbed categories:


### PR DESCRIPTION
## Summary

- Adds a public, read-only `GET /api/mobile/bootstrap` discovery endpoint for future first-class remote/mobile clients.
- Documents a local-first Hermes Desktop/Agent host + Flutter/mobile remote-client architecture.
- Adds focused tests covering loopback mode, auth-gated mode, and the no-sensitive-fields contract.
- Extends dashboard docs with the mobile bootstrap contract and security expectations.

## Test Plan

- `uv run --with pytest --with python-multipart python -m pytest tests/hermes_cli/test_dashboard_mobile_bootstrap.py -q -o 'addopts=' -s --tb=short`
  - Result: `3 passed, 1 warning in 0.67s`
- Direct smoke:
  - `uv run python - <<'PY' ... TestClient(...).get('/api/mobile/bootstrap') ... PY`
  - Result: HTTP 200 with expected bootstrap JSON

## Notes

This intentionally does **not** add device-pairing persistence yet. The endpoint advertises `device_pairing: false` and the design doc frames pairing as the next authenticated/revocable host feature.
