### PR TITLE
feat(gateway): add optional runtime model prefix

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8949,6 +8949,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         display_reasoning = last_reasoning.strip()
                     response = f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}"
 
+            # Compact runtime prefix — a small model tag at the START of the
+            # final visible reply (for example, [gpt5.5]). This is separate
+            # from the footer so users can identify the answering model
+            # without adding cwd/context chrome.
+            try:
+                from gateway.runtime_footer import (
+                    apply_runtime_prefix as _arp,
+                    build_runtime_prefix as _brp,
+                )
+
+                _runtime_prefix = _brp(
+                    user_config=_load_gateway_config(),
+                    platform_key=_platform_config_key(source.platform),
+                    model=agent_result.get("model"),
+                )
+            except Exception as _prefix_err:
+                logger.debug("runtime_prefix build failed: %s", _prefix_err)
+                _runtime_prefix = ""
+            if (
+                _runtime_prefix
+                and response
+                and not agent_result.get("already_sent")
+                and not _intentional_silence
+            ):
+                response = _arp(response, _runtime_prefix)
+
             # Runtime-metadata footer — only on the FINAL message of the turn.
             # Off by default (display.runtime_footer.enabled=false).  When
             # streaming already delivered the body, we can't mutate the sent

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -178,14 +178,27 @@ def resolve_prefix_config(
     }
     cfg = (user_config or {}).get("display") or {}
 
+    def _merge_labels(prefix_cfg: dict[str, Any]) -> None:
+        labels_cfg = (
+            prefix_cfg.get("labels")
+            or prefix_cfg.get("map")
+            or prefix_cfg.get("markers")
+        )
+        if not isinstance(labels_cfg, dict):
+            return
+        labels = dict(resolved["labels"])
+        for key, value in labels_cfg.items():
+            label_key = str(key).strip()
+            label_value = str(value).strip()
+            if label_key and label_value:
+                labels[label_key] = label_value
+        resolved["labels"] = labels
+
     global_cfg = cfg.get("runtime_prefix")
     if isinstance(global_cfg, dict):
         if "enabled" in global_cfg:
             resolved["enabled"] = bool(global_cfg.get("enabled"))
-        if isinstance(global_cfg.get("labels"), dict):
-            labels = dict(resolved["labels"])
-            labels.update({str(k): str(v) for k, v in global_cfg["labels"].items()})
-            resolved["labels"] = labels
+        _merge_labels(global_cfg)
 
     if platform_key:
         platforms = cfg.get("platforms") or {}
@@ -195,12 +208,7 @@ def resolve_prefix_config(
             if isinstance(plat_prefix, dict):
                 if "enabled" in plat_prefix:
                     resolved["enabled"] = bool(plat_prefix.get("enabled"))
-                if isinstance(plat_prefix.get("labels"), dict):
-                    labels = dict(resolved["labels"])
-                    labels.update(
-                        {str(k): str(v) for k, v in plat_prefix["labels"].items()}
-                    )
-                    resolved["labels"] = labels
+                _merge_labels(plat_prefix)
 
     return resolved
 

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -1,4 +1,4 @@
-"""Gateway runtime-metadata footer.
+"""Gateway runtime-metadata footer and compact runtime prefix.
 
 Renders a compact footer showing runtime state (model, context %, cwd) and
 appends it to the FINAL message of an agent turn when enabled.  Off by default
@@ -10,10 +10,14 @@ Config (``~/.hermes/config.yaml``)::
       runtime_footer:
         enabled: true                       # off by default
         fields: [model, context_pct, cwd]   # order shown; drop any to hide
+      runtime_prefix:
+        enabled: true                       # prepend compact model tag
+        labels:
+          gpt-5.5: "[gpt5.5]"
 
-Per-platform overrides live under ``display.platforms.<platform>.runtime_footer``.
-Users can toggle the global setting with ``/footer on|off`` from both the CLI
-and any gateway platform.
+Per-platform overrides live under ``display.platforms.<platform>.runtime_footer``
+and ``display.platforms.<platform>.runtime_prefix``.  Users can toggle the
+footer with ``/footer on|off`` from both the CLI and any gateway platform.
 
 The footer is appended to the final response text in ``gateway/run.py`` right
 before returning the response to the adapter send path — so it only lands on
@@ -29,6 +33,15 @@ import os
 from typing import Any, Iterable, Optional
 
 _DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
+_DEFAULT_PREFIX_LABELS: dict[str, str] = {
+    "grok-composer": "[grok]",
+    "grok": "[grok]",
+    "gpt-5.5": "[gpt5.5]",
+    "gpt": "[gpt]",
+    "glm-5.1": "[glm]",
+    "glm-5.2": "[glm2]",
+    "glm": "[glm]",
+}
 _SEP = " · "
 
 
@@ -40,7 +53,7 @@ def _home_relative_cwd(cwd: str) -> str:
         home = os.path.expanduser("~")
         p = os.path.abspath(cwd)
         if home and (p == home or p.startswith(home + os.sep)):
-            return "~" + p[len(home):]
+            return "~" + p[len(home) :]
         return p
     except Exception:
         return cwd
@@ -146,4 +159,116 @@ def build_footer_line(
         context_length=context_length,
         cwd=cwd,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
+    )
+
+
+def resolve_prefix_config(
+    user_config: dict[str, Any] | None,
+    platform_key: str | None = None,
+) -> dict[str, Any]:
+    """Resolve effective runtime-prefix config for *platform_key*.
+
+    The prefix is intentionally separate from ``runtime_footer``: it provides a
+    small model tag at the start of visible gateway replies without adding cwd
+    or context details. Merge order mirrors ``resolve_footer_config``.
+    """
+    resolved: dict[str, Any] = {
+        "enabled": False,
+        "labels": dict(_DEFAULT_PREFIX_LABELS),
+    }
+    cfg = (user_config or {}).get("display") or {}
+
+    global_cfg = cfg.get("runtime_prefix")
+    if isinstance(global_cfg, dict):
+        if "enabled" in global_cfg:
+            resolved["enabled"] = bool(global_cfg.get("enabled"))
+        if isinstance(global_cfg.get("labels"), dict):
+            labels = dict(resolved["labels"])
+            labels.update({str(k): str(v) for k, v in global_cfg["labels"].items()})
+            resolved["labels"] = labels
+
+    if platform_key:
+        platforms = cfg.get("platforms") or {}
+        plat_cfg = platforms.get(platform_key)
+        if isinstance(plat_cfg, dict):
+            plat_prefix = plat_cfg.get("runtime_prefix")
+            if isinstance(plat_prefix, dict):
+                if "enabled" in plat_prefix:
+                    resolved["enabled"] = bool(plat_prefix.get("enabled"))
+                if isinstance(plat_prefix.get("labels"), dict):
+                    labels = dict(resolved["labels"])
+                    labels.update(
+                        {str(k): str(v) for k, v in plat_prefix["labels"].items()}
+                    )
+                    resolved["labels"] = labels
+
+    return resolved
+
+
+def _label_for_model(model: Optional[str], labels: dict[str, Any] | None = None) -> str:
+    """Return the configured compact label for *model*, or a safe default."""
+    short = _model_short(model)
+    if not short:
+        return ""
+
+    labels = labels or {}
+    lowered = {str(k).lower(): str(v) for k, v in labels.items() if str(v)}
+    for candidate in (str(model or ""), short):
+        val = lowered.get(candidate.lower())
+        if val:
+            return val
+
+    # Fallback to longest prefix match so a broad label like ``gpt`` can cover
+    # ``gpt-5.5`` while exact labels (checked above) still win.
+    short_l = short.lower()
+    for key in sorted(lowered, key=len, reverse=True):
+        if short_l.startswith(key):
+            return lowered[key]
+    return f"[{short}]"
+
+
+def build_runtime_prefix(
+    *,
+    user_config: dict[str, Any] | None,
+    platform_key: str | None,
+    model: Optional[str],
+) -> str:
+    """Return compact model prefix, e.g. ``[gpt5.5]``, or empty if disabled."""
+    cfg = resolve_prefix_config(user_config, platform_key)
+    if not cfg.get("enabled"):
+        return ""
+    return _label_for_model(model, cfg.get("labels") or {})
+
+
+def apply_runtime_prefix(response: str, prefix: str) -> str:
+    """Prepend *prefix* once to a final gateway response."""
+    if not response or not prefix:
+        return response
+    stripped = response.lstrip()
+    if stripped.startswith(prefix):
+        return response
+    leading = response[: len(response) - len(stripped)]
+    return f"{leading}{prefix} {stripped}"
+
+
+def format_runtime_prefix(
+    *,
+    model: Optional[str],
+    labels: dict[str, str] | None = None,
+) -> str:
+    """Compatibility helper returning the compact marker for *model*."""
+    return _label_for_model(model, labels or _DEFAULT_PREFIX_LABELS)
+
+
+def build_prefix_line(
+    *,
+    user_config: dict[str, Any] | None,
+    platform_key: str | None,
+    model: Optional[str],
+) -> str:
+    """Compatibility alias for the first-line runtime prefix entry point."""
+    return build_runtime_prefix(
+        user_config=user_config,
+        platform_key=platform_key,
+        model=model,
     )

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1516,6 +1516,22 @@ DEFAULT_CONFIG = {
             "enabled": False,
             "fields": ["model", "context_pct", "cwd"],  # Order shown; drop any to hide
         },
+        # Gateway runtime prefix prepended to the FINAL visible reply when enabled.
+        # It is separate from runtime_footer so users can see a compact model tag
+        # without context/cwd metadata. Per-platform overrides go under
+        # display.platforms.<platform>.runtime_prefix.
+        "runtime_prefix": {
+            "enabled": False,
+            "labels": {
+                "grok-composer": "[grok]",
+                "grok": "[grok]",
+                "gpt-5.5": "[gpt5.5]",
+                "gpt": "[gpt]",
+                "glm-5.1": "[glm]",
+                "glm-5.2": "[glm2]",
+                "glm": "[glm]",
+            },
+        },
         "copy_shortcut": "auto",  # "auto" (platform default) | "ctrl_c" | "ctrl_shift_c" | "disabled"
     },
 

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -253,6 +253,21 @@ def test_resolve_prefix_platform_label_extends_global_labels():
     assert cfg["labels"]["gpt-5.5"] == "[tg-gpt]"
 
 
+def test_resolve_prefix_accepts_legacy_label_aliases():
+    user = {
+        "display": {
+            "runtime_prefix": {"enabled": True, "map": {"gpt-5.5": "[map-gpt]"}},
+            "platforms": {
+                "telegram": {"runtime_prefix": {"markers": {"glm-5.2": "[marker-glm]"}}}
+            },
+        }
+    }
+    cfg = resolve_prefix_config(user, "telegram")
+    assert cfg["enabled"] is True
+    assert cfg["labels"]["gpt-5.5"] == "[map-gpt]"
+    assert cfg["labels"]["glm-5.2"] == "[marker-glm]"
+
+
 def test_build_runtime_prefix_uses_exact_configured_label():
     assert (
         build_runtime_prefix(

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -10,9 +10,14 @@ import pytest
 from gateway.runtime_footer import (
     _home_relative_cwd,
     _model_short,
+    apply_runtime_prefix,
     build_footer_line,
+    build_prefix_line,
+    build_runtime_prefix,
     format_runtime_footer,
+    format_runtime_prefix,
     resolve_footer_config,
+    resolve_prefix_config,
 )
 
 
@@ -200,6 +205,126 @@ def test_resolve_ignores_malformed_config():
     user = {"display": {"runtime_footer": "on"}}
     cfg = resolve_footer_config(user, "telegram")
     assert cfg["enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# runtime_prefix — first-line model markers
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_prefix_global_enable_and_label():
+    user = {
+        "display": {
+            "runtime_prefix": {
+                "enabled": True,
+                "labels": {"gpt-5.5": "[gpt5.5-custom]"},
+            }
+        }
+    }
+    cfg = resolve_prefix_config(user, "slack")
+    assert cfg["enabled"] is True
+    assert cfg["labels"]["gpt-5.5"] == "[gpt5.5-custom]"
+
+
+def test_resolve_prefix_platform_override_wins():
+    user = {
+        "display": {
+            "runtime_prefix": {"enabled": False, "labels": {"gpt": "[gpt]"}},
+            "platforms": {"slack": {"runtime_prefix": {"enabled": True}}},
+        }
+    }
+    cfg = resolve_prefix_config(user, "slack")
+    assert cfg["enabled"] is True
+    assert cfg["labels"]["gpt"] == "[gpt]"
+
+
+def test_resolve_prefix_platform_label_extends_global_labels():
+    user = {
+        "display": {
+            "runtime_prefix": {"enabled": True, "labels": {"gpt": "[gpt]"}},
+            "platforms": {
+                "telegram": {"runtime_prefix": {"labels": {"gpt-5.5": "[tg-gpt]"}}}
+            },
+        }
+    }
+    cfg = resolve_prefix_config(user, "telegram")
+    assert cfg["enabled"] is True
+    assert cfg["labels"]["gpt"] == "[gpt]"
+    assert cfg["labels"]["gpt-5.5"] == "[tg-gpt]"
+
+
+def test_build_runtime_prefix_uses_exact_configured_label():
+    assert (
+        build_runtime_prefix(
+            user_config={
+                "display": {
+                    "runtime_prefix": {
+                        "enabled": True,
+                        "labels": {"gpt-5.5": "[gpt5.5-custom]"},
+                    }
+                }
+            },
+            platform_key="slack",
+            model="gpt-5.5",
+        )
+        == "[gpt5.5-custom]"
+    )
+
+
+def test_build_runtime_prefix_uses_default_label_when_enabled_without_label():
+    assert (
+        build_runtime_prefix(
+            user_config={"display": {"runtime_prefix": {"enabled": True}}},
+            platform_key="slack",
+            model="openai/gpt-5.5",
+        )
+        == "[gpt5.5]"
+    )
+
+
+def test_build_runtime_prefix_empty_when_disabled():
+    assert (
+        build_runtime_prefix(
+            user_config={},
+            platform_key="slack",
+            model="gpt-5.5",
+        )
+        == ""
+    )
+
+
+def test_format_runtime_prefix_defaults_grok_and_glm():
+    assert format_runtime_prefix(model="grok-composer-2.5-fast") == "[grok]"
+    assert format_runtime_prefix(model="glm-5.1") == "[glm]"
+    assert format_runtime_prefix(model="glm-5.2") == "[glm2]"
+    assert format_runtime_prefix(model="gpt-5.5") == "[gpt5.5]"
+
+
+def test_format_runtime_prefix_longest_key_wins():
+    assert (
+        format_runtime_prefix(
+            model="grok-composer-2.5-fast",
+            labels={"grok": "[generic]", "grok-composer": "[composer]"},
+        )
+        == "[composer]"
+    )
+
+
+def test_apply_runtime_prefix_prepends_once():
+    assert apply_runtime_prefix("hello", "[gpt5.5]") == "[gpt5.5] hello"
+    assert apply_runtime_prefix("[gpt5.5] hello", "[gpt5.5]") == "[gpt5.5] hello"
+    assert apply_runtime_prefix("  [gpt5.5] hello", "[gpt5.5]") == "  [gpt5.5] hello"
+
+
+def test_build_prefix_line_compatibility_alias():
+    assert (
+        build_prefix_line(
+            user_config={"display": {"runtime_prefix": {"enabled": True}}},
+            platform_key="telegram",
+            model="glm-5.1",
+        )
+        == "[glm]"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a disabled-by-default `display.runtime_prefix` gateway option
- resolve global and per-platform compact model labels
- prepend the compact model tag to the final visible gateway reply when enabled

## Safety
- default behavior is unchanged because `display.runtime_prefix.enabled` defaults to `false`
- prefix is skipped for already-sent streaming responses and intentional silence

## Tests
- `python3 -m py_compile gateway/run.py gateway/runtime_footer.py hermes_cli/config.py tests/gateway/test_runtime_footer.py`
- `python3 -m pytest tests/gateway/test_runtime_footer.py -q`
- `gitleaks git --log-opts=origin/main..HEAD --no-banner --redact`
