### PR TITLE
feat(gateway): add compact runtime model prefix

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8949,26 +8949,44 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         display_reasoning = last_reasoning.strip()
                     response = f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}"
 
-            # Runtime-metadata footer — only on the FINAL message of the turn.
-            # Off by default (display.runtime_footer.enabled=false).  When
-            # streaming already delivered the body, we can't mutate the sent
-            # text, so we fire a separate trailing send below.
+            # Runtime first-line prefix + metadata footer — only on the FINAL
+            # message of the turn. Both are off by default. When streaming has
+            # already delivered the body, we can't mutate the sent text; the
+            # footer is sent as a trailing message below, while the prefix is
+            # skipped because it would no longer be a first line.
             _footer_line = ""
+            _prefix_line = ""
             try:
-                from gateway.runtime_footer import build_footer_line as _bfl
+                from gateway.runtime_footer import (
+                    apply_runtime_prefix as _arp,
+                    build_footer_line as _bfl,
+                    build_prefix_line as _bpl,
+                )
+                _runtime_display_config = _load_gateway_config()
+                _platform_key = _platform_config_key(source.platform)
+                _result_model = agent_result.get("model")
+                _prefix_line = _bpl(
+                    user_config=_runtime_display_config,
+                    platform_key=_platform_key,
+                    model=_result_model,
+                )
                 _footer_line = _bfl(
-                    user_config=_load_gateway_config(),
-                    platform_key=_platform_config_key(source.platform),
-                    model=agent_result.get("model"),
+                    user_config=_runtime_display_config,
+                    platform_key=_platform_key,
+                    model=_result_model,
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
                 )
-            except Exception as _footer_err:
-                logger.debug("runtime_footer build failed: %s", _footer_err)
+            except Exception as _runtime_meta_err:
+                logger.debug("runtime footer/prefix build failed: %s", _runtime_meta_err)
                 _footer_line = ""
-            if _footer_line and response and not agent_result.get("already_sent") and not _intentional_silence:
-                response = f"{response}\n\n{_footer_line}"
+                _prefix_line = ""
+            if response and not agent_result.get("already_sent") and not _intentional_silence:
+                if _prefix_line:
+                    response = _arp(response, _prefix_line)
+                if _footer_line:
+                    response = f"{response}\n\n{_footer_line}"
 
             # Emit agent:end hook
             await self.hooks.emit("agent:end", {
@@ -10096,7 +10114,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
           in which case the base adapter won't have text for auto-TTS so the
           runner must handle it.
         """
-        if not response or response.startswith("Error:"):
+        # Runtime prefixes are applied before this decision, so keep the
+        # historical "do not speak gateway errors" behavior even when an
+        # opt-in model tag has been prepended (for example,
+        # ``[gpt5.5] Error: ...``).
+        response_for_error_check = response.lstrip() if response else ""
+        if not response_for_error_check:
+            return False
+        if response_for_error_check.startswith("Error:") or re.match(
+            r"^\[[^\]\n]{1,64}\]\s+Error:", response_for_error_check
+        ):
             return False
 
         chat_id = event.source.chat_id

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -1,8 +1,12 @@
-"""Gateway runtime-metadata footer.
+"""Gateway runtime-metadata footer and compact runtime prefix.
 
 Renders a compact footer showing runtime state (model, context %, cwd) and
 appends it to the FINAL message of an agent turn when enabled.  Off by default
 to keep replies minimal.
+
+The optional runtime prefix prepends a compact model tag to the FINAL message,
+e.g. ``[gpt5.5] Done``.  It is also off by default and supports global and
+per-platform label maps for short human-friendly model names.
 
 Config (``~/.hermes/config.yaml``)::
 
@@ -10,10 +14,14 @@ Config (``~/.hermes/config.yaml``)::
       runtime_footer:
         enabled: true                       # off by default
         fields: [model, context_pct, cwd]   # order shown; drop any to hide
+      runtime_prefix:
+        enabled: true                       # off by default
+        labels:
+          gpt-5.5: "[gpt5.5]"
 
-Per-platform overrides live under ``display.platforms.<platform>.runtime_footer``.
-Users can toggle the global setting with ``/footer on|off`` from both the CLI
-and any gateway platform.
+Per-platform overrides live under ``display.platforms.<platform>.runtime_footer``
+and ``display.platforms.<platform>.runtime_prefix``. Users can toggle the global
+footer setting with ``/footer on|off`` from both the CLI and any gateway platform.
 
 The footer is appended to the final response text in ``gateway/run.py`` right
 before returning the response to the adapter send path — so it only lands on
@@ -26,9 +34,11 @@ piecemeal, the footer is sent as a separate trailing message via
 from __future__ import annotations
 
 import os
+import re
 from typing import Any, Iterable, Optional
 
 _DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
+_DEFAULT_PREFIX_MAP: dict[str, str] = {}
 _SEP = " · "
 
 
@@ -86,6 +96,110 @@ def resolve_footer_config(
                     resolved["fields"] = [str(f) for f in plat_footer["fields"]]
 
     return resolved
+
+
+def resolve_prefix_config(
+    user_config: dict[str, Any] | None,
+    platform_key: str | None = None,
+) -> dict[str, Any]:
+    """Resolve effective compact runtime-prefix config for *platform_key*.
+
+    Merge order mirrors :func:`resolve_footer_config`:
+        1. Built-in defaults (enabled=False)
+        2. ``display.runtime_prefix``
+        3. ``display.platforms.<platform_key>.runtime_prefix``
+    """
+    resolved: dict[str, Any] = {"enabled": False, "labels": dict(_DEFAULT_PREFIX_MAP)}
+    cfg = (user_config or {}).get("display") or {}
+
+    def _apply(prefix_cfg: Any) -> None:
+        if not isinstance(prefix_cfg, dict):
+            return
+        if "enabled" in prefix_cfg:
+            resolved["enabled"] = bool(prefix_cfg.get("enabled"))
+        labels = prefix_cfg.get("labels") or prefix_cfg.get("map") or prefix_cfg.get("markers")
+        if isinstance(labels, dict):
+            merged = dict(resolved.get("labels") or {})
+            for key, value in labels.items():
+                k = str(key).strip().lower()
+                v = str(value).strip()
+                if k and v:
+                    merged[k] = v
+            resolved["labels"] = merged
+
+    _apply(cfg.get("runtime_prefix"))
+
+    if platform_key:
+        platforms = cfg.get("platforms") or {}
+        plat_cfg = platforms.get(platform_key)
+        if isinstance(plat_cfg, dict):
+            _apply(plat_cfg.get("runtime_prefix"))
+
+    return resolved
+
+
+def format_runtime_prefix(
+    *,
+    model: Optional[str],
+    labels: dict[str, str] | None = None,
+) -> str:
+    """Return a compact marker for *model*, or ``""`` when no model is known."""
+    short = _model_short(model)
+    if not short:
+        return ""
+    mapping = labels or _DEFAULT_PREFIX_MAP
+    model_l = str(model or "").lower()
+    short_l = short.lower()
+    for needle in sorted(mapping, key=len, reverse=True):
+        key = str(needle).strip().lower()
+        if key and (key in model_l or short_l.startswith(key)):
+            return _normalize_prefix_marker(mapping[needle])
+    return f"[{short}]"
+
+
+def _normalize_prefix_marker(value: Any) -> str:
+    """Return a compact, single-line bracket marker for configured labels.
+
+    Runtime prefix values are user-configurable, but downstream gateway logic
+    treats them as small first-line markers. Normalizing to ``[label]`` keeps
+    custom labels compact and strips multiline/control/mention punctuation so
+    arbitrary platform mentions cannot be prepended to every gateway reply.
+    """
+    marker = str(value).strip().splitlines()[0].strip() if value is not None else ""
+    if not marker:
+        return ""
+    marker = marker[:64].strip()
+    if marker.startswith("[") and marker.endswith("]"):
+        marker = marker[1:-1].strip()
+    else:
+        marker = marker.strip("[]").strip()
+    marker = re.sub(r"[^\w .:/+-]", "", marker).strip()
+    return f"[{marker}]" if marker else ""
+
+
+def build_prefix_line(
+    *,
+    user_config: dict[str, Any] | None,
+    platform_key: str | None,
+    model: Optional[str],
+) -> str:
+    """Top-level entry point used by gateway/run.py for model prefix markers."""
+    cfg = resolve_prefix_config(user_config, platform_key)
+    if not cfg.get("enabled"):
+        return ""
+    labels = cfg.get("labels") if isinstance(cfg.get("labels"), dict) else None
+    return format_runtime_prefix(model=model, labels=labels)
+
+
+def apply_runtime_prefix(response: str, prefix: str) -> str:
+    """Prepend *prefix* once to a final gateway response."""
+    if not response or not prefix:
+        return response
+    stripped = response.lstrip()
+    if stripped.startswith(prefix):
+        return response
+    leading = response[: len(response) - len(stripped)]
+    return f"{leading}{prefix} {stripped}"
 
 
 def format_runtime_footer(

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1516,6 +1516,14 @@ DEFAULT_CONFIG = {
             "enabled": False,
             "fields": ["model", "context_pct", "cwd"],  # Order shown; drop any to hide
         },
+        # Gateway compact model prefix prepended to the FINAL message of a turn
+        # (disabled by default to keep replies minimal). When enabled, renders
+        # e.g. `[gpt5.5] response text`. Per-platform overrides go under
+        # display.platforms.<platform>.runtime_prefix.
+        "runtime_prefix": {
+            "enabled": False,
+            "labels": {},
+        },
         "copy_shortcut": "auto",  # "auto" (platform default) | "ctrl_c" | "ctrl_shift_c" | "disabled"
     },
 

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -10,9 +10,13 @@ import pytest
 from gateway.runtime_footer import (
     _home_relative_cwd,
     _model_short,
+    apply_runtime_prefix,
     build_footer_line,
+    build_prefix_line,
     format_runtime_footer,
+    format_runtime_prefix,
     resolve_footer_config,
+    resolve_prefix_config,
 )
 
 
@@ -200,6 +204,93 @@ def test_resolve_ignores_malformed_config():
     user = {"display": {"runtime_footer": "on"}}
     cfg = resolve_footer_config(user, "telegram")
     assert cfg["enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# runtime_prefix — first-line model markers
+# ---------------------------------------------------------------------------
+
+def test_format_runtime_prefix_uses_configured_label():
+    assert format_runtime_prefix(
+        model="openai/gpt-5.5",
+        labels={"gpt-5.5": "[gpt5.5]"},
+    ) == "[gpt5.5]"
+
+
+def test_format_runtime_prefix_normalizes_custom_label_to_bracket_marker():
+    assert format_runtime_prefix(
+        model="openai/gpt-5.5",
+        labels={"gpt-5.5": "gpt5.5:"},
+    ) == "[gpt5.5:]"
+
+
+def test_format_runtime_prefix_drops_multiline_custom_label():
+    assert format_runtime_prefix(
+        model="openai/gpt-5.5",
+        labels={"gpt-5.5": "gpt5.5\n@everyone"},
+    ) == "[gpt5.5]"
+
+
+def test_format_runtime_prefix_sanitizes_mention_like_custom_label():
+    assert format_runtime_prefix(
+        model="openai/gpt-5.5",
+        labels={"gpt-5.5": "@everyone"},
+    ) == "[everyone]"
+    assert format_runtime_prefix(
+        model="openai/gpt-5.5",
+        labels={"gpt-5.5": "<!channel>"},
+    ) == "[channel]"
+
+
+def test_format_runtime_prefix_falls_back_to_model_short():
+    assert format_runtime_prefix(model="openai/gpt-5.5") == "[gpt-5.5]"
+
+
+def test_resolve_prefix_platform_override_and_custom_label():
+    user = {
+        "display": {
+            "runtime_prefix": {"enabled": False, "labels": {"gpt": "[gpt]"}},
+            "platforms": {"slack": {"runtime_prefix": {"enabled": True}}},
+        },
+    }
+    cfg = resolve_prefix_config(user, "slack")
+    assert cfg["enabled"] is True
+    assert cfg["labels"]["gpt"] == "[gpt]"
+
+
+def test_build_prefix_line_empty_when_disabled():
+    assert build_prefix_line(
+        user_config={}, platform_key="slack", model="openai/gpt-5.5"
+    ) == ""
+
+
+def test_build_prefix_line_when_enabled_with_label():
+    assert build_prefix_line(
+        user_config={
+            "display": {
+                "runtime_prefix": {"enabled": True, "labels": {"gpt-5.5": "[gpt5.5]"}}
+            }
+        },
+        platform_key="slack",
+        model="openai/gpt-5.5",
+    ) == "[gpt5.5]"
+
+
+def test_apply_runtime_prefix_prepends_once():
+    assert apply_runtime_prefix("hello", "[gpt5.5]") == "[gpt5.5] hello"
+    assert apply_runtime_prefix("[gpt5.5] hello", "[gpt5.5]") == "[gpt5.5] hello"
+
+
+def test_prefixed_error_still_matches_error_prefix_for_voice_suppression():
+    """Regression guard for gateway voice-mode error suppression.
+
+    Gateway responses may be decorated as ``[model] Error: ...`` before the
+    auto-TTS decision runs; the error must still be recognized as an error.
+    """
+    import re
+
+    response = apply_runtime_prefix("Error: provider unavailable", "[gpt5.5]").lstrip()
+    assert re.match(r"^\[[^\]\n]{1,64}\]\s+Error:", response)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_runtime_prefix_voice_reply.py
+++ b/tests/gateway/test_runtime_prefix_voice_reply.py
@@ -1,0 +1,47 @@
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.runtime_footer import apply_runtime_prefix, build_prefix_line
+from gateway.session import SessionSource
+
+
+def _event() -> MessageEvent:
+    return MessageEvent(
+        text="hello",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="channel-1",
+            user_id="user-1",
+        ),
+    )
+
+
+def test_runtime_prefix_does_not_make_gateway_errors_voice_eligible():
+    runner = GatewayRunner(GatewayConfig())
+    event = _event()
+    runner._voice_mode[runner._voice_key(Platform.DISCORD, "channel-1")] = "all"
+
+    assert runner._should_send_voice_reply(event, "Error: provider unavailable", []) is False
+    custom_prefix = build_prefix_line(
+        user_config={
+            "display": {
+                "runtime_prefix": {
+                    "enabled": True,
+                    "labels": {"gpt-5.5": "gpt5.5:"},
+                }
+            }
+        },
+        platform_key="discord",
+        model="openai/gpt-5.5",
+    )
+    assert custom_prefix == "[gpt5.5:]"
+    assert (
+        runner._should_send_voice_reply(
+            event,
+            apply_runtime_prefix("Error: provider unavailable", custom_prefix),
+            [],
+        )
+        is False
+    )
+    assert runner._should_send_voice_reply(event, "[gpt5.5] normal reply", []) is True


### PR DESCRIPTION
## Summary
- add an opt-in `display.runtime_prefix` gateway setting for compact model markers at the start of final replies
- support global and per-platform label maps, while normalizing custom labels into compact single-line bracket markers
- preserve existing runtime footer behavior and keep the new prefix disabled by default
- preserve auto-TTS error suppression for prefixed gateway errors such as `[gpt5.5] Error: ...`

## Why
Some gateway deployments want a short first-line model marker without the extra runtime footer fields such as context percentage or cwd. This keeps that display chrome explicit, config-driven, and opt-in.

## Configuration
```yaml
display:
  runtime_prefix:
    enabled: true
    labels:
      gpt-5.5: "[gpt5.5]"
```

Per-platform overrides are supported under `display.platforms.<platform>.runtime_prefix`.

## Safety
- default behavior is unchanged because `display.runtime_prefix.enabled` defaults to `false`
- custom label values are normalized to one-line bracket markers before being prepended
- prefix is skipped for already-sent streaming responses and intentional silence
- prefixed gateway errors remain ineligible for auto-TTS voice replies

## Test Plan
- `python -m pytest tests/gateway/test_runtime_footer.py tests/gateway/test_runtime_prefix_voice_reply.py -q -o 'addopts='`
- `python -m py_compile gateway/runtime_footer.py gateway/run.py hermes_cli/config.py`
- `git diff --check origin/main...HEAD`
- `gitleaks detect --source . --log-opts='origin/main..HEAD' --no-banner --redact --exit-code 1`
- private path/token regex scan over the public PR diff

## Notes
- Related but not identical to #43973: this PR provides configured compact label markers such as `[gpt5.5]`, while #43973 exposes a provider/model identity prefix.
- Supersedes the now-closed duplicate #46370; this PR contains the final label-normalization and auto-TTS regression coverage.
