### PR TITLE
fix(simplex): use structured /_send for standalone DM text sends

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -1195,8 +1195,10 @@ async def _standalone_send(
             )
             cmd_str = f"/_send #{group_id} json {composed}"
         else:
-            # Direct contacts are addressed by display name without brackets.
-            cmd_str = f"@{chat_id} {message}"
+            composed = json.dumps(
+                [{"msgContent": {"type": "text", "text": message}}]
+            )
+            cmd_str = f"/_send @{chat_id} json {composed}"
 
         payload = {
             "corrId": f"{_CORR_PREFIX}snd-{int(time.time() * 1000)}",

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -825,15 +825,17 @@ class SimplexAdapter(BasePlatformAdapter):
 
         if content:
             corr_id = self._make_corr_id()
+            # Structured form: addresses by ID, and json.dumps escapes
+            # newlines + special chars correctly.  The bare @id text
+            # syntax is unreliable for DMs — the daemon silently drops
+            # messages when it cannot resolve the display name.
+            composed = json.dumps(
+                [{"msgContent": {"type": "text", "text": content}}]
+            )
             if chat_id.startswith("group:"):
-                # Structured form: addresses by numeric ID, and json.dumps
-                # escapes newlines + special chars correctly.
-                composed = json.dumps(
-                    [{"msgContent": {"type": "text", "text": content}}]
-                )
                 cmd_str = f"/_send #{chat_id[6:]} json {composed}"
             else:
-                cmd_str = f"@{chat_id} {content}"
+                cmd_str = f"/_send @{chat_id} json {composed}"
 
             await self._send_ws({"corrId": corr_id, "cmd": cmd_str})
 

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -205,12 +205,13 @@ def test_corr_id_pending_set_self_trims():
 
 @pytest.mark.asyncio
 async def test_send_dm():
-    """DMs use the bare ``@<id> text`` chat-command form.
+    """DMs use the structured ``/_send @<id> json [...]`` form.
 
-    The bracketed form ``@[<id>] text`` is what the daemon's man page
-    documents, but in practice both addressing styles route through
-    the same chat-command parser; bare ``@<id>`` matches what every
-    Hermes deployment has been using in production for months.
+    The bare ``@<id> text`` chat-command form is unreliable — the
+    daemon silently drops messages when it cannot resolve the display
+    name.  The structured ``/_send`` form addresses by ID and
+    survives newlines/quoting through ``json.dumps``, matching what
+    ``send_image`` and ``send_document`` already do.
     """
     from gateway.config import PlatformConfig
     cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
@@ -222,7 +223,11 @@ async def test_send_dm():
     result = await adapter.send("contact-42", "Hello, SimpleX!")
     mock_ws.send.assert_called_once()
     payload = json.loads(mock_ws.send.call_args[0][0])
-    assert payload["cmd"] == "@contact-42 Hello, SimpleX!"
+    assert payload["cmd"].startswith("/_send @contact-42 json ")
+    msg_content = json.loads(payload["cmd"].split(" json ", 1)[1])[0][
+        "msgContent"
+    ]
+    assert msg_content == {"type": "text", "text": "Hello, SimpleX!"}
     assert payload["corrId"].startswith(_CORR_PREFIX)
     assert result.success is True
 

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -354,7 +354,11 @@ async def test_standalone_send_defaults_to_local_daemon(monkeypatch):
 
     result = await _standalone_send(pconfig, "contact-42", "hi")
     assert result == {"success": True, "platform": "simplex", "chat_id": "contact-42"}
-    assert sent_payloads[0]["cmd"] == "@contact-42 hi"
+    assert sent_payloads[0]["cmd"].startswith("/_send @contact-42 json ")
+    msg_content = json.loads(
+        sent_payloads[0]["cmd"].split(" json ", 1)[1]
+    )[0]["msgContent"]
+    assert msg_content == {"type": "text", "text": "hi"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Fixes the `_standalone_send()` function in the SimpleX adapter to use the structured `/_send @<id> json [...]` format for DM text messages, instead of the unreliable bare `@<id> text` format. This is the same bug class fixed in `send()` by PR #44444, but in the standalone send path used by the `send_message` tool for proactive/scheduled sends.

## Related Issue

Fixes #46265

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/simplex/adapter.py`: Replace bare `@{chat_id} {message}` with structured `/_send @{chat_id} json {composed}` in `_standalone_send()`, matching what `send_image`, `send_document`, and `send()` already use
- `tests/gateway/test_simplex_plugin.py`: Update `test_standalone_send_defaults_to_local_daemon` assertion to verify structured JSON format

## How to Test

1. Set up SimpleX gateway with `simplex-chat -p 5225`
2. Approve a DM contact
3. Send a message from the contact's app
4. Verify Hermes replies are received in the contact's app (previously silently dropped)
5. Run `pytest tests/gateway/test_simplex_plugin.py -q` — all 28 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_simplex_plugin.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus stale index — grep-based fallback used.
- Checked: `plugins/platforms/simplex/adapter.py` (2 call sites: `send()` L841 already fixed by #44444, `_standalone_send()` L1202 fixed here)
- Related: PR #44444 (same bug in `send()` method)
- Blast radius: LOW — SimpleX plugin only, no core changes
