### PR TITLE
fix(models): invalidate dev cache when config path changes

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -44,6 +44,7 @@ _MODELS_DEV_RETRY_DELAY = 300  # 5 minutes after a failed refresh
 _models_dev_cache: Dict[str, Any] = {}
 _models_dev_cache_time: float = 0
 _models_dev_retry_after: float = 0
+_models_dev_cache_path: Optional[Path] = None
 _models_dev_fetch_lock = threading.Lock()
 _models_dev_refresh_lock = threading.Lock()
 _models_dev_refresh_in_flight = False
@@ -386,7 +387,13 @@ def fetch_models_dev(
     made — used by latency-sensitive paths (gateway route-identity checks)
     that must never wait on the network.
     """
-    global _models_dev_cache, _models_dev_cache_time, _models_dev_retry_after
+    global _models_dev_cache, _models_dev_cache_time, _models_dev_retry_after, _models_dev_cache_path
+
+    cache_path = _get_cache_path()
+    if _models_dev_cache_path is not None and _models_dev_cache_path != cache_path:
+        _models_dev_cache = {}
+        _models_dev_cache_time = 0
+    _models_dev_cache_path = cache_path
 
     if not allow_network:
         if _models_dev_cache:

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -150,6 +150,7 @@ class TestFetchModelsDev:
         md._models_dev_cache_time = 0
         md._models_dev_retry_after = 0
         md._models_dev_refresh_in_flight = False
+        md._models_dev_cache_path = None
         yield
         md._models_dev_cache = {}
         md._models_dev_cache_time = 0
@@ -177,6 +178,34 @@ class TestFetchModelsDev:
         mock_get.assert_not_called()
         mock_refresh.assert_called_once()
         assert "anthropic" in result
+
+    @patch("agent.models_dev.requests.get")
+    def test_in_memory_cache_is_scoped_to_cache_path(self, mock_get, tmp_path):
+        """Changing HERMES_HOME/cache path must not reuse another profile's cache."""
+        import agent.models_dev as md
+
+        old_path = tmp_path / "old" / "models_dev_cache.json"
+        new_path = tmp_path / "new" / "models_dev_cache.json"
+        fresh_registry = {"openai": {"id": "openai", "models": {}}}
+
+        md._models_dev_cache = SAMPLE_REGISTRY
+        md._models_dev_cache_time = time.time()
+        md._models_dev_cache_path = old_path
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = fresh_registry
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        with patch.object(md, "_get_cache_path", return_value=new_path), \
+             patch.object(md, "_disk_cache_age_seconds", return_value=None), \
+             patch.object(md, "_save_disk_cache"):
+            result = fetch_models_dev()
+
+        mock_get.assert_called_once()
+        assert result == fresh_registry
+        assert md._models_dev_cache_path == new_path
 
 
 


### PR DESCRIPTION
### Summary

Include the active config path in the models.dev development cache key.

### Why

The previous cache key could reuse model metadata across isolated config paths. That makes tests and profile/config-specific runs observe stale model information from a different config context.

### Scope

- cache-key-only behavioral change
- no model catalog changes
- no new config fields or environment variables

### Test plan

- 108 focused model metadata/cache tests passed locally

---