### PR TITLE
fix(gateway): accept both media cache layouts safely

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -839,25 +839,47 @@ MEDIA_DELIVERY_TRUST_RECENT_SECONDS_ENV = "HERMES_MEDIA_TRUST_RECENT_SECONDS"
 # injection from one user could exfiltrate the host's secrets to that same
 # user should set this to true.
 MEDIA_DELIVERY_STRICT_ENV = "HERMES_MEDIA_DELIVERY_STRICT"
-MEDIA_DELIVERY_SAFE_ROOTS = (
-    IMAGE_CACHE_DIR,
-    AUDIO_CACHE_DIR,
-    VIDEO_CACHE_DIR,
-    DOCUMENT_CACHE_DIR,
-    SCREENSHOT_CACHE_DIR,
-    _HERMES_HOME / "image_cache",
-    _HERMES_HOME / "audio_cache",
-    _HERMES_HOME / "video_cache",
-    _HERMES_HOME / "document_cache",
-    _HERMES_HOME / "browser_screenshots",
-    # Canonical cache layout — listed alongside the legacy *_cache dirs so
-    # generated artifacts deliver on installs that have both (#31733).
-    _HERMES_HOME / "cache" / "images",
-    _HERMES_HOME / "cache" / "audio",
-    _HERMES_HOME / "cache" / "videos",
-    _HERMES_HOME / "cache" / "documents",
-    _HERMES_HOME / "cache" / "screenshots",
-)
+
+
+def _default_media_delivery_safe_roots(hermes_home: Path | None = None) -> Tuple[Path, ...]:
+    """Return Hermes-managed roots allowed for model-emitted media paths.
+
+    ``get_hermes_dir()`` intentionally selects either the legacy cache layout
+    (for example ``image_cache``) or the consolidated layout
+    (``cache/images``) based on what already exists. Tooling may still create
+    legitimate artifacts in the other Hermes-managed cache path during or
+    after a layout transition. Native attachment delivery should accept both
+    layouts while still rejecting arbitrary locations such as ``/tmp``.
+    """
+    home = hermes_home or _HERMES_HOME
+    roots = (
+        IMAGE_CACHE_DIR,
+        AUDIO_CACHE_DIR,
+        VIDEO_CACHE_DIR,
+        DOCUMENT_CACHE_DIR,
+        SCREENSHOT_CACHE_DIR,
+        home / "cache" / "images",
+        home / "cache" / "audio",
+        home / "cache" / "videos",
+        home / "cache" / "documents",
+        home / "cache" / "screenshots",
+        home / "image_cache",
+        home / "audio_cache",
+        home / "video_cache",
+        home / "document_cache",
+        home / "browser_screenshots",
+    )
+    seen: set[str] = set()
+    unique: list[Path] = []
+    for root in roots:
+        key = str(Path(root))
+        if key not in seen:
+            seen.add(key)
+            unique.append(Path(root))
+    return tuple(unique)
+
+
+MEDIA_DELIVERY_SAFE_ROOTS = _default_media_delivery_safe_roots(_HERMES_HOME)
 
 # Default recency window for trusting freshly-produced files (seconds).
 # The agent's actual work generally completes well inside 10 minutes; legitimate

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -13,6 +13,7 @@ from gateway.platforms.base import (
     safe_url_for_log,
     utf16_len,
     _log_safe_path,
+    _default_media_delivery_safe_roots,
     _prefix_within_utf16_limit,
 )
 
@@ -618,6 +619,38 @@ class TestMediaDeliveryPathValidation:
         self._patch_roots(monkeypatch, root)
 
         assert BasePlatformAdapter.validate_media_delivery_path(str(media_file)) == str(media_file.resolve())
+
+    def test_default_safe_roots_include_both_cache_layouts(self, tmp_path):
+        roots = _default_media_delivery_safe_roots(tmp_path)
+
+        assert tmp_path / "cache" / "images" in roots
+        assert tmp_path / "image_cache" in roots
+        assert tmp_path / "cache" / "audio" in roots
+        assert tmp_path / "audio_cache" in roots
+
+    def test_filter_allows_consolidated_image_cache_file(self, tmp_path, monkeypatch):
+        media_file = tmp_path / "cache" / "images" / "mindmap.png"
+        media_file.parent.mkdir(parents=True)
+        media_file.write_bytes(b"PNG")
+        self._patch_roots(monkeypatch, *_default_media_delivery_safe_roots(tmp_path))
+
+        filtered = BasePlatformAdapter.filter_media_delivery_paths([
+            (str(media_file), False),
+        ])
+
+        assert filtered == [(str(media_file.resolve()), False)]
+
+    def test_filter_allows_legacy_image_cache_file(self, tmp_path, monkeypatch):
+        media_file = tmp_path / "image_cache" / "mindmap.png"
+        media_file.parent.mkdir(parents=True)
+        media_file.write_bytes(b"PNG")
+        self._patch_roots(monkeypatch, *_default_media_delivery_safe_roots(tmp_path))
+
+        filtered = BasePlatformAdapter.filter_media_delivery_paths([
+            (str(media_file), False),
+        ])
+
+        assert filtered == [(str(media_file.resolve()), False)]
 
     def test_rejects_existing_file_outside_safe_root(self, tmp_path, monkeypatch):
         root = tmp_path / "media-cache"


### PR DESCRIPTION
### Summary

Allow gateway media delivery from both supported Hermes media-cache layouts while preserving path containment checks.

### Why

Hermes can produce cached media under more than one canonical runtime/cache layout. The gateway should not silently drop valid cached media just because it comes from the other supported layout, but it must also avoid widening delivery to arbitrary filesystem locations.

### Scope

- deduplicates safe-root handling
- accepts the known media-cache layouts
- preserves safe path/root validation
- does not introduce a user-configurable media-root escape hatch

### Related existing PRs to compare

Possible overlap with these earlier PRs; please compare before spending review time:

- #33586
- #33550
- #31764
- #33238
- #33901
- #42778

This PR is intended to be the narrow/safe-root variant, but it may overlap with those earlier attempts and should be compared before review time is spent.

### Test plan

- 151 focused gateway/platform tests passed locally
- 2 skipped locally

---