### PR TITLE
fix(gateway): collapse cron ticker backlog to one catch-up

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16097,7 +16097,13 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
 
     logger.info("Cron ticker started (interval=%ds)", interval)
     tick_count = 0
+    next_tick_at = time.monotonic()
     while not stop_event.is_set():
+        now = time.monotonic()
+        wait_seconds = max(0.0, next_tick_at - now)
+        if stop_event.wait(timeout=wait_seconds):
+            break
+
         try:
             cron_tick(verbose=False, adapters=adapters, loop=loop, sync=False)
         except Exception as e:
@@ -16163,7 +16169,15 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
             except Exception as e:
                 logger.debug("Curator tick error: %s", e)
 
-        stop_event.wait(timeout=interval)
+        finished_at = time.monotonic()
+        next_tick_at += interval
+        if finished_at > next_tick_at:
+            behind_seconds = finished_at - next_tick_at
+            logger.debug(
+                "Cron ticker fell behind by %.1fs; collapsing backlog to a single immediate catch-up tick",
+                behind_seconds,
+            )
+            next_tick_at = finished_at
     logger.info("Cron ticker stopped")
 
 

--- a/tests/gateway/test_cron_ticker.py
+++ b/tests/gateway/test_cron_ticker.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from gateway.run import _start_cron_ticker
+
+
+class _FakeStopEvent:
+    def __init__(self):
+        self._is_set = False
+        self.wait_calls: list[float] = []
+
+    def is_set(self) -> bool:
+        return self._is_set
+
+    def set(self) -> None:
+        self._is_set = True
+
+    def wait(self, timeout=None):
+        self.wait_calls.append(timeout)
+        return self._is_set
+
+
+def test_cron_ticker_collapses_multi_interval_overrun_to_single_immediate_catchup(monkeypatch, caplog):
+    """A slow tick should trigger at most one immediate catch-up pass.
+
+    Without the backlog collapse, a ticker that fell several intervals behind
+    would spin through multiple zero-sleep iterations in a burst. That is not
+    useful here because each cron tick already evaluates jobs against the
+    current wall clock; we only need one immediate catch-up pass after a slow
+    batch, then normal cadence should resume.
+    """
+
+    stop_event = _FakeStopEvent()
+    tick_calls: list[int] = []
+
+    def fake_tick(*, verbose, adapters, loop, sync=False):
+        tick_calls.append(len(tick_calls) + 1)
+        if len(tick_calls) >= 3:
+            stop_event.set()
+
+    monotonic_values = iter([
+        0.0,    # next_tick_at seed
+        0.0,    # loop 1 start: immediate first tick
+        190.0,  # loop 1 end: fell >3 intervals behind
+        190.0,  # loop 2 start: single immediate catch-up tick
+        190.1,  # loop 2 end: now back within one interval
+        190.1,  # loop 3 start: should sleep ~60s instead of bursting again
+        190.2,  # loop 3 end
+    ])
+
+    monkeypatch.setattr("cron.scheduler.tick", fake_tick)
+    monkeypatch.setattr("gateway.run.time.monotonic", lambda: next(monotonic_values))
+
+    with caplog.at_level("DEBUG", logger="gateway.run"):
+        _start_cron_ticker(stop_event, adapters=None, loop=None, interval=60)
+
+    assert tick_calls == [1, 2, 3]
+    assert stop_event.wait_calls[0] == 0.0
+    assert stop_event.wait_calls[1] == 0.0
+    assert stop_event.wait_calls[2] > 50.0
+    assert any(
+        "Cron ticker fell behind by" in record.message
+        for record in caplog.records
+    )


### PR DESCRIPTION
### Summary

Collapse accumulated cron ticker backlog into a single catch-up tick.

### Why

If the gateway/event loop stalls or resumes late, the scheduler can otherwise process a burst of stale ticker iterations. That produces noisy catch-up behavior without adding useful scheduling precision.

### Scope

- only changes ticker backlog handling
- does not change cron job definitions or scheduling semantics
- keeps one catch-up opportunity after delay

### Test plan

- focused cron ticker backlog test passed locally

---