### PR TITLE
fix(gateway): harden Honcho cache memo invalidation

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -28,6 +28,7 @@ import asyncio
 import concurrent.futures
 import dataclasses
 import inspect
+import hashlib
 import json
 import logging
 import os
@@ -16015,7 +16016,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         "honcho.runtime_peer_prefix",
         "honcho.user_peer_aliases",
     )
-    _HONCHO_CACHE_BUSTING_MEMO: dict[tuple[str, int | None], dict[str, Any]] = {}
+    _HONCHO_CACHE_BUSTING_MEMO: dict[tuple[str, int | None, int | None, str | None], dict[str, Any]] = {}
 
     @classmethod
     def _empty_honcho_cache_busting_config(cls) -> dict[str, Any]:
@@ -16023,16 +16024,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     @classmethod
     def _extract_honcho_cache_busting_config(cls) -> dict[str, Any]:
-        """Extract Honcho identity keys, memoized by honcho.json mtime."""
+        """Extract Honcho identity keys, memoized by honcho.json file identity."""
         try:
             from plugins.memory.honcho.client import HonchoClientConfig, resolve_config_path
 
             path = resolve_config_path()
             try:
-                mtime_ns = path.stat().st_mtime_ns
+                stat_result = path.stat()
+                mtime_ns = stat_result.st_mtime_ns
+                size = stat_result.st_size
+                content_hash = hashlib.sha256(path.read_bytes()).hexdigest()
             except OSError:
                 mtime_ns = None
-            memo_key = (str(path), mtime_ns)
+                size = None
+                content_hash = None
+            # Some filesystems available in lightweight/migrated deployments
+            # report coarse mtimes for rapid rewrites. Include a content hash so
+            # equal-size honcho.json edits still bust the memo when st_mtime_ns
+            # is unchanged within the same filesystem tick.
+            memo_key = (str(path), mtime_ns, size, content_hash)
             cached = cls._HONCHO_CACHE_BUSTING_MEMO.get(memo_key)
             if cached is not None:
                 return dict(cached)

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -10,6 +10,8 @@ Verifies that the agent cache correctly:
 """
 
 import threading
+import json
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -385,6 +387,61 @@ class TestExtractCacheBustingConfig:
         third = GatewayRunner._extract_honcho_cache_busting_config()
 
         assert third == first
+        assert parse_calls == [config_path, config_path]
+
+    def test_honcho_cache_busting_config_refreshes_on_equal_size_same_mtime_rewrite(self, monkeypatch, tmp_path):
+        """Equal-size rewrites under coarse mtimes must still refresh the Honcho parse."""
+        from types import SimpleNamespace
+        from gateway.run import GatewayRunner
+
+        config_path = tmp_path / "honcho.json"
+        config_path.write_text('{"peer_name":"alice"}')
+        parse_calls = []
+
+        class FakeConfig:
+            ai_peer = "hermes"
+            pin_peer_name = False
+            runtime_peer_prefix = "tg_"
+            user_peer_aliases = {"123": "eri"}
+
+            @classmethod
+            def from_global_config(cls, config_path=None):
+                parse_calls.append(config_path)
+                data = json.loads(config_path.read_text(encoding="utf-8"))
+                return type(
+                    "Cfg",
+                    (),
+                    {
+                        "peer_name": data["peer_name"],
+                        "ai_peer": cls.ai_peer,
+                        "pin_peer_name": cls.pin_peer_name,
+                        "runtime_peer_prefix": cls.runtime_peer_prefix,
+                        "user_peer_aliases": cls.user_peer_aliases,
+                    },
+                )()
+
+        fake_client = SimpleNamespace(
+            HonchoClientConfig=FakeConfig,
+            resolve_config_path=lambda: config_path,
+        )
+        monkeypatch.setitem(__import__("sys").modules, "plugins.memory.honcho.client", fake_client)
+        monkeypatch.setattr(GatewayRunner, "_HONCHO_CACHE_BUSTING_MEMO", {})
+
+        original_stat = config_path.stat()
+        fixed_ns = original_stat.st_mtime_ns
+        original_size = original_stat.st_size
+
+        first = GatewayRunner._extract_honcho_cache_busting_config()
+        assert first["honcho.peer_name"] == "alice"
+
+        rewritten = '{"peer_name":"bruce"}'
+        assert len(rewritten.encode("utf-8")) == original_size
+        config_path.write_text(rewritten, encoding="utf-8")
+        os.utime(config_path, ns=(fixed_ns, fixed_ns))
+
+        second = GatewayRunner._extract_honcho_cache_busting_config()
+
+        assert second["honcho.peer_name"] == "bruce"
         assert parse_calls == [config_path, config_path]
 
     def test_full_round_trip_busts_cache_on_real_edit(self):


### PR DESCRIPTION
### Summary

Harden the Honcho cache-busting memo key so coarse-mtime rewrites of `honcho.json` cannot reuse stale parsed identity state.

### Why

On coarse-mtime filesystems, rapid rewrites of `honcho.json` can keep the same `st_mtime_ns` while changing contents. The earlier size-only approach still missed equal-size rewrites. Using a SHA-256 content hash as a discriminator closes that remaining stale-config path.

### Scope

- memo/cache invalidation only
- no Honcho config schema changes

### Test plan

- `pytest tests/gateway/test_agent_cache.py`
  - includes a regression that forces equal `st_mtime_ns`, equal file size, changed `honcho.json` content, and asserts the Honcho parse is refreshed
  - 79 passed locally against the current head

### Related

- #39284 — adjacent gateway cache-busting (auxiliary compression); this PR adds an independent Honcho config identity discriminator.
