### PR TITLE
fix(signal): preserve document attachments

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -563,7 +563,7 @@ class SignalAdapter(BasePlatformAdapter):
                     logger.warning("Signal: attachment too large (%d bytes), skipping", att_size)
                     continue
                 try:
-                    cached_path, ext = await self._fetch_attachment(att_id)
+                    cached_path, ext = await self._fetch_attachment(att_id, att)
                     if cached_path:
                         # Use contentType from Signal if available, else map from extension
                         content_type = att.get("contentType") or _ext_to_mime(ext)
@@ -600,8 +600,6 @@ class SignalAdapter(BasePlatformAdapter):
         if media_types:
             if any(mt.startswith("audio/") for mt in media_types):
                 msg_type = MessageType.VOICE
-            elif any(mt.startswith("image/") for mt in media_types):
-                msg_type = MessageType.PHOTO
             elif any(mt.startswith("video/") for mt in media_types):
                 msg_type = MessageType.VIDEO
             else:
@@ -703,7 +701,7 @@ class SignalAdapter(BasePlatformAdapter):
     # Attachment Handling
     # ------------------------------------------------------------------
 
-    async def _fetch_attachment(self, attachment_id: str) -> tuple:
+    async def _fetch_attachment(self, attachment_id: str, attachment_meta: Optional[dict] = None) -> tuple:
         """Fetch an attachment via JSON-RPC and cache it. Returns (path, ext)."""
         result = await self._rpc("getAttachment", {
             "account": self.account,
@@ -729,7 +727,12 @@ class SignalAdapter(BasePlatformAdapter):
         elif _is_audio_ext(ext):
             path = cache_audio_from_bytes(raw_data, ext)
         else:
-            path = cache_document_from_bytes(raw_data, ext)
+            filename = None
+            if isinstance(attachment_meta, dict):
+                raw_filename = attachment_meta.get("filename") or attachment_meta.get("name")
+                if raw_filename:
+                    filename = Path(str(raw_filename)).name
+            path = cache_document_from_bytes(raw_data, filename or ext)
 
         return path, ext
 

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -273,6 +273,76 @@ class TestSignalAttachmentFetch:
         assert path == "/tmp/test.pdf"
         assert ext == ".pdf"
 
+    @pytest.mark.asyncio
+    async def test_fetch_attachment_preserves_signal_filename_for_documents(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+
+        pdf_data = b"%PDF-1.4" + b"\x00" * 100
+        b64_data = base64.b64encode(pdf_data).decode()
+        adapter._rpc, _ = _stub_rpc({"data": b64_data})
+
+        with patch("gateway.platforms.signal.cache_document_from_bytes", return_value="/tmp/document.pdf") as cache_doc:
+            path, ext = await adapter._fetch_attachment("doc-456", {"filename": "document.pdf"})
+
+        assert path == "/tmp/document.pdf"
+        assert ext == ".pdf"
+        cache_doc.assert_called_once_with(pdf_data, "document.pdf")
+
+    @pytest.mark.asyncio
+    async def test_fetch_attachment_strips_signal_filename_path_components(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+
+        pdf_data = b"%PDF-1.4" + b"\x00" * 100
+        b64_data = base64.b64encode(pdf_data).decode()
+        adapter._rpc, _ = _stub_rpc({"data": b64_data})
+
+        with patch("gateway.platforms.signal.cache_document_from_bytes", return_value="/tmp/passwd") as cache_doc:
+            await adapter._fetch_attachment("doc-456", {"filename": "../../../passwd"})
+
+        cache_doc.assert_called_once_with(pdf_data, "passwd")
+
+    @pytest.mark.asyncio
+    async def test_handle_envelope_marks_non_image_audio_attachment_as_document(self, monkeypatch):
+        from gateway.platforms.base import MessageType
+
+        adapter = _make_signal_adapter(monkeypatch)
+        captured = {}
+
+        async def fake_handle(event):
+            captured["event"] = event
+
+        adapter.handle_message = fake_handle
+
+        async def fake_fetch(attachment_id, attachment_meta=None):
+            assert attachment_id == "att-pdf"
+            assert attachment_meta["filename"] == "document.pdf"
+            return "/tmp/document.pdf", ".pdf"
+
+        adapter._fetch_attachment = fake_fetch
+
+        await adapter._handle_envelope({
+            "envelope": {
+                "sourceNumber": "+155****1111",
+                "sourceUuid": "uuid-sender",
+                "sourceName": "Tester",
+                "timestamp": 1000000000,
+                "dataMessage": {
+                    "message": "see attached",
+                    "attachments": [{
+                        "id": "att-pdf",
+                        "filename": "document.pdf",
+                        "contentType": "application/pdf",
+                        "size": 128,
+                    }],
+                },
+            }
+        })
+
+        event = captured["event"]
+        assert event.message_type == MessageType.DOCUMENT
+        assert event.media_urls == ["/tmp/document.pdf"]
+        assert event.media_types == ["application/pdf"]
+
 
 # ---------------------------------------------------------------------------
 # Session Source


### PR DESCRIPTION
### Summary

Classify non-audio/image/video Signal attachments as documents so they are cached and surfaced to the agent.

### Why

Signal documents can otherwise be dropped or under-classified because they are not one of the media categories handled specially by the gateway.

### Scope

- Signal attachment classification/cache behavior
- does not change audio/image/video handling

### Test plan

- 111 focused Signal attachment tests passed locally

---