### PR TITLE
fix(signal): scope group target parsing to Signal targets

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -509,6 +509,13 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         match = _EMAIL_TARGET_RE.fullmatch(target_ref)
         if match:
             return target_ref.strip(), None, True
+    if platform_name == "signal":
+        stripped_target = target_ref.strip()
+        if stripped_target.startswith("group:"):
+            group_id = stripped_target[len("group:"):].strip()
+            if group_id:
+                return f"group:{group_id}", None, True
+            return None, None, False
     if platform_name in _PHONE_PLATFORMS:
         match = _E164_TARGET_RE.fullmatch(target_ref)
         if match:


### PR DESCRIPTION
### Summary

Only parse `group:` targets as Signal group IDs when `send_message` is resolving a Signal target.

### Why

`group:` is not globally owned by Signal. Parsing it as Signal-specific outside Signal target resolution can misroute or reject targets for other platforms.

### Scope

- target parsing guard only
- Signal-specific interpretation remains available for Signal sends
- no behavior change for non-`group:` targets

### Test plan

- 2 focused send target parsing tests passed locally

---