### PR TITLE
feat(signal): include bounded recent chat history

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1447,6 +1447,9 @@ class MessageEvent:
     # Reply context
     reply_to_message_id: Optional[str] = None
     reply_to_text: Optional[str] = None  # Text of the replied-to message (for context injection)
+    reply_to_author_id: Optional[str] = None
+    reply_to_author_name: Optional[str] = None
+    reply_to_is_own_message: bool = False  # True when the user replied to this bot/assistant's message
     
     # Auto-loaded skill(s) for topic/channel bindings (e.g., Telegram DM Topics,
     # Discord channel_skill_bindings).  A single name or ordered list.

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -232,9 +232,15 @@ class SignalAdapter(BasePlatformAdapter):
         self._account_normalized = self.account.strip()
 
         # Track recently sent message timestamps to prevent echo-back loops
-        # in Note to Self / self-chat mode (mirrors WhatsApp recentlySentIds)
+        # in Note to Self / self-chat mode (mirrors WhatsApp recentlySentIds).
         self._recent_sent_timestamps: set = set()
         self._max_recent_timestamps = 50
+        # Keep a separate bounded cache of outbound Signal message timestamps.
+        # Signal quote.id is the timestamp of the quoted message, so this lets
+        # inbound replies identify that the user replied to a message sent by
+        # this bot even after the self-sync echo was filtered above.
+        self._sent_message_timestamps: set[str] = set()
+        self._max_sent_message_timestamps = 500
         # Signal increasingly exposes ACI/PNI UUIDs as stable recipient IDs.
         # Keep a best-effort mapping so outbound sends can upgrade from a
         # phone number to the corresponding UUID when signal-cli prefers it.
@@ -543,10 +549,16 @@ class SignalAdapter(BasePlatformAdapter):
                 )
                 return
 
-        # Extract quote (reply-to) context from Signal dataMessage
+        # Extract quote (reply-to) context from Signal dataMessage. Signal's
+        # quote.id is the timestamp of the quoted message; quote.author points
+        # at the quoted sender when available. Preserve both so the gateway can
+        # tell the agent when the user replied to a specific assistant message.
         quote_data = data_message.get("quote") or {}
         reply_to_id = str(quote_data.get("id")) if quote_data.get("id") else None
         reply_to_text = quote_data.get("text")
+        reply_to_author = self._extract_quote_author(quote_data)
+        reply_to_author_name = quote_data.get("authorName") or quote_data.get("authorProfileName")
+        reply_to_is_own = self._quote_references_own_message(reply_to_id, reply_to_author)
 
         # Process attachments
         attachments_data = data_message.get("attachments", [])
@@ -631,9 +643,16 @@ class SignalAdapter(BasePlatformAdapter):
             media_urls=media_urls,
             media_types=media_types,
             timestamp=timestamp,
-            raw_message={"sender": sender, "timestamp_ms": ts_ms},
+            raw_message={
+                "sender": sender,
+                "timestamp_ms": ts_ms,
+                "quote": quote_data if quote_data else None,
+            },
             reply_to_message_id=reply_to_id,
             reply_to_text=reply_to_text,
+            reply_to_author_id=reply_to_author,
+            reply_to_author_name=reply_to_author_name,
+            reply_to_is_own_message=reply_to_is_own,
         )
 
         logger.debug("Signal: message from %s in %s: %s",
@@ -647,6 +666,51 @@ class SignalAdapter(BasePlatformAdapter):
             return
         self._recipient_uuid_by_number[number] = service_id
         self._recipient_number_by_uuid[service_id] = number
+
+    @staticmethod
+    def _extract_quote_author(quote_data: Any) -> Optional[str]:
+        """Return the best available Signal sender identifier from quote metadata."""
+        if not isinstance(quote_data, dict):
+            return None
+        for key in (
+            "author",
+            "authorNumber",
+            "authorUuid",
+            "authorAci",
+            "authorServiceId",
+            "authorServiceIdString",
+        ):
+            value = quote_data.get(key)
+            if value:
+                return str(value)
+        return None
+
+    def _quote_references_own_message(
+        self,
+        reply_to_id: Optional[str],
+        reply_to_author: Optional[str],
+    ) -> bool:
+        """True when a Signal quote points at this adapter's outbound message."""
+        if reply_to_id and str(reply_to_id) in self._sent_message_timestamps:
+            return True
+        if not reply_to_author:
+            return False
+        author = str(reply_to_author).strip()
+        if self._account_normalized and author == self._account_normalized:
+            return True
+        cached_uuid = self._recipient_uuid_by_number.get(self._account_normalized)
+        if cached_uuid and author == cached_uuid:
+            return True
+        cached_number = self._recipient_number_by_uuid.get(author)
+        return bool(cached_number and cached_number == self._account_normalized)
+
+    def _remember_sent_message_timestamp(self, timestamp: Any) -> None:
+        """Keep a bounded cache of outbound Signal timestamps for quote matching."""
+        if timestamp is None:
+            return
+        self._sent_message_timestamps.add(str(timestamp))
+        if len(self._sent_message_timestamps) > self._max_sent_message_timestamps:
+            self._sent_message_timestamps.pop()
 
     def _extract_contact_uuid(self, contact: Any, phone_number: str) -> Optional[str]:
         """Best-effort extraction of a Signal service ID from listContacts output."""
@@ -1007,6 +1071,7 @@ class SignalAdapter(BasePlatformAdapter):
         ts = rpc_result.get("timestamp") if isinstance(rpc_result, dict) else None
         if ts:
             self._recent_sent_timestamps.add(ts)
+            self._remember_sent_message_timestamp(ts)
             if len(self._recent_sent_timestamps) > self._max_recent_timestamps:
                 self._recent_sent_timestamps.pop()
 

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -13,6 +13,7 @@ Requires:
 
 import asyncio
 import base64
+from collections import OrderedDict, deque
 import json
 import logging
 import os
@@ -63,6 +64,8 @@ SSE_RETRY_DELAY_INITIAL = 2.0
 SSE_RETRY_DELAY_MAX = 60.0
 HEALTH_CHECK_INTERVAL = 30.0  # seconds between health checks
 HEALTH_CHECK_STALE_THRESHOLD = 120.0  # seconds without SSE activity before concern
+SIGNAL_CHAT_HISTORY_MAX = 100  # recent messages retained per chat during runtime
+SIGNAL_CHAT_HISTORY_MAX_CHATS = 256  # distinct chats retained during runtime
 
 
 # ---------------------------------------------------------------------------
@@ -239,7 +242,7 @@ class SignalAdapter(BasePlatformAdapter):
         # Signal quote.id is the timestamp of the quoted message, so this lets
         # inbound replies identify that the user replied to a message sent by
         # this bot even after the self-sync echo was filtered above.
-        self._sent_message_timestamps: set[str] = set()
+        self._sent_message_timestamps: OrderedDict[str, None] = OrderedDict()
         self._max_sent_message_timestamps = 500
         # Signal increasingly exposes ACI/PNI UUIDs as stable recipient IDs.
         # Keep a best-effort mapping so outbound sends can upgrade from a
@@ -247,6 +250,8 @@ class SignalAdapter(BasePlatformAdapter):
         self._recipient_uuid_by_number: Dict[str, str] = {}
         self._recipient_number_by_uuid: Dict[str, str] = {}
         self._recipient_cache_lock = asyncio.Lock()
+        self._chat_history: OrderedDict[str, deque] = OrderedDict()
+        self._max_chat_history_chats = SIGNAL_CHAT_HISTORY_MAX_CHATS
 
         logger.info("Signal adapter initialized: url=%s account=%s groups=%s",
                      self.http_url, redact_phone(self.account),
@@ -658,6 +663,13 @@ class SignalAdapter(BasePlatformAdapter):
         logger.debug("Signal: message from %s in %s: %s",
                       redact_phone(sender), chat_id[:20], (text or "")[:50])
 
+        self._append_to_chat_history(
+            chat_id=chat_id,
+            ts_ms=ts_ms,
+            sender=sender,
+            name=sender_name or sender,
+            text=text or "",
+        )
         await self.handle_message(event)
 
     def _remember_recipient_identifiers(self, number: Optional[str], service_id: Optional[str]) -> None:
@@ -708,9 +720,48 @@ class SignalAdapter(BasePlatformAdapter):
         """Keep a bounded cache of outbound Signal timestamps for quote matching."""
         if timestamp is None:
             return
-        self._sent_message_timestamps.add(str(timestamp))
-        if len(self._sent_message_timestamps) > self._max_sent_message_timestamps:
-            self._sent_message_timestamps.pop()
+        timestamp_key = str(timestamp)
+        self._sent_message_timestamps[timestamp_key] = None
+        self._sent_message_timestamps.move_to_end(timestamp_key)
+        while len(self._sent_message_timestamps) > self._max_sent_message_timestamps:
+            self._sent_message_timestamps.popitem(last=False)
+
+    def _append_to_chat_history(
+        self,
+        chat_id: str,
+        ts_ms: Any,
+        sender: str,
+        name: str,
+        text: str,
+    ) -> None:
+        """Retain a bounded recent chat transcript for backlog-aware prompts."""
+        if not chat_id or not text:
+            return
+        history = self._chat_history.get(chat_id)
+        if history is None:
+            history = deque(maxlen=SIGNAL_CHAT_HISTORY_MAX)
+            self._chat_history[chat_id] = history
+        self._chat_history.move_to_end(chat_id)
+        try:
+            ts_value = int(ts_ms) if ts_ms else int(time.time() * 1000)
+        except (TypeError, ValueError):
+            ts_value = int(time.time() * 1000)
+        history.append({
+            "ts": ts_value,
+            "sender": sender,
+            "name": name or sender,
+            "text": text,
+        })
+        while len(self._chat_history) > self._max_chat_history_chats:
+            self._chat_history.popitem(last=False)
+
+    def get_recent_chat_messages(self, chat_id: str, n: int = 20) -> List[Dict[str, Any]]:
+        """Return up to the last ``n`` retained chat messages for a Signal chat."""
+        history = self._chat_history.get(chat_id)
+        if not history or n <= 0:
+            return []
+        self._chat_history.move_to_end(chat_id)
+        return list(history)[-n:]
 
     def _extract_contact_uuid(self, contact: Any, phone_number: str) -> Optional[str]:
         """Best-effort extraction of a Signal service ID from listContacts output."""
@@ -1060,6 +1111,14 @@ class SignalAdapter(BasePlatformAdapter):
 
         if result is not None:
             self._track_sent_timestamp(result)
+            sent_ts = (result.get("timestamp") if isinstance(result, dict) else None) or int(time.time() * 1000)
+            self._append_to_chat_history(
+                chat_id=chat_id,
+                ts_ms=sent_ts,
+                sender=self.account,
+                name="me",
+                text=plain_text,
+            )
             # Signal has no editable message identifier. Returning None keeps the
             # stream consumer on the non-edit fallback path instead of pretending
             # future edits can remove an in-progress cursor from the chat thread.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8053,7 +8053,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # multiple times, and without an explicit pointer the agent has to
             # guess (or answer for both subjects). Token overhead is minimal.
             reply_snippet = event.reply_to_text[:500]
-            message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
+            if getattr(event, "reply_to_is_own_message", False):
+                message_text = (
+                    f'[Replying to your previous message: "{reply_snippet}"]\n\n'
+                    f"{message_text}"
+                )
+            else:
+                message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
 
         if "@" in message_text:
             try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -302,6 +302,34 @@ def _gateway_provider_error_reply(text: str) -> str:
     )
 
 
+def _format_recent_signal_chat_history(
+    recent_messages: List[Dict[str, Any]],
+    *,
+    redact_pii: bool = False,
+) -> str:
+    """Render recent Signal messages for context-prompt injection."""
+    if not recent_messages:
+        return ""
+
+    recent_lines: List[str] = []
+    for message in recent_messages:
+        timestamp_ms = message.get("ts")
+        try:
+            dt = datetime.fromtimestamp(int(timestamp_ms) / 1000.0)
+            ts_label = dt.strftime("%H:%M")
+        except (TypeError, ValueError, OSError):
+            ts_label = "??:??"
+
+        sender = str(message.get("sender") or "")
+        label = str(message.get("name") or sender or "unknown")
+        if redact_pii and sender and label == sender:
+            label = _hash_sender_id(sender)
+
+        recent_lines.append(f"[{ts_label}] {label}: {message.get('text', '')}")
+
+    return "[Recent Signal chat history]\n" + "\n".join(recent_lines) + "\n\n"
+
+
 _GATEWAY_PROVIDER_ERROR_SHAPE_RE = re.compile(
     r"^\s*(\W*\s*)?("
     r"api\s+(?:call\s+)?failed"
@@ -1349,6 +1377,7 @@ from gateway.session import (
     build_session_context_prompt,
     build_session_key,
     is_shared_multi_user_session,
+    _hash_sender_id,
 )
 from gateway.delivery import DeliveryRouter
 from gateway.authz_mixin import GatewayAuthorizationMixin
@@ -8276,6 +8305,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Build the context prompt to inject
         context_prompt = build_session_context_prompt(context, redact_pii=_redact_pii)
+
+        if source.platform == Platform.SIGNAL:
+            signal_adapter = self.adapters.get(source.platform)
+            if signal_adapter and hasattr(signal_adapter, "get_recent_chat_messages"):
+                recent_messages = signal_adapter.get_recent_chat_messages(source.chat_id, n=30)
+                if recent_messages:
+                    context_prompt = (
+                        _format_recent_signal_chat_history(
+                            recent_messages,
+                            redact_pii=_redact_pii,
+                        )
+                        + context_prompt
+                    )
         
         # If the previous session expired and was auto-reset, prepend a notice
         # so the agent knows this is a fresh conversation (not an intentional /reset).

--- a/tests/gateway/test_reply_to_injection.py
+++ b/tests/gateway/test_reply_to_injection.py
@@ -100,6 +100,29 @@ async def test_reply_prefix_still_injected_when_text_in_history():
 
 
 @pytest.mark.asyncio
+async def test_own_message_reply_prefix_marks_assistant_message():
+    runner = _make_runner()
+    source = _source()
+    event = MessageEvent(
+        text="this one",
+        source=source,
+        reply_to_message_id="42",
+        reply_to_text="Use the direct train.",
+        reply_to_is_own_message=True,
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    assert result.startswith('[Replying to your previous message: "Use the direct train."]')
+    assert result.endswith("this one")
+
+
+@pytest.mark.asyncio
 async def test_no_prefix_without_reply_context():
     runner = _make_runner()
     source = _source()

--- a/tests/gateway/test_run_signal_recent_history.py
+++ b/tests/gateway/test_run_signal_recent_history.py
@@ -1,0 +1,43 @@
+"""Tests for Signal recent-history prompt rendering in gateway.run."""
+
+from gateway.run import _format_recent_signal_chat_history
+from gateway.session import _hash_sender_id
+
+
+def test_format_recent_signal_chat_history_hashes_raw_sender_when_redacting():
+    prompt = _format_recent_signal_chat_history(
+        [
+            {
+                "ts": 1712345678000,
+                "sender": "+15551234567",
+                "name": "+15551234567",
+                "text": "hello",
+            }
+        ],
+        redact_pii=True,
+    )
+
+    assert "+15551234567" not in prompt
+    assert _hash_sender_id("+15551234567") in prompt
+    assert "hello" in prompt
+
+
+def test_format_recent_signal_chat_history_preserves_display_name_when_redacting():
+    prompt = _format_recent_signal_chat_history(
+        [
+            {
+                "ts": 1712345678000,
+                "sender": "+15551234567",
+                "name": "Alice",
+                "text": "hello",
+            }
+        ],
+        redact_pii=True,
+    )
+
+    assert "Alice" in prompt
+    assert _hash_sender_id("+15551234567") not in prompt
+
+
+def test_format_recent_signal_chat_history_returns_empty_for_no_messages():
+    assert _format_recent_signal_chat_history([], redact_pii=True) == ""

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -69,6 +69,7 @@ class TestSignalConfigLoading:
 
     def test_signal_not_loaded_without_both_vars(self, monkeypatch):
         monkeypatch.setenv("SIGNAL_HTTP_URL", "http://localhost:9090")
+        monkeypatch.delenv("SIGNAL_ACCOUNT", raising=False)
         # No SIGNAL_ACCOUNT
 
         from gateway.config import GatewayConfig, _apply_env_overrides
@@ -1192,7 +1193,7 @@ class TestSignalQuoteExtraction:
                     "quote": {
                         "id": 99,
                         "text": "want to grab lunch?",
-                        "author": "+15550002222",
+                        "author": "other-author",
                     },
                 },
             }
@@ -1202,6 +1203,82 @@ class TestSignalQuoteExtraction:
         assert event.text == "yes I agree"
         assert event.reply_to_message_id == "99"
         assert event.reply_to_text == "want to grab lunch?"
+        assert event.reply_to_author_id == "other-author"
+        assert event.reply_to_is_own_message is False
+
+    @pytest.mark.asyncio
+    async def test_handle_envelope_marks_quote_to_own_sent_timestamp(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._remember_sent_message_timestamp(424242)
+        captured = {}
+
+        async def fake_handle(event):
+            captured["event"] = event
+
+        adapter.handle_message = fake_handle
+
+        await adapter._handle_envelope({
+            "envelope": {
+                "sourceNumber": "+155****1111",
+                "sourceUuid": "uuid-sender",
+                "sourceName": "Tester",
+                "timestamp": 1000000000,
+                "dataMessage": {
+                    "message": "this specific one",
+                    "quote": {
+                        "id": 424242,
+                        "text": "assistant answer",
+                        "author": "other-author",
+                    },
+                },
+            }
+        })
+
+        event = captured["event"]
+        assert event.reply_to_message_id == "424242"
+        assert event.reply_to_text == "assistant answer"
+        assert event.reply_to_author_id == "other-author"
+        assert event.reply_to_is_own_message is True
+
+    @pytest.mark.asyncio
+    async def test_handle_envelope_marks_quote_to_own_account_author(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch, account="bot-author")
+        captured = {}
+
+        async def fake_handle(event):
+            captured["event"] = event
+
+        adapter.handle_message = fake_handle
+
+        await adapter._handle_envelope({
+            "envelope": {
+                "sourceNumber": "+155****1111",
+                "sourceUuid": "uuid-sender",
+                "sourceName": "Tester",
+                "timestamp": 1000000000,
+                "dataMessage": {
+                    "message": "reply by author",
+                    "quote": {
+                        "id": 777,
+                        "text": "assistant answer",
+                        "author": "bot-author",
+                    },
+                },
+            }
+        })
+
+        event = captured["event"]
+        assert event.reply_to_message_id == "777"
+        assert event.reply_to_is_own_message is True
+
+    @pytest.mark.asyncio
+    async def test_track_sent_timestamp_keeps_reply_detection_cache_after_echo_discard(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._track_sent_timestamp({"timestamp": 111222333})
+        adapter._recent_sent_timestamps.discard(111222333)
+
+        assert "111222333" in adapter._sent_message_timestamps
+        assert adapter._quote_references_own_message("111222333", None) is True
 
     @pytest.mark.asyncio
     async def test_handle_envelope_without_quote_leaves_reply_fields_none(self, monkeypatch):

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -1010,9 +1010,188 @@ class TestSignalSendReturnsMessageId:
         assert result.message_id is None
 
 
-# ---------------------------------------------------------------------------
-# stop_typing() delegates to _stop_typing_indicator (#4647)
-# ---------------------------------------------------------------------------
+class TestSignalRecentChatHistory:
+    @pytest.mark.asyncio
+    async def test_inbound_group_message_is_retained_for_recent_history(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch, group_allowed="*")
+
+        async def fake_handle(_event):
+            return None
+
+        adapter.handle_message = fake_handle
+
+        await adapter._handle_envelope({
+            "envelope": {
+                "sourceNumber": "+155****1111",
+                "sourceUuid": "uuid-sender",
+                "sourceName": "Tester",
+                "timestamp": 1712345678000,
+                "dataMessage": {
+                    "message": "recent group context",
+                    "groupInfo": {"groupId": "group-123", "groupName": "Test Sports"},
+                },
+            }
+        })
+
+        assert adapter.get_recent_chat_messages("group:group-123", n=5) == [{
+            "ts": 1712345678000,
+            "sender": "+155****1111",
+            "name": "Tester",
+            "text": "recent group context",
+        }]
+
+    @pytest.mark.asyncio
+    async def test_send_retains_outbound_message_in_recent_history(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        mock_rpc, _ = _stub_rpc({"timestamp": 1712345678000})
+        adapter._rpc = mock_rpc
+        adapter._stop_typing_indicator = AsyncMock()
+
+        result = await adapter.send(chat_id="+155****4567", content="hello")
+
+        assert result.success is True
+        assert adapter.get_recent_chat_messages("+155****4567", n=5) == [{
+            "ts": 1712345678000,
+            "sender": adapter.account,
+            "name": "me",
+            "text": "hello",
+        }]
+
+    @pytest.mark.asyncio
+    async def test_inbound_dm_message_is_retained_under_sender_chat_id(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+
+        async def fake_handle(_event):
+            return None
+
+        adapter.handle_message = fake_handle
+
+        await adapter._handle_envelope({
+            "envelope": {
+                "sourceNumber": "+15559876543",
+                "sourceUuid": "uuid-dm-sender",
+                "sourceName": "Alice",
+                "timestamp": 1712300000000,
+                "dataMessage": {
+                    "message": "hello from DM",
+                },
+            }
+        })
+
+        assert adapter.get_recent_chat_messages("+15559876543", n=5) == [{
+            "ts": 1712300000000,
+            "sender": "+15559876543",
+            "name": "Alice",
+            "text": "hello from DM",
+        }]
+        # Groups must not bleed into DM slot
+        assert adapter.get_recent_chat_messages("group:anything", n=5) == []
+
+    @pytest.mark.asyncio
+    async def test_get_recent_chat_messages_caps_at_n(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        mock_rpc_fn, _ = _stub_rpc({"timestamp": 1000})
+        adapter._rpc = mock_rpc_fn
+        adapter._stop_typing_indicator = AsyncMock()
+
+        for i in range(5):
+            adapter._rpc = _stub_rpc({"timestamp": 1000 + i})[0]
+            await adapter.send(chat_id="+155****0001", content=f"msg {i}")
+
+        results = adapter.get_recent_chat_messages("+155****0001", n=3)
+        assert len(results) == 3
+        assert results[-1]["text"] == "msg 4"
+        assert results[0]["text"] == "msg 2"
+
+    def test_empty_text_is_not_stored_in_chat_history(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+
+        adapter._append_to_chat_history(
+            chat_id="group:grp1",
+            ts_ms=1712345678000,
+            sender="+15551234567",
+            name="Bob",
+            text="",
+        )
+
+        assert adapter.get_recent_chat_messages("group:grp1", n=10) == []
+
+    def test_get_recent_chat_messages_n_zero_returns_empty(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._append_to_chat_history(
+            chat_id="+155****0001",
+            ts_ms=1712345678000,
+            sender="+155****0001",
+            name="Carol",
+            text="something",
+        )
+
+        assert adapter.get_recent_chat_messages("+155****0001", n=0) == []
+
+    def test_chat_history_prunes_oldest_chats_when_global_cap_exceeded(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._max_chat_history_chats = 3
+
+        for i in range(4):
+            adapter._append_to_chat_history(
+                chat_id=f"group:grp{i}",
+                ts_ms=1712345678000 + i,
+                sender=f"+155****00{i}",
+                name=f"User {i}",
+                text=f"msg {i}",
+            )
+
+        assert adapter.get_recent_chat_messages("group:grp0", n=5) == []
+        assert adapter.get_recent_chat_messages("group:grp1", n=5) == [{
+            "ts": 1712345678001,
+            "sender": "+155****001",
+            "name": "User 1",
+            "text": "msg 1",
+        }]
+        assert adapter.get_recent_chat_messages("group:grp2", n=5) == [{
+            "ts": 1712345678002,
+            "sender": "+155****002",
+            "name": "User 2",
+            "text": "msg 2",
+        }]
+        assert adapter.get_recent_chat_messages("group:grp3", n=5) == [{
+            "ts": 1712345678003,
+            "sender": "+155****003",
+            "name": "User 3",
+            "text": "msg 3",
+        }]
+
+    def test_chat_history_read_promotes_chat_for_lru_eviction(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._max_chat_history_chats = 3
+
+        for i in range(3):
+            adapter._append_to_chat_history(
+                chat_id=f"group:grp{i}",
+                ts_ms=1712345678000 + i,
+                sender=f"+155****00{i}",
+                name=f"User {i}",
+                text=f"msg {i}",
+            )
+
+        assert adapter.get_recent_chat_messages("group:grp0", n=5)[0]["text"] == "msg 0"
+
+        adapter._append_to_chat_history(
+            chat_id="group:grp3",
+            ts_ms=1712345678003,
+            sender="+155****003",
+            name="User 3",
+            text="msg 3",
+        )
+
+        assert adapter.get_recent_chat_messages("group:grp1", n=5) == []
+        assert adapter.get_recent_chat_messages("group:grp0", n=5) == [{
+            "ts": 1712345678000,
+            "sender": "+155****000",
+            "name": "User 0",
+            "text": "msg 0",
+        }]
+
 
 class TestSignalStopTyping:
     """Signal must expose a public stop_typing() so base adapter's
@@ -1279,6 +1458,29 @@ class TestSignalQuoteExtraction:
 
         assert "111222333" in adapter._sent_message_timestamps
         assert adapter._quote_references_own_message("111222333", None) is True
+
+    def test_remember_sent_message_timestamp_evicts_oldest_first(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._max_sent_message_timestamps = 3
+
+        for ts in ("1", "2", "3", "4"):
+            adapter._remember_sent_message_timestamp(ts)
+
+        assert "1" not in adapter._sent_message_timestamps
+        assert "2" in adapter._sent_message_timestamps
+        assert "3" in adapter._sent_message_timestamps
+        assert "4" in adapter._sent_message_timestamps
+
+    def test_remember_sent_message_timestamp_reinsertion_promotes_entry(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._max_sent_message_timestamps = 2
+
+        for ts in ("1", "2", "1", "3"):
+            adapter._remember_sent_message_timestamp(ts)
+
+        assert "1" in adapter._sent_message_timestamps
+        assert "2" not in adapter._sent_message_timestamps
+        assert "3" in adapter._sent_message_timestamps
 
     @pytest.mark.asyncio
     async def test_handle_envelope_without_quote_leaves_reply_fields_none(self, monkeypatch):


### PR DESCRIPTION
### Summary

Inject bounded recent Signal chat history into gateway context and bound the runtime caches used for outbound quote tracking and retained chat history.

### Why

Short recent chat history helps the agent respond in Signal conversations without relying only on the latest message. The cache bounds keep this useful context from growing unbounded over long-running gateway sessions.

### Scope

- Signal gateway context only
- intentionally stacked on #46388 / `pr/signal-reply-context`
- deterministic eviction for retained chat history and outbound quote tracking

### Test plan

- 124 focused Signal recent-history tests passed locally

---