### PR TITLE
fix(gateway): detect macOS launchd gateway pids

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -135,7 +135,8 @@ def _get_service_pids() -> set:
                 timeout=5,
             )
             if result.returncode == 0:
-                # Output: "PID\tStatus\tLabel" header, then one data line
+                # `launchctl list <label>` may return either a tabular line or a
+                # plist-like block, depending on the host launchctl version.
                 for line in result.stdout.strip().splitlines():
                     parts = line.split()
                     if len(parts) >= 3 and parts[2] == label:
@@ -145,6 +146,16 @@ def _get_service_pids() -> set:
                                 pids.add(pid)
                         except ValueError:
                             pass
+                    stripped = line.strip()
+                    if not stripped.startswith('"PID"'):
+                        continue
+                    _, _, raw_value = stripped.partition("=")
+                    try:
+                        pid = int(raw_value.strip().rstrip(";"))
+                    except ValueError:
+                        continue
+                    if pid > 0:
+                        pids.add(pid)
         except (FileNotFoundError, subprocess.TimeoutExpired):
             pass
 
@@ -467,8 +478,12 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
                     pass
 
             if not _found_via_proc:
+                ps_cmd = ["ps", "-A", "eww", "-o", "pid=,command="]
+                if is_macos():
+                    # Darwin rejects the GNU-style `eww` positional token.
+                    ps_cmd = ["ps", "-A", "-ww", "-o", "pid=,command="]
                 result = subprocess.run(
-                    ["ps", "-A", "eww", "-o", "pid=,command="],
+                    ps_cmd,
                     capture_output=True,
                     text=True,
                     timeout=10,

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -807,7 +807,7 @@ def test_find_gateway_pids_falls_back_to_pid_file_when_process_scan_fails(monkey
     monkeypatch.setattr(gateway.os, "listdir", _no_proc_listdir)
 
     def fake_run(cmd, **kwargs):
-        if cmd[:4] == ["ps", "-A", "eww", "-o"]:
+        if cmd[:4] == ["ps", "-A", "eww", "-o"] or cmd[:4] == ["ps", "-A", "-ww", "-o"]:
             return SimpleNamespace(returncode=1, stdout="", stderr="ps failed")
         if cmd[:3] == ["ps", "-o", "ppid="]:
             # _get_ancestor_pids() walks up the tree; return "no parent" so
@@ -818,6 +818,49 @@ def test_find_gateway_pids_falls_back_to_pid_file_when_process_scan_fails(monkey
     monkeypatch.setattr(gateway.subprocess, "run", fake_run)
 
     assert gateway.find_gateway_pids() == [321]
+
+
+def test_get_service_pids_parses_launchctl_plist_output(monkeypatch):
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway, "is_macos", lambda: True)
+    monkeypatch.setattr(gateway, "get_launchd_label", lambda: "ai.hermes.gateway")
+
+    def fake_run(cmd, **kwargs):
+        assert cmd == ["launchctl", "list", "ai.hermes.gateway"]
+        return SimpleNamespace(
+            returncode=0,
+            stdout='{\n    "Label" = "ai.hermes.gateway";\n    "PID" = 855;\n};\n',
+            stderr="",
+        )
+
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+
+    assert gateway._get_service_pids() == {855}
+
+
+def test_scan_gateway_pids_uses_macos_ps_wide_flags(monkeypatch):
+    monkeypatch.setattr(gateway, "is_windows", lambda: False)
+    monkeypatch.setattr(gateway, "is_macos", lambda: True)
+    monkeypatch.setattr(gateway, "_get_ancestor_pids", lambda: set())
+    real_isdir = gateway.os.path.isdir
+    monkeypatch.setattr(
+        gateway.os.path,
+        "isdir",
+        lambda path: False if path == "/proc" else real_isdir(path),
+    )
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["ps", "-A", "-ww", "-o", "pid=,command="]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout="855 /usr/bin/python3 /tmp/hermes_cli/main.py gateway run --replace\n",
+                stderr="",
+            )
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+
+    assert gateway._scan_gateway_pids(set()) == [855]
 
 
 def test_scan_gateway_pids_detects_windows_hermes_exe_case_variants(monkeypatch):


### PR DESCRIPTION
## Summary
- parse `launchctl list <label>` plist-style output when detecting launchd-managed gateway PIDs on macOS
- switch the macOS process-table fallback from GNU-style `ps ... eww` to Darwin-compatible `ps -A -ww -o pid=,command=`
- add regression tests for both macOS detection paths

Fixes #15225

## Verification
- `uv run --frozen pytest tests/hermes_cli/test_gateway.py -k "launchctl_plist_output or macos_ps_wide_flags or falls_back_to_pid_file_when_process_scan_fails"`
- `uv run --frozen ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway.py`
- `git diff --check HEAD^ HEAD`
