### PR TITLE
chore: ignore Hermes runtime state directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,7 @@ docs/superpowers/*
 # also created in-repo when an agent operates in this checkout). Plans, audit
 # logs, and per-session caches are never artifacts of the codebase.
 .hermes/
+scripts/.state/
 
 # Desktop/bootstrap install marker written into the managed checkout root by the
 # bootstrap installer. It is Hermes-managed runtime state, never a code change —


### PR DESCRIPTION
### Summary

Ignore `scripts/.state/` runtime state files.

### Why

Local operational state under `scripts/.state/` should not be accidentally committed.

### Scope

- `.gitignore` only
- no source/test/runtime behavior changes

### Verification

- diff only touches `.gitignore`