### PR TITLE
fix(kanban): keep dashboard API mounted without multipart

### DIFF
--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -36,6 +36,7 @@ the port.
 from __future__ import annotations
 
 import asyncio
+import importlib.util
 import json
 import logging
 import sqlite3
@@ -54,6 +55,26 @@ from hermes_cli import kanban_diagnostics as kd
 log = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _multipart_available() -> bool:
+    """Return True when the optional multipart parser dependency is installed.
+
+    FastAPI validates ``File(...)`` / ``Form(...)`` parameters at route
+    registration time. If ``python-multipart`` is missing, merely importing this
+    module raises and prevents *all* kanban plugin routes from mounting,
+    including the read-only board endpoints. Treat attachment uploads as an
+    optional capability instead: keep the rest of the dashboard API alive and
+    expose a clear per-endpoint error for uploads.
+    """
+    return importlib.util.find_spec("multipart") is not None
+
+
+_MULTIPART_AVAILABLE = _multipart_available()
+if not _MULTIPART_AVAILABLE:
+    log.warning(
+        "Kanban attachment uploads disabled: python-multipart is not installed"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -684,79 +705,92 @@ def list_task_attachments(task_id: str, board: Optional[str] = Query(None)):
         conn.close()
 
 
-@router.post("/tasks/{task_id}/attachments")
-async def upload_task_attachment(
-    task_id: str,
-    file: UploadFile = File(...),
-    board: Optional[str] = Query(None),
-    uploaded_by: Optional[str] = Form(None),
-):
-    """Store an uploaded file for a task and record its metadata.
+if _MULTIPART_AVAILABLE:
+    @router.post("/tasks/{task_id}/attachments")
+    async def upload_task_attachment(
+        task_id: str,
+        file: UploadFile = File(...),
+        board: Optional[str] = Query(None),
+        uploaded_by: Optional[str] = Form(None),
+    ):
+        """Store an uploaded file for a task and record its metadata.
 
-    The blob lands under ``attachments_root(board)/<task_id>/`` with a
-    sanitised, collision-resolved name. The worker reads it via the
-    absolute path surfaced in ``build_worker_context``.
-    """
-    board = _resolve_board(board)
-    conn = _conn(board=board)
-    try:
-        if kanban_db.get_task(conn, task_id) is None:
-            raise HTTPException(status_code=404, detail=f"task {task_id} not found")
-
-        safe_name = _safe_attachment_name(file.filename or "")
-
-        # Stream to disk with a hard size cap so a huge upload can't fill
-        # the disk. Read in chunks; abort + clean up if the cap is hit.
-        dest_dir = kanban_db.task_attachments_dir(task_id, board=board)
-        dest_dir.mkdir(parents=True, exist_ok=True)
-
-        # Resolve name collisions: foo.pdf → foo (1).pdf, foo (2).pdf, …
-        stem, dot, ext = safe_name.partition(".")
-        candidate = safe_name
-        n = 1
-        while (dest_dir / candidate).exists():
-            candidate = f"{stem} ({n}){dot}{ext}"
-            n += 1
-        dest_path = dest_dir / candidate
-
-        total = 0
+        The blob lands under ``attachments_root(board)/<task_id>/`` with a
+        sanitised, collision-resolved name. The worker reads it via the
+        absolute path surfaced in ``build_worker_context``.
+        """
+        board = _resolve_board(board)
+        conn = _conn(board=board)
         try:
-            with open(dest_path, "wb") as out:
-                while True:
-                    chunk = await file.read(1024 * 1024)
-                    if not chunk:
-                        break
-                    total += len(chunk)
-                    if total > _MAX_ATTACHMENT_BYTES:
-                        out.close()
-                        dest_path.unlink(missing_ok=True)
-                        raise HTTPException(
-                            status_code=413,
-                            detail=(
-                                f"attachment exceeds {_MAX_ATTACHMENT_BYTES // (1024 * 1024)} MB limit"
-                            ),
-                        )
-                    out.write(chunk)
-        except HTTPException:
-            raise
-        except OSError as exc:
-            raise HTTPException(status_code=500, detail=f"failed to store attachment: {exc}")
+            if kanban_db.get_task(conn, task_id) is None:
+                raise HTTPException(status_code=404, detail=f"task {task_id} not found")
 
-        att_id = kanban_db.add_attachment(
-            conn,
-            task_id,
-            filename=candidate,
-            stored_path=str(dest_path.resolve()),
-            content_type=file.content_type,
-            size=total,
-            uploaded_by=(uploaded_by or "dashboard"),
+            safe_name = _safe_attachment_name(file.filename or "")
+
+            # Stream to disk with a hard size cap so a huge upload can't fill
+            # the disk. Read in chunks; abort + clean up if the cap is hit.
+            dest_dir = kanban_db.task_attachments_dir(task_id, board=board)
+            dest_dir.mkdir(parents=True, exist_ok=True)
+
+            # Resolve name collisions: foo.pdf → foo (1).pdf, foo (2).pdf, …
+            stem, dot, ext = safe_name.partition(".")
+            candidate = safe_name
+            n = 1
+            while (dest_dir / candidate).exists():
+                candidate = f"{stem} ({n}){dot}{ext}"
+                n += 1
+            dest_path = dest_dir / candidate
+
+            total = 0
+            try:
+                with open(dest_path, "wb") as out:
+                    while True:
+                        chunk = await file.read(1024 * 1024)
+                        if not chunk:
+                            break
+                        total += len(chunk)
+                        if total > _MAX_ATTACHMENT_BYTES:
+                            out.close()
+                            dest_path.unlink(missing_ok=True)
+                            raise HTTPException(
+                                status_code=413,
+                                detail=(
+                                    f"attachment exceeds {_MAX_ATTACHMENT_BYTES // (1024 * 1024)} MB limit"
+                                ),
+                            )
+                        out.write(chunk)
+            except HTTPException:
+                raise
+            except OSError as exc:
+                raise HTTPException(status_code=500, detail=f"failed to store attachment: {exc}")
+
+            att_id = kanban_db.add_attachment(
+                conn,
+                task_id,
+                filename=candidate,
+                stored_path=str(dest_path.resolve()),
+                content_type=file.content_type,
+                size=total,
+                uploaded_by=(uploaded_by or "dashboard"),
+            )
+            att = kanban_db.get_attachment(conn, att_id)
+            return {"attachment": _attachment_dict(att) if att else None}
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        finally:
+            conn.close()
+else:
+    @router.post("/tasks/{task_id}/attachments")
+    async def upload_task_attachment(
+        task_id: str,
+        board: Optional[str] = Query(None),
+    ):
+        """Return a clear error when attachment uploads are unavailable."""
+        _resolve_board(board)
+        raise HTTPException(
+            status_code=501,
+            detail="attachment uploads require python-multipart to be installed",
         )
-        att = kanban_db.get_attachment(conn, att_id)
-        return {"attachment": _attachment_dict(att) if att else None}
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    finally:
-        conn.close()
 
 
 @router.get("/attachments/{attachment_id}")

--- a/tests/plugins/test_kanban_attachments.py
+++ b/tests/plugins/test_kanban_attachments.py
@@ -29,17 +29,21 @@ from hermes_cli import kanban_db as kb
 
 
 def _load_plugin_router():
+    return _load_plugin_module("hermes_dashboard_plugin_kanban_attach_test").router
+
+
+def _load_plugin_module(module_name: str):
     repo_root = Path(__file__).resolve().parents[2]
     plugin_file = repo_root / "plugins" / "kanban" / "dashboard" / "plugin_api.py"
     assert plugin_file.exists(), f"plugin file missing: {plugin_file}"
     spec = importlib.util.spec_from_file_location(
-        "hermes_dashboard_plugin_kanban_attach_test", plugin_file,
+        module_name, plugin_file,
     )
     assert spec is not None and spec.loader is not None
     mod = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = mod
     spec.loader.exec_module(mod)
-    return mod.router
+    return mod
 
 
 @pytest.fixture
@@ -246,6 +250,34 @@ def test_upload_list_download_delete_roundtrip(client):
     assert client.get(
         f"/api/plugins/kanban/tasks/{task_id}/attachments"
     ).json()["attachments"] == []
+
+
+def test_board_routes_still_mount_without_python_multipart(kanban_home, monkeypatch):
+    """Missing multipart support must not take down the whole kanban API."""
+    orig_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name, package=None):
+        if name == "multipart":
+            return None
+        return orig_find_spec(name, package)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+
+    mod_name = "hermes_dashboard_plugin_kanban_nomultipart_test"
+    sys.modules.pop(mod_name, None)
+    mod = _load_plugin_module(mod_name)
+
+    app = FastAPI()
+    app.include_router(mod.router, prefix="/api/plugins/kanban")
+    client = TestClient(app)
+
+    board = client.get("/api/plugins/kanban/board")
+    assert board.status_code == 200, board.text
+
+    task_id = _create_task_via_api(client)
+    upload = client.post(f"/api/plugins/kanban/tasks/{task_id}/attachments")
+    assert upload.status_code == 501
+    assert "python-multipart" in upload.json()["detail"]
 
 
 def test_upload_sanitizes_traversal_filename(client):


### PR DESCRIPTION
Fixes #46205.

## Summary
- keep the kanban dashboard plugin API mounted even when `python-multipart` is not installed
- degrade attachment uploads into a clear `501` response instead of aborting the entire plugin router import
- add regression coverage for both the no-multipart fallback and the existing upload path when multipart support is present

## Verification
- `uv run --frozen pytest tests/plugins/test_kanban_attachments.py -k "board_routes_still_mount_without_python_multipart"`
- `uv run --with python-multipart pytest tests/plugins/test_kanban_attachments.py -k "upload_list_download_delete_roundtrip"`
- `uv run --with python-multipart pytest tests/hermes_cli/test_web_server.py -k "plugin_route_requires_auth"`
- `uv run --frozen ruff check plugins/kanban/dashboard/plugin_api.py tests/plugins/test_kanban_attachments.py`
- `git diff --check HEAD^ HEAD`
