### PR TITLE
fix(terminal): fall back to .env for env_passthrough in local backend

### DIFF
--- a/tests/tools/test_local_env_passthrough_dotenv.py
+++ b/tests/tools/test_local_env_passthrough_dotenv.py
@@ -1,0 +1,92 @@
+"""Tests for terminal.env_passthrough .env fallback in local backend.
+
+Verifies that passthrough keys listed in config or registered by skills
+are sourced from ~/.hermes/.env when they are not present in os.environ.
+
+See: https://github.com/NousResearch/hermes-agent/issues/46152
+"""
+
+import os
+import threading
+from unittest.mock import MagicMock, patch
+
+from tools.environments.local import _make_run_env
+
+
+class TestPassthroughDotenvFallback:
+    """Passthrough keys missing from os.environ should fall back to .env."""
+
+    def test_passthrough_key_from_dotenv_injected(self, monkeypatch):
+        """A passthrough key that only exists in .env appears in run_env."""
+        monkeypatch.delenv("MY_SECRET_TOKEN", raising=False)
+
+        with patch(
+            "tools.env_passthrough.get_all_passthrough",
+            return_value=frozenset({"MY_SECRET_TOKEN"}),
+        ), patch(
+            "hermes_cli.config.load_env",
+            return_value={"MY_SECRET_TOKEN": "tok123"},
+        ):
+            result = _make_run_env({})
+
+        assert result.get("MY_SECRET_TOKEN") == "tok123"
+
+    def test_passthrough_key_in_os_environ_not_overwritten(self, monkeypatch):
+        """When the key is already in os.environ, .env is not consulted."""
+        monkeypatch.setenv("MY_SECRET_TOKEN", "from_shell")
+
+        with patch(
+            "tools.env_passthrough.get_all_passthrough",
+            return_value=frozenset({"MY_SECRET_TOKEN"}),
+        ), patch(
+            "hermes_cli.config.load_env",
+            return_value={"MY_SECRET_TOKEN": "from_dotenv"},
+        ):
+            result = _make_run_env({})
+
+        assert result.get("MY_SECRET_TOKEN") == "from_shell"
+
+    def test_non_passthrough_key_not_loaded_from_dotenv(self, monkeypatch):
+        """Keys not in the passthrough list are not loaded from .env."""
+        monkeypatch.delenv("UNRELATED_VAR", raising=False)
+
+        with patch(
+            "tools.env_passthrough.get_all_passthrough",
+            return_value=frozenset(set()),
+        ), patch(
+            "hermes_cli.config.load_env",
+            return_value={"UNRELATED_VAR": "should_not_appear"},
+        ):
+            result = _make_run_env({})
+
+        assert "UNRELATED_VAR" not in result
+
+    def test_dotenv_load_failure_is_silent(self, monkeypatch):
+        """If load_env() raises, the fallback is silently skipped."""
+        monkeypatch.delenv("MY_TOKEN", raising=False)
+
+        with patch(
+            "tools.env_passthrough.get_all_passthrough",
+            return_value=frozenset({"MY_TOKEN"}),
+        ), patch(
+            "hermes_cli.config.load_env",
+            side_effect=Exception("no .env file"),
+        ):
+            result = _make_run_env({})
+
+        assert "MY_TOKEN" not in result
+
+    def test_passthrough_key_from_env_param(self, monkeypatch):
+        """Keys passed via the env parameter are already present — no .env needed."""
+        monkeypatch.delenv("MY_SECRET_TOKEN", raising=False)
+
+        with patch(
+            "tools.env_passthrough.get_all_passthrough",
+            return_value=frozenset({"MY_SECRET_TOKEN"}),
+        ), patch(
+            "hermes_cli.config.load_env",
+            return_value={"MY_SECRET_TOKEN": "from_dotenv"},
+        ):
+            result = _make_run_env({"MY_SECRET_TOKEN": "from_param"})
+
+        assert result.get("MY_SECRET_TOKEN") == "from_param"

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -378,6 +378,24 @@ def _make_run_env(env: dict) -> dict:
             run_env[real_key] = v
         elif k not in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_passthrough(k):
             run_env[k] = v
+
+    # Fallback: passthrough keys listed in config or registered by skills may
+    # live in ~/.hermes/.env without being exported to os.environ.  The Docker
+    # backend already does this (docker.py:_build_init_env_args); mirror it for
+    # the local backend so env_passthrough works consistently regardless of
+    # backend choice.
+    try:
+        from tools.env_passthrough import get_all_passthrough as _get_all_pt
+        missing = {k for k in _get_all_pt() if k not in run_env}
+        if missing:
+            from hermes_cli.config import load_env
+            hermes_env = load_env() or {}
+            for k in missing:
+                if k in hermes_env:
+                    run_env[k] = hermes_env[k]
+    except Exception:
+        pass
+
     path_key = _path_env_key(run_env)
     if path_key is not None:
         run_env[path_key] = _append_missing_sane_path_entries(run_env.get(path_key, ""))


### PR DESCRIPTION
## What does this PR do?

Fixes `terminal.env_passthrough` not working with the local backend when the variable only exists in `~/.hermes/.env` (not exported to `os.environ`). The Docker backend already has this fallback; this PR mirrors it for the local backend.

## Related Issue

Fixes #46152

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/local.py`: After building `run_env` from `os.environ | env`, fall back to `load_env()` for any passthrough keys that are still missing. Matches the existing Docker backend pattern (`docker.py:_build_init_env_args`, lines 930–934).
- `tests/tools/test_local_env_passthrough_dotenv.py`: 5 tests covering the new fallback — key injected from `.env`, `os.environ` takes precedence, non-passthrough keys not loaded, `load_env()` failure is silent, `env` parameter takes precedence.

## How to Test

1. Add a variable to `~/.hermes/.env` (e.g., `MY_TEST_VAR=hello`)
2. Configure `config.yaml`:
   ```yaml
   terminal:
     env_passthrough: ["MY_TEST_VAR"]
   ```
3. Run `echo $MY_TEST_VAR` in Hermes terminal — should print `hello`
4. Run `pytest tests/tools/test_local_env_passthrough_dotenv.py -v` — all 5 tests should pass
5. Run `pytest tests/tools/test_local_env_blocklist.py tests/tools/test_env_passthrough.py -v` — all existing tests still pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `_make_run_env` in `tools/environments/local.py` (callers: `LocalEnvironment.execute`, 2 call sites)
- Blast radius: LOW — additive change, existing env-building logic untouched; new block is guarded by try/except
- Related patterns: Docker backend `_build_init_env_args` (lines 930–934) uses identical `.env` fallback for passthrough keys
