### PR TITLE
fix(toolsets): include discord tools in core so tool_search never defers them

### DIFF
--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -214,9 +214,12 @@ class TestToolsetConsistency:
     def test_hermes_platforms_share_core_tools(self):
         """All hermes-* platform toolsets share the same core tools.
 
-        Platform-specific additions (e.g. ``discord`` / ``discord_admin``
-        on hermes-discord, gated on DISCORD_BOT_TOKEN) are allowed on top —
-        the invariant is that the core set is identical across platforms.
+        ``discord`` / ``discord_admin`` now live in ``_HERMES_CORE_TOOLS``
+        (gated by check_fn on ``DISCORD_BOT_TOKEN``), so they're part of the
+        shared set — invisible to CLI/cron sessions without a bot, but
+        available to the model on every hermes-* platform when the bot
+        token is present. Other platform-specific extras would still be
+        allowed on top via subset semantics here.
         """
         platforms = ["hermes-cli", "hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-homeassistant"]
         tool_sets = [set(TOOLSETS[p]["tools"]) for p in platforms]
@@ -225,6 +228,11 @@ class TestToolsetConsistency:
         core = set.intersection(*tool_sets)
         for name, ts in zip(platforms, tool_sets):
             assert core.issubset(ts), f"{name} is missing core tools: {core - ts}"
+        # Discord tools are now part of the shared core because they live
+        # in _HERMES_CORE_TOOLS — check_fn makes them invisible on platforms
+        # without a bot token, but the toolset always lists them.
+        assert "discord" in core
+        assert "discord_admin" in core
         # Sanity: the shared core must be non-trivial (i.e. we didn't
         # silently let a platform diverge so far that nothing is shared).
         assert len(core) > 20, f"Suspiciously small shared core: {len(core)} tools"

--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -623,22 +623,33 @@ class TestToolsetInclusion:
         assert "discord" in TOOLSETS["hermes-discord"]["tools"]
         assert "discord_admin" in TOOLSETS["hermes-discord"]["tools"]
 
-    def test_discord_tools_not_in_core_tools(self):
-        from toolsets import _HERMES_CORE_TOOLS
-        assert "discord" not in _HERMES_CORE_TOOLS
-        assert "discord_admin" not in _HERMES_CORE_TOOLS
+    def test_discord_tools_in_core_tools(self):
+        """``discord`` and ``discord_admin`` are part of _HERMES_CORE_TOOLS.
 
-    def test_discord_tools_not_in_other_toolsets(self):
+        check_fn gates visibility on DISCORD_BOT_TOKEN, so CLI/cron sessions
+        without a bot don't see them anyway — but putting them in core means
+        the model on any hermes-* platform can reach for them when a bot is
+        present, instead of having tool_search defer them out of sight.
+        """
+        from toolsets import _HERMES_CORE_TOOLS
+        assert "discord" in _HERMES_CORE_TOOLS
+        assert "discord_admin" in _HERMES_CORE_TOOLS
+
+    def test_discord_tools_only_in_hermes_platform_toolsets(self):
+        """Non-platform toolsets (web, search, cron, etc.) must NOT bundle
+        the Discord tools — only the hermes-* platform toolsets do, via
+        their inclusion of _HERMES_CORE_TOOLS.
+        """
         from toolsets import TOOLSETS
         for name, ts in TOOLSETS.items():
-            if name in {"hermes-discord", "hermes-gateway", "discord", "discord_admin"}:
+            if name.startswith("hermes-") or name in {"discord", "discord_admin"}:
                 continue
             tools = ts.get("tools", [])
-            assert "discord" not in tools or name == "discord", (
-                f"discord tool should not be in toolset '{name}'"
+            assert "discord" not in tools, (
+                f"discord tool should not be in non-platform toolset '{name}'"
             )
-            assert "discord_admin" not in tools or name == "discord_admin", (
-                f"discord_admin tool should not be in toolset '{name}'"
+            assert "discord_admin" not in tools, (
+                f"discord_admin tool should not be in non-platform toolset '{name}'"
             )
 
 

--- a/tests/tools/test_tool_search.py
+++ b/tests/tools/test_tool_search.py
@@ -96,7 +96,12 @@ class TestClassification:
         for core_name in ["terminal", "read_file", "write_file", "patch",
                           "search_files", "todo", "memory", "browser_navigate",
                           "web_search", "session_search", "clarify",
-                          "execute_code", "delegate_task", "send_message"]:
+                          "execute_code", "delegate_task", "send_message",
+                          # Platform-bound tools — gated by check_fn on the
+                          # bot token, but core so the model always sees them
+                          # when the bot is present (rather than being hidden
+                          # behind tool_search bridge tools).
+                          "discord", "discord_admin"]:
             assert not is_deferrable_tool_name(core_name), (
                 f"Core tool '{core_name}' must NEVER be deferrable"
             )

--- a/toolsets.py
+++ b/toolsets.py
@@ -61,6 +61,13 @@ _HERMES_CORE_TOOLS = [
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
     "send_message",
+    # Discord server introspection + thread/channel management. Both tools are
+    # gated on DISCORD_BOT_TOKEN via check_fn, so they're invisible on CLI/cron
+    # sessions without a bot token. They live in core (rather than only in the
+    # `hermes-discord` toolset) so the model can always reach for them when
+    # the bot is present — otherwise tool_search defers them out of the
+    # model-facing tools list and the model thinks Discord ops aren't possible.
+    "discord", "discord_admin",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
     # Kanban multi-agent coordination — only in schema when the agent is


### PR DESCRIPTION
## Summary

Fixes #46400 — when `tools.tool_search.enabled: "on"` is set, `discord` and `discord_admin` get deferred behind the `tool_search`/`tool_describe`/`tool_call` bridges and the model on a Discord-platform session can't see them, even though they're explicitly bundled by `hermes-discord`. The agent accurately but unhelpfully reports "no such tool available" when asked to e.g. rename a thread.

Add both tools to `_HERMES_CORE_TOOLS`. They remain gated on `DISCORD_BOT_TOKEN` via the existing `check_discord_tool_requirements` check_fn, so CLI / cron sessions without a bot continue to not see them. This matches the same pattern already used for `ha_*` (Home Assistant, gated on `HASS_TOKEN`).

## Notes for reviewers

- This is the surgical fix; the deeper architectural question is in the issue body (deferral logic ignores active-toolset membership). Happy to follow up with a more general patch if maintainers prefer that direction.
- The two existing invariant tests (`test_discord_tools_not_in_core_tools` and `test_discord_tools_not_in_other_toolsets`) inverted to match the new architecture.
- `test_hermes_platforms_share_core_tools` docstring updated and a positive assertion added: `discord` / `discord_admin` are now part of the shared core across all `hermes-*` platforms.
- `test_core_tools_never_defer` in `tests/tools/test_tool_search.py` extended to cover the two new core entries.

## Test plan

- [x] Modified invariant tests in `tests/tools/test_discord_tool.py::TestToolsetInclusion` reflect new architecture
- [x] `tests/test_toolsets.py::TestToolsetConsistency::test_hermes_platforms_share_core_tools` updated + positive assertion added
- [x] `tests/tools/test_tool_search.py::TestClassification::test_core_tools_never_defer` extended
- [x] Full `tests/test_toolsets.py`, `tests/tools/test_tool_search.py`, `tests/tools/test_discord_tool.py` suites pass: 161 of 161
- [x] Live-verified on a Discord gateway: prior behavior reproduced (model "no surface available"); after patch, model directly sees and calls `discord(action="rename_thread", ...)` without going through `tool_search`

Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)