### PR TITLE
fix(skills): fall back after rejected GitHub token

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1281,6 +1281,202 @@ class TestCheckForSkillUpdates:
 
         assert results[0]["status"] == "up_to_date"
 
+    def test_bad_env_github_token_falls_back_to_anonymous_source(self, monkeypatch):
+        """A stale env token must not make public skills look unavailable.
+
+        Hermes loads ~/.hermes/.env at CLI startup. If that file contains a
+        revoked GITHUB_TOKEN, GitHub returns 401 for otherwise-public skill
+        repos. Public skill update checks should retry without auth before
+        reporting the upstream bundle unavailable.
+        """
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_revoked")
+        source = GitHubSource(auth=GitHubAuth())
+        seen_auth_headers = []
+
+        def fake_get(*args, **kwargs):
+            seen_auth_headers.append((kwargs.get("headers") or {}).get("Authorization"))
+            if len(seen_auth_headers) == 1:
+                return httpx.Response(401, json={"message": "Bad credentials"})
+            return httpx.Response(200, json={"ok": True})
+
+        with (
+            patch.object(source.auth, "_try_gh_cli", return_value=None),
+            patch.object(source.auth, "_try_github_app", return_value=None),
+            patch("tools.skills_hub.httpx.get", side_effect=fake_get),
+        ):
+            result = source._github_get("https://api.github.com/repos/acme/skills")
+
+        assert result is not None
+        assert result.status_code == 200
+        assert seen_auth_headers == ["token ghp_revoked", None]
+        assert source.auth._disabled_tokens == {"ghp_revoked"}
+
+    def test_bad_github_token_falls_back_to_gh_token(self, monkeypatch):
+        """A bad GITHUB_TOKEN should not mask a valid GH_TOKEN."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_revoked")
+        monkeypatch.setenv("GH_TOKEN", "github_pat_valid")
+        source = GitHubSource(auth=GitHubAuth())
+        seen_auth_headers = []
+
+        def fake_get(*args, **kwargs):
+            seen_auth_headers.append((kwargs.get("headers") or {}).get("Authorization"))
+            if len(seen_auth_headers) == 1:
+                return httpx.Response(401, json={"message": "Bad credentials"})
+            return httpx.Response(200, json={"ok": True})
+
+        with patch("tools.skills_hub.httpx.get", side_effect=fake_get):
+            result = source._github_get("https://api.github.com/repos/acme/private-skills")
+
+        assert result is not None
+        assert result.status_code == 200
+        assert seen_auth_headers == ["token ghp_revoked", "token github_pat_valid"]
+        assert source.auth._disabled_tokens == {"ghp_revoked"}
+
+    def test_bad_env_token_retry_preserves_custom_accept_header(self, monkeypatch):
+        """401 retry must not drop raw Contents API Accept headers."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_revoked")
+        source = GitHubSource(auth=GitHubAuth())
+        seen_headers = []
+
+        def fake_get(*args, **kwargs):
+            headers = kwargs.get("headers") or {}
+            seen_headers.append(dict(headers))
+            if len(seen_headers) == 1:
+                return httpx.Response(401, json={"message": "Bad credentials"})
+            return httpx.Response(200, text="---\nname: demo\n---\n")
+
+        with (
+            patch.object(source.auth, "_try_gh_cli", return_value=None),
+            patch.object(source.auth, "_try_github_app", return_value=None),
+            patch("tools.skills_hub.httpx.get", side_effect=fake_get),
+        ):
+            result = source._github_get(
+                "https://api.github.com/repos/acme/skills/contents/demo/SKILL.md",
+                headers={
+                    "Accept": "application/vnd.github.v3.raw",
+                    "Authorization": "token ghp_revoked",
+                },
+            )
+
+        assert result is not None
+        assert result.status_code == 200
+        assert seen_headers == [
+            {
+                "Accept": "application/vnd.github.v3.raw",
+                "Authorization": "token ghp_revoked",
+            },
+            {"Accept": "application/vnd.github.v3.raw"},
+        ]
+
+    def test_bad_gh_cli_token_falls_back_to_anonymous_source(self, monkeypatch):
+        """A bad gh-cli token should not block anonymous public repo access."""
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        source = GitHubSource(auth=GitHubAuth())
+        seen_auth_headers = []
+
+        def fake_get(*args, **kwargs):
+            seen_auth_headers.append((kwargs.get("headers") or {}).get("Authorization"))
+            if len(seen_auth_headers) == 1:
+                return httpx.Response(401, json={"message": "Bad credentials"})
+            return httpx.Response(200, json={"ok": True})
+
+        with (
+            patch.object(source.auth, "_try_gh_cli", return_value="gho_revoked"),
+            patch.object(source.auth, "_try_github_app", return_value=None),
+            patch("tools.skills_hub.httpx.get", side_effect=fake_get),
+        ):
+            result = source._github_get("https://api.github.com/repos/acme/skills")
+
+        assert result is not None
+        assert result.status_code == 200
+        assert seen_auth_headers == ["token gho_revoked", None]
+        assert source.auth._disabled_tokens == {"gho_revoked"}
+
+    def test_bad_env_token_matching_gh_cli_still_falls_back_anonymous(self, monkeypatch):
+        """A disabled env token must not re-enter through gh-cli fallback."""
+        monkeypatch.setenv("GITHUB_TOKEN", "gho_same_revoked")
+        source = GitHubSource(auth=GitHubAuth())
+        seen_auth_headers = []
+
+        def fake_get(*args, **kwargs):
+            seen_auth_headers.append((kwargs.get("headers") or {}).get("Authorization"))
+            if len(seen_auth_headers) == 1:
+                return httpx.Response(401, json={"message": "Bad credentials"})
+            return httpx.Response(200, json={"ok": True})
+
+        with (
+            patch.object(source.auth, "_try_gh_cli", return_value="gho_same_revoked"),
+            patch.object(source.auth, "_try_github_app", return_value=None),
+            patch("tools.skills_hub.httpx.get", side_effect=fake_get),
+        ):
+            result = source._github_get("https://api.github.com/repos/acme/skills")
+
+        assert result is not None
+        assert result.status_code == 200
+        assert seen_auth_headers == ["token gho_same_revoked", None]
+        assert source.auth._disabled_tokens == {"gho_same_revoked"}
+
+    def test_multiple_bad_credentials_still_fall_back_anonymous(self, monkeypatch):
+        """Auth fallback should not consume the transient retry budget."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_revoked")
+        monkeypatch.setenv("GH_TOKEN", "github_pat_revoked")
+        source = GitHubSource(auth=GitHubAuth())
+        seen_auth_headers = []
+
+        def fake_get(*args, **kwargs):
+            seen_auth_headers.append((kwargs.get("headers") or {}).get("Authorization"))
+            if len(seen_auth_headers) < 4:
+                return httpx.Response(401, json={"message": "Bad credentials"})
+            return httpx.Response(200, json={"ok": True})
+
+        with (
+            patch.object(source.auth, "_try_gh_cli", return_value="gho_revoked"),
+            patch.object(source.auth, "_try_github_app", return_value=None),
+            patch("tools.skills_hub.httpx.get", side_effect=fake_get),
+        ):
+            result = source._github_get("https://api.github.com/repos/acme/skills")
+
+        assert result is not None
+        assert result.status_code == 200
+        assert seen_auth_headers == [
+            "token ghp_revoked",
+            "token github_pat_revoked",
+            "token gho_revoked",
+            None,
+        ]
+        assert source.auth._disabled_tokens == {
+            "ghp_revoked",
+            "github_pat_revoked",
+            "gho_revoked",
+        }
+
+    def test_repo_tree_lookup_recovers_from_bad_env_github_token(self, monkeypatch):
+        """Tree-cache path must share the same bad-token recovery as file fetches."""
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_revoked")
+        source = GitHubSource(auth=GitHubAuth())
+        seen_auth_headers = []
+
+        def fake_get(url, *args, **kwargs):
+            seen_auth_headers.append((kwargs.get("headers") or {}).get("Authorization"))
+            if len(seen_auth_headers) == 1:
+                return httpx.Response(401, json={"message": "Bad credentials"})
+            if url.endswith("/repos/acme/skills"):
+                return httpx.Response(200, json={"default_branch": "main"})
+            return httpx.Response(200, json={"tree": [
+                {"type": "blob", "path": "demo-skill/SKILL.md"},
+            ]})
+
+        with (
+            patch.object(source.auth, "_try_gh_cli", return_value=None),
+            patch.object(source.auth, "_try_github_app", return_value=None),
+            patch("tools.skills_hub.httpx.get", side_effect=fake_get),
+        ):
+            tree = source._get_repo_tree("acme/skills")
+
+        assert tree is not None
+        assert seen_auth_headers == ["token ghp_revoked", None, None]
+
 
 class TestCreateSourceRouter:
     def test_includes_skills_sh_source(self):

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -247,6 +247,24 @@ class GitHubAuth:
         self._cached_token: Optional[str] = None
         self._cached_method: Optional[str] = None
         self._app_token_expiry: float = 0
+        self._disabled_tokens: set[str] = set()
+
+    def mark_bad_credentials(self, authorization_header: Optional[str] = None) -> None:
+        """Forget a token that GitHub rejected so fallback auth can run.
+
+        A stale GITHUB_TOKEN in ~/.hermes/.env should not permanently mask a
+        valid GH_TOKEN, gh-cli token, or anonymous access to public skill
+        repositories.
+        """
+        token = ""
+        if authorization_header:
+            parts = authorization_header.split(None, 1)
+            token = parts[1].strip() if len(parts) == 2 else ""
+        if token:
+            self._disabled_tokens.add(token)
+        if not token or token == self._cached_token:
+            self._cached_token = None
+            self._cached_method = None
 
     def get_headers(self) -> Dict[str, str]:
         """Return authorization headers for GitHub API requests."""
@@ -266,27 +284,27 @@ class GitHubAuth:
 
     def _resolve_token(self) -> Optional[str]:
         # Return cached token if still valid
-        if self._cached_token:
+        if self._cached_token and self._cached_token not in self._disabled_tokens:
             if self._cached_method != "github-app" or time.time() < self._app_token_expiry:
                 return self._cached_token
 
         # 1. Environment variable
-        token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
-        if token:
-            self._cached_token = token
-            self._cached_method = "pat"
-            return token
+        for token in (os.environ.get("GITHUB_TOKEN"), os.environ.get("GH_TOKEN")):
+            if token and token not in self._disabled_tokens:
+                self._cached_token = token
+                self._cached_method = "pat"
+                return token
 
         # 2. gh CLI
         token = self._try_gh_cli()
-        if token:
+        if token and token not in self._disabled_tokens:
             self._cached_token = token
             self._cached_method = "gh-cli"
             return token
 
         # 3. GitHub App
         token = self._try_github_app()
-        if token:
+        if token and token not in self._disabled_tokens:
             self._cached_token = token
             self._cached_method = "github-app"
             self._app_token_expiry = time.time() + 3500  # ~58 min (tokens last 1 hour)
@@ -297,11 +315,16 @@ class GitHubAuth:
 
     def _try_gh_cli(self) -> Optional[str]:
         """Try to get a token from the gh CLI."""
+        env = os.environ.copy()
+        for key in ("GITHUB_TOKEN", "GH_TOKEN"):
+            if env.get(key) in self._disabled_tokens:
+                env.pop(key, None)
         try:
             result = subprocess.run(
                 ["gh", "auth", "token"],
                 capture_output=True, text=True, timeout=5,
                 stdin=subprocess.DEVNULL,
+                env=env,
             )
             if result.returncode == 0 and result.stdout.strip():
                 return result.stdout.strip()
@@ -603,32 +626,34 @@ class GitHubSource(SkillSource):
 
         # Resolve default branch
         try:
-            resp = httpx.get(
+            resp = self._github_get(
                 f"https://api.github.com/repos/{repo}",
-                headers=headers, timeout=15, follow_redirects=True,
+                headers=headers, timeout=15,
             )
-            if resp.status_code != 200:
-                self._check_rate_limit_response(resp)
+            if resp is None or resp.status_code != 200:
+                if resp is not None:
+                    self._check_rate_limit_response(resp)
                 return None
             default_branch = resp.json().get("default_branch", "main")
-        except (httpx.HTTPError, ValueError):
+        except ValueError:
             return None
 
         # Fetch recursive tree
         try:
-            resp = httpx.get(
+            resp = self._github_get(
                 f"https://api.github.com/repos/{repo}/git/trees/{default_branch}",
                 params={"recursive": "1"},
-                headers=headers, timeout=30, follow_redirects=True,
+                timeout=30,
             )
-            if resp.status_code != 200:
-                self._check_rate_limit_response(resp)
+            if resp is None or resp.status_code != 200:
+                if resp is not None:
+                    self._check_rate_limit_response(resp)
                 return None
             tree_data = resp.json()
             if tree_data.get("truncated"):
                 logger.debug("Git tree truncated for %s, cannot cache", repo)
                 return None
-        except (httpx.HTTPError, ValueError):
+        except ValueError:
             return None
 
         entries = tree_data.get("tree", [])
@@ -675,7 +700,9 @@ class GitHubSource(SkillSource):
         hdrs = headers if headers is not None else self.auth.get_headers()
         backoff = 1.0
         last_resp: Optional["httpx.Response"] = None
-        for attempt in range(max_retries):
+        attempt = 0
+        auth_fallbacks_remaining = 4  # env GITHUB_TOKEN, GH_TOKEN, gh CLI, app/anonymous
+        while attempt < max_retries:
             try:
                 resp = httpx.get(
                     url, params=params, headers=hdrs,
@@ -685,6 +712,7 @@ class GitHubSource(SkillSource):
                 logger.debug("GitHub GET %s failed (attempt %d/%d): %s",
                              url, attempt + 1, max_retries, e)
                 if attempt < max_retries - 1:
+                    attempt += 1
                     time.sleep(backoff)
                     backoff = min(backoff * 2, 30.0)
                     continue
@@ -693,6 +721,27 @@ class GitHubSource(SkillSource):
             last_resp = resp
             if resp.status_code == 200:
                 return resp
+
+            # A stale/revoked credential should not make public repositories
+            # look unavailable. Drop that credential and retry using the next
+            # auth source (GH_TOKEN / gh CLI / GitHub App / anonymous). These
+            # auth fallbacks are separate from transient retry budget.
+            if (
+                resp.status_code == 401
+                and hdrs.get("Authorization")
+                and auth_fallbacks_remaining > 0
+            ):
+                self.auth.mark_bad_credentials(hdrs.get("Authorization"))
+                fresh_headers = self.auth.get_headers()
+                if fresh_headers.get("Authorization") != hdrs.get("Authorization"):
+                    merged_headers = dict(hdrs)
+                    if fresh_headers.get("Authorization"):
+                        merged_headers["Authorization"] = fresh_headers["Authorization"]
+                    else:
+                        merged_headers.pop("Authorization", None)
+                    hdrs = merged_headers
+                    auth_fallbacks_remaining -= 1
+                    continue
 
             # Rate-limited: honor the reset header when present, else back off.
             if resp.status_code in (403, 429):
@@ -712,6 +761,7 @@ class GitHubSource(SkillSource):
                         "GitHub rate limited on %s, waiting %.1fs (attempt %d/%d)",
                         url, wait, attempt + 1, max_retries,
                     )
+                    attempt += 1
                     time.sleep(wait)
                     backoff = min(backoff * 2, 30.0)
                     continue
@@ -721,6 +771,7 @@ class GitHubSource(SkillSource):
 
             # 5xx — retry; 4xx (other than rate limit) — return immediately.
             if 500 <= resp.status_code < 600 and attempt < max_retries - 1:
+                attempt += 1
                 time.sleep(backoff)
                 backoff = min(backoff * 2, 30.0)
                 continue


### PR DESCRIPTION
## Summary

Fix skills hub update checks when a stale/revoked GitHub credential is present in the environment.

Hermes CLI loads `~/.hermes/.env` before running `hermes skills check`. If that file contains a revoked `GITHUB_TOKEN`, GitHub returns `401 Bad credentials` even for public repositories. Before this change, that credential masked otherwise-working fallback paths (`GH_TOKEN`, `gh auth token`, GitHub App, or anonymous public access), so hub-installed public skills could show as `unavailable`.

This surfaced with a public skills.sh install:

```bash
hermes skills check atlas-contract
# before: atlas-contract | skills.sh | unavailable
# after:  atlas-contract | skills.sh | up_to_date
```

## What changed

- Track tokens rejected by GitHub with `401 Bad credentials`.
- Skip disabled tokens across:
  - `GITHUB_TOKEN`
  - `GH_TOKEN`
  - `gh auth token`
  - GitHub App token lookup
- Strip disabled env tokens from the environment passed to `gh auth token`, so `gh` does not simply echo the same stale env credential back.
- Retry a 401 response with the next auth source, preserving caller-supplied headers (e.g. `Accept: application/vnd.github.v3.raw` for Contents API raw fetches).
- Keep auth fallback separate from transient network retry budget, so multiple bad credentials do not prevent anonymous public fallback.
- Route the GitHub tree-cache path through `_github_get()` so it benefits from the same fallback behavior.

## Tests

```bash
pytest tests/tools/test_skills_hub.py -q
# 150 passed

git diff --check
```

Manual verification on a machine with a stale `.env` `GITHUB_TOKEN` and valid `gh auth`:

```bash
hermes skills check atlas-contract
hermes skills check atlas-ledger
# both report up_to_date
```
