### PR TITLE
feat(kanban): allow create tasks to pin worker model

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -76,6 +76,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "completed_at": t.completed_at,
         "result": t.result,
         "skills": list(t.skills) if t.skills else [],
+        "model_override": t.model_override,
         "max_retries": t.max_retries,
         "session_id": t.session_id,
         "workflow_template_id": t.workflow_template_id,
@@ -338,6 +339,8 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "(repeatable). The kanban lifecycle is already "
                                "injected automatically. Example: "
                                "--skill translation --skill github-code-review")
+    p_create.add_argument("--model-override", default=None,
+                          help="Model id to use when dispatching this task's worker")
     p_create.add_argument("--max-retries", type=int, default=None,
                           metavar="N",
                           help="Per-task override for the consecutive-failure "
@@ -1343,6 +1346,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             idempotency_key=getattr(args, "idempotency_key", None),
             max_runtime_seconds=max_runtime,
             skills=getattr(args, "skills", None) or None,
+            model_override=getattr(args, "model_override", None),
             max_retries=max_retries,
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2400,6 +2400,7 @@ def create_task(
     idempotency_key: Optional[str] = None,
     max_runtime_seconds: Optional[int] = None,
     skills: Optional[Iterable[str]] = None,
+    model_override: Optional[str] = None,
     max_retries: Optional[int] = None,
     goal_mode: bool = False,
     goal_max_turns: Optional[int] = None,
@@ -2536,6 +2537,10 @@ def create_task(
             )
         skills_list = cleaned
 
+    model_override_value: Optional[str] = None
+    if model_override is not None:
+        model_override_value = str(model_override).strip() or None
+
     # Idempotency check — return the existing task instead of creating a
     # duplicate. Done BEFORE entering write_txn to keep the fast path fast
     # and to avoid holding a write lock during the lookup. Race is
@@ -2635,8 +2640,8 @@ def create_task(
                         created_by, created_at, workspace_kind, workspace_path,
                         branch_name, project_id, tenant, idempotency_key,
                         max_runtime_seconds,
-                        skills, max_retries, goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        skills, model_override, max_retries, goal_mode, goal_max_turns, session_id
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -2655,6 +2660,7 @@ def create_task(
                         idempotency_key,
                         int(max_runtime_seconds) if max_runtime_seconds is not None else None,
                         json.dumps(skills_list) if skills_list is not None else None,
+                        model_override_value,
                         int(max_retries) if max_retries is not None else None,
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
@@ -2677,6 +2683,7 @@ def create_task(
                         "tenant": tenant,
                         "branch_name": branch_name,
                         "skills": list(skills_list) if skills_list else None,
+                        "model_override": model_override_value,
                         "goal_mode": bool(goal_mode) or None,
                     },
                 )

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -91,6 +91,20 @@ def test_run_slash_create_and_list(kanban_home):
     assert "alice" in out
 
 
+def test_run_slash_create_accepts_model_override(kanban_home):
+    out = kc.run_slash(
+        "create 'ship with pinned model' --assignee alice "
+        "--model-override openai/gpt-5-codex --json"
+    )
+    task = json.loads(out)
+
+    assert task["model_override"] == "openai/gpt-5-codex"
+
+    with kb.connect() as conn:
+        stored = kb.get_task(conn, task["id"])
+    assert stored.model_override == "openai/gpt-5-codex"
+
+
 def test_run_slash_create_worktree_path_and_branch(kanban_home, tmp_path):
     target = tmp_path / ".worktrees" / "t6-wire"
     target_arg = target.as_posix()

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -222,6 +222,20 @@ def test_create_task_no_parents_is_ready(kanban_home):
     assert t.workspace_kind == "scratch"
 
 
+def test_create_task_preserves_model_override(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="use pinned model",
+            assignee="alice",
+            model_override="openai/gpt-5-codex",
+        )
+        t = kb.get_task(conn, tid)
+
+    assert t is not None
+    assert t.model_override == "openai/gpt-5-codex"
+
+
 def test_create_task_with_parent_is_todo_until_parent_done(kanban_home):
     with kb.connect() as conn:
         p = kb.create_task(conn, title="parent")

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -967,6 +967,26 @@ def test_create_parses_triage_string_true(worker_env):
         conn.close()
 
 
+def test_create_accepts_model_override(worker_env):
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+    out = kt._handle_create({
+        "title": "use pinned model",
+        "assignee": "peer",
+        "model": "openai/gpt-5-codex",
+    })
+    d = json.loads(out)
+
+    assert d["ok"] is True
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, d["task_id"])
+        assert task.model_override == "openai/gpt-5-codex"
+    finally:
+        conn.close()
+
+
 def test_create_rejects_bad_triage(worker_env):
     from tools import kanban_tools as kt
     out = kt._handle_create({
@@ -2010,3 +2030,11 @@ def test_maybe_auto_subscribe_swallows_add_notify_sub_failure(monkeypatch, worke
     d = json.loads(out)
     assert d["ok"] is True, d
     assert d["subscribed"] is False, d
+
+
+def test_kanban_create_schema_exposes_model_override():
+    from tools import kanban_tools as kt
+
+    props = kt.KANBAN_CREATE_SCHEMA["parameters"]["properties"]
+    assert props["model"]["type"] == "string"
+    assert "model" not in kt.KANBAN_CREATE_SCHEMA["parameters"].get("required", [])

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -805,6 +805,11 @@ def _handle_create(args: dict, **kw) -> str:
     if goal_bool_error:
         return tool_error(goal_bool_error)
     goal_max_turns = args.get("goal_max_turns")
+    model_override = args.get("model")
+    if model_override is None:
+        model_override = args.get("model_override")
+    if model_override is not None:
+        model_override = str(model_override).strip() or None
     if isinstance(parents, str):
         parents = [parents]
     if not isinstance(parents, (list, tuple)):
@@ -846,6 +851,7 @@ def _handle_create(args: dict, **kw) -> str:
                     if max_runtime_seconds is not None else None
                 ),
                 skills=skills,
+                model_override=model_override,
                 goal_mode=goal_mode,
                 goal_max_turns=(
                     int(goal_max_turns) if goal_max_turns is not None else None
@@ -1433,6 +1439,13 @@ KANBAN_CREATE_SCHEMA = {
                     "task, ['github-code-review'] for a reviewer task. "
                     "The names must match skills installed on the "
                     "assignee's profile."
+                ),
+            },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Optional per-task model id. When set, the dispatcher "
+                    "passes this model to the assigned worker for this card."
                 ),
             },
             "goal_mode": {


### PR DESCRIPTION
## What does this PR do?

Adds the missing create-time entry points for per-task Kanban worker model overrides. The DB row, Task dataclass, dispatcher, and show/list output already understood `model_override`; this PR wires the current create paths into that existing field instead of adding a new surface.

## Related Issue

Fixes #46376

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/kanban_db.py`: adds `model_override` to `create_task()`, stores it on insert, and records it in the creation event metadata.
- `hermes_cli/kanban.py`: adds `hermes kanban create --model-override <model>` and includes `model_override` in JSON task output.
- `tools/kanban_tools.py`: adds optional `model` to the `kanban_create` tool schema and maps it to the existing DB field.
- Adds DB, CLI slash, tool handler, and schema regression coverage.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli.py tests/tools/test_kanban_tools.py`
2. Verified 349 tests passed across the related Kanban DB, CLI, and tool suites.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — no platform-specific paths/process behavior changed
- [x] I've updated tool descriptions/schemas if I changed tool behavior

## Screenshots / Logs

Focused test output:

```
=== Summary: 3 files, 349 tests passed, 0 failed (100% complete) in 11.4s (20 workers) ===
```