### PR TITLE
fix(tirith): support Termux musl auto-install

### DIFF
--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -365,6 +365,12 @@ class TestUnsupportedPlatform:
              patch("tools.tirith_security.platform.machine", return_value="riscv64"):
             assert _tirith_mod.is_platform_supported() is False
 
+    def test_detect_target_prefers_musl_on_termux(self):
+        with patch("tools.tirith_security.platform.system", return_value="Linux"), \
+             patch("tools.tirith_security.platform.machine", return_value="aarch64"), \
+             patch("tools.tirith_security.is_termux", return_value=True):
+            assert _tirith_mod._detect_target() == "aarch64-unknown-linux-musl"
+
     @patch("tools.tirith_security._load_security_config")
     def test_ensure_installed_unsupported_returns_none_no_thread(self, mock_cfg):
         """Windows: don't start a background install thread, don't write a
@@ -535,6 +541,50 @@ class TestExplicitPathNoAutoDownload:
         assert result == "/auto/tirith"
 
         _tirith_mod._resolved_path = None
+
+
+class TestDownloadFile:
+    def test_download_file_uses_proxy_handler_and_longer_default_timeout(self, tmp_path):
+        opener = MagicMock()
+        opener.open.return_value.__enter__.return_value = io.BytesIO(b"payload")
+        dest = tmp_path / "tirith.tar.gz"
+
+        with patch("tools.tirith_security.urllib.request.getproxies", return_value={"https": "http://proxy:8080"}), \
+             patch("tools.tirith_security.urllib.request.ProxyHandler") as mock_proxy_handler, \
+             patch("tools.tirith_security.urllib.request.build_opener", return_value=opener) as mock_build_opener:
+            _tirith_mod._download_file("https://example.com/tirith.tar.gz", str(dest))
+
+        mock_proxy_handler.assert_called_once_with({"https": "http://proxy:8080"})
+        mock_build_opener.assert_called_once()
+        _, kwargs = opener.open.call_args
+        assert kwargs["timeout"] == 60
+        assert dest.read_bytes() == b"payload"
+
+    def test_download_file_uses_curl_for_socks_proxy(self, tmp_path):
+        dest = tmp_path / "tirith.tar.gz"
+
+        with patch("tools.tirith_security.urllib.request.getproxies", return_value={"https": "socks5h://127.0.0.1:7890"}), \
+             patch("tools.tirith_security.shutil.which", return_value="/usr/bin/curl"), \
+             patch("tools.tirith_security.subprocess.run") as mock_run, \
+             patch("tools.tirith_security.urllib.request.build_opener") as mock_build_opener:
+            _tirith_mod._download_file("https://example.com/tirith.tar.gz", str(dest))
+
+        mock_build_opener.assert_not_called()
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args.args[0]
+        assert cmd[:6] == [
+            "/usr/bin/curl",
+            "-fL",
+            "--max-time",
+            "60",
+            "-o",
+            str(dest),
+        ]
+        assert cmd[-3:] == [
+            "-x",
+            "socks5h://127.0.0.1:7890",
+            "https://example.com/tirith.tar.gz",
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -32,9 +32,10 @@ import tarfile
 import tempfile
 import threading
 import time
+import urllib.parse
 import urllib.request
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, is_termux
 
 logger = logging.getLogger(__name__)
 
@@ -227,7 +228,7 @@ def _detect_target() -> str | None:
     if system == "Darwin":
         plat = "apple-darwin"
     elif system in {"Linux", "Android"}:
-        plat = "unknown-linux-gnu"
+        plat = "unknown-linux-musl" if is_termux() else "unknown-linux-gnu"
     else:
         return None
 
@@ -251,13 +252,38 @@ def is_platform_supported() -> bool:
     return _detect_target() is not None
 
 
-def _download_file(url: str, dest: str, timeout: int = 10):
+def _proxy_url_for_download(url: str) -> str | None:
+    """Return the best proxy URL for a download target, if configured."""
+    proxies = urllib.request.getproxies()
+    scheme = urllib.parse.urlparse(url).scheme
+    return (
+        proxies.get(scheme)
+        or proxies.get("all")
+        or os.getenv("SOCKS_PROXY")
+        or os.getenv("socks_proxy")
+    )
+
+
+def _download_file(url: str, dest: str, timeout: int = 60):
     """Download a URL to a local file."""
+    timeout = max(1, _env_int("TIRITH_DOWNLOAD_TIMEOUT", timeout))
     req = urllib.request.Request(url)
     token = os.getenv("GITHUB_TOKEN")
     if token:
         req.add_header("Authorization", f"token {token}")
-    with urllib.request.urlopen(req, timeout=timeout) as resp, open(dest, "wb") as f:
+    proxy_url = _proxy_url_for_download(url)
+    if proxy_url and proxy_url.lower().startswith(("socks4://", "socks4a://", "socks5://", "socks5h://")):
+        curl = shutil.which("curl")
+        if curl:
+            cmd = [curl, "-fL", "--max-time", str(timeout), "-o", dest]
+            if token:
+                cmd.extend(["-H", f"Authorization: token {token}"])
+            cmd.extend(["-x", proxy_url, url])
+            subprocess.run(cmd, check=True, capture_output=True)
+            return
+
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler(urllib.request.getproxies()))
+    with opener.open(req, timeout=timeout) as resp, open(dest, "wb") as f:
         shutil.copyfileobj(resp, f)
 
 


### PR DESCRIPTION
## Summary
- detect Termux as a musl target for Tirith auto-install
- make Tirith downloads proxy-aware, including SOCKS via curl fallback
- raise the default download timeout and cover the regressions with tests

## Testing
- uv run --frozen pytest tests/tools/test_tirith_security.py
- uv run --frozen ruff check tools/tirith_security.py tests/tools/test_tirith_security.py
- git diff --check HEAD^ HEAD

Fixes #46353