### PR TITLE
fix(gateway): acknowledge queued busy text

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3622,12 +3622,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         effective_mode = self._busy_input_mode
         busy_text_mode = getattr(self, "_busy_text_mode", "interrupt")
-        if (
-            event.message_type == MessageType.TEXT
-            and busy_text_mode == "queue"
-            and effective_mode != "steer"
-        ):
-            return False
+        # Queue-mode TEXT follow-ups still go through this runner-level
+        # handler so the user gets the terse "queued" acknowledgement. Older
+        # code returned False here to let BasePlatformAdapter debounce and
+        # merge the text silently; that preserved the follow-up, but made
+        # WhatsApp/Telegram/Slack look like they had swallowed the message.
 
         # Steer mode: inject mid-run via running_agent.steer() instead of
         # queueing + interrupting.  If the agent isn't running yet

--- a/tests/gateway/test_busy_session_auth_bypass.py
+++ b/tests/gateway/test_busy_session_auth_bypass.py
@@ -165,6 +165,35 @@ class TestBusySessionAuthBypass:
         assert sk in adapter._pending_messages
 
     @pytest.mark.asyncio
+    async def test_authorized_queue_mode_text_sends_terse_ack(self):
+        """Queue-mode text should be preserved and visibly acknowledged."""
+        from gateway.run import GatewayRunner
+
+        runner, sentinel = _make_runner(authorized_users={"user1"})
+        runner._busy_input_mode = "queue"
+        runner._busy_text_mode = "queue"
+        adapter = _make_adapter()
+
+        event = _make_event(text="follow up", user_id="user1")
+        sk = build_session_key(event.source)
+
+        running_agent = MagicMock()
+        running_agent.get_activity_summary.return_value = {}
+        runner._running_agents[sk] = running_agent
+        runner._running_agents_ts[sk] = time.time()
+        runner.adapters[event.source.platform] = adapter
+
+        result = await GatewayRunner._handle_active_session_busy_message(
+            runner, event, sk
+        )
+
+        assert result is True
+        assert adapter._pending_messages[sk].text == "follow up"
+        adapter._send_with_retry.assert_awaited_once()
+        sent = adapter._send_with_retry.await_args.kwargs["content"]
+        assert "Queued for the next turn" in sent
+
+    @pytest.mark.asyncio
     async def test_unauthorized_user_during_drain_still_blocked(self):
         """Even during drain mode, unauthorized users must be dropped."""
         from gateway.run import GatewayRunner


### PR DESCRIPTION
## Summary
- keep queue-mode text follow-ups in the runner busy handler so users get the queued acknowledgement
- preserve the existing pending-message merge behavior
- add a regression test for queue-mode busy text acknowledgements

## Test Plan
- python3 -m py_compile gateway/run.py tests/gateway/test_busy_session_auth_bypass.py
- python3 -m pytest tests/gateway/test_busy_session_auth_bypass.py -q -o 'addopts='
