### PR TITLE
fix(security): block read_file credential access across sibling profiles

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -206,6 +206,19 @@ def get_read_block_error(path: str) -> Optional[str]:
         except Exception:
             continue
 
+    # Also enumerate sibling profile directories under <root>/profiles/
+    # so credential stores in other profiles are blocked too (#46411).
+    try:
+        profiles_dir = _hermes_root_path().resolve() / "profiles"
+        if profiles_dir.is_dir():
+            for child in profiles_dir.iterdir():
+                if child.is_dir():
+                    real = child.resolve()
+                    if real not in hermes_dirs:
+                        hermes_dirs.append(real)
+    except Exception:
+        pass
+
     # Skills .hub: prompt-injection carriers.
     for hd in hermes_dirs:
         blocked_dirs = [

--- a/tests/agent/test_file_safety_credentials.py
+++ b/tests/agent/test_file_safety_credentials.py
@@ -337,3 +337,63 @@ def test_profile_mode_blocks_root_credentials(tmp_path, monkeypatch):
     root_tok.parent.mkdir(parents=True, exist_ok=True)
     root_tok.write_text("x")
     assert "MCP token" in (get_read_block_error(str(root_tok)) or "")
+
+
+def test_sibling_profile_credentials_blocked(tmp_path, monkeypatch):
+    """Credential stores in sibling profiles must also be blocked (#46411).
+
+    A session in the default/root profile should NOT be able to read
+    ``auth.json`` or ``.anthropic_oauth.json`` from a sibling profile
+    under ``<root>/profiles/<other>/``.
+    """
+    import agent.file_safety as fs
+
+    root = tmp_path / "hermes"
+    active = root / "profiles" / "active"
+    sibling = root / "profiles" / "sibling"
+    active.mkdir(parents=True)
+    sibling.mkdir(parents=True)
+    monkeypatch.setattr(fs, "_hermes_home_path", lambda: active)
+    monkeypatch.setattr(fs, "_hermes_root_path", lambda: root)
+
+    from agent.file_safety import get_read_block_error
+
+    # Sibling profile auth.json: blocked
+    sib_auth = sibling / "auth.json"
+    sib_auth.write_text('{"token": "sibling_secret"}')
+    err = get_read_block_error(str(sib_auth))
+    assert err is not None, "sibling profile auth.json must be blocked"
+    assert "credential store" in err
+
+    # Sibling profile .anthropic_oauth.json: blocked
+    sib_oauth = sibling / ".anthropic_oauth.json"
+    sib_oauth.write_text('{"key": "sibling_oauth"}')
+    err = get_read_block_error(str(sib_oauth))
+    assert err is not None, "sibling profile .anthropic_oauth.json must be blocked"
+
+    # Sibling profile mcp-tokens dir: blocked
+    sib_mcp = sibling / "mcp-tokens"
+    sib_mcp.mkdir()
+    (sib_mcp / "token.json").write_text("secret")
+    err = get_read_block_error(str(sib_mcp))
+    assert err is not None, "sibling profile mcp-tokens/ must be blocked"
+
+    # Sibling profile webhook_subscriptions.json: blocked
+    sib_webhook = sibling / "webhook_subscriptions.json"
+    sib_webhook.write_text("{}")
+    err = get_read_block_error(str(sib_webhook))
+    assert err is not None, "sibling profile webhook_subscriptions.json must be blocked"
+
+    # Non-credential file in sibling profile: NOT blocked
+    sib_readme = sibling / "README.md"
+    sib_readme.write_text("# sibling")
+    err = get_read_block_error(str(sib_readme))
+    assert err is None, "non-credential file in sibling profile should be readable"
+
+    # Third sibling profile: also blocked
+    third = root / "profiles" / "third"
+    third.mkdir(parents=True)
+    third_auth = third / "auth.json"
+    third_auth.write_text('{"token": "third_secret"}')
+    err = get_read_block_error(str(third_auth))
+    assert err is not None, "third sibling profile auth.json must be blocked"


### PR DESCRIPTION
## What does this PR do?

Extends the `read_file` credential-store guard in `agent/file_safety.py` to also block reads of credential files (`auth.json`, `.anthropic_oauth.json`, `mcp-tokens/`, `webhook_subscriptions.json`, etc.) under sibling Hermes profiles at `<root>/profiles/<other>/`. Previously, only the active profile's credentials and the global root's credentials were blocked, leaving sibling profile stores readable by the agent.

## Related Issue

Fixes #46411

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/file_safety.py`: After building `hermes_dirs` from the active profile and global root, enumerate `<root>/profiles/*/` directories and add each to `hermes_dirs` so the credential-file denylist covers sibling profiles too. Wrapped in `try/except` to be fail-safe (no crash if profiles dir is missing or unreadable).
- `tests/agent/test_file_safety_credentials.py`: Added `test_sibling_profile_credentials_blocked` covering `auth.json`, `.anthropic_oauth.json`, `mcp-tokens/`, and `webhook_subscriptions.json` in sibling profiles, plus verification that non-credential files remain readable.

## How to Test

1. `pytest tests/agent/test_file_safety_credentials.py -v` — all 21 tests pass
2. `pytest tests/agent/test_file_safety_cross_profile.py tests/agent/test_file_safety.py -v` — all existing tests still pass
3. Manual: create a sibling profile with `auth.json`, verify `get_read_block_error()` returns a denial for that path

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_file_safety_credentials.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/file_safety.py::get_read_block_error` (callers: `read_file_tool`, `tools/file_tools.py`)
- Blast radius: LOW — extends an existing denylist; no behavior change for paths already blocked
- Related patterns: Same widening shape as #15981 (write deny) and #14157 (read deny for root credentials)
