### PR TITLE
fix(cli): recover project root outside editable installs

### DIFF
--- a/.paperclip_artifacts/candidate-skip-ledger.jsonl
+++ b/.paperclip_artifacts/candidate-skip-ledger.jsonl
@@ -1,2 +1,0 @@
-{"timestamp":"2026-06-15T02:31:09Z","issueNumber":46411,"issueUrl":"https://github.com/NousResearch/hermes-agent/issues/46411","reason":"active_linked_closing_pr","evidencePrUrl":"https://github.com/NousResearch/hermes-agent/pull/46412"}
-{"timestamp":"2026-06-15T02:31:09Z","issueNumber":46408,"issueUrl":"https://github.com/NousResearch/hermes-agent/issues/46408","reason":"claimed_in_issue_body","evidencePrUrl":null}

--- a/.paperclip_artifacts/candidate-skip-ledger.jsonl
+++ b/.paperclip_artifacts/candidate-skip-ledger.jsonl
@@ -1,0 +1,2 @@
+{"timestamp":"2026-06-15T02:31:09Z","issueNumber":46411,"issueUrl":"https://github.com/NousResearch/hermes-agent/issues/46411","reason":"active_linked_closing_pr","evidencePrUrl":"https://github.com/NousResearch/hermes-agent/pull/46412"}
+{"timestamp":"2026-06-15T02:31:09Z","issueNumber":46408,"issueUrl":"https://github.com/NousResearch/hermes-agent/issues/46408","reason":"claimed_in_issue_body","evidencePrUrl":null}

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -31,6 +31,11 @@ from typing import Dict, Any, Optional, List, Tuple
 
 from hermes_cli.secret_prompt import masked_secret_prompt
 
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
+    import tomli as tomllib
+
 logger = logging.getLogger(__name__)
 
 # Track which (config_path, mtime_ns, size) tuples we've already warned about
@@ -605,9 +610,55 @@ def get_env_path() -> Path:
     """Get the .env file path (for API keys)."""
     return get_hermes_home() / ".env"
 
+def _is_hermes_project_root(path: Path) -> bool:
+    """Return True when ``path`` looks like a Hermes source checkout."""
+    if not path or not path.is_dir():
+        return False
+
+    pyproject_path = path / "pyproject.toml"
+    hermes_main = path / "hermes_cli" / "main.py"
+    if not pyproject_path.is_file() or not hermes_main.is_file():
+        return False
+
+    try:
+        with pyproject_path.open("rb") as handle:
+            pyproject = tomllib.load(handle)
+    except (OSError, tomllib.TOMLDecodeError):
+        return False
+
+    project = pyproject.get("project")
+    return isinstance(project, dict) and project.get("name") == "hermes-agent"
+
 def get_project_root() -> Path:
-    """Get the project installation directory."""
-    return Path(__file__).parent.parent.resolve()
+    """Get the best Hermes project root for update/build style commands.
+
+    In editable/dev installs this is the checkout root containing
+    ``pyproject.toml``. In pip/site-packages installs there is no repo root
+    next to ``hermes_cli/``, so we first honor ``HERMES_PROJECT_ROOT`` and
+    then walk upward from the current working directory to recover the real
+    checkout when the operator launched ``hermes`` from inside one.
+    """
+    env_root = os.environ.get("HERMES_PROJECT_ROOT", "").strip()
+    if env_root:
+        candidate = Path(env_root).expanduser()
+        if _is_hermes_project_root(candidate):
+            return candidate.resolve()
+
+    install_root = Path(__file__).parent.parent.resolve()
+    if _is_hermes_project_root(install_root):
+        return install_root
+
+    try:
+        cwd = Path.cwd().resolve()
+    except OSError:
+        cwd = None
+
+    if cwd is not None:
+        for candidate in (cwd, *cwd.parents):
+            if _is_hermes_project_root(candidate):
+                return candidate
+
+    return install_root
 
 def _resolve_hermes_uid_gid() -> tuple[Optional[int], Optional[int]]:
     """Read the HERMES_UID / HERMES_GID env vars set by Docker deployments.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -319,9 +319,10 @@ def _require_tty(command_name: str) -> None:
         sys.exit(1)
 
 
-# Add project root to path
-PROJECT_ROOT = Path(__file__).parent.parent.resolve()
-sys.path.insert(0, str(PROJECT_ROOT))
+# Add the package parent to path so local-source imports work before
+# get_project_root() resolves the real checkout root for update/build flows.
+_IMPORT_ROOT = Path(__file__).parent.parent.resolve()
+sys.path.insert(0, str(_IMPORT_ROOT))
 
 
 # ---------------------------------------------------------------------------
@@ -498,9 +499,10 @@ _apply_profile_override()
 
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
-from hermes_cli.config import get_hermes_home
+from hermes_cli.config import get_hermes_home, get_project_root
 from hermes_cli.env_loader import load_hermes_dotenv
 
+PROJECT_ROOT = get_project_root()
 load_hermes_dotenv(project_env=PROJECT_ROOT / ".env")
 
 # Bridge security.redact_secrets from config.yaml → HERMES_REDACT_SECRETS env

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -11,6 +11,7 @@ from hermes_cli.config import (
     DEFAULT_CONFIG,
     check_config_version,
     get_hermes_home,
+    get_project_root,
     ensure_hermes_home,
     get_compatible_custom_providers,
     load_config,
@@ -60,6 +61,38 @@ class TestEnsureHermesHome:
             soul_path.write_text("custom soul", encoding="utf-8")
             ensure_hermes_home()
             assert soul_path.read_text(encoding="utf-8") == "custom soul"
+
+
+class TestGetProjectRoot:
+    def test_prefers_repo_root_from_cwd_when_running_from_site_packages(self, tmp_path, monkeypatch):
+        repo_root = tmp_path / "hermes-agent"
+        (repo_root / "hermes_cli").mkdir(parents=True)
+        (repo_root / "hermes_cli" / "main.py").write_text("", encoding="utf-8")
+        (repo_root / "pyproject.toml").write_text(
+            "[project]\nname = \"hermes-agent\"\n",
+            encoding="utf-8",
+        )
+
+        fake_site_packages = tmp_path / "site-packages" / "hermes_cli"
+        fake_site_packages.mkdir(parents=True)
+        monkeypatch.setattr("hermes_cli.config.__file__", str(fake_site_packages / "config.py"))
+        monkeypatch.chdir(repo_root / "hermes_cli")
+        monkeypatch.delenv("HERMES_PROJECT_ROOT", raising=False)
+
+        assert get_project_root() == repo_root.resolve()
+
+    def test_honors_valid_hermes_project_root_env_override(self, tmp_path, monkeypatch):
+        repo_root = tmp_path / "custom-root"
+        (repo_root / "hermes_cli").mkdir(parents=True)
+        (repo_root / "hermes_cli" / "main.py").write_text("", encoding="utf-8")
+        (repo_root / "pyproject.toml").write_text(
+            "[project]\nname = \"hermes-agent\"\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_PROJECT_ROOT", str(repo_root))
+
+        assert get_project_root() == repo_root.resolve()
 
 
 class TestLoadConfigDefaults:


### PR DESCRIPTION
## Summary
- recover the Hermes repo root from `HERMES_PROJECT_ROOT` or the current working tree when the CLI is running from site-packages
- make `hermes_cli.main` use the shared root resolver instead of hard-coding `Path(__file__).parent.parent`
- add regression tests covering the site-packages fallback and env override paths

## Testing
- uv run --frozen pytest tests/hermes_cli/test_config.py -k TestGetProjectRoot
- uv run --frozen pytest tests/hermes_cli/test_cmd_update.py -k BranchFallback
- uv run --frozen ruff check hermes_cli/config.py hermes_cli/main.py tests/hermes_cli/test_config.py
- git diff --check HEAD^ HEAD

Fixes #46406