### PR TITLE
fix: prevent copilot from leaking into model picker via GH_TOKEN

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1777,6 +1777,17 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         # Copilot tokens are resolved dynamically via `gh auth token` or
         # env vars (COPILOT_GITHUB_TOKEN / GH_TOKEN).  They don't live in
         # the auth store or credential pool, so we resolve them here.
+        #
+        # Gate on explicit configuration, mirroring the anthropic guard
+        # above.  Without this, a GH_TOKEN set for `gh` CLI silently
+        # auto-seeds copilot into the credential pool and makes it appear
+        # in the TUI model picker — even if the user never configured it.
+        try:
+            from hermes_cli.auth import is_provider_explicitly_configured
+            if not is_provider_explicitly_configured("copilot"):
+                return changed, active_sources
+        except ImportError:
+            pass
         try:
             from hermes_cli.copilot_auth import resolve_copilot_token, get_copilot_api_token
             token, source = resolve_copilot_token()

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1374,6 +1374,28 @@ def list_authenticated_providers(
 
         # Check if any env var is set
         has_creds = any(os.environ.get(ev) for ev in env_vars)
+        # Gate copilot behind explicit configuration.  GH_TOKEN /
+        # COPILOT_GITHUB_TOKEN set for `gh` CLI or from stale Docker
+        # env should not leak copilot into the picker unless the user
+        # actually selected copilot as their provider.
+        if has_creds and hermes_id == "copilot":
+            try:
+                from hermes_cli.auth import _load_auth_store
+                store = _load_auth_store()
+                active = (store.get("active_provider") or "").strip().lower()
+                is_active = active == "copilot"
+            except Exception:
+                is_active = False
+            try:
+                from hermes_cli.config import load_config
+                cfg = load_config()
+                model_cfg = cfg.get("model") if cfg else {}
+                cfg_provider = (model_cfg.get("provider") or "").strip().lower() if isinstance(model_cfg, dict) else ""
+                is_cfg_provider = cfg_provider == "copilot"
+            except Exception:
+                is_cfg_provider = False
+            if not is_active and not is_cfg_provider:
+                has_creds = False
         if not has_creds:
             try:
                 from hermes_cli.auth import _load_auth_store

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -96,7 +96,7 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
     ),
     "github-copilot": HermesOverlay(
         transport="openai_chat",
-        extra_env_vars=("COPILOT_GITHUB_TOKEN", "GH_TOKEN"),
+        extra_env_vars=(),
     ),
     "anthropic": HermesOverlay(
         transport="anthropic_messages",

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2228,9 +2228,14 @@ def test_load_pool_does_not_seed_claude_code_when_anthropic_not_configured(tmp_p
 
 
 def test_load_pool_seeds_copilot_via_gh_auth_token(tmp_path, monkeypatch):
-    """Copilot credentials from `gh auth token` should be seeded into the pool."""
+    """Copilot credentials from `gh auth token` should be seeded into the pool
+    when copilot is explicitly configured as the active provider."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
-    _write_auth_store(tmp_path, {"version": 1, "credential_pool": {}})
+    _write_auth_store(tmp_path, {
+        "version": 1,
+        "credential_pool": {},
+        "active_provider": "copilot",
+    })
 
     monkeypatch.setattr(
         "hermes_cli.copilot_auth.resolve_copilot_token",
@@ -2246,6 +2251,28 @@ def test_load_pool_seeds_copilot_via_gh_auth_token(tmp_path, monkeypatch):
     assert entries[0].source == "gh_cli"
     assert entries[0].access_token == "gho_fake_token_abc123"
     assert entries[0].base_url == "https://api.githubcopilot.com"
+
+
+def test_load_pool_does_not_seed_copilot_when_not_explicitly_configured(tmp_path, monkeypatch):
+    """Copilot should NOT be seeded from GH_TOKEN/env when the provider
+    is not explicitly configured (not active_provider, not model.provider)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {
+        "version": 1,
+        "credential_pool": {},
+        # No active_provider set — copilot is not explicitly configured
+    })
+
+    monkeypatch.setattr(
+        "hermes_cli.copilot_auth.resolve_copilot_token",
+        lambda: ("gho_fake_token_abc123", "gh auth token"),
+    )
+
+    from agent.credential_pool import load_pool
+    pool = load_pool("copilot")
+
+    assert not pool.has_credentials()
+    assert pool.entries() == []
 
 
 def test_load_pool_does_not_seed_copilot_when_no_token(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -1745,6 +1745,7 @@ def test_auth_remove_copilot_suppresses_all_variants(tmp_path, monkeypatch):
         {
             "version": 1,
             "credential_pool": {"copilot": []},
+            "active_provider": "copilot",
         },
     )
 


### PR DESCRIPTION
GH_TOKEN or COPILOT_GITHUB_TOKEN set for gh CLI or from stale Docker
env was causing GitHub Copilot to appear in the TUI model picker dropdown
even when the user never configured copilot as their provider.

Three-layer fix:
- providers.py: empty extra_env_vars for github-copilot overlay so the
  HERMES_OVERLAYS env-var short-circuit doesn't fire
- model_switch.py: gate copilot in Section 1 (PROVIDER_REGISTRY path)
  behind active_provider / model.provider check — not env vars, since
  the env var IS the leak vector
- credential_pool.py: gate _seed_from_singletons behind
  is_provider_explicitly_configured, mirroring the existing anthropic
  guard from PR #4210

## How to Test

1. Set GH_TOKEN or COPILOT_GITHUB_TOKEN in the environment
2. Ensure model.provider is NOT copilot and active_provider is NOT copilot
3. Open the model picker (TUI `/model`, desktop app dropdown, or
   `hermes model` CLI) — GitHub Copilot should NOT appear
4. Switch model.provider to copilot — it SHOULD appear in the picker

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows/Docker (desktop app + TUI)

### Documentation & Housekeeping
- [x] N/A — no config keys or architecture changes