### PR TITLE
fix(desktop): persist zoom level across conversations

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5056,6 +5056,14 @@ function wireCommonWindowHandlers(win) {
     event.preventDefault()
     openExternalUrl(url)
   })
+  // Restore persisted zoom level after every full navigation (cold start,
+  // session window open, reload).  Without this, a user who zooms in
+  // (Cmd+=) on one conversation and switches to another via sidebar loses
+  // their zoom — the new hash route triggers Chromium's per-URL
+  // per_host_zoom_levels which resets to 1.0 for the unseen URL.
+  win.webContents.on('did-finish-load', () => {
+    restorePersistedZoomLevel(win)
+  })
 }
 
 // Secondary "session windows" — one extra OS window per chat so a user can
@@ -5256,7 +5264,6 @@ function createWindow() {
   }
 
   mainWindow.webContents.once('did-finish-load', () => {
-    restorePersistedZoomLevel(mainWindow)
     broadcastBootProgress()
     sendWindowStateChanged()
     startHermes().catch(error => rememberLog(error.stack || error.message))


### PR DESCRIPTION
## Problem

When a user zooms in (`Cmd+=`) in one conversation and switches to another via the sidebar, the zoom level resets to default. This happens because Chromium stores per-URL zoom levels in `per_host_zoom_levels`, and each conversation has a unique hash route (`...#/session_a` vs `...#/session_b`). The unseen URL gets a fresh 1.0 zoom.

## Root Cause

The app already has zoom persistence infrastructure:

- `installZoomShortcuts()` — intercepts `Cmd+=`/`Cmd+-`/`Cmd+0` and writes the zoom level into both `webContents.setZoomLevel()` and `localStorage`
- `setAndPersistZoomLevel()` / `restorePersistedZoomLevel()` — round-trip through localStorage so zoom survives restarts

But `restorePersistedZoomLevel` was called **only** from a `once(did-finish-load)` on `mainWindow`. It was not wired into:
- Session windows (detached chats)
- Hash-route navigations inside the SPA (same window, new URL = new per-host entry)

## Fix

Move `restorePersistedZoomLevel` from the one-shot `mainWindow` callback into `wireCommonWindowHandlers`, which is already shared by every window (main + session). Now every `did-finish-load` — cold start, session window open, reload, and hash-route transitions — re-applies the user persisted zoom level.

## Changes

- `apps/desktop/electron/main.cjs`: +8 −1
- Move `restorePersistedZoomLevel(win)` into `wireCommonWindowHandlers` as a `did-finish-load` listener
- Remove the now-redundant call from `mainWindow` one-shot callback

## Testing

- [ ] Zoom in → switch conversation → zoom persists
- [ ] Zoom in → close & reopen window → zoom persists
- [ ] Zoom in → open session window → zoom is restored
- [ ] `Cmd+0` resets zoom → persists across navigation