### PR TITLE
fix(desktop): block Hermes credential stores in file preview IPC

### DIFF
--- a/apps/desktop/electron/hardening.cjs
+++ b/apps/desktop/electron/hardening.cjs
@@ -104,6 +104,23 @@ function sensitiveFileBlockReason(filePath) {
     return `${basename} is blocked because it may include auth credentials.`
   }
 
+  // Hermes credential stores (auth.json, OAuth tokens, MCP tokens, webhook secrets)
+  if (normalized.includes('/.hermes/') && (
+    basename === 'auth.json' ||
+    basename === '.anthropic_oauth.json' ||
+    basename === 'webhook_subscriptions.json'
+  )) {
+    return `${basename} is a Hermes credential store and is blocked.`
+  }
+
+  if (normalized.includes('/auth/') && basename.endsWith('_oauth.json')) {
+    return `${basename} contains OAuth credentials and is blocked.`
+  }
+
+  if (normalized.includes('/mcp-tokens/')) {
+    return 'MCP server token files are blocked.'
+  }
+
   return null
 }
 

--- a/apps/desktop/electron/hardening.test.cjs
+++ b/apps/desktop/electron/hardening.test.cjs
@@ -60,6 +60,19 @@ test('sensitiveFileBlockReason blocks obvious secret file patterns', () => {
   assert.match(String(sensitiveFileBlockReason('/tmp/server-cert.pem')), /\.pem/)
 })
 
+test('sensitiveFileBlockReason blocks Hermes credential stores', () => {
+  assert.match(String(sensitiveFileBlockReason('/home/user/.hermes/auth.json')), /credential store/)
+  assert.match(String(sensitiveFileBlockReason('/home/user/.hermes/.anthropic_oauth.json')), /credential store/)
+  assert.match(String(sensitiveFileBlockReason('/home/user/.hermes/webhook_subscriptions.json')), /credential store/)
+  assert.match(String(sensitiveFileBlockReason('/home/user/.hermes/auth/google_oauth.json')), /OAuth credentials/)
+  assert.match(String(sensitiveFileBlockReason('/home/user/.hermes/auth/xai_oauth.json')), /OAuth credentials/)
+  assert.match(String(sensitiveFileBlockReason('/home/user/.hermes/mcp-tokens/github.json')), /MCP server token/)
+
+  // Non-credential files in .hermes/ should NOT be blocked
+  assert.equal(sensitiveFileBlockReason('/home/user/.hermes/config.yaml'), null)
+  assert.equal(sensitiveFileBlockReason('/home/user/.hermes/skills/notes.md'), null)
+})
+
 test('path helpers reject blank non-string NUL and Windows device syntax', async () => {
   await rejectsWithCode(resolveReadableFileForIpc('', { purpose: 'File preview' }), 'invalid-path')
   await rejectsWithCode(resolveReadableFileForIpc('   ', { purpose: 'File preview' }), 'invalid-path')
@@ -214,6 +227,37 @@ test('resolveReadableFileForIpc blocks common sensitive files', async t => {
   const allowed = path.join(tempDir, '.env.example')
   fs.writeFileSync(allowed, 'EXAMPLE_TOKEN=value', 'utf8')
   assert.equal((await resolveReadableFileForIpc(allowed, { purpose: 'File preview' })).resolvedPath, allowed)
+})
+
+test('resolveReadableFileForIpc blocks Hermes credential stores via IPC preview', async t => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-desktop-creds-'))
+  t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }))
+
+  const hermesDir = path.join(tempDir, '.hermes')
+  const authDir = path.join(hermesDir, 'auth')
+  const mcpDir = path.join(hermesDir, 'mcp-tokens')
+  fs.mkdirSync(authDir, { recursive: true })
+  fs.mkdirSync(mcpDir, { recursive: true })
+
+  const blockedCreds = [
+    path.join(hermesDir, 'auth.json'),
+    path.join(hermesDir, '.anthropic_oauth.json'),
+    path.join(hermesDir, 'webhook_subscriptions.json'),
+    path.join(authDir, 'google_oauth.json'),
+    path.join(authDir, 'xai_oauth.json'),
+    path.join(mcpDir, 'github.json'),
+  ]
+
+  for (const filePath of blockedCreds) {
+    fs.writeFileSync(filePath, '{"token": "secret"}', 'utf8')
+    await rejectsWithCode(resolveReadableFileForIpc(filePath, { purpose: 'File preview' }), 'sensitive-file')
+  }
+
+  // Non-credential files in .hermes/ should still be previewable
+  const safeFile = path.join(hermesDir, 'config.yaml')
+  fs.writeFileSync(safeFile, 'model: gpt-4', 'utf8')
+  const resolved = await resolveReadableFileForIpc(safeFile, { purpose: 'File preview' })
+  assert.equal(resolved.resolvedPath, safeFile)
 })
 
 test('resolveReadableFileForIpc blocks symlinks whose realpath is sensitive', async t => {


### PR DESCRIPTION
## What does this PR do?

Extends the Electron Desktop `sensitiveFileBlockReason()` hardening guard to block Hermes credential store files (`auth.json`, `.anthropic_oauth.json`, `webhook_subscriptions.json`, `auth/*_oauth.json`, `mcp-tokens/*`) from being read via the file preview IPC path. Previously, the guard blocked `.env`, SSH keys, AWS credentials, and certificate files but returned `null` for Hermes' own token stores, allowing Desktop preview reads of sensitive credential files.

## Related Issue

Fixes #46413

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/hardening.cjs`: Added three new blocking rules to `sensitiveFileBlockReason()` — (1) Hermes root credential files under `/.hermes/`, (2) OAuth token files matching `*_oauth.json` under `/auth/`, (3) all files under `/mcp-tokens/`
- `apps/desktop/electron/hardening.test.cjs`: Added unit test for `sensitiveFileBlockReason` Hermes patterns and integration test for `resolveReadableFileForIpc` with real credential files in a simulated `.hermes/` directory

## How to Test

1. Run `node --test apps/desktop/electron/hardening.test.cjs` — all 14 tests pass
2. Verify `sensitiveFileBlockReason('/home/user/.hermes/auth.json')` returns a string containing "credential store"
3. Verify `sensitiveFileBlockReason('/home/user/.hermes/config.yaml')` returns `null` (non-credential files unaffected)
4. Verify `sensitiveFileBlockReason('/home/user/.hermes/mcp-tokens/github.json')` returns a string containing "MCP server token"

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `node --test apps/desktop/electron/hardening.test.cjs` and all 14 tests pass
- [x] I've added tests for my changes (unit + integration tests)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (path matching uses normalized forward slashes, works cross-platform)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `sensitiveFileBlockReason()` in `hardening.cjs` (callers: `resolveReadableFileForIpc`, `resolveRequestedPathForIpc`)
- Blast radius: LOW — additive-only guard, no existing behavior changed
- Related patterns: Follows existing blocking pattern for `.npmrc`/`.netrc`/`.pypirc` and directory-based blocks for `/.ssh/`/`/.gnupg/`
