### PR TITLE
fix(web): flag unavailable historical models

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -35,7 +35,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import yaml
 
@@ -9758,6 +9758,38 @@ async def get_models_analytics(days: int = 30, profile: Optional[str] = None):
     Returns token/cost/session breakdown per model plus capability metadata
     from models.dev (context window, vision, tools, reasoning, etc.).
     """
+    def _history_model_provider(model_name: str, billing_provider: str) -> str:
+        provider = str(billing_provider or "").strip()
+        if provider:
+            return provider
+        if "/" in model_name:
+            return model_name.split("/", 1)[0].strip()
+        return ""
+
+    def _current_model_inventory() -> Optional[Dict[str, Set[str]]]:
+        """Best-effort snapshot of currently selectable models by provider."""
+        try:
+            from hermes_cli.inventory import build_models_payload, load_picker_context
+
+            payload = build_models_payload(load_picker_context(), max_models=0)
+        except Exception:
+            _log.debug("Models analytics inventory snapshot failed", exc_info=True)
+            return None
+
+        inventory: Dict[str, Set[str]] = {}
+        for row in payload.get("providers", []) or []:
+            if not isinstance(row, dict):
+                continue
+            slug = str(row.get("slug", "") or "").strip()
+            if not slug:
+                continue
+            inventory[slug] = {
+                str(model_id).strip()
+                for model_id in (row.get("models") or [])
+                if str(model_id).strip()
+            }
+        return inventory
+
     db = _open_session_db_for_profile(profile)
     try:
         cutoff = time.time() - (days * 86400)
@@ -9846,10 +9878,12 @@ async def get_models_analytics(days: int = 30, profile: Optional[str] = None):
             reverse=True,
         )
 
+        current_inventory = _current_model_inventory()
         models = []
         for row in rows:
             provider = row.get("billing_provider") or ""
             model_name = row["model"]
+            provider_slug = _history_model_provider(model_name, provider)
             caps = {}
             try:
                 from agent.models_dev import get_model_capabilities
@@ -9866,9 +9900,14 @@ async def get_models_analytics(days: int = 30, profile: Optional[str] = None):
             except Exception:
                 pass
 
+            available = True
+            if current_inventory is not None and provider_slug:
+                available = model_name in current_inventory.get(provider_slug, set())
+
             models.append({
                 "model": model_name,
                 "provider": provider,
+                "available": available,
                 "input_tokens": row["input_tokens"],
                 "output_tokens": row["output_tokens"],
                 "cache_read_tokens": row["cache_read_tokens"],

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3420,6 +3420,62 @@ class TestNewEndpoints:
         assert row["api_calls"] == 9
         assert row["avg_tokens_per_session"] == 13_550
 
+    def test_models_analytics_marks_history_models_missing_from_current_inventory(self):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(
+                session_id="history-model-available",
+                source="cli",
+                model="anthropic/claude-sonnet-4",
+            )
+            db.update_token_counts(
+                "history-model-available",
+                input_tokens=120,
+                output_tokens=30,
+                billing_provider="openrouter",
+            )
+            db.create_session(
+                session_id="history-model-missing",
+                source="cli",
+                model="llama3.1:8b",
+            )
+            db.update_token_counts(
+                "history-model-missing",
+                input_tokens=80,
+                output_tokens=20,
+                billing_provider="ollama",
+            )
+        finally:
+            db.close()
+
+        inventory_payload = {
+            "providers": [
+                {"slug": "openrouter", "models": ["anthropic/claude-sonnet-4"]},
+                {"slug": "ollama", "models": ["llama3.2:3b"]},
+            ],
+            "model": "",
+            "provider": "",
+        }
+
+        with patch(
+            "hermes_cli.inventory.load_picker_context",
+            return_value=MagicMock(),
+        ), patch(
+            "hermes_cli.inventory.build_models_payload",
+            return_value=inventory_payload,
+        ):
+            resp = self.client.get("/api/analytics/models?days=7")
+
+        assert resp.status_code == 200
+        rows = {
+            (row["provider"], row["model"]): row
+            for row in resp.json()["models"]
+        }
+        assert rows[("openrouter", "anthropic/claude-sonnet-4")]["available"] is True
+        assert rows[("ollama", "llama3.1:8b")]["available"] is False
+
     def test_analytics_usage_includes_skill_breakdown(self):
         from hermes_state import SessionDB
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1806,6 +1806,7 @@ export interface ProfileInfo {
 export interface ModelsAnalyticsModelEntry {
   model: string;
   provider: string;
+  available: boolean;
   input_tokens: number;
   output_tokens: number;
   cache_read_tokens: number;

--- a/web/src/pages/ModelsPage.tsx
+++ b/web/src/pages/ModelsPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useState } from "react";
 import {
+  AlertTriangle,
   Brain,
   ChevronDown,
   Cpu,
@@ -196,6 +197,7 @@ function UseAsMenu({
   model,
   isMain,
   mainAuxTask,
+  disabled = false,
   onAssigned,
 }: {
   provider: string;
@@ -204,6 +206,7 @@ function UseAsMenu({
   isMain: boolean;
   /** If this model is assigned to a specific aux task, that task's key. */
   mainAuxTask: string | null;
+  disabled?: boolean;
   onAssigned(): void;
 }) {
   const [open, setOpen] = useState(false);
@@ -270,7 +273,7 @@ function UseAsMenu({
         size="sm"
         outlined
         onClick={() => setOpen((v) => !v)}
-        disabled={busy}
+        disabled={busy || disabled}
         className="h-6 px-2 text-xs uppercase"
         prefix={busy ? <Spinner /> : null}
       >
@@ -375,6 +378,7 @@ function ModelCard({
   const provider = entry.provider || modelVendor(entry.model);
   const totalTokens = entry.input_tokens + entry.output_tokens;
   const caps = entry.capabilities;
+  const isAvailable = entry.available !== false;
 
   const isMain =
     !!main &&
@@ -409,6 +413,11 @@ function ModelCard({
               {mainAuxTask && (
                 <span className="inline-flex items-center bg-purple-500/10 px-1.5 py-0.5 text-display text-xs font-medium tracking-wider text-purple-600 dark:text-purple-400">
                   aux · {mainAuxTask}
+                </span>
+              )}
+              {!isAvailable && (
+                <span className="inline-flex items-center gap-1 bg-amber-500/10 px-1.5 py-0.5 text-display text-xs font-medium tracking-wider text-amber-700 dark:text-amber-300">
+                  <AlertTriangle className="h-2.5 w-2.5" /> unavailable
                 </span>
               )}
             </div>
@@ -457,12 +466,19 @@ function ModelCard({
               model={entry.model}
               isMain={isMain}
               mainAuxTask={mainAuxTask}
+              disabled={!isAvailable}
               onAssigned={onAssigned}
             />
           </div>
         </div>
       </CardHeader>
       <CardContent className="space-y-3 pt-3">
+        {!isAvailable && (
+          <p className="text-xs leading-relaxed text-amber-700 dark:text-amber-300">
+            This model stays visible because it appears in session history, but
+            it is not in the current provider inventory.
+          </p>
+        )}
         {showTokens && (
           <>
             <TokenBar
@@ -841,6 +857,8 @@ export default function ModelsPage() {
   const [showTokens, setShowTokens] = useState(false);
   const { t } = useI18n();
   const { setAfterTitle, setEnd } = usePageHeader();
+  const unavailableCount =
+    data?.models.filter((entry) => entry.available === false).length ?? 0;
 
   useEffect(() => {
     api
@@ -923,7 +941,13 @@ export default function ModelsPage() {
   }, [days, loading, load, setAfterTitle, setEnd, t.common.refresh]);
 
   useEffect(() => {
-    load();
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (!cancelled) load();
+    });
+    return () => {
+      cancelled = true;
+    };
   }, [load]);
 
   // Model assignments can change outside this page (config editor, chat
@@ -1036,6 +1060,12 @@ export default function ModelsPage() {
 
       {data && (
         <>
+          <p className="text-xs leading-relaxed text-text-tertiary">
+            Models shown here come from recent session history. Use refresh to
+            re-check the current provider inventory.
+            {unavailableCount > 0 &&
+              ` ${unavailableCount} historical model${unavailableCount === 1 ? " is" : "s are"} currently unavailable and can't be reassigned from this page.`}
+          </p>
           {data.models.length > 0 ? (
             <div className="grid min-w-0 gap-4 md:grid-cols-2 xl:grid-cols-3">
               {data.models.map((m, i) => (


### PR DESCRIPTION
## Summary
- mark historical Models cards unavailable when the model is no longer in the current provider inventory
- disable reassignment from those stale cards and explain that the page mixes live inventory with session history
- add a regression test for availability marking on `/api/analytics/models`

## Testing
- uv run --frozen pytest tests/hermes_cli/test_web_server.py -k "models_analytics"
- uv run --frozen ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server.py
- npm exec --workspace web eslint -- src/pages/ModelsPage.tsx src/lib/api.ts
- npm exec --workspace web tsc -- -p tsconfig.json --noEmit
- git diff --check HEAD

Closes #46184