### PR TITLE
fix(hindsight): use local timezone in retain timestamps

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -37,7 +37,7 @@ import os
 import queue
 import threading
 
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any, Dict, List
 
 from agent.memory_provider import MemoryProvider
@@ -376,9 +376,13 @@ def _normalize_retain_tags(value: Any) -> List[str]:
     return normalized
 
 
-def _utc_timestamp() -> str:
-    """Return current UTC timestamp in ISO-8601 with milliseconds and Z suffix."""
-    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+def _local_timestamp() -> str:
+    """Return current local timestamp in ISO-8601 with timezone offset.
+
+    Uses the system's local timezone so downstream memory extraction LLMs
+    render dates/times in the user's local context, not UTC.
+    """
+    return datetime.now().astimezone().isoformat(timespec="milliseconds")
 
 
 def _embedded_profile_name(config: dict[str, Any]) -> str:
@@ -1369,7 +1373,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._prefetch_thread.start()
 
     def _build_turn_messages(self, user_content: str, assistant_content: str) -> List[Dict[str, str]]:
-        now = datetime.now(timezone.utc).isoformat()
+        now = _local_timestamp()
         return [
             {
                 "role": "user",
@@ -1385,7 +1389,7 @@ class HindsightMemoryProvider(MemoryProvider):
 
     def _build_metadata(self, *, message_count: int, turn_index: int) -> Dict[str, str]:
         metadata: Dict[str, str] = {
-            "retained_at": _utc_timestamp(),
+            "retained_at": _local_timestamp(),
             "message_count": str(message_count),
             "turn_index": str(turn_index),
         }

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -722,8 +722,8 @@ class TestSyncTurn:
         assert item["metadata"]["agent_identity"] == "fakeassistantname"
         assert item["metadata"]["turn_index"] == "1"
         assert item["metadata"]["message_count"] == "2"
-        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?\+00:00", content[0][0]["timestamp"])
-        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z", item["metadata"]["retained_at"])
+        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?[+-]\d{2}:\d{2}", content[0][0]["timestamp"])
+        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2}", item["metadata"]["retained_at"])
 
     def test_sync_turn_skipped_when_auto_retain_off(self, provider_with_config):
         p = provider_with_config(auto_retain=False)


### PR DESCRIPTION
## Problem

The Hindsight memory plugin hardcodes UTC Zulu timestamps (`...Z`) in retain payloads, discarding the user's local timezone offset. Downstream memory extraction LLMs then render all dates/times in UTC, producing semantically wrong date references in stored memories.

For example, a conversation at 7:00 PM local time (UTC-5) gets stamped as `2026-06-01T02:00:00Z`, and the extraction LLM writes "Monday, June 2" in the memory prose — a day ahead and several hours off from the user's actual experience.

Confirmed as a client-side issue by the Hindsight maintainer in [vectorize-io/hindsight#2033](https://github.com/vectorize-io/hindsight/issues/2033).

Fixes #46424

## Changes

- Rename `_utc_timestamp()` to `_local_timestamp()`
- Use `datetime.now().astimezone()` to produce ISO-8601 with local timezone offset (e.g., `2026-06-01T19:00:00-05:00`)
- Update `_build_turn_messages()` to use `_local_timestamp()` instead of inline `datetime.now(timezone.utc).isoformat()`
- Remove unused `timezone` import
- Update test regex to accept any timezone offset (`[+-]\d{2}:\d{2}`) instead of hardcoded `+00:00` / `Z`

## Testing

```
101 passed, 1 failed (pre-existing — hindsight-client import issue unrelated to this change)
```
