### PR TITLE
feat: add Google Colab plugin

### DIFF
--- a/docs/google-colab-plugin-deepresearch.md
+++ b/docs/google-colab-plugin-deepresearch.md
@@ -1,0 +1,44 @@
+# Google Colab CLI Plugin Deep Research
+
+## Decision
+
+Use a standalone Hermes plugin around the official `google-colab-cli`, not a new core model tool. Colab is a compute backend with account state, quota, and billable accelerator allocation, so it belongs behind explicit plugin enablement and confirmation.
+
+## Source Findings
+
+- Google announced Colab CLI on 2026-06-05 for terminal and agent workflows. It supports remote execution, artifact recovery, interactive access, and accelerator provisioning.
+- The official repository states that Colab CLI currently supports Linux and macOS only. Windows should use WSL for now.
+- `colab run` is the safest default for one-shot jobs because it provisions, executes, and stops the VM unless `--keep` is set.
+- Persistent sessions are useful for incremental work, but `colab new` creates a live rented VM and `colab stop` is required to avoid burning compute units.
+- Agent automation must avoid interactive `colab repl`, `colab console`, `colab auth`, and `colab drivemount` unless stdin/browser handling is deliberately arranged.
+- TRL `SFTTrainer` accepts text, prompt/completion, and conversational `messages` datasets. For Hermes-style traces, `messages` plus assistant-only loss is the preferred shape.
+- QLoRA should use 4-bit quantization plus LoRA/PEFT rather than full fine-tuning on Colab GPUs.
+- Irodori-TTS-Server is already OpenAI TTS API compatible and the Hermes repo already has an `irodori_tts` plugin. Colab should train or prepare artifacts; local Irodori serving should remain the runtime boundary.
+- `llama-server` exposes an OpenAI-compatible chat completions endpoint. Hermes should connect to that endpoint as a model provider or custom OpenAI-compatible provider after a GGUF model is available.
+
+## Implemented Surface
+
+- `hermes google-colab status`
+- `hermes google-colab sessions`
+- `hermes google-colab run --gpu T4 --confirm script.py`
+- `hermes google-colab sft-template --output-path script.py`
+
+The `google_colab_run` tool requires `confirmed=true` before invoking `colab run`.
+
+## Recommended Workflow
+
+1. Enable the plugin: `hermes plugins enable google-colab`.
+2. On Windows, install and authenticate Colab CLI inside WSL.
+3. Generate an SFT script with `hermes google-colab sft-template --output-path runs/hermes_sft.py`.
+4. Run the script with `hermes google-colab run --gpu T4 --confirm runs/hermes_sft.py`.
+5. Upload the adapter to Hugging Face or download it locally.
+6. Convert or publish GGUF separately if the target model architecture is supported by llama.cpp.
+7. Serve the GGUF with `llama-server` and point Hermes at `http://127.0.0.1:8080/v1`.
+
+## Boundaries
+
+- Do not add Colab as a core tool.
+- Do not hide billable allocation behind an automatic model tool call.
+- Do not store HF tokens in generated scripts.
+- Do not route Irodori synthesis through Colab for ordinary runtime use.
+- Do not claim Windows native support while upstream states it is unsupported.

--- a/plugins/google_colab/__init__.py
+++ b/plugins/google_colab/__init__.py
@@ -1,0 +1,64 @@
+"""Google Colab CLI bridge for Hermes."""
+
+from __future__ import annotations
+
+from . import core
+from .cli import google_colab_command, register_cli
+
+
+def _json_handler(fn):
+    def handler(values=None, **kwargs):
+        payload = values if isinstance(values, dict) else {}
+        payload.update(kwargs)
+        return core.to_json(fn(payload))
+
+    return handler
+
+
+def register(ctx) -> None:
+    """Register Colab tools, slash command, and CLI command."""
+    ctx.register_tool(
+        name="google_colab_status",
+        toolset="google-colab",
+        schema=core.STATUS_SCHEMA,
+        handler=_json_handler(core.status_payload),
+        check_fn=lambda: True,
+        description=core.STATUS_SCHEMA["description"],
+    )
+    ctx.register_tool(
+        name="google_colab_sessions",
+        toolset="google-colab",
+        schema=core.SESSIONS_SCHEMA,
+        handler=_json_handler(core.sessions_payload),
+        check_fn=core.check_available,
+        description=core.SESSIONS_SCHEMA["description"],
+    )
+    ctx.register_tool(
+        name="google_colab_run",
+        toolset="google-colab",
+        schema=core.RUN_SCHEMA,
+        handler=_json_handler(core.run_job),
+        check_fn=core.check_available,
+        description=core.RUN_SCHEMA["description"],
+    )
+    ctx.register_tool(
+        name="google_colab_sft_template",
+        toolset="google-colab",
+        schema=core.SFT_TEMPLATE_SCHEMA,
+        handler=_json_handler(core.write_sft_template),
+        check_fn=lambda: True,
+        description=core.SFT_TEMPLATE_SCHEMA["description"],
+    )
+    ctx.register_command(
+        "colab",
+        handler=lambda raw_args: core.handle_slash(raw_args),
+        description="Inspect and run Google Colab CLI accelerator jobs.",
+        args_hint="[status|sessions|run|sft-template]",
+    )
+    ctx.register_cli_command(
+        name="google-colab",
+        help="Google Colab CLI accelerator job runner",
+        setup_fn=register_cli,
+        handler_fn=google_colab_command,
+        description="Inspect Colab CLI state, run confirmed jobs, and generate SFT templates.",
+    )

--- a/plugins/google_colab/cli.py
+++ b/plugins/google_colab/cli.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from typing import Any
+
+from . import core
+
+
+def _print(payload: dict[str, Any]) -> None:
+    print(core.to_json(payload))
+
+
+def register_cli(subparser) -> None:
+    actions = subparser.add_subparsers(dest="google_colab_action")
+
+    status_parser = actions.add_parser("status", help="Show Colab CLI status.")
+    status_parser.add_argument("--probe-sessions", action="store_true")
+    status_parser.add_argument("--auth", choices=["adc", "oauth2"], default="adc")
+    status_parser.add_argument("--config-path")
+    status_parser.add_argument("--allow-windows-native", action="store_true")
+
+    sessions_parser = actions.add_parser("sessions", help="List active Colab sessions.")
+    sessions_parser.add_argument("--auth", choices=["adc", "oauth2"], default="adc")
+    sessions_parser.add_argument("--config-path")
+    sessions_parser.add_argument("--allow-windows-native", action="store_true")
+
+    run_parser = actions.add_parser("run", help="Run a script via colab run.")
+    run_parser.add_argument("script_path")
+    run_parser.add_argument("script_args", nargs="*")
+    run_parser.add_argument("--gpu", choices=sorted(core.ALLOWED_GPUS))
+    run_parser.add_argument("--tpu", choices=sorted(core.ALLOWED_TPUS))
+    run_parser.add_argument("-s", "--session-name")
+    run_parser.add_argument("--keep", action="store_true")
+    run_parser.add_argument("--confirm", action="store_true")
+    run_parser.add_argument("--auth", choices=["adc", "oauth2"], default="adc")
+    run_parser.add_argument("--config-path")
+    run_parser.add_argument("--timeout-seconds", type=int, default=core.DEFAULT_TIMEOUT_SECONDS)
+    run_parser.add_argument("--allow-windows-native", action="store_true")
+
+    sft_parser = actions.add_parser("sft-template", help="Write a TRL SFT Colab job template.")
+    sft_parser.add_argument("--output-path", required=True)
+    sft_parser.add_argument("--model-id", default="Qwen/Qwen3-0.6B")
+    sft_parser.add_argument("--dataset-name", default="trl-lib/Capybara")
+    sft_parser.add_argument("--dataset-split", default="train")
+    sft_parser.add_argument("--output-dir", default="./hermes-sft-adapter")
+    sft_parser.add_argument("--max-steps", type=int, default=120)
+    sft_parser.add_argument("--push-to-hub-repo", default="")
+
+    subparser.set_defaults(func=google_colab_command)
+
+
+def google_colab_command(args: Any) -> int:
+    action = getattr(args, "google_colab_action", None)
+    if action == "status":
+        _print(
+            core.status_payload(
+                {
+                    "probe_sessions": args.probe_sessions,
+                    "auth": args.auth,
+                    "config_path": args.config_path,
+                    "allow_windows_native": args.allow_windows_native,
+                }
+            )
+        )
+        return 0
+    if action == "sessions":
+        _print(
+            core.sessions_payload(
+                {
+                    "auth": args.auth,
+                    "config_path": args.config_path,
+                    "allow_windows_native": args.allow_windows_native,
+                }
+            )
+        )
+        return 0
+    if action == "run":
+        _print(
+            core.run_job(
+                {
+                    "script_path": args.script_path,
+                    "args": args.script_args,
+                    "gpu": args.gpu,
+                    "tpu": args.tpu,
+                    "keep": args.keep,
+                    "session_name": args.session_name,
+                    "auth": args.auth,
+                    "config_path": args.config_path,
+                    "timeout_seconds": args.timeout_seconds,
+                    "confirmed": args.confirm,
+                    "allow_windows_native": args.allow_windows_native,
+                }
+            )
+        )
+        return 0
+    if action == "sft-template":
+        _print(
+            core.write_sft_template(
+                {
+                    "output_path": args.output_path,
+                    "model_id": args.model_id,
+                    "dataset_name": args.dataset_name,
+                    "dataset_split": args.dataset_split,
+                    "output_dir": args.output_dir,
+                    "max_steps": args.max_steps,
+                    "push_to_hub_repo": args.push_to_hub_repo,
+                }
+            )
+        )
+        return 0
+    print("usage: hermes google-colab {status,sessions,run,sft-template}")
+    return 2

--- a/plugins/google_colab/core.py
+++ b/plugins/google_colab/core.py
@@ -1,0 +1,598 @@
+from __future__ import annotations
+
+import json
+import os
+import platform
+import shlex
+import shutil
+import subprocess
+import sys
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+ALLOWED_GPUS = {"T4", "L4", "G4", "H100", "A100"}
+ALLOWED_TPUS = {"v5e1", "v6e1"}
+DEFAULT_TIMEOUT_SECONDS = 60 * 60 * 6
+DEFAULT_STATUS_TIMEOUT_SECONDS = 20
+
+
+STATUS_SCHEMA = {
+    "description": "Report Google Colab CLI availability and platform support.",
+    "type": "object",
+    "properties": {
+        "probe_sessions": {
+            "type": "boolean",
+            "description": "Also run a read-only colab sessions probe.",
+            "default": False,
+        },
+        "auth": {
+            "type": "string",
+            "enum": ["adc", "oauth2"],
+            "description": "Colab CLI auth mode.",
+            "default": "adc",
+        },
+        "config_path": {
+            "type": "string",
+            "description": "Optional isolated colab-cli sessions config path.",
+        },
+        "allow_windows_native": {
+            "type": "boolean",
+            "description": "Allow unsupported native Windows colab executable if explicitly requested.",
+            "default": False,
+        },
+    },
+}
+
+SESSIONS_SCHEMA = {
+    "description": "Run read-only colab sessions through the Google Colab CLI.",
+    "type": "object",
+    "properties": {
+        "auth": {"type": "string", "enum": ["adc", "oauth2"], "default": "adc"},
+        "config_path": {"type": "string"},
+        "allow_windows_native": {"type": "boolean", "default": False},
+    },
+}
+
+RUN_SCHEMA = {
+    "description": "Run a local Python script through colab run after explicit confirmation.",
+    "type": "object",
+    "properties": {
+        "script_path": {
+            "type": "string",
+            "description": "Local Python script to execute remotely.",
+        },
+        "args": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Arguments forwarded to the remote script.",
+        },
+        "gpu": {
+            "type": "string",
+            "enum": sorted(ALLOWED_GPUS),
+            "description": "Optional GPU accelerator.",
+        },
+        "tpu": {
+            "type": "string",
+            "enum": sorted(ALLOWED_TPUS),
+            "description": "Optional TPU accelerator.",
+        },
+        "keep": {
+            "type": "boolean",
+            "description": "Keep the VM after the script exits.",
+            "default": False,
+        },
+        "session_name": {
+            "type": "string",
+            "description": "Optional stable session name passed to colab run.",
+        },
+        "auth": {
+            "type": "string",
+            "enum": ["adc", "oauth2"],
+            "default": "adc",
+        },
+        "config_path": {
+            "type": "string",
+            "description": "Optional isolated colab-cli sessions config path.",
+        },
+        "timeout_seconds": {
+            "type": "integer",
+            "description": "Subprocess timeout for the local colab command.",
+            "default": DEFAULT_TIMEOUT_SECONDS,
+        },
+        "confirmed": {
+            "type": "boolean",
+            "description": "Must be true because colab run can allocate billable compute.",
+            "default": False,
+        },
+        "allow_windows_native": {
+            "type": "boolean",
+            "description": "Allow unsupported native Windows colab executable if explicitly requested.",
+            "default": False,
+        },
+    },
+    "required": ["script_path", "confirmed"],
+}
+
+SFT_TEMPLATE_SCHEMA = {
+    "description": "Write a Hermes-oriented TRL SFT/QLoRA Colab job template.",
+    "type": "object",
+    "properties": {
+        "output_path": {
+            "type": "string",
+            "description": "Destination Python script path.",
+        },
+        "model_id": {
+            "type": "string",
+            "description": "Base model id.",
+            "default": "Qwen/Qwen3-0.6B",
+        },
+        "dataset_name": {
+            "type": "string",
+            "description": "Hugging Face dataset name.",
+            "default": "trl-lib/Capybara",
+        },
+        "dataset_split": {
+            "type": "string",
+            "default": "train",
+        },
+        "output_dir": {
+            "type": "string",
+            "default": "./hermes-sft-adapter",
+        },
+        "max_steps": {
+            "type": "integer",
+            "default": 120,
+        },
+        "push_to_hub_repo": {
+            "type": "string",
+            "description": "Optional repo id for adapter upload.",
+        },
+    },
+    "required": ["output_path"],
+}
+
+
+@dataclass(frozen=True)
+class ColabBackend:
+    mode: str
+    available: bool
+    command: list[str]
+    reason: str = ""
+    wsl: bool = False
+
+
+def to_json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=False, indent=2)
+
+
+def _is_windows() -> bool:
+    return os.name == "nt"
+
+
+def _colab_exe() -> str | None:
+    return shutil.which("colab")
+
+
+def _wsl_exe() -> str | None:
+    return shutil.which("wsl.exe") or shutil.which("wsl")
+
+
+def _run_command(
+    command: list[str],
+    *,
+    timeout_seconds: int | float,
+    cwd: str | Path | None = None,
+) -> dict[str, Any]:
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=str(cwd) if cwd else None,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout_seconds,
+        )
+        return {
+            "ok": completed.returncode == 0,
+            "exit_code": completed.returncode,
+            "command": command,
+            "stdout": completed.stdout,
+            "stderr": completed.stderr,
+        }
+    except subprocess.TimeoutExpired as exc:
+        return {
+            "ok": False,
+            "exit_code": None,
+            "command": command,
+            "stdout": exc.stdout or "",
+            "stderr": exc.stderr or "",
+            "error": f"timed out after {timeout_seconds} seconds",
+        }
+    except OSError as exc:
+        return {
+            "ok": False,
+            "exit_code": None,
+            "command": command,
+            "stdout": "",
+            "stderr": "",
+            "error": str(exc),
+        }
+
+
+def _wsl_run(script: str, timeout_seconds: int | float) -> dict[str, Any]:
+    wsl = _wsl_exe()
+    if not wsl:
+        return {
+            "ok": False,
+            "exit_code": None,
+            "command": ["wsl", "-e", "bash", "-lc", script],
+            "stdout": "",
+            "stderr": "",
+            "error": "WSL executable was not found.",
+        }
+    return _run_command([wsl, "-e", "bash", "-lc", script], timeout_seconds=timeout_seconds)
+
+
+def _wsl_colab_available() -> bool:
+    result = _wsl_run("command -v colab >/dev/null 2>&1", DEFAULT_STATUS_TIMEOUT_SECONDS)
+    return bool(result["ok"])
+
+
+def resolve_backend(*, allow_windows_native: bool = False) -> ColabBackend:
+    native = _colab_exe()
+    if _is_windows():
+        if _wsl_exe() and _wsl_colab_available():
+            return ColabBackend(
+                mode="wsl",
+                available=True,
+                command=[_wsl_exe() or "wsl.exe", "-e", "bash", "-lc"],
+                wsl=True,
+            )
+        if native and allow_windows_native:
+            return ColabBackend(
+                mode="native-windows-unsupported",
+                available=True,
+                command=[native],
+                reason="Native Windows is not officially supported by google-colab-cli.",
+            )
+        reason = (
+            "google-colab-cli currently supports Linux and macOS. "
+            "On Windows, install it inside WSL or pass allow_windows_native after accepting the unsupported path."
+        )
+        return ColabBackend(mode="unavailable", available=False, command=[], reason=reason)
+
+    if native:
+        return ColabBackend(mode="native", available=True, command=[native])
+    return ColabBackend(
+        mode="unavailable",
+        available=False,
+        command=[],
+        reason="The colab executable was not found on PATH.",
+    )
+
+
+def _quote_for_wsl(args: list[str]) -> str:
+    return " ".join(shlex.quote(arg) for arg in args)
+
+
+def _wslpath(path: Path) -> str:
+    result = _wsl_run(
+        "wslpath -a " + shlex.quote(str(path)),
+        DEFAULT_STATUS_TIMEOUT_SECONDS,
+    )
+    if result["ok"]:
+        converted = result["stdout"].strip().splitlines()
+        if converted:
+            return converted[-1]
+    # Fallback for default WSL mount layout.
+    resolved = path.resolve()
+    drive = resolved.drive.rstrip(":").lower()
+    tail = str(resolved)[3:].replace("\\", "/")
+    if drive and tail:
+        return f"/mnt/{drive}/{tail}"
+    return str(path)
+
+
+def _global_args(values: dict[str, Any], *, wsl: bool) -> list[str]:
+    args: list[str] = []
+    auth = str(values.get("auth") or "adc").strip()
+    if auth:
+        args.append(f"--auth={auth}")
+    config_path = values.get("config_path")
+    if config_path:
+        config = Path(str(config_path)).expanduser()
+        args.extend(["--config", _wslpath(config) if wsl else str(config)])
+    return args
+
+
+def _run_colab(
+    values: dict[str, Any],
+    colab_args: list[str],
+    *,
+    timeout_seconds: int | float,
+) -> dict[str, Any]:
+    backend = resolve_backend(allow_windows_native=bool(values.get("allow_windows_native")))
+    if not backend.available:
+        return {
+            "ok": False,
+            "backend": backend.mode,
+            "error": backend.reason,
+            "platform": platform.platform(),
+        }
+
+    full_args = _global_args(values, wsl=backend.wsl) + colab_args
+    if backend.wsl:
+        shell_script = "colab " + _quote_for_wsl(full_args)
+        result = _wsl_run(shell_script, timeout_seconds)
+    else:
+        result = _run_command(backend.command + full_args, timeout_seconds=timeout_seconds)
+    result["backend"] = backend.mode
+    return result
+
+
+def check_available() -> bool:
+    return resolve_backend().available
+
+
+def status_payload(values: dict[str, Any] | None = None) -> dict[str, Any]:
+    values = values or {}
+    backend = resolve_backend(allow_windows_native=bool(values.get("allow_windows_native")))
+    payload: dict[str, Any] = {
+        "ok": backend.available,
+        "available": backend.available,
+        "backend": backend.mode,
+        "platform": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "python": sys.version.split()[0],
+        },
+        "paths": {
+            "colab": _colab_exe(),
+            "wsl": _wsl_exe(),
+        },
+        "notes": [],
+    }
+    if backend.reason:
+        payload["notes"].append(backend.reason)
+    if backend.available:
+        payload["version"] = _run_colab(
+            values,
+            ["version"],
+            timeout_seconds=DEFAULT_STATUS_TIMEOUT_SECONDS,
+        )
+    if values.get("probe_sessions") and backend.available:
+        payload["sessions"] = sessions_payload(values)
+    return payload
+
+
+def sessions_payload(values: dict[str, Any] | None = None) -> dict[str, Any]:
+    values = values or {}
+    return _run_colab(
+        values,
+        ["sessions"],
+        timeout_seconds=DEFAULT_STATUS_TIMEOUT_SECONDS,
+    )
+
+
+def _validate_accelerator(values: dict[str, Any]) -> tuple[bool, str | None]:
+    gpu = values.get("gpu")
+    tpu = values.get("tpu")
+    if gpu and tpu:
+        return False, "Choose either gpu or tpu, not both."
+    if gpu and str(gpu) not in ALLOWED_GPUS:
+        return False, f"Unsupported GPU '{gpu}'. Supported: {', '.join(sorted(ALLOWED_GPUS))}."
+    if tpu and str(tpu) not in ALLOWED_TPUS:
+        return False, f"Unsupported TPU '{tpu}'. Supported: {', '.join(sorted(ALLOWED_TPUS))}."
+    return True, None
+
+
+def run_job(values: dict[str, Any]) -> dict[str, Any]:
+    if not values.get("confirmed"):
+        return {
+            "ok": False,
+            "confirmation_required": True,
+            "reason": "colab run can allocate billable compute. Re-run with confirmed=true.",
+        }
+
+    valid, error = _validate_accelerator(values)
+    if not valid:
+        return {"ok": False, "error": error}
+
+    raw_script = values.get("script_path")
+    if not raw_script:
+        return {"ok": False, "error": "script_path is required."}
+    script_path = Path(str(raw_script)).expanduser()
+    if not script_path.is_file():
+        return {"ok": False, "error": f"Script not found: {script_path}"}
+
+    backend = resolve_backend(allow_windows_native=bool(values.get("allow_windows_native")))
+    remote_script = _wslpath(script_path) if backend.wsl else str(script_path)
+    args: list[str] = ["run"]
+    if values.get("gpu"):
+        args.extend(["--gpu", str(values["gpu"])])
+    if values.get("tpu"):
+        args.extend(["--tpu", str(values["tpu"])])
+    if values.get("keep"):
+        args.append("--keep")
+    if values.get("session_name"):
+        args.extend(["-s", str(values["session_name"])])
+    args.append(remote_script)
+    for item in values.get("args") or []:
+        args.append(str(item))
+
+    timeout_seconds = int(values.get("timeout_seconds") or DEFAULT_TIMEOUT_SECONDS)
+    result = _run_colab(values, args, timeout_seconds=timeout_seconds)
+    result["script_path"] = str(script_path)
+    result["accelerator"] = {"gpu": values.get("gpu"), "tpu": values.get("tpu")}
+    result["kept_vm"] = bool(values.get("keep"))
+    return result
+
+
+def _sft_template_source(values: dict[str, Any]) -> str:
+    model_id = values.get("model_id") or "Qwen/Qwen3-0.6B"
+    dataset_name = values.get("dataset_name") or "trl-lib/Capybara"
+    dataset_split = values.get("dataset_split") or "train"
+    output_dir = values.get("output_dir") or "./hermes-sft-adapter"
+    max_steps = int(values.get("max_steps") or 120)
+    push_to_hub_repo = values.get("push_to_hub_repo") or ""
+    return textwrap.dedent(
+        f"""
+        #!/usr/bin/env python3
+        from __future__ import annotations
+
+        import os
+        import subprocess
+        import sys
+
+        REQUIRED = [
+            "accelerate",
+            "bitsandbytes>=0.46.1",
+            "datasets",
+            "huggingface_hub",
+            "peft",
+            "safetensors",
+            "torch",
+            "transformers",
+            "trl",
+        ]
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "-q", "-U", *REQUIRED])
+
+        import torch
+        from datasets import load_dataset
+        from peft import LoraConfig, prepare_model_for_kbit_training
+        from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
+        from trl import SFTConfig, SFTTrainer
+
+        MODEL_ID = {model_id!r}
+        DATASET_NAME = {dataset_name!r}
+        DATASET_SPLIT = {dataset_split!r}
+        OUTPUT_DIR = {output_dir!r}
+        MAX_STEPS = {max_steps!r}
+        PUSH_TO_HUB_REPO = {push_to_hub_repo!r}
+
+        hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGINGFACE_TOKEN")
+
+        print("Loading dataset:", DATASET_NAME, DATASET_SPLIT)
+        dataset = load_dataset(DATASET_NAME, split=DATASET_SPLIT)
+
+        def normalize(example):
+            if "messages" in example or ("prompt" in example and "completion" in example) or "text" in example:
+                return example
+            if "instruction" in example and "output" in example:
+                return {{"prompt": example["instruction"], "completion": example["output"]}}
+            raise ValueError(
+                "Dataset must contain messages, prompt+completion, text, or instruction+output columns."
+            )
+
+        dataset = dataset.map(normalize)
+
+        print("Loading model:", MODEL_ID)
+        tokenizer = AutoTokenizer.from_pretrained(MODEL_ID, token=hf_token)
+        if tokenizer.pad_token is None:
+            tokenizer.pad_token = tokenizer.eos_token
+
+        quantization = BitsAndBytesConfig(
+            load_in_4bit=True,
+            bnb_4bit_quant_type="nf4",
+            bnb_4bit_compute_dtype=torch.bfloat16,
+        )
+        model = AutoModelForCausalLM.from_pretrained(
+            MODEL_ID,
+            token=hf_token,
+            quantization_config=quantization,
+            device_map="auto",
+            torch_dtype=torch.bfloat16,
+        )
+        model = prepare_model_for_kbit_training(model)
+
+        peft_config = LoraConfig(
+            r=16,
+            lora_alpha=32,
+            lora_dropout=0.05,
+            target_modules="all-linear",
+            task_type="CAUSAL_LM",
+        )
+
+        assistant_only_loss = "messages" in dataset.column_names
+        args = SFTConfig(
+            output_dir=OUTPUT_DIR,
+            max_steps=MAX_STEPS,
+            per_device_train_batch_size=2,
+            gradient_accumulation_steps=4,
+            learning_rate=2e-4,
+            logging_steps=10,
+            save_strategy="steps",
+            save_steps=max(20, MAX_STEPS // 3),
+            report_to="none",
+            assistant_only_loss=assistant_only_loss,
+        )
+
+        trainer = SFTTrainer(
+            model=model,
+            args=args,
+            train_dataset=dataset,
+            processing_class=tokenizer,
+            peft_config=peft_config,
+        )
+        trainer.train()
+        trainer.save_model(OUTPUT_DIR)
+        tokenizer.save_pretrained(OUTPUT_DIR)
+        print("Saved adapter:", OUTPUT_DIR)
+
+        if PUSH_TO_HUB_REPO:
+            from huggingface_hub import HfApi
+
+            if not hf_token:
+                raise RuntimeError("HF_TOKEN or HUGGINGFACE_TOKEN is required to push to the Hub.")
+            api = HfApi(token=hf_token)
+            api.create_repo(PUSH_TO_HUB_REPO, repo_type="model", exist_ok=True)
+            api.upload_folder(
+                repo_id=PUSH_TO_HUB_REPO,
+                repo_type="model",
+                folder_path=OUTPUT_DIR,
+            )
+            print("Uploaded adapter:", PUSH_TO_HUB_REPO)
+        """
+    ).lstrip()
+
+
+def write_sft_template(values: dict[str, Any]) -> dict[str, Any]:
+    raw_output = values.get("output_path")
+    if not raw_output:
+        return {"ok": False, "error": "output_path is required."}
+    output_path = Path(str(raw_output)).expanduser()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    source = _sft_template_source(values)
+    output_path.write_text(source, encoding="utf-8", newline="\n")
+    return {
+        "ok": True,
+        "file_path": str(output_path),
+        "bytes": output_path.stat().st_size,
+        "run_hint": f"hermes google-colab run --gpu T4 --confirm {output_path}",
+        "notes": [
+            "For gated models or Hub upload, make HF_TOKEN available inside the Colab runtime.",
+            "Use T4 or L4 first unless the account has higher accelerator entitlement.",
+        ],
+    }
+
+
+def handle_slash(raw_args: str) -> str:
+    parts = shlex.split(raw_args or "")
+    action = parts[0] if parts else "status"
+    if action == "status":
+        return to_json(status_payload({}))
+    if action == "sessions":
+        return to_json(sessions_payload({}))
+    if action == "sft-template":
+        output = parts[1] if len(parts) > 1 else "hermes_colab_sft.py"
+        return to_json(write_sft_template({"output_path": output}))
+    return to_json(
+        {
+            "ok": False,
+            "error": "Supported /colab actions: status, sessions, sft-template.",
+        }
+    )

--- a/plugins/google_colab/plugin.yaml
+++ b/plugins/google_colab/plugin.yaml
@@ -1,0 +1,16 @@
+name: google-colab
+version: 0.1.0
+description: Google Colab CLI job runner for remote accelerator workloads.
+author: HermesAgent
+kind: standalone
+platforms:
+  - linux
+  - macos
+  - windows
+provides_tools:
+  - google_colab_status
+  - google_colab_sessions
+  - google_colab_run
+  - google_colab_sft_template
+provides_cli:
+  - google-colab

--- a/tests/plugins/test_google_colab_plugin.py
+++ b/tests/plugins/test_google_colab_plugin.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+from plugins.google_colab import core, register
+
+
+class _FakeContext:
+    def __init__(self) -> None:
+        self.tools = {}
+        self.commands = {}
+        self.cli_commands = {}
+
+    def register_tool(self, name, **kwargs):
+        self.tools[name] = kwargs
+
+    def register_command(self, name, **kwargs):
+        self.commands[name] = kwargs
+
+    def register_cli_command(self, name, **kwargs):
+        self.cli_commands[name] = kwargs
+
+
+def test_registers_tools_slash_and_cli_command() -> None:
+    ctx = _FakeContext()
+    register(ctx)
+
+    assert "google_colab_status" in ctx.tools
+    assert "google_colab_sessions" in ctx.tools
+    assert "google_colab_run" in ctx.tools
+    assert "google_colab_sft_template" in ctx.tools
+    assert "colab" in ctx.commands
+    assert "google-colab" in ctx.cli_commands
+
+
+def test_status_reports_unavailable_without_colab(monkeypatch) -> None:
+    monkeypatch.setattr(core, "_is_windows", lambda: False)
+    monkeypatch.setattr(core, "_colab_exe", lambda: None)
+
+    payload = core.status_payload({})
+
+    assert payload["ok"] is False
+    assert payload["backend"] == "unavailable"
+    assert "colab executable" in payload["notes"][0]
+
+
+def test_run_job_requires_confirmation(tmp_path: Path) -> None:
+    script = tmp_path / "job.py"
+    script.write_text("print('hello')\n", encoding="utf-8")
+
+    result = core.run_job({"script_path": str(script), "gpu": "T4"})
+
+    assert result["ok"] is False
+    assert result["confirmation_required"] is True
+
+
+def test_run_job_builds_colab_command(monkeypatch, tmp_path: Path) -> None:
+    script = tmp_path / "job.py"
+    script.write_text("print('hello')\n", encoding="utf-8")
+    calls = []
+
+    monkeypatch.setattr(core, "_is_windows", lambda: False)
+    monkeypatch.setattr(core, "_colab_exe", lambda: "colab")
+
+    def fake_run(command, *, timeout_seconds, cwd=None):
+        calls.append((command, timeout_seconds, cwd))
+        return {"ok": True, "exit_code": 0, "command": command, "stdout": "done", "stderr": ""}
+
+    monkeypatch.setattr(core, "_run_command", fake_run)
+
+    result = core.run_job(
+        {
+            "script_path": str(script),
+            "args": ["--epochs", "1"],
+            "gpu": "T4",
+            "session_name": "hermes-sft",
+            "auth": "adc",
+            "confirmed": True,
+            "timeout_seconds": 123,
+        }
+    )
+
+    assert result["ok"] is True
+    command = calls[0][0]
+    assert command[:3] == ["colab", "--auth=adc", "run"]
+    assert "--gpu" in command
+    assert "T4" in command
+    assert "-s" in command
+    assert str(script) in command
+    assert command[-2:] == ["--epochs", "1"]
+    assert calls[0][1] == 123
+
+
+def test_write_sft_template(tmp_path: Path) -> None:
+    output = tmp_path / "sft.py"
+
+    result = core.write_sft_template(
+        {
+            "output_path": str(output),
+            "model_id": "Qwen/Qwen3-0.6B",
+            "dataset_name": "trl-lib/Capybara",
+            "max_steps": 5,
+        }
+    )
+
+    assert result["ok"] is True
+    source = output.read_text(encoding="utf-8")
+    assert "SFTTrainer" in source
+    assert "prepare_model_for_kbit_training" in source
+    assert "HF_TOKEN" in source
+
+
+def test_module_importable() -> None:
+    assert importlib.import_module("plugins.google_colab.core") is core


### PR DESCRIPTION
## Summary
- Add a standalone Google Colab CLI plugin instead of growing the core model-tool surface
- Register Colab status, sessions, confirmed run, and SFT-template tools/CLI entry points
- Document safety boundaries around accelerator allocation, Windows/WSL support, and generated SFT jobs

## Validation
- `ruff check .` -> passed
- `python -m pytest tests/plugins/test_google_colab_plugin.py -q` -> 6 passed

## Notes
- `google_colab_run` requires `confirmed=true` before invoking `colab run` because Colab sessions can allocate billable compute.
- This PR is intentionally plugin-scoped per the footprint ladder.
