### PR TITLE
fix: guard json.loads() against malformed API responses

### DIFF
--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -87,7 +87,7 @@ def _discord_request(
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             if resp.status == 204:
                 return None
-            return json.loads(resp.read().decode("utf-8"))
+            raw = resp.read().decode("utf-8")
     except urllib.error.HTTPError as e:
         error_body = ""
         try:
@@ -95,6 +95,11 @@ def _discord_request(
         except Exception:
             pass
         raise DiscordAPIError(e.code, error_body) from e
+
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise DiscordAPIError(0, f"Invalid JSON response from Discord: {e}") from e
 
 
 class DiscordAPIError(Exception):

--- a/tools/osv_check.py
+++ b/tools/osv_check.py
@@ -162,7 +162,13 @@ def _query_osv(
     )
 
     with urllib.request.urlopen(req, timeout=_TIMEOUT) as resp:
-        result = json.loads(resp.read())
+        raw = resp.read()
+
+    try:
+        result = json.loads(raw)
+    except json.JSONDecodeError as e:
+        logger.warning("OSV API returned invalid JSON for %s/%s: %s", package, ecosystem, e)
+        return []
 
     vulns = result.get("vulns", [])
     # Only malware advisories — ignore regular CVEs


### PR DESCRIPTION
## Problem

`json.loads()` in `tools/osv_check.py` and `tools/discord_tool.py` is called without catching `json.JSONDecodeError`. When APIs return malformed JSON (5xx error pages, rate limit HTML responses, Cloudflare interstitials, or network corruption), this causes unhandled crashes instead of clean error messages.

## Changes

### tools/osv_check.py
- Wrap `json.loads()` in try/except `JSONDecodeError`
- Log warning and return empty list on malformed response (graceful degradation — no malware advisories reported is better than crashing)

### tools/discord_tool.py
- Separate HTTP response reading from JSON parsing
- Catch `JSONDecodeError` and raise `DiscordAPIError` with descriptive message
- All callers already handle `DiscordAPIError`, so this is fully backward-compatible

## Testing

Both changes are minimal and follow existing error-handling patterns in the codebase.
