### PR TITLE
feat(kanban): inherit notification subscriptions to child tasks

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2766,6 +2766,11 @@ DEFAULT_CONFIG = {
         # large bulk-load of triage tasks from spending a burst of aux
         # LLM calls in one tick. Excess tasks defer to the next tick.
         "auto_decompose_per_tick": 3,
+        # When true, child tasks created from a triage decomposition inherit
+        # the root task's gateway notification subscriptions. Defaults to
+        # false so only the root task reports back unless the user opts into
+        # per-child notification fan-out.
+        "inherit_notify_subscriptions_to_children": False,
         # Stale detection: running tasks that have exceeded this many
         # seconds without a heartbeat (since ``last_heartbeat_at``) are
         # auto-reclaimed to ``ready`` on the next dispatcher tick. The

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5213,6 +5213,7 @@ def decompose_triage_task(
     children: list[dict],
     author: Optional[str] = None,
     auto_promote: bool = True,
+    inherit_notify_subscriptions: bool = False,
 ) -> Optional[list[str]]:
     """Fan a triage task out into child tasks and promote the root to ``todo``.
 
@@ -5313,6 +5314,13 @@ def decompose_triage_task(
         # override with its own 'workspace_kind' / 'workspace_path'.
         root_ws_kind = root_row["workspace_kind"] or "scratch"
         root_ws_path = root_row["workspace_path"]
+        root_notify_subs = []
+        if inherit_notify_subscriptions:
+            root_notify_subs = conn.execute(
+                "SELECT platform, chat_id, thread_id, user_id, notifier_profile "
+                "FROM kanban_notify_subs WHERE task_id = ?",
+                (task_id,),
+            ).fetchall()
 
         # Create children. Status is 'todo' regardless of parents — we
         # link them under the root AFTER creation so the dispatcher
@@ -5356,6 +5364,24 @@ def decompose_triage_task(
                 conn, new_id, "created",
                 {"by": author or "decomposer", "from_decompose_of": task_id},
             )
+            for sub in root_notify_subs:
+                conn.execute(
+                    """
+                    INSERT OR IGNORE INTO kanban_notify_subs
+                        (task_id, platform, chat_id, thread_id, user_id,
+                         notifier_profile, created_at, last_event_id)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, 0)
+                    """,
+                    (
+                        new_id,
+                        sub["platform"],
+                        sub["chat_id"],
+                        sub["thread_id"] or "",
+                        sub["user_id"],
+                        sub["notifier_profile"],
+                        now,
+                    ),
+                )
             child_ids.append(new_id)
 
         # Link children to their sibling parents (within the decomposed graph).

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -295,6 +295,9 @@ def decompose_task(
     default_assignee = _resolve_default_assignee(cfg)
     kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
     auto_promote = bool(kanban_cfg.get("auto_promote_children", True))
+    inherit_notify_subscriptions = bool(
+        kanban_cfg.get("inherit_notify_subscriptions_to_children", False)
+    )
     roster, valid_names = _build_roster()
 
     try:
@@ -447,6 +450,7 @@ def decompose_task(
                 children=children,
                 author=audit_author,
                 auto_promote=auto_promote,
+                inherit_notify_subscriptions=inherit_notify_subscriptions,
             )
     except ValueError as exc:
         return DecomposeOutcome(task_id, False, f"DB rejected graph: {exc}")

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1528,8 +1528,9 @@
   // ---------------------------------------------------------------------
   // OrchestrationPanel — collapsible settings panel for the kanban
   // orchestrator (orchestrator profile picker, default assignee picker,
-  // auto-decompose toggle, plus per-profile description editing with
-  // auto-generate). Backed by /orchestration + /profiles endpoints.
+  // decomposition and child-notification toggles, plus per-profile
+  // description editing with auto-generate). Backed by /orchestration +
+  // /profiles endpoints.
   // ---------------------------------------------------------------------
 
   function OrchestrationPanel() {
@@ -1682,7 +1683,7 @@
           className: msg.ok ? "hermes-kanban-msg-ok" : "hermes-kanban-msg-err",
         }, msg.text) : null,
 
-        settings ? h("div", { className: "grid gap-3 sm:grid-cols-3" },
+        settings ? h("div", { className: "grid gap-3 sm:grid-cols-2 lg:grid-cols-4" },
           h("div", { className: "flex flex-col gap-1" },
             h(Label, { className: "text-xs text-muted-foreground" },
               "Orchestrator profile"),
@@ -1733,6 +1734,21 @@
               settings.auto_decompose
                 ? "The dispatcher decomposes new triage tasks automatically."
                 : "Triage tasks stay in triage until you click ⚗ Decompose."),
+          ),
+          h("div", { className: "flex flex-col gap-1" },
+            h(Label, { className: "text-xs text-muted-foreground" },
+              "Child notifications"),
+            h("label", { className: "flex items-center gap-2 text-xs min-h-8" },
+              h(Checkbox, {
+                checked: !!settings.inherit_notify_subscriptions_to_children,
+                onCheckedChange: function (checked) {
+                  saveSettings({ inherit_notify_subscriptions_to_children: checked === true });
+                },
+              }),
+              "Notify for each decomposed child",
+            ),
+            h("div", { className: "text-[10px] text-muted-foreground" },
+              "Copies the root task's subscriptions to every child. Each child can send its own completion or blocked notification."),
           ),
         ) : h("div", { className: "text-xs text-muted-foreground" },
           "Loading…"),

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -2296,8 +2296,7 @@ def decompose_task_endpoint(
 
 
 # ---------------------------------------------------------------------------
-# Orchestration settings (kanban.orchestrator_profile / default_assignee /
-# auto_decompose) — surfaced to the dashboard's settings panel
+# Orchestration settings — surfaced to the dashboard's settings panel
 # ---------------------------------------------------------------------------
 
 class OrchestrationSettingsBody(BaseModel):
@@ -2305,6 +2304,7 @@ class OrchestrationSettingsBody(BaseModel):
     default_assignee: Optional[str] = None
     auto_decompose: Optional[bool] = None
     auto_promote_children: Optional[bool] = None
+    inherit_notify_subscriptions_to_children: Optional[bool] = None
 
 
 @router.get("/orchestration")
@@ -2321,6 +2321,9 @@ def get_orchestration_settings():
     explicit_default = (kanban_cfg.get("default_assignee") or "").strip()
     auto_decompose = bool(kanban_cfg.get("auto_decompose", True))
     auto_promote_children = bool(kanban_cfg.get("auto_promote_children", True))
+    inherit_notify_subscriptions = bool(
+        kanban_cfg.get("inherit_notify_subscriptions_to_children", False)
+    )
 
     # Resolve fallbacks the same way the decomposer does.
     resolved_orch = explicit_orch
@@ -2344,6 +2347,7 @@ def get_orchestration_settings():
         "default_assignee": explicit_default,
         "auto_decompose": auto_decompose,
         "auto_promote_children": auto_promote_children,
+        "inherit_notify_subscriptions_to_children": inherit_notify_subscriptions,
         "resolved_orchestrator_profile": resolved_orch,
         "resolved_default_assignee": resolved_default,
         "active_profile": active_default,
@@ -2411,6 +2415,11 @@ def set_orchestration_settings(payload: OrchestrationSettingsBody):
 
     if payload.auto_promote_children is not None:
         kanban_section["auto_promote_children"] = bool(payload.auto_promote_children)
+
+    if payload.inherit_notify_subscriptions_to_children is not None:
+        kanban_section["inherit_notify_subscriptions_to_children"] = bool(
+            payload.inherit_notify_subscriptions_to_children
+        )
 
     try:
         save_config(cfg)

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -250,6 +250,53 @@ def test_decompose_fanout_false_invalid_llm_assignee_uses_default(kanban_home):
     assert task.assignee == "fallback"
 
 
+def test_decompose_config_can_inherit_notification_subscriptions(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="ship a feature", triage=True)
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="weixin",
+            chat_id="chat-123",
+            notifier_profile="default",
+        )
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "test split",
+        "tasks": [
+            {"title": "build", "body": "code it", "assignee": "engineer", "parents": []},
+        ],
+    })
+
+    patches = _patch_list_profiles(["orchestrator", "engineer"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body(), patch(
+            "hermes_cli.kanban_decompose._load_config",
+            return_value={
+                "kanban": {
+                    "orchestrator_profile": "orchestrator",
+                    "inherit_notify_subscriptions_to_children": True,
+                }
+            },
+        ):
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok, outcome.reason
+    assert outcome.child_ids and len(outcome.child_ids) == 1
+    with kb.connect() as conn:
+        child_subs = kb.list_notify_subs(conn, outcome.child_ids[0])
+    assert len(child_subs) == 1
+    assert child_subs[0]["platform"] == "weixin"
+    assert child_subs[0]["chat_id"] == "chat-123"
+    assert child_subs[0]["notifier_profile"] == "default"
+
+
 def test_decompose_unknown_assignee_falls_back_to_default(kanban_home):
     with kb.connect() as conn:
         tid = kb.create_task(conn, title="x", triage=True)

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -168,6 +168,74 @@ def test_decompose_records_audit_comment_and_event(kanban_home):
     assert any(ev.kind == "decomposed" for ev in events)
 
 
+def test_decompose_children_do_not_inherit_root_notification_subscriptions_by_default(kanban_home):
+    with kb.connect() as conn:
+        tid = _create_triage(conn, title="notify root only")
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="weixin",
+            chat_id="chat-123",
+            thread_id="thread-456",
+            user_id="user-789",
+            notifier_profile="default",
+        )
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orch",
+            children=[{"title": "backend", "assignee": "mabu"}],
+            author="alice",
+        )
+
+    assert child_ids is not None
+    with kb.connect() as conn:
+        assert len(kb.list_notify_subs(conn, tid)) == 1
+        assert kb.list_notify_subs(conn, child_ids[0]) == []
+
+
+def test_decompose_children_can_inherit_root_notification_subscriptions(kanban_home):
+    with kb.connect() as conn:
+        tid = _create_triage(conn, title="notify me")
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="weixin",
+            chat_id="chat-123",
+            thread_id="thread-456",
+            user_id="user-789",
+            notifier_profile="default",
+        )
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orch",
+            children=[
+                {"title": "backend", "assignee": "mabu"},
+                {"title": "review", "assignee": "reviewer", "parents": [0]},
+            ],
+            author="alice",
+            inherit_notify_subscriptions=True,
+        )
+
+    assert child_ids is not None
+    with kb.connect() as conn:
+        root_subs = kb.list_notify_subs(conn, tid)
+        child_subs = [kb.list_notify_subs(conn, cid) for cid in child_ids]
+
+    assert len(root_subs) == 1
+    assert len(child_subs) == 2
+    for subs in child_subs:
+        assert len(subs) == 1
+        sub = subs[0]
+        assert sub["platform"] == "weixin"
+        assert sub["chat_id"] == "chat-123"
+        assert sub["thread_id"] == "thread-456"
+        assert sub["user_id"] == "user-789"
+        assert sub["notifier_profile"] == "default"
+        assert sub["last_event_id"] == 0
+
+
 def test_decompose_children_inherit_dir_workspace(kanban_home):
     """Fan-out children inherit the root's dir workspace, not scratch."""
     proj = "/home/teknium/myproject"

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -211,6 +211,45 @@ def test_dashboard_workspace_picker_explains_persistence_contract():
     )
 
 
+def test_orchestration_notification_inheritance_defaults_off_and_persists(client):
+    initial = client.get("/api/plugins/kanban/orchestration")
+
+    assert initial.status_code == 200
+    assert initial.json()["inherit_notify_subscriptions_to_children"] is False
+
+    enabled = client.put(
+        "/api/plugins/kanban/orchestration",
+        json={"inherit_notify_subscriptions_to_children": True},
+    )
+
+    assert enabled.status_code == 200
+    assert enabled.json()["inherit_notify_subscriptions_to_children"] is True
+
+    partial_update = client.put(
+        "/api/plugins/kanban/orchestration",
+        json={"auto_decompose": False},
+    )
+
+    assert partial_update.status_code == 200
+    assert partial_update.json()["inherit_notify_subscriptions_to_children"] is True
+
+
+def test_dashboard_exposes_child_notification_inheritance_setting():
+    bundle = (
+        Path(__file__).resolve().parents[2]
+        / "plugins"
+        / "kanban"
+        / "dashboard"
+        / "dist"
+        / "index.js"
+    ).read_text(encoding="utf-8")
+
+    assert "settings.inherit_notify_subscriptions_to_children" in bundle
+    assert "inherit_notify_subscriptions_to_children: checked === true" in bundle
+    assert "Notify for each decomposed child" in bundle
+    assert "Each child can send its own completion or blocked notification." in bundle
+
+
 def test_scheduled_tasks_have_their_own_column_not_todo(client):
     """Scheduled/time-delay tasks must not be silently bucketed into todo."""
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -524,7 +524,10 @@ Config knobs (all under `kanban:` in `~/.hermes/config.yaml`):
 | `auto_decompose_per_tick` | `3` | Cap on decompositions per dispatcher tick. Excess defers to the next tick. |
 | `orchestrator_profile` | `""` | Profile assigned to the root/orchestration task after decomposition. Empty = fall back to active default profile. |
 | `default_assignee` | `""` | Where a child task lands when the LLM picks an unknown profile. Empty = fall back to active default. |
+| `inherit_notify_subscriptions_to_children` | `false` | Copy the root task's notification subscriptions to every child created by decomposition. Each child can then send its own completion or blocked notification, so enable this only when you want per-child notification fan-out. |
 | `auto_subscribe_on_create` | `true` | When a worker calls `kanban_create` from inside a session with a persistent delivery channel (messaging gateway or TUI), the originating session is auto-subscribed to the new task's completion/block events. The dispatcher still drives the delivery — this only changes whether the caller's chat/key shows up in the notify-sub table. Set to `false` to require explicit `kanban_notify-subscribe` calls per task. |
+
+`inherit_notify_subscriptions_to_children` is off by default, so existing installations continue to notify only through subscriptions already attached to the root task. You can enable it in the expanded **Orchestration settings** panel or in `config.yaml` when the originating chat should receive a separate notification from each decomposed child.
 
 And the two auxiliary LLM slots:
 
@@ -576,8 +579,8 @@ All routes are mounted under `/api/plugins/kanban/` and protected by the dashboa
 | `GET` | `/profiles` | List installed profiles with their descriptions (consumed by the dashboard's profile-description editor and the orchestrator picker). |
 | `PATCH` | `/profiles/:name` | Set or clear a profile's description (user-authored — `description_auto: false`). Returns `{ok, profile, description}`. |
 | `POST` | `/profiles/:name/describe-auto` | Generate a description for a profile via `auxiliary.profile_describer`. Persists with `description_auto: true` so the dashboard can surface a "review" badge. |
-| `GET` | `/orchestration` | Read the kanban orchestration settings (`orchestrator_profile`, `default_assignee`, `auto_decompose`) plus the *resolved* effective values after fallbacks. |
-| `PUT` | `/orchestration` | Update one or more of the three orchestration keys in `config.yaml`. Validates that non-empty profile names actually exist. |
+| `GET` | `/orchestration` | Read the kanban orchestration settings, including decomposition and child-notification flags, plus the *resolved* effective profile values after fallbacks. |
+| `PUT` | `/orchestration` | Update one or more orchestration keys in `config.yaml`. Validates that non-empty profile names actually exist. |
 | `POST` | `/links` | Add a dependency (`parent_id` → `child_id`) |
 | `DELETE` | `/links?parent_id=…&child_id=…` | Remove a dependency |
 | `POST` | `/dispatch?max=…&dry_run=…` | Nudge the dispatcher — skip the 60 s wait |


### PR DESCRIPTION
## Summary
- Add a `kanban.inherit_notify_subscriptions_to_children` config flag (default `false`).
- When enabled, child tasks created by triage decomposition inherit the root task's gateway notification subscriptions.
- Thread the flag through `kanban_decompose.decompose_task` to `kanban_db.decompose_triage_task`.
- Expose the setting through the dashboard orchestration GET/PUT API and settings panel.
- Document the default-off behavior and per-child notification fan-out.

## Why
When a triage task is fanned out, only the root task carries gateway notification subscriptions. Users who want updates from individual children currently have no opt-in path.

The default remains conservative: only the root reports back unless the user enables child notification inheritance. Inherited subscriptions start at `last_event_id = 0`, and `INSERT OR IGNORE` keeps the copy idempotent.

## Test Plan
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_decompose.py tests/hermes_cli/test_kanban_decompose_db.py tests/plugins/test_kanban_dashboard_plugin.py -q`
- Result: 135 passed, 0 failed.
- `ruff check` on all changed Python source and test files.
- `node --check plugins/kanban/dashboard/dist/index.js`.
- `scripts/check-windows-footguns.py` on all changed Python source and test files.

Tests cover default no-inheritance behavior, DB-layer field copying, config-driven inheritance, dashboard default/read/write persistence, partial updates, and the dashboard control contract.

## Cross-platform / Security impact
- No platform-specific logic: the change is SQLite, YAML config, dashboard API, and browser UI code.
- No new external destination or credential surface. Existing subscription rows are copied only within the same Kanban database.
- The flag defaults off, so existing deployments retain their current notification behavior.