### PR TITLE
feat: add Unsloth Studio plugin

### DIFF
--- a/docs/unsloth-studio-plugin.md
+++ b/docs/unsloth-studio-plugin.md
@@ -1,0 +1,29 @@
+# Unsloth Studio Plugin
+
+## Decision
+
+Unsloth Studio is a local browser-based UI for training, running, exporting, and comparing open models. Hermes should launch and observe it as a local service, not copy its training UI into Hermes core.
+
+## Implemented Surface
+
+- `hermes unsloth-studio status`
+- `hermes unsloth-studio start`
+- `hermes unsloth-studio stop`
+- `hermes unsloth-studio install-info`
+- `/unsloth-studio status`
+- `/unsloth-studio install-info`
+
+The default start command binds to `127.0.0.1:8888`. Binding to `0.0.0.0` or another non-loopback host requires `confirm_public_host`.
+
+## Source Findings
+
+- Unsloth Studio is Beta and works on Windows, Linux, WSL, and macOS.
+- The Studio quickstart launches with `unsloth studio -H 0.0.0.0 -p 8888`, then opens `http://localhost:8888`.
+- Windows install is `irm https://unsloth.ai/install.ps1 | iex`.
+- macOS, Linux, and WSL install is `curl -fsSL https://unsloth.ai/install.sh | sh`.
+- Studio can train via QLoRA, LoRA, and full fine-tuning, and export to safetensors or GGUF for llama.cpp, vLLM, Ollama, LM Studio, and similar runtimes.
+- The Unsloth repo describes Studio UI components as AGPL-3.0 while core Unsloth remains Apache-2.0. Treat Studio as a separate local service boundary.
+
+## Boundary
+
+The plugin does not run remote install scripts automatically. It returns install commands for the user and only starts a locally installed `unsloth` CLI.

--- a/plugins/unsloth_studio/__init__.py
+++ b/plugins/unsloth_studio/__init__.py
@@ -1,0 +1,64 @@
+"""Unsloth Studio bridge for Hermes."""
+
+from __future__ import annotations
+
+from . import core
+from .cli import register_cli, unsloth_studio_command
+
+
+def _json_handler(fn):
+    def handler(values=None, **kwargs):
+        payload = values if isinstance(values, dict) else {}
+        payload.update(kwargs)
+        return core.to_json(fn(payload))
+
+    return handler
+
+
+def register(ctx) -> None:
+    """Register Unsloth Studio tools, slash command, and CLI command."""
+    ctx.register_tool(
+        name="unsloth_studio_status",
+        toolset="unsloth-studio",
+        schema=core.STATUS_SCHEMA,
+        handler=_json_handler(core.status_payload),
+        check_fn=lambda: True,
+        description=core.STATUS_SCHEMA["description"],
+    )
+    ctx.register_tool(
+        name="unsloth_studio_start",
+        toolset="unsloth-studio",
+        schema=core.START_SCHEMA,
+        handler=_json_handler(core.start_studio),
+        check_fn=core.check_available,
+        description=core.START_SCHEMA["description"],
+    )
+    ctx.register_tool(
+        name="unsloth_studio_stop",
+        toolset="unsloth-studio",
+        schema=core.STOP_SCHEMA,
+        handler=_json_handler(core.stop_studio),
+        check_fn=lambda: True,
+        description=core.STOP_SCHEMA["description"],
+    )
+    ctx.register_tool(
+        name="unsloth_studio_install_info",
+        toolset="unsloth-studio",
+        schema=core.INSTALL_INFO_SCHEMA,
+        handler=_json_handler(core.install_info),
+        check_fn=lambda: True,
+        description=core.INSTALL_INFO_SCHEMA["description"],
+    )
+    ctx.register_command(
+        "unsloth-studio",
+        handler=lambda raw_args: core.handle_slash(raw_args),
+        description="Inspect, launch, and stop the local Unsloth Studio UI.",
+        args_hint="[status|start|stop|install-info]",
+    )
+    ctx.register_cli_command(
+        name="unsloth-studio",
+        help="Local Unsloth Studio launcher",
+        setup_fn=register_cli,
+        handler_fn=unsloth_studio_command,
+        description="Inspect, launch, and stop Unsloth Studio without reimplementing its UI.",
+    )

--- a/plugins/unsloth_studio/cli.py
+++ b/plugins/unsloth_studio/cli.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Any
+
+from . import core
+
+
+def _print(payload: dict[str, Any]) -> None:
+    print(core.to_json(payload))
+
+
+def register_cli(subparser) -> None:
+    actions = subparser.add_subparsers(dest="unsloth_studio_action")
+
+    status_parser = actions.add_parser("status", help="Show Unsloth Studio status.")
+    status_parser.add_argument("--host", default=core.DEFAULT_HOST)
+    status_parser.add_argument("--port", type=int, default=core.DEFAULT_PORT)
+    status_parser.add_argument("--no-probe-url", action="store_true")
+
+    start_parser = actions.add_parser("start", help="Start Unsloth Studio.")
+    start_parser.add_argument("--host", default=core.DEFAULT_HOST)
+    start_parser.add_argument("--port", type=int, default=core.DEFAULT_PORT)
+    start_parser.add_argument("--wait-seconds", type=float, default=core.DEFAULT_WAIT_SECONDS)
+    start_parser.add_argument("--cwd")
+    start_parser.add_argument("--confirm-public-host", action="store_true")
+    start_parser.add_argument("extra_args", nargs="*")
+
+    stop_parser = actions.add_parser("stop", help="Stop the recorded Unsloth Studio process.")
+    stop_parser.add_argument("--pid", type=int)
+
+    info_parser = actions.add_parser("install-info", help="Show official install commands.")
+    info_parser.add_argument("--local-only", action="store_true")
+
+    subparser.set_defaults(func=unsloth_studio_command)
+
+
+def unsloth_studio_command(args: Any) -> int:
+    action = getattr(args, "unsloth_studio_action", None)
+    if action == "status":
+        _print(
+            core.status_payload(
+                {
+                    "host": args.host,
+                    "port": args.port,
+                    "probe_url": not args.no_probe_url,
+                }
+            )
+        )
+        return 0
+    if action == "start":
+        _print(
+            core.start_studio(
+                {
+                    "host": args.host,
+                    "port": args.port,
+                    "wait_seconds": args.wait_seconds,
+                    "cwd": args.cwd,
+                    "extra_args": args.extra_args,
+                    "confirm_public_host": args.confirm_public_host,
+                }
+            )
+        )
+        return 0
+    if action == "stop":
+        _print(core.stop_studio({"pid": args.pid}))
+        return 0
+    if action == "install-info":
+        _print(core.install_info({"local_only": args.local_only}))
+        return 0
+    print("usage: hermes unsloth-studio {status,start,stop,install-info}")
+    return 2

--- a/plugins/unsloth_studio/core.py
+++ b/plugins/unsloth_studio/core.py
@@ -149,7 +149,14 @@ def _pid_alive(pid: int | None) -> bool:
     if not pid or pid <= 0:
         return False
     try:
-        os.kill(pid, 0)
+        import psutil  # type: ignore
+
+        return bool(psutil.pid_exists(int(pid)))
+    except Exception:
+        if _is_windows():
+            return False
+    try:
+        os.kill(pid, 0)  # windows-footgun: ok - POSIX-only fallback when psutil is unavailable.
         return True
     except OSError:
         return False

--- a/plugins/unsloth_studio/core.py
+++ b/plugins/unsloth_studio/core.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+import json
+import os
+import platform
+import shlex
+import signal
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from hermes_constants import get_hermes_home
+
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8888
+DEFAULT_WAIT_SECONDS = 3.0
+
+
+STATUS_SCHEMA = {
+    "description": "Report local Unsloth Studio launcher and server status.",
+    "type": "object",
+    "properties": {
+        "host": {"type": "string", "default": DEFAULT_HOST},
+        "port": {"type": "integer", "default": DEFAULT_PORT},
+        "probe_url": {"type": "boolean", "default": True},
+    },
+}
+
+START_SCHEMA = {
+    "description": "Start Unsloth Studio with the local unsloth CLI.",
+    "type": "object",
+    "properties": {
+        "host": {
+            "type": "string",
+            "description": "Bind host. Defaults to loopback. Public hosts require confirm_public_host.",
+            "default": DEFAULT_HOST,
+        },
+        "port": {"type": "integer", "default": DEFAULT_PORT},
+        "wait_seconds": {
+            "type": "number",
+            "description": "Seconds to wait for HTTP readiness after launch.",
+            "default": DEFAULT_WAIT_SECONDS,
+        },
+        "cwd": {
+            "type": "string",
+            "description": "Optional working directory for the launcher.",
+        },
+        "extra_args": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Additional arguments appended after unsloth studio -H HOST -p PORT.",
+        },
+        "confirm_public_host": {
+            "type": "boolean",
+            "description": "Required when host is not loopback.",
+            "default": False,
+        },
+    },
+}
+
+STOP_SCHEMA = {
+    "description": "Stop the Unsloth Studio process recorded by the Hermes plugin.",
+    "type": "object",
+    "properties": {
+        "pid": {
+            "type": "integer",
+            "description": "Optional explicit process id. Defaults to the plugin state file.",
+        }
+    },
+}
+
+INSTALL_INFO_SCHEMA = {
+    "description": "Return official Unsloth Studio installation and launch commands.",
+    "type": "object",
+    "properties": {
+        "local_only": {
+            "type": "boolean",
+            "description": "Return only local install commands, not cloud notebook links.",
+            "default": False,
+        }
+    },
+}
+
+
+def to_json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=False, indent=2)
+
+
+def _unsloth_exe() -> str | None:
+    return os.environ.get("UNSLOTH_STUDIO_BIN") or _which("unsloth")
+
+
+def _which(name: str) -> str | None:
+    from shutil import which
+
+    return which(name)
+
+
+def state_file() -> Path:
+    return get_hermes_home() / "unsloth_studio_state.json"
+
+
+def _read_state() -> dict[str, Any]:
+    path = state_file()
+    if not path.is_file():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _write_state(payload: dict[str, Any]) -> None:
+    path = state_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _clear_state() -> None:
+    try:
+        state_file().unlink()
+    except FileNotFoundError:
+        pass
+
+
+def _is_windows() -> bool:
+    return os.name == "nt"
+
+
+def _is_loopback(host: str) -> bool:
+    value = (host or "").strip().lower()
+    return value in {"127.0.0.1", "localhost", "::1"} or value.startswith("127.")
+
+
+def _display_url(host: str, port: int) -> str:
+    browser_host = "127.0.0.1" if host in {"0.0.0.0", "::"} else host
+    if ":" in browser_host and not browser_host.startswith("["):
+        browser_host = f"[{browser_host}]"
+    return f"http://{browser_host}:{port}"
+
+
+def _pid_alive(pid: int | None) -> bool:
+    if not pid or pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError:
+        return False
+
+
+def _http_probe(url: str, timeout: float = 2.0) -> dict[str, Any]:
+    request = Request(url, method="GET")
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            return {
+                "ok": 200 <= response.status < 500,
+                "status_code": response.status,
+                "url": url,
+            }
+    except HTTPError as exc:
+        return {"ok": exc.code < 500, "status_code": exc.code, "url": url, "error": str(exc)}
+    except (OSError, URLError) as exc:
+        return {"ok": False, "url": url, "error": str(exc)}
+
+
+def _url_ready(url: str, wait_seconds: float) -> bool:
+    deadline = time.monotonic() + max(0.0, wait_seconds)
+    while time.monotonic() <= deadline:
+        if _http_probe(url, timeout=1.0)["ok"]:
+            return True
+        time.sleep(0.25)
+    return False
+
+
+def check_available() -> bool:
+    return bool(_unsloth_exe())
+
+
+def status_payload(values: dict[str, Any] | None = None) -> dict[str, Any]:
+    values = values or {}
+    host = str(values.get("host") or DEFAULT_HOST)
+    port = int(values.get("port") or DEFAULT_PORT)
+    state = _read_state()
+    pid = int(state.get("pid") or 0) if state else 0
+    state_host = str(state.get("host") or host)
+    state_port = int(state.get("port") or port)
+    url = str(state.get("url") or _display_url(host, port))
+    running = _pid_alive(pid)
+    payload: dict[str, Any] = {
+        "ok": bool(_unsloth_exe()),
+        "available": bool(_unsloth_exe()),
+        "platform": {
+            "system": platform.system(),
+            "release": platform.release(),
+        },
+        "paths": {
+            "unsloth": _unsloth_exe(),
+            "state_file": str(state_file()),
+        },
+        "server": {
+            "pid": pid or None,
+            "running": running,
+            "host": state_host,
+            "port": state_port,
+            "url": url,
+        },
+        "notes": [],
+    }
+    if not _unsloth_exe():
+        payload["notes"].append("The unsloth CLI was not found on PATH.")
+    if values.get("probe_url", True):
+        payload["server"]["http"] = _http_probe(url)
+    return payload
+
+
+def _popen_kwargs(cwd: str | Path | None) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "cwd": str(cwd) if cwd else None,
+        "stdin": subprocess.DEVNULL,
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+    }
+    if _is_windows():
+        kwargs["creationflags"] = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0) | getattr(
+            subprocess, "DETACHED_PROCESS", 0
+        )
+    else:
+        kwargs["start_new_session"] = True
+    return kwargs
+
+
+def start_studio(values: dict[str, Any]) -> dict[str, Any]:
+    exe = _unsloth_exe()
+    if not exe:
+        return {
+            "ok": False,
+            "error": "The unsloth CLI was not found on PATH.",
+            "install": install_info({}),
+        }
+
+    host = str(values.get("host") or DEFAULT_HOST)
+    port = int(values.get("port") or DEFAULT_PORT)
+    if not _is_loopback(host) and not values.get("confirm_public_host"):
+        return {
+            "ok": False,
+            "confirmation_required": True,
+            "reason": "Binding Unsloth Studio outside loopback exposes a local training UI.",
+        }
+
+    url = _display_url(host, port)
+    existing = _read_state()
+    existing_pid = int(existing.get("pid") or 0) if existing else 0
+    if _pid_alive(existing_pid):
+        return {
+            "ok": True,
+            "already_running": True,
+            "pid": existing_pid,
+            "url": existing.get("url") or url,
+        }
+
+    command = [exe, "studio", "-H", host, "-p", str(port)]
+    command.extend(str(arg) for arg in values.get("extra_args") or [])
+    cwd = values.get("cwd")
+    try:
+        proc = subprocess.Popen(command, **_popen_kwargs(cwd))
+    except OSError as exc:
+        return {"ok": False, "error": str(exc), "command": command}
+
+    payload = {
+        "pid": proc.pid,
+        "host": host,
+        "port": port,
+        "url": url,
+        "command": command,
+        "cwd": str(cwd) if cwd else None,
+        "started_at": time.time(),
+    }
+    _write_state(payload)
+    wait_seconds = float(values.get("wait_seconds") or DEFAULT_WAIT_SECONDS)
+    ready = _url_ready(url, wait_seconds) if wait_seconds > 0 else False
+    return {
+        "ok": True,
+        "pid": proc.pid,
+        "url": url,
+        "ready": ready,
+        "command": command,
+        "state_file": str(state_file()),
+    }
+
+
+def _terminate_pid(pid: int) -> dict[str, Any]:
+    if not _pid_alive(pid):
+        return {"ok": True, "already_stopped": True, "pid": pid}
+    if _is_windows():
+        result = subprocess.run(
+            ["taskkill", "/PID", str(pid), "/T", "/F"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=20,
+        )
+        return {
+            "ok": result.returncode == 0,
+            "pid": pid,
+            "exit_code": result.returncode,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+        }
+    os.kill(pid, signal.SIGTERM)
+    return {"ok": True, "pid": pid, "signal": "SIGTERM"}
+
+
+def stop_studio(values: dict[str, Any] | None = None) -> dict[str, Any]:
+    values = values or {}
+    state = _read_state()
+    pid = int(values.get("pid") or state.get("pid") or 0)
+    if not pid:
+        return {"ok": False, "error": "No Unsloth Studio pid was provided or recorded."}
+    result = _terminate_pid(pid)
+    if result.get("ok") and int(state.get("pid") or 0) == pid:
+        _clear_state()
+    return result
+
+
+def install_info(values: dict[str, Any] | None = None) -> dict[str, Any]:
+    values = values or {}
+    system = platform.system().lower()
+    if "windows" in system:
+        install = "irm https://unsloth.ai/install.ps1 | iex"
+        update = install
+        developer = [
+            "git clone https://github.com/unslothai/unsloth.git",
+            "cd unsloth",
+            "Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass",
+            ".\\install.ps1 --local",
+            "unsloth studio -p 8888",
+        ]
+    else:
+        install = "curl -fsSL https://unsloth.ai/install.sh | sh"
+        update = install
+        developer = [
+            "git clone https://github.com/unslothai/unsloth",
+            "cd unsloth",
+            "./install.sh --local",
+            "unsloth studio -p 8888",
+        ]
+    payload: dict[str, Any] = {
+        "ok": True,
+        "platform": platform.system(),
+        "install": install,
+        "update": update,
+        "launch": f"unsloth studio -H {DEFAULT_HOST} -p {DEFAULT_PORT}",
+        "developer_install": developer,
+        "notes": [
+            "The Hermes plugin does not execute remote install scripts automatically.",
+            "Default launch binds to loopback; use confirm_public_host for a public bind.",
+        ],
+    }
+    if not values.get("local_only"):
+        payload["colab_notebook"] = (
+            "https://colab.research.google.com/github/unslothai/unsloth/"
+            "blob/main/studio/Unsloth_Studio_Colab.ipynb"
+        )
+    return payload
+
+
+def handle_slash(raw_args: str) -> str:
+    parts = shlex.split(raw_args or "")
+    action = parts[0] if parts else "status"
+    if action == "status":
+        return to_json(status_payload({}))
+    if action == "install-info":
+        return to_json(install_info({}))
+    if action == "start":
+        return to_json(start_studio({}))
+    if action == "stop":
+        return to_json(stop_studio({}))
+    return to_json(
+        {
+            "ok": False,
+            "error": "Supported /unsloth-studio actions: status, start, stop, install-info.",
+        }
+    )

--- a/plugins/unsloth_studio/core.py
+++ b/plugins/unsloth_studio/core.py
@@ -230,7 +230,6 @@ def status_payload(values: dict[str, Any] | None = None) -> dict[str, Any]:
 def _popen_kwargs(cwd: str | Path | None) -> dict[str, Any]:
     kwargs: dict[str, Any] = {
         "cwd": str(cwd) if cwd else None,
-        "stdin": subprocess.DEVNULL,
         "stdout": subprocess.DEVNULL,
         "stderr": subprocess.DEVNULL,
     }
@@ -276,7 +275,7 @@ def start_studio(values: dict[str, Any]) -> dict[str, Any]:
     command.extend(str(arg) for arg in values.get("extra_args") or [])
     cwd = values.get("cwd")
     try:
-        proc = subprocess.Popen(command, **_popen_kwargs(cwd))
+        proc = subprocess.Popen(command, stdin=subprocess.DEVNULL, **_popen_kwargs(cwd))
     except OSError as exc:
         return {"ok": False, "error": str(exc), "command": command}
 

--- a/plugins/unsloth_studio/plugin.yaml
+++ b/plugins/unsloth_studio/plugin.yaml
@@ -1,0 +1,16 @@
+name: unsloth-studio
+version: 0.1.0
+description: Local Unsloth Studio launcher and status bridge.
+author: HermesAgent
+kind: standalone
+platforms:
+  - windows
+  - linux
+  - macos
+provides_tools:
+  - unsloth_studio_status
+  - unsloth_studio_start
+  - unsloth_studio_stop
+  - unsloth_studio_install_info
+provides_cli:
+  - unsloth-studio

--- a/tests/plugins/test_unsloth_studio_plugin.py
+++ b/tests/plugins/test_unsloth_studio_plugin.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+from plugins.unsloth_studio import core, register
+
+
+class _FakeContext:
+    def __init__(self) -> None:
+        self.tools = {}
+        self.commands = {}
+        self.cli_commands = {}
+
+    def register_tool(self, name, **kwargs):
+        self.tools[name] = kwargs
+
+    def register_command(self, name, **kwargs):
+        self.commands[name] = kwargs
+
+    def register_cli_command(self, name, **kwargs):
+        self.cli_commands[name] = kwargs
+
+
+def test_registers_tools_slash_and_cli_command() -> None:
+    ctx = _FakeContext()
+    register(ctx)
+
+    assert "unsloth_studio_status" in ctx.tools
+    assert "unsloth_studio_start" in ctx.tools
+    assert "unsloth_studio_stop" in ctx.tools
+    assert "unsloth_studio_install_info" in ctx.tools
+    assert "unsloth-studio" in ctx.commands
+    assert "unsloth-studio" in ctx.cli_commands
+
+
+def test_status_reports_missing_cli(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(core, "_unsloth_exe", lambda: None)
+    monkeypatch.setattr(core, "state_file", lambda: tmp_path / "state.json")
+
+    payload = core.status_payload({"probe_url": False})
+
+    assert payload["ok"] is False
+    assert payload["available"] is False
+    assert "not found" in payload["notes"][0]
+
+
+def test_start_rejects_public_host_without_confirmation(monkeypatch) -> None:
+    monkeypatch.setattr(core, "_unsloth_exe", lambda: "unsloth")
+
+    result = core.start_studio({"host": "0.0.0.0", "port": 8888})
+
+    assert result["ok"] is False
+    assert result["confirmation_required"] is True
+
+
+def test_start_builds_detached_command(monkeypatch, tmp_path: Path) -> None:
+    calls = []
+
+    class FakeProc:
+        pid = 4242
+
+    def fake_popen(command, **kwargs):
+        calls.append((command, kwargs))
+        return FakeProc()
+
+    monkeypatch.setattr(core, "_unsloth_exe", lambda: "unsloth")
+    monkeypatch.setattr(core, "state_file", lambda: tmp_path / "state.json")
+    monkeypatch.setattr(core, "_pid_alive", lambda _pid: False)
+    monkeypatch.setattr(core, "_url_ready", lambda _url, _wait: True)
+    monkeypatch.setattr(core.subprocess, "Popen", fake_popen)
+
+    result = core.start_studio(
+        {
+            "host": "127.0.0.1",
+            "port": 8899,
+            "wait_seconds": 1,
+            "extra_args": ["--example"],
+        }
+    )
+
+    assert result["ok"] is True
+    assert result["pid"] == 4242
+    command = calls[0][0]
+    assert command == ["unsloth", "studio", "-H", "127.0.0.1", "-p", "8899", "--example"]
+    state = (tmp_path / "state.json").read_text(encoding="utf-8")
+    assert "4242" in state
+
+
+def test_stop_uses_recorded_pid(monkeypatch, tmp_path: Path) -> None:
+    state = tmp_path / "state.json"
+    state.write_text('{"pid": 3131, "url": "http://127.0.0.1:8888"}', encoding="utf-8")
+    seen = {}
+
+    def fake_terminate(pid):
+        seen["pid"] = pid
+        return {"ok": True}
+
+    monkeypatch.setattr(core, "state_file", lambda: state)
+    monkeypatch.setattr(core, "_terminate_pid", fake_terminate)
+
+    result = core.stop_studio({})
+
+    assert result["ok"] is True
+    assert seen["pid"] == 3131
+    assert not state.exists()
+
+
+def test_install_info_has_platform_command() -> None:
+    payload = core.install_info({"local_only": True})
+
+    assert payload["ok"] is True
+    assert "unsloth" in payload["install"].lower()
+    assert "colab_notebook" not in payload
+
+
+def test_module_importable() -> None:
+    assert importlib.import_module("plugins.unsloth_studio.core") is core


### PR DESCRIPTION
## Summary
- Add a standalone Unsloth Studio plugin for local fine-tuning UI workflows
- Register status/start/stop/install-info model tools plus CLI and slash-command surfaces
- Keep startup safe by binding to loopback by default and requiring confirmation for public binds

Closes #46450

## Validation
- `ruff check .` -> passed
- `python -m pytest tests/plugins/test_unsloth_studio_plugin.py -q` -> 7 passed

## Notes
- Plugin-scoped per the footprint ladder; no new core model tool.
- The plugin reports official install commands but does not run remote install scripts automatically.
