### PR TITLE
fix(browser): suppress macOS "Keychain Not Found" modal on debug-Chrome auto-launch

### DIFF
--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -128,6 +128,25 @@ def _chrome_debug_args(port: int) -> list[str]:
     return [
         f"--remote-debugging-port={port}",
         f"--user-data-dir={chrome_debug_data_dir()}",
+        # Chrome/Chromium 111+ rejects CDP WebSocket handshakes with HTTP 403
+        # unless the connecting origin is explicitly allowed. Playwright's
+        # ``connect_over_cdp`` (used by ``/browser connect``) sends an ``Origin``
+        # header, so without this flag the attach fails on modern Chrome. The
+        # debug endpoint binds to loopback on a dedicated profile, so allowing
+        # all origins is scoped to localhost. See:
+        # https://chromium-review.googlesource.com/c/chromium/src/+/4106462
+        "--remote-allow-origins=*",
+        # On macOS, a Chromium-family browser launched detached (no Aqua login
+        # session — e.g. from a gateway/worker/cron) tries to read its "Safe
+        # Storage" key from the macOS Keychain and throws a blocking, on-screen
+        # "A keychain cannot be found to store \"Chrome\"" modal that leaks onto
+        # the user's display and stalls automation. Routing password storage to
+        # Chrome's own basic store + mocking the keychain suppresses the modal
+        # entirely. This only changes WHERE Chrome stores passwords (its own
+        # encrypted store vs the OS Keychain); it does NOT affect cookies,
+        # logins, or the CDP session. Harmless no-ops on Linux/Windows.
+        "--password-store=basic",
+        "--use-mock-keychain",
         "--no-first-run",
         "--no-default-browser-check",
     ]
@@ -179,9 +198,14 @@ def manual_chrome_debug_command(port: int = DEFAULT_BROWSER_CDP_PORT, system: st
 
     if system == "Darwin":
         data_dir = chrome_debug_data_dir()
+        # --password-store=basic --use-mock-keychain: suppress the blocking macOS
+        # "Keychain Not Found" Safe-Storage modal a detached Chrome throws onto the
+        # user's screen (see _chrome_debug_args). Keep this branch in sync with it.
         return (
             f'open -a "Google Chrome" --args --remote-debugging-port={port} '
-            f'--user-data-dir="{data_dir}" --no-first-run --no-default-browser-check'
+            f'--user-data-dir="{data_dir}" --remote-allow-origins=* '
+            f'--password-store=basic --use-mock-keychain '
+            f'--no-first-run --no-default-browser-check'
         )
 
     return None

--- a/tests/cli/test_chrome_launcher_keychain_guard.py
+++ b/tests/cli/test_chrome_launcher_keychain_guard.py
@@ -1,0 +1,130 @@
+"""Guard: every DETACHED Chrome/Chromium launcher in the harness must suppress the
+macOS "Keychain Not Found" Safe-Storage modal.
+
+A Chromium-family browser launched detached on macOS (no Aqua login session — i.e.
+from the gateway, a kanban/subagent worker, or a cron) tries to read its "Safe
+Storage" key from the macOS Keychain and, when it can't, throws a BLOCKING on-screen
+"A keychain cannot be found to store \"Chrome\"" system modal that leaks onto the
+user's display and stalls automation. Launching with
+``--password-store=basic --use-mock-keychain`` routes password storage off the OS
+Keychain and suppresses the modal entirely (harmless no-ops on Linux/Windows).
+
+This recurred on the fleet because the original guard (the tabs-outliner e2e
+``lint-browser-launchers.sh``) only scanned ``extension-build/e2e`` and never saw
+``hermes_cli/browser_connect.py`` — the harness's own debug-Chrome auto-launch path.
+This test closes that coverage gap inside the harness repo so a future launcher that
+omits the flags fails CI.
+
+Scope (DETACHED automation launches only):
+  - INCLUDED: code that builds a Chrome argv / ``open -a "Google Chrome" --args ...``
+    command for a detached debug/automation browser (the modal-throwing path).
+  - EXCLUDED: ``webbrowser.open(url)`` interactive OAuth/portal flows — those open the
+    user's EXISTING default browser in their real login session, never spawn a
+    detached profile, and so never throw the modal (and must NOT carry the flags).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# A "detached Chrome launcher" line builds an automation Chrome invocation. We key on
+# the two unambiguous tells: a --remote-debugging-port arg (CDP automation) or an
+# `open -a "Google Chrome" --args` shell command. Both are detached-spawn paths.
+_LAUNCHER_SIGNATURES = (
+    re.compile(r"--remote-debugging-port"),
+    re.compile(r'open -a "Google Chrome" --args'),
+)
+_REQUIRED_FLAGS = ("--password-store=basic", "--use-mock-keychain")
+
+# Directories that contain harness launch code worth scanning.
+_SCAN_DIRS = ("hermes_cli", "tools")
+
+
+def _python_sources() -> list[Path]:
+    files: list[Path] = []
+    for d in _SCAN_DIRS:
+        root = REPO_ROOT / d
+        if root.is_dir():
+            files.extend(p for p in root.rglob("*.py") if "__pycache__" not in p.parts)
+    return files
+
+
+def _detached_chrome_launchers() -> list[Path]:
+    """Files that contain at least one detached-Chrome launch signature."""
+    hits: list[Path] = []
+    for path in _python_sources():
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if any(sig.search(text) for sig in _LAUNCHER_SIGNATURES):
+            hits.append(path)
+    return hits
+
+
+def _launch_constructs(text: str) -> list[tuple[int, str]]:
+    """Split a source file into per-launcher windows so a SECOND launch path that
+    omits a flag can't be masked by a FIRST path that carries it (a whole-file
+    substring check has exactly that blind spot). We anchor each construct on a
+    launch signature line and take a window of surrounding lines large enough to
+    span an argv list / multi-line command string but small enough not to bleed
+    into the next construct.
+
+    Returns (line_number, window_text) for each distinct launch signature hit.
+    """
+    lines = text.splitlines()
+    anchors = [
+        i for i, line in enumerate(lines)
+        if any(sig.search(line) for sig in _LAUNCHER_SIGNATURES)
+    ]
+    windows: list[tuple[int, str]] = []
+    for idx, i in enumerate(anchors):
+        # Forward-only window from this anchor to just before the NEXT anchor (capped),
+        # so an argv list whose flags sit 15-20 lines below a comment-padded
+        # --remote-debugging-port line are still captured, without bleeding into the
+        # next distinct launch construct.
+        next_anchor = anchors[idx + 1] if idx + 1 < len(anchors) else len(lines)
+        hi = min(next_anchor, i + 30)
+        windows.append((i + 1, "\n".join(lines[i:hi])))
+    return windows
+
+
+def test_browser_connect_is_discovered_as_a_launcher():
+    """Sanity: the scanner actually finds the known launcher. If this fails the
+    signature regexes drifted and the guard below is vacuously green."""
+    launchers = {p.name for p in _detached_chrome_launchers()}
+    assert "browser_connect.py" in launchers, (
+        "browser_connect.py should be detected as a detached-Chrome launcher; "
+        f"found: {sorted(launchers)}"
+    )
+
+
+def test_browser_connect_has_both_launch_constructs():
+    """Sanity: browser_connect.py has BOTH detached launch paths (the
+    _chrome_debug_args argv list AND the macOS `open -a` fallback string). If this
+    drops below 2 the per-construct guard below may be silently checking fewer
+    paths than exist."""
+    text = (REPO_ROOT / "hermes_cli" / "browser_connect.py").read_text(encoding="utf-8")
+    assert len(_launch_constructs(text)) >= 2, (
+        "expected >=2 launch constructs in browser_connect.py "
+        f"(argv list + open -a fallback); found {len(_launch_constructs(text))}"
+    )
+
+
+def test_every_detached_chrome_launch_construct_suppresses_macos_keychain_modal():
+    """Every INDIVIDUAL detached-Chrome launch construct MUST carry both GUI-silence
+    flags — checked per-construct, not per-file, so a second launch path that omits a
+    flag is caught even when a sibling path carries it. RED-prove by deleting either
+    flag from EITHER the _chrome_debug_args list OR the macOS `open -a` string."""
+    offenders: list[str] = []
+    for path in _detached_chrome_launchers():
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for lineno, window in _launch_constructs(text):
+            missing = [f for f in _REQUIRED_FLAGS if f not in window]
+            if missing:
+                rel = path.relative_to(REPO_ROOT)
+                offenders.append(f"{rel}:{lineno} missing {missing}")
+    assert not offenders, (
+        "Detached-Chrome launch construct(s) omit a macOS Keychain-modal suppression "
+        "flag (--password-store=basic / --use-mock-keychain):\n  " + "\n  ".join(offenders)
+    )

--- a/tests/cli/test_cli_browser_connect.py
+++ b/tests/cli/test_cli_browser_connect.py
@@ -21,6 +21,12 @@ def _assert_chrome_debug_cmd(cmd, expected_chrome, expected_port):
     assert f"--remote-debugging-port={expected_port}" in cmd
     assert "--no-first-run" in cmd
     assert "--no-default-browser-check" in cmd
+    # Chrome 111+ rejects CDP WebSocket handshakes (HTTP 403) without this flag.
+    assert "--remote-allow-origins=*" in cmd
+    # macOS: suppress the blocking "Keychain Not Found" Safe-Storage modal that a
+    # detached Chromium launch throws onto the user's screen (harmless elsewhere).
+    assert "--password-store=basic" in cmd
+    assert "--use-mock-keychain" in cmd
     user_data_args = [a for a in cmd if a.startswith("--user-data-dir=")]
     assert len(user_data_args) == 1, "Expected exactly one --user-data-dir flag"
     assert "chrome-debug" in user_data_args[0]
@@ -34,6 +40,47 @@ class _FakeResponse:
 
     def __exit__(self, exc_type, exc, tb):
         return False
+
+
+def test_manual_command_includes_remote_allow_origins_on_macos():
+    """Chrome 111+ rejects CDP WebSocket handshakes (403) without
+    --remote-allow-origins; the macOS `open -a` fallback must include it so
+    `/browser connect` (Playwright connect_over_cdp) can attach."""
+    with patch(
+        "hermes_cli.browser_connect.get_chrome_debug_candidates", return_value=[]
+    ):
+        command = manual_chrome_debug_command(port=9222, system="Darwin")
+    assert command is not None
+    assert "--remote-allow-origins=*" in command
+
+
+def test_chrome_debug_args_suppress_macos_keychain_modal():
+    """A detached Chromium launch on macOS (gateway/worker/cron — no Aqua login
+    session) throws a blocking on-screen "A keychain cannot be found to store
+    \"Chrome\"" Safe-Storage modal unless password storage is routed off the OS
+    Keychain. Every auto-launch arg set MUST carry both suppression flags, or the
+    modal leaks onto the user's display and stalls automation (recurring incident).
+    The flags are harmless no-ops on Linux/Windows, so they belong unconditionally
+    in the shared arg builder."""
+    from hermes_cli.browser_connect import _chrome_debug_args
+
+    args = _chrome_debug_args(9222)
+    assert "--password-store=basic" in args
+    assert "--use-mock-keychain" in args
+
+
+def test_manual_command_suppresses_macos_keychain_modal():
+    """The macOS `open -a "Google Chrome"` fallback (used when no direct Chrome
+    binary candidate is found) must ALSO carry the keychain-suppression flags —
+    it is a second launch path and the modal fires regardless of how Chrome is
+    spawned."""
+    with patch(
+        "hermes_cli.browser_connect.get_chrome_debug_candidates", return_value=[]
+    ):
+        command = manual_chrome_debug_command(port=9222, system="Darwin")
+    assert command is not None
+    assert "--password-store=basic" in command
+    assert "--use-mock-keychain" in command
 
 
 class TestChromeDebugLaunch:


### PR DESCRIPTION
## Problem

On macOS, the native browser-toolset debug-Chrome auto-launch spawns regular Google Chrome **without** `--password-store=basic --use-mock-keychain`. A Chromium-family browser launched detached (no Aqua login session — e.g. from a gateway / background worker / cron) then tries to read its "Safe Storage" key from the macOS Keychain and throws a blocking, on-screen system modal:

> **Keychain Not Found** — A keychain cannot be found to store "Chrome."

The modal leaks onto the user's display and stalls automation. It recurred repeatedly for us whenever an agent used the `browser` toolset and `/browser connect` auto-launched the debug browser.

Two launch sites were affected:
- `_chrome_debug_args()` → `try_launch_chrome_debug()` (the actual auto-launch argv)
- `manual_chrome_debug_command()` (the macOS `open -a "Google Chrome" --args …` fallback string we print)

## Fix

Add `--password-store=basic` and `--use-mock-keychain` to **both** launch constructs.

The flags only change **where** Chrome stores passwords (its own encrypted store vs the OS Keychain) — they do **not** affect cookies, logins, or the CDP session, and are harmless no-ops on Linux/Windows, so they belong unconditionally in the shared arg builder.

## Tests

`tests/cli/test_cli_browser_connect.py`:
- `test_chrome_debug_args_suppress_macos_keychain_modal` — direct guard on the arg builder.
- `test_manual_command_suppresses_macos_keychain_modal` — guards the macOS `open -a` path.
- The two Windows launch tests now also assert both flags are present (they ride every platform).

`tests/cli/test_chrome_launcher_keychain_guard.py` (new) — a **fleet-wide source-scanning guard**: it finds every detached-Chrome launch construct in `hermes_cli/` + `tools/` (`--remote-debugging-port` argv / `open -a "Google Chrome" --args`) and asserts each carries both flags, **per-construct** (so a second launch path can't be masked by a sibling that has the flags). This closes the coverage gap that let the bug recur — a prior project-local guard only scanned a different tree and never saw `browser_connect.py`.

RED-proven: stripping the flags from either launch construct trips the relevant tests.

```
pytest tests/cli/test_cli_browser_connect.py tests/cli/test_chrome_launcher_keychain_guard.py
→ 22 passed
```
