### PR TITLE
feat(desktop): native dashboard plugin loader — kanban + achievements tabs

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -97,7 +97,7 @@ import {
 
 import { type AppView, ARTIFACTS_ROUTE, MESSAGING_ROUTE, SKILLS_ROUTE } from '../../routes'
 import { SidebarPanelLabel } from '../../shell/sidebar-label'
-import type { SidebarNavItem } from '../../types'
+import type { PluginNavItem, SidebarNavItem } from '../../types'
 
 import { SidebarCronJobsSection } from './cron-jobs-section'
 import { SidebarLoadMoreRow } from './load-more-row'
@@ -133,6 +133,18 @@ const SIDEBAR_NAV: SidebarNavItem[] = [
   { id: 'messaging', label: '', icon: props => <Codicon name="comment" {...props} />, route: MESSAGING_ROUTE },
   { id: 'artifacts', label: '', icon: props => <Codicon name="files" {...props} />, route: ARTIFACTS_ROUTE }
 ]
+
+// Normalized render descriptor for a sidebar nav row — built-in tab or plugin
+// tab. Lets the nav render loop treat both uniformly.
+interface SidebarNavRow {
+  key: string
+  label: string
+  icon: React.ComponentType<{ className?: string }>
+  isInteractive: boolean
+  isNewSession: boolean
+  active: boolean
+  onActivate: () => void
+}
 
 const WORKSPACE_PAGE = 5
 // ALL-profiles view: show only the latest N per profile up front to keep the
@@ -299,6 +311,10 @@ function useSortableBindings(id: string) {
 
 interface ChatSidebarProps extends React.ComponentProps<typeof Sidebar> {
   currentView: AppView
+  /** Dashboard plugin tabs (kanban, …) to render as sidebar nav rows. */
+  pluginNav?: PluginNavItem[]
+  /** Current non-session route path, used to highlight an active plugin tab. */
+  activePluginPath?: string | null
   onNavigate: (item: SidebarNavItem) => void
   onLoadMoreSessions: () => void
   onLoadMoreProfileSessions?: (profile: string) => Promise<void> | void
@@ -313,6 +329,8 @@ interface ChatSidebarProps extends React.ComponentProps<typeof Sidebar> {
 
 export function ChatSidebar({
   currentView,
+  pluginNav,
+  activePluginPath,
   onNavigate,
   onLoadMoreSessions,
   onLoadMoreProfileSessions,
@@ -791,6 +809,66 @@ export function ChatSidebar({
       })
     )
 
+  // Merge built-in nav with dashboard-plugin tabs (kanban, …) into one ordered
+  // render list. Plugin rows honor their `position` hint ("after:skills" → right
+  // after the Skills tab) so they slot in like the web sidebar; unknown/`end`
+  // positions append. Each row is normalized to a common shape so the single
+  // render loop below handles built-ins and plugins identically.
+  const navRows = useMemo<SidebarNavRow[]>(() => {
+    const rows: SidebarNavRow[] = SIDEBAR_NAV.map(item => ({
+      key: item.id,
+      label: s.nav[item.id] ?? item.label,
+      icon: item.icon,
+      isInteractive: Boolean(item.action) || Boolean(item.route),
+      isNewSession: item.id === 'new-session',
+      active:
+        (item.id === 'skills' && currentView === 'skills') ||
+        (item.id === 'messaging' && currentView === 'messaging') ||
+        (item.id === 'artifacts' && currentView === 'artifacts'),
+      onActivate: () => {
+        // A plain new session lands in whatever profile the live gateway is on
+        // (= the active switcher context). null → no swap.
+        if (item.id === 'new-session') {
+          $newChatProfile.set(null)
+        }
+
+        onNavigate(item)
+      }
+    }))
+
+    for (const plugin of pluginNav ?? []) {
+      const PluginIcon = ({ className }: { className?: string }) => <Codicon className={className} name={plugin.iconName} />
+
+      const row: SidebarNavRow = {
+        key: `plugin:${plugin.id}`,
+        label: plugin.label,
+        icon: PluginIcon,
+        isInteractive: true,
+        isNewSession: false,
+        active: activePluginPath === plugin.route,
+        // selectSidebarItem only reads action/route, so a minimal nav item with
+        // the plugin's path routes to the <PluginPage> registered in the router.
+        // (id/icon are unused by navigation; reuse the plugin's own icon + a
+        // built-in id so the SidebarNavItem type is satisfied.)
+        onActivate: () => onNavigate({ id: 'artifacts', label: plugin.label, icon: PluginIcon, route: plugin.route })
+      }
+
+      const pos = plugin.position ?? 'end'
+
+      if (pos.startsWith('after:')) {
+        const idx = rows.findIndex(r => r.key === pos.slice(6))
+        rows.splice(idx >= 0 ? idx + 1 : rows.length, 0, row)
+      } else if (pos.startsWith('before:')) {
+        const idx = rows.findIndex(r => r.key === pos.slice(7))
+        rows.splice(idx >= 0 ? idx : rows.length, 0, row)
+      } else {
+        rows.push(row)
+      }
+    }
+
+    return rows
+  }, [activePluginPath, currentView, onNavigate, pluginNav, s.nav])
+
   return (
     <Sidebar
       className={cn(
@@ -810,20 +888,13 @@ export function ChatSidebar({
         <SidebarGroup className="shrink-0 p-0 pb-2 pt-[calc(var(--titlebar-height)+0.375rem)]">
           <SidebarGroupContent>
             <SidebarMenu className="gap-px">
-              {SIDEBAR_NAV.map(item => {
-                const isInteractive = Boolean(item.action) || Boolean(item.route)
-
-                const active =
-                  (item.id === 'skills' && currentView === 'skills') ||
-                  (item.id === 'messaging' && currentView === 'messaging') ||
-                  (item.id === 'artifacts' && currentView === 'artifacts')
-
-                const isNewSession = item.id === 'new-session'
+              {navRows.map(item => {
+                const RowIcon = item.icon
 
                 return (
-                  <SidebarMenuItem key={item.id}>
+                  <SidebarMenuItem key={item.key}>
                     <SidebarMenuButton
-                      aria-disabled={!isInteractive}
+                      aria-disabled={!item.isInteractive}
                       className={cn(
                         // no-drag: these rows sit directly under the titlebar's
                         // [-webkit-app-region:drag] strips (app-shell.tsx), with only
@@ -833,30 +904,20 @@ export function ChatSidebar({
                         // top rows. Same carve-out as USER_BUBBLE_BASE_CLASS in
                         // thread.tsx.
                         'flex h-7 w-full justify-start gap-2 rounded-md border border-transparent px-2 text-left text-[0.8125rem] font-medium text-(--ui-text-secondary) transition-colors duration-100 ease-out [-webkit-app-region:no-drag] hover:bg-(--ui-control-hover-background) hover:text-foreground hover:transition-none',
-                        active &&
+                        item.active &&
                           'border-(--ui-stroke-tertiary) bg-(--ui-control-active-background) text-foreground shadow-none hover:border-(--ui-stroke-tertiary)!',
-                        !isInteractive &&
+                        !item.isInteractive &&
                           'cursor-default hover:border-transparent hover:bg-transparent hover:text-inherit'
                       )}
-                      onClick={() => {
-                        // A plain new session lands in whatever profile the live
-                        // gateway is on (= the active switcher context). null →
-                        // no swap. The switcher header is the single place to
-                        // change which profile that is.
-                        if (isNewSession) {
-                          $newChatProfile.set(null)
-                        }
-
-                        onNavigate(item)
-                      }}
-                      tooltip={s.nav[item.id] ?? item.label}
+                      onClick={item.onActivate}
+                      tooltip={item.label}
                       type="button"
                     >
-                      <item.icon className="size-4 shrink-0 text-[color-mix(in_srgb,currentColor_72%,transparent)]" />
+                      <RowIcon className="size-4 shrink-0 text-[color-mix(in_srgb,currentColor_72%,transparent)]" />
                       {contentVisible && (
                         <>
-                          <span className="min-w-0 flex-1 truncate">{s.nav[item.id] ?? item.label}</span>
-                          {isNewSession && (
+                          <span className="min-w-0 flex-1 truncate">{item.label}</span>
+                          {item.isNewSession && (
                             <KbdGroup
                               className={cn('ml-auto opacity-55', newSessionKbdFlash && 'opacity-100!')}
                               keys={[...NEW_SESSION_KBD]}

--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -326,6 +326,13 @@ export function CommandPalette() {
             run: go(ARTIFACTS_ROUTE)
           },
           {
+            icon: Package,
+            id: 'nav-kanban',
+            keywords: ['kanban', 'board', 'tasks', 'cards'],
+            label: 'Kanban',
+            run: go('/kanban')
+          },
+          {
             action: 'nav.cron',
             icon: Clock,
             id: 'nav-cron',

--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -9,6 +9,7 @@ import { DesktopOnboardingOverlay } from '@/components/desktop-onboarding-overla
 import { GatewayConnectingOverlay } from '@/components/gateway-connecting-overlay'
 import { Pane, PaneMain } from '@/components/pane-shell'
 import { useMediaQuery } from '@/hooks/use-media-query'
+import { PluginPage, usePlugins } from '@/plugins'
 import { useSkinCommand } from '@/themes/use-skin-command'
 
 import { formatRefValue } from '../components/assistant-ui/directive-text'
@@ -101,7 +102,7 @@ import { ModelVisibilityOverlay } from './model-visibility-overlay'
 import { RightSidebarPane } from './right-sidebar'
 import { $terminalTakeover } from './right-sidebar/store'
 import { PersistentTerminal, TerminalSlot } from './right-sidebar/terminal/persistent'
-import { CRON_ROUTE, NEW_CHAT_ROUTE, routeSessionId, sessionRoute, SETTINGS_ROUTE } from './routes'
+import { CRON_ROUTE, NEW_CHAT_ROUTE, pluginIconCodicon, routeSessionId, sessionRoute, SETTINGS_ROUTE } from './routes'
 import { SessionPickerOverlay } from './session-picker-overlay'
 import { SessionSwitcher } from './session-switcher'
 import { useContextSuggestions } from './session/hooks/use-context-suggestions'
@@ -122,6 +123,7 @@ import { ModelMenuPanel } from './shell/model-menu-panel'
 import type { StatusbarItem } from './shell/statusbar-controls'
 import type { TitlebarTool } from './shell/titlebar-controls'
 import { useGroupRegistry } from './shell/use-group-registry'
+import type { PluginNavItem } from './types'
 import { UpdatesOverlay } from './updates-overlay'
 
 const AgentsView = lazy(async () => ({ default: (await import('./agents')).AgentsView }))
@@ -189,6 +191,11 @@ export function DesktopController() {
   const queryClient = useQueryClient()
   const location = useLocation()
   const navigate = useNavigate()
+
+  // Dashboard plugins (kanban, …). usePlugins fetches manifests from the backend
+  // and injects each plugin's <script>/<link>; the bundle calls register(),
+  // resolved by <PluginPage>. Mirrors web/src/App.tsx's plugin mount.
+  const { manifests: pluginManifests } = usePlugins()
 
   const busyRef = useRef(false)
   const creatingSessionRef = useRef(false)
@@ -856,8 +863,29 @@ export function DesktopController() {
     toggleCommandCenter
   })
 
+  // Plugin tabs (kanban, …) rendered as sidebar nav rows alongside the built-in
+  // tabs. The manifest's `tab.path` is the same absolute route registered in the
+  // <Routes> below, so navigate(route) (via selectSidebarItem) lands on the
+  // <PluginPage>. hidden/override plugins don't get a sidebar row (they need the
+  // web's override-merge handling kanban doesn't). position hints
+  // ("after:skills") are honored by the sidebar's nav builder.
+  const pluginNav = useMemo<PluginNavItem[]>(
+    () =>
+      pluginManifests
+        .filter(m => !m.tab.hidden && !m.tab.override)
+        .map(m => ({
+          id: m.name,
+          label: m.label,
+          iconName: pluginIconCodicon(m.icon),
+          route: m.tab.path,
+          position: m.tab.position
+        })),
+    [pluginManifests]
+  )
+
   const sidebar = (
     <ChatSidebar
+      activePluginPath={routeSessionId(location.pathname) ? null : location.pathname}
       currentView={currentView}
       onArchiveSession={sessionId => void archiveSession(sessionId)}
       onDeleteSession={sessionId => void removeSession(sessionId)}
@@ -876,6 +904,7 @@ export function DesktopController() {
           .then(() => refreshCronJobs())
           .catch(() => undefined)
       }}
+      pluginNav={pluginNav}
     />
   )
 
@@ -1121,6 +1150,28 @@ export function DesktopController() {
           <Route element={null} path="agents" />
           <Route element={<Navigate replace to={NEW_CHAT_ROUTE} />} path="new" />
           <Route element={<LegacySessionRedirect />} path="sessions/:sessionId" />
+          {/*
+            Dashboard plugin routes (kanban, …). Mirrors web/src/App.tsx's
+            buildRoutes addon path: a plugin declares `tab.path` (e.g. "/kanban")
+            and its bundle registers a component resolved by <PluginPage>. Web
+            routes are absolute because its <Routes> is the top-level router;
+            this nested <Routes> uses RELATIVE paths, so strip the leading slash
+            (HashRouter still produces `#/kanban`). Hidden/override plugins are
+            skipped — they need the web's override-merge handling kanban doesn't.
+          */}
+          {pluginManifests
+            .filter((m) => !m.tab.hidden && !m.tab.override)
+            .map((m) => (
+              <Route
+                element={
+                  <Suspense fallback={null}>
+                    <PluginPage name={m.name} />
+                  </Suspense>
+                }
+                key={`plugin:${m.name}`}
+                path={m.tab.path.replace(/^\//, '')}
+              />
+            ))}
           <Route element={<Navigate replace to={NEW_CHAT_ROUTE} />} path="*" />
         </Routes>
       </PaneMain>

--- a/apps/desktop/src/app/routes.ts
+++ b/apps/desktop/src/app/routes.ts
@@ -86,3 +86,28 @@ export function appViewForPath(pathname: string): AppView {
 
   return APP_VIEW_BY_PATH.get(pathname) ?? 'chat'
 }
+
+// Dashboard plugin icons are declared as web/lucide names (e.g. "Package") in
+// the manifest, but the desktop sidebar renders the codicon font. Map the names
+// kanban + the bundled plugins use to codicon glyphs; unknown names fall back to
+// a neutral "extensions" puzzle-piece glyph so a new plugin still gets an icon.
+const PLUGIN_ICON_CODICON: Record<string, string> = {
+  Package: 'package',
+  LayoutGrid: 'layout',
+  Kanban: 'project',
+  Columns: 'layout',
+  Boxes: 'package',
+  Box: 'package',
+  Activity: 'pulse',
+  Zap: 'zap',
+  Heart: 'heart',
+  Star: 'star-full',
+  Code: 'code',
+  Eye: 'eye',
+  Puzzle: 'extensions'
+}
+
+/** Resolve a plugin manifest icon name to a codicon glyph for the sidebar. */
+export function pluginIconCodicon(name: string | undefined): string {
+  return (name && PLUGIN_ICON_CODICON[name]) || 'extensions'
+}

--- a/apps/desktop/src/app/types.ts
+++ b/apps/desktop/src/app/types.ts
@@ -118,6 +118,22 @@ export interface SidebarNavItem {
   action?: 'new-session'
 }
 
+/** A dashboard-plugin tab rendered as a sidebar nav row (kanban, …). Distinct
+ *  from SidebarNavItem so plugin ids/labels stay free-form (not the built-in
+ *  SidebarNavId union) while reusing the same nav render + navigate(route) path. */
+export interface PluginNavItem {
+  /** Plugin name (manifest.name) — used as the React key and registry lookup. */
+  id: string
+  /** Display label (manifest.label), shown when the sidebar is expanded. */
+  label: string
+  /** Codicon glyph name resolved from manifest.icon. */
+  iconName: string
+  /** Absolute in-app route (manifest.tab.path, e.g. "/kanban"). */
+  route: string
+  /** Placement hint (manifest.tab.position): "end" | "after:<seg>" | "before:<seg>". */
+  position?: string
+}
+
 export interface ClientSessionState {
   storedSessionId: string | null
   messages: ChatMessage[]

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -13,9 +13,15 @@ import { HapticsProvider } from './components/haptics-provider'
 import { I18nProvider } from './i18n'
 import { installClipboardShim } from './lib/clipboard'
 import { queryClient } from './lib/query-client'
+import { exposePluginSDK } from './plugins'
 import { ThemeProvider } from './themes/context'
 
 installClipboardShim()
+
+// Expose the plugin SDK before rendering so plugins loaded via <script> can
+// access React, components, fetchJSON, etc. immediately. usePlugins only injects
+// plugin <script> tags after manifests resolve (post-mount), so this runs first.
+exposePluginSDK()
 
 // Dev-only: install __PERF_DRIVE__ + __PERF_PROBE__ on window so the
 // scripts/ harnesses can drive a synthetic stream + record render cost.

--- a/apps/desktop/src/plugins/PluginPage.tsx
+++ b/apps/desktop/src/plugins/PluginPage.tsx
@@ -1,0 +1,77 @@
+import { useSyncExternalStore } from "react";
+
+import { GlyphSpinner } from "@/components/ui/glyph-spinner";
+import { useI18n } from "@/i18n";
+import { cn } from "@/lib/utils";
+
+import {
+  getPluginComponent,
+  getPluginLoadError,
+  onPluginRegistered,
+} from "./registry";
+
+/** Renders a plugin tab once its bundle has called `register()`. */
+export function PluginPage({ name }: { name: string }) {
+  const { t } = useI18n();
+
+  // Subscribe in render (via useSyncExternalStore) so we never miss
+  // `register()` if the script loads before a useEffect would run.
+  const Component = useSyncExternalStore(
+    (onChange) => onPluginRegistered(onChange),
+    () => getPluginComponent(name) ?? null,
+    () => null,
+  );
+
+  const loadError = useSyncExternalStore(
+    (onChange) => onPluginRegistered(onChange),
+    () => getPluginLoadError(name) ?? null,
+    () => null,
+  );
+
+  if (Component) {
+    // The desktop pane wraps content in `overflow-hidden` and built-in views
+    // bring their own scroll host; plugins (kanban, achievements) render raw,
+    // so without this they get clipped and don't fill the pane. Give plugin
+    // views a full-size, scrollable host (the web's page layout does this).
+    return (
+      <div className="h-full w-full min-h-0 overflow-auto">
+        <Component />
+      </div>
+    );
+  }
+
+  if (loadError) {
+    const message = formatPluginError(loadError);
+
+    return (
+      <div
+        className={cn("max-w-lg p-4", "text-sm tracking-[0.08em] text-muted-foreground")}
+        role="alert"
+      >
+        {message}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn("flex items-center gap-2 p-4", "text-sm tracking-[0.1em] text-muted-foreground")}
+    >
+      <GlyphSpinner className="shrink-0" />
+      <span>{t.common.loading}</span>
+    </div>
+  );
+}
+
+// Desktop i18n's `common` block doesn't carry the dashboard's
+// `pluginLoadFailed` / `pluginNotRegistered` keys, so the two error strings are
+// inlined here (English) rather than threaded through every locale catalog.
+function formatPluginError(code: string): string {
+  if (code === "LOAD_FAILED")
+    {return "This plugin failed to load. Check the network tab and reload.";}
+
+  if (code === "NO_REGISTER")
+    {return "This plugin loaded but did not register a view.";}
+
+  return code;
+}

--- a/apps/desktop/src/plugins/index.ts
+++ b/apps/desktop/src/plugins/index.ts
@@ -1,0 +1,6 @@
+export { PluginPage } from "./PluginPage";
+export { exposePluginSDK, getPluginComponent, getRegisteredCount, onPluginRegistered } from "./registry";
+export { getSlotEntries, KNOWN_SLOT_NAMES, onSlotRegistered, PluginSlot, registerSlot, unregisterPluginSlots } from "./slots";
+export type { KnownSlotName } from "./slots";
+export type { PluginManifest, RegisteredPlugin } from "./types";
+export { usePlugins } from "./usePlugins";

--- a/apps/desktop/src/plugins/registry.ts
+++ b/apps/desktop/src/plugins/registry.ts
@@ -1,0 +1,224 @@
+/**
+ * Dashboard Plugin SDK + Registry (desktop port)
+ *
+ * Exposes React, UI components, hooks, and utilities on the window so that
+ * plugin bundles can use them without bundling their own copies.
+ *
+ * Plugins call window.__HERMES_PLUGINS__.register(name, Component) to register
+ * their tab component.
+ *
+ * Ported from web/src/plugins/registry.ts. The registry half is VERBATIM; the
+ * only adaptations are the backend-touch helpers (sourced from ./sdk-backend
+ * instead of the web's same-origin @/lib/api) and the `components` map (sourced
+ * from the desktop UI kit + ./sdk-components shims instead of @nous-research/ui).
+ */
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useI18n } from "@/i18n";
+import { cn } from "@/lib/utils";
+
+import {
+  api,
+  authedFetch,
+  buildWsAuthParam,
+  buildWsUrl,
+  fetchJSON,
+} from "./sdk-backend";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Label,
+  Select,
+  SelectOption,
+} from "./sdk-components";
+import { PluginSlot, registerSlot } from "./slots";
+
+// ---------------------------------------------------------------------------
+// timeAgo / isoTimeAgo — ported from web/src/lib/utils.ts (the desktop's
+// @/lib/utils only exports `cn`). The plugin SDK contract exposes these.
+// ---------------------------------------------------------------------------
+
+/** Relative time from a Unix epoch timestamp (seconds). */
+function timeAgo(ts: number): string {
+  const delta = Date.now() / 1000 - ts;
+
+  if (delta < 60) {return "just now";}
+
+  if (delta < 3600) {return `${Math.floor(delta / 60)}m ago`;}
+
+  if (delta < 86400) {return `${Math.floor(delta / 3600)}h ago`;}
+
+  if (delta < 172800) {return "yesterday";}
+
+  return `${Math.floor(delta / 86400)}d ago`;
+}
+
+/** Relative time from an ISO-8601 timestamp string. */
+function isoTimeAgo(iso: string): string {
+  const delta = (Date.now() - new Date(iso).getTime()) / 1000;
+
+  if (delta < 0 || Number.isNaN(delta)) {return "unknown";}
+
+  if (delta < 60) {return "just now";}
+
+  if (delta < 3600) {return `${Math.floor(delta / 60)}m ago`;}
+
+  if (delta < 86400) {return `${Math.floor(delta / 3600)}h ago`;}
+
+  return `${Math.floor(delta / 86400)}d ago`;
+}
+
+// ---------------------------------------------------------------------------
+// Plugin registry — plugins call register() to add their component.
+// ---------------------------------------------------------------------------
+
+type RegistryListener = () => void;
+
+const _registered: Map<string, React.ComponentType> = new Map();
+const _loadErrors: Map<string, string> = new Map();
+const _listeners: Set<RegistryListener> = new Set();
+
+function _notify() {
+  for (const fn of _listeners) {
+    try { fn(); } catch { /* ignore */ }
+  }
+}
+
+/** Re-run registry subscribers (e.g. after a plugin script onload, or dev HMR re-inject). */
+export function notifyPluginRegistry() {
+  _notify();
+}
+
+/** Register a plugin component. Called by plugin JS bundles. */
+function registerPlugin(name: string, component: React.ComponentType) {
+  _loadErrors.delete(name);
+  _registered.set(name, component);
+  _notify();
+}
+
+/** Get a registered component by plugin name. */
+export function getPluginComponent(name: string): React.ComponentType | undefined {
+  return _registered.get(name);
+}
+
+export function getPluginLoadError(name: string): string | undefined {
+  return _loadErrors.get(name);
+}
+
+export function setPluginLoadError(name: string, message: string) {
+  _loadErrors.set(name, message);
+  _notify();
+}
+
+/** Subscribe to registry changes (returns unsubscribe fn). */
+export function onPluginRegistered(fn: RegistryListener): () => void {
+  _listeners.add(fn);
+
+  return () => _listeners.delete(fn);
+}
+
+/** Get current count of registered plugins. */
+export function getRegisteredCount(): number {
+  return _registered.size;
+}
+
+// ---------------------------------------------------------------------------
+// Expose SDK + registry on window
+// ---------------------------------------------------------------------------
+
+/**
+ * Version of the plugin SDK contract (see ``plugins/sdk.d.ts``). Bump the
+ * major on any backwards-incompatible change to the exposed surface;
+ * additive changes (new optional fields / helpers) don't require a bump.
+ * Exposed at runtime as ``window.__HERMES_PLUGIN_SDK__.sdkVersion`` so a
+ * plugin (or a future host-side compatibility gate) can read it.
+ */
+export const SDK_CONTRACT_VERSION = "1.1.0";
+
+// Window globals for the plugin SDK are declared in ``plugins/sdk.d.ts`` —
+// the single source of truth for the public contract. Don't redeclare them
+// here (duplicate ambient declarations with differing modifiers conflict).
+
+export function exposePluginSDK() {
+  window.__HERMES_PLUGINS__ = {
+    register: registerPlugin,
+    registerSlot,
+  };
+
+  window.__HERMES_PLUGIN_SDK__ = {
+    // Contract version of the plugin SDK surface (see plugins/sdk.d.ts).
+    // Bump on backwards-incompatible changes; additive changes don't need it.
+    sdkVersion: SDK_CONTRACT_VERSION,
+    // React core — plugins use these instead of importing react
+    React,
+    hooks: {
+      useState,
+      useEffect,
+      useCallback,
+      useMemo,
+      useRef,
+      useContext,
+      createContext,
+    },
+
+    // Hermes API client (desktop-backed: routes through window.hermesDesktop)
+    api,
+    // Raw fetchJSON for plugin-specific JSON endpoints
+    fetchJSON,
+    // Authenticated fetch for non-JSON endpoints (uploads / blob downloads).
+    // Handles loopback-token vs gated-cookie auth so plugins never read
+    // window.__HERMES_SESSION_TOKEN__ directly.
+    authedFetch,
+    // Build a ws(s):// URL with the correct auth param for the active mode
+    // (token in loopback). Use this for any plugin WebSocket instead of
+    // hand-assembling the URL.
+    buildWsUrl,
+    // Lower-level: resolve just the [authParamName, authParamValue] pair, for
+    // plugins that need to build the WS URL themselves.
+    buildWsAuthParam,
+
+    // UI components — desktop UI kit where available, local shims elsewhere.
+    // Keys match the web SDK contract so the same plugin bundles render.
+    components: {
+      Card,
+      CardHeader,
+      CardTitle,
+      CardContent,
+      Badge,
+      Button,
+      Checkbox,
+      Input,
+      Label,
+      Select,
+      SelectOption,
+      Separator,
+      Tabs,
+      TabsList,
+      TabsTrigger,
+      PluginSlot,
+    },
+
+    // Utilities
+    utils: { cn, timeAgo, isoTimeAgo },
+
+    // Hooks
+    useI18n,
+  };
+}

--- a/apps/desktop/src/plugins/sdk-backend.ts
+++ b/apps/desktop/src/plugins/sdk-backend.ts
@@ -1,0 +1,147 @@
+/**
+ * Desktop plugin SDK backend shim.
+ *
+ * The web dashboard is served BY the backend (same origin), so its plugin SDK
+ * pulls `fetchJSON` / `authedFetch` / `buildWsUrl` straight out of
+ * `web/src/lib/api.ts`, which `fetch`es same-origin and reads the session token
+ * from `window.__HERMES_SESSION_TOKEN__`.
+ *
+ * The Electron renderer has NEITHER: it runs from `file://` (packaged) or the
+ * Vite dev server (`http://127.0.0.1:5174`), while the backend is a SEPARATE
+ * origin (`http://127.0.0.1:<port>`). The backend's absolute origin + session
+ * token live behind `window.hermesDesktop.getConnection()` →
+ * `HermesConnection { baseUrl, token, authMode, wsUrl }` (see global.d.ts).
+ *
+ * This module reimplements the three plugin-facing helpers against that
+ * connection so the SAME unmodified plugin bundles route correctly:
+ *  - `fetchJSON`   → delegates to `window.hermesDesktop.api` (handles token +
+ *                    oauth cookie in one place, in Electron main).
+ *  - `authedFetch` → raw cross-origin `fetch` to `${baseUrl}${path}` with the
+ *                    `X-Hermes-Session-Token` header (uploads / blob downloads).
+ *  - `buildWsUrl`  → builds a `ws(s)://` URL off `connection.wsUrl` /
+ *                    `getGatewayWsUrl()` with the session token query param.
+ */
+
+import type { HermesConnection } from "@/global";
+
+// Matches web/src/lib/api.ts (SESSION_HEADER) and apps/desktop/src/hermes.ts.
+const SESSION_HEADER = "X-Hermes-Session-Token";
+
+// Cache the resolved connection. The primary (window) backend descriptor is
+// stable for the window's lifetime; kanban v1 targets the primary. A profile
+// switch would relaunch the renderer (see global.d.ts: profile.set reloads the
+// window), so this cache never goes stale within a window session.
+let _connPromise: Promise<HermesConnection> | null = null;
+
+function getConnection(): Promise<HermesConnection> {
+  if (!_connPromise) {
+    _connPromise = window.hermesDesktop.getConnection();
+  }
+
+  return _connPromise;
+}
+
+/** Absolute backend origin (e.g. `http://127.0.0.1:<port>`) for the primary backend. */
+export async function getBackendBaseUrl(): Promise<string> {
+  const conn = await getConnection();
+
+  return conn.baseUrl;
+}
+
+/**
+ * JSON `fetch` for dashboard `/api/...` endpoints. Routes through
+ * `window.hermesDesktop.api`, which performs the request against
+ * `${connection.baseUrl}${path}` with the session token (and oauth-cookie mode)
+ * handled in Electron main. Throws `Error("<status>: <body>")` shapes via the
+ * IPC layer, matching the web `fetchJSON` contract closely enough for plugins.
+ */
+export async function fetchJSON<T = unknown>(
+  url: string,
+  init?: RequestInit,
+): Promise<T> {
+  const method = (init?.method ?? "GET").toUpperCase();
+  let body: unknown;
+
+  if (init?.body != null) {
+    if (typeof init.body === "string") {
+      try {
+        body = JSON.parse(init.body);
+      } catch {
+        body = init.body;
+      }
+    } else {
+      body = init.body;
+    }
+  }
+
+  return window.hermesDesktop.api<T>({ path: url, method, body });
+}
+
+/**
+ * Authenticated raw `fetch` for NON-JSON endpoints (uploads via `FormData`,
+ * binary/blob downloads). Mirrors web `authedFetch`: returns the raw `Response`,
+ * does not parse, does not throw on non-2xx. Cross-origin to the renderer
+ * (file:// or 5174) → backend (127.0.0.1:<port>); auth via the session-token
+ * header (token mode). OAuth-cookie mode rides along via `credentials`.
+ */
+export async function authedFetch(
+  url: string,
+  init?: RequestInit,
+): Promise<Response> {
+  const conn = await getConnection();
+  const headers = new Headers(init?.headers);
+
+  if (conn.token && !headers.has(SESSION_HEADER)) {
+    headers.set(SESSION_HEADER, conn.token);
+  }
+
+  return fetch(`${conn.baseUrl}${url}`, {
+    ...init,
+    headers,
+    credentials: init?.credentials ?? "include",
+  });
+}
+
+/**
+ * Build an absolute `ws(s)://` URL for a dashboard WebSocket endpoint with the
+ * session token query param. The desktop backend exposes its WS base via
+ * `connection.wsUrl` / `getGatewayWsUrl()`. Loopback/token mode appends
+ * `?token=<token>` (the same param the gateway accepts in non-gated mode).
+ *
+ * `path` is the dashboard-relative path (e.g. `/api/plugins/kanban/events`);
+ * the host + scheme come from the backend connection, NOT the renderer origin.
+ */
+export async function buildWsUrl(
+  path: string,
+  params?: Record<string, string>,
+): Promise<string> {
+  const [authName, authValue] = await buildWsAuthParam();
+  const conn = await getConnection();
+  // Derive scheme + host from the absolute backend origin so the URL points at
+  // the backend, never at the file:// / 5174 renderer origin.
+  const httpBase = new URL(conn.baseUrl);
+  const wsProto = httpBase.protocol === "https:" ? "wss:" : "ws:";
+  const qs = new URLSearchParams(params ?? {});
+  qs.set(authName, authValue);
+
+  return `${wsProto}//${httpBase.host}${path}?${qs}`;
+}
+
+/** Resolve the `[authParamName, authParamValue]` pair for a WS connect. */
+export async function buildWsAuthParam(): Promise<[string, string]> {
+  const conn = await getConnection();
+
+  // Gated (oauth) mode would need a single-use ticket; the desktop's loopback
+  // backend uses token mode, which the gateway accepts via ?token=.
+  return ["token", conn.token ?? ""];
+}
+
+/**
+ * Minimal `api` object for the SDK surface. The web SDK exposes the full
+ * `web/src/lib/api.ts` client; kanban only needs `getPlugins` (the loader fetch
+ * goes through usePlugins directly), so this is intentionally small. Plugins
+ * that need more call `fetchJSON` against their own `/api/plugins/<name>/...`.
+ */
+export const api = {
+  getPlugins: () => fetchJSON<unknown[]>("/api/dashboard/plugins"),
+};

--- a/apps/desktop/src/plugins/sdk-backend.ts
+++ b/apps/desktop/src/plugins/sdk-backend.ts
@@ -83,6 +83,14 @@ export async function fetchJSON<T = unknown>(
  * does not parse, does not throw on non-2xx. Cross-origin to the renderer
  * (file:// or 5174) → backend (127.0.0.1:<port>); auth via the session-token
  * header (token mode). OAuth-cookie mode rides along via `credentials`.
+ *
+ * v1 SCOPE (loopback/token-first): in OAuth-remote mode the authenticated
+ * HttpOnly cookies live in the dedicated `persist:hermes-remote-oauth` Electron
+ * session, which this renderer-side `fetch` (default partition) cannot attach —
+ * so plugin raw endpoints (e.g. kanban attachment upload/download) would 401
+ * under an OAuth-remote gateway. v1 targets the loopback/token backend where
+ * the header auth above is sufficient; an OAuth-partitioned main-process raw
+ * fetch IPC is a documented follow-up. (review: codex P2)
  */
 export async function authedFetch(
   url: string,
@@ -124,15 +132,27 @@ export async function buildWsUrl(
   const qs = new URLSearchParams(params ?? {});
   qs.set(authName, authValue);
 
-  return `${wsProto}//${httpBase.host}${path}?${qs}`;
+  // Preserve any path prefix on the backend origin (e.g. a remote gateway
+  // mounted at https://host/hermes) so the socket lands at /hermes/api/...,
+  // mirroring how REST calls build `${baseUrl}${path}`. Without this, plugin
+  // sockets behind a reverse proxy / prefixed deployment connect to the wrong
+  // path. (review: codex P2)
+  const prefix = httpBase.pathname.replace(/\/+$/, "");
+
+  return `${wsProto}//${httpBase.host}${prefix}${path}?${qs}`;
 }
 
 /** Resolve the `[authParamName, authParamValue]` pair for a WS connect. */
 export async function buildWsAuthParam(): Promise<[string, string]> {
   const conn = await getConnection();
 
-  // Gated (oauth) mode would need a single-use ticket; the desktop's loopback
-  // backend uses token mode, which the gateway accepts via ?token=.
+  // v1 SCOPE (loopback/token-first): an OAuth-gated remote backend needs a
+  // single-use ws-ticket (POST /api/auth/ws-ticket via the OAuth session)
+  // rather than ?token=. The desktop's loopback backend uses token mode, so v1
+  // targets that; plugin WebSockets under an OAuth-remote gateway are a
+  // documented follow-up (route through the main-process OAuth session, as the
+  // web SDK does). Returning the (possibly empty) token keeps loopback working.
+  // (review: codex P2)
   return ["token", conn.token ?? ""];
 }
 

--- a/apps/desktop/src/plugins/sdk-components.tsx
+++ b/apps/desktop/src/plugins/sdk-components.tsx
@@ -1,0 +1,144 @@
+/**
+ * SDK component shims for primitives the desktop UI kit doesn't ship but plugin
+ * bundles consume by key off `window.__HERMES_PLUGIN_SDK__.components`.
+ *
+ * The web dashboard exposes `@nous-research/ui` Card / Label / Select (a custom
+ * combobox that reads `<SelectOption value>` children). The desktop's own UI kit
+ * (apps/desktop/src/components/ui) has Badge / Button / Checkbox / Input /
+ * Separator / Tabs but NO Card / Label, and its `Select` is a Radix composite
+ * with an incompatible API. These thin shims reproduce the web prop contract so
+ * the SAME unmodified plugin bundle (e.g. kanban) renders identically.
+ */
+
+import {
+  Children,
+  type ComponentProps,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+} from "react";
+
+import { cn } from "@/lib/utils";
+
+// ── Card family ────────────────────────────────────────────────────────────
+// Mirrors @nous-research/ui Card: a bordered surface that accepts className +
+// children. Tones map to the desktop theme's card variables.
+
+export function Card({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "rounded-[4px] border border-(--ui-stroke-secondary) bg-(--ui-bg-secondary) text-(--ui-text-primary)",
+        className,
+      )}
+      data-slot="card"
+      {...props}
+    />
+  );
+}
+
+export function CardHeader({ className, ...props }: ComponentProps<"div">) {
+  return <div className={cn("flex flex-col gap-1 p-3", className)} data-slot="card-header" {...props} />;
+}
+
+export function CardTitle({ className, ...props }: ComponentProps<"div">) {
+  return <div className={cn("text-sm font-semibold leading-none", className)} data-slot="card-title" {...props} />;
+}
+
+export function CardContent({ className, ...props }: ComponentProps<"div">) {
+  return <div className={cn("p-3", className)} data-slot="card-content" {...props} />;
+}
+
+// ── Label ──────────────────────────────────────────────────────────────────
+
+export function Label({ className, ...props }: ComponentProps<"label">) {
+  return (
+    <label
+      className={cn("text-xs font-medium leading-none text-(--ui-text-secondary)", className)}
+      data-slot="label"
+      {...props}
+    />
+  );
+}
+
+// ── Select / SelectOption ──────────────────────────────────────────────────
+// Faithful reproduction of the @nous-research/ui contract the plugin bundles
+// use: `<Select value onValueChange className>` with `<SelectOption value>`
+// children. Implemented as a native <select> so behavior is robust without
+// pulling the DS combobox (which the desktop's nous-ui version omits).
+
+interface SelectProps {
+  children?: ReactNode;
+  className?: string;
+  disabled?: boolean;
+  id?: string;
+  onValueChange?: (value: string) => void;
+  placeholder?: string;
+  value?: string;
+}
+
+export function Select({
+  children,
+  className,
+  disabled,
+  id,
+  onValueChange,
+  value,
+}: SelectProps) {
+  const options = collectOptions(children);
+
+  return (
+    <select
+      className={cn(
+        "h-9 w-full rounded-[3px] border border-(--ui-stroke-secondary) bg-(--ui-bg-tertiary) px-2 text-sm text-(--ui-text-primary)",
+        "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/40",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      data-slot="select"
+      disabled={disabled}
+      id={id}
+      onChange={(e) => onValueChange?.(e.target.value)}
+      value={value ?? ""}
+    >
+      {options.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+// Marker component — `Select` reads value/children from the tree. Renders
+// nothing on its own (matches @nous-research/ui SelectOption).
+export function SelectOption(_props: { children?: ReactNode; value: string }) {
+  return null;
+}
+
+interface SelectOptionData {
+  label: string;
+  value: string;
+}
+
+function collectOptions(children: ReactNode): SelectOptionData[] {
+  const out: SelectOptionData[] = [];
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) {return;}
+    const el = child as ReactElement<{ children?: ReactNode; value?: unknown }>;
+
+    if (el.props.value !== undefined) {
+      out.push({
+        label:
+          typeof el.props.children === "string"
+            ? el.props.children
+            : String(el.props.value),
+        value: String(el.props.value),
+      });
+    } else if (el.props.children) {
+      out.push(...collectOptions(el.props.children));
+    }
+  });
+
+  return out;
+}

--- a/apps/desktop/src/plugins/sdk.d.ts
+++ b/apps/desktop/src/plugins/sdk.d.ts
@@ -1,0 +1,170 @@
+/**
+ * Hermes Dashboard Plugin SDK — typed contract (SPIKE)
+ * ====================================================
+ *
+ * This is the public type surface for ``window.__HERMES_PLUGIN_SDK__`` and
+ * ``window.__HERMES_PLUGINS__``, the globals the dashboard host exposes to
+ * plugin bundles (see ``web/src/plugins/registry.ts::exposePluginSDK``).
+ *
+ * STATUS: spike. This file documents the contract and gives plugin authors
+ * (in-repo IIFEs and external bundles alike) editor types without bundling
+ * their own copies of React / the API client. It is intentionally a
+ * hand-authored ambient declaration rather than ``typeof
+ * window.__HERMES_PLUGIN_SDK__`` because:
+ *   1. The runtime object is assembled from many internal modules
+ *      (``@/lib/api``, ``@nous-research/ui``, …). Deriving the type would
+ *      leak those internal import paths into the public contract and couple
+ *      external plugins to the host's internal module layout.
+ *   2. A hand-authored contract is the *versioned API boundary* — changing
+ *      it is a deliberate act, visible in review, not an accidental
+ *      consequence of refactoring an internal helper.
+ *
+ * Versioning: bump ``HermesPluginSDK["sdkVersion"]`` (and the
+ * ``SDK_CONTRACT_VERSION`` const the host exposes) on any
+ * backwards-incompatible change to this surface. Additive changes
+ * (new optional fields, new helpers) don't require a major bump.
+ *
+ * OPEN QUESTIONS for productionising this spike (do not block the auth fix):
+ *   - Ship as a published ``@hermes/dashboard-plugin-sdk`` types package, or
+ *     keep in-repo and copy into external plugin repos?
+ *   - Should the host assert at runtime that a plugin's declared
+ *     ``manifest.sdk_version`` is compatible before executing it?
+ *   - The ``components`` map is typed loosely as ``Record<string,
+ *     ComponentType>`` here; do we want exact per-component prop types
+ *     (pulls @nous-research/ui types into the contract) or is the loose
+ *     shape the right boundary for external authors?
+ */
+
+import type {
+  ComponentType,
+  createContext as ReactCreateContext,
+  default as ReactDefault,
+  useCallback as ReactUseCallback,
+  useContext as ReactUseContext,
+  useEffect as ReactUseEffect,
+  useMemo as ReactUseMemo,
+  useRef as ReactUseRef,
+  useState as ReactUseState,
+} from "react";
+
+// ---------------------------------------------------------------------------
+// Auth-relevant helpers (the surface this PR adds/sanctions)
+// ---------------------------------------------------------------------------
+
+/**
+ * JSON ``fetch`` for dashboard ``/api/...`` endpoints. Handles auth in both
+ * modes (loopback session-token header / gated cookie), throws
+ * ``Error("<status>: <body>")`` on non-2xx, and triggers the global
+ * 401 → /login redirect in gated mode. Use for all JSON plugin endpoints.
+ */
+export type FetchJSON = <T = unknown>(
+  url: string,
+  init?: RequestInit,
+  options?: { allowUnauthorized?: boolean },
+) => Promise<T>;
+
+/**
+ * Authenticated ``fetch`` for NON-JSON endpoints (uploads via ``FormData``,
+ * binary/blob downloads). Same auth handling as ``fetchJSON`` but returns
+ * the raw ``Response``, does not parse, does not throw on non-2xx, and does
+ * not run the 401 redirect. Plugins MUST use this (or ``fetchJSON``) instead
+ * of calling ``fetch`` with a hand-read ``window.__HERMES_SESSION_TOKEN__``.
+ */
+export type AuthedFetch = (url: string, init?: RequestInit) => Promise<Response>;
+
+/**
+ * Build an absolute ``ws(s)://`` URL for a dashboard WebSocket endpoint with
+ * the correct auth query param for the active mode (single-use ``ticket`` in
+ * gated OAuth mode, ``token`` in loopback). Plugins MUST use this for any
+ * WebSocket instead of hand-assembling the URL + reading the session token.
+ */
+export type BuildWsUrl = (
+  path: string,
+  params?: Record<string, string>,
+) => Promise<string>;
+
+/** Lower-level: just the ``[authParamName, authParamValue]`` pair. */
+export type BuildWsAuthParam = () => Promise<[string, string]>;
+
+// ---------------------------------------------------------------------------
+// Registry surface (window.__HERMES_PLUGINS__)
+// ---------------------------------------------------------------------------
+
+export interface PluginRegistry {
+  /** Register the plugin's main tab component by manifest name. */
+  register(name: string, component: ComponentType<Record<string, never>>): void;
+  /** Register a component into a named host slot. */
+  registerSlot(slot: string, name: string, component: ComponentType): void;
+}
+
+// ---------------------------------------------------------------------------
+// SDK surface (window.__HERMES_PLUGIN_SDK__)
+// ---------------------------------------------------------------------------
+
+export interface HermesPluginSDK {
+  /** Contract version of this SDK surface (see SDK_CONTRACT_VERSION). */
+  readonly sdkVersion: string;
+
+  /** React core — use instead of importing/bundling react. */
+  React: typeof ReactDefault;
+  hooks: {
+    useState: typeof ReactUseState;
+    useEffect: typeof ReactUseEffect;
+    useCallback: typeof ReactUseCallback;
+    useMemo: typeof ReactUseMemo;
+    useRef: typeof ReactUseRef;
+    useContext: typeof ReactUseContext;
+    createContext: typeof ReactCreateContext;
+  };
+
+  /**
+   * Typed convenience client for core dashboard endpoints. Typed permissively
+   * at the boundary (methods vary in arity and return type — most return
+   * ``Promise<T>``, a few return a URL string synchronously); plugins call the
+   * specific methods they need. See ``web/src/lib/api.ts`` for the concrete shape.
+   */
+  api: Record<string, (...args: never[]) => unknown>;
+
+  /** JSON fetch with host auth handling. */
+  fetchJSON: FetchJSON;
+  /** Authenticated raw fetch for uploads / blob downloads. */
+  authedFetch: AuthedFetch;
+  /** Build an auth'd WebSocket URL for the active mode. */
+  buildWsUrl: BuildWsUrl;
+  /** Resolve just the WS auth query-param pair. */
+  buildWsAuthParam: BuildWsAuthParam;
+
+  /**
+   * Shared UI primitives (Nous DS / shadcn). Typed permissively at the
+   * boundary: the host's concrete components (some of which require props like
+   * ``active``/``value``/``name``) must be assignable here, and external plugin
+   * authors render them dynamically without the host's internal prop types.
+   * ``ComponentType<never>`` accepts any component regardless of its prop
+   * requirements (props are contravariant).
+   */
+  components: Record<string, ComponentType<never>>;
+
+  utils: {
+    cn: (...classes: Array<string | false | null | undefined>) => string;
+    /** Relative-time formatter. Accepts an epoch-ms number. */
+    timeAgo: (ts: number) => string;
+    /** Relative-time formatter for an ISO-8601 string. */
+    isoTimeAgo: (iso: string) => string;
+  };
+
+  /**
+   * i18n hook. Returns the host's i18n context value; typed loosely at the
+   * boundary so the contract doesn't couple to the host's internal
+   * ``I18nContextValue`` shape. Plugins typically call ``useI18n().t(...)``.
+   */
+  useI18n: () => unknown;
+}
+
+declare global {
+  interface Window {
+    __HERMES_PLUGIN_SDK__?: HermesPluginSDK;
+    __HERMES_PLUGINS__?: PluginRegistry;
+  }
+}
+
+export {};

--- a/apps/desktop/src/plugins/slots.ts
+++ b/apps/desktop/src/plugins/slots.ts
@@ -1,0 +1,205 @@
+/**
+ * Plugin slot registry.
+ *
+ * Plugins can inject components into named locations in the app shell
+ * (header-left, sidebar, backdrop, etc.) by calling
+ * `window.__HERMES_PLUGINS__.registerSlot(pluginName, slotName, Component)`
+ * from their JS bundle. Multiple plugins can populate the same slot — they
+ * render stacked in registration order.
+ *
+ * The canonical slot names are documented in `KNOWN_SLOT_NAMES` below. The
+ * registry accepts any string so plugin ecosystems can define their own
+ * slots; the shell only renders `<PluginSlot name="..." />` for the slots
+ * it knows about.
+ */
+
+import React, { Fragment, useEffect, useState } from "react";
+
+/** Slot locations the built-in shell renders. Plugins declaring any of
+ *  these in their manifest's `slots` field get wired in automatically.
+ *
+ *  Shell-wide slots:
+ *  - `backdrop`         — rendered inside `<Backdrop />`, above the noise layer
+ *  - `header-left`      — injected before the Hermes brand in the top bar
+ *  - `header-right`     — injected before the theme/language switchers
+ *  - `header-banner`    — injected below the top nav bar, full-width
+ *  - `sidebar`          — the cockpit sidebar rail (only rendered when
+ *                         `layoutVariant === "cockpit"`)
+ *  - `pre-main`         — rendered above the route outlet (inside `<main>`)
+ *  - `post-main`        — rendered below the route outlet (inside `<main>`)
+ *  - `footer-left`      — replaces the left footer cell content
+ *  - `footer-right`     — replaces the right footer cell content
+ *  - `overlay`          — fixed-position layer above everything else;
+ *                         useful for chrome (scanlines, vignettes) the
+ *                         theme's customCSS can't achieve alone
+ *
+ *  Page-scoped slots (rendered inside a specific built-in page — use these
+ *  to inject widgets, cards, or toolbars into existing pages without
+ *  overriding the whole route):
+ *  - `sessions:top`     — top of /sessions page (above session list)
+ *  - `sessions:bottom`  — bottom of /sessions page
+ *  - `analytics:top`    — top of /analytics page
+ *  - `analytics:bottom` — bottom of /analytics page
+ *  - `logs:top`         — top of /logs page (above filter toolbar)
+ *  - `logs:bottom`      — bottom of /logs page (below log viewer)
+ *  - `cron:top`         — top of /cron page
+ *  - `cron:bottom`      — bottom of /cron page
+ *  - `skills:top`       — top of /skills page
+ *  - `skills:bottom`    — bottom of /skills page
+ *  - `plugins:top`       — top of /plugins page
+ *  - `plugins:bottom`    — bottom of /plugins page
+ *  - `config:top`       — top of /config page
+ *  - `config:bottom`    — bottom of /config page
+ *  - `env:top`          — top of /env (Keys) page
+ *  - `env:bottom`       — bottom of /env (Keys) page
+ *  - `docs:top`         — top of /docs page (above the docs iframe)
+ *  - `docs:bottom`      — bottom of /docs page
+ *  - `chat:top`         — top of /chat page (above the composer, when embedded chat is on)
+ *  - `chat:bottom`      — bottom of /chat page
+ */
+export const KNOWN_SLOT_NAMES = [
+  // Shell-wide
+  "backdrop",
+  "header-left",
+  "header-right",
+  "header-banner",
+  "sidebar",
+  "pre-main",
+  "post-main",
+  "footer-left",
+  "footer-right",
+  "overlay",
+  // Page-scoped
+  "sessions:top",
+  "sessions:bottom",
+  "analytics:top",
+  "analytics:bottom",
+  "logs:top",
+  "logs:bottom",
+  "cron:top",
+  "cron:bottom",
+  "skills:top",
+  "skills:bottom",
+  "plugins:top",
+  "plugins:bottom",
+  "config:top",
+  "config:bottom",
+  "env:top",
+  "env:bottom",
+  "docs:top",
+  "docs:bottom",
+  "chat:top",
+  "chat:bottom",
+] as const;
+
+export type KnownSlotName = (typeof KNOWN_SLOT_NAMES)[number];
+
+type SlotListener = () => void;
+
+interface SlotEntry {
+  plugin: string;
+  component: React.ComponentType;
+}
+
+/** Map<slotName, SlotEntry[]>. Entries are appended in registration order. */
+const _slotRegistry: Map<string, SlotEntry[]> = new Map();
+const _slotListeners: Set<SlotListener> = new Set();
+
+function _notifySlots() {
+  for (const fn of _slotListeners) {
+    try {
+      fn();
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+/** Register a component for a slot. Called by plugin bundles via
+ *  `window.__HERMES_PLUGINS__.registerSlot(...)`.
+ *
+ *  If the same (plugin, slot) pair is registered twice, the later call
+ *  replaces the earlier one — this matches how React HMR expects plugin
+ *  re-mounts to behave. */
+export function registerSlot(
+  plugin: string,
+  slot: string,
+  component: React.ComponentType,
+): void {
+  const existing = _slotRegistry.get(slot) ?? [];
+  const filtered = existing.filter((e) => e.plugin !== plugin);
+  filtered.push({ plugin, component });
+  _slotRegistry.set(slot, filtered);
+  _notifySlots();
+}
+
+/** Read current entries for a slot. Returns a copy so callers can't mutate
+ *  registry state. */
+export function getSlotEntries(slot: string): SlotEntry[] {
+  return (_slotRegistry.get(slot) ?? []).slice();
+}
+
+/** Subscribe to registry changes. Returns an unsubscribe function. */
+export function onSlotRegistered(fn: SlotListener): () => void {
+  _slotListeners.add(fn);
+
+  return () => {
+    _slotListeners.delete(fn);
+  };
+}
+
+/** Clear a specific plugin's slot registrations. Useful for HMR /
+ *  plugin reload flows — not wired in by default. */
+export function unregisterPluginSlots(plugin: string): void {
+  let changed = false;
+
+  for (const [slot, entries] of _slotRegistry.entries()) {
+    const kept = entries.filter((e) => e.plugin !== plugin);
+
+    if (kept.length !== entries.length) {
+      changed = true;
+
+      if (kept.length === 0) {_slotRegistry.delete(slot);}
+      else {_slotRegistry.set(slot, kept);}
+    }
+  }
+
+  if (changed) {_notifySlots();}
+}
+
+interface PluginSlotProps {
+  /** Slot identifier (e.g. `"sidebar"`, `"header-left"`). */
+  name: string;
+  /** Optional content rendered when no plugins have claimed the slot.
+   *  Useful for built-in defaults the plugin would replace. */
+  fallback?: React.ReactNode;
+}
+
+/** Render all components registered for a given slot, stacked in order.
+ *
+ *  Component re-renders when the slot registry changes so plugins that
+ *  arrive after initial mount show up without a manual refresh. */
+export function PluginSlot({ name, fallback }: PluginSlotProps) {
+  const [entries, setEntries] = useState<SlotEntry[]>(() => getSlotEntries(name));
+
+  useEffect(() => {
+    // Pick up anything registered between the initial `useState` call
+    // and the first effect tick, then subscribe for future changes.
+    setEntries(getSlotEntries(name));
+    const unsub = onSlotRegistered(() => setEntries(getSlotEntries(name)));
+
+    return unsub;
+  }, [name]);
+
+  if (entries.length === 0) {
+    return fallback ? React.createElement(Fragment, null, fallback) : null;
+  }
+
+  return React.createElement(
+    Fragment,
+    null,
+    ...entries.map((entry) =>
+      React.createElement(entry.component, { key: entry.plugin }),
+    ),
+  );
+}

--- a/apps/desktop/src/plugins/types.ts
+++ b/apps/desktop/src/plugins/types.ts
@@ -1,0 +1,37 @@
+/** Types for the dashboard plugin system. */
+
+import type { ComponentType } from "react";
+
+export interface PluginManifest {
+  name: string;
+  label: string;
+  description: string;
+  icon: string;
+  version: string;
+  tab: {
+    path: string;
+    /** "end", "after:<pathSegment>", "before:<pathSegment>" (e.g. "after:skills" → after `/skills`) */
+    position?: string;
+    /** When set to a built-in route path, this plugin replaces that page instead of adding a new tab. */
+    override?: string;
+    /** When true, the plugin may register without a sidebar tab (slot-only, etc.). */
+    hidden?: boolean;
+  };
+  /** Declared for discovery; actual slots use registerSlot in the plugin bundle. */
+  slots?: string[];
+  entry: string;
+  css?: string | null;
+  has_api: boolean;
+  /**
+   * Optional Subresource Integrity hash (e.g. "sha384-..."). When set,
+   * the browser will refuse to execute the plugin bundle if its hash
+   * does not match. This protects against tampered plugin delivery.
+   */
+  integrity?: string;
+  source: string;
+}
+
+export interface RegisteredPlugin {
+  manifest: PluginManifest;
+  component: ComponentType;
+}

--- a/apps/desktop/src/plugins/usePlugins.ts
+++ b/apps/desktop/src/plugins/usePlugins.ts
@@ -1,0 +1,166 @@
+/**
+ * usePlugins hook — discovers and loads dashboard plugins (desktop port).
+ *
+ * 1. Fetches plugin manifests from GET /api/dashboard/plugins
+ * 2. Injects CSS <link> tags for plugins that declare css
+ * 3. Loads plugin JS bundles via <script> tags
+ * 4. Waits for plugins to call register() and resolves them
+ *
+ * Ported from web/src/plugins/usePlugins.ts. The only adaptations: manifests are
+ * fetched through `window.hermesDesktop.api` (cross-origin IPC, not same-origin
+ * fetch), and asset URLs are built off the backend's ABSOLUTE origin
+ * (`connection.baseUrl`) rather than the web's same-origin `HERMES_BASE_PATH`.
+ * The renderer runs from file:// / 127.0.0.1:5174, so plugin <script>/<link>
+ * must point at the separate backend origin. Everything else (DEV cache-bust,
+ * SRI integrity, onerror/onload register-check, 2s safety timeout) is verbatim.
+ */
+
+import { useEffect, useRef, useState } from "react";
+
+import {
+  getPluginComponent,
+  notifyPluginRegistry,
+  onPluginRegistered,
+  setPluginLoadError,
+} from "./registry";
+import { api, getBackendBaseUrl } from "./sdk-backend";
+import type { PluginManifest, RegisteredPlugin } from "./types";
+
+export function usePlugins() {
+  const [manifests, setManifests] = useState<PluginManifest[]>([]);
+  const [plugins, setPlugins] = useState<RegisteredPlugin[]>([]);
+  const [loading, setLoading] = useState(true);
+  const loadedScripts = useRef<Set<string>>(new Set());
+
+  // Fetch manifests on mount.
+  useEffect(() => {
+    (api.getPlugins() as Promise<PluginManifest[]>)
+      .then((list) => {
+        setManifests(list);
+
+        if (list.length === 0) {setLoading(false);}
+      })
+      .catch(() => setLoading(false));
+  }, []);
+
+  // Load plugin assets when manifests arrive.
+  useEffect(() => {
+    if (manifests.length === 0) {return;}
+
+    let cancelled = false;
+    const injectedScripts: HTMLScriptElement[] = [];
+
+    // Resolve the backend's absolute origin once, then inject assets. The web
+    // uses a synchronous same-origin HERMES_BASE_PATH; the desktop must await
+    // the connection descriptor (window.hermesDesktop.getConnection), so the
+    // injection loop is wrapped in an async resolve.
+    void getBackendBaseUrl().then((baseUrl) => {
+      if (cancelled) {return;}
+
+      for (const manifest of manifests) {
+        // Inject CSS if specified.
+        if (manifest.css) {
+          const cssUrl = `${baseUrl}/dashboard-plugins/${manifest.name}/${manifest.css}`;
+
+          if (!document.querySelector(`link[href="${cssUrl}"]`)) {
+            const link = document.createElement("link");
+            link.rel = "stylesheet";
+            link.href = cssUrl;
+            document.head.appendChild(link);
+          }
+        }
+
+        // Load JS bundle. In dev, cache-bust so Vite HMR can clear the
+        // in-memory registry while the browser would otherwise never
+        // re-execute a previously cached <script> URL.
+        const bundleUrl = `${baseUrl}/dashboard-plugins/${manifest.name}/${manifest.entry}`;
+
+        const scriptSrc = import.meta.env.DEV
+          ? `${bundleUrl}?hermes_dv=${Date.now()}`
+          : bundleUrl;
+
+        if (!import.meta.env.DEV) {
+          if (loadedScripts.current.has(bundleUrl)) {continue;}
+          loadedScripts.current.add(bundleUrl);
+        }
+
+        const script = document.createElement("script");
+        script.setAttribute("data-hermes-plugin", manifest.name);
+        script.src = scriptSrc;
+        script.async = true;
+
+        // SRI integrity verification — defense against compromised plugin
+        // delivery. Plugin manifests can declare an integrity hash
+        // (e.g. "sha384-...") which the browser verifies before executing.
+        // Without this, a man-in-the-middle or compromised plugin server
+        // can substitute the JS bundle silently. Opt-in: when no integrity
+        // is declared in the manifest, behavior is unchanged.
+        if (manifest.integrity && typeof manifest.integrity === "string") {
+          script.integrity = manifest.integrity;
+          script.crossOrigin = "anonymous";
+        }
+
+        script.onerror = () => {
+          setPluginLoadError(manifest.name, "LOAD_FAILED");
+          console.warn(
+            `[plugins] Failed to load ${manifest.name} from ${scriptSrc} (open Network tab)`,
+          );
+        };
+
+        script.onload = () => {
+          notifyPluginRegistry();
+          queueMicrotask(() => {
+            if (getPluginComponent(manifest.name)) {return;}
+            setPluginLoadError(manifest.name, "NO_REGISTER");
+          });
+        };
+
+        document.body.appendChild(script);
+        injectedScripts.push(script);
+      }
+    });
+
+    // Give plugins a moment to load and register, then stop loading state.
+    const timeout = setTimeout(() => setLoading(false), 2000);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timeout);
+
+      if (import.meta.env.DEV) {
+        for (const el of injectedScripts) {
+          el.remove();
+        }
+      }
+    };
+  }, [manifests]);
+
+  // Listen for plugin registrations and resolve them against manifests.
+  useEffect(() => {
+    function resolvePlugins() {
+      const resolved: RegisteredPlugin[] = [];
+
+      for (const manifest of manifests) {
+        const component = getPluginComponent(manifest.name);
+
+        if (component) {
+          resolved.push({ manifest, component });
+        }
+      }
+
+      setPlugins(resolved);
+
+      // If all plugins registered, stop loading early.
+      if (resolved.length === manifests.length && manifests.length > 0) {
+        setLoading(false);
+      }
+    }
+
+    resolvePlugins();
+    const unsub = onPluginRegistered(resolvePlugins);
+
+    return unsub;
+  }, [manifests]);
+
+  return { plugins, manifests, loading };
+}

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -847,6 +847,32 @@
       if (col.tasks && col.tasks.length > 0) setLastSelectedId(col.tasks[0].id);
     }, [filteredBoard, selectedIds]);
 
+    // Bulk review: post one comment to every selected card, then unblock them
+    // all (status -> ready). Lets a reviewer clear a stack of review-required
+    // cards in a single pass instead of opening each drawer to comment. Per-card
+    // comment failures don't abort siblings (same spirit as /tasks/bulk).
+    const bulkCommentUnblock = useCallback(function (commentBody) {
+      const body = (commentBody || "").trim();
+      const ids = Array.from(selectedIds);
+      if (!body || ids.length === 0) return Promise.resolve();
+      return Promise.all(ids.map(function (id) {
+        return SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(id)}/comments`, board), {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ body: body }),
+        }).catch(function () { /* independent — keep going */ });
+      })).then(function () {
+        return SDK.fetchJSON(withBoard(`${API}/tasks/bulk`, board), {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ ids: ids, status: "ready" }),
+        });
+      }).then(function () {
+        loadBoard();
+        clearSelected();
+      }).catch(function (e) { setError(String(e && e.message ? e.message : e)); });
+    }, [selectedIds, board]);
+
     const applyBulk = useCallback(function (patch, confirmMsg) {
       if (selectedIds.size === 0) return;
       if (confirmMsg && !window.confirm(confirmMsg)) return;
@@ -1023,6 +1049,7 @@
          count: selectedIds.size,
          assignees: (boardData && boardData.assignees) || [],
          onApply: applyBulk,
+         onCommentUnblock: bulkCommentUnblock,
          onClear: clearSelected,
          onSelectAllVisible: selectAllVisible,
          onDelete: deleteSelected,
@@ -2055,9 +2082,35 @@
     const [assignee, setAssignee] = useState("");
     const [reclaimFirst, setReclaimFirst] = useState(false);
     const [priority, setPriority] = useState("");
+    const [comment, setComment] = useState("");
+    const submitCommentUnblock = function () {
+      if (!comment.trim() || !props.onCommentUnblock) return;
+      props.onCommentUnblock(comment);
+      setComment("");
+    };
     return h("div", { className: "hermes-kanban-bulk" },
       h("span", { className: "hermes-kanban-bulk-count" },
         `${props.count} ${tx(t, "selected", "selected")}`),
+      h("div", {
+        className: "hermes-kanban-bulk-comment",
+        title: "Post this comment to every selected card, then unblock them all (promote to Ready). Clears review-required cards in one pass.",
+      },
+        h(Input, {
+          value: comment,
+          onChange: function (e) { setComment(e.target.value); },
+          onKeyDown: function (e) {
+            if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); submitCommentUnblock(); }
+          },
+          placeholder: tx(t, "bulkCommentPlaceholder", "Review comment…"),
+          className: "h-8 text-sm",
+        }),
+        h(Button, {
+          onClick: submitCommentUnblock,
+          size: "sm",
+          disabled: !comment.trim(),
+          title: "Comment on + unblock all selected",
+        }, tx(t, "commentUnblock", "Comment & unblock")),
+      ),
       h(Button, {
         onClick: function () { props.onApply({ status: "todo" }); },
         size: "sm",
@@ -2196,7 +2249,7 @@
     const handleDrop = function (e) {
       e.preventDefault();
       setDragOver(false);
-      const taskId = e.dataTransfer.getData(MIME_TASK);
+      const taskId = e.dataTransfer.getData(MIME_TASK) || e.dataTransfer.getData("text/plain");
       if (!taskId) return;
       if (props.selectedIds && props.selectedIds.has(taskId) && props.selectedIds.size > 1) {
         if (window.confirm(tx(t, "trash.confirmMany", "Permanently delete {n} selected tasks? This cannot be undone.", { n: props.selectedIds.size }))) {
@@ -2300,7 +2353,7 @@
     const handleDrop = function (e) {
       e.preventDefault();
       setDragOver(false);
-      const taskId = e.dataTransfer.getData(MIME_TASK);
+      const taskId = e.dataTransfer.getData(MIME_TASK) || e.dataTransfer.getData("text/plain");
       if (!taskId) return;
       if (props.selectedIds && props.selectedIds.has(taskId) && props.selectedIds.size > 1) {
         if (props.onMoveSelected) props.onMoveSelected(props.column.name);
@@ -2446,6 +2499,12 @@
 
     const handleDragStart = function (e) {
       e.dataTransfer.setData(MIME_TASK, t.id);
+      // Also carry the id on the standard text/plain type. Chromium sanitizes
+      // non-standard (text/x-*) dataTransfer types under the file:// origin the
+      // Electron desktop loads from, so the custom MIME arrives empty at the
+      // drop handler there; text/plain survives. Web (http://) keeps using
+      // MIME_TASK. Drop handlers read MIME_TASK first, then fall back. (#desktop-dnd)
+      e.dataTransfer.setData("text/plain", t.id);
       e.dataTransfer.effectAllowed = "move";
       const selectedCards = document.querySelectorAll(".hermes-kanban-card--selected");
       if (selectedCards.length > 1 && props.selected) {

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -340,6 +340,12 @@
   height: 100dvh;
   max-height: 100dvh;
   background: var(--color-card);
+  /* The drawer is a body-level fixed overlay, so it escapes the host pane's
+     text-color context and would otherwise inherit document.body's ambient
+     color (light-brown in light themes). Anchor it to the readable foreground
+     token so bare comment-body text is legible in both light and dark; the
+     -author / -ago / muted-label rules keep their own explicit colors. */
+  color: var(--color-foreground);
   border-left: 1px solid var(--color-border);
   display: flex;
   flex-direction: column;
@@ -1532,6 +1538,19 @@
   gap: 0.25rem;
   padding-left: 0.5rem;
   border-left: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+}
+/* Bulk review: comment box + "Comment & unblock" button. Wider input than the
+   priority field since it holds prose; same left-border separator as the other
+   bulk groups. */
+.hermes-kanban-bulk-comment {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding-left: 0.5rem;
+  border-left: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+}
+.hermes-kanban-bulk-comment > input {
+  min-width: 12rem;
 }
 .hermes-kanban-bulk-reclaim-first {
   display: inline-flex;

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "willies578@gmail.com": "grimmjoww",
     "kenmege@yahoo.com": "Kenmege",
     "dkobi16@gmail.com": "Diyoncrz18",
     "arnaud@nolimitdevelopment.com": "ali-nld",


### PR DESCRIPTION
Brings the web dashboard's plugin system into the native Electron desktop, so dashboard plugins (**kanban** + **achievements**) render in-app instead of falling back to the web UI.

## What changed and why
**Desktop host** (`apps/desktop/src/plugins/`, new): plugin registry/SDK on `window`, an Electron-IPC backend shim (routes through `window.hermesDesktop` instead of same-origin fetch), UI-kit component shims (Card/Label/Select), discovery + CSS/script injection + a scroll/fill mount host. Wired into the sidebar (after Skills), routes, command palette, `main.tsx`. General — any dashboard plugin with a manifest mounts on the desktop. Without it, desktop users drop back to the web UI for kanban/achievements.

**Plugins on the loader:**
- **achievements** — renders via the loader, no plugin-specific code (mount host fixes scrolling).
- **kanban** — desktop-targeted fixes: readable drawer/comment text (foreground token); bulk **Comment & unblock** on the multi-select bar; card **drag** under `file://` (carry id on `text/plain` since Chromium drops custom `text/x-*` MIME there); WS builder preserves the remote path prefix.

## How to test
1. `cd apps/desktop && npm run pack`, then launch `release/win-unpacked/Hermes.exe` (or `npm run start`).
2. **Kanban** tab (after Skills) → board loads; drag a card between columns; select 2+ cards → **Comment & unblock**; open a card → comment text legible in light + dark.
3. **Achievements** tab → renders + scrolls.

## Platforms tested
- **Windows 11** — packaged Electron build, all of the above exercised live.
- macOS/Linux not manually run, but the changes are platform-agnostic (Electron `file://` load + the IPC SDK shim behave identically across platforms; the `text/plain` drag workaround targets Chromium's `file://` behavior, which is cross-platform). CI `nix (macos-latest)` + `nix (ubuntu-latest)` + `typecheck (apps/desktop)` were green on the source branch.

## Scope note
This bundles the plugin-loader port with three small kanban fixes that make it usable on the desktop (readability, file:// drag) plus one kanban feature (bulk Comment & unblock). Happy to split the bulk-review feature into its own PR if you'd prefer it focused.

## Notes for maintainers
- The kanban fixes are applied to its compiled `plugins/kanban/dashboard/dist/{index.js,style.css}` (the form the plugin ships in-repo). If kanban is built from an external source, these need re-applying there — happy to redo against source if pointed at it.
- OAuth-remote plugin transport (ws-ticket, OAuth cookie partition) is a documented follow-up; this targets the loopback/token desktop. Code comments mark the spots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)