### PR TITLE
fix(desktop): route profile-scoped settings to the right profile in global remote mode

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5574,6 +5574,85 @@ async function mergeRemoteProfileSessions(searchParams, remoteProfiles) {
   return { ...base, sessions: merged.slice(offset, offset + limit), total, profile_totals: profileTotals }
 }
 
+// Profile-scoped SETTINGS endpoints have the same remote hazard as per-session
+// requests: in global-remote mode a single shared backend serves every profile,
+// disambiguated only by ?profile=. The renderer sends these with a bare path and
+// the profile only in request.profile — which ensureBackend() can't act on when
+// there's just one backend — so they silently read/write the remote's DEFAULT
+// profile no matter which profile the rail shows. Mirror
+// interceptSessionRequestForRemote: in global-remote mode, append ?profile= and
+// route through the shared backend. Backends already honor the query param
+// (web_server.py: _profile_scope(body.profile or profile)); this is the desktop
+// analogue of the dashboard's withManagementProfile() (web/src/lib/api.ts), and
+// PROFILE_SCOPED_REMOTE_PREFIXES is kept identical to its PROFILE_SCOPED_PREFIXES.
+const PROFILE_SCOPED_REMOTE_PREFIXES = [
+  '/api/analytics',
+  '/api/skills',
+  '/api/tools/toolsets',
+  '/api/config',
+  '/api/env',
+  '/api/mcp',
+  '/api/messaging/platforms',
+  '/api/model/info',
+  '/api/model/set',
+  '/api/model/auxiliary',
+  '/api/model/options'
+]
+
+async function interceptProfileScopedSettingForRemote(request) {
+  if (!globalRemoteActive()) {
+    return undefined
+  }
+  if (typeof request?.path !== 'string') {
+    return undefined
+  }
+
+  // Default profile is exactly what the bare path already resolves to on the
+  // shared backend, so there's nothing to rewrite (empty === default here).
+  const profile = (request.profile || '').trim()
+  if (!profile || profile === 'default') {
+    return undefined
+  }
+
+  // A profile with its own remote override is served by its OWN backend, where
+  // the bare path already hits the right state.db — let ensureBackend(profile)
+  // handle it (matches interceptSessionRequestForRemote's override branch).
+  if (profileHasRemoteOverride(profile)) {
+    return undefined
+  }
+
+  let parsed
+  try {
+    parsed = new URL(request.path, 'http://x')
+  } catch {
+    return undefined
+  }
+
+  const { pathname, search, searchParams } = parsed
+  // An explicit ?profile= already on the path wins — don't double-scope.
+  if (searchParams.has('profile')) {
+    return undefined
+  }
+  const matches = PROFILE_SCOPED_REMOTE_PREFIXES.some(
+    prefix => pathname === prefix || pathname.startsWith(`${prefix}/`)
+  )
+  if (!matches) {
+    return undefined
+  }
+
+  // Keep any existing query and append profile= so the single backend opens the
+  // right state.db. Handlers read it from the query (a typed body.profile still
+  // wins where present), so request.body is forwarded untouched — we never
+  // mutate typed request bodies (e.g. /api/config's {config}).
+  const sep = search ? '&' : '?'
+  const path = `${pathname}${search}${sep}profile=${encodeURIComponent(profile)}`
+  const method = (request.method || 'GET').toUpperCase()
+  if (method === 'GET') {
+    return fetchJsonForProfile(null, path)
+  }
+  return requestJsonForProfile(null, path, method, request.body)
+}
+
 ipcMain.handle('hermes:api', async (_event, request) => {
   // Remote-profile session requests would otherwise hit the local primary off
   // each profile's on-disk state.db — fine for local profiles, but a remote
@@ -5582,6 +5661,14 @@ ipcMain.handle('hermes:api', async (_event, request) => {
   const rerouted = await interceptSessionRequestForRemote(request)
   if (rerouted !== undefined) {
     return rerouted
+  }
+
+  // Profile-scoped settings (skills/tools/config/env/model/…) need the same
+  // remote rewrite as sessions; without it they hit the remote's default
+  // profile. See interceptProfileScopedSettingForRemote.
+  const settingsRerouted = await interceptProfileScopedSettingForRemote(request)
+  if (settingsRerouted !== undefined) {
+    return settingsRerouted
   }
 
   await prepareProfileDeleteRequest(request)


### PR DESCRIPTION
## Problem

In **global remote mode** (Settings → connect Desktop to a remote gateway URL), the Desktop talks to a **single shared backend that serves every profile**, disambiguated only by a `?profile=` query param.

The renderer sends profile-scoped **settings** calls — `/api/skills`, `/api/tools/toolsets`, `/api/config`, `/api/env`, `/api/model/*`, … — with a **bare path**, carrying the profile only in `request.profile`. The `hermes:api` handler resolves a backend with `ensureBackend(request.profile)`, but in global remote mode there is exactly one backend, so `request.profile` can't disambiguate anything and the bare path hits the backend's **`default`** profile.

**Result:** with a non-default profile selected in the rail, Skills & Tools (and config/env/model) **read and write the remote's `default` profile**:

- Switching to a non-default profile on Skills & Tools shows the **default** profile's skills/tools (e.g. count stays on default's value and never updates).
- Toggling a skill/toolset while a non-default profile is selected **mutates the `default` profile** instead.

Sessions already avoid this via `interceptSessionRequestForRemote()`, which rewrites session endpoints to carry `?profile=` in global remote mode. The settings endpoints never got the equivalent.

## Repro

1. Remote Desktop (global remote mode) against a gateway that hosts two profiles with **different** skill states (e.g. `default` = 90 enabled, `pm-james` = 95 enabled).
2. Open **Skills & Tools** under `default` → 90.
3. Switch the rail to `pm-james`, click refresh.
4. **Expected:** 95. **Actual:** stays 90 (reads `default`). Toggling a skill writes `default`, not `pm-james`.

(A refresh ruling out stale React state is what isolates this to the wire request, not the renderer.)

## Fix

Add `interceptProfileScopedSettingForRemote()` in `apps/desktop/electron/main.cjs`, called from the `hermes:api` handler right after the existing session interceptor. In **global remote mode** it appends `?profile=<profile>` and routes the call through the shared backend (`fetchJsonForProfile`/`requestJsonForProfile`) — mirroring `interceptSessionRequestForRemote()`'s global-remote branch.

The endpoint allowlist (`PROFILE_SCOPED_REMOTE_PREFIXES`) is kept **identical** to the web dashboard's `PROFILE_SCOPED_PREFIXES` in `web/src/lib/api.ts` (`withManagementProfile`), which already does exactly this rewrite for the same backend.

### Why no backend change

Every targeted endpoint already accepts a `profile` query param — reads use `_profile_scope(profile)`, writes use `_profile_scope(body.profile or profile)` (see `hermes_cli/web_server.py`). The web dashboard relies on this today; `web_server.py` even documents it ("*the query param injected by the global dashboard profile switcher*"). This change just makes Desktop do in global remote mode what the dashboard already does.

### Safety / scope

- **Local mode:** gated on `globalRemoteActive()` → returns `undefined`, so the existing per-profile-backend path is unchanged.
- **Default profile:** early-returns (the bare path already resolves to `default` on the shared backend) → no behavior change.
- **Per-profile remote overrides:** early-returns via `profileHasRemoteOverride()`, leaving those to `ensureBackend(profile)`, whose bare path already targets the profile's own backend (matches the session interceptor).
- **Bodies untouched:** the rewrite only touches the query string and forwards `request.body` verbatim — handlers read the query param (a typed `body.profile` still wins where present), so typed bodies like `/api/config`'s `{config}` are never mutated.
- **Explicit `?profile=` already present** on the path → left as-is.

## Test plan

- Standalone logic check covering 12 cases — rewrite only on global-remote, non-default settings calls; no-op for local mode / default profile / non-allowlisted paths / per-profile overrides / an explicit `?profile=` already present; existing query preserved with the correct `?`/`&` separator; request body forwarded untouched. All pass.
- `node --check` and the Electron `--build-only` package build both pass.
- Mechanism traced end-to-end: Desktop appends `?profile=`; the backend honors it via `_profile_scope(body.profile or profile)` — the same path the web dashboard already exercises against this backend in production.
- **Recommended manual check** (needs a remote Desktop with two profiles of differing skill state): open Skills & Tools, switch the rail to the non-default profile — its counts should now show, and toggling a skill should persist to that profile's `config.yaml` (`skills.disabled`), leaving `default` untouched.

## Prior art

Desktop analogue of the web-dashboard fix that introduced profile-scoped settings (`web/src/lib/api.ts` `withManagementProfile` / `PROFILE_SCOPED_PREFIXES`).
