### PR TITLE
feat(telegram): add opt-in HERMES_TELEGRAM_PRESERVE_BACKLOG flag

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2082,7 +2082,14 @@ class TelegramAdapter(BasePlatformAdapter):
 
                 await self._app.updater.start_polling(
                     allowed_updates=Update.ALL_TYPES,
-                    drop_pending_updates=True,
+                    # HERMES_TELEGRAM_PRESERVE_BACKLOG: keep messages received
+                    # while the gateway was down (an on-demand wake answers the
+                    # message that woke it; a suspended agent catches up on
+                    # resume) instead of dropping them on a cold start.
+                    drop_pending_updates=(
+                        os.getenv("HERMES_TELEGRAM_PRESERVE_BACKLOG", "").strip().lower()
+                        not in ("1", "true", "yes", "on")
+                    ),
                     error_callback=_polling_error_callback,
                 )
             


### PR DESCRIPTION
## What

Adds an opt-in environment flag, `HERMES_TELEGRAM_PRESERVE_BACKLOG`. When it is set to a truthy value (`1`, `true`, `yes`, `on`), the Telegram poller starts with `drop_pending_updates=False` instead of the current `drop_pending_updates=True`.

## Why

By default `start_polling` is called with `drop_pending_updates=True`, which discards any update that arrived while the gateway was offline. On memory constrained or on-demand deployments the gateway is routinely stopped and restarted (for example to free RAM, or to wake only when a message arrives). With the default, the message that triggered the wake, and anything received during a restart, is silently dropped.

This flag lets those deployments preserve the backlog, so a freshly started gateway still answers the messages it received while it was down.

## Behavior

- Flag unset (default): unchanged, `drop_pending_updates=True`.
- Flag set to a truthy value: `drop_pending_updates=False`.

Single call site, pure `os.getenv`, no platform specific code, fully backward compatible.

## Testing

Running in production on a single box, memory constrained deployment. With the flag enabled, a gateway restarted after being stopped processes the messages it received while it was offline; with the flag unset, startup behavior is unchanged. Happy to add a unit test if that would help.
