### PR TITLE
fix(desktop): bump gateway timeout to 120s and directly call resumeSession on sidebar click

### DIFF
--- a/apps/desktop/src/app/desktop-controller.tsx
+++ b/apps/desktop/src/app/desktop-controller.tsx
@@ -870,7 +870,7 @@ export function DesktopController() {
       }}
       onNavigate={selectSidebarItem}
       onNewSessionInWorkspace={startSessionInWorkspace}
-      onResumeSession={sessionId => navigate(sessionRoute(sessionId))}
+      onResumeSession={sessionId => { navigate(sessionRoute(sessionId)); void resumeSession(sessionId) }}
       onTriggerCronJob={jobId => {
         void triggerCronJob(jobId)
           .then(() => refreshCronJobs())

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -42,7 +42,7 @@ import type {
   ToolsetInfo
 } from '@/types/hermes'
 
-const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 30_000
+const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 120_000
 const SESSION_LIST_REQUEST_TIMEOUT_MS = 60_000
 
 export type {


### PR DESCRIPTION
## Summary

Fixes two desktop bugs:

### 1. `request timed out: prompt.submit` (30s → 120s timeout)

**Root cause:** `DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS` in `apps/desktop/src/hermes.ts` was set to `30_000` (30s), but the shared base class `JsonRpcGatewayClient` defaults to `120_000` (120s). Operations like auto-compaction, MCP tool discovery during `session.resume`, and session recovery after sleep/wake can legitimately exceed 30s. When they do, the desktop frontend shows:

> 提示词发送失败 / request timed out: prompt.submit

The CLI is unaffected because it has no frontend timeout.

**Fix:** Bump `DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS` to `120_000` to match the shared base class default (`json-rpc-gateway.ts:61`). This aligns the desktop client with the base class's own safe default.

### 2. Clicking a session in the sidebar opens a new chat instead of resuming

**Root cause:** `onResumeSession` in `desktop-controller.tsx` only called `navigate(sessionRoute(sessionId))` — it changed the URL hash but did NOT directly call `resumeSession()`. The actual resume was delegated to the `useRouteResume` hook, which fires `resumeSession()` only when ALL of these conditions are met:

- `gatewayState === 'open'`
- `!creatingSessionRef.current` (no session being created)
- Session is not already "active"
- Route is not in fresh-draft state (`freshDraftReady`)

When any guard fails (a race condition during new-chat clear-up, gateway reconnect, etc.), the resume is skipped. `activeSessionId` stays `null`, so the next `prompt.submit` calls `createBackendSessionForSend()` → a brand new session is created instead of continuing the clicked one.

**Fix:** Call `resumeSession(sessionId)` directly in the `onResumeSession` callback alongside `navigate()`. This makes the sidebar click deterministic — `resumeSession()` already handles idempotency internally and will no-op if the session is already active.

```diff
- onResumeSession={sessionId => navigate(sessionRoute(sessionId))}
+ onResumeSession={sessionId => { navigate(sessionRoute(sessionId)); void resumeSession(sessionId) }}
```

## Testing

- `npm run build` passes (TypeScript compilation + Vite bundle)
- Verified both bugs reproduce on `main` at `c2b7669ad`
- Verified `resumeSession` is already destructured from `useSessionActions` at line 645 and available in scope

## Scope

Two-line change. No new dependencies, no API changes, no behavioral changes to existing flows — only makes the existing resume path deterministic and aligns the timeout with the base class.
