### PR TITLE
fix(feishu): render all markdown via Card 2.0 interactive cards

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -156,7 +156,7 @@ _MARKDOWN_HINT_RE = re.compile(
     re.MULTILINE,
 )
 # Detect markdown tables: a line starting with | followed by a separator line.
-# Feishu post-type 'md' elements do not render tables, so we force text mode.
+# Used by the legacy post/text routing path when interactive cards are disabled.
 _MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
@@ -164,6 +164,14 @@ _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
+_MAX_CARD_JSON_BYTES = 30 * 1024
+
+
+def _utf8_len(content: str) -> int:
+    """Measure Feishu outbound content in UTF-8 bytes."""
+    return len(content.encode("utf-8"))
+
+
 # ---------------------------------------------------------------------------
 # Media type sets and upload constants
 # ---------------------------------------------------------------------------
@@ -409,6 +417,7 @@ class FeishuAdapterSettings:
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
     allow_bots: str = "none"  # "none" | "mentions" | "all"
     require_mention: bool = True
+    interactive_cards: bool = True
 
 
 @dataclass
@@ -569,6 +578,17 @@ def _build_markdown_post_payload(content: str) -> str:
             "zh_cn": {
                 "content": rows,
             }
+        },
+        ensure_ascii=False,
+    )
+
+
+def _build_markdown_card_payload(content: str) -> str:
+    """Build a Card 2.0 payload containing one full Markdown element."""
+    return json.dumps(
+        {
+            "schema": "2.0",
+            "body": {"elements": [{"tag": "markdown", "content": content}]},
         },
         ensure_ascii=False,
     )
@@ -1426,6 +1446,8 @@ class FeishuAdapter(BasePlatformAdapter):
     supports_code_blocks = True  # Feishu renders fenced code blocks
     splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
 
+    # Measured with message_len_fn (UTF-8 bytes). Keeping the existing 8K
+    # budget leaves ample room below Feishu's 30KB Card 2.0 JSON limit.
     MAX_MESSAGE_LENGTH = 8000
     # Max distinct chat IDs retained in _chat_locks before LRU eviction kicks in.
     CHAT_LOCK_MAX_SIZE: int = 1000
@@ -1499,6 +1521,11 @@ class FeishuAdapter(BasePlatformAdapter):
         # by create, so we cache it per message_id.
         self._pending_processing_reactions: "OrderedDict[str, str]" = OrderedDict()
         self._load_seen_message_ids()
+
+    @property
+    def message_len_fn(self):
+        """Feishu card limits are byte-based, not Python code-point based."""
+        return _utf8_len
 
     @staticmethod
     def _load_settings(extra: Dict[str, Any]) -> FeishuAdapterSettings:
@@ -1600,6 +1627,7 @@ class FeishuAdapter(BasePlatformAdapter):
             require_mention=_to_boolean(
                 extra.get("require_mention", os.getenv("FEISHU_REQUIRE_MENTION", "true"))
             ),
+            interactive_cards=_to_boolean(extra.get("interactive_cards", True)),
         )
 
     def _apply_settings(self, settings: FeishuAdapterSettings) -> None:
@@ -1632,6 +1660,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_ping_timeout = settings.ws_ping_timeout
         self._allow_bots = settings.allow_bots
         self._require_mention = settings.require_mention
+        self._use_interactive_cards = settings.interactive_cards
 
     def _build_event_handler(self) -> Any:
         if EventDispatcherHandler is None:
@@ -1896,7 +1925,11 @@ class FeishuAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         formatted = self.format_message(content)
-        chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+        chunks = self.truncate_message(
+            formatted,
+            self.MAX_MESSAGE_LENGTH,
+            len_fn=self.message_len_fn,
+        )
         last_response = None
 
         try:
@@ -1911,17 +1944,41 @@ class FeishuAdapter(BasePlatformAdapter):
                         metadata=metadata,
                     )
                 except Exception as exc:
-                    if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
+                    if msg_type == "interactive":
+                        fallback_text = chunk
+                        logger.warning(
+                            "[Feishu] Interactive card send failed; falling back to plain text: %s",
+                            exc,
+                        )
+                    elif msg_type == "post" and _POST_CONTENT_INVALID_RE.search(str(exc)):
+                        fallback_text = _strip_markdown_to_plain_text(chunk)
+                        logger.warning(
+                            "[Feishu] Invalid post payload rejected by API; falling back to plain text"
+                        )
+                    else:
                         raise
-                    logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
                         msg_type="text",
-                        payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                        payload=json.dumps({"text": fallback_text}, ensure_ascii=False),
                         reply_to=reply_to,
                         metadata=metadata,
                     )
                 if (
+                    msg_type == "interactive"
+                    and not self._response_succeeded(response)
+                ):
+                    logger.warning(
+                        "[Feishu] Interactive card rejected by API response; falling back to plain text"
+                    )
+                    response = await self._feishu_send_with_retry(
+                        chat_id=chat_id,
+                        msg_type="text",
+                        payload=json.dumps({"text": chunk}, ensure_ascii=False),
+                        reply_to=reply_to,
+                        metadata=metadata,
+                    )
+                elif (
                     msg_type == "post"
                     and not self._response_succeeded(response)
                     and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or ""))
@@ -1960,7 +2017,24 @@ class FeishuAdapter(BasePlatformAdapter):
             request = self._build_update_message_request(message_id=message_id, request_body=body)
             response = await self._run_blocking(self._client.im.v1.message.update, request)
             result = self._finalize_send_result(response, "update failed")
-            if not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
+            if not result.success and msg_type == "interactive":
+                logger.warning(
+                    "[Feishu] Interactive card update rejected; retrying as a plain interactive card"
+                )
+                fallback_body = self._build_update_message_body(
+                    msg_type="interactive",
+                    content=_build_markdown_card_payload(_strip_markdown_to_plain_text(content)),
+                )
+                fallback_request = self._build_update_message_request(
+                    message_id=message_id,
+                    request_body=fallback_body,
+                )
+                fallback_response = await self._run_blocking(
+                    self._client.im.v1.message.update,
+                    fallback_request,
+                )
+                result = self._finalize_send_result(fallback_response, "update failed")
+            elif not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
                 logger.warning("[Feishu] Invalid post update payload rejected by API; falling back to plain text")
                 fallback_body = self._build_update_message_body(
                     msg_type="text",
@@ -4526,6 +4600,9 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
+        if self._use_interactive_cards:
+            return "interactive", _build_markdown_card_payload(content)
+
         # Feishu post-type 'md' elements do not render markdown tables; sending
         # table content as post causes the message to appear blank on the client.
         # Force plain text for anything that looks like a markdown table.

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -507,7 +507,7 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         async def _direct(func, *args, **kwargs):
             return func(*args, **kwargs)
 
-        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+        with patch.object(adapter, "_run_blocking", side_effect=_direct):
             result = asyncio.run(
                 adapter.edit_message(
                     chat_id="oc_chat",
@@ -519,14 +519,15 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         self.assertTrue(result.success)
         self.assertEqual(result.message_id, "om_progress")
         self.assertEqual(captured["request"].message_id, "om_progress")
-        self.assertEqual(captured["request"].request_body.msg_type, "text")
+        self.assertEqual(captured["request"].request_body.msg_type, "interactive")
+        payload = json.loads(captured["request"].request_body.content)
         self.assertEqual(
-            captured["request"].request_body.content,
-            json.dumps({"text": "📖 read_file: \"/tmp/image.png\""}, ensure_ascii=False),
+            payload["body"]["elements"],
+            [{"tag": "markdown", "content": "📖 read_file: \"/tmp/image.png\""}],
         )
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_edit_message_falls_back_to_text_when_post_update_is_rejected(self):
+    def test_edit_message_keeps_interactive_type_when_card_update_is_rejected(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter
 
@@ -551,7 +552,7 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
         async def _direct(func, *args, **kwargs):
             return func(*args, **kwargs)
 
-        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+        with patch.object(adapter, "_run_blocking", side_effect=_direct):
             result = asyncio.run(
                 adapter.edit_message(
                     chat_id="oc_chat",
@@ -561,11 +562,12 @@ class TestFeishuAdapterMessaging(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["calls"][0].request_body.msg_type, "post")
-        self.assertEqual(captured["calls"][1].request_body.msg_type, "text")
+        self.assertEqual(captured["calls"][0].request_body.msg_type, "interactive")
+        self.assertEqual(captured["calls"][1].request_body.msg_type, "interactive")
+        fallback = json.loads(captured["calls"][1].request_body.content)
         self.assertEqual(
-            captured["calls"][1].request_body.content,
-            json.dumps({"text": "可以用 粗体 和 斜体。"}, ensure_ascii=False),
+            fallback["body"]["elements"],
+            [{"tag": "markdown", "content": "可以用 粗体 和 斜体。"}],
         )
 
     @patch.dict(os.environ, {}, clear=True)
@@ -2691,7 +2693,62 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_send_uses_post_for_inline_markdown(self):
+    def test_outbound_defaults_to_card_2_markdown_for_plain_text_and_tables(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        for content in ("hello", "| a | b |\n|---|---|\n| 1 | 2 |"):
+            msg_type, raw_payload = adapter._build_outbound_payload(content)
+            payload = json.loads(raw_payload)
+            self.assertEqual(msg_type, "interactive")
+            self.assertEqual(payload["schema"], "2.0")
+            self.assertEqual(
+                payload["body"]["elements"],
+                [{"tag": "markdown", "content": content}],
+            )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_interactive_cards_can_be_disabled_for_legacy_routing(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig(extra={"interactive_cards": False}))
+
+        self.assertEqual(adapter._build_outbound_payload("hello")[0], "text")
+        self.assertEqual(adapter._build_outbound_payload("**bold**")[0], "post")
+        self.assertEqual(
+            adapter._build_outbound_payload("| a | b |\n|---|---|\n| 1 | 2 |")[0],
+            "text",
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_multibyte_fenced_content_splits_on_utf8_bytes_with_valid_cards(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import (
+            FeishuAdapter,
+            _MAX_CARD_JSON_BYTES,
+        )
+
+        adapter = FeishuAdapter(PlatformConfig())
+        content = "```python\n" + ("print('中文😀')\n" * 900) + "```"
+        chunks = adapter.truncate_message(
+            content,
+            adapter.MAX_MESSAGE_LENGTH,
+            len_fn=adapter.message_len_fn,
+        )
+
+        self.assertGreater(len(chunks), 1)
+        for chunk in chunks:
+            self.assertLessEqual(adapter.message_len_fn(chunk), adapter.MAX_MESSAGE_LENGTH)
+            self.assertEqual(chunk.count("```"), 2)
+            msg_type, payload = adapter._build_outbound_payload(chunk)
+            self.assertEqual(msg_type, "interactive")
+            self.assertLess(len(payload.encode("utf-8")), _MAX_CARD_JSON_BYTES)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_uses_interactive_card_for_inline_markdown(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter
 
@@ -2717,7 +2774,7 @@ class TestAdapterBehavior(unittest.TestCase):
         async def _direct(func, *args, **kwargs):
             return func(*args, **kwargs)
 
-        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+        with patch.object(adapter, "_run_blocking", side_effect=_direct):
             result = asyncio.run(
                 adapter.send(
                     chat_id="oc_chat",
@@ -2726,13 +2783,16 @@ class TestAdapterBehavior(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["request"].request_body.msg_type, "post")
+        self.assertEqual(captured["request"].request_body.msg_type, "interactive")
         payload = json.loads(captured["request"].request_body.content)
-        elements = payload["zh_cn"]["content"][0]
-        self.assertEqual(elements, [{"tag": "md", "text": "可以用 **粗体** 和 *斜体*。"}])
+        self.assertEqual(payload["schema"], "2.0")
+        self.assertEqual(
+            payload["body"]["elements"],
+            [{"tag": "markdown", "content": "可以用 **粗体** 和 *斜体*。"}],
+        )
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_send_splits_fenced_code_blocks_into_separate_post_rows(self):
+    def test_send_preserves_fenced_code_block_in_markdown_card(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter
 
@@ -2768,7 +2828,7 @@ class TestAdapterBehavior(unittest.TestCase):
             "后续说明仍应保留。"
         )
 
-        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+        with patch.object(adapter, "_run_blocking", side_effect=_direct):
             result = asyncio.run(
                 adapter.send(
                     chat_id="oc_chat",
@@ -2777,21 +2837,11 @@ class TestAdapterBehavior(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["request"].request_body.msg_type, "post")
+        self.assertEqual(captured["request"].request_body.msg_type, "interactive")
         payload = json.loads(captured["request"].request_body.content)
-        rows = payload["zh_cn"]["content"]
         self.assertEqual(
-            rows,
-            [
-                [
-                    {
-                        "tag": "md",
-                        "text": "确认已入库 ✓\n文件路径：`/root/.hermes/profiles/agent_cto/cron/jobs.json`\n**解码后的内容：**",
-                    }
-                ],
-                [{"tag": "md", "text": "```json\n{\"cron\": \"list\"}\n```"}],
-                [{"tag": "md", "text": "后续说明仍应保留。"}],
-            ],
+            payload["body"]["elements"],
+            [{"tag": "markdown", "content": content}],
         )
 
     @patch.dict(os.environ, {}, clear=True)
@@ -2860,7 +2910,7 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_send_falls_back_to_text_when_post_payload_is_rejected(self):
+    def test_send_falls_back_to_text_when_interactive_payload_is_rejected(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter
 
@@ -2870,7 +2920,7 @@ class TestAdapterBehavior(unittest.TestCase):
         class _MessageAPI:
             def create(self, request):
                 captured["calls"].append(request)
-                if len(captured["calls"]) == 1:
+                if request.request_body.msg_type == "interactive":
                     raise RuntimeError("content format of the post type is incorrect")
                 return SimpleNamespace(
                     success=lambda: True,
@@ -2888,7 +2938,10 @@ class TestAdapterBehavior(unittest.TestCase):
         async def _direct(func, *args, **kwargs):
             return func(*args, **kwargs)
 
-        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+        with (
+            patch.object(adapter, "_run_blocking", side_effect=_direct),
+            patch("plugins.platforms.feishu.adapter.asyncio.sleep", new=AsyncMock()),
+        ):
             result = asyncio.run(
                 adapter.send(
                     chat_id="oc_chat",
@@ -2897,15 +2950,15 @@ class TestAdapterBehavior(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["calls"][0].request_body.msg_type, "post")
-        self.assertEqual(captured["calls"][1].request_body.msg_type, "text")
+        self.assertEqual(captured["calls"][0].request_body.msg_type, "interactive")
+        self.assertEqual(captured["calls"][-1].request_body.msg_type, "text")
         self.assertEqual(
-            captured["calls"][1].request_body.content,
-            json.dumps({"text": "可以用 粗体 和 斜体。"}, ensure_ascii=False),
+            captured["calls"][-1].request_body.content,
+            json.dumps({"text": "可以用 **粗体** 和 *斜体*。"}, ensure_ascii=False),
         )
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_send_falls_back_to_text_when_post_response_is_unsuccessful(self):
+    def test_send_falls_back_to_text_when_interactive_response_is_unsuccessful(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter
 
@@ -2933,7 +2986,7 @@ class TestAdapterBehavior(unittest.TestCase):
         async def _direct(func, *args, **kwargs):
             return func(*args, **kwargs)
 
-        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+        with patch.object(adapter, "_run_blocking", side_effect=_direct):
             result = asyncio.run(
                 adapter.send(
                     chat_id="oc_chat",
@@ -2942,15 +2995,15 @@ class TestAdapterBehavior(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["calls"][0].request_body.msg_type, "post")
+        self.assertEqual(captured["calls"][0].request_body.msg_type, "interactive")
         self.assertEqual(captured["calls"][1].request_body.msg_type, "text")
         self.assertEqual(
             captured["calls"][1].request_body.content,
-            json.dumps({"text": "可以用 粗体 和 斜体。"}, ensure_ascii=False),
+            json.dumps({"text": "可以用 **粗体** 和 *斜体*。"}, ensure_ascii=False),
         )
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_send_uses_post_for_advanced_markdown_lines(self):
+    def test_send_uses_interactive_card_for_advanced_markdown_lines(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter
 
@@ -2976,7 +3029,7 @@ class TestAdapterBehavior(unittest.TestCase):
         async def _direct(func, *args, **kwargs):
             return func(*args, **kwargs)
 
-        with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+        with patch.object(adapter, "_run_blocking", side_effect=_direct):
             result = asyncio.run(
                 adapter.send(
                     chat_id="oc_chat",
@@ -2985,12 +3038,11 @@ class TestAdapterBehavior(unittest.TestCase):
             )
 
         self.assertTrue(result.success)
-        self.assertEqual(captured["request"].request_body.msg_type, "post")
+        self.assertEqual(captured["request"].request_body.msg_type, "interactive")
         payload = json.loads(captured["request"].request_body.content)
-        rows = payload["zh_cn"]["content"]
         self.assertEqual(
-            rows,
-            [[{"tag": "md", "text": "---\n1. 第一项\n<u>下划线</u>\n~~删除线~~"}]],
+            payload["body"]["elements"],
+            [{"tag": "markdown", "content": "---\n1. 第一项\n<u>下划线</u>\n~~删除线~~"}],
         )
 
 

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -398,7 +398,7 @@ For small text-based documents (.txt, .md), the file content is automatically in
 
 | Method | What it sends |
 |--------|--------------|
-| `send` | Text or rich post messages (auto-detected based on markdown content) |
+| `send` | Card 2.0 Markdown messages by default; legacy text/post routing is configurable |
 | `send_image` / `send_image_file` | Uploads image to Feishu, then sends as native image bubble (with optional caption) |
 | `send_document` | Uploads file to Feishu API, then sends as file attachment |
 | `send_voice` | Uploads audio file as a Feishu file attachment |
@@ -412,13 +412,20 @@ File upload routing is automatic based on extension:
 - `.pdf`, `.doc(x)`, `.xls(x)`, `.ppt(x)` → uploaded with their document type
 - Everything else → uploaded as a generic stream file
 
-## Markdown Rendering and Post Fallback
+## Markdown Rendering and Card Fallback
 
-When outbound text contains markdown formatting (headings, bold, lists, code blocks, links, etc.), the adapter automatically sends it as a Feishu **post** message with an embedded `md` tag rather than as plain text. This enables rich rendering in the Feishu client.
+By default, all outbound text is sent as a Feishu **Interactive Card 2.0** containing a `markdown` element. This renderer supports headings, lists, fenced code blocks, links, and GFM tables more consistently than the legacy post-message `md` element. Plain text also uses the same card type so streaming previews and final edits never need to switch message types.
 
-If the Feishu API rejects the post payload (e.g., due to unsupported markdown constructs), the adapter automatically falls back to sending as plain text with markdown stripped. This two-stage fallback ensures messages are always delivered.
+Long replies use Hermes's normal message splitter. Feishu measures these chunks in UTF-8 bytes, and fenced code blocks are closed and reopened at chunk boundaries so each card remains valid. If a new card cannot be sent, Hermes retries that chunk as plain text. If an in-place card update is rejected, Hermes retries with a simplified plain-text card while keeping the `interactive` message type.
 
-Plain text messages (no markdown detected) are sent as the simple `text` message type.
+To restore the legacy routing behavior (plain text → `text`, Markdown → `post`, tables → `text`), disable interactive cards in `config.yaml`:
+
+```yaml
+platforms:
+  feishu:
+    extra:
+      interactive_cards: false
+```
 
 ## Processing Status Reactions
 
@@ -563,7 +570,7 @@ Inbound messages are deduplicated using message IDs with a 24-hour TTL. The dedu
 | `HERMES_FEISHU_TEXT_BATCH_MAX_CHARS` | — | `4000` | Max characters merged per text batch |
 | `HERMES_FEISHU_MEDIA_BATCH_DELAY_SECONDS` | — | `0.8` | Media burst debounce quiet period |
 
-WebSocket and per-group ACL settings are configured via `config.yaml` under `platforms.feishu.extra` (see [WebSocket Tuning](#websocket-tuning) and [Per-Group Access Control](#per-group-access-control) above).
+Interactive-card rendering, WebSocket tuning, and per-group ACL settings are configured via `config.yaml` under `platforms.feishu.extra` (see [Markdown Rendering and Card Fallback](#markdown-rendering-and-card-fallback), [WebSocket Tuning](#websocket-tuning), and [Per-Group Access Control](#per-group-access-control) above).
 
 ## Troubleshooting
 
@@ -577,7 +584,7 @@ WebSocket and per-group ACL settings are configured via `config.yaml` under `pla
 | Bot doesn't respond in groups | Ensure the bot is @mentioned, check `FEISHU_GROUP_POLICY`, and verify the sender is in `FEISHU_ALLOWED_USERS` if policy is `allowlist` |
 | `Webhook rejected: invalid verification token` | Ensure `FEISHU_VERIFICATION_TOKEN` matches the token in your Feishu app's Event Subscriptions config |
 | `Webhook rejected: invalid signature` | Ensure `FEISHU_ENCRYPT_KEY` matches the encrypt key in your Feishu app config |
-| Post messages show as plain text | The Feishu API rejected the post payload; this is normal fallback behavior. Check logs for details. |
+| Card messages fall back to plain text | The Feishu API rejected an interactive card payload; Hermes preserves delivery by retrying the chunk as text. Check logs for details. |
 | Images/files not received by bot | Grant `im:message` and `im:resource` permission scopes to your Feishu app |
 | Bot identity not auto-detected | Usually a transient network issue reaching Feishu's bot info endpoint. Set `FEISHU_BOT_OPEN_ID` and `FEISHU_BOT_NAME` manually as a workaround. |
 | Peer bot messages still ignored after enabling `FEISHU_ALLOW_BOTS` | Hermes can't identify itself yet — set `FEISHU_BOT_OPEN_ID` (and `FEISHU_BOT_USER_ID` if your app uses `sender_id_type=user_id`). |


### PR DESCRIPTION
Fixes #46470
Closes #25452
Closes #26841
Closes #29471
Supersedes #25453

## Summary

Render all Feishu outbound text and Markdown through a Card 2.0 `markdown` element, replacing the limited post-message `md` renderer. This fixes GFM table rendering and keeps streaming sends and edits on one stable `interactive` message type.

## Why Card 2.0 Markdown

Live Feishu card probes showed that Card 2.0 Markdown renders tables, fenced code blocks, lists, headings, blockquotes, and GFM alignment directly. The native table component rejects alignment and requires substantially more parsing code, so this PR keeps the content as Markdown and lets Feishu render it.

## Changes

- Add `_build_markdown_card_payload()` with one Card 2.0 `markdown` element.
- Route all outbound content to `interactive` by default, including plain text, so streaming send/edit paths keep the same `msg_type`.
- Add `platforms.feishu.extra.interactive_cards: false` as a documented rollback to the legacy text/post routing.
- Reuse Hermes's existing fence-aware message splitter instead of maintaining a Feishu-specific card packer.
- Measure Feishu chunks in UTF-8 bytes so Chinese and emoji remain safely below the 30KB card JSON limit.
- Fall back to raw text when a new card cannot be sent; rejected edits retry as a simplified interactive card to preserve message type.
- Update the Feishu user guide.

## Review-driven scope reduction

- Removed Mermaid-to-image rendering.
- Removed the default `mermaid.ink` external fallback and all implicit content export.
- Removed the custom card block parser, table counter, pagination headers, and 30KB bin-packer.
- Removed generic `gateway/platforms/base.py` and `gateway/run.py` language-tag changes.
- Removed the Feishu-specific system-prompt instruction.

Mermaid remains a normal fenced code block. A future renderer, if pursued, should be a separate opt-in change with explicit privacy documentation.

## Tests

- [x] 17 focused Feishu tests passed through `scripts/run_tests.sh`, covering Card 2.0 routing, tables, multibyte fenced content, legacy rollback, send/edit fallback, post helpers, and the pinned `lark-oapi` `extra_ua_tags` contract.
- [x] Rebased onto current `upstream/main`.
- [ ] CI green.

## Related work

| PR | Approach | Relationship |
|---|---|---|
| #25453 | Native table component on the old adapter path | Superseded by this focused Card 2.0 implementation |
| #45036 / #45907 | Card 2.0 Markdown | Same rendering primitive; this PR also keeps streaming message types stable and adds rollback/tests |
| #40445 | Native table component | More parsing and no alignment support |
| #45583 / #38867 | Post-message Markdown | Uses the limited post `md` renderer rather than Card 2.0 Markdown |

Co-authored-by: gpt-5.6-sol <215057067+openai-codex[bot]@users.noreply.github.com>
