### PR TITLE
fix: convert single newlines to MarkdownV2 hard breaks for slash-command output on Telegram

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4518,6 +4518,20 @@ class TelegramAdapter(BasePlatformAdapter):
                 _safe_parts.append(re.sub(r'[(){}]', _esc_bare, _seg))
         text = ''.join(_safe_parts)
 
+        # 13) Convert single newlines to MarkdownV2 hard breaks (  \n).
+        #     Telegram MarkdownV2 collapses single \n as whitespace, which
+        #     breaks slash-command output with structured line-by-line text
+        #     (e.g. /commands, /platform list).  Paragraph breaks (\n\n)
+        #     and inside-code newlines are left untouched.
+        _code_split2 = re.split(r'(```[\s\S]*?```|`[^`]+`)', text)
+        _hard_parts = []
+        for _i2, _seg2 in enumerate(_code_split2):
+            if _i2 % 2 == 1:
+                _hard_parts.append(_seg2)
+            else:
+                _hard_parts.append(re.sub(r'(?<!\n)\n(?!\n)', '  \n', _seg2))
+        text = ''.join(_hard_parts)
+
         return text
 
     # ── Group mention gating ──────────────────────────────────────────────


### PR DESCRIPTION
## Root Cause

Telegram MarkdownV2 treats single `\n` as a soft break (renders as whitespace), which causes structured slash-command output (`/commands`, `/new`, `/platform list`) to render as a single collapsed paragraph instead of line-by-line.

## Fix

In `TelegramAdapter.format_message()`, add a final pass that converts single newlines to MarkdownV2 hard breaks (`  \n`) — except inside code blocks/spans and paragraph breaks (`\n\n`).

## Changes

- `gateway/platforms/telegram.py`: Add step 13 to `format_message()` that splits on code blocks and applies `\n →   \n` only outside them

## Testing

All existing `test_telegram_format.py` tests pass (91 tests).  The only failures are pre-existing async-test infrastructure issues unrelated to this change.

Closes #46070