### PR TITLE
fix(terminal): load passthrough env vars from dotenv

### DIFF
--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -212,6 +212,34 @@ class TestProviderEnvBlocklist:
         assert "MY_CUSTOM_VAR" in result_env
         assert result_env["MY_CUSTOM_VAR"] == "keep-this"
 
+    def test_passthrough_var_missing_from_os_env_is_loaded_from_dotenv(self):
+        """terminal.env_passthrough values should work even when only stored in .env."""
+        from tools.environments.local import _make_run_env
+
+        base_env = {"PATH": "/usr/bin:/bin", "HOME": "/home/user"}
+        with patch.dict(os.environ, base_env, clear=True), \
+             patch("tools.env_passthrough.get_all_passthrough", return_value=frozenset({"CUSTOM_SERVICE_TOKEN"})), \
+             patch("hermes_cli.config.load_env", return_value={"CUSTOM_SERVICE_TOKEN": "from-dotenv"}):
+            result = _make_run_env({})
+
+        assert result["CUSTOM_SERVICE_TOKEN"] == "from-dotenv"
+
+    def test_os_env_wins_over_dotenv_for_passthrough_var(self):
+        """A real parent environment value should not be overwritten by .env fallback."""
+        from tools.environments.local import _make_run_env
+
+        base_env = {
+            "PATH": "/usr/bin:/bin",
+            "HOME": "/home/user",
+            "CUSTOM_SERVICE_TOKEN": "from-os-env",
+        }
+        with patch.dict(os.environ, base_env, clear=True), \
+             patch("tools.env_passthrough.get_all_passthrough", return_value=frozenset({"CUSTOM_SERVICE_TOKEN"})), \
+             patch("hermes_cli.config.load_env", return_value={"CUSTOM_SERVICE_TOKEN": "from-dotenv"}):
+            result = _make_run_env({})
+
+        assert result["CUSTOM_SERVICE_TOKEN"] == "from-os-env"
+
 
 class TestForceEnvOptIn:
     """Callers can opt in to passing a blocked var via _HERMES_FORCE_ prefix."""

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -366,8 +366,12 @@ def _path_env_key(run_env: dict) -> str | None:
 def _make_run_env(env: dict) -> dict:
     """Build a run environment with a sane PATH and provider-var stripping."""
     try:
-        from tools.env_passthrough import is_env_passthrough as _is_passthrough
+        from tools.env_passthrough import (
+            get_all_passthrough as _get_all_passthrough,
+            is_env_passthrough as _is_passthrough,
+        )
     except Exception:
+        _get_all_passthrough = lambda: frozenset()  # noqa: E731
         _is_passthrough = lambda _: False  # noqa: E731
 
     merged = dict(os.environ | env)
@@ -378,6 +382,25 @@ def _make_run_env(env: dict) -> dict:
             run_env[real_key] = v
         elif k not in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_passthrough(k):
             run_env[k] = v
+
+    # ``terminal.env_passthrough`` and skill-declared env vars are allowlists,
+    # not only blocklist overrides.  The user may keep the value in
+    # ``~/.hermes/.env`` without exporting it into the parent shell; mirror the
+    # Docker backend by filling only explicitly allowlisted missing values from
+    # Hermes' parsed .env, while preserving os.environ/self.env precedence.
+    passthrough_keys = [key for key in _get_all_passthrough() if key not in run_env]
+    if passthrough_keys:
+        try:
+            from hermes_cli.config import load_env
+
+            hermes_env = load_env() or {}
+        except Exception:
+            hermes_env = {}
+        for key in passthrough_keys:
+            value = hermes_env.get(key)
+            if value:
+                run_env[key] = value
+
     path_key = _path_env_key(run_env)
     if path_key is not None:
         run_env[path_key] = _append_missing_sane_path_entries(run_env.get(path_key, ""))


### PR DESCRIPTION
## Summary
- Load explicitly allowlisted local terminal env vars from `~/.hermes/.env` when they are not exported in the parent process.
- Preserve existing precedence: `os.environ` / explicit environment values still win over `.env` fallback.
- Add regression coverage for `.env` fallback and precedence.

Closes #46152

## Verification
- `scripts/run_tests.sh tests/tools/test_local_env_blocklist.py`
- `scripts/run_tests.sh tests/tools/test_local_env_blocklist.py tests/tools/test_local_env_windows_msys.py tests/tools/test_local_env_cwd_recovery.py`
- `ruff check tools/environments/local.py tests/tools/test_local_env_blocklist.py`
- `git diff --check -- tools/environments/local.py tests/tools/test_local_env_blocklist.py`
- Independent delegated code review: passed

Codex was attempted first, but its sandbox could not read the repo / CA bundle; Hermes handled the fallback implementation.
