### PR TITLE
fix(memory): reject invalid memory targets

### DIFF
--- a/tests/test_memory_target_validation.py
+++ b/tests/test_memory_target_validation.py
@@ -1,0 +1,48 @@
+"""Regression test for MemoryStore invalid target rejection."""
+import tempfile
+from pathlib import Path
+import sys
+
+HERMES_ROOT = Path(__file__).resolve().parent.parent
+if str(HERMES_ROOT) not in sys.path:
+    sys.path.insert(0, str(HERMES_ROOT))
+
+from tools.memory_tool import MemoryStore
+
+
+def test_invalid_target_add():
+    store = MemoryStore()
+    result = store.add("invalid_target", "hello")
+    assert result["success"] is False
+    assert "invalid_target" in result["error"]
+    assert "memory" in result["error"]
+
+
+def test_invalid_target_replace():
+    store = MemoryStore()
+    result = store.replace("bogus", "old", "new")
+    assert result["success"] is False
+    assert "bogus" in result["error"]
+
+
+def test_invalid_target_remove():
+    store = MemoryStore()
+    result = store.remove("not_a_target", "old")
+    assert result["success"] is False
+    assert "not_a_target" in result["error"]
+
+
+def test_valid_target_still_works():
+    with tempfile.TemporaryDirectory() as tmp:
+        store = MemoryStore()
+        store._memory_dir = Path(tmp)
+        result = store.add("memory", "hello world")
+        assert result["success"] is True
+
+
+if __name__ == "__main__":
+    test_invalid_target_add()
+    test_invalid_target_replace()
+    test_invalid_target_remove()
+    test_valid_target_still_works()
+    print("ALL TESTS PASSED")

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -121,6 +121,11 @@ class MemoryStore:
         Tool responses always reflect this live state.
     """
 
+    # Supported memory targets. Unknown targets are rejected at every public
+    # mutation boundary so an LLM/tool cannot accidentally route a user entry
+    # into MEMORY.md or invent a new target that silently aliases to it.
+    VALID_TARGETS = {"memory", "user"}
+
     def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375):
         self.memory_entries: List[str] = []
         self.user_entries: List[str] = []
@@ -244,10 +249,26 @@ class MemoryStore:
 
     @staticmethod
     def _path_for(target: str) -> Path:
+        """Return the on-disk path for a supported memory target."""
+        if target not in MemoryStore.VALID_TARGETS:
+            raise ValueError(f"Unsupported memory target {target!r}. Valid targets: {sorted(MemoryStore.VALID_TARGETS)}")
         mem_dir = get_memory_dir()
         if target == "user":
             return mem_dir / "USER.md"
         return mem_dir / "MEMORY.md"
+
+    def _validate_target(self, target: str) -> Optional[Dict[str, Any]]:
+        """Return a structured error dict if target is not supported, else None."""
+        if target not in self.VALID_TARGETS:
+            return {
+                "success": False,
+                "error": (
+                    f"Unsupported memory target {target!r}. "
+                    f"Valid targets are: {', '.join(sorted(self.VALID_TARGETS))}."
+                ),
+                "target": target,
+            }
+        return None
 
     def _reload_target(self, target: str) -> Optional[str]:
         """Re-read entries from disk into in-memory state.
@@ -296,6 +317,10 @@ class MemoryStore:
 
     def add(self, target: str, content: str) -> Dict[str, Any]:
         """Append a new entry. Returns error if it would exceed the char limit."""
+        target_error = self._validate_target(target)
+        if target_error:
+            return target_error
+
         content = content.strip()
         if not content:
             return {"success": False, "error": "Content cannot be empty."}
@@ -348,6 +373,10 @@ class MemoryStore:
 
     def replace(self, target: str, old_text: str, new_content: str) -> Dict[str, Any]:
         """Find entry containing old_text substring, replace it with new_content."""
+        target_error = self._validate_target(target)
+        if target_error:
+            return target_error
+
         old_text = old_text.strip()
         new_content = new_content.strip()
         if not old_text:
@@ -413,6 +442,10 @@ class MemoryStore:
 
     def remove(self, target: str, old_text: str) -> Dict[str, Any]:
         """Remove the entry containing old_text substring."""
+        target_error = self._validate_target(target)
+        if target_error:
+            return target_error
+
         old_text = old_text.strip()
         if not old_text:
             return {"success": False, "error": "old_text cannot be empty."}


### PR DESCRIPTION
# PR Draft: fix/memory-target-validation

## Title
fix(memory): reject invalid memory targets

## Summary
`MemoryStore.add/replace/remove` previously accepted any `target` string and
silently wrote it to the file backing `MEMORY.md`. This allowed a tool or LLM
to pass a fabricated target (e.g. `user_profile`) that silently aliased to
the curated memory file. The patch introduces `VALID_TARGETS = {"memory",
"user"}` and rejects unknown targets at every public mutation boundary.

## Root Cause
No validation existed on the `target` parameter. The `_path_for` method
mapped any non-`"user"` value to `MEMORY.md`, so invented targets looked like
they were persisted but actually shared storage with the curated memory.

## Reproduction
```python
from tools.memory_tool import MemoryStore
s = MemoryStore()
result = s.add("invalid_target", "hello")
# before: wrote to MEMORY.md; after: result["success"] == False with target error
```

## Fix
- Add `MemoryStore.VALID_TARGETS = {"memory", "user"}`.
- Add `_validate_target(target)` returning a structured error dict.
- Guard `add`, `replace`, and `remove` with the validator.
- Make `_path_for` raise `ValueError` for unsupported targets.

## Regression Coverage
`tests/test_memory_target_validation.py`
- `test_invalid_target_add`
- `test_invalid_target_replace`
- `test_invalid_target_remove`
- `test_valid_target_still_works`

## Risk Assessment
Low. The public API returns the same dict shape; only the previously silent
write path now returns `success=False` for bad targets. Valid usage is
unaffected.
