### PR TITLE
fix(slack): force top-level cron channel delivery

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -483,11 +483,14 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
         except Exception:
             pass
 
-        return {
+        target = {
             "platform": platform_name,
             "chat_id": chat_id,
             "thread_id": thread_id,
         }
+        if platform_key == "slack" and thread_id is None:
+            target["force_top_level"] = True
+        return target
 
     platform_name = deliver_value
     if origin and origin.get("platform") == platform_name:
@@ -757,7 +760,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         runtime_adapter = (adapters or {}).get(platform)
         delivered = False
         if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
-            send_metadata = {"thread_id": thread_id} if thread_id else None
+            send_metadata = None
+            if thread_id:
+                send_metadata = {"thread_id": thread_id}
+            elif target.get("force_top_level"):
+                send_metadata = {"force_top_level": True}
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content
                 text_to_send = cleaned_delivery_content.strip()

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1346,6 +1346,9 @@ class SlackAdapter(BasePlatformAdapter):
         thread replies.  Messages that originate inside an existing thread are
         always replied to in-thread to preserve conversation context.
         """
+        if metadata and metadata.get("force_top_level"):
+            return None
+
         # When reply_in_thread is disabled (default: True for backward compat),
         # only thread messages that are already part of an existing thread.
         # For top-level channel messages, the inbound handler sets

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -837,6 +837,113 @@ class TestDeliverResultWrapping:
         assert send_mock.call_args.kwargs["thread_id"] == "17585"
 
 
+class TestSlackCronLiveAdapterThreadMetadata:
+    def _safe_media_path(self, tmp_path, monkeypatch, name, data=b"media"):
+        root = tmp_path / "media-cache"
+        media_file = root / name
+        media_file.parent.mkdir(parents=True, exist_ok=True)
+        media_file.write_bytes(data)
+        monkeypatch.setattr(
+            "gateway.platforms.base.MEDIA_DELIVERY_SAFE_ROOTS",
+            (root,),
+        )
+        return media_file.resolve()
+
+    @staticmethod
+    def _complete_scheduled_coroutine(coro, _loop):
+        from concurrent.futures import Future
+
+        coro.close()
+        completed = Future()
+        send_result = MagicMock()
+        send_result.success = True
+        send_result.raw_response = None
+        completed.set_result(send_result)
+        return completed
+
+    def test_explicit_slack_channel_live_delivery_forces_top_level_for_text_and_media(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        from gateway.config import Platform
+
+        media_path = self._safe_media_path(tmp_path, monkeypatch, "photo.jpg")
+        adapter = MagicMock()
+        adapter.send = AsyncMock()
+        adapter.send_image_file = AsyncMock()
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.SLACK: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        job = {
+            "id": "slack-channel-job",
+            "deliver": "slack:C0B44PKUDNF",
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=self._complete_scheduled_coroutine):
+            result = _deliver_result(
+                job,
+                f"Hello world\nMEDIA:{media_path}",
+                adapters={Platform.SLACK: adapter},
+                loop=loop,
+            )
+
+        assert result is None
+        expected_metadata = {"force_top_level": True}
+        adapter.send.assert_called_once_with(
+            "C0B44PKUDNF",
+            "Hello world",
+            metadata=expected_metadata,
+        )
+        adapter.send_image_file.assert_called_once()
+        assert adapter.send_image_file.call_args.kwargs["metadata"] == expected_metadata
+        assert "thread_id" not in adapter.send.call_args.kwargs["metadata"]
+
+    def test_explicit_slack_thread_live_delivery_preserves_thread_id_without_force_top_level(self):
+        from gateway.config import Platform
+
+        adapter = MagicMock()
+        adapter.send = AsyncMock()
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.SLACK: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        job = {
+            "id": "slack-thread-job",
+            "deliver": "slack:C1234567890:1779004845.013839",
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=self._complete_scheduled_coroutine):
+            result = _deliver_result(
+                job,
+                "Hello thread",
+                adapters={Platform.SLACK: adapter},
+                loop=loop,
+            )
+
+        assert result is None
+        adapter.send.assert_called_once_with(
+            "C1234567890",
+            "Hello thread",
+            metadata={"thread_id": "1779004845.013839"},
+        )
+
+
 class TestDeliverResultErrorReturns:
     """Verify _deliver_result returns error strings on failure, None on success."""
 

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -495,6 +495,35 @@ def test_config_bridges_slack_reply_in_thread(monkeypatch, tmp_path):
     ) == "171.000"
 
 
+def test_force_top_level_metadata_skips_all_thread_sources():
+    adapter = _make_adapter()
+
+    result = adapter._resolve_thread_ts(
+        reply_to="171.500",
+        metadata={
+            "force_top_level": True,
+            "thread_id": "171.000",
+            "thread_ts": "171.001",
+        },
+    )
+
+    assert result is None
+
+
+def test_force_top_level_absent_or_false_preserves_thread_resolution():
+    adapter = _make_adapter()
+
+    assert adapter._resolve_thread_ts(
+        reply_to="171.500",
+        metadata={"thread_id": "171.000"},
+    ) == "171.000"
+    assert adapter._resolve_thread_ts(
+        reply_to="171.500",
+        metadata={"force_top_level": False, "thread_ts": "171.001"},
+    ) == "171.001"
+    assert adapter._resolve_thread_ts(reply_to="171.500", metadata={}) == "171.500"
+
+
 def test_config_bridges_slack_strict_mention(monkeypatch, tmp_path):
     from gateway.config import load_gateway_config
 


### PR DESCRIPTION
## Summary
- add `force_top_level` Slack metadata opt-out so `_resolve_thread_ts()` returns top-level even when thread metadata exists
- mark explicit `slack:C...` cron delivery targets as top-level for live adapters while preserving explicit thread targets
- cover text/media live adapter metadata and Slack thread-resolution regressions

## Test Plan
- `PYTHONPATH=$PWD /home/claw/.hermes-agent/venv/bin/python -m pytest tests/gateway/test_slack_mention.py tests/cron/test_scheduler.py -q -o 'addopts='` — 195 passed\n- `PYTHONPATH=$PWD /home/claw/.hermes-agent/venv/bin/python -m pytest tests/gateway/test_slack*.py -q -o 'addopts='` — 311 passed (existing async mock warnings)