### PR TITLE
feat(slack): make link unfurls configurable (gateway.slack.unfurl_links/media)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -725,6 +725,10 @@ platform_toolsets:
 #     extra:
 #       disable_link_previews: false  # Set true to suppress Telegram URL previews in bot messages
 #       rich_messages: false          # Opt in to Bot API 10.1 rich messages; default uses legacy MarkdownV2
+#   slack:
+#     extra:
+#       unfurl_links: false  # Set false to suppress Slack link-preview cards (useful for link-heavy bots)
+#       unfurl_media: false  # Set false to suppress media/rich-link preview cards
 #
 # Discord-specific settings (config.yaml top-level, not under platforms:):
 #

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1164,12 +1164,23 @@ class SlackAdapter(BasePlatformAdapter):
             # Controlled via platform config: gateway.slack.reply_broadcast
             broadcast = self.config.extra.get("reply_broadcast", False)
 
+            # Link unfurls: use Slack's default behavior unless explicitly
+            # overridden via platform config (gateway.slack.unfurl_links /
+            # unfurl_media). Link-heavy bots can set these to false to suppress
+            # the preview cards. Left unset → kwarg omitted, behavior unchanged.
+            unfurl_links = self.config.extra.get("unfurl_links")
+            unfurl_media = self.config.extra.get("unfurl_media")
+
             for i, chunk in enumerate(chunks):
                 kwargs = {
                     "channel": chat_id,
                     "text": chunk,
                     "mrkdwn": True,
                 }
+                if unfurl_links is not None:
+                    kwargs["unfurl_links"] = unfurl_links
+                if unfurl_media is not None:
+                    kwargs["unfurl_media"] = unfurl_media
                 if thread_ts:
                     kwargs["thread_ts"] = thread_ts
                     # Only broadcast the first chunk of the first reply

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "denghaoke0420@gmail.com": "DengHaoke",
     "kenmege@yahoo.com": "Kenmege",
     "dkobi16@gmail.com": "Diyoncrz18",
     "arnaud@nolimitdevelopment.com": "ali-nld",

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3122,6 +3122,33 @@ class TestReplyBroadcast:
 
 
 # ---------------------------------------------------------------------------
+# TestUnfurl
+# ---------------------------------------------------------------------------
+
+
+class TestUnfurl:
+    """Test unfurl_links / unfurl_media config options."""
+
+    @pytest.mark.asyncio
+    async def test_unfurl_omitted_by_default(self, adapter):
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "ts1"})
+        await adapter.send("C123", "see https://example.com")
+        kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert "unfurl_links" not in kwargs
+        assert "unfurl_media" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_unfurl_disabled_via_config(self, adapter):
+        adapter.config.extra["unfurl_links"] = False
+        adapter.config.extra["unfurl_media"] = False
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "ts1"})
+        await adapter.send("C123", "see https://example.com")
+        kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert kwargs.get("unfurl_links") is False
+        assert kwargs.get("unfurl_media") is False
+
+
+# ---------------------------------------------------------------------------
 # TestFallbackPreservesThreadContext
 # ---------------------------------------------------------------------------
 

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -340,6 +340,11 @@ platforms:
       # (Slack's "Also send to channel" feature).
       # Only the first chunk of the first reply is broadcast.
       reply_broadcast: false
+
+      # Suppress link-preview cards ("unfurls"). Useful for link-heavy bots.
+      # Omit to keep Slack's default behavior.
+      # unfurl_links: false
+      # unfurl_media: false
 ```
 
 | Key | Default | Description |
@@ -347,6 +352,8 @@ platforms:
 | `platforms.slack.reply_to_mode` | `"first"` | Threading mode for multi-part messages: `"off"`, `"first"`, or `"all"` |
 | `platforms.slack.extra.reply_in_thread` | `true` | When `false`, channel messages get direct replies instead of threads. Messages inside existing threads still reply in-thread. |
 | `platforms.slack.extra.reply_broadcast` | `false` | When `true`, thread replies are also posted to the main channel. Only the first chunk is broadcast. |
+| `platforms.slack.extra.unfurl_links` | _(Slack default)_ | When set, passes `unfurl_links` to `chat.postMessage`. Set `false` to suppress text-link preview cards. Unset → Slack default. |
+| `platforms.slack.extra.unfurl_media` | _(Slack default)_ | When set, passes `unfurl_media` to `chat.postMessage`. Set `false` to suppress media/rich-link preview cards. Unset → Slack default. |
 
 ### Session Isolation
 


### PR DESCRIPTION
## What does this PR do?

Slack expands link previews by default. Link-heavy bots — e.g. a digest/briefing bot that posts many URLs per message — produce a wall of preview cards, with no gateway-level way to turn them off. This adds two optional Slack platform-config flags, read the same way as the existing `reply_broadcast`:

- `platforms.slack.extra.unfurl_links`
- `platforms.slack.extra.unfurl_media`

When unset, the kwarg is omitted and Slack's default behavior is unchanged (fully backward compatible). When set to `false`, `chat.postMessage` is called with `unfurl_links` / `unfurl_media = false`, suppressing the preview cards.

## Related Issue

None — small, additive, backward-compatible enhancement.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/platforms/slack.py` — read `unfurl_links` / `unfurl_media` from the Slack platform `config.extra` and pass them to `chat_postMessage` only when explicitly set (unset → kwarg omitted → behavior unchanged).
- `tests/gateway/test_slack.py` — `TestUnfurl`: asserts the kwargs are omitted by default and passed through when configured (mirrors the existing `TestReplyBroadcast`).
- `website/docs/user-guide/messaging/slack.md` — config table rows + YAML example.
- `cli-config.yaml.example` — commented Slack `extra` example.
- `scripts/release.py` — `AUTHOR_MAP` entry for contributor attribution.

## How to Test

1. With no config set, send a message containing a link → Slack shows its usual preview (kwarg omitted, behavior unchanged).
2. Set `platforms.slack.extra.unfurl_links: false` and `unfurl_media: false`, restart the gateway, then send a message containing links → no preview cards.
3. `pytest tests/gateway/test_slack.py -k Unfurl`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(slack): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the new `TestUnfurl` locally (passed); did not run the full suite locally, relying on CI
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (Linux), live Slack workspace

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/messaging/slack.md`)
- [x] I've updated `cli-config.yaml.example` (added config keys)
- [x] N/A — no architecture/workflow change (CONTRIBUTING / AGENTS)
- [x] I've considered cross-platform impact — pure Python, no platform-specific calls
- [x] N/A — no tool description/schema change
