### PR TITLE
Fix raw read_file support in execute_code sandbox

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -91,6 +91,14 @@ class TestHermesToolsGeneration(unittest.TestCase):
         self.assertIn("def web_search(", src)
         self.assertNotIn("def read_file(", src)
 
+    def test_read_file_stub_supports_raw_mode(self):
+        src = generate_hermes_tools_module(["read_file"])
+        self.assertIn(
+            "def read_file(path: str, offset: int = 1, limit: int = 500, raw: bool = False):",
+            src,
+        )
+        self.assertIn('"raw": raw', src)
+
     def test_empty_list_generates_nothing(self):
         src = generate_hermes_tools_module([])
         self.assertNotIn("def terminal(", src)
@@ -240,6 +248,41 @@ print(f"file lines: {r2['total_lines']}")
         result = self._run(code)
         self.assertEqual(result["status"], "success")
         self.assertEqual(result["tool_calls_made"], 2)
+
+    def test_raw_read_content_round_trips_into_write_file(self):
+        """Regression for #46465: execute_code must be able to request plain
+        text from read_file and pass that exact content into write_file."""
+        code = """
+from hermes_tools import read_file, write_file
+
+payload = read_file("notes.txt", raw=True)
+write_file("copy.txt", payload["content"])
+print("done")
+"""
+        seen = {}
+
+        def dispatcher(function_name, function_args, task_id=None, user_task=None):
+            if function_name == "read_file":
+                seen["read_args"] = function_args
+                return json.dumps({"content": "alpha\nbeta\n", "total_lines": 2})
+            if function_name == "write_file":
+                seen["write_args"] = function_args
+                return json.dumps({"status": "ok", "path": function_args.get("path", "")})
+            return _mock_handle_function_call(
+                function_name, function_args, task_id=task_id, user_task=user_task
+            )
+
+        with patch("model_tools.handle_function_call", side_effect=dispatcher):
+            result = execute_code(
+                code=code,
+                task_id="test-raw-read-write",
+                enabled_tools=list(SANDBOX_ALLOWED_TOOLS),
+            )
+
+        payload = json.loads(result)
+        self.assertEqual(payload["status"], "success")
+        self.assertEqual(seen["read_args"]["raw"], True)
+        self.assertEqual(seen["write_args"]["content"], "alpha\nbeta\n")
 
     def test_syntax_error(self):
         """Script with a syntax error returns error status."""

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -8,8 +8,10 @@ import json
 import logging
 from unittest.mock import MagicMock, patch
 
+from tools.file_operations import ReadResult
 from tools.file_tools import (
     PATCH_SCHEMA,
+    READ_FILE_SCHEMA,
 )
 
 
@@ -56,6 +58,21 @@ class TestReadFileHandler:
         mock_ops.read_file.assert_called_once_with("/tmp/big.txt", 1, 1)
 
     @patch("tools.file_tools._get_file_ops")
+    def test_raw_mode_reads_plain_content_without_line_numbers(self, mock_get):
+        mock_ops = MagicMock()
+        mock_ops.read_file_raw.return_value = ReadResult(content="alpha\nbeta\n", file_size=11)
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import read_file_tool
+
+        result = json.loads(read_file_tool("/tmp/test.txt", raw=True))
+        assert result["content"] == "alpha\nbeta\n"
+        assert result["total_lines"] == 2
+        assert result["raw"] is True
+        mock_ops.read_file_raw.assert_called_once_with("/tmp/test.txt")
+        mock_ops.read_file.assert_not_called()
+
+    @patch("tools.file_tools._get_file_ops")
     def test_exception_returns_error_json(self, mock_get):
         mock_get.side_effect = RuntimeError("terminal not available")
 
@@ -63,6 +80,10 @@ class TestReadFileHandler:
         result = json.loads(read_file_tool("/tmp/test.txt"))
         assert "error" in result
         assert "terminal not available" in result["error"]
+
+    def test_schema_exposes_raw_flag(self):
+        assert "raw" in READ_FILE_SCHEMA["parameters"]["properties"]
+        assert READ_FILE_SCHEMA["parameters"]["properties"]["raw"]["default"] is False
 
 
 class TestWriteFileHandler:

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -225,9 +225,9 @@ _TOOL_STUBS = {
     ),
     "read_file": (
         "read_file",
-        "path: str, offset: int = 1, limit: int = 500",
-        '"""Read a file (1-indexed lines). Returns dict with "content" and "total_lines"."""',
-        '{"path": path, "offset": offset, "limit": limit}',
+        "path: str, offset: int = 1, limit: int = 500, raw: bool = False",
+        '"""Read a file. Default mode returns 1-indexed line-numbered content; raw=True returns plain text for round-trip writes."""',
+        '{"path": path, "offset": offset, "limit": limit, "raw": raw}',
     ),
     "write_file": (
         "write_file",

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -742,10 +742,17 @@ def clear_file_ops_cache(task_id: str = None):
             _file_ops_cache.clear()
 
 
-def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = "default") -> str:
-    """Read a file with pagination and line numbers."""
+def read_file_tool(
+    path: str,
+    offset: int = 1,
+    limit: int = 500,
+    raw: bool = False,
+    task_id: str = "default",
+) -> str:
+    """Read a file with pagination and line numbers by default."""
     try:
-        offset, limit = normalize_read_pagination(offset, limit)
+        if not raw:
+            offset, limit = normalize_read_pagination(offset, limit)
 
         # ── Device path guard ─────────────────────────────────────────
         # Block paths that would hang the process (infinite output,
@@ -833,7 +840,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         # file hasn't been modified since, return a lightweight stub
         # instead of re-sending the same content.  Saves context tokens.
         resolved_str = str(_resolved)
-        dedup_key = (resolved_str, offset, limit)
+        dedup_key = (resolved_str, "raw") if raw else (resolved_str, offset, limit)
         with _read_tracker_lock:
             task_data = _read_tracker.setdefault(task_id, {
                 "last_key": None, "consecutive": 0,
@@ -890,8 +897,15 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
 
         # ── Perform the read ──────────────────────────────────────────
         file_ops = _get_file_ops(task_id)
-        result = file_ops.read_file(path, offset, limit)
+        if raw:
+            result = file_ops.read_file_raw(path)
+            if result.content and not result.total_lines:
+                result.total_lines = len(result.content.splitlines())
+        else:
+            result = file_ops.read_file(path, offset, limit)
         result_dict = result.to_dict()
+        if raw:
+            result_dict["raw"] = True
 
         # ── Character-count guard ─────────────────────────────────────
         # We're model-agnostic so we can't count tokens; characters are
@@ -924,7 +938,8 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
 
         # Large-file hint: if the file is big and the caller didn't ask
         # for a narrow window, nudge toward targeted reads.
-        if (file_size and file_size > _LARGE_FILE_HINT_BYTES
+        if (not raw
+                and file_size and file_size > _LARGE_FILE_HINT_BYTES
                 and limit > 200
                 and result_dict.get("truncated")):
             result_dict.setdefault("_hint", (
@@ -934,7 +949,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
             ))
 
         # ── Track for consecutive-loop detection ──────────────────────
-        read_key = ("read", path, offset, limit)
+        read_key = ("read_raw", path) if raw else ("read", path, offset, limit)
         with _read_tracker_lock:
             # Ensure "dedup" / "dedup_hits" keys exist (backward compat with
             # old tracker state from pre-dedup-guard sessions).
@@ -1473,13 +1488,14 @@ def _check_file_reqs():
 
 READ_FILE_SCHEMA = {
     "name": "read_file",
-    "description": "Read a text file with line numbers and pagination. Use this instead of cat/head/tail in terminal. Output format: 'LINE_NUM|CONTENT'. Suggests similar filenames if not found. Use offset and limit for large files. Reads exceeding ~100K characters are rejected; use offset and limit to read specific sections of large files. Jupyter notebooks (.ipynb), Word documents (.docx), and Excel workbooks (.xlsx) are auto-extracted to readable text. NOTE: Cannot read images or other binary files — use vision_analyze for images.",
+    "description": "Read a text file with line numbers and pagination. Use this instead of cat/head/tail in terminal. Output format: 'LINE_NUM|CONTENT'. Set raw=true only when you need plain text without line prefixes for round-trip writes or exact content copying. Suggests similar filenames if not found. Use offset and limit for large files. Reads exceeding ~100K characters are rejected; use offset and limit to read specific sections of large files. Jupyter notebooks (.ipynb), Word documents (.docx), and Excel workbooks (.xlsx) are auto-extracted to readable text. NOTE: Cannot read images or other binary files — use vision_analyze for images.",
     "parameters": {
         "type": "object",
         "properties": {
             "path": {"type": "string", "description": "Path to the file to read (absolute, relative, or ~/path)"},
             "offset": {"type": "integer", "description": "Line number to start reading from (1-indexed, default: 1)", "default": 1, "minimum": 1},
-            "limit": {"type": "integer", "description": "Maximum number of lines to read (default: 500, max: 2000)", "default": 500, "maximum": 2000}
+            "limit": {"type": "integer", "description": "Maximum number of lines to read (default: 500, max: 2000)", "default": 500, "maximum": 2000},
+            "raw": {"type": "boolean", "description": "Return plain file text without line numbers or pagination. Intended for exact content round-trips such as feeding the result into write_file.", "default": False},
         },
         "required": ["path"]
     }
@@ -1576,7 +1592,13 @@ SEARCH_FILES_SCHEMA = {
 
 def _handle_read_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid)
+    return read_file_tool(
+        path=args.get("path", ""),
+        offset=args.get("offset", 1),
+        limit=args.get("limit", 500),
+        raw=bool(args.get("raw", False)),
+        task_id=tid,
+    )
 
 
 def _handle_write_file(args, **kw):


### PR DESCRIPTION
Fixes #46465.

## Summary
- add optional `raw=True` support to sandbox `hermes_tools.read_file()`
- route core `read_file` through `read_file_raw()` when raw mode is requested
- keep default line-numbered behavior unchanged and add regression coverage

## Testing
- `uv run --frozen pytest tests/tools/test_code_execution.py tests/tools/test_file_read_guards.py`
- `uv run --frozen ruff check tools/code_execution_tool.py tools/file_tools.py tests/tools/test_code_execution.py tests/tools/test_file_tools.py`
- `git diff --check`