### PR TITLE
fix(mcp): support OAuth client credentials auth

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -122,6 +122,11 @@ def _env_key_for_server(name: str) -> str:
     return f"MCP_{name.upper().replace('-', '_')}_API_KEY"
 
 
+def _client_secret_env_key_for_server(name: str) -> str:
+    """Convert server name to an env-var key for OAuth client secrets."""
+    return f"MCP_{name.upper().replace('-', '_')}_CLIENT_SECRET"
+
+
 def _strip_bearer_prefix(token: str) -> str:
     """Strip a leading ``Bearer `` from a pasted token.
 
@@ -390,6 +395,44 @@ def cmd_mcp_add(args):
                 _info("Cancelled.")
                 return
 
+    elif url and auth_type == "client_credentials":
+        print()
+        _info("Configuring OAuth client_credentials (non-interactive).")
+        if name.lower() == "linear":
+            _info(
+                "LINEAR_API_KEY is not used for this auth mode; "
+                "use OAuth client credentials."
+            )
+        token_url = _prompt(
+            "OAuth token URL (blank for built-in Linear default)",
+            default="",
+        ).strip()
+        client_id = _prompt("OAuth client ID", default="").strip()
+        secret_env_key = _client_secret_env_key_for_server(name)
+        existing_secret = get_env_value(secret_env_key)
+        if existing_secret:
+            _success(f"{secret_env_key}: already configured")
+        else:
+            client_secret = _prompt("OAuth client secret", password=True)
+            if client_secret:
+                save_env_value(secret_env_key, client_secret)
+                _success(
+                    f"Saved to {display_hermes_home()}/.env as {secret_env_key}"
+                )
+        scope = _prompt("OAuth scopes (optional)", default="").strip()
+
+        oauth_cfg: Dict[str, Any] = {
+            "client_secret": f"${{{secret_env_key}}}",
+        }
+        if token_url:
+            oauth_cfg["token_url"] = token_url
+        if client_id:
+            oauth_cfg["client_id"] = client_id
+        if scope:
+            oauth_cfg["scope"] = scope
+        server_config["auth"] = "client_credentials"
+        server_config["oauth"] = oauth_cfg
+
     elif url:
         # Prompt for API key / Bearer token for HTTP servers
         print()
@@ -629,6 +672,8 @@ def cmd_mcp_test(args):
     headers = cfg.get("headers", {})
     if auth_type == "oauth":
         _info("Auth: OAuth 2.1 PKCE")
+    elif auth_type == "client_credentials":
+        _info("Auth: OAuth 2.0 client_credentials")
     elif headers:
         for k, v in headers.items():
             if isinstance(v, str) and ("key" in k.lower() or "auth" in k.lower()):

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -58,7 +58,11 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
         default=[],
         help="Arguments for stdio command; must be the last option",
     )
-    mcp_add_p.add_argument("--auth", choices=["oauth", "header"], help="Auth method")
+    mcp_add_p.add_argument(
+        "--auth",
+        choices=["oauth", "header", "client_credentials"],
+        help="Auth method",
+    )
     mcp_add_p.add_argument("--preset", help="Known MCP preset name")
     mcp_add_p.add_argument(
         "--env",

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -397,6 +397,52 @@ class TestMcpAdd:
         assert srv["args"] == ["custom-server"]
         assert "env" not in srv
 
+
+    def test_add_http_server_client_credentials_saves_secret_placeholder(
+        self, tmp_path, capsys, monkeypatch
+    ):
+        fake_tools = [FakeTool("issues", "List issues")]
+
+        def mock_probe(name, config, **kw):
+            assert config["auth"] == "client_credentials"
+            assert config["oauth"]["client_id"] == "linear-client-id"
+            assert config["oauth"]["client_secret"] == "${MCP_LINEAR_CLIENT_SECRET}"
+            assert "LINEAR_API_KEY" not in str(config)
+            return [(t.name, t.description) for t in fake_tools]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+        prompt_inputs = iter([
+            "",  # token URL: use built-in Linear default
+            "linear-client-id",
+            "linear-client-secret",
+            "read,comments:create",
+        ])
+
+        from hermes_cli import mcp_config as mc
+        from hermes_cli.mcp_config import cmd_mcp_add
+        from hermes_cli.config import read_raw_config, get_env_value
+
+        monkeypatch.setattr(mc, "_prompt", lambda *a, **kw: next(prompt_inputs))
+        monkeypatch.setattr("builtins.input", lambda _: "")
+
+        cmd_mcp_add(_make_args(
+            name="linear",
+            url="https://mcp.linear.app/mcp",
+            auth="client_credentials",
+        ))
+        out = capsys.readouterr().out
+
+        assert "Saved" in out
+        assert "LINEAR_API_KEY" in out
+        assert "linear-client-secret" not in out
+        assert get_env_value("MCP_LINEAR_CLIENT_SECRET") == "linear-client-secret"
+        srv = read_raw_config()["mcp_servers"]["linear"]
+        assert srv["auth"] == "client_credentials"
+        assert srv["oauth"]["client_secret"] == "${MCP_LINEAR_CLIENT_SECRET}"
+        assert "LINEAR_API_KEY" not in str(srv)
+
     def test_unknown_preset_rejected(self, capsys):
         """An unknown preset name is rejected with a clear error."""
         from hermes_cli.mcp_config import cmd_mcp_add
@@ -746,3 +792,31 @@ class TestMcpLogin:
         assert "Authenticated — 3 tool(s) available" in out
         assert "no OAuth token" not in out
 
+
+
+class TestMcpClientCredentialsAuthDisplay:
+    def test_test_command_displays_client_credentials_without_secrets(self, tmp_path, capsys, monkeypatch):
+        _seed_config(tmp_path, {
+            "linear": {
+                "url": "https://mcp.linear.app/mcp",
+                "auth": "client_credentials",
+                "oauth": {
+                    "client_id": "linear-client-id",
+                    "client_secret": "linear-client-secret",
+                    "scope": "read,comments:create",
+                },
+            },
+        })
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server",
+            lambda name, cfg: [("issues", "List issues")],
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_test
+
+        cmd_mcp_test(_make_args(name="linear"))
+        out = capsys.readouterr().out
+
+        assert "client_credentials" in out
+        assert "linear-client-secret" not in out
+        assert "LINEAR_API_KEY" not in out

--- a/tests/hermes_cli/test_subcommands_followup.py
+++ b/tests/hermes_cli/test_subcommands_followup.py
@@ -64,3 +64,23 @@ def test_mcp_and_acp_accept_hooks_flag():
     # acp takes --accept-hooks at top level
     ns = parser.parse_args(["acp", "--accept-hooks"])
     assert ns.accept_hooks is True
+
+
+def test_mcp_add_accepts_client_credentials_auth_choice():
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    build_mcp_parser(sub, cmd_mcp=_h("mcp"))
+
+    ns = parser.parse_args([
+        "mcp",
+        "add",
+        "linear",
+        "--url",
+        "https://mcp.linear.app/mcp",
+        "--auth",
+        "client_credentials",
+    ])
+
+    assert ns.command == "mcp"
+    assert ns.mcp_action == "add"
+    assert ns.auth == "client_credentials"

--- a/tests/tools/test_mcp_client_credentials.py
+++ b/tests/tools/test_mcp_client_credentials.py
@@ -1,0 +1,213 @@
+"""Tests for noninteractive MCP OAuth client_credentials auth."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+
+import httpx
+import pytest
+
+
+def test_client_credentials_does_not_use_browser_callback(monkeypatch, tmp_path):
+    """client_credentials must not route through the OAuth browser callback flow."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    import tools.mcp_oauth as mcp_oauth
+
+    async def _fail_callback():  # pragma: no cover - should never be called
+        raise AssertionError("client_credentials called browser callback")
+
+    monkeypatch.setattr(mcp_oauth, "_wait_for_callback", _fail_callback)
+
+    from tools.mcp_client_credentials import build_client_credentials_auth
+
+    auth = build_client_credentials_auth(
+        "linear",
+        "https://mcp.linear.app/mcp",
+        {
+            "client_id": "linear-client-id",
+            "client_secret": "linear-client-secret",
+            "scope": "read,comments:create",
+        },
+    )
+
+    assert auth is not None
+
+
+def test_refreshes_in_memory_token_before_expiry(monkeypatch, tmp_path):
+    """A near-expiry token is reminted in memory and is not written to mcp-tokens."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.mcp_client_credentials import MCPClientCredentialsAuth
+
+    now = {"value": 1_000.0}
+    minted_tokens = iter([
+        {"access_token": "first-token", "token_type": "Bearer", "expires_in": 90},
+        {"access_token": "second-token", "token_type": "Bearer", "expires_in": 300},
+    ])
+    token_requests: list[httpx.Request] = []
+
+    async def token_handler(request: httpx.Request) -> httpx.Response:
+        token_requests.append(request)
+        return httpx.Response(200, json=next(minted_tokens))
+
+    seen_auth_headers: list[str | None] = []
+
+    async def mcp_handler(request: httpx.Request) -> httpx.Response:
+        seen_auth_headers.append(request.headers.get("Authorization"))
+        return httpx.Response(200, json={"ok": True})
+
+    def token_client_factory() -> httpx.AsyncClient:
+        return httpx.AsyncClient(transport=httpx.MockTransport(token_handler))
+
+    auth = MCPClientCredentialsAuth(
+        server_name="linear",
+        token_url="https://api.linear.app/oauth/token",
+        client_id="linear-client-id",
+        client_secret="linear-client-secret",
+        scope="read,comments:create",
+        refresh_skew_seconds=60,
+        now=lambda: now["value"],
+        token_client_factory=token_client_factory,
+    )
+
+    async def drive():
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(mcp_handler), auth=auth
+        ) as client:
+            await client.get("https://mcp.linear.app/mcp")
+            now["value"] = 1_031.0
+            await client.get("https://mcp.linear.app/mcp")
+
+    asyncio.run(drive())
+
+    assert seen_auth_headers == ["Bearer first-token", "Bearer second-token"]
+    assert len(token_requests) == 2
+    assert not (Path(tmp_path) / "mcp-tokens" / "linear.json").exists()
+
+
+def test_remints_and_retries_once_after_401(monkeypatch, tmp_path):
+    """A 401 from the MCP endpoint forces a fresh client_credentials token."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.mcp_client_credentials import MCPClientCredentialsAuth
+
+    token_payloads = iter([
+        {"access_token": "expired-token", "token_type": "Bearer", "expires_in": 300},
+        {"access_token": "fresh-token", "token_type": "Bearer", "expires_in": 300},
+    ])
+    token_call_count = 0
+
+    async def token_handler(request: httpx.Request) -> httpx.Response:
+        nonlocal token_call_count
+        token_call_count += 1
+        return httpx.Response(200, json=next(token_payloads))
+
+    mcp_auth_headers: list[str | None] = []
+
+    async def mcp_handler(request: httpx.Request) -> httpx.Response:
+        mcp_auth_headers.append(request.headers.get("Authorization"))
+        if len(mcp_auth_headers) == 1:
+            return httpx.Response(401, json={"error": "expired"})
+        return httpx.Response(200, json={"ok": True})
+
+    def token_client_factory() -> httpx.AsyncClient:
+        return httpx.AsyncClient(transport=httpx.MockTransport(token_handler))
+
+    auth = MCPClientCredentialsAuth(
+        server_name="linear",
+        token_url="https://api.linear.app/oauth/token",
+        client_id="linear-client-id",
+        client_secret="linear-client-secret",
+        scope="read,comments:create",
+        now=lambda: 2_000.0,
+        token_client_factory=token_client_factory,
+    )
+
+    async def drive():
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(mcp_handler), auth=auth
+        ) as client:
+            return await client.get("https://mcp.linear.app/mcp")
+
+    response = asyncio.run(drive())
+
+    assert response.status_code == 200
+    assert mcp_auth_headers == ["Bearer expired-token", "Bearer fresh-token"]
+    assert token_call_count == 2
+
+
+def test_token_mint_errors_redact_secrets(monkeypatch, tmp_path, caplog):
+    """Token endpoint failures must not log or raise client secrets or tokens."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.mcp_client_credentials import (
+        ClientCredentialsTokenError,
+        MCPClientCredentialsAuth,
+    )
+
+    secret = "linear-client-secret-value"
+    leaked_token = "tok_1234567890"
+
+    async def token_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400,
+            json={
+                "error": "invalid_client",
+                "error_description": f"bad secret {secret}; access_token={leaked_token}",
+            },
+        )
+
+    def token_client_factory() -> httpx.AsyncClient:
+        return httpx.AsyncClient(transport=httpx.MockTransport(token_handler))
+
+    auth = MCPClientCredentialsAuth(
+        server_name="linear",
+        token_url="https://api.linear.app/oauth/token",
+        client_id="linear-client-id",
+        client_secret=secret,
+        scope="read",
+        token_client_factory=token_client_factory,
+    )
+
+    async def drive():
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(lambda request: httpx.Response(200)),
+            auth=auth,
+        ) as client:
+            return await client.get("https://mcp.linear.app/mcp")
+
+    caplog.set_level(logging.WARNING, logger="tools.mcp_client_credentials")
+    with pytest.raises(ClientCredentialsTokenError) as exc_info:
+        asyncio.run(drive())
+
+    message = str(exc_info.value)
+    assert secret not in message
+    assert leaked_token not in message
+    assert secret not in caplog.text
+    assert leaked_token not in caplog.text
+    assert "[REDACTED]" in message
+
+
+def test_linear_api_key_is_not_used_as_client_credentials(monkeypatch, tmp_path):
+    """LINEAR_API_KEY is not a fallback for the client_credentials lane."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("LINEAR_API_KEY", "linear-api-key-that-must-not-be-used")
+
+    from tools.mcp_client_credentials import (
+        ClientCredentialsConfigError,
+        build_client_credentials_auth,
+    )
+
+    with pytest.raises(ClientCredentialsConfigError) as exc_info:
+        build_client_credentials_auth(
+            "linear",
+            "https://mcp.linear.app/mcp",
+            {"scope": "read"},
+        )
+
+    assert "LINEAR_API_KEY" not in str(exc_info.value)
+    assert "client_id" in str(exc_info.value)
+    assert "client_secret" in str(exc_info.value)

--- a/tests/tools/test_mcp_client_credentials_transport.py
+++ b/tests/tools/test_mcp_client_credentials_transport.py
@@ -1,0 +1,82 @@
+"""Transport wiring tests for MCP client_credentials auth."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def test_http_transport_passes_client_credentials_auth_to_httpx(monkeypatch):
+    """auth: client_credentials is a first-class HTTP auth provider, not a static header."""
+    import httpx
+    from tools.mcp_tool import MCPServerTask
+
+    captured_client_kwargs: dict = {}
+    fake_auth_provider = object()
+    fake_manager = MagicMock()
+    fake_manager.get_or_build_provider.return_value = fake_auth_provider
+
+    class _FakeHTTPClient:
+        def __init__(self, **kwargs):
+            captured_client_kwargs.clear()
+            captured_client_kwargs.update(kwargs)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+    class _FakeStreamableHTTP:
+        async def __aenter__(self):
+            return (AsyncMock(), AsyncMock(), lambda: None)
+
+        async def __aexit__(self, *args):
+            return False
+
+    def _fake_streamable_http_client(url, http_client):
+        return _FakeStreamableHTTP()
+
+    class _FakeSession:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            session = MagicMock()
+            session.initialize = AsyncMock()
+            return session
+
+        async def __aexit__(self, *args):
+            return False
+
+    server = MCPServerTask("linear")
+    server._auth_type = "client_credentials"
+    server._sampling = None
+
+    async def drive():
+        with patch.object(MCPServerTask, "_wait_for_lifecycle_event", new=AsyncMock(return_value="shutdown")), \
+             patch.object(MCPServerTask, "_discover_tools", new=AsyncMock()), \
+             patch("tools.mcp_client_credentials.get_client_credentials_manager", return_value=fake_manager), \
+             patch("tools.mcp_tool.streamable_http_client", new=_fake_streamable_http_client), \
+             patch("tools.mcp_tool.ClientSession", new=_FakeSession):
+            monkeypatch.setattr("tools.mcp_tool._MCP_HTTP_AVAILABLE", True)
+            monkeypatch.setattr("tools.mcp_tool._MCP_NEW_HTTP", True)
+            monkeypatch.setattr(httpx, "AsyncClient", _FakeHTTPClient)
+            await server._run_http({
+                "url": "https://mcp.linear.app/mcp",
+                "auth": "client_credentials",
+                "oauth": {
+                    "client_id": "linear-client-id",
+                    "client_secret": "linear-client-secret",
+                    "scope": "read,comments:create",
+                },
+            })
+
+    asyncio.run(drive())
+
+    assert captured_client_kwargs["auth"] is fake_auth_provider
+    fake_manager.get_or_build_provider.assert_called_once()
+    called_name, called_url, called_cfg = fake_manager.get_or_build_provider.call_args.args
+    assert called_name == "linear"
+    assert called_url == "https://mcp.linear.app/mcp"
+    assert called_cfg["client_id"] == "linear-client-id"

--- a/tools/mcp_client_credentials.py
+++ b/tools/mcp_client_credentials.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""In-memory OAuth client_credentials auth for remote MCP servers.
+
+This module supports ``mcp_servers.<name>.auth: client_credentials`` without
+using the interactive OAuth browser callback flow. Access tokens minted by this
+provider live only on the provider instance in this process; they are never
+written to the Hermes MCP OAuth token store.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import time
+import threading
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+from urllib.parse import urlparse
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_LINEAR_TOKEN_URL = "https://api.linear.app/oauth/token"
+_DEFAULT_EXPIRES_IN = 3600
+_DEFAULT_REFRESH_SKEW_SECONDS = 60
+
+_SECRET_PATTERN = re.compile(
+    r"(?:"
+    r"Bearer\s+\S+"
+    r"|access_token[=\s:]+[^\s,;\"']+"
+    r"|refresh_token[=\s:]+[^\s,;\"']+"
+    r"|client_secret[=\s:]+[^\s,;\"']+"
+    r"|secret[=\s:]+[^\s,;\"']+"
+    r"|token[=\s:]+[^\s,;\"']+"
+    r"|key[=\s:]+[^\s,;\"']+"
+    r"|tok_[A-Za-z0-9_\-]+"
+    r")",
+    re.IGNORECASE,
+)
+
+
+class ClientCredentialsConfigError(ValueError):
+    """Raised when an MCP client_credentials config is incomplete."""
+
+
+class ClientCredentialsTokenError(RuntimeError):
+    """Raised when the token endpoint does not mint a usable access token."""
+
+
+@dataclass(frozen=True)
+class _TokenState:
+    access_token: str
+    expires_at: float
+    token_type: str = "Bearer"
+
+
+def _redact(text: Any, *explicit_secrets: str | None) -> str:
+    """Return *text* with token/secret material replaced by ``[REDACTED]``."""
+    redacted = str(text)
+    for secret in explicit_secrets:
+        if secret:
+            redacted = redacted.replace(str(secret), "[REDACTED]")
+    return _SECRET_PATTERN.sub("[REDACTED]", redacted)
+
+
+def _cfg_str(cfg: dict[str, Any], key: str) -> str | None:
+    value = cfg.get(key)
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _cfg_env_value(cfg: dict[str, Any], key: str, env_key: str) -> str | None:
+    value = _cfg_str(cfg, key)
+    if value:
+        return value
+    env_name = _cfg_str(cfg, env_key)
+    if not env_name:
+        return None
+    # Exact, user-declared lookup only. Do not infer provider-specific fallback
+    # names such as LINEAR_API_KEY; that API-key lane is intentionally not
+    # supported by client_credentials.
+    env_value = os.environ.get(env_name)
+    if env_value is None:
+        return None
+    env_value = str(env_value).strip()
+    return env_value or None
+
+
+def _is_linear_server(server_name: str, server_url: str) -> bool:
+    if server_name.strip().lower() == "linear":
+        return True
+    host = (urlparse(server_url).hostname or "").lower()
+    return host == "linear.app" or host.endswith(".linear.app")
+
+
+def _resolve_token_url(server_name: str, server_url: str, cfg: dict[str, Any]) -> str:
+    token_url = _cfg_str(cfg, "token_url") or _cfg_str(cfg, "token_endpoint")
+    if not token_url and _is_linear_server(server_name, server_url):
+        token_url = _LINEAR_TOKEN_URL
+    if not token_url:
+        raise ClientCredentialsConfigError(
+            "mcp_servers.<name>.auth: client_credentials requires oauth.token_url "
+            "(or token_endpoint) unless the server is the built-in Linear MCP host"
+        )
+    parsed = urlparse(token_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ClientCredentialsConfigError(
+            "mcp_servers.<name>.oauth.token_url must be an http(s) URL"
+        )
+    return token_url
+
+
+def _token_config_from_oauth(
+    server_name: str,
+    server_url: str,
+    oauth_config: Optional[dict[str, Any]],
+) -> dict[str, Any]:
+    cfg = dict(oauth_config or {})
+    token_url = _resolve_token_url(server_name, server_url, cfg)
+    client_id = _cfg_env_value(cfg, "client_id", "client_id_env")
+    client_secret = _cfg_env_value(cfg, "client_secret", "client_secret_env")
+    missing = []
+    if not client_id:
+        missing.append("client_id")
+    if not client_secret:
+        missing.append("client_secret")
+    if missing:
+        raise ClientCredentialsConfigError(
+            "mcp_servers.<name>.auth: client_credentials requires oauth."
+            + " and oauth.".join(missing)
+            + " (or matching *_env keys)"
+        )
+
+    token_params = cfg.get("token_params") or {}
+    if not isinstance(token_params, dict):
+        raise ClientCredentialsConfigError(
+            "mcp_servers.<name>.oauth.token_params must be a mapping"
+        )
+
+    return {
+        "token_url": token_url,
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "scope": _cfg_str(cfg, "scope"),
+        "auth_method": (_cfg_str(cfg, "auth_method") or _cfg_str(
+            cfg, "token_endpoint_auth_method"
+        ) or "client_secret_basic"),
+        "timeout": float(cfg.get("timeout", 30.0)),
+        "refresh_skew_seconds": float(
+            cfg.get("refresh_skew_seconds", _DEFAULT_REFRESH_SKEW_SECONDS)
+        ),
+        "token_params": {str(k): str(v) for k, v in token_params.items()},
+    }
+
+
+class MCPClientCredentialsAuth(httpx.Auth):
+    """httpx auth provider for OAuth 2.0 client_credentials.
+
+    The provider mints tokens lazily, stores the current access token only in
+    memory, refreshes before expiry, and retries once with a fresh token after
+    a 401 challenge.
+    """
+
+    def __init__(
+        self,
+        *,
+        server_name: str,
+        token_url: str,
+        client_id: str,
+        client_secret: str,
+        scope: str | None = None,
+        auth_method: str = "client_secret_basic",
+        timeout: float = 30.0,
+        refresh_skew_seconds: float = _DEFAULT_REFRESH_SKEW_SECONDS,
+        token_params: Optional[dict[str, str]] = None,
+        now: Callable[[], float] = time.time,
+        token_client_factory: Optional[Callable[[], httpx.AsyncClient]] = None,
+    ) -> None:
+        self.server_name = server_name
+        self.token_url = token_url
+        self.client_id = client_id
+        self._client_secret = client_secret
+        self.scope = scope
+        self.auth_method = auth_method
+        self.timeout = timeout
+        self.refresh_skew_seconds = max(float(refresh_skew_seconds), 0.0)
+        self.token_params = dict(token_params or {})
+        self._now = now
+        self._token_client_factory = token_client_factory
+        self._token: _TokenState | None = None
+        self._lock = asyncio.Lock()
+
+    def auth_flow(self, request: httpx.Request):  # pragma: no cover - sync unsupported
+        raise RuntimeError("MCP client_credentials auth requires an async httpx client")
+
+    async def async_auth_flow(self, request: httpx.Request):  # type: ignore[override]
+        token = await self._ensure_token()
+        request.headers["Authorization"] = f"Bearer {token}"
+        response = yield request
+        if response.status_code == 401:
+            token = await self.force_refresh()
+            request.headers["Authorization"] = f"Bearer {token}"
+            yield request
+
+    async def force_refresh(self) -> str:
+        """Mint a fresh access token even if the cached one is not expired."""
+        async with self._lock:
+            return await self._mint_token_locked()
+
+    async def _ensure_token(self) -> str:
+        token = self._token
+        if token is not None and not self._token_expiring(token):
+            return token.access_token
+        async with self._lock:
+            token = self._token
+            if token is not None and not self._token_expiring(token):
+                return token.access_token
+            return await self._mint_token_locked()
+
+    def _token_expiring(self, token: _TokenState) -> bool:
+        return token.expires_at <= self._now() + self.refresh_skew_seconds
+
+    def _make_token_client(self) -> httpx.AsyncClient:
+        if self._token_client_factory is not None:
+            return self._token_client_factory()
+        return httpx.AsyncClient(timeout=self.timeout)
+
+    async def _mint_token_locked(self) -> str:
+        data = {"grant_type": "client_credentials", **self.token_params}
+        if self.scope:
+            data["scope"] = self.scope
+
+        auth: tuple[str, str] | None = None
+        method = self.auth_method.lower().strip()
+        if method in {"client_secret_basic", "basic"}:
+            auth = (self.client_id, self._client_secret)
+        elif method in {"client_secret_post", "post"}:
+            data["client_id"] = self.client_id
+            data["client_secret"] = self._client_secret
+        else:
+            raise ClientCredentialsConfigError(
+                "mcp_servers.<name>.oauth.auth_method must be "
+                "client_secret_basic or client_secret_post"
+            )
+
+        try:
+            async with self._make_token_client() as client:
+                response = await client.post(
+                    self.token_url,
+                    data=data,
+                    auth=auth,
+                    headers={"Accept": "application/json"},
+                )
+        except Exception as exc:
+            sanitized = _redact(exc, self._client_secret)
+            logger.warning(
+                "MCP client_credentials '%s': token mint failed: %s",
+                self.server_name,
+                sanitized,
+            )
+            raise ClientCredentialsTokenError(
+                f"client_credentials token mint failed: {sanitized}"
+            ) from exc
+
+        if response.status_code >= 400:
+            detail = self._response_detail(response)
+            sanitized = _redact(
+                f"HTTP {response.status_code}: {detail}", self._client_secret
+            )
+            logger.warning(
+                "MCP client_credentials '%s': token mint failed: %s",
+                self.server_name,
+                sanitized,
+            )
+            raise ClientCredentialsTokenError(
+                f"client_credentials token mint failed: {sanitized}"
+            )
+
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            sanitized = _redact(response.text, self._client_secret)
+            logger.warning(
+                "MCP client_credentials '%s': token endpoint returned invalid JSON: %s",
+                self.server_name,
+                sanitized,
+            )
+            raise ClientCredentialsTokenError(
+                "client_credentials token mint failed: token endpoint returned invalid JSON"
+            ) from exc
+
+        access_token = payload.get("access_token") if isinstance(payload, dict) else None
+        if not access_token:
+            logger.warning(
+                "MCP client_credentials '%s': token endpoint response missing access_token",
+                self.server_name,
+            )
+            raise ClientCredentialsTokenError(
+                "client_credentials token mint failed: token endpoint response missing access_token"
+            )
+
+        token_type = str(payload.get("token_type") or "Bearer")
+        try:
+            expires_in = int(payload.get("expires_in", _DEFAULT_EXPIRES_IN))
+        except (TypeError, ValueError):
+            expires_in = _DEFAULT_EXPIRES_IN
+        expires_in = max(expires_in, 1)
+        self._token = _TokenState(
+            access_token=str(access_token),
+            expires_at=self._now() + expires_in,
+            token_type=token_type,
+        )
+        return self._token.access_token
+
+    @staticmethod
+    def _response_detail(response: httpx.Response) -> str:
+        try:
+            payload = response.json()
+        except ValueError:
+            return response.text
+        if not isinstance(payload, dict):
+            return str(payload)
+        parts = []
+        for key in ("error", "error_description", "message"):
+            value = payload.get(key)
+            if value:
+                parts.append(f"{key}={value}")
+        return "; ".join(parts) if parts else str(payload)
+
+
+def build_client_credentials_auth(
+    server_name: str,
+    server_url: str,
+    oauth_config: Optional[dict[str, Any]] = None,
+) -> MCPClientCredentialsAuth:
+    """Build an in-memory client_credentials auth provider for an MCP server."""
+    resolved = _token_config_from_oauth(server_name, server_url, oauth_config)
+    return MCPClientCredentialsAuth(server_name=server_name, **resolved)
+
+
+@dataclass
+class _ClientCredentialsEntry:
+    server_url: str
+    fingerprint: tuple[Any, ...]
+    provider: MCPClientCredentialsAuth
+
+
+class MCPClientCredentialsManager:
+    """Process-local cache for client_credentials providers.
+
+    The cache keeps refreshable in-memory tokens across reconnects inside the
+    current Hermes process. It never writes rotating access tokens to disk.
+    """
+
+    def __init__(self) -> None:
+        self._entries: dict[str, _ClientCredentialsEntry] = {}
+        self._entries_lock = threading.Lock()
+
+    def get_or_build_provider(
+        self,
+        server_name: str,
+        server_url: str,
+        oauth_config: Optional[dict[str, Any]],
+    ) -> MCPClientCredentialsAuth:
+        resolved = _token_config_from_oauth(server_name, server_url, oauth_config)
+        fingerprint = self._fingerprint(server_url, resolved)
+        with self._entries_lock:
+            entry = self._entries.get(server_name)
+            if entry is None or entry.fingerprint != fingerprint:
+                entry = _ClientCredentialsEntry(
+                    server_url=server_url,
+                    fingerprint=fingerprint,
+                    provider=MCPClientCredentialsAuth(
+                        server_name=server_name,
+                        **resolved,
+                    ),
+                )
+                self._entries[server_name] = entry
+            return entry.provider
+
+    async def handle_401(self, server_name: str) -> bool:
+        with self._entries_lock:
+            entry = self._entries.get(server_name)
+        if entry is None:
+            return False
+        try:
+            await entry.provider.force_refresh()
+            return True
+        except Exception as exc:
+            logger.warning(
+                "MCP client_credentials '%s': 401 refresh failed: %s",
+                server_name,
+                _redact(exc, entry.provider._client_secret),
+            )
+            return False
+
+    @staticmethod
+    def _fingerprint(server_url: str, resolved: dict[str, Any]) -> tuple[Any, ...]:
+        token_params = tuple(sorted((resolved.get("token_params") or {}).items()))
+        return (
+            server_url,
+            resolved.get("token_url"),
+            resolved.get("client_id"),
+            resolved.get("client_secret"),
+            resolved.get("scope"),
+            resolved.get("auth_method"),
+            resolved.get("timeout"),
+            resolved.get("refresh_skew_seconds"),
+            token_params,
+        )
+
+    def remove(self, server_name: str) -> None:
+        with self._entries_lock:
+            self._entries.pop(server_name, None)
+
+
+_MANAGER: MCPClientCredentialsManager | None = None
+_MANAGER_LOCK = threading.Lock()
+
+
+def get_client_credentials_manager() -> MCPClientCredentialsManager:
+    """Return the process-wide client_credentials manager."""
+    global _MANAGER
+    with _MANAGER_LOCK:
+        if _MANAGER is None:
+            _MANAGER = MCPClientCredentialsManager()
+        return _MANAGER
+
+
+def reset_client_credentials_manager_for_tests() -> None:
+    global _MANAGER
+    with _MANAGER_LOCK:
+        _MANAGER = None

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1646,21 +1646,35 @@ class MCPServerTask:
         ssl_verify = config.get("ssl_verify", True)
         client_cert = _resolve_client_cert(self.name, config)
 
-        # OAuth 2.1 PKCE: route through the central MCPOAuthManager so the
-        # same provider instance is reused across reconnects, pre-flow
-        # disk-watch is active, and config-time CLI code paths share state.
-        # If OAuth setup fails (e.g. non-interactive env without cached
-        # tokens), re-raise so this server is reported as failed without
-        # blocking other MCP servers from connecting.
-        _oauth_auth = None
+        # HTTP auth providers: OAuth 2.1 PKCE routes through the central
+        # MCPOAuthManager; OAuth client_credentials routes through its own
+        # process-local manager so rotating access tokens stay in memory only.
+        # If auth setup fails, re-raise so this server is reported as failed
+        # without blocking other MCP servers from connecting.
+        _http_auth = None
         if self._auth_type == "oauth":
             try:
                 from tools.mcp_oauth_manager import get_manager
-                _oauth_auth = get_manager().get_or_build_provider(
+                _http_auth = get_manager().get_or_build_provider(
                     self.name, url, config.get("oauth"),
                 )
             except Exception as exc:
                 logger.warning("MCP OAuth setup failed for '%s': %s", self.name, exc)
+                raise
+        elif self._auth_type == "client_credentials":
+            try:
+                from tools.mcp_client_credentials import get_client_credentials_manager
+                _http_auth = get_client_credentials_manager().get_or_build_provider(
+                    self.name,
+                    url,
+                    config.get("oauth") or config.get("client_credentials"),
+                )
+            except Exception as exc:
+                logger.warning(
+                    "MCP client_credentials setup failed for '%s': %s",
+                    self.name,
+                    _sanitize_error(str(exc)),
+                )
                 raise
 
         sampling_kwargs = self._sampling.session_kwargs() if self._sampling else {}
@@ -1691,11 +1705,10 @@ class MCPServerTask:
                 "timeout": float(connect_timeout),
                 "sse_read_timeout": 300.0,
             }
-            if _oauth_auth is not None:
-                # Pass OAuth auth through to sse_client so SSE MCP servers
-                # behind OAuth 2.1 PKCE work. Previously built but never
-                # forwarded — SSE OAuth would silently fail with 401s.
-                _sse_kwargs["auth"] = _oauth_auth
+            if _http_auth is not None:
+                # Pass HTTP auth through to sse_client so SSE MCP servers
+                # behind OAuth 2.1 PKCE or client_credentials work.
+                _sse_kwargs["auth"] = _http_auth
             if client_cert is not None or ssl_verify is not True:
                 # SSE transport doesn't expose verify/cert as kwargs, so route
                 # them through an httpx_client_factory that wraps the SDK's
@@ -1768,8 +1781,8 @@ class MCPServerTask:
             }
             if headers:
                 client_kwargs["headers"] = headers
-            if _oauth_auth is not None:
-                client_kwargs["auth"] = _oauth_auth
+            if _http_auth is not None:
+                client_kwargs["auth"] = _http_auth
             if client_cert is not None:
                 client_kwargs["cert"] = client_cert
 
@@ -1797,8 +1810,8 @@ class MCPServerTask:
                 "timeout": float(connect_timeout),
                 "verify": ssl_verify,
             }
-            if _oauth_auth is not None:
-                _http_kwargs["auth"] = _oauth_auth
+            if _http_auth is not None:
+                _http_kwargs["auth"] = _http_auth
             async with streamablehttp_client(url, **_http_kwargs) as (
                 read_stream, write_stream, _get_session_id,
             ):
@@ -1960,9 +1973,9 @@ class MCPServerTask:
                 if not self._ready.is_set():
                     if _is_auth_error(exc):
                         logger.warning(
-                            "MCP server '%s' failed initial OAuth authentication, "
+                            "MCP server '%s' failed initial HTTP authentication, "
                             "not retrying automatically: %s",
-                            self.name, exc,
+                            self.name, _sanitize_error(str(exc)),
                         )
                         self._error = exc
                         self._ready.set()
@@ -2143,6 +2156,8 @@ def _get_auth_error_types() -> tuple:
         optional import for forward/backward compatibility.
       - ``tools.mcp_oauth.OAuthNonInteractiveError`` — raised by our callback
         handler when no user is present to complete a browser flow.
+      - ``tools.mcp_client_credentials.ClientCredentialsTokenError`` — raised
+        when noninteractive client_credentials token minting fails.
       - ``httpx.HTTPStatusError`` — caller must additionally check
         ``status_code == 401`` via :func:`_is_auth_error`.
     """
@@ -2164,6 +2179,11 @@ def _get_auth_error_types() -> tuple:
     try:
         from tools.mcp_oauth import OAuthNonInteractiveError
         types.append(OAuthNonInteractiveError)
+    except ImportError:
+        pass
+    try:
+        from tools.mcp_client_credentials import ClientCredentialsTokenError
+        types.append(ClientCredentialsTokenError)
     except ImportError:
         pass
     try:
@@ -2205,9 +2225,8 @@ def _handle_auth_error_and_retry(
     Called by the 5 MCP tool handlers when ``session.<op>()`` raises an
     auth-related exception. Workflow:
 
-      1. Ask :class:`tools.mcp_oauth_manager.MCPOAuthManager.handle_401` if
-         recovery is viable (i.e., disk has fresh tokens, or the SDK can
-         refresh in-place).
+      1. Ask the configured auth manager (OAuth PKCE or client_credentials)
+         if recovery is viable.
       2. If yes, set the server's ``_reconnect_event`` so the server task
          tears down the current MCP session and rebuilds it with fresh
          credentials. Wait briefly for ``_ready`` to re-fire.
@@ -2231,24 +2250,35 @@ def _handle_auth_error_and_retry(
     if not _is_auth_error(exc):
         return None
 
-    from tools.mcp_oauth_manager import get_manager
-    manager = get_manager()
+    with _lock:
+        srv = _servers.get(server_name)
+    auth_type = (getattr(srv, "_auth_type", "") or "").lower().strip()
 
-    async def _recover():
-        return await manager.handle_401(server_name, None)
+    recovery_label = "OAuth"
+    if auth_type == "client_credentials":
+        recovery_label = "client_credentials"
+
+        async def _recover():
+            from tools.mcp_client_credentials import get_client_credentials_manager
+            return await get_client_credentials_manager().handle_401(server_name)
+
+    else:
+        from tools.mcp_oauth_manager import get_manager
+        manager = get_manager()
+
+        async def _recover():
+            return await manager.handle_401(server_name, None)
 
     try:
         recovered = _run_on_mcp_loop(_recover, timeout=10)
     except Exception as rec_exc:
         logger.warning(
-            "MCP OAuth '%s': recovery attempt failed: %s",
-            server_name, rec_exc,
+            "MCP %s '%s': recovery attempt failed: %s",
+            recovery_label, server_name, _sanitize_error(str(rec_exc)),
         )
         recovered = False
 
     if recovered:
-        with _lock:
-            srv = _servers.get(server_name)
         if srv is not None and hasattr(srv, "_reconnect_event"):
             loop = _mcp_loop
             if loop is not None and loop.is_running():
@@ -2271,8 +2301,8 @@ def _handle_auth_error_and_retry(
                     _run_on_mcp_loop(_await_ready(), timeout=15)
                 except Exception as exc:
                     logger.warning(
-                        "MCP OAuth '%s': ready poll failed: %s",
-                        server_name, exc,
+                        "MCP %s '%s': ready poll failed: %s",
+                        recovery_label, server_name, _sanitize_error(str(exc)),
                     )
 
         # A successful OAuth recovery is independent evidence that the
@@ -2298,13 +2328,24 @@ def _handle_auth_error_and_retry(
         except Exception as retry_exc:
             logger.warning(
                 "MCP %s/%s retry after auth recovery failed: %s",
-                server_name, op_description, retry_exc,
+                server_name, op_description, _sanitize_error(str(retry_exc)),
             )
 
     # No recovery available, or retry also failed: surface a structured
     # needs_reauth error. Bumps the circuit breaker so the model stops
     # retrying the tool.
     _bump_server_error(server_name)
+    if auth_type == "client_credentials":
+        return json.dumps({
+            "error": (
+                f"MCP server '{server_name}' client_credentials token refresh "
+                "failed. Check mcp_servers.<name>.oauth client_id, "
+                "client_secret, token_url, and scopes. Do NOT retry this tool "
+                "until the configuration is fixed."
+            ),
+            "needs_reauth": True,
+            "server": server_name,
+        }, ensure_ascii=False)
     return json.dumps({
         "error": (
             f"MCP server '{server_name}' requires re-authentication. "


### PR DESCRIPTION
## Summary

Add noninteractive OAuth 2.0 `client_credentials` auth for remote MCP servers.

- supports `mcp_servers.<name>.auth: client_credentials`
- mints access tokens at runtime and keeps rotating access tokens in memory only
- avoids the interactive OAuth browser callback flow for client-credentials servers
- refreshes before expiry and remints/retries once after a 401
- redacts token/secret material in token-mint errors/logs
- keeps `LINEAR_API_KEY` out of this auth lane
- adds CLI/parser/display support for `--auth client_credentials`

Linear MCP gets the default token endpoint `https://api.linear.app/oauth/token` when the server is the built-in Linear MCP host.

## Verification

- `scripts/run_tests.sh tests/tools/test_mcp_client_credentials.py tests/tools/test_mcp_client_credentials_transport.py tests/hermes_cli/test_mcp_config.py tests/hermes_cli/test_subcommands_followup.py -- -q` → 61 passed
- `scripts/run_tests.sh tests/tools/test_mcp_sse_transport.py tests/tools/test_mcp_tool_401_handling.py tests/tools/test_mcp_oauth.py -- -q` → 78 passed
- `python3 -m py_compile tools/mcp_client_credentials.py tools/mcp_tool.py hermes_cli/mcp_config.py hermes_cli/subcommands/mcp.py`
- `git diff --check`

## Notes

This is intended for headless/gateway MCP use cases where an interactive `authorization_code` callback cannot complete.
