### PR TITLE
fix(transports): promote Ollama reasoning field to content when content is empty

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -652,10 +652,13 @@ class ChatCompletionsTransport(ProviderTransport):
         # so keep them apart in provider_data rather than merging.
         reasoning = getattr(msg, "reasoning", None)
         reasoning_content = getattr(msg, "reasoning_content", None)
-        if reasoning_content is None and hasattr(msg, "model_extra"):
+        if reasoning_content is None or reasoning is None:
             model_extra = getattr(msg, "model_extra", None) or {}
-            if isinstance(model_extra, dict) and "reasoning_content" in model_extra:
-                reasoning_content = model_extra["reasoning_content"]
+            if isinstance(model_extra, dict):
+                if reasoning_content is None and "reasoning_content" in model_extra:
+                    reasoning_content = model_extra["reasoning_content"]
+                if reasoning is None and "reasoning" in model_extra:
+                    reasoning = model_extra["reasoning"]
 
         provider_data: Dict[str, Any] = {}
         if reasoning_content is not None:
@@ -697,6 +700,12 @@ class ChatCompletionsTransport(ProviderTransport):
                 content = refusal
                 if finish_reason in (None, "stop"):
                     finish_reason = "content_filter"
+
+        # Ollama reasoning models return content="" with the actual output in
+        # the ``reasoning`` field.  Promote reasoning to content so the agent
+        # loop does not treat it as an empty response and retry 3 times.
+        if not (isinstance(content, str) and content.strip()) and isinstance(reasoning, str) and reasoning.strip():
+            content = reasoning
 
         return NormalizedResponse(
             content=content,

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -967,6 +967,60 @@ class TestChatCompletionsNormalize:
         assert nr.content in (None, "")
         assert nr.provider_data == {"refusal": "cannot continue"}
 
+    def test_ollama_reasoning_promoted_to_content(self, transport):
+        """Ollama reasoning models return content="" with actual output in the
+        ``reasoning`` field.  The transport must promote reasoning to content
+        so the agent loop does not treat it as an empty response."""
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content="", tool_calls=None,
+                    reasoning="Here is the answer to your question.",
+                    reasoning_content=None,
+                ),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+        nr = transport.normalize_response(r)
+        assert nr.content == "Here is the answer to your question."
+        assert nr.reasoning == "Here is the answer to your question."
+
+    def test_ollama_reasoning_from_model_extra(self, transport):
+        """Ollama's reasoning field may arrive via model_extra if the OpenAI SDK
+        does not map it to a direct attribute."""
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content=None, tool_calls=None,
+                    reasoning=None, reasoning_content=None,
+                    model_extra={"reasoning": "deep thought output"},
+                ),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+        nr = transport.normalize_response(r)
+        assert nr.content == "deep thought output"
+        assert nr.reasoning == "deep thought output"
+
+    def test_non_empty_content_not_overridden_by_reasoning(self, transport):
+        """When content already has text, reasoning must NOT override it."""
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content="actual answer", tool_calls=None,
+                    reasoning="internal reasoning trace",
+                    reasoning_content=None,
+                ),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+        nr = transport.normalize_response(r)
+        assert nr.content == "actual answer"
+        assert nr.reasoning == "internal reasoning trace"
+
 
 class TestChatCompletionsCacheStats:
 


### PR DESCRIPTION
## What does this PR do?

Promotes Ollama's `reasoning` field to `content` when the model returns an empty `content` string. This fixes Ollama reasoning models (deepseek-r1, qwen3.5, etc.) returning blank responses — the agent loop previously retried 3 times and gave up because it only read `content`, while Ollama puts the actual output in a separate `reasoning` field.

## Related Issue

Fixes #46131

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/transports/chat_completions.py`: Added `model_extra` fallback for the `reasoning` field (symmetric with existing `reasoning_content` fallback for DeepSeek/Moonshot). Added reasoning-to-content promotion when content is empty/blank but reasoning has text.
- `tests/agent/transports/test_chat_completions.py`: Added 3 tests — Ollama reasoning promotion, model_extra fallback, and non-override guard.

## How to Test

1. Run `pytest tests/agent/transports/test_chat_completions.py -xvs -k "ollama_reasoning or non_empty_content_not_overridden"` — all 3 new tests should pass
2. Run full transport test suite: `pytest tests/agent/transports/test_chat_completions.py -x` — all 84 tests should pass (zero regression)
3. With a local Ollama instance running a reasoning model (e.g. `deepseek-r1`), send a chat message via Hermes — the response should now display correctly instead of appearing blank

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (transport-layer change, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/transports/chat_completions.py::normalize_response` (callers: 2, flows: 3)
- Analyzed: `agent/transports/types.py::NormalizedResponse.reasoning` (callers: 2)
- Blast radius: LOW — fallback only activates when content is empty AND reasoning has text; existing providers with non-empty content are unaffected
- Related patterns: mirrors existing `refusal` → `content` promotion (lines 684-699), `reasoning_content` → `provider_data` preservation (lines 654-662)
