### PR TITLE
fix: add tui copy-on-select toggle

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1823,6 +1823,7 @@ DEFAULT_CONFIG = {
         #   "verbose" — include a compact content preview of what changed
         # Per-platform overrides via display.platforms.<platform>.memory_notifications.
         "memory_notifications": "on",
+        "copy_on_select": True,  # macOS TUI: auto-copy text selection to clipboard
         "streaming": False,
         "timestamps": False,      # Show timestamp on user and assistant labels
         "timestamp_format": "%H:%M",  # strftime format for timestamps (e.g. "%b-%d %H:%M")

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -67,6 +67,20 @@ describe('applyDisplay', () => {
     expect(s.statusBar).toBe('top')
     expect(s.streaming).toBe(true)
     expect(s.sections).toEqual({})
+    expect(s.copyOnSelect).toBe(true)
+  })
+
+  it('keeps macOS copy-on-select enabled unless explicitly disabled', () => {
+    const setBell = vi.fn()
+
+    applyDisplay({ config: { display: { copy_on_select: false } } }, setBell)
+    expect($uiState.get().copyOnSelect).toBe(false)
+
+    applyDisplay({ config: { display: { copy_on_select: true } } }, setBell)
+    expect($uiState.get().copyOnSelect).toBe(true)
+
+    applyDisplay({ config: { display: {} } }, setBell)
+    expect($uiState.get().copyOnSelect).toBe(true)
   })
 
   it('uses documented mouse_tracking with legacy tui_mouse fallback', () => {

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -162,6 +162,7 @@ export interface UiState {
   busy: boolean
   busyInputMode: BusyInputMode
   compact: boolean
+  copyOnSelect: boolean
   detailsMode: DetailsMode
   detailsModeCommandOverride: boolean
   info: null | SessionInfo

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -11,6 +11,7 @@ const buildUiState = (): UiState => ({
   busy: false,
   busyInputMode: 'queue',
   compact: false,
+  copyOnSelect: true,
   detailsMode: 'collapsed',
   detailsModeCommandOverride: false,
   indicatorStyle: DEFAULT_INDICATOR_STYLE,

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -138,16 +138,12 @@ const _pasteCollapseLinesFromConfig = (cfg: ConfigFullResponse | null): number =
   if (!cfg?.config) {
     return 5
   }
-
   const raw = cfg.config.paste_collapse_threshold
-
   if (typeof raw === 'number' && Number.isFinite(raw) && raw >= 0) {
     return Math.round(raw)
   }
-
   if (typeof raw === 'string') {
     const n = parseInt(raw, 10)
-
     if (Number.isFinite(n) && n >= 0) {
       return n
     }
@@ -160,16 +156,12 @@ const _pasteCollapseCharsFromConfig = (cfg: ConfigFullResponse | null): number =
   if (!cfg?.config) {
     return 2000
   }
-
   const raw = cfg.config.paste_collapse_char_threshold
-
   if (typeof raw === 'number' && Number.isFinite(raw) && raw >= 0) {
     return Math.round(raw)
   }
-
   if (typeof raw === 'string') {
     const n = parseInt(raw, 10)
-
     if (Number.isFinite(n) && n >= 0) {
       return n
     }
@@ -219,6 +211,7 @@ export const applyDisplay = (
   patchUiState({
     busyInputMode: normalizeBusyInputMode(d.busy_input_mode),
     compact: !!d.tui_compact,
+    copyOnSelect: d.copy_on_select !== false,
     detailsMode: resolveDetailsMode(d),
     detailsModeCommandOverride: false,
     indicatorStyle: normalizeIndicatorStyle(d.tui_status_indicator),

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -248,6 +248,10 @@ export function useMainApp(gw: GatewayClient) {
     }
 
     return selection.subscribe(() => {
+      if (!getUiState().copyOnSelect) {
+        return
+      }
+
       if (!selection.hasSelection()) {
         return
       }

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -154,6 +154,7 @@ export type CommandDispatchResponse =
 export interface ConfigDisplayConfig {
   bell_on_complete?: boolean
   busy_input_mode?: string
+  copy_on_select?: boolean
   details_mode?: string
   inline_diffs?: boolean
   mouse_tracking?: boolean | null | number | string


### PR DESCRIPTION
Summary:
- Add display.copy_on_select to config and TUI config types.
- Keep macOS TUI copy-on-select enabled by default, but skip automatic copy when the setting is false.
- Add config-sync coverage for default-on and explicit-off behavior.

Tests:
- npm run --prefix ui-tui test -- --run src/__tests__/useConfigSync.test.ts
- npm exec -- eslint src/__tests__/useConfigSync.test.ts src/app/useConfigSync.ts src/app/useMainApp.ts src/app/interfaces.ts src/app/uiStore.ts src/gatewayTypes.ts --quiet (from ui-tui/)
- npm run --prefix ui-tui typecheck
- git diff --check

Fixes #46467