### PR TITLE
fix(tui): keep manual viewport anchored during resizes

### DIFF
--- a/ui-tui/src/__tests__/virtualHistoryOffsetCache.test.ts
+++ b/ui-tui/src/__tests__/virtualHistoryOffsetCache.test.ts
@@ -245,6 +245,44 @@ describe('useVirtualHistory offset cache reuse', () => {
     }
   })
 
+  it('keeps a manual viewport anchored when rows above it resize', async () => {
+    const before = [
+      { height: 4, key: 'a' },
+      { height: 4, key: 'b' },
+      { height: 4, key: 'c' }
+    ]
+
+    const after = [
+      { height: 7, key: 'a' },
+      { height: 4, key: 'b' },
+      { height: 4, key: 'c' }
+    ]
+
+    const expose = { current: null as Exposed | null }
+    const streams = makeStreams()
+
+    const instance = renderSync(React.createElement(Harness, { expose, height: 4, items: before }), {
+      patchConsole: false,
+      stderr: streams.stderr as NodeJS.WriteStream,
+      stdin: streams.stdin as NodeJS.ReadStream,
+      stdout: streams.stdout as NodeJS.WriteStream
+    })
+
+    try {
+      await delay(20)
+      expose.current!.scroll!.scrollTo(4)
+      await delay(40)
+
+      instance.rerender(React.createElement(Harness, { expose, height: 4, items: after }))
+      await delay(80)
+
+      expect(expose.current!.scroll!.getScrollTop()).toBe(7)
+    } finally {
+      instance.unmount()
+      instance.cleanup()
+    }
+  })
+
   it('ignores stale reused offset-array entries after the item count shrinks', async () => {
     const beforeShrink = Array.from({ length: 1400 }, (_, index) => ({ height: 1, key: `old${index}` }))
     const afterShrink = Array.from({ length: 800 }, (_, index) => ({ height: 7, key: `new${index}` }))

--- a/ui-tui/src/hooks/useVirtualHistory.ts
+++ b/ui-tui/src/hooks/useVirtualHistory.ts
@@ -456,6 +456,16 @@ export function useVirtualHistory(
     let dirty = false
     let heightDirty = false
 
+    const viewport = s
+      ? {
+          sticky: s.isSticky(),
+          top: Math.max(0, s.getScrollTop() + s.getPendingDelta()),
+          vp: Math.max(0, s.getViewportHeight())
+        }
+      : null
+
+    let anchorDelta = 0
+
     // Give the renderer the mounted-row coverage for passive scroll clamping.
     // Clamp MUST use the EFFECTIVE (deferred) range, not the immediate one.
     // During fast scroll, immediate [start,end] may already cover the new
@@ -492,13 +502,27 @@ export function useVirtualHistory(
         }
 
         const h = Math.ceil((nodes.current.get(k) as MeasuredNode | undefined)?.yogaNode?.getComputedHeight?.() ?? 0)
+        const prev = heights.current.get(k)
 
-        if (h > 0 && heights.current.get(k) !== h) {
+        if (h > 0 && prev !== h) {
+          const rowBottom = offsets[i + 1] ?? total
+
+          if (viewport && !viewport.sticky && prev !== undefined && rowBottom <= viewport.top) {
+            anchorDelta += h - prev
+          }
+
           heights.current.set(k, h)
           dirty = true
           heightDirty = true
         }
       }
+    }
+
+    if (s && anchorDelta !== 0 && viewport && !viewport.sticky) {
+      // Preserve the same visible content when rows above the viewport grow
+      // or shrink during live updates. Without this, keeping raw scrollTop
+      // unchanged makes the viewport drift into earlier/later messages.
+      s.scrollTo(Math.max(0, viewport.top + anchorDelta))
     }
 
     if (s) {


### PR DESCRIPTION
Fixes #46469

## Summary
- preserve the user's manual viewport when measured transcript rows above it grow or shrink
- compensate scrollTop only for non-sticky views and only by the height delta of rows fully above the viewport
- cover the regression with a virtual-history test that proves the old behavior drifted from scrollTop 4 to the expected anchored 7

## Testing
- npm exec vitest run src/__tests__/virtualHistoryOffsetCache.test.ts
- npm exec eslint src/hooks/useVirtualHistory.ts src/__tests__/virtualHistoryOffsetCache.test.ts
- git diff --check HEAD^ HEAD