### PR TITLE
feat(telegram): set media_write_timeout when python-telegram-bot supports it

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1924,6 +1924,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 "read_timeout": _env_float("HERMES_TELEGRAM_HTTP_READ_TIMEOUT", 20.0),
                 "write_timeout": _env_float("HERMES_TELEGRAM_HTTP_WRITE_TIMEOUT", 20.0),
             }
+            try:
+                import inspect as _ptb_inspect
+                if "media_write_timeout" in _ptb_inspect.signature(HTTPXRequest.__init__).parameters:
+                    request_kwargs["media_write_timeout"] = _env_float("HERMES_TELEGRAM_HTTP_MEDIA_WRITE_TIMEOUT", 180.0)
+            except Exception:
+                pass
 
             disable_fallback = (os.getenv("HERMES_TELEGRAM_DISABLE_FALLBACK_IPS", "").strip().lower() in {"1", "true", "yes", "on"})
             fallback_ips = self._fallback_ips()


### PR DESCRIPTION
## What

Passes `media_write_timeout` to the Telegram `HTTPXRequest` when the installed `python-telegram-bot` supports it, configurable via `HERMES_TELEGRAM_HTTP_MEDIA_WRITE_TIMEOUT` (default 180 seconds).

## Why

Large media uploads (voice notes, images, documents) can take longer than the default write timeout on slower links, which makes the send fail. `python-telegram-bot` added a separate `media_write_timeout` on `HTTPXRequest`, but only in newer versions.

## How

The kwarg is added only when `inspect.signature(HTTPXRequest.__init__)` shows it is accepted, so older versions are unaffected. Any error in detection is swallowed and the kwarg is skipped. Fully backward compatible.

## Testing

Running in production. With a newer python-telegram-bot the media write timeout is applied and large uploads on a slow link stop failing; with an older version the kwarg is skipped and behavior is unchanged.
