### PR TITLE
feat(matrix): use emoji reactions for clarify prompts

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3142,6 +3142,36 @@ class BasePlatformAdapter(ABC):
             metadata=metadata,
         )
 
+    async def cleanup_clarify(
+        self,
+        chat_id: str,
+        clarify_id: str,
+        message_id: Optional[str] = None,
+        session_key: Optional[str] = None,
+    ) -> None:
+        """Retire platform-side clarify prompt UI after the clarify settles.
+
+        The gateway calls this once per clarify, after
+        ``tools.clarify_gateway.wait_for_response`` returns — regardless of
+        outcome (resolved via button/reaction callback, resolved via the
+        gateway's typed-text intercept, waiter timeout, or session
+        cancellation).  Adapters that render stateful prompt UI in
+        ``send_clarify`` (tracked prompt entries, seeded reactions, inline
+        keyboards) should override this to drop that state so a clarify
+        resolved outside the adapter's own callback path does not leave
+        stale controls behind.
+
+        Overrides MUST be idempotent: when the adapter's own callback path
+        already cleaned up (e.g. a Matrix reaction resolved the clarify),
+        this call arrives afterwards and must be a no-op.
+
+        ``message_id`` is the ``SendResult.message_id`` returned by
+        ``send_clarify`` (None when unavailable).  The default
+        implementation does nothing — the base text fallback keeps no
+        prompt state.
+        """
+        return None
+
     async def send_private_notice(
         self,
         chat_id: str,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18418,6 +18418,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     pass
 
                 send_ok = False
+                prompt_message_id = None
                 fut = safe_schedule_threadsafe(
                     _status_adapter.send_clarify(
                         chat_id=_status_chat_id,
@@ -18437,6 +18438,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     try:
                         result = fut.result(timeout=15)
                         send_ok = bool(getattr(result, "success", False))
+                        _prompt_mid = getattr(result, "message_id", None)
+                        prompt_message_id = str(_prompt_mid) if _prompt_mid else None
                     except Exception as exc:
                         logger.warning("Clarify send failed: %s", exc)
                         send_ok = False
@@ -18450,6 +18453,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                 timeout = _clarify_mod.get_clarify_timeout()
                 response = _clarify_mod.wait_for_response(clarify_id, timeout=float(timeout))
+                # The clarify has settled — resolved via the adapter's own
+                # callback path (button/reaction), resolved via the gateway's
+                # typed-text intercept, timed out, or cancelled.  Let the
+                # adapter retire any platform-side prompt UI it still tracks
+                # (e.g. Matrix pops its reaction prompt and redacts the bot's
+                # seeded reactions, #46495).  Fire-and-forget: cleanup must
+                # never block the agent thread, and adapter overrides are
+                # idempotent when their own callback already cleaned up.
+                safe_schedule_threadsafe(
+                    _status_adapter.cleanup_clarify(
+                        chat_id=_status_chat_id,
+                        clarify_id=clarify_id,
+                        message_id=prompt_message_id,
+                        session_key=session_key or "",
+                    ),
+                    _loop_for_step,
+                    logger=logger,
+                    log_message="Clarify cleanup failed to schedule",
+                )
                 if response is None or response == "":
                     # Timeout or session-boundary cancellation
                     return f"[user did not respond within {int(timeout / 60)}m]"

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -337,6 +337,23 @@ class _MatrixModelPickerPrompt:
     bot_reaction_events: dict[str, str] = field(default_factory=dict)
 
 
+@dataclass
+class _MatrixClarifyPrompt:
+    """Tracks a pending Matrix reaction-based clarify prompt (#46490)."""
+
+    chat_id: str
+    message_id: str
+    session_key: str
+    clarify_id: str
+    choices: list[str]
+    emoji_to_index: dict[str, int]  # number emoji -> choice index
+    other_emoji: str
+    requester_user_id: str | None = None
+    expires_at: float | None = None
+    resolved: bool = False
+    bot_reaction_events: dict[str, str] = field(default_factory=dict)
+
+
 # Matrix message size limit (4000 chars practical, spec has no hard limit
 # but clients render poorly above this).
 MAX_MESSAGE_LENGTH = 4000
@@ -954,6 +971,11 @@ class MatrixAdapter(BasePlatformAdapter):
         except ValueError:
             self._approval_timeout_seconds = 300
         self._model_picker_prompts_by_event: Dict[str, _MatrixModelPickerPrompt] = {}
+        # Matrix reaction-based clarify prompts (#46490): number emojis pick a
+        # choice, ✏️ arms free-text capture (resolved by the gateway
+        # text-intercept, exactly like a text-fallback "Other" reply).
+        self._clarify_other_emoji = "✏️"
+        self._clarify_prompts_by_event: Dict[str, _MatrixClarifyPrompt] = {}
         allowed_users_raw = os.getenv("MATRIX_ALLOWED_USERS", "")
         self._allowed_user_ids: Set[str] = {
             u.strip() for u in allowed_users_raw.split(",") if u.strip()
@@ -2124,6 +2146,84 @@ class MatrixAdapter(BasePlatformAdapter):
                     prompt.bot_reaction_events[emoji] = str(reaction_event_id)
             except Exception as exc:
                 logger.debug("Matrix: failed to add model picker reaction %s: %s", emoji, exc)
+
+        return result
+
+    async def send_clarify(
+        self,
+        chat_id: str,
+        question: str,
+        choices: Optional[list],
+        clarify_id: str,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Render a clarify prompt as reaction controls (#46490).
+
+        Multi-choice (``choices`` non-empty): post the question + a numbered
+        choice list, then self-react with 1️⃣..4️⃣ (one per choice) plus ✏️
+        for a free-text answer — mirroring the exec-approval / model-picker
+        reaction idiom.  A number reaction resolves the clarify primitive
+        directly; ✏️ flips the entry into text-capture mode so the gateway's
+        platform-agnostic text-intercept
+        (:meth:`GatewayRunner._maybe_intercept_clarify_text`) picks up the next
+        typed message — no Matrix-specific text machinery.  A typed reply
+        ("2" or the choice text) also resolves via that same intercept.
+
+        Open-ended (``choices`` empty): delegate to the base implementation,
+        which renders the plain question and arms the same text-intercept.
+        """
+        if not choices:
+            return await super().send_clarify(
+                chat_id=chat_id,
+                question=question,
+                choices=choices,
+                clarify_id=clarify_id,
+                session_key=session_key,
+                metadata=metadata,
+            )
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        # One number emoji per choice (clarify caps choices at 4; the model
+        # picker reaction tuple supplies 1️⃣..🔟 so a larger list degrades
+        # gracefully instead of raising).
+        number_emojis = _MATRIX_MODEL_PICKER_REACTIONS[: len(choices)]
+        emoji_to_index: dict[str, int] = {}
+        lines = [f"❓ **{question}**", ""]
+        for idx, choice in enumerate(choices):
+            emoji = number_emojis[idx]
+            emoji_to_index[emoji] = idx
+            lines.append(f"{emoji} {choice}")
+        other_emoji = self._clarify_other_emoji
+        lines.append(f"{other_emoji} Other (type your own answer)")
+        lines.append("")
+        lines.append("React to choose, or reply with the number or your own answer.")
+
+        result = await self.send(chat_id, "\n".join(lines), metadata=metadata)
+        if not result.success or not result.message_id:
+            return result
+
+        prompt = _MatrixClarifyPrompt(
+            chat_id=chat_id,
+            message_id=result.message_id,
+            session_key=session_key,
+            clarify_id=clarify_id,
+            choices=list(choices),
+            emoji_to_index=emoji_to_index,
+            other_emoji=other_emoji,
+            requester_user_id=str((metadata or {}).get("requester_user_id") or "") or None,
+            expires_at=time.monotonic() + max(self._approval_timeout_seconds, 0),
+        )
+        self._clarify_prompts_by_event[result.message_id] = prompt
+
+        for emoji in list(emoji_to_index) + [other_emoji]:
+            try:
+                reaction_event_id = await self._send_reaction(chat_id, result.message_id, emoji)
+                if reaction_event_id:
+                    prompt.bot_reaction_events[emoji] = str(reaction_event_id)
+            except Exception as exc:
+                logger.debug("Matrix: failed to add clarify reaction %s: %s", emoji, exc)
 
         return result
 
@@ -3318,6 +3418,109 @@ class MatrixAdapter(BasePlatformAdapter):
                         reply_to=reacts_to,
                     )
                 return
+
+            # Check if this reaction resolves a pending clarify prompt (#46490).
+            clarify_prompt = self._clarify_prompts_by_event.get(reacts_to)
+            if clarify_prompt and not clarify_prompt.resolved:
+                if room_id != clarify_prompt.chat_id:
+                    return
+                if self._matrix_prompt_expired(clarify_prompt):
+                    await self._expire_matrix_clarify_prompt(room_id, reacts_to, clarify_prompt)
+                    return
+                if not await self._validate_matrix_prompt_reactor(
+                    room_id, reacts_to, sender, clarify_prompt, "clarify"
+                ):
+                    return
+                await self._resolve_matrix_clarify_reaction(
+                    room_id, reacts_to, sender, key, clarify_prompt
+                )
+                return
+
+    async def _resolve_matrix_clarify_reaction(
+        self,
+        room_id: str,
+        target_event_id: str,
+        sender: str,
+        key: str,
+        prompt: "_MatrixClarifyPrompt",
+    ) -> None:
+        """Resolve a clarify reaction: a number picks a choice, ✏️ arms text."""
+        from tools import clarify_gateway as _clarify_mod
+
+        # ✏️ → enter text-capture mode.  The gateway's platform-agnostic
+        # text-intercept resolves the clarify from the user's next typed
+        # message, so there is no Matrix-side text bookkeeping.
+        if key == prompt.other_emoji:
+            if not _clarify_mod.mark_awaiting_text(prompt.clarify_id):
+                # Entry evicted (clarify_timeout) or gateway restarted between
+                # ask and tap — a typed answer would go nowhere.
+                await self._finalize_expired_clarify(room_id, target_event_id, prompt)
+                return
+            await self._send_invalid_reaction_feedback(
+                room_id,
+                target_event_id,
+                "✏️ Type your answer and I'll use it as your response.",
+            )
+            return
+
+        idx = prompt.emoji_to_index.get(key)
+        if idx is None or not (0 <= idx < len(prompt.choices)):
+            await self._send_invalid_reaction_feedback(
+                room_id,
+                target_event_id,
+                "That reaction is not one of the available choices.",
+            )
+            return
+
+        choice_text = str(prompt.choices[idx])
+        try:
+            if _clarify_mod.resolve_gateway_clarify(prompt.clarify_id, choice_text):
+                prompt.resolved = True
+                self._clarify_prompts_by_event.pop(target_event_id, None)
+                logger.info(
+                    "Matrix reaction resolved clarify for session %s (choice=%r, user=%s)",
+                    prompt.session_key, choice_text, sender,
+                )
+                # Redact the bot's seed reactions, leaving only the user's.
+                await self._redact_bot_clarify_reactions(room_id, prompt)
+            else:
+                # Entry evicted / gateway restarted — surface expiry.
+                await self._finalize_expired_clarify(room_id, target_event_id, prompt)
+        except Exception as exc:
+            logger.error("Failed to resolve gateway clarify from Matrix reaction: %s", exc)
+
+    async def _expire_matrix_clarify_prompt(
+        self,
+        room_id: str,
+        target_event_id: str,
+        prompt: "_MatrixClarifyPrompt",
+    ) -> None:
+        await self._finalize_expired_clarify(room_id, target_event_id, prompt)
+
+    async def _finalize_expired_clarify(
+        self,
+        room_id: str,
+        target_event_id: str,
+        prompt: "_MatrixClarifyPrompt",
+    ) -> None:
+        prompt.resolved = True
+        self._clarify_prompts_by_event.pop(target_event_id, None)
+        await self._redact_bot_clarify_reactions(room_id, prompt)
+        await self._send_invalid_reaction_feedback(
+            room_id,
+            target_event_id,
+            "This clarify prompt has expired. Send a new request if you still want to answer.",
+        )
+
+    async def _redact_bot_clarify_reactions(
+        self,
+        room_id: str,
+        prompt: "_MatrixClarifyPrompt",
+    ) -> None:
+        """Redact the bot's seeded clarify reactions, leaving only the user's."""
+        for emoji, evt_id in prompt.bot_reaction_events.items():
+            self._schedule_reaction_redaction(room_id, evt_id, "clarify resolved")
+            logger.debug("Matrix: scheduled bot clarify reaction redaction %s (%s)", emoji, evt_id)
 
     def _matrix_prompt_expired(self, prompt: Any) -> bool:
         expires_at = getattr(prompt, "expires_at", None)

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2235,6 +2235,52 @@ class MatrixAdapter(BasePlatformAdapter):
 
         return result
 
+    async def cleanup_clarify(
+        self,
+        chat_id: str,
+        clarify_id: str,
+        message_id: Optional[str] = None,
+        session_key: Optional[str] = None,
+    ) -> None:
+        """Retire a settled clarify prompt and redact its seed reactions.
+
+        The reaction path already pops the tracked prompt in
+        ``_resolve_matrix_clarify_reaction``, but every other settlement
+        path bypasses the adapter entirely: typed replies (a number, the
+        choice text, or a free-form answer after ✏️) resolve through the
+        gateway's text-intercept (``tools.clarify_gateway.
+        resolve_text_response_for_session``), and a waiter timeout or
+        session cancellation evicts only the gateway-side entry.  Without
+        this hook those paths left the ``_clarify_prompts_by_event`` entry
+        and the bot's seeded reactions live on a dead prompt.
+
+        The gateway calls this after ``wait_for_response`` returns,
+        regardless of outcome.  Retirement is silent — no feedback message
+        is posted, because the agent (or the gateway's timeout sentinel)
+        produces the next user-facing message.  Idempotent: a prompt the
+        reaction path already cleaned up is a no-op.
+        """
+        target_event_id: Optional[str] = None
+        prompt: Optional[_MatrixClarifyPrompt] = None
+        if message_id and message_id in self._clarify_prompts_by_event:
+            target_event_id = message_id
+            prompt = self._clarify_prompts_by_event[message_id]
+        else:
+            # Fallback scan for callers that only know the clarify_id.
+            for evt_id, candidate in list(self._clarify_prompts_by_event.items()):
+                if candidate.clarify_id == clarify_id:
+                    target_event_id, prompt = evt_id, candidate
+                    break
+        if prompt is None or target_event_id is None:
+            return  # Already retired by the reaction path — nothing to do.
+        prompt.resolved = True
+        self._clarify_prompts_by_event.pop(target_event_id, None)
+        logger.debug(
+            "Matrix: retired settled clarify prompt %s (clarify_id=%s, session=%s)",
+            target_event_id, clarify_id, prompt.session_key,
+        )
+        await self._redact_bot_clarify_reactions(prompt.chat_id, prompt)
+
     def format_message(self, content: str) -> str:
         """Pass-through — Matrix supports standard Markdown natively."""
         # Strip image markdown; media is uploaded separately.

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2204,6 +2204,14 @@ class MatrixAdapter(BasePlatformAdapter):
         if not result.success or not result.message_id:
             return result
 
+        # Match the gateway waiter deadline.  Approval/model-picker prompts use
+        # MATRIX_APPROVAL_TIMEOUT_SECONDS (default 300s), but clarify waits on
+        # agent.clarify_timeout via tools.clarify_gateway (default 3600s).
+        # Keeping the reaction controls alive for the same interval prevents a
+        # tap after five minutes from expiring while the agent is still blocked.
+        from tools import clarify_gateway as _clarify_mod
+
+        clarify_timeout = _clarify_mod.get_clarify_timeout()
         prompt = _MatrixClarifyPrompt(
             chat_id=chat_id,
             message_id=result.message_id,
@@ -2213,7 +2221,7 @@ class MatrixAdapter(BasePlatformAdapter):
             emoji_to_index=emoji_to_index,
             other_emoji=other_emoji,
             requester_user_id=str((metadata or {}).get("requester_user_id") or "") or None,
-            expires_at=time.monotonic() + max(self._approval_timeout_seconds, 0),
+            expires_at=time.monotonic() + max(float(clarify_timeout), 0.0),
         )
         self._clarify_prompts_by_event[result.message_id] = prompt
 

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -354,9 +354,54 @@ class _MatrixClarifyPrompt:
     bot_reaction_events: dict[str, str] = field(default_factory=dict)
 
 
-# Matrix message size limit (4000 chars practical, spec has no hard limit
-# but clients render poorly above this).
-MAX_MESSAGE_LENGTH = 4000
+@dataclass
+class _MatrixChoicePickerPrompt:
+    """Tracks a pending Matrix reaction-based choice picker (/reasoning, /fast)."""
+
+    chat_id: str
+    message_id: str
+    session_key: str
+    choices: dict[str, str]  # emoji -> value
+    on_choice_selected: Any
+    requester_user_id: str | None = None
+    expires_at: float | None = None
+    resolved: bool = False
+    bot_reaction_events: dict[str, str] = field(default_factory=dict)
+
+
+# Matrix message size limit. The spec allows large events (~65 KB), but very
+# large bodies can render poorly in some clients. The previous 4,000-char
+# default was overly conservative and split Markdown tables mid-row (#53026).
+DEFAULT_MAX_MESSAGE_LENGTH = 16000
+MATRIX_MAX_MESSAGE_LENGTH_CEILING = 65535
+
+
+def _resolve_max_message_length(config) -> int:
+    """Resolve outbound chunk size from config, env, or plugin registry."""
+    extra = getattr(config, "extra", {}) or {}
+    raw = extra.get("max_message_length")
+    if raw is None:
+        raw = os.getenv("MATRIX_MAX_MESSAGE_LENGTH")
+    if raw is None:
+        try:
+            from gateway.platform_registry import platform_registry
+
+            entry = platform_registry.get("matrix")
+            if entry and entry.max_message_length:
+                raw = entry.max_message_length
+        except Exception:
+            pass
+    if raw is None:
+        return DEFAULT_MAX_MESSAGE_LENGTH
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_MAX_MESSAGE_LENGTH
+    return max(500, min(value, MATRIX_MAX_MESSAGE_LENGTH_CEILING))
+
+
+# Back-compat alias for callers/tests that import the module constant.
+MAX_MESSAGE_LENGTH = DEFAULT_MAX_MESSAGE_LENGTH
 
 # Store directory for E2EE keys and sync state.
 # Uses get_hermes_home() so each profile gets its own Matrix store.
@@ -401,6 +446,14 @@ _MATRIX_MODEL_PICKER_REACTIONS = (
     "8\ufe0f\u20e3",
     "9\ufe0f\u20e3",
     "\U0001f51f",
+)
+
+# Choice pickers (/reasoning, /fast) can need more than 10 slots
+# (8 effort levels + none + reset/show/hide = 12), so extend the keycap
+# set with lettered squares.
+_MATRIX_CHOICE_PICKER_REACTIONS = _MATRIX_MODEL_PICKER_REACTIONS + (
+    "\U0001f170\ufe0f",  # 🅰️
+    "\U0001f171\ufe0f",  # 🅱️
 )
 
 _MATRIX_CAPABILITIES: Dict[str, str] = {
@@ -976,6 +1029,7 @@ class MatrixAdapter(BasePlatformAdapter):
         # text-intercept, exactly like a text-fallback "Other" reply).
         self._clarify_other_emoji = "✏️"
         self._clarify_prompts_by_event: Dict[str, _MatrixClarifyPrompt] = {}
+        self._choice_picker_prompts_by_event: Dict[str, _MatrixChoicePickerPrompt] = {}
         allowed_users_raw = os.getenv("MATRIX_ALLOWED_USERS", "")
         self._allowed_user_ids: Set[str] = {
             u.strip() for u in allowed_users_raw.split(",") if u.strip()
@@ -2281,6 +2335,66 @@ class MatrixAdapter(BasePlatformAdapter):
         )
         await self._redact_bot_clarify_reactions(prompt.chat_id, prompt)
 
+    async def send_choice_picker(
+        self,
+        chat_id: str,
+        title: str,
+        choices: list,
+        session_key: str,
+        on_choice_selected,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a Matrix reaction-based choice picker (/reasoning, /fast).
+
+        Generic single-level companion to ``send_model_picker``. Each choice
+        dict: ``{"value": str, "label": str, "is_current": bool}``.
+        """
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        emoji_choices: dict[str, str] = {}
+        lines = [title, ""]
+        for i, choice in enumerate(choices):
+            if i >= len(_MATRIX_CHOICE_PICKER_REACTIONS):
+                break
+            emoji = _MATRIX_CHOICE_PICKER_REACTIONS[i]
+            value = str(choice.get("value") or "")
+            label = str(choice.get("label") or value)
+            if choice.get("is_current"):
+                label = f"{label} ← current"
+            emoji_choices[emoji] = value
+            lines.append(f"{emoji} {label}")
+
+        if not emoji_choices:
+            return SendResult(success=False, error="No choices")
+
+        lines.append("")
+        lines.append("React to choose.")
+        result = await self.send(chat_id, "\n".join(lines), metadata=metadata)
+        if not result.success or not result.message_id:
+            return result
+
+        prompt = _MatrixChoicePickerPrompt(
+            chat_id=chat_id,
+            message_id=result.message_id,
+            session_key=session_key,
+            choices=emoji_choices,
+            on_choice_selected=on_choice_selected,
+            requester_user_id=str((metadata or {}).get("requester_user_id") or "") or None,
+            expires_at=time.monotonic() + max(self._approval_timeout_seconds, 0),
+        )
+        self._choice_picker_prompts_by_event[result.message_id] = prompt
+
+        for emoji in emoji_choices:
+            try:
+                reaction_event_id = await self._send_reaction(chat_id, result.message_id, emoji)
+                if reaction_event_id:
+                    prompt.bot_reaction_events[emoji] = str(reaction_event_id)
+            except Exception as exc:
+                logger.debug("Matrix: failed to add choice picker reaction %s: %s", emoji, exc)
+
+        return result
+
     def format_message(self, content: str) -> str:
         """Pass-through — Matrix supports standard Markdown natively."""
         # Strip image markdown; media is uploaded separately.
@@ -3488,6 +3602,40 @@ class MatrixAdapter(BasePlatformAdapter):
                 await self._resolve_matrix_clarify_reaction(
                     room_id, reacts_to, sender, key, clarify_prompt
                 )
+                return
+
+            choice_prompt = self._choice_picker_prompts_by_event.get(reacts_to)
+            if choice_prompt and not choice_prompt.resolved:
+                if room_id != choice_prompt.chat_id:
+                    return
+                if self._matrix_prompt_expired(choice_prompt):
+                    self._choice_picker_prompts_by_event.pop(reacts_to, None)
+                    return
+                if not await self._validate_matrix_prompt_reactor(
+                    room_id, reacts_to, sender, choice_prompt, "choice picker"
+                ):
+                    return
+                value = choice_prompt.choices.get(key)
+                if value is None:
+                    await self._send_invalid_reaction_feedback(
+                        room_id,
+                        reacts_to,
+                        "That reaction is not one of the available choices.",
+                    )
+                    return
+                choice_prompt.resolved = True
+                self._choice_picker_prompts_by_event.pop(reacts_to, None)
+                try:
+                    confirmation = await choice_prompt.on_choice_selected(room_id, value)
+                    if confirmation:
+                        await self.send(room_id, confirmation, reply_to=reacts_to)
+                except Exception as exc:
+                    logger.error("Failed to apply choice from Matrix reaction: %s", exc)
+                    await self.send(
+                        room_id,
+                        f"Failed to apply selection: {exc}",
+                        reply_to=reacts_to,
+                    )
                 return
 
     async def _resolve_matrix_clarify_reaction(

--- a/tests/gateway/test_matrix_clarify_reactions.py
+++ b/tests/gateway/test_matrix_clarify_reactions.py
@@ -81,6 +81,53 @@ class TestMatrixClarifyReactions:
         assert emojis == _number_emojis(2) + ["✏️"]
 
     @pytest.mark.asyncio
+    async def test_reaction_after_approval_timeout_still_resolves(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter._approval_timeout_seconds = 300
+        adapter.send = AsyncMock(
+            return_value=types.SimpleNamespace(success=True, message_id="$clar1")
+        )
+        adapter._send_reaction = AsyncMock(return_value="$r")
+        adapter._redact_bot_clarify_reactions = AsyncMock()
+
+        from tools import clarify_gateway
+
+        clarify_gateway.register(
+            clarify_id="c1",
+            session_key="sess-1",
+            question="Which fruit?",
+            choices=["Apple", "Banana"],
+        )
+        try:
+            with (
+                patch("tools.clarify_gateway.get_clarify_timeout", return_value=3600),
+                patch("plugins.platforms.matrix.adapter.time.monotonic", return_value=1000.0),
+            ):
+                await adapter.send_clarify(
+                    chat_id="!room:example.org",
+                    question="Which fruit?",
+                    choices=["Apple", "Banana"],
+                    clarify_id="c1",
+                    session_key="sess-1",
+                )
+
+            prompt = adapter._clarify_prompts_by_event["$clar1"]
+            assert prompt.expires_at == 4600.0
+
+            # The Matrix prompt must remain live after the approval timeout
+            # (300s) while the gateway clarify waiter (3600s) is still active.
+            event = _reaction_event("@liizfq:liizfq.top", "$clar1", _number_emojis(2)[1])
+            with patch("plugins.platforms.matrix.adapter.time.monotonic", return_value=1301.0):
+                await adapter._on_reaction(event)
+
+            entry = clarify_gateway._entries["c1"]
+            assert entry.response == "Banana"
+            assert entry.event.is_set()
+            assert "$clar1" not in adapter._clarify_prompts_by_event
+        finally:
+            clarify_gateway.clear_session("sess-1")
+
+    @pytest.mark.asyncio
     async def test_reaction_resolves_choice(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
         from plugins.platforms.matrix.adapter import _MatrixClarifyPrompt

--- a/tests/gateway/test_matrix_clarify_reactions.py
+++ b/tests/gateway/test_matrix_clarify_reactions.py
@@ -7,7 +7,10 @@ override and the clarify branch of ``_on_reaction``:
   * a number reaction resolves the clarify with the right choice string,
   * ✏️ arms the gateway text-capture (``mark_awaiting_text``),
   * an unauthorized reaction is ignored,
-  * open-ended (no choices) falls back to the base plain-text path.
+  * open-ended (no choices) falls back to the base plain-text path,
+  * settlement cleanup (``cleanup_clarify``) retires the tracked prompt and
+    redacts seed reactions for typed-text resolution and waiter timeout,
+    and stays idempotent after a reaction already cleaned up.
 """
 
 import types
@@ -240,3 +243,153 @@ class TestMatrixClarifyReactions:
         sent = adapter.send.await_args
         body = sent.kwargs.get("content") or sent.args[1]
         assert "Anything else?" in body
+
+    @pytest.mark.asyncio
+    async def test_typed_reply_settlement_retires_prompt(self, monkeypatch):
+        """Regression (#46495 review): a typed reply resolves the clarify
+        through the gateway text path, which bypasses the adapter's reaction
+        handler — the settlement cleanup must retire the tracked prompt and
+        redact the bot's seeded reactions."""
+        adapter = _make_adapter(monkeypatch)
+        adapter.send = AsyncMock(
+            return_value=types.SimpleNamespace(success=True, message_id="$clar1")
+        )
+        adapter._send_reaction = AsyncMock(return_value="$r")
+        adapter._redact_bot_clarify_reactions = AsyncMock()
+
+        from tools import clarify_gateway
+
+        clarify_gateway.register(
+            clarify_id="c1",
+            session_key="sess-1",
+            question="Which fruit?",
+            choices=["Apple", "Banana"],
+        )
+        try:
+            await adapter.send_clarify(
+                chat_id="!room:example.org",
+                question="Which fruit?",
+                choices=["Apple", "Banana"],
+                clarify_id="c1",
+                session_key="sess-1",
+            )
+            assert "$clar1" in adapter._clarify_prompts_by_event
+
+            # The user types "2" — the gateway text-intercept
+            # (gateway/run.py _handle_message) resolves via
+            # resolve_text_response_for_session, never touching the adapter.
+            assert clarify_gateway.resolve_text_response_for_session("sess-1", "2")
+            entry = clarify_gateway._entries["c1"]
+            assert entry.response == "Banana"
+            assert entry.event.is_set()
+
+            # The typed path leaves the Matrix prompt live — that's the bug
+            # this hook fixes.
+            assert "$clar1" in adapter._clarify_prompts_by_event
+
+            # The gateway's clarify callback fires cleanup_clarify after
+            # wait_for_response returns.
+            await adapter.cleanup_clarify(
+                chat_id="!room:example.org",
+                clarify_id="c1",
+                message_id="$clar1",
+                session_key="sess-1",
+            )
+
+            assert "$clar1" not in adapter._clarify_prompts_by_event
+            adapter._redact_bot_clarify_reactions.assert_awaited_once()
+        finally:
+            clarify_gateway.clear_session("sess-1")
+
+    @pytest.mark.asyncio
+    async def test_timeout_settlement_retires_prompt(self, monkeypatch):
+        """Waiter timeout evicts only the gateway entry; the settlement
+        cleanup must still retire the Matrix prompt.  Also exercises the
+        clarify_id fallback scan (message_id=None)."""
+        adapter = _make_adapter(monkeypatch)
+        adapter.send = AsyncMock(
+            return_value=types.SimpleNamespace(success=True, message_id="$clar1")
+        )
+        adapter._send_reaction = AsyncMock(return_value="$r")
+        adapter._redact_bot_clarify_reactions = AsyncMock()
+
+        from tools import clarify_gateway
+
+        clarify_gateway.register(
+            clarify_id="c1",
+            session_key="sess-1",
+            question="Which fruit?",
+            choices=["Apple", "Banana"],
+        )
+        try:
+            await adapter.send_clarify(
+                chat_id="!room:example.org",
+                question="Which fruit?",
+                choices=["Apple", "Banana"],
+                clarify_id="c1",
+                session_key="sess-1",
+            )
+            assert "$clar1" in adapter._clarify_prompts_by_event
+
+            # Timeout: wait_for_response evicts the gateway-side entry and
+            # returns None — nothing tells the adapter.
+            assert clarify_gateway.wait_for_response("c1", timeout=0) is None
+            assert "c1" not in clarify_gateway._entries
+            assert "$clar1" in adapter._clarify_prompts_by_event
+
+            await adapter.cleanup_clarify(
+                chat_id="!room:example.org",
+                clarify_id="c1",
+                message_id=None,
+                session_key="sess-1",
+            )
+
+            assert "$clar1" not in adapter._clarify_prompts_by_event
+            adapter._redact_bot_clarify_reactions.assert_awaited_once()
+        finally:
+            clarify_gateway.clear_session("sess-1")
+
+    @pytest.mark.asyncio
+    async def test_cleanup_after_reaction_resolution_is_noop(self, monkeypatch):
+        """The reaction path pops the prompt itself; the settlement cleanup
+        that follows must be idempotent (no double redaction)."""
+        adapter = _make_adapter(monkeypatch)
+        from plugins.platforms.matrix.adapter import _MatrixClarifyPrompt
+        from tools import clarify_gateway
+
+        number_emojis = _number_emojis(2)
+        clarify_gateway.register(
+            clarify_id="c1",
+            session_key="sess-1",
+            question="Which fruit?",
+            choices=["Apple", "Banana"],
+        )
+        try:
+            adapter._clarify_prompts_by_event["$clar1"] = _MatrixClarifyPrompt(
+                chat_id="!room:example.org",
+                message_id="$clar1",
+                session_key="sess-1",
+                clarify_id="c1",
+                choices=["Apple", "Banana"],
+                emoji_to_index={number_emojis[0]: 0, number_emojis[1]: 1},
+                other_emoji="✏️",
+            )
+            adapter._redact_bot_clarify_reactions = AsyncMock()
+
+            event = _reaction_event("@liizfq:liizfq.top", "$clar1", number_emojis[1])
+            await adapter._on_reaction(event)
+            assert "$clar1" not in adapter._clarify_prompts_by_event
+            assert adapter._redact_bot_clarify_reactions.await_count == 1
+
+            # Gateway settlement cleanup arrives after the waiter wakes.
+            await adapter.cleanup_clarify(
+                chat_id="!room:example.org",
+                clarify_id="c1",
+                message_id="$clar1",
+                session_key="sess-1",
+            )
+
+            # Idempotent — no second redaction pass.
+            assert adapter._redact_bot_clarify_reactions.await_count == 1
+        finally:
+            clarify_gateway.clear_session("sess-1")

--- a/tests/gateway/test_matrix_clarify_reactions.py
+++ b/tests/gateway/test_matrix_clarify_reactions.py
@@ -1,0 +1,195 @@
+"""Tests for Matrix reaction-based clarify (#46490).
+
+Mirrors test_matrix_exec_approval.py (harness) for the ``send_clarify``
+override and the clarify branch of ``_on_reaction``:
+
+  * render — question + numbered choices, self-reactions 1️⃣.. + ✏️,
+  * a number reaction resolves the clarify with the right choice string,
+  * ✏️ arms the gateway text-capture (``mark_awaiting_text``),
+  * an unauthorized reaction is ignored,
+  * open-ended (no choices) falls back to the base plain-text path.
+"""
+
+import types
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from gateway.config import PlatformConfig
+
+
+def _make_adapter(monkeypatch):
+    monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@liizfq:liizfq.top")
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    adapter = MatrixAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="tok",
+            extra={"homeserver": "https://matrix.example.org"},
+        )
+    )
+    adapter._client = types.SimpleNamespace()
+    # Resolve user_id so _is_self_sender doesn't defensively drop all traffic.
+    adapter._user_id = "@bot:example.org"
+    return adapter
+
+
+def _number_emojis(count):
+    from plugins.platforms.matrix.adapter import _MATRIX_MODEL_PICKER_REACTIONS
+
+    return list(_MATRIX_MODEL_PICKER_REACTIONS[:count])
+
+
+def _reaction_event(sender, reacts_to, key):
+    return types.SimpleNamespace(
+        sender=sender,
+        event_id="$react1",
+        room_id="!room:example.org",
+        content={"m.relates_to": {"event_id": reacts_to, "key": key}},
+    )
+
+
+class TestMatrixClarifyReactions:
+    @pytest.mark.asyncio
+    async def test_send_clarify_renders_and_seeds_reactions(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter.send = AsyncMock(
+            return_value=types.SimpleNamespace(success=True, message_id="$clar1")
+        )
+        adapter._send_reaction = AsyncMock(return_value="$r")
+
+        result = await adapter.send_clarify(
+            chat_id="!room:example.org",
+            question="Which fruit?",
+            choices=["Apple", "Banana"],
+            clarify_id="c1",
+            session_key="sess-1",
+        )
+
+        assert result.success is True
+        # Message body carries the question + numbered choices.
+        body = adapter.send.await_args.args[1]
+        assert "Which fruit?" in body
+        assert "Apple" in body and "Banana" in body
+        # Prompt is tracked by the message event_id for the reaction handler.
+        prompt = adapter._clarify_prompts_by_event["$clar1"]
+        assert prompt.clarify_id == "c1"
+        assert prompt.session_key == "sess-1"
+        # Self-reactions: one number per choice + the ✏️ "Other" control.
+        emojis = [call.args[2] for call in adapter._send_reaction.await_args_list]
+        assert emojis == _number_emojis(2) + ["✏️"]
+
+    @pytest.mark.asyncio
+    async def test_reaction_resolves_choice(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        from plugins.platforms.matrix.adapter import _MatrixClarifyPrompt
+        from tools import clarify_gateway
+
+        number_emojis = _number_emojis(2)
+        clarify_gateway.register(
+            clarify_id="c1",
+            session_key="sess-1",
+            question="Which fruit?",
+            choices=["Apple", "Banana"],
+        )
+        try:
+            adapter._clarify_prompts_by_event["$clar1"] = _MatrixClarifyPrompt(
+                chat_id="!room:example.org",
+                message_id="$clar1",
+                session_key="sess-1",
+                clarify_id="c1",
+                choices=["Apple", "Banana"],
+                emoji_to_index={number_emojis[0]: 0, number_emojis[1]: 1},
+                other_emoji="✏️",
+            )
+
+            event = _reaction_event("@liizfq:liizfq.top", "$clar1", number_emojis[1])
+            await adapter._on_reaction(event)
+
+            # The exact chosen string crosses into the gateway primitive.
+            entry = clarify_gateway._entries["c1"]
+            assert entry.response == "Banana"
+            assert entry.event.is_set()
+            assert "$clar1" not in adapter._clarify_prompts_by_event
+        finally:
+            clarify_gateway.clear_session("sess-1")
+
+    @pytest.mark.asyncio
+    async def test_other_reaction_arms_text_capture(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        from plugins.platforms.matrix.adapter import _MatrixClarifyPrompt
+
+        adapter._clarify_prompts_by_event["$clar1"] = _MatrixClarifyPrompt(
+            chat_id="!room:example.org",
+            message_id="$clar1",
+            session_key="sess-1",
+            clarify_id="c1",
+            choices=["Apple", "Banana"],
+            emoji_to_index={e: i for i, e in enumerate(_number_emojis(2))},
+            other_emoji="✏️",
+        )
+        adapter._send_invalid_reaction_feedback = AsyncMock()
+
+        event = _reaction_event("@liizfq:liizfq.top", "$clar1", "✏️")
+        with patch(
+            "tools.clarify_gateway.mark_awaiting_text", return_value=True
+        ) as mock_arm:
+            await adapter._on_reaction(event)
+
+        mock_arm.assert_called_once_with("c1")
+        # Prompt stays pending — the typed reply resolves it via the gateway
+        # text-intercept, not a second reaction.
+        assert "$clar1" in adapter._clarify_prompts_by_event
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_reaction_ignored(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        from plugins.platforms.matrix.adapter import _MatrixClarifyPrompt
+
+        number_emojis = _number_emojis(2)
+        adapter._clarify_prompts_by_event["$clar1"] = _MatrixClarifyPrompt(
+            chat_id="!room:example.org",
+            message_id="$clar1",
+            session_key="sess-1",
+            clarify_id="c1",
+            choices=["Apple", "Banana"],
+            emoji_to_index={number_emojis[0]: 0, number_emojis[1]: 1},
+            other_emoji="✏️",
+        )
+        adapter._send_invalid_reaction_feedback = AsyncMock()
+
+        event = _reaction_event("@stranger:example.org", "$clar1", number_emojis[1])
+        with patch("tools.clarify_gateway.resolve_gateway_clarify") as mock_resolve:
+            await adapter._on_reaction(event)
+
+        mock_resolve.assert_not_called()
+        # Prompt is left pending; only the auth-denied feedback fires.
+        assert "$clar1" in adapter._clarify_prompts_by_event
+        assert not adapter._clarify_prompts_by_event["$clar1"].resolved
+
+    @pytest.mark.asyncio
+    async def test_open_ended_falls_back_to_base(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        adapter.send = AsyncMock(
+            return_value=types.SimpleNamespace(success=True, message_id="$open1")
+        )
+        adapter._send_reaction = AsyncMock(return_value="$r")
+
+        result = await adapter.send_clarify(
+            chat_id="!room:example.org",
+            question="Anything else?",
+            choices=None,
+            clarify_id="c2",
+            session_key="sess-2",
+        )
+
+        assert result.success is True
+        # Base path renders a plain question and seeds no reactions / prompt.
+        adapter._send_reaction.assert_not_awaited()
+        assert "$open1" not in adapter._clarify_prompts_by_event
+        # Base send_clarify calls self.send(content=...) by keyword.
+        sent = adapter.send.await_args
+        body = sent.kwargs.get("content") or sent.args[1]
+        assert "Anything else?" in body


### PR DESCRIPTION

## What does this PR do?

Adds a send_clarify override to the Matrix adapter that renders multiple-choice questions with numbered emoji reactions (1️⃣through4️⃣), matching the reaction-based UX already used for approval prompts and the model picker.

Key changes:
- New _MatrixClarifyPrompt dataclass to track pending clarify prompts
- send_clarify override: posts question + emoji-keyed options, seeds bot reactions, enables text fallback for typing answers
- Reaction dispatch in _handle_reaction checks _clarify_prompts_by_event and resolves via clarify_gateway.resolve_gateway_clarify
- Cleanup methods: _expire_matrix_clarify_prompt, _redact_bot_clarify_reactions
- _MATRIX_CLARIFY_REACTIONS constant (reuses model picker emoji set)

## Related Issue

(https://github.com/NousResearch/hermes-agent/issues/46490)

Fixes #46490 

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

gateway/platforms/matrix.py — added _MatrixClarifyPrompt dataclass, _MATRIX_CLARIFY_REACTIONS constant, send_clarify override with emoji reaction UI, reaction dispatch handler in _handle_reaction, and cleanup methods (_expire_matrix_clarify_prompt, _redact_bot_clarify_reactions)

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Restart Matrix gateway (hermes gateway restart)
2. Ask Hermes a question with choices (e.g. "I'm going to Tasmania from Sydney — how should I get there?")
3. Observe the question renders with numbered emoji (1️⃣–4️⃣) that are clickable as reactions
4. Click a reaction → Hermes should respond acknowledging your choice
5. Also verify text fallback still works: type 2 or the option text instead of clicking

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [X] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform: hermes on mac os - element apps on android and windows

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

<img width="868" height="244" alt="image" src="https://github.com/user-attachments/assets/1ee7cca7-abdf-46e1-934e-75e2515769e7" />