### PR TITLE
feat(cron): mirror delivered cron output into the target session

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -656,6 +656,67 @@ def _send_media_via_adapter(
             logger.warning("Job '%s': failed to send media %s: %s", job.get("id", "?"), media_path, e)
 
 
+def _origin_user_id_for_target(job: dict, target: dict) -> Optional[str]:
+    """Return the originating gateway user id when *target* is the job origin."""
+    origin = _resolve_origin(job) or {}
+    if not origin:
+        return None
+    if str(origin.get("platform", "")).lower() != str(target.get("platform", "")).lower():
+        return None
+    if str(origin.get("chat_id", "")) != str(target.get("chat_id", "")):
+        return None
+    origin_thread = origin.get("thread_id")
+    target_thread = target.get("thread_id")
+    if origin_thread is not None and str(origin_thread) != str(target_thread or ""):
+        return None
+    user_id = origin.get("user_id")
+    return str(user_id) if user_id is not None else None
+
+
+def _mirror_cron_delivery_to_session(
+    job: dict,
+    target: dict,
+    message_text: str,
+    platform_message_id: Optional[str] = None,
+) -> None:
+    """Best-effort mirror of delivered cron output into the target gateway session.
+
+    Cron runs are isolated from live chat sessions, but users often reply to
+    their delivered cron messages later ("Correct", "yes", "stop this").
+    Mirroring the exact delivered text into the target session gives the next
+    live turn the same context the user sees in Telegram/Slack/etc. This is
+    intentionally non-fatal: delivery succeeded even if there is no active
+    gateway session to mirror into.
+    """
+    try:
+        # Default on: gateway.mirror.py has long supported delivery mirrors,
+        # but cron's direct delivery path previously skipped it. Keep an escape
+        # hatch for installations that prefer isolated cron transcripts.
+        try:
+            user_cfg = load_config() or {}
+            cron_cfg = user_cfg.get("cron", {}) if isinstance(user_cfg, dict) else {}
+            if cron_cfg.get("mirror_deliveries") is False:
+                return
+        except Exception:
+            pass
+
+        from gateway.mirror import mirror_to_session
+
+        mirror_to_session(
+            str(target.get("platform", "")),
+            str(target.get("chat_id", "")),
+            message_text,
+            source_label=f"cron:{job.get('id', '')}",
+            thread_id=target.get("thread_id"),
+            user_id=_origin_user_id_for_target(job, target),
+            role="assistant",
+            platform_message_id=platform_message_id,
+            observed=True,
+        )
+    except Exception as exc:
+        logger.debug("Job '%s': cron delivery mirror failed: %s", job.get("id", "?"), exc)
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -762,6 +823,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # Send cleaned text (MEDIA tags stripped) — not the raw content
                 text_to_send = cleaned_delivery_content.strip()
                 adapter_ok = True
+                platform_message_id = None
                 if text_to_send:
                     from agent.async_utils import safe_schedule_threadsafe
                     future = safe_schedule_threadsafe(
@@ -789,6 +851,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                             and getattr(send_result, "raw_response", None)
                             and send_result.raw_response.get("thread_fallback")
                         ):
+                            platform_message_id = getattr(send_result, "message_id", None)
                             requested_thread_id = send_result.raw_response.get("requested_thread_id") or thread_id
                             msg = (
                                 f"configured thread_id {requested_thread_id} for "
@@ -796,6 +859,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                             )
                             logger.warning("Job '%s': %s", job["id"], msg)
                             delivery_errors.append(msg)
+
+                if text_to_send and adapter_ok and send_result:
+                    platform_message_id = getattr(send_result, "message_id", None) or platform_message_id
 
                 # Send extracted media files as native attachments via the live adapter
                 if adapter_ok and media_files:
@@ -810,6 +876,12 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     )
 
                 if adapter_ok:
+                    _mirror_cron_delivery_to_session(
+                        job,
+                        target,
+                        cleaned_delivery_content.strip(),
+                        platform_message_id=str(platform_message_id) if platform_message_id is not None else None,
+                    )
                     logger.info("Job '%s': delivered to %s:%s via live adapter", job["id"], platform_name, chat_id)
                     delivered = True
             except Exception as e:
@@ -844,6 +916,12 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 delivery_errors.append(msg)
                 continue
 
+            _mirror_cron_delivery_to_session(
+                job,
+                target,
+                cleaned_delivery_content.strip(),
+                platform_message_id=str(result.get("message_id")) if isinstance(result, dict) and result.get("message_id") is not None else None,
+            )
             logger.info("Job '%s': delivered to %s:%s", job["id"], platform_name, chat_id)
 
     if delivery_errors:

--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -29,6 +29,9 @@ def mirror_to_session(
     source_label: str = "cli",
     thread_id: Optional[str] = None,
     user_id: Optional[str] = None,
+    role: str = "assistant",
+    platform_message_id: Optional[str] = None,
+    observed: bool = False,
 ) -> bool:
     """
     Append a delivery-mirror message to the target session's transcript.
@@ -57,11 +60,13 @@ def mirror_to_session(
             return False
 
         mirror_msg = {
-            "role": "assistant",
+            "role": role or "assistant",
             "content": message_text,
             "timestamp": datetime.now().isoformat(),
             "mirror": True,
             "mirror_source": source_label,
+            "platform_message_id": platform_message_id,
+            "observed": observed,
         }
 
         _append_to_sqlite(session_id, mirror_msg)
@@ -160,6 +165,8 @@ def _append_to_sqlite(session_id: str, message: dict) -> None:
             session_id=session_id,
             role=message.get("role", "assistant"),
             content=message.get("content"),
+            platform_message_id=message.get("platform_message_id"),
+            observed=bool(message.get("observed")),
         )
     except Exception as e:
         logger.debug("Mirror SQLite write failed: %s", e)

--- a/tests/cron/test_cron_delivery_mirror.py
+++ b/tests/cron/test_cron_delivery_mirror.py
@@ -1,0 +1,107 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from cron import scheduler
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+
+def test_cron_delivery_is_mirrored_after_standalone_send(monkeypatch):
+    job = {
+        "id": "job123",
+        "name": "Daily check",
+        "deliver": "origin",
+        "origin": {
+            "platform": "telegram",
+            "chat_id": "12345",
+            "user_id": "user-1",
+        },
+    }
+    target = {"platform": "telegram", "chat_id": "12345", "thread_id": None}
+    mirrored = []
+
+    async def fake_send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None):
+        return {"success": True, "message_id": "777"}
+
+    monkeypatch.setattr(scheduler, "_resolve_delivery_targets", lambda _job: [target])
+    monkeypatch.setattr(scheduler, "load_config", lambda: {"cron": {"wrap_response": True}})
+    monkeypatch.setattr(
+        "gateway.config.load_gateway_config",
+        lambda: GatewayConfig(platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="tok")}),
+    )
+    monkeypatch.setattr("tools.send_message_tool._send_to_platform", fake_send_to_platform)
+    monkeypatch.setattr(
+        "gateway.mirror.mirror_to_session",
+        lambda *args, **kwargs: mirrored.append((args, kwargs)) or True,
+    )
+
+    assert scheduler._deliver_result(job, "Body") is None
+
+    assert len(mirrored) == 1
+    args, kwargs = mirrored[0]
+    assert args[:3] == (
+        "telegram",
+        "12345",
+        'Cronjob Response: Daily check\n(job_id: job123)\n-------------\n\nBody\n\nTo stop or manage this job, send me a new message (e.g. "stop reminder Daily check").',
+    )
+    assert kwargs["source_label"] == "cron:job123"
+    assert kwargs["user_id"] == "user-1"
+    assert kwargs["platform_message_id"] == "777"
+    assert kwargs["observed"] is True
+
+
+def test_cron_delivery_mirror_can_be_disabled(monkeypatch):
+    job = {"id": "job123", "deliver": "telegram"}
+    target = {"platform": "telegram", "chat_id": "12345", "thread_id": None}
+    calls = []
+
+    monkeypatch.setattr(scheduler, "load_config", lambda: {"cron": {"mirror_deliveries": False}})
+    monkeypatch.setattr(
+        "gateway.mirror.mirror_to_session",
+        lambda *args, **kwargs: calls.append((args, kwargs)) or True,
+    )
+
+    scheduler._mirror_cron_delivery_to_session(job, target, "message", platform_message_id="777")
+
+    assert calls == []
+
+
+def test_cron_delivery_is_mirrored_after_live_adapter_send(monkeypatch):
+    job = {"id": "job123", "name": "Daily check", "deliver": "telegram"}
+    target = {"platform": "telegram", "chat_id": "12345", "thread_id": None}
+    mirrored = []
+
+    class FakeFuture:
+        def result(self, timeout=None):
+            return SimpleNamespace(success=True, message_id="888", raw_response={})
+
+    class FakeLoop:
+        def is_running(self):
+            return True
+
+    class FakeAdapter:
+        def send(self, chat_id, text, metadata=None):
+            return object()
+
+    monkeypatch.setattr(scheduler, "_resolve_delivery_targets", lambda _job: [target])
+    monkeypatch.setattr(scheduler, "load_config", lambda: {"cron": {"wrap_response": False}})
+    monkeypatch.setattr(
+        "gateway.config.load_gateway_config",
+        lambda: GatewayConfig(platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="tok")}),
+    )
+    monkeypatch.setattr("agent.async_utils.safe_schedule_threadsafe", lambda coro, loop: FakeFuture())
+    monkeypatch.setattr(
+        "gateway.mirror.mirror_to_session",
+        lambda *args, **kwargs: mirrored.append((args, kwargs)) or True,
+    )
+
+    assert scheduler._deliver_result(
+        job,
+        "Body",
+        adapters={Platform.TELEGRAM: FakeAdapter()},
+        loop=FakeLoop(),
+    ) is None
+
+    assert len(mirrored) == 1
+    args, kwargs = mirrored[0]
+    assert args[:3] == ("telegram", "12345", "Body")
+    assert kwargs["platform_message_id"] == "888"


### PR DESCRIPTION
## What

Mirrors the text delivered by a cron job into the target gateway session, so the next live turn has the same context the user sees in their chat client. Adds optional `role`, `platform_message_id`, and `observed` fields to `gateway.mirror.mirror_to_session` to carry the delivery metadata.

## Why

Cron runs are isolated from live chat sessions. When a user replies to a delivered cron message (for example "Correct", "yes", or "stop this"), the next live turn has no record of what was delivered, so it lacks the context to interpret the reply. Mirroring the delivered text closes that gap.

## Behavior

- Best-effort and non-fatal: if there is no active session to mirror into, delivery still succeeds.
- Default on, with an escape hatch for installs that prefer isolated cron transcripts: set `cron.mirror_deliveries: false`.

## Testing

Includes `tests/cron/test_cron_delivery_mirror.py`. Also running in production: replies to delivered cron messages are now interpreted with the delivered text in context.
