### PR TITLE
feat(telegram): optional dash stripping for outgoing messages

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2224,6 +2224,20 @@ class TelegramAdapter(BasePlatformAdapter):
         # Skip whitespace-only text to prevent Telegram 400 empty-text errors.
         if not content or not content.strip():
             return SendResult(success=True, message_id=None)
+
+        # Mechanically enforce the no-dash rule (gated per-profile by
+        # HERMES_TELEGRAM_STRIP_DASHES): the persona forbids em dashes and
+        # hyphens, but models still slip, so strip them from outgoing text.
+        if os.getenv("HERMES_TELEGRAM_STRIP_DASHES", "").strip().lower() in ("1", "true", "yes", "on"):
+            _d = content
+            _d = re.sub(r"\s*[\u2014\u2013\u2012\u2015\u2212]\s*", ", ", _d)
+            _d = re.sub(r"\s+[\u2010\u2011-]\s+", ", ", _d)
+            _d = _d.replace("\u2010", " ").replace("\u2011", " ").replace("-", " ")
+            _d = re.sub(r"[ \t]{2,}", " ", _d)
+            _d = re.sub(r"\s+([,.;:!?])", r"\1", _d)
+            _d = re.sub(r"(,\s*){2,}", ", ", _d)
+            _d = re.sub(r"^[\s,]+", "", _d)
+            content = _d
         
         try:
             # Bot API 10.1 rich fast-path: send the raw agent markdown via


### PR DESCRIPTION
## What

Adds an opt-in filter, gated by `HERMES_TELEGRAM_STRIP_DASHES`, that removes dash characters (em dash, en dash, hyphen, and related code points) from outgoing Telegram text and tidies the resulting spacing and punctuation. Default off.

## Why

Some agent personas are configured to avoid dashes in their writing voice, but language models still emit them. A mechanical pass on outgoing text enforces that style reliably without depending on the model.

## Behavior

- Flag unset (default): unchanged.
- Flag set to a truthy value (1, true, yes, on): dash characters are replaced and spacing and punctuation are tidied.

This is intentionally opt-in and off by default, since it is a stylistic choice rather than a general default. Happy to scope it differently (for example a documented config block) if that fits better.

## Testing

Running in production for a dash-averse persona: outgoing messages no longer contain dash characters when the flag is enabled, and are unchanged when it is not.
