### PR TITLE
fix: show media upload feedback

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -34,6 +34,8 @@ _AUDIO_EXTS = frozenset({'.ogg', '.opus', '.mp3', '.wav', '.m4a', '.flac'})
 _TELEGRAM_AUDIO_ATTACHMENT_EXTS = frozenset({'.mp3', '.m4a'})
 _TELEGRAM_VOICE_EXTS = frozenset({'.ogg', '.opus'})
 _POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS = 30.0
+_UPLOAD_FEEDBACK_THRESHOLD_BYTES = 1 * 1024 * 1024
+_UPLOAD_FAILURE_NOTICE_MAX_CHARS = 300
 
 
 def _platform_name(platform) -> str:
@@ -3288,8 +3290,30 @@ class BasePlatformAdapter(ABC):
                     )
                 if not img_result.success:
                     logger.error("[%s] Failed to send image: %s", self.name, img_result.error)
+                    failed_path = (
+                        _unquote(image_url[7:])
+                        if image_url.startswith("file://")
+                        else image_url
+                    )
+                    await self._send_upload_failure_notice(
+                        chat_id=chat_id,
+                        file_path=failed_path,
+                        error=img_result.error,
+                        metadata=metadata,
+                    )
             except Exception as img_err:
                 logger.error("[%s] Error sending image: %s", self.name, img_err, exc_info=True)
+                failed_path = (
+                    _unquote(image_url[7:])
+                    if image_url.startswith("file://")
+                    else image_url
+                )
+                await self._send_upload_failure_notice(
+                    chat_id=chat_id,
+                    file_path=failed_path,
+                    error=img_err,
+                    metadata=metadata,
+                )
 
     async def send_image(
         self,
@@ -4861,6 +4885,78 @@ class BasePlatformAdapter(ABC):
             max_ms = 2500
         return random.uniform(min_ms / 1000.0, max_ms / 1000.0)
 
+    @staticmethod
+    def _format_upload_size(size_bytes: int) -> str:
+        """Return a compact human-readable upload size."""
+        units = ("B", "KB", "MB", "GB")
+        value = float(max(size_bytes, 0))
+        unit = units[0]
+        for unit in units:
+            if value < 1024 or unit == units[-1]:
+                break
+            value /= 1024
+        if unit == "B":
+            return f"{int(value)} {unit}"
+        return f"{value:.1f} {unit}"
+
+    @classmethod
+    def _upload_notice_for_file(cls, file_path: str) -> Optional[str]:
+        """Build an upload-start notice for large local attachments."""
+        try:
+            size_bytes = os.path.getsize(file_path)
+        except OSError:
+            return None
+        if size_bytes < _UPLOAD_FEEDBACK_THRESHOLD_BYTES:
+            return None
+        name = Path(file_path).name or "attachment"
+        return f"Uploading attachment: {name} ({cls._format_upload_size(size_bytes)})..."
+
+    async def _send_upload_started_notice(
+        self,
+        *,
+        chat_id: str,
+        file_path: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Best-effort visible feedback before a large attachment upload."""
+        notice = self._upload_notice_for_file(file_path)
+        if not notice:
+            return
+        try:
+            await self.send(
+                chat_id=chat_id,
+                content=notice,
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+        except Exception as e:
+            logger.debug("[%s] Could not send upload-start notice: %s", self.name, e)
+
+    async def _send_upload_failure_notice(
+        self,
+        *,
+        chat_id: str,
+        file_path: str,
+        error: Any,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Best-effort visible error when an attachment upload fails."""
+        name = Path(file_path).name or "attachment"
+        detail = _LOG_UNSAFE_CHARS.sub("?", str(error or "unknown error"))
+        if len(detail) > _UPLOAD_FAILURE_NOTICE_MAX_CHARS:
+            detail = detail[:_UPLOAD_FAILURE_NOTICE_MAX_CHARS].rstrip() + "..."
+        try:
+            await self.send(
+                chat_id=chat_id,
+                content=f"Attachment upload failed: {name}: {detail}",
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+        except Exception as e:
+            logger.debug("[%s] Could not send upload-failure notice: %s", self.name, e)
+
     async def _process_message_background(self, event: MessageEvent, session_key: str) -> None:
         """Background task that actually processes the message."""
         # Track delivery outcomes for the processing-complete hook
@@ -5005,6 +5101,7 @@ class BasePlatformAdapter(ABC):
                 # metadata stays unmarked and progress bubbles remain
                 # thread-strict.
                 _final_thread_metadata = _mark_notify_metadata(_thread_metadata)
+                _reply_anchor = _reply_anchor_for_event(event)
 
                 # Auto-TTS: if voice message, generate audio FIRST (before sending text)
                 # Gated via ``_should_auto_tts_for_chat``: fires when the chat has
@@ -5059,7 +5156,6 @@ class BasePlatformAdapter(ABC):
                 # Send the text portion
                 if text_content and not _tts_caption_delivered:
                     logger.info("[%s] Sending response (%d chars) to %s", self.name, len(text_content), event.source.chat_id)
-                    _reply_anchor = _reply_anchor_for_event(event)
                     result = await self._send_with_retry(
                         chat_id=event.source.chat_id,
                         content=text_content,
@@ -5131,6 +5227,13 @@ class BasePlatformAdapter(ABC):
 
                 if _image_paths:
                     try:
+                        for image_path in _image_paths:
+                            await self._send_upload_started_notice(
+                                chat_id=event.source.chat_id,
+                                file_path=image_path,
+                                reply_to=_reply_anchor,
+                                metadata=_thread_metadata,
+                            )
                         _batch = [(f"file://{_quote(p)}", "") for p in _image_paths]
                         await self.send_multiple_images(
                             chat_id=event.source.chat_id,
@@ -5140,11 +5243,24 @@ class BasePlatformAdapter(ABC):
                         )
                     except Exception as batch_err:
                         logger.warning("[%s] Error batching images: %s", self.name, batch_err, exc_info=True)
+                        await self._send_upload_failure_notice(
+                            chat_id=event.source.chat_id,
+                            file_path=_image_paths[0],
+                            error=batch_err,
+                            reply_to=_reply_anchor,
+                            metadata=_thread_metadata,
+                        )
 
                 for media_path, is_voice in _non_image_media:
                     if human_delay > 0:
                         await asyncio.sleep(human_delay)
                     try:
+                        await self._send_upload_started_notice(
+                            chat_id=event.source.chat_id,
+                            file_path=media_path,
+                            reply_to=_reply_anchor,
+                            metadata=_thread_metadata,
+                        )
                         ext = Path(media_path).suffix.lower()
                         if should_send_media_as_audio(self.platform, ext, is_voice=is_voice):
                             media_result = await self.send_voice(
@@ -5165,31 +5281,71 @@ class BasePlatformAdapter(ABC):
                                 metadata=_final_thread_metadata,
                             )
 
+                        _record_delivery(media_result)
                         if not media_result.success:
                             logger.warning("[%s] Failed to send media (%s): %s", self.name, ext, media_result.error)
+                            await self._send_upload_failure_notice(
+                                chat_id=event.source.chat_id,
+                                file_path=media_path,
+                                error=media_result.error,
+                                reply_to=_reply_anchor,
+                                metadata=_thread_metadata,
+                            )
                     except Exception as media_err:
                         logger.warning("[%s] Error sending media: %s", self.name, media_err)
+                        _record_delivery(SendResult(success=False, error=str(media_err)))
+                        await self._send_upload_failure_notice(
+                            chat_id=event.source.chat_id,
+                            file_path=media_path,
+                            error=media_err,
+                            reply_to=_reply_anchor,
+                            metadata=_thread_metadata,
+                        )
 
                 # Send auto-detected local non-image files as native attachments
                 for file_path in _non_image_local:
                     if human_delay > 0:
                         await asyncio.sleep(human_delay)
                     try:
+                        await self._send_upload_started_notice(
+                            chat_id=event.source.chat_id,
+                            file_path=file_path,
+                            reply_to=_reply_anchor,
+                            metadata=_thread_metadata,
+                        )
                         ext = Path(file_path).suffix.lower()
                         if ext in _VIDEO_EXTS:
-                            await self.send_video(
+                            file_result = await self.send_video(
                                 chat_id=event.source.chat_id,
                                 video_path=file_path,
                                 metadata=_final_thread_metadata,
                             )
                         else:
-                            await self.send_document(
+                            file_result = await self.send_document(
                                 chat_id=event.source.chat_id,
                                 file_path=file_path,
                                 metadata=_final_thread_metadata,
                             )
+                        _record_delivery(file_result)
+                        if not file_result.success:
+                            logger.warning("[%s] Failed to send local file (%s): %s", self.name, ext, file_result.error)
+                            await self._send_upload_failure_notice(
+                                chat_id=event.source.chat_id,
+                                file_path=file_path,
+                                error=file_result.error,
+                                reply_to=_reply_anchor,
+                                metadata=_thread_metadata,
+                            )
                     except Exception as file_err:
                         logger.error("[%s] Error sending local file %s: %s", self.name, file_path, file_err)
+                        _record_delivery(SendResult(success=False, error=str(file_err)))
+                        await self._send_upload_failure_notice(
+                            chat_id=event.source.chat_id,
+                            file_path=file_path,
+                            error=file_err,
+                            reply_to=_reply_anchor,
+                            metadata=_thread_metadata,
+                        )
 
                 # A3 (#29346): if a non-empty response produced nothing
                 # deliverable, fail loudly rather than dropping it in silence.

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -176,6 +176,9 @@ _FEISHU_IMAGE_UPLOAD_TYPE = "message"
 _FEISHU_FILE_UPLOAD_TYPE = "stream"
 _FEISHU_OPUS_UPLOAD_EXTENSIONS = {".ogg", ".opus"}
 _FEISHU_MEDIA_UPLOAD_EXTENSIONS = {".mp4", ".mov", ".avi", ".m4v"}
+_FEISHU_IMAGE_UPLOAD_LIMIT_BYTES = 10 * 1024 * 1024
+_FEISHU_DOCUMENT_UPLOAD_LIMIT_BYTES = 20 * 1024 * 1024
+_FEISHU_VIDEO_UPLOAD_LIMIT_BYTES = 25 * 1024 * 1024
 _FEISHU_DOC_UPLOAD_TYPES = {
     ".pdf": "pdf",
     ".doc": "doc",
@@ -185,6 +188,35 @@ _FEISHU_DOC_UPLOAD_TYPES = {
     ".ppt": "ppt",
     ".pptx": "ppt",
 }
+
+
+def _format_upload_size(size_bytes: int) -> str:
+    units = ("B", "KB", "MB", "GB")
+    value = float(max(size_bytes, 0))
+    unit = units[0]
+    for unit in units:
+        if value < 1024 or unit == units[-1]:
+            break
+        value /= 1024
+    if unit == "B":
+        return f"{int(value)} {unit}"
+    return f"{value:.1f} {unit}"
+
+
+def _feishu_upload_limit_error(file_path: str, *, limit_bytes: int, label: str) -> Optional[str]:
+    try:
+        size_bytes = os.path.getsize(file_path)
+    except OSError:
+        return None
+    if size_bytes <= limit_bytes:
+        return None
+    name = os.path.basename(file_path) or "attachment"
+    return (
+        f"File too large: {name} is {_format_upload_size(size_bytes)} and "
+        f"exceeds Feishu {label} limit ({_format_upload_size(limit_bytes)})"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Connection, retry and batching tuning
 # ---------------------------------------------------------------------------
@@ -2231,6 +2263,13 @@ class FeishuAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
         if not os.path.exists(image_path):
             return SendResult(success=False, error=f"Image file not found: {image_path}")
+        size_error = _feishu_upload_limit_error(
+            image_path,
+            limit_bytes=_FEISHU_IMAGE_UPLOAD_LIMIT_BYTES,
+            label="image",
+        )
+        if size_error:
+            return SendResult(success=False, error=size_error)
 
         try:
             import io as _io
@@ -4558,6 +4597,19 @@ class FeishuAdapter(BasePlatformAdapter):
             file_path=display_name,
             requested_message_type=outbound_message_type,
         )
+        limit_label = "video" if resolved_message_type == "media" else "file"
+        limit_bytes = (
+            _FEISHU_VIDEO_UPLOAD_LIMIT_BYTES
+            if resolved_message_type == "media"
+            else _FEISHU_DOCUMENT_UPLOAD_LIMIT_BYTES
+        )
+        size_error = _feishu_upload_limit_error(
+            file_path,
+            limit_bytes=limit_bytes,
+            label=limit_label,
+        )
+        if size_error:
+            return SendResult(success=False, error=size_error)
         try:
             with open(file_path, "rb") as file_obj:
                 body = self._build_file_upload_body(
@@ -5431,6 +5483,11 @@ async def _standalone_send(
             if not os.path.exists(media_path):
                 return {"error": f"Media file not found: {media_path}"}
             ext = os.path.splitext(media_path)[1].lower()
+            await adapter._send_upload_started_notice(
+                chat_id=chat_id,
+                file_path=media_path,
+                metadata=metadata,
+            )
             if ext in _MIGRATION_IMAGE_EXTS:
                 last_result = await adapter.send_image_file(chat_id, media_path, metadata=metadata)
             elif ext in _MIGRATION_VIDEO_EXTS:
@@ -5442,6 +5499,12 @@ async def _standalone_send(
             else:
                 last_result = await adapter.send_document(chat_id, media_path, metadata=metadata)
             if not last_result.success:
+                await adapter._send_upload_failure_notice(
+                    chat_id=chat_id,
+                    file_path=media_path,
+                    error=last_result.error,
+                    metadata=metadata,
+                )
                 return {"error": f"Feishu media send failed: {last_result.error}"}
 
         if last_result is None:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2542,6 +2542,39 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertIn("截图说明", captured["message_request"].request_body.content)
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_send_image_file_rejects_oversized_image_before_upload(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        class _ImageAPI:
+            def create(self, request):
+                raise AssertionError("oversized image must not reach upload API")
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    image=_ImageAPI(),
+                    message=SimpleNamespace(),
+                )
+            )
+        )
+
+        with tempfile.NamedTemporaryFile("wb", suffix=".png", delete=False) as tmp:
+            tmp.write(b"12345")
+            image_path = tmp.name
+
+        try:
+            with patch("plugins.platforms.feishu.adapter._FEISHU_IMAGE_UPLOAD_LIMIT_BYTES", 4):
+                result = asyncio.run(adapter.send_image_file(chat_id="oc_chat", image_path=image_path))
+        finally:
+            os.unlink(image_path)
+
+        self.assertFalse(result.success)
+        self.assertIn("exceeds Feishu image limit", result.error)
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_video_uploads_file_and_sends_media_message(self):
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter
@@ -2591,6 +2624,108 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(captured["upload_request"].request_body.file_type, "mp4")
         self.assertEqual(captured["message_request"].request_body.msg_type, "media")
         self.assertEqual(captured["message_request"].request_body.content, '{"file_key": "file_video_123"}')
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_video_rejects_oversized_video_before_upload(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        class _FileAPI:
+            def create(self, request):
+                raise AssertionError("oversized video must not reach upload API")
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    file=_FileAPI(),
+                    message=SimpleNamespace(),
+                )
+            )
+        )
+
+        with tempfile.NamedTemporaryFile("wb", suffix=".mp4", delete=False) as tmp:
+            tmp.write(b"12345")
+            video_path = tmp.name
+
+        try:
+            with patch("plugins.platforms.feishu.adapter._FEISHU_VIDEO_UPLOAD_LIMIT_BYTES", 4):
+                result = asyncio.run(adapter.send_video(chat_id="oc_chat", video_path=video_path))
+        finally:
+            os.unlink(video_path)
+
+        self.assertFalse(result.success)
+        self.assertIn("exceeds Feishu video limit", result.error)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_document_rejects_oversized_file_before_upload(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        class _FileAPI:
+            def create(self, request):
+                raise AssertionError("oversized file must not reach upload API")
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    file=_FileAPI(),
+                    message=SimpleNamespace(),
+                )
+            )
+        )
+
+        with tempfile.NamedTemporaryFile("wb", suffix=".pdf", delete=False) as tmp:
+            tmp.write(b"12345")
+            file_path = tmp.name
+
+        try:
+            with patch("plugins.platforms.feishu.adapter._FEISHU_DOCUMENT_UPLOAD_LIMIT_BYTES", 4):
+                result = asyncio.run(adapter.send_document(chat_id="oc_chat", file_path=file_path))
+        finally:
+            os.unlink(file_path)
+
+        self.assertFalse(result.success)
+        self.assertIn("exceeds Feishu file limit", result.error)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_standalone_send_surfaces_media_upload_failure(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.base import SendResult
+        from plugins.platforms.feishu import adapter as feishu_mod
+
+        fake_adapter = Mock()
+        fake_adapter._domain_name = "feishu"
+        fake_adapter._build_lark_client.return_value = object()
+        fake_adapter._send_upload_started_notice = AsyncMock()
+        fake_adapter._send_upload_failure_notice = AsyncMock()
+        fake_adapter.send_document = AsyncMock(
+            return_value=SendResult(success=False, error="file upload rejected")
+        )
+
+        with tempfile.NamedTemporaryFile("wb", suffix=".pdf") as tmp, \
+             patch.object(feishu_mod, "FeishuAdapter", return_value=fake_adapter), \
+             patch.object(feishu_mod, "FEISHU_AVAILABLE", True):
+            result = asyncio.run(
+                feishu_mod._standalone_send(
+                    PlatformConfig(),
+                    "oc_chat",
+                    "",
+                    media_files=[(tmp.name, False)],
+                )
+            )
+
+        fake_adapter._send_upload_started_notice.assert_awaited_once()
+        fake_adapter._send_upload_failure_notice.assert_awaited_once_with(
+            chat_id="oc_chat",
+            file_path=tmp.name,
+            error="file upload rejected",
+            metadata=None,
+        )
+        self.assertEqual(result, {"error": "Feishu media send failed: file upload rejected"})
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_voice_uploads_opus_and_sends_audio_message(self):

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -21,6 +21,7 @@ from gateway.session import SessionSource, build_session_key
 class _MediaRoutingAdapter(BasePlatformAdapter):
     def __init__(self):
         super().__init__(PlatformConfig(enabled=True, token="test"), Platform.TELEGRAM)
+        self.sent_texts = []
 
     async def connect(self, *, is_reconnect: bool = False):
         return True
@@ -29,6 +30,7 @@ class _MediaRoutingAdapter(BasePlatformAdapter):
         pass
 
     async def send(self, chat_id, content=None, **kwargs):
+        self.sent_texts.append(content)
         return SendResult(success=True, message_id="text")
 
     async def get_chat_info(self, chat_id):
@@ -119,6 +121,63 @@ async def test_base_adapter_routes_voice_tagged_telegram_ogg_media_tag_to_voice_
         metadata={"notify": True},
     )
     adapter.send_document.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_base_adapter_announces_large_media_upload_before_send(tmp_path, monkeypatch):
+    adapter = _MediaRoutingAdapter()
+    event = _event()
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "report.pdf")
+    media_file.write_bytes(b"x" * (1024 * 1024 + 1))
+    adapter._message_handler = AsyncMock(return_value=f"MEDIA:{media_file}")
+    adapter.send_document = AsyncMock(return_value=SendResult(success=True, message_id="doc"))
+
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    assert any(
+        text and text.startswith("Uploading attachment: report.pdf")
+        for text in adapter.sent_texts
+    )
+    adapter.send_document.assert_awaited_once_with(
+        chat_id="chat-1",
+        file_path=str(media_file),
+        metadata={"notify": True},
+    )
+
+
+@pytest.mark.asyncio
+async def test_base_adapter_surfaces_media_upload_failure_to_chat(tmp_path, monkeypatch):
+    adapter = _MediaRoutingAdapter()
+    event = _event()
+    media_file = _allowed_media_path(tmp_path, monkeypatch, "report.pdf")
+    adapter._message_handler = AsyncMock(return_value=f"MEDIA:{media_file}")
+    adapter.send_document = AsyncMock(
+        return_value=SendResult(success=False, error="Feishu file upload failed: file too large")
+    )
+
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    assert any(
+        text == "Attachment upload failed: report.pdf: Feishu file upload failed: file too large"
+        for text in adapter.sent_texts
+    )
+
+
+@pytest.mark.asyncio
+async def test_base_adapter_surfaces_returned_image_failure_to_chat(tmp_path):
+    adapter = _MediaRoutingAdapter()
+    image_file = tmp_path / "failed.png"
+    image_file.write_bytes(b"image")
+    adapter.send_image_file = AsyncMock(
+        return_value=SendResult(success=False, error="image upload rejected")
+    )
+
+    await adapter.send_multiple_images(
+        chat_id="chat-1",
+        images=[(image_file.as_uri(), "")],
+    )
+
+    assert "Attachment upload failed: failed.png: image upload rejected" in adapter.sent_texts
 
 
 def _fake_runner(thread_meta):

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -682,6 +682,35 @@ class TestSendTelegramMediaDelivery:
         bot.send_audio.assert_awaited_once()
         bot.send_voice.assert_not_awaited()
 
+    def test_large_media_sends_upload_notice_before_attachment(self, tmp_path, monkeypatch):
+        file_path = tmp_path / "large-report.pdf"
+        file_path.write_bytes(b"x" * (1024 * 1024 + 1))
+
+        bot = MagicMock()
+        bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=1))
+        bot.send_photo = AsyncMock()
+        bot.send_video = AsyncMock()
+        bot.send_voice = AsyncMock()
+        bot.send_audio = AsyncMock()
+        bot.send_document = AsyncMock(return_value=SimpleNamespace(message_id=2))
+        _install_telegram_mock(monkeypatch, bot)
+
+        result = asyncio.run(
+            _send_telegram(
+                "token",
+                "12345",
+                "",
+                media_files=[(str(file_path), False)],
+            )
+        )
+
+        assert result["success"] is True
+        bot.send_message.assert_awaited_once()
+        assert bot.send_message.await_args.kwargs["text"].startswith(
+            "Uploading attachment: large-report.pdf"
+        )
+        bot.send_document.assert_awaited_once()
+
     def test_missing_media_returns_error_without_leaking_raw_tag(self, monkeypatch):
         bot = MagicMock()
         bot.send_message = AsyncMock()
@@ -1013,6 +1042,51 @@ class TestSendToPlatformChunking:
         assert calls == [
             ("connect",),
             ("send", "!room:example.com", "report attached", None),
+            ("send_document", "!room:example.com", str(file_path), None),
+            ("disconnect",),
+        ]
+
+    def test_send_matrix_via_adapter_announces_large_upload(self, tmp_path):
+        file_path = tmp_path / "large-report.pdf"
+        file_path.write_bytes(b"x" * (1024 * 1024 + 1))
+
+        calls = []
+
+        class FakeAdapter:
+            def __init__(self, _config):
+                pass
+
+            async def connect(self):
+                calls.append(("connect",))
+                return True
+
+            async def send(self, chat_id, message, metadata=None):
+                calls.append(("send", chat_id, message, metadata))
+                return SimpleNamespace(success=True, message_id="$text")
+
+            async def send_document(self, chat_id, file_path, metadata=None):
+                calls.append(("send_document", chat_id, file_path, metadata))
+                return SimpleNamespace(success=True, message_id="$file")
+
+            async def disconnect(self):
+                calls.append(("disconnect",))
+
+        fake_module = SimpleNamespace(MatrixAdapter=FakeAdapter)
+
+        with patch.dict(sys.modules, {"gateway.platforms.matrix": fake_module}):
+            result = asyncio.run(
+                _send_matrix_via_adapter(
+                    SimpleNamespace(enabled=True, token="tok", extra={"homeserver": "https://matrix.example.com"}),
+                    "!room:example.com",
+                    "",
+                    media_files=[(str(file_path), False)],
+                )
+            )
+
+        assert result["success"] is True
+        assert calls == [
+            ("connect",),
+            ("send", "!room:example.com", "Uploading attachment: large-report.pdf (1.0 MB)...", None),
             ("send_document", "!room:example.com", str(file_path), None),
             ("disconnect",),
         ]

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -61,6 +61,8 @@ _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
 _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".3gp"}
 _AUDIO_EXTS = {".ogg", ".opus", ".mp3", ".wav", ".m4a", ".flac"}
 _VOICE_EXTS = {".ogg", ".opus"}
+_UPLOAD_FEEDBACK_THRESHOLD_BYTES = 1 * 1024 * 1024
+_UPLOAD_FAILURE_NOTICE_MAX_CHARS = 300
 # Telegram's Bot API sendAudio only accepts MP3 / M4A. Other audio
 # formats either route through sendVoice (Opus/OGG) or fall back to
 # document delivery.
@@ -149,6 +151,84 @@ def _display_chat_id(platform_name: str, chat_id: str) -> str:
     if platform_name == "signal" and str(chat_id).startswith("group:"):
         return "group:***"
     return chat_id
+
+
+def _format_upload_size(size_bytes: int) -> str:
+    units = ("B", "KB", "MB", "GB")
+    value = float(max(size_bytes, 0))
+    unit = units[0]
+    for unit in units:
+        if value < 1024 or unit == units[-1]:
+            break
+        value /= 1024
+    if unit == "B":
+        return f"{int(value)} {unit}"
+    return f"{value:.1f} {unit}"
+
+
+def _upload_notice_for_file(file_path: str) -> str | None:
+    try:
+        size_bytes = os.path.getsize(file_path)
+    except OSError:
+        return None
+    if size_bytes < _UPLOAD_FEEDBACK_THRESHOLD_BYTES:
+        return None
+    name = os.path.basename(file_path) or "attachment"
+    return f"Uploading attachment: {name} ({_format_upload_size(size_bytes)})..."
+
+
+def _upload_failure_notice(file_path: str, error) -> str:
+    name = os.path.basename(file_path) or "attachment"
+    detail = _sanitize_error_text(error or "unknown error")
+    if len(detail) > _UPLOAD_FAILURE_NOTICE_MAX_CHARS:
+        detail = detail[:_UPLOAD_FAILURE_NOTICE_MAX_CHARS].rstrip() + "..."
+    return f"Attachment upload failed: {name}: {detail}"
+
+
+async def _send_adapter_upload_notice(adapter, chat_id: str, file_path: str, metadata=None) -> None:
+    notice = _upload_notice_for_file(file_path)
+    if not notice:
+        return
+    try:
+        await adapter.send(chat_id, notice, metadata=metadata)
+    except Exception as e:
+        logger.debug("Could not send upload-start notice: %s", _sanitize_error_text(e))
+
+
+async def _send_adapter_upload_failure(adapter, chat_id: str, file_path: str, error, metadata=None) -> None:
+    try:
+        await adapter.send(chat_id, _upload_failure_notice(file_path, error), metadata=metadata)
+    except Exception as e:
+        logger.debug("Could not send upload-failure notice: %s", _sanitize_error_text(e))
+
+
+async def _send_telegram_upload_notice(bot, int_chat_id: int, file_path: str, thread_kwargs: dict) -> None:
+    notice = _upload_notice_for_file(file_path)
+    if not notice:
+        return
+    try:
+        await _send_telegram_message_with_retry(
+            bot,
+            chat_id=int_chat_id,
+            text=notice,
+            parse_mode=None,
+            **thread_kwargs,
+        )
+    except Exception as e:
+        logger.debug("Could not send Telegram upload-start notice: %s", _sanitize_error_text(e))
+
+
+async def _send_telegram_upload_failure(bot, int_chat_id: int, file_path: str, error, thread_kwargs: dict) -> None:
+    try:
+        await _send_telegram_message_with_retry(
+            bot,
+            chat_id=int_chat_id,
+            text=_upload_failure_notice(file_path, error),
+            parse_mode=None,
+            **thread_kwargs,
+        )
+    except Exception as e:
+        logger.debug("Could not send Telegram upload-failure notice: %s", _sanitize_error_text(e))
 
 
 def _telegram_retry_delay(exc: Exception, attempt: int) -> float | None:
@@ -1305,6 +1385,12 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
 
             ext = os.path.splitext(media_path)[1].lower()
             try:
+                await _send_telegram_upload_notice(
+                    bot,
+                    int_chat_id,
+                    media_path,
+                    thread_kwargs,
+                )
                 with open(media_path, "rb") as f:
                     media_kwargs = dict(thread_kwargs)
                     # Attach the MEDIA:<path> caption to the bubble itself for
@@ -1403,6 +1489,13 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                 warning = _sanitize_error_text(f"Failed to send media {media_path}: {e}")
                 logger.error(warning)
                 warnings.append(warning)
+                await _send_telegram_upload_failure(
+                    bot,
+                    int_chat_id,
+                    media_path,
+                    e,
+                    thread_kwargs,
+                )
 
         if last_msg is None:
             error = "No deliverable text or media remained after processing MEDIA tags"
@@ -1736,6 +1829,12 @@ async def _matrix_send_core(adapter, chat_id, message, media_files, metadata):
             return _error(f"Media file not found: {media_path}")
 
         ext = os.path.splitext(media_path)[1].lower()
+        await _send_adapter_upload_notice(
+            adapter,
+            chat_id,
+            media_path,
+            metadata=metadata,
+        )
         if ext in _IMAGE_EXTS:
             last_result = await adapter.send_image_file(chat_id, media_path, metadata=metadata)
         elif ext in _VIDEO_EXTS:
@@ -1748,6 +1847,13 @@ async def _matrix_send_core(adapter, chat_id, message, media_files, metadata):
             last_result = await adapter.send_document(chat_id, media_path, metadata=metadata)
 
         if not last_result.success:
+            await _send_adapter_upload_failure(
+                adapter,
+                chat_id,
+                media_path,
+                last_result.error,
+                metadata=metadata,
+            )
             return _error(f"Matrix media send failed: {last_result.error}")
 
     if last_result is None:


### PR DESCRIPTION
## Summary
- Show a visible upload-start notice for local media attachments over 1 MB in both gateway MEDIA delivery and send_message helper paths.
- Surface attachment upload failures back into the chat instead of only logging them.
- Reject Feishu/Lark images, files, and videos above known platform limits before calling the upload API.

Fixes #46454.

## Problem
Large attachment sends could look idle while the platform upload was in flight. If the upload failed, final-response MEDIA delivery usually only logged the failed SendResult, so the user did not get a clear chat-visible failure.

## Validation
- python3 -m py_compile gateway/platforms/base.py gateway/platforms/feishu.py tools/send_message_tool.py tests/gateway/test_tts_media_routing.py tests/gateway/test_feishu.py tests/tools/test_send_message_tool.py
- $HOME/.hermes/hermes-agent/venv/bin/python -m ruff check gateway/platforms/base.py gateway/platforms/feishu.py tools/send_message_tool.py tests/gateway/test_tts_media_routing.py tests/gateway/test_feishu.py tests/tools/test_send_message_tool.py
- scripts/run_tests.sh tests/gateway/test_tts_media_routing.py tests/gateway/test_feishu.py
- scripts/run_tests.sh tests/tools/test_send_message_tool.py (0 tests collected here because the optional Telegram test dependency is unavailable in this env)
