### PR TITLE
fix(credential-pool): persist request_count after least_used selection

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1356,6 +1356,7 @@ class CredentialPool:
             # Increment usage counter so subsequent selections distribute load
             updated = replace(entry, request_count=entry.request_count + 1)
             self._replace_entry(entry, updated)
+            self._persist()
             self._current_id = entry.id
             return updated
 


### PR DESCRIPTION
## Summary

The `least_used` credential pool strategy increments `request_count` in memory after selecting a credential, but never calls `_persist()` to write the updated counter back to `auth.json`. Because each Hermes invocation loads the pool fresh from disk, every selection starts with `request_count=0` for all entries, which makes `min(request_count)` deterministically pick the first credential every time.

**Result:** load is never distributed across the pool — only the first credential receives traffic, and counters in `auth.json` stay at 0.

This PR adds the missing `self._persist()` call, matching the pattern already used by `round_robin` at line 1367.

## Reproduction

1. Configure two API keys for the same custom provider:
   ```bash
   hermes auth add custom:my-provider --type api-key --label key-1 --api-key XXX
   hermes auth add custom:my-provider --type api-key --label key-2 --api-key YYY
   hermes config set credential_pool_strategies.custom:my-provider least_used
   ```
2. Send N requests via `hermes chat -q "..." -m <model>`.
3. Inspect `auth.json` — only `key-1` has `request_count=N`. The upstream provider's dashboard only shows traffic on `key-1`.

## After Fix

Counters increment correctly across process invocations, and traffic distributes evenly:

```
key-1: request_count=N/2
key-2: request_count=N/2
```

## Diff

```diff
@@ -1356,6 +1356,7 @@ class CredentialPool:
             # Increment usage counter so subsequent selections distribute load
             updated = replace(entry, request_count=entry.request_count + 1)
             self._replace_entry(entry, updated)
+            self._persist()
             self._current_id = entry.id
             return updated
```

One-line change. The persistence pattern matches `round_robin` directly above.

## Test Plan

- [x] Manually verified before fix: counts stay at 0, only first key sees traffic
- [x] Manually verified after fix: counts increment, traffic distributes
