### PR TITLE
fix(tools): strip line-number prefixes in sandbox write_file to prevent read→write accumulation

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -138,6 +138,37 @@ class TestHermesToolsGeneration(unittest.TestCase):
         self.assertIn("_seq_lock = threading.Lock()", src)
         self.assertIn("with _seq_lock:", src)
 
+    def test_write_file_strips_line_number_prefixes(self):
+        """Regression (#46465): sandbox write_file must strip the N| prefixes
+        that read_file injects so round-tripping read→write is lossless."""
+        src = generate_hermes_tools_module(["read_file", "write_file"])
+        # write_file should strip line numbers
+        self.assertIn("re.sub", src.split("def write_file")[1])
+        # read_file should NOT strip line numbers
+        read_block = src.split("def read_file(")[1].split("def ")[0]
+        self.assertNotIn("re.sub", read_block)
+
+    def test_write_file_strips_line_numbers_correctly(self):
+        """Verify the generated regex strips N| prefixes but leaves
+        regular content untouched."""
+        import re
+        pattern = r"(?m)^\d+\|"
+        # Line-prefixed content (from read_file)
+        self.assertEqual(
+            re.sub(pattern, "", "1|hello\n2|world\n3|foo"),
+            "hello\nworld\nfoo",
+        )
+        # Regular content is not affected
+        self.assertEqual(
+            re.sub(pattern, "", "hello\nworld"),
+            "hello\nworld",
+        )
+        # Content with pipes but no leading digits is not affected
+        self.assertEqual(
+            re.sub(pattern, "", "ls -la | grep foo"),
+            "ls -la | grep foo",
+        )
+
 
 class TestExecuteCodeRemoteTempDir(unittest.TestCase):
     def test_execute_remote_uses_backend_temp_dir_for_sandbox(self):

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -276,11 +276,23 @@ def generate_hermes_tools_module(enabled_tools: List[str],
         if tool_name not in _TOOL_STUBS:
             continue
         func_name, sig, doc, args_expr = _TOOL_STUBS[tool_name]
-        stub_functions.append(
-            f"def {func_name}({sig}):\n"
-            f"    {doc}\n"
-            f"    return _call({func_name!r}, {args_expr})\n"
-        )
+        if func_name == "write_file":
+            # Strip line-number prefixes (``N|content``) that read_file
+            # injects so that round-tripping read→write inside the sandbox
+            # does not embed the formatting into the output file.  See #46465.
+            stub_functions.append(
+                f"def {func_name}({sig}):\n"
+                f"    {doc}\n"
+                f"    import re as _re\n"
+                f"    content = _re.sub(r'(?m)^\\d+\\|', '', content)\n"
+                f"    return _call({func_name!r}, {args_expr})\n"
+            )
+        else:
+            stub_functions.append(
+                f"def {func_name}({sig}):\n"
+                f"    {doc}\n"
+                f"    return _call({func_name!r}, {args_expr})\n"
+            )
         export_names.append(func_name)
 
     if transport == "file":


### PR DESCRIPTION
## What does this PR do?

Fixes line-number prefix accumulation when sandbox code reads a file and writes it back via `execute_code`. The sandbox `read_file` returns content with `N|` prefixes (e.g. `1|hello`), and the `write_file` stub wrote those prefixes directly into the output file. On the second read→write cycle, the prefixes doubled (`1|1|hello`).

The fix adds a regex strip in the generated `write_file` sandbox stub that removes leading `^\d+|` prefixes before delegating to the actual `write_file` tool.

## Related Issue

Fixes #46465

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/code_execution_tool.py`: Modified `generate_hermes_tools_module()` to inject `re.sub(r'(?m)^\d+\|', '', content)` in the sandbox `write_file` stub before calling `_call()`
- `tests/tools/test_code_execution.py`: Added `test_write_file_strips_line_number_prefixes` (verifies generated stub contains the strip logic) and `test_write_file_strips_line_numbers_correctly` (verifies regex correctness against line-prefixed, clean, and pipe-containing content)

## How to Test

1. Run `pytest tests/tools/test_code_execution.py -k "write_file_strips" -v` — both new tests should pass
2. Verify the generated stub contains the regex: `python3 -c "from tools.code_execution_tool import generate_hermes_tools_module; print(generate_hermes_tools_module(['write_file']))"` — the `write_file` function should contain `re.sub`
3. Manual sandbox test: in `execute_code`, `read_file` a file, pass the content to `write_file`, then `read_file` again — the second read should NOT have doubled line-number prefixes

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `generate_hermes_tools_module()` in `code_execution_tool.py` (callers: 2 test files + RPC setup)
- Blast radius: LOW — change only affects the sandbox stub generation, not the actual `write_file` tool
- Related patterns: `read_file_raw()` exists in `file_operations.py` but is not exposed to the sandbox; this fix handles the symptom at the write boundary instead
