### PR TITLE
fix(hindsight): surface missing hindsight-all in local_embedded (#7718)

### DIFF
--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -5,7 +5,7 @@ Long-term memory with knowledge graph, entity resolution, and multi-strategy ret
 ## Requirements
 
 - **Cloud:** API key from [ui.hindsight.vectorize.io](https://ui.hindsight.vectorize.io)
-- **Local Embedded:** API key for a supported LLM provider (OpenAI, Anthropic, Gemini, Groq, OpenRouter, MiniMax, Ollama, or any OpenAI-compatible endpoint). Embeddings and reranking run locally — no additional API keys needed.
+- **Local Embedded:** API key for a supported LLM provider (OpenAI, Anthropic, Gemini, Groq, OpenRouter, MiniMax, Ollama, or any OpenAI-compatible endpoint). Embeddings and reranking run locally — no additional API keys needed. Also requires the `hindsight-all` package (the setup wizard installs it; if you configure `local_embedded` by hand, run `uv pip install hindsight-all`).
 - **Local External:** A running Hindsight instance (Docker or self-hosted) reachable over HTTP.
 
 ## Setup
@@ -34,6 +34,8 @@ Supports any OpenAI-compatible LLM endpoint (llama.cpp, vLLM, LM Studio, etc.) �
 
 Daemon startup logs: `~/.hermes/logs/hindsight-embed.log`
 Daemon runtime logs: `~/.hindsight/profiles/<profile>.log`
+
+**Missing `hindsight-all`?** If you configured `local_embedded` by hand — or upgraded from the legacy `"mode": "local"` — without running `hermes memory setup`, the embedded runtime package may be absent. You'll see a one-time warning like `Hindsight is configured for local_embedded mode but its runtime is not installed (No module named 'hindsight'). Long-term memory is disabled.` and memory will be off for the session. Fix: `uv pip install hindsight-all` (or `pip install hindsight-all`), then restart.
 
 To open the Hindsight web UI (local embedded mode only):
 ```bash

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -99,6 +99,42 @@ def _check_local_runtime() -> tuple[bool, str | None]:
         return False, str(exc)
 
 
+# The embedded runtime lives in the `hindsight-all` package (it provides the
+# top-level `hindsight` module). A "No module named 'hindsight...'" probe failure
+# means that package is missing — distinct from intentional graceful-degradation
+# cases (e.g. NumPy CPU-baseline errors). See #7718.
+_EMBEDDED_INSTALL_HINT = (
+    " Install the embedded runtime: `uv pip install hindsight-all` "
+    "(or `pip install hindsight-all`)."
+)
+_warned_missing_embedded_runtime = False
+
+
+def _missing_embedded_runtime(reason: str | None) -> bool:
+    """True when *reason* indicates the `hindsight-all` package is absent."""
+    return bool(reason) and "no module named 'hindsight" in reason.lower()
+
+
+def _embedded_runtime_hint(reason: str | None) -> str:
+    """Actionable install hint for a missing `hindsight-all`, else empty string."""
+    return _EMBEDDED_INSTALL_HINT if _missing_embedded_runtime(reason) else ""
+
+
+def _warn_missing_embedded_runtime_once(reason: str | None) -> None:
+    """Emit a one-time actionable warning when local_embedded is configured but
+    `hindsight-all` is missing, so the provider isn't dropped silently (#7718)."""
+    global _warned_missing_embedded_runtime
+    if _warned_missing_embedded_runtime or not _missing_embedded_runtime(reason):
+        return
+    _warned_missing_embedded_runtime = True
+    logger.warning(
+        "Hindsight is configured for local_embedded mode but its runtime is not "
+        "installed (%s). Long-term memory is disabled.%s",
+        reason,
+        _EMBEDDED_INSTALL_HINT,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Hindsight API capability probe — mirrors hindsight-integrations/openclaw.
 # ---------------------------------------------------------------------------
@@ -609,7 +645,9 @@ class HindsightMemoryProvider(MemoryProvider):
             cfg = _load_config()
             mode = cfg.get("mode", "cloud")
             if mode in {"local", "local_embedded"}:
-                available, _ = _check_local_runtime()
+                available, reason = _check_local_runtime()
+                if not available:
+                    _warn_missing_embedded_runtime_once(reason)
                 return available
             if mode == "local_external":
                 return True
@@ -892,6 +930,7 @@ class HindsightMemoryProvider(MemoryProvider):
                     raise RuntimeError(
                         "Hindsight local runtime is unavailable"
                         + (f": {reason}" if reason else "")
+                        + _embedded_runtime_hint(reason)
                     )
                 try:
                     from tools.lazy_deps import ensure as _lazy_ensure
@@ -900,7 +939,19 @@ class HindsightMemoryProvider(MemoryProvider):
                     pass
                 except Exception as _e:
                     raise ImportError(str(_e))
-                from hindsight import HindsightEmbedded
+                try:
+                    from hindsight import HindsightEmbedded
+                except ImportError as exc:
+                    # `local_embedded` needs the `hindsight-all` package (top-level
+                    # `hindsight` module); `hindsight-client` alone is not enough. Turn
+                    # the cryptic "No module named 'hindsight'" into an actionable
+                    # error so memory isn't silently disabled (#7718).
+                    raise ImportError(
+                        "Hindsight local_embedded mode requires the 'hindsight-all' "
+                        "package (it provides the top-level 'hindsight' module). "
+                        "Install it: `uv pip install hindsight-all` "
+                        "(or `pip install hindsight-all`)."
+                    ) from exc
                 HindsightEmbedded.__del__ = lambda self: None
                 llm_provider = self._config.get("llm_provider", "")
                 if llm_provider in {"openai_compatible", "openrouter"}:
@@ -1138,13 +1189,20 @@ class HindsightMemoryProvider(MemoryProvider):
         )
         # "local" is a legacy alias for "local_embedded"
         if self._mode == "local":
+            logger.warning(
+                "Hindsight config uses the legacy mode 'local'; treating it as "
+                "'local_embedded'. Update your config's \"mode\" to \"local_embedded\" "
+                "to silence this warning."
+            )
             self._mode = "local_embedded"
         if self._mode == "local_embedded":
             available, reason = _check_local_runtime()
             if not available:
                 logger.warning(
-                    "Hindsight local mode disabled because its runtime could not be imported: %s",
+                    "Hindsight local mode disabled because its runtime could not be "
+                    "imported: %s.%s",
                     reason,
+                    _embedded_runtime_hint(reason),
                 )
                 self._mode = "disabled"
                 return

--- a/plugins/memory/hindsight/plugin.yaml
+++ b/plugins/memory/hindsight/plugin.yaml
@@ -2,6 +2,10 @@ name: hindsight
 version: 1.0.0
 description: "Hindsight — long-term memory with knowledge graph, entity resolution, and multi-strategy retrieval."
 pip_dependencies:
+  # Cloud / local_external need only the lightweight client. local_embedded also
+  # requires `hindsight-all` (it provides the top-level `hindsight` module); the
+  # setup wizard installs it on demand. It is deliberately kept out of the static
+  # deps so cloud-only users don't pull the heavy embedded runtime. See #7718.
   - "hindsight-client>=0.4.22"
 requires_env: []
 hooks:

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1531,6 +1531,197 @@ class TestAvailability:
         p.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
         assert p._mode == "disabled"
 
+    def test_initialize_warns_actionably_when_hindsight_all_missing(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """Issue #7718: a missing hindsight-all in local_embedded must name the
+        package and an install command, not just 'No module named hindsight'."""
+        import logging
+
+        config = {"mode": "local_embedded"}
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
+
+        def _raise(_name):
+            raise ModuleNotFoundError("No module named 'hindsight'")
+
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.importlib.import_module", _raise
+        )
+
+        p = HindsightMemoryProvider()
+        with caplog.at_level(logging.WARNING, logger="plugins.memory.hindsight"):
+            p.initialize(session_id="s", hermes_home=str(tmp_path), platform="cli")
+
+        assert p._mode == "disabled"
+        msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("hindsight-all" in m for m in msgs), msgs
+        assert any("install" in m.lower() for m in msgs), msgs
+
+    def test_initialize_warns_on_legacy_local_mode_migration(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """Issue #7718: legacy 'mode: local' is silently remapped to
+        'local_embedded' — warn so users can update their config."""
+        import logging
+
+        config = {"mode": "local"}
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
+        # Runtime available so init proceeds past the disable branch.
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_local_runtime", lambda: (True, "")
+        )
+
+        p = HindsightMemoryProvider()
+        with caplog.at_level(logging.WARNING, logger="plugins.memory.hindsight"):
+            p.initialize(session_id="s", hermes_home=str(tmp_path), platform="cli")
+
+        assert p._mode == "local_embedded"
+        msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("legacy" in m.lower() and "local_embedded" in m for m in msgs), msgs
+
+    def test_get_client_raises_actionable_error_when_hindsight_all_missing(
+        self, monkeypatch
+    ):
+        """Issue #7718: if the embedded import fails at client creation, the
+        error must name hindsight-all and an install command."""
+        import builtins
+        import tools.lazy_deps as _ld
+
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_local_runtime", lambda: (True, "")
+        )
+        # Neutralize lazy-deps so the test never attempts a real install.
+        monkeypatch.setattr(_ld, "ensure", lambda *a, **k: None)
+
+        orig_import = builtins.__import__
+
+        def blocked(name, *a, **k):
+            if name == "hindsight":
+                raise ModuleNotFoundError("No module named 'hindsight'")
+            return orig_import(name, *a, **k)
+
+        monkeypatch.setattr(builtins, "__import__", blocked)
+
+        p = HindsightMemoryProvider()
+        p._mode = "local_embedded"
+        p._config = {"profile": "hermes", "llm_provider": "openai", "llm_model": "gpt-4o-mini"}
+        p._client = None
+
+        with pytest.raises(ImportError, match="hindsight-all"):
+            p._get_client()
+
+    def test_is_available_warns_actionably_when_hindsight_all_missing(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """Issue #7718 (Codex): the primary startup path drops the provider via
+        is_available() before initialize() runs, so is_available() itself must
+        surface the actionable hindsight-all hint instead of failing silently."""
+        import logging
+        import plugins.memory.hindsight as hs
+
+        config = {"mode": "local_embedded"}
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_local_runtime",
+            lambda: (False, "No module named 'hindsight'"),
+        )
+        # Reset the one-time warn guard so the assertion is deterministic.
+        monkeypatch.setattr(hs, "_warned_missing_embedded_runtime", False, raising=False)
+
+        p = HindsightMemoryProvider()
+        with caplog.at_level(logging.WARNING, logger="plugins.memory.hindsight"):
+            assert p.is_available() is False
+        msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("hindsight-all" in m and "install" in m.lower() for m in msgs), msgs
+
+    def test_is_available_silent_for_non_hindsight_runtime_failure(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """Intentional graceful-degradation cases (e.g. NumPy CPU baseline) stay
+        quiet — only the missing hindsight-all case gets the install nudge."""
+        import logging
+        import plugins.memory.hindsight as hs
+
+        config = {"mode": "local_embedded"}
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_local_runtime",
+            lambda: (False, "NumPy was built with baseline optimizations: (x86_64-v2)"),
+        )
+        monkeypatch.setattr(hs, "_warned_missing_embedded_runtime", False, raising=False)
+
+        p = HindsightMemoryProvider()
+        with caplog.at_level(logging.WARNING, logger="plugins.memory.hindsight"):
+            assert p.is_available() is False
+        msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert not any("hindsight-all" in m for m in msgs), msgs
+
+    def test_get_client_raises_actionable_error_on_missing_runtime(self, monkeypatch):
+        """Issue #7718 (Codex): the real production path hits _check_local_runtime()
+        failing, which raises before the import guard — that error must also name
+        hindsight-all, not just 'Hindsight local runtime is unavailable'."""
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_local_runtime",
+            lambda: (False, "No module named 'hindsight'"),
+        )
+        p = HindsightMemoryProvider()
+        p._mode = "local_embedded"
+        p._config = {"profile": "hermes"}
+        p._client = None
+        with pytest.raises(RuntimeError, match="hindsight-all"):
+            p._get_client()
+
+    def test_is_available_warns_only_once_per_process(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """The missing-hindsight-all nudge fires once per process, not on every
+        is_available() probe (#7718)."""
+        import logging
+        import plugins.memory.hindsight as hs
+
+        config = {"mode": "local_embedded"}
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home", lambda: tmp_path
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._check_local_runtime",
+            lambda: (False, "No module named 'hindsight'"),
+        )
+        monkeypatch.setattr(hs, "_warned_missing_embedded_runtime", False, raising=False)
+
+        p = HindsightMemoryProvider()
+        with caplog.at_level(logging.WARNING, logger="plugins.memory.hindsight"):
+            assert p.is_available() is False
+            assert p.is_available() is False
+        warns = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING and "hindsight-all" in r.getMessage()
+        ]
+        assert len(warns) == 1, [r.getMessage() for r in warns]
+
 
 class TestSharedEventLoopLifecycle:
     """Regression tests for #11923 — Hindsight leaking aiohttp ClientSession /


### PR DESCRIPTION
## Summary

`local_embedded` imports the top-level `hindsight` module (from the `hindsight-all` package), but `plugin.yaml` only declares `hindsight-client`. Users who configure `local_embedded` by hand — or upgrade from the legacy `"mode": "local"` — never run the setup wizard that installs `hindsight-all`, so long-term memory is **silently disabled** behind a non-actionable `No module named 'hindsight'` warning.

The agent-startup path (`agent/agent_init.py`) gates the provider on `is_available()` and drops it with a silent `logger.debug` **before** `initialize()` runs — so the actionable message has to live where the provider is actually dropped.

## Changes

- **`is_available()`** — emits a one-time actionable warning naming `hindsight-all` + the install command when `local_embedded` is configured but the runtime package is missing. Stays silent for intentional graceful-degradation failures (e.g. NumPy CPU-baseline errors).
- **`_get_client()`** — the `RuntimeError` raised when the runtime probe fails now carries the same actionable hint (the real raise point), with an `ImportError` backstop around the embedded import.
- **`initialize()`** — actionable disable warning + a migration warning when the legacy `"mode": "local"` is remapped to `local_embedded`.
- Shared `_embedded_runtime_hint()` / `_warn_missing_embedded_runtime_once()` helpers keep the messaging DRY and reason-gated.
- **Docs** — README troubleshooting note + `plugin.yaml` comment explaining why `hindsight-all` is intentionally not a static dependency (avoids pulling the heavy embedded runtime for cloud-only users).

## Testing

```
scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py
# 109 passed, 0 failed
```

7 new regression tests cover: `is_available()` warning + silence + once-per-process; `_get_client()` real-path `RuntimeError` and import backstop; `initialize()` disable + legacy-migration warnings.

Fixes #7718
