### PR TITLE
fix(tools): expose raw sandbox file reads

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -91,6 +91,14 @@ class TestHermesToolsGeneration(unittest.TestCase):
         self.assertIn("def web_search(", src)
         self.assertNotIn("def read_file(", src)
 
+    def test_read_file_stub_exposes_raw_mode(self):
+        src = generate_hermes_tools_module(["read_file"])
+        self.assertIn(
+            "def read_file(path: str, offset: int = 1, limit: int = 500, raw: bool = False)",
+            src,
+        )
+        self.assertIn('"raw": raw', src)
+
     def test_empty_list_generates_nothing(self):
         src = generate_hermes_tools_module([])
         self.assertNotIn("def terminal(", src)
@@ -240,6 +248,40 @@ print(f"file lines: {r2['total_lines']}")
         result = self._run(code)
         self.assertEqual(result["status"], "success")
         self.assertEqual(result["tool_calls_made"], 2)
+
+    def test_read_file_raw_mode_forwards_to_dispatcher(self):
+        """Regression for #46465: sandbox scripts need unnumbered content."""
+        seen_args = []
+
+        def raw_aware_mock(function_name, function_args, task_id=None, user_task=None):
+            if function_name == "read_file":
+                seen_args.append(dict(function_args))
+                if function_args.get("raw"):
+                    return json.dumps({"content": "hello\nworld\n", "total_lines": 2})
+                return json.dumps({"content": "1|hello\n2|world\n", "total_lines": 2})
+            return _mock_handle_function_call(
+                function_name, function_args, task_id=task_id, user_task=user_task
+            )
+
+        code = """
+from hermes_tools import read_file
+result = read_file("/tmp/example.txt", raw=True)
+print(result["content"])
+"""
+        with patch("model_tools.handle_function_call", side_effect=raw_aware_mock):
+            result = json.loads(execute_code(
+                code=code,
+                task_id="test-read-file-raw",
+                enabled_tools=list(SANDBOX_ALLOWED_TOOLS),
+            ))
+
+        self.assertEqual(result["status"], "success", msg=result)
+        self.assertEqual(
+            seen_args,
+            [{"path": "/tmp/example.txt", "offset": 1, "limit": 500, "raw": True}],
+        )
+        self.assertIn("hello\nworld", result["output"])
+        self.assertNotIn("1|hello", result["output"])
 
     def test_syntax_error(self):
         """Script with a syntax error returns error status."""

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -43,6 +43,41 @@ class TestReadFileHandler:
         mock_ops.read_file.assert_called_once_with("/tmp/big.txt", 10, 20)
 
     @patch("tools.file_tools._get_file_ops")
+    def test_positional_task_id_remains_backward_compatible(self, mock_get):
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.content = "line1"
+        result_obj.to_dict.return_value = {"content": "line1", "total_lines": 1}
+        mock_ops.read_file.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import read_file_tool
+        read_file_tool("/tmp/big.txt", 1, 500, "legacy-task")
+
+        mock_get.assert_called_once_with("legacy-task")
+        mock_ops.read_file.assert_called_once_with("/tmp/big.txt", 1, 500)
+
+    @patch("tools.file_tools.file_state.record_read")
+    @patch("tools.file_tools._resolve_path_for_task", return_value="/tmp/example.txt")
+    @patch("tools.file_tools._get_file_ops")
+    def test_raw_mode_returns_content_without_line_numbers(self, mock_get, _mock_resolve, mock_record_read):
+        mock_ops = MagicMock()
+        result_obj = MagicMock()
+        result_obj.content = "hello\nworld\n"
+        result_obj.to_dict.return_value = {"content": "hello\nworld\n", "file_size": 12}
+        mock_ops.read_file_raw.return_value = result_obj
+        mock_get.return_value = mock_ops
+
+        from tools.file_tools import read_file_tool
+        result = json.loads(read_file_tool("/tmp/example.txt", raw=True, task_id="task-raw"))
+
+        assert result["content"] == "hello\nworld\n"
+        assert "1|" not in result["content"]
+        mock_ops.read_file_raw.assert_called_once_with("/tmp/example.txt")
+        mock_ops.read_file.assert_not_called()
+        mock_record_read.assert_called_once_with("task-raw", "/tmp/example.txt", partial=False)
+
+    @patch("tools.file_tools._get_file_ops")
     def test_invalid_offset_and_limit_are_normalized_before_dispatch(self, mock_get):
         mock_ops = MagicMock()
         result_obj = MagicMock()

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -225,9 +225,9 @@ _TOOL_STUBS = {
     ),
     "read_file": (
         "read_file",
-        "path: str, offset: int = 1, limit: int = 500",
-        '"""Read a file (1-indexed lines). Returns dict with "content" and "total_lines"."""',
-        '{"path": path, "offset": offset, "limit": limit}',
+        "path: str, offset: int = 1, limit: int = 500, raw: bool = False",
+        '"""Read a file (1-indexed lines by default). raw=True returns unnumbered content for safe read/transform/write scripts."""',
+        '{"path": path, "offset": offset, "limit": limit, "raw": raw}',
     ),
     "write_file": (
         "write_file",
@@ -1720,8 +1720,8 @@ _TOOL_DOC_LINES = [
      "  web_extract(urls: list[str]) -> dict\n"
      "    Returns {\"results\": [{\"url\", \"title\", \"content\", \"error\"}, ...]} where content is markdown"),
     ("read_file",
-     "  read_file(path: str, offset: int = 1, limit: int = 500) -> dict\n"
-     "    Lines are 1-indexed. Returns {\"content\": \"...\", \"total_lines\": N}"),
+     "  read_file(path: str, offset: int = 1, limit: int = 500, raw: bool = False) -> dict\n"
+     "    Lines are 1-indexed by default. raw=True returns unnumbered content for read/transform/write scripts."),
     ("write_file",
      "  write_file(path: str, content: str) -> dict\n"
      "    Always overwrites the entire file."),

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -742,9 +742,20 @@ def clear_file_ops_cache(task_id: str = None):
             _file_ops_cache.clear()
 
 
-def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = "default") -> str:
-    """Read a file with pagination and line numbers."""
+def read_file_tool(
+    path: str,
+    offset: int = 1,
+    limit: int = 500,
+    task_id: str = "default",
+    *,
+    raw: bool = False,
+) -> str:
+    """Read a file with pagination and line numbers, or raw unnumbered content."""
     try:
+        if isinstance(raw, str):
+            raw = raw.strip().lower() in {"1", "true", "yes", "on"}
+        else:
+            raw = bool(raw)
         offset, limit = normalize_read_pagination(offset, limit)
 
         # ── Device path guard ─────────────────────────────────────────
@@ -765,7 +776,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         # Malformed documents fall through to the normal path/binary guard.
         from tools.read_extract import ExtractionError, extract_document_text, is_extractable_document
 
-        if is_extractable_document(str(_resolved)):
+        if not raw and is_extractable_document(str(_resolved)):
             try:
                 extracted_text = extract_document_text(str(_resolved))
             except ExtractionError:
@@ -828,11 +839,41 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         if block_error:
             return json.dumps({"error": block_error})
 
+        resolved_str = str(_resolved)
+
+        if raw:
+            file_ops = _get_file_ops(task_id)
+            result = file_ops.read_file_raw(path)
+            result_dict = result.to_dict()
+            content_len = len(result.content or "")
+            file_size = result_dict.get("file_size", 0)
+            max_chars = _get_max_read_chars()
+            if content_len > max_chars:
+                return json.dumps({
+                    "error": (
+                        f"Raw read produced {content_len:,} characters which exceeds "
+                        f"the safety limit ({max_chars:,} chars). Use normal "
+                        "read_file offset/limit pagination or narrow the file first."
+                    ),
+                    "path": path,
+                    "file_size": file_size,
+                }, ensure_ascii=False)
+
+            if result.content:
+                result.content = redact_sensitive_text(result.content, code_file=True)
+                result_dict["content"] = result.content
+
+            try:
+                file_state.record_read(task_id, resolved_str, partial=False)
+            except Exception:
+                logger.debug("file_state.record_read failed for raw read", exc_info=True)
+
+            return json.dumps(result_dict, ensure_ascii=False)
+
         # ── Dedup check ───────────────────────────────────────────────
         # If we already read this exact (path, offset, limit) and the
         # file hasn't been modified since, return a lightweight stub
         # instead of re-sending the same content.  Saves context tokens.
-        resolved_str = str(_resolved)
         dedup_key = (resolved_str, offset, limit)
         with _read_tracker_lock:
             task_data = _read_tracker.setdefault(task_id, {
@@ -1576,7 +1617,13 @@ SEARCH_FILES_SCHEMA = {
 
 def _handle_read_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid)
+    return read_file_tool(
+        path=args.get("path", ""),
+        offset=args.get("offset", 1),
+        limit=args.get("limit", 500),
+        raw=args.get("raw", False),
+        task_id=tid,
+    )
 
 
 def _handle_write_file(args, **kw):


### PR DESCRIPTION
## Summary
- Adds `raw=True` support to execute_code's generated `hermes_tools.read_file()` stub so sandbox scripts can request unnumbered file content before transforming/writing it back.
- Routes raw sandbox reads through the existing `read_file_raw()` implementation while preserving normal line-numbered reads and the existing positional `task_id` API.
- Adds regression coverage for stub generation, sandbox forwarding, raw file handler behavior, and legacy positional `task_id` compatibility.

## Test Plan
- [x] `python3 -m pytest tests/tools/test_file_tools.py::TestReadFileHandler tests/tools/test_code_execution.py::TestHermesToolsGeneration tests/tools/test_code_execution.py::TestExecuteCode::test_read_file_raw_mode_forwards_to_dispatcher -q`
- [x] `python3 -m py_compile tools/code_execution_tool.py tools/file_tools.py tests/tools/test_code_execution.py tests/tools/test_file_tools.py`
- [x] `git diff --check`

Fixes #46465
