### PR TITLE
Fix channels profile scope

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4236,6 +4236,10 @@ def _messaging_env_info(key: str) -> dict[str, Any]:
     }
 
 
+def _env_flag_truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"true", "1", "yes"}
+
+
 def _gateway_platform_config(platform_id: str):
     from gateway.config import Platform, load_gateway_config
 
@@ -4289,6 +4293,10 @@ def _messaging_platform_payload(
             if not isinstance(plat_cfg, dict):
                 plat_cfg = {}
             enabled = bool(plat_cfg.get("enabled"))
+            if not enabled:
+                env_toggle_key = f"{platform_id.upper()}_ENABLED"
+                if env_toggle_key in entry["env_vars"]:
+                    enabled = _env_flag_truthy(env_on_disk.get(env_toggle_key))
             hc = plat_cfg.get("home_channel")
             home_channel = hc if isinstance(hc, dict) else None
         except Exception:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4295,7 +4295,12 @@ def _messaging_platform_payload(
             enabled = bool(plat_cfg.get("enabled"))
             if not enabled:
                 env_toggle_key = f"{platform_id.upper()}_ENABLED"
-                if env_toggle_key in entry["env_vars"]:
+                supported_env_keys = {
+                    env_info["key"]
+                    for env_info in env_vars
+                    if isinstance(env_info, dict) and env_info.get("key")
+                }
+                if env_toggle_key in supported_env_keys:
                     enabled = _env_flag_truthy(env_on_disk.get(env_toggle_key))
             hc = plat_cfg.get("home_channel")
             home_channel = hc if isinstance(hc, dict) else None

--- a/tests/hermes_cli/test_web_server_messaging_profiles.py
+++ b/tests/hermes_cli/test_web_server_messaging_profiles.py
@@ -58,6 +58,10 @@ def _telegram(payload):
     return next(p for p in payload["platforms"] if p["id"] == "telegram")
 
 
+def _platform(payload, platform_id):
+    return next(p for p in payload["platforms"] if p["id"] == platform_id)
+
+
 def _env_field(platform, key):
     return next(f for f in platform["env_vars"] if f["key"] == key)
 
@@ -90,6 +94,21 @@ class TestProfileScopedMessagingReads:
             "/api/messaging/platforms", params={"profile": "no_such_profile"}
         )
         assert resp.status_code == 404
+
+    def test_scoped_read_honors_whatsapp_env_enable_flag(
+        self, client, isolated_profiles
+    ):
+        worker_home = isolated_profiles["worker_alpha"]
+        (worker_home / ".env").write_text(
+            "WHATSAPP_ENABLED=true\n", encoding="utf-8"
+        )
+
+        resp = client.get(
+            "/api/messaging/platforms", params={"profile": "worker_alpha"}
+        )
+        assert resp.status_code == 200
+        whatsapp = _platform(resp.json(), "whatsapp")
+        assert whatsapp["enabled"] is True
 
 
 class TestProfileScopedMessagingWrites:

--- a/web/src/pages/ChannelsPage.tsx
+++ b/web/src/pages/ChannelsPage.tsx
@@ -32,6 +32,7 @@ import type {
 } from "@/lib/api";
 import { useModalBehavior } from "@/hooks/useModalBehavior";
 import { usePageHeader } from "@/contexts/usePageHeader";
+import { useProfileScope } from "@/contexts/useProfileScope";
 import { cn, themedBody } from "@/lib/utils";
 
 // State → badge mapping. The backend emits a small, fixed vocabulary plus
@@ -74,6 +75,7 @@ export default function ChannelsPage() {
   const [loading, setLoading] = useState(true);
   const { toast, showToast } = useToast();
   const { setEnd } = usePageHeader();
+  const { profile, currentProfile } = useProfileScope();
 
   // Config modal state
   const [editing, setEditing] = useState<MessagingPlatform | null>(null);
@@ -95,9 +97,12 @@ export default function ChannelsPage() {
       .getMessagingPlatforms()
       .then((res) => setPlatforms(res.platforms))
       .catch((e) => showToast(`Error: ${e}`, "error"));
-  }, [showToast]);
+  }, [profile, showToast]);
 
   useEffect(() => {
+    // The management profile can settle after the first mount when a deep
+    // link arrives through remote/global mode. Reload on scope changes so
+    // Channels does not stay pinned to the dashboard's own profile.
     load().finally(() => setLoading(false));
   }, [load]);
 
@@ -212,6 +217,13 @@ export default function ChannelsPage() {
     [platforms],
   );
 
+  const credentialsPath = useMemo(() => {
+    const managedProfile = profile || currentProfile || "default";
+    return managedProfile === "default"
+      ? "~/.hermes/.env"
+      : `~/.hermes/profiles/${managedProfile}/.env`;
+  }, [profile, currentProfile]);
+
   if (loading) {
     return (
       <div className="flex items-center justify-center py-24">
@@ -262,7 +274,7 @@ export default function ChannelsPage() {
 
       <p className="text-xs text-muted-foreground">
         {configured} of {platforms.length} channels configured. Credentials are
-        written to <code className="font-courier">~/.hermes/.env</code>; the
+        written to <code className="font-courier">{credentialsPath}</code>; the
         gateway connects each enabled channel on its next restart.
       </p>
 

--- a/web/src/pages/ChannelsPage.tsx
+++ b/web/src/pages/ChannelsPage.tsx
@@ -91,13 +91,14 @@ export default function ChannelsPage() {
   const [restarting, setRestarting] = useState(false);
 
   const gatewayRunning = platforms.length > 0 && platforms[0].gateway_running;
+  const managedProfile = profile || currentProfile || "default";
 
   const load = useCallback(() => {
     return api
       .getMessagingPlatforms()
       .then((res) => setPlatforms(res.platforms))
       .catch((e) => showToast(`Error: ${e}`, "error"));
-  }, [profile, showToast]);
+  }, [managedProfile, showToast]);
 
   useEffect(() => {
     // The management profile can settle after the first mount when a deep
@@ -218,11 +219,10 @@ export default function ChannelsPage() {
   );
 
   const credentialsPath = useMemo(() => {
-    const managedProfile = profile || currentProfile || "default";
     return managedProfile === "default"
       ? "~/.hermes/.env"
       : `~/.hermes/profiles/${managedProfile}/.env`;
-  }, [profile, currentProfile]);
+  }, [managedProfile]);
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary
- reload the Channels page when the managed dashboard profile changes so deep links with ?profile= do not stay pinned to the default scope
- show the selected profile's credentials path in the Channels footer text
- honor env-based platform enablement flags such as WHATSAPP_ENABLED in the profile-scoped messaging payload and cover it with a regression test

## Validation
- cd web && npm run build
- source venv/bin/activate && python -m pytest tests/hermes_cli/test_web_server_messaging_profiles.py -q