### PR TITLE
feat(cli): add xAI OAuth device-code login for headless servers

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -104,6 +104,14 @@ XAI_OAUTH_REDIRECT_HOST = "127.0.0.1"
 XAI_OAUTH_REDIRECT_PORT = 56121
 XAI_OAUTH_REDIRECT_PATH = "/callback"
 XAI_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
+# RFC 8628 device-authorization grant. Used by the headless ``--device-code``
+# login path (no loopback listener, no browser on the box). Mirrors OpenClaw's
+# xAI device-code support (extensions/xai/xai-oauth.ts) and Hermes's own
+# OpenAI-Codex device-code login (``_codex_device_code_login``).
+XAI_DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
+XAI_DEVICE_CODE_DEFAULT_INTERVAL_SECONDS = 5  # poll cadence when server omits ``interval``
+XAI_DEVICE_CODE_MAX_WAIT_SECONDS = 15 * 60    # hard ceiling when server omits ``expires_in``
+XAI_DEVICE_CODE_SLOW_DOWN_INCREMENT_SECONDS = 5  # RFC 8628 §3.5 back-off step
 QWEN_OAUTH_CLIENT_ID = "f0304373b74a44d2b584a3fb70ca9e56"
 QWEN_OAUTH_TOKEN_URL = "https://chat.qwen.ai/api/v1/oauth2/token"
 QWEN_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
@@ -4119,6 +4127,71 @@ def _xai_oauth_discovery(timeout_seconds: float = 15.0) -> Dict[str, str]:
     }
 
 
+def _xai_oauth_device_discovery(timeout_seconds: float = 15.0) -> Dict[str, str]:
+    """Resolve the RFC 8628 device-authorization + token endpoints.
+
+    The device-code login path doesn't need an ``authorization_endpoint``
+    (there is no browser redirect on the box), but it does need the
+    ``device_authorization_endpoint``, which the PKCE-loopback discovery
+    above doesn't surface. Both endpoints are validated against the xAI
+    origin via :func:`_xai_validate_oauth_endpoint` for the same
+    cache-poisoning reason documented there.
+    """
+    try:
+        response = httpx.get(
+            XAI_OAUTH_DISCOVERY_URL,
+            headers={"Accept": "application/json"},
+            timeout=timeout_seconds,
+        )
+    except Exception as exc:
+        raise AuthError(
+            f"xAI OIDC discovery failed: {exc}",
+            provider="xai-oauth",
+            code="xai_discovery_failed",
+        ) from exc
+    if response.status_code != 200:
+        raise AuthError(
+            f"xAI OIDC discovery returned status {response.status_code}.",
+            provider="xai-oauth",
+            code="xai_discovery_failed",
+        )
+    try:
+        payload = response.json()
+    except Exception as exc:
+        raise AuthError(
+            f"xAI OIDC discovery returned invalid JSON: {exc}",
+            provider="xai-oauth",
+            code="xai_discovery_invalid_json",
+        ) from exc
+    if not isinstance(payload, dict):
+        raise AuthError(
+            "xAI OIDC discovery response was not a JSON object.",
+            provider="xai-oauth",
+            code="xai_discovery_incomplete",
+        )
+    device_authorization_endpoint = str(
+        payload.get("device_authorization_endpoint", "") or ""
+    ).strip()
+    token_endpoint = str(payload.get("token_endpoint", "") or "").strip()
+    if not device_authorization_endpoint or not token_endpoint:
+        raise AuthError(
+            "xAI OIDC discovery response was missing the device-code endpoints "
+            "(device_authorization_endpoint / token_endpoint). Your xAI tenant "
+            "may not have device-code OAuth enabled; use the loopback or "
+            "`--manual-paste` flow instead.",
+            provider="xai-oauth",
+            code="xai_device_discovery_incomplete",
+        )
+    _xai_validate_oauth_endpoint(
+        device_authorization_endpoint, field="device_authorization_endpoint"
+    )
+    _xai_validate_oauth_endpoint(token_endpoint, field="token_endpoint")
+    return {
+        "device_authorization_endpoint": device_authorization_endpoint,
+        "token_endpoint": token_endpoint,
+    }
+
+
 def refresh_xai_oauth_pure(
     access_token: str,
     refresh_token: str,
@@ -6611,12 +6684,31 @@ def _login_xai_oauth(
     if _is_remote_session():
         open_browser = False
     manual_paste = bool(getattr(args, "manual_paste", False))
+    device_code = bool(getattr(args, "device_code", False))
 
-    creds = _xai_oauth_loopback_login(
-        timeout_seconds=timeout_seconds,
-        open_browser=open_browser,
-        manual_paste=manual_paste,
-    )
+    if device_code and manual_paste:
+        raise AuthError(
+            "--device-code and --manual-paste are mutually exclusive: the "
+            "device-code flow has no loopback callback to paste. Pick one.",
+            provider="xai-oauth",
+            code="xai_login_flag_conflict",
+        )
+
+    if device_code:
+        # Headless device-code flow (RFC 8628): no loopback listener, no
+        # browser required on this box. Ideal for SSH-only VPS deployments
+        # where 127.0.0.1 on the remote isn't reachable from the operator's
+        # browser. Mutually exclusive with --manual-paste at the parser level.
+        creds = _xai_oauth_device_code_login(
+            timeout_seconds=timeout_seconds,
+            open_browser=open_browser,
+        )
+    else:
+        creds = _xai_oauth_loopback_login(
+            timeout_seconds=timeout_seconds,
+            open_browser=open_browser,
+            manual_paste=manual_paste,
+        )
     _save_xai_oauth_tokens(
         creds["tokens"],
         discovery=creds.get("discovery"),
@@ -6778,6 +6870,299 @@ def _xai_oauth_exchange_code_for_tokens(
             code="xai_token_exchange_invalid",
         )
     return payload
+
+
+def _xai_oauth_request_device_code(
+    *,
+    device_authorization_endpoint: str,
+    timeout_seconds: float = 20.0,
+) -> Dict[str, Any]:
+    """POST to xAI's device-authorization endpoint (RFC 8628 §3.1/§3.2).
+
+    Returns the parsed payload containing ``device_code``, ``user_code``,
+    ``verification_uri`` (and optionally ``verification_uri_complete``),
+    ``expires_in`` and ``interval``. The device-code grant is a public-client
+    flow with no PKCE, so we only send ``client_id`` + ``scope`` — matching
+    OpenClaw's ``requestXaiDeviceCode`` (extensions/xai/xai-oauth.ts).
+    """
+    try:
+        response = httpx.post(
+            device_authorization_endpoint,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Accept": "application/json",
+            },
+            data={
+                "client_id": XAI_OAUTH_CLIENT_ID,
+                "scope": XAI_OAUTH_SCOPE,
+            },
+            timeout=max(20.0, timeout_seconds),
+        )
+    except Exception as exc:
+        raise AuthError(
+            f"xAI device code request failed: {exc}",
+            provider="xai-oauth",
+            code="xai_device_code_request_failed",
+        ) from exc
+
+    if response.status_code != 200:
+        body = response.text.strip()
+        raise AuthError(
+            f"xAI device code request failed (HTTP {response.status_code})."
+            + (f" Response: {body}" if body else ""),
+            provider="xai-oauth",
+            code="xai_device_code_request_error",
+        )
+
+    try:
+        payload = response.json()
+    except Exception as exc:
+        raise AuthError(
+            f"xAI device code request returned invalid JSON: {exc}",
+            provider="xai-oauth",
+            code="xai_device_code_invalid_json",
+        ) from exc
+    if not isinstance(payload, dict):
+        raise AuthError(
+            "xAI device code response was not a JSON object.",
+            provider="xai-oauth",
+            code="xai_device_code_invalid",
+        )
+
+    device_code = str(payload.get("device_code", "") or "").strip()
+    user_code = str(payload.get("user_code", "") or "").strip()
+    verification_uri = str(payload.get("verification_uri", "") or "").strip()
+    if not device_code or not user_code or not verification_uri:
+        raise AuthError(
+            "xAI device code response is missing device_code, user_code, "
+            "or verification_uri.",
+            provider="xai-oauth",
+            code="xai_device_code_incomplete",
+        )
+    return payload
+
+
+def _xai_oauth_poll_device_token(
+    *,
+    token_endpoint: str,
+    device_code: str,
+    expires_in: int,
+    poll_interval: int,
+    timeout_seconds: float = 20.0,
+) -> Dict[str, Any]:
+    """Poll xAI's token endpoint until the device is authorized (RFC 8628 §3.4/§3.5).
+
+    Handles ``authorization_pending`` (keep waiting), ``slow_down`` (back off),
+    ``access_denied`` / ``expired_token`` (terminal). Mirrors OpenClaw's
+    ``pollXaiDeviceCodeToken`` and Hermes's nous ``_poll_for_token`` semantics.
+    """
+    import time as _time
+
+    deadline = _time.monotonic() + max(1, expires_in)
+    current_interval = max(1, poll_interval)
+
+    with httpx.Client(timeout=httpx.Timeout(max(20.0, timeout_seconds))) as client:
+        while _time.monotonic() < deadline:
+            _time.sleep(current_interval)
+            try:
+                response = client.post(
+                    token_endpoint,
+                    headers={
+                        "Content-Type": "application/x-www-form-urlencoded",
+                        "Accept": "application/json",
+                    },
+                    data={
+                        "grant_type": XAI_DEVICE_CODE_GRANT_TYPE,
+                        "client_id": XAI_OAUTH_CLIENT_ID,
+                        "device_code": device_code,
+                    },
+                )
+            except Exception as exc:
+                raise AuthError(
+                    f"xAI device token poll failed: {exc}",
+                    provider="xai-oauth",
+                    code="xai_device_poll_failed",
+                ) from exc
+
+            if response.status_code == 200:
+                try:
+                    payload = response.json()
+                except Exception as exc:
+                    raise AuthError(
+                        f"xAI device token response returned invalid JSON: {exc}",
+                        provider="xai-oauth",
+                        code="xai_device_token_invalid_json",
+                    ) from exc
+                if not isinstance(payload, dict):
+                    raise AuthError(
+                        "xAI device token response was not a JSON object.",
+                        provider="xai-oauth",
+                        code="xai_device_token_invalid",
+                    )
+                return payload
+
+            try:
+                error_payload = response.json()
+            except Exception:
+                error_payload = {}
+            error_code = ""
+            if isinstance(error_payload, dict):
+                error_code = str(error_payload.get("error", "") or "").strip()
+
+            if error_code == "authorization_pending":
+                continue
+            if error_code == "slow_down":
+                current_interval = min(
+                    current_interval + XAI_DEVICE_CODE_SLOW_DOWN_INCREMENT_SECONDS, 30
+                )
+                continue
+            if error_code in {"access_denied", "authorization_denied"}:
+                raise AuthError(
+                    "xAI device authorization was denied.",
+                    provider="xai-oauth",
+                    code="xai_device_access_denied",
+                )
+            if error_code == "expired_token":
+                raise AuthError(
+                    "xAI device code expired before authorization. Re-run the login.",
+                    provider="xai-oauth",
+                    code="xai_device_code_expired",
+                )
+
+            body = response.text.strip()
+            raise AuthError(
+                f"xAI device token exchange failed (HTTP {response.status_code})."
+                + (f" Response: {body}" if body else ""),
+                provider="xai-oauth",
+                code="xai_device_token_exchange_failed",
+            )
+
+    raise AuthError(
+        "xAI device authorization timed out waiting for approval.",
+        provider="xai-oauth",
+        code="xai_device_code_timeout",
+    )
+
+
+def _xai_oauth_device_code_login(
+    *,
+    timeout_seconds: float = 20.0,
+    open_browser: bool = True,
+) -> Dict[str, Any]:
+    """Run the xAI OAuth device-code flow and return a credentials dict.
+
+    Returns the same shape as :func:`_xai_oauth_loopback_login` so the
+    callers (``_login_xai_oauth`` and ``auth_commands``) persist tokens
+    identically. The device-code path needs no loopback listener and no
+    browser on the box — the user authorizes from any device — which is
+    why headless VPS deployments need it (the loopback flow binds
+    127.0.0.1 on the remote, unreachable from the operator's laptop;
+    same gap OpenClaw closed with ``xai-device-code`` in 2026.5.18).
+    """
+    discovery = _xai_oauth_device_discovery(timeout_seconds)
+    device_authorization_endpoint = discovery["device_authorization_endpoint"]
+    token_endpoint = discovery["token_endpoint"]
+
+    device_data = _xai_oauth_request_device_code(
+        device_authorization_endpoint=device_authorization_endpoint,
+        timeout_seconds=timeout_seconds,
+    )
+    user_code = str(device_data.get("user_code", "") or "").strip()
+    device_code = str(device_data.get("device_code", "") or "").strip()
+    verification_uri = str(device_data.get("verification_uri", "") or "").strip()
+    verification_uri_complete = str(
+        device_data.get("verification_uri_complete", "") or ""
+    ).strip()
+    expires_in = _coerce_ttl_seconds(device_data.get("expires_in", 0)) or (
+        XAI_DEVICE_CODE_MAX_WAIT_SECONDS
+    )
+    poll_interval = max(
+        1,
+        int(device_data.get("interval", XAI_DEVICE_CODE_DEFAULT_INTERVAL_SECONDS) or
+            XAI_DEVICE_CODE_DEFAULT_INTERVAL_SECONDS),
+    )
+
+    browser_url = verification_uri_complete or verification_uri
+    print("To continue, follow these steps:\n")
+    print("  1. Open this URL in your browser (any device):")
+    print(f"     \033[94m{verification_uri}\033[0m\n")
+    print("  2. Enter this code:")
+    print(f"     \033[94m{user_code}\033[0m\n")
+    print(
+        f"Code expires in ~{max(1, expires_in // 60)} minutes. Never share it."
+    )
+    print("Waiting for sign-in... (press Ctrl+C to cancel)")
+
+    # Best-effort browser open — only when this isn't a headless/remote
+    # session. On a remote VM the browser would open on the wrong machine,
+    # so we leave the URL printed above for the operator to open locally.
+    if (
+        open_browser
+        and verification_uri_complete
+        and not _is_remote_session()
+        and _can_open_graphical_browser()
+    ):
+        try:
+            webbrowser.open(browser_url)
+        except Exception:
+            pass
+
+    try:
+        payload = _xai_oauth_poll_device_token(
+            token_endpoint=token_endpoint,
+            device_code=device_code,
+            expires_in=expires_in,
+            poll_interval=poll_interval,
+            timeout_seconds=timeout_seconds,
+        )
+    except KeyboardInterrupt:
+        print("\nLogin cancelled.")
+        raise SystemExit(130)
+
+    access_token = str(payload.get("access_token", "") or "").strip()
+    refresh_token = str(payload.get("refresh_token", "") or "").strip()
+    if not access_token:
+        raise AuthError(
+            "xAI device token exchange did not return an access_token.",
+            provider="xai-oauth",
+            code="xai_token_exchange_invalid",
+        )
+    if not refresh_token:
+        raise AuthError(
+            "xAI device token exchange did not return a refresh_token. "
+            "Re-run the login; if this persists, the OAuth client did not "
+            "issue a refresh token (commonly because the offline_access "
+            "scope was rejected).",
+            provider="xai-oauth",
+            code="xai_token_exchange_invalid",
+        )
+
+    base_url = _xai_validate_inference_base_url(
+        os.getenv("HERMES_XAI_BASE_URL", "").strip().rstrip("/")
+        or os.getenv("XAI_BASE_URL", "").strip().rstrip("/"),
+        fallback=DEFAULT_XAI_OAUTH_BASE_URL,
+    )
+    # The token_endpoint is persisted in ``discovery`` so refreshes reuse the
+    # validated endpoint rather than re-running discovery; ``_save_xai_oauth_tokens``
+    # stores it under state["discovery"]. We carry both endpoints for parity
+    # with the loopback path's discovery dict.
+    return {
+        "tokens": {
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+            "id_token": str(payload.get("id_token", "") or "").strip(),
+            "expires_in": payload.get("expires_in"),
+            "token_type": str(payload.get("token_type") or "Bearer").strip() or "Bearer",
+        },
+        "discovery": {
+            "token_endpoint": token_endpoint,
+            "device_authorization_endpoint": device_authorization_endpoint,
+        },
+        "redirect_uri": "",
+        "base_url": base_url,
+        "last_refresh": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "source": "device-code",
+    }
 
 
 def _xai_oauth_loopback_login(

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -345,11 +345,22 @@ def auth_add_command(args) -> None:
         return
 
     if provider == "xai-oauth":
-        creds = auth_mod._xai_oauth_loopback_login(
-            timeout_seconds=getattr(args, "timeout", None) or 20.0,
-            open_browser=not getattr(args, "no_browser", False),
-            manual_paste=bool(getattr(args, "manual_paste", False)),
-        )
+        if bool(getattr(args, "device_code", False)):
+            # Headless device-code flow (RFC 8628): no loopback listener and
+            # no browser on this box. For SSH-only VPS where 127.0.0.1 on the
+            # remote isn't reachable from the operator's browser. Tokens land
+            # in the same xai-oauth singleton, so they seed the pool under the
+            # existing ``loopback_pkce`` source (refresh/runtime path unchanged).
+            creds = auth_mod._xai_oauth_device_code_login(
+                timeout_seconds=getattr(args, "timeout", None) or 20.0,
+                open_browser=not getattr(args, "no_browser", False),
+            )
+        else:
+            creds = auth_mod._xai_oauth_loopback_login(
+                timeout_seconds=getattr(args, "timeout", None) or 20.0,
+                open_browser=not getattr(args, "no_browser", False),
+                manual_paste=bool(getattr(args, "manual_paste", False)),
+            )
         auth_mod._save_xai_oauth_tokens(
             creds["tokens"],
             discovery=creds.get("discovery"),

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -465,11 +465,13 @@ def _model_flow_xai_oauth(_config, current_model="", *, args=None):
             print()
             try:
                 # Forward CLI flags from ``hermes model --manual-paste``
-                # / ``--no-browser`` / ``--timeout`` into the loopback
-                # login. Without this, browser-only remotes (#26923)
-                # can't reach the manual-paste path via ``hermes model``.
+                # / ``--device-code`` / ``--no-browser`` / ``--timeout``
+                # into the login. Without this, headless / browser-only
+                # remotes (#26923) can't reach the manual-paste or
+                # device-code paths via ``hermes model``.
                 mock_args = argparse.Namespace(
                     manual_paste=bool(getattr(args, "manual_paste", False)),
+                    device_code=bool(getattr(args, "device_code", False)),
                     no_browser=bool(getattr(args, "no_browser", False)),
                     timeout=getattr(args, "timeout", None),
                 )
@@ -492,6 +494,7 @@ def _model_flow_xai_oauth(_config, current_model="", *, args=None):
         try:
             mock_args = argparse.Namespace(
                 manual_paste=bool(getattr(args, "manual_paste", False)),
+                device_code=bool(getattr(args, "device_code", False)),
                 no_browser=bool(getattr(args, "no_browser", False)),
                 timeout=getattr(args, "timeout", None),
             )

--- a/hermes_cli/subcommands/auth.py
+++ b/hermes_cli/subcommands/auth.py
@@ -52,6 +52,18 @@ def build_auth_parser(subparsers, *, cmd_auth: Callable) -> None:
         ),
     )
     auth_add.add_argument(
+        "--device-code",
+        action="store_true",
+        help=(
+            "Use the RFC 8628 device-code flow instead of the loopback "
+            "callback. No listener and no browser are needed on this box — "
+            "you authorize from any device by visiting a URL and entering a "
+            "short code. Ideal for headless / SSH-only servers. Currently "
+            "supported for xai-oauth (and openai-codex / nous use device-code "
+            "by default). Mutually exclusive with --manual-paste."
+        ),
+    )
+    auth_add.add_argument(
         "--timeout", type=float, help="OAuth/network timeout in seconds"
     )
     auth_add.add_argument(

--- a/hermes_cli/subcommands/model.py
+++ b/hermes_cli/subcommands/model.py
@@ -56,6 +56,16 @@ def build_model_parser(subparsers, *, cmd_model: Callable) -> None:
         ),
     )
     model_parser.add_argument(
+        "--device-code",
+        action="store_true",
+        help=(
+            "For xai-oauth: use the RFC 8628 device-code flow — no callback "
+            "listener and no browser needed on this box. Authorize from any "
+            "device by visiting a URL and entering a short code. Ideal for "
+            "headless / SSH-only servers. Mutually exclusive with --manual-paste."
+        ),
+    )
+    model_parser.add_argument(
         "--timeout",
         type=float,
         default=15.0,

--- a/tests/hermes_cli/test_xai_oauth_device_code.py
+++ b/tests/hermes_cli/test_xai_oauth_device_code.py
@@ -1,0 +1,323 @@
+"""Coverage for the xAI OAuth device-code login flow (RFC 8628).
+
+NousResearch/hermes-agent previously supported xAI Grok OAuth only via the
+PKCE loopback flow (``--manual-paste`` for browser-only remotes). That flow
+binds 127.0.0.1 on the box and/or expects the operator to copy a callback URL
+out of a browser — neither works cleanly on a headless, SSH-only VPS.
+
+This adds a device-authorization-grant path (``hermes auth add xai-oauth
+--device-code`` / ``hermes model --device-code``) mirroring:
+
+* Hermes's own OpenAI-Codex device-code login (``_codex_device_code_login``).
+* OpenClaw's ``xai-device-code`` method (extensions/xai/xai-oauth.ts), which
+  hits ``device_authorization_endpoint`` then polls ``token_endpoint`` with
+  ``grant_type=urn:ietf:params:oauth:grant-type:device_code``.
+
+These tests pin the wire contract (no PKCE on the device path), the RFC 8628
+polling semantics (authorization_pending / slow_down / terminal errors), the
+loopback-compatible return shape, and the mutually-exclusive flag guard. None
+of them touch the network.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any, Dict, List
+
+import httpx
+import pytest
+
+from hermes_cli.auth import (
+    AuthError,
+    XAI_DEVICE_CODE_GRANT_TYPE,
+    XAI_OAUTH_CLIENT_ID,
+    XAI_OAUTH_SCOPE,
+    _login_xai_oauth,
+    _xai_oauth_device_code_login,
+    _xai_oauth_poll_device_token,
+    _xai_oauth_request_device_code,
+)
+
+
+# ---------------------------------------------------------------------------
+# httpx recorders (no network)
+# ---------------------------------------------------------------------------
+
+
+class _PostRecorder:
+    """Capture ``httpx.post`` calls and replay a fixed response."""
+
+    def __init__(self, response: httpx.Response) -> None:
+        self.response = response
+        self.calls: List[Dict[str, Any]] = []
+
+    def __call__(self, url, *, headers=None, data=None, timeout=None, **kw):
+        self.calls.append(
+            {"url": url, "headers": headers or {}, "data": data or {}}
+        )
+        return self.response
+
+
+class _ClientPostSequence:
+    """A fake ``httpx.Client`` whose ``.post`` replays a fixed sequence.
+
+    Used to drive ``_xai_oauth_poll_device_token`` through its
+    authorization_pending / slow_down / success states deterministically.
+    """
+
+    def __init__(self, responses: List[httpx.Response]) -> None:
+        self._responses = list(responses)
+        self.calls: List[Dict[str, Any]] = []
+
+    def __enter__(self) -> "_ClientPostSequence":
+        return self
+
+    def __exit__(self, *exc: Any) -> bool:
+        return False
+
+    def post(self, url, *, headers=None, data=None, **kw):
+        self.calls.append({"url": url, "headers": headers or {}, "data": data or {}})
+        if len(self._responses) > 1:
+            return self._responses.pop(0)
+        return self._responses[0]
+
+
+def _ok(payload: dict) -> httpx.Response:
+    return httpx.Response(200, json=payload)
+
+
+def _err(status: int, payload: dict) -> httpx.Response:
+    return httpx.Response(status, json=payload)
+
+
+# ---------------------------------------------------------------------------
+# Device-code request: no PKCE, just client_id + scope
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def device_code_post(monkeypatch):
+    recorder = _PostRecorder(
+        _ok(
+            {
+                "device_code": "DC-123",
+                "user_code": "WXYZ-1234",
+                "verification_uri": "https://accounts.x.ai/device",
+                "verification_uri_complete": "https://accounts.x.ai/device?code=WXYZ-1234",
+                "expires_in": 900,
+                "interval": 5,
+            }
+        )
+    )
+    monkeypatch.setattr("hermes_cli.auth.httpx.post", recorder)
+    return recorder
+
+
+def test_device_code_request_sends_client_id_and_scope(device_code_post):
+    """The device-authorization request is a public-client call — only
+    ``client_id`` + ``scope`` go on the wire, never a PKCE verifier."""
+    _xai_oauth_request_device_code(
+        device_authorization_endpoint="https://auth.x.ai/oauth2/device/code",
+    )
+    sent = device_code_post.calls[-1]["data"]
+    assert sent["client_id"] == XAI_OAUTH_CLIENT_ID
+    assert sent["scope"] == XAI_OAUTH_SCOPE
+    assert "code_verifier" not in sent
+    assert "code_challenge" not in sent
+
+
+def test_device_code_request_uses_form_urlencoded(device_code_post):
+    _xai_oauth_request_device_code(
+        device_authorization_endpoint="https://auth.x.ai/oauth2/device/code",
+    )
+    headers = device_code_post.calls[-1]["headers"]
+    assert headers["Content-Type"] == "application/x-www-form-urlencoded"
+
+
+def test_device_code_request_rejects_incomplete_response(monkeypatch):
+    recorder = _PostRecorder(_ok({"user_code": "ABCD"}))  # no device_code
+    monkeypatch.setattr("hermes_cli.auth.httpx.post", recorder)
+    with pytest.raises(AuthError) as ei:
+        _xai_oauth_request_device_code(
+            device_authorization_endpoint="https://auth.x.ai/oauth2/device/code",
+        )
+    assert ei.value.code == "xai_device_code_incomplete"
+
+
+# ---------------------------------------------------------------------------
+# Token poll: device-code grant + RFC 8628 §3.5 error handling
+# ---------------------------------------------------------------------------
+
+
+def test_poll_uses_device_code_grant(monkeypatch):
+    """The poll body must carry the device_code grant + client_id +
+    device_code, and never a PKCE code/verifier."""
+    seq = _ClientPostSequence([_ok({"access_token": "AT", "refresh_token": "RT"})])
+    monkeypatch.setattr("hermes_cli.auth.httpx.Client", lambda *a, **k: seq)
+    # Patch sleep so the test doesn't wait for the poll interval.
+    monkeypatch.setattr("time.sleep", lambda *_a, **_k: None)
+
+    payload = _xai_oauth_poll_device_token(
+        token_endpoint="https://auth.x.ai/oauth2/token",
+        device_code="DC-123",
+        expires_in=900,
+        poll_interval=5,
+    )
+    assert payload["access_token"] == "AT"
+    sent = seq.calls[-1]["data"]
+    assert sent["grant_type"] == XAI_DEVICE_CODE_GRANT_TYPE
+    assert sent["client_id"] == XAI_OAUTH_CLIENT_ID
+    assert sent["device_code"] == "DC-123"
+    assert "code_verifier" not in sent
+
+
+def test_poll_waits_through_authorization_pending(monkeypatch):
+    """``authorization_pending`` keeps polling; success on a later attempt
+    is returned."""
+    seq = _ClientPostSequence(
+        [
+            _err(400, {"error": "authorization_pending"}),
+            _err(400, {"error": "authorization_pending"}),
+            _ok({"access_token": "AT", "refresh_token": "RT"}),
+        ]
+    )
+    monkeypatch.setattr("hermes_cli.auth.httpx.Client", lambda *a, **k: seq)
+    monkeypatch.setattr("time.sleep", lambda *_a, **_k: None)
+
+    payload = _xai_oauth_poll_device_token(
+        token_endpoint="https://auth.x.ai/oauth2/token",
+        device_code="DC-123",
+        expires_in=900,
+        poll_interval=1,
+    )
+    assert payload["refresh_token"] == "RT"
+    assert len(seq.calls) == 3
+
+
+def test_poll_raises_on_access_denied(monkeypatch):
+    seq = _ClientPostSequence([_err(400, {"error": "access_denied"})])
+    monkeypatch.setattr("hermes_cli.auth.httpx.Client", lambda *a, **k: seq)
+    monkeypatch.setattr("time.sleep", lambda *_a, **_k: None)
+    with pytest.raises(AuthError) as ei:
+        _xai_oauth_poll_device_token(
+            token_endpoint="https://auth.x.ai/oauth2/token",
+            device_code="DC-123",
+            expires_in=900,
+            poll_interval=1,
+        )
+    assert ei.value.code == "xai_device_access_denied"
+
+
+def test_poll_raises_on_expired_token(monkeypatch):
+    seq = _ClientPostSequence([_err(400, {"error": "expired_token"})])
+    monkeypatch.setattr("hermes_cli.auth.httpx.Client", lambda *a, **k: seq)
+    monkeypatch.setattr("time.sleep", lambda *_a, **_k: None)
+    with pytest.raises(AuthError) as ei:
+        _xai_oauth_poll_device_token(
+            token_endpoint="https://auth.x.ai/oauth2/token",
+            device_code="DC-123",
+            expires_in=900,
+            poll_interval=1,
+        )
+    assert ei.value.code == "xai_device_code_expired"
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator: loopback-compatible return shape
+# ---------------------------------------------------------------------------
+
+
+def test_device_code_login_returns_loopback_compatible_shape(monkeypatch):
+    """``_xai_oauth_device_code_login`` must return the same dict shape as
+    ``_xai_oauth_loopback_login`` so the shared persistence path
+    (``_save_xai_oauth_tokens``) works unchanged."""
+    monkeypatch.setattr(
+        "hermes_cli.auth._xai_oauth_device_discovery",
+        lambda *_a, **_k: {
+            "device_authorization_endpoint": "https://auth.x.ai/oauth2/device/code",
+            "token_endpoint": "https://auth.x.ai/oauth2/token",
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._xai_oauth_request_device_code",
+        lambda *_a, **_k: {
+            "device_code": "DC-123",
+            "user_code": "WXYZ-1234",
+            "verification_uri": "https://accounts.x.ai/device",
+            "expires_in": 900,
+            "interval": 5,
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._xai_oauth_poll_device_token",
+        lambda *_a, **_k: {
+            "access_token": "AT-dev",
+            "refresh_token": "RT-dev",
+            "id_token": "ID",
+            "expires_in": 3600,
+            "token_type": "Bearer",
+        },
+    )
+    # Never try to open a browser in the test env.
+    monkeypatch.setattr("hermes_cli.auth._is_remote_session", lambda: True)
+
+    creds = _xai_oauth_device_code_login(open_browser=False)
+    assert creds["tokens"]["access_token"] == "AT-dev"
+    assert creds["tokens"]["refresh_token"] == "RT-dev"
+    assert creds["source"] == "device-code"
+    # discovery carries the validated token_endpoint for refresh reuse.
+    assert creds["discovery"]["token_endpoint"] == "https://auth.x.ai/oauth2/token"
+    # Same top-level keys the loopback login returns.
+    for key in ("tokens", "discovery", "redirect_uri", "base_url", "last_refresh"):
+        assert key in creds
+
+
+def test_device_code_login_requires_refresh_token(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.auth._xai_oauth_device_discovery",
+        lambda *_a, **_k: {
+            "device_authorization_endpoint": "https://auth.x.ai/oauth2/device/code",
+            "token_endpoint": "https://auth.x.ai/oauth2/token",
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._xai_oauth_request_device_code",
+        lambda *_a, **_k: {
+            "device_code": "DC-123",
+            "user_code": "WXYZ-1234",
+            "verification_uri": "https://accounts.x.ai/device",
+            "expires_in": 900,
+            "interval": 5,
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth._xai_oauth_poll_device_token",
+        lambda *_a, **_k: {"access_token": "AT-dev"},  # no refresh_token
+    )
+    monkeypatch.setattr("hermes_cli.auth._is_remote_session", lambda: True)
+    with pytest.raises(AuthError) as ei:
+        _xai_oauth_device_code_login(open_browser=False)
+    assert ei.value.code == "xai_token_exchange_invalid"
+
+
+# ---------------------------------------------------------------------------
+# Flag guard: --device-code and --manual-paste are mutually exclusive
+# ---------------------------------------------------------------------------
+
+
+def test_login_rejects_device_code_with_manual_paste(monkeypatch):
+    """``_login_xai_oauth`` must refuse both flags together — the device-code
+    flow has no loopback callback to paste."""
+    # Force a fresh login path (skip the "reuse existing creds" branch).
+    monkeypatch.setattr(
+        "hermes_cli.auth.resolve_xai_oauth_runtime_credentials",
+        lambda *_a, **_k: (_ for _ in ()).throw(
+            AuthError("none", provider="xai-oauth", code="missing")
+        ),
+    )
+    args = argparse.Namespace(
+        device_code=True, manual_paste=True, no_browser=True, timeout=None
+    )
+    with pytest.raises(AuthError) as ei:
+        _login_xai_oauth(args, None, force_new_login=True)
+    assert ei.value.code == "xai_login_flag_conflict"

--- a/website/docs/guides/xai-grok-oauth.md
+++ b/website/docs/guides/xai-grok-oauth.md
@@ -67,6 +67,22 @@ hermes auth add xai-oauth
 
 On servers, containers, or SSH sessions where no browser is available, Hermes detects the remote environment and prints the authorization URL instead of opening a browser.
 
+#### Device-code flow (recommended for headless servers)
+
+The simplest option for a headless / SSH-only box is the [RFC 8628](https://www.rfc-editor.org/rfc/rfc8628) device-code flow. There is **no loopback listener and no browser needed on the server** — Hermes prints a short code and a URL, you open that URL on any device (your laptop, phone, ...), enter the code, and Hermes finishes the login by polling xAI's token endpoint:
+
+```bash
+hermes auth add xai-oauth --device-code
+# Or via the model picker:
+hermes model --device-code
+```
+
+This avoids the `ssh -L` port-forward entirely. It mirrors the device-code login already used by `openai-codex` and the Nous Portal, and matches the `xai-device-code` method in OpenClaw. (Requires that your xAI tenant exposes the `device_authorization_endpoint` in its OIDC discovery document; if it doesn't, Hermes falls back with a clear error and you can use the loopback or `--manual-paste` flow below.)
+
+`--device-code` and `--manual-paste` are mutually exclusive — the device-code flow has no callback URL to paste.
+
+#### Loopback flow over an SSH port-forward
+
 **Important:** the loopback listener still runs on the remote machine at `127.0.0.1:56121`. The xAI redirect needs to reach *that* listener, so opening the URL on your laptop will fail (`Could not establish connection. We couldn't reach your app.`) unless you forward the port:
 
 ```bash


### PR DESCRIPTION
## Problem

xAI Grok OAuth currently supports only the PKCE **loopback** flow (with `--manual-paste` for browser-only remotes). Neither path works cleanly on a **headless, SSH-only server**:

- The loopback flow binds `127.0.0.1:56121` on the remote box. The operator's browser can't reach that listener without an `ssh -L 56121:127.0.0.1:56121` port-forward (documented in the guide, but a real friction point and impossible on some setups).
- `--manual-paste` (#26923) still expects the user to copy a callback URL out of a browser session — fine for Cloud Shell / Codespaces, but awkward when you're just `ssh`'d into a plain VPS with no graphical browser anywhere in the loop.

Hermes already solves this for **OpenAI Codex** and the **Nous Portal** with the RFC 8628 device-code grant. OpenClaw shipped the same approach for xAI (`xai-device-code`, `extensions/xai/xai-oauth.ts`). This PR brings xAI device-code to Hermes.

## What this adds

A device-authorization-grant login path for `xai-oauth`:

```bash
hermes auth add xai-oauth --device-code
# or via the model picker:
hermes model --device-code
```

No loopback listener, no browser on the box. Hermes prints a short user code + a verification URL; you authorize from any device; Hermes polls the token endpoint to completion.

## How it works (and what it mirrors)

- `_xai_oauth_device_discovery` — extracts `device_authorization_endpoint` + `token_endpoint` from xAI's OIDC discovery doc, validated against the xAI origin via the existing `_xai_validate_oauth_endpoint` (same cache-poisoning protection as the loopback discovery).
- `_xai_oauth_request_device_code` — public-client device request (`client_id` + `scope`, **no PKCE**), mirroring OpenClaw's `requestXaiDeviceCode`.
- `_xai_oauth_poll_device_token` — polls `token_endpoint` with `grant_type=urn:ietf:params:oauth:grant-type:device_code`; handles `authorization_pending` (wait), `slow_down` (back off), `access_denied` / `expired_token` (terminal). Mirrors OpenClaw's `pollXaiDeviceCodeToken` and Hermes's nous `_poll_for_token` semantics, and the codex device-code login (`_codex_device_code_login`).
- `_xai_oauth_device_code_login` — orchestrator that returns the **same dict shape** as `_xai_oauth_loopback_login`, so tokens persist through the shared `_save_xai_oauth_tokens` path and seed the credential pool under the existing `loopback_pkce` singleton source. **Refresh and runtime resolution are unchanged** — the device-code tokens are ordinary OAuth `access_token` + `refresh_token`, refreshed the same way as loopback tokens.
- Wired `--device-code` into `hermes auth add xai-oauth`, `hermes model`, and the model picker. `--device-code` and `--manual-paste` are mutually exclusive (clear `AuthError`).
- Docs: a "Device-code flow (recommended for headless servers)" subsection in `website/docs/guides/xai-grok-oauth.md`.

## Testing

- New `tests/hermes_cli/test_xai_oauth_device_code.py` (10 cases, no network) pins:
  - the device request sends only `client_id` + `scope` (no PKCE), form-urlencoded;
  - the poll uses the device-code grant and handles `authorization_pending` / `access_denied` / `expired_token`;
  - the orchestrator returns a loopback-compatible shape and requires a `refresh_token`;
  - `--device-code` + `--manual-paste` is rejected.
- Existing `test_xai_oauth_pkce_token_exchange.py` and `test_auth_xai_oauth_provider.py` still pass (96/96 with `openai` installed).

```bash
scripts/run_tests.sh tests/hermes_cli/test_xai_oauth_device_code.py -q
```

**Platforms tested:** macOS (unit tests, no live network).

## Testing caveats

- The unit tests do not perform a live login. I have **not** completed a real end-to-end device-code authorization against `auth.x.ai` (no SuperGrok/Premium+ test tenant available in this environment). The flow shape is verified against OpenClaw's working `xai-device-code` implementation and Hermes's existing codex/nous device-code logins, but a reviewer with xAI OAuth access should confirm a live `hermes auth add xai-oauth --device-code` round-trip.
- The exact `device_authorization_endpoint` is read from xAI's OIDC discovery document at runtime rather than hardcoded; if a tenant's discovery doc omits it, Hermes raises a clear `xai_device_discovery_incomplete` error and the user can fall back to the loopback / `--manual-paste` flow.

## Notes

This follows the OpenClaw reference (`extensions/xai/xai-oauth.ts`, `XAI_DEVICE_CODE_*` constants, `loginXaiDeviceCode`) for the device endpoint + flow, and the in-repo `_codex_device_code_login` for the CLI UX and persistence pattern.


---

## Live validation (2026-06-15)

Validated end-to-end against the real `auth.x.ai` endpoints, using the exact Grok-CLI `client_id` + scope this PR sends (full RFC 8628 round-trip):

- OIDC discovery exposes `device_authorization_endpoint` = `https://auth.x.ai/oauth2/device/code` and `token_endpoint` = `https://auth.x.ai/oauth2/token`.
- `POST /oauth2/device/code` (`client_id` + `scope=openid profile email offline_access grok-cli:access api:access`, no PKCE) → **accepted**: returns `user_code`, `verification_uri_complete`, `expires_in=900`, `interval=5`.
- After approving the user code in a browser on a real SuperGrok/Premium+ account, `POST /oauth2/token` with `grant_type=urn:ietf:params:oauth:grant-type:device_code` → **returns `access_token` + `refresh_token`** (`token_type=Bearer`, `expires_in=21600`).

So the device-authorization grant is live-confirmed for the impersonated Grok-CLI client on a production xAI tenant. The request/poll/exchange logic itself is additionally covered by the 10 new unit tests.
