### PR TITLE
Add config cap for cron delivery text

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -656,6 +656,33 @@ def _send_media_via_adapter(
             logger.warning("Job '%s': failed to send media %s: %s", job.get("id", "?"), media_path, e)
 
 
+def _cron_delivery_max_chars(config: dict) -> Optional[int]:
+    """Return configured max chars for user-facing cron delivery text."""
+    try:
+        cron_cfg = config.get("cron", {}) if isinstance(config, dict) else {}
+        raw = cron_cfg.get("max_delivery_chars") or cron_cfg.get("delivery_max_chars")
+        if raw in (None, "", False):
+            return None
+        limit = int(float(raw))
+        return limit if limit > 0 else None
+    except Exception:
+        return None
+
+
+def _truncate_cron_delivery_text(text: str, limit: Optional[int], job_id: str) -> str:
+    """Bound oversized cron chat text while keeping full output in cron/output."""
+    if not limit or len(text) <= limit:
+        return text
+    marker = (
+        "\n\n…\n"
+        f"[cron output truncated to {limit} chars; full output saved under "
+        f"cron/output/{job_id}/ in Hermes home]"
+    )
+    if limit <= len(marker) + 20:
+        return text[:limit]
+    return text[: limit - len(marker)].rstrip() + marker
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -682,6 +709,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     # is a cron delivery.  Wrapping is on by default; set cron.wrap_response: false
     # in config.yaml for clean output.
     wrap_response = True
+    user_cfg = {}
     try:
         user_cfg = load_config()
         wrap_response = user_cfg.get("cron", {}).get("wrap_response", True)
@@ -701,10 +729,17 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     else:
         delivery_content = content
 
-    # Extract MEDIA: tags so attachments are forwarded as files, not raw text
+    # Extract MEDIA: tags so attachments are forwarded as files, not raw text.
+    # Apply the delivery length cap after extraction so MEDIA attachments are
+    # not accidentally removed from long report text.
     from gateway.platforms.base import BasePlatformAdapter
     media_files, cleaned_delivery_content = BasePlatformAdapter.extract_media(delivery_content)
     media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    cleaned_delivery_content = _truncate_cron_delivery_text(
+        cleaned_delivery_content,
+        _cron_delivery_max_chars(user_cfg),
+        job.get("id", ""),
+    )
 
     try:
         config = load_gateway_config()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "veritas-7@users.noreply.github.com": "Veritas-7",
     "kenmege@yahoo.com": "Kenmege",
     "dkobi16@gmail.com": "Diyoncrz18",
     "arnaud@nolimitdevelopment.com": "ali-nld",

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -575,6 +575,103 @@ class TestDeliverResultWrapping:
         assert "Cronjob Response" not in sent_content
         assert "The agent cannot see" not in sent_content
 
+    def test_delivery_truncates_oversized_chat_text_when_configured(self):
+        """cron.max_delivery_chars caps user-facing text while preserving a file pointer."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False, "max_delivery_chars": 180}}):
+            job = {
+                "id": "long-job",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+            }
+            _deliver_result(job, "A" * 500)
+
+        sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
+        assert len(sent_content) <= 180
+        assert "cron output truncated" in sent_content
+        assert "cron/output/long-job/ in Hermes home" in sent_content
+
+    def test_delivery_cap_defaults_to_no_truncation_when_unset(self):
+        """Absent cron.max_delivery_chars preserves existing delivery behavior."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            job = {
+                "id": "uncapped-job",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+            }
+            _deliver_result(job, "A" * 500)
+
+        sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
+        assert sent_content == "A" * 500
+        assert "cron output truncated" not in sent_content
+
+    def test_delivery_cap_applies_to_wrapped_default_response(self):
+        """Default wrapped cron responses are also bounded when cap is configured."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"max_delivery_chars": 180}}):
+            job = {
+                "id": "wrapped-long-job",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+            }
+            _deliver_result(job, "A" * 500)
+
+        sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
+        assert len(sent_content) <= 180
+        assert "Cronjob Response: wrapped-long-job" in sent_content
+        assert "cron output truncated" in sent_content
+        assert "cron/output/wrapped-long-job/ in Hermes home" in sent_content
+
+    def test_delivery_length_cap_does_not_drop_media_attachments(self, tmp_path, monkeypatch):
+        """MEDIA tags are extracted before text truncation, so attachments survive."""
+        from gateway.config import Platform
+        media_path = self._safe_media_path(tmp_path, monkeypatch, "long-report.png")
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False, "max_delivery_chars": 140}}):
+            job = {
+                "id": "media-long-job",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+            }
+            _deliver_result(job, ("A" * 500) + f"\nMEDIA:{media_path}")
+
+        args, kwargs = send_mock.call_args
+        assert len(args[3]) <= 140
+        assert "MEDIA:" not in args[3]
+        assert kwargs["media_files"] == [(str(media_path), False)]
+
     def test_delivery_extracts_media_tags_before_send(self, tmp_path, monkeypatch):
         """Cron delivery should pass MEDIA attachments separately to the send helper."""
         from gateway.config import Platform

--- a/website/docs/developer-guide/cron-internals.md
+++ b/website/docs/developer-guide/cron-internals.md
@@ -190,6 +190,15 @@ By default (`cron.wrap_response: true`), cron deliveries are wrapped with:
 - A header identifying the cron job name and task
 - A footer noting the agent cannot see the delivered message in conversation
 
+Set `cron.max_delivery_chars` in `config.yaml` to cap the user-facing text delivered to chat platforms. The scheduler saves the full, untruncated job output under `cron/output/<job_id>/` in Hermes home before delivery, then truncates only the chat text and appends a pointer to that output directory. `MEDIA:` attachments are extracted before truncation, so file/image/audio attachments still deliver even when the text is capped.
+
+```yaml
+cron:
+  max_delivery_chars: 900
+```
+
+The cap is opt-in; when unset or invalid, delivery text is not truncated.
+
 The `[SILENT]` prefix in a cron response suppresses delivery entirely — useful for jobs that only need to write to files or perform side effects.
 
 ### Session Isolation


### PR DESCRIPTION
## Summary
- add opt-in `cron.max_delivery_chars` to cap user-facing cron delivery text
- keep full job output saved under Hermes cron output and truncate only chat text
- extract/filter `MEDIA:` attachments before truncation so attachments still deliver
- document the config option in cron internals

## Tests
- `python -m py_compile cron/scheduler.py tests/cron/test_scheduler.py`
- `pytest tests/cron/test_scheduler.py -q` (140 passed)
- private/token regex scan over PR diff (0 hits)
- `gitleaks git --no-banner --redact --log-opts=<base>..HEAD .` (no leaks)

## Safety
- GLM public-safety review: epistula PASS
- non-GLM quality review: nuntinus PASS after docs/wrap-default tests were added
- controller gate: `AUTO_PR_READY.json` generated by `pre_action_consensus_guard.py check-pr-ready`
