### PR TITLE
fix(desktop): preserve provider errors in transcript

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3977,12 +3977,16 @@ def run_conversation(
                             force=True,
                         )
                     logger.error(f"{agent.log_prefix}Non-retryable client error: {api_error}")
-                    # Skip session persistence when the error is likely
-                    # context-overflow related (status 400 + large session).
+                    # Skip persistence only after the classifier confirms
+                    # context overflow. Large sessions can also receive
+                    # descriptive 400s such as Copilot model_not_supported;
+                    # those failures must remain visible in the transcript.
                     # Persisting the failed user message would make the
                     # session even larger, causing the same failure on the
                     # next attempt. (#1630)
-                    if status_code == 400 and (approx_tokens > 50000 or len(api_messages) > 80):
+                    if is_context_length_error and (
+                        approx_tokens > 50000 or len(api_messages) > 80
+                    ):
                         agent._vprint(
                             f"{agent.log_prefix}⚠️  Skipping session persistence "
                             f"for large failed session to prevent growth loop.",

--- a/apps/desktop/src/app/session/hooks/use-message-stream/error-completion.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/error-completion.test.tsx
@@ -1,0 +1,77 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './index'
+
+const SID = 'session-1'
+const hydrateFromStoredSession = vi.fn(async () => undefined)
+
+let handleEvent: ((event: RpcEvent) => void) | null = null
+let sessionState: ClientSessionState | undefined
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(SID)
+  const sessionStateByRuntimeIdRef = useRef(new Map<string, ClientSessionState>())
+  const queryClientRef = useRef(new QueryClient())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession,
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater) => {
+      const current = sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState()
+      const next = updater(current)
+      sessionStateByRuntimeIdRef.current.set(sessionId, next)
+      sessionState = next
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    handleEvent = stream.handleGatewayEvent
+  }, [stream.handleGatewayEvent])
+
+  return null
+}
+
+describe('useMessageStream error completion', () => {
+  beforeEach(() => {
+    handleEvent = null
+    sessionState = undefined
+    hydrateFromStoredSession.mockClear()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('preserves a gateway-reported error even when its text is not error-shaped', async () => {
+    render(<Harness />)
+    await waitFor(() => expect(handleEvent).not.toBeNull())
+
+    const message = 'The requested model is not supported for this Copilot subscription.'
+    act(() =>
+      handleEvent!({
+        payload: { status: 'error', text: message },
+        session_id: SID,
+        type: 'message.complete'
+      })
+    )
+
+    expect(sessionState?.messages).toEqual([
+      expect.objectContaining({ error: message, parts: [], role: 'assistant' })
+    ])
+    expect(hydrateFromStoredSession).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -71,7 +71,11 @@ interface GatewayEventDeps {
   nativeSubagentSessionsRef: MutableRefObject<Set<string>>
   appendAssistantDelta: (sessionId: string, delta: string) => void
   appendReasoningDelta: (sessionId: string, delta: string, replace?: boolean) => void
-  completeAssistantMessage: (sessionId: string, text: string) => void
+  completeAssistantMessage: (
+    sessionId: string,
+    text: string,
+    options?: { status?: 'complete' | 'error' }
+  ) => void
   failAssistantMessage: (sessionId: string, errorMessage: string) => void
   flushQueuedDeltas: (sessionId?: string) => void
   queryClient: QueryClient
@@ -381,7 +385,8 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         playCompletionSound()
 
         const finalText = coerceGatewayText(payload?.text) || coerceGatewayText(payload?.rendered)
-        completeAssistantMessage(sessionId, finalText)
+        const status = payload?.status === 'error' || payload?.status === 'complete' ? payload.status : undefined
+        completeAssistantMessage(sessionId, finalText, { status })
 
         if (isActiveEvent) {
           setTurnStartedAt(null)

--- a/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/index.ts
@@ -331,7 +331,7 @@ export function useMessageStream({
   )
 
   const completeAssistantMessage = useCallback(
-    (sessionId: string, text: string) => {
+    (sessionId: string, text: string, options?: { status?: 'complete' | 'error' }) => {
       let shouldHydrate = false
 
       const completedState = updateSessionState(sessionId, state => {
@@ -353,7 +353,10 @@ export function useMessageStream({
 
         const streamId = state.streamId
         const finalText = renderMediaTags(text).trim()
-        const completionError = completionErrorText(finalText)
+
+        const completionError =
+          options?.status === 'error' ? finalText || 'Hermes reported an error' : completionErrorText(finalText)
+
         const normalize = (value: string) => value.replace(/\s+/g, ' ').trim()
 
         const replaceTextPart = (parts: ChatMessagePart[]) => {

--- a/tests/run_agent/test_1630_context_overflow_loop.py
+++ b/tests/run_agent/test_1630_context_overflow_loop.py
@@ -260,32 +260,36 @@ class TestContextOverflowErrorMessages:
 # ---------------------------------------------------------------------------
 
 class TestAgentSkipsPersistenceForLargeFailedSessions:
-    """When a 400 error occurs and the session is large, the agent
-    should skip persisting to prevent the growth loop."""
+    """Persistence behavior must be exercised through the real loop."""
 
-    def test_large_session_400_skips_persistence(self):
-        """Status 400 + high token count should skip persistence."""
-        status_code = 400
-        approx_tokens = 60000  # > 50000 threshold
-        api_messages = [{"role": "user", "content": "x"}] * 10
+    def test_large_model_not_supported_400_persists_through_real_loop(self):
+        class ModelNotSupportedError(Exception):
+            status_code = 400
+            body = {
+                "error": {
+                    "code": "model_not_supported",
+                    "message": "The requested model is not supported for this Copilot subscription.",
+                }
+            }
 
-        should_skip = status_code == 400 and (approx_tokens > 50000 or len(api_messages) > 80)
-        assert should_skip
+        agent = TestGeneric400Heuristic()._make_agent()
+        agent.max_iterations = 1
+        agent._interruptible_api_call = MagicMock(
+            side_effect=ModelNotSupportedError(
+                "model_not_supported: The requested model is not supported for this Copilot subscription."
+            )
+        )
+        agent._persist_session = MagicMock()
+        history = [
+            {
+                "role": "user" if index % 2 == 0 else "assistant",
+                "content": f"history message {index}",
+            }
+            for index in range(82)
+        ]
 
-    def test_small_session_400_persists_normally(self):
-        """Status 400 + small session should still persist."""
-        status_code = 400
-        approx_tokens = 5000  # < 50000
-        api_messages = [{"role": "user", "content": "x"}] * 10  # < 80
+        result = agent.run_conversation("switch model", conversation_history=history)
 
-        should_skip = status_code == 400 and (approx_tokens > 50000 or len(api_messages) > 80)
-        assert not should_skip
-
-    def test_non_400_error_persists_normally(self):
-        """Non-400 errors should always persist normally."""
-        status_code = 401  # Auth error
-        approx_tokens = 100000  # Large session, but not a 400
-        api_messages = [{"role": "user", "content": "x"}] * 100
-
-        should_skip = status_code == 400 and (approx_tokens > 50000 or len(api_messages) > 80)
-        assert not should_skip
+        assert result["failed"] is True
+        assert "not supported" in result["error"]
+        assert agent._persist_session.call_count == 2


### PR DESCRIPTION
## Summary

- persist large-session HTTP 400 failures unless the existing classifier confirms context overflow
- forward `message.complete` status through the Desktop gateway-event split
- render gateway-reported failures as inline assistant errors even when their text does not match an error prefix
- keep slash-worker lifecycle changes out of this PR; that isolated fix lives in #46288

## Testing

- `uv run pytest -q tests/run_agent/test_1630_context_overflow_loop.py` (14 passed)
- focused Desktop stream tests (10 passed)
- Desktop TypeScript typecheck
- Ruff, ESLint, and `git diff --check`