### PR TITLE
fix(desktop): extend voice transcription timeout

### DIFF
--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -10,7 +10,8 @@ import {
   getSessionMessages,
   getStatus,
   listAllProfileSessions,
-  listSessions
+  listSessions,
+  transcribeAudio
 } from './hermes'
 import { refreshActiveProfile } from './store/profile'
 
@@ -122,6 +123,20 @@ describe('Hermes REST session helpers', () => {
     const call = api.mock.calls[0]?.[0] as { path: string; timeoutMs?: number }
     expect(call.path).toBe('/api/status')
     expect(call.timeoutMs).toBeUndefined()
+  })
+
+  it('allows voice transcription to outlast the default request timeout', async () => {
+    const transcriptionTimeoutMs = 2 * 60_000
+
+    api.mockResolvedValue({ text: 'hello' })
+    await transcribeAudio('data:audio/webm;base64,AAAA', 'audio/webm')
+
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/audio/transcribe',
+        timeoutMs: transcriptionTimeoutMs
+      })
+    )
   })
 
   it('tags cross-profile message reads for Electron routing and backend lookup', async () => {

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -69,6 +69,7 @@ import type {
 // global default: interactive/runtime calls and the liveness poll (/api/status)
 // keep the short default so a genuinely-dead backend is still detected fast.
 export const STARTUP_REQUEST_TIMEOUT_MS = 60_000
+const AUDIO_TRANSCRIPTION_REQUEST_TIMEOUT_MS = 120_000
 const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 30_000
 const SESSION_LIST_REQUEST_TIMEOUT_MS = 60_000
 // prompt.submit is effectively fire-and-forget: turn completion is signaled by
@@ -1101,6 +1102,7 @@ export function transcribeAudio(dataUrl: string, mimeType?: string): Promise<Aud
   return window.hermesDesktop.api<AudioTranscriptionResponse>({
     path: '/api/audio/transcribe',
     method: 'POST',
+    timeoutMs: AUDIO_TRANSCRIPTION_REQUEST_TIMEOUT_MS,
     body: {
       data_url: dataUrl,
       mime_type: mimeType


### PR DESCRIPTION
## Summary

- give `/api/audio/transcribe` a focused 120-second request timeout
- leave the global request timeout and other interactive endpoints unchanged
- add a regression test for the exact transcription request options

## Testing

- `npm run test:ui --workspace apps/desktop -- src/hermes.test.ts` (10 passed)
- Desktop TypeScript typecheck
- ESLint and `git diff --check`