### PR TITLE
fix(cron): fallback providers when OAuth token refresh returns 429

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1681,8 +1681,30 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             if runtime is None:
                 raise RuntimeError(format_runtime_provider_error(auth_exc)) from auth_exc
         except Exception as exc:
-            message = format_runtime_provider_error(exc)
-            raise RuntimeError(message) from exc
+            # Primary provider resolution failed (e.g. 429 during OAuth token
+            # refresh, transient network error). Try the fallback chain before
+            # giving up — mirrors the AuthError handler above.
+            logger.warning("Job '%s': primary provider failed (%s), trying fallback", job_id, exc)
+            fb = _cfg.get("fallback_providers") or _cfg.get("fallback_model")
+            fb_list = (fb if isinstance(fb, list) else [fb]) if fb else []
+            runtime = None
+            for entry in fb_list:
+                if not isinstance(entry, dict):
+                    continue
+                try:
+                    fb_kwargs = {"requested": entry.get("provider")}
+                    if entry.get("base_url"):
+                        fb_kwargs["explicit_base_url"] = entry["base_url"]
+                    if entry.get("api_key"):
+                        fb_kwargs["explicit_api_key"] = entry["api_key"]
+                    runtime = resolve_runtime_provider(**fb_kwargs)
+                    logger.info("Job '%s': fallback resolved to %s", job_id, runtime.get("provider"))
+                    break
+                except Exception as fb_exc:
+                    logger.debug("Job '%s': fallback %s failed: %s", job_id, entry.get("provider"), fb_exc)
+            if runtime is None:
+                message = format_runtime_provider_error(exc)
+                raise RuntimeError(message) from exc
 
         fallback_model = _cfg.get("fallback_providers") or _cfg.get("fallback_model") or None
         credential_pool = None
@@ -1692,13 +1714,21 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 from agent.credential_pool import load_pool
                 pool = load_pool(runtime_provider)
                 if pool.has_credentials():
-                    credential_pool = pool
-                    logger.info(
-                        "Job '%s': loaded credential pool for provider %s with %d entries",
-                        job_id,
-                        runtime_provider,
-                        len(pool.entries()),
-                    )
+                    if pool.has_available():
+                        credential_pool = pool
+                        logger.info(
+                            "Job '%s': loaded credential pool for provider %s with %d entries",
+                            job_id,
+                            runtime_provider,
+                            len(pool.entries()),
+                        )
+                    else:
+                        logger.info(
+                            "Job '%s': credential pool for %s is fully exhausted — "
+                            "fallback chain will handle runtime rate limits",
+                            job_id,
+                            runtime_provider,
+                        )
             except Exception as e:
                 logger.debug("Job '%s': failed to load credential pool for %s: %s", job_id, runtime_provider, e)
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1672,6 +1672,189 @@ class TestRunJobConfigEnvVarExpansion:
         assert kwargs["model"] == "${_HERMES_TEST_CRON_UNSET_VAR}"
 
 
+class TestRunJobProviderFallback:
+    """Cron jobs must fall back to fallback_providers when the primary
+    provider fails with any exception (not just AuthError). Covers the
+    bug where the except Exception handler raised RuntimeError immediately
+    without consulting the fallback chain (issue #46511)."""
+
+    _FALLBACK_RUNTIME = {
+        "api_key": "fallback-key",
+        "base_url": "https://fallback.example.invalid/v1",
+        "provider": "openrouter",
+        "api_mode": "chat_completions",
+    }
+
+    def _make_resolve(self, primary_exc, fallback_runtime):
+        """Return a side_effect list: first call raises, subsequent calls return runtime."""
+        calls = [primary_exc, fallback_runtime]
+        idx = 0
+
+        def _resolve(**kwargs):
+            nonlocal idx
+            val = calls[idx] if idx < len(calls) else fallback_runtime
+            idx += 1
+            if isinstance(val, Exception):
+                raise val
+            return val
+
+        return _resolve
+
+    def test_non_auth_exception_uses_fallback_providers(self, tmp_path):
+        """When resolve_runtime_provider raises a plain Exception (e.g. 429
+        during OAuth token refresh), the job should succeed via fallback_providers."""
+        (tmp_path / "config.yaml").write_text(
+            "fallback_providers:\n"
+            "  - provider: openrouter\n"
+            "    model: gpt-4o-mini\n"
+        )
+
+        job = {"id": "oauth-job", "name": "oauth test", "prompt": "hello"}
+        fake_db = MagicMock()
+
+        primary_error = Exception("HTTP 429 from token refresh endpoint")
+        resolve_fn = self._make_resolve(primary_error, self._FALLBACK_RUNTIME)
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+                   side_effect=resolve_fn), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            success, _, _, error = run_job(job)
+
+        assert success is True, f"Job should succeed via fallback, got error={error!r}"
+        assert error is None
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs["provider"] == "openrouter"
+
+    def test_non_auth_exception_no_fallback_raises(self, tmp_path):
+        """When resolve_runtime_provider raises and no fallback is configured,
+        the job should fail with a RuntimeError."""
+        (tmp_path / "config.yaml").write_text("model: gpt-4o\n")
+
+        job = {"id": "no-fb-job", "name": "no fallback", "prompt": "hello"}
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+                   side_effect=Exception("token refresh 429")):
+            success, _, _, error = run_job(job)
+
+        assert success is False
+        assert error is not None
+
+    def test_all_fallbacks_exhausted_raises(self, tmp_path):
+        """When both primary and every fallback entry fail, the job fails."""
+        (tmp_path / "config.yaml").write_text(
+            "fallback_providers:\n"
+            "  - provider: openrouter\n"
+            "    model: gpt-4o-mini\n"
+        )
+
+        job = {"id": "all-fail-job", "name": "all fail", "prompt": "hello"}
+        fake_db = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+                   side_effect=Exception("all providers down")):
+            success, _, _, error = run_job(job)
+
+        assert success is False
+        assert error is not None
+
+
+class TestRunJobCredentialPoolExhausted:
+    """When a credential pool exists but all entries are exhausted,
+    the pool must NOT be passed to AIAgent as credential_pool so that
+    AIAgent can use the fallback chain cleanly (issue #46511 secondary fix)."""
+
+    _RUNTIME = {
+        "api_key": "test-key",
+        "base_url": "https://example.invalid/v1",
+        "provider": "openai-codex",
+        "api_mode": "chat_completions",
+    }
+
+    def test_exhausted_pool_not_passed_to_agent(self, tmp_path):
+        """has_credentials()=True but has_available()=False → credential_pool=None."""
+        (tmp_path / "config.yaml").write_text(
+            "provider: openai-codex\n"
+            "model: gpt-4o\n"
+        )
+
+        job = {"id": "exhaust-job", "name": "exhausted pool", "prompt": "hello"}
+        fake_db = MagicMock()
+
+        mock_pool = MagicMock()
+        mock_pool.has_credentials.return_value = True
+        mock_pool.has_available.return_value = False
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+                   return_value=self._RUNTIME), \
+             patch("agent.credential_pool.load_pool", return_value=mock_pool), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            success, _, _, error = run_job(job)
+
+        assert success is True, f"Job should still succeed, got error={error!r}"
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs.get("credential_pool") is None, (
+            "Exhausted pool must not be forwarded to AIAgent; "
+            f"got credential_pool={kwargs.get('credential_pool')!r}"
+        )
+
+    def test_available_pool_is_passed_to_agent(self, tmp_path):
+        """has_credentials()=True and has_available()=True → credential_pool forwarded."""
+        (tmp_path / "config.yaml").write_text(
+            "provider: openai-codex\n"
+            "model: gpt-4o\n"
+        )
+
+        job = {"id": "avail-job", "name": "available pool", "prompt": "hello"}
+        fake_db = MagicMock()
+
+        mock_pool = MagicMock()
+        mock_pool.has_credentials.return_value = True
+        mock_pool.has_available.return_value = True
+        mock_pool.entries.return_value = ["entry1", "entry2"]
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider",
+                   return_value=self._RUNTIME), \
+             patch("agent.credential_pool.load_pool", return_value=mock_pool), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+            success, _, _, error = run_job(job)
+
+        assert success is True, f"Got error={error!r}"
+        kwargs = mock_agent_cls.call_args.kwargs
+        assert kwargs.get("credential_pool") is mock_pool, (
+            "Available pool must be forwarded to AIAgent"
+        )
+
+
 class TestRunJobSkillBacked:
     def test_run_job_preserves_skill_env_passthrough_into_worker_thread(self, tmp_path):
         job = {


### PR DESCRIPTION
## Summary

Fixes #46511 â€” cron jobs using OAuth providers (e.g. `openai-codex`) crashed with `RuntimeError` when the credential pool was exhausted and the primary provider resolution failed with a non-`AuthError` exception (e.g. HTTP 429 from the token refresh endpoint), instead of using the configured `fallback_providers` chain.

- **Primary fix**: The `except Exception` handler in `cron/scheduler.py` now walks `fallback_providers`/`fallback_model` before raising `RuntimeError`, mirroring the existing `AuthError` handler above it.
- **Secondary fix**: `pool.has_available()` guards the `credential_pool` assignment so a fully-exhausted pool (entries exist but all on cooldown) is no longer forwarded to `AIAgent`, allowing the agent-level fallback chain to fire cleanly.

## Root cause

`resolve_codex_runtime_credentials()` reads an expired OAuth access token, attempts `refresh_codex_oauth_pure()`, and the OpenAI token refresh endpoint returns HTTP 429. This raises a plain `Exception` (not `AuthError`). The `except AuthError` handler already had correct fallback logic; the `except Exception` handler did not.

## Test plan

- [ ] `test_non_auth_exception_uses_fallback_providers` â€” primary raises plain `Exception`, job succeeds via `fallback_providers`
- [ ] `test_non_auth_exception_no_fallback_raises` â€” no fallback configured, job fails cleanly
- [ ] `test_all_fallbacks_exhausted_raises` â€” all fallback entries also fail, job fails cleanly
- [ ] `test_exhausted_pool_not_passed_to_agent` â€” `has_available()=False` results in `credential_pool=None` in AIAgent kwargs
- [ ] `test_available_pool_is_passed_to_agent` â€” `has_available()=True` pool is forwarded as expected

```
pytest tests/cron/test_scheduler.py  # 141 passed
```
