### PR TITLE
fix(gateway): omit expect_edits on finalize so Telegram uses sendRichMessage

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -1532,7 +1532,15 @@ class GatewayStreamConsumer:
                     chat_id=self.chat_id,
                     content=text,
                     reply_to=self._initial_reply_to_id,
-                    metadata={**(self.metadata or {}), "expect_edits": True},
+                    # Skip expect_edits on finalize — this is the last
+                    # message; no more edits will follow.  Keeping it would
+                    # disable Telegram's sendRichMessage path (which checks
+                    # expect_edits) and force a plain MarkdownV2 fallback,
+                    # losing the rich formatting the user saw in the draft.
+                    metadata={
+                        **(self.metadata or {}),
+                        **({} if finalize else {"expect_edits": True}),
+                    },
                 )
                 if result.success:
                     if result.message_id:

--- a/tests/gateway/test_stream_consumer_draft.py
+++ b/tests/gateway/test_stream_consumer_draft.py
@@ -507,3 +507,66 @@ class TestRichAwareOverflow:
         assert consumer._message_id == "final1"
         assert consumer._preview_message_ids == set()
         assert consumer.final_response_sent is True
+
+
+class TestFinalizeDoesNotSetExpectEdits:
+    """When the final message in a draft-based stream is sent via
+    ``adapter.send()``, the metadata must NOT carry ``expect_edits: True``.
+    That flag disables Telegram's ``sendRichMessage`` path in
+    ``_should_attempt_rich()`` and forces a plain MarkdownV2 fallback,
+    losing the rich formatting the user saw during the draft preview.
+    """
+
+    @pytest.mark.asyncio
+    async def test_finalize_send_omits_expect_edits(self):
+        """Final send after draft streaming must not set expect_edits."""
+        adapter = _make_draft_capable_adapter()
+        cfg = StreamConsumerConfig(
+            transport="auto", chat_type="dm",
+            edit_interval=0.01, buffer_threshold=5, cursor="",
+        )
+        consumer = GatewayStreamConsumer(adapter, "12345", cfg)
+
+        consumer.on_delta("Hello world!")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        consumer.finish()
+        await task
+
+        # The final send must have been called.
+        adapter.send.assert_awaited()
+        final_meta = adapter.send.call_args.kwargs.get("metadata", {})
+        assert "expect_edits" not in final_meta, (
+            "finalize send must not set expect_edits — it disables "
+            "Telegram's sendRichMessage path"
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_finalize_first_send_sets_expect_edits(self):
+        """Mid-stream first send (non-draft, edit-based) must still set
+        expect_edits: True so adapters know to keep the message editable.
+        """
+        from gateway.platforms.base import SendResult
+
+        adapter = _make_draft_capable_adapter(supports_draft=False)
+        cfg = StreamConsumerConfig(
+            transport="edit", chat_type="dm",
+            edit_interval=0.01, buffer_threshold=5, cursor="▉",
+        )
+        consumer = GatewayStreamConsumer(adapter, "12345", cfg)
+
+        consumer.on_delta("Hello")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        # Don't finish yet — this is a mid-stream send.
+        consumer.on_delta(" world!")
+        await asyncio.sleep(0.05)
+        consumer.finish()
+        await task
+
+        # The first send call (non-finalize) should have expect_edits.
+        assert adapter.send.await_count >= 1
+        first_meta = adapter.send.call_args_list[0].kwargs.get("metadata", {})
+        assert first_meta.get("expect_edits") is True, (
+            "mid-stream first send must set expect_edits: True"
+        )


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where Telegram's final streamed message falls back to plain MarkdownV2 instead of `sendRichMessage`, even though the draft preview showed rich formatting (tables, task lists, etc.). The root cause is that `expect_edits: True` is unconditionally set in the "First message" path of `_send_or_edit()`, which disables `_should_attempt_rich()` in the Telegram adapter.

## Related Issue

Fixes #46515

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/stream_consumer.py`: Skip `expect_edits` in metadata when `finalize=True` — no more edits will follow, so the rich send path should remain available.
- `tests/gateway/test_stream_consumer_draft.py`: Added `TestFinalizeDoesNotSetExpectEdits` class with 2 tests: one verifying the final send omits `expect_edits`, and one verifying mid-stream first sends still set it.

## How to Test

1. Enable `telegram.extra.rich_messages: true` in config
2. Send a message to the Telegram bot that triggers a response with tables or task lists
3. Watch the streaming draft — it should render as rich markdown
4. When streaming completes, the final message should now also be rich (not plain MarkdownV2)
5. Run `pytest tests/gateway/test_stream_consumer_draft.py -x -q` — all 20 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/stream_consumer.py::_send_or_edit` (callers: 8, flows: streaming draft + edit paths)
- Blast radius: LOW — single conditional on `finalize` flag, only affects Telegram's `_should_attempt_rich()` gate
- Related patterns: `expect_edits` is only consumed by `telegram.py:988`; `_send_new_chunk` (line 764) correctly keeps `expect_edits: True` for mid-stream chunks
