### PR TITLE
[codex] fix gateway DSML tool-call markup leaks

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -42,6 +42,7 @@ from agent.model_metadata import (
 from agent.process_bootstrap import _install_safe_stdio
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.think_scrubber import StreamingThinkScrubber
+from agent.tool_call_scrubber import StreamingToolCallScrubber
 from agent.tool_guardrails import (
     ToolCallGuardrailConfig,
     ToolCallGuardrailController,
@@ -608,6 +609,10 @@ def init_agent(
     # erased delta1, so downstream state machines never learned a
     # block was open and leaked delta2 as content).
     agent._stream_think_scrubber = StreamingThinkScrubber()
+    # Stateful scrubber for provider-native text tool-call markup (for
+    # example DeepSeek-style DSML) that can otherwise leak to chat when an
+    # upstream parser fails to convert it into structured tool_calls.
+    agent._stream_tool_call_scrubber = StreamingToolCallScrubber()
     # Visible assistant text already delivered through live token callbacks
     # during the current model response. Used to avoid re-sending the same
     # commentary when the provider later returns it as a completed interim

--- a/agent/tool_call_scrubber.py
+++ b/agent/tool_call_scrubber.py
@@ -1,0 +1,115 @@
+"""Stateful scrubber for provider-native tool-call markup in text streams.
+
+Some OpenAI-compatible providers fall back to text-encoded tool calls when
+their tool parser misses a call.  DeepSeek-style DSML is one such format:
+
+    <｜DSML｜tool_calls> <｜DSML｜invoke name="write_file"> ...
+
+That markup is internal control data, not assistant prose.  If it reaches the
+gateway, long JSON arguments get split into dozens of chat messages with
+``(n/N)`` suffixes.  This scrubber drops those spans before they reach users.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+__all__ = ["StreamingToolCallScrubber", "strip_tool_call_markup"]
+
+
+class StreamingToolCallScrubber:
+    """Remove text-encoded tool-call spans across streaming boundaries."""
+
+    _OPEN_MARKERS: Tuple[str, ...] = (
+        "<|DSML|tool_calls>",
+        "<｜DSML｜tool_calls>",
+    )
+    _CLOSE_MARKERS: Tuple[str, ...] = (
+        "<|DSML|/tool_calls>",
+        "<｜DSML｜/tool_calls>",
+        "<|DSML|end_tool_calls>",
+        "<｜DSML｜end_tool_calls>",
+        "</tool_calls>",
+    )
+    _MAX_MARKER_LEN: int = max(len(m) for m in _OPEN_MARKERS + _CLOSE_MARKERS)
+
+    def __init__(self) -> None:
+        self._in_tool_call = False
+        self._buf = ""
+
+    def reset(self) -> None:
+        self._in_tool_call = False
+        self._buf = ""
+
+    def feed(self, text: str) -> str:
+        if not text:
+            return ""
+        buf = self._buf + text
+        self._buf = ""
+        out: list[str] = []
+
+        while buf:
+            if self._in_tool_call:
+                close_idx, close_len = self._find_first(buf, self._CLOSE_MARKERS)
+                if close_idx == -1:
+                    held = self._max_partial_suffix(buf, self._CLOSE_MARKERS)
+                    self._buf = buf[-held:] if held else ""
+                    return "".join(out)
+                buf = buf[close_idx + close_len :]
+                self._in_tool_call = False
+                continue
+
+            open_idx, open_len = self._find_first(buf, self._OPEN_MARKERS)
+            if open_idx == -1:
+                held = self._max_partial_suffix(buf, self._OPEN_MARKERS)
+                if held:
+                    out.append(buf[:-held])
+                    self._buf = buf[-held:]
+                else:
+                    out.append(buf)
+                return "".join(out)
+
+            if open_idx:
+                out.append(buf[:open_idx])
+            buf = buf[open_idx + open_len :]
+            self._in_tool_call = True
+
+        return "".join(out)
+
+    def flush(self) -> str:
+        """Flush benign marker-prefix tails, dropping unfinished tool spans."""
+        if self._in_tool_call:
+            self._in_tool_call = False
+            self._buf = ""
+            return ""
+        tail = self._buf
+        self._buf = ""
+        return tail
+
+    @staticmethod
+    def _find_first(buf: str, markers: Tuple[str, ...]) -> tuple[int, int]:
+        best_idx = -1
+        best_len = 0
+        for marker in markers:
+            idx = buf.find(marker)
+            if idx != -1 and (best_idx == -1 or idx < best_idx):
+                best_idx = idx
+                best_len = len(marker)
+        return best_idx, best_len
+
+    @classmethod
+    def _max_partial_suffix(cls, buf: str, markers: Tuple[str, ...]) -> int:
+        max_check = min(len(buf), cls._MAX_MARKER_LEN - 1)
+        for size in range(max_check, 0, -1):
+            suffix = buf[-size:]
+            if any(marker.startswith(suffix) for marker in markers if len(marker) > size):
+                return size
+        return 0
+
+
+def strip_tool_call_markup(text: str) -> str:
+    """One-shot DSML tool-call markup removal for completed responses."""
+    if not isinstance(text, str) or not text:
+        return text
+    scrubber = StreamingToolCallScrubber()
+    return scrubber.feed(text) + scrubber.flush()

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -283,6 +283,9 @@ def build_turn_context(
     think_scrubber = getattr(agent, "_stream_think_scrubber", None)
     if think_scrubber is not None:
         think_scrubber.reset()
+    tool_call_scrubber = getattr(agent, "_stream_tool_call_scrubber", None)
+    if tool_call_scrubber is not None:
+        tool_call_scrubber.reset()
 
     # Preserve the original user message (no nudge injection).
     original_user_message = persist_user_message if persist_user_message is not None else user_message

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -55,6 +55,7 @@ from typing import Dict, Optional, Any, List, Union
 from agent.account_usage import fetch_account_usage, render_account_usage_lines
 from agent.async_utils import safe_schedule_threadsafe
 from agent.i18n import t
+from agent.tool_call_scrubber import strip_tool_call_markup
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
 
@@ -423,10 +424,23 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     if _gateway_surface_passes_raw_text(platform):
         return text
 
-    redacted = _redact_gateway_user_facing_secrets(str(text))
+    text = strip_tool_call_markup(str(text)).strip()
+    if not text:
+        return (
+            "⚠️ The model produced an internal tool call as plain text instead "
+            "of a user-visible reply. I suppressed it to avoid leaking tool "
+            "arguments into chat. Please try again."
+        )
+
+    redacted = _redact_gateway_user_facing_secrets(text)
     if _looks_like_gateway_provider_error(redacted):
         return _gateway_provider_error_reply(redacted)
     return redacted
+
+
+def _sanitize_gateway_interim_assistant_text(text: Any) -> str:
+    """Sanitize completed interim assistant commentary before platform send."""
+    return strip_tool_call_markup(str(text or "")).strip()
 
 
 def _prepare_gateway_status_message(platform: Any, event_type: str, message: str) -> Optional[str]:
@@ -16268,13 +16282,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             def _interim_assistant_cb(text: str, *, already_streamed: bool = False) -> None:
                 if not _run_still_current():
                     return
+                text = _sanitize_gateway_interim_assistant_text(text)
+                if not text:
+                    return
                 if _stream_consumer is not None:
                     if already_streamed:
                         _stream_consumer.on_segment_break()
                     else:
                         _stream_consumer.on_commentary(text)
                     return
-                if already_streamed or not _status_adapter or not str(text or "").strip():
+                if already_streamed or not _status_adapter:
                     return
                 safe_schedule_threadsafe(
                     _status_adapter.send(

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -32,6 +32,7 @@ from gateway.config import (
     DEFAULT_STREAMING_BUFFER_THRESHOLD as _DEFAULT_STREAMING_BUFFER_THRESHOLD,
     DEFAULT_STREAMING_CURSOR as _DEFAULT_STREAMING_CURSOR,
 )
+from agent.tool_call_scrubber import StreamingToolCallScrubber
 
 logger = logging.getLogger("gateway.stream_consumer")
 
@@ -187,6 +188,7 @@ class GatewayStreamConsumer:
         # Think-block filter state (mirrors CLI's _stream_delta tag suppression)
         self._in_think_block = False
         self._think_buffer = ""
+        self._tool_call_scrubber = StreamingToolCallScrubber()
 
         # Native draft-streaming state.  Resolved at the start of run() based
         # on cfg.transport, cfg.chat_type, and the adapter's
@@ -369,6 +371,9 @@ class GatewayStreamConsumer:
         discarded.  Partial tags at buffer boundaries are held back in
         ``_think_buffer`` until enough characters arrive to decide.
         """
+        text = self._tool_call_scrubber.feed(text)
+        if not text:
+            return
         buf = self._think_buffer + text
         self._think_buffer = ""
 
@@ -455,6 +460,9 @@ class GatewayStreamConsumer:
         Called when the stream ends (got_done) so that partial text that
         was held back waiting for a possible opening tag is not lost.
         """
+        tool_tail = self._tool_call_scrubber.flush()
+        if tool_tail:
+            self._filter_and_accumulate(tool_tail)
         if self._think_buffer and not self._in_think_block:
             self._accumulated += self._think_buffer
             self._think_buffer = ""

--- a/run_agent.py
+++ b/run_agent.py
@@ -146,6 +146,7 @@ from tools.browser_tool import cleanup_browser
 
 # Agent internals extracted to agent/ package for modularity
 from agent.memory_manager import sanitize_context
+from agent.tool_call_scrubber import strip_tool_call_markup
 from agent.error_classifier import FailoverReason
 from agent.redact import redact_sensitive_text
 from agent.model_metadata import (
@@ -4249,6 +4250,20 @@ class AIAgent:
         scrubber = getattr(self, "_stream_context_scrubber", None)
         if scrubber is not None:
             tail = scrubber.flush()
+            tool_scrubber = getattr(self, "_stream_tool_call_scrubber", None)
+            if tail and tool_scrubber is not None:
+                tail = tool_scrubber.feed(tail)
+            if tail:
+                callbacks = [cb for cb in (self.stream_delta_callback, self._stream_callback) if cb is not None]
+                for cb in callbacks:
+                    try:
+                        cb(tail)
+                    except Exception:
+                        pass
+                self._record_streamed_assistant_text(tail)
+        tool_scrubber = getattr(self, "_stream_tool_call_scrubber", None)
+        if tool_scrubber is not None:
+            tail = tool_scrubber.flush()
             if tail:
                 callbacks = [cb for cb in (self.stream_delta_callback, self._stream_callback) if cb is not None]
                 for cb in callbacks:
@@ -4333,6 +4348,11 @@ class AIAgent:
             else:
                 # Defensive: legacy callers without the scrubber attribute.
                 text = sanitize_context(text)
+            tool_scrubber = getattr(self, "_stream_tool_call_scrubber", None)
+            if tool_scrubber is not None:
+                text = tool_scrubber.feed(text)
+            else:
+                text = strip_tool_call_markup(text)
             # Only strip leading newlines on the first delta — mid-stream "\n" is legitimate markdown.
             if not prepended_break and not getattr(
                 self, "_current_streamed_assistant_text", ""

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -97,6 +97,7 @@ AUTHOR_MAP = {
     "izumi0uu@gmail.com": "izumi0uu",  # PR #49544 salvage (native rich reply echo; #49534)
     "dev@pixlmedia.no": "texhy",  # PR #27435 salvage (few-but-huge preflight compression gate; #27405)
     "qdaszx@naver.com": "qdaszx",  # PR #29190 salvage (non-blocking OSV malware preflight; #29184)
+    "1026060507@qq.com": "magic524",  # PR #46537 (gateway DSML tool-call leak suppression)
     "w31rdm4ch1n3z@protonmail.com": "w31rdm4ch1nZ",
     "xtpeeps@gmail.com": "x7peeps",
     "ahmad@madsgency.com": "ahmadashfq",

--- a/tests/agent/test_tool_call_scrubber.py
+++ b/tests/agent/test_tool_call_scrubber.py
@@ -1,0 +1,39 @@
+"""Tests for suppressing text-encoded provider tool-call markup."""
+
+from __future__ import annotations
+
+from agent.tool_call_scrubber import StreamingToolCallScrubber, strip_tool_call_markup
+
+
+def _drive(deltas: list[str]) -> str:
+    scrubber = StreamingToolCallScrubber()
+    return "".join(scrubber.feed(delta) for delta in deltas) + scrubber.flush()
+
+
+def test_strip_dsml_tool_call_from_completed_response() -> None:
+    raw = (
+        "I will update that.\n"
+        "<｜DSML｜tool_calls> <｜DSML｜invoke name=\"write_file\">"
+        "<｜DSML｜parameter name=\"arguments\">{\"content\":\"secret code\"}"
+    )
+    assert strip_tool_call_markup(raw) == "I will update that.\n"
+
+
+def test_streaming_dsml_tool_call_split_across_deltas() -> None:
+    out = _drive(
+        [
+            "Working\n<｜DSM",
+            "L｜tool_calls> <｜DSML｜invoke name=\"write_file\">",
+            "{\"content\":\"internal\"}",
+            "<｜DSML｜/tool_calls>Done",
+        ]
+    )
+    assert out == "Working\nDone"
+
+
+def test_ascii_dsml_variant_is_stripped() -> None:
+    assert _drive(["ok <|DSML|tool_calls>{}", "<|DSML|/tool_calls> done"]) == "ok  done"
+
+
+def test_unclosed_dsml_tool_call_dropped_at_flush() -> None:
+    assert _drive(["visible <｜DSML｜tool_calls>{\"content\":\"internal\"}"]) == "visible "

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -1528,6 +1528,22 @@ class TestFilterAndAccumulate:
         c._filter_and_accumulate("still hidden</think>visible")
         assert c._accumulated == "visible"
 
+    def test_dsml_tool_call_block_stripped(self):
+        c = _make_consumer()
+        c._filter_and_accumulate("Before <｜DSML｜tool_calls>")
+        c._filter_and_accumulate("<｜DSML｜invoke name=\"write_file\">")
+        c._filter_and_accumulate("{\"content\":\"internal\"}")
+        c._filter_and_accumulate("<｜DSML｜/tool_calls> After")
+        assert c._accumulated == "Before  After"
+
+    def test_split_dsml_tool_call_opening_stripped(self):
+        c = _make_consumer()
+        c._filter_and_accumulate("Before <｜DSM")
+        assert c._accumulated == "Before "
+        c._filter_and_accumulate("L｜tool_calls>{\"content\":\"internal\"}")
+        c._flush_think_buffer()
+        assert c._accumulated == "Before "
+
 
 class TestFilterAndAccumulateIntegration:
     """Integration: verify think blocks don't leak through the full run() path."""
@@ -2111,4 +2127,3 @@ class TestFreshFinalRespectsAdapterDecline:
         assert adapter.send.call_count == 2, (
             f"Expected 2 send calls (initial + fresh-final), got {adapter.send.call_count}"
         )
-

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -6,6 +6,7 @@ from gateway.config import Platform
 from gateway.run import (
     _prepare_gateway_status_message,
     _sanitize_gateway_final_response,
+    _sanitize_gateway_interim_assistant_text,
 )
 
 # Every human-facing chat surface that must receive noise-filtered,
@@ -232,3 +233,36 @@ def test_chat_gateways_redact_all_issue_23810_credential_shapes(platform, shape_
     # Prose around the secret is preserved — redaction is surgical.
     assert "here is the token you asked me to echo" in sanitized
     assert sanitized.endswith("done.")
+
+
+def test_non_telegram_final_response_strips_dsml_tool_call_markup():
+    """Weixin/QQ should not receive provider text-encoded tool calls."""
+    raw = (
+        "Master 说得对，我会重建页面。\n"
+        "<｜DSML｜tool_calls> <｜DSML｜invoke name=\"write_file\">"
+        "<｜DSML｜parameter name=\"arguments\">{\"content\":\"internal\"}"
+    )
+
+    sanitized = _sanitize_gateway_final_response(Platform.WEIXIN, raw)
+
+    assert sanitized == "Master 说得对，我会重建页面。"
+    assert "DSML" not in sanitized
+    assert "write_file" not in sanitized
+
+
+def test_interim_assistant_text_strips_dsml_tool_call_markup():
+    """Direct interim commentary sends should not leak DSML tool calls."""
+    raw = (
+        "Let me check specific posts to see which have fabricated URLs.\n"
+        "<｜DSML｜tool_calls>\n"
+        "<｜DSML｜invoke name=\"terminal\">\n"
+        "<｜DSML｜parameter name=\"arguments\" string=\"false\">"
+        "{\"command\":\"curl https://example.test\"}"
+    )
+
+    sanitized = _sanitize_gateway_interim_assistant_text(raw)
+
+    assert sanitized == "Let me check specific posts to see which have fabricated URLs."
+    assert "DSML" not in sanitized
+    assert "terminal" not in sanitized
+    assert "curl" not in sanitized


### PR DESCRIPTION
## Summary

Fixes a gateway display/send leak where provider-native DSML tool-call markup could be delivered to messaging platforms as normal assistant text.

When a model emits text like `<｜DSML｜tool_calls> ... <｜DSML｜invoke name="write_file"> ...` in `content` instead of structured `tool_calls`, Hermes could treat it as the final reply. On platforms such as Weixin and QQ, the long internal tool arguments are then passed through the normal message chunker, producing user-visible `(1/N)` / `(n/N)` spam.

This PR adds a small display-boundary scrubber for DSML tool-call spans and wires it into:

- streamed assistant deltas in `run_agent.py`
- the gateway `GatewayStreamConsumer`
- final gateway response sanitization before platform delivery

It also resets the scrubber per turn and adds focused regression tests for full-width DSML markers, split markers across deltas, final-response sanitization, and stream-consumer filtering.

## Relationship to #35129

Refs #35129, but this is intentionally narrower and complementary.

#35129 promotes several content-embedded tool-call formats into executable structured `tool_calls`. It explicitly leaves DeepSeek/DSML promotion out of scope because those forms are false-positive-prone. This PR does not execute DSML markup. It only suppresses internal DSML tool-call text at user-visible output boundaries so tool arguments do not leak into chat.

## Validation

Rebased onto `origin/main@7cfa2fa13` on 2026-06-29. Current head: `61b7ffd87`.

```bash
venv/bin/python -m py_compile run_agent.py agent/tool_call_scrubber.py gateway/run.py gateway/stream_consumer.py agent/agent_init.py agent/turn_context.py
venv/bin/python -m pytest tests/agent/test_tool_call_scrubber.py tests/gateway/test_telegram_noise_filter.py tests/gateway/test_stream_consumer.py -q
```

Result: `300 passed`.

Manual smoke from the original report: restarted `hermes-gateway-ram.service` and verified the ram Weixin conversation no longer showed large backend-code DSML chunks during testing.