### PR TITLE
fix(gateway): filter proxy replay history

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -136,6 +136,35 @@ _GATEWAY_SECRET_PATTERNS = (
 )
 
 
+def _proxy_text_history(history: List[Dict[str, Any]]) -> List[Dict[str, str]]:
+    """Return safe compact text history for remote proxy mode.
+
+    Proxy mode sends a text-only transcript to a remote Hermes API server.
+    Assistant tool-call rows are not replayable in that compact shape and, on
+    some transports, their ``content`` can contain internal planning/reasoning
+    text. Replaying those rows as ordinary assistant messages contaminates
+    later turns with stale implementation state.
+
+    Keep user text and final assistant prose; drop assistant tool-call rows.
+    """
+    result: List[Dict[str, str]] = []
+    for msg in history or []:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role")
+        content = msg.get("content")
+        if not isinstance(content, str) or not content.strip():
+            continue
+        if role == "user":
+            result.append({"role": "user", "content": content})
+            continue
+        if role == "assistant":
+            if msg.get("tool_calls") or msg.get("finish_reason") == "tool_calls":
+                continue
+            result.append({"role": "assistant", "content": content})
+    return result
+
+
 def _ensure_windows_gateway_venv_imports() -> None:
     """Make detached Windows gateway runs see the Hermes venv packages.
 
@@ -13174,11 +13203,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if context_prompt:
             api_messages.append({"role": "system", "content": context_prompt})
 
-        for msg in history:
-            role = msg.get("role")
-            content = msg.get("content")
-            if role in {"user", "assistant"} and content:
-                api_messages.append({"role": role, "content": content})
+        api_messages.extend(_proxy_text_history(history))
 
         api_messages.append({"role": "user", "content": message})
 

--- a/tests/gateway/test_proxy_history_filter.py
+++ b/tests/gateway/test_proxy_history_filter.py
@@ -1,0 +1,42 @@
+from gateway.run import _proxy_text_history
+
+
+def test_proxy_text_history_drops_assistant_tool_call_analysis_content():
+    history = [
+        {"role": "user", "content": "start roadmap docs"},
+        {
+            "role": "assistant",
+            "content": "Need maybe do architecture audit? stale internal plan",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "todo", "arguments": "{}"},
+                }
+            ],
+            "finish_reason": "tool_calls",
+        },
+        {"role": "tool", "content": "{}", "tool_call_id": "call_1"},
+        {"role": "assistant", "content": "Roadmap docs are the active task.", "finish_reason": "stop"},
+        {"role": "assistant", "content": "", "finish_reason": "stop"},
+    ]
+
+    assert _proxy_text_history(history) == [
+        {"role": "user", "content": "start roadmap docs"},
+        {"role": "assistant", "content": "Roadmap docs are the active task."},
+    ]
+
+
+def test_proxy_text_history_drops_tool_call_rows_even_without_finish_reason():
+    history = [
+        {
+            "role": "assistant",
+            "content": "Need verify status.",
+            "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "terminal"}}],
+        },
+        {"role": "assistant", "content": "Visible final answer."},
+    ]
+
+    assert _proxy_text_history(history) == [
+        {"role": "assistant", "content": "Visible final answer."},
+    ]


### PR DESCRIPTION
## Summary
- filter remote proxy replay history through a text-only helper
- drop assistant tool-call rows so internal planning/tool-call content is not replayed as normal assistant prose
- add regression coverage for stale internal planning text in proxy history

## Test Plan
- uv run --extra dev pytest tests/gateway/test_proxy_history_filter.py tests/agent/test_skill_commands.py -q