### PR TITLE
fix: hand off gateway-child restart via SIGUSR1

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6785,6 +6785,34 @@ def _gateway_command_inner(args):
         # Defense: refuse self-targeting gateway restart from inside the gateway.
         # Prevents agent-initiated kill loops when combined with supervisor KeepAlive.
         if os.getenv("_HERMES_GATEWAY") == "1":
+            candidate_pids: list[int] = []
+            raw_gateway_pid = (os.getenv("SYSTEMD_EXEC_PID") or "").strip()
+            if raw_gateway_pid:
+                try:
+                    candidate_pids.append(int(raw_gateway_pid))
+                except ValueError:
+                    pass
+
+            try:
+                from gateway.status import get_running_pid
+
+                running_pid = get_running_pid()
+            except Exception:
+                running_pid = None
+            if running_pid is not None and running_pid not in candidate_pids:
+                candidate_pids.append(running_pid)
+
+            for candidate_pid in candidate_pids:
+                if _request_gateway_self_restart(candidate_pid):
+                    try:
+                        (get_hermes_home() / ".restart_pending.json").write_text("{}", encoding="utf-8")
+                    except Exception:
+                        pass
+                    print_success(
+                        f"Requested graceful gateway self-restart via SIGUSR1 (gateway pid {candidate_pid})."
+                    )
+                    return
+
             print_error(
                 "Refusing to restart the gateway from inside the gateway process.\n"
                 "This command was blocked to prevent restart loops.\n"

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -206,11 +206,32 @@ class TestGatewaySelfTargetingGuard:
 
     def test_restart_refuses_inside_gateway(self, monkeypatch):
         monkeypatch.setenv("_HERMES_GATEWAY", "1")
-        from hermes_cli.gateway import gateway_command
+        monkeypatch.delenv("SYSTEMD_EXEC_PID", raising=False)
+        import hermes_cli.gateway as gw
+
+        monkeypatch.setattr(gw, "_request_gateway_self_restart", lambda pid: False)
+
         args = Namespace(gateway_command="restart", all=False, system=False)
         with pytest.raises(SystemExit) as exc_info:
-            gateway_command(args)
+            gw.gateway_command(args)
         assert exc_info.value.code == 1
+
+    def test_restart_from_gateway_child_shell_requests_sigusr1(self, monkeypatch, tmp_path, capsys):
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        monkeypatch.setenv("SYSTEMD_EXEC_PID", "43210")
+        import hermes_cli.gateway as gw
+
+        requested = []
+        monkeypatch.setattr(gw, "_request_gateway_self_restart", lambda pid: requested.append(pid) or True)
+        monkeypatch.setattr(gw, "get_hermes_home", lambda: tmp_path)
+
+        args = Namespace(gateway_command="restart", all=False, system=False)
+        gw.gateway_command(args)
+
+        assert requested == [43210]
+        assert (tmp_path / ".restart_pending.json").exists()
+        out = capsys.readouterr().out
+        assert "Requested graceful gateway self-restart via SIGUSR1" in out
 
     def test_stop_allows_outside_gateway(self, monkeypatch):
         # With the gateway marker unset, the self-targeting guard must NOT


### PR DESCRIPTION
## Summary
- allow `hermes gateway restart` from a gateway-derived child shell to request graceful self-restart via the existing SIGUSR1 handoff path
- preserve the existing refusal when no safe handoff PID can be identified
- add regression coverage for both the safe handoff path and the refusal fallback

## Why
When `hermes gateway restart` is launched from a shell spawned under the running gateway, that shell inherits gateway context markers such as `_HERMES_GATEWAY=1`. Before this patch, Hermes treated that case as an unconditional in-gateway restart attempt and hard-refused it, even when the request originated from a legitimate child shell rather than an unsafe self-kill path.

This patch narrows the behavior change to the safe case: if Hermes can identify a real gateway PID, it hands restart back to the gateway's existing graceful SIGUSR1 restart mechanism; otherwise it still refuses exactly as before.

## Verification
- `pytest -q tests/hermes_cli/test_gateway_restart_loop.py`
- live verification from a gateway-derived lane:
  - restart request accepted via `✓ Requested graceful gateway self-restart via SIGUSR1 (gateway pid 396).`
  - gateway entered draining state
  - gateway came back on a new PID (`396` -> `71142`)

## Notes
- `stop` behavior is unchanged
- branch contains only the restart handoff fix and its tests
