### PR TITLE
fix(copilot): stop gpt-5-mini from inheriting codex_responses and losing reasoning (#46527)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -842,6 +842,19 @@ def init_agent(
                             agent.provider = _fb["provider"]
                             agent.model = _fb_model or _fb["model"]
                             agent._fallback_activated = True
+                            # Recompute api_mode for the fallback provider/model —
+                            # otherwise it stays whatever was computed above for
+                            # the (unreachable) primary, e.g. a Nous primary
+                            # configured with api_mode: codex_responses leaves
+                            # a Copilot gpt-5-mini fallback stuck on the
+                            # Responses API and silently drops reasoning/
+                            # thinking content. See #46527.
+                            from agent.chat_completion_helpers import resolve_fallback_api_mode
+                            agent.api_mode = resolve_fallback_api_mode(
+                                agent, agent.provider, agent.model, str(_fb_client.base_url),
+                            )
+                            if hasattr(agent, "_transport_cache"):
+                                agent._transport_cache.clear()
                             client_kwargs = {
                                 "api_key": _fb_client.api_key,
                                 "base_url": str(_fb_client.base_url),

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1042,6 +1042,45 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
 
 
 
+def resolve_fallback_api_mode(agent, fb_provider: str, fb_model: str, fb_base_url: str) -> str:
+    """Determine the ``api_mode`` a (provider, model, base_url) triple requires.
+
+    Shared by :func:`try_activate_fallback` (per-turn automatic fallback)
+    and the init-time fallback path in ``agent_init.py`` (#17929) so both
+    recompute ``api_mode`` for the *new* backend instead of inheriting it
+    from whatever provider was active before the switch.  See #46527 —
+    without this, a fallback to e.g. Copilot's ``gpt-5-mini`` (chat
+    completions only) silently inherited ``codex_responses`` from a Nous
+    primary configured with ``api_mode: codex_responses``, and the
+    response came back with no reasoning/thinking content.
+    """
+    fb_api_mode = "chat_completions"
+    if fb_provider == "openai-codex":
+        fb_api_mode = "codex_responses"
+    elif fb_provider == "anthropic" or fb_base_url.rstrip("/").lower().endswith("/anthropic"):
+        fb_api_mode = "anthropic_messages"
+    elif agent._is_azure_openai_url(fb_base_url):
+        # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT
+        # support the Responses API. Stay on chat_completions.
+        fb_api_mode = "chat_completions"
+    elif agent._is_direct_openai_url(fb_base_url):
+        fb_api_mode = "codex_responses"
+    elif agent._provider_model_requires_responses_api(
+        fb_model,
+        provider=fb_provider,
+    ):
+        # GPT-5.x models usually need Responses API, but keep
+        # provider-specific exceptions like Copilot gpt-5-mini on
+        # chat completions.
+        fb_api_mode = "codex_responses"
+    elif fb_provider == "bedrock" or (
+        base_url_hostname(fb_base_url).startswith("bedrock-runtime.")
+        and base_url_host_matches(fb_base_url, "amazonaws.com")
+    ):
+        fb_api_mode = "bedrock_converse"
+    return fb_api_mode
+
+
 def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool:
     """Switch to the next fallback model/provider in the chain.
 
@@ -1140,32 +1179,8 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             )
 
         # Determine api_mode from provider / base URL / model
-        fb_api_mode = "chat_completions"
         fb_base_url = str(fb_client.base_url)
-        _fb_is_azure = agent._is_azure_openai_url(fb_base_url)
-        if fb_provider == "openai-codex":
-            fb_api_mode = "codex_responses"
-        elif fb_provider == "anthropic" or fb_base_url.rstrip("/").lower().endswith("/anthropic"):
-            fb_api_mode = "anthropic_messages"
-        elif _fb_is_azure:
-            # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT
-            # support the Responses API. Stay on chat_completions.
-            fb_api_mode = "chat_completions"
-        elif agent._is_direct_openai_url(fb_base_url):
-            fb_api_mode = "codex_responses"
-        elif agent._provider_model_requires_responses_api(
-            fb_model,
-            provider=fb_provider,
-        ):
-            # GPT-5.x models usually need Responses API, but keep
-            # provider-specific exceptions like Copilot gpt-5-mini on
-            # chat completions.
-            fb_api_mode = "codex_responses"
-        elif fb_provider == "bedrock" or (
-            base_url_hostname(fb_base_url).startswith("bedrock-runtime.")
-            and base_url_host_matches(fb_base_url, "amazonaws.com")
-        ):
-            fb_api_mode = "bedrock_converse"
+        fb_api_mode = resolve_fallback_api_mode(agent, fb_provider, fb_model, fb_base_url)
 
         old_model = agent.model
 

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -179,7 +179,14 @@ class ResponsesApiTransport(ProviderTransport):
             if is_github_responses:
                 github_reasoning = params.get("github_reasoning_extra")
                 if github_reasoning is not None:
-                    kwargs["reasoning"] = github_reasoning
+                    # Request a reasoning summary so the Responses API actually
+                    # returns reasoning text. Without summary="auto" the
+                    # reasoning items come back with no summary and Hermes
+                    # persists empty reasoning/thinking content — the same loss
+                    # the non-GitHub branch below already avoids. Verified
+                    # against api.githubcopilot.com /responses: the summary is
+                    # only emitted when summary="auto" is sent. See #46527.
+                    kwargs["reasoning"] = {**github_reasoning, "summary": "auto"}
             else:
                 kwargs["reasoning"] = {"effort": reasoning_effort, "summary": "auto"}
                 kwargs["include"] = (

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -224,10 +224,27 @@ def _provider_supports_explicit_api_mode(provider: Optional[str], configured_pro
 def _copilot_runtime_api_mode(model_cfg: Dict[str, Any], api_key: str) -> str:
     configured_provider = str(model_cfg.get("provider") or "").strip().lower()
     configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
+    model_name = str(model_cfg.get("default") or "").strip()
     if configured_mode and _provider_supports_explicit_api_mode("copilot", configured_provider):
+        # A stale/incompatible explicit ``codex_responses`` must not override
+        # Copilot's hard per-model requirement.  Copilot serves ``gpt-5-mini``
+        # on chat completions only; a Responses-API request there silently
+        # succeeds but returns no reasoning/thinking content.  This stale
+        # value commonly survives a provider switch (e.g. a previous Nous or
+        # Codex primary wrote ``api_mode: codex_responses``, then the primary
+        # was changed to Copilot + gpt-5-mini without clearing it).  The
+        # check is the pure-regex Copilot exception — no network call.  See
+        # #46527.
+        if configured_mode == "codex_responses" and model_name:
+            try:
+                from hermes_cli.models import _should_use_copilot_responses_api
+
+                if not _should_use_copilot_responses_api(model_name):
+                    return "chat_completions"
+            except Exception:
+                pass
         return configured_mode
 
-    model_name = str(model_cfg.get("default") or "").strip()
     if not model_name:
         return "chat_completions"
 

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -100,6 +100,18 @@ class TestCodexBuildKwargs:
         )
         assert "prompt_cache_key" not in kw
 
+    def test_github_responses_requests_reasoning_summary(self, transport):
+        """#46527: the GitHub Responses branch must request summary="auto" so
+        Copilot returns reasoning text. Without it, reasoning items come back
+        empty and Hermes persists no reasoning/thinking content."""
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4", messages=messages, tools=[],
+            is_github_responses=True,
+            github_reasoning_extra={"effort": "medium"},
+        )
+        assert kw.get("reasoning") == {"effort": "medium", "summary": "auto"}
+
     def test_xai_responses_sends_cache_key_via_extra_body(self, transport):
         """xAI's Responses API documents ``prompt_cache_key`` as the
         body-level cache-routing key (the ``x-grok-conv-id`` header is

--- a/tests/hermes_cli/test_copilot_runtime_api_mode_stale.py
+++ b/tests/hermes_cli/test_copilot_runtime_api_mode_stale.py
@@ -1,0 +1,46 @@
+"""Regression tests for #46527: Copilot primary api_mode resolution must not
+honor a stale/incompatible explicit ``api_mode``.
+
+The gateway resolves and snapshots the primary provider/model at startup via
+``resolve_runtime_provider`` -> ``_copilot_runtime_api_mode``.  When the
+config carries a stale ``api_mode: codex_responses`` (e.g. left over from a
+previous Nous/Codex primary) and the primary is later changed to Copilot +
+``gpt-5-mini``, the old code honored the stale ``codex_responses`` verbatim.
+That dispatches gpt-5-mini through the Responses API — which Copilot serves
+on chat completions only — and the response comes back with no reasoning/
+thinking content (the symptom in #46527).
+"""
+from hermes_cli.runtime_provider import _copilot_runtime_api_mode
+
+
+def test_stale_codex_responses_vetoed_for_gpt5_mini():
+    """gpt-5-mini + stale api_mode=codex_responses must resolve to chat_completions."""
+    cfg = {"provider": "copilot", "default": "gpt-5-mini", "api_mode": "codex_responses"}
+    assert _copilot_runtime_api_mode(cfg, api_key="x") == "chat_completions"
+
+
+def test_explicit_codex_responses_kept_for_gpt5_variant():
+    """gpt-5.4-mini legitimately uses the Responses API on Copilot — an explicit
+    codex_responses must still be honored (no over-correction)."""
+    cfg = {"provider": "copilot", "default": "gpt-5.4-mini", "api_mode": "codex_responses"}
+    assert _copilot_runtime_api_mode(cfg, api_key="x") == "codex_responses"
+
+
+def test_no_explicit_mode_derives_chat_completions_for_gpt5_mini():
+    """Without an explicit api_mode, gpt-5-mini derives chat_completions (unchanged)."""
+    cfg = {"provider": "copilot", "default": "gpt-5-mini"}
+    assert _copilot_runtime_api_mode(cfg, api_key="x") == "chat_completions"
+
+
+def test_explicit_chat_completions_unchanged():
+    """An explicit chat_completions stays chat_completions for gpt-5-mini."""
+    cfg = {"provider": "copilot", "default": "gpt-5-mini", "api_mode": "chat_completions"}
+    assert _copilot_runtime_api_mode(cfg, api_key="x") == "chat_completions"
+
+
+def test_stale_mode_from_different_provider_not_honored():
+    """When the config's provider doesn't match copilot, the explicit mode is
+    not honored at all (existing _provider_supports_explicit_api_mode guard),
+    so gpt-5-mini still derives chat_completions."""
+    cfg = {"provider": "nous", "default": "gpt-5-mini", "api_mode": "codex_responses"}
+    assert _copilot_runtime_api_mode(cfg, api_key="x") == "chat_completions"

--- a/tests/run_agent/test_init_fallback_api_mode.py
+++ b/tests/run_agent/test_init_fallback_api_mode.py
@@ -1,0 +1,99 @@
+"""Regression test for #46527: the init-time fallback path (#17929) must
+recompute ``api_mode`` for the fallback provider/model instead of
+inheriting it from the (unreachable) primary.
+
+Concretely: a primary configured as ``provider: nous`` with an explicit
+``api_mode: codex_responses`` (required for Nous-served GPT-5.x reasoning
+models) that has no usable credentials at init time falls back to
+``provider: copilot`` / ``model: gpt-5-mini``.  Copilot's ``gpt-5-mini`` is
+the documented exception that uses Chat Completions, not the Responses API
+(see ``tests/hermes_cli/test_model_switch_copilot_api_mode.py``).  Before
+the fix, ``agent.api_mode`` stayed ``"codex_responses"`` after the
+fallback activated, so every request for the fallback model went out via
+the Responses API and silently returned no reasoning/thinking content.
+"""
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _make_tool_defs():
+    return [{"type": "function", "function": {"name": "web_search",
+             "description": "search", "parameters": {"type": "object", "properties": {}}}}]
+
+
+def _mock_client(api_key="fb-key-1234567890", base_url="https://api.githubcopilot.com"):
+    c = MagicMock()
+    c.api_key = api_key
+    c.base_url = base_url
+    c._default_headers = None
+    return c
+
+
+def test_init_fallback_recomputes_api_mode_for_copilot_gpt5_mini():
+    """Nous primary (api_mode=codex_responses, no creds) -> Copilot gpt-5-mini
+    fallback must end up with api_mode=chat_completions, not codex_responses."""
+    fb_client = _mock_client()
+
+    def fake_resolve(provider, model=None, raw_codex=False,
+                      explicit_base_url=None, explicit_api_key=None):
+        if provider == "copilot":
+            return fb_client, "gpt-5-mini"
+        return None, None  # primary (nous) has no usable credentials
+
+    with patch("agent.auxiliary_client.resolve_provider_client", side_effect=fake_resolve), \
+         patch("run_agent.get_tool_definitions", return_value=_make_tool_defs()), \
+         patch("run_agent.check_toolset_requirements", return_value={}), \
+         patch("run_agent.OpenAI", return_value=MagicMock()):
+
+        agent = AIAgent(
+            provider="nous",
+            model="gpt-5.4-mini",
+            api_mode="codex_responses",
+            api_key=None,
+            base_url=None,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=[{"provider": "copilot", "model": "gpt-5-mini"}],
+        )
+
+        assert agent.provider == "copilot"
+        assert agent.model == "gpt-5-mini"
+        assert agent._fallback_activated is True
+        assert agent.api_mode == "chat_completions"
+
+
+def test_init_fallback_keeps_codex_responses_for_openai_codex():
+    """Nous primary (api_mode=codex_responses, no creds) -> openai-codex
+    fallback must keep api_mode=codex_responses (openai-codex always uses
+    the Responses API)."""
+    fb_client = _mock_client(base_url="https://chatgpt.com/backend-api/codex")
+
+    def fake_resolve(provider, model=None, raw_codex=False,
+                      explicit_base_url=None, explicit_api_key=None):
+        if provider == "openai-codex":
+            return fb_client, "gpt-5.4-mini"
+        return None, None
+
+    with patch("agent.auxiliary_client.resolve_provider_client", side_effect=fake_resolve), \
+         patch("run_agent.get_tool_definitions", return_value=_make_tool_defs()), \
+         patch("run_agent.check_toolset_requirements", return_value={}), \
+         patch("run_agent.OpenAI", return_value=MagicMock()):
+
+        agent = AIAgent(
+            provider="nous",
+            model="gpt-5.4-mini",
+            api_mode="codex_responses",
+            api_key=None,
+            base_url=None,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=[{"provider": "openai-codex", "model": "gpt-5.4-mini"}],
+        )
+
+        assert agent.provider == "openai-codex"
+        assert agent.model == "gpt-5.4-mini"
+        assert agent._fallback_activated is True
+        assert agent.api_mode == "codex_responses"

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -385,7 +385,9 @@ def test_build_api_kwargs_copilot_responses_omits_openai_only_fields(monkeypatch
     assert kwargs["store"] is False
     assert kwargs["tool_choice"] == "auto"
     assert kwargs["parallel_tool_calls"] is True
-    assert kwargs["reasoning"] == {"effort": "medium"}
+    # #46527: Copilot's Responses API only returns reasoning text when
+    # summary="auto" is requested; without it reasoning is persisted empty.
+    assert kwargs["reasoning"] == {"effort": "medium", "summary": "auto"}
     assert "prompt_cache_key" not in kwargs
     assert "include" not in kwargs
 


### PR DESCRIPTION
## Summary

Fixes #46527 — Copilot `gpt-5-mini` dispatched via the Responses API and returning **no reasoning/thinking content**, even with `reasoning_effort` set. The request succeeds (HTTP 200); it just silently carries no reasoning, which is why it's easy to miss.

`gpt-5-mini` is the documented Copilot exception: it must use **chat completions**, not the Responses API. This PR fixes the resolution path that let it run on `codex_responses` (the root cause of the report), plus two related Copilot reasoning bugs found while tracing it.

> **Note for reviewers** who verified the *automatic per-turn fallback* path (`try_activate_fallback`): that path already recomputes `api_mode` correctly and is **not** the bug. The failing session had no fallback chain at all — Copilot was the sole primary. The fixes below are in other paths.

## 1. Root cause — primary resolution honors a stale `api_mode` (`hermes_cli/runtime_provider.py`)

The gateway resolves and **snapshots the primary provider/model at startup**. `_copilot_runtime_api_mode()` honored an explicit `api_mode` from config verbatim whenever the config's `provider` matched `copilot`.

The stale value arises from an ordinary flow, no manual editing required: the Copilot OAuth setup (`hermes model` / Desktop) writes `api_mode: codex_responses`, which is *correct* for the `gpt-5.4-mini` it initially selects. A free-tier user then changes the model to `gpt-5-mini` (the id their plan grants) — but `api_mode` isn't recomputed, so `gpt-5-mini` inherits `codex_responses`. On the next gateway start that becomes the snapshotted primary, and every turn dispatches via the Responses API.

```
_copilot_runtime_api_mode({provider: copilot, default: gpt-5-mini, api_mode: codex_responses}) -> codex_responses   ❌  (before)
copilot_model_api_mode("gpt-5-mini")                                                            -> chat_completions  ✅
```

`_provider_supports_explicit_api_mode()` only guards against *cross-provider* api_mode leakage (a different provider name); it doesn't catch a within-Copilot mode that violates a hard per-model requirement. This PR closes that gap: a stale `codex_responses` is vetoed to `chat_completions` for models the Copilot exception (`_should_use_copilot_responses_api`, pure regex, no network) says are chat-only, while a legitimate `codex_responses` for GPT-5 variants like `gpt-5.4-mini` is still honored.

## 2. Reasoning summary omitted on the GitHub Responses API (`agent/transports/codex.py`)

The GitHub/Copilot branch of the Responses request builder sent `reasoning = {"effort": ...}` and **omitted `summary: "auto"`**, which every other provider's Responses request already includes. Without `summary: "auto"`, Copilot's `/responses` endpoint returns reasoning items with **no summary text**, so Hermes persists empty reasoning for every Copilot model that uses the Responses API (`gpt-5.4-mini`, `gpt-5`, …).

Verified directly against `api.githubcopilot.com/responses`: the reasoning summary is only emitted when `summary: "auto"` is sent. Fixed by mirroring the non-GitHub branch.

(This does **not** affect `gpt-5-mini`, which uses chat completions on Copilot — where the provider returns no reasoning at all. That's a Copilot API limitation, not a Hermes bug.)

## 3. Related hardening — init-time fallback doesn't recompute `api_mode` (`agent/agent_init.py`)

A separate latent bug in the same class (not the path behind this report). When the primary provider has no usable credentials at construction time, the init-time fallback (#17929) swaps `provider`/`model` to the first usable `fallback_providers` entry but left `api_mode` untouched. Worse, `_primary_runtime` is snapshotted *after* that swap, freezing the stale mode so `restore_primary_runtime` re-applies it every turn. The `fb_api_mode` computation is extracted from `try_activate_fallback()` into a shared `resolve_fallback_api_mode()` helper and reused here so the init-time path recomputes like the per-turn path already does.

## Test plan

- [x] `tests/hermes_cli/test_copilot_runtime_api_mode_stale.py` — stale `codex_responses` + `gpt-5-mini` → `chat_completions`; `gpt-5.4-mini` keeps `codex_responses`; cross-provider stale mode not honored.
- [x] `tests/agent/transports/test_codex_transport.py::test_github_responses_requests_reasoning_summary` — GitHub Responses request includes `summary: "auto"`.
- [x] `tests/run_agent/test_init_fallback_api_mode.py` — init-time fallback to Copilot `gpt-5-mini` → `chat_completions`; to `openai-codex` → `codex_responses`.
- [x] `pytest tests/agent/transports/test_codex_transport.py tests/run_agent/test_run_agent_codex_responses.py tests/hermes_cli/test_copilot_runtime_api_mode_stale.py tests/hermes_cli/test_model_switch_copilot_api_mode.py tests/run_agent/test_init_fallback_api_mode.py tests/run_agent/test_provider_fallback.py` — 163 passed.
