### PR TITLE
fix(fallback): prevent credential pool from overwriting fallback base_url

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -615,6 +615,19 @@ def recover_with_credential_pool(
     # subsequent request then goes to the wrong host and 404s (see #33163).
     # The pool should only act when the agent is still on the same provider
     # that seeded the pool.
+    #
+    # Additional guard: when fallback is activated, the pool belongs to the
+    # primary provider and should NOT mutate the agent's state. The fallback
+    # provider has its own credentials resolved during _try_activate_fallback().
+    # Allowing pool operations after fallback would overwrite the fallback's
+    # base_url/api_key back to the primary's values via _swap_credential().
+    if getattr(agent, "_fallback_activated", False):
+        _ra().logger.debug(
+            "Credential pool: fallback active — skipping pool mutation "
+            "to preserve fallback provider's base_url/api_key"
+        )
+        return False, has_retried_429
+
     current_provider = (getattr(agent, "provider", "") or "").strip().lower()
     pool_provider = (getattr(pool, "provider", "") or "").strip().lower()
     if current_provider and pool_provider and current_provider != pool_provider:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -662,6 +662,44 @@ def has_named_custom_provider(requested_provider: str) -> bool:
         return False
 
 
+def _resolve_key_from_fallback_providers(base_url: str) -> str:
+    """Look up API key from fallback_providers config for a matching base_url.
+
+    When session resume restores a fallback provider's base_url but the
+    provider identity cannot be recovered (e.g. fallback_providers entries
+    don't have names), this function extracts the key_env from the matching
+    fallback entry and resolves the actual key from environment.
+
+    Returns the resolved API key or empty string.
+    """
+    target = _normalize_base_url_for_match(base_url)
+    if not target:
+        return ""
+    try:
+        config = load_config()
+    except Exception:
+        return ""
+
+    fallback_providers = config.get("fallback_providers")
+    if not isinstance(fallback_providers, list):
+        return ""
+
+    for entry in fallback_providers:
+        if not isinstance(entry, dict):
+            continue
+        entry_url = _normalize_base_url_for_match(entry.get("base_url", ""))
+        if entry_url and entry_url == target:
+            key_env = str(entry.get("key_env", "") or "").strip()
+            if key_env:
+                return os.getenv(key_env, "").strip()
+            # Fall back to api_key if key_env is not set
+            api_key = str(entry.get("api_key", "") or "").strip()
+            if api_key:
+                return api_key
+
+    return ""
+
+
 def find_custom_provider_identity(base_url: str) -> Optional[str]:
     """Map an endpoint URL back to its canonical ``custom:<name>`` menu key.
 
@@ -758,6 +796,8 @@ def _resolve_named_custom_runtime(
             return pool_result
         _da_is_openai_url   = base_url_host_matches(base_url, "openai.com") or base_url_host_matches(base_url, "openai.azure.com")
         _da_is_openrouter   = base_url_host_matches(base_url, "openrouter.ai")
+        # Check fallback_providers for a matching base_url with key_env
+        _fallback_key = _resolve_key_from_fallback_providers(base_url)
         api_key_candidates = [
             (explicit_api_key or "").strip(),
             # Gate env key fallbacks on authoritative hosts (#28660)
@@ -767,6 +807,8 @@ def _resolve_named_custom_runtime(
             # who set DEEPSEEK_API_KEY / GROQ_API_KEY / MISTRAL_API_KEY get the
             # intuitive match without configuring `custom_providers` first.
             _host_derived_api_key(base_url),
+            # Check fallback_providers config for key_env (e.g. BAIDU_API_KEY)
+            _fallback_key or "",
         ]
         api_key = next(
             (c for c in api_key_candidates if has_usable_secret(c)),


### PR DESCRIPTION
## Problem

When both primary and fallback providers use `custom` type (e.g., DashScope + Baidu Qianfan), the credential pool's `_swap_credential()` overwrites the fallback's `base_url` back to the primary's endpoint after fallback is activated.

### Symptoms
- After DashScope 429 → fallback to Baidu → session turn ends → resume:
  - `model=qianfan-code-latest` but `base_url=coding.dashscope.aliyuncs.com`
- HTTP 400: `model 'qianfan-code-latest' is not supported`
- Log shows: `Fallback skip: chain entry matches current provider/model` (but wrong URL)

### Root Cause
1. **Credential pool guard insufficient**: The guard in `recover_with_credential_pool()` only checks provider name match. When both primary and fallback are `custom`, the guard doesn't trigger, allowing `_swap_credential()` to overwrite the fallback's `base_url`.

2. **Session resume can't find fallback key**: When session resume restores a fallback provider's `base_url`, `find_custom_provider_identity()` returns `None` because `fallback_providers` entries don't have names. The key resolution then falls back to wrong sources.

## Solution

### Fix 1: Skip credential pool when fallback is activated
In `agent/agent_runtime_helpers.py`, added early return when `_fallback_activated` is True:

```python
if getattr(agent, "_fallback_activated", False):
    logger.debug("Credential pool: fallback active — skipping pool mutation")
    return False, has_retried_429
```

### Fix 2: Resolve keys from fallback_providers config
In `hermes_cli/runtime_provider.py`, added `_resolve_key_from_fallback_providers()` function that:
- Matches `base_url` against `fallback_providers` entries
- Extracts `key_env` (e.g., `BAIDU_API_KEY`)
- Resolves actual key from environment

## Testing
- ✅ `test_credential_pool_routing.py`: 10 passed
- ✅ `test_runtime_provider_resolution.py`: 129 passed
- ✅ `test_tui_gateway_server.py`: 270 passed (1 pre-existing failure unrelated to this change)

## Files Changed
- `agent/agent_runtime_helpers.py`: +13 lines
- `hermes_cli/runtime_provider.py`: +42 lines
