### PR TITLE
feat(api_server): include delegate_task result in tool progress SSE events

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3856,11 +3856,17 @@ class APIServerAdapter(BasePlatformAdapter):
                 if not tool_call_id or tool_call_id not in _started_tool_call_ids:
                     return
                 _started_tool_call_ids.discard(tool_call_id)
-                _stream_q.put(("__tool_progress__", {
+                payload = {
                     "tool": function_name,
                     "toolCallId": tool_call_id,
                     "status": "completed",
-                }))
+                }
+                # Include tool body for delegate_task so desktop clients can
+                # populate Subagents panel (api_server does not forward
+                # tool_progress_callback subagent.* events on this path).
+                if function_result and function_name == "delegate_task":
+                    payload["result"] = function_result
+                _stream_q.put(("__tool_progress__", payload))
 
             # Start agent in background.  agent_ref is a mutable container
             # so the SSE writer can interrupt the agent on client disconnect.

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -129,6 +129,61 @@ MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
 RESPONSES_AUTO_TRUNCATION_HISTORY_LIMIT = 100
 _COMPRESSED_SUMMARY_METADATA_KEY = "_compressed_summary"
+# Maximum payload size for delegate_task SSE completion events (bytes).
+# The raw delegate result can carry per-child summaries; this cap prevents
+# oversized SSE frames while still passing actionable sub-agent metadata.
+MAX_DELEGATE_TASK_RESULT_BYTES = 4_096
+
+
+def _redact_delegate_task_result(function_result: str) -> dict:
+    """Project delegate_task metadata into a small, redacted SSE payload.
+
+    Drops summary, error text, and file paths to avoid leaking internal
+    agent content or credentials through the API-server SSE stream.
+    Keeps only structured metadata needed by downstream UIs for sub-agent
+    panels: subagent_id, model, status, duration, tokens, toolsets,
+    exit_reason.
+    """
+    import json as _json
+
+    _SAFE_KEYS = frozenset({
+        "subagent_id", "model", "status", "duration_seconds",
+        "input_tokens", "output_tokens", "total_tokens",
+        "granted_toolsets", "missing_toolsets", "exit_reason",
+    })
+    _TOKEN_KEYS = frozenset({"input_tokens", "output_tokens", "total_tokens"})
+    payload: dict = {}
+    try:
+        if isinstance(function_result, str):
+            raw = _json.loads(function_result)
+        elif isinstance(function_result, dict):
+            raw = function_result
+        else:
+            return {"_error": "unparseable delegate result"}
+    except Exception:
+        return {"_error": "unparseable delegate result"}
+
+    for key in _SAFE_KEYS:
+        value = raw.get(key)
+        if value is None:
+            continue
+        if key in _TOKEN_KEYS:
+            try:
+                payload[key] = int(value)
+            except (TypeError, ValueError):
+                pass
+        elif isinstance(value, (str, int, float, bool, list)):
+            payload[key] = value
+
+    # Guard against ballooning payloads from unexpectedly large lists.
+    result_bytes = len(_json.dumps(payload, ensure_ascii=False).encode("utf-8"))
+    if result_bytes > MAX_DELEGATE_TASK_RESULT_BYTES:
+        payload = {
+            k: v
+            for k, v in payload.items()
+            if k in ("subagent_id", "status", "exit_reason")
+        }
+    return payload
 
 
 def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
@@ -3861,11 +3916,14 @@ class APIServerAdapter(BasePlatformAdapter):
                     "toolCallId": tool_call_id,
                     "status": "completed",
                 }
-                # Include tool body for delegate_task so desktop clients can
-                # populate Subagents panel (api_server does not forward
-                # tool_progress_callback subagent.* events on this path).
+                # Include a redacted metadata projection for delegate_task so
+                # downstream SSE consumers can populate sub-agent panels
+                # without exposing raw summaries, file paths, or secrets.
+                # Fields kept: subagent_id, model, status, duration, tokens,
+                # granted/missing toolsets, exit_reason.  Summary and error
+                # content are dropped.
                 if function_result and function_name == "delegate_task":
-                    payload["result"] = function_result
+                    payload["result"] = _redact_delegate_task_result(function_result)
                 _stream_q.put(("__tool_progress__", payload))
 
             # Start agent in background.  agent_ref is a mutable container

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -5217,6 +5217,7 @@ class TestModelRoutesAgentCreation:
 
 
 # ---------------------------------------------------------------------------
+
 # Event-loop offloading for synchronous SessionDB calls (P1)
 # ---------------------------------------------------------------------------
 
@@ -5743,3 +5744,213 @@ class TestCreateAgentModelRecovery:
         )
 
         assert captured["model"] == "session-row/model"
+
+
+# delegate_task SSE completion — redacted result projection
+# ---------------------------------------------------------------------------
+
+
+class TestDelegateTaskSSECompletion:
+    """Verify that delegate_task completion events use the redacted projection."""
+
+    @pytest.mark.asyncio
+    async def test_delegate_task_result_includes_safe_metadata(self, adapter):
+        """completion event carries redacted metadata, not raw summary."""
+        import asyncio
+        import json as _json
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                ts_cb = kwargs.get("tool_start_callback")
+                tc_cb = kwargs.get("tool_complete_callback")
+                if ts_cb:
+                    ts_cb("call_delegate_1", "delegate_task", {
+                        "tasks": [{"goal": "research trends"}]
+                    })
+                if tc_cb:
+                    # Simulate a realistic delegate_task result with a
+                    # summary that should be redacted.
+                    tc_cb("call_delegate_1", "delegate_task", {
+                        "tasks": [{"goal": "research trends"}]
+                    }, _json.dumps({
+                        "subagent_id": "child-abcd",
+                        "model": "hermes-agent",
+                        "status": "completed",
+                        "duration_seconds": 2.1,
+                        "input_tokens": 800,
+                        "output_tokens": 90,
+                        "total_tokens": 890,
+                        "granted_toolsets": ["web", "search", "skills"],
+                        "missing_toolsets": [],
+                        "exit_reason": "stop_sequence",
+                        "summary": "SECRET RESEARCH RESULTS — should be redacted",
+                        "file_path": "/tmp/secret-summary-12345.md",
+                        "error": "should not appear",
+                    }))
+                if cb:
+                    await asyncio.sleep(0.01)
+                    cb("done.")
+                return (
+                    {"final_response": "done.", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "research"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+            # Extract the completed delegate_task event.
+            lines = body.splitlines()
+            completed_payload = None
+            for i, line in enumerate(lines):
+                if line.strip() != "event: hermes.tool.progress":
+                    continue
+                for follow in lines[i + 1: i + 4]:
+                    if follow.startswith("data: "):
+                        try:
+                            p = _json.loads(follow[len("data: "):])
+                        except _json.JSONDecodeError:
+                            break
+                        if p.get("tool") == "delegate_task" and p.get("status") == "completed":
+                            completed_payload = p
+                        break
+
+            assert completed_payload is not None, "delegate_task completed event not found"
+            result = completed_payload.get("result", {})
+            assert isinstance(result, dict), f"result should be dict, got {type(result)}"
+            # Safe keys present.
+            assert result.get("subagent_id") == "child-abcd"
+            assert result.get("model") == "hermes-agent"
+            assert result.get("status") == "completed"
+            assert result.get("duration_seconds") == 2.1
+            assert result.get("granted_toolsets") == ["web", "search", "skills"]
+            # Redacted — summary and error must not appear.
+            assert "summary" not in result
+            assert "error" not in result
+            assert "file_path" not in result
+
+    @pytest.mark.asyncio
+    async def test_delegate_task_non_delegate_no_result(self, adapter):
+        """Non-delegate_task tools should not receive result metadata."""
+        import asyncio
+        import json as _json
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                ts_cb = kwargs.get("tool_start_callback")
+                tc_cb = kwargs.get("tool_complete_callback")
+                if ts_cb:
+                    ts_cb("call_term_1", "terminal", {"command": "ls"})
+                if tc_cb:
+                    tc_cb("call_term_1", "terminal", {"command": "ls"}, "file1\nfile2")
+                if cb:
+                    await asyncio.sleep(0.01)
+                    cb("done.")
+                return (
+                    {"final_response": "done.", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "ls"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+            lines = body.splitlines()
+            for i, line in enumerate(lines):
+                if line.strip() != "event: hermes.tool.progress":
+                    continue
+                for follow in lines[i + 1: i + 4]:
+                    if follow.startswith("data: "):
+                        try:
+                            p = _json.loads(follow[len("data: "):])
+                        except _json.JSONDecodeError:
+                            break
+                        if p.get("tool") == "terminal" and p.get("status") == "completed":
+                            # Non-delegate_task should NOT have result.
+                            assert "result" not in p, (
+                                f"terminal tool should not have result: {p}"
+                            )
+                        break
+
+    @pytest.mark.asyncio
+    async def test_delegate_task_result_drops_summary_for_size(self, adapter):
+        """Oversized payloads fall back to minimal projection."""
+        import asyncio
+        import json as _json
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                ts_cb = kwargs.get("tool_start_callback")
+                tc_cb = kwargs.get("tool_complete_callback")
+                if ts_cb:
+                    ts_cb("call_del_1", "delegate_task", {"tasks": [{"goal": "big"}]})
+                if tc_cb:
+                    # Large granted_toolsets list to trigger size guard.
+                    tc_cb("call_del_1", "delegate_task", {"tasks": [{"goal": "big"}]},
+                          _json.dumps({
+                              "subagent_id": "child-xyz",
+                              "status": "completed",
+                              "exit_reason": "stop",
+                              "granted_toolsets": [
+                                  f"toolset-{i:03d}" for i in range(300)
+                              ],
+                          }))
+                if cb:
+                    await asyncio.sleep(0.01)
+                    cb("done.")
+                return (
+                    {"final_response": "done.", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "delegate"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+            lines = body.splitlines()
+            for i, line in enumerate(lines):
+                if line.strip() != "event: hermes.tool.progress":
+                    continue
+                for follow in lines[i + 1: i + 4]:
+                    if follow.startswith("data: "):
+                        try:
+                            p = _json.loads(follow[len("data: "):])
+                        except _json.JSONDecodeError:
+                            break
+                        if p.get("tool") == "delegate_task" and p.get("status") == "completed":
+                            result = p.get("result", {})
+                            # Size guard kicked in — only minimal keys survive.
+                            assert "subagent_id" in result
+                            assert "granted_toolsets" not in result
+                        break
+


### PR DESCRIPTION
## Summary

Adds a redacted delegation-result projection to `__tool_progress__` completion events when the tool is `delegate_task`, so downstream SSE consumers can populate sub-agent panels.

## Security review fixes (per @teknium1)

- [x] **Redaction**: replaced raw `function_result` with `_redact_delegate_task_result()` — only safe metadata keys survive (subagent_id, model, status, duration, tokens, toolsets, exit_reason). Summary, error text, and file paths are dropped.
- [x] **Size guard**: projected result capped at 4 KiB; oversized payloads fall back to minimal keys (subagent_id, status, exit_reason)
- [x] **Regression tests**: 3 SSE streaming tests covering safe metadata, non-delegate tools unaffected, and size-guard trigger

## Safe metadata projection

| Key | Reason |
|-----|--------|
| subagent_id | Identify child session |
| model | Model used |
| status | completed / failed |
| duration_seconds | Performance tracking |
| input_tokens / output_tokens / total_tokens | Cost tracking |
| granted_toolsets | What the child had access to |
| missing_toolsets | Tool gaps for parent feedback |
| exit_reason | Why the child stopped |

## Redacted (never exposed)

summary, error, file_path, and any unrecognized keys