### PR TITLE
fix(kanban): review tasks bypass dup-PR respawn guards (active_pr/recent_success)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5882,12 +5882,18 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
     ``"recent_success"``
         A completed run exists within ``_RESPAWN_GUARD_SUCCESS_WINDOW``
         seconds.  Useful work already succeeded for this task; wait for
-        human review rather than immediately re-spawning.
+        human review rather than immediately re-spawning.  **Skipped when
+        the task is in status ``review``** — the build run that produced
+        the artifact under review is itself a recent ``completed`` run, so
+        this guard would otherwise wedge the reviewer out for the window.
 
     ``"active_pr"``
         A GitHub PR URL appears in a recent task comment (within
         ``_RESPAWN_GUARD_PR_WINDOW`` seconds).  A prior worker already
         opened a PR; re-spawning risks a duplicate PR on the same task.
+        **Skipped when the task is in status ``review``** — a reviewer
+        never opens a PR, and the PR-URL comment is exactly what it needs
+        to act on, not a duplicate-PR risk.
 
     Stale / dead claim locks are NOT a guard reason — they are handled
     by ``release_stale_claims`` and ``detect_crashed_workers`` which
@@ -5895,13 +5901,21 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
     genuinely dead (no live PID on this host).
     """
     row = conn.execute(
-        "SELECT last_failure_error FROM tasks WHERE id = ?",
+        "SELECT last_failure_error, status FROM tasks WHERE id = ?",
         (task_id,),
     ).fetchone()
     if row is None:
         return None
 
     now = int(time.time())
+
+    # A reviewer never opens a PR, so the dup-PR (step 4) and recent-success
+    # (step 3) guards are irrelevant to a review pass — yet they'd wedge a
+    # review-status card for up to 24h, because the BUILD run that shipped the
+    # PR counts as a recent ``completed`` run AND left a PR-URL comment. The
+    # rate-limit cooldown (step 1) and auth blocker (step 2) still apply: a
+    # rate-limited or auth-blocked reviewer should defer like any other spawn.
+    is_review = row["status"] == "review"
 
     # 1. Rate-limit cooldown. The most recent run ended ``rate_limited``
     #    (quota wall) — defer while inside the cooldown window, then allow a
@@ -5945,22 +5959,29 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
         return "blocker_auth"
 
     # 3. Completed run within guard window — proof of recent success.
-    cutoff = now - _RESPAWN_GUARD_SUCCESS_WINDOW
-    if conn.execute(
-        "SELECT id FROM task_runs "
-        "WHERE task_id = ? AND outcome = 'completed' AND ended_at >= ?",
-        (task_id, cutoff),
-    ).fetchone():
-        return "recent_success"
+    #    Skipped for review tasks: the build run that produced the artifact
+    #    under review is itself a recent ``completed`` run, which would
+    #    otherwise block the reviewer from ever spawning.
+    if not is_review:
+        cutoff = now - _RESPAWN_GUARD_SUCCESS_WINDOW
+        if conn.execute(
+            "SELECT id FROM task_runs "
+            "WHERE task_id = ? AND outcome = 'completed' AND ended_at >= ?",
+            (task_id, cutoff),
+        ).fetchone():
+            return "recent_success"
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
-    pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
-    for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
-        (task_id, pr_cutoff),
-    ).fetchall():
-        if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
-            return "active_pr"
+    #    Skipped for review tasks: the PR-URL comment is exactly what the
+    #    reviewer needs to act on, not a signal of a duplicate-PR risk.
+    if not is_review:
+        pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
+        for c in conn.execute(
+            "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
+            (task_id, pr_cutoff),
+        ).fetchall():
+            if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
+                return "active_pr"
 
     return None
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1737,6 +1737,100 @@ def test_respawn_guard_old_pr_comment_not_guarded(kanban_home):
     assert reason is None
 
 
+# ---------------------------------------------------------------------------
+# Review tasks bypass the dup-PR guards (recent_success / active_pr) but a
+# build-lane task in the same shape must still be guarded. The invariant being
+# asserted: review spawns are never wedged by the build-only dup-PR guards,
+# while build spawns keep that protection. (rate_limit_cooldown / blocker_auth
+# are orthogonal and still apply to both — covered by the tests above.)
+# ---------------------------------------------------------------------------
+
+def test_respawn_guard_review_bypasses_active_pr_build_does_not(kanban_home):
+    """A PR-URL comment guards a build (ready) task but not a review task.
+
+    Same task, same comment — only the status differs. The reviewer never
+    opens a PR, so the active_pr guard must not apply to it; the builder
+    might re-open a duplicate PR, so the guard must still apply.
+    """
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="pr-shipped", assignee="alice")
+        kb.add_comment(
+            conn, t, "worker",
+            "PR created: https://github.com/totemx-AI/subsidysmart/pull/42",
+        )
+
+        # Build lane: dup-PR protection intact.
+        conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (t,))
+        assert kb.check_respawn_guard(conn, t) == "active_pr"
+
+        # Review lane: same PR comment, guard bypassed.
+        conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (t,))
+        assert kb.check_respawn_guard(conn, t) is None
+
+
+def test_respawn_guard_review_bypasses_recent_success_build_does_not(kanban_home):
+    """A recent completed run guards a build (ready) task but not a review task.
+
+    The build run that produced the artifact under review IS a recent
+    completed run; without the bypass it would lock the reviewer out for
+    the whole success window.
+    """
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="build-done", assignee="alice")
+        now = int(time.time())
+        conn.execute(
+            "INSERT INTO task_runs (task_id, status, outcome, started_at, ended_at) "
+            "VALUES (?, 'done', 'completed', ?, ?)",
+            (t, now - 120, now - 60),
+        )
+
+        # Build lane: recent_success guard intact.
+        conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (t,))
+        assert kb.check_respawn_guard(conn, t) == "recent_success"
+
+        # Review lane: same completed run, guard bypassed.
+        conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (t,))
+        assert kb.check_respawn_guard(conn, t) is None
+
+
+def test_respawn_guard_review_with_pr_and_success_returns_none(kanban_home):
+    """Acceptance shape: a review task with BOTH a PR comment and a recent
+    completed run returns None (both dup-PR guards bypassed), while the same
+    task on the build lane is still guarded."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="review-me", assignee="alice")
+        now = int(time.time())
+        conn.execute(
+            "INSERT INTO task_runs (task_id, status, outcome, started_at, ended_at) "
+            "VALUES (?, 'done', 'completed', ?, ?)",
+            (t, now - 120, now - 60),
+        )
+        kb.add_comment(
+            conn, t, "worker",
+            "PR created: https://github.com/totemx-AI/subsidysmart/pull/99",
+        )
+
+        # Build lane: still guarded (recent_success fires first, before active_pr).
+        conn.execute("UPDATE tasks SET status = 'ready' WHERE id = ?", (t,))
+        assert kb.check_respawn_guard(conn, t) is not None
+
+        # Review lane: fully unguarded — reviewer can spawn.
+        conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (t,))
+        assert kb.check_respawn_guard(conn, t) is None
+
+
+def test_respawn_guard_review_still_honors_blocker_auth(kanban_home):
+    """Review status bypasses the dup-PR guards but NOT the auth blocker —
+    a rate-limited / auth-blocked reviewer should still defer."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="review-but-authwall", assignee="alice")
+        conn.execute(
+            "UPDATE tasks SET status = 'review', last_failure_error = ? WHERE id = ?",
+            ("Authentication failed: invalid credentials", t),
+        )
+        assert kb.check_respawn_guard(conn, t) == "blocker_auth"
+
+
 def test_dispatch_respawn_guard_defers_auth_error_without_auto_block(
     kanban_home, all_assignees_spawnable
 ):


### PR DESCRIPTION
## Symptom (reproduced live on `main`, 2026-06-15)

Review-required cards never get reviewed. A card that shipped a PR sits in `status='review'` but the dispatcher refuses to spawn the reviewer for up to 24h — the review lane is wedged out by guards that only make sense for the *build* lane.

## Root cause

`hermes_cli/kanban_db.py :: check_respawn_guard(conn, task_id)` runs in `dispatch_once` for *every* ready+assigned task, build and review alike. Two of its four guards exist solely to stop a **builder** re-running and opening a **duplicate PR**:

- `"recent_success"` — a `completed` run exists within `_RESPAWN_GUARD_SUCCESS_WINDOW` (1h).
- `"active_pr"` — a GitHub PR URL appears in a comment within `_RESPAWN_GUARD_PR_WINDOW` (24h).

But the build run that ships a PR *is itself* a recent `completed` run **and** leaves a PR-URL comment. When that same card transitions to `status='review'`, both guards fire and defer the reviewer spawn — for up to the 24h PR window. A reviewer never opens a PR, so neither rationale applies to a review pass.

## Fix (surgical — only `check_respawn_guard` + tests)

1. Extend the existing task-row `SELECT` to also read `tasks.status`.
2. `is_review = (status == "review")`.
3. Skip the `recent_success` and `active_pr` checks when `is_review` is true (`return None` path).
4. **Keep** `rate_limit_cooldown` and `blocker_auth` active for review spawns — a rate-limited / auth-blocked reviewer should still defer.

No new config keys, no new env vars, no refactor. One extra column in one existing query, two `if not is_review:` guards.

## Tests

Added 4 invariant tests in `tests/hermes_cli/test_kanban_db.py` (asserting the *invariant*, not a snapshot):

- `test_respawn_guard_review_bypasses_active_pr_build_does_not` — same PR-comment task returns `"active_pr"` on `status='ready'` but `None` on `status='review'`.
- `test_respawn_guard_review_bypasses_recent_success_build_does_not` — same recent-completed-run task returns `"recent_success"` on `ready` but `None` on `review`.
- `test_respawn_guard_review_with_pr_and_success_returns_none` — acceptance shape: review task with *both* a PR comment and a recent completed run returns `None`; the build-lane equivalent stays guarded.
- `test_respawn_guard_review_still_honors_blocker_auth` — review status still defers on an auth/quota error.

### Verification

```
.venv/bin/python -m pytest tests/hermes_cli/test_kanban_db.py -q
218 passed
```

(The dup-PR protection for the **build** lane is fully intact — every existing `check_respawn_guard` test still passes.)

## Acceptance criteria (from the task)

- [x] `check_respawn_guard` returns `None` for a review-status task that has a PR comment + recent completed run.
- [x] `check_respawn_guard` still returns `"active_pr"` for a ready-status task with a PR comment (build dup-PR protection intact).
- [x] New/extended tests pass.
- [x] PR opened, not merged.
