### PR TITLE
feat(desktop): system-browser OIDC sign-in (passkeys / WebAuthn / Touch ID)

### DIFF
--- a/apps/desktop/electron/connection-config.cjs
+++ b/apps/desktop/electron/connection-config.cjs
@@ -269,10 +269,68 @@ function cookiesHaveLiveSession(cookies) {
   )
 }
 
+/**
+ * Build the gateway URL to open in the system browser for a loopback
+ * (RFC 8252) sign-in, so the IdP ceremony runs in the real browser where
+ * passkeys / Touch ID / WebAuthn work — unlike the embedded login window.
+ *
+ * Omitting `provider` targets the gateway's picker page; pass one to skip it.
+ * `appRedirect` (the app's loopback listener) and `appState` (a CSRF nonce)
+ * are the values the gateway round-trips back as the one-time handoff code.
+ *
+ * @param {string} baseUrl  normalized gateway base URL
+ * @param {{ provider?: string, appRedirect: string, appState: string }} opts
+ * @returns {string}
+ */
+function buildExternalLoginUrl(baseUrl, { provider, appRedirect, appState } = {}) {
+  const parsed = new URL(baseUrl)
+  const prefix = parsed.pathname.replace(/\/+$/, '')
+  const path = provider ? '/auth/login' : '/login'
+  const url = new URL(`${parsed.origin}${prefix}${path}`)
+  if (provider) url.searchParams.set('provider', provider)
+  url.searchParams.set('app_redirect', appRedirect)
+  if (appState) url.searchParams.set('app_state', appState)
+  return url.toString()
+}
+
+/**
+ * Parse the loopback `/callback` request the system browser is redirected to
+ * after sign-in, returning the one-time handoff `code`. Enforces the
+ * `app_state` nonce so an unrelated local request can't drive the exchange.
+ *
+ * @param {string} requestUrl  the listener's request URL (path + query)
+ * @param {string} expectedState  the nonce minted for this login attempt
+ * @returns {{ code: string }}
+ * @throws if the path is not the callback, state mismatches, or code missing
+ */
+function parseLoopbackCallback(requestUrl, expectedState) {
+  // Base is irrelevant — we only read path + query from a relative URL.
+  const parsed = new URL(requestUrl, 'http://127.0.0.1')
+  if (parsed.pathname !== '/callback') {
+    const err = new Error(`Unexpected loopback path: ${parsed.pathname}`)
+    err.ignore = true
+    throw err
+  }
+  const error = parsed.searchParams.get('error')
+  if (error) {
+    throw new Error(`Sign-in failed at the provider: ${error}`)
+  }
+  const state = parsed.searchParams.get('state') || ''
+  if (!expectedState || state !== expectedState) {
+    throw new Error('Loopback sign-in state mismatch (possible CSRF).')
+  }
+  const code = parsed.searchParams.get('code') || ''
+  if (!code) {
+    throw new Error('Loopback callback carried no handoff code.')
+  }
+  return { code }
+}
+
 module.exports = {
   AT_COOKIE_VARIANTS,
   RT_COOKIE_VARIANTS,
   authModeFromStatus,
+  buildExternalLoginUrl,
   buildGatewayWsUrl,
   buildGatewayWsUrlWithTicket,
   connectionScopeKey,
@@ -280,6 +338,7 @@ module.exports = {
   cookiesHaveLiveSession,
   normAuthMode,
   normalizeRemoteBaseUrl,
+  parseLoopbackCallback,
   pathWithGlobalRemoteProfile,
   profileRemoteOverride,
   resolveAuthMode,

--- a/apps/desktop/electron/connection-config.test.cjs
+++ b/apps/desktop/electron/connection-config.test.cjs
@@ -17,6 +17,7 @@ const {
   AT_COOKIE_VARIANTS,
   RT_COOKIE_VARIANTS,
   authModeFromStatus,
+  buildExternalLoginUrl,
   buildGatewayWsUrl,
   buildGatewayWsUrlWithTicket,
   connectionScopeKey,
@@ -24,6 +25,7 @@ const {
   cookiesHaveLiveSession,
   normAuthMode,
   normalizeRemoteBaseUrl,
+  parseLoopbackCallback,
   pathWithGlobalRemoteProfile,
   profileRemoteOverride,
   resolveAuthMode,
@@ -393,4 +395,83 @@ test('resolveTestWsUrl (oauth) requires a mintTicket function', async () => {
     () => resolveTestWsUrl('https://gw.example.com', 'oauth', null),
     /mintTicket function is required/
   )
+})
+
+// --- buildExternalLoginUrl (system-browser loopback sign-in) ---
+
+test('buildExternalLoginUrl targets /auth/login with a provider', () => {
+  const url = new URL(
+    buildExternalLoginUrl('https://gw.example.com', {
+      provider: 'pocket-id',
+      appRedirect: 'http://127.0.0.1:54321/callback',
+      appState: 'nonce123'
+    })
+  )
+  assert.equal(url.pathname, '/auth/login')
+  assert.equal(url.searchParams.get('provider'), 'pocket-id')
+  assert.equal(url.searchParams.get('app_redirect'), 'http://127.0.0.1:54321/callback')
+  assert.equal(url.searchParams.get('app_state'), 'nonce123')
+})
+
+test('buildExternalLoginUrl targets the /login picker when no provider given', () => {
+  const url = new URL(
+    buildExternalLoginUrl('https://gw.example.com', {
+      appRedirect: 'http://127.0.0.1:5000/callback',
+      appState: 'n'
+    })
+  )
+  assert.equal(url.pathname, '/login')
+  assert.equal(url.searchParams.has('provider'), false)
+  assert.equal(url.searchParams.get('app_redirect'), 'http://127.0.0.1:5000/callback')
+})
+
+test('buildExternalLoginUrl preserves a gateway path prefix', () => {
+  const url = new URL(
+    buildExternalLoginUrl('https://gw.example.com/hermes', {
+      provider: 'p',
+      appRedirect: 'http://127.0.0.1:5000/callback',
+      appState: 'n'
+    })
+  )
+  assert.equal(url.pathname, '/hermes/auth/login')
+})
+
+// --- parseLoopbackCallback ---
+
+test('parseLoopbackCallback returns the handoff code on a matching state', () => {
+  const { code } = parseLoopbackCallback(
+    '/callback?code=handoff-abc&state=nonce123',
+    'nonce123'
+  )
+  assert.equal(code, 'handoff-abc')
+})
+
+test('parseLoopbackCallback rejects a state mismatch (CSRF guard)', () => {
+  assert.throws(
+    () => parseLoopbackCallback('/callback?code=x&state=wrong', 'nonce123'),
+    /state mismatch/
+  )
+})
+
+test('parseLoopbackCallback rejects a missing code', () => {
+  assert.throws(
+    () => parseLoopbackCallback('/callback?state=nonce123', 'nonce123'),
+    /no handoff code/
+  )
+})
+
+test('parseLoopbackCallback surfaces a provider error param', () => {
+  assert.throws(
+    () => parseLoopbackCallback('/callback?error=access_denied&state=n', 'n'),
+    /access_denied/
+  )
+})
+
+test('parseLoopbackCallback flags non-callback paths as ignorable', () => {
+  try {
+    parseLoopbackCallback('/favicon.ico', 'nonce123')
+    assert.fail('expected throw')
+  } catch (err) {
+    assert.equal(err.ignore, true)
+  }
 })

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -58,6 +58,7 @@ const {
 const { isPackagedInstallPath: isPackagedInstallPathUnderRoots } = require('./workspace-cwd.cjs')
 const {
   authModeFromStatus,
+  buildExternalLoginUrl,
   buildGatewayWsUrl,
   buildGatewayWsUrlWithTicket,
   connectionScopeKey,
@@ -65,6 +66,7 @@ const {
   cookiesHaveLiveSession,
   normAuthMode,
   normalizeRemoteBaseUrl,
+  parseLoopbackCallback,
   pathWithGlobalRemoteProfile,
   profileRemoteOverride,
   resolveAuthMode,
@@ -3912,6 +3914,141 @@ function openOauthLoginWindow(baseUrl) {
   })
 }
 
+function loopbackResultHtml(title, detail) {
+  const esc = s =>
+    String(s).replace(/[&<>]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[c]))
+  return (
+    '<!doctype html><meta charset="utf-8">' +
+    '<title>' + esc(title) + '</title>' +
+    '<body style="font:16px system-ui;margin:3rem auto;max-width:28rem;text-align:center">' +
+    '<h2>' + esc(title) + '</h2><p>' + esc(detail) + '</p></body>'
+  )
+}
+
+// The embedded login window cannot raise the OS passkey / Touch ID / WebAuthn
+// prompt, so passwordless IdP sign-in dead-ends there (issue #42448). This
+// runs the IdP ceremony in the user's real browser instead (RFC 8252 loopback
+// redirect): open the gateway login URL with shell.openExternal, capture the
+// gateway's one-time handoff code on an ephemeral 127.0.0.1 listener, and
+// trade it at /api/auth/desktop-exchange THROUGH the OAuth partition so the
+// Set-Cookie lands in the same jar the rest of the OAuth REST path reads.
+// `oauthProviders` is the non-password provider list from
+// /api/auth/providers; a lone entry lets us skip the gateway's picker page.
+function openOauthLoginExternal(baseUrl, oauthProviders = []) {
+  return new Promise((resolve, reject) => {
+    let settled = false
+    let server = null
+    let timeoutTimer = null
+
+    const finish = err => {
+      if (settled) return
+      settled = true
+      if (timeoutTimer) clearTimeout(timeoutTimer)
+      try {
+        if (server) server.close()
+      } catch {
+        // listener already torn down
+      }
+      if (err) reject(err)
+      else resolve({ baseUrl, ok: true })
+    }
+
+    const appState = crypto.randomBytes(16).toString('hex')
+
+    server = http.createServer((req, res) => {
+      let parsed
+      try {
+        parsed = parseLoopbackCallback(req.url, appState)
+      } catch (error) {
+        // A browser preflight (e.g. /favicon.ico) is not the callback —
+        // 404 it without settling the login.
+        if (error && error.ignore) {
+          res.statusCode = 404
+          res.end('Not found')
+          return
+        }
+        res.statusCode = 400
+        res.setHeader('Content-Type', 'text/html; charset=utf-8')
+        res.end(loopbackResultHtml('Sign-in failed', 'Close this tab and try again from Hermes.'))
+        finish(error instanceof Error ? error : new Error(String(error)))
+        return
+      }
+      fetchJsonViaOauthSession(`${baseUrl}/api/auth/desktop-exchange`, {
+        method: 'POST',
+        body: { code: parsed.code, state: appState },
+        timeoutMs: 10_000
+      })
+        .then(() => {
+          res.statusCode = 200
+          res.setHeader('Content-Type', 'text/html; charset=utf-8')
+          res.end(loopbackResultHtml('Signed in to Hermes', 'Close this tab and return to the app.'))
+          finish(null)
+        })
+        .catch(error => {
+          res.statusCode = 500
+          res.setHeader('Content-Type', 'text/html; charset=utf-8')
+          res.end(loopbackResultHtml('Sign-in could not be completed', 'Close this tab and try again from Hermes.'))
+          finish(error instanceof Error ? error : new Error(String(error)))
+        })
+    })
+
+    server.on('error', error =>
+      finish(error instanceof Error ? error : new Error(String(error)))
+    )
+
+    // Ephemeral port, loopback interface only — never reachable off-host.
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address()
+      const port = addr && typeof addr === 'object' ? addr.port : null
+      if (!port) {
+        finish(new Error('Could not start the local sign-in listener.'))
+        return
+      }
+      const appRedirect = `http://127.0.0.1:${port}/callback`
+      const provider = oauthProviders.length === 1 ? oauthProviders[0].name : undefined
+      let loginUrl
+      try {
+        loginUrl = buildExternalLoginUrl(normalizeRemoteBaseUrl(baseUrl), {
+          provider,
+          appRedirect,
+          appState
+        })
+      } catch (error) {
+        finish(error instanceof Error ? error : new Error(String(error)))
+        return
+      }
+      if (!openExternalUrl(loginUrl)) {
+        finish(new Error('Could not open the system browser for sign-in.'))
+      }
+    })
+
+    // Generous window: the user may be hunting for a YubiKey or completing MFA.
+    timeoutTimer = setTimeout(() => {
+      finish(new Error('Sign-in timed out. Please try again.'))
+    }, 5 * 60_000)
+  })
+}
+
+// Probe whether a gateway supports the system-browser handoff. A gateway that
+// predates this feature (or the Nous-hosted path) omits `app_handoff`, so the
+// caller falls back to the embedded login window. Network/HTTP failures are
+// swallowed into "unsupported" for the same fallback.
+async function gatewayAppHandoffInfo(baseUrl) {
+  try {
+    const body = await fetchJsonViaOauthSession(`${baseUrl}/api/auth/providers`, {
+      method: 'GET',
+      timeoutMs: 8_000
+    })
+    const providers = Array.isArray(body?.providers) ? body.providers : []
+    return {
+      supported: body?.app_handoff === true,
+      oauthProviders: providers.filter(p => p && !p.supports_password)
+    }
+  } catch {
+    return { supported: false, oauthProviders: [] }
+  }
+}
+
 // JSON request routed through the OAuth session partition so the HttpOnly
 // session cookie is attached automatically by Electron's net stack. Used for
 // authed REST against a gated gateway, including minting WS tickets.
@@ -5394,7 +5531,16 @@ ipcMain.handle('hermes:connection-config:oauth-login', async (_event, rawUrl) =>
   // remote config with authMode='oauth' first, then calls this. We normalize
   // the URL defensively so a login can be driven from a raw URL too.
   const baseUrl = normalizeRemoteBaseUrl(rawUrl)
-  await openOauthLoginWindow(baseUrl)
+  // Prefer the system browser when the gateway advertises the loopback
+  // handoff AND exposes an OAuth (non-password) provider — that path lets
+  // passkeys / Touch ID work (issue #42448). Otherwise keep the embedded
+  // window, so older gateways and the Nous-hosted path are unaffected.
+  const handoff = await gatewayAppHandoffInfo(baseUrl)
+  if (handoff.supported && handoff.oauthProviders.length > 0) {
+    await openOauthLoginExternal(baseUrl, handoff.oauthProviders)
+  } else {
+    await openOauthLoginWindow(baseUrl)
+  }
   return { ok: true, baseUrl, connected: await hasOauthSessionCookie(baseUrl) }
 })
 ipcMain.handle('hermes:connection-config:oauth-logout', async (_event, rawUrl) => {

--- a/hermes_cli/dashboard_auth/app_handoff.py
+++ b/hermes_cli/dashboard_auth/app_handoff.py
@@ -1,0 +1,108 @@
+"""One-time session handoff codes for the desktop system-browser flow.
+
+The desktop app cannot complete the OAuth round trip inside an embedded
+window: that context cannot raise the OS WebAuthn / passkey / Touch ID
+prompt (issue #42448). The fix is to run the IdP ceremony in the user's
+real browser via ``shell.openExternal`` and bounce back to a loopback
+``http://127.0.0.1:<port>/callback`` the app is listening on (RFC 8252,
+"OAuth 2.0 for Native Apps").
+
+That creates a session-handoff problem: ``/auth/callback`` runs in the
+system browser, so the HttpOnly session cookie would land in the browser,
+not the app. This module bridges the gap. When ``/auth/callback`` detects
+an app-handoff request it mints a single-use **handoff code** bound to the
+freshly minted :class:`~hermes_cli.dashboard_auth.base.Session`'s cookie
+material, and redirects to the app's loopback URL carrying only that code
+(never the tokens). The app then trades the code at
+``POST /api/auth/desktop-exchange``, which sets the same session cookies
+the browser flow would — but on the app's request, so they land in the
+app's cookie jar. All token handling stays server-side: the app only ever
+sees an opaque, short-lived, single-use code.
+
+The store mirrors :mod:`hermes_cli.dashboard_auth.ws_tickets`: in-memory
+(the dashboard is a single process), functional API so tests can patch
+``time.time`` cleanly, single-use, short TTL.
+"""
+
+from __future__ import annotations
+
+import secrets
+import threading
+import time
+from typing import Dict, Tuple
+
+#: Time-to-live for a handoff code in seconds. The code is minted at
+#: ``/auth/callback`` and consumed by the app's loopback listener moments
+#: later, so the live window is small. 120 s leaves slack for a slow
+#: browser redirect or a momentarily busy app without leaving a usable
+#: code lying around for long. The code is single-use regardless.
+TTL_SECONDS = 120
+
+_lock = threading.Lock()
+#: handoff_code -> (expires_at, cookie material). The stored dict carries
+#: exactly what ``set_session_cookies`` needs and nothing else — no user
+#: identity, no provider — so a leaked store entry reveals only the tokens
+#: it would have set as cookies anyway.
+_codes: Dict[str, Tuple[int, Dict[str, object]]] = {}
+
+
+class HandoffInvalid(Exception):
+    """Handoff code missing, expired, or already consumed."""
+
+
+def mint_handoff(
+    *, access_token: str, refresh_token: str, expires_at: int
+) -> str:
+    """Generate a one-shot handoff code bound to a session's cookie material.
+
+    ``expires_at`` is the access token's unix-seconds expiry (the
+    ``Session.expires_at`` field); the exchange endpoint recomputes the
+    cookie ``Max-Age`` from it at consume time. Returns a base64url code
+    with 256 bits of entropy — unguessable, so no rate limiting is needed
+    on the exchange endpoint.
+    """
+    code = secrets.token_urlsafe(32)
+    material = {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "expires_at": int(expires_at),
+    }
+    with _lock:
+        _codes[code] = (int(time.time()) + TTL_SECONDS, material)
+        _gc_expired_locked()
+    return code
+
+
+def consume_handoff(code: str) -> Dict[str, object]:
+    """Validate and consume a handoff code.
+
+    Single-use: a successful consume removes the code from the store, so a
+    replay raises ``HandoffInvalid``. Raises :class:`HandoffInvalid` on a
+    missing, expired, or already-consumed code. Returns the cookie-material
+    dict (``access_token``, ``refresh_token``, ``expires_at``).
+    """
+    now = int(time.time())
+    with _lock:
+        entry = _codes.pop(code, None)
+        if entry is None:
+            # Truncate so a misused/guessed code never lands in logs in full.
+            truncated = (code[:8] + "…") if code else "<empty>"
+            raise HandoffInvalid(f"unknown handoff code: {truncated}")
+        expires_at, material = entry
+        if expires_at < now:
+            raise HandoffInvalid("expired")
+        return material
+
+
+def _gc_expired_locked() -> None:
+    """Drop expired codes. Caller must hold ``_lock``."""
+    now = int(time.time())
+    expired = [c for c, (exp, _) in _codes.items() if exp < now]
+    for c in expired:
+        _codes.pop(c, None)
+
+
+def _reset_for_tests() -> None:
+    """Test-only: drop all handoff codes."""
+    with _lock:
+        _codes.clear()

--- a/hermes_cli/dashboard_auth/login_page.py
+++ b/hermes_cli/dashboard_auth/login_page.py
@@ -455,7 +455,9 @@ _PASSWORD_FORM_SCRIPT = """\
 """
 
 
-def render_login_html(*, next_path: str = "") -> str:
+def render_login_html(
+    *, next_path: str = "", app_redirect: str = "", app_state: str = ""
+) -> str:
     """Return the full HTML for ``GET /login``.
 
     ``next_path`` — when set, the post-login landing path the user
@@ -464,20 +466,42 @@ def render_login_html(*, next_path: str = "") -> str:
     end-to-end. The caller (``routes.login_page``) is responsible for
     validating ``next_path`` against the same-origin rules before we
     emit it; we still HTML-escape it as defence in depth.
+
+    ``app_redirect`` / ``app_state`` — the desktop system-browser sign-in
+    loopback target and nonce. When set, they are threaded onto the
+    OAuth provider buttons (not the local password forms — passkeys live
+    at the IdP, which is the redirect path) so a multi-provider
+    self-hosted gateway can still hand the session back to the app. The
+    caller validates ``app_redirect`` to a loopback URL first; HTML-escaped
+    here as defence in depth.
     """
     providers = list_providers()
     if not providers:
         return _EMPTY_HTML
+
+    from urllib.parse import quote
 
     if next_path:
         # URL-encode then HTML-escape. The URL-encode step matches the
         # gate's ``_safe_next_target`` output shape (also URL-encoded),
         # so a value that round-tripped from /login?next=... back into
         # the button href is byte-identical.
-        from urllib.parse import quote
         next_qs = f"&next={html.escape(quote(next_path, safe=''), quote=True)}"
     else:
         next_qs = ""
+
+    if app_redirect:
+        app_qs = (
+            f"&app_redirect="
+            f"{html.escape(quote(app_redirect, safe=''), quote=True)}"
+        )
+        if app_state:
+            app_qs += (
+                f"&app_state="
+                f"{html.escape(quote(app_state, safe=''), quote=True)}"
+            )
+    else:
+        app_qs = ""
 
     buttons = []
     needs_password_script = False
@@ -488,7 +512,8 @@ def render_login_html(*, next_path: str = "") -> str:
         else:
             buttons.append(
                 f'      <a class="provider-btn" '
-                f'href="/auth/login?provider={html.escape(p.name, quote=True)}{next_qs}">'
+                f'href="/auth/login?provider={html.escape(p.name, quote=True)}'
+                f'{next_qs}{app_qs}">'
                 f'Sign in with {html.escape(p.display_name)}</a>'
             )
     script = _PASSWORD_FORM_SCRIPT if needs_password_script else ""

--- a/hermes_cli/dashboard_auth/middleware.py
+++ b/hermes_cli/dashboard_auth/middleware.py
@@ -42,6 +42,9 @@ _GATE_PUBLIC_PREFIXES: tuple[str, ...] = (
     "/auth/logout",
     "/login",
     "/api/auth/providers",
+    # Native-app session handoff: trades a one-time code for the session
+    # cookies, so it must be reachable before any session exists.
+    "/api/auth/desktop-exchange",
     "/assets/",
     "/favicon.ico",
     "/ds-assets/",

--- a/hermes_cli/dashboard_auth/routes.py
+++ b/hermes_cli/dashboard_auth/routes.py
@@ -136,8 +136,20 @@ async def login_page(request: Request) -> HTMLResponse:
     next_path = _validate_post_login_target(
         request.query_params.get("next", "")
     )
+    # Desktop system-browser sign-in threads its loopback handoff target
+    # through /login when the gateway has more than one provider (the
+    # single-provider case skips the page and hits /auth/login directly).
+    # Validated to a loopback URL here; /auth/login re-validates on click.
+    app_redirect = _validate_app_redirect(
+        request.query_params.get("app_redirect", "")
+    )
+    app_state = request.query_params.get("app_state", "") if app_redirect else ""
     return HTMLResponse(
-        render_login_html(next_path=next_path),
+        render_login_html(
+            next_path=next_path,
+            app_redirect=app_redirect,
+            app_state=app_state,
+        ),
         headers={"Cache-Control": "no-store, no-cache, must-revalidate"},
     )
 
@@ -167,6 +179,13 @@ async def api_auth_providers() -> Any:
             }
             for p in providers
         ],
+        # Capability flag for native apps: this gateway can complete the
+        # OAuth round trip in the system browser and hand the session back
+        # to a loopback redirect (see app_handoff + /api/auth/desktop-exchange).
+        # The desktop app feature-detects on this before opening the
+        # system browser, and falls back to its embedded login window when
+        # absent — so older gateways and the Nous-hosted path keep working.
+        "app_handoff": True,
     }
 
 
@@ -176,7 +195,13 @@ async def api_auth_providers() -> Any:
 
 
 @router.get("/auth/login", name="auth_login")
-async def auth_login(request: Request, provider: str, next: str = ""):
+async def auth_login(
+    request: Request,
+    provider: str,
+    next: str = "",
+    app_redirect: str = "",
+    app_state: str = "",
+):
     p = get_provider(provider)
     if p is None:
         raise HTTPException(
@@ -221,6 +246,19 @@ async def auth_login(request: Request, provider: str, next: str = ""):
     if safe_next:
         from urllib.parse import quote
         pkce = f"{pkce};next={quote(safe_next, safe='')}"
+    # Carry the native-app loopback handoff target through the round trip
+    # the same way ``next`` rides: real IDPs only echo ``code`` + ``state``
+    # on the callback, so the server-set PKCE cookie is the only channel
+    # that survives. ``app_redirect`` is validated to a loopback http URL
+    # so an attacker who reaches /auth/login directly can't redirect the
+    # one-time handoff code to a host they control. ``app_state`` is the
+    # app's own CSRF/correlation nonce, echoed back verbatim.
+    safe_app_redirect = _validate_app_redirect(app_redirect)
+    if safe_app_redirect:
+        from urllib.parse import quote
+        pkce = f"{pkce};app_redirect={quote(safe_app_redirect, safe='')}"
+        if app_state:
+            pkce = f"{pkce};app_state={quote(app_state, safe='')}"
     set_pkce_cookie(
         resp, payload=pkce, use_https=detect_https(request),
         prefix=_prefix(request),
@@ -263,6 +301,11 @@ async def auth_callback(
     # next= query parameter on the callback URL is attacker-controlled
     # and MUST be ignored.
     next_from_cookie = parts.get("next", "")
+    # Native-app loopback handoff target + nonce, set by /auth/login when
+    # the desktop app drives the flow. Same cookie-only trust model as
+    # ``next``: re-validated below before use.
+    app_redirect_from_cookie = parts.get("app_redirect", "")
+    app_state_from_cookie = parts.get("app_state", "")
 
     p = get_provider(provider_name)
     if p is None:
@@ -332,6 +375,49 @@ async def auth_callback(
         ip=_client_ip(request),
     )
 
+    # Native-app system-browser handoff. This callback ran in the user's
+    # real browser, so the OS passkey / Touch ID / WebAuthn prompt could
+    # fire (the whole point — issue #42448). But the session cookie must
+    # land in the APP, not the browser. So rather than set cookies here we
+    # mint a single-use handoff code bound to the session and 302 to the
+    # app's loopback listener carrying only that code; the app trades it at
+    # ``POST /api/auth/desktop-exchange`` for the cookies. No session
+    # cookie is set on the browser, so no stray session is left behind. An
+    # invalid/absent app_redirect simply falls through to the normal
+    # browser-cookie path below.
+    if app_redirect_from_cookie:
+        safe_app_redirect = _validate_app_redirect(app_redirect_from_cookie)
+        if safe_app_redirect:
+            from urllib.parse import (
+                unquote,
+                urlencode,
+                urlparse,
+                urlunparse,
+            )
+
+            from hermes_cli.dashboard_auth.app_handoff import mint_handoff
+
+            handoff_code = mint_handoff(
+                access_token=session.access_token,
+                refresh_token=session.refresh_token,
+                expires_at=session.expires_at,
+            )
+            app_state = (
+                unquote(app_state_from_cookie)
+                if app_state_from_cookie else ""
+            )
+            parsed = urlparse(safe_app_redirect)
+            handoff_query = urlencode(
+                {"code": handoff_code, "state": app_state}
+            )
+            sep = "&" if parsed.query else ""
+            target = urlunparse(
+                parsed._replace(query=f"{parsed.query}{sep}{handoff_query}")
+            )
+            resp = RedirectResponse(url=target, status_code=302)
+            clear_pkce_cookie(resp, prefix=_prefix(request))
+            return resp
+
     expires_in = max(60, session.expires_at - int(time.time()))
     # Honour the ``next=`` value the gate's _unauth_response set in the
     # /login redirect URL and that /auth/login persisted into the PKCE
@@ -385,6 +471,109 @@ def _validate_post_login_target(raw: str) -> str:
     if decoded == "/api" or decoded.startswith("/api/"):
         return ""
     return decoded
+
+
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
+
+def _validate_app_redirect(raw: str) -> str:
+    """Return ``raw`` (URL-decoded) if it's a safe loopback http URL, else "".
+
+    The desktop app passes ``app_redirect`` so ``/auth/callback`` can bounce
+    the one-time handoff code to its ephemeral local listener. This value
+    survives the full OAuth round trip in the server-set PKCE cookie, but it
+    enters via the URL at ``/auth/login`` — so an attacker could craft
+    ``/auth/login?provider=…&app_redirect=https://evil.example/grab`` to try
+    to exfiltrate a handoff code. We therefore accept ONLY an ``http://``
+    URL whose host is a loopback literal and which carries an explicit port
+    (the app's ephemeral listener) and an absolute path. That confines the
+    handoff code to a listener on the same machine.
+    """
+    if not raw:
+        return ""
+    from urllib.parse import unquote, urlparse
+
+    decoded = unquote(raw)
+    try:
+        parsed = urlparse(decoded)
+    except ValueError:
+        return ""
+    # Loopback listeners are plain http; never accept https (or anything
+    # else) here — the only valid target is a local socket.
+    if parsed.scheme != "http":
+        return ""
+    if (parsed.hostname or "") not in _LOOPBACK_HOSTS:
+        return ""
+    # Credentials in the authority are never legitimate here.
+    if parsed.username or parsed.password:
+        return ""
+    try:
+        port = parsed.port
+    except ValueError:
+        return ""
+    if port is None:
+        return ""
+    if not parsed.path.startswith("/"):
+        return ""
+    return decoded
+
+
+# ---------------------------------------------------------------------------
+# Public: native-app session handoff (desktop system-browser sign-in)
+# ---------------------------------------------------------------------------
+
+
+class _DesktopExchangeBody(BaseModel):
+    code: str
+    state: str = ""
+
+
+@router.post("/api/auth/desktop-exchange", name="auth_desktop_exchange")
+async def auth_desktop_exchange(request: Request, body: _DesktopExchangeBody):
+    """Trade a one-time handoff code for the dashboard session cookies.
+
+    Completes the desktop system-browser sign-in: the app obtained the
+    handoff code on its loopback listener after ``/auth/callback`` ran in
+    the user's real browser. The app POSTs the code here through its OAuth
+    session partition; we set the same HttpOnly session cookies the browser
+    flow would (``set_session_cookies``), which land in the app's cookie
+    jar. All token material stays server-side — the app never sees a token,
+    only the opaque code.
+
+    Allowlisted past the auth gate (it is the thing that establishes the
+    session). The code is single-use, short-TTL, and 256-bit, so a missing
+    or stale code is the only meaningful failure and brute force is
+    infeasible — no rate limiting needed.
+    """
+    from hermes_cli.dashboard_auth.app_handoff import (
+        HandoffInvalid,
+        consume_handoff,
+    )
+
+    try:
+        material = consume_handoff(body.code)
+    except HandoffInvalid:
+        audit_log(
+            AuditEvent.LOGIN_FAILURE,
+            reason="invalid_handoff_code",
+            ip=_client_ip(request),
+        )
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid or expired handoff code",
+        )
+
+    expires_in = max(60, int(material["expires_at"]) - int(time.time()))
+    resp = JSONResponse({"ok": True})
+    set_session_cookies(
+        resp,
+        access_token=str(material["access_token"]),
+        refresh_token=str(material["refresh_token"]),
+        access_token_expires_in=expires_in,
+        use_https=detect_https(request),
+        prefix=_prefix(request),
+    )
+    return resp
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_dashboard_auth_app_handoff.py
+++ b/tests/hermes_cli/test_dashboard_auth_app_handoff.py
@@ -1,0 +1,103 @@
+"""Unit tests for the desktop system-browser session-handoff store.
+
+The store mints single-use, short-TTL codes that ``/auth/callback`` binds to a
+freshly authenticated session and the app trades at
+``/api/auth/desktop-exchange``. These tests pin the round trip, single-use
+semantics, expiry, and the log-truncation behaviour — mirroring the
+``ws_tickets`` tests, which share the same shape.
+"""
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.dashboard_auth import app_handoff
+from hermes_cli.dashboard_auth.app_handoff import (
+    TTL_SECONDS,
+    HandoffInvalid,
+    consume_handoff,
+    mint_handoff,
+    _reset_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_store():
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+
+
+def _mint(**over):
+    kwargs = {
+        "access_token": "at-value",
+        "refresh_token": "rt-value",
+        "expires_at": 2_000_000_000,
+    }
+    kwargs.update(over)
+    return mint_handoff(**kwargs)
+
+
+def test_round_trip_returns_cookie_material():
+    code = _mint()
+    material = consume_handoff(code)
+    assert material["access_token"] == "at-value"
+    assert material["refresh_token"] == "rt-value"
+    assert material["expires_at"] == 2_000_000_000
+
+
+def test_codes_are_unique_and_high_entropy():
+    codes = {_mint() for _ in range(50)}
+    assert len(codes) == 50
+    # token_urlsafe(32) → 43 base64url chars.
+    assert all(len(c) >= 43 for c in codes)
+
+
+def test_second_consume_is_rejected():
+    code = _mint()
+    consume_handoff(code)
+    with pytest.raises(HandoffInvalid):
+        consume_handoff(code)
+
+
+def test_unknown_code_rejected():
+    with pytest.raises(HandoffInvalid):
+        consume_handoff("not-a-real-code")
+
+
+def test_empty_code_rejected():
+    with pytest.raises(HandoffInvalid):
+        consume_handoff("")
+
+
+def test_ttl_is_two_minutes():
+    # Pinned so a refactor that widened the live window surfaces here.
+    assert TTL_SECONDS == 120
+
+
+def test_expired_code_rejected(monkeypatch):
+    # Mock time inside the module so mint and consume see a controlled clock;
+    # ``time`` is module-level there, matching the ws_tickets test approach.
+    clock = {"now": 1_000.0}
+    monkeypatch.setattr(app_handoff.time, "time", lambda: clock["now"])
+    code = _mint()
+    clock["now"] += TTL_SECONDS + 1
+    with pytest.raises(HandoffInvalid):
+        consume_handoff(code)
+
+
+def test_at_exact_ttl_boundary_still_valid(monkeypatch):
+    clock = {"now": 1_000.0}
+    monkeypatch.setattr(app_handoff.time, "time", lambda: clock["now"])
+    code = _mint()
+    # expires_at == mint_time + TTL; the check rejects only when strictly past.
+    clock["now"] += TTL_SECONDS
+    assert consume_handoff(code)["access_token"] == "at-value"
+
+
+def test_unknown_code_error_truncates_value():
+    # A misused/guessed code must never appear in full in the error text.
+    secret = "S" * 40
+    with pytest.raises(HandoffInvalid) as exc:
+        consume_handoff(secret)
+    assert secret not in str(exc.value)
+    assert "S" * 8 in str(exc.value)

--- a/tests/hermes_cli/test_dashboard_auth_desktop_handoff.py
+++ b/tests/hermes_cli/test_dashboard_auth_desktop_handoff.py
@@ -1,0 +1,172 @@
+"""End-to-end tests for the desktop system-browser sign-in handoff.
+
+Covers the gateway half of the fix for issue #42448: ``/auth/login`` carrying
+the loopback ``app_redirect``/``app_state`` across the IdP round trip,
+``/auth/callback`` minting a one-time handoff code (and NOT setting browser
+cookies) when the request is app-driven, and ``/api/auth/desktop-exchange``
+trading that code for the session cookies. Also pins the loopback-only
+validation that keeps the handoff code from leaking to an attacker host.
+
+The gated_app harness mirrors ``test_dashboard_auth_middleware.py``: register
+the stub provider, flip ``app.state.auth_required = True``, drive a
+``TestClient``.
+"""
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+# Shares the dashboard-auth app-state xdist group: these tests mutate
+# ``web_server.app.state.auth_required`` at module level.
+pytestmark = pytest.mark.xdist_group("dashboard_auth_app_state")
+
+from fastapi.testclient import TestClient
+
+from hermes_cli import web_server
+from hermes_cli.dashboard_auth import clear_providers, register_provider
+from hermes_cli.dashboard_auth.app_handoff import _reset_for_tests
+from hermes_cli.dashboard_auth.routes import _validate_app_redirect
+from tests.hermes_cli.conftest_dashboard_auth import StubAuthProvider
+
+_LOOPBACK = "http://127.0.0.1:54321/callback"
+_NONCE = "app-nonce-abc123"
+
+
+@pytest.fixture
+def gated_app():
+    clear_providers()
+    register_provider(StubAuthProvider())
+    _reset_for_tests()
+    prev_host = getattr(web_server.app.state, "bound_host", None)
+    prev_port = getattr(web_server.app.state, "bound_port", None)
+    prev_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.bound_host = "fly-app.fly.dev"
+    web_server.app.state.bound_port = 443
+    web_server.app.state.auth_required = True
+    client = TestClient(web_server.app, base_url="https://fly-app.fly.dev")
+    yield client
+    clear_providers()
+    _reset_for_tests()
+    web_server.app.state.bound_host = prev_host
+    web_server.app.state.bound_port = prev_port
+    web_server.app.state.auth_required = prev_required
+
+
+def _drive_to_handoff(client: TestClient) -> str:
+    """Walk /auth/login → /auth/callback with the app params, returning the
+    one-time handoff code the callback bounced to the loopback URL."""
+    r1 = client.get(
+        f"/auth/login?provider=stub&app_redirect={_LOOPBACK}&app_state={_NONCE}",
+        follow_redirects=False,
+    )
+    assert r1.status_code == 302
+    state = r1.headers["location"].split("state=")[1]
+
+    r2 = client.get(
+        f"/auth/callback?code=stub_code&state={state}",
+        follow_redirects=False,
+    )
+    assert r2.status_code == 302
+    # The callback must NOT set browser session cookies on the app path —
+    # the session belongs in the app, reached via the handoff code only.
+    set_cookies = r2.headers.get_list("set-cookie")
+    assert not any("hermes_session_at" in c for c in set_cookies)
+    assert not any("hermes_session_rt" in c for c in set_cookies)
+
+    loc = urlparse(r2.headers["location"])
+    assert f"{loc.scheme}://{loc.netloc}{loc.path}" == _LOOPBACK
+    q = parse_qs(loc.query)
+    assert q["state"] == [_NONCE]
+    return q["code"][0]
+
+
+# ---------------------------------------------------------------------------
+# Capability advertisement
+# ---------------------------------------------------------------------------
+
+
+def test_providers_endpoint_advertises_handoff(gated_app):
+    r = gated_app.get("/api/auth/providers")
+    assert r.status_code == 200
+    assert r.json().get("app_handoff") is True
+
+
+# ---------------------------------------------------------------------------
+# Full handoff round trip
+# ---------------------------------------------------------------------------
+
+
+def test_handoff_round_trip_establishes_session(gated_app):
+    code = _drive_to_handoff(gated_app)
+
+    # The app trades the code for cookies. No prior session cookie exists,
+    # proving /api/auth/desktop-exchange is allowlisted past the gate.
+    r = gated_app.post("/api/auth/desktop-exchange", json={"code": code, "state": _NONCE})
+    assert r.status_code == 200, r.text
+    assert r.json() == {"ok": True}
+    set_cookies = r.headers.get_list("set-cookie")
+    assert any("hermes_session_at" in c for c in set_cookies)
+    assert any("hermes_session_rt" in c for c in set_cookies)
+
+    # The client now holds the cookies → a gated API route succeeds.
+    r2 = gated_app.get("/api/sessions")
+    assert r2.status_code == 200, r2.text
+
+
+def test_handoff_code_is_single_use(gated_app):
+    code = _drive_to_handoff(gated_app)
+    first = gated_app.post("/api/auth/desktop-exchange", json={"code": code})
+    assert first.status_code == 200
+    # A replay (or a stolen code re-presented) must be rejected.
+    gated_app.cookies.clear()
+    second = gated_app.post("/api/auth/desktop-exchange", json={"code": code})
+    assert second.status_code == 400
+
+
+def test_exchange_rejects_unknown_code(gated_app):
+    r = gated_app.post("/api/auth/desktop-exchange", json={"code": "nope"})
+    assert r.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Loopback-only guard: a non-loopback app_redirect must NOT trigger handoff
+# ---------------------------------------------------------------------------
+
+
+def test_non_loopback_app_redirect_falls_back_to_browser_login(gated_app):
+    evil = "https://evil.example/grab"
+    r1 = gated_app.get(
+        f"/auth/login?provider=stub&app_redirect={evil}&app_state={_NONCE}",
+        follow_redirects=False,
+    )
+    assert r1.status_code == 302
+    state = r1.headers["location"].split("state=")[1]
+
+    r2 = gated_app.get(
+        f"/auth/callback?code=stub_code&state={state}",
+        follow_redirects=False,
+    )
+    # No handoff: this is an ordinary browser login — cookies set, lands on /.
+    assert r2.status_code == 302
+    assert r2.headers["location"] == "/"
+    set_cookies = r2.headers.get_list("set-cookie")
+    assert any("hermes_session_at" in c for c in set_cookies)
+
+
+@pytest.mark.parametrize(
+    "raw,expected_ok",
+    [
+        ("http://127.0.0.1:54321/callback", True),
+        ("http://localhost:8080/callback", True),
+        ("http://[::1]:9000/cb", True),
+        ("https://127.0.0.1:54321/callback", False),  # https never accepted
+        ("http://evil.example:80/callback", False),   # non-loopback host
+        ("http://127.0.0.1/callback", False),         # no explicit port
+        ("http://user:pw@127.0.0.1:5000/cb", False),  # credentials in authority
+        ("ftp://127.0.0.1:21/cb", False),             # wrong scheme
+        ("", False),
+    ],
+)
+def test_validate_app_redirect(raw, expected_ok):
+    assert bool(_validate_app_redirect(raw)) is expected_ok


### PR DESCRIPTION
## What does this PR do?

Makes the Hermes Desktop remote-gateway OIDC sign-in run in the **system browser** instead of an embedded Electron window.

The embedded `BrowserWindow` cannot raise the macOS passkey / Touch ID / WebAuthn prompt, so passwordless sign-in against a custom OIDC provider (Authentik, Pocket ID, and so on) dead-ends. That is issue #42448. The same isolation also means the window never holds a proper browser session, so token refresh does not fire and the session expires quickly. Both have the same fix: do the OAuth ceremony in a real browser.

The approach is the standard native-app pattern (RFC 8252, "OAuth 2.0 for Native Apps"): authorization-code + PKCE with a **loopback redirect**, plus a small server-side session handoff so all token handling stays on the gateway and the HttpOnly cookie model is preserved. The handoff code is single-use, 256-bit, 120s TTL, and `app_redirect` is accepted only as a loopback URL, so the one-time code can never be redirected to an attacker host.

## Related Issue

Fixes #42448

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**Desktop, `apps/desktop/electron/`**
- `main.cjs`: `openOauthLoginExternal()` spins an ephemeral `127.0.0.1:<port>/callback` listener, opens the gateway login URL with `shell.openExternal`, captures a one-time handoff code on the loopback, and trades it at `/api/auth/desktop-exchange` through the OAuth session partition so the `Set-Cookie` lands in the same jar the existing OAuth REST path already reads. `gatewayAppHandoffInfo()` feature-detects support; the `oauth-login` IPC handler uses the system browser only when the gateway advertises `app_handoff` and exposes an OAuth (non-password) provider, otherwise it keeps the existing embedded window.
- `connection-config.cjs`: pure, unit-tested helpers `buildExternalLoginUrl()` and `parseLoopbackCallback()` (state-nonce CSRF check).

**Gateway, `hermes_cli/dashboard_auth/`**
- `app_handoff.py` (new): single-use, 120s, in-memory handoff-code store mirroring `ws_tickets.py`.
- `routes.py`: `/auth/login` carries a loopback-validated `app_redirect` + `app_state` across the IdP round trip in the PKCE cookie; `/auth/callback` mints a handoff code and 302s to the loopback (setting no browser cookies) on the app path; new `POST /api/auth/desktop-exchange` trades the code for the session cookies; `/api/auth/providers` advertises the `app_handoff` capability.
- `middleware.py`: allowlist `/api/auth/desktop-exchange` (it establishes the session, so it must be reachable pre-auth).
- `login_page.py`: propagate the app params onto OAuth provider buttons for multi-provider gateways.

No client secret and no JWKS fetch move into the app: all token handling stays server-side, the same as the existing cookie flow. The static-token and Nous OAuth paths are untouched.

## How to Test

Automated (macOS):
1. `scripts/run_tests.sh tests/hermes_cli/test_dashboard_auth_app_handoff.py tests/hermes_cli/test_dashboard_auth_desktop_handoff.py` for the new store + route E2E (handoff round trip, single-use, loopback-only validation, no-browser-cookies on the app path).
2. `scripts/run_tests.sh $(ls tests/hermes_cli/test_dashboard_auth_*.py)` for the full dashboard-auth suite (270 tests, no regressions).
3. `node --test apps/desktop/electron/connection-config.test.cjs` for the desktop helpers (53 tests).

Manual (system-browser passkey flow), against a self-hosted OIDC gateway (for example Pocket ID):
1. Settings, Gateway, sign in. The default browser opens the IdP, not an embedded window.
2. Authenticate with a passkey, Touch ID, or security key. The OS prompt now appears.
3. The browser shows a "signed in, you can close this tab" page; the app is connected.
4. Leave it more than 15 minutes and use the app. The session refreshes silently (no re-login).

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 and Linux (Ubuntu aarch64)

Tested on both macOS and Linux. The full suite passes on Linux (1480 files, 30,984 tests, 0 failures). On macOS the dashboard-auth (270) and desktop helper (53) suites pass; the only macOS failures are systemd / D-Bus / POSIX-file-mode tests that cannot run without systemd (`test_gateway_service`, `test_service_manager`, `test_gateway_wsl`, `test_signal_handler_kanban_worker`), and all four pass on Linux. They are unrelated to this change.

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

Verified end to end on macOS against a self-hosted Pocket ID IdP: the passkey / Touch ID prompt appeared in the default browser (it never could in the embedded window), the loopback handoff completed, and the desktop app connected and stayed connected.

---

🤖 Generated with Claude Code (Claude Opus 4.8)
🧑‍💻 Ideated, directed and reviewed by a human, @Omee11
