### PR TITLE
test(cli): pin _STREAM_PAD < 4 spaces (regression guard)

### DIFF
--- a/tests/test_stream_pad_regression.py
+++ b/tests/test_stream_pad_regression.py
@@ -11,8 +11,10 @@ spec, any text block with 4+ leading spaces is rendered as a code block.
 This caused copied CLI output to render as ``<pre><code>`` in GitHub
 issues, PR comments, and any other Markdown environment.
 
-The fix removes the leading whitespace entirely (empty string), which
-avoids the code-block threshold and keeps copy/paste from terminal clean.
+Upstream later removed the indent entirely (flush-left streaming +
+native /copy). This regression test pins the invariant that matters:
+the streamed-line prefix must never reach 4 leading spaces, whatever
+the exact value is chosen (empty, 2, or configurable).
 """
 
 
@@ -28,13 +30,6 @@ class TestStreamPadLength:
             f"_STREAM_PAD is {len(_STREAM_PAD)} spaces; "
             "values >= 4 trigger CommonMark code blocks when pasted "
             "into GitHub issues, PR comments, etc."
-        )
-
-    def test_stream_pad_is_empty(self):
-        """Regression: _STREAM_PAD should be empty string (no leading whitespace)."""
-        assert _STREAM_PAD == "", (
-            f"_STREAM_PAD is {len(_STREAM_PAD)}-char string "
-            f"({_STREAM_PAD!r}); expected empty string"
         )
 
     def test_stream_pad_is_spaces_only(self):

--- a/tests/test_stream_pad_regression.py
+++ b/tests/test_stream_pad_regression.py
@@ -1,0 +1,58 @@
+"""Regression test for _STREAM_PAD — ensures streamed CLI output does not
+trigger CommonMark's code-block rule (4+ leading spaces = <pre><code>).
+
+Related: https://github.com/NousResearch/hermes-agent/pull/46557
+
+Background
+----------
+The original `_STREAM_PAD` was hardcoded to 4 spaces, which meant every
+streamed response line started with 4 leading spaces.  Per the CommonMark
+spec, any text block with 4+ leading spaces is rendered as a code block.
+This caused copied CLI output to render as ``<pre><code>`` in GitHub
+issues, PR comments, and any other Markdown environment.
+
+The fix removes the leading whitespace entirely (empty string), which
+avoids the code-block threshold and keeps copy/paste from terminal clean.
+"""
+
+
+from cli import _STREAM_PAD
+
+
+class TestStreamPadLength:
+    """_STREAM_PAD must be short enough to avoid Markdown code blocks."""
+
+    def test_stream_pad_below_code_block_threshold(self):
+        """CommonMark code-block rule triggers at 4+ leading spaces."""
+        assert len(_STREAM_PAD) < 4, (
+            f"_STREAM_PAD is {len(_STREAM_PAD)} spaces; "
+            "values >= 4 trigger CommonMark code blocks when pasted "
+            "into GitHub issues, PR comments, etc."
+        )
+
+    def test_stream_pad_is_empty(self):
+        """Regression: _STREAM_PAD should be empty string (no leading whitespace)."""
+        assert _STREAM_PAD == "", (
+            f"_STREAM_PAD is {len(_STREAM_PAD)}-char string "
+            f"({_STREAM_PAD!r}); expected empty string"
+        )
+
+    def test_stream_pad_is_spaces_only(self):
+        """_STREAM_PAD must not contain tabs or other whitespace."""
+        assert _STREAM_PAD.strip(" ") == "", (
+            "_STREAM_PAD should contain only space characters"
+        )
+
+
+class TestStreamPadUsage:
+    """Verify _STREAM_PAD produces output that stays below 4-space indent."""
+
+    def test_streamed_line_prefix(self):
+        """A typical streamed line should start with <4 leading spaces."""
+        line = _STREAM_PAD + "hello world"
+        # Count leading whitespace
+        leading = len(line) - len(line.lstrip(" "))
+        assert leading < 4, (
+            f"Streamed line has {leading} leading spaces; "
+            "this will render as a code block in Markdown"
+        )


### PR DESCRIPTION
What

Regression test pinning the CLI stream-pad invariant: _STREAM_PAD must stay below 4 leading spaces, so streamed output never triggers CommonMark's code-block rule when copied into GitHub, Discord, or any Markdown surface.

Why this PR's shape changed

This PR originally changed _STREAM_PAD from 4 spaces → 2 spaces (June 15). Upstream then merged flush-left streaming + native /copy on July 27 (empty _STREAM_PAD), which supersedes the 2-space change — the indent is now gone at the source, and clean copy/paste is handled by a dedicated /copy path instead of fighting indentation.

After rebasing, the only remaining content is the regression test (per the hermes-sweeper review). I relaxed the exact-value assertion (== "") down to the invariant that actually matters — < 4 spaces — so the test holds whether the pad is empty, 2 spaces, or made configurable. It's a cheap guardrail against the behavior regressing back to ≥4.

Changes

- tests/test_stream_pad_regression.py: asserts len(_STREAM_PAD) < 4, prefix stays <4 leading spaces, and pad is spaces-only (no tabs).

How to test


pytest tests/test_stream_pad_regression.py -v   # 3 passed

