### PR TITLE
feat(terminal): add terminal.foreground_guard config option

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -974,6 +974,10 @@ DEFAULT_CONFIG = {
         # this off if your rc files misbehave when sourced
         # non-interactively (e.g. one that hard-exits on TTY checks).
         "auto_source_bashrc": True,
+        # When true (default), Hermes blocks foreground commands that look
+        # like long-lived server/watch processes and suggests background
+        # mode. Set to false to allow docker compose up -d and similar.
+        "foreground_guard": True,
         "docker_image": "nikolaik/python-nodejs:python3.11-nodejs20",
         "docker_forward_env": [],
         # Explicit environment variables to set inside Docker containers.
@@ -5331,6 +5335,7 @@ TERMINAL_CONFIG_ENV_MAP = {
     "docker_orphan_reaper": "TERMINAL_DOCKER_ORPHAN_REAPER",
     "sandbox_dir": "TERMINAL_SANDBOX_DIR",
     "persistent_shell": "TERMINAL_PERSISTENT_SHELL",
+    "foreground_guard": "TERMINAL_FOREGROUND_GUARD",
 }
 
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1929,7 +1929,8 @@ def terminal_tool(
 
         # Guardrail: long-lived server/watch commands should run as managed
         # background sessions, not foreground shell hacks.
-        if not background:
+        # Gated by terminal.foreground_guard in config.yaml (default: true).
+        if not background and os.environ.get("TERMINAL_FOREGROUND_GUARD", "true").lower() not in ("false", "0"):
             guidance = _foreground_background_guidance(command)
             if guidance:
                 return json.dumps({


### PR DESCRIPTION
The terminal tool's `_foreground_background_guidance` guard blocks foreground commands it detects as "long-lived server/watch" processes. This is overly aggressive — it blocks perfectly safe commands like `docker compose up -d` which run briefly and exit.

Adds a new `terminal.foreground_guard` config option (default: `true`). Set to `false` to disable the guard:

```yaml
terminal:
  foreground_guard: false
```

Or via env var: `TERMINAL_FOREGROUND_GUARD=false`

Changes:
- Adds `foreground_guard` to `TERMINAL_CONFIG_ENV_MAP` so config.yaml bridges to `TERMINAL_FOREGROUND_GUARD` env var
- Adds `foreground_guard: true` as default in terminal config
- Gates the guard check on `TERMINAL_FOREGROUND_GUARD` env var in `terminal_tool.py`