### PR TITLE
feat(web): add iFlow Search as native Web Search & Extract provider

### DIFF
--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -17,7 +17,7 @@ The active provider is chosen by configuration with this precedence:
 3. If exactly one capability-eligible provider is registered AND available,
    use it.
 4. Legacy preference order — ``firecrawl`` → ``parallel`` → ``tavily`` →
-   ``exa`` → ``searxng`` → ``brave-free`` → ``ddgs`` — filtered by
+   ``exa`` → ``iflow`` → ``searxng`` → ``brave-free`` → ``ddgs`` — filtered by
    availability. Matches the historic ``tools.web_tools._get_backend()``
    candidate order so installs that never set a config key keep landing
    on the same provider they did before the plugin migration.
@@ -124,6 +124,7 @@ _LEGACY_PREFERENCE = (
     "parallel",
     "tavily",
     "exa",
+    "iflow",
     "searxng",
     "brave-free",
     "ddgs",
@@ -148,7 +149,7 @@ def _resolve(configured: Optional[str], *, capability: str) -> Optional[WebSearc
 
     3. **Legacy preference walk, filtered by availability.** Walk the
        :data:`_LEGACY_PREFERENCE` order (firecrawl → parallel → tavily →
-       exa → searxng → brave-free → ddgs) looking for a provider whose
+       exa → iflow → searxng → brave-free → ddgs) looking for a provider whose
        ``supports_<capability>()`` is True AND whose ``is_available()`` is
        True. Matches the historic ``tools.web_tools._get_backend()``
        candidate order so users with credentials but no explicit config

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3004,6 +3004,14 @@ OPTIONAL_ENV_VARS = {
         "password": True,
         "category": "tool",
     },
+    "IFLOW_BASE_URL": {
+        "description": "Override the iFlow Search API base URL (default: https://platform.iflow.cn)",
+        "prompt": "iFlow Search API base URL (leave empty for cloud)",
+        "url": "https://platform.iflow.cn/docs/",
+        "password": False,
+        "category": "tool",
+        "advanced": True,
+    },
     "FIRECRAWL_GATEWAY_URL": {
         "description": "Exact Firecrawl tool-gateway origin override for Nous Subscribers only (optional)",
         "prompt": "Firecrawl gateway URL (leave empty to derive from domain)",
@@ -6037,6 +6045,7 @@ def show_config():
         ("OPENROUTER_API_KEY", "OpenRouter"),
         ("VOICE_TOOLS_OPENAI_KEY", "OpenAI (STT/TTS)"),
         ("EXA_API_KEY", "Exa"),
+        ("IFLOW_API_KEY", "iFlow Search"),
         ("PARALLEL_API_KEY", "Parallel"),
         ("FIRECRAWL_API_KEY", "Firecrawl"),
         ("TAVILY_API_KEY", "Tavily"),
@@ -6242,9 +6251,10 @@ def set_config_value(key: str, value: str):
     # Check if it's an API key (goes to .env)
     api_keys = [
         'OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'VOICE_TOOLS_OPENAI_KEY',
-        'EXA_API_KEY', 'PARALLEL_API_KEY', 'FIRECRAWL_API_KEY', 'FIRECRAWL_API_URL',
-        'FIRECRAWL_GATEWAY_URL', 'TOOL_GATEWAY_DOMAIN', 'TOOL_GATEWAY_SCHEME',
-        'TOOL_GATEWAY_USER_TOKEN', 'TAVILY_API_KEY',
+        'EXA_API_KEY', 'IFLOW_API_KEY', 'IFLOW_BASE_URL', 'PARALLEL_API_KEY',
+        'FIRECRAWL_API_KEY', 'FIRECRAWL_API_URL', 'FIRECRAWL_GATEWAY_URL',
+        'TOOL_GATEWAY_DOMAIN', 'TOOL_GATEWAY_SCHEME', 'TOOL_GATEWAY_USER_TOKEN',
+        'TAVILY_API_KEY',
         'BROWSERBASE_API_KEY', 'BROWSERBASE_PROJECT_ID', 'BROWSER_USE_API_KEY',
         'FAL_KEY', 'TELEGRAM_BOT_TOKEN', 'DISCORD_BOT_TOKEN',
         'TERMINAL_SSH_HOST', 'TERMINAL_SSH_USER', 'TERMINAL_SSH_KEY',

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2996,6 +2996,14 @@ OPTIONAL_ENV_VARS = {
         "category": "tool",
         "advanced": True,
     },
+    "IFLOW_API_KEY": {
+        "description": "iFlow Search API key for web search and page fetch",
+        "prompt": "iFlow Search API key",
+        "url": "https://platform.iflow.cn/docs/",
+        "tools": ["web_search", "web_extract"],
+        "password": True,
+        "category": "tool",
+    },
     "FIRECRAWL_GATEWAY_URL": {
         "description": "Exact Firecrawl tool-gateway origin override for Nous Subscribers only (optional)",
         "prompt": "Firecrawl gateway URL (leave empty to derive from domain)",

--- a/plugins/web/iflow/__init__.py
+++ b/plugins/web/iflow/__init__.py
@@ -1,0 +1,10 @@
+"""iFlow Search plugin — bundled, auto-loaded."""
+
+from __future__ import annotations
+
+from plugins.web.iflow.provider import IFlowWebSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the iFlow Search provider with the plugin context."""
+    ctx.register_web_search_provider(IFlowWebSearchProvider())

--- a/plugins/web/iflow/plugin.yaml
+++ b/plugins/web/iflow/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-iflow
+version: 1.0.0
+description: "iFlow Search — web search and page fetch via iFlow Search API. Requires IFLOW_API_KEY."
+author: NousResearch
+kind: backend
+provides_web_providers:
+  - iflow

--- a/plugins/web/iflow/provider.py
+++ b/plugins/web/iflow/provider.py
@@ -1,0 +1,319 @@
+"""iFlow Search web search + content extraction provider.
+
+Subclasses :class:`agent.web_search_provider.WebSearchProvider` and maps Hermes
+web tools to the iFlow Search API:
+
+- ``search()``  -> ``POST /api/search/webSearch``
+- ``extract()`` -> ``POST /api/search/webFetch``
+
+Config keys this provider responds to::
+
+    web:
+      search_backend: "iflow"
+      extract_backend: "iflow"
+      backend: "iflow"
+
+Env vars::
+
+    IFLOW_API_KEY=...                       # required
+    IFLOW_BASE_URL=https://platform.iflow.cn # optional
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_IFLOW_BASE_URL = "https://platform.iflow.cn"
+_MISSING_KEY_ERROR = (
+    "IFLOW_API_KEY is not set. Run hermes tools and select iFlow Search, "
+    "or set IFLOW_API_KEY in ~/.hermes/.env."
+)
+
+
+def _env_value(name: str) -> str:
+    """Resolve env values through Hermes' config-aware env layer."""
+    try:
+        from hermes_cli.config import get_env_value
+
+        value = get_env_value(name)
+    except Exception:
+        value = None
+    if value is None:
+        value = os.getenv(name, "")
+    return (value or "").strip()
+
+
+def _iflow_api_key() -> str:
+    return _env_value("IFLOW_API_KEY")
+
+
+def _iflow_base_url() -> str:
+    return (_env_value("IFLOW_BASE_URL") or DEFAULT_IFLOW_BASE_URL).rstrip("/")
+
+
+def _clamp_limit(limit: int) -> int:
+    try:
+        value = int(limit)
+    except (TypeError, ValueError):
+        value = 5
+    return max(1, min(value, 100))
+
+
+def _headers(api_key: str) -> Dict[str, str]:
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+
+def _http_error_message(status_code: int) -> str:
+    if status_code in {401, 403}:
+        return "iFlow API key is invalid or unauthorized"
+    if status_code == 429:
+        return "iFlow rate limit exceeded"
+    if 500 <= status_code <= 599:
+        return f"iFlow service error: HTTP {status_code}"
+    return f"iFlow returned HTTP {status_code}"
+
+
+def _parse_json_response(response: Any) -> Dict[str, Any]:
+    try:
+        data = response.json()
+    except Exception as exc:  # noqa: BLE001
+        raise ValueError("iFlow returned an invalid JSON response") from exc
+    if not isinstance(data, dict):
+        raise ValueError("iFlow returned an invalid JSON response")
+    return data
+
+
+def _business_error(data: Dict[str, Any]) -> str | None:
+    success = data.get("success")
+    code = data.get("code")
+    if success is False or (code not in {None, "", "200", 200}):
+        message = str(data.get("message") or "iFlow request failed")
+        if code not in {None, ""}:
+            return f"iFlow request failed ({code}): {message}"
+        return f"iFlow request failed: {message}"
+    return None
+
+
+def _compact_metadata(result: Dict[str, Any]) -> Dict[str, Any]:
+    metadata: Dict[str, Any] = {}
+    for source_key, target_key in (
+        ("source", "source"),
+        ("date", "published_time"),
+        ("published_time", "published_time"),
+        ("metadata", "metadata"),
+    ):
+        value = result.get(source_key)
+        if value is not None and value != "":
+            metadata[target_key] = value
+    return metadata
+
+
+def _normalize_search_response(data: Dict[str, Any], limit: int) -> Dict[str, Any]:
+    error = _business_error(data)
+    if error:
+        return {"success": False, "error": error}
+
+    payload = data.get("data") or {}
+    if not isinstance(payload, dict):
+        payload = {}
+    raw_results = payload.get("organic") or payload.get("results") or payload.get("web") or []
+    if not isinstance(raw_results, list):
+        raw_results = []
+
+    web_results = []
+    for index, item in enumerate(raw_results[:limit]):
+        if not isinstance(item, dict):
+            continue
+        url = item.get("url") or item.get("link") or ""
+        description = item.get("snippet") or item.get("content") or item.get("summary") or ""
+        result: Dict[str, Any] = {
+            "title": str(item.get("title") or ""),
+            "url": str(url or ""),
+            "description": str(description or ""),
+            "position": int(item.get("position") or index + 1),
+        }
+        metadata = _compact_metadata(item)
+        if metadata:
+            result["metadata"] = metadata
+        web_results.append(result)
+
+    return {"success": True, "data": {"web": web_results}}
+
+
+def _normalize_fetch_response(data: Dict[str, Any], fallback_url: str) -> Dict[str, Any]:
+    error = _business_error(data)
+    if error:
+        return {
+            "url": fallback_url,
+            "title": "",
+            "content": "",
+            "raw_content": "",
+            "error": error,
+            "metadata": {"sourceURL": fallback_url},
+        }
+
+    payload = data.get("data") or {}
+    if not isinstance(payload, dict):
+        payload = {}
+    url = str(payload.get("url") or fallback_url)
+    title = str(payload.get("title") or "")
+    content = str(
+        payload.get("content")
+        or payload.get("markdown")
+        or payload.get("text")
+        or payload.get("raw_content")
+        or ""
+    )
+    metadata: Dict[str, Any] = {"sourceURL": url, "title": title}
+    if "fromCache" in payload:
+        metadata["fromCache"] = payload.get("fromCache")
+    if "metadata" in payload and isinstance(payload["metadata"], dict):
+        metadata["metadata"] = payload["metadata"]
+
+    return {
+        "url": url,
+        "title": title,
+        "content": content,
+        "raw_content": content,
+        "metadata": metadata,
+    }
+
+
+def _iflow_post(path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """POST to iFlow and return parsed JSON without exposing credentials."""
+    import httpx
+
+    api_key = _iflow_api_key()
+    if not api_key:
+        raise ValueError(_MISSING_KEY_ERROR)
+
+    url = f"{_iflow_base_url()}/{path.lstrip('/')}"
+    try:
+        response = httpx.post(
+            url,
+            json=payload,
+            headers=_headers(api_key),
+            timeout=30,
+        )
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        raise RuntimeError(_http_error_message(exc.response.status_code)) from exc
+    except httpx.TimeoutException as exc:
+        raise RuntimeError("iFlow request timeout") from exc
+    except httpx.RequestError as exc:
+        raise RuntimeError(f"Could not reach iFlow Search: {exc}") from exc
+
+    return _parse_json_response(response)
+
+
+class IFlowWebSearchProvider(WebSearchProvider):
+    """iFlow Search provider for Hermes web search and extract tools."""
+
+    @property
+    def name(self) -> str:
+        return "iflow"
+
+    @property
+    def display_name(self) -> str:
+        return "iFlow Search"
+
+    def is_available(self) -> bool:
+        return bool(_iflow_api_key())
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return True
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        """Execute web search via iFlow ``/api/search/webSearch``."""
+        try:
+            from tools.interrupt import is_interrupted
+
+            if is_interrupted():
+                return {"success": False, "error": "Interrupted"}
+
+            count = _clamp_limit(limit)
+            logger.info("iFlow search: '%s' (limit=%d)", query, count)
+            data = _iflow_post(
+                "/api/search/webSearch",
+                {"keywords": query, "num": count},
+            )
+            return _normalize_search_response(data, count)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("iFlow search error: %s", exc)
+            return {"success": False, "error": str(exc)}
+
+    def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+        """Extract URL content via iFlow ``/api/search/webFetch``."""
+        try:
+            from tools.interrupt import is_interrupted
+
+            if is_interrupted():
+                return [
+                    {
+                        "url": url,
+                        "title": "",
+                        "content": "",
+                        "raw_content": "",
+                        "error": "Interrupted",
+                    }
+                    for url in urls
+                ]
+
+            results: List[Dict[str, Any]] = []
+            for url in urls:
+                try:
+                    data = _iflow_post("/api/search/webFetch", {"url": url})
+                    results.append(_normalize_fetch_response(data, fallback_url=url))
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("iFlow fetch error for %s: %s", url, exc)
+                    results.append(
+                        {
+                            "url": url,
+                            "title": "",
+                            "content": "",
+                            "raw_content": "",
+                            "error": str(exc),
+                            "metadata": {"sourceURL": url},
+                        }
+                    )
+            return results
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("iFlow extract error: %s", exc)
+            return [
+                {
+                    "url": url,
+                    "title": "",
+                    "content": "",
+                    "raw_content": "",
+                    "error": f"iFlow extract failed: {exc}",
+                    "metadata": {"sourceURL": url},
+                }
+                for url in urls
+            ]
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "iFlow Search",
+            "badge": "paid",
+            "tag": "Search + extract in one provider.",
+            "env_vars": [
+                {
+                    "key": "IFLOW_API_KEY",
+                    "prompt": "Enter your IFLOW_API_KEY",
+                    "url": "https://platform.iflow.cn/docs/",
+                },
+            ],
+        }

--- a/plugins/web/iflow/provider.py
+++ b/plugins/web/iflow/provider.py
@@ -30,10 +30,15 @@ from agent.web_search_provider import WebSearchProvider
 logger = logging.getLogger(__name__)
 
 DEFAULT_IFLOW_BASE_URL = "https://platform.iflow.cn"
-_MISSING_KEY_ERROR = (
-    "IFLOW_API_KEY is not set. Run hermes tools and select iFlow Search, "
-    "or set IFLOW_API_KEY in ~/.hermes/.env."
-)
+
+
+def _missing_key_error() -> str:
+    from hermes_constants import display_hermes_home
+
+    return (
+        "IFLOW_API_KEY is not set. Run hermes tools and select iFlow Search, "
+        f"or set IFLOW_API_KEY in {display_hermes_home()}/.env."
+    )
 
 
 def _env_value(name: str) -> str:
@@ -195,7 +200,7 @@ def _iflow_post(path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
 
     api_key = _iflow_api_key()
     if not api_key:
-        raise ValueError(_MISSING_KEY_ERROR)
+        raise ValueError(_missing_key_error())
 
     url = f"{_iflow_base_url()}/{path.lstrip('/')}"
     try:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -96,6 +96,7 @@ AUTHOR_MAP = {
     "kdunn926@gmail.com": "kdunn926",
     "mvanhorn@MacBook-Pro.local": "mvanhorn",
     "470766206@qq.com": "youjunxiaji",
+    "2039222749@qq.com": "zhengyanglsun",
     "mharris@parallel.ai": "NormallyGaussian",
     "roger@roger.local": "mollusk",
     "ted.malone@outlook.com": "temalo",

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -2,7 +2,7 @@
 
 Covers:
 
-- All eight bundled plugins (brave-free, ddgs, searxng, exa, parallel,
+- All nine bundled plugins (brave-free, ddgs, searxng, exa, iflow, parallel,
   tavily, firecrawl, xai) instantiate and self-report the expected
   capabilities + ABC-derived defaults.
 - Each plugin's ``is_available()`` correctly reflects env-var presence.
@@ -47,6 +47,10 @@ def _clear_web_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "XAI_API_KEY",
     ):
         monkeypatch.delenv(k, raising=False)
+    # iFlow reads through Hermes' config-aware env layer, so an explicit empty
+    # process env value keeps a developer's ~/.hermes/.env key out of unit tests.
+    monkeypatch.setenv("IFLOW_API_KEY", "")
+    monkeypatch.setenv("IFLOW_BASE_URL", "")
 
 
 def _ensure_plugins_loaded() -> None:
@@ -68,9 +72,9 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestBundledPluginsRegister:
-    """All eight bundled web plugins discover and register correctly."""
+    """All nine bundled web plugins discover and register correctly."""
 
-    def test_all_seven_plugins_present_in_registry(self) -> None:
+    def test_all_nine_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
         from agent.web_search_registry import list_providers
 
@@ -80,6 +84,7 @@ class TestBundledPluginsRegister:
             "ddgs",
             "exa",
             "firecrawl",
+            "iflow",
             "parallel",
             "searxng",
             "tavily",
@@ -93,6 +98,7 @@ class TestBundledPluginsRegister:
             ("ddgs", True, False),
             ("searxng", True, False),
             ("exa", True, True),
+            ("iflow", True, True),
             ("parallel", True, True),
             ("tavily", True, True),
             ("firecrawl", True, True),
@@ -116,7 +122,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "exa", "iflow", "parallel", "tavily", "firecrawl", "xai"],
     )
     def test_each_plugin_has_name_and_display_name(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -129,7 +135,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "exa", "iflow", "parallel", "tavily", "firecrawl", "xai"],
     )
     def test_each_plugin_has_setup_schema(self, plugin_name: str) -> None:
         """``get_setup_schema()`` returns a dict the picker can consume."""
@@ -190,6 +196,16 @@ class TestIsAvailable:
         assert p is not None
         assert p.is_available() is False
         monkeypatch.setenv("EXA_API_KEY", "real")
+        assert p.is_available() is True
+
+    def test_iflow_requires_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("iflow")
+        assert p is not None
+        assert p.is_available() is False
+        monkeypatch.setenv("IFLOW_API_KEY", "real")
         assert p.is_available() is True
 
     def test_parallel_requires_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -24,6 +24,7 @@ def register_all_web_providers():
     from plugins.web.ddgs.provider import DDGSWebSearchProvider
     from plugins.web.exa.provider import ExaWebSearchProvider
     from plugins.web.firecrawl.provider import FirecrawlWebSearchProvider
+    from plugins.web.iflow.provider import IFlowWebSearchProvider
     from plugins.web.parallel.provider import ParallelWebSearchProvider
     from plugins.web.searxng.provider import SearXNGWebSearchProvider
     from plugins.web.tavily.provider import TavilyWebSearchProvider
@@ -35,6 +36,7 @@ def register_all_web_providers():
         DDGSWebSearchProvider,
         ExaWebSearchProvider,
         FirecrawlWebSearchProvider,
+        IFlowWebSearchProvider,
         ParallelWebSearchProvider,
         SearXNGWebSearchProvider,
         TavilyWebSearchProvider,

--- a/tests/tools/test_web_providers_iflow.py
+++ b/tests/tools/test_web_providers_iflow.py
@@ -67,6 +67,7 @@ class TestIFlowSearch:
         result = IFlowWebSearchProvider().search("test", limit=5)
         assert result["success"] is False
         assert "IFLOW_API_KEY is not set" in result["error"]
+        assert "~/.hermes" not in result["error"]
 
     def test_web_search_success_normalizes_results(self, monkeypatch):
         monkeypatch.setenv("IFLOW_API_KEY", "test-key")

--- a/tests/tools/test_web_providers_iflow.py
+++ b/tests/tools/test_web_providers_iflow.py
@@ -1,0 +1,338 @@
+"""Tests for the iFlow Search web provider."""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.tools.conftest import register_all_web_providers
+
+
+def _clear_iflow_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("IFLOW_API_KEY", "")
+    monkeypatch.setenv("IFLOW_BASE_URL", "")
+
+
+class TestIFlowProviderAvailability:
+    def test_provider_name_and_capabilities(self):
+        from plugins.web.iflow.provider import IFlowWebSearchProvider
+
+        provider = IFlowWebSearchProvider()
+        assert provider.name == "iflow"
+        assert provider.display_name == "iFlow Search"
+        assert provider.supports_search() is True
+        assert provider.supports_extract() is True
+
+    def test_available_when_key_set(self, monkeypatch):
+        monkeypatch.setenv("IFLOW_API_KEY", "test-key")
+        from plugins.web.iflow.provider import IFlowWebSearchProvider
+
+        assert IFlowWebSearchProvider().is_available() is True
+
+    def test_unavailable_when_key_missing(self, monkeypatch):
+        _clear_iflow_env(monkeypatch)
+        from plugins.web.iflow.provider import IFlowWebSearchProvider
+
+        assert IFlowWebSearchProvider().is_available() is False
+
+    def test_default_base_url(self, monkeypatch):
+        _clear_iflow_env(monkeypatch)
+        from plugins.web.iflow.provider import DEFAULT_IFLOW_BASE_URL, _iflow_base_url
+
+        assert _iflow_base_url() == DEFAULT_IFLOW_BASE_URL
+
+    def test_base_url_strips_trailing_slash(self, monkeypatch):
+        monkeypatch.setenv("IFLOW_BASE_URL", "https://example.test///")
+        from plugins.web.iflow.provider import _iflow_base_url
+
+        assert _iflow_base_url() == "https://example.test"
+
+
+class TestIFlowSearch:
+    @staticmethod
+    def _mock_resp(json_data, status_code=200):
+        response = MagicMock()
+        response.status_code = status_code
+        response.json.return_value = json_data
+        response.raise_for_status = MagicMock()
+        return response
+
+    def test_missing_key_returns_error(self, monkeypatch):
+        _clear_iflow_env(monkeypatch)
+        from plugins.web.iflow.provider import IFlowWebSearchProvider
+
+        result = IFlowWebSearchProvider().search("test", limit=5)
+        assert result["success"] is False
+        assert "IFLOW_API_KEY is not set" in result["error"]
+
+    def test_web_search_success_normalizes_results(self, monkeypatch):
+        monkeypatch.setenv("IFLOW_API_KEY", "test-key")
+        monkeypatch.setenv("IFLOW_BASE_URL", "https://platform.iflow.cn/")
+        from plugins.web.iflow.provider import IFlowWebSearchProvider
+
+        sample = {
+            "success": True,
+            "code": "200",
+            "message": "ok",
+            "data": {
+                "organic": [
+                    {
+                        "title": "A",
+                        "link": "https://a.example",
+                        "snippet": "desc A",
+                        "position": 1,
+                        "date": "2026-01-01",
+                    },
+                    {
+                        "title": "B",
+                        "url": "https://b.example",
+                        "content": "desc B",
+                    },
+                ]
+            },
+        }
+        captured = {}
+
+        def fake_post(url, **kwargs):
+            captured["url"] = url
+            captured["json"] = kwargs["json"]
+            captured["headers"] = kwargs["headers"]
+            return self._mock_resp(sample)
+
+        with patch("httpx.post", side_effect=fake_post):
+            result = IFlowWebSearchProvider().search("hello", limit=2)
+
+        assert captured["url"] == "https://platform.iflow.cn/api/search/webSearch"
+        assert captured["json"] == {"keywords": "hello", "num": 2}
+        assert captured["headers"]["Authorization"] == "Bearer test-key"
+        assert result["success"] is True
+        assert result["data"]["web"][0]["url"] == "https://a.example"
+        assert result["data"]["web"][0]["description"] == "desc A"
+        assert result["data"]["web"][0]["metadata"]["published_time"] == "2026-01-01"
+        assert result["data"]["web"][1]["position"] == 2
+
+    def test_limit_is_clamped(self, monkeypatch):
+        monkeypatch.setenv("IFLOW_API_KEY", "test-key")
+        from plugins.web.iflow.provider import IFlowWebSearchProvider
+
+        captured = {}
+
+        def fake_post(url, **kwargs):
+            captured["json"] = kwargs["json"]
+            return self._mock_resp({"success": True, "code": "200", "data": {"organic": []}})
+
+        with patch("httpx.post", side_effect=fake_post):
+            IFlowWebSearchProvider().search("hello", limit=1000)
+
+        assert captured["json"]["num"] == 100
+
+    def test_http_error_is_sanitized(self, monkeypatch):
+        import httpx
+
+        monkeypatch.setenv("IFLOW_API_KEY", "test-key")
+        from plugins.web.iflow.provider import IFlowWebSearchProvider
+
+        response = self._mock_resp({}, status_code=401)
+        response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "unauthorized",
+            request=MagicMock(),
+            response=response,
+        )
+
+        with patch("httpx.post", return_value=response):
+            result = IFlowWebSearchProvider().search("hello")
+
+        assert result["success"] is False
+        assert "invalid or unauthorized" in result["error"]
+        assert "test-key" not in result["error"]
+
+    def test_bad_json_returns_invalid_response(self, monkeypatch):
+        monkeypatch.setenv("IFLOW_API_KEY", "test-key")
+        from plugins.web.iflow.provider import IFlowWebSearchProvider
+
+        response = self._mock_resp({})
+        response.json.side_effect = ValueError("not json")
+
+        with patch("httpx.post", return_value=response):
+            result = IFlowWebSearchProvider().search("hello")
+
+        assert result["success"] is False
+        assert "invalid JSON response" in result["error"]
+
+    def test_business_error(self, monkeypatch):
+        monkeypatch.setenv("IFLOW_API_KEY", "test-key")
+        from plugins.web.iflow.provider import IFlowWebSearchProvider
+
+        response = self._mock_resp(
+            {"success": False, "code": "40101", "message": "bad credentials"}
+        )
+
+        with patch("httpx.post", return_value=response):
+            result = IFlowWebSearchProvider().search("hello")
+
+        assert result["success"] is False
+        assert "40101" in result["error"]
+        assert "bad credentials" in result["error"]
+
+
+class TestIFlowExtract:
+    @staticmethod
+    def _mock_resp(json_data, status_code=200):
+        response = MagicMock()
+        response.status_code = status_code
+        response.json.return_value = json_data
+        response.raise_for_status = MagicMock()
+        return response
+
+    def test_web_fetch_success_normalizes_document(self, monkeypatch):
+        monkeypatch.setenv("IFLOW_API_KEY", "test-key")
+        from plugins.web.iflow.provider import IFlowWebSearchProvider
+
+        sample = {
+            "success": True,
+            "code": "200",
+            "data": {
+                "title": "Example",
+                "content": "Page content",
+                "url": "https://example.com/",
+                "fromCache": True,
+            },
+        }
+
+        with patch("httpx.post", return_value=self._mock_resp(sample)):
+            result = IFlowWebSearchProvider().extract(["https://example.com"])
+
+        assert result == [
+            {
+                "url": "https://example.com/",
+                "title": "Example",
+                "content": "Page content",
+                "raw_content": "Page content",
+                "metadata": {
+                    "sourceURL": "https://example.com/",
+                    "title": "Example",
+                    "fromCache": True,
+                },
+            }
+        ]
+
+    def test_web_fetch_error_returns_per_url_error(self, monkeypatch):
+        monkeypatch.setenv("IFLOW_API_KEY", "test-key")
+        from plugins.web.iflow.provider import IFlowWebSearchProvider
+
+        with patch(
+            "httpx.post",
+            return_value=self._mock_resp(
+                {"success": False, "code": "50001", "message": "fetch failed"}
+            ),
+        ):
+            result = IFlowWebSearchProvider().extract(["https://example.com"])
+
+        assert result[0]["url"] == "https://example.com"
+        assert result[0]["content"] == ""
+        assert "fetch failed" in result[0]["error"]
+
+
+class TestIFlowBackendWiring:
+    def test_backend_available_true_when_key_set(self, monkeypatch):
+        monkeypatch.setenv("IFLOW_API_KEY", "test-key")
+        from tools.web_tools import _is_backend_available
+
+        assert _is_backend_available("iflow") is True
+
+    def test_backend_available_false_when_key_missing(self, monkeypatch):
+        _clear_iflow_env(monkeypatch)
+        from tools.web_tools import _is_backend_available
+
+        assert _is_backend_available("iflow") is False
+
+    def test_configured_backend_accepted(self, monkeypatch):
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "iflow"})
+        monkeypatch.setenv("IFLOW_API_KEY", "test-key")
+        assert web_tools._get_backend() == "iflow"
+
+    def test_auto_detect_picks_iflow_when_only_key_set(self, monkeypatch):
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
+        for key in (
+            "FIRECRAWL_API_KEY",
+            "FIRECRAWL_API_URL",
+            "PARALLEL_API_KEY",
+            "TAVILY_API_KEY",
+            "EXA_API_KEY",
+            "SEARXNG_URL",
+            "BRAVE_SEARCH_API_KEY",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("IFLOW_API_KEY", "test-key")
+        monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
+        monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: False)
+        assert web_tools._get_backend() == "iflow"
+
+    def test_check_web_api_key_true_when_iflow_configured(self, monkeypatch):
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "iflow"})
+        monkeypatch.setenv("IFLOW_API_KEY", "test-key")
+        assert web_tools.check_web_api_key() is True
+
+    def test_web_search_tool_dispatches_iflow(self, monkeypatch):
+        from tools import web_tools
+
+        register_all_web_providers()
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "iflow"})
+        monkeypatch.setenv("IFLOW_API_KEY", "test-key")
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
+
+        with patch(
+            "httpx.post",
+            return_value=TestIFlowSearch._mock_resp(
+                {"success": True, "code": "200", "data": {"organic": []}}
+            ),
+        ):
+            result = json.loads(web_tools.web_search_tool("hello", limit=1))
+
+        assert result == {"success": True, "data": {"web": []}}
+
+    def test_tools_config_provider_row_is_visible(self, monkeypatch):
+        from hermes_cli import tools_config
+
+        monkeypatch.setenv("IFLOW_API_KEY", "")
+        rows = tools_config._plugin_web_search_providers()
+        row = next((r for r in rows if r.get("web_backend") == "iflow"), None)
+
+        assert row is not None
+        assert row["name"] == "iFlow Search"
+        assert row["badge"] == "paid"
+        assert row["tag"] == "Search + extract in one provider."
+        assert [e["key"] for e in row["env_vars"]] == ["IFLOW_API_KEY"]
+
+
+@pytest.mark.integration
+class TestIFlowLiveIntegration:
+    def test_live_web_search_when_key_present(self):
+        if not os.getenv("IFLOW_API_KEY"):
+            pytest.skip("IFLOW_API_KEY is not set")
+
+        from plugins.web.iflow.provider import IFlowWebSearchProvider
+
+        result = IFlowWebSearchProvider().search("Hermes Agent", limit=1)
+        assert result["success"] is True
+        assert "web" in result["data"]
+
+    def test_live_web_fetch_when_key_present(self):
+        if not os.getenv("IFLOW_API_KEY"):
+            pytest.skip("IFLOW_API_KEY is not set")
+
+        from plugins.web.iflow.provider import IFlowWebSearchProvider
+
+        result = IFlowWebSearchProvider().extract(["https://example.com"])
+        assert len(result) == 1
+        assert result[0]["url"]
+        assert "content" in result[0]

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -149,7 +149,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}:
+    if configured in {"parallel", "firecrawl", "tavily", "exa", "iflow", "searxng", "brave-free", "ddgs", "xai"}:
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -165,6 +165,7 @@ def _get_backend() -> str:
         ("parallel", _has_env("PARALLEL_API_KEY")),
         ("firecrawl", _has_env("FIRECRAWL_API_KEY") or _has_env("FIRECRAWL_API_URL")),
         ("firecrawl", _is_tool_gateway_ready()),
+        ("iflow", _has_env("IFLOW_API_KEY")),
         ("searxng", _has_env("SEARXNG_URL")),
         ("brave-free", _has_env("BRAVE_SEARCH_API_KEY")),
         ("ddgs", _ddgs_package_importable()),
@@ -218,6 +219,8 @@ def _is_backend_available(backend: str) -> bool:
     """Return True when the selected backend is currently usable."""
     if backend == "exa":
         return _has_env("EXA_API_KEY")
+    if backend == "iflow":
+        return _has_env("IFLOW_API_KEY")
     if backend == "parallel":
         return _has_env("PARALLEL_API_KEY")
     if backend == "firecrawl":
@@ -758,7 +761,7 @@ def clean_base64_images(text: str) -> str:
 def _ensure_web_plugins_loaded() -> None:
     """Idempotently trigger plugin discovery so the web registry is populated.
 
-    Every bundled web provider (brave-free, ddgs, searxng, exa, parallel,
+    Every bundled web provider (brave-free, ddgs, searxng, exa, iflow, parallel,
     tavily, firecrawl) registers itself via ``plugins/web/<vendor>/__init__.py``
     during plugin discovery. Tool dispatch can be reached from contexts that
     haven't already triggered discovery — subprocess agent runs, delegate
@@ -840,8 +843,8 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         if is_interrupted():
             return tool_error("Interrupted", success=False)
 
-        # Dispatch through the web search registry. All 7 providers
-        # (brave-free, ddgs, searxng, exa, parallel, tavily, firecrawl)
+        # Dispatch through the web search registry. Bundled providers
+        # (brave-free, ddgs, searxng, exa, iflow, parallel, tavily, firecrawl)
         # now live as plugins; the dispatcher is just a registry lookup +
         # delegation. Sync only — every provider's search() is sync.
         _ensure_web_plugins_loaded()
@@ -978,8 +981,8 @@ async def web_extract_tool(
         else:
             backend = _get_extract_backend()
 
-            # All seven providers (brave-free, ddgs, searxng, exa, parallel,
-            # tavily, firecrawl) now live as plugins. The dispatcher is a
+            # All bundled providers (brave-free, ddgs, searxng, exa, iflow,
+            # parallel, tavily, firecrawl) now live as plugins. The dispatcher is a
             # registry lookup + delegation. Some providers' extract() is
             # async (parallel, firecrawl), others sync (exa, tavily) — we
             # detect coroutine functions and await; sync functions run
@@ -1185,11 +1188,11 @@ async def web_extract_tool(
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai"}:
+    if configured in {"exa", "iflow", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai"}:
         return _is_backend_available(configured)
     return any(
         _is_backend_available(backend)
-        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai")
+        for backend in ("exa", "iflow", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "xai")
     )
 
 
@@ -1221,6 +1224,8 @@ if __name__ == "__main__":
         print(f"✅ Web backend: {backend}")
         if backend == "exa":
             print("   Using Exa API (https://exa.ai)")
+        elif backend == "iflow":
+            print("   Using iFlow Search API (https://platform.iflow.cn)")
         elif backend == "parallel":
             print("   Using Parallel API (https://parallel.ai)")
         elif backend == "tavily":
@@ -1242,7 +1247,7 @@ if __name__ == "__main__":
     else:
         print("❌ No web search backend configured")
         print(
-            "Set EXA_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, FIRECRAWL_API_KEY, FIRECRAWL_API_URL"
+            "Set EXA_API_KEY, IFLOW_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, FIRECRAWL_API_KEY, FIRECRAWL_API_URL"
             f"{_firecrawl_backend_help_suffix()}"
         )
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -137,6 +137,8 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `SEARXNG_URL` | SearXNG instance URL for free self-hosted web search — no API key required ([searxng.github.io](https://searxng.github.io/searxng/)) |
 | `TAVILY_BASE_URL` | Override the Tavily API endpoint. Useful for corporate proxies and self-hosted Tavily-compatible search backends. Same pattern as `GROQ_BASE_URL`. |
 | `EXA_API_KEY` | Exa API key for AI-native web search and contents ([exa.ai](https://exa.ai/)) |
+| `IFLOW_API_KEY` | iFlow Search API key for web search and page fetch ([platform.iflow.cn](https://platform.iflow.cn/docs/)) |
+| `IFLOW_BASE_URL` | Override the iFlow Search API base URL (default: `https://platform.iflow.cn`). Useful for corporate proxies and private deployments. |
 | `BROWSERBASE_API_KEY` | Browser automation ([browserbase.com](https://browserbase.com/)) |
 | `BROWSERBASE_PROJECT_ID` | Browserbase project ID |
 | `BROWSER_USE_API_KEY` | Browser Use cloud browser API key ([browser-use.com](https://browser-use.com/)) |

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/reference/environment-variables.md
@@ -130,6 +130,8 @@ description: "Hermes Agent 使用的所有环境变量完整参考"
 | `SEARXNG_URL` | 免费自托管网络搜索的 SearXNG 实例 URL——无需 API 密钥（[searxng.github.io](https://searxng.github.io/searxng/)） |
 | `TAVILY_BASE_URL` | 覆盖 Tavily API 端点。适用于企业代理和自托管 Tavily 兼容搜索后端。与 `GROQ_BASE_URL` 模式相同。 |
 | `EXA_API_KEY` | Exa API 密钥，用于 AI 原生网络搜索和内容获取（[exa.ai](https://exa.ai/)） |
+| `IFLOW_API_KEY` | iFlow Search API 密钥，用于网络搜索和页面抓取（[platform.iflow.cn](https://platform.iflow.cn/docs/)） |
+| `IFLOW_BASE_URL` | 覆盖 iFlow Search API 基础 URL（默认：`https://platform.iflow.cn`）。适用于企业代理或私有部署。 |
 | `BROWSERBASE_API_KEY` | 浏览器自动化（[browserbase.com](https://browserbase.com/)） |
 | `BROWSERBASE_PROJECT_ID` | Browserbase 项目 ID |
 | `BROWSER_USE_API_KEY` | Browser Use 云浏览器 API 密钥（[browser-use.com](https://browser-use.com/)） |


### PR DESCRIPTION
## What does this PR do?

Adds **iFlow Search** as a bundled native Web Search & Extract provider (`iflow`), following the plugin architecture from #25182. Users select iFlow from the Web Search & Extract provider picker and configure `IFLOW_API_KEY` (BYOK). Maps `WebSearchProvider.search()` → `POST /api/search/webSearch` and `extract()` → `POST /api/search/webFetch` against `https://platform.iflow.cn` (override via `IFLOW_BASE_URL`).

Intentionally separate from the existing MCP-based iFlow docs route (#29632).

## Related Issue

Fixes #42646

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/web/iflow/{plugin.yaml,__init__.py,provider.py}` — `IFlowWebSearchProvider` (search + extract), BYOK
- `tools/web_tools.py` — register `iflow` in backend sets, auto-detect, availability checks
- `hermes_cli/config.py` — `IFLOW_API_KEY`, `IFLOW_BASE_URL` in `OPTIONAL_ENV_VARS`; status display
- `agent/web_search_registry.py` — legacy fallback preference order
- `tests/tools/test_web_providers_iflow.py` — dedicated provider tests (mocked httpx, no network)
- `tests/plugins/web/test_web_search_provider_plugins.py` — bundled provider set includes `iflow`
- `website/docs/reference/environment-variables.md` + zh-Hans i18n — document `IFLOW_API_KEY` / `IFLOW_BASE_URL`

## How to Test

1. Provider plugin discovery + behavior (no network):
   `uv run --extra dev pytest tests/tools/test_web_providers_iflow.py tests/plugins/web/test_web_search_provider_plugins.py -m "not integration"`
   → **74 passed**, 2 deselected
2. Lint:
   `uv run --extra dev ruff check plugins/web/iflow tests/tools/test_web_providers_iflow.py hermes_cli/config.py`
   → **All checks passed**
3. Live BYOK smoke (requires `IFLOW_API_KEY`, outside pytest hermetic env):
   - `webSearch("Hermes Agent", limit=1)` → success
   - `webFetch(["https://example.com"])` → success
   - Direct `POST https://platform.iflow.cn/api/search/webSearch` → HTTP 200

Note: `pytest -m integration` skips by design because root `conftest.py` strips credential env vars.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs / issues to avoid duplicates
- [x] My PR contains only changes related to this feature
- [x] Scoped provider tests pass (74 passed); full `pytest tests/ -q` pending upstream CI after workflow approval
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS / Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`environment-variables.md`, en + zh-Hans)
- [x] `cli-config.yaml.example` — N/A (only new `web.backend` value `iflow`)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — pure-Python httpx provider
- [x] Tool descriptions/schemas — N/A (reuses existing `web_search`/`web_extract` schemas)

Closes #42646