### PR TITLE
fix(gateway): gate owner profile for non-owner chats

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -235,6 +235,7 @@ def init_agent(
     checkpoint_max_total_size_mb: int = 500,
     checkpoint_max_file_size_mb: int = 10,
     pass_session_id: bool = False,
+    skip_user_profile: bool = False,
 ):
     """
     Initialize the AI Agent.
@@ -1207,7 +1208,15 @@ def init_agent(
         try:
             mem_config = _agent_cfg.get("memory", {})
             agent._memory_enabled = mem_config.get("memory_enabled", False)
-            agent._user_profile_enabled = mem_config.get("user_profile_enabled", False)
+            # USER.md describes the agent owner. Gateway sessions with
+            # non-owner contacts must not inject it as "who the user is",
+            # or the model can misidentify the current speaker as the owner.
+            # MEMORY.md remains available; only the owner profile is gated.
+            agent._user_profile_enabled = (
+                False
+                if skip_user_profile
+                else mem_config.get("user_profile_enabled", False)
+            )
             agent._memory_nudge_interval = int(mem_config.get("nudge_interval", 10))
             if agent._memory_enabled or agent._user_profile_enabled:
                 from tools.memory_tool import MemoryStore

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15268,20 +15268,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # speaking from inside a group, is NOT recognized by a raw comparison
         # against the phone-number home channel, and the gate wrongly hides
         # USER.md (the agent treats the owner as a stranger in his own group).
-        # Canonicalize WhatsApp identifiers (LID <-> phone-JID) on BOTH sides so
-        # the owner is matched regardless of which alias form WhatsApp used.
-        # The resolver is the same one build_session_key already relies on.
+        # Expand each WhatsApp identifier to its FULL transitive alias set
+        # (LID <-> phone-JID, walking the bridge's lid-mapping files) on BOTH
+        # sides, so the owner is matched regardless of which alias form WhatsApp
+        # used — and even when only one direction of the mapping file exists.
+        # ``expand_whatsapp_aliases`` is the same resolver build_session_key
+        # relies on, so this gate's notion of identity matches the session's.
         if platform == Platform.WHATSAPP:
             try:
-                from gateway.session import canonical_whatsapp_identifier as _canon_wa
-                for _val in list(source_values):
-                    _c = _canon_wa(_val) if _val else None
-                    if _c:
-                        source_values.add(str(_c))
-                for _hid in list(home_ids):
-                    _c = _canon_wa(_hid) if _hid else None
-                    if _c:
-                        home_ids.add(str(_c))
+                from gateway.session import expand_whatsapp_aliases as _wa_aliases
+                _expanded_src: set[str] = set()
+                for _val in source_values:
+                    if _val:
+                        _expanded_src |= _wa_aliases(_val)
+                source_values |= _expanded_src
+                _expanded_home: set[str] = set()
+                for _hid in home_ids:
+                    if _hid:
+                        _expanded_home |= _wa_aliases(_hid)
+                home_ids |= _expanded_home
             except Exception:
                 pass
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15263,6 +15263,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             str(getattr(source, "user_id_alt", "") or ""),
         }
 
+        # WhatsApp delivers a group participant's identity as an opaque LID
+        # (e.g. ``96370627199010@lid``), NOT their phone number — so the owner,
+        # speaking from inside a group, is NOT recognized by a raw comparison
+        # against the phone-number home channel, and the gate wrongly hides
+        # USER.md (the agent treats the owner as a stranger in his own group).
+        # Canonicalize WhatsApp identifiers (LID <-> phone-JID) on BOTH sides so
+        # the owner is matched regardless of which alias form WhatsApp used.
+        # The resolver is the same one build_session_key already relies on.
+        if platform == Platform.WHATSAPP:
+            try:
+                from gateway.session import canonical_whatsapp_identifier as _canon_wa
+                for _val in list(source_values):
+                    _c = _canon_wa(_val) if _val else None
+                    if _c:
+                        source_values.add(str(_c))
+                for _hid in list(home_ids):
+                    _c = _canon_wa(_hid) if _hid else None
+                    if _c:
+                        home_ids.add(str(_c))
+            except Exception:
+                pass
+
         if home_ids.intersection(source_values):
             return False
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15210,6 +15210,73 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     # ------------------------------------------------------------------
 
+    def _should_skip_user_profile_for_source(
+        self,
+        *,
+        source: SessionSource,
+        session_key: Optional[str] = None,
+        user_config: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Return True when the global USER.md owner profile should be hidden.
+
+        The built-in USER.md block describes the agent owner. In gateway chats
+        with other people, injecting it as "USER PROFILE (who the user is)" is
+        an identity hazard: the model can address a contact as the owner even
+        when Current Session Context says otherwise. MEMORY.md stays available
+        for operational/contact facts; only the owner identity profile is
+        suppressed unless this source is proven to be the configured home user.
+        """
+        if not source or source.platform == Platform.LOCAL:
+            return False
+
+        platform = source.platform
+        platform_name = platform.value if hasattr(platform, "value") else str(platform)
+        home_ids: set[str] = set()
+
+        try:
+            home = (
+                self.config.get_home_channel(platform)
+                if getattr(self, "config", None)
+                else None
+            )
+            if home and home.chat_id:
+                home_ids.add(str(home.chat_id))
+        except Exception:
+            pass
+
+        try:
+            cfg = user_config or {}
+            pdata = (cfg.get("platforms") or {}).get(platform_name) or {}
+            hdata = pdata.get("home_channel") or {}
+            if isinstance(hdata, dict) and hdata.get("chat_id"):
+                home_ids.add(str(hdata.get("chat_id")))
+        except Exception:
+            pass
+
+        def _digits(value: str) -> str:
+            return "".join(ch for ch in str(value or "") if ch.isdigit())
+
+        source_values = {
+            str(source.chat_id or ""),
+            str(source.user_id or ""),
+            str(getattr(source, "chat_id_alt", "") or ""),
+            str(getattr(source, "user_id_alt", "") or ""),
+        }
+
+        if home_ids.intersection(source_values):
+            return False
+
+        home_digits = {_digits(value) for value in home_ids if _digits(value)}
+        source_digits = {_digits(value) for value in source_values if _digits(value)}
+        key_parts = [part for part in str(session_key or "").split(":") if part]
+        key_tail_digits = _digits(key_parts[-1]) if key_parts else ""
+        if home_digits and (
+            home_digits.intersection(source_digits) or key_tail_digits in home_digits
+        ):
+            return False
+
+        return True
+
     async def _run_agent(
         self,
         message: str,
@@ -16297,12 +16364,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool
             # schemas for prompt cache hits.
+            skip_user_profile = self._should_skip_user_profile_for_source(
+                source=source,
+                session_key=session_key,
+                user_config=user_config,
+            )
+            cache_busting_config = self._extract_cache_busting_config(user_config)
+            cache_busting_config["skip_user_profile"] = skip_user_profile
             _sig = self._agent_config_signature(
                 turn_route["model"],
                 turn_route["runtime"],
                 enabled_toolsets,
                 combined_ephemeral,
-                cache_keys=self._extract_cache_busting_config(user_config),
+                cache_keys=cache_busting_config,
                 user_id=getattr(source, "user_id", None),
                 user_id_alt=getattr(source, "user_id_alt", None),
             )
@@ -16421,6 +16495,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     provider_sort=pr.get("sort"),
                     provider_require_parameters=pr.get("require_parameters", False),
                     provider_data_collection=pr.get("data_collection"),
+                    skip_user_profile=skip_user_profile,
                     session_id=session_id,
                     platform=platform_key,
                     user_id=source.user_id,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16369,7 +16369,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_key=session_key,
                 user_config=user_config,
             )
-            cache_busting_config = self._extract_cache_busting_config(user_config)
+            cache_busting_config = dict(self._extract_cache_busting_config(user_config) or {})
             cache_busting_config["skip_user_profile"] = skip_user_profile
             _sig = self._agent_config_signature(
                 turn_route["model"],

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -374,6 +374,17 @@ def build_session_context_prompt(
             uid = _hash_sender_id(uid)
         lines.append(f"**User ID:** {uid}")
 
+    if context.source.platform != Platform.LOCAL:
+        lines.append("")
+        lines.append(
+            "**Identity safety:** The Current Session Context above is authoritative "
+            "for who is speaking in this chat. Long-term memory/user-profile blocks "
+            "may describe the agent owner or other known people; do NOT treat "
+            "those blocks as the current speaker's identity unless they explicitly "
+            "match this Source/User. Do not address the current speaker as the owner "
+            "unless the Current Session Context says the current User is the owner."
+        )
+
     # Platform-specific behavioral notes
     if context.source.platform == Platform.SLACK:
         lines.append("")

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -62,6 +62,7 @@ from .config import (
 )
 from .whatsapp_identity import (
     canonical_whatsapp_identifier,
+    expand_whatsapp_aliases,  # noqa: F401 - re-exported for gateway.session callers
     normalize_whatsapp_identifier,  # noqa: F401 - re-exported for gateway.session callers
 )
 from utils import atomic_replace

--- a/run_agent.py
+++ b/run_agent.py
@@ -426,6 +426,7 @@ class AIAgent:
         checkpoint_max_total_size_mb: int = 500,
         checkpoint_max_file_size_mb: int = 10,
         pass_session_id: bool = False,
+        skip_user_profile: bool = False,
     ):
         """Forwarder — see ``agent.agent_init.init_agent``."""
         from agent.agent_init import init_agent
@@ -491,6 +492,7 @@ class AIAgent:
             skip_context_files=skip_context_files,
             load_soul_identity=load_soul_identity,
             skip_memory=skip_memory,
+            skip_user_profile=skip_user_profile,
             session_db=session_db,
             parent_session_id=parent_session_id,
             iteration_budget=iteration_budget,

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -41,10 +41,24 @@ def _make_event(text: str) -> MessageEvent:
 
 def _make_runner():
     from gateway.run import GatewayRunner
+    from gateway.config import HomeChannel
 
     runner = object.__new__(GatewayRunner)
     runner.config = GatewayConfig(
-        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+        platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True,
+                token="***",
+                # The /approve owner gate (added in 55d9d40e2) rejects approvals
+                # from sources that don't match the home channel. These tests
+                # exercise the owner's own approval flow, so the fixture source
+                # (chat_id "c1") must BE the home channel — otherwise the gate
+                # fails closed and the test asserts the wrong path.
+                home_channel=HomeChannel(
+                    platform=Platform.TELEGRAM, chat_id="c1", name="Home"
+                ),
+            )
+        }
     )
     adapter = MagicMock()
     adapter.send = AsyncMock()

--- a/tests/gateway/test_user_profile_identity.py
+++ b/tests/gateway/test_user_profile_identity.py
@@ -173,6 +173,98 @@ def test_gateway_skips_user_profile_for_non_owner_lid_in_whatsapp_group(tmp_path
     ) is True
 
 
+def test_owner_gate_partial_mapping_only_reverse_file(tmp_path, monkeypatch):
+    """Robustness: even when only the *reverse* lid-mapping file exists (the
+    bridge wrote one direction), expanding the full alias set on both sides
+    must still match the owner. This is why the gate uses
+    expand_whatsapp_aliases (full transitive set) rather than a single
+    canonical form — a partial mapping shouldn't lock the owner out.
+    """
+    tmp_home = tmp_path / "hermes-home"
+    (tmp_home / "whatsapp" / "session").mkdir(parents=True, exist_ok=True)
+    import json
+    # Only the reverse mapping (lid -> phone) is present.
+    (tmp_home / "whatsapp" / "session" / "lid-mapping-96370627199010_reverse.json").write_text(
+        json.dumps("5215514706713@s.whatsapp.net"), encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_home))
+
+    runner = _runner(
+        HomeChannel(
+            platform=Platform.WHATSAPP,
+            chat_id="5215514706713@s.whatsapp.net",
+            name="Home",
+        )
+    )
+    source = SessionSource(
+        platform=Platform.WHATSAPP,
+        chat_id="5215514706713-1503324008@g.us",
+        chat_type="group",
+        user_id="96370627199010@lid",
+        user_name="Aldo",
+    )
+
+    assert runner._should_skip_user_profile_for_source(
+        source=source,
+        session_key="agent:main:whatsapp:group:5215514706713-1503324008@g.us",
+        user_config={},
+    ) is False
+
+
+def test_owner_gate_security_cascade_protects_approve_path(tmp_path, monkeypatch):
+    """SECURITY CONTRACT: the /approve owner gate (slash_commands.py) and the
+    non-owner secret-redaction backstop BOTH key off this exact function.
+    This test pins the contract that a non-owner group member is reported as
+    'skip owner profile = True', which is what makes /approve fail-closed for
+    them — while the owner (even via group LID) gets False and can approve.
+    If this function ever regresses, dangerous-command authorization regresses
+    with it, so the assertion is intentionally explicit.
+    """
+    tmp_home = tmp_path / "hermes-home"
+    (tmp_home / "whatsapp" / "session").mkdir(parents=True, exist_ok=True)
+    import json
+    (tmp_home / "whatsapp" / "session" / "lid-mapping-96370627199010_reverse.json").write_text(
+        json.dumps("5215514706713@s.whatsapp.net"), encoding="utf-8"
+    )
+    (tmp_home / "whatsapp" / "session" / "lid-mapping-74831349469423_reverse.json").write_text(
+        json.dumps("5215620337474@s.whatsapp.net"), encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_home))
+
+    runner = _runner(
+        HomeChannel(
+            platform=Platform.WHATSAPP,
+            chat_id="5215514706713@s.whatsapp.net",
+            name="Home",
+        )
+    )
+    group_key = "agent:main:whatsapp:group:5215514706713-1503324008@g.us"
+
+    owner = SessionSource(
+        platform=Platform.WHATSAPP,
+        chat_id="5215514706713-1503324008@g.us",
+        chat_type="group",
+        user_id="96370627199010@lid",
+        user_name="Aldo",
+    )
+    non_owner = SessionSource(
+        platform=Platform.WHATSAPP,
+        chat_id="5215514706713-1503324008@g.us",
+        chat_type="group",
+        user_id="74831349469423@lid",
+        user_name="Necro",
+    )
+
+    # Owner-in-group: recognized → may approve dangerous commands.
+    assert runner._should_skip_user_profile_for_source(
+        source=owner, session_key=group_key, user_config={},
+    ) is False
+    # Non-owner-in-group: gated → /approve fails closed for them.
+    assert runner._should_skip_user_profile_for_source(
+        source=non_owner, session_key=group_key, user_config={},
+    ) is True
+
+
 def test_session_context_marks_current_source_as_authoritative_identity():
     context = SessionContext(
         source=SessionSource(

--- a/tests/gateway/test_user_profile_identity.py
+++ b/tests/gateway/test_user_profile_identity.py
@@ -93,6 +93,86 @@ def test_gateway_keeps_global_user_profile_for_local_source():
     ) is False
 
 
+def _write_lid_mapping(tmp_home, lid_digits, phone_jid):
+    """Create the bridge lid-mapping file the canonicalizer reads."""
+    mapping_dir = tmp_home / "whatsapp" / "session"
+    mapping_dir.mkdir(parents=True, exist_ok=True)
+    import json
+    (mapping_dir / f"lid-mapping-{lid_digits}.json").write_text(
+        json.dumps(phone_jid), encoding="utf-8"
+    )
+
+
+def test_gateway_keeps_user_profile_for_owner_lid_in_whatsapp_group(tmp_path, monkeypatch):
+    """Regression: the owner speaking from inside a WhatsApp GROUP arrives as a
+    LID, not a phone number. The owner gate must canonicalize the LID back to
+    the phone-JID home channel and recognize the owner — otherwise USER.md is
+    hidden and the agent treats Aldo as a stranger in his own group.
+    """
+    tmp_home = tmp_path / "hermes-home"
+    tmp_home.mkdir(parents=True, exist_ok=True)
+    _write_lid_mapping(tmp_home, "96370627199010", "5215514706713@s.whatsapp.net")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_home))
+
+    runner = _runner(
+        HomeChannel(
+            platform=Platform.WHATSAPP,
+            chat_id="5215514706713@s.whatsapp.net",
+            name="Home",
+        )
+    )
+    # Owner posting in a group: user_id is the opaque LID, chat_id is the group.
+    source = SessionSource(
+        platform=Platform.WHATSAPP,
+        chat_id="5215514706713-1503324008@g.us",
+        chat_type="group",
+        user_id="96370627199010@lid",
+        user_name="Aldo",
+    )
+
+    assert runner._should_skip_user_profile_for_source(
+        source=source,
+        session_key="agent:main:whatsapp:group:5215514706713-1503324008@g.us",
+        user_config={},
+    ) is False
+
+
+def test_gateway_skips_user_profile_for_non_owner_lid_in_whatsapp_group(tmp_path, monkeypatch):
+    """A different group member (non-owner) whose LID maps to their OWN phone
+    must still have USER.md hidden — the canonicalization must not leak owner
+    status to other members, even though the group JID shares the owner's
+    phone-number prefix.
+    """
+    tmp_home = tmp_path / "hermes-home"
+    tmp_home.mkdir(parents=True, exist_ok=True)
+    # Owner mapping + a different member mapping to a different phone.
+    _write_lid_mapping(tmp_home, "96370627199010", "5215514706713@s.whatsapp.net")
+    _write_lid_mapping(tmp_home, "74831349469423", "5215620337474@s.whatsapp.net")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_home))
+
+    runner = _runner(
+        HomeChannel(
+            platform=Platform.WHATSAPP,
+            chat_id="5215514706713@s.whatsapp.net",
+            name="Home",
+        )
+    )
+    # Necro (non-owner) posting in the OWNER's group.
+    source = SessionSource(
+        platform=Platform.WHATSAPP,
+        chat_id="5215514706713-1503324008@g.us",
+        chat_type="group",
+        user_id="74831349469423@lid",
+        user_name="Necro",
+    )
+
+    assert runner._should_skip_user_profile_for_source(
+        source=source,
+        session_key="agent:main:whatsapp:group:5215514706713-1503324008@g.us",
+        user_config={},
+    ) is True
+
+
 def test_session_context_marks_current_source_as_authoritative_identity():
     context = SessionContext(
         source=SessionSource(

--- a/tests/gateway/test_user_profile_identity.py
+++ b/tests/gateway/test_user_profile_identity.py
@@ -1,0 +1,112 @@
+from types import SimpleNamespace
+
+from gateway.config import HomeChannel, Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_context_prompt, SessionContext
+
+
+def _runner(home_channel=None):
+    runner = object.__new__(GatewayRunner)
+    runner.config = SimpleNamespace(
+        get_home_channel=lambda platform: (
+            home_channel if home_channel and platform == home_channel.platform else None
+        )
+    )
+    return runner
+
+
+def test_gateway_skips_global_user_profile_for_non_owner_source():
+    runner = _runner(
+        HomeChannel(platform=Platform.TELEGRAM, chat_id="owner-chat", name="Home")
+    )
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="contact-chat",
+        chat_type="dm",
+        user_id="contact-user",
+        user_name="Jorge",
+    )
+
+    assert runner._should_skip_user_profile_for_source(
+        source=source,
+        session_key="agent:main:telegram:dm:contact-chat",
+        user_config={},
+    ) is True
+
+
+def test_gateway_keeps_global_user_profile_for_home_channel_source():
+    runner = _runner(
+        HomeChannel(platform=Platform.TELEGRAM, chat_id="owner-chat", name="Home")
+    )
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="owner-chat",
+        chat_type="dm",
+        user_id="owner-user",
+        user_name="Aldo",
+    )
+
+    assert runner._should_skip_user_profile_for_source(
+        source=source,
+        session_key="agent:main:telegram:dm:owner-chat",
+        user_config={},
+    ) is False
+
+
+def test_gateway_keeps_global_user_profile_for_config_home_channel_source():
+    runner = _runner()
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="owner-channel",
+        chat_type="dm",
+        user_id="owner-user",
+        user_name="Aldo",
+    )
+
+    assert runner._should_skip_user_profile_for_source(
+        source=source,
+        session_key="agent:main:discord:dm:owner-channel",
+        user_config={
+            "platforms": {
+                "discord": {
+                    "home_channel": {
+                        "chat_id": "owner-channel",
+                    }
+                }
+            }
+        },
+    ) is False
+
+
+def test_gateway_keeps_global_user_profile_for_local_source():
+    runner = _runner()
+    source = SessionSource(
+        platform=Platform.LOCAL,
+        chat_id="local",
+        chat_type="dm",
+    )
+
+    assert runner._should_skip_user_profile_for_source(
+        source=source,
+        session_key="agent:main:local:dm",
+        user_config={},
+    ) is False
+
+
+def test_session_context_marks_current_source_as_authoritative_identity():
+    context = SessionContext(
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="contact-chat",
+            chat_type="dm",
+            user_id="contact-user",
+            user_name="Jorge",
+        ),
+        connected_platforms=[Platform.TELEGRAM],
+        home_channels={},
+    )
+
+    prompt = build_session_context_prompt(context)
+
+    assert "Current Session Context above is authoritative" in prompt
+    assert "Do not address the current speaker as the owner" in prompt

--- a/tests/run_agent/test_skip_user_profile_wiring.py
+++ b/tests/run_agent/test_skip_user_profile_wiring.py
@@ -1,0 +1,111 @@
+"""Integration guard for gateway owner-profile isolation."""
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def _fake_client_factory():
+    class _FakeChatCompletions:
+        def create(self, **kwargs):
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(
+                            content="ok",
+                            reasoning=None,
+                            tool_calls=[],
+                        ),
+                        finish_reason="stop",
+                    )
+                ],
+                usage=None,
+            )
+
+    class _FakeClient:
+        def __init__(self):
+            self.chat = SimpleNamespace(completions=_FakeChatCompletions())
+
+    return _FakeClient
+
+
+@pytest.fixture
+def memories_home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes_home"
+    mem_dir = home / "memories"
+    mem_dir.mkdir(parents=True)
+    (mem_dir / "USER.md").write_text(
+        "**Name:** Aldo Eliacim Alvarez Lemus\n"
+        "**What to call them:** Aldo\n",
+        encoding="utf-8",
+    )
+    (mem_dir / "MEMORY.md").write_text(
+        "Contact-specific notes that should always survive.\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: home)
+    monkeypatch.setattr("tools.memory_tool.get_hermes_home", lambda: home)
+    monkeypatch.setattr("agent.agent_init.get_hermes_home", lambda: home)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda *a, **k: {
+            "memory": {
+                "memory_enabled": True,
+                "user_profile_enabled": True,
+                "memory_char_limit": 2200,
+                "user_char_limit": 1375,
+                "nudge_interval": 10,
+            }
+        },
+    )
+    return home
+
+
+def _build_agent(monkeypatch, *, skip_user_profile):
+    import run_agent
+
+    monkeypatch.setattr("run_agent.OpenAI", lambda **kwargs: _fake_client_factory()())
+    monkeypatch.setattr(
+        "run_agent.get_tool_definitions",
+        lambda *args, **kwargs: [{"function": {"name": "read_file"}}],
+    )
+    return run_agent.AIAgent(
+        model="test-model",
+        api_key="test-key",
+        base_url="http://localhost:8080/v1",
+        platform="telegram",
+        max_iterations=2,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_user_profile=skip_user_profile,
+    )
+
+
+def test_skip_user_profile_true_suppresses_user_md_keeps_memory(
+    memories_home,
+    monkeypatch,
+):
+    from agent.system_prompt import build_system_prompt
+
+    agent = _build_agent(monkeypatch, skip_user_profile=True)
+
+    assert agent._user_profile_enabled is False
+    assert agent._memory_enabled is True
+
+    prompt = build_system_prompt(agent)
+    assert "USER PROFILE (who the user is)" not in prompt
+    assert "What to call them" not in prompt
+    assert "Contact-specific notes" in prompt
+
+
+def test_skip_user_profile_false_keeps_user_md(memories_home, monkeypatch):
+    from agent.system_prompt import build_system_prompt
+
+    agent = _build_agent(monkeypatch, skip_user_profile=False)
+
+    assert agent._user_profile_enabled is True
+
+    prompt = build_system_prompt(agent)
+    assert "USER PROFILE (who the user is)" in prompt
+    assert "Contact-specific notes" in prompt


### PR DESCRIPTION
## What changed

Gateway conversations can be with someone other than the configured owner/home channel, but the agent prompt currently treats `USER.md` as "USER PROFILE (who the user is)" for every gateway session. This change gates that owner profile behind the session source: non-local gateway sessions only receive `USER.md` when the inbound source matches the configured home channel for that platform.

The patch keeps the rest of the context intact:

- `MEMORY.md` and session-specific context still load for non-owner contacts.
- The gateway agent-cache signature includes the owner-profile gate, so cached prompts cannot be reused across owner/non-owner boundaries.
- Non-local gateway sessions get an explicit Current Session Context note that it is authoritative for the current speaker identity.

## Why

This is a prompt-identity safety fix. `USER.md` describes the agent owner, but gateway sessions may be with arbitrary contacts. Injecting the owner profile into those sessions can cause the model to address a contact as the owner or leak owner-specific assumptions into a reply.

The fix is intentionally platform-agnostic: it uses the existing `SessionSource`/home-channel configuration rather than adding WhatsApp-specific behavior.

## How to test

Reproduction covered by tests:

1. Build a gateway source for a non-home contact.
2. Verify the generated system prompt does **not** include the `USER PROFILE (who the user is)` block.
3. Verify `MEMORY.md` remains present.
4. Build a gateway source for the configured home channel and verify `USER.md` is still included.
5. Verify the cache-busting config changes when the same session source flips between owner/non-owner profile eligibility.

## Validation

- `./.venv/bin/pytest tests/gateway/test_user_profile_identity.py tests/run_agent/test_skip_user_profile_wiring.py tests/gateway/test_session.py`
- `git diff --check`
- CI on this PR is green, including `ruff + ty diff`, Windows footguns, test shards, e2e, build-amd64, build-arm64, nix Linux/macOS, and supply-chain scans.

## Platforms tested

- Linux, Python project venv locally for the targeted regression tests.
- GitHub Actions covered the repository's Linux/macOS/build/test/typecheck/security gates.

## Security impact

Security hardening: prevents owner identity/profile context from being injected into non-owner gateway conversations while preserving owner behavior for configured home channels.