### PR TITLE
fix(kanban): keep initial_status=blocked tasks blocked across recompute_ready

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2280,6 +2280,18 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                     },
                 )
+                # A task parked directly in blocked (initial_status="blocked")
+                # needs an explicit "blocked" event so _has_sticky_block() treats
+                # it as sticky — otherwise recompute_ready() (run on every list/
+                # dispatch) auto-promotes it straight back to ready. See test
+                # test_create_task_initial_status_blocked_survives_recompute.
+                if task_status == "blocked":
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {"reason": "initial_status=blocked"},
+                    )
             return task_id
         except sqlite3.IntegrityError:
             if attempt == 1:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -213,6 +213,20 @@ def test_create_task_with_parent_is_todo_until_parent_done(kanban_home):
         assert kb.get_task(conn, c).status == "ready"
 
 
+def test_create_task_initial_status_blocked_survives_recompute(kanban_home):
+    """initial_status='blocked' must stay blocked after recompute_ready.
+
+    Regression: a card created with --initial-status blocked only emitted a
+    "created" event, so _has_sticky_block() returned False and recompute_ready
+    (called on every `list`) auto-promoted it to ready → unwanted auto-dispatch.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="stay blocked", initial_status="blocked")
+        assert kb.get_task(conn, tid).status == "blocked"
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, tid).status == "blocked"
+
+
 def test_create_task_unknown_parent_errors(kanban_home):
     with kb.connect() as conn, pytest.raises(ValueError, match="unknown parent"):
         kb.create_task(conn, title="orphan", parents=["t_ghost"])


### PR DESCRIPTION
## Problem
`hermes kanban create --initial-status blocked` reports the card as blocked, but it
lands in `ready` — and the dispatcher immediately picks it up. Backlog items meant
to stay parked get auto-dispatched.

## Root cause
`create_task()` writes `status='blocked'` for `initial_status="blocked"` but only
emits a `created` event. `_has_sticky_block()` looks for a `blocked`/`unblocked`
event, finds none, returns `False`, so `recompute_ready()` (run on every
`kanban list` and by the dispatcher) auto-promotes the card back to `ready`.

## Fix
Emit an explicit `blocked` event at create time when `initial_status="blocked"`, so
`_has_sticky_block()` treats the card as sticky and `recompute_ready()` leaves it
parked. Adds a regression test.

## Tests
- New `test_create_task_initial_status_blocked_survives_recompute` — fails before, passes after.
- Full `tests/hermes_cli/test_kanban_db.py`: 215 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
