### PR TITLE
fix(telegram): restore reply context for replies to rich messages

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -14,8 +14,10 @@ import json
 import logging
 import os
 import tempfile
+import time
 import html as _html
 import re
+from collections import OrderedDict
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Any
 
@@ -358,6 +360,15 @@ class TelegramAdapter(BasePlatformAdapter):
     # When a chunk is near this limit, a continuation is almost certain.
     _SPLIT_THRESHOLD = 4000
     MEDIA_GROUP_WAIT_SECONDS = 0.8
+    # Outbound reply-context cache bounds. Telegram exposes
+    # message.reply_to_message.message_id for replies to rich (sendRichMessage)
+    # messages but leaves .text/.caption empty, so the inbound extractor has no
+    # body to quote. We remember a bounded snippet of what we sent, keyed by
+    # (chat_id, message_id), and fall back to it on reply. Three independent
+    # caps keep the cache from growing without bound.
+    _OUTBOUND_CTX_MAX_ENTRIES = 1024
+    _OUTBOUND_CTX_MAX_CHARS = 2000
+    _OUTBOUND_CTX_TTL_SECONDS = 48 * 60 * 60  # 48 hours
     _GENERAL_TOPIC_THREAD_ID = "1"
 
     # Telegram's edit_message applies MarkdownV2 formatting only on the
@@ -511,6 +522,86 @@ class TelegramAdapter(BasePlatformAdapter):
         # Tracks status bubbles owned by this adapter so subsequent calls with the
         # same key edit the same message instead of appending new ones (#30045).
         self._status_message_ids: Dict[tuple, str] = {}
+        # Bounded, TTL-expiring snippets of recently sent outbound content,
+        # keyed by (chat_id, message_id). Restores reply context when a user
+        # replies to a rich (sendRichMessage) message whose body does not
+        # round-trip through reply_to_message.text/.caption (#46515-adjacent
+        # rich-reply parity).
+        self._outbound_reply_context: "OrderedDict[tuple[str, str], tuple[str, float]]" = OrderedDict()
+
+    def _outbound_context_cache(self) -> "OrderedDict[tuple[str, str], tuple[str, float]]":
+        """Return the outbound reply-context cache, initializing it on demand.
+
+        The adapter is occasionally built via ``object.__new__`` (notably in
+        send-path tests) which bypasses ``__init__``, so the helpers must not
+        assume the attribute already exists.
+        """
+        cache = getattr(self, "_outbound_reply_context", None)
+        if cache is None:
+            cache = OrderedDict()
+            self._outbound_reply_context = cache
+        return cache
+
+    def _remember_outbound_context(
+        self, chat_id: Any, message_id: Any, content: Optional[str]
+    ) -> None:
+        """Remember a bounded snippet of an outbound message for reply context.
+
+        Keyed by (str(chat_id), str(message_id)). No-op when the id or content
+        is missing. Caps the snippet, prunes expired entries, and evicts the
+        oldest entries past the size cap so the cache cannot grow unbounded.
+        """
+        if not message_id or not content:
+            return
+        key = (str(chat_id), str(message_id))
+        snippet = content[: self._OUTBOUND_CTX_MAX_CHARS]
+        now = time.monotonic()
+        cache = self._outbound_context_cache()
+        self._prune_outbound_context(now)
+        cache[key] = (snippet, now)
+        # Keep the freshest entry at the tail even when updating an existing key
+        # (new keys land at the tail automatically; value-updates do not move).
+        cache.move_to_end(key)
+        while len(cache) > self._OUTBOUND_CTX_MAX_ENTRIES:
+            cache.popitem(last=False)
+
+    def _prune_outbound_context(self, now: Optional[float] = None) -> None:
+        """Drop entries older than the TTL.
+
+        Called on every write. The read path (_lookup_outbound_context) does a
+        per-entry TTL check on the single fetched key instead of a full scan.
+        """
+        cache = self._outbound_context_cache()
+        if not cache:
+            return
+        if now is None:
+            now = time.monotonic()
+        ttl = self._OUTBOUND_CTX_TTL_SECONDS
+        expired = [k for k, (_, ts) in cache.items() if now - ts > ttl]
+        for k in expired:
+            cache.pop(k, None)
+
+    def _lookup_outbound_context(
+        self, chat_id: Any, message_id: Any
+    ) -> Optional[str]:
+        """Return the remembered snippet for (chat_id, message_id), or None.
+
+        Expired entries are dropped on access so a stale snippet is never
+        returned. This is a last-resort fallback only; native quotes and real
+        reply_to_message text always take precedence at the call site.
+        """
+        if not message_id:
+            return None
+        key = (str(chat_id), str(message_id))
+        cache = self._outbound_context_cache()
+        entry = cache.get(key)
+        if entry is None:
+            return None
+        snippet, ts = entry
+        if time.monotonic() - ts > self._OUTBOUND_CTX_TTL_SECONDS:
+            cache.pop(key, None)
+            return None
+        return snippet
 
     def _notification_kwargs(
         self, metadata: Optional[Dict[str, Any]]
@@ -2235,6 +2326,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 rich_result = await self._try_send_rich(chat_id, content, reply_to, metadata)
                 if rich_result is not None:
                     if rich_result.success:
+                        # Remember the delivered rich content so a later reply
+                        # recovers context: rich sends carry no legacy text
+                        # field that would round-trip via reply_to_message.text.
+                        self._remember_outbound_context(
+                            chat_id, rich_result.message_id, content
+                        )
                         # Re-trigger typing like the legacy success path does.
                         try:
                             await self.send_typing(chat_id, metadata=metadata)
@@ -2456,6 +2553,12 @@ class TelegramAdapter(BasePlatformAdapter):
                                 continue
                         raise
                 message_ids.append(str(msg.message_id))
+
+            # Remember the delivered content under every chunk id so a later
+            # reply to any chunk recovers reply context, even when Telegram
+            # exposes no quotable body (parity with the rich path above).
+            for mid in message_ids:
+                self._remember_outbound_context(chat_id, mid, content)
 
             # Re-trigger typing indicator after sending a message.
             # Telegram clears the typing state when a new message is delivered,
@@ -6581,6 +6684,15 @@ class TelegramAdapter(BasePlatformAdapter):
                     or message.reply_to_message.caption
                     or None
                 )
+                if reply_to_text is None:
+                    # Rich (sendRichMessage) bodies do not round-trip through
+                    # reply_to_message.text/.caption, so the reply pointer would
+                    # otherwise carry no context. Fall back to the snippet we
+                    # cached when we sent the message. Last resort only: the
+                    # native quote and the real text/caption always win above.
+                    reply_to_text = self._lookup_outbound_context(
+                        chat.id, reply_to_id
+                    )
 
         # Per-channel/topic ephemeral prompt
         from gateway.platforms.base import resolve_channel_prompt

--- a/tests/gateway/test_telegram_rich_reply_context.py
+++ b/tests/gateway/test_telegram_rich_reply_context.py
@@ -1,0 +1,368 @@
+"""Tests for the Telegram outbound reply-context cache.
+
+When ``telegram.extra.rich_messages`` is enabled, final replies are sent via
+``sendRichMessage``. That payload carries the agent text in a ``rich_message``
+structure and no legacy ``text`` field, so a user replying to such a message
+arrives with ``message.reply_to_message.text`` / ``.caption`` empty and the
+adapter has nothing to quote. The adapter therefore remembers a bounded,
+TTL-expiring snippet of what it sent, keyed by ``(chat_id, message_id)``, and
+falls back to it in ``_build_message_event`` so ``reply_to_text`` is restored.
+
+This brings rich-message replies (and rich cron announcements) to parity with
+legacy text replies, which already round-trip through ``reply_to_message.text``.
+
+The ``telegram`` package is mocked by ``tests/gateway/conftest.py``, so these
+tests construct a real ``TelegramAdapter`` and wire a mock bot.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageType, SendResult
+from gateway.platforms.telegram import TelegramAdapter
+
+
+def _make_adapter(extra=None):
+    """Build a TelegramAdapter with a mock bot wired for both send paths."""
+    config = PlatformConfig(
+        enabled=True,
+        token="fake-token",
+        extra={"rich_messages": True, **(extra or {})},
+    )
+    adapter = TelegramAdapter(config)
+    bot = MagicMock()
+    # AsyncMock makes inspect.iscoroutinefunction(...) True so the adapter's
+    # rich-capability probe is satisfied (real Bot.do_api_request is async).
+    bot.do_api_request = AsyncMock(return_value=SimpleNamespace(message_id=123))
+    bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
+    bot.send_chat_action = AsyncMock()
+    bot.send_message_draft = AsyncMock(return_value=True)
+    adapter._bot = bot
+    return adapter
+
+
+def _make_reply_message(
+    *,
+    reply_to_id=123,
+    reply_to_text=None,
+    reply_to_caption=None,
+    quote_text=None,
+    chat_id=12345,
+    text="follow-up",
+):
+    """Build a SimpleNamespace message that IS a reply.
+
+    ``reply_to_message`` is always present (it has an id), but its ``text`` and
+    ``caption`` default to ``None`` to model a reply to a rich message.
+    """
+    chat = SimpleNamespace(id=chat_id, type="private", title=None, full_name="Alice")
+    user = SimpleNamespace(id=42, full_name="Alice")
+    reply_to_message = SimpleNamespace(
+        message_id=reply_to_id,
+        text=reply_to_text,
+        caption=reply_to_caption,
+    )
+    quote = SimpleNamespace(text=quote_text) if quote_text is not None else None
+    return SimpleNamespace(
+        chat=chat,
+        from_user=user,
+        text=text,
+        message_thread_id=None,
+        message_id=1001,
+        reply_to_message=reply_to_message,
+        quote=quote,
+        date=None,
+        forum_topic_created=None,
+    )
+
+
+# ── U1: cache helper behavior ──────────────────────────────────────────────
+
+
+def test_remember_then_lookup_roundtrip():
+    adapter = _make_adapter()
+    adapter._remember_outbound_context("chat", "10", "hello world")
+    assert adapter._lookup_outbound_context("chat", "10") == "hello world"
+
+
+def test_snippet_capped_to_max_chars():
+    adapter = _make_adapter()
+    long = "x" * (adapter._OUTBOUND_CTX_MAX_CHARS + 500)
+    adapter._remember_outbound_context("chat", "10", long)
+    stored = adapter._lookup_outbound_context("chat", "10")
+    assert stored is not None
+    assert len(stored) == adapter._OUTBOUND_CTX_MAX_CHARS
+
+
+def test_ttl_expiry_drops_entry():
+    adapter = _make_adapter()
+    adapter._remember_outbound_context("chat", "10", "stale")
+    # Backdate the stored timestamp beyond the TTL so lookup treats it expired.
+    key = ("chat", "10")
+    snippet, ts = adapter._outbound_reply_context[key]
+    expired_ts = ts - adapter._OUTBOUND_CTX_TTL_SECONDS - 1
+    adapter._outbound_reply_context[key] = (snippet, expired_ts)
+    assert adapter._lookup_outbound_context("chat", "10") is None
+    # Expired entry is dropped on access.
+    assert key not in adapter._outbound_reply_context
+
+
+def test_entry_cap_evicts_oldest():
+    adapter = _make_adapter()
+    cap = adapter._OUTBOUND_CTX_MAX_ENTRIES
+    for i in range(cap + 5):
+        adapter._remember_outbound_context("chat", str(i), f"msg-{i}")
+    assert len(adapter._outbound_reply_context) == cap
+    # The five oldest are evicted; the newest survive.
+    assert adapter._lookup_outbound_context("chat", "0") is None
+    assert adapter._lookup_outbound_context("chat", "4") is None
+    assert adapter._lookup_outbound_context("chat", str(cap + 4)) == f"msg-{cap + 4}"
+
+
+def test_remember_guards_missing_id_or_content():
+    adapter = _make_adapter()
+    adapter._remember_outbound_context("chat", None, "content")
+    adapter._remember_outbound_context("chat", "10", "")
+    adapter._remember_outbound_context("chat", "10", None)
+    assert len(adapter._outbound_reply_context) == 0
+
+
+def test_lookup_unknown_key_returns_none():
+    adapter = _make_adapter()
+    assert adapter._lookup_outbound_context("chat", "nope") is None
+    assert adapter._lookup_outbound_context("chat", None) is None
+
+
+def test_key_normalization_int_vs_str():
+    adapter = _make_adapter()
+    adapter._remember_outbound_context(12345, 123, "normalized")
+    # Stored with ints, retrieved with strings (the inbound code path uses str).
+    assert adapter._lookup_outbound_context("12345", "123") == "normalized"
+    # And the reverse direction resolves too.
+    assert adapter._lookup_outbound_context(12345, 123) == "normalized"
+
+
+# ── U2: send-path registration ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rich_send_registers_outbound_context():
+    adapter = _make_adapter()
+    content = "## Report\n\n| a | b |\n|---|---|\n| 1 | 2 |"
+
+    result = await adapter.send("12345", content)
+
+    assert result.success is True
+    assert result.message_id == "123"
+    # The rich path used sendRichMessage, and the content was remembered.
+    adapter._bot.do_api_request.assert_awaited_once()
+    assert adapter._lookup_outbound_context("12345", "123") == content
+
+
+@pytest.mark.asyncio
+async def test_legacy_single_chunk_registers_outbound_context():
+    adapter = _make_adapter(extra={"rich_messages": False})
+    content = "a short legacy reply"
+
+    result = await adapter.send("12345", content)
+
+    assert result.success is True
+    adapter._bot.send_message.assert_awaited()
+    for mid in result.raw_response["message_ids"]:
+        assert adapter._lookup_outbound_context("12345", mid) == content
+
+
+@pytest.mark.asyncio
+async def test_legacy_multichunk_registers_each_chunk():
+    adapter = _make_adapter(extra={"rich_messages": False})
+
+    counter = {"n": 0}
+
+    def _next_message(*args, **kwargs):
+        counter["n"] += 1
+        return MagicMock(message_id=counter["n"])
+
+    adapter._bot.send_message = AsyncMock(side_effect=_next_message)
+    # Force a multi-chunk split well past the 4096 single-message limit.
+    content = "B" * (adapter.MAX_MESSAGE_LENGTH * 2 + 100)
+
+    result = await adapter.send("12345", content)
+
+    assert result.success is True
+    message_ids = result.raw_response["message_ids"]
+    assert len(message_ids) >= 2
+    expected = content[: adapter._OUTBOUND_CTX_MAX_CHARS]
+    # A reply to ANY delivered chunk recovers the original content snippet.
+    for mid in message_ids:
+        assert adapter._lookup_outbound_context("12345", mid) == expected
+
+
+@pytest.mark.asyncio
+async def test_failed_or_idless_send_registers_nothing():
+    adapter = _make_adapter()
+    # Rich result shape with no message_id (success but unparseable id).
+    adapter._bot.do_api_request = AsyncMock(return_value={"result": None})
+
+    result = await adapter.send("12345", "content with no id")
+
+    assert result.message_id is None
+    assert len(adapter._outbound_reply_context) == 0
+
+
+# ── U3: inbound fallback in _build_message_event ───────────────────────────
+
+
+def test_reply_to_rich_message_uses_cached_context():
+    """The bug: rich reply has empty text/caption but a seeded cache hit."""
+    adapter = _make_adapter()
+    adapter._remember_outbound_context("12345", "123", "the original rich body")
+
+    msg = _make_reply_message(reply_to_id=123, chat_id=12345)
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.reply_to_message_id == "123"
+    assert event.reply_to_text == "the original rich body"
+
+
+def test_native_quote_wins_over_cache():
+    adapter = _make_adapter()
+    adapter._remember_outbound_context("12345", "123", "cached body")
+
+    msg = _make_reply_message(
+        reply_to_id=123,
+        chat_id=12345,
+        reply_to_text="full prior body",
+        quote_text="selected substring",
+    )
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.reply_to_text == "selected substring"
+
+
+def test_real_reply_text_wins_over_cache():
+    adapter = _make_adapter()
+    adapter._remember_outbound_context("12345", "123", "cached body")
+
+    msg = _make_reply_message(
+        reply_to_id=123, chat_id=12345, reply_to_text="real telegram text"
+    )
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.reply_to_text == "real telegram text"
+
+
+def test_cache_miss_yields_none():
+    adapter = _make_adapter()
+    msg = _make_reply_message(reply_to_id=999, chat_id=12345)
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.reply_to_message_id == "999"
+    assert event.reply_to_text is None
+
+
+def test_non_reply_message_does_not_consult_cache():
+    adapter = _make_adapter()
+    adapter._remember_outbound_context("12345", "123", "cached body")
+
+    chat = SimpleNamespace(id=12345, type="private", title=None, full_name="Alice")
+    user = SimpleNamespace(id=42, full_name="Alice")
+    msg = SimpleNamespace(
+        chat=chat,
+        from_user=user,
+        text="just a message",
+        message_thread_id=None,
+        message_id=1001,
+        reply_to_message=None,
+        quote=None,
+        date=None,
+        forum_topic_created=None,
+    )
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.reply_to_message_id is None
+    assert event.reply_to_text is None
+
+
+def test_injection_condition_satisfied_for_rich_reply():
+    """gateway/run.py injects `[Replying to: ...]` when both fields are set."""
+    adapter = _make_adapter()
+    adapter._remember_outbound_context("12345", "123", "context body")
+
+    msg = _make_reply_message(reply_to_id=123, chat_id=12345)
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert bool(event.reply_to_text) and bool(event.reply_to_message_id)
+
+
+# ── U4: end-to-end cron-announcement parity ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cron_rich_reply_recovers_context_end_to_end():
+    """Reproduce the reported bug: reply to a rich cron announcement.
+
+    Sending a `Cronjob Response: ...` body via the rich path, then replying to
+    it (with empty reply_to_message.text), must restore the cron snippet so the
+    agent knows what the user is referring to.
+    """
+    adapter = _make_adapter()
+    cron_body = "Cronjob Response: Daily Digest (job_id: abc123)\n\n- 3 PRs merged\n- 1 alert"
+
+    send_result = await adapter.send("12345", cron_body)
+    assert send_result.message_id == "123"
+
+    reply = _make_reply_message(reply_to_id=123, chat_id=12345, text="do that again")
+    event = adapter._build_message_event(reply, MessageType.TEXT)
+
+    assert event.reply_to_text == cron_body
+    assert "Cronjob Response: Daily Digest" in event.reply_to_text
+
+
+# ── Review hardening: precedence, failure path, shape-independent TTL ───────
+
+
+def test_caption_wins_over_cache():
+    """A replied-to media message exposes .caption; it must beat the cache."""
+    adapter = _make_adapter()
+    adapter._remember_outbound_context("12345", "123", "cached body")
+
+    msg = _make_reply_message(
+        reply_to_id=123,
+        chat_id=12345,
+        reply_to_text=None,
+        reply_to_caption="a media caption",
+    )
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.reply_to_text == "a media caption"
+
+
+@pytest.mark.asyncio
+async def test_rich_send_failure_registers_nothing():
+    """A rich send that fails (success=False) must not populate the cache."""
+    adapter = _make_adapter()
+    adapter._try_send_rich = AsyncMock(
+        return_value=SendResult(success=False, error="transient", retryable=True)
+    )
+
+    result = await adapter.send("12345", "rich body that failed to send")
+
+    assert result.success is False
+    assert len(adapter._outbound_context_cache()) == 0
+
+
+def test_ttl_expiry_via_clock_advance(monkeypatch):
+    """Shape-independent TTL test: advance the monotonic clock past the TTL."""
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(
+        "gateway.platforms.telegram.time.monotonic", lambda: clock["t"]
+    )
+    adapter = _make_adapter()
+    adapter._remember_outbound_context("c", "m", "fresh")
+    assert adapter._lookup_outbound_context("c", "m") == "fresh"
+
+    clock["t"] += adapter._OUTBOUND_CTX_TTL_SECONDS + 1
+    assert adapter._lookup_outbound_context("c", "m") is None


### PR DESCRIPTION
## What does this PR do?

When `telegram.extra.rich_messages: true` is enabled (Bot API 10.1 `sendRichMessage`, added in #44829), final replies are sent with the agent text in a `rich_message` payload and no legacy `text` field. A user replying to one of those messages arrives with `reply_to_message.text` and `.caption` empty, so `_build_message_event` sets `reply_to_text=None` and `gateway/run.py` injects no `[Replying to: "..."]` pointer. The agent loses the context of what the user is replying to. This is most visible on replies to rich cron announcements (`Cronjob Response: ...`).

It worked before rich messages because the legacy `sendMessage` path always carried a real `text` field that round-tripped into `reply_to_message.text`.

This restores that context with a bounded outbound reply-context cache, at parity with legacy text replies. It does not disable rich messages and adds no new stale-task-revival surface beyond the existing legacy-reply behavior (reference-only semantics for quoted cron text remain the injection layer's responsibility, related: #26714).

## Related Issue

Fixes #46568

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/telegram.py`: add a bounded, TTL-expiring outbound reply-context cache (`_outbound_context_cache`, `_remember_outbound_context`, `_prune_outbound_context`, `_lookup_outbound_context`) keyed by `(chat_id, message_id)`; register delivered content on both the rich (`_try_send_rich`) and legacy chunked (`send`) paths; fall back to the cached snippet in `_build_message_event` only when there is no native quote and no `text`/`caption` (precedence preserved, keeps the #22619 quote-narrowing behavior).
- `tests/gateway/test_telegram_rich_reply_context.py`: new regression suite (cache helpers, send-path registration, inbound precedence, TTL/eviction, empty/failed-send guards, end-to-end rich cron-reply scenario).

The cache is in-memory only and bounded three independent ways: 1024 entries, 2000 chars per entry, and a 48h TTL. It stores only the bot's own outbound content and surfaces it only on an explicit user reply. Cron deliveries benefit automatically because live delivery already routes through `adapter.send`; no scheduler change was needed.

## How to Test

1. Set `telegram.extra.rich_messages: true` and run the bot.
2. Have the bot send a rich message (e.g. a cron announcement, or any reply that renders via `sendRichMessage`).
3. Reply to that message in Telegram.
4. Before: the agent receives the reply with no `[Replying to: "..."]` context. After: the reply context is restored.

Automated:
- `scripts/run_tests.sh tests/gateway/test_telegram_rich_reply_context.py` (21 tests).
- `scripts/run_tests.sh tests/gateway/test_telegram_rich_messages.py tests/gateway/test_telegram_reply_quote.py tests/gateway/test_telegram_reply_mode.py tests/gateway/test_reply_to_injection.py tests/gateway/test_telegram_thread_fallback.py` (no regressions).
- A RED/GREEN check confirmed the regression test fails on unfixed code (with the fallback neutralized) and passes with the fix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(telegram): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the suite via `scripts/run_tests.sh` (CI-parity) and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (Linux), via `scripts/run_tests.sh` and full CI (6 test shards green). Note: live end-to-end verification on a real Telegram bot was not run in my environment; the one edge that needs live confirmation is called out under Residual findings below.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (no user-facing docs affected)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (cache bounds are internal constants by design, no new config key)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — pure stdlib (`time`, `collections.OrderedDict`), no platform-specific primitives
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool behavior change)

## Screenshots / Logs

Backend gateway change, no UI. All CI checks green on the first run (6 test shards, both nix, both arch builds, e2e, `check-attribution`, `ruff + ty diff`).

## Residual findings

Surfaced by an internal review pass; both are low severity and do not affect correctness.

- **[P3] Legacy-path cache entries are never read yet share the entry cap.** Legacy text replies round-trip via `reply_to_message.text`, so cached legacy entries are never consulted on the fallback path, yet they occupy slots in the shared 1024-entry cache and can evict rich entries under sustained load before a reply arrives. Output stays correct; only effective retention degrades. Options: register only on the rich path, scope the cap per-chat, or document the tradeoff.
- **[P3, needs verification] Quoted reply to a rich message and the #22619 protection.** If Telegram does not populate `message.quote.text` for native-quote replies to a `sendRichMessage` message, the cache fallback would inject the full cached body instead of the user's selected substring, regressing the #22619 quote-narrowing protection. Needs verification on live Telegram of whether `quote.text` round-trips for rich-message replies; if it does not, suppress full-body cache injection on quoted rich replies.

Advisory: the cache is in-memory only, so it is lost on gateway restart and not shared across processes (a reply after a restart, or on a different instance, falls back to no context). Reasonable for a first cut given the 48h TTL window.
