### PR TITLE
fix(desktop): settle idle turns missing assistant payload

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.test.tsx
@@ -1,0 +1,126 @@
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import type { MutableRefObject } from 'react'
+import { useEffect, useRef } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createClientSessionState } from '@/lib/chat-runtime'
+import type { RpcEvent } from '@/types/hermes'
+
+import type { ClientSessionState } from '../../types'
+
+import { useMessageStream } from './use-message-stream'
+
+const RUNTIME_SESSION_ID = 'rt-running-code'
+const STORED_SESSION_ID = '20260615_105331_404f55'
+
+interface HarnessHandle {
+  handleGatewayEvent: (event: RpcEvent) => void
+  stateRef: MutableRefObject<Map<string, ClientSessionState>>
+}
+
+function runningWithoutAssistantPayload(): ClientSessionState {
+  return {
+    ...createClientSessionState(STORED_SESSION_ID),
+    awaitingResponse: true,
+    busy: true,
+    messages: [
+      {
+        id: 'user-1',
+        parts: [{ text: 'count pictures', type: 'text' }],
+        role: 'user'
+      }
+    ],
+    sawAssistantPayload: false,
+    streamId: 'assistant-stream-1',
+    turnStartedAt: 1_720_000_000_000
+  }
+}
+
+function Harness({
+  hydrateFromStoredSession,
+  initialState,
+  onReady
+}: {
+  hydrateFromStoredSession: (
+    attempts?: number,
+    storedSessionId?: null | string,
+    runtimeSessionId?: null | string
+  ) => Promise<void>
+  initialState: ClientSessionState
+  onReady: (handle: HarnessHandle) => void
+}) {
+  const activeSessionIdRef: MutableRefObject<string | null> = { current: RUNTIME_SESSION_ID }
+  const stateRef = useRef(new Map([[RUNTIME_SESSION_ID, initialState]]))
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession,
+    queryClient: { invalidateQueries: vi.fn() } as never,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    sessionStateByRuntimeIdRef: stateRef,
+    updateSessionState: (sessionId, updater, storedSessionId) => {
+      const previous = stateRef.current.get(sessionId) ?? createClientSessionState(storedSessionId ?? null)
+
+      const next = updater({
+        ...previous,
+        messages: previous.messages,
+        storedSessionId: storedSessionId !== undefined ? storedSessionId : previous.storedSessionId
+      })
+
+      stateRef.current.set(sessionId, next)
+
+      return next
+    }
+  })
+
+  useEffect(() => {
+    onReady({ handleGatewayEvent: stream.handleGatewayEvent, stateRef })
+  }, [onReady, stream.handleGatewayEvent])
+
+  return null
+}
+
+describe('useMessageStream session.info running state', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('settles and hydrates when running ends before any assistant payload arrives', async () => {
+    const hydrateFromStoredSession = vi.fn(async () => undefined)
+    let handle: HarnessHandle | null = null
+
+    render(
+      <Harness
+        hydrateFromStoredSession={hydrateFromStoredSession}
+        initialState={runningWithoutAssistantPayload()}
+        onReady={value => {
+          handle = value
+        }}
+      />
+    )
+
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    act(() => {
+      handle!.handleGatewayEvent({
+        payload: { running: false },
+        session_id: RUNTIME_SESSION_ID,
+        type: 'session.info'
+      } as RpcEvent)
+    })
+
+    const state = handle!.stateRef.current.get(RUNTIME_SESSION_ID)
+
+    expect(state).toMatchObject({
+      awaitingResponse: false,
+      busy: false,
+      needsInput: false,
+      pendingBranchGroup: null,
+      streamId: null,
+      turnStartedAt: null
+    })
+    expect(hydrateFromStoredSession).toHaveBeenCalledWith(3, STORED_SESSION_ID, RUNTIME_SESSION_ID)
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream.ts
@@ -779,7 +779,9 @@ export function useMessageStream({
 
         if (apply) {
           if (runningChanged && sessionId) {
-            updateSessionState(sessionId, state => {
+            let hydrateIdleFallback = false
+
+            const updatedState = updateSessionState(sessionId, state => {
               const busy = Boolean(payload!.running)
 
               if (state.busy === busy && (busy || !state.awaitingResponse)) {
@@ -795,7 +797,17 @@ export function useMessageStream({
               }
 
               if (state.awaitingResponse && !state.sawAssistantPayload) {
-                return state
+                hydrateIdleFallback = true
+
+                return {
+                  ...state,
+                  awaitingResponse: false,
+                  busy: false,
+                  needsInput: false,
+                  pendingBranchGroup: null,
+                  streamId: null,
+                  turnStartedAt: null
+                }
               }
 
               return {
@@ -807,6 +819,14 @@ export function useMessageStream({
                 turnStartedAt: null
               }
             })
+
+            if (hydrateIdleFallback) {
+              clearAllPrompts(sessionId)
+              setSessionCompacting(sessionId, false)
+              compactedTurnRef.current.delete(sessionId)
+              void refreshSessions().catch(() => undefined)
+              void hydrateFromStoredSession(3, updatedState.storedSessionId, sessionId)
+            }
           }
         }
 
@@ -1123,8 +1143,10 @@ export function useMessageStream({
       completeAssistantMessage,
       failAssistantMessage,
       flushQueuedDeltas,
+      hydrateFromStoredSession,
       queryClient,
       refreshHermesConfig,
+      refreshSessions,
       sessionInterrupted,
       updateSessionState,
       upsertToolCall


### PR DESCRIPTION
Handles a Desktop edge case where `session.info` reports `running: false` before the renderer has seen any assistant payload for the turn. The previous guard kept `busy`/`awaitingResponse` true in that state, which could leave the session or tool row looking active even after the backend had persisted the final transcript.

This now settles the local running state, clears transient prompt/compaction markers, refreshes the session list, and hydrates the transcript from the stored session as a fallback.

Closes #46517

Checked with:
- `npm --workspace apps/desktop exec -- vitest run src/app/session/hooks/use-message-stream.test.tsx --environment jsdom`
- `npm --workspace apps/desktop exec -- eslint src/app/session/hooks/use-message-stream.ts src/app/session/hooks/use-message-stream.test.tsx`
- `npm --workspace apps/desktop run typecheck`
- `git diff --check`