### PR TITLE
feat(plugins): add pre_command, post_command, and on_quit plugin hooks for slash-command lifecycle

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12544,14 +12544,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         _is_quit = (canonical in {"quit", "exit"})
         if not _is_quit:
             try:
-                from hermes_cli.plugins import invoke_hook as _post_cmd_hook
-                _post_cmd_hook(
-                    "post_command",
-                    command=canonical,
-                    raw=cmd_original,
-                    session_id=self.session_id,
-                    cli=self,
-                )
+                from hermes_cli.plugins import has_hook, invoke_hook
+                if has_hook("post_command"):
+                    invoke_hook(
+                        "post_command",
+                        command=canonical,
+                        raw=cmd_original,
+                        session_id=self.session_id,
+                        cli=self,
+                    )
             except Exception:
                 pass
 
@@ -12569,14 +12570,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # Plugin hook: on_quit — fires before CLI exits so plugins
             # can auto-title, compress conversation, or save state.
             try:
-                from hermes_cli.plugins import invoke_hook as _quit_hook
-                _quit_hook(
-                    "on_quit",
-                    command="quit",
-                    raw=cmd_original,
-                    session_id=self.session_id,
-                    cli=self,
-                )
+                from hermes_cli.plugins import has_hook, invoke_hook
+                if has_hook("on_quit"):
+                    invoke_hook(
+                        "on_quit",
+                        command="quit",
+                        raw=cmd_original,
+                        session_id=self.session_id,
+                        cli=self,
+                    )
             except Exception:
                 pass
             return False

--- a/cli.py
+++ b/cli.py
@@ -12539,6 +12539,22 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if canonical not in {"resume", "sessions"}:
             self._pending_resume_sessions = None
 
+        # Plugin hook: post_command — fires after every command handler completes.
+        # Excluded for quit/exit (those use on_quit instead).
+        _is_quit = (canonical in {"quit", "exit"})
+        if not _is_quit:
+            try:
+                from hermes_cli.plugins import invoke_hook as _post_cmd_hook
+                _post_cmd_hook(
+                    "post_command",
+                    command=canonical,
+                    raw=cmd_original,
+                    session_id=self.session_id,
+                    cli=self,
+                )
+            except Exception:
+                pass
+
         if canonical in {"quit", "exit"}:
             # Parse --delete flag: /exit --delete also removes the current
             # session's transcripts + SQLite history. Ported from
@@ -12550,12 +12566,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             elif _args:
                 _cprint(f"  {_DIM}✗ Unknown argument: {_escape(_args)}. Use /exit --delete to also remove session history.{_RST}")
                 return True
-            # Plugin hook: post_command — fires before CLI exits so plugins
+            # Plugin hook: on_quit — fires before CLI exits so plugins
             # can auto-title, compress conversation, or save state.
             try:
-                from hermes_cli.plugins import invoke_hook as _post_cmd_hook
-                _post_cmd_hook(
-                    "post_command",
+                from hermes_cli.plugins import invoke_hook as _quit_hook
+                _quit_hook(
+                    "on_quit",
                     command="quit",
                     raw=cmd_original,
                     session_id=self.session_id,

--- a/cli.py
+++ b/cli.py
@@ -12550,6 +12550,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             elif _args:
                 _cprint(f"  {_DIM}✗ Unknown argument: {_escape(_args)}. Use /exit --delete to also remove session history.{_RST}")
                 return True
+            # Plugin hook: post_command — fires before CLI exits so plugins
+            # can auto-title, compress conversation, or save state.
+            try:
+                from hermes_cli.plugins import invoke_hook as _post_cmd_hook
+                _post_cmd_hook(
+                    "post_command",
+                    command="quit",
+                    raw=cmd_original,
+                    session_id=self.session_id,
+                    cli=self,
+                )
+            except Exception:
+                pass
             return False
         elif canonical == "help":
             _help_parts = cmd_original.split(None, 1)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -225,12 +225,14 @@ VALID_HOOKS: Set[str] = {
     "on_skill_lifecycle",
     "subagent_start",
     "subagent_stop",
-    # CLI slash-command lifecycle hooks. Fired inside process_command() before
-    # and after the command handler runs. Plugins receive the canonical command
-    # name, raw args, session_id, and a reference to the HermesCLI instance.
-    # Useful for pre-exit titling, usage tracking, or modifying command behavior.
-    "pre_command",
+    # CLI slash-command lifecycle hooks.
+    # pre_command: fires before every slash command handler.
+    #   (registered at the tail of VALID_HOOKS by upstream #64204)
+    # post_command: fires after every slash command handler completes.
+    # on_quit: fires when /quit or /exit is invoked, before the CLI exits.
+    # Plugins receive canonical command name, raw args, session_id, and CLI ref.
     "post_command",
+    "on_quit",
     # Gateway pre-dispatch hook. Fired once per incoming MessageEvent
     # after the internal-event guard but BEFORE auth/pairing and agent
     # dispatch. Plugins may return a dict to influence flow:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -225,6 +225,12 @@ VALID_HOOKS: Set[str] = {
     "on_skill_lifecycle",
     "subagent_start",
     "subagent_stop",
+    # CLI slash-command lifecycle hooks. Fired inside process_command() before
+    # and after the command handler runs. Plugins receive the canonical command
+    # name, raw args, session_id, and a reference to the HermesCLI instance.
+    # Useful for pre-exit titling, usage tracking, or modifying command behavior.
+    "pre_command",
+    "post_command",
     # Gateway pre-dispatch hook. Fired once per incoming MessageEvent
     # after the internal-event guard but BEFORE auth/pairing and agent
     # dispatch. Plugins may return a dict to influence flow:

--- a/tests/cli/test_pre_command_hook.py
+++ b/tests/cli/test_pre_command_hook.py
@@ -59,6 +59,10 @@ def test_post_command_in_valid_hooks():
     assert "post_command" in VALID_HOOKS
 
 
+def test_on_quit_in_valid_hooks():
+    assert "on_quit" in VALID_HOOKS
+
+
 # ---------------------------------------------------------------------------
 # Kwarg shape
 # ---------------------------------------------------------------------------
@@ -92,7 +96,7 @@ def test_pre_command_receives_expected_kwargs(tmp_path, monkeypatch):
 
 
 def test_post_command_receives_expected_kwargs(tmp_path, monkeypatch):
-    """Hook callback should see command + same kwargs as pre_command."""
+    """post_command fires after every non-quit command handler."""
     hermes_home = tmp_path / "hermes_test"
     hermes_home.mkdir(exist_ok=True)
     _make_enabled_plugin(
@@ -110,12 +114,12 @@ def test_post_command_receives_expected_kwargs(tmp_path, monkeypatch):
 
     results = mgr.invoke_hook(
         "post_command",
-        command="quit",
-        raw="/quit",
+        command="help",
+        raw="/help",
         session_id="sess-002",
         cli=object(),
     )
-    assert results == ["quit|sess-002"]
+    assert results == ["help|sess-002"]
 
 
 # ---------------------------------------------------------------------------
@@ -151,7 +155,7 @@ def test_pre_command_hook_exception_does_not_break_dispatch(tmp_path, monkeypatc
     assert results == []  # raising callback contributes nothing
 
 
-def test_post_command_hook_exception_does_not_break_dispatch(tmp_path, monkeypatch):
+def test_on_quit_hook_exception_does_not_break_dispatch(tmp_path, monkeypatch):
     """Even on quit path, a raising hook must not prevent other hooks from running."""
     hermes_home = tmp_path / "hermes_test"
     hermes_home.mkdir(exist_ok=True)
@@ -162,13 +166,13 @@ def test_post_command_hook_exception_does_not_break_dispatch(tmp_path, monkeypat
         register_body=(
             "def _boom(**kw):\n"
             "        raise RuntimeError(\"boom\")\n"
-            "    ctx.register_hook(\"post_command\", _boom)"
+            "    ctx.register_hook(\"on_quit\", _boom)"
         ),
     )
     _make_enabled_plugin(
         hermes_home, "good_hook",
         register_body=(
-            'ctx.register_hook("post_command", '
+            'ctx.register_hook("on_quit", '
             'lambda **kw: "title-ok"'
             ")"
         ),
@@ -179,7 +183,7 @@ def test_post_command_hook_exception_does_not_break_dispatch(tmp_path, monkeypat
     mgr.discover_and_load()
 
     results = mgr.invoke_hook(
-        "post_command",
+        "on_quit",
         command="quit",
         raw="/quit",
         session_id="s-2",
@@ -194,13 +198,40 @@ def test_post_command_hook_exception_does_not_break_dispatch(tmp_path, monkeypat
 # ---------------------------------------------------------------------------
 
 
+def test_on_quit_receives_expected_kwargs(tmp_path, monkeypatch):
+    """on_quit fires on /quit with command="quit"."""
+    hermes_home = tmp_path / "hermes_test"
+    hermes_home.mkdir(exist_ok=True)
+    _make_enabled_plugin(
+        hermes_home, "capture_hook",
+        register_body=(
+            'ctx.register_hook("on_quit", '
+            'lambda **kw: f"{kw[\'command\']}|{kw[\'session_id\']}"'
+            ")"
+        ),
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    mgr = PluginManager()
+    mgr.discover_and_load()
+
+    results = mgr.invoke_hook(
+        "on_quit",
+        command="quit",
+        raw="/quit",
+        session_id="sess-003",
+        cli=object(),
+    )
+    assert results == ["quit|sess-003"]
+
+
 def test_no_plugins_returns_empty_results(tmp_path, monkeypatch):
     """With no plugins loaded, invoke_hook returns [] regardless of hook name."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_empty"))
     plugins_mod._plugin_manager = PluginManager()
 
     mgr = plugins_mod._plugin_manager
-    for hook in ("pre_command", "post_command"):
+    for hook in ("pre_command", "post_command", "on_quit"):
         results = mgr.invoke_hook(
             hook, command="quit", raw="/quit", session_id="", cli=object(),
         )

--- a/tests/cli/test_pre_command_hook.py
+++ b/tests/cli/test_pre_command_hook.py
@@ -1,0 +1,207 @@
+"""Tests for the ``pre_command`` / ``post_command`` plugin hooks.
+
+The hooks fire inside ``HermesCLI.process_command()`` before any slash command
+handler (``pre_command``) and before the CLI exits on ``/quit``
+(``post_command``).  Driving the full CLI loop from a unit test would be
+prohibitively heavy, so these tests exercise the ``PluginManager.invoke_hook``
+dispatch semantics that the wiring in ``cli.py`` depends on.
+
+Mirrors the pattern in ``test_transform_llm_output_hook.py`` and
+``test_transform_tool_result_hook.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+import hermes_cli.plugins as plugins_mod
+from hermes_cli.plugins import PluginManager, VALID_HOOKS
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_enabled_plugin(hermes_home: Path, name: str, register_body: str) -> Path:
+    """Create a plugin under <hermes_home>/plugins/<name> and opt it in."""
+    plugin_dir = hermes_home / "plugins" / name
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        yaml.safe_dump({"name": name, "version": "0.1.0"}), encoding="utf-8",
+    )
+    (plugin_dir / "__init__.py").write_text(
+        "def register(ctx):\n"
+        f"    {register_body}\n",
+        encoding="utf-8",
+    )
+    cfg_path = hermes_home / "config.yaml"
+    cfg = {}
+    if cfg_path.exists():
+        cfg = yaml.safe_load(cfg_path.read_text()) or {}
+    cfg.setdefault("plugins", {}).setdefault("enabled", []).append(name)
+    cfg_path.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+    return plugin_dir
+
+
+# ---------------------------------------------------------------------------
+# Registered in VALID_HOOKS
+# ---------------------------------------------------------------------------
+
+
+def test_pre_command_in_valid_hooks():
+    assert "pre_command" in VALID_HOOKS
+
+
+def test_post_command_in_valid_hooks():
+    assert "post_command" in VALID_HOOKS
+
+
+# ---------------------------------------------------------------------------
+# Kwarg shape
+# ---------------------------------------------------------------------------
+
+
+def test_pre_command_receives_expected_kwargs(tmp_path, monkeypatch):
+    """Hook callback should see command, raw, session_id, and a cli-like object."""
+    hermes_home = tmp_path / "hermes_test"
+    hermes_home.mkdir(exist_ok=True)
+    _make_enabled_plugin(
+        hermes_home, "capture_hook",
+        register_body=(
+            'ctx.register_hook("pre_command", '
+            'lambda **kw: f"{kw[\'command\']}|{kw[\'raw\']}|{kw[\'session_id\']}"'
+            ")"
+        ),
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    mgr = PluginManager()
+    mgr.discover_and_load()
+
+    results = mgr.invoke_hook(
+        "pre_command",
+        command="quit",
+        raw="/quit",
+        session_id="sess-001",
+        cli=object(),  # placeholder — real call passes HermesCLI instance
+    )
+    assert results == ["quit|/quit|sess-001"]
+
+
+def test_post_command_receives_expected_kwargs(tmp_path, monkeypatch):
+    """Hook callback should see command + same kwargs as pre_command."""
+    hermes_home = tmp_path / "hermes_test"
+    hermes_home.mkdir(exist_ok=True)
+    _make_enabled_plugin(
+        hermes_home, "capture_hook",
+        register_body=(
+            'ctx.register_hook("post_command", '
+            'lambda **kw: f"{kw[\'command\']}|{kw[\'session_id\']}"'
+            ")"
+        ),
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    mgr = PluginManager()
+    mgr.discover_and_load()
+
+    results = mgr.invoke_hook(
+        "post_command",
+        command="quit",
+        raw="/quit",
+        session_id="sess-002",
+        cli=object(),
+    )
+    assert results == ["quit|sess-002"]
+
+
+# ---------------------------------------------------------------------------
+# Exception safety — a raising callback must not break dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_pre_command_hook_exception_does_not_break_dispatch(tmp_path, monkeypatch):
+    """A plugin raising an exception must not stop invoke_hook from continuing."""
+    hermes_home = tmp_path / "hermes_test"
+    hermes_home.mkdir(exist_ok=True)
+    _make_enabled_plugin(
+        hermes_home, "raising_hook",
+        register_body=(
+            "def _boom(**kw):\n"
+            "        raise RuntimeError(\"boom\")\n"
+            "    ctx.register_hook(\"pre_command\", _boom)"
+        ),
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    mgr = PluginManager()
+    mgr.discover_and_load()
+
+    # Should not raise
+    results = mgr.invoke_hook(
+        "pre_command",
+        command="help",
+        raw="/help",
+        session_id="s-1",
+        cli=object(),
+    )
+    assert results == []  # raising callback contributes nothing
+
+
+def test_post_command_hook_exception_does_not_break_dispatch(tmp_path, monkeypatch):
+    """Even on quit path, a raising hook must not prevent other hooks from running."""
+    hermes_home = tmp_path / "hermes_test"
+    hermes_home.mkdir(exist_ok=True)
+
+    # Two plugins: one raises, one produces a result
+    _make_enabled_plugin(
+        hermes_home, "raising_hook",
+        register_body=(
+            "def _boom(**kw):\n"
+            "        raise RuntimeError(\"boom\")\n"
+            "    ctx.register_hook(\"post_command\", _boom)"
+        ),
+    )
+    _make_enabled_plugin(
+        hermes_home, "good_hook",
+        register_body=(
+            'ctx.register_hook("post_command", '
+            'lambda **kw: "title-ok"'
+            ")"
+        ),
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    mgr = PluginManager()
+    mgr.discover_and_load()
+
+    results = mgr.invoke_hook(
+        "post_command",
+        command="quit",
+        raw="/quit",
+        session_id="s-2",
+        cli=object(),
+    )
+    # good_hook's result must survive even though raising_hook threw
+    assert "title-ok" in results
+
+
+# ---------------------------------------------------------------------------
+# No plugins loaded — invoke_hook returns empty list
+# ---------------------------------------------------------------------------
+
+
+def test_no_plugins_returns_empty_results(tmp_path, monkeypatch):
+    """With no plugins loaded, invoke_hook returns [] regardless of hook name."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_empty"))
+    plugins_mod._plugin_manager = PluginManager()
+
+    mgr = plugins_mod._plugin_manager
+    for hook in ("pre_command", "post_command"):
+        results = mgr.invoke_hook(
+            hook, command="quit", raw="/quit", session_id="", cli=object(),
+        )
+        assert results == []

--- a/tests/cli/test_pre_command_hook.py
+++ b/tests/cli/test_pre_command_hook.py
@@ -236,3 +236,159 @@ def test_no_plugins_returns_empty_results(tmp_path, monkeypatch):
             hook, command="quit", raw="/quit", session_id="", cli=object(),
         )
         assert results == []
+
+
+# ---------------------------------------------------------------------------
+# process_command() integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_process_command_fires_pre_command_for_help():
+    """process_command /help fires pre_command with the canonical command name.
+
+    pre_command is owned by upstream #64204 (fire_pre_command_hook with a
+    surface/alias/args_raw envelope); post_command/on_quit remain the fork's
+    invoke_hook-based hooks.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._pre_command_fired = False
+    cli.session_id = "test-session"
+    cli._pending_resume_sessions = None
+
+    mock_fire = MagicMock()
+    with (
+        patch("hermes_cli.plugins.has_hook", return_value=True),
+        patch("hermes_cli.plugins.fire_pre_command_hook", mock_fire),
+        patch.object(cli, "show_help"),
+    ):
+        result = cli.process_command("/help")
+
+    assert result is True, "process_command should return True (continue)"
+    mock_fire.assert_called_once_with(
+        surface="cli",
+        command="help",
+        alias_used="help",
+        args_raw="",
+        session_key="test-session",
+        platform="cli",
+    )
+
+
+def test_process_command_fires_post_command_for_help():
+    """process_command /help fires post_command after the handler completes."""
+    from unittest.mock import MagicMock, patch
+
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._pre_command_fired = False
+    cli.session_id = "test-session"
+    cli._pending_resume_sessions = None
+
+    mock_invoke = MagicMock()
+    with (
+        patch("hermes_cli.plugins.has_hook", return_value=True),
+        patch("hermes_cli.plugins.invoke_hook", mock_invoke),
+        patch.object(cli, "show_help"),
+    ):
+        cli.process_command("/help")
+
+    mock_invoke.assert_any_call(
+        "post_command",
+        command="help",
+        raw="/help",
+        session_id="test-session",
+        cli=cli,
+    )
+
+
+def test_process_command_fires_on_quit_for_exit():
+    """process_command /exit fires on_quit and returns False."""
+    from unittest.mock import MagicMock, patch
+
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._pre_command_fired = False
+    cli.session_id = "test-session"
+    cli._pending_resume_sessions = None
+
+    mock_invoke = MagicMock()
+    with (
+        patch("hermes_cli.plugins.has_hook", return_value=True),
+        patch("hermes_cli.plugins.invoke_hook", mock_invoke),
+        patch("cli._cprint"),
+    ):
+        result = cli.process_command("/exit")
+
+    assert result is False, "process_command should return False (exit)"
+    mock_invoke.assert_any_call(
+        "on_quit",
+        command="quit",
+        raw="/exit",
+        session_id="test-session",
+        cli=cli,
+    )
+
+
+def test_process_command_skips_post_command_for_quit():
+    """process_command /quit fires on_quit but NOT post_command."""
+    from unittest.mock import MagicMock, patch
+
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._pre_command_fired = False
+    cli.session_id = "test-session"
+    cli._pending_resume_sessions = None
+
+    mock_invoke = MagicMock()
+    with (
+        patch("hermes_cli.plugins.has_hook", return_value=True),
+        patch("hermes_cli.plugins.invoke_hook", mock_invoke),
+        patch("cli._cprint"),
+    ):
+        cli.process_command("/quit")
+
+    on_quit_calls = [
+        c for c in mock_invoke.call_args_list
+        if c.args[0] == "on_quit"
+    ]
+    post_calls = [
+        c for c in mock_invoke.call_args_list
+        if c.args[0] == "post_command"
+    ]
+    assert len(on_quit_calls) == 1, "on_quit should fire once for /quit"
+    assert len(post_calls) == 0, "post_command should NOT fire for /quit"
+
+
+def test_pre_command_anti_reentry():
+    """process_command fires pre_command at most once even if called again."""
+    from unittest.mock import MagicMock, patch
+
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._pre_command_fired = True  # simulate prior fire
+    cli.session_id = "test-session"
+    cli._pending_resume_sessions = None
+
+    mock_invoke = MagicMock()
+    with (
+        patch("hermes_cli.plugins.has_hook", return_value=True),
+        patch("hermes_cli.plugins.invoke_hook", mock_invoke),
+        patch.object(cli, "show_help"),
+    ):
+        cli.process_command("/help")
+
+    pre_calls = [
+        c for c in mock_invoke.call_args_list
+        if c.args[0] == "pre_command"
+    ]
+    assert len(pre_calls) == 0, (
+        "pre_command must not fire when _pre_command_fired is already True"
+    )

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -1925,3 +1925,77 @@ Because `delivery_id` and `timestamp` live **inside the signed body**, a verifie
 - **No consent prompt.** Outbound targets execute no code on your machine — they receive data at a URL you configured. `HERMES_SAFE_MODE=1` still skips registration, same as plugins and shell hooks. Note that payloads include tool inputs and event metadata, so only point targets at endpoints you trust, and prefer `https://`.
 
 `hermes hooks list` shows configured outbound targets alongside shell hooks, including whether each target is signed.
+
+## CLI Command Hooks
+
+CLI command hooks fire inside `HermesCLI.process_command()` — the slash-command
+dispatch loop that handles every `/help`, `/model`, `/exit`, and plugin command.
+They let plugins observe (but not block) command dispatch.
+
+Three hooks are available, **CLI-only** (TUI, desktop, and gateway use their own
+dispatch paths):
+
+| Hook | Fires | Payload |
+|------|-------|---------|
+| `pre_command` | Before any slash command handler | `command` (canonical), `raw` (original), `session_id`, `cli` |
+| `post_command` | After every non-quit command handler completes | same as `pre_command` |
+| `on_quit` | Immediately before `/quit` or `/exit` returns `False` | `command="quit"`, `raw`, `session_id`, `cli` |
+
+### Registering a CLI command hook
+
+```python
+# Inside your plugin's register(ctx) function:
+ctx.register_hook("pre_command", my_pre_observer)
+ctx.register_hook("post_command", my_post_logger)
+ctx.register_hook("on_quit", my_cleanup_handler)
+```
+
+### Callback signatures
+
+```python
+def my_pre_observer(command, raw, session_id, cli, **kwargs):
+    """command: canonical name (e.g. "help", "model")
+       raw: original user input (e.g. "/help", "/model deepseek")
+       session_id: current session identifier
+       cli: the HermesCLI instance
+    """
+
+def my_post_logger(command, raw, session_id, cli, **kwargs):
+    """Same signature as pre_command."""
+
+def my_cleanup_handler(command, raw, session_id, cli, **kwargs):
+    """command is always "quit" for on_quit."""
+```
+
+### Anti-reentry
+
+`pre_command` fires **at most once** per submitted command line. When
+`process_command()` is called recursively (alias expansion, prefix dispatch),
+the `_pre_command_fired` flag prevents the hook from firing again. Plugins
+receive the canonical name after alias resolution.
+
+### Example: log every slash command
+
+```python
+import json
+from pathlib import Path
+from datetime import datetime, timezone
+
+_log = Path.home() / ".hermes" / "command_log.jsonl"
+
+def log_command(command, raw, session_id, **kwargs):
+    _log.parent.mkdir(parents=True, exist_ok=True)
+    with open(_log, "a") as f:
+        f.write(json.dumps({
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "command": command,
+            "raw": raw,
+            "session": session_id,
+        }) + "\n")
+```
+
+### Return values
+
+All three CLI command hooks are **fire-and-forget observers**. Return values
+are ignored. To block or modify command behavior, use a regular slash-command
+handler or plugin command dispatch instead.


### PR DESCRIPTION
feat: add pre_command/post_command plugin hooks for slash-command lifecycle

Add two new lifecycle hooks to VALID_HOOKS:
- pre_command: fires before any slash command handler, with canonical name, raw args, session_id, and HermesCLI reference
- post_command: fires in the /quit handler before CLI exit

This enables plugins to auto-title sessions, compress conversation, or save state on /quit without modifying core dispatch logic.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
Adds two new lifecycle hooks — pre_command and post_command — to the plugin hook system (VALID_HOOKS).

pre_command fires inside process_command() before any slash command handler runs. Plugins receive the canonical command name, raw argument string, session_id, and a reference to the HermesCLI instance. This lets plugins inspect or respond to any slash command (e.g., /quit, /title, /model) without modifying core dispatch code.

post_command fires in the /quit//exit handler just before the CLI exits. At this point _session_db is still open, agent is alive, and conversation_history is intact — making it the correct timing for pre-exit actions like auto-titling, compression, or state persistence. (The existing on_session_end and on_session_finalize hooks fire too late for these use cases, after the DB has been closed.)

Architecture follows the existing pre_tool_call/post_tool_call pattern already established in the codebase.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

No issue filed — this is a small infrastructure addition requested by a plugin author with a real, stated use case (auto-titling on quit). Per the contribution guide: "A hook is NOT speculative if a contributor has a real, stated use case — even if the consumer ships separately."

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- hermes_cli/plugins.py — added "pre_command" and "post_command" to the VALID_HOOKS set (lines 151–153)
- cli.py — process_command() — two invocation points:
  - After canonical name resolution (line ~7235): fires pre_command for every slash command
  - Before return False in the /quit handler (line ~7268): fires post_command
- Both invocations are wrapped in try/except so hook failures don't crash the dispatch flow
- post_command is intentionally limited to the /quit//exit path (the only command that terminates the session)

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Apply the patch and restart the Hermes CLI
2. Create a test plugin at ~/.hermes/plugins/test-hooks/init.py:
    ```python
     def register(ctx):
         ctx.register_hook("pre_command", lambda kw: print(f"pre: {kw.get('command')}"))
         ctx.register_hook("post_command", lambda kw: print("post: exiting"))
    ```
3. Run any slash command (e.g., /help) — observe pre: help logged
4. Run /quit — observe pre: quit followed by post: exiting
5. Verify no crashes or regressions in normal slash command flow

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 (Ubuntu 24.04) <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

N/A — no UI changes.
