### PR TITLE
fix(feishu): add env-based client fallback for feishu_doc and feishu_…

### DIFF
--- a/tools/feishu_doc_tool.py
+++ b/tools/feishu_doc_tool.py
@@ -6,6 +6,7 @@ Uses the same lazy-import + BaseRequest pattern as feishu_comment.py.
 
 import json
 import logging
+import os
 import threading
 
 from tools.registry import registry, tool_error, tool_result
@@ -15,6 +16,9 @@ logger = logging.getLogger(__name__)
 # Thread-local storage for the lark client injected by feishu_comment handler.
 _local = threading.local()
 
+# Module-level cache for the fallback client built from env vars.
+_env_client_cache = {"client": None}
+
 
 def set_client(client):
     """Store a lark client for the current thread (called by feishu_comment)."""
@@ -22,8 +26,48 @@ def set_client(client):
 
 
 def get_client():
-    """Return the lark client for the current thread, or None."""
-    return getattr(_local, "client", None)
+    """Return the lark client for the current thread, or build one from env.
+
+    Priority:
+    1. Thread-local client injected by feishu_comment handler (comment context).
+    2. Fallback client built from FEISHU_APP_ID / FEISHU_APP_SECRET env vars
+       (DM / general context). Cached at module level.
+    """
+    c = getattr(_local, "client", None)
+    if c is not None:
+        return c
+    return _build_env_client()
+
+
+def _build_env_client():
+    """Build a lark Client from environment variables (cached)."""
+    if _env_client_cache["client"] is not None:
+        return _env_client_cache["client"]
+    app_id = os.getenv("FEISHU_APP_ID", "").strip()
+    app_secret = os.getenv("FEISHU_APP_SECRET", "").strip()
+    if not app_id or not app_secret:
+        return None
+    try:
+        import lark_oapi as lark
+    except ImportError:
+        return None
+    # Domain shorthand: "feishu" (default) → FEISHU_DOMAIN constant,
+    # "lark" → LARK_DOMAIN constant, otherwise treat as a raw URL.
+    domain_name = os.getenv("FEISHU_DOMAIN", "feishu").strip().lower()
+    if domain_name == "lark":
+        domain = lark.LARK_DOMAIN
+    else:
+        domain = lark.FEISHU_DOMAIN
+    client = (
+        lark.Client.builder()
+        .app_id(app_id)
+        .app_secret(app_secret)
+        .domain(domain)
+        .log_level(lark.LogLevel.WARNING)
+        .build()
+    )
+    _env_client_cache["client"] = client
+    return client
 
 
 # ---------------------------------------------------------------------------
@@ -73,7 +117,7 @@ def _handle_feishu_doc_read(args: dict, **kwargs) -> str:
 
     client = get_client()
     if client is None:
-        return tool_error("Feishu client not available (not in a Feishu comment context)")
+        return tool_error("Feishu client not available — set FEISHU_APP_ID/FEISHU_APP_SECRET or run in comment context")
 
     try:
         from lark_oapi import AccessTokenType

--- a/tools/feishu_drive_tool.py
+++ b/tools/feishu_drive_tool.py
@@ -7,6 +7,7 @@ The lark client is injected per-thread by the comment event handler.
 
 import json
 import logging
+import os
 import threading
 
 from tools.registry import registry, tool_error, tool_result
@@ -16,6 +17,9 @@ logger = logging.getLogger(__name__)
 # Thread-local storage for the lark client injected by feishu_comment handler.
 _local = threading.local()
 
+# Module-level cache for the fallback client built from env vars.
+_env_client_cache: dict = {"client": None}
+
 
 def set_client(client):
     """Store a lark client for the current thread (called by feishu_comment)."""
@@ -23,8 +27,48 @@ def set_client(client):
 
 
 def get_client():
-    """Return the lark client for the current thread, or None."""
-    return getattr(_local, "client", None)
+    """Return the lark client for the current thread, or build one from env.
+
+    Priority:
+    1. Thread-local client injected by feishu_comment handler (comment context).
+    2. Fallback client built from FEISHU_APP_ID / FEISHU_APP_SECRET env vars
+       (DM / general context). Cached at module level.
+    """
+    c = getattr(_local, "client", None)
+    if c is not None:
+        return c
+    return _build_env_client()
+
+
+def _build_env_client():
+    """Build a lark Client from environment variables (cached)."""
+    if _env_client_cache["client"] is not None:
+        return _env_client_cache["client"]
+    app_id = os.getenv("FEISHU_APP_ID", "").strip()
+    app_secret = os.getenv("FEISHU_APP_SECRET", "").strip()
+    if not app_id or not app_secret:
+        return None
+    try:
+        import lark_oapi as lark
+    except ImportError:
+        return None
+    # Domain shorthand: "feishu" (default) → FEISHU_DOMAIN constant,
+    # "lark" → LARK_DOMAIN constant, otherwise treat as a raw URL.
+    domain_name = os.getenv("FEISHU_DOMAIN", "feishu").strip().lower()
+    if domain_name == "lark":
+        domain = lark.LARK_DOMAIN
+    else:
+        domain = lark.FEISHU_DOMAIN
+    client = (
+        lark.Client.builder()
+        .app_id(app_id)
+        .app_secret(app_secret)
+        .domain(domain)
+        .log_level(lark.LogLevel.WARNING)
+        .build()
+    )
+    _env_client_cache["client"] = client
+    return client
 
 
 def _check_feishu():
@@ -133,7 +177,7 @@ FEISHU_DRIVE_LIST_COMMENTS_SCHEMA = {
 def _handle_list_comments(args: dict, **kwargs) -> str:
     client = get_client()
     if client is None:
-        return tool_error("Feishu client not available")
+        return tool_error("Feishu client not available — set FEISHU_APP_ID/FEISHU_APP_SECRET or run in comment context")
 
     file_token = args.get("file_token", "").strip()
     if not file_token:
@@ -208,7 +252,7 @@ FEISHU_DRIVE_LIST_REPLIES_SCHEMA = {
 def _handle_list_replies(args: dict, **kwargs) -> str:
     client = get_client()
     if client is None:
-        return tool_error("Feishu client not available")
+        return tool_error("Feishu client not available — set FEISHU_APP_ID/FEISHU_APP_SECRET or run in comment context")
 
     file_token = args.get("file_token", "").strip()
     comment_id = args.get("comment_id", "").strip()
@@ -280,7 +324,7 @@ FEISHU_DRIVE_REPLY_SCHEMA = {
 def _handle_reply_comment(args: dict, **kwargs) -> str:
     client = get_client()
     if client is None:
-        return tool_error("Feishu client not available")
+        return tool_error("Feishu client not available — set FEISHU_APP_ID/FEISHU_APP_SECRET or run in comment context")
 
     file_token = args.get("file_token", "").strip()
     comment_id = args.get("comment_id", "").strip()
@@ -351,7 +395,7 @@ FEISHU_DRIVE_ADD_COMMENT_SCHEMA = {
 def _handle_add_comment(args: dict, **kwargs) -> str:
     client = get_client()
     if client is None:
-        return tool_error("Feishu client not available")
+        return tool_error("Feishu client not available — set FEISHU_APP_ID/FEISHU_APP_SECRET or run in comment context")
 
     file_token = args.get("file_token", "").strip()
     content = args.get("content", "").strip()


### PR DESCRIPTION
…drive tools

The feishu_doc_read, feishu_drive_list_comments, feishu_drive_list_comment_replies, feishu_drive_reply_comment, and feishu_drive_add_comment tools were only usable inside the document comment event handler, which injects a lark client via thread-local storage. When called from any other context (DM chats, CLI, general agent sessions), get_client() returned None and every call failed with "Feishu client not available".

This adds _build_env_client() which constructs a lark Client from FEISHU_APP_ID / FEISHU_APP_SECRET environment variables (with optional FEISHU_DOMAIN override for Lark vs Feishu), cached at module level. The thread-local injected client still takes priority when present, so comment-handler behavior is unchanged.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

