### PR TITLE
fix(terminal): prefer Git for Windows bash over non-MSYS bash on Windows

### DIFF
--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -267,10 +267,10 @@ def _find_bash() -> str:
             if os.path.isfile(candidate):
                 return candidate
 
-    found = shutil.which("bash")
-    if found:
-        return found
-
+    # Check known Git for Windows install locations before PATH lookup.
+    # On machines with both WSL and Git for Windows, shutil.which("bash")
+    # may return WSL's bash (which doesn't understand Windows paths and
+    # will fail silently).  Explicit Git-for-Windows paths avoid that.
     for candidate in (
         os.path.join(os.environ.get("ProgramFiles", r"C:\Program Files"), "Git", "bin", "bash.exe"),
         os.path.join(os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"), "Git", "bin", "bash.exe"),
@@ -278,6 +278,10 @@ def _find_bash() -> str:
     ):
         if candidate and os.path.isfile(candidate):
             return candidate
+
+    found = shutil.which("bash")
+    if found:
+        return found
 
     raise RuntimeError(
         "Git Bash not found. Hermes Agent requires Git for Windows on Windows.\n"


### PR DESCRIPTION
## Problem

On Windows machines with both a Linux environment and Git for Windows installed, `_find_bash()` calls `shutil.which("bash")` before checking known Git-for-Windows install paths. `shutil.which()` may return a non-MSYS bash (e.g., Linux subsystem bash at `/usr/bin/bash`) which does not understand Windows-style paths like `C:\Users\Asus`.

**Result**: every terminal command fails with exit code 126 because the cwd prefix injected by the tool wrapper is rejected by the non-MSYS bash. The command after `&&` never executes.

## Fix

Reorder the search in `_find_bash()`: check explicit Git-for-Windows install locations (`ProgramFiles/Git/bin/bash.exe` etc.) **before** falling back to `shutil.which("bash")`.

This matches the intent of the surrounding code — portable Git is already preferred, system Git should also be preferred, and PATH lookup is the last resort.

## Change

`tools/environments/local.py` — moved the `shutil.which("bash")` block from after portable Git to after system Git path checks.

## Related

- #23846 — same file, same class of Windows path issues