### PR TITLE
fix(agent): flush messages before compression session rotation (#46567)

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -286,6 +286,7 @@ def compress_context(
     approx_tokens: Optional[int] = None,
     task_id: str = "default",
     focus_topic: Optional[str] = None,
+    conversation_history: Optional[list] = None,
     force: bool = False,
 ) -> Tuple[list, str]:
     """Compress conversation context and split the session in SQLite.
@@ -299,6 +300,9 @@ def compress_context(
         focus_topic: Optional focus string for guided compression — the
             summariser will prioritise preserving information related to
             this topic.  Inspired by Claude Code's ``/compact <focus>``.
+        conversation_history: Previously-persisted history for the active turn.
+            Passed through to the SQLite flush so compression only writes the
+            pending mid-turn tail before rotating the session.
         force: If True, bypass any active summary-failure cooldown.  Set
             by the manual ``/compress`` slash command so users can retry
             immediately after an auto-compress abort.  Auto-compress
@@ -512,6 +516,14 @@ def compress_context(
             old_title = agent._session_db.get_session_title(agent.session_id)
             # Trigger memory extraction on the old session before it rotates.
             agent.commit_memory_session(messages)
+            # Flush pending messages to SQLite BEFORE closing the old session.
+            # _persist_session only runs at turn-exit, so without this flush
+            # intermediate sessions created by chained mid-turn compressions
+            # lose all their messages to SQLite (#46567).
+            agent._flush_messages_to_session_db(
+                messages,
+                conversation_history=conversation_history,
+            )
             agent._session_db.end_session(agent.session_id, "compression")
             old_session_id = agent.session_id
             agent.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2704,6 +2704,7 @@ def run_conversation(
                             messages, system_message,
                             approx_tokens=approx_tokens,
                             task_id=effective_task_id,
+                            conversation_history=conversation_history,
                         )
                         # Compression created a new session — clear history
                         # so _flush_messages_to_session_db writes compressed

--- a/run_agent.py
+++ b/run_agent.py
@@ -5048,7 +5048,7 @@ class AIAgent:
         """
         return self.api_mode != "codex_responses"
 
-    def _compress_context(self, messages: list, system_message: str, *, approx_tokens: int = None, task_id: str = "default", focus_topic: str = None, force: bool = False) -> tuple:
+    def _compress_context(self, messages: list, system_message: str, *, approx_tokens: Optional[int] = None, task_id: str = "default", focus_topic: Optional[str] = None, conversation_history: Optional[list] = None, force: bool = False) -> tuple:
         """Forwarder — see ``agent.conversation_compression.compress_context``.
 
         ``force=True`` is passed by the manual ``/compress`` slash command
@@ -5060,7 +5060,7 @@ class AIAgent:
         return compress_context(
             self, messages, system_message,
             approx_tokens=approx_tokens, task_id=task_id, focus_topic=focus_topic,
-            force=force,
+            conversation_history=conversation_history, force=force,
         )
 
     def _set_tool_guardrail_halt(self, decision: ToolGuardrailDecision) -> None:

--- a/tests/agent/test_compression_flush_before_rotate.py
+++ b/tests/agent/test_compression_flush_before_rotate.py
@@ -1,0 +1,199 @@
+"""Regression tests for compression-driven session rotation.
+
+Verifies that messages are flushed to the session DB BEFORE the old session
+is closed during compression rotation (#46567). Without the flush,
+intermediate sessions created by chained mid-turn compressions lose all
+messages to SQLite.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from agent.conversation_compression import compress_context
+
+
+def _make_mock_agent():
+    """Build a minimal mock agent exercising the real ``compress_context``
+    production code path."""
+    call_order = []
+
+    class _TodoStore:
+        def format_for_injection(self):
+            return ""
+
+    class _MockDB:
+        def try_acquire_compression_lock(self, sid, holder):
+            return True
+
+        def release_compression_lock(self, *a, **kw):
+            pass
+
+        def get_session_title(self, sid):
+            return "test-title"
+
+        def end_session(self, sid, reason):
+            call_order.append(("end_session", sid))
+
+        def create_session(self, **kw):
+            call_order.append(("create_session",))
+
+        def get_next_title_in_lineage(self, title):
+            return title + " (2)"
+
+        def set_session_title(self, *a, **kw):
+            pass
+
+        def update_system_prompt(self, *a, **kw):
+            pass
+
+    class _MockCompressor:
+        _last_compress_aborted = False
+        _last_summary_error = None
+        _last_aux_model_failure_model = None
+        compression_count = 1
+        last_compression_rough_tokens = 0
+        last_prompt_tokens = 0
+        last_completion_tokens = 0
+        awaiting_real_usage_after_compression = False
+
+        def compress(self, messages, **kw):
+            return [{"role": "system", "content": "summary"}]
+
+        def on_session_start(self, *a, **kw):
+            pass
+
+    class _MockAgent:
+        def __init__(self):
+            self.session_id = "old-session-id"
+            self.model = "test/model"
+            self.platform = "cli"
+            self._session_db = _MockDB()
+            self._session_db_created = True
+            self._memory_manager = None
+            self._cached_system_prompt = "cached"
+            self._last_flushed_db_idx = 5
+            self._session_init_model_config = {}
+            self._compression_feasibility_checked = True
+            self._todo_store = _TodoStore()
+            self.context_compressor = _MockCompressor()
+            self.tools = []
+            self.log_prefix = ""
+            self._call_order = call_order
+
+        def _emit_status(self, *a, **kw):
+            pass
+
+        def _emit_warning(self, *a, **kw):
+            pass
+
+        def _vprint(self, *a, **kw):
+            pass
+
+        def _invalidate_system_prompt(self):
+            pass
+
+        def _build_system_prompt(self, sm):
+            return sm or "system"
+
+        def commit_memory_session(self, messages):
+            call_order.append(("commit_memory_session",))
+
+        def _flush_messages_to_session_db(self, messages, conversation_history=None):
+            call_order.append(("flush", conversation_history))
+
+    agent = _MockAgent()
+    return agent, call_order
+
+
+class TestCompressionFlushBeforeRotate:
+    """Messages must be flushed to SQLite before end_session closes the old
+    session during compression rotation."""
+
+    def test_flush_called_before_end_session(self):
+        """The flush call must appear before end_session in the call order."""
+        agent, call_order = _make_mock_agent()
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+            {"role": "user", "content": "do more work"},
+            {"role": "assistant", "content": "ok"},
+        ]
+
+        compress_context(agent, messages, "system prompt")
+
+        flush_indices = [i for i, c in enumerate(call_order) if c[0] == "flush"]
+        end_indices = [i for i, c in enumerate(call_order) if c[0] == "end_session"]
+
+        assert len(end_indices) == 1, f"expected one end_session, got {call_order}"
+        assert len(flush_indices) == 1, (
+            f"expected one flush call before end_session, got {call_order}"
+        )
+        assert flush_indices[0] < end_indices[0], (
+            f"flush (idx {flush_indices[0]}) must precede end_session "
+            f"(idx {end_indices[0]}); order was {call_order}"
+        )
+
+    def test_flush_uses_current_session_id(self):
+        """The flush must write to the OLD session id (before rotation),
+        not the new one."""
+        agent, call_order = _make_mock_agent()
+        old_id = agent.session_id
+
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+
+        compress_context(agent, messages, "system prompt")
+
+        # After compression, session_id should have rotated
+        assert agent.session_id != old_id
+        # end_session must have been called with the OLD id
+        end_calls = [c for c in call_order if c[0] == "end_session"]
+        assert end_calls[0][1] == old_id, (
+            f"end_session should close old session '{old_id}', "
+            f"got '{end_calls[0][1]}'"
+        )
+
+    def test_flush_present_in_call_order(self):
+        """On upstream/main (without the fix) this test fails because
+        _flush_messages_to_session_db is never called during compression.
+        This is the RED-phase regression test."""
+        agent, call_order = _make_mock_agent()
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+
+        compress_context(agent, messages, "system prompt")
+
+        flush_calls = [c for c in call_order if c[0] == "flush"]
+        assert len(flush_calls) == 1, (
+            f"_flush_messages_to_session_db was not called during compression "
+            f"rotation — messages in intermediate sessions are lost (#46567). "
+            f"Call order: {call_order}"
+        )
+
+    def test_flush_receives_conversation_history_to_avoid_duplicate_rows(self):
+        """Compression flushes only the mid-turn tail, not already-persisted
+        history rows from previous turns."""
+        agent, call_order = _make_mock_agent()
+        history = [
+            {"role": "user", "content": "already persisted"},
+            {"role": "assistant", "content": "also persisted"},
+        ]
+        messages = history + [
+            {"role": "user", "content": "new tool-triggering request"},
+            {"role": "tool", "tool_name": "terminal", "content": "large output"},
+        ]
+
+        compress_context(
+            agent,
+            messages,
+            "system prompt",
+            conversation_history=history,
+        )
+
+        flush_calls = [c for c in call_order if c[0] == "flush"]
+        assert len(flush_calls) == 1, f"expected one flush call, got {call_order}"
+        assert flush_calls[0][1] is history


### PR DESCRIPTION
## Summary

Fixes #46567 by flushing pending messages to the SQLite session DB before compression closes and rotates away from the current session.

The initial fix added the missing flush before `end_session(...)`. During Path B review, I tightened the patch so the compression-time flush receives `conversation_history`, which preserves the existing `_flush_messages_to_session_db(...)` contract: already-persisted history rows are skipped, and only the pending mid-turn tail is written to the old session before rotation.

## What changed

- `compress_context(...)` accepts optional `conversation_history` and passes it through to `_flush_messages_to_session_db(...)` before `end_session(...)`.
- The main conversation loop supplies the active turn's `conversation_history` when auto-compression fires.
- Added regression coverage for:
  - flush is called before `end_session`
  - flush runs against the old session id before rotation
  - flush is present during compression rotation
  - conversation history is passed through to avoid duplicate SQLite rows

## Verification

- RED proof from build artifact: 2/3 original regression tests failed on upstream/main because compression never called `_flush_messages_to_session_db(...)` before rotation.
- Focused tests after reviewer revision:
  - `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/agent/test_compression_flush_before_rotate.py -v -o "addopts=" --tb=short`
  - Result: 4 passed
- Nearby compression tests:
  - `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/agent/test_compression*.py -v -o "addopts=" --tb=short`
  - Result: 9 passed, 1 warning (`discord.player` `audioop` deprecation)
- Branch check: `git rev-list --left-right --count upstream/main...HEAD` → `0 1`

## Duplicate / competitor check

- Same-author PR search for `46567` in title/body: none
- Same-author branch search for `fix/46567*`: none
- Open PR issue-number search: none
- Open PR keyword search for `compression flush session rotation`: none

Auto-published by Moonsong via Path B automated pipeline.
