### PR TITLE
fix(gateway): protect against boot-time PID reuse when start_time matches

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -627,6 +627,16 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
                     and current_start != existing.get("start_time")
                 ):
                     stale = True
+                
+                # Protect against boot-time PID reuse/collisions (e.g. another system
+                # service starting at the exact same clock tick). If the running process
+                # does not look like a gateway, and we successfully read its command line,
+                # the lock is stale.
+                if not stale and existing_pid is not None and not _looks_like_gateway_process(existing_pid):
+                    live_cmdline = _read_process_cmdline(existing_pid)
+                    if live_cmdline is not None:
+                        stale = True
+
                 # When start_time comparison is unavailable (macOS / Windows
                 # have no /proc, so both sides are None), fall back to
                 # checking the live process command line.  When cmdline is

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -444,6 +444,31 @@ class TestScopedLocks:
         assert acquired is False
         assert existing["pid"] == 99999
 
+    def test_acquire_scoped_lock_replaces_reused_pid_even_with_matching_start_time(self, tmp_path, monkeypatch):
+        """If another system service starts at the exact same clock tick (reused PID
+        and matching start_time) but is not a gateway process, the lock must be
+        treated as stale.
+        """
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": 123,
+            "kind": "hermes-gateway",
+        }))
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(status, "_looks_like_gateway_process", lambda pid: False)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: "/usr/sbin/nginx")
+
+        acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
+
+        assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+
     def test_acquire_scoped_lock_replaces_pid_reused_by_unrelated_process(self, tmp_path, monkeypatch):
         """macOS regression: PID reused by an unrelated process with start_time=None.
 


### PR DESCRIPTION
## Summary
When a system reboots, system services can start at the exact same clock tick and get assigned identical PIDs as previous runs. This causes start_time comparison checks to pass and incorrectly mark stale locks as active.

This PR adds a secondary defense to `acquire_scoped_lock` in `gateway/status.py`: even when the start_time comparison matches, if `_looks_like_gateway_process` returns `False` (meaning the process is not a gateway, e.g., nginx or bluetoothuserd), and we successfully retrieved its command line, treat the lock as stale and evict it.

## Test Plan
- Added `test_acquire_scoped_lock_replaces_reused_pid_even_with_matching_start_time` regression test.
- All 59 gateway status tests pass.