### PR TITLE
fix(agent): redact secrets in API request debug dumps

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1217,12 +1217,24 @@ def dump_api_request_debug(
 
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
         dump_file = agent.logs_dir / f"request_dump_{agent.session_id}_{timestamp}.json"
-        atomic_json_write(dump_file, dump_payload, default=str)
+
+        # Redact secrets before persisting — the request body may contain
+        # tokens that legitimately flowed into model context (MCP env values,
+        # credential echoes in tool results, etc.).  The error path fires
+        # unconditionally on API failures, so this is not gated behind
+        # HERMES_DUMP_REQUESTS.  Reuse the existing scrubber.
+        from agent.redact import redact_sensitive_text
+        _serialized = json.dumps(dump_payload, ensure_ascii=False, indent=2, default=str)
+        _redacted = redact_sensitive_text(_serialized, force=True)
+
+        _tmp = dump_file.with_name(dump_file.name + ".tmp")
+        _tmp.write_text(_redacted, encoding="utf-8")
+        _tmp.replace(dump_file)
 
         agent._vprint(f"{agent.log_prefix}🧾 Request debug dump written to: {dump_file}")
 
         if env_var_enabled("HERMES_DUMP_REQUEST_STDOUT"):
-            print(json.dumps(dump_payload, ensure_ascii=False, indent=2, default=str))
+            print(_redacted)
 
         return dump_file
     except Exception as dump_error:

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -104,6 +104,7 @@ _PREFIX_PATTERNS = [
     r"mem0_[A-Za-z0-9]{10,}",           # Mem0 Platform API key
     r"brv_[A-Za-z0-9]{10,}",            # ByteRover API key
     r"xai-[A-Za-z0-9]{30,}",            # xAI (Grok) API key
+    r"ntn_[A-Za-z0-9]{10,}",            # Notion internal integration token
 ]
 
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -57,6 +57,13 @@ class TestKnownPrefixes:
         result = redact_sensitive_text("key=sk-short1234567")
         assert "***" in result
 
+    def test_notion_integration_token(self):
+        """Notion internal integration tokens (ntn_ prefix) must be redacted."""
+        text = "Use this token: ntn_abc123def456ghi789jkl"
+        result = redact_sensitive_text(text)
+        assert "ntn_abc123def456ghi789jkl" not in result
+        assert "ntn_" in result  # prefix preserved for debugging
+
 
 class TestEnvAssignments:
     def test_export_api_key(self):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -672,6 +672,85 @@ class TestSaveSessionLogRedactsSecrets:
         assert parts[1]["image_url"]["url"].startswith("data:image")
 
 
+class TestDumpApiRequestRedactsSecrets:
+    """Regression: request_dump_*.json must not contain plaintext secrets (#46583)."""
+
+    @pytest.fixture(autouse=True)
+    def _ensure_redaction_enabled(self, monkeypatch):
+        monkeypatch.delenv("HERMES_REDACT_SECRETS", raising=False)
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+
+    def test_redacts_secret_in_request_body(self, agent, tmp_path):
+        agent.logs_dir = tmp_path
+        api_kwargs = {
+            "model": "gpt-4o",
+            "messages": [
+                {"role": "system", "content": "Use key sk-abc123def456ghi789jklm for API calls"},
+                {"role": "user", "content": "hello"},
+            ],
+        }
+        dump_file = agent._dump_api_request_debug(api_kwargs, reason="test")
+        assert dump_file is not None
+        snapshot = dump_file.read_text(encoding="utf-8")
+        assert "sk-abc123def456ghi789jklm" not in snapshot
+
+    def test_redacts_notion_token_in_body(self, agent, tmp_path):
+        agent.logs_dir = tmp_path
+        api_kwargs = {
+            "model": "gpt-4o",
+            "messages": [
+                {"role": "tool", "content": "Notion API token: ntn_abc123def456ghi789jkl"},
+            ],
+        }
+        dump_file = agent._dump_api_request_debug(api_kwargs, reason="test")
+        snapshot = dump_file.read_text(encoding="utf-8")
+        assert "ntn_abc123def456ghi789jkl" not in snapshot
+
+    def test_redacts_error_message(self, agent, tmp_path):
+        agent.logs_dir = tmp_path
+        api_kwargs = {"model": "gpt-4o", "messages": []}
+        error = Exception("Auth failed with key ghp_abc123def456ghi789jklm")
+        dump_file = agent._dump_api_request_debug(api_kwargs, reason="test", error=error)
+        snapshot = dump_file.read_text(encoding="utf-8")
+        assert "ghp_abc123def456ghi789jklm" not in snapshot
+
+    def test_redacts_env_key_in_body(self, agent, tmp_path):
+        agent.logs_dir = tmp_path
+        api_kwargs = {
+            "model": "gpt-4o",
+            "messages": [
+                {"role": "user", "content": "NOTION_API_KEY=secrettokenvalue123456789"},
+            ],
+        }
+        dump_file = agent._dump_api_request_debug(api_kwargs, reason="test")
+        snapshot = dump_file.read_text(encoding="utf-8")
+        assert "secrettokenvalue123456789" not in snapshot
+
+    def test_stdout_also_redacted(self, agent, tmp_path, monkeypatch, capsys):
+        agent.logs_dir = tmp_path
+        monkeypatch.setenv("HERMES_DUMP_REQUEST_STDOUT", "1")
+        api_kwargs = {
+            "model": "gpt-4o",
+            "messages": [
+                {"role": "user", "content": "Token: hf_abc123def456ghi789jklm"},
+            ],
+        }
+        agent._dump_api_request_debug(api_kwargs, reason="test")
+        captured = capsys.readouterr()
+        assert "hf_abc123def456ghi789jklm" not in captured.out
+
+    def test_non_secret_content_preserved(self, agent, tmp_path):
+        agent.logs_dir = tmp_path
+        api_kwargs = {
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "Hello, how are you?"}],
+        }
+        dump_file = agent._dump_api_request_debug(api_kwargs, reason="test")
+        snapshot = dump_file.read_text(encoding="utf-8")
+        assert "Hello, how are you?" in snapshot
+        assert "gpt-4o" in snapshot
+
+
 class TestGetMessagesUpToLastAssistant:
     def test_empty_list(self, agent):
         assert agent._get_messages_up_to_last_assistant([]) == []


### PR DESCRIPTION
## What does this PR do?

Redacts secrets in `dump_api_request_debug()` output before persisting to disk. The request body and error messages are now run through the existing `redact_sensitive_text()` scrubber. Also adds Notion internal integration token prefix (`ntn_`) to `_PREFIX_PATTERNS`.

## Related Issue

Fixes #46583

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_runtime_helpers.py`: Serialize dump payload to JSON string, apply `redact_sensitive_text(force=True)`, then write atomically via temp file + replace. Also redact the `HERMES_DUMP_REQUEST_STDOUT` print path.
- `agent/redact.py`: Add `ntn_[A-Za-z0-9]{10,}` to `_PREFIX_PATTERNS` for Notion internal integration tokens.
- `tests/agent/test_redact.py`: Add `test_notion_integration_token` to verify Notion token prefix redaction.
- `tests/run_agent/test_run_agent.py`: Add `TestDumpApiRequestRedactsSecrets` class with 6 tests covering body redaction, Notion token redaction, error message redaction, ENV key redaction, stdout redaction, and non-secret content preservation.

## How to Test

1. Run `pytest tests/agent/test_redact.py -xvs` — all 75 tests pass including the new Notion token test.
2. Run `pytest tests/run_agent/test_run_agent.py::TestDumpApiRequestRedactsSecrets -xvs` — all 6 new tests pass.
3. Run `pytest tests/run_agent/test_run_agent_codex_responses.py -k dump_api_request_debug -xvs` — existing dump tests still pass.
4. Manual verification: trigger an API error with a secret in context, inspect the `request_dump_*.json` file — secrets should be masked.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `dump_api_request_debug` (callers: 3 in conversation_loop.py + run_agent.py forwarder, 2 in existing tests)
- Blast radius: LOW — isolated debug dump function, no control-flow changes to agent loop
- Related patterns: `redact_sensitive_text` already used by `_save_session_log`, `save_trajectory`, gateway log writers
