### PR TITLE
fix(desktop): scan backward for most recent reasoning part

### DIFF
--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -213,12 +213,14 @@ export function appendAssistantTextPart(parts: ChatMessagePart[], delta: string)
 
 export function appendReasoningPart(parts: ChatMessagePart[], delta: string): ChatMessagePart[] {
   const next = [...parts]
-  const last = next.at(-1)
 
-  if (last?.type === 'reasoning') {
-    next[next.length - 1] = { ...last, text: `${last.text}${delta}` }
+  for (let i = next.length - 1; i >= 0; i--) {
+    if (next[i].type === 'reasoning') {
+      const prev = next[i] as Extract<ChatMessagePart, { type: 'reasoning' }>
+      next[i] = { ...prev, text: `${prev.text}${delta}` }
 
-    return next
+      return next
+    }
   }
 
   next.push(reasoningPart(delta))


### PR DESCRIPTION
appendReasoningPart() only checked parts[-1]. When a tool-call part is inserted between two reasoning deltas, the last element is no longer a reasoning part, so a new independent Thinking block is created instead of appending to the existing one — splitting one continuous thought across two blocks.

Fix: scan backward from the end of the parts array to find the most recent reasoning part, same pattern as appendAssistantTextPart.

Related Issue
Fixes #39968

Type of Change
🐛 Bug fix