### PR TITLE
fix(bedrock): check boto3 version >= 1.34.59 before using converse_stream

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -58,17 +58,34 @@ _bedrock_runtime_client_cache: Dict[str, Any] = {}
 _bedrock_control_client_cache: Dict[str, Any] = {}
 
 
+_MIN_BOTO3_VERSION = (1, 34, 59)
+
+
 def _require_boto3():
-    """Import boto3, raising a clear error if not installed."""
+    """Import boto3, raising a clear error if not installed or too old."""
     try:
         import boto3
-        return boto3
     except ImportError:
         raise ImportError(
             "The 'boto3' package is required for the AWS Bedrock provider. "
             "Install it with: pip install boto3\n"
             "Or install Hermes with Bedrock support: pip install -e '.[bedrock]'"
         )
+    # converse() / converse_stream() were added in boto3 1.34.59.
+    # When Hermes is installed editable into system Python, the system boto3
+    # (e.g. Ubuntu 24.04 ships 1.34.46) may take precedence over the venv
+    # version pinned in pyproject.toml.
+    try:
+        version = tuple(int(x) for x in boto3.__version__.split(".")[:3])
+    except (AttributeError, ValueError):
+        return boto3  # can't parse — don't block on version check
+    if version < _MIN_BOTO3_VERSION:
+        raise RuntimeError(
+            f"boto3 {boto3.__version__} does not support converse_stream "
+            f"(minimum 1.34.59 required). Upgrade with: "
+            f"pip install --upgrade boto3"
+        )
+    return boto3
 
 
 def _get_bedrock_runtime_client(region: str):

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -1663,3 +1663,53 @@ class TestCallConverseStreamIamFallback:
         assert result.choices[0].message.content == "hi"
         # Not a stale connection — client stays cached.
         assert _bedrock_runtime_client_cache.get("us-east-1") is client
+
+
+# ---------------------------------------------------------------------------
+# boto3 version check
+# ---------------------------------------------------------------------------
+
+
+class TestRequireBoto3VersionCheck:
+    """Test that _require_boto3() rejects boto3 versions older than 1.34.59."""
+
+    def test_raises_runtime_error_when_boto3_too_old(self):
+        """boto3 < 1.34.59 should raise RuntimeError with upgrade instructions."""
+        from agent.bedrock_adapter import _require_boto3
+
+        fake_boto3 = MagicMock()
+        fake_boto3.__version__ = "1.34.46"
+        with patch.dict("sys.modules", {"boto3": fake_boto3}):
+            with pytest.raises(RuntimeError, match="does not support converse_stream"):
+                _require_boto3()
+
+    def test_accepts_boto3_at_minimum_version(self):
+        """boto3 == 1.34.59 should be accepted."""
+        from agent.bedrock_adapter import _require_boto3
+
+        fake_boto3 = MagicMock()
+        fake_boto3.__version__ = "1.34.59"
+        with patch.dict("sys.modules", {"boto3": fake_boto3}):
+            result = _require_boto3()
+            assert result is fake_boto3
+
+    def test_accepts_newer_boto3(self):
+        """boto3 > 1.34.59 should be accepted."""
+        from agent.bedrock_adapter import _require_boto3
+
+        fake_boto3 = MagicMock()
+        fake_boto3.__version__ = "1.42.89"
+        with patch.dict("sys.modules", {"boto3": fake_boto3}):
+            result = _require_boto3()
+            assert result is fake_boto3
+
+    def test_accepts_boto3_with_unparseable_version(self):
+        """If version string can't be parsed, don't block on version check."""
+        from agent.bedrock_adapter import _require_boto3
+
+        fake_boto3 = MagicMock()
+        fake_boto3.__version__ = "dev"
+        with patch.dict("sys.modules", {"boto3": fake_boto3}):
+            result = _require_boto3()
+            assert result is fake_boto3
+


### PR DESCRIPTION
## What does this PR do?

Adds a runtime version check in `_require_boto3()` to catch boto3 versions older than 1.34.59 (which lack `converse`/`converse_stream` methods) and raise an actionable `RuntimeError` instead of a confusing `AttributeError` on the first inference call.

## Related Issue

Fixes #46592

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/bedrock_adapter.py`: Add `_MIN_BOTO3_VERSION = (1, 34, 59)` constant and version check in `_require_boto3()` — parses `boto3.__version__`, raises `RuntimeError` with upgrade instructions if below minimum
- `tests/agent/test_bedrock_adapter.py`: Add `TestRequireBoto3VersionCheck` class with 4 tests: too-old rejected, minimum accepted, newer accepted, unparseable version accepted

## How to Test

1. `pip install boto3==1.34.46` (simulates Ubuntu 24.04 system boto3)
2. Configure a Bedrock model and trigger any inference call
3. Before this PR: `AttributeError: 'BedrockRuntime' object has no attribute 'converse_stream'` (silent agent crash)
4. After this PR: `RuntimeError: boto3 1.34.46 does not support converse_stream (minimum 1.34.59 required). Upgrade with: pip install --upgrade boto3`
5. Run `pytest tests/agent/test_bedrock_adapter.py -x -q` — 132 tests pass (4 new)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/bedrock_adapter.py::_require_boto3()` (callers: `_get_bedrock_runtime_client`, `_get_bedrock_control_client` — 2 call sites)
- Blast radius: LOW — only affects Bedrock provider initialization; early-fail before any client creation
- Related patterns: lazy import guard pattern (same as `_require_boto3()` ImportError guard)
