### PR TITLE
fix(gateway): evict scoped lock when PID+start_time match but process is not a gateway

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -643,6 +643,21 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
                     live_cmdline = _read_process_cmdline(existing_pid)
                     if live_cmdline is not None or not _record_looks_like_gateway(existing):
                         stale = True
+                # Secondary defence against boot-time PID+start_time collisions:
+                # systemd spawns core services deterministically, so an unrelated
+                # process (e.g. cron) can land on the exact same PID and jiffy
+                # count as a previous gateway. If both start_times are known and
+                # match but the live process is not a gateway, and we can confirm
+                # that by reading its cmdline, the lock is stale.
+                if (
+                    not stale
+                    and existing.get("start_time") is not None
+                    and current_start is not None
+                    and not _looks_like_gateway_process(existing_pid)
+                ):
+                    live_cmdline = _read_process_cmdline(existing_pid)
+                    if live_cmdline is not None:
+                        stale = True
                 # Check if process is stopped (Ctrl+Z / SIGTSTP) — stopped
                 # processes still appear alive to _pid_exists but are not
                 # actually running. Treat them as stale so --replace works.

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -636,6 +636,36 @@ class TestScopedLocks:
         assert removed == 0
         assert reused_pid_lock.exists()
 
+    def test_acquire_scoped_lock_replaces_reused_pid_even_with_matching_start_time(self, tmp_path, monkeypatch):
+        """Regression: boot-time PID+start_time collision must not block gateway startup.
+
+        On Linux, systemd assigns PIDs and jiffy start_times deterministically
+        across reboots. A core service (e.g. cron) can land on the exact same
+        PID and start_time as a previous gateway. The start_time check passes,
+        but the live process is not a gateway — the lock must be evicted.
+        """
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 840,
+            "start_time": 123,
+            "kind": "hermes-gateway",
+            "argv": ["/usr/bin/python", "-m", "hermes_cli.main", "gateway", "run"],
+        }))
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(status, "_looks_like_gateway_process", lambda pid: False)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: "/usr/sbin/nginx")
+
+        acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
+
+        assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+        assert payload["metadata"]["platform"] == "telegram"
+
 
 class TestTakeoverMarker:
     """Tests for the --replace takeover marker.


### PR DESCRIPTION
## What does this PR do?

Fixes a boot-time PID collision bug in `acquire_scoped_lock` that permanently blocks gateway startup after a system reboot.

On Linux, systemd spawns core services (cron, nginx, sshd) with deterministic PIDs and jiffy-based `start_time` values across reboots. A system service can land on the exact same PID and `start_time` as a previous gateway. The existing stale-lock detection had two paths:

- Both `start_time` values non-None and **different** → stale ✓
- Both `start_time` values **None** (macOS/Windows, no `/proc`) → fall back to cmdline check ✓

The boot collision falls through both: times are non-None and **equal**, so neither branch fires. The lock is mistakenly treated as live and startup fails permanently with `"Telegram bot token already in use (PID 840). Stop the other gateway first."` — until the lock file is manually deleted.

The fix adds a third check: when both start_times match but the live process fails `_looks_like_gateway_process`, read its cmdline. A readable non-gateway cmdline is positive evidence of an impostor → evict. If cmdline is unreadable we stay conservative and do not evict. The `existing.get("start_time") is not None` guard ensures no overlap with the existing macOS/Windows `None/None` path.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/status.py`: added third stale-detection branch in `acquire_scoped_lock` after the existing `None/None` fallback block, guarded by `start_time is not None` on both sides
- `tests/gateway/test_status.py`: added `test_acquire_scoped_lock_replaces_reused_pid_even_with_matching_start_time` in `TestScopedLocks` — mocks `_pid_exists=True`, `_get_process_start_time=123` (matching lock record), `_looks_like_gateway_process=False`, `_read_process_cmdline="/usr/sbin/nginx"`, asserts lock is evicted and re-acquired

## How to Test

1. `pytest tests/gateway/test_status.py -q` — all 59 tests pass including the new regression test
2. To reproduce the bug without the fix: write a lock file with any PID and `start_time`, mock `_pid_exists=True` and `_get_process_start_time` to return the same value, mock `_looks_like_gateway_process=False` and `_read_process_cmdline` to return a non-gateway string — without this fix `acquire_scoped_lock` returns `False` (blocked); with it, `True`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Raspberry Pi OS (Linux 6.18, Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — fix is gated on `start_time is not None` on both sides, making it a no-op on macOS/Windows where `_get_process_start_time` returns `None`
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

```
============================== 59 passed in 0.65s ==============================
```