### PR TITLE
Redact secrets in API request debug dumps

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1217,12 +1217,24 @@ def dump_api_request_debug(
 
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
         dump_file = agent.logs_dir / f"request_dump_{agent.session_id}_{timestamp}.json"
-        atomic_json_write(dump_file, dump_payload, default=str)
+
+        # Redact secrets before persisting/printing. This dump captures the
+        # full request body (system prompt, tool defs, context-embedded
+        # values), and this path fires unconditionally on API errors — so it
+        # otherwise lands any context-embedded secret in cleartext on disk.
+        # Run the serialized dump through the same scrubber used for logs/tool
+        # output. Atomicity preserved via temp-file + Path.replace.
+        from agent.redact import redact_sensitive_text
+        _serialized = json.dumps(dump_payload, ensure_ascii=False, indent=2, default=str)
+        _redacted = redact_sensitive_text(_serialized, force=True)
+        _tmp = dump_file.with_name(dump_file.name + ".tmp")
+        _tmp.write_text(_redacted, encoding="utf-8")
+        _tmp.replace(dump_file)
 
         agent._vprint(f"{agent.log_prefix}🧾 Request debug dump written to: {dump_file}")
 
         if env_var_enabled("HERMES_DUMP_REQUEST_STDOUT"):
-            print(json.dumps(dump_payload, ensure_ascii=False, indent=2, default=str))
+            print(_redacted)
 
         return dump_file
     except Exception as dump_error:

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -104,6 +104,7 @@ _PREFIX_PATTERNS = [
     r"mem0_[A-Za-z0-9]{10,}",           # Mem0 Platform API key
     r"brv_[A-Za-z0-9]{10,}",            # ByteRover API key
     r"xai-[A-Za-z0-9]{30,}",            # xAI (Grok) API key
+    r"ntn_[A-Za-z0-9]{10,}",            # Notion internal integration token
 ]
 
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name


### PR DESCRIPTION
Fixes the redaction gap reported in #46583.

## Problem
`agent/agent_runtime_helpers.py:dump_api_request_debug()` masks the provider
`Authorization` header but writes the request **`body`** (system prompt, tool
defs, context-embedded values) and the error `message` **raw** via
`atomic_json_write`. This path fires **unconditionally on API errors** (not only
under `HERMES_DUMP_REQUESTS`), so any secret surfaced into context — e.g. an
integration token — lands in cleartext at `request_dump_*.json` on every failed
inference call. Hermes already has a scrubber (`agent/redact.py`) used for
logs/tool output; it just wasn't applied here.

## Fix
- Serialize the dump and run it through the existing
  `redact_sensitive_text(force=True)` before persisting, and before the
  `HERMES_DUMP_REQUEST_STDOUT` print. Atomicity preserved via temp-file +
  `Path.replace()`.
- Add the Notion internal-integration prefix `ntn_` to `_PREFIX_PATTERNS` so
  bare values (no adjacent key name) are caught.

## Verification
`NOTION_API_KEY=ntn_…`, `"NOTION_API_KEY":"ntn_…"`, a bare `ntn_…`, and
`sk-ant-…` are all masked after the change; the provider header was already
masked. `py_compile` clean on both files.

## Scope note
Per `SECURITY.md` §3.2 this is a redaction (in-process heuristic) hardening, not
a §3.1 vulnerability — secrets here stay on the operator's own disk, inside the
trust envelope. Filed as a regular issue/PR accordingly.