### PR TITLE
fix(compression): flush messages before session rotation (#46567)

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -512,6 +512,11 @@ def compress_context(
             old_title = agent._session_db.get_session_title(agent.session_id)
             # Trigger memory extraction on the old session before it rotates.
             agent.commit_memory_session(messages)
+            # Flush any messages accumulated since the last _persist_session
+            # call to the old session's DB before we close it.  Without this,
+            # messages created between the last turn-exit persist and the
+            # compression rotation are silently lost (see #46567).
+            agent._flush_messages_to_session_db(messages)
             agent._session_db.end_session(agent.session_id, "compression")
             old_session_id = agent.session_id
             agent.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"


### PR DESCRIPTION
Fixes #46567. When auto-compression fires multiple times within a single turn, intermediate sessions are created via end_session(old_id, 'compression') before _persist_session ever runs. Messages accumulated in these intermediate sessions are silently lost to SQLite. This fix calls _flush_messages_to_session_db() before end_session() so all messages are persisted before the old session is closed.