### PR TITLE
feat(email): Markdown-to-HTML rendering for outbound emails

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -69,6 +69,10 @@ _HERMES_EMAIL_HTML_TEMPLATE = """\
 """
 
 # Inline CSS per-element for email client compat (Gmail strips <style> tags).
+# Note: Python-Markdown generates <pre><code>...</code></pre> for fenced code.
+# The <pre> styling provides the dark background; <code> inside inherits it.
+# We use a two-pass approach: first style all <code> (inline code gets light bg),
+# then override <code> inside <pre> blocks to be transparent.
 _HERMES_EMAIL_STYLES = [
     ("h1", 'style="font-size:24px;font-weight:700;color:#1a202c;margin:24px 0 12px;border-bottom:2px solid #667eea;padding-bottom:8px;"'),
     ("h2", 'style="font-size:20px;font-weight:700;color:#2d3748;margin:24px 0 10px;border-bottom:1px solid #e2e8f0;padding-bottom:6px;"'),
@@ -84,10 +88,15 @@ _HERMES_EMAIL_STYLES = [
     ("td", 'style="padding:8px 12px;border-bottom:1px solid #e2e8f0;"'),
     ("code", 'style="background:#edf2f7;padding:2px 5px;border-radius:3px;font-size:13px;font-family:Menlo,Monaco,Consolas,monospace;"'),
     ("pre", 'style="background:#2d3748;color:#e2e8f0;padding:16px;border-radius:6px;overflow-x:auto;font-size:13px;line-height:1.5;"'),
-    ("pre code", 'style="background:transparent;padding:0;color:inherit;"'),
     ("a", 'style="color:#667eea;text-decoration:none;"'),
     ("hr", 'style="border:none;border-top:1px solid #e2e8f0;margin:20px 0;"'),
 ]
+
+# Regex to match <code> inside <pre> blocks — override inline code styling
+_PRE_CODE_OVERRIDE = (
+    re.compile(r"(<pre[^>]*>.*?)<code(\s|>)", re.DOTALL),
+    r'\1<code style="background:transparent;padding:0;color:inherit;font-size:13px;font-family:Menlo,Monaco,Consolas,monospace;"\2',
+)
 
 
 def _markdown_to_html_email(body: str) -> str:
@@ -97,7 +106,10 @@ def _markdown_to_html_email(body: str) -> str:
     # Inject inline styles per element (Gmail strips <style> blocks)
     for tag, style in _HERMES_EMAIL_STYLES:
         html = re.sub(rf"<{tag}(\s|>)", rf"<{tag} {style}\1", html)
-    return _HERMES_EMAIL_HTML_TEMPLATE.format(body=html)
+    # Override <code> inside <pre> blocks (two-pass: inline code already styled above)
+    html = _PRE_CODE_OVERRIDE[0].sub(_PRE_CODE_OVERRIDE[1], html)
+    # Use .replace() instead of .format() — body may contain { } braces
+    return _HERMES_EMAIL_HTML_TEMPLATE.replace("{body}", html)
 
 
 # Automated sender patterns — emails from these are silently ignored
@@ -686,25 +698,23 @@ class EmailAdapter(BasePlatformAdapter):
 
     def _attach_body(self, msg: MIMEMultipart, body: str) -> None:
         """Attach body as plain text + optional HTML to a message."""
-        msg.attach(MIMEText(body, "plain", "utf-8"))
-        if self._html_format:
-            try:
-                html = _markdown_to_html_email(body)
-                msg.attach(MIMEText(html, "html", "utf-8"))
-            except Exception as e:
-                logger.warning("[Email] HTML conversion failed, sending plain only: %s", e)
+        self._attach_parts(msg, body)
 
     def _create_body_part(self, body: str) -> MIMEMultipart:
         """Create a multipart/alternative body part (for use inside multipart/mixed)."""
         alt = MIMEMultipart("alternative")
-        alt.attach(MIMEText(body, "plain", "utf-8"))
+        self._attach_parts(alt, body)
+        return alt
+
+    def _attach_parts(self, container: MIMEMultipart, body: str) -> None:
+        """Attach plain + optional HTML parts to a multipart container."""
+        container.attach(MIMEText(body, "plain", "utf-8"))
         if self._html_format:
             try:
                 html = _markdown_to_html_email(body)
-                alt.attach(MIMEText(html, "html", "utf-8"))
+                container.attach(MIMEText(html, "html", "utf-8"))
             except Exception as e:
-                logger.warning("[Email] HTML conversion failed, sending plain only: %s", e)
-        return alt
+                logger.warning("[Email] HTML conversion failed, sending plain only: %s", e, exc_info=True)
 
     def _send_email(
         self,

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -45,6 +45,61 @@ from gateway.platforms.base import (
 from gateway.config import Platform, PlatformConfig
 
 logger = logging.getLogger(__name__)
+
+# ── HTML Email Formatting ───────────────────────────────────────────────────
+# Converts Markdown to styled HTML for rich email rendering.
+# Config: platforms.email.html_format (default: true)
+
+_HERMES_EMAIL_HTML_TEMPLATE = """\
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="margin:0;padding:0;background:#f4f4f7;">
+<div style="max-width:680px;margin:0 auto;background:#ffffff;
+  font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;
+  font-size:15px;line-height:1.6;color:#2d3748;padding:32px;">
+{body}
+<div style="margin-top:32px;padding-top:16px;border-top:1px solid #e2e8f0;
+  font-size:12px;color:#a0aec0;">
+  Sent by <strong>Hermes Agent</strong>
+</div>
+</div>
+</body>
+</html>
+"""
+
+# Inline CSS per-element for email client compat (Gmail strips <style> tags).
+_HERMES_EMAIL_STYLES = [
+    ("h1", 'style="font-size:24px;font-weight:700;color:#1a202c;margin:24px 0 12px;border-bottom:2px solid #667eea;padding-bottom:8px;"'),
+    ("h2", 'style="font-size:20px;font-weight:700;color:#2d3748;margin:24px 0 10px;border-bottom:1px solid #e2e8f0;padding-bottom:6px;"'),
+    ("h3", 'style="font-size:17px;font-weight:600;color:#4a5568;margin:18px 0 8px;"'),
+    ("h4", 'style="font-size:15px;font-weight:600;color:#718096;margin:14px 0 6px;"'),
+    ("p", 'style="margin:0 0 12px;"'),
+    ("ul", 'style="margin:0 0 12px;padding-left:24px;"'),
+    ("ol", 'style="margin:0 0 12px;padding-left:24px;"'),
+    ("li", 'style="margin-bottom:4px;"'),
+    ("blockquote", 'style="margin:12px 0;padding:12px 16px;border-left:4px solid #667eea;background:#f7fafc;color:#4a5568;font-style:italic;"'),
+    ("table", 'style="border-collapse:collapse;width:100%;margin:12px 0;font-size:14px;"'),
+    ("th", 'style="background:#667eea;color:#fff;padding:8px 12px;text-align:left;font-weight:600;"'),
+    ("td", 'style="padding:8px 12px;border-bottom:1px solid #e2e8f0;"'),
+    ("code", 'style="background:#edf2f7;padding:2px 5px;border-radius:3px;font-size:13px;font-family:Menlo,Monaco,Consolas,monospace;"'),
+    ("pre", 'style="background:#2d3748;color:#e2e8f0;padding:16px;border-radius:6px;overflow-x:auto;font-size:13px;line-height:1.5;"'),
+    ("pre code", 'style="background:transparent;padding:0;color:inherit;"'),
+    ("a", 'style="color:#667eea;text-decoration:none;"'),
+    ("hr", 'style="border:none;border-top:1px solid #e2e8f0;margin:20px 0;"'),
+]
+
+
+def _markdown_to_html_email(body: str) -> str:
+    """Convert Markdown body to styled HTML email content."""
+    import markdown as _md_mod
+    html = _md_mod.markdown(body, extensions=["tables", "fenced_code", "nl2br"])
+    # Inject inline styles per element (Gmail strips <style> blocks)
+    for tag, style in _HERMES_EMAIL_STYLES:
+        html = re.sub(rf"<{tag}(\s|>)", rf"<{tag} {style}\1", html)
+    return _HERMES_EMAIL_HTML_TEMPLATE.format(body=html)
+
+
 # Automated sender patterns — emails from these are silently ignored
 _NOREPLY_PATTERNS = (
     "noreply", "no-reply", "no_reply", "donotreply", "do-not-reply",
@@ -320,6 +375,7 @@ class EmailAdapter(BasePlatformAdapter):
         #       skip_attachments: true
         extra = config.extra or {}
         self._skip_attachments = extra.get("skip_attachments", False)
+        self._html_format = extra.get("html_format", True)
 
         # Track message IDs we've already processed to avoid duplicates
         self._seen_uids: set = set()
@@ -626,6 +682,30 @@ class EmailAdapter(BasePlatformAdapter):
             logger.error("[Email] Send failed to %s: %s", chat_id, e)
             return SendResult(success=False, error=str(e))
 
+    # ── HTML email helpers ──────────────────────────────────────────────────
+
+    def _attach_body(self, msg: MIMEMultipart, body: str) -> None:
+        """Attach body as plain text + optional HTML to a message."""
+        msg.attach(MIMEText(body, "plain", "utf-8"))
+        if self._html_format:
+            try:
+                html = _markdown_to_html_email(body)
+                msg.attach(MIMEText(html, "html", "utf-8"))
+            except Exception as e:
+                logger.warning("[Email] HTML conversion failed, sending plain only: %s", e)
+
+    def _create_body_part(self, body: str) -> MIMEMultipart:
+        """Create a multipart/alternative body part (for use inside multipart/mixed)."""
+        alt = MIMEMultipart("alternative")
+        alt.attach(MIMEText(body, "plain", "utf-8"))
+        if self._html_format:
+            try:
+                html = _markdown_to_html_email(body)
+                alt.attach(MIMEText(html, "html", "utf-8"))
+            except Exception as e:
+                logger.warning("[Email] HTML conversion failed, sending plain only: %s", e)
+        return alt
+
     def _send_email(
         self,
         to_addr: str,
@@ -633,7 +713,7 @@ class EmailAdapter(BasePlatformAdapter):
         reply_to_msg_id: Optional[str] = None,
     ) -> str:
         """Send an email via SMTP. Runs in executor thread."""
-        msg = MIMEMultipart()
+        msg = MIMEMultipart("alternative")
         msg["From"] = self._address
         msg["To"] = to_addr
 
@@ -654,7 +734,7 @@ class EmailAdapter(BasePlatformAdapter):
         msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._address.split('@')[1]}>"
         msg["Message-ID"] = msg_id
 
-        msg.attach(MIMEText(body, "plain", "utf-8"))
+        self._attach_body(msg, body)
 
         smtp = self._connect_smtp()
         try:
@@ -763,7 +843,7 @@ class EmailAdapter(BasePlatformAdapter):
         msg["Message-ID"] = msg_id
 
         if body:
-            msg.attach(MIMEText(body, "plain", "utf-8"))
+            msg.attach(self._create_body_part(body))
 
         for file_path in file_paths:
             p = Path(file_path)
@@ -843,7 +923,7 @@ class EmailAdapter(BasePlatformAdapter):
         msg["Message-ID"] = msg_id
 
         if body:
-            msg.attach(MIMEText(body, "plain", "utf-8"))
+            msg.attach(self._create_body_part(body))
 
         # Attach file
         p = Path(file_path)


### PR DESCRIPTION
## What does this PR do?

Adds automatic Markdown-to-HTML rendering for all outbound emails. Sends emails as `multipart/alternative` with both `text/plain` (raw body) and `text/html` (styled HTML), so HTML-capable clients render rich formatting while plain-text clients fall back gracefully.

**Addresses:** Closes #11941 (2 reactions), also related to #25439.

## How it works

1. `_markdown_to_html_email(body)` converts Markdown to HTML using the `markdown` library (tables, fenced code, nl2br), then injects **inline CSS** per element (because Gmail strips `<style>` blocks).

2. All 3 send paths use new helpers:
   - `_send_email` uses `_attach_body(msg, body)` — plain + HTML parts on `MIMEMultipart("alternative")`
   - `_send_email_with_attachment` uses `_create_body_part(body)` — wrapped in `multipart/alternative` inside `multipart/mixed`
   - `_send_email_with_attachments` — same wrapper pattern

3. Config opt-out: `platforms.email.html_format: false` disables HTML and keeps plain-text-only behavior (default: `true`).

4. Graceful fallback: if `markdown` is not installed or conversion fails, plain text is sent as before.

## Why inline CSS instead of style blocks

Gmail (both web and mobile) strips `<style>` tags from emails. Every style must be on the element itself. This is a well-known email development constraint.

## Design decisions

- **Lazy `import markdown`**: Avoids hard dependency — email adapter loads even if `markdown` is not installed. Falls back to plain text.
- **Inline CSS per element**: Gmail compatibility — `<style>` blocks are stripped.
- **`html_format: true` default**: Rich email is the better default. Users who want plain-only can opt out.
- **`MIMEMultipart("alternative")`**: Standard email multipart for plain+HTML — all clients understand it.

## Changes Made

- `gateway/platforms/email.py`:
  - Add `_HERMES_EMAIL_HTML_TEMPLATE` — responsive HTML wrapper
  - Add `_HERMES_EMAIL_STYLES` — inline CSS map for 17 HTML elements
  - Add `_markdown_to_html_email()` — Markdown to HTML to styled HTML
  - Add `EmailAdapter._attach_body()` — attach plain+HTML to a message
  - Add `EmailAdapter._create_body_part()` — wrap body for multipart/mixed (attachments)
  - Modify `__init__`: read `html_format` from `config.extra` (default: `true`)
  - Modify `_send_email`: use `MIMEMultipart("alternative")` + `_attach_body`
  - Modify `_send_email_with_attachment`: use `_create_body_part`
  - Modify `_send_email_with_attachments`: use `_create_body_part`

## How to Test

```bash
# Unit: syntax + import check
python3 -c "from gateway.platforms.email import _markdown_to_html_email; print(_markdown_to_html_email('**bold** and *italic*'))"

# E2E: send a message via email, check:
# - Gmail: renders headings, bold, tables, code blocks
# - Apple Mail: same
# - Thunderbird: same
# - Plain-text client (mutt): sees raw Markdown (unchanged)
```

## Checklist

- [x] Only `gateway/platforms/email.py` touched (1 file, 84 insertions, 4 deletions)
- [x] Lazy import — no hard dependency added to `pyproject.toml`
- [x] Config opt-out available (`html_format: false`)
- [x] Graceful fallback: markdown missing leads to plain text; conversion error leads to plain text + warning
- [x] All 3 send paths updated
- [x] Conventional Commits format (`feat(email): ...`)
- [x] Cross-platform: pure Python `email.mime` + `markdown` library, no OS-specific code
- [x] No tool schema change

## MIME Structure

With `html_format: true` (default):
```
multipart/alternative
+-- text/plain   (raw Markdown body)
+-- text/html    (styled HTML with inline CSS)
```

With attachments:
```
multipart/mixed
+-- multipart/alternative
|   +-- text/plain
|   +-- text/html
+-- application/octet-stream (attachment)
```

With `html_format: false`:
```
text/plain   (unchanged from current behavior)
```

## Note on markdown dependency

The `markdown` library is a lightweight pure-Python package (~100KB, no transitive deps, widely used by Django/MkDocs/Jupyter). It is lazily imported — the email adapter loads and works even if `markdown` is not installed (falls back to plain text). If the maintainers prefer, it can be added to `pyproject.toml` as an exact-pinned dependency or moved to an optional extra.
