### PR TITLE
fix(models): merge Z.AI curated models with live API results

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2370,7 +2370,7 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             if api_key:
                 live = _p.fetch_models(api_key=api_key)
                 if live:
-                    if normalized in {"kimi-coding", "kimi-coding-cn"}:
+                    if normalized in {"kimi-coding", "kimi-coding-cn", "zai"}:
                         curated = list(_PROVIDER_MODELS.get(normalized, []))
                         merged = list(curated)
                         merged_lower = {m.lower() for m in curated}


### PR DESCRIPTION
## Problem

Z.AI free-tier API returns only 2 models for some accounts, so the curated model list (`_PROVIDER_MODELS["zai"]`) was invisible in the Dashboard picker. Only the API-returned models appeared, even though the curated list contains 18 models covering text, vision, and thinking tiers.

## Fix

Add `"zai"` to the set of providers that merge curated entries with live API results in `provider_model_ids()`. This matches the existing Kimi merge pattern:

```python
if normalized in {"kimi-coding", "kimi-coding-cn", "zai"}:
    curated = list(_PROVIDER_MODELS.get(normalized, []))
    merged = list(curated)
    merged_lower = {m.lower() for m in curated}
    for m in live:
        if m.lower() not in merged_lower:
            merged.append(m)
    return merged
```

Curated models appear first (in priority order), then any additional models from the API.

## Change

`hermes_cli/models.py` — 1 line, added `"zai"` to the merge set.