### PR TITLE
fix(dump): report effective terminal backend in `hermes debug`

### DIFF
--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -227,9 +227,24 @@ def run_dump(args):
     except Exception:
         profile = "(default)"
 
-    # Terminal backend
+    # Terminal backend — report the EFFECTIVE backend, not just config.yaml.
+    # ``terminal.backend`` in config.yaml is bridged to the TERMINAL_ENV env var,
+    # but a TERMINAL_ENV set directly in .env / the shell overrides config and is
+    # what terminal_tool actually uses (tools/terminal_tool.py reads TERMINAL_ENV).
+    # Reporting only the config value hides that override and sends users chasing
+    # the wrong cause when the agent runs in a docker/podman sandbox even though
+    # config says "local" (and vice-versa). run_dump() has already loaded .env,
+    # so os.environ reflects the real override here.
     terminal_cfg = config.get("terminal", {})
-    backend = terminal_cfg.get("backend", "local")
+    config_backend = terminal_cfg.get("backend", "local")
+    env_backend = (os.environ.get("TERMINAL_ENV") or "").strip().lower()
+    if env_backend and env_backend != str(config_backend).strip().lower():
+        backend = (
+            f"{env_backend}  (TERMINAL_ENV overrides config.yaml "
+            f"terminal.backend={config_backend})"
+        )
+    else:
+        backend = config_backend
 
     # OpenAI SDK version
     try:

--- a/tests/hermes_cli/test_dump_terminal_backend.py
+++ b/tests/hermes_cli/test_dump_terminal_backend.py
@@ -1,0 +1,80 @@
+"""`hermes debug` must report the EFFECTIVE terminal backend.
+
+``terminal.backend`` in config.yaml is bridged to the ``TERMINAL_ENV`` env var,
+but a ``TERMINAL_ENV`` set in .env / the shell overrides config and is what
+``terminal_tool`` actually uses.  The dump used to print only the config value,
+which hid the override and made users believe the agent was running ``local``
+while it was really jailed in a docker/podman sandbox (and vice-versa).
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _terminal_line(out: str) -> str:
+    for line in out.splitlines():
+        if line.startswith("terminal:"):
+            return line
+    raise AssertionError(f"no 'terminal:' line in dump output:\n{out}")
+
+
+def _seed(home: Path, *, config_yaml: str, env_text: str) -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text(config_yaml)
+    (home / ".env").write_text(env_text)
+
+
+def test_dump_surfaces_terminal_env_override(monkeypatch, capsys, tmp_path):
+    from hermes_cli import dump
+    from hermes_cli.config import get_hermes_home
+
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    # Keep run_dump's project-.env fallback from touching the real repo.
+    monkeypatch.setattr(dump, "get_project_root", lambda: tmp_path / "noproject")
+
+    home = get_hermes_home()
+    _seed(home, config_yaml="terminal:\n  backend: local\n", env_text="TERMINAL_ENV=docker\n")
+
+    dump.run_dump(SimpleNamespace(show_keys=False))
+
+    line = _terminal_line(capsys.readouterr().out)
+    # Effective backend (docker) is what actually runs, not the config 'local'.
+    assert "docker" in line
+    assert "overrides config.yaml" in line
+    # The shadowed config value is still shown so the mismatch is obvious.
+    assert "terminal.backend=local" in line
+
+
+def test_dump_reports_config_backend_when_no_override(monkeypatch, capsys, tmp_path):
+    from hermes_cli import dump
+    from hermes_cli.config import get_hermes_home
+
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    monkeypatch.setattr(dump, "get_project_root", lambda: tmp_path / "noproject")
+
+    home = get_hermes_home()
+    _seed(home, config_yaml="terminal:\n  backend: docker\n", env_text="")
+
+    dump.run_dump(SimpleNamespace(show_keys=False))
+
+    line = _terminal_line(capsys.readouterr().out)
+    assert "docker" in line
+    assert "overrides" not in line
+
+
+def test_dump_no_override_when_env_matches_config(monkeypatch, capsys, tmp_path):
+    from hermes_cli import dump
+    from hermes_cli.config import get_hermes_home
+
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    monkeypatch.setattr(dump, "get_project_root", lambda: tmp_path / "noproject")
+
+    home = get_hermes_home()
+    # TERMINAL_ENV agrees with config — no spurious "override" note.
+    _seed(home, config_yaml="terminal:\n  backend: docker\n", env_text="TERMINAL_ENV=docker\n")
+
+    dump.run_dump(SimpleNamespace(show_keys=False))
+
+    line = _terminal_line(capsys.readouterr().out)
+    assert "docker" in line
+    assert "overrides" not in line


### PR DESCRIPTION
## What does this PR do?

`hermes debug` printed the terminal backend straight from
`config.yaml` (`terminal.backend`, default `local`). But the backend that
`terminal_tool` actually uses comes from the `TERMINAL_ENV` env var, and a
`TERMINAL_ENV` set in `.env` / the shell **overrides** config.yaml. When that
happens, the dump still reported `terminal: local` while the agent was really
running a docker/podman sandbox — sending users (and anyone reading their debug
paste) chasing the wrong cause.

This makes the dump report the **effective** backend and flag the override:

```
terminal:         docker  (TERMINAL_ENV overrides config.yaml terminal.backend=local)
```

When there's no override (or env agrees with config) the output is unchanged
(`terminal: local`).

`run_dump()` already loads `.env` before this point, and the config→env bridge
does not run in the `debug` subcommand, so `os.environ["TERMINAL_ENV"]` is the
real override value at dump time.

## Why

A user reported their agent was "trapped in a Podman container" even though
`hermes debug` showed `terminal: local`. The dump was masking a `TERMINAL_ENV`
override; the misleading line is what made the misconfiguration hard to spot.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests

## Changes Made

- `hermes_cli/dump.py` — compute the effective backend from `TERMINAL_ENV`
  vs `config.yaml terminal.backend` and annotate overrides.
- `tests/hermes_cli/test_dump_terminal_backend.py` — cover override surfaced,
  config value when no override, and no spurious note when env == config.

## How to Test

```bash
scripts/run_tests.sh tests/hermes_cli/test_dump_terminal_backend.py
```

## Infographic

![vaporwave](https://v3b.fal.media/files/b/0a9e6eba/GE2vvEpQP_LyXTnPHfZWW_q9Xhkl88.png)
