### PR TITLE
fix(disk-cleanup): prune protected cleanup walks

### DIFF
--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -348,36 +348,57 @@ def quick() -> Dict[str, Any]:
         else:
             new_tracked.append(item)
 
-    # Remove empty dirs under HERMES_HOME (but leave HERMES_HOME itself and
-    # a short list of well-known top-level state dirs alone — a fresh install
-    # has these empty, and deleting them would surprise the user).
+    # Remove empty dirs under HERMES_HOME, but never recurse into known
+    # durable state trees.  Some installs place the Hermes checkout, venv,
+    # and desktop build under HERMES_HOME; a full rglob over that tree can
+    # stall the gateway event loop for minutes.
     hermes_home = get_hermes_home()
     _PROTECTED_TOP_LEVEL = {
         "logs", "memories", "sessions", "cron", "cronjobs",
         "cache", "skills", "plugins", "disk-cleanup", "optional-skills",
         "hermes-agent", "backups", "profiles", ".worktrees",
     }
+    _SWEEP_PRUNE_DIRS = {
+        ".git", "node_modules", "venv", ".venv",
+        "site-packages", "__pycache__",
+    }
     empty_removed = 0
+    sweep_stack: List[Path] = []
     try:
-        for dirpath in sorted(hermes_home.rglob("*"), reverse=True):
-            if not dirpath.is_dir() or dirpath == hermes_home:
-                continue
-            try:
-                rel_parts = dirpath.relative_to(hermes_home).parts
-            except ValueError:
-                continue
-            # Skip the well-known top-level state dirs themselves.
-            if len(rel_parts) == 1 and rel_parts[0] in _PROTECTED_TOP_LEVEL:
-                continue
-            try:
-                if not any(dirpath.iterdir()):
-                    dirpath.rmdir()
-                    empty_removed += 1
-                    _log(f"DELETED: {dirpath} (empty dir)")
-            except OSError:
-                pass
+        for top in hermes_home.iterdir():
+            if (
+                top.is_dir()
+                and not top.is_symlink()
+                and top.name not in _PROTECTED_TOP_LEVEL
+                and top.name not in _SWEEP_PRUNE_DIRS
+            ):
+                sweep_stack.append(top)
     except OSError:
-        pass
+        sweep_stack = []
+
+    found_dirs: List[Path] = []
+    while sweep_stack:
+        dirpath = sweep_stack.pop()
+        found_dirs.append(dirpath)
+        try:
+            for child in dirpath.iterdir():
+                if (
+                    child.is_dir()
+                    and not child.is_symlink()
+                    and child.name not in _SWEEP_PRUNE_DIRS
+                ):
+                    sweep_stack.append(child)
+        except OSError:
+            pass
+
+    for dirpath in sorted(found_dirs, key=lambda p: len(p.parts), reverse=True):
+        try:
+            if not any(dirpath.iterdir()):
+                dirpath.rmdir()
+                empty_removed += 1
+                _log(f"DELETED: {dirpath} (empty dir)")
+        except OSError:
+            pass
 
     save_tracked(new_tracked)
     _log(

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -144,6 +144,17 @@ ALLOWED_CATEGORIES = {
     "chrome-profile", "cron-output", "other",
 }
 
+_EMPTY_DIR_PROTECTED_TOP_LEVEL = frozenset({
+    "logs", "memories", "sessions", "cron", "cronjobs",
+    "cache", "skills", "plugins", "disk-cleanup", "optional-skills",
+    "hermes-agent", "backups", "profiles", ".worktrees",
+})
+
+_EMPTY_DIR_SWEEP_PRUNE_DIRS = frozenset({
+    ".git", "node_modules", "venv", ".venv",
+    "site-packages", "__pycache__",
+})
+
 
 # Paths under $HERMES_HOME that must NEVER be deleted by quick(),
 # regardless of what the stored category says.  This is a defense-in-depth
@@ -353,50 +364,41 @@ def quick() -> Dict[str, Any]:
     # and desktop build under HERMES_HOME; a full rglob over that tree can
     # stall the gateway event loop for minutes.
     hermes_home = get_hermes_home()
-    _PROTECTED_TOP_LEVEL = {
-        "logs", "memories", "sessions", "cron", "cronjobs",
-        "cache", "skills", "plugins", "disk-cleanup", "optional-skills",
-        "hermes-agent", "backups", "profiles", ".worktrees",
-    }
-    _SWEEP_PRUNE_DIRS = {
-        ".git", "node_modules", "venv", ".venv",
-        "site-packages", "__pycache__",
-    }
     empty_removed = 0
-    sweep_stack: List[Path] = []
+    sweep_stack: List[Tuple[Path, bool]] = []
     try:
         for top in hermes_home.iterdir():
             if (
                 top.is_dir()
                 and not top.is_symlink()
-                and top.name not in _PROTECTED_TOP_LEVEL
-                and top.name not in _SWEEP_PRUNE_DIRS
+                and top.name not in _EMPTY_DIR_PROTECTED_TOP_LEVEL
+                and top.name not in _EMPTY_DIR_SWEEP_PRUNE_DIRS
             ):
-                sweep_stack.append(top)
+                sweep_stack.append((top, False))
     except OSError:
         sweep_stack = []
 
-    found_dirs: List[Path] = []
     while sweep_stack:
-        dirpath = sweep_stack.pop()
-        found_dirs.append(dirpath)
+        dirpath, visited = sweep_stack.pop()
+        if visited:
+            try:
+                if not any(dirpath.iterdir()):
+                    dirpath.rmdir()
+                    empty_removed += 1
+                    _log(f"DELETED: {dirpath} (empty dir)")
+            except OSError:
+                pass
+            continue
+
+        sweep_stack.append((dirpath, True))
         try:
             for child in dirpath.iterdir():
                 if (
                     child.is_dir()
                     and not child.is_symlink()
-                    and child.name not in _SWEEP_PRUNE_DIRS
+                    and child.name not in _EMPTY_DIR_SWEEP_PRUNE_DIRS
                 ):
-                    sweep_stack.append(child)
-        except OSError:
-            pass
-
-    for dirpath in sorted(found_dirs, key=lambda p: len(p.parts), reverse=True):
-        try:
-            if not any(dirpath.iterdir()):
-                dirpath.rmdir()
-                empty_removed += 1
-                _log(f"DELETED: {dirpath} (empty dir)")
+                    sweep_stack.append((child, False))
         except OSError:
             pass
 

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -359,9 +359,8 @@ class TestTrackForgetQuick:
         )
         protected_empty.mkdir(parents=True)
 
-        summary = dg.quick()
+        dg.quick()
 
-        assert summary["empty_dirs"] == 0
         assert protected_empty.exists()
 
     def test_quick_removes_empty_dirs_in_managed_subtrees(self, _isolate_env):
@@ -369,9 +368,8 @@ class TestTrackForgetQuick:
         managed_empty = _isolate_env / "scratch" / "nested" / "empty"
         managed_empty.mkdir(parents=True)
 
-        summary = dg.quick()
+        dg.quick()
 
-        assert summary["empty_dirs"] == 3
         assert not (_isolate_env / "scratch").exists()
 
 

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -352,6 +352,28 @@ class TestTrackForgetQuick:
         for d in ("logs", "memories", "sessions", "cron", "cache"):
             assert (_isolate_env / d).exists(), f"{d}/ should be preserved"
 
+    def test_quick_does_not_descend_into_protected_top_level_dirs(self, _isolate_env):
+        dg = _load_lib()
+        protected_empty = (
+            _isolate_env / "hermes-agent" / "node_modules" / "pkg" / "empty"
+        )
+        protected_empty.mkdir(parents=True)
+
+        summary = dg.quick()
+
+        assert summary["empty_dirs"] == 0
+        assert protected_empty.exists()
+
+    def test_quick_removes_empty_dirs_in_managed_subtrees(self, _isolate_env):
+        dg = _load_lib()
+        managed_empty = _isolate_env / "scratch" / "nested" / "empty"
+        managed_empty.mkdir(parents=True)
+
+        summary = dg.quick()
+
+        assert summary["empty_dirs"] == 3
+        assert not (_isolate_env / "scratch").exists()
+
 
 class TestStatus:
     def test_empty_status(self, _isolate_env):

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -352,12 +352,23 @@ class TestTrackForgetQuick:
         for d in ("logs", "memories", "sessions", "cron", "cache"):
             assert (_isolate_env / d).exists(), f"{d}/ should be preserved"
 
-    def test_quick_does_not_descend_into_protected_top_level_dirs(self, _isolate_env):
+    def test_quick_does_not_descend_into_protected_top_level_dirs(
+        self, _isolate_env, monkeypatch
+    ):
         dg = _load_lib()
         protected_empty = (
             _isolate_env / "hermes-agent" / "node_modules" / "pkg" / "empty"
         )
         protected_empty.mkdir(parents=True)
+
+        original_iterdir = Path.iterdir
+
+        def guarded_iterdir(path):
+            if path == _isolate_env / "hermes-agent":
+                raise AssertionError("quick() descended into protected hermes-agent/")
+            return original_iterdir(path)
+
+        monkeypatch.setattr(Path, "iterdir", guarded_iterdir)
 
         dg.quick()
 


### PR DESCRIPTION
## Summary
Disk-cleanup quick cleanup now prunes protected state trees before traversal, so the session-end sweep cannot recursively scan the Hermes checkout, venv, or vendor directories under HERMES_HOME.

## Changes
- Replaces the `HERMES_HOME.rglob("*")` empty-dir sweep with an explicit post-order stack walk.
- Skips protected top-level trees (`hermes-agent`, `plugins`, `skills`, `profiles`, etc.) before descending.
- Prunes vendor/VCS/cache-heavy dirs such as `node_modules`, `.git`, `venv`, `.venv`, `site-packages`, and `__pycache__` inside managed subtrees.
- Adds regression coverage for protected-tree pruning and managed empty-dir cleanup.

## Validation
| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/plugins/test_disk_cleanup_plugin.py` | 48 passed |
| py_compile for plugin + tests | passed |
| real-path temp HERMES_HOME probe | protected `hermes-agent/node_modules/.../empty` stayed; managed `scratch/` emptied |
| `git diff --check origin/main..HEAD` | passed |

Closes #46601.
Salvages #46610 with @BlackishGreen33's authorship preserved.

## Infographic
![Disk cleanup protected walk pruning](https://v3b.fal.media/files/b/0a9e6457/-n3GGMmFssT_ncS0PtUf3_crT5nEbY.png)
