### PR TITLE
fix(pairing): store plaintext code so list_pending shows approvable value

### DIFF
--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -242,10 +242,14 @@ class PairingStore:
             # Use a unique entry id as the key (not the code itself)
             entry_id = secrets.token_hex(8)
 
-            # Store pending request with hashed code
+            # Store pending request with hashed code.
+            # The plaintext code is also stored so that ``list_pending``
+            # can display an approvable value to the operator (the hash
+            # prefix alone is not accepted by ``approve_code``).
             pending[entry_id] = {
                 "hash": code_hash,
                 "salt": salt.hex(),
+                "code": code,
                 "user_id": normalized_user_id,
                 "user_name": user_name,
                 "created_at": time.time(),
@@ -328,11 +332,10 @@ class PairingStore:
     def list_pending(self, platform: str = None) -> list:
         """List pending pairing requests, optionally filtered by platform.
 
-        Codes are stored hashed — the ``code`` field is replaced with the
-        first 8 hex characters of the hash so admins can distinguish entries
-        without revealing the original code. Legacy plaintext-key entries
-        (pre-hash format) are shown with a "legacy" placeholder so admins
-        can see them age out without crashing on a missing ``hash`` field.
+        The ``code`` field contains the original pairing code that was
+        sent to the user.  Entries written before the plaintext-code change
+        (no ``code`` key) fall back to the first 8 hex characters of the
+        stored hash as a visual placeholder.
         """
         results = []
         with self._lock:
@@ -347,8 +350,9 @@ class PairingStore:
                     if not isinstance(created_at, (int, float)):
                         continue
                     age_min = int((time.time() - created_at) / 60)
-                    hash_val = info.get("hash")
-                    code_display = hash_val[:8] if isinstance(hash_val, str) else "legacy"
+                    code_display = info.get("code") or (
+                        info.get("hash", "")[:8] or "legacy"
+                    )
                     results.append({
                         "platform": p,
                         "code": code_display,

--- a/tests/test_pairing_code_display.py
+++ b/tests/test_pairing_code_display.py
@@ -1,0 +1,85 @@
+"""Tests for pairing code display — issue #46580.
+
+Verify that ``list_pending`` returns the original pairing code (not the
+hash prefix) so that ``hermes pairing list`` shows a value the operator
+can pass directly to ``hermes pairing approve``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from gateway.pairing import PairingStore
+
+
+@pytest.fixture()
+def store(tmp_path):
+    """PairingStore rooted in a temp directory."""
+    with patch("gateway.pairing.PAIRING_DIR", tmp_path):
+        yield PairingStore()
+
+
+class TestListPendingShowsActualCode:
+    """``list_pending`` must return the original code, not the hash prefix."""
+
+    def test_code_is_approvable(self, store):
+        """The code returned by list_pending can be fed to approve_code."""
+        actual_code = store.generate_code("telegram", "u1", "Alice")
+        pending = store.list_pending("telegram")
+
+        assert len(pending) == 1
+        displayed_code = pending[0]["code"]
+        # Must be the actual code, not a hash prefix
+        assert displayed_code == actual_code
+
+        # Approving with the displayed code must succeed
+        result = store.approve_code("telegram", displayed_code)
+        assert result is not None
+        assert result["user_id"] == "u1"
+
+    def test_code_not_hash_prefix(self, store):
+        """Displayed code must be 8 uppercase alpha chars from ALPHABET."""
+        store.generate_code("signal", "u2", "Bob")
+        pending = store.list_pending("signal")
+
+        assert len(pending) == 1
+        code = pending[0]["code"]
+        assert len(code) == 8
+        assert all(ch in "ABCDEFGHJKLMNPQRSTUVWXYZ23456789" for ch in code)
+
+    def test_legacy_entry_without_code_field(self, store, tmp_path):
+        """Entries from before the fix (no ``code`` key) fall back to hash[:8]."""
+        # Manually write a legacy pending entry (no "code" key)
+        platform_dir = tmp_path / "telegram-pending.json"
+        legacy_entry = {
+            "abc12345": {
+                "hash": "aabbccdd11223344" * 4,
+                "salt": os.urandom(16).hex(),
+                "user_id": "u3",
+                "user_name": "Charlie",
+                "created_at": time.time(),
+            }
+        }
+        platform_dir.write_text(json.dumps(legacy_entry))
+
+        pending = store.list_pending("telegram")
+        assert len(pending) == 1
+        # Should fall back to hash[:8]
+        assert pending[0]["code"] == "aabbccdd"
+
+    def test_multiple_platforms(self, store):
+        """Codes are correct across multiple platforms."""
+        code_tg = store.generate_code("telegram", "u1", "Alice")
+        code_sig = store.generate_code("signal", "u2", "Bob")
+
+        pending_tg = store.list_pending("telegram")
+        pending_sig = store.list_pending("signal")
+
+        assert pending_tg[0]["code"] == code_tg
+        assert pending_sig[0]["code"] == code_sig


### PR DESCRIPTION
## What does this PR do?

Fixes ``hermes pairing list`` displaying a hash prefix instead of the actual pairing code.  The displayed value could not be used with ``hermes pairing approve``, causing "Code not found or expired" errors and eventual lockout.

## Related Issue

Fixes #46580

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- ``gateway/pairing.py``: Store plaintext code in pending entry during ``generate_code()``; update ``list_pending()`` to return the stored code instead of ``hash[:8]``; add backward-compatible fallback for legacy entries without a ``code`` key.
- ``tests/test_pairing_code_display.py``: 4 tests — code-is-approvable round-trip, code format validation, legacy-entry fallback, multi-platform correctness.

## How to Test

1. Start a Hermes instance with Telegram gateway enabled
2. Send a message from an unrecognized Telegram user to trigger pairing
3. Run ``hermes pairing list`` — the Code column now shows the actual code sent to the user
4. Run ``hermes pairing approve telegram <displayed-code>`` — should succeed without lockout
5. Verify the dashboard Approve button also works (it uses the same ``code`` field)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (``fix(scope):``, ``feat(scope):``, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run ``pytest tests/ -q`` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, ``docs/``, docstrings) — or N/A
- [x] I've updated ``cli-config.yaml.example`` if I added/changed config keys — or N/A
- [x] I've updated ``CONTRIBUTING.md`` or ``AGENTS.md`` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: ``gateway/pairing.py`` — ``PairingStore.generate_code()``, ``PairingStore.list_pending()``, ``PairingStore.approve_code()``
- Callers of ``list_pending()``: ``hermes_cli/pairing.py::_cmd_list()``, ``hermes_cli/web_server.py::list_pairing()``
- Blast radius: LOW — 1 data field added to pending entries; backward-compatible fallback for old entries
- Related patterns: hash-stored credentials with display-side plaintext (common in pairing/OAuth flows)
