### PR TITLE
fix(desktop): add timeout override for audio transcription requests

### DIFF
--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -44,6 +44,7 @@ import type {
 
 const DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS = 30_000
 const SESSION_LIST_REQUEST_TIMEOUT_MS = 60_000
+const AUDIO_TRANSCRIPTION_TIMEOUT_MS = 120_000  // local STT (whisper medium/large-v3) can take 30-60s+
 
 export type {
   ActionResponse,
@@ -730,6 +731,7 @@ export function transcribeAudio(dataUrl: string, mimeType?: string): Promise<Aud
   return window.hermesDesktop.api<AudioTranscriptionResponse>({
     path: '/api/audio/transcribe',
     method: 'POST',
+    timeoutMs: AUDIO_TRANSCRIPTION_TIMEOUT_MS,
     body: {
       data_url: dataUrl,
       mime_type: mimeType


### PR DESCRIPTION
## What does this PR do?

Adds a 120-second timeout override to the ``transcribeAudio`` API call in the Desktop app.  The default 15-second REST timeout is too short for local STT models (whisper medium/large-v3 on CPU), which can take 30-60+ seconds for longer audio clips.

## Related Issue

Fixes #46573

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- ``apps/desktop/src/hermes.ts``: Added ``AUDIO_TRANSCRIPTION_TIMEOUT_MS = 120_000`` constant and ``timeoutMs`` override to ``transcribeAudio()``.

## How to Test

1. Configure STT with a local faster-whisper medium or large-v3 model
2. Record or send a voice message longer than 15 seconds
3. Transcription should complete without timeout errors
4. Verify short audio (< 15s) still works as before

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (``fix(scope):``, ``feat(scope):``, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run ``pytest tests/ -q`` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — or N/A (1-line constant addition)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, ``docs/``, docstrings) — or N/A
- [x] I've updated ``cli-config.yaml.example`` if I added/changed config keys — or N/A
- [x] I've updated ``CONTRIBUTING.md`` or ``AGENTS.md`` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (Desktop Electron, same behavior cross-platform)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: ``apps/desktop/src/hermes.ts`` — ``transcribeAudio()``, ``speakText()``
- Callers: ``use-prompt-actions.ts::1277``
- Blast radius: LOW — adds timeout to one API call, no behavior change for requests completing under 120s
- Related patterns: ``SESSION_LIST_REQUEST_TIMEOUT_MS`` (same pattern for session list requests)
