### PR TITLE
fix(cli): consolidate Bitwarden startup warning handling

### DIFF
--- a/agent/secret_sources/bitwarden.py
+++ b/agent/secret_sources/bitwarden.py
@@ -618,6 +618,13 @@ def apply_bitwarden_secrets(
         return result
 
     access_token = os.environ.get(access_token_env, "").strip()
+
+    # `enabled: true` with neither a token nor a project configured means
+    # Bitwarden was never actually set up. Stay silent instead of warning on
+    # every startup; the errors below are actionable once setup is partial.
+    if not access_token and not project_id:
+        return result
+
     if not access_token:
         result.error = (
             f"secrets.bitwarden.enabled is true but {access_token_env} is "

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -38,6 +38,11 @@ _SECRET_SOURCES: dict[str, str] = {}
 # config re-parse, and the ASCII sanitization sweep still ran every time.
 _APPLIED_HOMES: set[str] = set()
 
+# Cross-process dedup for the Bitwarden status line. Startup can spawn child
+# Python processes that each call load_hermes_dotenv() at import time; they
+# inherit os.environ but not the in-process _APPLIED_HOMES guard above.
+_BWS_STATUS_PRINTED_ENV = "_HERMES_BWS_STATUS_PRINTED"
+
 
 def get_secret_source(env_var: str) -> str | None:
     """Return the label of the secret source that supplied ``env_var``, if any.
@@ -63,6 +68,7 @@ def reset_secret_source_cache() -> None:
     that want to refresh after a config change.
     """
     _APPLIED_HOMES.clear()
+    os.environ.pop(_BWS_STATUS_PRINTED_ENV, None)
 
 
 def format_secret_source_suffix(env_var: str) -> str:
@@ -305,6 +311,15 @@ def _apply_external_secret_sources(home_path: Path) -> None:
         # came from BSM rather than .env.
         for name in result.applied:
             _SECRET_SOURCES[name] = "bitwarden"
+
+    has_status = bool(result.applied or result.error or result.warnings)
+    if not has_status:
+        return
+    if os.environ.get(_BWS_STATUS_PRINTED_ENV):
+        return
+    os.environ[_BWS_STATUS_PRINTED_ENV] = "1"
+
+    if result.applied:
         print(
             f"  Bitwarden Secrets Manager: applied {len(result.applied)} "
             f"secret{'s' if len(result.applied) != 1 else ''} "

--- a/tests/test_bitwarden_secrets.py
+++ b/tests/test_bitwarden_secrets.py
@@ -500,6 +500,16 @@ def test_apply_disabled_returns_empty():
     assert not result.error
 
 
+def test_apply_unconfigured_is_silent(monkeypatch):
+    monkeypatch.delenv("BWS_ACCESS_TOKEN", raising=False)
+    result = bw.apply_bitwarden_secrets(
+        enabled=True, project_id="", auto_install=False
+    )
+    assert result.ok
+    assert not result.applied
+    assert not result.error
+
+
 def test_apply_missing_token(monkeypatch):
     monkeypatch.delenv("BWS_ACCESS_TOKEN", raising=False)
     result = bw.apply_bitwarden_secrets(

--- a/tests/test_env_loader_secret_sources.py
+++ b/tests/test_env_loader_secret_sources.py
@@ -7,6 +7,7 @@ don't see an unexplained "credentials ✓" line when their .env is empty.
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
@@ -119,6 +120,81 @@ def test_apply_external_secret_sources_noop_when_disabled(tmp_path, monkeypatch)
     env_loader._apply_external_secret_sources(tmp_path)
 
     assert env_loader.get_secret_source("ANTHROPIC_API_KEY") is None
+
+
+def test_apply_external_secret_sources_dedupes_across_subprocesses(
+    tmp_path, monkeypatch, capsys
+):
+    """An inherited parent marker suppresses duplicated child-process noise."""
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "secrets:\n"
+        "  bitwarden:\n"
+        "    enabled: true\n"
+        "    project_id: test-project\n"
+        "    access_token_env: BWS_ACCESS_TOKEN\n",
+        encoding="utf-8",
+    )
+
+    from agent.secret_sources.bitwarden import FetchResult
+
+    def _fake_apply(**_kwargs):
+        return FetchResult(
+            error=(
+                "secrets.bitwarden.enabled is true but BWS_ACCESS_TOKEN is "
+                "not set.  Run `hermes secrets bitwarden setup`."
+            )
+        )
+
+    import agent.secret_sources.bitwarden as bw_module
+
+    monkeypatch.setattr(bw_module, "apply_bitwarden_secrets", _fake_apply)
+    monkeypatch.setenv(env_loader._BWS_STATUS_PRINTED_ENV, "1")
+
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    captured = capsys.readouterr()
+    assert "Bitwarden Secrets Manager" not in captured.err
+
+
+def test_apply_external_secret_sources_prints_warning_once_then_sets_marker(
+    tmp_path, monkeypatch, capsys
+):
+    """The first process prints the status line and marks inherited environ."""
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "secrets:\n"
+        "  bitwarden:\n"
+        "    enabled: true\n"
+        "    project_id: test-project\n"
+        "    access_token_env: BWS_ACCESS_TOKEN\n",
+        encoding="utf-8",
+    )
+
+    from agent.secret_sources.bitwarden import FetchResult
+
+    err_text = (
+        "secrets.bitwarden.enabled is true but BWS_ACCESS_TOKEN is "
+        "not set.  Run `hermes secrets bitwarden setup`."
+    )
+
+    def _fake_apply(**_kwargs):
+        return FetchResult(error=err_text)
+
+    import agent.secret_sources.bitwarden as bw_module
+
+    monkeypatch.setattr(bw_module, "apply_bitwarden_secrets", _fake_apply)
+    monkeypatch.delenv(env_loader._BWS_STATUS_PRINTED_ENV, raising=False)
+
+    env_loader._apply_external_secret_sources(tmp_path)
+
+    captured = capsys.readouterr()
+    assert err_text in captured.err
+    assert os.environ.get(env_loader._BWS_STATUS_PRINTED_ENV) == "1"
 
 
 def test_apply_external_secret_sources_dedupes_within_process(tmp_path, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Consolidates the Bitwarden startup warning fixes for #32715. If `secrets.bitwarden.enabled` is true but neither `BWS_ACCESS_TOKEN` nor `project_id` is configured, Hermes treats Bitwarden as not set up and stays silent. If setup is partial and a status line is actionable, Hermes still emits it once and suppresses duplicate inherited child-process prints during startup.

## Related Issue

Fixes #32715

## Supersedes

Supersedes #32784, #34314

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/secret_sources/bitwarden.py`: return a clean empty result when Bitwarden is enabled but both the access token and project id are absent, so fresh or untouched Bitwarden config does not print a warning.
- `hermes_cli/env_loader.py`: add an inherited process-environment marker for Bitwarden status output so child startup processes suppress duplicate status lines while still applying secrets and source tracking.
- `tests/test_bitwarden_secrets.py`: cover the enabled-but-unconfigured silent no-op case while preserving warnings for partial setup.
- `tests/test_env_loader_secret_sources.py`: cover inherited status suppression and first-process marker creation for actionable warnings.

## How to Test

1. `/opt/homebrew/bin/timeout -k 30 480 pytest tests/test_bitwarden_secrets.py tests/test_env_loader_secret_sources.py -q` -> 53 passed.
2. Full suite command `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` stopped during collection before reaching this change because local `fastapi` is missing for `tests/hermes_cli/test_dashboard_auth_401_reauth.py`; one deselect rerun then stopped on the same missing dependency in `tests/hermes_cli/test_dashboard_auth_cookies.py`.
3. Mechanical covering subset discovered by grepping changed modules/importers completed past the Bitwarden/env-loader tests: 424 passed, with unrelated local-environment failures in `tests/tools/test_transcription_dotenv_fallback.py::TestTranscribeCallSitesReadDotenv::test_transcribe_mistral_forwards_dotenv_key` (PEP 668 blocks lazy `mistralai` install in the system Python) and `tests/tui_gateway/test_goal_command.py` goal-state assertions.
4. `python scripts/check-windows-footguns.py agent/secret_sources/bitwarden.py hermes_cli/env_loader.py tests/test_bitwarden_secrets.py tests/test_env_loader_secret_sources.py` -> no Windows footguns found.
5. Scoped lint on changed Python files with `ruff check` -> all checks passed.
6. `git diff --check` -> clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS/darwin-arm64 local worker

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A

<!-- autocontrib:worker-id=pr-consolidate-03c2333e kind=pr-open -->