### PR TITLE
fix(gateway): consolidate Codex quota error handling

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1466,19 +1466,21 @@ def _resolve_runtime_agent_kwargs() -> dict:
         format_runtime_provider_error,
         _get_model_config,
     )
-    from hermes_cli.auth import AuthError, is_rate_limited_auth_error
+    from hermes_cli.auth import AuthError
 
     try:
         runtime = resolve_runtime_provider()
     except AuthError as auth_exc:
-        # Distinguish a transient rate-limit/quota cap (credentials are fine,
-        # re-auth cannot help) from a genuine auth failure (expired/revoked
-        # token). Both fall through to the fallback chain, but the log message
-        # must not mislabel a quota exhaustion as an auth failure (#32790).
-        if is_rate_limited_auth_error(auth_exc):
-            logger.warning("Primary provider rate-limited (429): %s — trying fallback", auth_exc)
-        else:
+        # AuthError covers both real credential problems and transient upstream
+        # failures such as quota/rate-limit caps. Only the former should tell
+        # operators that authentication failed; re-auth cannot fix a usage cap.
+        if getattr(auth_exc, "relogin_required", False):
             logger.warning("Primary provider auth failed: %s — trying fallback", auth_exc)
+        else:
+            logger.warning(
+                "Primary provider unavailable (transient/rate-limit): %s — trying fallback",
+                auth_exc,
+            )
         fb_config = _try_resolve_fallback_provider()
         if fb_config is not None:
             return fb_config

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3806,26 +3806,16 @@ def resolve_codex_runtime_credentials(
                 "last_refresh": None,
                 "auth_mode": "chatgpt",
             }
-        pool_rate_limit = _codex_pool_rate_limit_status()
-        if pool_rate_limit:
-            reset_at = pool_rate_limit.get("reset_at")
-            if isinstance(reset_at, (int, float)) and reset_at > time.time():
-                remaining = int(reset_at - time.time())
-                message = (
-                    f"Codex provider quota exhausted (429); retry after {remaining}s. "
-                    "Credentials are still valid."
-                )
-            else:
-                message = (
-                    "Codex provider quota exhausted (429). Credentials are still valid; "
-                    "retry after the usage limit resets."
-                )
+        cooldown_remaining = _pool_codex_rate_limit_remaining()
+        if cooldown_remaining is not None:
             raise AuthError(
-                message,
+                "Codex provider quota exhausted (429); every stored credential "
+                f"is in cooldown. Retry after {_format_cooldown_wait(cooldown_remaining)}. "
+                "Credentials are still valid.",
                 provider="openai-codex",
                 code=CODEX_RATE_LIMITED_CODE,
                 relogin_required=False,
-            )
+            ) from read_error
         if read_error is not None:
             raise read_error
         raise AuthError(
@@ -3983,6 +3973,57 @@ def _pool_codex_access_token() -> str:
     except Exception:
         logger.debug("Codex pool fallback lookup failed", exc_info=True)
     return ""
+
+
+def _pool_codex_rate_limit_remaining() -> Optional[float]:
+    """Return the longest remaining 429 cooldown if all pool credentials are capped."""
+    try:
+        with _auth_store_lock():
+            auth_store = _load_auth_store()
+        pool = auth_store.get("credential_pool")
+        if not isinstance(pool, dict):
+            return None
+        entries = pool.get("openai-codex")
+        if not isinstance(entries, list):
+            return None
+
+        now = time.time()
+        longest: Optional[float] = None
+        saw_token = False
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            token = entry.get("access_token")
+            if not isinstance(token, str) or not token.strip():
+                continue
+            saw_token = True
+            if entry.get("last_error_code") != 429:
+                return None
+            reset_at = entry.get("last_error_reset_at")
+            if not isinstance(reset_at, (int, float)) or reset_at <= now:
+                return None
+            remaining = float(reset_at - now)
+            if longest is None or remaining > longest:
+                longest = remaining
+
+        if not saw_token:
+            return None
+        return longest
+    except Exception:
+        logger.debug("Codex pool rate-limit lookup failed", exc_info=True)
+        return None
+
+
+def _format_cooldown_wait(seconds: float) -> str:
+    """Format remaining cooldown seconds as a compact human-readable duration."""
+    total = max(0, int(seconds))
+    minutes, secs = divmod(total, 60)
+    hours, minutes = divmod(minutes, 60)
+    if hours:
+        return f"{hours}h {minutes}m"
+    if minutes:
+        return f"{minutes}m {secs}s"
+    return f"{secs}s"
 
 
 # =============================================================================

--- a/tests/gateway/test_auth_fallback.py
+++ b/tests/gateway/test_auth_fallback.py
@@ -1,5 +1,6 @@
 """Test that AuthError triggers fallback provider resolution (#7230)."""
 
+import logging
 from unittest.mock import patch
 
 import pytest
@@ -113,3 +114,145 @@ class TestResolveRuntimeAgentKwargsAuthFallback:
         assert calls == ["openrouter", "nous"]
         assert result["provider"] == "nous"
         assert result["model"] == "Hermes-4"
+
+
+class TestProviderErrorClassification:
+    """Gateway logs must not turn transient provider failures into auth failures."""
+
+    def test_transient_auth_error_not_logged_as_auth_failed(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        from hermes_cli.auth import AuthError
+
+        (tmp_path / "config.yaml").write_text(
+            "model:\n  provider: openai-codex\n"
+            "fallback_model:\n  provider: openrouter\n"
+            "  model: meta-llama/llama-4-maverick\n"
+        )
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+
+        call_count = {"n": 0}
+
+        def _mock_resolve(**kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise AuthError(
+                    "Codex provider quota exhausted (429)",
+                    provider="openai-codex",
+                    code="codex_rate_limited",
+                    relogin_required=False,
+                )
+            return {
+                "api_key": "fallback-key",
+                "base_url": "https://openrouter.ai/api/v1",
+                "provider": "openrouter",
+                "api_mode": "openai_chat",
+                "command": None,
+                "args": None,
+                "credential_pool": None,
+            }
+
+        with (
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                side_effect=_mock_resolve,
+            ),
+            caplog.at_level(logging.WARNING, logger="gateway.run"),
+        ):
+            from gateway.run import _resolve_runtime_agent_kwargs
+
+            _resolve_runtime_agent_kwargs()
+
+        messages = [record.getMessage() for record in caplog.records]
+        assert any("transient/rate-limit" in message for message in messages), messages
+        assert not any("auth failed" in message for message in messages), messages
+
+    def test_credential_auth_error_still_logged_as_auth_failed(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        from hermes_cli.auth import AuthError
+
+        (tmp_path / "config.yaml").write_text(
+            "model:\n  provider: openai-codex\n"
+            "fallback_model:\n  provider: openrouter\n"
+            "  model: meta-llama/llama-4-maverick\n"
+        )
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+
+        call_count = {"n": 0}
+
+        def _mock_resolve(**kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise AuthError(
+                    "No Codex credentials stored. Run `hermes auth` to authenticate.",
+                    provider="openai-codex",
+                    code="codex_auth_missing",
+                    relogin_required=True,
+                )
+            return {
+                "api_key": "fallback-key",
+                "base_url": "https://openrouter.ai/api/v1",
+                "provider": "openrouter",
+                "api_mode": "openai_chat",
+                "command": None,
+                "args": None,
+                "credential_pool": None,
+            }
+
+        with (
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                side_effect=_mock_resolve,
+            ),
+            caplog.at_level(logging.WARNING, logger="gateway.run"),
+        ):
+            from gateway.run import _resolve_runtime_agent_kwargs
+
+            _resolve_runtime_agent_kwargs()
+
+        messages = [record.getMessage() for record in caplog.records]
+        assert any("Primary provider auth failed" in message for message in messages)
+
+    def test_fallback_resolution_logs_config_provider_not_category(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        (tmp_path / "config.yaml").write_text(
+            "fallback_providers:\n"
+            "  - provider: ollama\n"
+            "    base_url: http://localhost:11434/v1\n"
+            "    model: llama3.1\n"
+        )
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+
+        def _mock_resolve(**kwargs):
+            return {
+                "api_key": "",
+                "base_url": "http://localhost:11434/v1",
+                "provider": "openrouter",
+                "api_mode": "openai_chat",
+                "command": None,
+                "args": None,
+                "credential_pool": None,
+            }
+
+        with (
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                side_effect=_mock_resolve,
+            ),
+            caplog.at_level(logging.INFO, logger="gateway.run"),
+        ):
+            from gateway.run import _try_resolve_fallback_provider
+
+            result = _try_resolve_fallback_provider()
+
+        assert result is not None
+        resolved_logs = [
+            record.getMessage()
+            for record in caplog.records
+            if "Fallback provider resolved" in record.getMessage()
+        ]
+        assert resolved_logs
+        assert any("ollama" in message for message in resolved_logs), resolved_logs
+        assert not any("openrouter" in message for message in resolved_logs), resolved_logs

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -215,6 +215,124 @@ def test_resolve_codex_runtime_credentials_pool_fallback_no_usable_entry(tmp_pat
     assert exc.value.code == "codex_auth_missing"
 
 
+def test_resolve_codex_runtime_credentials_pool_all_rate_limited(tmp_path, monkeypatch):
+    """Singleton missing + every pool entry in 429 cooldown raises rate-limit."""
+    from hermes_cli.auth import CODEX_RATE_LIMITED_CODE, is_rate_limited_auth_error
+
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    future_reset = time.time() + 3 * 3600 + 15 * 60
+    auth_store = {
+        "version": 1,
+        "providers": {},
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "source": "device_code",
+                    "access_token": "rate-limited-token",
+                    "last_status": "exhausted",
+                    "last_error_code": 429,
+                    "last_error_reason": "usage_limit_reached",
+                    "last_error_reset_at": future_reset,
+                },
+                {
+                    "source": "manual:device_code",
+                    "access_token": "also-rate-limited",
+                    "last_status": "exhausted",
+                    "last_error_code": 429,
+                    "last_error_reason": "usage_limit_reached",
+                    "last_error_reset_at": future_reset + 60,
+                },
+            ],
+        },
+    }
+    (hermes_home / "auth.json").write_text(json.dumps(auth_store))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with pytest.raises(AuthError) as exc:
+        resolve_codex_runtime_credentials()
+    err = exc.value
+    assert err.code == CODEX_RATE_LIMITED_CODE
+    assert err.relogin_required is False
+    assert is_rate_limited_auth_error(err) is True
+
+    rendered = str(err)
+    assert "No Codex credentials stored" not in rendered
+    assert "quota" in rendered.lower()
+    assert "Credentials are still valid" in rendered
+    assert "3h" in rendered
+
+
+def test_resolve_codex_runtime_credentials_pool_401_remains_auth_error(
+    tmp_path, monkeypatch
+):
+    """401 cooldowns represent credential failures and must not be reclassified."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    future_reset = time.time() + 600
+    auth_store = {
+        "version": 1,
+        "providers": {},
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "source": "device_code",
+                    "access_token": "revoked-token",
+                    "last_status": "exhausted",
+                    "last_error_code": 401,
+                    "last_error_reason": "token_invalidated",
+                    "last_error_reset_at": future_reset,
+                },
+            ],
+        },
+    }
+    (hermes_home / "auth.json").write_text(json.dumps(auth_store))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with pytest.raises(AuthError) as exc:
+        resolve_codex_runtime_credentials()
+    assert exc.value.code == "codex_auth_missing"
+    assert exc.value.relogin_required is True
+
+
+def test_resolve_codex_runtime_credentials_pool_mixed_429_401_requires_auth(
+    tmp_path, monkeypatch
+):
+    """A mixed pool is not an all-credentials quota cap; keep auth remediation."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    future_reset = time.time() + 600
+    auth_store = {
+        "version": 1,
+        "providers": {},
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "source": "device_code",
+                    "access_token": "rate-limited-token",
+                    "last_status": "exhausted",
+                    "last_error_code": 429,
+                    "last_error_reset_at": future_reset,
+                },
+                {
+                    "source": "manual:device_code",
+                    "access_token": "revoked-token",
+                    "last_status": "exhausted",
+                    "last_error_code": 401,
+                    "last_error_reset_at": future_reset,
+                },
+            ],
+        },
+    }
+    (hermes_home / "auth.json").write_text(json.dumps(auth_store))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    with pytest.raises(AuthError) as exc:
+        resolve_codex_runtime_credentials()
+    assert exc.value.code == "codex_auth_missing"
+    assert exc.value.relogin_required is True
+
+
 def test_resolve_provider_explicit_codex_does_not_fallback(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)


### PR DESCRIPTION
## What does this PR do?

Consolidates the competing fixes for #32790 so Codex OAuth quota exhaustion is no longer surfaced as missing credentials. The gateway now uses `AuthError.relogin_required` to avoid logging transient upstream failures as authentication failures, and pool-only `openai-codex` credentials that are all in active 429 cooldown now raise the existing Codex rate-limit error instead of `codex_auth_missing`.

## Supersedes

Supersedes #32881, #34325

## Related Issue

Fixes #32790

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/auth.py`: detects the pool-only case where every token-bearing `openai-codex` credential is in a live 429 cooldown and raises `CODEX_RATE_LIMITED_CODE` with retry guidance instead of reusing the missing-credentials error.
- `gateway/run.py`: logs non-relogin `AuthError`s as transient provider unavailability while preserving auth-failed wording for real credential failures.
- `tests/hermes_cli/test_auth_codex_provider.py`: covers all-429 pool cooldowns, 401 cooldowns, and mixed 429/401 pools.
- `tests/gateway/test_auth_fallback.py`: covers transient-vs-auth gateway log wording and config-provider fallback labels.

## How to Test

1. `HERMES_HOME=/private/tmp/pr-consolidate-1d689186-hermes-home /opt/homebrew/bin/timeout -k 30 480 pytest tests/gateway/test_auth_fallback.py tests/hermes_cli/test_auth_codex_provider.py tests/hermes_cli/test_auth_codex_self_heal.py tests/hermes_cli/test_runtime_provider_resolution.py tests/agent/test_credential_pool_routing.py tests/cron/test_codex_execution_paths.py tests/run_agent/test_run_agent_codex_responses.py tests/test_account_usage.py -q --timeout=60` (266 passed)
2. `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh` aborted during collection because local dev deps do not include `fastapi` for `tests/hermes_cli/test_dashboard_auth_401_reauth.py`.
3. Rerunning the broad suite with that file ignored then aborted on the same missing `fastapi` dependency in `tests/hermes_cli/test_dashboard_auth_cookies.py`; CI should cover the full suite in the hermetic environment.
4. `python scripts/check-windows-footguns.py gateway/run.py hermes_cli/auth.py tests/gateway/test_auth_fallback.py tests/hermes_cli/test_auth_codex_provider.py`
5. `ruff check gateway/run.py hermes_cli/auth.py tests/gateway/test_auth_fallback.py tests/hermes_cli/test_auth_codex_provider.py`
6. `git diff --check main...HEAD`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS / Darwin 24.6.0 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

N/A

<!-- autocontrib:worker-id=pr-consolidate-1d689186 kind=pr-open -->