### PR TITLE
feat: sync session titles to Telegram forum topic names (groups + /title)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15005,7 +15005,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "api_mode": getattr(agent, "api_mode", None),
                         } if agent else None,
                     }
-                    if self._is_telegram_topic_lane(source):
+                    if self._is_telegram_renamable_thread(source):
                         maybe_auto_title_kwargs["title_callback"] = lambda title: self._schedule_telegram_topic_title_rename(
                             source,
                             effective_session_id,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10645,7 +10645,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         title: str,
     ) -> None:
         """Best-effort rename of a Telegram DM topic when Hermes auto-titles a session."""
-        if not self._is_telegram_topic_lane(source) or not source.chat_id or not source.thread_id:
+        if not self._is_telegram_renamable_thread(source) or not source.chat_id or not source.thread_id:
             return
 
         # Operator can fully disable per-topic auto-rename via

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10753,7 +10753,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         title: str,
     ) -> None:
         """Schedule a topic rename from the auto-title background thread."""
-        if not title or not self._is_telegram_topic_lane(source):
+        if not title or not self._is_telegram_renamable_thread(source):
             return
         if self._telegram_topic_auto_rename_disabled(source):
             return

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2715,6 +2715,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return False
         return True
 
+    def _is_telegram_renamable_thread(self, source: SessionSource) -> bool:
+        """True for any Telegram forum thread whose name can be synced to the
+        session title: DM topic lanes AND group forum topics.
+
+        Excludes the General (pinned) topic -- that's the lobby/root.
+        Does NOT gate on chat_type, so this works for both ``dm`` and
+        ``group``/``supergroup`` forum threads.
+        """
+        if source.platform != Platform.TELEGRAM:
+            return False
+        tid = str(source.thread_id or "")
+        if not tid or tid in self._TELEGRAM_GENERAL_TOPIC_IDS:
+            return False
+        return True
+
     _TELEGRAM_LOBBY_REMINDER_COOLDOWN_S = 30.0
 
     def _should_send_telegram_lobby_reminder(self, source: SessionSource) -> bool:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2679,6 +2679,13 @@ class GatewaySlashCommandsMixin:
             # Set the title
             try:
                 if self._session_db.set_session_title(session_id, sanitized):
+                    # Sync the Telegram forum topic name to match
+                    if self._is_telegram_renamable_thread(source):
+                        asyncio.ensure_future(
+                            self._rename_telegram_topic_for_session_title(
+                                source, session_id, sanitized,
+                            )
+                        )
                     return t("gateway.title.set_to", title=sanitized)
                 else:
                     return t("gateway.title.not_found")

--- a/tests/gateway/test_title_command.py
+++ b/tests/gateway/test_title_command.py
@@ -7,6 +7,7 @@ across all gateway messenger platforms.
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+import asyncio
 import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
@@ -43,6 +44,80 @@ def _make_runner(session_db=None):
     runner.session_store = mock_store
 
     return runner
+
+
+# ---------------------------------------------------------------------------
+# _is_telegram_renamable_thread
+# ---------------------------------------------------------------------------
+
+
+class TestIsTelegramRenamableThread:
+    """Tests for GatewayRunner._is_telegram_renamable_thread."""
+
+    def test_dm_topic_lane_is_renamable(self):
+        """A DM topic lane with a real thread_id is renamable."""
+        from gateway.run import GatewayRunner
+        runner = object.__new__(GatewayRunner)
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_type="dm",
+            chat_id="12345",
+            user_id="user1",
+            thread_id="42",
+        )
+        assert runner._is_telegram_renamable_thread(source) is True
+
+    def test_group_forum_topic_is_renamable(self):
+        """A group forum topic with a real thread_id is renamable."""
+        from gateway.run import GatewayRunner
+        runner = object.__new__(GatewayRunner)
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_type="group",
+            chat_id="-1001234567890",
+            user_id="user1",
+            thread_id="99",
+        )
+        assert runner._is_telegram_renamable_thread(source) is True
+
+    def test_general_topic_is_not_renamable(self):
+        """The General (pinned) topic is not renamable."""
+        from gateway.run import GatewayRunner
+        runner = object.__new__(GatewayRunner)
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_type="dm",
+            chat_id="12345",
+            user_id="user1",
+            thread_id="1",
+        )
+        assert runner._is_telegram_renamable_thread(source) is False
+
+    def test_no_thread_id_is_not_renamable(self):
+        """A DM or group without a thread_id is not renamable."""
+        from gateway.run import GatewayRunner
+        runner = object.__new__(GatewayRunner)
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_type="dm",
+            chat_id="12345",
+            user_id="user1",
+            # no thread_id
+        )
+        assert runner._is_telegram_renamable_thread(source) is False
+
+    def test_non_telegram_platform_is_not_renamable(self):
+        """Discord threads are not renamable via this method."""
+        from gateway.run import GatewayRunner
+        runner = object.__new__(GatewayRunner)
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            chat_type="group",
+            chat_id="12345",
+            user_id="user1",
+            thread_id="42",
+        )
+        assert runner._is_telegram_renamable_thread(source) is False
 
 
 # ---------------------------------------------------------------------------
@@ -179,6 +254,33 @@ class TestHandleTitleCommand:
             assert "Cross-Platform Test" in result
             assert db.get_session_title("test_session_123") == "Cross-Platform Test"
             db.close()
+
+    @pytest.mark.asyncio
+    async def test_title_renames_forum_topic(self, tmp_path):
+        """Setting a title in a Telegram forum topic fires the rename pipeline."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("test_session_123", "telegram")
+
+        runner = _make_runner(session_db=db)
+        rename_mock = AsyncMock()
+        runner._rename_telegram_topic_for_session_title = rename_mock
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="12345",
+            chat_id="67890",
+            chat_type="group",
+            thread_id="42",
+        )
+        event = MessageEvent(text="/title My Topic", source=source)
+        result = await runner._handle_title_command(event)
+        assert "My Topic" in result
+        # Flush pending asyncio tasks so the ensure_future completes
+        await asyncio.sleep(0)
+        rename_mock.assert_awaited_once_with(
+            source, "test_session_123", "My Topic",
+        )
+        db.close()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Hermes auto-generates session titles via `agent/title_generator.py` but only
syncs them to Telegram DM private-chat topic lanes. Forum topics in Telegram
groups are excluded by the `chat_type != "dm"` guard in
`_is_telegram_topic_lane()`. Additionally, setting a title manually via `/title`
never renames the Telegram topic — not even for DM topics.

## Changes

- **New guard**: `_is_telegram_renamable_thread(source)` — returns True for any
  Telegram chat with a non-General thread_id. No `chat_type` restriction.
- **3 guard swaps** in `gateway/run.py`: replace `_is_telegram_topic_lane` with
  `_is_telegram_renamable_thread` in the rename pipeline methods and auto-title
  call site.
- **`/title` handler** in `gateway/slash_commands.py`: after setting the title
  in the DB, fire the rename pipeline via `asyncio.ensure_future()`.
- **Tests** for the new guard and the `/title` forum rename path.

## Edge cases

| Case | Behavior |
|------|----------|
| Bot lacks `can_change_info` | `TelegramError` caught by existing try/except → silent skip |
| General (pinned) topic | Excluded by `_TELEGRAM_GENERAL_TOPIC_IDS` check |
| Operator-declared `dm_topics` | Skipped — `_get_dm_topic_info` check in rename method |
| `disable_topic_auto_rename` config | Respected — checked inside rename method |
| Plain DM (no thread_id) | `_is_telegram_renamable_thread` returns False |