### PR TITLE
fix(gateway): re-baseline agent-cache message_count before in-band queued follow-up turn

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15802,6 +15802,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     except Exception:
                         pass
 
+                # Re-baseline the cached agent's message_count snapshot before
+                # recursing into the in-band queued (/queue) follow-up turn.
+                # The first turn has completed and flushed its own user +
+                # assistant rows to the SessionDB, so the cross-process
+                # coherence guard (#45966) — which this recursive _run_agent
+                # call re-enters — would otherwise see the grown on-disk count
+                # against the stale build-time snapshot and rebuild the agent
+                # on THIS process's OWN writes, destroying the prompt-cache
+                # prefix #46237 was merged to preserve.  The existing
+                # re-baseline in _handle_message_with_agent only runs after the
+                # whole _run_agent chain unwinds — too late for the in-band
+                # follow-up.  Use the same (session_key, session_id) the
+                # recursive call runs under so the snapshot matches exactly
+                # what the follow-up's guard will consult.  Fail-safe in helper.
+                self._refresh_agent_cache_message_count(session_key, session_id)
+
                 followup_result = await self._run_agent(
                     message=next_message,
                     context_prompt=context_prompt,

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -1706,3 +1706,76 @@ class TestAgentCacheMessageCountRebaseline:
         runner._refresh_agent_cache_message_count("telegram:s1", "s1")
         with runner._agent_cache_lock:
             assert runner._agent_cache["telegram:s1"][2] == 5
+
+    def test_in_band_followup_reuses_cached_agent(self, tmp_path):
+        """Behavioral regression for the in-band queued (/queue) follow-up.
+
+        #46237 re-baselines the snapshot only on the EXTERNAL-turn boundary
+        (in ``_handle_message_with_agent``, after the whole ``_run_agent``
+        chain unwinds).  The recursive in-band follow-up re-enters the cache
+        guard MID-CHAIN — while the cache still holds the build-time snapshot
+        and the first turn has already flushed its own rows — so without a
+        re-baseline at the follow-up boundary the guard sees the grown count
+        and rebuilds the agent on THIS process's own writes, re-introducing
+        the every-turn rebuild #46237 set out to fix, on the follow-up path.
+
+        Pins both halves at that boundary: WITHOUT the re-baseline the in-band
+        follow-up would rebuild; WITH it the follow-up REUSES the warm agent.
+        The guard's reuse decision (``_guard_would_reuse``) mirrors the real
+        cache-hit guard, which reads ``get_session(session_id)`` with the same
+        ``session_id`` the recursive ``_run_agent`` call is given.
+        """
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "sessions.db")
+        db.create_session("s1", source="telegram")
+        runner = self._runner_with_db(db)
+        agent = object()
+
+        # First turn: cache miss -> build. Snapshot is the pre-turn count.
+        _row = db.get_session("s1")
+        build_count = _row.get("message_count", 0) if _row else 0
+        with runner._agent_cache_lock:
+            runner._agent_cache["telegram:s1"] = (agent, "sig", build_count)
+
+        # First turn flushes its own user + assistant rows.
+        db.append_message("s1", role="user", content="u")
+        db.append_message("s1", role="assistant", content="a")
+
+        # Bug reproduction: re-entering the guard at the in-band follow-up
+        # boundary WITHOUT the re-baseline sees the grown count and rebuilds.
+        assert self._guard_would_reuse(runner, "telegram:s1", "s1") is False
+
+        # The fix: re-baseline at the follow-up boundary.
+        runner._refresh_agent_cache_message_count("telegram:s1", "s1")
+
+        # The in-band follow-up now REUSES the cached, warm-prefix agent.
+        assert self._guard_would_reuse(runner, "telegram:s1", "s1") is True
+        with runner._agent_cache_lock:
+            assert runner._agent_cache["telegram:s1"][0] is agent
+
+    def test_in_band_followup_rebaseline_precedes_recursion(self):
+        """Pin the FIX PLACEMENT in the production source.
+
+        The behavioral test above proves the re-baseline makes the in-band
+        follow-up reuse the cached agent, but it calls the helper directly —
+        it would still pass if the production call were deleted.  This guards
+        the actual call site: inside ``_run_agent`` the queued (/queue)
+        follow-up recurses via ``followup_result = await self._run_agent(...)``
+        and the re-baseline MUST run BEFORE that recursion (running it only
+        after, like the external-turn site at 8888, is too late for the
+        in-band path — the follow-up would already have rebuilt).
+        """
+        import inspect
+        from gateway.run import GatewayRunner
+
+        src = inspect.getsource(GatewayRunner._run_agent)
+        marker = "followup_result = await self._run_agent("
+        assert marker in src, "in-band queued follow-up recursion not found in _run_agent"
+        before_recursion = src[: src.index(marker)]
+        assert "_refresh_agent_cache_message_count" in before_recursion, (
+            "the in-band queued follow-up recursion must be preceded by a "
+            "_refresh_agent_cache_message_count re-baseline, else the follow-up "
+            "rebuilds the agent on this process's own first-turn writes"
+        )
+


### PR DESCRIPTION
### Problem

#46237 added the cross-process agent-cache coherence guard (#45966) **plus** a
re-baseline so the gateway's own turn doesn't trip the guard on its next turn —
but the re-baseline (`_refresh_agent_cache_message_count`) is only called on the
**external-turn boundary**, in `_handle_message_with_agent` (after the external
`await self._run_agent(...)` returns).

The **in-band queued (`/queue`) follow-up** path is missed. After a turn
completes, `_run_agent` recurses into itself for the queued follow-up:

```python
followup_result = await self._run_agent(..., session_id=session_id, session_key=session_key, ...)
```

By that point the first turn has flushed its own user + assistant rows to the
`SessionDB` (so `message_count` has grown), but the cache still holds the
**build-time** snapshot. When the recursion re-enters the cache-hit guard it
reads `get_session(session_id).message_count` (the same `session_id` the
recursion is given), sees `current != snapshot`, and **rebuilds the agent on
this process's own writes** — re-introducing exactly the every-turn rebuild /
prompt-cache-prefix destruction #46237 was merged to prevent, on the in-band
follow-up path. The existing re-baseline at `_handle_message_with_agent` only
runs once the whole `_run_agent` chain unwinds — too late for the follow-up.

### Fix

Re-baseline immediately **before** the in-band follow-up recursion, using the
same `(session_key, session_id)` the recursive `_run_agent` call runs under — so
the cached snapshot matches exactly what the follow-up's guard will consult, and
the follow-up **reuses** the warm-prefix agent. This makes the in-band path
symmetric with the maintainer-accepted external-path fix; the helper is already
fail-safe (only touches a live 3-tuple cache entry, swallows DB errors).

`gateway/run.py`: +1 call (1-line), inserted before the queued-follow-up recursion.

### Tests

`tests/gateway/test_agent_cache.py` (extends `TestAgentCacheMessageCountRebaseline`):

- `test_in_band_followup_reuses_cached_agent` — drives the real `SessionDB` + the
  guard's reuse decision at the follow-up boundary: **without** the re-baseline the
  in-band follow-up rebuilds (`_guard_would_reuse` is `False`); **with** it the
  follow-up reuses the cached agent.
- `test_in_band_followup_rebaseline_precedes_recursion` — pins the **placement** via
  `inspect.getsource(GatewayRunner._run_agent)`: the re-baseline must appear before
  the `followup_result = await self._run_agent(` recursion (a helper-in-isolation
  test alone would pass even if the production line were deleted).

### Known tradeoff (transparent)

The re-baseline is unconditional w.r.t. *who* grew the count — in the small window
between the first turn's flush and the follow-up's re-entry, a concurrent
cross-process write would be absorbed and the follow-up would reuse instead of
rebuilding. This is the **same** property the accepted external-path call at
`_handle_message_with_agent` already has; this PR introduces no new masking class,
and the in-band window (first-turn flush → immediate in-process follow-up dispatch)
is strictly **smaller** than the external one.

---

Cross-checked against current `main` (no guessed symbols). If this has already been
addressed via a separate patch, please feel free to close — happy to adjust scope.
