### PR TITLE
fix: propagate provider quota failures through API gateway

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1011,6 +1011,40 @@ class APIServerAdapter(BasePlatformAdapter):
                     status=500,
                 )
 
+        # run_conversation can return a structured terminal failure
+        # without raising. Do not expose that as a successful empty HTTP 200.
+        if result.get("failed"):
+            failure_reason = str(
+                result.get("failure_reason") or "agent_failed"
+            )
+            failure_message = (
+                result.get("final_response")
+                or result.get("error")
+                or (
+                    "The upstream provider rate limit was reached. "
+                    "Please retry after the provider cooldown."
+                    if failure_reason == "rate_limit"
+                    else "The agent could not complete the request."
+                )
+            )
+
+            status = 429 if failure_reason == "rate_limit" else 502
+            error_type = (
+                "rate_limit_error"
+                if failure_reason == "rate_limit"
+                else "server_error"
+            )
+
+            return web.json_response(
+                _openai_error(
+                    str(failure_message),
+                    err_type=error_type,
+                    code=failure_reason,
+                ),
+                status=status,
+                headers={"X-Hermes-Session-Id": session_id},
+            )
+
         final_response = result.get("final_response", "")
         if not final_response:
             final_response = result.get("error", "(No response generated)")
@@ -1069,6 +1103,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         try:
             last_activity = time.monotonic()
+            content_emitted = False
 
             # Role chunk
             role_chunk = {
@@ -1089,12 +1124,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 frontends can display them without storing the markers in
                 conversation history.  See #6972.
                 """
+                nonlocal content_emitted
                 if isinstance(item, tuple) and len(item) == 2 and item[0] == "__tool_progress__":
                     event_data = json.dumps(item[1])
                     await response.write(
                         f"event: hermes.tool.progress\ndata: {event_data}\n\n".encode()
                     )
                 else:
+                    content_emitted = True
                     content_chunk = {
                         "id": completion_id, "object": "chat.completion.chunk",
                         "created": created, "model": model,
@@ -1130,13 +1167,41 @@ class APIServerAdapter(BasePlatformAdapter):
 
                 last_activity = await _emit(delta)
 
-            # Get usage from completed agent
+            # Get usage and terminal result from completed agent
             usage = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
             try:
                 result, agent_usage = await agent_task
                 usage = agent_usage or usage
-            except Exception:
-                pass
+
+                # HTTP headers are already committed for streaming requests.
+                # Therefore structured terminal failures must be emitted as
+                # visible assistant content instead of becoming an empty SSE
+                # response.
+                if result.get("failed") and not content_emitted:
+                    failure_reason = str(
+                        result.get("failure_reason") or "agent_failed"
+                    )
+                    failure_message = (
+                        result.get("final_response")
+                        or result.get("error")
+                        or (
+                            "The upstream provider rate limit was reached. "
+                            "Please retry after the provider cooldown."
+                            if failure_reason == "rate_limit"
+                            else "The agent could not complete the request."
+                        )
+                    )
+                    last_activity = await _emit(str(failure_message))
+            except Exception as exc:
+                logger.error(
+                    "Streaming chat completion agent failed: %s",
+                    exc,
+                    exc_info=True,
+                )
+                if not content_emitted:
+                    last_activity = await _emit(
+                        f"The agent request failed: {exc}"
+                    )
 
             # Finish chunk
             finish_chunk = {

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1339,6 +1339,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         final_response_text = ""
         agent_error: Optional[str] = None
+        agent_failure_reason: Optional[str] = None
         usage: Dict[str, int] = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
         terminal_snapshot_persisted = False
 
@@ -1606,8 +1607,25 @@ class APIServerAdapter(BasePlatformAdapter):
                     await _emit_text_delta(agent_final)
                 if agent_final and not final_response_text:
                     final_response_text = agent_final
-                if isinstance(result, dict) and result.get("error") and not final_response_text:
-                    agent_error = result["error"]
+                if isinstance(result, dict) and result.get("failed"):
+                    agent_failure_reason = str(
+                        result.get("failure_reason") or "agent_failed"
+                    )
+                    agent_error = str(
+                        result.get("error")
+                        or result.get("final_response")
+                        or (
+                            "The upstream provider usage limit has been reached."
+                            if agent_failure_reason == "rate_limit"
+                            else "The agent could not complete the request."
+                        )
+                    )
+                elif (
+                    isinstance(result, dict)
+                    and result.get("error")
+                    and not final_response_text
+                ):
+                    agent_error = str(result["error"])
             except Exception as e:  # noqa: BLE001
                 logger.error("Error running agent for streaming responses: %s", e, exc_info=True)
                 agent_error = str(e)
@@ -1654,7 +1672,15 @@ class APIServerAdapter(BasePlatformAdapter):
             if agent_error:
                 failed_env = _envelope("failed")
                 failed_env["output"] = final_items
-                failed_env["error"] = {"message": agent_error, "type": "server_error"}
+                failed_env["error"] = {
+                    "message": agent_error,
+                    "type": (
+                        "rate_limit_error"
+                        if agent_failure_reason == "rate_limit"
+                        else "server_error"
+                    ),
+                    "code": agent_failure_reason or "agent_failed",
+                }
                 failed_env["usage"] = {
                     "input_tokens": usage.get("input_tokens", 0),
                     "output_tokens": usage.get("output_tokens", 0),
@@ -1946,6 +1972,37 @@ class APIServerAdapter(BasePlatformAdapter):
                     _openai_error(f"Internal server error: {e}", err_type="server_error"),
                     status=500,
                 )
+
+        # run_conversation can return a structured terminal failure
+        # without raising. Do not expose it as a successful completed response.
+        if result.get("failed"):
+            failure_reason = str(
+                result.get("failure_reason") or "agent_failed"
+            )
+            failure_message = str(
+                result.get("error")
+                or result.get("final_response")
+                or (
+                    "The upstream provider usage limit has been reached."
+                    if failure_reason == "rate_limit"
+                    else "The agent could not complete the request."
+                )
+            )
+            status = 429 if failure_reason == "rate_limit" else 502
+            error_type = (
+                "rate_limit_error"
+                if failure_reason == "rate_limit"
+                else "server_error"
+            )
+            return web.json_response(
+                _openai_error(
+                    failure_message,
+                    err_type=error_type,
+                    code=failure_reason,
+                ),
+                status=status,
+                headers={"X-Hermes-Session-Id": session_id},
+            )
 
         final_response = result.get("final_response", "")
         if not final_response:

--- a/run_agent.py
+++ b/run_agent.py
@@ -11423,6 +11423,14 @@ class AIAgent:
                                 "execute_code with Python's open() for large "
                                 "files, or to write in smaller sections."
                             )
+                        _error_status = (
+                            getattr(api_error, "status_code", None)
+                            or getattr(
+                                getattr(api_error, "response", None),
+                                "status_code",
+                                None,
+                            )
+                        )
                         return {
                             "final_response": _final_response,
                             "messages": messages,
@@ -11430,6 +11438,12 @@ class AIAgent:
                             "completed": False,
                             "failed": True,
                             "error": _final_summary,
+                            "failure_reason": (
+                                "rate_limit" if is_rate_limited else "api_error"
+                            ),
+                            "error_status": (
+                                429 if is_rate_limited else _error_status
+                            ),
                         }
 
                     # For rate limits, respect the Retry-After header if present

--- a/run_agent.py
+++ b/run_agent.py
@@ -11446,7 +11446,61 @@ class AIAgent:
                             ),
                         }
 
-                    # For rate limits, respect the Retry-After header if present
+                    # Account-level quota exhaustion is not a transient rate
+                    # limit. Retrying the same provider and credential only
+                    # delays the inevitable terminal failure.
+                    _hard_quota_summary = str(api_error)
+                    _hard_quota_markers = (
+                        "usage limit has been reached",
+                        "usage_limit_reached",
+                        "insufficient_quota",
+                        "quota has been exhausted",
+                        "quota exceeded",
+                    )
+                    _hard_quota_exhausted = (
+                        is_rate_limited
+                        and any(
+                            marker in _hard_quota_summary.lower()
+                            for marker in _hard_quota_markers
+                        )
+                    )
+
+                    if _hard_quota_exhausted:
+                        logging.error(
+                            "%sHard provider quota exhaustion detected; "
+                            "skipping retries. %s | provider=%s model=%s "
+                            "msgs=%s tokens=~%s",
+                            self.log_prefix,
+                            _hard_quota_summary,
+                            _provider,
+                            _model,
+                            len(api_messages),
+                            f"{approx_tokens:,}",
+                        )
+                        if api_kwargs is not None:
+                            self._dump_api_request_debug(
+                                api_kwargs,
+                                reason="hard_quota_exhausted",
+                                error=api_error,
+                            )
+                        self._persist_session(messages, conversation_history)
+                        return {
+                            "final_response": (
+                                "The provider usage limit has been reached. "
+                                "Hermes is running, but the current provider "
+                                "cannot process new requests until its quota "
+                                "is available again."
+                            ),
+                            "messages": messages,
+                            "api_calls": api_call_count,
+                            "completed": False,
+                            "failed": True,
+                            "error": _hard_quota_summary,
+                            "failure_reason": "rate_limit",
+                            "error_status": 429,
+                        }
+
+                    # For transient rate limits, respect Retry-After if present.
                     _retry_after = None
                     if is_rate_limited:
                         _resp_headers = getattr(getattr(api_error, "response", None), "headers", None)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2315,3 +2315,141 @@ class TestSessionIdHeader:
             call_kwargs = mock_run.call_args.kwargs
             assert call_kwargs["conversation_history"] == []
             assert call_kwargs["session_id"] == "some-session"
+
+
+# --- Hermes provider quota regression tests ---
+
+
+class TestProviderQuotaFailureRegression:
+    @staticmethod
+    def _failed_result():
+        return (
+            {
+                "final_response": (
+                    "The provider usage limit has been reached. "
+                    "Hermes is running, but the current provider cannot "
+                    "process new requests until its quota is available again."
+                ),
+                "messages": [],
+                "api_calls": 1,
+                "completed": False,
+                "failed": True,
+                "error": "The usage limit has been reached",
+                "failure_reason": "rate_limit",
+                "error_status": 429,
+            },
+            {
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "total_tokens": 0,
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_chat_completion_rate_limit_returns_http_429(self, adapter):
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                adapter,
+                "_run_agent",
+                new_callable=AsyncMock,
+                return_value=self._failed_result(),
+            ):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "stream": False,
+                        "messages": [
+                            {"role": "user", "content": "hello"}
+                        ],
+                    },
+                )
+
+                assert resp.status == 429
+                body = await resp.json()
+                assert body["error"]["type"] == "rate_limit_error"
+                assert body["error"]["code"] == "rate_limit"
+                assert "usage limit" in body["error"]["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_responses_rate_limit_returns_http_429(self, adapter):
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                adapter,
+                "_run_agent",
+                new_callable=AsyncMock,
+                return_value=self._failed_result(),
+            ):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "stream": False,
+                        "input": "hello",
+                    },
+                )
+
+                assert resp.status == 429
+                body = await resp.json()
+                assert body["error"]["type"] == "rate_limit_error"
+                assert body["error"]["code"] == "rate_limit"
+
+    @pytest.mark.asyncio
+    async def test_streaming_chat_surfaces_quota_message(self, adapter):
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                adapter,
+                "_run_agent",
+                new_callable=AsyncMock,
+                return_value=self._failed_result(),
+            ):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "stream": True,
+                        "messages": [
+                            {"role": "user", "content": "hello"}
+                        ],
+                    },
+                )
+
+                assert resp.status == 200
+                body = await resp.text()
+                assert "provider usage limit has been reached" in body.lower()
+                assert "data: [DONE]" in body
+
+    @pytest.mark.asyncio
+    async def test_streaming_responses_emits_rate_limit_failure(self, adapter):
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                adapter,
+                "_run_agent",
+                new_callable=AsyncMock,
+                return_value=self._failed_result(),
+            ):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "stream": True,
+                        "input": "hello",
+                    },
+                )
+
+                assert resp.status == 200
+                body = await resp.text()
+
+                assert "event: response.failed" in body
+                assert '"status": "failed"' in body
+                assert '"type": "rate_limit_error"' in body
+                assert '"code": "rate_limit"' in body
+                assert "event: response.completed" not in body


### PR DESCRIPTION
## Summary

Fixes provider quota exhaustion handling across the Hermes API gateway.

- propagates structured rate-limit failures from `run_agent.py`;
- returns HTTP 429 instead of HTTP 502 or successful empty responses;
- skips repeated retries for confirmed account-level quota exhaustion;
- handles both `/v1/chat/completions` and `/v1/responses`;
- emits visible streaming failure output;
- emits `response.failed` with `rate_limit_error` for Responses SSE;
- adds regression coverage for non-streaming and streaming paths.

## Production verification

Verified against a real exhausted OpenAI Codex quota:

- gateway remained healthy;
- `/health` returned HTTP 200;
- non-streaming Chat Completions returned HTTP 429;
- non-streaming Responses returned HTTP 429;
- streaming Chat Completions displayed a clear quota message;
- streaming Responses emitted `response.failed`;
- repeated retries were skipped for `usage_limit_reached`.

## Tests

Targeted API gateway regression tests passed in an isolated test environment.
