### PR TITLE
fix(desktop): sync $connection on profile switch so remote profiles upload image bytes

### DIFF
--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -1,0 +1,89 @@
+import { atom } from 'nanostores'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { HermesConnection } from '@/global'
+
+// Keep profile.ts's side-effecting imports inert: the gateway socket layer and
+// the REST query client must not run for real in a unit test.
+const ensureGatewayForProfile = vi.fn(async () => undefined)
+const $gateway = atom<unknown>({ id: 'live-socket' })
+
+vi.mock('@/store/gateway', () => ({ $gateway, ensureGatewayForProfile }))
+vi.mock('@/hermes', () => ({
+  getProfiles: vi.fn(async () => ({ profiles: [] })),
+  setApiRequestProfile: vi.fn()
+}))
+vi.mock('@/lib/query-client', () => ({ queryClient: { invalidateQueries: vi.fn() } }))
+
+const { $activeGatewayProfile, ensureGatewayProfile } = await import('./profile')
+const { $connection } = await import('./session')
+
+const remoteConn = (over: Partial<HermesConnection> = {}): HermesConnection =>
+  ({ baseUrl: 'https://hermes-roy.tail.ts.net', mode: 'remote', profile: 'vps-remote', ...over }) as HermesConnection
+
+const localConn = (over: Partial<HermesConnection> = {}): HermesConnection =>
+  ({ baseUrl: '', mode: 'local', profile: 'default', ...over }) as HermesConnection
+
+const getConnection = vi.fn<(profile?: string | null) => Promise<HermesConnection>>()
+
+beforeEach(() => {
+  getConnection.mockReset()
+  ensureGatewayForProfile.mockClear()
+  $gateway.set({ id: 'live-socket' })
+  $activeGatewayProfile.set('default')
+  $connection.set(localConn())
+  vi.stubGlobal('window', { hermesDesktop: { getConnection } })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  $connection.set(null)
+})
+
+describe('ensureGatewayProfile → $connection sync (#46651)', () => {
+  it('refreshes $connection to the remote descriptor when activating a remote pool profile', async () => {
+    // Regression: the primary window backend is local, so $connection.mode is
+    // "local". Activating the remote profile must flip it to "remote" — without
+    // this, image attach uses path-based image.attach against the remote
+    // gateway ("image not found: C:\\…") instead of image.attach_bytes.
+    getConnection.mockResolvedValue(remoteConn())
+
+    await ensureGatewayProfile('vps-remote')
+
+    expect(ensureGatewayForProfile).toHaveBeenCalledWith('vps-remote')
+    expect(getConnection).toHaveBeenCalledWith('vps-remote')
+    expect($connection.get()?.mode).toBe('remote')
+    expect($connection.get()?.profile).toBe('vps-remote')
+  })
+
+  it('resyncs $connection back to local when returning to the default profile', async () => {
+    $activeGatewayProfile.set('vps-remote')
+    $connection.set(remoteConn())
+    getConnection.mockResolvedValue(localConn())
+
+    await ensureGatewayProfile('default')
+
+    expect(getConnection).toHaveBeenCalledWith('default')
+    expect($connection.get()?.mode).toBe('local')
+  })
+
+  it('leaves the prior connection intact when the descriptor fetch fails', async () => {
+    getConnection.mockRejectedValue(new Error('backend unreachable'))
+
+    await ensureGatewayProfile('vps-remote')
+
+    // Best-effort: boot/reconnect resyncs later; we must not null it out here.
+    expect($connection.get()?.mode).toBe('local')
+  })
+
+  it('does not churn $connection when the target is already the active profile', async () => {
+    $activeGatewayProfile.set('vps-remote')
+    $connection.set(remoteConn())
+
+    await ensureGatewayProfile('vps-remote')
+
+    expect(getConnection).not.toHaveBeenCalled()
+    expect(ensureGatewayForProfile).not.toHaveBeenCalled()
+    expect($connection.get()?.mode).toBe('remote')
+  })
+})

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -12,6 +12,7 @@ import {
   storedStringRecord
 } from '@/lib/storage'
 import { $gateway, ensureGatewayForProfile } from '@/store/gateway'
+import { setConnection } from '@/store/session'
 import type { ProfileInfo } from '@/types/hermes'
 
 // Canonical key for a profile: trimmed, empty → "default". Used everywhere we
@@ -178,6 +179,32 @@ export const $gatewaySwapTarget = atom<string | null>(null)
 
 let gatewaySwitch: Promise<void> | null = null
 
+// Keep the renderer's $connection (mode / baseUrl / profile) in lockstep with
+// the profile the live gateway is now on. $connection seeds from the PRIMARY
+// (window) backend at boot and otherwise only refreshes on a sleep/wake
+// reconnect — so activating a *background* profile left $connection describing
+// the primary, with the wrong `mode` for everything that branches on
+// local-vs-remote. Headline symptom: with a local primary and a remote pool
+// profile active, image attachments went out via the path-based `image.attach`
+// instead of `image.attach_bytes`, handing the remote gateway a client-only
+// path it can't resolve ("image not found: C:\…"), while the /api/fs/* file
+// browser and /api/media fetches targeted the wrong machine (#46651).
+// Best-effort: a failed descriptor fetch leaves the prior connection intact for
+// boot/reconnect to resync.
+async function syncConnectionToActiveProfile(profile: string): Promise<void> {
+  const getConnection = window.hermesDesktop?.getConnection
+
+  if (!getConnection) {
+    return
+  }
+
+  try {
+    setConnection(await getConnection(profile))
+  } catch {
+    // Leave the prior connection in place; boot/reconnect resyncs it later.
+  }
+}
+
 // Make `profile`'s backend the active gateway, lazily opening its socket if it
 // isn't live yet. Unlike the old single-socket swap, background profiles keep
 // their sockets — so their sessions keep streaming concurrently. A null/empty
@@ -218,6 +245,9 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
     // the active gateway at it — without closing the profile you came from.
     await ensureGatewayForProfile(target)
     $activeGatewayProfile.set(target)
+    // The active backend just changed; resync $connection so remote-aware
+    // paths (image.attach_bytes vs image.attach, /api/fs/*, /api/media) follow.
+    await syncConnectionToActiveProfile(target)
   })()
 
   try {


### PR DESCRIPTION
## Summary

Fixes #46651 — attaching an image in Hermes Desktop fails with **"image not found: C:\Users\…\<file>"** when the active chat is a **remote profile that isn't the primary window backend**, and the file browser / `/api/media` also hit the wrong machine (`404: No such API endpoint: /api/fs/list`).

### Root cause

The renderer's `$connection` store seeds from the **primary (window) backend** at boot (`getConnection()` with no profile) and otherwise only refreshes on a sleep/wake reconnect. When the user activates a **background profile** via `ensureGatewayProfile()`, the live gateway socket *and* the REST bridge are pointed at that profile's backend, but `$connection` is **never updated** — so `$connection.mode` stays stuck on the primary.

In the reporter's setup the primary is **local** and the active profile (`vps-remote`) is **remote**, so every code path that branches on local-vs-remote misfired:

- `uploadComposerAttachment()` read `$connection.get()?.mode === 'remote'` as **false** → called the path-based `image.attach` instead of `image.attach_bytes`, handing the remote gateway a **client-only Windows path** it can't resolve → `image not found: C:\…`.
- `desktop-fs` / `media` (`/api/fs/list`, `/api/media`) ran their "remote" branch against a `mode`/`baseUrl` that didn't match the active backend.

This matches the issue logs exactly: a **local** primary backend plus a **remote** `vps-remote` pool backend, with `/api/fs/list` 404ing against the remote.

### Fix

Resync `$connection` from the now-active profile's connection descriptor right after the gateway swap in `ensureGatewayProfile()`, so all remote-aware surfaces (`image.attach_bytes` vs `image.attach`, `/api/fs/*`, `/api/media`) follow the live backend. Best-effort: a failed descriptor fetch leaves the prior connection intact for boot/reconnect to resync.

Single-profile users are unaffected — the same-profile fast path returns before the swap, so `$connection` is never touched for them.

## Test plan

- [x] New `apps/desktop/src/store/profile.test.ts`:
  - activating a remote pool profile flips `$connection.mode` to `remote`
  - returning to the default profile resyncs back to `local`
  - a failed descriptor fetch leaves the prior connection intact
  - same-profile activation doesn't churn `$connection` (no swap)
- [x] `vitest run --environment jsdom` for `profile`, `session`, `desktop-fs`, `media.remote`, `use-prompt-actions`, `use-session-actions` — all green (the only failures locally are pre-existing `use-gateway-boot` cases, identical on clean `main`, caused by an incomplete local `node_modules`).

## Infographic

![Remote Profile Media Sync](https://v3b.fal.media/files/b/0a9e6734/29_T94IIzjm07VDuFn3Kn_mkFOrWB2.png)
