### PR TITLE
fix(kanban): commit dirty worktree to its task branch before block/complete

### DIFF
--- a/tests/tools/test_kanban_checkpoint_guard.py
+++ b/tests/tools/test_kanban_checkpoint_guard.py
@@ -1,0 +1,202 @@
+"""Regression tests for the kanban commit-before-handoff guard.
+
+``_checkpoint_workspace`` auto-commits a dirty worktree to its task branch
+before ``kanban_block`` / ``kanban_complete`` hand off, so the branch (the unit
+of handoff) carries the work for the reviewer / downstream verify card / PR.
+The guard is best-effort and must NEVER block a handoff: it only acts for the
+dispatched worker on its own task, on a non-default branch, outside a
+merge/rebase, and swallows every error.
+
+See the field failure that motivated it: card ``t_adfbe7f0`` blocked
+``review-required`` on a branch with no commits, handing the reviewer an empty
+diff.
+"""
+import subprocess
+
+import pytest
+
+from tools.kanban_tools import _checkpoint_workspace
+
+
+def _git(args, cwd):
+    return subprocess.run(["git", *args], cwd=str(cwd), capture_output=True, text=True)
+
+
+def _commits(repo):
+    r = _git(["rev-list", "--count", "HEAD"], repo)
+    return int(r.stdout.strip()) if r.returncode == 0 else -1
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A git repo on `main`, with origin/HEAD -> origin/main and one commit."""
+    d = tmp_path / "repo"
+    d.mkdir()
+    _git(["init", "-q"], d)
+    _git(["config", "user.email", "t@t"], d)
+    _git(["config", "user.name", "t"], d)
+    _git(["config", "commit.gpgsign", "false"], d)
+    _git(["checkout", "-q", "-b", "main"], d)
+    (d / "f.txt").write_text("base\n")
+    _git(["add", "f.txt"], d)
+    _git(["commit", "-q", "-m", "base"], d)
+    _git(["update-ref", "refs/remotes/origin/main", "HEAD"], d)
+    _git(["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"], d)
+    return d
+
+
+def _as_worker(monkeypatch, task, ws):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task)
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(ws))
+
+
+def test_feature_branch_dirty_is_committed(repo, monkeypatch):
+    _git(["checkout", "-q", "-b", "wt/t_abc"], repo)
+    (repo / "f.txt").write_text("base\nfix\n")
+    _as_worker(monkeypatch, "t_abc", repo)
+    before = _commits(repo)
+    _checkpoint_workspace("t_abc")
+    assert _commits(repo) == before + 1
+    subject = _git(["log", "-1", "--pretty=%s"], repo).stdout
+    assert "t_abc" in subject and "wt/t_abc" in subject
+
+
+def test_never_commits_on_default_branch(repo, monkeypatch):
+    (repo / "f.txt").write_text("base\nx\n")  # dirty, but on main
+    _as_worker(monkeypatch, "t_main", repo)
+    before = _commits(repo)
+    _checkpoint_workspace("t_main")
+    assert _commits(repo) == before
+
+
+def test_clean_worktree_is_noop(repo, monkeypatch):
+    _git(["checkout", "-q", "-b", "wt/t_clean"], repo)
+    _as_worker(monkeypatch, "t_clean", repo)
+    before = _commits(repo)
+    _checkpoint_workspace("t_clean")
+    assert _commits(repo) == before
+
+
+def test_only_acts_on_own_task(repo, monkeypatch):
+    _git(["checkout", "-q", "-b", "wt/t_other"], repo)
+    (repo / "f.txt").write_text("base\ny\n")
+    _as_worker(monkeypatch, "t_SOMEONE_ELSE", repo)  # env task != tid
+    before = _commits(repo)
+    _checkpoint_workspace("t_other")
+    assert _commits(repo) == before
+
+
+def test_skips_mid_merge(repo, monkeypatch):
+    _git(["checkout", "-q", "-b", "wt/t_merge"], repo)
+    (repo / "f.txt").write_text("base\nz\n")
+    (repo / ".git" / "MERGE_HEAD").write_text("deadbeef\n")
+    _as_worker(monkeypatch, "t_merge", repo)
+    before = _commits(repo)
+    _checkpoint_workspace("t_merge")
+    assert _commits(repo) == before
+
+
+def test_captures_new_untracked_files(repo, monkeypatch):
+    _git(["checkout", "-q", "-b", "wt/t_new"], repo)
+    (repo / "newsrc.py").write_text("print('hi')\n")
+    _as_worker(monkeypatch, "t_new", repo)
+    before = _commits(repo)
+    _checkpoint_workspace("t_new")
+    assert _commits(repo) == before + 1
+    names = _git(["show", "--name-only", "--pretty=format:", "HEAD"], repo).stdout
+    assert "newsrc.py" in names
+
+
+def test_no_workspace_env_is_noop(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_nows")
+    monkeypatch.delenv("HERMES_KANBAN_WORKSPACE", raising=False)
+    _checkpoint_workspace("t_nows")  # must not raise
+
+
+def test_non_git_workspace_is_noop(tmp_path, monkeypatch):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    _as_worker(monkeypatch, "t_plain", plain)
+    _checkpoint_workspace("t_plain")  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the full _handle_block / _handle_complete tool path must commit
+# the worktree BEFORE transitioning the card, against an isolated kanban DB.
+# ---------------------------------------------------------------------------
+
+def _dirty_feature_repo(base):
+    d = base / "ws"
+    d.mkdir()
+    _git(["init", "-q"], d)
+    _git(["config", "user.email", "t@t"], d)
+    _git(["config", "user.name", "t"], d)
+    _git(["config", "commit.gpgsign", "false"], d)
+    _git(["checkout", "-q", "-b", "main"], d)
+    (d / "f.txt").write_text("base\n")
+    _git(["add", "f.txt"], d)
+    _git(["commit", "-q", "-m", "base"], d)
+    _git(["update-ref", "refs/remotes/origin/main", "HEAD"], d)
+    _git(["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"], d)
+    _git(["checkout", "-q", "-b", "wt/feature"], d)
+    (d / "f.txt").write_text("base\nthe worker's edit\n")  # uncommitted change
+    return d
+
+
+@pytest.fixture
+def worker_task(monkeypatch, tmp_path):
+    """Isolated kanban DB with a claimed task; returns (tid, repo_path)."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "test-worker")
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    from pathlib import Path as _Path
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="commit-guard-e2e", assignee="test-worker")
+        kb.claim_task(conn, tid)
+    finally:
+        conn.close()
+
+    repo = _dirty_feature_repo(tmp_path)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", str(repo))
+    return tid, repo
+
+
+def test_handle_block_commits_worktree_then_blocks(worker_task):
+    tid, repo = worker_task
+    from tools import kanban_tools as kt
+    before = _commits(repo)
+    out = kt._handle_block({"reason": "review-required: e2e guard test"})
+    assert '"ok": true' in out or '"ok":true' in out, out
+    # the dirty worktree was committed to the feature branch by the guard
+    assert _commits(repo) == before + 1
+    # and the card actually transitioned to blocked
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, tid).status == "blocked"
+    finally:
+        conn.close()
+
+
+def test_handle_complete_commits_worktree_then_completes(worker_task):
+    tid, repo = worker_task
+    from tools import kanban_tools as kt
+    before = _commits(repo)
+    out = kt._handle_complete({"summary": "done; e2e guard test", "created_cards": []})
+    assert '"ok": true' in out or '"ok":true' in out, out
+    assert _commits(repo) == before + 1
+    from hermes_cli import kanban_db as kb
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, tid).status == "done"
+    finally:
+        conn.close()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -31,11 +31,125 @@ from __future__ import annotations
 import json
 import logging
 import os
+import subprocess
 from typing import Any, Optional
 
 from tools.registry import registry, tool_error
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Commit-before-handoff guard
+# ---------------------------------------------------------------------------
+
+# Branches we must NEVER auto-commit on (in addition to the remote default).
+_CHECKPOINT_PROTECTED_BRANCHES = {"main", "master"}
+
+
+def _git_ws(args: list, cwd: str, timeout: int = 30):
+    """Run a git command in ``cwd``; return (rc, stdout, stderr). Never raises."""
+    try:
+        p = subprocess.run(
+            ["git", *args], cwd=cwd,
+            capture_output=True, text=True, timeout=timeout,
+        )
+        return p.returncode, (p.stdout or "").strip(), (p.stderr or "").strip()
+    except Exception as exc:  # pragma: no cover - defensive
+        return 1, "", str(exc)
+
+
+def _checkpoint_workspace(tid: str) -> None:
+    """Best-effort: commit a dirty worktree to its task branch BEFORE a
+    ``kanban_block`` / ``kanban_complete`` handoff.
+
+    Why: the branch — not the working tree — is the unit of handoff. The
+    reviewer, the downstream verify card, and the eventual PR all act on the
+    *branch*; uncommitted edits are invisible to them and the next
+    branch/worktree switch silently wipes them. A ``review-required`` block on
+    a branch with no commits hands the reviewer an empty diff. (This is the
+    failure that prompted the guard.)
+
+    Safe by design — this can checkpoint work but can NEVER block a handoff:
+      - only acts for the dispatched worker finishing its OWN task
+        (``HERMES_KANBAN_TASK`` must equal ``tid``)
+      - only on a git worktree on a NON-default branch; never on the remote
+        default, ``main``, or ``master``
+      - never mid merge/rebase/cherry-pick/revert/bisect
+      - never pushes
+      - NEVER raises: any error is logged and the handoff proceeds regardless
+    """
+    try:
+        # Only the dispatched worker checkpoints its own task's workspace.
+        if os.environ.get("HERMES_KANBAN_TASK") != tid:
+            return
+        ws = os.environ.get("HERMES_KANBAN_WORKSPACE")
+        if not ws or not os.path.isdir(ws):
+            return
+
+        # Must be inside a git work tree.
+        rc, out, _ = _git_ws(["rev-parse", "--is-inside-work-tree"], ws)
+        if rc != 0 or out != "true":
+            return
+
+        # Skip if a merge/rebase/cherry-pick/revert/bisect is in progress.
+        rc, git_dir, _ = _git_ws(["rev-parse", "--git-dir"], ws)
+        if rc != 0 or not git_dir:
+            return
+        gd = git_dir if os.path.isabs(git_dir) else os.path.join(ws, git_dir)
+        for marker in ("MERGE_HEAD", "CHERRY_PICK_HEAD", "REVERT_HEAD",
+                       "BISECT_LOG", "rebase-merge", "rebase-apply"):
+            if os.path.exists(os.path.join(gd, marker)):
+                return
+
+        # Current branch (skip detached HEAD).
+        rc, branch, _ = _git_ws(["symbolic-ref", "--short", "-q", "HEAD"], ws)
+        if rc != 0 or not branch:
+            return
+
+        # Resolve the default branch; never auto-commit on it / main / master.
+        rc, def_ref, _ = _git_ws(
+            ["symbolic-ref", "--short", "-q", "refs/remotes/origin/HEAD"], ws)
+        default = def_ref.split("/", 1)[1] if (rc == 0 and "/" in def_ref) else "main"
+        if branch == default or branch in _CHECKPOINT_PROTECTED_BRANCHES:
+            return
+
+        # Anything to checkpoint? Tracked changes (staged or not) OR new files.
+        rc_tracked, _, _ = _git_ws(["diff", "--quiet", "--ignore-submodules", "HEAD"], ws)
+        has_tracked = rc_tracked != 0
+        rc_unt, untracked, _ = _git_ws(["ls-files", "--others", "--exclude-standard"], ws)
+        has_untracked = rc_unt == 0 and bool(untracked)
+        if not has_tracked and not has_untracked:
+            return
+
+        # Commit. The kanban worktree is the worker's own isolated checkout, so
+        # `git add -A` (which still respects .gitignore) is appropriate here.
+        _git_ws(["add", "-A"], ws)
+        commit_args = [
+            "commit", "--no-verify",
+            "-m", f"wip: kanban worker checkpoint for {tid} on {branch}",
+            "-m", ("Auto-committed before block/complete so the branch carries "
+                   "the work for the reviewer / downstream card / PR. "
+                   "Safe to squash or amend."),
+        ]
+        # If the worktree has no committer identity, supply a fallback so the
+        # commit can't fail on `user.email`/`user.name` being unset.
+        rc_id, email, _ = _git_ws(["config", "user.email"], ws)
+        if rc_id != 0 or not email:
+            commit_args = [
+                "-c", "user.email=kanban-worker@hermes.local",
+                "-c", "user.name=hermes-kanban-worker",
+            ] + commit_args
+        rc, _, err = _git_ws(commit_args, ws)
+        if rc == 0:
+            logger.info(
+                "kanban checkpoint: committed worktree for %s on %s", tid, branch)
+        else:
+            logger.warning(
+                "kanban checkpoint: commit failed for %s on %s: %s", tid, branch, err)
+    except Exception:  # pragma: no cover - the guard must never block a handoff
+        logger.warning(
+            "kanban checkpoint: skipped for %s (unexpected error)", tid, exc_info=True)
 
 
 # ---------------------------------------------------------------------------
@@ -483,6 +597,9 @@ def _handle_complete(args: dict, **kw) -> str:
     ownership_err = _enforce_worker_task_ownership(tid)
     if ownership_err:
         return ownership_err
+    # Commit the worktree to the task branch first — the branch is the handoff
+    # unit. Best-effort and non-blocking: never raises, never gates completion.
+    _checkpoint_workspace(tid)
     summary = args.get("summary")
     metadata = args.get("metadata")
     result = args.get("result")
@@ -605,6 +722,9 @@ def _handle_block(args: dict, **kw) -> str:
     ownership_err = _enforce_worker_task_ownership(tid)
     if ownership_err:
         return ownership_err
+    # Commit the worktree to the task branch first — the branch is the handoff
+    # unit. Best-effort and non-blocking: never raises, never gates the block.
+    _checkpoint_workspace(tid)
     reason = args.get("reason")
     if not reason or not str(reason).strip():
         return tool_error("reason is required — explain what input you need")


### PR DESCRIPTION
## Problem

A kanban worker working in a `worktree` workspace can finish its edits and hand off (`kanban_block` / `kanban_complete`) while leaving the changes uncommitted in the working tree. Because the **branch** is the unit of handoff — the reviewer checks out the branch, the downstream verify task runs on the branch, the PR is cut from the branch — uncommitted edits are invisible downstream, and the next branch/worktree switch silently discards them. A `review-required` block on a branch with no commits hands the reviewer an empty diff.

(Observed in practice: a worker shipped a correct fix, blocked `review-required`, but never committed — so the verify task and the PR operated on an empty branch.)

## Fix

`_checkpoint_workspace(tid)` runs at the top of `_handle_complete` and `_handle_block` and commits a dirty worktree to its task branch *before* the state transition.

Fail-safe by design — it can checkpoint work but can **never block a handoff**:

- only the dispatched worker's own task (`HERMES_KANBAN_TASK == tid`)
- only a git worktree on a **non-default** branch (never the remote default / `main` / `master`)
- skips when a merge/rebase/cherry-pick/revert/bisect is in progress
- never pushes; supplies a fallback committer identity only if none is set
- swallows every error and returns normally — a guard failure cannot gate completion

The worktree is the worker's own isolated checkout, so `git add -A` (which still respects `.gitignore`) is appropriate; new source files are part of the handoff.

## Tests

`tests/tools/test_kanban_checkpoint_guard.py` — 10 cases including two end-to-end `_handle_block` / `_handle_complete` tests that prove the full tool path commits the worktree and *then* transitions the card, against an isolated kanban DB. Existing `tests/tools/test_kanban_tools.py` continues to pass (94 passed on this base).

## Notes

- The `kanban-worker` skill and the auto-injected `KANBAN_GUIDANCE` lifecycle already point workers at committing before handoff; this makes it a hard, harness-level guarantee that doesn't depend on the model remembering.
- Complementary to #44811 (don't prune worktrees with uncommitted work): that guards the CLI prune path; this ensures the work is committed at handoff in the first place.
