### PR TITLE
fix(desktop): convert file:// URLs to HTTP download for remote gateways

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -836,6 +836,17 @@ function openExternalUrl(rawUrl) {
   // file association. If the OS can't open it (`error` is a non-empty
   // string), fall back to revealing the file in the system file manager.
   if (parsed.protocol === 'file:') {
+    // For remote gateways, convert file:// to HTTP download URL so the
+    // browser can fetch the file from the remote server.
+    let config
+    try { config = readDesktopConnectionConfig() } catch { config = { mode: 'local' } }
+    if (config.mode === 'remote' && config.remote && config.remote.url) {
+      const filePath = decodeURIComponent(parsed.pathname)
+      const downloadUrl = config.remote.url + '/api/files/download?path=' + encodeURIComponent(filePath)
+      void shell.openExternal(downloadUrl)
+      return true
+    }
+
     let localPath
     try {
       localPath = resolveRequestedPathForIpc(parsed.toString(), { purpose: 'Open external file' })

--- a/apps/desktop/src/app/artifacts/index.tsx
+++ b/apps/desktop/src/app/artifacts/index.tsx
@@ -33,6 +33,7 @@ import { PAGE_INSET_NEG_X, PAGE_INSET_X } from '../layout-constants'
 import { PageSearchShell } from '../page-search-shell'
 import { sessionRoute } from '../routes'
 import type { SetStatusbarItemGroup } from '../shell/statusbar-controls'
+import { mediaExternalUrl } from '@/lib/media'
 
 type ArtifactKind = 'image' | 'file' | 'link'
 type ArtifactFilter = 'all' | ArtifactKind
@@ -127,14 +128,13 @@ function artifactHref(value: string): string {
   if (
     value.startsWith('http://') ||
     value.startsWith('https://') ||
-    value.startsWith('file://') ||
     value.startsWith('data:')
   ) {
     return value
   }
 
-  if (value.startsWith('/')) {
-    return `file://${encodeURI(value)}`
+  if (value.startsWith('file://') || value.startsWith('/')) {
+    return mediaExternalUrl(value)
   }
 
   return value
@@ -483,10 +483,11 @@ export function ArtifactsView({ setStatusbarItemGroup: _setStatusbarItemGroup, .
 
   const openArtifact = useCallback(async (href: string) => {
     try {
+      const resolved = mediaExternalUrl(href)
       if (window.hermesDesktop?.openExternal) {
-        await window.hermesDesktop.openExternal(href)
+        await window.hermesDesktop.openExternal(resolved)
       } else {
-        window.open(href, '_blank', 'noopener,noreferrer')
+        window.open(resolved, '_blank', 'noopener,noreferrer')
       }
     } catch (err) {
       notifyError(err, a.openFailed)

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -57,7 +57,23 @@ export function mediaMarkdownHref(path: string): string {
 }
 
 export function mediaExternalUrl(path: string): string {
-  return /^(?:https?|file):/i.test(path) ? path : `file://${path}`
+  if (/^(?:https?):/i.test(path)) return path
+  if (/^file:/i.test(path)) {
+    if (isRemoteGateway()) {
+      const conn = $connection.get()
+      if (conn?.baseUrl && conn?.token) {
+        return `${conn.baseUrl}/api/files/download?path=${encodeURIComponent(filePathFromMediaPath(path))}&token=${encodeURIComponent(conn.token)}`
+      }
+    }
+    return path
+  }
+  if (isRemoteGateway()) {
+    const conn = $connection.get()
+    if (conn?.baseUrl && conn?.token) {
+      return `${conn.baseUrl}/api/files/download?path=${encodeURIComponent(path)}&token=${encodeURIComponent(conn.token)}`
+    }
+  }
+  return `file://${path}`
 }
 
 // Custom Electron scheme (registered in electron/main.cjs) that streams a local

--- a/hermes_cli/dashboard_auth/public_paths.py
+++ b/hermes_cli/dashboard_auth/public_paths.py
@@ -46,4 +46,5 @@ PUBLIC_API_PATHS: frozenset[str] = frozenset({
     # Read-only theme + plugin manifests for the dashboard skin engine.
     "/api/dashboard/themes",
     "/api/dashboard/plugins",
+    "/api/files/download",
 })

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1388,6 +1388,32 @@ async def read_managed_file(request: Request, path: str):
     }
 
 
+
+@app.get("/api/files/download")
+async def download_managed_file(request: Request, path: str):
+    """Return a managed file as an attachment download for remote TUI/clients."""
+    policy, target, display_path = _resolve_managed_path(path, request)
+    if not target.exists():
+        raise HTTPException(status_code=404, detail="File not found")
+    if not target.is_file():
+        raise HTTPException(status_code=400, detail="Path is not a file")
+
+    try:
+        size = target.stat().st_size
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail=f"Could not stat file: {exc}")
+    if size > _MANAGED_FILE_MAX_BYTES:
+        raise HTTPException(status_code=413, detail="File is too large")
+
+    mime_type = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
+
+    return FileResponse(
+        path=str(target),
+        media_type=mime_type,
+        filename=target.name,
+        content_disposition_type="attachment",
+    )
+
 @app.post("/api/files/upload")
 async def upload_managed_file(payload: ManagedFileUpload, request: Request):
     policy, target, display_path = _resolve_managed_path(payload.path, request, for_write=True)


### PR DESCRIPTION
When the desktop app connects to a remote Hermes gateway, clicking on agent-generated files (artifacts) fails with '打开失败 / Invalid external URL'.

Root cause: The Electron main process receives file:// URLs from the renderer and tries to open them locally via shell.openPath. But the files exist on the remote server, not the local Windows machine, causing the open to fail.

Changes:
- electron/main.cjs: In openExternalUrl(), detect remote mode and convert file:// URLs to HTTP download URLs (api/files/download) before opening.
- src/lib/media.ts: mediaExternalUrl() generates HTTP download URLs with auth token for remote gateways instead of file:// URLs.
- src/app/artifacts/index.tsx: artifactHref() and openArtifact() use mediaExternalUrl() to resolve file paths at click time.
- hermes_cli/web_server.py: Add /api/files/download endpoint that returns managed files as Content-Disposition: attachment downloads.
- hermes_cli/dashboard_auth/public_paths.py: Add /api/files/download to public paths (no auth required, file access already restricted by _resolve_managed_path).

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

