### PR TITLE
fix(telegram): preserve update queue on reconnect after outage (#46621)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2289,10 +2289,14 @@ class BasePlatformAdapter(ABC):
         self._session_store = session_store
     
     @abstractmethod
-    async def connect(self) -> bool:
+    async def connect(self, **kwargs) -> bool:
         """
         Connect to the platform and start receiving messages.
-        
+
+        Subclasses may accept additional keyword arguments (e.g.
+        ``drop_pending_updates`` for Telegram) that callers can pass through
+        via ``_connect_adapter_with_timeout``.
+
         Returns True if connection was successful.
         """
         pass

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1852,13 +1852,20 @@ class TelegramAdapter(BasePlatformAdapter):
                             self.name, topic_name, seed_err,
                         )
 
-    async def connect(self) -> bool:
+    async def connect(self, drop_pending_updates: bool = True) -> bool:
         """Connect to Telegram via polling or webhook.
 
         By default, uses long polling (outbound connection to Telegram).
         If ``TELEGRAM_WEBHOOK_URL`` is set, starts an HTTP webhook server
         instead.  Webhook mode is useful for cloud deployments (Fly.io,
         Railway) where inbound HTTP can wake a suspended machine.
+
+        Args:
+            drop_pending_updates: If True (default for initial gateway start),
+                discard any updates queued on Telegram's servers. Set to False
+                for reconnect paths (e.g. after a prolonged outage) so that
+                user messages sent while the bot was offline are not silently
+                lost.
 
         Env vars for webhook mode::
 
@@ -2049,7 +2056,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     webhook_url=webhook_url,
                     secret_token=webhook_secret,
                     allowed_updates=Update.ALL_TYPES,
-                    drop_pending_updates=True,
+                    drop_pending_updates=drop_pending_updates,
                 )
                 self._webhook_mode = True
                 logger.info(
@@ -2082,7 +2089,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
                 await self._app.updater.start_polling(
                     allowed_updates=Update.ALL_TYPES,
-                    drop_pending_updates=True,
+                    drop_pending_updates=drop_pending_updates,
                     error_callback=_polling_error_callback,
                 )
             

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2626,13 +2626,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return max(0.0, timeout)
         return _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT
 
-    async def _connect_adapter_with_timeout(self, adapter, platform) -> bool:
-        """Connect an adapter without allowing one platform to block others."""
+    async def _connect_adapter_with_timeout(self, adapter, platform, **connect_kwargs) -> bool:
+        """Connect an adapter without allowing one platform to block others.
+
+        Any extra keyword arguments are forwarded to ``adapter.connect()`` so
+        callers can, for example, pass ``drop_pending_updates=False`` during
+        reconnect attempts.  Adapters that do not accept the given kwargs
+        will receive an empty call (kwargs are silently dropped).
+        """
         timeout = self._platform_connect_timeout_secs()
-        if timeout <= 0:
-            return await adapter.connect()
+        # Only forward kwargs that the adapter's connect() actually accepts.
+        import inspect
         try:
-            return await asyncio.wait_for(adapter.connect(), timeout=timeout)
+            sig = inspect.signature(adapter.connect)
+            accepted = set(sig.parameters.keys()) | {
+                name for name, p in sig.parameters.items()
+                if p.kind == inspect.Parameter.VAR_KEYWORD
+            }
+            filtered = {k: v for k, v in connect_kwargs.items() if k in accepted}
+        except (ValueError, TypeError):
+            filtered = {}
+        if timeout <= 0:
+            return await adapter.connect(**filtered)
+        try:
+            return await asyncio.wait_for(adapter.connect(**filtered), timeout=timeout)
         except asyncio.TimeoutError as exc:
             raise TimeoutError(
                 f"{platform.value} connect timed out after {timeout:g}s"
@@ -5830,7 +5847,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     adapter.set_topic_recovery_fn(self._recover_telegram_topic_thread_id)
                     adapter._busy_text_mode = self._busy_text_mode
 
-                    success = await self._connect_adapter_with_timeout(adapter, platform)
+                    # Reconnect after a prolonged outage: preserve Telegram's
+                    # server-side update queue so user messages sent while the
+                    # bot was offline are delivered rather than silently dropped.
+                    success = await self._connect_adapter_with_timeout(
+                        adapter, platform, drop_pending_updates=False,
+                    )
                     if success:
                         self.adapters[platform] = adapter
                         self._sync_voice_mode_state_to_adapter(adapter)

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -27,7 +27,7 @@ class StubAdapter(BasePlatformAdapter):
         self._fatal_error = fatal_error
         self._fatal_retryable = fatal_retryable
 
-    async def connect(self):
+    async def connect(self, **kwargs):
         if self._fatal_error:
             self._set_fatal_error("test_error", self._fatal_error, retryable=self._fatal_retryable)
             return False


### PR DESCRIPTION
Fixes #46621. After a prolonged outage, the platform reconnect watcher previously called connect() with drop_pending_updates=True (the same value used at initial gateway startup). This silently discarded every update the Bot API queued during the outage. Now connect() accepts a drop_pending_updates parameter (default True for backward compat). The reconnect watcher passes drop_pending_updates=False so queued user messages are delivered instead of lost. Uses inspect.signature to safely filter kwargs for adapters that do not accept them.