### PR TITLE
fix(vision): respect MiMo tool-result media limits

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -541,6 +541,7 @@ AUTHOR_MAP = {
     "79389617+txbxxx@users.noreply.github.com": "txbxxx",
     "liuhao03@bilibili.com": "liuhao1024",
     "130918800+devorun@users.noreply.github.com": "devorun",
+    "82179872+NemoJaaskelainen@users.noreply.github.com": "NemoJaaskelainen",
     "surat.s@itm.kmutnb.ac.th": "beesrsj2500",
     "beesr@bee.localdomain": "beesrsj2500",
     "mind-dragon@nous.research": "Mind-Dragon",
@@ -1545,6 +1546,7 @@ AUTHOR_MAP = {
     "andreas@schwarz-ketsch.de": "Nea74",  # PR #40022 co-author credit (same Windows ConPTY bridge design)
     "chanhokyim@gmail.com": "joel611",  # PR #33958 salvage (DISCORD_ALLOWED_ROLES role_authorized gateway flag)
     "desg38@gmail.com": "dschnurbusch",  # PR #42373 salvage (archive compressed conversation lineages)
+    "gkd2323c@users.noreply.github.com": "gkd2323c",  # PR #45571 salvage (Xiaomi MiMo vision tool-result routing)
     "bsmith@bramarstrategicservices.com": "bcsmith528",  # PR #20589 salvage (register_slack_action_handler plugin API)
     "sunsky.lau@gmail.com": "liuhao1024",  # PR #45494 salvage (claim session slot before auto-resume task; #45456)
     "andrewdmwalker@gmail.com": "capt-marbles",  # PR #38440 salvage (resolve xAI OAuth credentials across profiles; #43589)

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -53,6 +53,9 @@ class TestSupportsMediaInToolResults:
     def test_gemini_2_no(self):
         assert _supports_media_in_tool_results("google", "gemini-2.5-pro") is False
 
+    def test_xiaomi_vision_models_reject_tool_result_media(self):
+        assert _supports_media_in_tool_results("xiaomi", "mimo-v2.5-pro") is False
+
     def test_unknown_provider_conservative_no(self):
         assert _supports_media_in_tool_results("brand-new-provider", "any-model") is False
 
@@ -272,6 +275,32 @@ class TestHandleVisionAnalyzeFastPath:
 
         assert isinstance(result, dict) and result.get("_multimodal") is True
         mock_aux.assert_not_called()
+
+    def test_supports_vision_override_does_not_bypass_provider_tool_result_deny(self, tmp_path):
+        """Xiaomi accepts image user messages but rejects image tool results."""
+        img = tmp_path / "x.png"
+        img.write_bytes(_TINY_PNG)
+
+        async def _aux_sentinel(*args, **kwargs):
+            return '{"sentinel": "aux-path"}'
+
+        from agent.auxiliary_client import set_runtime_main, clear_runtime_main
+        set_runtime_main("xiaomi", "mimo-v2.5-pro")
+        try:
+            with patch(
+                "hermes_cli.config.load_config",
+                return_value={"model": {"supports_vision": True}},
+            ), patch(
+                "tools.vision_tools.vision_analyze_tool", side_effect=_aux_sentinel,
+            ) as mock_aux:
+                coro = _handle_vision_analyze({"image_url": str(img), "question": "?"})
+                result = asyncio.get_event_loop().run_until_complete(coro)
+        finally:
+            clear_runtime_main()
+
+        assert isinstance(result, str)
+        assert json.loads(result) == {"sentinel": "aux-path"}
+        mock_aux.assert_called_once()
 
     def test_text_mode_wins_over_supports_vision_override(self, tmp_path):
         """Explicit text routing blocks the fast path even with supports_vision."""

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -545,14 +545,25 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
         results. Older Gemini does NOT.
 
     For unknown / legacy providers we conservatively return False — the
-    caller falls back to the legacy aux-LLM text path.  The check is relaxed
-    when the provider's ``ProviderProfile`` declares ``supports_vision=True``.
+    caller falls back to the legacy aux-LLM text path.  Model-level vision
+    support is deliberately not enough here: providers like Xiaomi MiMo accept
+    image content in user messages but reject list-type tool-result content.
     """
     if not isinstance(provider, str):
         return False
     p = provider.strip().lower()
     if not p:
         return False
+
+    # Provider profiles can explicitly deny list-type tool-result content
+    # even when their models accept multimodal user messages.
+    try:
+        from providers import get_provider_profile
+        profile = get_provider_profile(p)
+        if profile is not None and getattr(profile, "supports_vision_tool_messages", True) is False:
+            return False
+    except Exception:
+        pass
 
     # Aggregators that route to multiple vendors — assume support since
     # users on these aggregators are typically using vision-capable
@@ -583,17 +594,6 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
             return True
         return False
 
-    # Check the provider's registered profile for the supports_vision flag.
-    # This covers vision-capable providers like xiaomi, minimax, etc. that
-    # aren't in the hardcoded list above.
-    try:
-        from providers import get_provider_profile
-        profile = get_provider_profile(p)
-        if profile is not None and profile.supports_vision:
-            return True
-    except Exception:
-        pass
-
     # Other vision-capable provider stacks. Conservative default: False.
     # Add explicit entries here as we verify each provider's tool-result
     # multimodal support empirically.
@@ -606,14 +606,15 @@ def _should_use_native_vision_fast_path() -> bool:
 
     True when image routing resolves to ``native`` AND either the provider is
     known to accept images inside tool results, or the user explicitly declared
-    the model vision-capable via the ``model.supports_vision`` config override.
-    The override is the escape hatch for custom/local providers that aren't in
-    the static allowlist. Best-effort: any resolution failure returns False so
-    the caller falls back to the legacy aux-LLM path.
+    the model vision-capable via the ``model.supports_vision`` config override
+    without the provider profile explicitly denying tool-message vision. The
+    override is the escape hatch for custom/local providers that aren't in the
+    static allowlist. Best-effort: any resolution failure returns False so the
+    caller falls back to the legacy aux-LLM path.
     """
     try:
         from agent.auxiliary_client import _read_main_provider, _read_main_model
-        from agent.image_routing import decide_image_input_mode, _lookup_supports_vision
+        from agent.image_routing import decide_image_input_mode, _supports_vision_override
         from hermes_cli.config import load_config
 
         provider = _read_main_provider()
@@ -621,9 +622,18 @@ def _should_use_native_vision_fast_path() -> bool:
         cfg = load_config()
         if decide_image_input_mode(provider, model, cfg) != "native":
             return False
+
+        try:
+            from providers import get_provider_profile
+            profile = get_provider_profile((provider or "").strip())
+            if profile is not None and getattr(profile, "supports_vision_tool_messages", True) is False:
+                return False
+        except Exception:
+            pass
+
         return (
             _supports_media_in_tool_results(provider, model)
-            or _lookup_supports_vision(provider, model, cfg) is True
+            or _supports_vision_override(cfg, provider, model) is True
         )
     except Exception as exc:
         logger.debug("Native vision fast-path check failed: %s", exc)


### PR DESCRIPTION
## Summary
Prevents Xiaomi MiMo vision-capable models from taking the native `vision_analyze` fast path when the provider profile says tool-result media is unsupported. MiMo can accept image user messages, but rejects list-type tool-result content, so the vision tool now falls back to the auxiliary path instead of generating a poisoned multimodal tool result.

## Changes
- `tools/vision_tools.py`: stop treating `ProviderProfile.supports_vision` as proof that image content is valid inside tool-result messages.
- `tools/vision_tools.py`: honor `supports_vision_tool_messages=False` before using the native `vision_analyze` fast path, even when `model.supports_vision: true` is configured.
- `tests/tools/test_vision_native_fast_path.py`: add Xiaomi regression coverage for provider media gating and the config-override escape hatch.
- `scripts/release.py`: add missing author map entries for salvaged contributors.

## Salvaged from
- #39692 by @liuhao1024 — require provider API media support for the native vision fast path.
- #45571 by @gkd2323c — use `supports_vision_tool_messages` as the explicit provider deny signal.
- #43686 by @NemoJaaskelainen — fast-path boolean gate direction.

I did not include #44305 in this PR because changing `auxiliary.vision` precedence is a broader product behavior change, not required to stop MiMo tool-result media failures.

## Validation
| Check | Result |
|---|---|
| `scripts/run_tests.sh tests/tools/test_vision_native_fast_path.py tests/agent/test_image_routing.py tests/run_agent/test_vision_tool_messages.py tests/run_agent/test_multimodal_tool_content_recovery.py` | 131 passed |
| E2E import/probe for Xiaomi `vision_analyze` with `supports_vision: true` | aux path used |
| `python3 -m py_compile tools/vision_tools.py tests/tools/test_vision_native_fast_path.py scripts/release.py` | passed |
| `git diff --check` | passed |

## Infographic

![Hermes Agent Vision Tool Routing](https://v3b.fal.media/files/b/0a9e66c9/IdKUl3Bhx-W_jUn62VFV7_TER7tNVZ.png)
