### PR TITLE
fix(agent): copilot gpt-5-mini fallback keeps chat completions mode (#46527)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1248,6 +1248,11 @@ class AIAgent:
                 # Fall back to the generic GPT-5 rule if Copilot-specific
                 # logic is unavailable for any reason.
                 pass
+            # Copilot-specific logic determined this model should NOT use
+            # Responses API (e.g. gpt-5-mini).  Do NOT fall through to the
+            # generic GPT-5 check which would incorrectly force Responses
+            # API for models that Copilot serves on chat completions.
+            return False
         return AIAgent._model_requires_responses_api(model)
 
     def _max_tokens_param(self, value: int) -> dict:


### PR DESCRIPTION
Fixes #46527. When the copilot-specific check (_should_use_copilot_responses_api) returns False for gpt-5-mini, the code fell through to the generic GPT-5 name check which returned True. This caused gpt-5-mini on Copilot to incorrectly use codex_responses mode, silently dropping reasoning content. Added an explicit return False after copilot-specific logic so models that Copilot serves on chat completions are not forced onto the Responses API.