### PR TITLE
fix(tools): keep switch_desktop from resurrecting a disabled overlay

### DIFF
--- a/tests/tools/test_computer_use_windows.py
+++ b/tests/tools/test_computer_use_windows.py
@@ -577,3 +577,73 @@ class TestSharedTreeWalk:
         els = b._walk_elements(1, _WIDE)
         assert [e.label for e in els] == ["field"]
         assert b._control_at_index(1, 1).Name == "field"
+
+
+# ---------------------------------------------------------------------------
+# switch_desktop overlay safety. A virtual-desktop transition tears down the
+# overlay subprocess, so the action stops it, switches, then restarts it — but
+# only an overlay that was actually running comes back. A deliberately-disabled
+# overlay (HERMES_COMPUTER_USE_OVERLAY=0) or one that already failed itself off
+# must stay down. Regression guard: an earlier revision force-cleared _dead
+# before start(), resurrecting the kill-switched overlay on every switch.
+# ---------------------------------------------------------------------------
+
+class _FakeOverlay:
+    """Mirrors _OverlayClient.start/stop/_proc/_dead semantics."""
+
+    def __init__(self, *, dead, proc):
+        self._dead = dead
+        self._proc = proc
+        self.calls = []
+
+    def stop(self):
+        self.calls.append("stop")
+        self._proc = None
+
+    def start(self):
+        self.calls.append("start")
+        if self._dead or self._proc is not None:   # same guard as the real client
+            return
+        self._proc = "spawned"
+
+    def send(self, msg):
+        self.calls.append(("send", msg.get("cmd")))
+
+
+class TestSwitchDesktopOverlaySafety:
+    @pytest.fixture
+    def wb_no_input(self, monkeypatch):
+        """windows_backend with the win32 input layer stubbed out."""
+        from tools.computer_use import windows_backend as wb
+        sent = []
+        monkeypatch.setattr(wb, "_key_event", lambda vk, down: (vk, down))
+        monkeypatch.setattr(wb, "_send_inputs", lambda seq: sent.append(seq))
+        monkeypatch.setattr(wb.time, "sleep", lambda *_a: None)
+        return wb, sent
+
+    def test_live_overlay_is_restarted_after_switch(self, wb_no_input):
+        wb, sent = wb_no_input
+        ov = _FakeOverlay(dead=False, proc="running")
+        assert wb._switch_desktop_via_keybd("left", ov) is True
+        assert ov.calls == ["stop", "start"]       # stopped, then brought back
+        assert ov._proc == "spawned"               # actually respawned
+        assert len(sent) == 1 and len(sent[0]) == 6  # the Ctrl+Win+Arrow combo
+
+    def test_disabled_overlay_is_not_resurrected(self, wb_no_input):
+        # HERMES_COMPUTER_USE_OVERLAY=0 → _dead set, no subprocess. The switch
+        # must still happen, but the overlay must NOT be revived. This fails on
+        # the force-clear-_dead revision (which respawned it every switch).
+        wb, sent = wb_no_input
+        ov = _FakeOverlay(dead=True, proc=None)
+        assert wb._switch_desktop_via_keybd("right", ov) is True
+        assert "start" not in ov.calls             # never tried to revive it
+        assert ov._proc is None                    # stays down
+        assert ov._dead is True                    # kill switch left intact
+        assert len(sent) == 1                       # desktop still switched
+
+    def test_invalid_direction_is_rejected_without_side_effects(self, wb_no_input):
+        wb, sent = wb_no_input
+        ov = _FakeOverlay(dead=False, proc="running")
+        assert wb._switch_desktop_via_keybd("up", ov) is False
+        assert ov.calls == []                       # overlay untouched
+        assert sent == []                           # no input injected

--- a/tools/computer_use/windows_backend.py
+++ b/tools/computer_use/windows_backend.py
@@ -309,7 +309,9 @@ def _switch_desktop_via_keybd(direction: str, overlay_client) -> bool:
 
     The overlay subprocess (full-screen tkinter window) is killed by any
     virtual-desktop transition, so we stop it before switching and restart
-    it on the new desktop.
+    it on the new desktop — but only if it was running, so a deliberately
+    disabled overlay (``computer_use.overlay: false`` /
+    ``HERMES_COMPUTER_USE_OVERLAY=0``) is never resurrected by a switch.
     """
     if direction not in ("left", "right"):
         return False
@@ -331,22 +333,30 @@ def _switch_desktop_via_keybd(direction: str, overlay_client) -> bool:
            _key_event(VK_LWIN, False),
            _key_event(VK_CONTROL, False)]
 
+    # Capture liveness before stop() clears _proc. Only an overlay that was
+    # actually running comes back: a user who disabled it leaves _dead set,
+    # and force-clearing _dead here (as an earlier revision did) would
+    # resurrect a deliberately-killed overlay on every desktop switch. start()
+    # already no-ops while _dead is set, so this guard is the single source of
+    # truth for whether the overlay returns.
+    overlay_was_live = overlay_client._proc is not None and not overlay_client._dead
+
     try:
         overlay_client.stop()
         _send_inputs(seq)
-        # The virtual-desktop transition is asynchronous — a brief delay
-        # before restarting the overlay avoids racing the DWM compositor.
-        time.sleep(0.15)
-        overlay_client._dead = False
-        overlay_client.start()
+        if overlay_was_live:
+            # The virtual-desktop transition is asynchronous — a brief delay
+            # before restarting the overlay avoids racing the DWM compositor.
+            time.sleep(0.15)
+            overlay_client.start()
         return True
     except Exception as e:
         logger.warning("switch_desktop SendInput failed: %s", e)
-        try:
-            overlay_client._dead = False
-            overlay_client.start()
-        except Exception as e2:
-            logger.warning("switch_desktop overlay restart also failed: %s", e2)
+        if overlay_was_live:
+            try:
+                overlay_client.start()
+            except Exception as e2:
+                logger.warning("switch_desktop overlay restart also failed: %s", e2)
         return False
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes a kill-switch regression in the `switch_desktop` action on the
`salvage/windows-uia-computer-use` branch behind #46667.

`_switch_desktop_via_keybd` force-cleared `overlay_client._dead` and called
`start()` **unconditionally** on every virtual-desktop switch:

```python
time.sleep(0.15)
overlay_client._dead = False   # ← clears the kill switch
overlay_client.start()
```

So an overlay the user had deliberately turned off — `computer_use.overlay: false`,
or the `HERMES_COMPUTER_USE_OVERLAY=0` escape hatch (both set `_dead=True` with no
subprocess) — was respawned on screen on **every** desktop switch, overriding the
off switch. An overlay that had already failed itself off was likewise force-retried
on each switch.

This restores the guard from `ea294afb5` (dropped in the salvage): capture liveness
*before* `stop()` clears `_proc`, and only restart an overlay that was actually
running. The `_dead` force-clear is removed — `_OverlayClient.start()` already
no-ops `if self._dead or self._proc is not None`, so the `overlay_was_live` guard is
the single source of truth for whether the overlay comes back.

**Verified in code:** `start()` in `tools/computer_use/windows_backend.py` returns
early while `_dead` is set, so clearing `_dead` immediately before `start()` is
exactly what defeats the kill switch.

## Related Issue

Stacked on #46667 — targets the `salvage/windows-uia-computer-use` branch so the fix
lands *with* the salvage rather than after it. Restores behavior introduced in the
original #43927 (`ea294afb5`). (No `Fixes #` keyword on purpose — this shouldn't
auto-close #46667.)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/computer_use/windows_backend.py` — `_switch_desktop_via_keybd`: compute
  `overlay_was_live = overlay_client._proc is not None and not overlay_client._dead`
  before `stop()`; gate both the success-path and the except-path overlay restart on
  it; remove the two `overlay_client._dead = False` force-clears. Docstring updated to
  state a deliberately-disabled overlay is never resurrected by a switch.
- `tests/tools/test_computer_use_windows.py` — re-add the
  `TestSwitchDesktopOverlaySafety` suite (with a `_FakeOverlay` mirroring the real
  `start`/`stop`/`_proc`/`_dead` semantics): `test_live_overlay_is_restarted_after_switch`,
  `test_disabled_overlay_is_not_resurrected` (the regression guard), and
  `test_invalid_direction_is_rejected_without_side_effects`.

## How to Test

Before → after, against the branch's own backend code:

1. `test_disabled_overlay_is_not_resurrected` on the **unpatched** branch → **FAILS**:
   `AssertionError: assert 'start' not in ['stop', 'start']` — the disabled overlay was
   revived on the switch.
2. With this fix → **PASSES**: a `_FakeOverlay(dead=True, proc=None)` is never started,
   `_dead` stays `True`, and the desktop still switches.
3. Full relevant suite, run per-file (matching `scripts/run_tests.sh`'s subprocess-per-file
   isolation), venv python on Windows 11:

```
tests/tools/test_computer_use.py                  79 passed
tests/tools/test_computer_use_capture_routing.py  14 passed
tests/tools/test_computer_use_windows.py          50 passed   (incl. the 3 new tests)
tests/hermes_cli/test_tools_config.py             99 passed
                                                  --------- 242 passed, 0 failed
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(tools): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (windows_backend.py + its test)
- [x] I've run the tests and all pass — per-file isolation, 242 passed (see note below)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (live-install venv python)

### Documentation & Housekeeping

- [x] Updated the `_switch_desktop_via_keybd` docstring; README/`docs/` — N/A (no user-facing surface change)
- [x] `cli-config.yaml.example` — N/A (no config keys added/changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact considered — Windows-only file (`windows_backend.py`, gated to `win32`); no behavior change on macOS/Linux
- [x] Tool descriptions/schemas — N/A (`switch_desktop` tool surface and schema unchanged)

## Screenshots / Logs

**Regression reproduced, then fixed** (same `_FakeOverlay`, run against each version of the backend):

```
RUN 1 — unpatched salvage backend:
  test_disabled_overlay_is_not_resurrected  FAILED
    assert 'start' not in ['stop', 'start']

RUN 2 — with this fix:
  test_live_overlay_is_restarted_after_switch          PASSED
  test_disabled_overlay_is_not_resurrected             PASSED
  test_invalid_direction_is_rejected_without_side_effects PASSED
  3 passed
```

Windows-footgun scan + ruff on the diff: clean.

> Note on `pytest tests/ -q`: I ran the relevant files via the venv python with
> `--timeout-method=thread` (the repo's pinned SIGALRM method crashes pytest on
> Windows). The four files pass individually (242 total). In a *single shared
> process*, plugin/platform registration leaked from earlier files trips
> `test_tools_config.py::test_get_platform_tools_recovers_non_configurable_toolsets_from_composite`;
> it passes in isolation (1 passed) and under `run_tests.sh`'s subprocess-per-file
> isolation — which is how CI runs it. Unrelated to this diff, which only touches
> `windows_backend.py` and its test.
