### PR TITLE
fix: make gateway approvals human-readable

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -65,6 +65,7 @@ from gateway.platforms.base import (
     cache_document_from_bytes,
     SUPPORTED_DOCUMENT_TYPES,
 )
+from tools.approval import command_approval_summary
 from tools.url_safety import is_safe_url
 
 
@@ -4033,12 +4034,19 @@ class DiscordAdapter(BasePlatformAdapter):
             # Discord embed description limit is 4096; show full command up to that
             max_desc = 4088
             cmd_display = command if len(command) <= max_desc else command[: max_desc - 3] + "..."
+            summary = command_approval_summary(command, description)
             embed = discord.Embed(
                 title="⚠️ Command Approval Required",
-                description=f"```\n{cmd_display}\n```",
+                description=f"**{summary['action']}**",
                 color=discord.Color.orange(),
             )
-            embed.add_field(name="Reason", value=description, inline=False)
+            embed.add_field(name="Mode", value=summary["mode"], inline=True)
+            embed.add_field(name="Category", value=summary["category"], inline=True)
+            embed.add_field(name="Target", value=summary["target"], inline=False)
+            embed.add_field(name="Need", value=summary["need"], inline=False)
+            embed.add_field(name="Reason", value=summary["reason"], inline=False)
+            embed.add_field(name="Risk", value=summary["risk"], inline=False)
+            embed.add_field(name="Raw command", value=f"```\n{cmd_display}\n```", inline=False)
 
             view = ExecApprovalView(
                 session_key=session_key,

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -4037,15 +4037,10 @@ class DiscordAdapter(BasePlatformAdapter):
             summary = command_approval_summary(command, description)
             embed = discord.Embed(
                 title="⚠️ Command Approval Required",
-                description=f"**{summary['action']}**",
+                description=f"**Explanation:** {summary['explanation']}",
                 color=discord.Color.orange(),
             )
-            embed.add_field(name="Mode", value=summary["mode"], inline=True)
-            embed.add_field(name="Category", value=summary["category"], inline=True)
-            embed.add_field(name="Target", value=summary["target"], inline=False)
-            embed.add_field(name="Need", value=summary["need"], inline=False)
-            embed.add_field(name="Reason", value=summary["reason"], inline=False)
-            embed.add_field(name="Risk", value=summary["risk"], inline=False)
+            embed.add_field(name="Why approval is needed", value=summary["reason"], inline=False)
             embed.add_field(name="Raw command", value=f"```\n{cmd_display}\n```", inline=False)
 
             view = ExecApprovalView(

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -141,6 +141,7 @@ from gateway.platforms.base import (
 )
 from gateway.status import acquire_scoped_lock, release_scoped_lock
 from hermes_constants import get_hermes_home
+from tools.approval import command_approval_summary
 from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
@@ -1863,6 +1864,7 @@ class FeishuAdapter(BasePlatformAdapter):
         try:
             approval_id = next(self._approval_counter)
             cmd_preview = command[:3000] + "..." if len(command) > 3000 else command
+            summary = command_approval_summary(command, description)
 
             def _btn(label: str, action_name: str, btn_type: str = "default") -> dict:
                 return {
@@ -1881,7 +1883,16 @@ class FeishuAdapter(BasePlatformAdapter):
                 "elements": [
                     {
                         "tag": "markdown",
-                        "content": f"```\n{cmd_preview}\n```\n**Reason:** {description}",
+                        "content": (
+                            f"**{summary['action']}**\n\n"
+                            f"**Mode:** {summary['mode']}\n"
+                            f"**Target:** {summary['target']}\n"
+                            f"**Category:** {summary['category']}\n"
+                            f"**Need:** {summary['need']}\n"
+                            f"**Reason:** {summary['reason']}\n"
+                            f"**Risk:** {summary['risk']}\n\n"
+                            f"**Raw command:**\n```\n{cmd_preview}\n```"
+                        ),
                     },
                     {
                         "tag": "action",

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1884,13 +1884,8 @@ class FeishuAdapter(BasePlatformAdapter):
                     {
                         "tag": "markdown",
                         "content": (
-                            f"**{summary['action']}**\n\n"
-                            f"**Mode:** {summary['mode']}\n"
-                            f"**Target:** {summary['target']}\n"
-                            f"**Category:** {summary['category']}\n"
-                            f"**Need:** {summary['need']}\n"
-                            f"**Reason:** {summary['reason']}\n"
-                            f"**Risk:** {summary['risk']}\n\n"
+                            f"**Explanation:** {summary['explanation']}\n"
+                            f"**Why approval is needed:** {summary['reason']}\n\n"
                             f"**Raw command:**\n```\n{cmd_preview}\n```"
                         ),
                     },

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -104,6 +104,7 @@ from gateway.platforms.base import (
     proxy_kwargs_for_aiohttp,
 )
 from gateway.platforms.helpers import ThreadParticipationTracker
+from tools.approval import command_approval_summary
 
 logger = logging.getLogger(__name__)
 
@@ -1241,10 +1242,19 @@ class MatrixAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         cmd_preview = command[:2000] + "..." if len(command) > 2000 else command
+        summary = command_approval_summary(command, description)
         text = (
             "⚠️ **Dangerous command requires approval**\n"
+            f"**{summary['action']}**\n"
+            f"Mode: {summary['mode']}\n"
+            f"Target: {summary['target']}\n"
+            f"Category: {summary['category']}\n"
+            f"Need: {summary['need']}\n"
+            f"Reason: {summary['reason']}\n"
+            f"Risk: {summary['risk']}\n\n"
+            "Raw command:\n"
             f"```\n{cmd_preview}\n```\n"
-            f"Reason: {description}\n\n"
+            "\n"
             "Reply `/approve` to execute, `/approve session` to approve this pattern for the session, "
             "`/approve always` to approve permanently, or `/deny` to cancel.\n\n"
             "You can also click the reaction to approve:\n"

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -1245,13 +1245,8 @@ class MatrixAdapter(BasePlatformAdapter):
         summary = command_approval_summary(command, description)
         text = (
             "⚠️ **Dangerous command requires approval**\n"
-            f"**{summary['action']}**\n"
-            f"Mode: {summary['mode']}\n"
-            f"Target: {summary['target']}\n"
-            f"Category: {summary['category']}\n"
-            f"Need: {summary['need']}\n"
-            f"Reason: {summary['reason']}\n"
-            f"Risk: {summary['risk']}\n\n"
+            f"**Explanation:** {summary['explanation']}\n"
+            f"**Why approval is needed:** {summary['reason']}\n\n"
             "Raw command:\n"
             f"```\n{cmd_preview}\n```\n"
             "\n"

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -135,6 +135,7 @@ from gateway.platforms.qqbot.keyboards import (
     parse_interaction_event,
     parse_update_prompt_button_data,
 )
+from tools.approval import command_approval_summary
 
 
 def check_qq_requirements() -> bool:
@@ -2549,11 +2550,19 @@ class QQAdapter(BasePlatformAdapter):
         # QQ requires a msg_id on outbound messages to a user we've never
         # seen; the last inbound msg_id is the natural choice.
         msg_id = self._last_msg_id.get(chat_id)
+        summary = command_approval_summary(command, description)
 
         req = ApprovalRequest(
             session_key=session_key,
-            title=f"Execute this command?",
-            description=description,
+            title=summary["action"],
+            description=(
+                f"Mode: {summary['mode']}\n"
+                f"Target: {summary['target']}\n"
+                f"Category: {summary['category']}\n"
+                f"Need: {summary['need']}\n"
+                f"Reason: {summary['reason']}\n"
+                f"Risk: {summary['risk']}"
+            ),
             command_preview=command,
             timeout_sec=self._APPROVAL_TIMEOUT_SECONDS,
         )

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -2554,14 +2554,9 @@ class QQAdapter(BasePlatformAdapter):
 
         req = ApprovalRequest(
             session_key=session_key,
-            title=summary["action"],
+            title=summary["explanation"],
             description=(
-                f"Mode: {summary['mode']}\n"
-                f"Target: {summary['target']}\n"
-                f"Category: {summary['category']}\n"
-                f"Need: {summary['need']}\n"
-                f"Reason: {summary['reason']}\n"
-                f"Risk: {summary['risk']}"
+                f"Why approval is needed: {summary['reason']}"
             ),
             command_preview=command,
             timeout_sec=self._APPROVAL_TIMEOUT_SECONDS,

--- a/gateway/platforms/qqbot/keyboards.py
+++ b/gateway/platforms/qqbot/keyboards.py
@@ -306,15 +306,17 @@ def build_approval_text(req: ApprovalRequest) -> str:
 
 def _build_exec_text(req: ApprovalRequest) -> str:
     lines: List[str] = ["🔐 **命令执行审批**", ""]
-    if req.command_preview:
-        preview = req.command_preview[:300]
-        lines.append(f"```\n{preview}\n```")
-    if req.cwd:
-        lines.append(f"📁 目录: {req.cwd}")
     if req.title and req.title != req.command_preview:
         lines.append(f"📋 {req.title}")
     if req.description:
         lines.append(f"📝 {req.description}")
+    if req.cwd:
+        lines.append(f"📁 目录: {req.cwd}")
+    if req.command_preview:
+        preview = req.command_preview[:300]
+        lines.append("")
+        lines.append("Raw command:")
+        lines.append(f"```\n{preview}\n```")
     lines.append("")
     lines.append(f"⏱️ 超时: {req.timeout_sec} 秒")
     return "\n".join(lines)

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -48,6 +48,7 @@ from gateway.platforms.base import (
     safe_url_for_log,
     cache_document_from_bytes,
 )
+from tools.approval import command_approval_summary
 
 
 logger = logging.getLogger(__name__)
@@ -2255,6 +2256,7 @@ class SlackAdapter(BasePlatformAdapter):
         try:
             cmd_preview = command[:2900] + "..." if len(command) > 2900 else command
             thread_ts = self._resolve_thread_ts(None, metadata)
+            summary = command_approval_summary(command, description)
 
             blocks = [
                 {
@@ -2263,8 +2265,14 @@ class SlackAdapter(BasePlatformAdapter):
                         "type": "mrkdwn",
                         "text": (
                             f":warning: *Command Approval Required*\n"
-                            f"```{cmd_preview}```\n"
-                            f"Reason: {description}"
+                            f"*{summary['action']}*\n"
+                            f"*Mode:* {summary['mode']}\n"
+                            f"*Target:* {summary['target']}\n"
+                            f"*Category:* {summary['category']}\n"
+                            f"*Need:* {summary['need']}\n"
+                            f"*Reason:* {summary['reason']}\n"
+                            f"*Risk:* {summary['risk']}\n\n"
+                            f"*Raw command:*\n```{cmd_preview}```"
                         ),
                     },
                 },
@@ -2303,7 +2311,7 @@ class SlackAdapter(BasePlatformAdapter):
 
             kwargs: Dict[str, Any] = {
                 "channel": chat_id,
-                "text": f"⚠️ Command approval required: {cmd_preview[:100]}",
+                "text": f"⚠️ Command approval required: {summary['action']}",
                 "blocks": blocks,
             }
             if thread_ts:

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2265,13 +2265,8 @@ class SlackAdapter(BasePlatformAdapter):
                         "type": "mrkdwn",
                         "text": (
                             f":warning: *Command Approval Required*\n"
-                            f"*{summary['action']}*\n"
-                            f"*Mode:* {summary['mode']}\n"
-                            f"*Target:* {summary['target']}\n"
-                            f"*Category:* {summary['category']}\n"
-                            f"*Need:* {summary['need']}\n"
-                            f"*Reason:* {summary['reason']}\n"
-                            f"*Risk:* {summary['risk']}\n\n"
+                            f"*Explanation:* {summary['explanation']}\n"
+                            f"*Why approval is needed:* {summary['reason']}\n\n"
                             f"*Raw command:*\n```{cmd_preview}```"
                         ),
                     },

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -84,6 +84,7 @@ from gateway.platforms.telegram_network import (
     discover_fallback_ips,
     parse_fallback_ip_env,
 )
+from tools.approval import command_approval_summary
 from utils import atomic_replace
 
 _TELEGRAM_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
@@ -2392,10 +2393,19 @@ class TelegramAdapter(BasePlatformAdapter):
 
         try:
             cmd_preview = command[:3800] + "..." if len(command) > 3800 else command
+            summary = command_approval_summary(command, description)
             text = (
                 f"⚠️ <b>Command Approval Required</b>\n\n"
+                f"<b>{_html.escape(summary['action'])}</b>\n"
+                f"Mode: {_html.escape(summary['mode'])}\n"
+                f"Target: {_html.escape(summary['target'])}\n"
+                f"Category: {_html.escape(summary['category'])}\n"
+                f"Need: {_html.escape(summary['need'])}\n"
+                f"Reason: {_html.escape(summary['reason'])}\n"
+                f"Risk: {_html.escape(summary['risk'])}\n\n"
+                f"Raw command:\n"
                 f"<pre>{_html.escape(cmd_preview)}</pre>\n\n"
-                f"Reason: {_html.escape(description)}"
+                f"Choose a scope below."
             )
 
             # Resolve thread context for thread replies

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2396,13 +2396,8 @@ class TelegramAdapter(BasePlatformAdapter):
             summary = command_approval_summary(command, description)
             text = (
                 f"⚠️ <b>Command Approval Required</b>\n\n"
-                f"<b>{_html.escape(summary['action'])}</b>\n"
-                f"Mode: {_html.escape(summary['mode'])}\n"
-                f"Target: {_html.escape(summary['target'])}\n"
-                f"Category: {_html.escape(summary['category'])}\n"
-                f"Need: {_html.escape(summary['need'])}\n"
-                f"Reason: {_html.escape(summary['reason'])}\n"
-                f"Risk: {_html.escape(summary['risk'])}\n\n"
+                f"<b>Explanation:</b> {_html.escape(summary['explanation'])}\n"
+                f"<b>Why approval is needed:</b> {_html.escape(summary['reason'])}\n\n"
                 f"Raw command:\n"
                 f"<pre>{_html.escape(cmd_preview)}</pre>\n\n"
                 f"Choose a scope below."

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16533,6 +16533,7 @@ class GatewayRunner:
             # The callback bridges sync→async to send the approval request
             # to the user immediately.
             from tools.approval import (
+                command_approval_summary,
                 register_gateway_notify,
                 reset_current_session_key,
                 set_current_session_key,
@@ -16592,10 +16593,19 @@ class GatewayRunner:
 
                 # Fallback: plain text approval prompt
                 cmd_preview = cmd[:200] + "..." if len(cmd) > 200 else cmd
+                summary = command_approval_summary(cmd, desc)
                 msg = (
                     f"⚠️ **Dangerous command requires approval:**\n"
+                    f"**{summary['action']}**\n"
+                    f"Mode: {summary['mode']}\n"
+                    f"Target: {summary['target']}\n"
+                    f"Category: {summary['category']}\n"
+                    f"Need: {summary['need']}\n"
+                    f"Reason: {summary['reason']}\n"
+                    f"Risk: {summary['risk']}\n\n"
+                    f"Raw command:\n"
                     f"```\n{cmd_preview}\n```\n"
-                    f"Reason: {desc}\n\n"
+                    f"\n"
                     f"Reply `/approve` to execute, `/approve session` to approve this pattern "
                     f"for the session, `/approve always` to approve permanently, or `/deny` to cancel."
                 )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16596,13 +16596,8 @@ class GatewayRunner:
                 summary = command_approval_summary(cmd, desc)
                 msg = (
                     f"⚠️ **Dangerous command requires approval:**\n"
-                    f"**{summary['action']}**\n"
-                    f"Mode: {summary['mode']}\n"
-                    f"Target: {summary['target']}\n"
-                    f"Category: {summary['category']}\n"
-                    f"Need: {summary['need']}\n"
-                    f"Reason: {summary['reason']}\n"
-                    f"Risk: {summary['risk']}\n\n"
+                    f"**Explanation:** {summary['explanation']}\n"
+                    f"**Why approval is needed:** {summary['reason']}\n\n"
                     f"Raw command:\n"
                     f"```\n{cmd_preview}\n```\n"
                     f"\n"

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -107,6 +107,35 @@ class TestTelegramExecApproval:
         assert kwargs["reply_markup"] is not None  # InlineKeyboardMarkup
 
     @pytest.mark.asyncio
+    async def test_human_summary_precedes_raw_command(self):
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 42
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        command = (
+            "bash -lc \"printf 'Public DNS\\n'; getent ahostsv4 "
+            "portal.re-evolution-world.com || true; curl -4 -I --max-time 8 "
+            "https://portal.re-evolution-world.com/api/admin/agent06 || true\""
+        )
+
+        await adapter.send_exec_approval(
+            chat_id="12345",
+            command=command,
+            session_key="agent:main:telegram:dm:12345",
+            description="Security scan — raw IP address; insecure TLS flag",
+        )
+
+        text = adapter._bot.send_message.call_args[1]["text"]
+        summary_index = text.index("Approve this")
+        raw_index = text.index("Raw command:")
+        command_index = text.index("bash -lc")
+
+        assert summary_index < raw_index < command_index
+        assert "Mode: Appears read-only" in text
+        assert "Target: portal.re-evolution-world.com" in text
+
+    @pytest.mark.asyncio
     async def test_stores_approval_state(self):
         adapter = _make_adapter()
         mock_msg = MagicMock()

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -127,13 +127,18 @@ class TestTelegramExecApproval:
         )
 
         text = adapter._bot.send_message.call_args[1]["text"]
-        summary_index = text.index("Approve this")
+        summary_index = text.index("Explanation:")
         raw_index = text.index("Raw command:")
         command_index = text.index("bash -lc")
 
         assert summary_index < raw_index < command_index
-        assert "Mode: Appears read-only" in text
-        assert "Target: portal.re-evolution-world.com" in text
+        assert (
+            "This will run a read-only shell check against "
+            "portal.re-evolution-world.com."
+        ) in text
+        assert "Why approval is needed:" in text
+        for old_label in ("Mode:", "Target:", "Category:", "Need:", "Risk:"):
+            assert old_label not in text
 
     @pytest.mark.asyncio
     async def test_stores_approval_state(self):

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -10,6 +10,7 @@ from tools.approval import (
     _get_approval_mode,
     _smart_approve,
     approve_session,
+    command_approval_summary,
     detect_dangerous_command,
     is_approved,
     load_permanent,
@@ -41,6 +42,34 @@ class TestSmartApproval:
         assert mock_call.call_args.kwargs["task"] == "approval"
         assert mock_call.call_args.kwargs["temperature"] == 0
         assert mock_call.call_args.kwargs["max_tokens"] == 16
+
+
+class TestCommandApprovalSummary:
+    def test_network_check_gets_human_readable_summary(self):
+        command = (
+            "bash -lc \"printf 'Public DNS\\n'; getent ahostsv4 "
+            "portal.re-evolution-world.com || true; curl -4 -I --max-time 8 "
+            "https://portal.re-evolution-world.com/api/admin/agent06 || true\""
+        )
+
+        summary = command_approval_summary(
+            command,
+            "Security scan — raw IP address; insecure TLS flag",
+        )
+
+        assert summary["action"].startswith("Approve this")
+        assert "shell script" in summary["action"]
+        assert summary["mode"] == "Appears read-only"
+        assert "portal.re-evolution-world.com" in summary["target"]
+        assert "Security scan" in summary["reason"]
+
+    def test_mutating_command_is_not_described_as_read_only(self):
+        summary = command_approval_summary(
+            "git push origin master",
+            "git push can publish changes",
+        )
+
+        assert summary["mode"] == "May change system state"
 
 
 class TestDetectDangerousRm:

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -57,11 +57,22 @@ class TestCommandApprovalSummary:
             "Security scan — raw IP address; insecure TLS flag",
         )
 
-        assert summary["action"].startswith("Approve this")
-        assert "shell script" in summary["action"]
+        assert summary["explanation"] == (
+            "This will run a read-only shell check against portal.re-evolution-world.com."
+        )
         assert summary["mode"] == "Appears read-only"
         assert "portal.re-evolution-world.com" in summary["target"]
         assert "Security scan" in summary["reason"]
+
+    def test_github_pr_view_explains_actual_action(self):
+        summary = command_approval_summary(
+            "gh pr view 46682 --repo NousResearch/hermes-agent --json url,state",
+            "GitHub PR status check",
+        )
+
+        assert summary["explanation"] == (
+            "This will check the status of NousResearch/hermes-agent#46682 without changing it."
+        )
 
     def test_mutating_command_is_not_described_as_read_only(self):
         summary = command_approval_summary(
@@ -70,6 +81,9 @@ class TestCommandApprovalSummary:
         )
 
         assert summary["mode"] == "May change system state"
+        assert summary["explanation"] == (
+            "This will push local Git commits or branches to origin, which can publish code changes."
+        )
 
 
 class TestDetectDangerousRm:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -12,6 +12,7 @@ import contextvars
 import logging
 import os
 import re
+import shlex
 import sys
 import threading
 import time
@@ -694,6 +695,113 @@ def save_permanent_allowlist(patterns: set):
 # =========================================================================
 # Approval prompting + orchestration
 # =========================================================================
+
+_MUTATING_COMMAND_RE = re.compile(
+    r'\b('
+    r'rm|mv|cp|chmod|chown|chgrp|mkdir|rmdir|touch|tee|truncate|'
+    r'git\s+(?:commit|push|pull|merge|rebase|reset|checkout|switch|restore|clean|'
+    r'fetch|add|rm)|'
+    r'docker\s+(?:run|compose\s+(?:up|down|restart|build)|restart|stop|start|rm|rmi|'
+    r'exec|cp)|'
+    r'kubectl\s+(?:apply|delete|create|patch|rollout|scale)|'
+    r'curl\b.*\b(?:-X\s*(?:POST|PUT|PATCH|DELETE)|--request\s*(?:POST|PUT|PATCH|DELETE))|'
+    r'python[23]?\b.*\b(?:open\([^)]*,\s*[\'"][wa]|write\(|remove\(|unlink\(|rmtree\()'
+    r')\b',
+    re.IGNORECASE | re.DOTALL,
+)
+
+_READ_ONLY_HINT_RE = re.compile(
+    r'\b('
+    r'cat|less|head|tail|sed|awk|grep|rg|find|ls|pwd|printf|echo|'
+    r'git\s+(?:status|diff|log|show|rev-parse)|'
+    r'docker\s+(?:ps|logs|inspect)|'
+    r'curl|wget|getent|dig|nslookup|python[23]?\s+-c'
+    r')\b',
+    re.IGNORECASE,
+)
+
+
+def _extract_approval_targets(command: str, limit: int = 3) -> list[str]:
+    """Return compact human-relevant targets from a shell command."""
+    targets: list[str] = []
+    for pattern in (
+        r'https?://[^\s\'"`<>]+',
+        r'(?<![\w.-])(?:/[\w.@%+=:,~/-]+)',
+        r'\b[\w.-]+\.[a-z]{2,}(?:/[^\s\'"`<>]*)?',
+    ):
+        for match in re.finditer(pattern, command, re.IGNORECASE):
+            value = match.group(0).rstrip(".,;)")
+            if len(value) > 80:
+                value = value[:77] + "..."
+            if value and value not in targets:
+                targets.append(value)
+            if len(targets) >= limit:
+                return targets
+    return targets
+
+
+def _command_category(command: str) -> str:
+    """Describe the command shape without requiring the user to parse it."""
+    try:
+        parts = shlex.split(command, posix=True)
+    except Exception:
+        parts = command.strip().split()
+
+    if not parts:
+        return "terminal command"
+
+    first = parts[0].split("/")[-1].lower()
+    joined = " ".join(parts[:4]).lower()
+
+    if first in {"bash", "sh", "zsh", "fish", "ksh"}:
+        return "shell script"
+    if first.startswith("python") or first in {"node", "ruby", "perl"}:
+        return "inline script"
+    if first == "ssh":
+        return "remote SSH inspection"
+    if first == "curl" or " curl " in f" {joined} ":
+        return "HTTP/network check"
+    if first == "git":
+        return "Git repository check"
+    if first == "docker":
+        return "Docker/service check"
+    if first in {"getent", "dig", "nslookup"}:
+        return "DNS/network check"
+    return f"{first} command"
+
+
+def command_approval_summary(command: str, description: str) -> dict[str, str]:
+    """Build human-first approval text for gateway/CLI prompts.
+
+    Raw commands are still shown for auditability, but the approval decision
+    must not require users to decode shell/Python syntax first.
+    """
+    category = _command_category(command)
+    targets = _extract_approval_targets(command)
+
+    if _MUTATING_COMMAND_RE.search(command):
+        mode = "May change system state"
+    elif _READ_ONLY_HINT_RE.search(command):
+        mode = "Appears read-only"
+    else:
+        mode = "Effect unclear; inspect raw command before approving"
+
+    target_text = f" targeting {', '.join(targets)}" if targets else ""
+    action = f"Approve this {category}{target_text}. It {mode.lower()}."
+    reason = description or "flagged by command approval policy"
+
+    return {
+        "action": action,
+        "mode": mode,
+        "target": ", ".join(targets) if targets else "not automatically identified",
+        "category": category,
+        "reason": reason,
+        "need": "Hermes needs your approval before it can run this flagged command.",
+        "risk": (
+            "Review the raw command below before choosing; approval can run code "
+            "with the agent's current permissions."
+        ),
+    }
 
 def prompt_dangerous_approval(command: str, description: str,
                               timeout_seconds: int | None = None,

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -770,11 +770,84 @@ def _command_category(command: str) -> str:
     return f"{first} command"
 
 
+def _approval_explanation(command: str, description: str) -> str:
+    """Return the one sentence a human is actually approving or denying."""
+    try:
+        parts = shlex.split(command, posix=True)
+    except Exception:
+        parts = command.strip().split()
+
+    first = parts[0].split("/")[-1].lower() if parts else ""
+    targets = _extract_approval_targets(command, limit=1)
+    target = targets[0] if targets else ""
+    lowered = command.lower()
+
+    repo = ""
+    pr_number = ""
+    for idx, part in enumerate(parts):
+        if part == "--repo" and idx + 1 < len(parts):
+            repo = parts[idx + 1]
+            continue
+        if part.isdigit() and not pr_number:
+            pr_number = part
+
+    if first == "gh" and len(parts) >= 3 and parts[1:3] == ["pr", "view"]:
+        pr_target = f"{repo} PR {pr_number}".strip()
+        if repo and pr_number:
+            pr_target = f"{repo}#{pr_number}"
+        elif pr_number:
+            pr_target = f"pull request {pr_number}"
+        else:
+            pr_target = "a GitHub pull request"
+        return f"This will check the status of {pr_target} without changing it."
+
+    if first == "git":
+        subcmd = parts[1].lower() if len(parts) > 1 else ""
+        if subcmd in {"status", "diff", "log", "show", "rev-parse"}:
+            return "This will inspect the local Git repository without changing files or publishing anything."
+        if subcmd == "push":
+            remote = parts[2] if len(parts) > 2 else "the configured remote"
+            return f"This will push local Git commits or branches to {remote}, which can publish code changes."
+        if subcmd in {"fetch", "pull"}:
+            return f"This will contact the Git remote to {subcmd} repository data and may update local repository state."
+        if subcmd:
+            return f"This will run `git {subcmd}`, which may change repository state."
+
+    if first in {"curl", "wget"} or " curl " in f" {lowered} ":
+        if re.search(r'\b(?:-X|--request)\s*(?:POST|PUT|PATCH|DELETE)\b', command, re.IGNORECASE):
+            return f"This will send a mutating HTTP request to {target or 'a network endpoint'}."
+        return f"This will make a read-only network request to {target or 'a network endpoint'}."
+
+    if "redis-cli" in lowered:
+        if re.search(r'\b(xlen|xinfo|keys|scan|type|exists|get)\b', lowered):
+            return "This will read Redis metadata or values without writing to Redis."
+        return "This will run a Redis command; inspect the raw command to confirm whether it writes data."
+
+    if first == "ssh":
+        return f"This will run a command on the remote SSH target {parts[1] if len(parts) > 1 else target or 'shown below'}."
+
+    if first in {"bash", "sh", "zsh", "fish", "ksh"}:
+        if _MUTATING_COMMAND_RE.search(command):
+            return "This will run a shell script that may change system, file, service, or repository state."
+        if target:
+            return f"This will run a read-only shell check against {target}."
+        return "This will run a shell command for inspection; review the raw command before approving."
+
+    if first.startswith("python") or first in {"node", "ruby", "perl"}:
+        if _MUTATING_COMMAND_RE.search(command):
+            return "This will run inline code that may write files or change system state."
+        return "This will run inline code for inspection; review the raw code before approving."
+
+    if description:
+        return f"This will run a flagged command because: {description}."
+    return "This will run a flagged command; review the raw command before approving."
+
+
 def command_approval_summary(command: str, description: str) -> dict[str, str]:
     """Build human-first approval text for gateway/CLI prompts.
 
     Raw commands are still shown for auditability, but the approval decision
-    must not require users to decode shell/Python syntax first.
+    must be anchored by one plain-English sentence.
     """
     category = _command_category(command)
     targets = _extract_approval_targets(command)
@@ -789,8 +862,10 @@ def command_approval_summary(command: str, description: str) -> dict[str, str]:
     target_text = f" targeting {', '.join(targets)}" if targets else ""
     action = f"Approve this {category}{target_text}. It {mode.lower()}."
     reason = description or "flagged by command approval policy"
+    explanation = _approval_explanation(command, description)
 
     return {
+        "explanation": explanation,
         "action": action,
         "mode": mode,
         "target": ", ".join(targets) if targets else "not automatically identified",


### PR DESCRIPTION
## Summary
- add a shared command approval summary builder for gateway approval prompts
- render Action, Mode, Target, Category, Need, Reason, and Risk before Raw command across gateway adapters
- add regression coverage for Telegram approval cards and summary classification

## Context
This preserves the Hermes/ReBot approval UX hotfix that was verified in the running runtime at /opt/hermes. The goal is to make raw shell/code approval cards human-readable before the user sees the raw command.

## Validation
- python3 -m py_compile tools/approval.py gateway/run.py gateway/platforms/telegram.py gateway/platforms/slack.py gateway/platforms/feishu.py gateway/platforms/matrix.py gateway/platforms/discord.py gateway/platforms/qqbot/adapter.py gateway/platforms/qqbot/keyboards.py tests/gateway/test_telegram_approval_buttons.py tests/tools/test_approval.py
- git diff --check HEAD~1..HEAD

Targeted pytest was attempted but the active local Python environment is missing PyYAML, so collection failed before tests ran.