### PR TITLE
fix(agent): whitelist read_file in background review fork

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -10,7 +10,8 @@ touched.
 The fork inherits the parent's live runtime (provider, model, base_url,
 credentials, cached system prompt) so it hits the same prefix cache and
 uses the same auth.  It runs with a tool whitelist limited to memory and
-skill management tools; everything else is denied at runtime.
+skill management tools plus read-only file inspection; everything else
+is denied at runtime.
 
 See the ``hermes-agent-dev`` skill (``references/self-improvement-loop.md``)
 for invariants and PR review criteria.
@@ -474,20 +475,27 @@ def _run_review_in_thread(
                     quiet_mode=True,
                 )
             }
+            # read_file is read-only and needed when the review fork inspects
+            # source files outside the skill directory (e.g. config schemas,
+            # existing code the skill references).  The broader file toolset
+            # (write_file, patch, search_files) stays denied.
+            review_whitelist.add("read_file")
             set_thread_tool_whitelist(
                 review_whitelist,
                 deny_msg_fmt=(
                     "Background review denied non-whitelisted tool: "
-                    "{tool_name}. Only memory/skill tools are allowed."
+                    "{tool_name}. Only memory/skill/read_file tools are allowed."
                 ),
             )
             try:
                 review_agent.run_conversation(
                     user_message=(
                         prompt
-                        + "\n\nYou can only call memory and skill "
-                        "management tools. Other tools will be denied "
-                        "at runtime — do not attempt them."
+                        + "\n\nYou can use memory and skill management tools "
+                        "plus read_file for read-only inspection of external "
+                        "files. Do not copy private local file contents into "
+                        "durable skills unless necessary. Other tools are "
+                        "denied at runtime — do not attempt them."
                     ),
                     conversation_history=messages_snapshot,
                 )

--- a/tests/run_agent/test_background_review_readfile_whitelist.py
+++ b/tests/run_agent/test_background_review_readfile_whitelist.py
@@ -1,0 +1,170 @@
+"""Regression tests: background review tool whitelist includes read_file.
+
+Covers the fix for silent review failures caused by the runtime whitelist
+excluding read-only file access (issue #15204, PR #27422).  The review fork
+needs read_file to inspect source files when authoring skills, but must
+NOT have write_file / patch / search_files (the rest of the file toolset).
+"""
+
+from unittest.mock import patch
+import threading
+
+
+def _make_stub(agent_cls):
+    """Bare-minimum AIAgent look-alike for _spawn_background_review."""
+    a = object.__new__(agent_cls)
+    a.model = "test"
+    a.platform = "test"
+    a.provider = "openai"
+    a.session_id = "s-001"
+    a.quiet_mode = True
+    a._memory_store = None
+    a._memory_enabled = True
+    a._user_profile_enabled = False
+    a._memory_nudge_interval = 5
+    a._skill_nudge_interval = 5
+    a.background_review_callback = None
+    a.status_callback = None
+    a._cached_system_prompt = None
+    import datetime as _dt
+    a.session_start = _dt.datetime(2026, 6, 1)
+    a._MEMORY_REVIEW_PROMPT = "memory"
+    a._SKILL_REVIEW_PROMPT = "skills"
+    a._COMBINED_REVIEW_PROMPT = "both"
+    a.enabled_toolsets = ["memory", "skills"]
+    a.disabled_toolsets = []
+    return a
+
+
+class _InlineThread:
+    """Run target synchronously so tests don't need real threads."""
+
+    def __init__(self, *, target=None, daemon=None, name=None):
+        self._fn = target
+
+    def start(self):
+        if self._fn:
+            self._fn()
+
+
+def _spawn_and_capture(agent_cls, *, review_memory=True, review_skills=True):
+    """Spawn a background review and return captured whitelist + prompt."""
+    import run_agent
+    from hermes_cli import plugins as _plugins
+
+    agent = _make_stub(agent_cls)
+    captured = {"whitelist": None, "deny": None, "prompt": None}
+
+    def _grab_whitelist(whitelist, deny_msg_fmt=None):
+        captured["whitelist"] = set(whitelist)
+        captured["deny"] = deny_msg_fmt
+
+    def _grab_run(self, *, user_message, conversation_history=None):
+        captured["prompt"] = user_message
+        raise SystemExit("captured")
+
+    with (
+        patch.object(run_agent.AIAgent, "__init__", lambda s, *a, **k: None),
+        patch.object(_plugins, "set_thread_tool_whitelist", _grab_whitelist),
+        patch.object(run_agent.AIAgent, "run_conversation", _grab_run),
+        patch("threading.Thread", _InlineThread),
+    ):
+        try:
+            agent._spawn_background_review(
+                messages_snapshot=[],
+                review_memory=review_memory,
+                review_skills=review_skills,
+            )
+        except SystemExit:
+            pass  # expected — raised after capture
+
+    return agent, captured
+
+
+class TestWhitelistComposition:
+    """read_file must be present; write_file / patch / search_files must not."""
+
+    def test_read_file_allowed(self):
+        _, cap = _spawn_and_capture(
+            __import__("run_agent").AIAgent
+        )
+        assert "read_file" in cap["whitelist"], (
+            f"read_file missing from whitelist: {cap['whitelist']}"
+        )
+
+    def test_write_file_denied(self):
+        _, cap = _spawn_and_capture(
+            __import__("run_agent").AIAgent
+        )
+        assert "write_file" not in cap["whitelist"]
+
+    def test_patch_denied(self):
+        _, cap = _spawn_and_capture(
+            __import__("run_agent").AIAgent
+        )
+        assert "patch" not in cap["whitelist"]
+
+    def test_search_files_denied(self):
+        _, cap = _spawn_and_capture(
+            __import__("run_agent").AIAgent
+        )
+        assert "search_files" not in cap["whitelist"]
+
+    def test_dangerous_tools_still_denied(self):
+        _, cap = _spawn_and_capture(
+            __import__("run_agent").AIAgent
+        )
+        for tool in ("terminal", "send_message", "delegate_task",
+                      "execute_code", "web_search"):
+            assert tool not in cap["whitelist"], f"{tool} leaked into whitelist"
+
+    def test_memory_and_skills_still_allowed(self):
+        _, cap = _spawn_and_capture(
+            __import__("run_agent").AIAgent
+        )
+        for tool in ("memory", "skill_manage", "skill_view", "skills_list"):
+            assert tool in cap["whitelist"], f"{tool} missing from whitelist"
+
+
+class TestDenyMessage:
+    """Deny message must mention read_file so logs are clear."""
+
+    def test_deny_mentions_read_file(self):
+        _, cap = _spawn_and_capture(
+            __import__("run_agent").AIAgent
+        )
+        assert "read_file" in cap["deny"]
+
+    def test_deny_mentions_memory_skill(self):
+        _, cap = _spawn_and_capture(
+            __import__("run_agent").AIAgent
+        )
+        assert "memory" in cap["deny"]
+        assert "skill" in cap["deny"]
+
+
+class TestPromptContent:
+    """Review prompt must instruct the fork about read_file usage."""
+
+    def test_prompt_mentions_read_file(self):
+        _, cap = _spawn_and_capture(
+            __import__("run_agent").AIAgent,
+            review_skills=True,
+        )
+        assert "read_file" in cap["prompt"]
+
+    def test_prompt_mentions_read_only(self):
+        _, cap = _spawn_and_capture(
+            __import__("run_agent").AIAgent,
+            review_skills=True,
+        )
+        # should say "read-only" or "read only" — not imply write access
+        assert "read" in cap["prompt"].lower()
+
+    def test_prompt_warns_about_private_content(self):
+        _, cap = _spawn_and_capture(
+            __import__("run_agent").AIAgent,
+            review_skills=True,
+        )
+        # privacy guard: don't dump local file contents into durable skills
+        assert "private" in cap["prompt"].lower() or "copy" in cap["prompt"].lower()

--- a/tests/run_agent/test_background_review_toolset_restriction.py
+++ b/tests/run_agent/test_background_review_toolset_restriction.py
@@ -86,12 +86,13 @@ def test_background_review_matches_parent_toolset_config():
 
 
 def test_background_review_installs_thread_local_whitelist():
-    """The review fork must install a memory/skills-only thread-local whitelist.
+    """The review fork must install a memory/skills/read_file whitelist.
 
     The schema-level toolset narrowing was lifted (for prefix-cache parity),
     so #15204's safety contract now relies on the runtime whitelist gate to
-    deny terminal/send_message/delegate_task at dispatch time. Verify the
-    whitelist is set with exactly the memory+skills tool names.
+    deny terminal/send_message/delegate_task at dispatch time.  It also
+    allows read_file so the skill review can inspect relevant external
+    files without opening write/search tools.
     """
     import run_agent
     from hermes_cli import plugins as _plugins
@@ -127,12 +128,16 @@ def test_background_review_installs_thread_local_whitelist():
     assert "skill_manage" in whitelist
     assert "skill_view" in whitelist
     assert "skills_list" in whitelist
+    assert "read_file" in whitelist
     # dangerous tools must NOT be in the whitelist
     assert "terminal" not in whitelist
     assert "send_message" not in whitelist
     assert "delegate_task" not in whitelist
     assert "web_search" not in whitelist
     assert "execute_code" not in whitelist
+    assert "write_file" not in whitelist
+    assert "patch" not in whitelist
+    assert "search_files" not in whitelist
 
 
 def test_background_review_agent_tools_are_limited():


### PR DESCRIPTION
## Background

Background review whitelist only allows memory+skills toolsets. `read_file` is blocked despite being read-only and needed for the review fork to inspect source files when authoring skills.

Without `read_file` the model fabricates content or hits `skill_manage` denials when referencing external files. 15 sessions failed silently between May 14-18 before local patch.

**Supersedes stale #27422** which targeted the old `run_agent.py` path (since refactored into `agent/background_review.py`).

## Changes

- Add `read_file` to `review_whitelist` after toolset-derived build
- Update deny message and review prompt to mention `read_file`
- Update module docstring to reflect expanded whitelist
- Add privacy guard: do not copy private local file contents into durable skills

## Tests

- New `test_background_review_readfile_whitelist.py` (11 tests) covering whitelist composition, deny message, and prompt content
- Update existing `test_background_review_toolset_restriction.py` to assert `read_file` is allowed and file write tools are denied

## Why not the full file toolset?

Only `read_file` is added. `write_file`, `patch`, and `search_files` remain denied - the review fork should read, not write, external files.

## Verification

```bash
uv run --extra dev python -m pytest tests/run_agent/test_background_review_toolset_restriction.py tests/run_agent/test_background_review_readfile_whitelist.py -v
uv run --extra dev python -m ruff check agent/background_review.py tests/run_agent/test_background_review_readfile_whitelist.py tests/run_agent/test_background_review_toolset_restriction.py
```

Both #40060 and #40007 address the same issue - closing in favor of this one which has full test coverage.