### PR TITLE
fix(model_metadata): add HERMES_DISABLE_MODEL_METADATA and tighter timeout

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -682,6 +682,19 @@ def fetch_model_metadata(force_refresh: bool = False) -> Dict[str, Dict[str, Any
     """Fetch model metadata from OpenRouter (cached for 1 hour)."""
     global _model_metadata_cache, _model_metadata_cache_time
 
+    # Allow disabling the OpenRouter metadata fetch entirely.  Useful for
+    # air-gapped / proxied deployments where openrouter.ai is unreachable
+    # and the synchronous requests.get() blocks gateway startup for minutes
+    # while urllib3 retries against a proxy that returns 403 on CONNECT.
+    if os.getenv("HERMES_DISABLE_MODEL_METADATA", "").lower() in {"1", "true", "yes"}:
+        if _model_metadata_cache:
+            return _model_metadata_cache
+        disk_cache = _load_model_metadata_disk_cache()
+        if disk_cache:
+            _model_metadata_cache = disk_cache
+            return _model_metadata_cache
+        return {}
+
     if not force_refresh and _model_metadata_cache and (time.time() - _model_metadata_cache_time) < _MODEL_CACHE_TTL:
         return _model_metadata_cache
 
@@ -695,7 +708,16 @@ def fetch_model_metadata(force_refresh: bool = False) -> Dict[str, Dict[str, Any
                 return _model_metadata_cache
 
     try:
-        response = requests.get(OPENROUTER_MODELS_URL, timeout=10, verify=_resolve_requests_verify())
+        # Use a (connect_timeout, read_timeout) tuple to fail fast when the
+        # endpoint is unreachable (e.g. corporate proxy returns 403 on
+        # CONNECT).  A single int sets both to the same value; the old
+        # timeout=10 meant urllib3 could block for 10s *per retry stage*
+        # through a proxy, ballooning to minutes on retryable failures.
+        response = requests.get(
+            OPENROUTER_MODELS_URL,
+            timeout=(5, 10),
+            verify=_resolve_requests_verify(),
+        )
         response.raise_for_status()
         data = response.json()
 


### PR DESCRIPTION
## Fixes #46620

### Problem
`fetch_model_metadata()` uses `timeout=10` (single int) which sets both connect and read timeout to 10s. Through a corporate HTTP proxy that returns 403 on CONNECT to `openrouter.ai`, urllib3 can retry/block for 7+ minutes, preventing the gateway from reaching `start_polling`.

### Changes

1. **`HERMES_DISABLE_MODEL_METADATA` env var** — allows completely skipping the OpenRouter metadata fetch. Useful for air-gapped/proxied deployments where `openrouter.ai` is unreachable. Returns cached data (memory or disk) if available, otherwise empty dict.

2. **Tuple timeout `(5, 10)`** — 5s connect timeout, 10s read timeout. Fails fast when the endpoint is unreachable through a proxy, instead of allowing urllib3 to block for the full 10s per retry stage.

### Testing
- Set `HERMES_DISABLE_MODEL_METADATA=1` and verify gateway starts without hanging
- With metadata enabled, verify connect timeout is 5s (not 10s)
- Verify normal OpenRouter metadata fetch still works when endpoint is reachable