### PR TITLE
fix(desktop): pin assistant-ui store to tap-compatible version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "web"
       ],
       "dependencies": {
+        "@assistant-ui/store": "0.2.10",
         "@streamdown/math": "^1.0.2",
         "agent-browser": "^0.26.0"
       },
@@ -387,15 +388,15 @@
       }
     },
     "node_modules/@assistant-ui/store": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/@assistant-ui/store/-/store-0.2.18.tgz",
-      "integrity": "sha512-5MiZXAXjsZuH3ZVEemuiD5L8wq/pXax8lSlaIsdTPEkDZDFupsiDwuOeum+h+ctX8H8oKgkCpN4iPUIiiLKuVg==",
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/store/-/store-0.2.10.tgz",
+      "integrity": "sha512-cgbSFIv0Ovu6yls4GQy7brLVx6qwUyLTf1Ki/lkj3UFJrO6oktxstosWvQBwk5mNgH6t3DOIrGSBDJSKRfCW5Q==",
       "license": "MIT",
       "dependencies": {
         "use-effect-event": "^2.0.3"
       },
       "peerDependencies": {
-        "@assistant-ui/tap": "^0.9.0",
+        "@assistant-ui/tap": "^0.5.11",
         "@types/react": "*",
         "react": "^18 || ^19"
       },

--- a/package.json
+++ b/package.json
@@ -32,10 +32,12 @@
   },
   "homepage": "https://github.com/NousResearch/Hermes-Agent#readme",
   "dependencies": {
+    "@assistant-ui/store": "0.2.10",
     "@streamdown/math": "^1.0.2",
     "agent-browser": "^0.26.0"
   },
   "overrides": {
+    "@assistant-ui/store": "0.2.10",
     "lodash": "4.18.1"
   },
   "engines": {


### PR DESCRIPTION
## Summary
- pin @assistant-ui/store to 0.2.10 so it remains compatible with the current @assistant-ui/tap 0.5.x API used by @assistant-ui/react 0.12.x
- add a root npm override so future installs do not resolve @assistant-ui/store 0.2.18, which expects @assistant-ui/tap ^0.9.0 and imports react-shim subpaths that tap 0.5.x does not export

## Problem
Desktop builds can fail when npm resolves @assistant-ui/store@0.2.18 alongside @assistant-ui/tap@0.5.14. Store 0.2.18 imports @assistant-ui/tap/react-shim and expects the tap 0.9 API, while @assistant-ui/react@0.12.28 still depends on the tap 0.5 line.

## Validation
- npm run build --workspace apps/desktop
- hermes desktop --build-only

Both passed locally on macOS arm64. The build-only path produced apps/desktop/release/mac-arm64/Hermes.app/Contents/MacOS/Hermes. Packaging skipped signing/notarization because no Apple signing credentials are configured locally.