### PR TITLE
fix(code-exec): preserve PATH on Windows when env keys are mixed-case (#46645)

### DIFF
--- a/tests/tools/test_code_execution_windows_env.py
+++ b/tests/tools/test_code_execution_windows_env.py
@@ -707,3 +707,162 @@ class TestChildStdioIsUtf8:
             )
         # Otherwise: crash OR garbled output — both count as proving the
         # bug is real on this system.
+
+
+class TestScrubChildEnvCaseInsensitiveSafePrefix:
+    """Regression for #46645: Windows env keys preserve their original case
+    (``Path``, ``Home``, ``Tmp``), but ``_scrub_child_env``'s safe-prefix
+    check was a case-sensitive ``str.startswith`` against the uppercase
+    prefix list.  On a real Windows box the child subprocess therefore
+    lost PATH and crashed with ``FileNotFoundError: [WinError 2]`` on
+    every executable lookup.  These tests pin the fix: safe-prefix
+    matching must be case-insensitive, secrets must still be blocked,
+    and POSIX behavior must not regress.
+    """
+
+    @staticmethod
+    def _windows_case_env():
+        """A realistic Windows env whose keys use the native mixed case
+        the OS actually returns from ``os.environ`` (``Path``, ``Home``,
+        ``Tmp``, etc.)."""
+        return {
+            "Path": r"C:\Windows\System32;C:\Python311",
+            "Home": r"C:\Users\alice",
+            "Tmp": r"C:\Users\alice\AppData\Local\Temp",
+            "TmpDir": r"C:\Users\alice\AppData\Local\Temp",
+            "Shell": r"C:\Windows\System32\cmd.exe",
+            "UserName": "alice",                       # covered by USER prefix
+            "Logname": "alice",                        # exact-prefix match
+            "Windir": r"C:\Windows",                   # in essentials allowlist
+            "SystemRoot": r"C:\Windows",               # in essentials allowlist
+            # Should still be blocked (secret-substring check is upper-normalized
+            # and continues to work — guard against regression).
+            "Github_Token": "ghp_secret",
+            "My_Apikey": "sk-secret",
+        }
+
+    def test_path_preserved_with_mixed_case_key_on_windows(self):
+        """L1: ``Path`` (Windows native case) must survive scrub on Windows."""
+        scrubbed = _scrub_child_env(
+            self._windows_case_env(),
+            is_passthrough=_no_passthrough,
+            is_windows=True,
+        )
+        assert "Path" in scrubbed, (
+            f"_scrub_child_env dropped Windows-native 'Path' key; "
+            f"surviving keys: {sorted(scrubbed)}"
+        )
+        assert scrubbed["Path"] == r"C:\Windows\System32;C:\Python311"
+
+    def test_path_preserved_with_lowercase_key_on_windows(self):
+        """L1: ``path`` (lowercase) must also survive — fully case-insensitive."""
+        env = {"path": r"C:\Windows\System32", "Windir": r"C:\Windows"}
+        scrubbed = _scrub_child_env(
+            env,
+            is_passthrough=_no_passthrough,
+            is_windows=True,
+        )
+        assert "path" in scrubbed
+        assert scrubbed["path"] == r"C:\Windows\System32"
+
+    def test_home_preserved_with_mixed_case_key_on_windows(self):
+        """L1: ``Home`` (Windows native case) must survive."""
+        scrubbed = _scrub_child_env(
+            self._windows_case_env(),
+            is_passthrough=_no_passthrough,
+            is_windows=True,
+        )
+        assert "Home" in scrubbed
+        assert scrubbed["Home"] == r"C:\Users\alice"
+
+    def test_tmp_and_tmpdir_preserved_with_mixed_case_keys(self):
+        """L1: ``Tmp`` and ``TmpDir`` (Windows variants of TMP/TMPDIR)."""
+        scrubbed = _scrub_child_env(
+            self._windows_case_env(),
+            is_passthrough=_no_passthrough,
+            is_windows=True,
+        )
+        assert "Tmp" in scrubbed
+        assert "TmpDir" in scrubbed
+
+    def test_shell_preserved_with_mixed_case_key(self):
+        """L1: ``Shell`` (Windows variant) is required for subprocess shell=True."""
+        scrubbed = _scrub_child_env(
+            self._windows_case_env(),
+            is_passthrough=_no_passthrough,
+            is_windows=True,
+        )
+        assert "Shell" in scrubbed
+        assert scrubbed["Shell"] == r"C:\Windows\System32\cmd.exe"
+
+    def test_user_prefix_matches_mixed_case_username(self):
+        """L1: ``USER`` prefix matches ``UserName`` (User* is in the safe
+        prefix list).  Confirms the prefix normalization is not too narrow
+        (e.g. not just exact-match on the prefix word)."""
+        scrubbed = _scrub_child_env(
+            self._windows_case_env(),
+            is_passthrough=_no_passthrough,
+            is_windows=True,
+        )
+        assert "UserName" in scrubbed
+
+    def test_case_insensitive_prefix_does_not_regress_hermes_hardening(self):
+        """Regression guard for #27303 interaction: the broad ``HERMES_``
+        safe-prefix was deliberately removed so non-secret HERMES_* config
+        vars (e.g. ``HERMES_BASE_URL``) no longer leak into the child env.
+        The fix in #46645 only adds case-insensitivity to the safe-prefix
+        check, NOT a new ``HERMES_`` prefix — it must not bring back the
+        broad ``HERMES_*`` leak.  ``Hermes_Base_Url`` (mixed case) is a
+        perfect probe: it would match a broad case-insensitive ``HERMES_``
+        prefix, so this test pins that the fix does NOT introduce one.
+        """
+        env = {
+            "Hermes_Base_Url": "https://internal.example",  # not in allowlist
+            "Hermes_Kanban_Db": "/var/hermes/kanban.db",     # not in allowlist
+            "Windir": r"C:\Windows",
+        }
+        scrubbed = _scrub_child_env(
+            env,
+            is_passthrough=_no_passthrough,
+            is_windows=True,
+        )
+        # Neither mixed-case HERMES_* var should be in the scrubbed env
+        # — the safe-prefix list still doesn't include "HERMES_", so the
+        # trailing case-sensitive drop branch handles them.
+        assert "Hermes_Base_Url" not in scrubbed
+        assert "Hermes_Kanban_Db" not in scrubbed
+        # But Windows-essential Windir must still pass.
+        assert "Windir" in scrubbed
+
+    def test_secrets_still_blocked_with_mixed_case_keys(self):
+        """L4: case-insensitive safe-prefix must not defeat the secret block."""
+        scrubbed = _scrub_child_env(
+            self._windows_case_env(),
+            is_passthrough=_no_passthrough,
+            is_windows=True,
+        )
+        assert "Github_Token" not in scrubbed
+        assert "My_Apikey" not in scrubbed
+
+    def test_posix_path_unchanged_uppercase(self):
+        """Regression guard: the POSIX case (uppercase PATH) must still work."""
+        env = {"PATH": "/usr/bin:/bin", "HOME": "/root"}
+        scrubbed = _scrub_child_env(
+            env,
+            is_passthrough=_no_passthrough,
+            is_windows=False,
+        )
+        assert "PATH" in scrubbed
+        assert "HOME" in scrubbed
+
+    def test_posix_path_unchanged_lowercase(self):
+        """Regression guard: lowercase PATH on POSIX is unusual but
+        legitimate (custom shells, Linux namespaces, Docker configs)."""
+        env = {"path": "/usr/bin:/bin", "home": "/root"}
+        scrubbed = _scrub_child_env(
+            env,
+            is_passthrough=_no_passthrough,
+            is_windows=False,
+        )
+        assert "path" in scrubbed
+        assert "home" in scrubbed

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -147,6 +147,16 @@ def _scrub_child_env(source_env, is_passthrough=None, is_windows=None):
 
     Extracted into a helper so tests can exercise the logic without
     spawning a subprocess.
+
+    Note on case-sensitivity (#46645): env-var names on Windows are
+    case-insensitive at the OS level, and ``os.environ`` on Windows
+    preserves whatever case the OS reported (``Path``, ``Home``, ``Tmp``).
+    The safe-prefix check therefore compares against ``k.upper()`` so a
+    Windows env key like ``Path`` is recognized as a ``PATH``-prefix match.
+    The secret-substring check was already upper-normalized; the
+    ``_HERMES_CHILD_ALLOWED`` set and the trailing ``HERMES_*`` drop
+    intentionally remain case-sensitive (HERMES_* is an exact product
+    namespace, not an OS concept).
     """
     if is_passthrough is None:
         try:
@@ -157,6 +167,7 @@ def _scrub_child_env(source_env, is_passthrough=None, is_windows=None):
     if is_windows is None:
         is_windows = _IS_WINDOWS
 
+    safe_prefixes_upper = tuple(p.upper() for p in _SAFE_ENV_PREFIXES)
     scrubbed = {}
     # Non-secret HERMES_* vars dropped by the tightened allowlist (#27303). The
     # broad "HERMES_" prefix used to pass these through; now only the
@@ -170,15 +181,16 @@ def _scrub_child_env(source_env, is_passthrough=None, is_windows=None):
         if is_passthrough(k):
             scrubbed[k] = v
             continue
-        if any(s in k.upper() for s in _SECRET_SUBSTRINGS):
+        k_upper = k.upper()
+        if any(s in k_upper for s in _SECRET_SUBSTRINGS):
             continue
-        if any(k.startswith(p) for p in _SAFE_ENV_PREFIXES):
+        if any(k_upper.startswith(p) for p in safe_prefixes_upper):
             scrubbed[k] = v
             continue
         if k in _HERMES_CHILD_ALLOWED:
             scrubbed[k] = v
             continue
-        if is_windows and k.upper() in _WINDOWS_ESSENTIAL_ENV_VARS:
+        if is_windows and k_upper in _WINDOWS_ESSENTIAL_ENV_VARS:
             scrubbed[k] = v
             continue
         if k.startswith("HERMES_"):


### PR DESCRIPTION
## Summary

Fixes #46645 by making sandbox child-environment safe-prefix matching case-insensitive. On Windows, environment keys often arrive as mixed-case names such as `Path`, `Home`, and `Tmp`; the sandbox scrubber previously compared those keys against uppercase safe prefixes with a case-sensitive `startswith`, so child subprocesses could lose `PATH` and fail executable lookup.

## Changes

- Normalize env keys to uppercase for safe-prefix matching in `_scrub_child_env`.
- Reuse the normalized key for the existing secret-substring and Windows-essential checks.
- Keep the operational `HERMES_*` allowlist exact and preserve the tightened broad-`HERMES_*` hardening.
- Add regression coverage for mixed/lowercase Windows env keys, secret blocking, HERMES hardening, and POSIX behavior.

## Testing

- `python3 -m pytest tests/tools/test_code_execution_windows_env.py tests/tools/test_execute_code_approval_cluster.py -q -o addopts= --tb=short`
  - `56 passed, 3 skipped`
- Builder RED/GREEN evidence captured in automation artifacts:
  - 7 of 10 new case-insensitive env-key tests fail on upstream/main.
  - Fix branch: `36 passed, 3 skipped` for `test_code_execution_windows_env.py`.

Auto-published by Moonsong via Path B fallback automated review.
