### PR TITLE
feat(whatsapp): QR pairing panel in dashboard

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4738,6 +4738,42 @@ async def cancel_telegram_onboarding(pairing_id: str):
     return {"ok": True}
 
 
+
+
+# ---------------------------------------------------------------------------
+# WhatsApp QR pairing endpoints
+# ---------------------------------------------------------------------------
+
+_WHATSAPP_BRIDGE_PORT = int(os.environ.get("WHATSAPP_BRIDGE_PORT", "3000"))
+
+
+def _whatsapp_bridge_request(method, path):
+    import urllib.request as _ur
+    url = f"http://127.0.0.1:{_WHATSAPP_BRIDGE_PORT}{path}"
+    data = b"{}" if method == "POST" else None
+    headers = {"Host": "localhost"}
+    if data:
+        headers["Content-Type"] = "application/json"
+    req = _ur.Request(url, data=data, method=method, headers=headers)
+    try:
+        with _ur.urlopen(req, timeout=10) as resp:
+            import json as _json
+            return _json.loads(resp.read().decode())
+    except Exception as exc:
+        raise HTTPException(status_code=503, detail=f"Bridge unreachable: {exc}")
+
+
+@app.get("/api/messaging/whatsapp/qr")
+async def get_whatsapp_qr():
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, lambda: _whatsapp_bridge_request("GET", "/qr"))
+
+
+@app.post("/api/messaging/whatsapp/reset")
+async def reset_whatsapp_session():
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, lambda: _whatsapp_bridge_request("POST", "/reset-session"))
+
 @app.get("/api/messaging/platforms")
 async def get_messaging_platforms(profile: Optional[str] = None):
     # Profile-scoped so the dashboard's global profile switcher shows the

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -196,6 +196,7 @@ const MAX_RECENT_IDS = 50;
 
 let sock = null;
 let connectionState = 'disconnected';
+let latestQR = null;
 
 async function startSocket() {
   const { state, saveCreds } = await useMultiFileAuthState(SESSION_DIR);
@@ -224,6 +225,8 @@ async function startSocket() {
     const { connection, lastDisconnect, qr } = update;
 
     if (qr) {
+      latestQR = qr;
+      connectionState = "qr_pending";
       console.log('\n📱 Scan this QR code with WhatsApp on your phone:\n');
       qrcode.generate(qr, { small: true });
       console.log('\nWaiting for scan...\n');
@@ -234,6 +237,7 @@ async function startSocket() {
       connectionState = 'disconnected';
 
       if (reason === DisconnectReason.loggedOut) {
+        latestQR = null;
         console.log('❌ Logged out. Delete session and restart to re-authenticate.');
         process.exit(1);
       } else {
@@ -712,6 +716,30 @@ app.get('/chat/:id', async (req, res) => {
     isGroup,
     participants: [],
   });
+});
+
+// QR code for dashboard pairing
+app.get("/qr", (req, res) => {
+  res.json({ status: connectionState, qr: latestQR });
+});
+
+// Reset session
+app.post("/reset-session", async (req, res) => {
+  try {
+    const { readdirSync: rd, unlinkSync: ul, existsSync: ex } = await import("fs");
+    if (ex(SESSION_DIR)) {
+      for (const f of rd(SESSION_DIR)) {
+        try { ul(SESSION_DIR + "/" + f); } catch (_) {}
+      }
+    }
+    latestQR = null;
+    connectionState = "disconnected";
+    if (sock) { try { sock.end(undefined); } catch (_) {} sock = null; }
+    setTimeout(startSocket, 500);
+    res.json({ ok: true });
+  } catch (err) {
+    res.status(500).json({ error: String(err) });
+  }
 });
 
 // Health check

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -817,6 +817,11 @@ export const api = {
       { method: "DELETE" },
     ),
 
+  getWhatsappQR: () =>
+    fetchJSON<WhatsappQRResponse>("/api/messaging/whatsapp/qr"),
+  resetWhatsappSession: () =>
+    fetchJSON<{ ok: boolean }>("/api/messaging/whatsapp/reset", { method: "POST" }),
+
   // Gateway / update actions
   restartGateway: () =>
     fetchJSON<ActionResponse>("/api/gateway/restart", { method: "POST" }),
@@ -1628,6 +1633,11 @@ export interface EnvVarInfo {
   advanced: boolean;
   /** True when this var is a messaging-platform credential owned by the Channels page. */
   channel_managed?: boolean;
+}
+
+export interface WhatsappQRResponse {
+  status: "disconnected" | "qr_pending" | "connected" | string;
+  qr: string | null;
 }
 
 export interface TelegramOnboardingStartResponse {

--- a/web/src/pages/ChannelsPage.tsx
+++ b/web/src/pages/ChannelsPage.tsx
@@ -29,6 +29,7 @@ import type {
   MessagingPlatformEnvVar,
   MessagingPlatformUpdate,
   TelegramOnboardingStartResponse,
+  WhatsappQRResponse,
 } from "@/lib/api";
 import { useModalBehavior } from "@/hooks/useModalBehavior";
 import { usePageHeader } from "@/contexts/usePageHeader";
@@ -451,6 +452,9 @@ export default function ChannelsPage() {
                     showToast={showToast}
                   />
                 )}
+                {platform.id === "whatsapp" && (
+                  <WhatsappOnboardingPanel showToast={showToast} />
+                )}
               </CardContent>
             </Card>
           );
@@ -803,6 +807,113 @@ function TelegramOnboardingPanel({
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+function WhatsappOnboardingPanel({
+  showToast,
+}: {
+  showToast: (message: string, type: "success" | "error") => void;
+}) {
+  const [data, setData] = useState<WhatsappQRResponse | null>(null);
+  const [qrDataUrl, setQrDataUrl] = useState<string>("");
+  const [resetting, setResetting] = useState(false);
+
+  const fetchQR = useCallback(async () => {
+    try {
+      const res = await api.getWhatsappQR();
+      setData(res);
+      if (res.qr) {
+        const url = await QRCode.toDataURL(res.qr, {
+          errorCorrectionLevel: "M",
+          margin: 1,
+          width: 224,
+        });
+        setQrDataUrl(url);
+      } else {
+        setQrDataUrl("");
+      }
+    } catch {
+      // bridge not running — silently skip
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchQR();
+    const timer = setInterval(fetchQR, 3000);
+    return () => clearInterval(timer);
+  }, [fetchQR]);
+
+  const handleReset = async () => {
+    if (!window.confirm("Delete WhatsApp session and re-pair with a new QR code?")) return;
+    setResetting(true);
+    try {
+      await api.resetWhatsappSession();
+      setData(null);
+      setQrDataUrl("");
+      showToast("Session reset — scan the new QR code", "success");
+      setTimeout(fetchQR, 1500);
+    } catch (e) {
+      showToast(`Reset failed: ${e}`, "error");
+    } finally {
+      setResetting(false);
+    }
+  };
+
+  if (!data) return null;
+
+  const isConnected = data.status === "connected";
+  const isPending = data.status === "qr_pending";
+
+  return (
+    <div className="mt-4 flex flex-col gap-3">
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-medium text-muted-foreground">WhatsApp pairing</span>
+        {isConnected && (
+          <Badge tone="success">Connected</Badge>
+        )}
+        {isPending && (
+          <Badge tone="warning">Scan QR to pair</Badge>
+        )}
+        {!isConnected && !isPending && (
+          <Badge tone="outline">{data.status}</Badge>
+        )}
+      </div>
+
+      {isPending && qrDataUrl && (
+        <div className="flex flex-col items-start gap-2">
+          <p className="text-xs text-muted-foreground">
+            Open WhatsApp on your phone → Linked Devices → Link a Device
+          </p>
+          <img
+            src={qrDataUrl}
+            alt="WhatsApp QR code"
+            className="rounded border border-border"
+            width={224}
+            height={224}
+          />
+        </div>
+      )}
+
+      {isConnected && (
+        <p className="text-xs text-muted-foreground">
+          WhatsApp is connected. Use the button below to re-pair if needed.
+        </p>
+      )}
+
+      <div>
+        <Button
+          ghost
+          size="sm"
+          className="uppercase text-destructive"
+          onClick={handleReset}
+          disabled={resetting}
+          prefix={resetting ? <Spinner /> : <RotateCw className="h-4 w-4" />}
+        >
+          {resetting ? "Resetting…" : "Reset & re-pair"}
+        </Button>
+      </div>
     </div>
   );
 }

--- a/web/src/pages/ChannelsPage.tsx
+++ b/web/src/pages/ChannelsPage.tsx
@@ -819,11 +819,17 @@ function WhatsappOnboardingPanel({
   const [data, setData] = useState<WhatsappQRResponse | null>(null);
   const [qrDataUrl, setQrDataUrl] = useState<string>("");
   const [resetting, setResetting] = useState(false);
+  const [phase, setPhase] = useState<"idle" | "connecting" | "ready">("idle");
 
   const fetchQR = useCallback(async () => {
     try {
       const res = await api.getWhatsappQR();
       setData(res);
+      if (res.status === "connected") {
+        setPhase("ready");
+      } else if (res.status === "qr_pending") {
+        setPhase("connecting");
+      }
       if (res.qr) {
         const url = await QRCode.toDataURL(res.qr, {
           errorCorrectionLevel: "M",
@@ -831,8 +837,6 @@ function WhatsappOnboardingPanel({
           width: 224,
         });
         setQrDataUrl(url);
-      } else {
-        setQrDataUrl("");
       }
     } catch {
       // bridge not running — silently skip
@@ -852,67 +856,86 @@ function WhatsappOnboardingPanel({
       await api.resetWhatsappSession();
       setData(null);
       setQrDataUrl("");
+      setPhase("idle");
       showToast("Session reset — scan the new QR code", "success");
       setTimeout(fetchQR, 1500);
     } catch (e) {
-      showToast(`Reset failed: ${e}`, "error");
+      showToast("Reset failed: " + String(e), "error");
     } finally {
       setResetting(false);
     }
   };
 
-  if (!data) return null;
-
-  const isConnected = data.status === "connected";
-  const isPending = data.status === "qr_pending";
+  const isPending = data?.status === "qr_pending";
+  const isConnected = data?.status === "connected";
 
   return (
-    <div className="mt-4 flex flex-col gap-3">
-      <div className="flex items-center gap-2">
-        <span className="text-sm font-medium text-muted-foreground">WhatsApp pairing</span>
-        {isConnected && (
-          <Badge tone="success">Connected</Badge>
-        )}
-        {isPending && (
-          <Badge tone="warning">Scan QR to pair</Badge>
-        )}
-        {!isConnected && !isPending && (
-          <Badge tone="outline">{data.status}</Badge>
-        )}
-      </div>
-
-      {isPending && qrDataUrl && (
-        <div className="flex flex-col items-start gap-2">
-          <p className="text-xs text-muted-foreground">
-            Open WhatsApp on your phone → Linked Devices → Link a Device
-          </p>
-          <img
-            src={qrDataUrl}
-            alt="WhatsApp QR code"
-            className="rounded border border-border"
-            width={224}
-            height={224}
-          />
+    <div className="mt-4">
+      <div className="rounded-sm border border-border bg-background/35 p-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            size="sm"
+            className="uppercase"
+            onClick={handleReset}
+            disabled={phase === "idle" || resetting}
+            prefix={resetting ? <Spinner /> : <RotateCw className="h-4 w-4" />}
+          >
+            {resetting ? "Resetting…" : isPending ? "Connecting…" : isConnected ? "Re-pair with QR" : "Set up with QR"}
+          </Button>
+          {phase === "idle" && !isPending && !isConnected && (
+            <span className="text-xs text-muted-foreground">
+              WhatsApp bridge not running or not configured.
+            </span>
+          )}
         </div>
-      )}
 
-      {isConnected && (
-        <p className="text-xs text-muted-foreground">
-          WhatsApp is connected. Use the button below to re-pair if needed.
-        </p>
-      )}
+        {isPending && qrDataUrl && (
+          <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1fr)_260px]">
+            <div className="grid gap-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge tone="warning">Scan to pair</Badge>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Open WhatsApp on your phone, go to{" "}
+                <span className="font-courier">Linked Devices</span> →{" "}
+                <span className="font-courier">Link a Device</span>, and scan
+                the QR code.
+              </p>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  size="sm"
+                  ghost
+                  className="uppercase text-destructive"
+                  onClick={handleReset}
+                  disabled={resetting}
+                  prefix={<X className="h-4 w-4" />}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
 
-      <div>
-        <Button
-          ghost
-          size="sm"
-          className="uppercase text-destructive"
-          onClick={handleReset}
-          disabled={resetting}
-          prefix={resetting ? <Spinner /> : <RotateCw className="h-4 w-4" />}
-        >
-          {resetting ? "Resetting…" : "Reset & re-pair"}
-        </Button>
+            <div className="flex flex-col items-center justify-center gap-3">
+              <img
+                src={qrDataUrl}
+                alt="WhatsApp QR code"
+                className="h-56 w-56 bg-white p-2"
+              />
+              <Badge tone="warning">waiting</Badge>
+            </div>
+          </div>
+        )}
+
+        {isConnected && (
+          <div className="mt-4 grid gap-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge tone="success">Connected</Badge>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              WhatsApp is paired and connected.
+            </p>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Adds a WhatsApp QR pairing flow directly in the Channels dashboard page, so users can link their phone without touching the terminal.

### Problem
The existing WhatsApp integration required users to run a terminal command to display a QR code for pairing — a poor experience for non-technical users.

### Solution
- **`scripts/whatsapp-bridge/bridge.js`**: Exposes two new HTTP endpoints on the local bridge:
  - `GET /qr` — returns `{ status, qr }` where `qr` is the raw Baileys QR string when pairing is needed (status `qr_pending`), or `null` when connected/disconnected.
  - `POST /reset-session` — wipes saved credentials and triggers a fresh reconnect, generating a new QR code.
  - Tracks a `latestQR` variable and introduces `qr_pending` as a connection state.

- **`hermes_cli/web_server.py`**: Adds two proxy endpoints that forward to the bridge over loopback:
  - `GET /api/messaging/whatsapp/qr`
  - `POST /api/messaging/whatsapp/reset`

- **`web/src/lib/api.ts`**: Adds `getWhatsappQR()`, `resetWhatsappSession()` client methods and the `WhatsappQRResponse` interface.

- **`web/src/pages/ChannelsPage.tsx`**: Adds `WhatsappOnboardingPanel` rendered inside the WhatsApp platform card. It:
  - Polls `/api/messaging/whatsapp/qr` every 3 s
  - Renders a QR image (using the existing `qrcode` library) when `status === "qr_pending"`
  - Shows a "Connected" badge when linked
  - Provides a "Reset & re-pair" button that wipes the session and prompts a new QR

## Test plan

- [ ] Enable WhatsApp in `.env` (`WHATSAPP_ENABLED=true`)
- [ ] Open the Channels page → WhatsApp card shows QR code when not connected
- [ ] Scan QR with WhatsApp → badge changes to "Connected", QR disappears
- [ ] Click "Reset & re-pair" → session wiped, new QR appears
- [ ] Other messaging platform cards are unaffected
- [ ] Dashboard build passes (`npm run build` in `web/`)
