### PR TITLE
fix(desktop): pin assistant-ui tap shim dependency

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "@assistant-ui/react": "^0.12.28",
     "@assistant-ui/react-streamdown": "^0.1.11",
+    "@assistant-ui/tap": "^0.9.2",
     "@audiowave/react": "^0.6.2",
     "@chenglou/pretext": "^0.0.6",
     "@dnd-kit/core": "^6.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
       "dependencies": {
         "@assistant-ui/react": "^0.12.28",
         "@assistant-ui/react-streamdown": "^0.1.11",
+        "@assistant-ui/tap": "^0.9.2",
         "@audiowave/react": "^0.6.2",
         "@chenglou/pretext": "^0.0.6",
         "@dnd-kit/core": "^6.3.1",
@@ -146,6 +147,21 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "apps/desktop/node_modules/@assistant-ui/tap": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/tap/-/tap-0.9.2.tgz",
+      "integrity": "sha512-wrvZqozwHH9o/buoaLeK1m9oRWEXyfeWDXqijUn0qdidLh5/6tR8aAfhrUgWPHvBpvU925rqjZ+8fFjewt20Gg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "apps/desktop/node_modules/@nous-research/ui": {


### PR DESCRIPTION
## Summary
- add `@assistant-ui/tap@^0.9.2` as an explicit desktop dependency
- updates the npm lockfile so the desktop workspace installs a `tap` version that exports `./react-shim`

## Why
Recent desktop rebuilds fail during Vite/Rolldown resolution with:

```text
"./react-shim" is not exported under the conditions ["module", "browser", "production", "import"] from package .../node_modules/@assistant-ui/tap/package.json
```

`@assistant-ui/tap@0.5.10` does not export `./react-shim`; `0.9.2` does.

## Verification
- `npm run build --workspace apps/desktop`
- `npm run pack --workspace apps/desktop`
