### PR TITLE
fix(tui): show compression summary in _mirror_slash_side_effects

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4626,16 +4626,72 @@ def test_mirror_slash_compress_does_not_prelock_history(monkeypatch):
     monkeypatch.setattr(server, "_sync_session_key_after_compress", _fake_sync)
     monkeypatch.setattr(server, "_session_info", lambda _agent, *a: {"model": "x"})
     monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
+    monkeypatch.setattr(
+        "agent.model_metadata.estimate_request_tokens_rough",
+        lambda *a, **kw: 0,
+    )
 
     session = _session(running=False)
     session["agent"] = types.SimpleNamespace(model="x")
 
     warning = server._mirror_slash_side_effects("sid", session, "/compress")
 
-    assert warning == ""
     assert seen["compress"]
     assert seen["sync"]
-    assert ("session.info", "sid", {"model": "x"}) in emitted
+    assert (".info", "sid", {"model": "x"}) in emitted or ("session.info", "sid", {"model": "x"}) in emitted
+    # Now returns a formatted summary instead of empty string
+    assert "Compressed" in warning or "No changes" in warning
+
+
+def test_mirror_slash_compress_returns_summary(monkeypatch):
+    """/compress side effect must return a formatted summary with before/after
+    stats, matching the CLI and gateway code paths."""
+    import types
+
+    emitted = []
+    before_history = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+        {"role": "user", "content": "how are you?"},
+        {"role": "assistant", "content": "I'm fine"},
+    ]
+    after_history = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "summarized"},
+    ]
+
+    def _fake_compress(session, focus_topic=None, **_kw):
+        # Simulate compression: replace history with shorter version
+        session["history"] = list(after_history)
+        return (2, {"total": 100})
+
+    monkeypatch.setattr(server, "_compress_session_history", _fake_compress)
+    monkeypatch.setattr(
+        server, "_sync_session_key_after_compress", lambda *a, **kw: None
+    )
+    monkeypatch.setattr(server, "_session_info", lambda _agent, *a: {"model": "x"})
+    monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
+    call_count = {"n": 0}
+
+    def _fake_estimate(messages, **_kw):
+        call_count["n"] += 1
+        # First call = before (4 msgs), second call = after (2 msgs)
+        return 400 if len(messages) == 4 else 150
+
+    monkeypatch.setattr(
+        "agent.model_metadata.estimate_request_tokens_rough", _fake_estimate
+    )
+
+    session = _session(running=False, history=list(before_history))
+    session["agent"] = types.SimpleNamespace(model="x")
+
+    warning = server._mirror_slash_side_effects("sid", session, "/compress")
+
+    # Must include headline and token line
+    assert "Compressed: 4 → 2 messages" in warning
+    assert "~400" in warning and "~150" in warning
+    # Must emit session.info
+    assert any(e[0] == "session.info" for e in emitted)
 
 
 # ---------------------------------------------------------------------------

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9086,9 +9086,46 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
             agent.ephemeral_system_prompt = new_prompt or None
             agent._cached_system_prompt = None
         elif name == "compress" and agent:
+            from agent.manual_compression_feedback import summarize_manual_compression
+            from agent.model_metadata import estimate_request_tokens_rough
+
+            with session["history_lock"]:
+                before_messages = list(session.get("history", []))
+            _sys_prompt = getattr(agent, "_cached_system_prompt", "") or ""
+            _tools = getattr(agent, "tools", None) or None
+            before_tokens = (
+                estimate_request_tokens_rough(
+                    before_messages, system_prompt=_sys_prompt, tools=_tools
+                )
+                if before_messages
+                else 0
+            )
             _compress_session_history(session, arg)
             _sync_session_key_after_compress(sid, session)
+            with session["history_lock"]:
+                after_messages = list(session.get("history", []))
+            _sys_prompt_after = (
+                getattr(agent, "_cached_system_prompt", "") or _sys_prompt
+            )
+            _tools_after = getattr(agent, "tools", None) or _tools
+            after_tokens = (
+                estimate_request_tokens_rough(
+                    after_messages,
+                    system_prompt=_sys_prompt_after,
+                    tools=_tools_after,
+                )
+                if after_messages
+                else 0
+            )
+            summary = summarize_manual_compression(
+                before_messages, after_messages, before_tokens, after_tokens
+            )
             _emit("session.info", sid, _session_info(agent, session))
+            icon = "🗜️" if summary["noop"] else "✅"
+            lines = [f"{icon} {summary['headline']}", f"   {summary['token_line']}"]
+            if summary["note"]:
+                lines.append(f"   {summary['note']}")
+            return "\n".join(lines)
         elif name == "fast" and agent:
             mode = arg.lower()
             if mode in {"fast", "on"}:


### PR DESCRIPTION
## What does this PR do?

Adds the missing `summarize_manual_compression()` call in `_mirror_slash_side_effects` so that `/compress` in TUI and Desktop shows the before/after message count and token estimate, matching the CLI and gateway code paths.

## Related Issue

Fixes #46686

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/server.py`: In the `compress` branch of `_mirror_slash_side_effects`, capture before/after message state and token estimates, call `summarize_manual_compression()`, and return the formatted summary as the warning string.
- `tests/test_tui_gateway_server.py`: Updated `test_mirror_slash_compress_does_not_prelock_history` to account for the new summary return value. Added `test_mirror_slash_compress_returns_summary` to verify the summary content (headline, token line).

## How to Test

1. Open the TUI or Desktop app
2. Send a few messages to build conversation history
3. Run `/compress`
4. Verify the output includes "Compressed: N → M messages" and "Approx request size: ~X → ~Y tokens"
5. Run `pytest tests/test_tui_gateway_server.py -k compress -xvs` — all 5 compress tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tui_gateway/server.py::_mirror_slash_side_effects` (callers: 1 in `slash.exec`)
- Analyzed: `agent/manual_compression_feedback.py::summarize_manual_compression` (callers: cli.py, gateway/slash_commands.py, now also tui_gateway/server.py)
- Blast radius: LOW — only affects the compress branch of `_mirror_slash_side_effects`
- Related patterns: CLI `_manual_compress` (cli.py:8231), gateway `_handle_compress_command` (slash_commands.py:2506), `session.compress` RPC (server.py:5013) — all three already call `summarize_manual_compression()` with identical pattern
