### PR TITLE
Fix scoped TUI dependency freshness check

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -259,7 +259,7 @@ import shutil
 import stat
 import subprocess
 from pathlib import Path
-from typing import Optional
+from typing import Iterable, Optional
 
 
 from hermes_cli.subcommands._shared import add_accept_hooks_flag as _add_accept_hooks_flag
@@ -1373,6 +1373,89 @@ installed, so we exclude them from the comparison in :func:`_tui_need_npm_instal
 to avoid false-positive reinstalls on every launch.
 """
 
+_NPM_LOCK_DEPENDENCY_KEYS = (
+    "dependencies",
+    "devDependencies",
+    "optionalDependencies",
+    "peerDependencies",
+)
+
+
+def _lockfile_dependency_candidates(package_name: str, dep_name: str) -> list[str]:
+    """Return package-lock paths npm may use to resolve *dep_name* from a package."""
+    parts = package_name.split("/") if package_name else []
+    candidates: list[str] = []
+    for index in range(len(parts), 0, -1):
+        candidate = "/".join([*parts[:index], "node_modules", dep_name])
+        candidates.append(candidate)
+    candidates.append(f"node_modules/{dep_name}")
+    return candidates
+
+
+def _lockfile_dependency_closure(
+    packages: dict, start_names: Iterable[str]
+) -> set[str]:
+    """Return package-lock entries reachable from workspace package entries."""
+    seen: set[str] = set()
+    pending = [name for name in start_names if name in packages]
+
+    while pending:
+        name = pending.pop()
+        if name in seen:
+            continue
+        seen.add(name)
+
+        pkg = packages.get(name)
+        if not isinstance(pkg, dict):
+            continue
+
+        resolved = pkg.get("resolved")
+        if pkg.get("link") and isinstance(resolved, str) and resolved in packages:
+            pending.append(resolved)
+
+        for key in _NPM_LOCK_DEPENDENCY_KEYS:
+            deps = pkg.get(key)
+            if not isinstance(deps, dict):
+                continue
+            for dep_name in deps:
+                for dep_entry in _lockfile_dependency_candidates(name, dep_name):
+                    if dep_entry in packages:
+                        pending.append(dep_entry)
+                        break
+
+    return seen
+
+
+def _tui_lockfile_package_scope(
+    root: Path, ws_root: Path, packages: dict
+) -> set[str] | None:
+    """Return package-lock entries relevant to the TUI workspace.
+
+    ``npm install --workspace ui-tui`` intentionally leaves unrelated
+    workspaces out of npm's hidden lockfile.  Comparing the whole root
+    lockfile therefore creates a false positive after a scoped install.
+    """
+    if ws_root == root:
+        return None
+
+    try:
+        workspace = root.relative_to(ws_root).as_posix()
+    except ValueError:
+        return None
+
+    start_names = [workspace]
+    workspace_packages = root / "packages"
+    if workspace_packages.is_dir():
+        prefix = f"{workspace}/packages/"
+        start_names.extend(
+            name
+            for name in packages
+            if isinstance(name, str) and name.startswith(prefix)
+        )
+
+    scoped = _lockfile_dependency_closure(packages, start_names)
+    return scoped or None
+
 
 def _workspace_root(dir: Path) -> Path:
     """Return the npm workspace root for *dir*.
@@ -1488,7 +1571,12 @@ def _tui_need_npm_install(root: Path) -> bool:
     def comparable(pkg: dict) -> dict:
         return {k: v for k, v in pkg.items() if k not in _NPM_LOCK_RUNTIME_KEYS}
 
+    relevant_packages = _tui_lockfile_package_scope(root, ws_root, wanted)
+
     for name, pkg in wanted.items():
+        if relevant_packages is not None and name not in relevant_packages:
+            continue
+
         if not name:
             continue
 

--- a/tests/hermes_cli/test_tui_npm_install.py
+++ b/tests/hermes_cli/test_tui_npm_install.py
@@ -1,5 +1,6 @@
 """_tui_need_npm_install: auto npm when node_modules is behind the lockfile."""
 
+import json
 import os
 import types
 from pathlib import Path
@@ -89,6 +90,148 @@ def test_no_install_when_only_peer_annotation_differs(tmp_path: Path, main_mod) 
         '}}'
     )
     assert main_mod._tui_need_npm_install(tmp_path) is False
+
+
+def test_workspace_scoped_tui_install_ignores_uninstalled_sibling_workspaces(
+    tmp_path: Path, main_mod
+) -> None:
+    """A TUI-scoped npm install does not populate hidden lock entries for
+    unrelated workspaces, so those entries must not force a reinstall.
+    """
+    tui_dir = tmp_path / "ui-tui"
+    (tui_dir / "packages" / "hermes-ink").mkdir(parents=True)
+    (tui_dir / "package.json").write_text("{}")
+    (tmp_path / "apps" / "bootstrap-installer").mkdir(parents=True)
+    _touch_ink(tmp_path)
+
+    wanted_packages = {
+        "": {"workspaces": ["apps/*", "ui-tui", "ui-tui/packages/*"]},
+        "apps/bootstrap-installer": {"dependencies": {"react-dom": "^19.0.0"}},
+        "ui-tui": {
+            "dependencies": {
+                "@hermes/ink": "file:./packages/hermes-ink",
+                "react": "^19.0.0",
+            },
+            "devDependencies": {"tsx": "^4.0.0"},
+        },
+        "ui-tui/packages/hermes-ink": {"dependencies": {"chalk": "^5.0.0"}},
+        "node_modules/@hermes/ink": {
+            "resolved": "ui-tui/packages/hermes-ink",
+            "link": True,
+        },
+        "node_modules/chalk": {"version": "5.0.0"},
+        "node_modules/react": {"version": "19.0.0"},
+        "node_modules/react-dom": {"version": "19.0.0"},
+        "node_modules/tsx": {"version": "4.0.0"},
+    }
+    installed_packages = {
+        name: pkg
+        for name, pkg in wanted_packages.items()
+        if name not in {"apps/bootstrap-installer", "node_modules/react-dom"}
+    }
+    (tmp_path / "package-lock.json").write_text(
+        json.dumps({"packages": wanted_packages})
+    )
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(
+        json.dumps({"packages": installed_packages})
+    )
+
+    assert main_mod._tui_need_npm_install(tui_dir) is False
+
+
+def test_workspace_scoped_tui_install_still_detects_missing_tui_dependency(
+    tmp_path: Path, main_mod
+) -> None:
+    tui_dir = tmp_path / "ui-tui"
+    (tui_dir / "packages" / "hermes-ink").mkdir(parents=True)
+    (tui_dir / "package.json").write_text("{}")
+    _touch_ink(tmp_path)
+
+    wanted_packages = {
+        "ui-tui": {"dependencies": {"@hermes/ink": "file:./packages/hermes-ink"}},
+        "ui-tui/packages/hermes-ink": {"dependencies": {"chalk": "^5.0.0"}},
+        "node_modules/@hermes/ink": {
+            "resolved": "ui-tui/packages/hermes-ink",
+            "link": True,
+        },
+        "node_modules/chalk": {"version": "5.0.0"},
+    }
+    installed_packages = {
+        name: pkg
+        for name, pkg in wanted_packages.items()
+        if name != "node_modules/chalk"
+    }
+    (tmp_path / "package-lock.json").write_text(
+        json.dumps({"packages": wanted_packages})
+    )
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(
+        json.dumps({"packages": installed_packages})
+    )
+
+    assert main_mod._tui_need_npm_install(tui_dir) is True
+
+
+def test_workspace_scoped_tui_install_prefers_nested_transitive_dependency(
+    tmp_path: Path, main_mod
+) -> None:
+    tui_dir = tmp_path / "ui-tui"
+    tui_dir.mkdir()
+    (tui_dir / "package.json").write_text("{}")
+    _touch_ink(tmp_path)
+
+    wanted_packages = {
+        "ui-tui": {"devDependencies": {"vite": "^7.0.0"}},
+        "node_modules/vite": {"dependencies": {"postcss": "^8.0.0"}},
+        "node_modules/postcss": {"dependencies": {"nanoid": "^3.3.11"}},
+        "node_modules/nanoid": {"version": "5.1.11"},
+        "node_modules/postcss/node_modules/nanoid": {"version": "3.3.12"},
+    }
+    installed_packages = {
+        name: pkg
+        for name, pkg in wanted_packages.items()
+        if name != "node_modules/nanoid"
+    }
+    (tmp_path / "package-lock.json").write_text(
+        json.dumps({"packages": wanted_packages})
+    )
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(
+        json.dumps({"packages": installed_packages})
+    )
+
+    assert main_mod._tui_need_npm_install(tui_dir) is False
+
+
+def test_workspace_scoped_tui_install_uses_workspace_ancestor_dependency(
+    tmp_path: Path, main_mod
+) -> None:
+    tui_dir = tmp_path / "ui-tui"
+    (tui_dir / "packages" / "hermes-ink").mkdir(parents=True)
+    (tui_dir / "package.json").write_text("{}")
+    _touch_ink(tmp_path)
+
+    wanted_packages = {
+        "ui-tui": {"dependencies": {"@hermes/ink": "file:./packages/hermes-ink"}},
+        "ui-tui/packages/hermes-ink": {"dependencies": {"wrap-ansi": "^9.0.0"}},
+        "node_modules/@hermes/ink": {
+            "resolved": "ui-tui/packages/hermes-ink",
+            "link": True,
+        },
+        "node_modules/wrap-ansi": {"version": "7.0.0"},
+        "ui-tui/node_modules/wrap-ansi": {"version": "9.0.2"},
+    }
+    installed_packages = {
+        name: pkg
+        for name, pkg in wanted_packages.items()
+        if name != "node_modules/wrap-ansi"
+    }
+    (tmp_path / "package-lock.json").write_text(
+        json.dumps({"packages": wanted_packages})
+    )
+    (tmp_path / "node_modules" / ".package-lock.json").write_text(
+        json.dumps({"packages": installed_packages})
+    )
+
+    assert main_mod._tui_need_npm_install(tui_dir) is False
 
 
 def test_install_when_version_differs_even_with_peer_drop(tmp_path: Path, main_mod) -> None:


### PR DESCRIPTION
## Summary

Fixes a false-positive TUI dependency reinstall loop after running a scoped npm install for the `ui-tui` workspace.

`hermes --tui` installs dependencies with `npm install --workspace ui-tui`, but `_tui_need_npm_install()` compared the full root `package-lock.json` against npm's hidden `node_modules/.package-lock.json`. A scoped install can legitimately omit sibling workspaces such as desktop/web/bootstrap packages, causing Hermes to print `Installing TUI dependencies...` on every launch even when the TUI dependencies are current.

This change scopes the lockfile comparison to packages reachable from the TUI workspace and its bundled `ui-tui/packages/*` packages. It also resolves npm lockfile dependency paths through nested and workspace-ancestor `node_modules` entries so hoisted/version-split dependencies are handled correctly.

## Validation

- `python -m pytest tests/hermes_cli/test_tui_npm_install.py`
- Verified the local TUI install check returns `False` after a scoped install state that previously returned `True`.