### PR TITLE
fix(cron): force UTF-8 decoding for no_agent script stdout on Windows

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -969,12 +969,20 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
 
     try:
         popen_kwargs = {"creationflags": windows_hide_flags()} if sys.platform == "win32" else {}
+        # Ensure the child Python process uses UTF-8 for stdout/stderr.
+        # Without this, a long-running scheduler on Windows may decode the
+        # script's UTF-8 output as cp1252, producing mojibake in Discord/etc.
+        env = os.environ.copy()
+        env.setdefault("PYTHONIOENCODING", "utf-8")
         result = subprocess.run(
             argv,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=script_timeout,
             cwd=str(path.parent),
+            env=env,
             **popen_kwargs,
         )
         stdout = (result.stdout or "").strip()


### PR DESCRIPTION
## Problem

On Windows, `_run_job_script()` calls `subprocess.run(text=True)` without specifying `encoding=`. This falls back to `locale.getpreferredencoding()`, which can return `cp1252` on Windows. When a no_agent cron script emits UTF-8 bytes (emojis, Unicode bullets, em-dashes), the scheduler decodes them as cp1252, producing mojibake in Discord/Telegram delivery.

## Fix

Three changes to `_run_job_script()`:

1. `encoding="utf-8"` — explicitly decode subprocess stdout/stderr as UTF-8
2. `errors="replace"` — prevent crashes if a legacy script emits non-UTF-8 bytes
3. `env=env` with `PYTHONIOENCODING=utf-8` — ensure child Python uses UTF-8 mode

| Character | UTF-8 bytes | Mojibake (before fix) |
|-----------|------------|----------------------|
| 📥 | F0 9F 93 A5 | `ðŸ"¥` |
| • | E2 80 A2 | `â€¢` |
| — | E2 80 94 | `â€"` |

## Testing

- Verified: scripts emitting UTF-8 decode correctly via subprocess capture
- Verified: `errors="replace"` handles legacy non-UTF-8 scripts gracefully
- Verified: `env.setdefault` preserves user-set `PYTHONIOENCODING`
- No change to Linux/macOS where UTF-8 is already the default

## Related

See hermes-operations-health skill: `references/windows-cron-script-encoding.md` for full documented fix + regression test.