### PR TITLE
fix(dashboard): gate user plugin manifests by config

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11138,6 +11138,57 @@ def _safe_plugin_api_relpath(api_field: Any, *, dashboard_dir: Path) -> Optional
     return api_field
 
 
+def _dashboard_plugin_config_sets() -> Tuple[set[str], set[str]]:
+    """Return (enabled, disabled) plugin allow/deny sets from config.yaml."""
+    try:
+        config = load_config()
+        plugins_cfg = config.get("plugins")
+        if not isinstance(plugins_cfg, dict):
+            return set(), set()
+        enabled = plugins_cfg.get("enabled", [])
+        disabled = plugins_cfg.get("disabled", [])
+        return (
+            {str(p) for p in enabled if isinstance(p, str) and p.strip()}
+            if isinstance(enabled, list) else set(),
+            {str(p) for p in disabled if isinstance(p, str) and p.strip()}
+            if isinstance(disabled, list) else set(),
+        )
+    except Exception:
+        return set(), set()
+
+
+def _dashboard_plugin_allowed_by_config(
+    *,
+    name: Any,
+    source: str,
+    plugin_dir_name: Optional[str] = None,
+    enabled: Optional[set[str]] = None,
+    disabled: Optional[set[str]] = None,
+) -> bool:
+    """Apply the runtime plugin enable/disable contract to dashboard plugins.
+
+    Bundled dashboard plugins ship with Hermes and remain available by default.
+    User/project dashboard plugins are unreviewed code and must be explicitly
+    listed in ``plugins.enabled`` before the dashboard advertises their assets
+    or imports their Python API module. ``plugins.disabled`` always wins.
+    """
+    if enabled is None or disabled is None:
+        enabled, disabled = _dashboard_plugin_config_sets()
+
+    aliases = {str(name).strip()} if isinstance(name, str) and name.strip() else set()
+    if plugin_dir_name:
+        aliases.add(str(plugin_dir_name).strip())
+    aliases.discard("")
+
+    if not aliases:
+        return False
+    if aliases & disabled:
+        return False
+    if source == "bundled":
+        return True
+    return bool(aliases & enabled)
+
+
 def _discover_dashboard_plugins() -> list:
     """Scan plugins/*/dashboard/manifest.json for dashboard extensions.
 
@@ -11148,6 +11199,7 @@ def _discover_dashboard_plugins() -> list:
     """
     plugins = []
     seen_names: set = set()
+    enabled_plugins, disabled_plugins = _dashboard_plugin_config_sets()
 
     from hermes_cli.plugins import get_bundled_plugins_dir
     bundled_root = get_bundled_plugins_dir()
@@ -11180,6 +11232,19 @@ def _discover_dashboard_plugins() -> list:
             try:
                 data = json.loads(manifest_file.read_text(encoding="utf-8"))
                 name = data.get("name", child.name)
+                if not _dashboard_plugin_allowed_by_config(
+                    name=name,
+                    source=source,
+                    plugin_dir_name=child.name,
+                    enabled=enabled_plugins,
+                    disabled=disabled_plugins,
+                ):
+                    _log.debug(
+                        "Skipping dashboard plugin %s from %s "
+                        "(not enabled or explicitly disabled)",
+                        name, source,
+                    )
+                    continue
                 if name in seen_names:
                     continue
                 seen_names.add(name)
@@ -11634,6 +11699,18 @@ def _mount_plugin_api_routes():
         api_file_name = plugin.get("_api_file")
         if not api_file_name:
             continue
+        dashboard_dir = Path(plugin["_dir"])
+        if not _dashboard_plugin_allowed_by_config(
+            name=plugin.get("name"),
+            source=str(plugin.get("source") or ""),
+            plugin_dir_name=dashboard_dir.parent.name,
+        ):
+            _log.warning(
+                "Plugin %s: refusing backend api=%s (dashboard plugin is "
+                "not enabled or is explicitly disabled in config.yaml)",
+                plugin.get("name"), api_file_name,
+            )
+            continue
         if plugin.get("source") == "project":
             _log.warning(
                 "Plugin %s: ignoring backend api=%s (project plugins may "
@@ -11642,7 +11719,6 @@ def _mount_plugin_api_routes():
                 plugin["name"], api_file_name,
             )
             continue
-        dashboard_dir = Path(plugin["_dir"])
         api_path = dashboard_dir / api_file_name
         try:
             resolved_api = api_path.resolve()

--- a/tests/hermes_cli/test_project_plugin_rce_bypass.py
+++ b/tests/hermes_cli/test_project_plugin_rce_bypass.py
@@ -110,11 +110,131 @@ class TestProjectPluginsEnvGate:
     def test_truthy_values_enable_project_plugins(
         self, project_plugin, monkeypatch, value
     ):
+        (project_plugin.parent / "home" / "config.yaml").write_text(
+            "plugins:\n  enabled:\n    - evil\n"
+        )
         monkeypatch.setenv("HERMES_ENABLE_PROJECT_PLUGINS", value)
         plugins = web_server._get_dashboard_plugins(force_rescan=True)
         evil = next((p for p in plugins if p["name"] == "evil"), None)
         assert evil is not None
         assert evil["source"] == "project"
+
+
+# ---------------------------------------------------------------------------
+# Layer 1b — dashboard plugins also honor plugins.enabled/disabled.
+# ---------------------------------------------------------------------------
+
+
+class TestDashboardPluginsEnabledGate:
+    """User/project dashboard plugins carry browser JS and optional Python API
+    code. They must follow the same opt-in contract as agent plugins."""
+
+    def _write_plugin_config(self, hermes_home: Path, *, enabled=(), disabled=()):
+        import yaml
+
+        cfg = {
+            "plugins": {
+                "enabled": list(enabled),
+                "disabled": list(disabled),
+            }
+        }
+        (hermes_home / "config.yaml").write_text(yaml.safe_dump(cfg))
+
+    def test_user_dashboard_plugin_hidden_until_enabled(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        _write_plugin_manifest(
+            tmp_path / "plugins",
+            "side-panel",
+            {
+                "name": "side-panel",
+                "label": "Side Panel",
+                "entry": "dist/index.js",
+            },
+        )
+
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        assert "side-panel" not in {p["name"] for p in plugins}
+
+        self._write_plugin_config(tmp_path, enabled=["side-panel"])
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        enabled = next((p for p in plugins if p["name"] == "side-panel"), None)
+        assert enabled is not None
+        assert enabled["source"] == "user"
+
+    def test_disabled_beats_dashboard_enabled(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        self._write_plugin_config(
+            tmp_path,
+            enabled=["side-panel"],
+            disabled=["side-panel"],
+        )
+        _write_plugin_manifest(
+            tmp_path / "plugins",
+            "side-panel",
+            {
+                "name": "side-panel",
+                "label": "Side Panel",
+                "entry": "dist/index.js",
+            },
+        )
+
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        assert "side-panel" not in {p["name"] for p in plugins}
+
+    def test_project_dashboard_plugin_requires_env_and_enabled(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        (tmp_path / "home").mkdir()
+        cwd = tmp_path / "repo"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        monkeypatch.setenv("HERMES_ENABLE_PROJECT_PLUGINS", "1")
+        _write_plugin_manifest(
+            cwd / ".hermes" / "plugins",
+            "project-panel",
+            {
+                "name": "project-panel",
+                "label": "Project Panel",
+                "entry": "dist/index.js",
+            },
+        )
+
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        assert "project-panel" not in {p["name"] for p in plugins}
+
+        self._write_plugin_config(tmp_path / "home", enabled=["project-panel"])
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        project = next((p for p in plugins if p["name"] == "project-panel"), None)
+        assert project is not None
+        assert project["source"] == "project"
+
+    def test_mount_refuses_cached_user_plugin_when_not_enabled(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        dash = tmp_path / "plugins" / "side-panel" / "dashboard"
+        dash.mkdir(parents=True)
+        (dash / "api.py").write_text(
+            "from fastapi import APIRouter\nrouter = APIRouter()\n"
+        )
+        web_server._dashboard_plugins_cache = [{
+            "name": "side-panel",
+            "label": "Side Panel",
+            "tab": {"path": "/side-panel", "position": "end"},
+            "slots": [],
+            "entry": "dist/index.js",
+            "css": None,
+            "has_api": True,
+            "source": "user",
+            "_dir": str(dash),
+            "_api_file": "api.py",
+        }]
+
+        with patch("importlib.util.spec_from_file_location") as spec:
+            web_server._mount_plugin_api_routes()
+
+        assert spec.call_count == 0
 
 
 # ---------------------------------------------------------------------------
@@ -186,9 +306,16 @@ class TestDiscoveryScrubsApiField:
     def user_plugin_factory(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         monkeypatch.delenv("HERMES_ENABLE_PROJECT_PLUGINS", raising=False)
+        enabled: set[str] = set()
 
         def _make(name: str, manifest: dict) -> None:
             _write_plugin_manifest(tmp_path / "plugins", name, manifest)
+            enabled.add(name)
+            (tmp_path / "config.yaml").write_text(
+                "plugins:\n"
+                "  enabled:\n"
+                + "".join(f"    - {plugin}\n" for plugin in sorted(enabled))
+            )
 
         return _make
 


### PR DESCRIPTION
## Summary

Fixes #46435

This makes the dashboard plugin loader honor the same `plugins.enabled` / `plugins.disabled` contract used by the runtime plugin loader for unreviewed dashboard plugins.

The change keeps bundled dashboard plugins available by default, but user and project dashboard plugins must now be explicitly enabled before the dashboard advertises their frontend assets or imports their Python API module. `plugins.disabled` wins even if the plugin is also listed in `plugins.enabled`.

The guard is applied in two places:

- discovery: disabled or not-enabled user/project dashboard plugins are not returned by `/api/dashboard/plugins`
- API mounting: cached/tampered plugin entries are rechecked before `plugin_api.py` can be imported

## Tests

- `scripts/run_tests.sh tests/hermes_cli/test_project_plugin_rce_bypass.py`
- `git diff --check`
