### PR TITLE
fix(discord): include thread starter context

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -143,6 +143,93 @@ def _clean_discord_id(entry: str) -> str:
     return entry.strip()
 
 
+def _discord_message_type_value(message_type: Any) -> Optional[int]:
+    """Return a stable integer value for discord.py MessageType-like objects."""
+    value = getattr(message_type, "value", message_type)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _is_thread_starter_message(message: Any) -> bool:
+    """Return True for Discord THREAD_STARTER_MESSAGE system messages."""
+    message_type = getattr(message, "type", None)
+    if _discord_message_type_value(message_type) == 21:
+        return True
+    return str(getattr(message_type, "name", "")).lower() == "thread_starter_message"
+
+
+def _obj_value(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _compact_context_text(value: Any, limit: int) -> str:
+    text = str(value or "").strip()
+    text = re.sub(r"\s+", " ", text)
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)].rstrip() + "…"
+
+
+def _format_discord_message_context(message: Any, *, max_chars: int = 1800) -> str:
+    """Format a Discord message's content/embed payload for prompt context."""
+    if message is None:
+        return ""
+
+    lines: list[str] = ["[Thread started from Discord message]"]
+
+    author = getattr(message, "author", None)
+    author_name = (
+        getattr(author, "display_name", None)
+        or getattr(author, "name", None)
+        or getattr(author, "global_name", None)
+    )
+    if author_name:
+        suffix = " [bot]" if getattr(author, "bot", False) else ""
+        lines.append(f"author: {author_name}{suffix}")
+
+    content = getattr(message, "clean_content", None) or getattr(message, "content", None)
+    if content:
+        lines.append(f"content: {_compact_context_text(content, 700)}")
+
+    for embed in list(getattr(message, "embeds", []) or [])[:3]:
+        title = _obj_value(embed, "title")
+        description = _obj_value(embed, "description")
+        if title:
+            lines.append(f"embed title: {_compact_context_text(title, 240)}")
+        if description:
+            lines.append(f"embed description: {_compact_context_text(description, 700)}")
+        for field in list(_obj_value(embed, "fields", []) or [])[:8]:
+            name = _obj_value(field, "name", "field")
+            value = _obj_value(field, "value", "")
+            if value:
+                lines.append(
+                    f"{_compact_context_text(name, 120)}: "
+                    f"{_compact_context_text(value, 500)}"
+                )
+
+    attachments = list(getattr(message, "attachments", []) or [])
+    if attachments:
+        names = []
+        for att in attachments[:5]:
+            names.append(
+                getattr(att, "filename", None)
+                or getattr(att, "url", None)
+                or "attachment"
+            )
+        lines.append(f"attachments: {', '.join(names)}")
+
+    context = "\n".join(line for line in lines if line.strip())
+    if context == "[Thread started from Discord message]":
+        return ""
+    if len(context) <= max_chars:
+        return context
+    return context[: max(0, max_chars - 1)].rstrip() + "…"
+
+
 def check_discord_requirements() -> bool:
     """Check if Discord dependencies are available.
 
@@ -4213,6 +4300,79 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.warning("[%s] Failed to fetch channel history: %s", self.name, e)
             return ""
 
+    async def _fetch_referenced_message(self, reference: Any, fallback_channel: Any = None) -> Any:
+        """Resolve a Discord message reference to the referenced message."""
+        if reference is None:
+            return None
+
+        resolved = getattr(reference, "resolved", None)
+        if resolved is not None and not isinstance(resolved, int):
+            if _format_discord_message_context(resolved):
+                return resolved
+
+        message_id = getattr(reference, "message_id", None)
+        if message_id is None:
+            return None
+
+        channel = None
+        channel_id = getattr(reference, "channel_id", None)
+        if channel_id is not None and self._client:
+            try:
+                channel = self._client.get_channel(int(channel_id))
+                if channel is None:
+                    channel = await self._client.fetch_channel(int(channel_id))
+            except Exception as exc:
+                logger.debug("[%s] Could not resolve referenced channel %s: %s", self.name, channel_id, exc)
+                channel = None
+
+        channel = channel or fallback_channel
+        fetch_message = getattr(channel, "fetch_message", None)
+        if not fetch_message:
+            return None
+
+        try:
+            return await fetch_message(int(message_id))
+        except Exception as exc:
+            logger.debug("[%s] Could not fetch referenced message %s: %s", self.name, message_id, exc)
+            return None
+
+    async def _fetch_thread_starter_context(
+        self,
+        channel: Any,
+        before: "DiscordMessage",
+    ) -> tuple[Optional[str], Optional[str]]:
+        """Return parent-message context for threads started from a Discord message.
+
+        Discord represents message-started threads with a first system message
+        of type THREAD_STARTER_MESSAGE. That system message has no content of
+        its own; it points back to the parent-channel message via
+        ``message_reference`` / ``referenced_message``.
+        """
+        if not isinstance(channel, discord.Thread):
+            return None, None
+
+        parent = getattr(channel, "parent", None)
+        try:
+            async for msg in channel.history(limit=10, before=before, oldest_first=True):
+                if not _is_thread_starter_message(msg):
+                    continue
+                reference = getattr(msg, "reference", None)
+                starter = await self._fetch_referenced_message(reference, fallback_channel=parent)
+                context = _format_discord_message_context(starter)
+                if context:
+                    starter_id = (
+                        getattr(reference, "message_id", None)
+                        or getattr(starter, "id", None)
+                        or getattr(msg, "id", None)
+                    )
+                    return str(starter_id), context
+                break
+        except discord.Forbidden:
+            logger.debug("[%s] Missing permissions to fetch thread starter context", self.name)
+        except Exception as exc:
+            logger.warning("[%s] Failed to fetch thread starter context: %s", self.name, exc)
+        return None, None
+
     def _thread_parent_channel(self, channel: Any) -> Any:
         """Return the parent text channel when invoked from a thread."""
         return getattr(channel, "parent", None) or channel
@@ -5231,6 +5391,15 @@ class DiscordAdapter(BasePlatformAdapter):
             reply_to_id = str(message.reference.message_id)
             if message.reference.resolved:
                 reply_to_text = getattr(message.reference.resolved, "content", None) or None
+
+        if is_thread and not reply_to_text:
+            starter_id, starter_text = await self._fetch_thread_starter_context(
+                message.channel,
+                before=message,
+            )
+            if starter_text:
+                reply_to_id = starter_id
+                reply_to_text = starter_text
 
         event = MessageEvent(
             text=event_text,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -175,7 +175,11 @@ def _compact_context_text(value: Any, limit: int) -> str:
 
 
 def _format_discord_message_context(message: Any, *, max_chars: int = 1800) -> str:
-    """Format a Discord message's content/embed payload for prompt context."""
+    """Format a Discord message's content/embed payload for prompt context.
+
+    The prompt snippet is intentionally bounded: only the first 3 embeds and
+    first 8 fields per embed are included, with omitted counts noted inline.
+    """
     if message is None:
         return ""
 
@@ -195,14 +199,16 @@ def _format_discord_message_context(message: Any, *, max_chars: int = 1800) -> s
     if content:
         lines.append(f"content: {_compact_context_text(content, 700)}")
 
-    for embed in list(getattr(message, "embeds", []) or [])[:3]:
+    embeds = list(getattr(message, "embeds", []) or [])
+    for embed in embeds[:3]:
         title = _obj_value(embed, "title")
         description = _obj_value(embed, "description")
         if title:
             lines.append(f"embed title: {_compact_context_text(title, 240)}")
         if description:
             lines.append(f"embed description: {_compact_context_text(description, 700)}")
-        for field in list(_obj_value(embed, "fields", []) or [])[:8]:
+        fields = list(_obj_value(embed, "fields", []) or [])
+        for field in fields[:8]:
             name = _obj_value(field, "name", "field")
             value = _obj_value(field, "value", "")
             if value:
@@ -210,6 +216,10 @@ def _format_discord_message_context(message: Any, *, max_chars: int = 1800) -> s
                     f"{_compact_context_text(name, 120)}: "
                     f"{_compact_context_text(value, 500)}"
                 )
+        if len(fields) > 8:
+            lines.append(f"[{len(fields) - 8} more embed fields omitted]")
+    if len(embeds) > 3:
+        lines.append(f"[{len(embeds) - 3} more embeds omitted]")
 
     attachments = list(getattr(message, "attachments", []) or [])
     if attachments:

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -147,17 +147,47 @@ def make_history_message(
     msg_id: int,
     msg_type=None,
     attachments=None,
+    reference=None,
+    embeds=None,
 ):
     return SimpleNamespace(
         id=msg_id,
         author=author,
         content=content,
+        clean_content=content,
         attachments=list(attachments or []),
         type=msg_type if msg_type is not None else discord_platform.discord.MessageType.default,
+        reference=reference,
+        embeds=list(embeds or []),
     )
 
 
 class FakeHistoryChannel(FakeTextChannel):
+    def __init__(self, history_messages, **kwargs):
+        super().__init__(**kwargs)
+        self._history_messages = list(history_messages)
+
+    def history(self, *, limit, before, after=None, oldest_first=None):
+        before_id = int(getattr(before, "id", before))
+        after_id = int(getattr(after, "id", after)) if after is not None else None
+        if oldest_first is None:
+            oldest_first = after is not None
+
+        messages = [
+            message for message in self._history_messages
+            if int(message.id) < before_id
+            and (after_id is None or int(message.id) > after_id)
+        ]
+        messages.sort(key=lambda message: int(message.id), reverse=not oldest_first)
+
+        async def _iter():
+            for message in messages[:limit]:
+                yield message
+
+        return _iter()
+
+
+class FakeHistoryThread(FakeThread):
     def __init__(self, history_messages, **kwargs):
         super().__init__(**kwargs)
         self._history_messages = list(history_messages)
@@ -491,6 +521,101 @@ async def test_discord_thread_participation_tracked_on_dispatch(adapter, monkeyp
     await adapter._handle_message(message)
 
     assert "777" in adapter._threads
+
+
+@pytest.mark.asyncio
+async def test_discord_message_started_thread_injects_parent_alert_context(adapter, monkeypatch):
+    """Thread replies like "fix this" should include the parent alert message."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_THREAD_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter.config.extra["history_backfill"] = True
+    adapter._threads.mark("456")
+
+    parent = FakeTextChannel(channel_id=200, name="infra")
+    alert_author = SimpleNamespace(id=77, display_name="Robusta", name="Robusta", bot=True)
+    alert_embed = SimpleNamespace(
+        title="Clock not synchronising.",
+        description="Clock at 192.168.0.15:9100 is not synchronising.",
+        fields=[
+            SimpleNamespace(name="alertname", value="NodeClockNotSynchronising"),
+            SimpleNamespace(name="instance", value="192.168.0.15:9100"),
+        ],
+    )
+    parent_alert = make_history_message(
+        author=alert_author,
+        content="✅ resolved - :yellow_circle: LOW - **",
+        msg_id=900,
+        embeds=[alert_embed],
+    )
+    starter_reference = SimpleNamespace(
+        message_id=900,
+        channel_id=200,
+        resolved=parent_alert,
+    )
+    starter_message = make_history_message(
+        author=SimpleNamespace(id=0, display_name="Discord", name="Discord", bot=True),
+        content="",
+        msg_id=901,
+        msg_type=21,
+        reference=starter_reference,
+    )
+    thread = FakeHistoryThread(
+        [starter_message],
+        channel_id=456,
+        name="resolved alert",
+        parent=parent,
+    )
+    message = make_message(channel=thread, content="이거 맨날 뜨는거 해결해줘")
+    message.id = 902
+
+    await adapter._handle_message(message)
+
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "이거 맨날 뜨는거 해결해줘"
+    assert event.reply_to_message_id == "900"
+    assert event.reply_to_text is not None
+    assert "[Thread started from Discord message]" in event.reply_to_text
+    assert "Clock not synchronising." in event.reply_to_text
+    assert "NodeClockNotSynchronising" in event.reply_to_text
+    assert "192.168.0.15:9100" in event.reply_to_text
+
+
+@pytest.mark.asyncio
+async def test_discord_thread_starter_context_fetches_unresolved_parent_message(adapter):
+    """If Discord omits referenced_message, fetch the parent message by reference."""
+    parent = FakeTextChannel(channel_id=200, name="infra")
+    parent.fetch_message = AsyncMock(
+        return_value=make_history_message(
+            author=SimpleNamespace(id=77, display_name="Robusta", name="Robusta", bot=True),
+            content="Clock at 192.168.0.15:9100 is not synchronising.",
+            msg_id=900,
+        )
+    )
+    adapter._client.get_channel = lambda channel_id: parent if channel_id == 200 else None
+
+    starter_message = make_history_message(
+        author=SimpleNamespace(id=0, display_name="Discord", name="Discord", bot=True),
+        content="",
+        msg_id=901,
+        msg_type=21,
+        reference=SimpleNamespace(message_id=900, channel_id=200, resolved=None),
+    )
+    thread = FakeHistoryThread(
+        [starter_message],
+        channel_id=456,
+        name="resolved alert",
+        parent=parent,
+    )
+    trigger = make_message(channel=thread, content="이거 해결")
+    trigger.id = 902
+
+    starter_id, context = await adapter._fetch_thread_starter_context(thread, before=trigger)
+
+    assert starter_id == "900"
+    assert context is not None
+    assert "Clock at 192.168.0.15:9100" in context
+    parent.fetch_message.assert_awaited_once_with(900)
 
 
 @pytest.mark.asyncio
@@ -925,5 +1050,3 @@ async def test_discord_auto_thread_skips_backfill(adapter, monkeypatch):
 
     adapter._auto_create_thread.assert_awaited_once()
     adapter._fetch_channel_context.assert_not_awaited()
-
-

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -581,6 +581,26 @@ async def test_discord_message_started_thread_injects_parent_alert_context(adapt
     assert "192.168.0.15:9100" in event.reply_to_text
 
 
+def test_discord_thread_starter_context_notes_omitted_embed_fields():
+    fields = [
+        SimpleNamespace(name=f"field-{idx}", value=f"value-{idx}")
+        for idx in range(15)
+    ]
+    message = make_history_message(
+        author=SimpleNamespace(id=77, display_name="Robusta", name="Robusta", bot=True),
+        content="alert details",
+        msg_id=900,
+        embeds=[SimpleNamespace(title="Alert", description="Many labels", fields=fields)],
+    )
+
+    context = discord_platform._format_discord_message_context(message)
+
+    assert "field-0: value-0" in context
+    assert "field-7: value-7" in context
+    assert "field-8: value-8" not in context
+    assert "[7 more embed fields omitted]" in context
+
+
 @pytest.mark.asyncio
 async def test_discord_thread_starter_context_fetches_unresolved_parent_message(adapter):
     """If Discord omits referenced_message, fetch the parent message by reference."""


### PR DESCRIPTION
## Summary
- include the parent Discord message as reply context when a user replies inside a thread that was started from an existing Discord message
- resolve both embedded `referenced_message` payloads and fallback parent-channel fetches when Discord only provides a message reference
- add regression coverage for Robusta-style alert embeds and unresolved parent-message references

## Why
When an alert message is converted into a Discord thread, follow-up messages often say only things like "fix this" or "why does this keep firing". The bot was resuming the thread session, but the first user turn inside that thread did not include the parent alert content, so the agent could choose the wrong task.

## Validation
- `python -m py_compile plugins/platforms/discord/adapter.py tests/gateway/test_discord_free_response.py`
- mini venv: `python -m pytest -q tests/gateway/test_discord_free_response.py tests/gateway/test_reply_to_injection.py` -> 43 passed