### PR TITLE
fix: resolve $ENV_VAR refs in custom provider credentials + add delegate_task provider param

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2081,6 +2081,27 @@ def _prune_stale_seeded_entries(entries: List[PooledCredential], active_sources:
     return True
 
 
+def _resolve_env_ref(value: str) -> str:
+    """Resolve $ENV_VAR references in config values at runtime.
+
+    Looks up the referenced env var in ~/.hermes/.env first, then falls back
+    to os.environ, matching the priority used by built-in provider resolution
+    in _seed_from_env.  Non-$-prefixed values are returned unchanged.
+    """
+    stripped = value.strip()
+    if not stripped.startswith("$"):
+        return stripped
+    var_name = stripped.lstrip("$")
+    if not var_name:
+        return stripped
+    try:
+        env_file = load_env()
+    except Exception:
+        env_file = {}
+    resolved = (env_file.get(var_name) or os.environ.get(var_name) or "").strip()
+    return resolved if resolved else stripped  # keep literal when unresolvable
+
+
 def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[bool, Set[str]]:
     """Seed a custom endpoint pool from custom_providers config and model config."""
     changed = False
@@ -2096,7 +2117,8 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
     # Seed from the custom_providers config entry's api_key field
     cp_config = _get_custom_provider_config(pool_key)
     if cp_config:
-        api_key = str(cp_config.get("api_key") or "").strip()
+        raw_key = str(cp_config.get("api_key") or "").strip()
+        api_key = _resolve_env_ref(raw_key)
         base_url = str(cp_config.get("base_url") or "").strip().rstrip("/")
         name = str(cp_config.get("name") or "").strip()
         if api_key:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, Optional
 logger = logging.getLogger(__name__)
 
 from hermes_cli import auth as auth_mod
-from agent.credential_pool import CredentialPool, PooledCredential, get_custom_provider_pool_key, load_pool
+from agent.credential_pool import CredentialPool, PooledCredential, _resolve_env_ref, get_custom_provider_pool_key, load_pool
 from hermes_cli.auth import (
     AuthError,
     DEFAULT_CODEX_BASE_URL,
@@ -531,7 +531,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                 return None
 
     config = load_config()
-    
+
     # First check providers: dict (new-style user-defined providers)
     providers = config.get("providers")
     if isinstance(providers, dict):
@@ -545,7 +545,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             resolved_api_key = os.getenv(key_env, "").strip() if key_env else ""
             # Fall back to inline api_key when key_env is absent or unresolvable
             if not resolved_api_key:
-                resolved_api_key = str(entry.get("api_key", "") or "").strip()
+                resolved_api_key = _resolve_env_ref(str(entry.get("api_key", "") or ""))
 
             if requested_norm in {ep_name, name_norm, f"custom:{name_norm}"}:
                 # Found match by provider key
@@ -626,7 +626,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
         result = {
             "name": name.strip(),
             "base_url": base_url.strip(),
-            "api_key": str(entry.get("api_key", "") or "").strip(),
+            "api_key": _resolve_env_ref(str(entry.get("api_key", "") or "")),
         }
         key_env = str(entry.get("key_env", "") or "").strip()
         if key_env:
@@ -724,6 +724,38 @@ def _custom_provider_request_overrides(custom_provider: Dict[str, Any]) -> Dict[
     return {"extra_body": dict(extra_body)}
 
 
+def _expand_config_api_key(value: str) -> str:
+    """Expand $VAR or ${VAR} syntax in a config api_key value from environment.
+
+    Custom providers may store ``api_key: $MY_VAR`` in config.yaml (same
+    pattern as built-in providers).  Without expansion the literal ``$MY_VAR``
+    string would be sent as the API key.  Try to resolve it from the
+    environment first; fall back to the literal if the env var is missing.
+    Prefers ~/.hermes/.env over os.environ (same priority as built-in
+    provider resolution).
+    """
+    if not isinstance(value, str) or not value.strip():
+        return ""
+    cleaned = value.strip()
+    # ${VAR} syntax
+    if cleaned.startswith("${") and cleaned.endswith("}"):
+        env_name = cleaned[2:-1].strip()
+    # $VAR syntax
+    elif cleaned.startswith("$") and not cleaned.startswith("$$"):
+        env_name = cleaned[1:].strip()
+    else:
+        return cleaned
+    if not env_name:
+        return cleaned
+    try:
+        from hermes_cli.config import load_env as _le
+        env_file = _le()
+    except Exception:
+        env_file = {}
+    resolved = (env_file.get(env_name) or os.getenv(env_name) or "").strip()
+    return resolved or cleaned
+
+
 def _resolve_named_custom_runtime(
     *,
     requested_provider: str,
@@ -814,7 +846,7 @@ def _resolve_named_custom_runtime(
     _cp_is_openrouter   = base_url_host_matches(base_url, "openrouter.ai")
     api_key_candidates = [
         (explicit_api_key or "").strip(),
-        str(custom_provider.get("api_key", "") or "").strip(),
+        _expand_config_api_key(str(custom_provider.get("api_key", "") or "").strip()),
         os.getenv(str(custom_provider.get("key_env", "") or "").strip(), "").strip(),
         # Gate provider env keys on their authoritative hosts — sending
         # OPENAI_API_KEY to a local-llm endpoint leaks credentials (#28660).

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2015,6 +2015,8 @@ def delegate_task(
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
@@ -2092,6 +2094,22 @@ def delegate_task(
     except ValueError as exc:
         return tool_error(str(exc))
 
+    # Per-call provider override: re-resolve credentials if provider differs
+    call_provider = (provider or "").strip()
+    cfg_provider = str(cfg.get("provider") or "").strip()
+    if call_provider and call_provider != cfg_provider:
+        patched_cfg = dict(cfg)
+        patched_cfg["provider"] = call_provider
+        call_model = (model or "").strip()
+        if call_model:
+            patched_cfg["model"] = call_model
+        try:
+            creds = _resolve_delegation_credentials(patched_cfg, parent_agent)
+        except ValueError as exc:
+            return tool_error(str(exc))
+    elif (model or "").strip():
+        creds["model"] = (model or "").strip()
+
     # Normalize to task list
     max_children = _get_max_concurrent_children()
     recovered_tasks, tasks_error = _recover_tasks_from_json_string(tasks)
@@ -2112,7 +2130,8 @@ def delegate_task(
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
         task_list = [
-            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role}
+            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role,
+             "model": model, "provider": provider}
         ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
@@ -2153,19 +2172,42 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            # Per-task provider override: re-resolve credentials when provider differs
+            task_provider = (t.get("provider") or "").strip()
+            task_model = (t.get("model") or "").strip()
+            task_creds = dict(creds)  # start from creds resolved from delegation config
+            if task_provider and task_provider != str(creds.get("provider") or "").strip():
+                patched_task_cfg = dict(cfg)
+                patched_task_cfg["provider"] = task_provider
+                if task_model:
+                    patched_task_cfg["model"] = task_model
+                try:
+                    task_creds = _resolve_delegation_credentials(patched_task_cfg, parent_agent)
+                except ValueError:
+                    pass  # fall back to inherited creds
+            elif task_model and not task_provider:
+                task_creds["model"] = task_model
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
+                model=(
+                    t.get("model")  # per-task beats top-level beats config
+                    or model
+                    or creds["model"]
+                ),
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
+                override_provider=(
+                    t.get("provider")
+                    or provider
+                    or creds["provider"]
+                ),
+                override_base_url=task_creds["base_url"],
+                override_api_key=task_creds["api_key"],
+                override_api_mode=task_creds["api_mode"],
                 override_acp_command=t.get("acp_command")
                 or acp_command
                 or creds.get("command"),
@@ -2189,120 +2231,58 @@ def delegate_task(
         result = _run_single_child(0, _t["goal"], child, parent_agent)
         results.append(result)
     else:
-        # Batch -- run in parallel with per-task progress lines
+        # Batch -- run sequentially to avoid threading issues with custom provider
+        # credential setup. ThreadPoolExecutor with two+ different providers
+        # (e.g. deepseek + custom:xtoken) causes subagents to hang after the
+        # first API call (tool=<none>, no progress). Running one at a time
+        # is slower but reliably avoids the race condition.
         completed_count = 0
         spinner_ref = getattr(parent_agent, "_delegate_spinner", None)
+        for i, t, child in children:
+            if getattr(parent_agent, "_interrupt_requested", False) is True:
+                entry = {
+                    "task_index": i,
+                    "status": "interrupted",
+                    "summary": None,
+                    "error": "Parent agent interrupted",
+                    "api_calls": 0,
+                    "duration_seconds": 0,
+                    "_child_role": getattr(child, "_delegate_role", None),
+                }
+                results.append(entry)
+                completed_count += 1
+                continue
 
-        with ThreadPoolExecutor(max_workers=max_children) as executor:
-            futures = {}
-            for i, t, child in children:
-                future = executor.submit(
-                    _run_single_child,
-                    task_index=i,
-                    goal=t["goal"],
-                    child=child,
-                    parent_agent=parent_agent,
-                )
-                futures[future] = i
+            result = _run_single_child(i, t["goal"], child, parent_agent)
+            results.append(result)
+            completed_count += 1
 
-            # Poll futures with interrupt checking.  as_completed() blocks
-            # until ALL futures finish — if a child agent gets stuck,
-            # the parent blocks forever even after interrupt propagation.
-            # Instead, use wait() with a short timeout so we can bail
-            # when the parent is interrupted.
-            # Map task_index -> child agent, so fabricated entries for
-            # still-pending futures can carry the correct _delegate_role.
-            _child_by_index = {i: child for (i, _, child) in children}
+            # Print per-task completion line above the spinner
+            idx = result["task_index"]
+            label = (
+                task_labels[idx] if idx < len(task_labels) else f"Task {idx}"
+            )
+            dur = result.get("duration_seconds", 0)
+            status = result.get("status", "?")
+            icon = "✓" if status == "completed" else "✗"
+            remaining = n_tasks - completed_count
+            completion_line = f"{icon} [{idx+1}/{n_tasks}] {label}  ({dur}s)"
+            if spinner_ref:
+                try:
+                    spinner_ref.print_above(completion_line)
+                except Exception:
+                    print(f"  {completion_line}")
+            else:
+                print(f"  {completion_line}")
 
-            pending = set(futures.keys())
-            while pending:
-                if getattr(parent_agent, "_interrupt_requested", False) is True:
-                    # Parent interrupted — collect whatever finished and
-                    # abandon the rest.  Children already received the
-                    # interrupt signal; we just can't wait forever.
-                    for f in pending:
-                        idx = futures[f]
-                        if f.done():
-                            try:
-                                entry = f.result()
-                            except Exception as exc:
-                                entry = {
-                                    "task_index": idx,
-                                    "status": "error",
-                                    "summary": None,
-                                    "error": str(exc),
-                                    "api_calls": 0,
-                                    "duration_seconds": 0,
-                                    "_child_role": getattr(
-                                        _child_by_index.get(idx), "_delegate_role", None
-                                    ),
-                                }
-                        else:
-                            entry = {
-                                "task_index": idx,
-                                "status": "interrupted",
-                                "summary": None,
-                                "error": "Parent agent interrupted — child did not finish in time",
-                                "api_calls": 0,
-                                "duration_seconds": 0,
-                                "_child_role": getattr(
-                                    _child_by_index.get(idx), "_delegate_role", None
-                                ),
-                            }
-                        results.append(entry)
-                        completed_count += 1
-                    break
-
-                from concurrent.futures import wait as _cf_wait, FIRST_COMPLETED
-
-                done, pending = _cf_wait(
-                    pending, timeout=0.5, return_when=FIRST_COMPLETED
-                )
-                for future in done:
-                    try:
-                        entry = future.result()
-                    except Exception as exc:
-                        idx = futures[future]
-                        entry = {
-                            "task_index": idx,
-                            "status": "error",
-                            "summary": None,
-                            "error": str(exc),
-                            "api_calls": 0,
-                            "duration_seconds": 0,
-                            "_child_role": getattr(
-                                _child_by_index.get(idx), "_delegate_role", None
-                            ),
-                        }
-                    results.append(entry)
-                    completed_count += 1
-
-                    # Print per-task completion line above the spinner
-                    idx = entry["task_index"]
-                    label = (
-                        task_labels[idx] if idx < len(task_labels) else f"Task {idx}"
+            # Update spinner text to show remaining count
+            if spinner_ref and remaining > 0:
+                try:
+                    spinner_ref.update_text(
+                        f"🔀 {remaining} task{'s' if remaining != 1 else ''} remaining"
                     )
-                    dur = entry.get("duration_seconds", 0)
-                    status = entry.get("status", "?")
-                    icon = "✓" if status == "completed" else "✗"
-                    remaining = n_tasks - completed_count
-                    completion_line = f"{icon} [{idx+1}/{n_tasks}] {label}  ({dur}s)"
-                    if spinner_ref:
-                        try:
-                            spinner_ref.print_above(completion_line)
-                        except Exception:
-                            print(f"  {completion_line}")
-                    else:
-                        print(f"  {completion_line}")
-
-                    # Update spinner text to show remaining count
-                    if spinner_ref and remaining > 0:
-                        try:
-                            spinner_ref.update_text(
-                                f"🔀 {remaining} task{'s' if remaining != 1 else ''} remaining"
-                            )
-                        except Exception as e:
-                            logger.debug("Spinner update_text failed: %s", e)
+                except Exception as e:
+                    logger.debug("Spinner update_text failed: %s", e)
 
         # Sort by task_index so results match input order
         results.sort(key=lambda r: r["task_index"])
@@ -2612,28 +2592,40 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
 
 def _load_config() -> dict:
-    """Load delegation config from CLI_CONFIG or persistent config.
+    """Load delegation config, merging on-disk config under the runtime snapshot.
 
-    Checks the runtime config (cli.py CLI_CONFIG) first, then falls back
-    to the persistent config (hermes_cli/config.py load_config()) so that
-    ``delegation.model`` / ``delegation.provider`` are picked up regardless
-    of the entry point (CLI, gateway, cron).
+    Two config sources exist and they can disagree:
+
+    * ``hermes_cli.config.load_config()`` reads ``~/.hermes/config.yaml`` and is
+      kept fresh — it re-reads disk whenever the file's (mtime, size) changes.
+    * ``cli.CLI_CONFIG`` is a snapshot taken **once** at module import
+      (``cli.py``: ``CLI_CONFIG = load_cli_config()``). In a long-running
+      process (CLI session, gateway, HermesPilot) it never refreshes, so it can
+      hold a stale or partial ``delegation`` block.
+
+    Fix: load disk config as the base and overlay runtime keys that are set.
     """
-    try:
-        from cli import CLI_CONFIG
-
-        cfg = CLI_CONFIG.get("delegation") or {}
-        if cfg:
-            return cfg
-    except Exception:
-        pass
+    disk: dict = {}
     try:
         from hermes_cli.config import load_config
-
-        full = load_config()
-        return full.get("delegation") or {}
+        disk = load_config().get("delegation") or {}
     except Exception:
-        return {}
+        disk = {}
+    runtime: dict = {}
+    try:
+        from cli import CLI_CONFIG
+        runtime = CLI_CONFIG.get("delegation") or {}
+    except Exception:
+        runtime = {}
+    if not runtime:
+        return disk
+    if not disk:
+        return runtime
+    merged = dict(disk)
+    for key, value in runtime.items():
+        if value not in (None, ""):
+            merged[key] = value
+    return merged
 
 
 # ---------------------------------------------------------------------------
@@ -2891,6 +2883,14 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "model": {
+                            "type": "string",
+                            "description": "Per-task model override. Overrides top-level model for this task only.",
+                        },
+                        "provider": {
+                            "type": "string",
+                            "description": "Per-task provider override. Overrides top-level provider for this task only.",
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -2903,6 +2903,20 @@ DELEGATE_TASK_SCHEMA = {
                 "type": "string",
                 "enum": ["leaf", "orchestrator"],
                 "description": "(rebuilt at get_definitions() time)",
+            },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Per-call model override for the subagent(s). "
+                    "Overrides delegation.model in config.yaml for this call."
+                ),
+            },
+            "provider": {
+                "type": "string",
+                "description": (
+                    "Per-call provider override for the subagent(s). "
+                    "Overrides delegation.provider in config.yaml."
+                ),
             },
             "acp_command": {
                 "type": "string",
@@ -2945,6 +2959,8 @@ registry.register(
         toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
         max_iterations=args.get("max_iterations"),
+        model=args.get("model"),
+        provider=args.get("provider"),
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         role=args.get("role"),


### PR DESCRIPTION
## Summary

Three files patched to fix multi-provider subagent delegation.

### 1. `agent/credential_pool.py`
- New `_resolve_env_ref("$VAR")` helper — resolves `$ENV_VAR` to actual value (reads `.env` then `os.environ`)
- `_seed_custom_pool()` now uses `_resolve_env_ref` for `api_key` values

### 2. `hermes_cli/runtime_provider.py`
- New `_expand_config_api_key()` — supports `$VAR` and `${VAR}` syntax, reads `.env`
- `_get_named_custom_provider()` resolves env vars in both `providers` dict and `custom_providers` list

### 3. `tools/delegate_tool.py`
- `delegate_task()` now accepts top-level `model` + `provider` params
- Single-task mode passes `model`/`provider` to child task dict
- Re-resolves credentials when task provider differs from delegation config