### PR TITLE
fix(install): kill venv-resident gateway before recreating venv on Windows

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1431,13 +1431,36 @@ function Install-Venv {
     
     if (Test-Path "venv") {
         Write-Info "Virtual environment already exists, recreating..."
-        # On Windows, native Python extensions (e.g. _bcrypt.pyd) are loaded as
-        # DLLs by any running hermes process. Windows denies deletion of loaded
-        # DLLs, so kill any hermes.exe tree before removing the venv.
+        # On Windows, native Python extensions (e.g. _bcrypt.pyd, tornado's
+        # speedups.pyd) are loaded as DLLs by any running hermes process.
+        # Windows denies deletion of loaded DLLs, so every process running out
+        # of this venv must be stopped before removing it -- otherwise
+        # Remove-Item fails with "Access to the path '...' is denied" and the
+        # whole install/update aborts at this stage.
         if ($env:OS -eq "Windows_NT") {
             $myPid = $PID
             Write-Info "Stopping any running hermes processes before recreating venv..."
+            # The launcher CLI (hermes.exe) plus its child tree.
             & taskkill /F /T /IM hermes.exe /FI "PID ne $myPid" 2>$null | Out-Null
+            # taskkill /IM hermes.exe is NOT enough: the gateway/agent that a
+            # scheduled task or watchdog autostarts runs as
+            # `pythonw.exe -m hermes_cli.main gateway run` straight out of
+            # venv\Scripts\, so its image name is python/pythonw, not hermes.exe.
+            # That process holds the venv's .pyd files open and re-triggers the
+            # access-denied failure. Kill anything whose executable lives under
+            # THIS venv, matched by path so the image name does not matter and a
+            # global/system python outside the venv is never touched.
+            $venvRoot = (Join-Path $InstallDir "venv")
+            try {
+                Get-CimInstance Win32_Process -ErrorAction Stop |
+                    Where-Object { $_.ProcessId -ne $myPid -and $_.ExecutablePath -and $_.ExecutablePath -like "$venvRoot\*" } |
+                    ForEach-Object {
+                        Write-Info "  stopping PID $($_.ProcessId) ($($_.Name)) running from venv"
+                        Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue
+                    }
+            } catch {
+                Write-Warn "Could not enumerate venv processes: $($_.Exception.Message)"
+            }
             Start-Sleep -Milliseconds 800
         }
         Remove-Item -Recurse -Force "venv"


### PR DESCRIPTION
## Problem

On Windows, the desktop app re-runs `scripts/install.ps1` on every launch. When an update is pulled it recreates the venv. The existing guard before `Remove-Item venv` only does:

```powershell
& taskkill /F /T /IM hermes.exe /FI "PID ne $myPid"
```

That misses the most common lock-holder. The gateway/agent that a **scheduled task or watchdog autostarts** runs as:

```
pythonw.exe -m hermes_cli.main gateway run    # straight out of venv\Scripts\
```

Its image name is `python`/`pythonw`, not `hermes.exe`, so `taskkill /IM hermes.exe` never matches it. It keeps the venv's native extensions loaded (observed on `tornado\speedups.pyd`; also `_bcrypt.pyd`), so the next line fails:

```
venv → FAILED: Cannot remove item ...\venv\Lib\site-packages\tornado\speedups.pyd:
Access to the path 'speedups.pyd' is denied.
```

The bootstrap aborts at the `venv` stage and the desktop never loads — even though killing the leftover gateway and relaunching fixes it every time.

## Fix

Keep the existing `hermes.exe` taskkill, and additionally stop **any process whose executable lives under the venv being deleted**, matched by path (`ExecutablePath -like "$venvRoot\*"`) so:

- the image name is irrelevant (`python.exe` / `pythonw.exe` / `hermes.exe` all caught), and
- a global/system Python outside the venv is never touched, and the installer's own PID is excluded.

Scoped to `Install-Venv`, Windows-only, no behavior change on other platforms.

## Test

- `[System.Management.Automation.Language.Parser]::ParseFile(...)` → parses cleanly.
- Reproduced the original failure on a live install (gateway autostarted from `venv\Scripts\pythonw.exe` locking `speedups.pyd`); with the leftover venv-resident process stopped, `Remove-Item venv` and the full bootstrap (`venv → dependencies → … → ready`) complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)