### PR TITLE
fix(gateway): cancel pending clarify on interrupt so follow-ups aren't ignored

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3893,6 +3893,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 running_agent.interrupt(event.text)
             except Exception:
                 pass  # don't let interrupt failure block the ack
+            # Wake any clarify wait blocked on a threading.Event so the soft
+            # interrupt can actually take effect (see the PRIORITY interrupt
+            # path for the full rationale). Without this the agent thread sits
+            # in clarify_gateway.wait_for_response() until the 10-minute timeout.
+            try:
+                from tools import clarify_gateway as _clarify_mod
+                if _clarify_mod.has_pending(session_key):
+                    _cancelled = _clarify_mod.clear_session(session_key)
+                    logger.info(
+                        "Busy-ack interrupt cancelled %d pending clarify request(s) "
+                        "for session %s (user sent a follow-up)",
+                        _cancelled, session_key,
+                    )
+            except Exception:
+                pass
 
         # Check if busy ack is disabled — skip sending but still process the input.
         # Placed before debounce so we don't stamp a "last ack" timestamp that was
@@ -7262,6 +7277,27 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return None
             logger.debug("PRIORITY interrupt for session %s", _quick_key)
             running_agent.interrupt(event.text)
+            # The agent thread may be blocked inside clarify_gateway.wait_for_response()
+            # on a threading.Event — exactly like the tool-approval path above. A soft
+            # interrupt() only sets _interrupt_requested; the blocked thread never checks
+            # it until the 10-minute clarify timeout fires, so the user's follow-up appears
+            # ignored for minutes. When the user sends a new message they've moved on, so
+            # the pending clarify is obsolete: cancel it to wake the thread immediately,
+            # letting the agent loop resume and observe the interrupt we just set.
+            try:
+                from tools import clarify_gateway as _clarify_mod
+                if _clarify_mod.has_pending(_quick_key):
+                    _cancelled = _clarify_mod.clear_session(_quick_key)
+                    logger.info(
+                        "PRIORITY interrupt cancelled %d pending clarify request(s) "
+                        "for session %s (user sent a follow-up)",
+                        _cancelled, _quick_key,
+                    )
+            except Exception as _clarify_exc:
+                logger.debug(
+                    "Failed to cancel pending clarify on interrupt for %s: %s",
+                    _quick_key, _clarify_exc,
+                )
             # NOTE: self._pending_messages was write-only (never consumed).
             # The actual interrupt message is delivered via adapter._pending_messages
             # which is read by _run_agent. Removed to prevent unbounded growth.

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -669,3 +669,92 @@ class TestBusySessionOnboardingHint:
         assert "/busy interrupt" in content
         # Must NOT tell the user to /busy queue when they're already on queue.
         assert "/busy queue" not in content
+
+
+class TestInterruptCancelsPendingClarify:
+    """A follow-up message in interrupt mode must cancel a blocked clarify.
+
+    Regression: when the agent thread is blocked inside
+    clarify_gateway.wait_for_response() (a button-choice clarify, which is
+    NOT awaiting free-form text), a soft interrupt only sets a flag — the
+    blocked thread never checks it and sits until the 10-minute clarify
+    timeout. The fix wakes the blocked thread by clearing the session's
+    pending clarify entries whenever an interrupt fires.
+    """
+
+    @pytest.mark.asyncio
+    async def test_busy_ack_interrupt_cancels_pending_clarify(self):
+        from tools import clarify_gateway as cg
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+
+        event = _make_event(text="actually do something else")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {
+            "api_call_count": 2,
+            "max_iterations": 60,
+            "last_activity_desc": "clarify",
+            "seconds_since_activity": 1.0,
+        }
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time() - 5
+
+        # Register a BUTTON-choice clarify (awaiting_text=False) — the kind
+        # that the text-fallback intercept deliberately does NOT resolve.
+        cg.register(
+            clarify_id="clar-busy-1",
+            session_key=sk,
+            question="Which option?",
+            choices=["A", "B", "C"],
+        )
+        try:
+            assert cg.has_pending(sk) is True
+
+            with patch("gateway.run.merge_pending_message_event"):
+                await runner._handle_active_session_busy_message(event, sk)
+
+            # Interrupt was sent AND the blocked clarify was cancelled.
+            agent.interrupt.assert_called_once()
+            assert cg.has_pending(sk) is False
+        finally:
+            cg.clear_session(sk)
+
+    @pytest.mark.asyncio
+    async def test_busy_ack_queue_mode_leaves_clarify_pending(self):
+        """Queue mode does NOT interrupt, so a pending clarify stays alive."""
+        from tools import clarify_gateway as cg
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter()
+
+        event = _make_event(text="a follow-up")
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        runner._running_agents[sk] = agent
+
+        cg.register(
+            clarify_id="clar-queue-1",
+            session_key=sk,
+            question="Which option?",
+            choices=["A", "B"],
+        )
+        try:
+            assert cg.has_pending(sk) is True
+
+            with patch("gateway.run.merge_pending_message_event"):
+                await runner._handle_active_session_busy_message(event, sk)
+
+            # Queue mode must not interrupt, and must leave clarify untouched
+            # (the user may still click a button).
+            agent.interrupt.assert_not_called()
+            assert cg.has_pending(sk) is True
+        finally:
+            cg.clear_session(sk)


### PR DESCRIPTION
## Problem

When the agent asks a **button-choice clarify** (the kind with selectable options, `awaiting_text=False`) and the user — instead of clicking a button — types a new message, the agent appears to hang for minutes before responding.

### Root cause

A button-choice clarify blocks the agent thread inside `clarify_gateway.wait_for_response()` on a `threading.Event`. When a follow-up message arrives in `interrupt` mode, the gateway calls `running_agent.interrupt()` — but that is a *soft* interrupt: it only sets `_interrupt_requested`. The thread blocked on the Event never checks that flag, so it sits until the 10-minute clarify timeout (`agent.clarify_timeout`) fires. The user's follow-up looks ignored.

This is the same class of issue already handled for tool approvals (see the `/approve` / `/deny` path, which signals the blocking `threading.Event` directly rather than relying on a soft interrupt). The clarify path simply lacked the equivalent wake-up.

Note the text-fallback intercept (`get_pending_for_session`) deliberately only resolves `awaiting_text=True` clarifies, so a free-form-text clarify is unaffected — this bug is specific to button-choice clarifies.

## Fix

When an interrupt fires and the session has a pending clarify, wake the blocked thread by clearing the session's pending clarify entries (`clarify_gateway.clear_session()`). A user sending a new message means the prior clarify is obsolete — matching the intuitive UX: *"I said something new, so what you asked me to pick no longer matters."*

Applied to **both** interrupt paths:
- `_handle_active_session_busy_message` (busy-ack path)
- the PRIORITY running-agent fast-path in `_handle_message`

`clear_session()` only touches the clarify module's own registries — it does **not** affect conversation history, session context, or message state. Queue/steer modes are unchanged (they don't interrupt, so a pending clarify stays alive and the user can still click).

## Tests

Added `TestInterruptCancelsPendingClarify` to `tests/gateway/test_busy_session_ack.py`:
- interrupt mode cancels a pending button-choice clarify (and still calls `interrupt()`)
- queue mode leaves the clarify pending (no interrupt, user may still click)

All 20 tests in the file pass on top of current `main`.