### PR TITLE
fix(gateway): bootout stale launchd registration before bootstrap on restart

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3722,10 +3722,15 @@ def launchd_restart():
                 _launchd_fallback_to_detached(f"launchctl kickstart exit {e.returncode}")
                 return
             raise
-        # Job not loaded — bootstrap and start fresh
+        # Job not loaded — bootout any stale registration, then bootstrap fresh.
         print("↻ launchd job was unloaded; reloading")
         plist_path = get_launchd_plist_path()
         try:
+            subprocess.run(
+                ["launchctl", "bootout", target],
+                check=False,
+                timeout=30,
+            )
             subprocess.run(
                 ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
                 check=True,

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -945,6 +945,36 @@ class TestLaunchdServiceRecovery:
 
         assert spawned == [True]
 
+    def test_launchd_restart_bootouts_before_bootstrap_on_unloaded(self, monkeypatch, capsys):
+        """When kickstart reports 'job unloaded', bootout stale registration before bootstrap (#42006)."""
+        target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 5.0)
+        monkeypatch.setattr(gateway_cli, "_request_gateway_self_restart", lambda pid: False)
+        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda timeout, force_after=None: True)
+        monkeypatch.setattr(gateway_cli, "terminate_pid", lambda pid, force=False: None)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            if cmd == ["launchctl", "kickstart", "-k", target]:
+                raise gateway_cli.subprocess.CalledProcessError(
+                    3, cmd, stderr="No such process"
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_restart()
+
+        # Verify bootout is called before bootstrap
+        assert ["launchctl", "bootout", target] in calls
+        bootout_idx = calls.index(["launchctl", "bootout", target])
+        bootstrap_idx = calls.index(["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(gateway_cli.get_launchd_plist_path())])
+        assert bootout_idx < bootstrap_idx, "bootout must precede bootstrap"
+        assert "Service restarted" in capsys.readouterr().out
+
     def test_launchd_stop_tolerates_domain_unsupported_bootout(self, monkeypatch, capsys):
         """bootout exit 125 (macOS 26) must fall through to PID-based kill, not raise."""
         def fake_run(cmd, check=False, **kwargs):


### PR DESCRIPTION
## What does this PR do?

Adds a `launchctl bootout` call before `launchctl bootstrap` in `launchd_restart()` when `kickstart -k` reports the job as unloaded. This prevents bootstrap failure (exit code 5) when the launchd job is merely stopped but still registered.

## Related Issue

Fixes #42006

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py`: Added `subprocess.run(["launchctl", "bootout", target], check=False, timeout=30)` before the `bootstrap` call in the "job not loaded" branch of `launchd_restart()`. This clears any stale registration before re-bootstrapping, matching the pattern already used in `refresh_launchd_plist_if_needed()`.
- `tests/hermes_cli/test_gateway_service.py`: Added `test_launchd_restart_bootouts_before_bootstrap_on_unloaded` verifying that when `kickstart -k` returns exit code 3 (job unloaded), the code calls `bootout` before `bootstrap` and successfully restarts the service.

## How to Test

1. Install Hermes as a launchd service: `hermes gateway install`
2. Kill the gateway process: `kill <gateway_pid>`
3. Run `hermes gateway restart` — previously this would fall back to detached mode with "launchctl exit 5"; now it should successfully restart via launchd
4. Run `pytest tests/hermes_cli/test_gateway_service.py -k launchd_restart -xvs` — all 5 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (macOS-only launchd code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/gateway.py::launchd_restart` (callers: 2, flows: gateway restart)
- Blast radius: LOW — only affects the "job unloaded" branch of `launchd_restart()`, which currently falls back to detached mode anyway
- Related patterns: `refresh_launchd_plist_if_needed()` already uses the bootout-before-bootstrap pattern (line 3472)
