### PR TITLE
fix: keep interval cron jobs on scheduled cadence

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -44,6 +44,7 @@ JOBS_FILE = CRON_DIR / "jobs.json"
 _jobs_file_lock = threading.Lock()
 OUTPUT_DIR = CRON_DIR / "output"
 ONESHOT_GRACE_SECONDS = 120
+EARLY_DUE_GRACE_SECONDS = 2
 
 # Fields on a cron job that must never change after creation. ``id`` is used
 # as a filesystem path component under ``OUTPUT_DIR``; allowing it to be
@@ -879,6 +880,7 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
         for i, job in enumerate(jobs):
             if job["id"] == job_id:
                 now = _hermes_now().isoformat()
+                previous_next_run_at = job.get("next_run_at")
                 job["last_run_at"] = now
                 job["last_status"] = "ok" if success else "error"
                 job["last_error"] = error if not success else None
@@ -898,8 +900,27 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                         save_jobs(jobs)
                         return
                 
-                # Compute next run
-                job["next_run_at"] = compute_next_run(job["schedule"], now)
+                # Compute next run. For recurring jobs, preserve the scheduled
+                # grid instead of anchoring to actual completion time. The
+                # scheduler pre-advances next_run_at before execution for
+                # crash safety; if that future slot is already present, keep
+                # it. If mark_job_run() is called without a prior advance,
+                # advance from the previous scheduled slot rather than from
+                # ``now`` so small ticker jitter does not become interval+tick
+                # cadence drift.
+                schedule_kind = job.get("schedule", {}).get("kind")
+                if schedule_kind in {"cron", "interval"} and previous_next_run_at:
+                    try:
+                        previous_next_dt = _ensure_aware(datetime.fromisoformat(previous_next_run_at))
+                        now_dt = _ensure_aware(datetime.fromisoformat(now))
+                        if previous_next_dt > now_dt:
+                            job["next_run_at"] = previous_next_run_at
+                        else:
+                            job["next_run_at"] = compute_next_run(job["schedule"], previous_next_run_at)
+                    except Exception:
+                        job["next_run_at"] = compute_next_run(job["schedule"], now)
+                else:
+                    job["next_run_at"] = compute_next_run(job["schedule"], now)
 
                 # If no next run, decide whether this is terminal completion
                 # (one-shot) or a transient failure (recurring schedule couldn't
@@ -955,8 +976,13 @@ def advance_next_run(job_id: str) -> bool:
                 kind = job.get("schedule", {}).get("kind")
                 if kind not in {"cron", "interval"}:
                     return False
-                now = _hermes_now().isoformat()
-                new_next = compute_next_run(job["schedule"], now)
+                # Advance from the existing scheduled slot, not from wall-clock
+                # now. Otherwise a ticker that arrives milliseconds before the
+                # stored due timestamp misses the run, and the subsequent
+                # actual execution time becomes the new anchor, creating a
+                # repeatable interval+tick cadence.
+                anchor = job.get("next_run_at") or _hermes_now().isoformat()
+                new_next = compute_next_run(job["schedule"], anchor)
                 if new_next and new_next != job.get("next_run_at"):
                     job["next_run_at"] = new_next
                     save_jobs(jobs)
@@ -1030,7 +1056,7 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
                     break
 
         next_run_dt = _ensure_aware(datetime.fromisoformat(next_run))
-        if next_run_dt <= now:
+        if next_run_dt <= now + timedelta(seconds=EARLY_DUE_GRACE_SECONDS):
             schedule = job.get("schedule", {})
             kind = schedule.get("kind")
 
@@ -1038,7 +1064,8 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
             # (gateway was down and missed the window). Fast-forward to
             # the next future occurrence instead of firing a stale run.
             grace = _compute_grace_seconds(schedule)
-            if kind in {"cron", "interval"} and (now - next_run_dt).total_seconds() > grace:
+            lateness = (now - next_run_dt).total_seconds()
+            if kind in {"cron", "interval"} and lateness > grace:
                 # Job is past its catch-up grace window — this is a stale missed run.
                 # Grace scales with schedule period: daily=2h, hourly=30m, 10min=5m.
                 new_next = compute_next_run(schedule, now.isoformat())

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -502,6 +502,45 @@ class TestMarkJobRun:
         assert updated["last_error"] == "model timeout"
         assert updated["last_delivery_error"] == "platform 'discord' not enabled"
 
+    def test_recurring_mark_preserves_preadvanced_future_slot(self, tmp_cron_dir, monkeypatch):
+        """mark_job_run must not re-anchor recurring jobs to completion time.
+
+        tick() advances next_run_at before execution for crash safety. If the
+        completion path overwrites that future slot with now+interval, small
+        gateway ticker jitter becomes a permanent interval+tick cadence.
+        """
+        now = datetime(2026, 6, 15, 10, 5, 0, 500000, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = create_job(prompt="Heartbeat", schedule="every 5m")
+        preadvanced_slot = "2026-06-15T10:10:00+00:00"
+        jobs = load_jobs()
+        jobs[0]["next_run_at"] = preadvanced_slot
+        save_jobs(jobs)
+
+        mark_job_run(job["id"], success=True)
+
+        updated = get_job(job["id"])
+        assert updated is not None
+        assert updated["next_run_at"] == preadvanced_slot
+        assert updated["last_run_at"] == now.isoformat()
+
+    def test_recurring_mark_advances_from_due_slot_without_preadvance(self, tmp_cron_dir, monkeypatch):
+        """Fallback path still uses the scheduled slot, not completion time."""
+        now = datetime(2026, 6, 15, 10, 5, 0, 500000, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = create_job(prompt="Heartbeat", schedule="every 5m")
+        due_slot = "2026-06-15T10:05:00+00:00"
+        jobs = load_jobs()
+        jobs[0]["next_run_at"] = due_slot
+        save_jobs(jobs)
+
+        mark_job_run(job["id"], success=True)
+
+        updated = get_job(job["id"])
+        assert updated is not None
+        assert updated["next_run_at"] == "2026-06-15T10:10:00+00:00"
+        assert updated["next_run_at"] != "2026-06-15T10:10:00.500000+00:00"
+
     def test_recurring_cron_not_disabled_when_croniter_missing(self, tmp_cron_dir, monkeypatch):
         """Regression test for issue #16265.
 
@@ -516,7 +555,10 @@ class TestMarkJobRun:
         assert job["schedule"]["kind"] == "cron"
 
         # Simulate the runtime env having lost croniter between job creation
-        # and this run.
+        # and a due run that was not successfully pre-advanced.
+        jobs = load_jobs()
+        jobs[0]["next_run_at"] = datetime.now().astimezone().isoformat()
+        save_jobs(jobs)
         monkeypatch.setattr("cron.jobs.HAS_CRONITER", False)
 
         mark_job_run(job["id"], success=True)
@@ -542,7 +584,12 @@ class TestMarkJobRun:
 
         # Force compute_next_run to return None for this call — simulates
         # any future regression where a recurring schedule loses its
-        # next-run computation (missing dep, corrupt schedule, etc.).
+        # next-run computation (missing dep, corrupt schedule, etc.). Use a
+        # due next_run_at so mark_job_run() must compute rather than preserve
+        # a pre-advanced future slot.
+        jobs = load_jobs()
+        jobs[0]["next_run_at"] = datetime.now().astimezone().isoformat()
+        save_jobs(jobs)
         monkeypatch.setattr("cron.jobs.compute_next_run", lambda *a, **kw: None)
 
         mark_job_run(job["id"], success=True)
@@ -604,6 +651,28 @@ class TestAdvanceNextRun:
         from cron.jobs import _ensure_aware, _hermes_now
         new_next_dt = _ensure_aware(datetime.fromisoformat(updated["next_run_at"]))
         assert new_next_dt > _hermes_now(), "next_run_at should be in the future after advance"
+
+    def test_advances_interval_from_scheduled_slot_not_wall_clock(self, tmp_cron_dir, monkeypatch):
+        """A slightly-future due slot must not become now+interval.
+
+        This is the core regression for interval jobs firing every
+        interval+60s under the gateway's 60s ticker.
+        """
+        now = datetime(2026, 6, 15, 10, 5, 0, 500000, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = create_job(prompt="Heartbeat", schedule="every 5m")
+        scheduled_slot = "2026-06-15T10:05:00.800000+00:00"
+        jobs = load_jobs()
+        jobs[0]["next_run_at"] = scheduled_slot
+        save_jobs(jobs)
+
+        result = advance_next_run(job["id"])
+
+        assert result is True
+        updated = get_job(job["id"])
+        assert updated is not None
+        assert updated["next_run_at"] == "2026-06-15T10:10:00.800000+00:00"
+        assert updated["next_run_at"] != "2026-06-15T10:10:00.500000+00:00"
 
     def test_advances_cron_job(self, tmp_cron_dir):
         """Cron-expression jobs should have next_run_at bumped to the next occurrence."""
@@ -670,6 +739,34 @@ class TestAdvanceNextRun:
 
 
 class TestGetDueJobs:
+    def test_slightly_future_due_within_early_grace_returned(self, tmp_cron_dir, monkeypatch):
+        """Ticker calls that arrive milliseconds early should still fire.
+
+        Without this, a next_run_at that is just after the current 60s ticker
+        pass waits for the next ticker and effectively adds 60s to every
+        interval run.
+        """
+        now = datetime(2026, 6, 15, 10, 5, 0, 500000, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        job = create_job(prompt="Due almost now", schedule="every 5m")
+        jobs = load_jobs()
+        jobs[0]["next_run_at"] = "2026-06-15T10:05:01+00:00"
+        save_jobs(jobs)
+
+        due = get_due_jobs()
+
+        assert [j["id"] for j in due] == [job["id"]]
+
+    def test_future_beyond_early_grace_not_returned(self, tmp_cron_dir, monkeypatch):
+        now = datetime(2026, 6, 15, 10, 5, 0, 500000, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+        create_job(prompt="Not quite due", schedule="every 5m")
+        jobs = load_jobs()
+        jobs[0]["next_run_at"] = "2026-06-15T10:05:03+00:00"
+        save_jobs(jobs)
+
+        assert get_due_jobs() == []
+
     def test_past_due_within_window_returned(self, tmp_cron_dir):
         """Jobs within the dynamic grace window are still considered due (not stale).
 


### PR DESCRIPTION
## Summary

Fix interval cron jobs drifting to `interval + gateway tick` cadence by keeping recurring schedules anchored to their scheduled slot instead of the actual completion timestamp.

## Problem

The gateway cron ticker runs every 60 seconds. If an interval job's `next_run_at` lands a few milliseconds after the ticker pass, it misses that tick and fires on the next one. Because completion time was then used as the next interval anchor, the extra 60 seconds became permanent for every subsequent run.

Observed locally:

- `every 5m` job firing every ~6 minutes
- `every 15m` job firing every ~16 minutes

## Fix

- Add a small `EARLY_DUE_GRACE_SECONDS = 2` window so jobs due milliseconds after the current tick are treated as due.
- Make `advance_next_run()` advance from the existing scheduled slot instead of wall-clock now.
- Make `mark_job_run()` preserve a pre-advanced future slot, or advance from the previous scheduled slot when pre-advance did not happen.
- Keep recurring jobs on their schedule grid while preserving at-most-once semantics.

## Tests

Added regression coverage for:

- preserving pre-advanced future slots
- advancing from the due scheduled slot instead of completion time
- due-within-grace behavior
- future-beyond-grace behavior

Validation run locally:

```text
python -m pytest tests/cron/test_jobs.py -q -o 'addopts='
92 passed, 1 warning

python -m pytest tests/cron -q -o 'addopts='
442 passed, 2 warnings
```

## Live verification

After gateway restart on patched code, the `ct109-claude-secret-request-watchdog` next run advanced on the scheduled 5-minute grid:

```text
14:41:58 -> 14:46:58
```

Actual run time was later due to ticker timing, but the next schedule no longer re-anchored to that delayed completion time.
