### PR TITLE
fix: prevent guardrail and desktop duplicate messages

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3924,7 +3924,6 @@ def run_conversation(
                         if agent.stream_delta_callback:
                             try:
                                 agent.stream_delta_callback(final_response)
-                                agent.stream_delta_callback(None)
                             except Exception:
                                 pass
                     break

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -176,6 +176,26 @@ describe('renderMediaTags', () => {
 })
 
 describe('preserveLocalAssistantErrors', () => {
+  it('does not preserve local assistant errors into an empty/new transcript', () => {
+    const currentMessages: ChatMessage[] = [
+      {
+        id: 'local-user',
+        parts: [{ text: 'unsent prompt', type: 'text' }],
+        role: 'user'
+      },
+      {
+        error: 'OpenRouter 403',
+        id: 'local-assistant-error',
+        parts: [],
+        role: 'assistant'
+      }
+    ]
+
+    const merged = preserveLocalAssistantErrors([], currentMessages)
+
+    expect(merged).toEqual([])
+  })
+
   it('preserves a local user+error pair when hydration omits the failed turn', () => {
     const nextMessages: ChatMessage[] = [
       {

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -825,6 +825,10 @@ export function preserveLocalAssistantErrors(
   nextMessages: ChatMessage[],
   currentMessages: ChatMessage[]
 ): ChatMessage[] {
+  if (nextMessages.length === 0) {
+    return nextMessages
+  }
+
   const localById = new Map(currentMessages.map(message => [message.id, message]))
 
   const mergedNextMessages = nextMessages.map(message => {

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -353,3 +353,8 @@ def test_guardrail_halt_emits_final_response_through_stream_delta_callback():
     assert halt_text in text_deltas, (
         f"halt message was never streamed; callback only saw {deltas!r}"
     )
+    assert deltas[-1] == halt_text, (
+        "guardrail halt text is final turn content; a trailing None would be "
+        "misinterpreted by gateway streaming as a tool/segment boundary and "
+        "allow the normal final-send path to deliver the same text again"
+    )


### PR DESCRIPTION
## Summary

Fixes two recent issues:

- Fixes #46731 by treating guardrail halt text as final streamed content instead of following it with a `None` segment-boundary callback. That trailing boundary made the gateway believe the final content had not been delivered and allowed the normal final-send path to duplicate the same error message.
- Fixes #46732 by preventing `preserveLocalAssistantErrors()` from carrying stale local failed/unsent assistant errors into an empty/new desktop transcript. Empty transcripts have no same-session anchor, so they should remain empty.

## Latest PR checked

I reviewed latest open PR #46729 (`fix(telegram): keep status notices off rich path`). This change is separate: #46729 routes Telegram operational notices away from rich messages and fixes General-topic draft routing; this PR fixes guardrail final-stream duplication and desktop local-error transcript leakage.

## Test plan

- `uv run pytest tests/run_agent/test_tool_call_guardrail_runtime.py::test_guardrail_halt_emits_final_response_through_stream_delta_callback tests/gateway/test_stream_consumer_fresh_final.py::TestSegmentBreakDoesNotMarkFinalSent::test_preamble_fresh_final_at_tool_boundary_does_not_mark_final -q`
- `uv run pytest tests/run_agent/test_tool_call_guardrail_runtime.py tests/gateway/test_duplicate_reply_suppression.py tests/gateway/test_stream_consumer_fresh_final.py -q`
- `npm exec --workspace apps/desktop -- vitest run src/lib/chat-messages.test.ts --environment jsdom`
- `python3 -m compileall -q agent/conversation_loop.py run_agent.py`
- `git diff --check`

Known local blocker: `npm exec --workspace apps/desktop -- vitest run src/lib/chat-messages.test.ts src/app/session/hooks/use-session-actions.test.tsx --environment jsdom` fails before tests because local install cannot resolve `@testing-library/react`; the targeted `chat-messages` regression suite passes.
