### PR TITLE
feat(telegram): auto-enable rich messages for tables

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -419,11 +419,14 @@ class TelegramAdapter(BasePlatformAdapter):
         self._mention_patterns = self._compile_mention_patterns()
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
         self._disable_link_previews: bool = self._coerce_bool_extra("disable_link_previews", False)
-        # Bot API 10.1 Rich Messages: when explicitly enabled, send final
-        # replies via sendRichMessage with the raw agent markdown so
-        # tables/task lists/etc. render natively. Disabled by default because
-        # several Telegram clients accept but render rich messages poorly.
-        self._rich_messages_enabled: bool = self._coerce_bool_extra("rich_messages", False)
+        # Bot API 10.1 Rich Messages: default to "auto" so rich-only markdown
+        # constructs (tables, task lists, display math) render natively while
+        # ordinary text stays on the battle-tested MarkdownV2 path. Operators
+        # can still force "always"/true or disable with false/"off".
+        self._rich_messages_mode: str = self._coerce_rich_messages_mode(
+            self.config.extra.get("rich_messages", "auto")
+        )
+        self._rich_messages_enabled: bool = self._rich_messages_mode != "off"
         # Latched off after a capability failure on sendRichMessage /
         # sendRichMessageDraft (e.g. older python-telegram-bot without the
         # endpoint) so later sends skip the doomed rich attempt entirely.
@@ -912,6 +915,47 @@ class TelegramAdapter(BasePlatformAdapter):
             return default
         return bool(value)
 
+    @staticmethod
+    def _coerce_rich_messages_mode(value: Any) -> str:
+        """Normalize ``extra.rich_messages`` to off/auto/always.
+
+        Backwards compatible with the previous boolean contract:
+        ``true`` means force rich for all final messages, ``false`` disables
+        rich entirely. The new default string ``auto`` only uses rich delivery
+        for Markdown constructs the legacy MarkdownV2 path cannot preserve.
+        """
+        if isinstance(value, str):
+            lowered = value.strip().lower()
+            if lowered in {"auto", "smart", "needed"}:
+                return "auto"
+            if lowered in {"true", "1", "yes", "on", "always", "all"}:
+                return "always"
+            if lowered in {"false", "0", "no", "off", "never"}:
+                return "off"
+            return "auto"
+        return "always" if bool(value) else "off"
+
+    @staticmethod
+    def _content_needs_rich_markdown(content: str) -> bool:
+        """True for Markdown constructs degraded by sendMessage+MarkdownV2."""
+        if not content:
+            return False
+        if "|" in content and any(
+            _TABLE_SEPARATOR_RE.match(line) for line in content.splitlines()
+        ):
+            return True
+        if re.search(r"(?m)^\s*\$\$[\s\S]*?\$\$\s*$", content):
+            return True
+        if re.search(r"(?m)^```math\b", content):
+            return True
+        if re.search(r"(?m)^\s*[-*+]\s+\[[ xX]\]\s+", content):
+            return True
+        return False
+
+    def _rich_mode_allows_content(self, content: str) -> bool:
+        mode = getattr(self, "_rich_messages_mode", "off")
+        return mode == "always" or (mode == "auto" and self._content_needs_rich_markdown(content))
+
     def _link_preview_kwargs(self) -> Dict[str, Any]:
         if not getattr(self, "_disable_link_previews", False):
             return {}
@@ -988,6 +1032,7 @@ class TelegramAdapter(BasePlatformAdapter):
             and not (metadata or {}).get("expect_edits")
             and content
             and content.strip()
+            and self._rich_mode_allows_content(content)
             and not self._has_telegram_desktop_details_math_crash_shape(content)
             and self._content_fits_rich_limits(content)
             and self._bot_supports_rich()
@@ -1020,6 +1065,7 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         if (
             getattr(self, "_rich_messages_enabled", False)
+            and getattr(self, "_rich_messages_mode", "off") == "always"
             and not getattr(self, "_rich_send_disabled", False)
             and self._bot_supports_rich()
         ):
@@ -1214,6 +1260,7 @@ class TelegramAdapter(BasePlatformAdapter):
             and not getattr(self, "_rich_draft_disabled", False)
             and content
             and content.strip()
+            and self._rich_mode_allows_content(content)
             and not self._has_telegram_desktop_details_math_crash_shape(content)
             and self._content_fits_rich_limits(content)
             and self._bot_supports_rich()

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -184,7 +184,7 @@ async def test_rich_messages_opt_out_accepts_string_false():
 
 
 @pytest.mark.asyncio
-async def test_rich_messages_default_is_disabled():
+async def test_rich_messages_default_auto_sends_structured_markdown():
     config = PlatformConfig(enabled=True, token="fake-token")
     adapter = TelegramAdapter(config)
     bot = MagicMock()
@@ -196,8 +196,23 @@ async def test_rich_messages_default_is_disabled():
     result = await adapter.send("12345", RICH_CONTENT)
 
     assert result.success is True
-    bot = adapter._bot
-    assert bot is not None
+    bot.do_api_request.assert_awaited_once()
+    bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rich_messages_default_auto_keeps_plain_text_on_legacy_path():
+    config = PlatformConfig(enabled=True, token="fake-token")
+    adapter = TelegramAdapter(config)
+    bot = MagicMock()
+    bot.do_api_request = AsyncMock(return_value=SimpleNamespace(message_id=123))
+    bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
+    bot.send_chat_action = AsyncMock()
+    adapter._bot = bot
+
+    result = await adapter.send("12345", "Plain **bold** text")
+
+    assert result.success is True
     bot.do_api_request.assert_not_called()
     bot.send_message.assert_awaited()
 

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -138,6 +138,33 @@ hermes gateway
 
 The bot should come online within seconds. Send it a message on Telegram to verify.
 
+### Rich message formatting
+
+Hermes uses Telegram Bot API Rich Messages automatically for Markdown constructs
+that Telegram's legacy `sendMessage` + MarkdownV2 path cannot render natively,
+including tables, task lists, and display math. Plain messages still use the
+legacy path by default for maximum client compatibility.
+
+You can override the default in `config.yaml` under the Telegram platform
+`extra` block:
+
+```yaml
+platforms:
+  telegram:
+    extra:
+      rich_messages: auto    # default: auto | always | off
+```
+
+- `auto` — use rich messages only when needed for tables/task lists/math
+- `always` or `true` — send all final messages through `sendRichMessage`
+- `off` or `false` — disable rich messages entirely
+
+Restart the gateway after changing this setting:
+
+```bash
+hermes gateway restart
+```
+
 ## Sending Generated Files from Docker-backed Terminals
 
 If your terminal backend is `docker`, keep in mind that Telegram attachments are


### PR DESCRIPTION
## Summary

- Defaults Telegram rich messages to `auto` instead of fully disabled
- Uses `sendRichMessage` only for Markdown constructs the legacy MarkdownV2 path degrades: tables, task lists, display math, and ```math blocks
- Keeps ordinary messages on the existing `sendMessage` + MarkdownV2 path for client compatibility
- Preserves existing `rich_messages: true/false` behavior and adds documented `auto | always | off` modes

## Why

Telegram Bot API 10.1 supports native Rich Messages. Hermes already has the rich send path, but users must opt in globally, which means tables still degrade by default. This change makes the safe case automatic: only content that needs Rich Messages takes the rich path.

## Test Plan

- `python -m py_compile gateway/platforms/telegram.py`
- `uv run --with pytest --with pytest-asyncio python -m pytest tests/gateway/test_telegram_format.py tests/gateway/test_telegram_rich_messages.py -q -o 'addopts='`

Result: `144 passed`
