### PR TITLE
ci(security): include bridge lockfiles in OSV scan

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -42,12 +42,14 @@ jobs:
     name: Scan lockfiles
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
     with:
-      # Scan explicit lockfiles rather than recursing, so we only look at
-      # the three sources of truth and skip vendored / test / worktree dirs.
+      # Scan only the five tracked lockfiles, skipping vendored, test, and
+      # worktree directories.
       scan-args: |-
         --lockfile=uv.lock
         --lockfile=package-lock.json
         --lockfile=website/package-lock.json
+        --lockfile=scripts/whatsapp-bridge/package-lock.json
+        --lockfile=plugins/platforms/photon/sidecar/package-lock.json
       # The upstream reusable workflow uploads this exact file under its
       # fixed artifact name, which the wrapper downloads below.
       results-file-name: osv-results.sarif


### PR DESCRIPTION
## Summary
- Add the WhatsApp bridge lockfile to the OSV scan
- Add the Photon sidecar lockfile to the OSV scan
- Keep the current inline scanner and reporting steps from `main`

Fixes #46738.

## Validation
- Parsed `.github/workflows/osv-scanner.yml` with PyYAML
- Confirmed all five configured lockfiles exist and are passed to the scanner
- Confirmed the scanner still uses `continue-on-error: true`
- Prettier passed
- zizmor reported no findings
- `git diff --check` passed
