### PR TITLE
fix(desktop): add ready-to-show fallback for Wayland-in-VM

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -5197,6 +5197,19 @@ function createWindow() {
     if (mainWindow && !mainWindow.isDestroyed()) mainWindow.show()
   })
 
+  // Wayland-in-VM (e.g. GNOME-on-Wayland in a Proxmox/KVM guest accessed via
+  // VNC, with no DRM render node and no xdg-desktop-portal) can finish loading
+  // the renderer but never deliver the first-paint signal that backs
+  // ready-to-show, so the window — created with show:false — stays hidden
+  // forever. Force show after 4s if ready-to-show hasn't fired yet; the
+  // renderer keeps streaming frames once a surface is mapped, so a
+  // slightly-empty first paint is fine.
+  setTimeout(() => {
+    if (mainWindow && !mainWindow.isDestroyed() && !mainWindow.isVisible()) {
+      try { mainWindow.show() } catch { /* destroyed mid-call */ }
+    }
+  }, 4000)
+
   mainWindow.on('will-enter-full-screen', () => sendWindowStateChanged(true))
   mainWindow.on('enter-full-screen', () => sendWindowStateChanged(true))
   mainWindow.on('will-leave-full-screen', () => sendWindowStateChanged(false))


### PR DESCRIPTION
## Summary
Add a fallback timer that force-shows the Electron window after 4 seconds if `ready-to-show` never fires. This fixes the blank/hidden window problem on Wayland-in-VM environments.

## Problem
On some Wayland compositors in VM environments (GNOME-on-Wayland in Proxmox/KVM without GPU passthrough), Electron's `ready-to-show` event never fires because the compositor never confirms the first frame commit. 

The main window is created with `show: false` and only shown when `ready-to-show` fires. Since it never fires, `mainWindow.show()` is never called and the window stays permanently hidden — even though:
- The renderer loads successfully (`did-finish-load` fires)
- The backend starts normally (`Hermes backend is ready`)
- All processes are alive

## Fix
Added a 4-second `setTimeout` fallback after the `ready-to-show` handler. If `ready-to-show` hasn't fired by then, the window is force-shown.

On normal environments where `ready-to-show` fires promptly, this is a no-op (window is already visible by then, so `!mainWindow.isVisible()` is false).

## Verification
- 13-line addition to `apps/desktop/electron/main.cjs`
- No behavior change on normal desktop environments (macOS, Windows, GPU-accelerated Linux)
- On affected Wayland-in-VM setups, the window now appears after 4s instead of staying hidden forever

Fixes #46523