### PR TITLE
fix(gateway): cancel blocked button-clarify when user types instead of clicking

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4029,6 +4029,33 @@ class BasePlatformAdapter(ABC):
                 except Exception:
                     _has_text_clarify = False
 
+                # Button-choice clarify (awaiting_text=False) that the user
+                # IGNORED by typing instead of clicking. get_pending_for_session
+                # only returns text-awaiting entries, so the bypass above misses
+                # these — the agent thread stays blocked in
+                # clarify_gateway.wait_for_response() on a threading.Event and the
+                # typed message gets queued as a follow-up that never runs (the
+                # current turn never ends), so the user sees a multi-minute hang
+                # until the 10-minute clarify timeout. A new message means the
+                # prior clarify is obsolete: cancel it here so the blocked thread
+                # wakes immediately and the current turn can finish, then let this
+                # message fall through to normal busy handling (interrupt/queue).
+                if not _has_text_clarify:
+                    try:
+                        from tools import clarify_gateway as _clarify_mod2
+                        if _clarify_mod2.has_pending(session_key):
+                            _cancelled = _clarify_mod2.clear_session(session_key)
+                            logger.info(
+                                "[%s] Cancelled %d pending button-clarify for %s "
+                                "(user typed a new message instead of clicking)",
+                                self.name, _cancelled, session_key,
+                            )
+                    except Exception as _btn_clarify_exc:
+                        logger.debug(
+                            "[%s] Failed to cancel button-clarify for %s: %s",
+                            self.name, session_key, _btn_clarify_exc,
+                        )
+
                 if _has_text_clarify:
                     logger.debug(
                         "[%s] Routing message to clarify text-intercept for %s",

--- a/tests/gateway/test_active_session_text_merge.py
+++ b/tests/gateway/test_active_session_text_merge.py
@@ -376,3 +376,96 @@ def test_busy_text_mode_respects_env_var_override(monkeypatch):
     adapter = _make_initialized_adapter()
     assert adapter._busy_text_mode == "interrupt"
     assert not adapter._is_queue_text_debounce_candidate(_make_event("test"))
+
+
+@pytest.mark.asyncio
+async def test_typing_cancels_pending_button_clarify():
+    """A typed follow-up must cancel a blocked BUTTON-choice clarify.
+
+    Regression: button-choice clarify (awaiting_text=False) blocks the agent
+    thread in clarify_gateway.wait_for_response() on a threading.Event.
+    get_pending_for_session() only returns text-awaiting entries, so the
+    existing clarify text-intercept missed button clarifies entirely — a typed
+    message got queued as a follow-up that never ran (the current turn never
+    ends), so the user saw a multi-minute hang until the 10-minute timeout.
+
+    The fix cancels the pending button-clarify inside handle_message so the
+    blocked thread wakes immediately, letting the current turn finish.
+    """
+    import threading
+    from tools import clarify_gateway as cg
+
+    adapter = _make_adapter()
+    adapter._busy_text_mode = ""  # direct path, no debounce
+    event = _make_event("actually never mind, do this instead")
+    session_key = build_session_key(event.source)
+    adapter._active_sessions[session_key] = asyncio.Event()
+
+    # Register a BUTTON-choice clarify (awaiting_text=False).
+    cg.register(
+        clarify_id="cid-button",
+        session_key=session_key,
+        question="Which one?",
+        choices=["A", "B", "C"],
+    )
+
+    # Simulate the agent thread blocked waiting for the user to click.
+    woke = {"done": False}
+
+    def _blocked_agent():
+        cg.wait_for_response("cid-button", timeout=30)
+        woke["done"] = True
+
+    t = threading.Thread(target=_blocked_agent)
+    t.start()
+    try:
+        await asyncio.sleep(0.1)
+        assert t.is_alive()  # genuinely blocked
+        assert cg.has_pending(session_key) is True
+        assert cg.get_pending_for_session(session_key) is None  # button-type
+
+        # User types instead of clicking.
+        await adapter.handle_message(event)
+
+        # The blocked thread must have been woken by the cancel.
+        t.join(timeout=5)
+        assert woke["done"] is True
+        assert cg.has_pending(session_key) is False
+    finally:
+        cg.clear_session(session_key)
+        t.join(timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_typing_leaves_textawaiting_clarify_for_intercept():
+    """A free-form (awaiting_text=True) clarify must NOT be cancelled here.
+
+    Those are resolved by the existing text-intercept (the typed message IS
+    the answer), so the button-cancel branch must leave them alone.
+    """
+    from tools import clarify_gateway as cg
+
+    adapter = _make_adapter()
+    adapter._busy_text_mode = ""
+    adapter._message_handler = AsyncMock(return_value=None)
+    event = _make_event("my free-form answer")
+    session_key = build_session_key(event.source)
+    adapter._active_sessions[session_key] = asyncio.Event()
+
+    # Open-ended clarify → awaiting_text=True from the start.
+    cg.register(
+        clarify_id="cid-text",
+        session_key=session_key,
+        question="What is your name?",
+        choices=None,
+    )
+    try:
+        assert cg.get_pending_for_session(session_key) is not None  # text-awaiting
+
+        await adapter.handle_message(event)
+
+        # The text-intercept path handles it (calls _message_handler), and it
+        # must NOT be swept by the button-cancel branch.
+        adapter._message_handler.assert_awaited_once()
+    finally:
+        cg.clear_session(session_key)


### PR DESCRIPTION
## Problem

When the agent asks a **button-choice clarify** (selectable options) and the user — instead of clicking a button — types a new message, the agent hangs for minutes before the typed message is handled.

### Root cause

A button-choice clarify (`awaiting_text=False`) blocks the agent thread inside `clarify_gateway.wait_for_response()` on a `threading.Event`.

The existing clarify text-intercept in `BasePlatformAdapter.handle_message` only fires for `get_pending_for_session()`, which returns **only `awaiting_text=True`** entries (open-ended clarifies, or ones where the user picked "Other"). Button clarifies are therefore missed entirely.

The typed follow-up falls through to the busy handler, where the `busy_text_mode == 'queue'` default early-returns and queues the message as a next-turn follow-up. But the current turn never ends (the agent thread is still blocked on the clarify Event), so the queued message never runs — the user sees a multi-minute hang until the 10-minute clarify timeout fires.

This was confirmed from real gateway logs: a typed follow-up during a pending button-clarify produced **no inbound-message record at all** — proof the message was intercepted upstream of normal turn handling.

### Why this is distinct from the existing intercept

`get_pending_for_session` deliberately only returns text-awaiting entries (those should be resolved as the answer). Button clarifies need the opposite behavior: a typed message means the user is **ignoring** the prompt and moving on, so the clarify should be **cancelled**, not treated as an answer.

## Fix

In `handle_message`, when there is a pending clarify that is **not** text-awaiting (`has_pending()` true but `get_pending_for_session()` is None — i.e. a button clarify the user ignored by typing), cancel it via `clear_session()`. This wakes the blocked thread immediately so the current turn can finish, then lets the typed message flow through normal busy handling.

`clear_session()` only touches the clarify module's own registries — conversation history, session context, and message state are untouched.

## Tests

Added to `tests/gateway/test_active_session_text_merge.py`:
- `test_typing_cancels_pending_button_clarify` — spins up a thread genuinely blocked in `wait_for_response()`, calls `handle_message` with a typed follow-up, and asserts the thread is woken (end-to-end, not a mock).
- `test_typing_leaves_textawaiting_clarify_for_intercept` — a free-form (`awaiting_text=True`) clarify is left for the existing text-intercept and not swept by the button-cancel branch.

All 17 tests in the file pass on top of current `main`.

Verified live on a Discord gateway: typing during a button clarify now logs `Cancelled N pending button-clarify` and the follow-up is answered immediately, instead of hanging until timeout.