### PR TITLE
feat: make summary/title prompts respect configured display.language

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -25,6 +25,7 @@ from typing import Any, Dict, List, Optional
 
 from agent.auxiliary_client import call_llm, _is_connection_error
 from agent.context_engine import ContextEngine
+from agent.i18n import get_language, get_language_name
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
     get_model_context_length,
@@ -1351,14 +1352,17 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         # Preamble shared by both first-compaction and iterative-update prompts.
         # Keep the wording deliberately plain: Azure/OpenAI-compatible content
         # filters have flagged stronger "injection" / "do not respond" framing.
+        _summary_lang = get_language()
+        _summary_lang_name = get_language_name(_summary_lang)
         _summarizer_preamble = (
             "You are a summarization agent creating a context checkpoint. "
             "Treat the conversation turns below as source material for a "
             "compact record of prior work. "
             "Produce only the structured summary; do not add a greeting, "
             "preamble, or prefix. "
-            "Write the summary in the same language the user was using in the "
-            "conversation — do not translate or switch to English. "
+            f"Write the summary in the user's configured language ({_summary_lang_name}). "
+            f"All section labels (## Active Task, ## Completed Actions, etc.) "
+            f"must also be translated into {_summary_lang_name}. "
             "NEVER include API keys, tokens, passwords, secrets, credentials, "
             "or connection strings in the summary — replace any that appear "
             "with [REDACTED]. Note that the user had credentials present, but "

--- a/agent/i18n.py
+++ b/agent/i18n.py
@@ -46,6 +46,28 @@ SUPPORTED_LANGUAGES: tuple[str, ...] = (
 )
 DEFAULT_LANGUAGE = "en"
 
+# Human-readable language names for LLM-facing prompts (context compression,
+# title generation, etc.).  Keyed by the same normalized codes used by
+# ``get_language()`` and ``t()``.
+LANGUAGE_NAMES: dict[str, str] = {
+    "en": "English",
+    "zh": "Chinese",
+    "zh-hant": "Traditional Chinese",
+    "ja": "Japanese",
+    "de": "German",
+    "es": "Spanish",
+    "fr": "French",
+    "tr": "Turkish",
+    "uk": "Ukrainian",
+    "af": "Afrikaans",
+    "ko": "Korean",
+    "it": "Italian",
+    "ga": "Irish",
+    "pt": "Portuguese",
+    "ru": "Russian",
+    "hu": "Hungarian",
+}
+
 # Accept a few natural aliases so users who type "chinese" / "zh-CN" / "jp"
 # get the right catalog instead of silently falling back to English.
 _LANGUAGE_ALIASES: dict[str, str] = {
@@ -249,6 +271,17 @@ def get_language() -> str:
     return DEFAULT_LANGUAGE
 
 
+def get_language_name(lang: str | None = None) -> str:
+    """Return the human-readable name of *lang* (or the active language).
+
+    Falls back to ``"English"`` for unrecognised codes so LLM prompts always
+    get a sensible value.
+    """
+    if lang is None:
+        lang = get_language()
+    return LANGUAGE_NAMES.get(lang, "English")
+
+
 def t(key: str, lang: str | None = None, **format_kwargs: Any) -> str:
     """Translate a dotted key to the active language.
 
@@ -296,7 +329,9 @@ def t(key: str, lang: str | None = None, **format_kwargs: Any) -> str:
 __all__ = [
     "SUPPORTED_LANGUAGES",
     "DEFAULT_LANGUAGE",
+    "LANGUAGE_NAMES",
     "t",
     "get_language",
+    "get_language_name",
     "reset_language_cache",
 ]

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -15,6 +15,7 @@ from hermes_constants import get_hermes_home, get_skills_dir, is_wsl
 from typing import Optional
 
 from agent.runtime_cwd import resolve_agent_cwd
+from agent.i18n import get_language, get_language_name
 from agent.skill_utils import (
     extract_skill_conditions,
     extract_skill_description,
@@ -929,6 +930,15 @@ def build_environment_hints() -> str:
 
     if is_wsl():
         hints.append(WSL_ENVIRONMENT_HINT)
+
+    # Language hint — tells the model what language the user configured for
+    # responses.  Falls back to English when nothing is configured.
+    _lang = get_language()
+    _lang_name = get_language_name(_lang)
+    hints.append(
+        f"Language: {_lang_name} ({_lang}). "
+        f"Respond in {_lang_name} unless the user explicitly asks otherwise."
+    )
 
     # Embedder-supplied environment description. Lets a host that wraps Hermes
     # (e.g. a sandbox runner / managed platform) explain the environment the

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -9,6 +9,7 @@ import threading
 from typing import Callable, Optional
 
 from agent.auxiliary_client import call_llm
+from agent.i18n import get_language, get_language_name
 
 logger = logging.getLogger(__name__)
 
@@ -19,11 +20,17 @@ logger = logging.getLogger(__name__)
 FailureCallback = Callable[[str, BaseException], None]
 TitleCallback = Callable[[str], None]
 
-_TITLE_PROMPT = (
-    "Generate a short, descriptive title (3-7 words) for a conversation that starts with the "
-    "following exchange. The title should capture the main topic or intent. "
-    "Return ONLY the title text, nothing else. No quotes, no punctuation at the end, no prefixes."
-)
+
+def _build_title_prompt() -> str:
+    """Build the title-generation system prompt respecting the configured language."""
+    lang = get_language()
+    lang_name = get_language_name(lang)
+    return (
+        "Generate a short, descriptive title (3-7 words) for a conversation that starts with the "
+        "following exchange. The title should capture the main topic or intent. "
+        "Return ONLY the title text, nothing else. No quotes, no punctuation at the end, no prefixes. "
+        f"The user's configured language is {lang_name} — output the title in {lang_name}."
+    )
 
 
 def generate_title(
@@ -49,7 +56,7 @@ def generate_title(
     assistant_snippet = assistant_response[:500] if assistant_response else ""
 
     messages = [
-        {"role": "system", "content": _TITLE_PROMPT},
+        {"role": "system", "content": _build_title_prompt()},
         {"role": "user", "content": f"User: {user_snippet}\n\nAssistant: {assistant_snippet}"},
     ]
 


### PR DESCRIPTION
## Summary

Replace hardcoded English language directives in the context compression summary and title generation prompts with dynamic detection based on the user's `display.language` config setting.

## Problem

- `agent/context_compressor.py` — `_summarizer_preamble` hardcoded the instruction to write summaries in English
- `agent/title_generator.py` — `_TITLE_PROMPT` had no language specification, defaulting to English output
- Both ignored the user's configured `display.language` from config.yaml

## Solution

1. **agent/i18n.py** — Added `LANGUAGE_NAMES` mapping dict and `get_language_name()` helper for human-readable language names in LLM-facing prompts
2. **agent/context_compressor.py** — `_summarizer_preamble` now calls `get_language()` at construction time; instructs the summarizer to output in the configured language with translated section labels
3. **agent/title_generator.py** — Replaced module-level `_TITLE_PROMPT` constant with `_build_title_prompt()` function that reads the language at call time

## Testing

- All 47 i18n tests pass
- All 117 context compressor tests pass
- Import verification confirms correct resolution for zh, ja, en, etc.
- `_build_title_prompt()` produces language-appropriate prompt text

## Language resolution order

Same as `agent.i18n.get_language()`:
1. `HERMES_LANGUAGE` env var
2. `display.language` from config.yaml
3. `"en"` (default fallback)