### PR TITLE
fix(windows): suppress console window flashes in gateway

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -430,6 +430,14 @@ class CopilotACPClient:
 
     def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
         try:
+            _extra: dict = {}
+            if sys.platform == "win32":
+                from hermes_cli._subprocess_compat import windows_hide_flags
+                _si = subprocess.STARTUPINFO()
+                _si.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+                _si.wShowWindow = 0  # SW_HIDE
+                _extra["creationflags"] = windows_hide_flags()
+                _extra["startupinfo"] = _si
             proc = subprocess.Popen(
                 [self._acp_command] + self._acp_args,
                 stdin=subprocess.PIPE,
@@ -439,6 +447,7 @@ class CopilotACPClient:
                 bufsize=1,
                 cwd=self._acp_cwd,
                 env=_build_subprocess_env(),
+                **_extra,
             )
         except FileNotFoundError as exc:
             raise RuntimeError(

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -390,6 +390,10 @@ def _spawn(spec: ShellHookSpec, stdin_json: str) -> Dict[str, Any]:
 
     t0 = time.monotonic()
     try:
+        _extra: dict = {}
+        if sys.platform == "win32":
+            from hermes_cli._subprocess_compat import windows_hide_flags
+            _extra["creationflags"] = windows_hide_flags()
         proc = subprocess.run(
             argv,
             input=stdin_json,
@@ -397,6 +401,7 @@ def _spawn(spec: ShellHookSpec, stdin_json: str) -> Dict[str, Any]:
             timeout=spec.timeout,
             text=True,
             shell=False,
+            **_extra,
         )
     except subprocess.TimeoutExpired:
         result["timed_out"] = True

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -965,7 +965,24 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             )
         argv = [_bash, str(path)]
     else:
-        argv = [sys.executable, str(path)]
+        if sys.platform == "win32":
+            # On Windows, wrap Python scripts so hermes_bootstrap is
+            # imported first.  The bootstrap monkey-patches subprocess.Popen
+            # to inject CREATE_NO_WINDOW -- without it, any subprocess call
+            # inside the script (e.g. spawning pwsh) flashes a console
+            # window because the cron child process does not load bootstrap
+            # on its own.
+            _script_path = str(path).replace("\\", "\\\\")
+            argv = [
+                sys.executable, "-c",
+                (
+                    "import hermes_bootstrap; "
+                    f"exec(compile(open(r'{_script_path}').read(),"
+                    f" r'{_script_path}', 'exec'))"
+                ),
+            ]
+        else:
+            argv = [sys.executable, str(path)]
 
     try:
         popen_kwargs = {"creationflags": windows_hide_flags()} if sys.platform == "win32" else {}

--- a/hermes_bootstrap.py
+++ b/hermes_bootstrap.py
@@ -127,3 +127,33 @@ def apply_windows_utf8_bootstrap() -> bool:
 # the very top of their module, before importing anything else.  The
 # import side effect does the right thing.
 apply_windows_utf8_bootstrap()
+
+
+def _patch_subprocess_no_window() -> None:
+    """Monkey-patch subprocess.Popen on Windows to always set CREATE_NO_WINDOW.
+
+    Prevents console window flashes when the gateway (running under pythonw.exe,
+    which has no console) spawns child processes (copilot CLI, git, rg, ffprobe,
+    etc.).  Without this flag every console-subsystem .exe briefly shows a black
+    window before hiding itself.
+
+    Only active on win32.  Uses the lowest-level hook point (the class __init__)
+    so it covers every caller — our code, third-party libs, asyncio subprocesses.
+    """
+    if not (hasattr(__import__("sys"), "platform") and __import__("sys").platform == "win32"):
+        return
+    import subprocess as _sp
+
+    _CREATE_NO_WINDOW = 0x08000000
+    _orig_popen_init = _sp.Popen.__init__
+
+    def _patched_popen_init(self, args, **kwargs):
+        flags = kwargs.get("creationflags", 0) or 0
+        if not (flags & _CREATE_NO_WINDOW):
+            kwargs["creationflags"] = flags | _CREATE_NO_WINDOW
+        _orig_popen_init(self, args, **kwargs)
+
+    _sp.Popen.__init__ = _patched_popen_init
+
+
+_patch_subprocess_no_window()

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -35,6 +35,12 @@ import signal
 import subprocess
 import sys
 import time
+
+if sys.platform == "win32":
+    from hermes_cli._subprocess_compat import windows_hide_flags as _windows_hide_flags
+else:
+    def _windows_hide_flags() -> int:  # type: ignore[misc]
+        return 0
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
@@ -736,6 +742,7 @@ class PhotonAdapter(BasePlatformAdapter):
             stderr=subprocess.STDOUT,
             env=env,
             start_new_session=(sys.platform != "win32"),
+            **({"creationflags": _windows_hide_flags()} if sys.platform == "win32" else {}),
         )
 
         # Pump sidecar stderr/stdout into our logger so users see crashes.


### PR DESCRIPTION
## Problem

When the Hermes gateway runs under `pythonw.exe` (windowless Python, as used by the Windows service/task scheduler), every `subprocess.Popen` call for a console-subsystem executable (copilot.exe, git.exe, rg.exe, ffprobe.exe, etc.) briefly flashes a black console window. This happens on every message send and during response generation, making the gateway unusable in a Windows desktop environment.

The same issue affects **CLI sessions** — when `hermes` is launched from certain environments (e.g. VS Code integrated terminal, Windows Terminal with specific configurations), the parent process may have no attached console (`GetConsoleWindow() == 0`), triggering the same flash behavior for every tool call.

## Root Cause

`CREATE_NO_WINDOW` (0x08000000) was not being passed to `subprocess.Popen` across the codebase. When a process has no console (like `pythonw.exe`), Windows briefly allocates a new console window for each console-subsystem child process before it exits.

**Important limitation:** The monkey-patch only covers direct Python `subprocess.Popen` calls. When a shell (bash/git-bash) is spawned as a child process, its own native child spawning (e.g. bash to pwsh, bash to git) bypasses the Python patch entirely. Grandchild processes flash because bash does not inherit or propagate `CREATE_NO_WINDOW` to its children.

### Cron scripts on Windows

`no_agent=True` cron jobs that use `.sh` wrappers to call PowerShell (`pwsh`) will flash because:
1. Hermes spawns bash with `CREATE_NO_WINDOW`
2. Bash spawns `pwsh` natively — no `CREATE_NO_WINDOW`

**Workaround:** Use `.py` wrappers instead of `.sh` — Python `subprocess.run` with the bootstrap patch applies `CREATE_NO_WINDOW` to grandchildren.

## Fix

**Primary fix:** Monkey-patch `subprocess.Popen.__init__` in `hermes_bootstrap.py` — the very first import in every Hermes entry point — to unconditionally inject `CREATE_NO_WINDOW` on `win32`. This covers all callers in one place: our code, third-party libs, and `asyncio` subprocesses.

**Targeted fixes:** Also add `CREATE_NO_WINDOW` to the three highest-frequency callers:
- `agent/copilot_acp_client.py` — spawns copilot CLI on every message turn
- `agent/shell_hooks.py` — runs shell hook subprocesses
- `plugins/platforms/photon/adapter.py` — spawns the Node.js Discord sidecar

## Testing

Verified on Windows 10 with:
- Gateway running as Scheduled Task under `pythonw.exe` connected to Discord — no console flashes
- CLI session with no attached console — no flashes from terminal(), search_files(), patch() tool calls
- Cron `no_agent=True` jobs using `.py` wrappers — silent execution, no flashes
- Cron jobs using `.sh` to `pwsh` chain — confirmed grandchild flash (documented as limitation above)