### PR TITLE
fix(desktop): surface backend stderr in boot-failure overlay

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -4965,7 +4965,16 @@ async function startHermes() {
       connectionPromise = null
       sendBackendExit({ code, signal })
       if (!backendReady) {
-        const message = `Hermes backend exited before it became ready (${signal || code}).`
+        // Surface the most recent backend output (before the exit line we just
+        // pushed) so the user sees actionable information — e.g. "fastapi not
+        // installed" with the install command — directly in the boot failure
+        // overlay, rather than only in the expandable log viewer.
+        const recentOutput = hermesLog
+          .slice(-10, -1)
+          .join('\n')
+          .trim()
+        const message =
+          `Hermes backend exited before it became ready (${signal || code}).${recentOutput ? `\n\n${recentOutput}` : ''}`
         updateBootProgress(
           {
             error: message,


### PR DESCRIPTION
## Problem

When the Hermes Desktop backend exits before becoming ready — for example, because `fastapi` or `uvicorn` are not installed — the boot-failure overlay shows only a generic message:

> Hermes backend exited before it became ready (1).

The Python process prints a clear, actionable message to stderr (e.g. *"Web UI requires fastapi and uvicorn. Install with: pip install fastapi uvicorn[standard]"*), and that output is captured in the in-memory `hermesLog` buffer. It is available in the expandable log viewer, but the user has to know to click "Show recent logs" to find it.

## Fix

Include the last 10 lines of backend output (before the exit line) directly in the `error` / `message` field passed to `updateBootProgress`. This makes the actionable information render in the visible error box on the boot-failure overlay's first appearance, rather than buried behind a click.

### Before

> Hermes backend exited before it became ready (1).

### After

> Hermes backend exited before it became ready (1).
> 
> \[hermes\] Web UI dependencies not installed (need fastapi + uvicorn).
> \[hermes\] Re-install the package into this interpreter so metadata updates apply:
> \[hermes\]   cd /home/brian/.hermes/hermes-agent
> \[hermes\]   /usr/bin/python3 -m pip install -e .
> \[hermes\] If `pip` is missing in this venv, use:  uv pip install -e .
> \[hermes\] Import error: No module named 'fastapi'

## Testing

1. Uninstall fastapi from the Python interpreter the desktop uses: `pip3 uninstall fastapi`
2. Launch the desktop: `./release/linux-unpacked/Hermes`
3. Observe the boot-failure overlay now shows the actionable pip command inline

## Notes

- Uses `hermesLog.slice(-10, -1)` — 10 lookback lines excluding the exit line just pushed by `rememberLog`. This is broad enough to capture the relevant output from missing-dependency errors without flooding the error box.
- The full log is still available via the existing "Show recent logs" toggle and the `hermes:logs:recent` IPC channel.
- The `rejectBackendStart` Error (used for programmatic callers) still includes all 20 lines from `recentHermesLog()` unchanged.