### PR TITLE
fix(oauth): use platform.claude.com endpoint for PKCE token exchange

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1251,7 +1251,14 @@ def run_oauth_setup_token() -> Optional[str]:
 # Stores credentials in ~/.hermes/.anthropic_oauth.json (our own file).
 
 _OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
-_OAUTH_TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
+# Anthropic deprecated console.anthropic.com/v1/oauth/token in April 2026 in
+# favor of platform.claude.com/v1/oauth/token. Try the new endpoint first and
+# fall back to the legacy host, mirroring the dual-endpoint pattern used in
+# refresh_anthropic_oauth_pure() above.
+_OAUTH_TOKEN_URLS = (
+    "https://platform.claude.com/v1/oauth/token",
+    "https://console.anthropic.com/v1/oauth/token",
+)
 _OAUTH_REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
 _OAUTH_SCOPES = "org:create_api_key user:profile user:inference"
 _HERMES_OAUTH_FILE = get_hermes_home() / ".anthropic_oauth.json"
@@ -1350,7 +1357,7 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
         }).encode()
 
         req = urllib.request.Request(
-            _OAUTH_TOKEN_URL,
+            _OAUTH_TOKEN_URLS[0],  # placeholder; overridden inside loop
             data=exchange_data,
             headers={
                 "Content-Type": "application/json",
@@ -1359,8 +1366,22 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
             method="POST",
         )
 
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            result = json.loads(resp.read().decode())
+        result = None
+        last_error: Optional[Exception] = None
+        for endpoint in _OAUTH_TOKEN_URLS:
+            req.full_url = endpoint
+            try:
+                with urllib.request.urlopen(req, timeout=15) as resp:
+                    result = json.loads(resp.read().decode())
+                break
+            except Exception as exc:
+                last_error = exc
+                logger.debug("PKCE token exchange failed at %s: %s", endpoint, exc)
+                continue
+        if result is None:
+            raise last_error if last_error is not None else RuntimeError(
+                "PKCE token exchange failed against all known endpoints"
+            )
     except Exception as e:
         print(f"Token exchange failed: {e}")
         return None

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -5299,7 +5299,7 @@ _oauth_sessions_lock = threading.Lock()
 try:
     from agent.anthropic_adapter import (
         _OAUTH_CLIENT_ID as _ANTHROPIC_OAUTH_CLIENT_ID,
-        _OAUTH_TOKEN_URL as _ANTHROPIC_OAUTH_TOKEN_URL,
+        _OAUTH_TOKEN_URLS as _ANTHROPIC_OAUTH_TOKEN_URLS,
         _OAUTH_REDIRECT_URI as _ANTHROPIC_OAUTH_REDIRECT_URI,
         _OAUTH_SCOPES as _ANTHROPIC_OAUTH_SCOPES,
         _generate_pkce as _generate_pkce_pair,
@@ -5455,7 +5455,7 @@ def _submit_anthropic_pkce(session_id: str, code_input: str) -> Dict[str, Any]:
         "code_verifier": sess["verifier"],
     }).encode()
     req = urllib.request.Request(
-        _ANTHROPIC_OAUTH_TOKEN_URL,
+        _ANTHROPIC_OAUTH_TOKEN_URLS[0],  # placeholder; overridden inside loop
         data=exchange_data,
         headers={
             "Content-Type": "application/json",
@@ -5463,13 +5463,22 @@ def _submit_anthropic_pkce(session_id: str, code_input: str) -> Dict[str, Any]:
         },
         method="POST",
     )
-    try:
-        with urllib.request.urlopen(req, timeout=20) as resp:
-            result = json.loads(resp.read().decode())
-    except Exception as e:
+    result = None
+    last_error: Optional[Exception] = None
+    for endpoint in _ANTHROPIC_OAUTH_TOKEN_URLS:
+        req.full_url = endpoint
+        try:
+            with urllib.request.urlopen(req, timeout=20) as resp:
+                result = json.loads(resp.read().decode())
+            break
+        except Exception as exc:
+            last_error = exc
+            _log.debug("Anthropic PKCE token exchange failed at %s: %s", endpoint, exc)
+            continue
+    if result is None:
         with _oauth_sessions_lock:
             sess["status"] = "error"
-            sess["error_message"] = f"Token exchange failed: {e}"
+            sess["error_message"] = f"Token exchange failed: {last_error}"
         return {"ok": False, "status": "error", "message": sess["error_message"]}
 
     access_token = result.get("access_token", "")


### PR DESCRIPTION
Anthropic deprecated `console.anthropic.com/v1/oauth/token` in April 2026 in favor of `platform.claude.com/v1/oauth/token`. The refresh-token path at `_refresh_oauth_token` already tries both endpoints. The initial PKCE token exchange (`hermes auth add anthropic --type oauth`) hits only the dead endpoint and fails with `Token exchange failed: HTTP Error 404: Not Found`.

Repro:
```
hermes auth add anthropic --type oauth --label test
# → opens browser, paste code → 404
```

Verified live with curl:
- `POST platform.claude.com/v1/oauth/token` → `invalid_request_error` (alive, rejects bad grant_type properly)
- `POST console.anthropic.com/v1/oauth/token` → `not_found_error` (dead)

Fix: mirror the dual-endpoint pattern from `_refresh_oauth_token` in the PKCE initial-exchange path so it tries `platform.claude.com` first, falls back to `console.anthropic.com`. The same patch is applied to the dashboard PKCE flow in `hermes_cli/web_server.py`, which imported the constant from `anthropic_adapter` and shared the bug.

Tested locally on 5 profiles (Hermes Army setup). Without this patch, every new OAuth wireup fails. With it, all 5 land cleanly. `tests/hermes_cli/test_anthropic_oauth_flow.py`, `test_web_server_oauth_write.py`, `test_web_oauth_dispatch.py` all pass (21/21).
