### PR TITLE
fix(gateway): honor server retry_after in _send_with_retry for Telegram flood control

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1556,6 +1556,9 @@ class SendResult:
     # stream consumer can send the missing tail instead of marking a clipped
     # response complete.
     retryable: bool = False  # True for transient connection errors — base will retry automatically
+    # Server-requested retry delay in seconds (e.g. Telegram FloodWait retry_after).
+    # When present, _send_with_retry() honors this instead of its default backoff.
+    retry_after: Optional[float] = None
     # When the adapter had to split an oversized payload across multiple
     # platform messages (e.g. Telegram edit_message overflow split-and-deliver),
     # ``message_id`` is the LAST visible message id (so subsequent edits target
@@ -3450,9 +3453,16 @@ class BasePlatformAdapter(ABC):
             return result
 
         if is_network:
-            # Retry with exponential backoff for transient errors
+            # Retry with exponential backoff for transient errors.
+            # Honor server-requested retry_after (e.g. Telegram FloodWait)
+            # when present — it is authoritative over our backoff schedule.
+            server_retry_after = result.retry_after
             for attempt in range(1, max_retries + 1):
-                delay = base_delay * (2 ** (attempt - 1)) + random.uniform(0, 1)
+                if server_retry_after is not None:
+                    delay = server_retry_after + random.uniform(0, 1)
+                    server_retry_after = None  # only honor once per send
+                else:
+                    delay = base_delay * (2 ** (attempt - 1)) + random.uniform(0, 1)
                 logger.warning(
                     "[%s] Send failed (attempt %d/%d, retrying in %.1fs): %s",
                     self.name, attempt, max_retries, delay, error_str,
@@ -3468,6 +3478,8 @@ class BasePlatformAdapter(ABC):
                     logger.info("[%s] Send succeeded on retry %d", self.name, attempt)
                     return result
                 error_str = result.error or ""
+                if result.retry_after is not None:
+                    server_retry_after = result.retry_after
                 if not (result.retryable or self._is_retryable_error(error_str)):
                     break  # error switched to non-transient — fall through to plain-text fallback
             else:

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1185,6 +1185,15 @@ class TelegramAdapter(BasePlatformAdapter):
                 _TimedOut = None
             is_timeout = (_TimedOut and isinstance(exc, _TimedOut)) or "timed out" in err_str
             is_connect_timeout = self._looks_like_connect_timeout(exc)
+            # Extract server-requested retry_after for flood control so the
+            # base retry layer honors Telegram's backoff instead of its own
+            # short exponential schedule.
+            _retry_after = getattr(exc, "retry_after", None)
+            if _retry_after is None:
+                import re as _re
+                _m = _re.search(r"retry\s+(?:in\s+)?(\d+)", err_str, _re.IGNORECASE)
+                if _m:
+                    _retry_after = float(_m.group(1))
             logger.warning(
                 "[%s] sendRichMessage transient failure (no legacy resend): %s",
                 self.name, exc,
@@ -1193,6 +1202,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 success=False,
                 error=str(exc),
                 retryable=(is_connect_timeout or not is_timeout),
+                retry_after=_retry_after,
             )
 
         message_id = None

--- a/tests/gateway/test_send_retry.py
+++ b/tests/gateway/test_send_retry.py
@@ -282,3 +282,57 @@ class TestSendWithRetryFallback:
             result = await adapter._send_with_retry("chat1", "hello", max_retries=2)
         assert not result.success
         assert len(adapter._send_calls) == 2  # original + fallback only
+
+
+# ---------------------------------------------------------------------------
+# _send_with_retry — retry_after honor
+# ---------------------------------------------------------------------------
+
+class TestSendWithRetryAfter:
+    @pytest.mark.asyncio
+    async def test_retry_after_honored_on_first_retry(self):
+        """When the initial result has retry_after, the first retry waits that long."""
+        adapter = _StubAdapter()
+        adapter._send_results = [
+            SendResult(success=False, error="Flood control exceeded. Retry in 37 seconds",
+                       retryable=True, retry_after=37.0),
+            SendResult(success=True, message_id="ok"),
+        ]
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await adapter._send_with_retry("chat1", "hello", max_retries=2, base_delay=2.0)
+        assert result.success
+        # First sleep should use retry_after (~37s + jitter), not base_delay (~2s)
+        first_sleep = mock_sleep.call_args_list[0][0][0]
+        assert first_sleep >= 36.0  # 37 - 1 (max jitter)
+
+    @pytest.mark.asyncio
+    async def test_retry_after_from_subsequent_result(self):
+        """If a retry itself returns retry_after, the next retry honors it."""
+        adapter = _StubAdapter()
+        adapter._send_results = [
+            SendResult(success=False, error="ConnectError", retryable=True),
+            SendResult(success=False, error="Flood control exceeded. Retry in 30 seconds",
+                       retryable=True, retry_after=30.0),
+            SendResult(success=True, message_id="ok"),
+        ]
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await adapter._send_with_retry("chat1", "hello", max_retries=3, base_delay=2.0)
+        assert result.success
+        # Second sleep should use the retry_after from the second result
+        second_sleep = mock_sleep.call_args_list[1][0][0]
+        assert second_sleep >= 29.0  # 30 - 1 (max jitter)
+
+    @pytest.mark.asyncio
+    async def test_no_retry_after_uses_default_backoff(self):
+        """Without retry_after, default exponential backoff is used."""
+        adapter = _StubAdapter()
+        adapter._send_results = [
+            SendResult(success=False, error="ConnectError", retryable=True),
+            SendResult(success=True, message_id="ok"),
+        ]
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await adapter._send_with_retry("chat1", "hello", max_retries=2, base_delay=2.0)
+        assert result.success
+        # Sleep should be ~2s (base_delay * 2^0 + jitter), NOT 37s
+        first_sleep = mock_sleep.call_args_list[0][0][0]
+        assert first_sleep < 5.0


### PR DESCRIPTION
## What does this PR do?

Honors the server-provided `retry_after` value when `_send_with_retry()` retries a Telegram flood-control failure, instead of using the default short exponential backoff (~2s, ~4s). This prevents the retry budget from being exhausted against a server that demands a 25–37s wait.

## Related Issue

Fixes #46762

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/base.py`: Added `retry_after: Optional[float]` field to `SendResult`. Updated `_send_with_retry()` to use `retry_after` as the delay on the first retry when present, and to track `retry_after` from subsequent retry results.
- `gateway/platforms/telegram.py`: In `_try_send_rich()`, extract `retry_after` from the exception (via `getattr(exc, "retry_after", None)` with regex fallback on the error string) and propagate it through `SendResult.retry_after`.
- `tests/gateway/test_send_retry.py`: Added 3 tests — `retry_after` honored on first retry, `retry_after` from subsequent result honored, default backoff still used when no `retry_after`.

## How to Test

1. `pytest tests/gateway/test_send_retry.py -q` — all 38 tests pass (35 existing + 3 new)
2. The new tests verify:
   - When `SendResult(retry_after=37.0)` is returned, `_send_with_retry` sleeps ~37s instead of ~2s
   - When a retry itself returns `retry_after`, the next retry honors it
   - Without `retry_after`, default exponential backoff is unchanged

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `SendResult` (callers: 40+ across gateway), `_send_with_retry` (called from `_process_message_background`, `send_or_update_status`), `_try_send_rich` (called from `send()`)
- Blast radius: LOW — additive field on dataclass, backward-compatible (default `None`)
- Related patterns: `edit_message` already handles `retry_after` inline (line 2618); this fix extends the same contract to the base retry layer
