### PR TITLE
docs(hermes-agent skill): document project context files and their discovery rules

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -264,7 +264,8 @@ def init_agent(
             output_config.format instead of a trailing-assistant prefill.
         platform (str): The interface platform the user is on (e.g. "cli", "telegram", "discord", "whatsapp").
             Used to inject platform-specific formatting hints into the system prompt.
-        skip_context_files (bool): If True, skip auto-injection of SOUL.md, AGENTS.md, and .cursorrules
+        skip_context_files (bool): If True, skip auto-injection of project context files
+            (SOUL.md, .hermes.md, AGENTS.md, CLAUDE.md, .cursorrules) from the cwd / HERMES_HOME
             into the system prompt. Use this for batch processing and data generation to avoid
             polluting trajectories with user-specific persona or project instructions.
         load_soul_identity (bool): If True, still use ~/.hermes/SOUL.md as the primary

--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hermes-agent
 description: "Configure, extend, or contribute to Hermes Agent."
-version: 2.1.0
+version: 2.2.0
 author: Hermes Agent + Teknium
 license: MIT
 platforms: [linux, macos, windows]
@@ -446,6 +446,55 @@ Full enumeration lives in `toolsets.py` as the `TOOLSETS` dict; `_HERMES_CORE_TO
 Tool changes take effect on `/reset` (new session). They do NOT apply mid-conversation to preserve prompt caching.
 
 ---
+
+## Project Context Files
+
+Hermes injects project-level instructions into the system prompt by reading context files from the working directory. The discovery order is **first match wins** — only one project context source is loaded per session.
+
+| File (in priority order) | Discovery | Use when |
+|---|---|---|
+| `.hermes.md` / `HERMES.md` | Walks parents up to the git root, stops at git root | You want hierarchical project rules (root + per-package overrides) |
+| `AGENTS.md` / `agents.md` | **Cwd only** — subdirectory and parent copies are ignored | You want portable agent instructions that work the same in Hermes, Claude Code, Codex, etc. |
+| `CLAUDE.md` / `claude.md` | Cwd only | Same as AGENTS.md, Claude-flavored |
+| `.cursorrules` / `.cursor/rules/*.mdc` | Cwd only | Migrating from Cursor |
+
+`SOUL.md` (in `$HERMES_HOME`) is independent and always loaded when present — it sets the agent's identity, not project rules.
+
+### Pick the right one
+
+- **Use `.hermes.md`** when you want Hermes-specific behavior that lives above the cwd (root + subtree), or when you want rules to inherit from a parent directory. The parent walk stops at the git root, so a home-level `.hermes.md` won't leak into every project (a git repo's root is the boundary).
+- **Use `AGENTS.md`** when the same project will also be worked on by other agents (Codex, Claude Code, OpenCode). Those tools all have their own conventions for `AGENTS.md`, and the "cwd only" contract keeps the file portable.
+- **Don't put project rules in `~/.hermes/AGENTS.md`** (or any other home-level location). When Hermes runs with that directory as cwd, the file loads — but only for that one directory. For cross-project context, use `SOUL.md` (in `$HERMES_HOME`, identity-only) or install a skill via `hermes skills install`.
+
+### Size and truncation
+
+Each context file is capped at 20,000 characters. Files longer than that get **head + tail** truncated (the middle is dropped, with a `[...truncated...]` marker). For large project rules, prefer splitting into multiple skills over cramming one file.
+
+### Security
+
+All context files pass through the threat-pattern scanner before reaching the system prompt. Patterns matching prompt injection or promptware are replaced with a `[BLOCKED: ...]` placeholder. This means an `AGENTS.md` containing obvious injection attempts won't reach the model — the scanner blocks the content, not the file, so the rest of the file still loads.
+
+### Disable for one session
+
+`hermes --ignore-rules` skips auto-injection of all project context files (`.hermes.md`, `AGENTS.md`, `CLAUDE.md`, `.cursorrules`) **and** `SOUL.md` identity, plus user config, plugins, and MCP servers. Use it to isolate whether a problem is your setup or Hermes itself.
+
+### Example: a small `.hermes.md`
+
+```markdown
+# My Project
+
+Hermes: when working in this repo, follow these rules.
+
+## Build
+- Always run `make test` before declaring a change done.
+- Use `uv run` for Python, not `pip install`.
+
+## Style
+- Prefer `pathlib.Path` over `os.path`.
+- No `print()` in production code — use the `logger`.
+```
+
+That file at `/home/me/projects/myrepo/.hermes.md` is auto-loaded when Hermes runs in any subdirectory of `/home/me/projects/myrepo`, but not when it runs in `/home/me/other-project`.
 
 ## Security & Privacy Toggles
 


### PR DESCRIPTION
## Summary

Adds a new "Project Context Files" section to the `hermes-agent` skill (the skill shipped with Hermes for self-configuration and contribution), and fixes an inaccurate docstring in `agent/agent_init.py`.

## What's in the new section

A user-facing reference for the four project context files Hermes reads (`prompt_builder.py`):

| File | Discovery | Use when |
|---|---|---|
| `.hermes.md` / `HERMES.md` | Walks parents up to the git root | Hierarchical project rules |
| `AGENTS.md` / `agents.md` | Cwd only | Portable agent instructions (Hermes, Codex, Claude Code, etc.) |
| `CLAUDE.md` / `claude.md` | Cwd only | Same as AGENTS.md, Claude-flavored |
| `.cursorrules` / `.cursor/rules/*.mdc` | Cwd only | Migrating from Cursor |

It also covers:
- The "first match wins" priority
- The 20K cap and head+tail truncation
- The threat-pattern scanner (blocks content, not file)
- What `hermes --ignore-rules` actually skips (everything)
- A worked `.hermes.md` example

## Why docs only (no behavior change)

I considered submitting a feature PR to make `AGENTS.md` walk parents like `.hermes.md` does, but the existing `test_agents_md_top_level_only` test enforces "cwd only" deliberately — likely because AGENTS.md is a portable convention shared with other tools (Codex, Claude Code, OpenCode), each of which has its own semantics. Changing Hermes' behavior would diverge from those tools and could surprise users.

## Docstring fix

`agent/agent_init.py:267` said `skip_context_files` skips "SOUL.md, AGENTS.md, and .cursorrules." The actual code (per `build_context_files_prompt` in `prompt_builder.py` and the `--ignore-rules` flag in `hermes_cli/_parser.py`) skips **all** of: SOUL.md, .hermes.md, AGENTS.md, CLAUDE.md, .cursorrules. The docstring now matches behavior.

## Related

- Closes the design question in #46775 (or at least, the docs half of it)
- No code behavior change, no test changes required (existing tests still pass — `_load_agents_md` and `_load_hermes_md` are unchanged)

## Validation

- All claims in the new section were verified against the actual `agent/prompt_builder.py` source (the priority order in `build_context_files_prompt`, the parent walk in `_find_hermes_md`, the cwd-only contract in `_load_agents_md`, the 20K cap in `CONTEXT_FILE_MAX_CHARS`).
- The `--ignore-rules` description was verified against `hermes_cli/_parser.py` and the `skip_context_files` branch in `agent/system_prompt.py:330`.
- The threat-pattern scanner claim was verified against `_scan_context_content` in `agent/prompt_builder.py:45`.
