### PR TITLE
fix(desktop): tree-kill pool backends so reaper/quit don't orphan dashboard children

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -4776,10 +4776,22 @@ function stopPoolBackend(profile) {
   if (!entry) return
   backendPool.delete(profile)
   if (entry.process && !entry.process.killed) {
+    const pid = entry.process.pid
     try {
       entry.process.kill('SIGTERM')
     } catch {
       // Already gone.
+    }
+    // Mirror the update-path teardown (see line ~1721) and the primary backend
+    // teardown (teardownPrimaryBackendAndWait): SIGTERM alone is not enough.
+    // If the Python child stalls during graceful shutdown (e.g. mid-cron-tick),
+    // it gets reparented to launchd when the desktop app exits, leaking a
+    // dashboard process per reap cycle. Tree-kill after 5s catches it.
+    if (typeof pid === 'number') {
+      const timer = setTimeout(() => {
+        try { forceKillProcessTree(pid) } catch { void 0 }
+      }, 5000)
+      timer.unref?.()
     }
   }
 }
@@ -6532,10 +6544,29 @@ app.on('before-quit', () => {
   flushDesktopLogBufferSync()
   closePreviewWatchers()
 
+  // Collect PIDs before signalling so we can synchronously tree-kill any
+  // children that don't honour SIGTERM in time — Electron's before-quit does
+  // not wait for async cleanup, so the setTimeout escalation in
+  // stopPoolBackend won't fire before the app exits. Mirror the update path
+  // (line ~1721) which already does this correctly.
+  const dyingPids = []
   if (hermesProcess && !hermesProcess.killed) {
-    hermesProcess.kill('SIGTERM')
+    dyingPids.push(hermesProcess.pid)
+    try {
+      hermesProcess.kill('SIGTERM')
+    } catch {
+      void 0
+    }
+  }
+  for (const [, entry] of backendPool.entries()) {
+    if (entry.process && !entry.process.killed && typeof entry.process.pid === 'number') {
+      dyingPids.push(entry.process.pid)
+    }
   }
   stopAllPoolBackends()
+  for (const pid of dyingPids) {
+    try { forceKillProcessTree(pid) } catch { void 0 }
+  }
 })
 
 app.on('window-all-closed', () => {


### PR DESCRIPTION
<!-- PR title: fix(desktop): tree-kill pool backends so reaper/quit don't orphan dashboard children -->

## What does this PR do?

Fixes a process leak in the Electron desktop app where pool-backed `hermes dashboard` processes are orphaned (reparented to launchd / `PPID=1`) on every idle-reap cycle and on app quit. Over a ~7.5h session I accumulated 10 such orphans (~240 MB RSS combined), all running the same `python -m hermes_cli.main --profile <name> dashboard --no-open --host 127.0.0.1 --port 0` command.

Two teardown paths in `apps/desktop/electron/main.cjs` send SIGTERM and stop. If the Python child is mid-cron-tick (the dashboard runs the cron scheduler when `HERMES_DESKTOP=1`, see comment at line ~4712), graceful shutdown stalls and nothing escalates. The same file already has **two correct** teardown implementations (`teardownPrimaryBackendAndWait` at line 4547 — SIGKILL after 5 s; the update path at line 1720-1721 — `forceKillProcessTree`). This PR mirrors them onto the pool-backend paths.

## Related Issue

Fixes #46778

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

`apps/desktop/electron/main.cjs`:

- **`stopPoolBackend()` (~line 4774)** — after the polite `SIGTERM`, schedule `forceKillProcessTree(pid)` via a 5 s `setTimeout` (with `.unref()` so it doesn't keep the loop alive). Mirrors the `teardownPrimaryBackendAndWait` 5-second escalation semantics, but stays fire-and-forget so it doesn't block the reaper interval.
- **`before-quit` handler (~line 6535)** — snapshot the PIDs of `hermesProcess` and every pool backend *before* sending SIGTERM, then synchronously `forceKillProcessTree` each PID after `stopAllPoolBackends()`. Electron's `before-quit` does **not** wait for async work, so the `setTimeout` escalation above can't fire here — we have to clean up synchronously, exactly like the update path at line 1720-1721 already does.

No new dependencies; both call into the existing `forceKillProcessTree` helper.

## How to Test

**Reproduce the bug (without this PR):**

1. Launch the desktop app, switch to a non-default profile to spawn a pool backend
2. Leave that profile idle for `POOL_IDLE_MS` (default 600 s)
3. After the reaper fires:
   ```bash
   ps -Ao pid,ppid,etime,command | grep "hermes_cli.*dashboard"
   ```
   Observe one or more `PPID=1` rows with elapsed time `> POOL_IDLE_MS`. Repeat to accumulate.

**Verify the fix:**

1. Apply this PR, rebuild/reload the desktop app
2. Repeat steps 1-2 above
3. After the reaper fires, the `ps` query returns no rows (or only the currently-active backend, never an orphan)
4. Verify on app quit: open several profiles, `Cmd+Q`/`File → Quit`, then re-run the `ps` query — no Python `hermes_cli.*dashboard` processes should survive

Unit/integration coverage is hard for process-lifecycle behaviour; I'd suggest a `tests/desktop/` smoke that spawns a dummy child, calls the helper, and asserts `child.killed === true` plus that any grandchild is also gone.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass <!-- N/A: change is .cjs only -->
- [ ] I've added tests for my changes <!-- see "How to Test" note above -->
- [x] I've tested on my platform: macOS 15.5 (Darwin 25.5.0), Electron desktop app

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal helper behaviour)
- [x] I've updated `cli-config.yaml.example` — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — `forceKillProcessTree` is already cross-platform and used by the update path on all platforms; this PR only adds new call sites, no platform-specific code

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
