### PR TITLE
Fix Windows desktop updater PATH for managed Node

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -254,6 +254,10 @@ function resolveHermesHome() {
 }
 
 const HERMES_HOME = resolveHermesHome()
+
+function hermesManagedNodePathEntry() {
+  return IS_WINDOWS ? path.join(HERMES_HOME, 'node') : path.join(HERMES_HOME, 'node', 'bin')
+}
 // ACTIVE_HERMES_ROOT — the canonical mutable Hermes install. Same path
 // install.ps1 / install.sh use, so a desktop-only user and a CLI-only user end
 // up with identical layouts and can share one install.
@@ -1813,7 +1817,7 @@ async function applyUpdates(opts = {}) {
       env: {
         ...process.env,
         HERMES_HOME,
-        PATH: [path.join(HERMES_HOME, 'node', 'bin'), venvBin, process.env.PATH].filter(Boolean).join(path.delimiter)
+        PATH: [hermesManagedNodePathEntry(), venvBin, process.env.PATH].filter(Boolean).join(path.delimiter)
       },
       detached: true,
       stdio: 'ignore',
@@ -1857,7 +1861,7 @@ async function handOffWindowsBootstrapRecovery(reason) {
     env: {
       ...process.env,
       HERMES_HOME,
-      PATH: [path.join(HERMES_HOME, 'node', 'bin'), venvBin, process.env.PATH].filter(Boolean).join(path.delimiter)
+      PATH: [hermesManagedNodePathEntry(), venvBin, process.env.PATH].filter(Boolean).join(path.delimiter)
     },
     detached: true,
     stdio: 'ignore',
@@ -1939,7 +1943,7 @@ async function applyUpdatesPosixInApp() {
 
   // Put the Hermes-managed Node and the venv on PATH so `hermes desktop`'s
   // npm build can find them on a machine with no system Node.
-  const extraPath = [path.join(HERMES_HOME, 'node', 'bin'), path.join(updateRoot, 'venv', 'bin')]
+  const extraPath = [hermesManagedNodePathEntry(), path.join(updateRoot, 'venv', 'bin')]
     .filter(Boolean)
     .join(path.delimiter)
   const env = {


### PR DESCRIPTION
## Summary

Fixes the Desktop updater/rebuild environment so Windows uses the Hermes-managed portable Node directory on `PATH`.

Previously, the updater used:

```text
HERMES_HOME/node/bin