### PR TITLE
fix(desktop): align assistant-ui store and tap versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -387,15 +387,15 @@
       }
     },
     "node_modules/@assistant-ui/store": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/@assistant-ui/store/-/store-0.2.18.tgz",
-      "integrity": "sha512-5MiZXAXjsZuH3ZVEemuiD5L8wq/pXax8lSlaIsdTPEkDZDFupsiDwuOeum+h+ctX8H8oKgkCpN4iPUIiiLKuVg==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/store/-/store-0.2.12.tgz",
+      "integrity": "sha512-XIm0XfbC4gdZLuwbqnOTZgp3Okl8BGdl0LlDIRHV/KYHo1KGH572Gow0t/W0KfuAKbmOtngiZDoHn6pu7nhzjg==",
       "license": "MIT",
       "dependencies": {
         "use-effect-event": "^2.0.3"
       },
       "peerDependencies": {
-        "@assistant-ui/tap": "^0.9.0",
+        "@assistant-ui/tap": "^0.5.12",
         "@types/react": "*",
         "react": "^18 || ^19"
       },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "agent-browser": "^0.26.0"
   },
   "overrides": {
-    "lodash": "4.18.1"
+    "lodash": "4.18.1",
+    "@assistant-ui/store": "0.2.12"
   },
   "engines": {
     "node": ">=20.0.0"


### PR DESCRIPTION
## Summary
- pins `@assistant-ui/store` to `0.2.12` via root npm overrides
- updates the lockfile so the assistant-ui stack uses compatible `store@0.2.12` + `tap@0.5.x`

## Why
Desktop rebuilds currently fail in Vite/Rolldown because assistant-ui resolves an incompatible pair:

- `@assistant-ui/react@0.12.28` imports `@assistant-ui/tap/react`
- newer `@assistant-ui/store@0.2.18` expects the post-rename `tap@^0.9.x` line, where `./react` was removed in favor of `./react-shim`

No single `@assistant-ui/tap` version satisfies both old `./react` and new `./react-shim` consumers. Pinning store to `0.2.12` keeps the current `@assistant-ui/react@0.12.28` stack on the compatible tap 0.5.x line.

Longer-term, the cleaner fix is upgrading the assistant-ui stack to `@assistant-ui/react@^0.14.x`, but that is a broader dependency/API change.

## Verification
From a clean worktree based on latest `origin/main`:

- `npm ci --ignore-scripts`
- `npm run build --workspace apps/desktop`
- `npm run pack --workspace apps/desktop`