### PR TITLE
fix: add gateway final-message sentinel

### DIFF
--- a/gateway/final_sentinel.py
+++ b/gateway/final_sentinel.py
@@ -1,0 +1,47 @@
+"""User-facing final-message sentinel helpers for gateway delivery.
+
+The sentinel is a display-only UX marker for normal Telegram/Discord replies.
+It is intentionally separate from runtime telemetry/footer handling.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+FINAL_MESSAGE_SENTINEL = "COMPLETE"
+SUPPORTED_FINAL_SENTINEL_PLATFORMS = frozenset({"telegram", "discord"})
+_SENTINEL_RE = re.compile(r"(?:\n\s*)+COMPLETE\s*$")
+
+
+def platform_name(platform: Any) -> str:
+    """Normalize a Platform enum / raw string into a lowercase name."""
+    value = getattr(platform, "value", platform)
+    return str(value or "").lower()
+
+
+def should_send_final_sentinel(
+    platform: Any,
+    *,
+    is_internal: bool = False,
+    is_command: bool = False,
+) -> bool:
+    """Return True when a standalone final sentinel should be sent."""
+    if is_internal or is_command:
+        return False
+    return platform_name(platform) in SUPPORTED_FINAL_SENTINEL_PLATFORMS
+
+
+def strip_trailing_final_sentinel(content: str) -> tuple[str, bool]:
+    """Remove a model-produced trailing standalone COMPLETE if present.
+
+    Non-streaming delivery can then send the canonical standalone marker once.
+    Streaming delivery cannot retract already-sent text, so callers there should
+    use this only for detection/duplicate suppression.
+    """
+    if not content:
+        return content, False
+    stripped = _SENTINEL_RE.sub("", content).rstrip()
+    if stripped != content.rstrip():
+        return stripped, True
+    return content, False

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -20,6 +20,11 @@ import uuid
 from abc import ABC, abstractmethod
 from urllib.parse import urlsplit
 
+from gateway.final_sentinel import (
+    FINAL_MESSAGE_SENTINEL,
+    should_send_final_sentinel,
+    strip_trailing_final_sentinel,
+)
 from utils import normalize_proxy_url
 
 logger = logging.getLogger(__name__)
@@ -4192,6 +4197,8 @@ class BasePlatformAdapter(ABC):
             # string, and remember the TTL + platform capability so the
             # post-send block can schedule the deletion.
             response, _ephemeral_ttl = self._unwrap_ephemeral(response)
+            if response:
+                response, _ = strip_trailing_final_sentinel(response)
 
             # Send response if any.  A None/empty response is normal when
             # streaming already delivered the text (already_sent=True) or
@@ -4478,6 +4485,40 @@ class BasePlatformAdapter(ABC):
                         "for %s (empty after extract, recovery yielded nothing).",
                         self.name, len(_response_pre_extract), event.source.chat_id,
                     )
+
+                _sentinel_delivery_ok = (
+                    delivery_succeeded
+                    or _tts_caption_delivered
+                    or bool(images or local_files or media_files)
+                )
+                _is_command = False
+                try:
+                    _is_command = bool(event.is_command())
+                except Exception:
+                    _is_command = False
+                if (
+                    _sentinel_delivery_ok
+                    and should_send_final_sentinel(
+                        self.platform,
+                        is_internal=bool(getattr(event, "internal", False)),
+                        is_command=_is_command,
+                    )
+                ):
+                    _sentinel_metadata = dict(_thread_metadata or {})
+                    _sentinel_metadata["notify"] = True
+                    _sentinel_result = await self._send_with_retry(
+                        chat_id=event.source.chat_id,
+                        content=FINAL_MESSAGE_SENTINEL,
+                        reply_to=None,
+                        metadata=_sentinel_metadata,
+                    )
+                    if not getattr(_sentinel_result, "success", False):
+                        logger.debug(
+                            "[%s] final sentinel delivery failed for %s: %s",
+                            self.name,
+                            event.source.chat_id,
+                            getattr(_sentinel_result, "error", None),
+                        )
 
             # Determine overall success for the processing hook
             processing_ok = delivery_succeeded if delivery_attempted else not bool(response)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -56,6 +56,11 @@ from agent.async_utils import safe_schedule_threadsafe
 from agent.i18n import t
 from hermes_cli.config import cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
+from gateway.final_sentinel import (
+    FINAL_MESSAGE_SENTINEL,
+    should_send_final_sentinel,
+    strip_trailing_final_sentinel,
+)
 
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
@@ -8909,11 +8914,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             # Normalize empty responses: surface errors, partial failures, and
             # the case where agent did work but returned no text. Fix for #18765.
+            _response_had_model_sentinel = False
             if not _intentional_silence:
                 response = _normalize_empty_agent_response(
                     agent_result, response, history_len=len(history),
                 )
                 response = _sanitize_gateway_final_response(source.platform, response)
+                response, _response_had_model_sentinel = strip_trailing_final_sentinel(response)
 
             # Ordering contract: the agent thread already updated the contextvar
             # in conversation_compression.py; propagate to SessionEntry + _save().
@@ -9251,6 +9258,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             )
                     except Exception as _e:
                         logger.debug("trailing footer send failed: %s", _e)
+                if not _response_had_model_sentinel:
+                    _is_command = False
+                    try:
+                        _is_command = bool(event.is_command())
+                    except Exception:
+                        _is_command = False
+                    if should_send_final_sentinel(
+                        source.platform,
+                        is_internal=bool(getattr(event, "internal", False)),
+                        is_command=_is_command,
+                    ):
+                        try:
+                            _sentinel_adapter = self.adapters.get(source.platform)
+                            if _sentinel_adapter:
+                                _sentinel_metadata = self._thread_metadata_for_source(
+                                    source,
+                                    self._reply_anchor_for_event(event),
+                                ) or {}
+                                _sentinel_metadata = dict(_sentinel_metadata)
+                                _sentinel_metadata["notify"] = True
+                                await _sentinel_adapter.send(
+                                    source.chat_id,
+                                    FINAL_MESSAGE_SENTINEL,
+                                    metadata=_sentinel_metadata,
+                                )
+                        except Exception as _e:
+                            logger.debug("final sentinel send failed: %s", _e)
                 return None
 
             return response

--- a/tests/gateway/test_final_message_sentinel.py
+++ b/tests/gateway/test_final_message_sentinel.py
@@ -1,0 +1,141 @@
+"""Regression tests for Telegram/Discord standalone final-message sentinels."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.final_sentinel import FINAL_MESSAGE_SENTINEL, strip_trailing_final_sentinel
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.session import SessionSource, build_session_key
+
+
+class _StubAdapter(BasePlatformAdapter):
+    _sentinel_sends: list[tuple[str, dict]]
+
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None, **kwargs):
+        return SendResult(success=True, message_id="sent")
+
+    async def get_chat_info(self, chat_id):
+        return {}
+
+
+def _make_adapter(platform: Platform):
+    adapter = _StubAdapter(PlatformConfig(enabled=True, token="t"), platform)
+    sends: list[tuple[str, dict]] = []
+
+    async def _send_with_retry(chat_id, content, **kwargs):
+        sends.append((content, kwargs))
+        return SendResult(success=True, message_id=f"m{len(sends)}")
+
+    adapter._send_with_retry = AsyncMock(side_effect=_send_with_retry)
+    adapter._sentinel_sends = sends
+    return adapter
+
+
+def _make_event(platform: Platform, text: str = "hello", *, internal: bool = False):
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(platform=platform, chat_id="42", chat_type="dm"),
+        internal=internal,
+    )
+
+
+def _session_key(platform: Platform):
+    return build_session_key(SessionSource(platform=platform, chat_id="42", chat_type="dm"))
+
+
+async def _run_turn(adapter, event, response="main response"):
+    async def handler(_event):
+        return response
+
+    adapter._message_handler = handler
+    await adapter.handle_message(event)
+    key = _session_key(event.source.platform)
+    for _ in range(100):
+        if key not in adapter._active_sessions:
+            break
+        await asyncio.sleep(0.01)
+    await adapter.cancel_background_tasks()
+
+
+@pytest.mark.asyncio
+async def test_telegram_normal_response_gets_standalone_complete_once():
+    adapter = _make_adapter(Platform.TELEGRAM)
+
+    await _run_turn(adapter, _make_event(Platform.TELEGRAM), "main response")
+
+    assert [content for content, _ in adapter._sentinel_sends] == [
+        "main response",
+        FINAL_MESSAGE_SENTINEL,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_discord_normal_response_gets_standalone_complete_once():
+    adapter = _make_adapter(Platform.DISCORD)
+
+    await _run_turn(adapter, _make_event(Platform.DISCORD), "main response")
+
+    assert [content for content, _ in adapter._sentinel_sends] == [
+        "main response",
+        FINAL_MESSAGE_SENTINEL,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_non_telegram_discord_platform_gets_no_sentinel():
+    adapter = _make_adapter(Platform.SLACK)
+
+    await _run_turn(adapter, _make_event(Platform.SLACK), "main response")
+
+    assert [content for content, _ in adapter._sentinel_sends] == ["main response"]
+
+
+@pytest.mark.asyncio
+async def test_slash_command_gets_no_sentinel():
+    adapter = _make_adapter(Platform.TELEGRAM)
+
+    await _run_turn(adapter, _make_event(Platform.TELEGRAM, text="/status"), "status response")
+
+    assert [content for content, _ in adapter._sentinel_sends] == ["status response"]
+
+
+@pytest.mark.asyncio
+async def test_internal_event_gets_no_sentinel():
+    adapter = _make_adapter(Platform.TELEGRAM)
+
+    await _run_turn(
+        adapter,
+        _make_event(Platform.TELEGRAM, text="background", internal=True),
+        "background response",
+    )
+
+    assert [content for content, _ in adapter._sentinel_sends] == ["background response"]
+
+
+@pytest.mark.asyncio
+async def test_model_trailing_complete_is_stripped_and_sent_once_standalone():
+    adapter = _make_adapter(Platform.TELEGRAM)
+
+    await _run_turn(adapter, _make_event(Platform.TELEGRAM), "main response\n\nCOMPLETE")
+
+    assert [content for content, _ in adapter._sentinel_sends] == [
+        "main response",
+        FINAL_MESSAGE_SENTINEL,
+    ]
+
+
+def test_strip_trailing_final_sentinel_detects_only_standalone_marker():
+    assert strip_trailing_final_sentinel("body\n\nCOMPLETE") == ("body", True)
+    assert strip_trailing_final_sentinel("body COMPLETE") == ("body COMPLETE", False)


### PR DESCRIPTION
## Summary
- Add a centralized gateway final-message sentinel helper for Telegram/Discord.
- Send standalone `COMPLETE` after completed normal user-facing responses in non-streamed and streamed/already-sent paths.
- Strip model-authored trailing standalone `COMPLETE` to avoid duplicate markers.

## Commit
- f622ca396ff876c3bac7f63802b95e9d16b53374

## Validation
- Focused validation: `python -m pytest tests/gateway/test_final_message_sentinel.py -q` — 7 passed
- Adjacent validation: `python -m pytest tests/gateway/test_stream_consumer_draft.py tests/gateway/test_pending_drain_race.py -q` — 21 passed

## Notes
- Gateway restart has not occurred yet.
- Manual Telegram/Discord smoke test has not occurred yet.
- No merge/deploy included in this gate.