### PR TITLE
fix(gateway): filter internal kanban artifact uploads

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -18,9 +18,85 @@ import time
 from pathlib import Path
 from typing import Any, Optional
 
+from hermes_constants import get_hermes_home
+
 # Match the logger run.py uses (logging.getLogger(__name__) where __name__ ==
 # "gateway.run") so extracted log records keep their original logger name.
 logger = logging.getLogger("gateway.run")
+
+
+_KANBAN_INTERNAL_ARTIFACT_BASENAMES = {
+    "approvals.md",
+    "decisions.md",
+    "manifest.json",
+    "manifest.yaml",
+    "manifest.yml",
+    "plan-critique-checklist.json",
+    "plan-depth.json",
+    "planner-contract.json",
+    "planner-handoff-bundle.json",
+    "planner-handoff-bundle.stub.yaml",
+    "planner-handoff-bundle.yaml",
+    "project.yaml",
+    "risk-gate.json",
+    "state.json",
+    "status.json",
+    "traceability.stub.json",
+    "workers.example.yaml",
+}
+
+_KANBAN_INTERNAL_CONTROL_EXTS = {".cfg", ".ini", ".json", ".toml", ".yaml", ".yml"}
+
+# Bare paths in kanban completion summaries are usually evidence pointers, not
+# files the user asked Slack/Telegram to download. Keep auto-upload narrow; a
+# worker can still pass a deliberate non-internal file via artifacts=[...].
+_KANBAN_SUMMARY_AUTO_DELIVER_EXTS = {
+    ".bmp", ".csv", ".doc", ".docx", ".gif", ".htm", ".html", ".jpeg",
+    ".jpg", ".key", ".mp3", ".mp4", ".ods", ".odt", ".pdf", ".png",
+    ".ppt", ".pptx", ".svg", ".webp", ".xls", ".xlsx", ".zip",
+}
+
+
+def _is_under_hermes_workflows(path: Path) -> bool:
+    """Return True when ``path`` lives under the active Hermes workflows root."""
+    try:
+        resolved_path = path.expanduser().resolve()
+        workflows_root = (get_hermes_home() / "workflows").expanduser().resolve()
+        resolved_path.relative_to(workflows_root)
+    except (OSError, RuntimeError, ValueError):
+        return False
+    return True
+
+
+def _looks_like_internal_kanban_artifact(path: str) -> bool:
+    """Return True for workflow/control-plane files that should not auto-upload.
+
+    Hermes workflows keep manifests, planner bundles, risk gates, and state
+    under ``~/.hermes/workflows``. Those files are useful evidence for agents
+    but noisy and privacy-sensitive as native chat attachments: Slack clients
+    may save them into ``~/Downloads`` with numbered duplicates. Final reports
+    or rendered dashboards can still be delivered when they use user-facing
+    extensions such as ``.html``/``.pdf``/``.zip``.
+    """
+    p = Path(path)
+    name = p.name.lower()
+
+    if not _is_under_hermes_workflows(p):
+        return False
+    if name in _KANBAN_INTERNAL_ARTIFACT_BASENAMES:
+        return True
+    if name.startswith("planner-handoff-bundle"):
+        return True
+    return p.suffix.lower() in _KANBAN_INTERNAL_CONTROL_EXTS
+
+
+def _allow_kanban_artifact_delivery(path: str, source: str) -> bool:
+    """Return True if the kanban notifier should upload ``path`` natively."""
+    if _looks_like_internal_kanban_artifact(path):
+        return False
+    if source == "explicit":
+        return True
+    return Path(path).suffix.lower() in _KANBAN_SUMMARY_AUTO_DELIVER_EXTS
 
 
 class GatewayKanbanWatchersMixin:
@@ -474,10 +550,10 @@ class GatewayKanbanWatchersMixin:
         """
         from pathlib import Path as _Path
 
-        candidates: list[str] = []
+        candidates: list[tuple[str, str]] = []
         seen: set[str] = set()
 
-        def _add(path: str) -> None:
+        def _add(path: str, source: str) -> None:
             if not path:
                 return
             expanded = os.path.expanduser(path)
@@ -486,7 +562,7 @@ class GatewayKanbanWatchersMixin:
             if not os.path.isfile(expanded):
                 return
             seen.add(expanded)
-            candidates.append(expanded)
+            candidates.append((expanded, source))
 
         # 1. Explicit artifacts list in payload.
         if isinstance(event_payload, dict):
@@ -494,29 +570,43 @@ class GatewayKanbanWatchersMixin:
             if isinstance(raw, (list, tuple)):
                 for item in raw:
                     if isinstance(item, str):
-                        _add(item)
+                        _add(item, "explicit")
 
             # 2. Paths embedded in the payload summary.
             summary = event_payload.get("summary")
             if isinstance(summary, str) and summary:
                 paths, _ = adapter.extract_local_files(summary)
                 for p in paths:
-                    _add(p)
+                    _add(p, "summary")
 
         # 3. Legacy: paths embedded in task.result.
         if task is not None and getattr(task, "result", None):
             result_text = str(task.result)
             paths, _ = adapter.extract_local_files(result_text)
             for p in paths:
-                _add(p)
+                _add(p, "legacy_result")
 
         if not candidates:
             return
 
         from gateway.platforms.base import BasePlatformAdapter
-        candidates = BasePlatformAdapter.filter_local_delivery_paths(candidates)
+        safe_candidates: list[tuple[str, str]] = []
+        safe_seen: set[str] = set()
+        for path, source in candidates:
+            safe_paths = BasePlatformAdapter.filter_local_delivery_paths([path])
+            if not safe_paths:
+                continue
+            safe_path = safe_paths[0]
+            if safe_path in safe_seen:
+                continue
+            safe_seen.add(safe_path)
+            if _allow_kanban_artifact_delivery(safe_path, source):
+                safe_candidates.append((safe_path, source))
+        candidates = safe_candidates
         if not candidates:
             return
+
+        delivery_paths = [path for path, _ in candidates]
 
         _IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
         _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"}
@@ -525,8 +615,8 @@ class GatewayKanbanWatchersMixin:
 
         # Partition images so they ride a single send_multiple_images call
         # on platforms that support batch image uploads (Signal/Slack RPCs).
-        image_paths = [p for p in candidates if _Path(p).suffix.lower() in _IMAGE_EXTS]
-        other_paths = [p for p in candidates if _Path(p).suffix.lower() not in _IMAGE_EXTS]
+        image_paths = [p for p in delivery_paths if _Path(p).suffix.lower() in _IMAGE_EXTS]
+        other_paths = [p for p in delivery_paths if _Path(p).suffix.lower() not in _IMAGE_EXTS]
 
         if image_paths:
             try:

--- a/tests/gateway/test_kanban_watchers_mixin.py
+++ b/tests/gateway/test_kanban_watchers_mixin.py
@@ -7,9 +7,13 @@ that GatewayRunner picks them up via the MRO (behavior-neutral relocation).
 
 from __future__ import annotations
 
+import asyncio
 import inspect
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
+from gateway.platforms.base import BasePlatformAdapter
 
 KANBAN_METHODS = [
     "_kanban_notifier_watcher",
@@ -43,3 +47,178 @@ def test_watcher_loops_are_coroutines():
     # The two long-running watchers are async loops.
     assert inspect.iscoroutinefunction(GatewayKanbanWatchersMixin._kanban_notifier_watcher)
     assert inspect.iscoroutinefunction(GatewayKanbanWatchersMixin._kanban_dispatcher_watcher)
+
+
+class _ArtifactAdapter:
+    extract_local_files = staticmethod(BasePlatformAdapter.extract_local_files)
+
+    def __init__(self):
+        self.send_document = AsyncMock()
+        self.send_multiple_images = AsyncMock()
+        self.send_video = AsyncMock()
+
+
+def test_kanban_artifact_delivery_skips_internal_workflow_control_files(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    workflow = tmp_path / ".hermes" / "workflows" / "run-1"
+    artifacts = workflow / "artifacts"
+    artifacts.mkdir(parents=True)
+    manifest = workflow / "manifest.yaml"
+    planner_bundle = artifacts / "planner-handoff-bundle.yaml"
+    report = artifacts / "final-report.html"
+    manifest.write_text("run_id: run-1\n", encoding="utf-8")
+    planner_bundle.write_text("schema: hermes.planner_handoff_bundle.v1\n", encoding="utf-8")
+    report.write_text("<html>ok</html>\n", encoding="utf-8")
+
+    adapter = _ArtifactAdapter()
+    runner = GatewayKanbanWatchersMixin()
+
+    asyncio.run(
+        runner._deliver_kanban_artifacts(
+            adapter=adapter,
+            chat_id="chat-1",
+            metadata={},
+            event_payload={"artifacts": [str(manifest), str(planner_bundle), str(report)]},
+            task=None,
+        )
+    )
+
+    adapter.send_document.assert_awaited_once_with(
+        chat_id="chat-1", file_path=str(report), metadata={}
+    )
+    adapter.send_multiple_images.assert_not_awaited()
+    adapter.send_video.assert_not_awaited()
+
+
+def test_kanban_summary_path_auto_upload_is_user_facing_only(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    workflow = tmp_path / ".hermes" / "workflows" / "run-2"
+    artifacts = workflow / "artifacts"
+    artifacts.mkdir(parents=True)
+    planner_bundle = artifacts / "planner-handoff-bundle.yaml"
+    rendered_report = artifacts / "dashboard.html"
+    unrelated_yaml = tmp_path / "customer-facing-config.yaml"
+    for path in (planner_bundle, rendered_report, unrelated_yaml):
+        path.write_text("ok\n", encoding="utf-8")
+
+    adapter = _ArtifactAdapter()
+    runner = GatewayKanbanWatchersMixin()
+    summary = f"evidence: {planner_bundle}\nreport: {rendered_report}\nyaml: {unrelated_yaml}"
+
+    asyncio.run(
+        runner._deliver_kanban_artifacts(
+            adapter=adapter,
+            chat_id="chat-1",
+            metadata={"thread_id": "t1"},
+            event_payload={"summary": summary},
+            task=SimpleNamespace(result=f"legacy path: {unrelated_yaml}"),
+        )
+    )
+
+    adapter.send_document.assert_awaited_once_with(
+        chat_id="chat-1", file_path=str(rendered_report), metadata={"thread_id": "t1"}
+    )
+
+
+def test_explicit_non_workflow_manifest_can_still_be_delivered(tmp_path):
+    manifest = tmp_path / "customer" / "manifest.json"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text('{"deliverable": true}\n', encoding="utf-8")
+
+    adapter = _ArtifactAdapter()
+    runner = GatewayKanbanWatchersMixin()
+
+    asyncio.run(
+        runner._deliver_kanban_artifacts(
+            adapter=adapter,
+            chat_id="chat-1",
+            metadata={},
+            event_payload={"artifacts": [str(manifest)]},
+            task=None,
+        )
+    )
+
+    adapter.send_document.assert_awaited_once_with(
+        chat_id="chat-1", file_path=str(manifest.resolve()), metadata={}
+    )
+
+
+def test_custom_hermes_home_workflow_control_file_is_skipped(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "custom-hermes-home"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    workflow = hermes_home / "workflows" / "run-3"
+    workflow.mkdir(parents=True)
+    state = workflow / "state.toml"
+    report = workflow / "report.pdf"
+    state.write_text("phase = 'planning'\n", encoding="utf-8")
+    report.write_bytes(b"%PDF-1.4")
+
+    adapter = _ArtifactAdapter()
+    runner = GatewayKanbanWatchersMixin()
+
+    asyncio.run(
+        runner._deliver_kanban_artifacts(
+            adapter=adapter,
+            chat_id="chat-1",
+            metadata={},
+            event_payload={"artifacts": [str(state), str(report)]},
+            task=None,
+        )
+    )
+
+    adapter.send_document.assert_awaited_once_with(
+        chat_id="chat-1", file_path=str(report.resolve()), metadata={}
+    )
+
+
+def test_explicit_non_workflow_planner_bundle_can_still_be_delivered(tmp_path):
+    bundle = tmp_path / "customer" / "planner-handoff-bundle.pdf"
+    bundle.parent.mkdir(parents=True)
+    bundle.write_bytes(b"%PDF-1.4")
+
+    adapter = _ArtifactAdapter()
+    runner = GatewayKanbanWatchersMixin()
+
+    asyncio.run(
+        runner._deliver_kanban_artifacts(
+            adapter=adapter,
+            chat_id="chat-1",
+            metadata={},
+            event_payload={"artifacts": [str(bundle)]},
+            task=None,
+        )
+    )
+
+    adapter.send_document.assert_awaited_once_with(
+        chat_id="chat-1", file_path=str(bundle.resolve()), metadata={}
+    )
+
+
+def test_artifact_delivery_uses_normalized_safe_path(tmp_path):
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    report = real_dir / "report.pdf"
+    report.write_bytes(b"%PDF-1.4")
+    link_dir = tmp_path / "link"
+    try:
+        link_dir.symlink_to(real_dir, target_is_directory=True)
+    except OSError:
+        return
+    symlinked_report = link_dir / "report.pdf"
+
+    adapter = _ArtifactAdapter()
+    runner = GatewayKanbanWatchersMixin()
+
+    asyncio.run(
+        runner._deliver_kanban_artifacts(
+            adapter=adapter,
+            chat_id="chat-1",
+            metadata={},
+            event_payload={"artifacts": [str(symlinked_report)]},
+            task=None,
+        )
+    )
+
+    adapter.send_document.assert_awaited_once_with(
+        chat_id="chat-1", file_path=str(report.resolve()), metadata={}
+    )


### PR DESCRIPTION
## Summary
- Prevent Kanban notifier artifact delivery from uploading internal Hermes workflow/control-plane files as native chat attachments.
- Keep explicit non-workflow artifacts deliverable and keep user-facing summary outputs such as HTML/PDF/images deliverable.
- Add focused regression coverage for default/custom Hermes home workflow paths, summary filtering, non-workflow explicit artifacts, and normalized safe paths.

## Problem
Kanban task summaries and result text often include local workflow evidence paths. The notifier treated those paths as deliverable files, so internal control files such as manifests, planner bundles, state, or risk gates could be uploaded to chat platforms just because they were mentioned in a completion summary or artifact list.

## Tests
- `python3 -m py_compile gateway/kanban_watchers.py tests/gateway/test_kanban_watchers_mixin.py`
- `python3 -m pytest tests/gateway/test_kanban_watchers_mixin.py -q -o 'addopts='` → 9 passed
- `git diff --check origin/main...HEAD`
- `gitleaks git --log-opts='origin/main..HEAD' --no-banner --redact` → no leaks
- Refined private-context/token regex scan over candidate diff → no hits
