### PR TITLE
fix(slack): track assistant status per thread

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -363,8 +363,9 @@ class SlackAdapter(BasePlatformAdapter):
         # Track message IDs that should get reaction lifecycle (DMs / @mentions).
         self._reacting_message_ids: set = set()
         # Track active assistant thread status indicators so stop_typing can
-        # clear them (chat_id → thread_ts).
-        self._active_status_threads: Dict[str, str] = {}
+        # clear them. Multiple Slack threads in the same channel can run at
+        # once, so this must be chat_id → set(thread_ts), not a single value.
+        self._active_status_threads: Dict[str, set[str]] = {}
         # Slash-command contexts: stash response_url + user_id so send()
         # can route the first reply ephemerally.  Keyed by
         # (channel_id, user_id) to avoid cross-user collisions.
@@ -1180,7 +1181,7 @@ class SlackAdapter(BasePlatformAdapter):
 
             # Clear Slack Assistant status as soon as the final message is posted.
             if thread_ts:
-                await self.stop_typing(chat_id)
+                await self.stop_typing(chat_id, metadata={"thread_ts": thread_ts})
 
             # Track the sent message ts so we can auto-respond to thread
             # replies without requiring @mention.
@@ -1248,6 +1249,7 @@ class SlackAdapter(BasePlatformAdapter):
         content: str,
         *,
         finalize: bool = False,
+        metadata=None,
     ) -> SendResult:
         """Edit a previously sent Slack message."""
         if not self._app:
@@ -1260,7 +1262,7 @@ class SlackAdapter(BasePlatformAdapter):
                 text=formatted,
             )
             if finalize:
-                await self.stop_typing(chat_id)
+                await self.stop_typing(chat_id, metadata=metadata)
             return SendResult(success=True, message_id=message_id)
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error(
@@ -1289,7 +1291,7 @@ class SlackAdapter(BasePlatformAdapter):
         if not thread_ts:
             return  # Can only set status in a thread context
 
-        self._active_status_threads[chat_id] = thread_ts
+        self._active_status_threads.setdefault(chat_id, set()).add(thread_ts)
         try:
             await self._get_client(chat_id).assistant_threads_setStatus(
                 channel_id=chat_id,
@@ -1305,17 +1307,31 @@ class SlackAdapter(BasePlatformAdapter):
         """Clear the assistant thread status indicator."""
         if not self._app:
             return
-        thread_ts = self._active_status_threads.pop(chat_id, None)
-        if not thread_ts:
+        requested_thread_ts = None
+        if metadata:
+            requested_thread_ts = metadata.get("thread_id") or metadata.get("thread_ts")
+
+        if requested_thread_ts:
+            tracked = self._active_status_threads.get(chat_id)
+            if tracked is not None:
+                tracked.discard(requested_thread_ts)
+                if not tracked:
+                    self._active_status_threads.pop(chat_id, None)
+            thread_targets = [requested_thread_ts]
+        else:
+            thread_targets = list(self._active_status_threads.pop(chat_id, set()))
+
+        if not thread_targets:
             return
-        try:
-            await self._get_client(chat_id).assistant_threads_setStatus(
-                channel_id=chat_id,
-                thread_ts=thread_ts,
-                status="",
-            )
-        except Exception as e:
-            logger.debug("[Slack] assistant.threads.setStatus clear failed: %s", e)
+        for thread_ts in thread_targets:
+            try:
+                await self._get_client(chat_id).assistant_threads_setStatus(
+                    channel_id=chat_id,
+                    thread_ts=thread_ts,
+                    status="",
+                )
+            except Exception as e:
+                logger.debug("[Slack] assistant.threads.setStatus clear failed: %s", e)
 
     def _dm_top_level_threads_as_sessions(self) -> bool:
         """Whether top-level Slack DMs get per-message session threads.

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1897,7 +1897,7 @@ class TestSendTyping:
 
     @pytest.mark.asyncio
     async def test_stop_typing_handles_api_error_gracefully(self, adapter):
-        adapter._active_status_threads["C123"] = "parent_ts"
+        adapter._active_status_threads["C123"] = {"parent_ts"}
         adapter._app.client.assistant_threads_setStatus = AsyncMock(
             side_effect=Exception("missing_scope")
         )
@@ -1917,7 +1917,7 @@ class TestSendTyping:
             return_value={"ts": "reply_ts"}
         )
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
-        adapter._active_status_threads["C123"] = "parent_ts"
+        adapter._active_status_threads["C123"] = {"parent_ts"}
 
         result = await adapter.send("C123", "done", metadata={"thread_id": "parent_ts"})
 
@@ -1931,10 +1931,39 @@ class TestSendTyping:
         assert "C123" not in adapter._active_status_threads
 
     @pytest.mark.asyncio
+    async def test_parallel_thread_statuses_do_not_overwrite_each_other(self, adapter):
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        await adapter.send_typing("C123", metadata={"thread_id": "thread_a"})
+        await adapter.send_typing("C123", metadata={"thread_id": "thread_b"})
+
+        await adapter.stop_typing("C123", metadata={"thread_id": "thread_a"})
+
+        assert adapter._active_status_threads["C123"] == {"thread_b"}
+        assert adapter._app.client.assistant_threads_setStatus.call_args_list[-1] == call(
+            channel_id="C123",
+            thread_ts="thread_a",
+            status="",
+        )
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_without_metadata_clears_all_tracked_threads(self, adapter):
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        adapter._active_status_threads["C123"] = {"thread_a", "thread_b"}
+
+        await adapter.stop_typing("C123")
+
+        cleared_threads = {
+            call_args.kwargs["thread_ts"]
+            for call_args in adapter._app.client.assistant_threads_setStatus.call_args_list
+        }
+        assert cleared_threads == {"thread_a", "thread_b"}
+        assert "C123" not in adapter._active_status_threads
+
+    @pytest.mark.asyncio
     async def test_streaming_final_edit_clears_status(self, adapter):
         adapter._app.client.chat_update = AsyncMock()
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
-        adapter._active_status_threads["C123"] = "parent_ts"
+        adapter._active_status_threads["C123"] = {"parent_ts"}
 
         result = await adapter.edit_message(
             "C123",
@@ -1957,10 +1986,32 @@ class TestSendTyping:
         assert "C123" not in adapter._active_status_threads
 
     @pytest.mark.asyncio
+    async def test_streaming_final_edit_with_metadata_clears_only_target_thread(self, adapter):
+        adapter._app.client.chat_update = AsyncMock()
+        adapter._app.client.assistant_threads_setStatus = AsyncMock()
+        adapter._active_status_threads["C123"] = {"thread_a", "thread_b"}
+
+        result = await adapter.edit_message(
+            "C123",
+            "reply_ts",
+            "done",
+            finalize=True,
+            metadata={"thread_id": "thread_a"},
+        )
+
+        assert result.success
+        adapter._app.client.assistant_threads_setStatus.assert_called_once_with(
+            channel_id="C123",
+            thread_ts="thread_a",
+            status="",
+        )
+        assert adapter._active_status_threads["C123"] == {"thread_b"}
+
+    @pytest.mark.asyncio
     async def test_streaming_intermediate_edit_keeps_status(self, adapter):
         adapter._app.client.chat_update = AsyncMock()
         adapter._app.client.assistant_threads_setStatus = AsyncMock()
-        adapter._active_status_threads["C123"] = "parent_ts"
+        adapter._active_status_threads["C123"] = {"parent_ts"}
 
         result = await adapter.edit_message(
             "C123",
@@ -1971,7 +2022,7 @@ class TestSendTyping:
 
         assert result.success
         adapter._app.client.assistant_threads_setStatus.assert_not_called()
-        assert adapter._active_status_threads["C123"] == "parent_ts"
+        assert adapter._active_status_threads["C123"] == {"parent_ts"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Track Slack assistant thread status per channel as a set of thread timestamps.
- Clear only the target thread status when final send/edit metadata identifies a thread.
- Add regression tests for parallel thread status cleanup and streaming final edits.

## Problem
Slack assistant status tracking used one active thread timestamp per channel. Concurrent assistant threads in the same channel could overwrite each other, and final cleanup for one thread could clear another thread's active status indicator.

## Tests
- `python3 -m py_compile gateway/platforms/slack.py`
- `pytest -q tests/gateway/test_slack.py -q`
- `git diff --check origin/main...HEAD`
- `gitleaks git --log-opts=origin/main..HEAD --no-banner --redact`
- Regex scan over the candidate diff for private paths/tokens/customer context
