### PR TITLE
fix(kanban): skip internal workflow artifacts in notifications

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -23,6 +23,60 @@ from typing import Any, Optional
 logger = logging.getLogger("gateway.run")
 
 
+_KANBAN_INTERNAL_ARTIFACT_BASENAMES = {
+    "approvals.md",
+    "decisions.md",
+    "manifest.json",
+    "manifest.yaml",
+    "manifest.yml",
+    "plan-critique-checklist.json",
+    "plan-depth.json",
+    "planner-contract.json",
+    "planner-handoff-bundle.json",
+    "planner-handoff-bundle.stub.yaml",
+    "planner-handoff-bundle.yaml",
+    "project.yaml",
+    "risk-gate.json",
+    "state.json",
+    "status.json",
+    "traceability.stub.json",
+    "workers.example.yaml",
+}
+
+_KANBAN_INTERNAL_CONTROL_EXTS = {".json", ".yaml", ".yml"}
+
+
+def _looks_like_internal_kanban_artifact(path: str) -> bool:
+    """Return True for workflow/control-plane files that should not auto-upload.
+
+    Hermes workflows keep manifests, planner bundles, risk gates, and state
+    under ``~/.hermes/workflows``. Those files are useful evidence for agents
+    but noisy and privacy-sensitive as native chat attachments: Slack clients
+    may save them into ``~/Downloads`` with numbered duplicates. Final reports
+    or rendered dashboards can still be delivered when they use user-facing
+    extensions such as ``.html``/``.pdf``/``.zip``.
+    """
+    p = Path(path)
+    name = p.name.lower()
+    parts = [part.lower() for part in p.parts]
+    in_hermes_workflow = any(
+        parts[i] == ".hermes" and parts[i + 1] == "workflows"
+        for i in range(len(parts) - 1)
+    )
+    if not in_hermes_workflow:
+        return False
+    if name in _KANBAN_INTERNAL_ARTIFACT_BASENAMES:
+        return True
+    if name.startswith("planner-handoff-bundle"):
+        return p.suffix.lower() in _KANBAN_INTERNAL_CONTROL_EXTS
+    return False
+
+
+def _allow_kanban_artifact_delivery(path: str, source: str) -> bool:
+    """Return True if the kanban notifier should upload ``path`` natively."""
+    return not _looks_like_internal_kanban_artifact(path)
+
+
 class GatewayKanbanWatchersMixin:
     """Kanban watcher / notifier / dispatcher loops for GatewayRunner."""
 
@@ -474,10 +528,10 @@ class GatewayKanbanWatchersMixin:
         """
         from pathlib import Path as _Path
 
-        candidates: list[str] = []
+        candidates: list[tuple[str, str]] = []
         seen: set[str] = set()
 
-        def _add(path: str) -> None:
+        def _add(path: str, source: str) -> None:
             if not path:
                 return
             expanded = os.path.expanduser(path)
@@ -486,7 +540,7 @@ class GatewayKanbanWatchersMixin:
             if not os.path.isfile(expanded):
                 return
             seen.add(expanded)
-            candidates.append(expanded)
+            candidates.append((expanded, source))
 
         # 1. Explicit artifacts list in payload.
         if isinstance(event_payload, dict):
@@ -494,29 +548,43 @@ class GatewayKanbanWatchersMixin:
             if isinstance(raw, (list, tuple)):
                 for item in raw:
                     if isinstance(item, str):
-                        _add(item)
+                        _add(item, "explicit")
 
             # 2. Paths embedded in the payload summary.
             summary = event_payload.get("summary")
             if isinstance(summary, str) and summary:
                 paths, _ = adapter.extract_local_files(summary)
                 for p in paths:
-                    _add(p)
+                    _add(p, "summary")
 
         # 3. Legacy: paths embedded in task.result.
         if task is not None and getattr(task, "result", None):
             result_text = str(task.result)
             paths, _ = adapter.extract_local_files(result_text)
             for p in paths:
-                _add(p)
+                _add(p, "legacy_result")
 
         if not candidates:
             return
 
         from gateway.platforms.base import BasePlatformAdapter
-        candidates = BasePlatformAdapter.filter_local_delivery_paths(candidates)
+        safe_candidates: list[tuple[str, str]] = []
+        safe_seen: set[str] = set()
+        for path, source in candidates:
+            safe_paths = BasePlatformAdapter.filter_local_delivery_paths([path])
+            if not safe_paths:
+                continue
+            safe_path = safe_paths[0]
+            if safe_path in safe_seen:
+                continue
+            safe_seen.add(safe_path)
+            if _allow_kanban_artifact_delivery(safe_path, source):
+                safe_candidates.append((safe_path, source))
+        candidates = safe_candidates
         if not candidates:
             return
+
+        delivery_paths = [path for path, _ in candidates]
 
         _IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
         _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"}
@@ -525,8 +593,8 @@ class GatewayKanbanWatchersMixin:
 
         # Partition images so they ride a single send_multiple_images call
         # on platforms that support batch image uploads (Signal/Slack RPCs).
-        image_paths = [p for p in candidates if _Path(p).suffix.lower() in _IMAGE_EXTS]
-        other_paths = [p for p in candidates if _Path(p).suffix.lower() not in _IMAGE_EXTS]
+        image_paths = [p for p in delivery_paths if _Path(p).suffix.lower() in _IMAGE_EXTS]
+        other_paths = [p for p in delivery_paths if _Path(p).suffix.lower() not in _IMAGE_EXTS]
 
         if image_paths:
             try:

--- a/tests/gateway/test_kanban_watchers_mixin.py
+++ b/tests/gateway/test_kanban_watchers_mixin.py
@@ -7,9 +7,13 @@ that GatewayRunner picks them up via the MRO (behavior-neutral relocation).
 
 from __future__ import annotations
 
+import asyncio
 import inspect
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
+from gateway.platforms.base import BasePlatformAdapter
 
 KANBAN_METHODS = [
     "_kanban_notifier_watcher",
@@ -43,3 +47,148 @@ def test_watcher_loops_are_coroutines():
     # The two long-running watchers are async loops.
     assert inspect.iscoroutinefunction(GatewayKanbanWatchersMixin._kanban_notifier_watcher)
     assert inspect.iscoroutinefunction(GatewayKanbanWatchersMixin._kanban_dispatcher_watcher)
+
+
+class _ArtifactAdapter:
+    extract_local_files = staticmethod(BasePlatformAdapter.extract_local_files)
+
+    def __init__(self):
+        self.send_document = AsyncMock()
+        self.send_multiple_images = AsyncMock()
+        self.send_video = AsyncMock()
+
+
+def test_kanban_artifact_delivery_skips_internal_workflow_control_files(tmp_path):
+    workflow = tmp_path / ".hermes" / "workflows" / "run-1"
+    artifacts = workflow / "artifacts"
+    artifacts.mkdir(parents=True)
+    manifest = workflow / "manifest.yaml"
+    planner_bundle = artifacts / "planner-handoff-bundle.yaml"
+    report = artifacts / "final-report.html"
+    manifest.write_text("run_id: run-1\n", encoding="utf-8")
+    planner_bundle.write_text("schema: hermes.planner_handoff_bundle.v1\n", encoding="utf-8")
+    report.write_text("<html>ok</html>\n", encoding="utf-8")
+
+    adapter = _ArtifactAdapter()
+    runner = GatewayKanbanWatchersMixin()
+
+    asyncio.run(
+        runner._deliver_kanban_artifacts(
+            adapter=adapter,
+            chat_id="chat-1",
+            metadata={},
+            event_payload={"artifacts": [str(manifest), str(planner_bundle), str(report)]},
+            task=None,
+        )
+    )
+
+    adapter.send_document.assert_awaited_once_with(
+        chat_id="chat-1", file_path=str(report), metadata={}
+    )
+    adapter.send_multiple_images.assert_not_awaited()
+    adapter.send_video.assert_not_awaited()
+
+
+def test_kanban_summary_path_skips_workflow_control_files(tmp_path):
+    workflow = tmp_path / ".hermes" / "workflows" / "run-2"
+    artifacts = workflow / "artifacts"
+    artifacts.mkdir(parents=True)
+    planner_bundle = artifacts / "planner-handoff-bundle.yaml"
+    rendered_report = artifacts / "dashboard.html"
+    project_yaml = workflow / "project.yaml"
+    for path in (planner_bundle, rendered_report, project_yaml):
+        path.write_text("ok\n", encoding="utf-8")
+
+    adapter = _ArtifactAdapter()
+    runner = GatewayKanbanWatchersMixin()
+    summary = f"evidence: {planner_bundle}\nreport: {rendered_report}\nyaml: {project_yaml}"
+
+    asyncio.run(
+        runner._deliver_kanban_artifacts(
+            adapter=adapter,
+            chat_id="chat-1",
+            metadata={"thread_id": "t1"},
+            event_payload={"summary": summary},
+            task=SimpleNamespace(result=f"legacy path: {project_yaml}"),
+        )
+    )
+
+    adapter.send_document.assert_awaited_once_with(
+        chat_id="chat-1", file_path=str(rendered_report), metadata={"thread_id": "t1"}
+    )
+
+
+def test_explicit_non_workflow_manifest_can_still_be_delivered(tmp_path):
+    manifest = tmp_path / "customer" / "manifest.json"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text('{"deliverable": true}\n', encoding="utf-8")
+
+    adapter = _ArtifactAdapter()
+    runner = GatewayKanbanWatchersMixin()
+
+    asyncio.run(
+        runner._deliver_kanban_artifacts(
+            adapter=adapter,
+            chat_id="chat-1",
+            metadata={},
+            event_payload={"artifacts": [str(manifest)]},
+            task=None,
+        )
+    )
+
+    adapter.send_document.assert_awaited_once_with(
+        chat_id="chat-1", file_path=str(manifest.resolve()), metadata={}
+    )
+
+
+def test_manifest_path_with_non_adjacent_hermes_workflows_parts_is_not_suppressed(tmp_path):
+    manifest = tmp_path / "workflows" / "customer" / ".hermes" / "report" / "manifest.yaml"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text("kind: deliverable\n", encoding="utf-8")
+
+    adapter = _ArtifactAdapter()
+    runner = GatewayKanbanWatchersMixin()
+
+    asyncio.run(
+        runner._deliver_kanban_artifacts(
+            adapter=adapter,
+            chat_id="chat-1",
+            metadata={},
+            event_payload={"artifacts": [str(manifest)]},
+            task=None,
+        )
+    )
+
+    adapter.send_document.assert_awaited_once_with(
+        chat_id="chat-1", file_path=str(manifest.resolve()), metadata={}
+    )
+
+
+def test_artifact_delivery_uses_normalized_safe_path(tmp_path):
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    report = real_dir / "report.pdf"
+    report.write_bytes(b"%PDF-1.4")
+    link_dir = tmp_path / "link"
+    try:
+        link_dir.symlink_to(real_dir, target_is_directory=True)
+    except OSError:
+        return
+    symlinked_report = link_dir / "report.pdf"
+
+    adapter = _ArtifactAdapter()
+    runner = GatewayKanbanWatchersMixin()
+
+    asyncio.run(
+        runner._deliver_kanban_artifacts(
+            adapter=adapter,
+            chat_id="chat-1",
+            metadata={},
+            event_payload={"artifacts": [str(symlinked_report)]},
+            task=None,
+        )
+    )
+
+    adapter.send_document.assert_awaited_once_with(
+        chat_id="chat-1", file_path=str(report.resolve()), metadata={}
+    )


### PR DESCRIPTION
## Summary
- Skip native upload of known internal Kanban workflow/control-plane artifacts under `~/.hermes/workflows`.
- Preserve delivery for user-facing rendered reports and non-workflow manifest files.
- Add synthetic regression coverage for explicit artifacts, summary/result extraction, workflow path detection, and normalized symlink delivery.

## Problem
Kanban completion notifications can collect local file paths from explicit artifacts, summaries, and legacy result text. Internal workflow files such as manifests, planner bundles, risk gates, and state files are useful agent evidence, but they are noisy and potentially sensitive as chat-native attachments.

## Tests
- `python -m pytest tests/gateway/test_kanban_watchers_mixin.py -q -o 'addopts='` → 8 passed
- `python -m pytest tests/gateway/test_kanban_watchers_mixin.py tests/hermes_cli/test_kanban_notify.py::test_notifier_uploads_artifacts_on_completion tests/hermes_cli/test_kanban_notify.py::test_notifier_artifact_delivery_skips_missing_files tests/gateway/test_platform_base.py -q -o 'addopts='` → 158 passed, 2 skipped
- `git diff --check origin/main...HEAD` → pass
- `gitleaks git --log-opts='origin/main..HEAD' --no-banner --redact` → no leaks found
- Private regex scan over candidate diff → 0 hits
