### PR TITLE
fix(gateway): fall through to PID check when lock file is missing

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -1029,8 +1029,14 @@ def get_running_pid(
     resolved_lock_path = _get_gateway_lock_path(resolved_pid_path)
     lock_active = is_gateway_runtime_lock_active(resolved_lock_path)
     if not lock_active:
-        _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
-        return None
+        # Only clean up when the lock file exists but is genuinely unlocked.
+        # When the lock file is absent (e.g. virtiofs unlinked the directory
+        # entry behind the gateway's open FD, or a user/CI deleted it while
+        # the gateway is still running), fall through to the PID-file check
+        # so we don't falsely report the gateway as down.
+        if resolved_lock_path.exists():
+            _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
+            return None
 
     primary_record = _read_pid_record(resolved_pid_path)
     fallback_record = _read_gateway_lock_record(resolved_lock_path)

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -146,6 +146,62 @@ class TestGatewayPidState:
         assert status.get_running_pid(pid_path, cleanup_stale=False) == os.getpid()
         assert pid_path.exists()
 
+    def test_get_running_pid_falls_through_to_pid_when_lock_file_missing(self, tmp_path, monkeypatch):
+        """virtiofs can unlink the lock file while the gateway still holds the FD.
+
+        When the lock file is absent, ``get_running_pid`` must fall through
+        to the PID-file check instead of immediately returning None.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        pid_path.write_text(json.dumps({
+            "pid": os.getpid(),
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway"],
+            "start_time": 123,
+        }))
+
+        monkeypatch.setattr(status.os, "kill", lambda pid, sig: None)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: None)
+        # Simulate missing lock file (virtiofs unlinked it)
+        monkeypatch.setattr(
+            status, "is_gateway_runtime_lock_active", lambda lock_path=None: False
+        )
+
+        assert status.get_running_pid(pid_path) == os.getpid()
+        # PID file must NOT be cleaned up — the gateway is still running.
+        assert pid_path.exists()
+
+    def test_get_running_pid_cleans_stale_when_lock_file_present_but_unlocked(self, tmp_path, monkeypatch):
+        """Lock file exists but is not held — genuine stale state.
+
+        The PID file should be cleaned up (original behavior preserved).
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        dead_pid = 999999
+        pid_path.write_text(json.dumps({
+            "pid": dead_pid,
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway"],
+            "start_time": 111,
+        }))
+
+        lock_path = tmp_path / "gateway.lock"
+        lock_path.write_text("{}")
+
+        def _dead_process(pid, sig):
+            raise ProcessLookupError
+
+        monkeypatch.setattr(status.os, "kill", _dead_process)
+        monkeypatch.setattr(
+            status, "is_gateway_runtime_lock_active", lambda lock_path=None: False
+        )
+
+        assert status.get_running_pid(pid_path) is None
+        assert not pid_path.exists()
+
     def test_runtime_lock_claims_and_releases_liveness(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 
@@ -157,7 +213,9 @@ class TestGatewayPidState:
 
         assert status.is_gateway_runtime_lock_active() is False
 
-    def test_get_running_pid_treats_pid_file_as_stale_without_runtime_lock(self, tmp_path, monkeypatch):
+    def test_get_running_pid_falls_through_when_lock_file_missing(self, tmp_path, monkeypatch):
+        """When the lock file is absent (e.g. deleted or virtiofs-unlinked),
+        ``get_running_pid`` must fall through to the PID-file check."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         pid_path = tmp_path / "gateway.pid"
         pid_path.write_text(json.dumps({
@@ -171,8 +229,9 @@ class TestGatewayPidState:
         monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
         monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: None)
 
-        assert status.get_running_pid() is None
-        assert not pid_path.exists()
+        # Lock file missing + live PID with gateway metadata → gateway found.
+        assert status.get_running_pid() == os.getpid()
+        assert pid_path.exists()
 
     def test_get_running_pid_cleans_stale_metadata_from_dead_foreign_pid(self, tmp_path, monkeypatch):
         """Stale PID file from a *different* PID (crashed process) must still be cleaned.


### PR DESCRIPTION
## What does this PR do?

Fixes `get_running_pid()` falsely reporting the gateway as down when the lock file's directory entry is absent (e.g. virtiofs unlinked it behind the gateway's open FD). The function now falls through to the PID-file check instead of immediately returning `None`.

## Related Issue

Fixes #46788

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/status.py`: When `is_gateway_runtime_lock_active()` returns `False`, only clean up the PID file if the lock file actually exists on disk. When the lock file is absent (virtiofs unlinked, user/CI deleted), fall through to the PID-file check so a running gateway is still detected.
- `tests/gateway/test_status.py`: Updated `test_get_running_pid_treats_pid_file_as_stale_without_runtime_lock` → `test_get_running_pid_falls_through_when_lock_file_missing` to reflect new behavior. Added `test_get_running_pid_falls_through_to_pid_when_lock_file_missing` (lock file missing + live PID → gateway found) and `test_get_running_pid_cleans_stale_when_lock_file_present_but_unlocked` (lock file exists but unlocked → cleanup).

## How to Test

1. `python -m pytest tests/gateway/test_status.py -v` — all 61 tests pass
2. On macOS with Docker Desktop (virtiofs): start gateway, manually delete `.hermes/gateway.lock`, call `get_running_pid()` — should still return the running PID instead of `None`
3. On any platform: with gateway stopped, both PID and lock files present but unlocked — `get_running_pid()` should return `None` and clean up (existing behavior preserved)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_status.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/status.py:get_running_pid`, `gateway/status.py:is_gateway_runtime_lock_active`
- Blast radius: LOW — single early-return guard in a read-only status-check function
- Related patterns: Advisory lock + PID-file dual-check architecture in gateway status tracking
