### PR TITLE
fix(agent): continue after post-tool progress updates

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2162,6 +2162,135 @@ def looks_like_codex_intermediate_ack(
 
 
 
+def looks_like_post_tool_progress_only(
+    agent,
+    assistant_content: str,
+    messages: List[Dict[str, Any]],
+) -> bool:
+    """Detect status/progress text that should not close a post-tool turn.
+
+    Some weaker/tool-shaky models answer after tool results with text like
+    "정보수집중" / "찾은 내용 분석중" / "I'm analyzing the results" and no
+    tool call. Treating that as final leaves Slack threads with a progress
+    notice instead of a closeout. Keep this deliberately narrow: it only
+    applies when recent tool results exist and the visible text is short,
+    status-shaped, and lacks final-answer markers.
+    """
+    if not any(isinstance(msg, dict) and msg.get("role") == "tool" for msg in messages[-8:]):
+        return False
+
+    visible = agent._strip_think_blocks(assistant_content or "").strip()
+    if not visible:
+        return False
+    if len(visible) > 500:
+        return False
+
+    lowered = re.sub(r"\s+", " ", visible.lower()).strip()
+    compact = re.sub(r"\s+", "", visible.lower())
+
+    final_markers = (
+        "작업한 일",
+        "검증 근거",
+        "남은 일",
+        "보안/주의",
+        "결론",
+        "최종",
+        "완료했습니다",
+        "완료됨",
+        "완료:",
+        "done:",
+        "completed",
+        "final answer",
+        "here is",
+        "here's",
+        "result:",
+        "results:",
+        "summary:",
+        "verified",
+    )
+    if any(marker in lowered for marker in final_markers):
+        return False
+
+    # Avoid substring matches: a real final answer may legitimately contain
+    # phrases such as "자료 수집 중 발견한 핵심" or "확인 중 오류를 발견".
+    # Treat the response as progress-only only when every visible clause is a
+    # bare status/update phrase and contains no result payload.
+    payload_markers = (
+        "발견",
+        "확인했습니다",
+        "확인했",
+        "확인됨",
+        "원인",
+        "오류",
+        "문제",
+        "핵심",
+        "결과:",
+        "중간 결과",
+        "수정",
+        "적용",
+        "found ",
+        "discovered",
+        "because",
+        "root cause",
+    )
+    if any(marker in lowered for marker in payload_markers):
+        return False
+
+    status_clause_patterns = (
+        r"(?:정보|자료|데이터|소스)?\s*(?:수집|검색)\s*중(?:입니다|이에요|입니다요|요)?",
+        r"찾은\s*내용\s*분석\s*중(?:입니다|이에요|요)?",
+        r"(?:조사|분석|정리|검토|확인|처리|진행)\s*중(?:입니다|이에요|요)?",
+        r"작업\s*(?:진행\s*)?중(?:입니다|이에요|요)?",
+        r"잠시만(?:요)?",
+        r"곧\s*(?:정리|보고)(?:하겠습니다|할게요|합니다)?",
+        r"마저\s*(?:확인|분석|정리)(?:하겠습니다|할게요|합니다)?",
+        r"working on it",
+        r"still (?:checking|analyzing|analysing|researching|working)",
+        r"i(?:'|’)m (?:checking|analyzing|analysing|researching|working)",
+        r"i am (?:checking|analyzing|analysing|researching|working)",
+        r"looking into (?:it|this)",
+        r"gathering (?:info|information|data|sources)",
+        r"analy[sz]ing (?:the )?(?:results|findings|data|sources)",
+        r"i(?:'|’)ll (?:check|analy[sz]e|review|summari[sz]e|report back)",
+        r"i will (?:check|analy[sz]e|review|summari[sz]e|report back)",
+    )
+    clauses = [
+        clause.strip(" \t\r\n.!?。．…·-–—:：")
+        for clause in re.split(r"[\n.!?。．…]+", visible)
+    ]
+    clauses = [clause for clause in clauses if clause]
+    if clauses and all(
+        any(re.fullmatch(pattern, clause, re.IGNORECASE) for pattern in status_clause_patterns)
+        for clause in clauses
+    ):
+        return True
+
+    # Catch compact Korean status strings without spaces/punctuation, e.g.
+    # "정보수집중찾은내용분석중", but still require the entire response to be
+    # made only of status units.
+    compact_units = (
+        "정보수집중",
+        "자료수집중",
+        "데이터수집중",
+        "소스수집중",
+        "검색중",
+        "찾은내용분석중",
+        "분석중",
+        "조사중",
+        "정리중",
+        "검토중",
+        "확인중",
+        "처리중",
+        "작업중",
+        "작업진행중",
+        "진행중",
+        "잠시만",
+        "잠시만요",
+    )
+    compact_status_re = "(?:" + "|".join(re.escape(unit) for unit in compact_units) + ")+"
+    return bool(re.fullmatch(compact_status_re, compact))
+
+
 
 def copy_reasoning_content_for_api(agent, source_msg: dict, api_msg: dict) -> None:
     """Copy provider-facing reasoning fields onto an API replay message."""
@@ -2597,6 +2726,7 @@ __all__ = [
     "repair_tool_call",
     "sanitize_api_messages",
     "looks_like_codex_intermediate_ack",
+    "looks_like_post_tool_progress_only",
     "copy_reasoning_content_for_api",
     "cleanup_dead_connections",
     "extract_api_error_context",

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3885,9 +3885,10 @@ def run_conversation(
                     agent._thinking_prefill_retries = 0
                     agent._empty_content_retries = 0
                 # Successful tool execution — reset the post-tool nudge
-                # flag so it can fire again if the model goes empty on
-                # a LATER tool round.
+                # flags so they can fire again if the model goes empty or
+                # returns progress-only text on a LATER tool round.
                 agent._post_tool_empty_retried = False
+                agent._post_tool_progress_retried = 0
 
                 messages.append(assistant_msg)
                 agent._emit_interim_assistant_message(assistant_msg)
@@ -4280,6 +4281,60 @@ def run_conversation(
                 # status from earlier failed attempts in this turn.
                 agent._clear_status_buffer()
 
+                if agent._looks_like_post_tool_progress_only(final_response, messages):
+                    agent._post_tool_progress_retried = getattr(
+                        agent, "_post_tool_progress_retried", 0
+                    ) + 1
+                    logger.info(
+                        "Progress-only response after tool calls — nudging model "
+                        "to produce final closeout (%d/2)",
+                        agent._post_tool_progress_retried,
+                    )
+                    if agent._post_tool_progress_retried <= 2:
+                        agent._buffer_status(
+                            "⚠️ Model returned only a progress update after "
+                            "tool calls — nudging for final answer"
+                        )
+                        interim_msg = agent._build_assistant_message(assistant_message, "incomplete")
+                        interim_msg["_post_tool_progress_synthetic"] = True
+                        messages.append(interim_msg)
+                        messages.append({
+                            "role": "user",
+                            "content": (
+                                "You just executed tool calls and then returned only a "
+                                "progress/status update. Do not say you are still "
+                                "working. Use the tool results above to provide the "
+                                "final answer now, including what was done, verified, "
+                                "and any remaining blockers."
+                            ),
+                            "_post_tool_progress_synthetic": True,
+                        })
+                        agent._session_messages = messages
+                        continue
+
+                    _turn_exit_reason = "post_tool_progress_only_exhausted"
+                    final_response = (
+                        "No final answer: the model returned only progress/status "
+                        "updates after tool execution twice. Please retry in a fresh, "
+                        "narrower turn or switch profiles."
+                    )
+                    final_msg = agent._build_assistant_message(assistant_message, finish_reason)
+                    final_msg["content"] = final_response
+                    # Internal progress-nudge turns are for the retry API calls only.
+                    # Do not persist them as user-visible/resumable conversation
+                    # history, especially on the exhaustion path where they are no
+                    # longer at the transcript tail after the failure response.
+                    messages = [
+                        msg for msg in messages
+                        if not (
+                            isinstance(msg, dict)
+                            and msg.get("_post_tool_progress_synthetic")
+                        )
+                    ]
+                    agent._session_messages = messages
+                    messages.append(final_msg)
+                    break
+
                 if (
                     agent.api_mode == "codex_responses"
                     and agent.valid_tool_names
@@ -4328,6 +4383,7 @@ def run_conversation(
                         messages[-1].get("_thinking_prefill")
                         or messages[-1].get("_empty_recovery_synthetic")
                         or messages[-1].get("_empty_terminal_sentinel")
+                        or messages[-1].get("_post_tool_progress_synthetic")
                     )
                 ):
                     messages.pop()

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -136,6 +136,7 @@ def build_turn_context(
     agent._codex_incomplete_retries = 0
     agent._thinking_prefill_retries = 0
     agent._post_tool_empty_retried = False
+    agent._post_tool_progress_retried = 0
     agent._last_content_with_tools = None
     agent._last_content_tools_all_housekeeping = False
     agent._mute_post_response = False

--- a/run_agent.py
+++ b/run_agent.py
@@ -1388,6 +1388,15 @@ class AIAgent:
         from agent.agent_runtime_helpers import looks_like_codex_intermediate_ack
         return looks_like_codex_intermediate_ack(self, user_message, assistant_content, messages)
 
+    def _looks_like_post_tool_progress_only(
+        self,
+        assistant_content: str,
+        messages: List[Dict[str, Any]],
+    ) -> bool:
+        """Forwarder — see ``agent.agent_runtime_helpers.looks_like_post_tool_progress_only``."""
+        from agent.agent_runtime_helpers import looks_like_post_tool_progress_only
+        return looks_like_post_tool_progress_only(self, assistant_content, messages)
+
     def _extract_reasoning(self, assistant_message) -> Optional[str]:
         """Forwarder — see ``agent.agent_runtime_helpers.extract_reasoning``."""
         from agent.agent_runtime_helpers import extract_reasoning

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3429,6 +3429,110 @@ class TestRunConversation:
         assert mock_handle_function_call.call_args.kwargs["tool_call_id"] == "c1"
         assert mock_handle_function_call.call_args.kwargs["session_id"] == agent.session_id
 
+    def test_post_tool_progress_only_response_continues_instead_of_finishing(self, agent):
+        self._setup_agent(agent)
+        tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
+        resp1 = _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc])
+        progress = _mock_response(
+            content="정보수집중. 찾은 내용 분석중입니다.",
+            finish_reason="stop",
+        )
+        final = _mock_response(
+            content="작업한 일 : 검색 결과를 확인했습니다.\n검증 근거 : search result",
+            finish_reason="stop",
+        )
+        agent.client.chat.completions.create.side_effect = [resp1, progress, final]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("search something and report final")
+
+        assert result["final_response"].startswith("작업한 일")
+        assert result["api_calls"] == 3
+        assert not any(
+            m.get("_post_tool_progress_synthetic")
+            for m in result["messages"]
+        )
+
+    def test_repeated_post_tool_progress_only_fails_with_explicit_final(self, agent):
+        self._setup_agent(agent)
+        tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
+        resp1 = _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc])
+        progress = _mock_response(content="찾은 내용 분석중입니다.", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [resp1, progress, progress, progress]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("search something and report final")
+
+        assert result["turn_exit_reason"] == "post_tool_progress_only_exhausted"
+        assert result["final_response"].startswith("No final answer:")
+        assert "progress/status" in result["final_response"]
+        assert not any(
+            m.get("_post_tool_progress_synthetic")
+            for m in result["messages"]
+        )
+        assert [m.get("role") for m in result["messages"]][-3:] == [
+            "assistant",
+            "tool",
+            "assistant",
+        ]
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "자료 수집 중 발견한 핵심은 A입니다.",
+            "확인 중 오류를 발견했습니다.",
+            "분석 중간 결과: 원인은 캐시입니다.",
+        ],
+    )
+    def test_post_tool_progress_phrases_inside_final_answers_are_not_retried(self, agent, content):
+        self._setup_agent(agent)
+        tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
+        resp1 = _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc])
+        final = _mock_response(content=content, finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [resp1, final]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("search something and report final")
+
+        assert result["final_response"] == content
+        assert result["api_calls"] == 2
+
+    def test_post_tool_final_markers_are_not_treated_as_progress_only(self, agent):
+        self._setup_agent(agent)
+        tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
+        resp1 = _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc])
+        final = _mock_response(
+            content="작업한 일 : 자료 수집 중 발견한 항목을 정리했습니다.",
+            finish_reason="stop",
+        )
+        agent.client.chat.completions.create.side_effect = [resp1, final]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("search something and report final")
+
+        assert result["final_response"].startswith("작업한 일")
+        assert result["api_calls"] == 2
+
     def test_request_scoped_api_hooks_fire_for_each_api_call(self, agent):
         self._setup_agent(agent)
         tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")


### PR DESCRIPTION
## Summary
- Detect narrow post-tool progress/status-only replies and nudge the model to provide a final answer instead of closing the turn early.
- Remove synthetic retry messages from returned conversation history on success and exhaustion paths.
- Add regression coverage for successful recovery, bounded exhaustion, and false-positive cases where final answers contain phrases like “자료 수집 중 발견…”.

## Problem
Some models can execute tools successfully, then respond with only a short progress update such as “I’m analyzing the results” or “정보수집중” and no further tool calls. Treating that text as final leaves users with an incomplete progress notice instead of a closeout.

## Tests
- `python -m pytest tests/run_agent/test_run_agent.py -q -o 'addopts=' -k 'post_tool_progress or post_tool_final_markers'`
- `python -m py_compile agent/agent_runtime_helpers.py agent/conversation_loop.py agent/turn_context.py run_agent.py`
- `git diff --check`
- `gitleaks git --log-opts='origin/main..HEAD' --no-banner --redact --log-level error`
- Private-context/token regex scan over the committed diff
