### PR TITLE
fix(doctor): accept NVIDIA vendor slugs

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -796,6 +796,7 @@ def run_doctor(args):
                 "huggingface",
                 "lmstudio",
                 "nous",
+                "nvidia",
             }
             provider_accepts_vendor_slug = (
                 provider_policy_id in providers_accepting_vendor_slugs

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -493,6 +493,7 @@ def test_run_doctor_flags_missing_credentials_for_active_openrouter_provider(mon
         ("opencode-zen", "anthropic/claude-sonnet-4.6"),
         ("kilocode", "anthropic/claude-sonnet-4.6"),
         ("kimi-coding", "kimi-k2"),
+        ("nvidia", "qwen/qwen3.5-122b-a10b"),
     ],
 )
 def test_run_doctor_accepts_hermes_provider_ids_that_catalog_aliases(
@@ -533,7 +534,7 @@ def test_run_doctor_accepts_hermes_provider_ids_that_catalog_aliases(
     out = buf.getvalue()
     assert f"model.provider '{provider}' is not a recognised provider" not in out
     assert f"model.provider '{provider}' is unknown" not in out
-    if provider in {"opencode-zen", "kilocode"}:
+    if provider in {"opencode-zen", "kilocode", "nvidia"}:
         assert (
             f"model.default '{default_model}' uses a vendor/model slug but provider is '{provider}'"
             not in out


### PR DESCRIPTION
## Summary
Hermes Doctor no longer warns when the NVIDIA provider uses vendor/model slugs that NVIDIA NIM requires.

## Changes
- `hermes_cli/doctor.py`: treats `nvidia` as vendor-slug-capable for model.default validation.
- `tests/hermes_cli/test_doctor.py`: covers the NVIDIA `qwen/...` slug case alongside other provider-id aliases.

## Validation
| Check | Result |
|---|---|
| Targeted tests | `scripts/run_tests.sh tests/hermes_cli/test_doctor.py` → 66 passed |
| Live repro | `model.provider: nvidia` + `model.default: qwen/qwen3.5-122b-a10b` no longer emits the vendor-slug warning |

Cherry-picked from #35438 with @liuhao1024's authorship preserved.
Closes #35425.

## Infographic

![nvidia-doctor-check](https://v3b.fal.media/files/b/0a9e6d52/x01dyzLlfIU7H8ep-uEOl_13CbZn7t.png)
