### PR TITLE
fix: correct Azure Foundry endpoint routing and API mode

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -785,9 +785,12 @@ def init_agent(
             _routed_client, _ = resolve_provider_client(
                 agent.provider or "auto", model=agent.model, raw_codex=True)
             if _routed_client is not None:
+                # Update agent metadata from the resolved client so feature
+                # detection (Azure, Copilot, etc.) reflects the active endpoint.
+                agent.base_url = str(_routed_client.base_url)
                 client_kwargs = {
                     "api_key": _routed_client.api_key,
-                    "base_url": str(_routed_client.base_url),
+                    "base_url": agent.base_url,
                 }
                 if _provider_timeout is not None:
                     client_kwargs["timeout"] = _provider_timeout
@@ -800,6 +803,21 @@ def init_agent(
                     _routed_headers = getattr(_routed_client, "_default_headers", None)
                 if _routed_headers:
                     client_kwargs["default_headers"] = dict(_routed_headers)
+
+                # Preserve provider-specific query params (e.g. Azure api-version)
+                # the router set.
+                _routed_query = getattr(_routed_client, "_custom_query", None)
+                if not _routed_query:
+                    _routed_query = getattr(_routed_client, "default_query", None)
+                if _routed_query:
+                    client_kwargs["default_query"] = dict(_routed_query)
+
+                # RE-EVALUATE api_mode if it was auto-upgraded to codex_responses
+                # but the resolved URL is actually Azure (which doesn't support it).
+                if agent.api_mode == "codex_responses" and api_mode is None and agent._is_azure_openai_url():
+                    agent.api_mode = "chat_completions"
+                    if hasattr(agent, "_transport_cache"):
+                        agent._transport_cache.clear()
             else:
                 # When the user explicitly chose a non-OpenRouter provider
                 # but no credentials were found, fail fast with a clear

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -1036,14 +1036,17 @@ def _resolve_azure_foundry_runtime(
     # explicitly chosen anthropic_messages (Anthropic-style endpoint).
     effective_model = str(target_model or model_cfg.get("default") or "").strip()
     if effective_model and cfg_api_mode != "anthropic_messages":
-        try:
-            from hermes_cli.models import azure_foundry_model_api_mode
+        if str(model_cfg.get("api_mode") or "").strip().lower() == "chat_completions":
+            pass # Respect explicit configuration
+        else:
+            try:
+                from hermes_cli.models import azure_foundry_model_api_mode
 
-            inferred = azure_foundry_model_api_mode(effective_model)
-        except Exception:
-            inferred = None
-        if inferred:
-            cfg_api_mode = inferred
+                inferred = azure_foundry_model_api_mode(effective_model)
+            except Exception:
+                inferred = None
+            if inferred:
+                cfg_api_mode = inferred
 
     env_base_url = os.getenv("AZURE_FOUNDRY_BASE_URL", "").strip().rstrip("/")
     base_url = explicit_base_url_clean or cfg_base_url or env_base_url

--- a/package-lock.json
+++ b/package-lock.json
@@ -19707,7 +19707,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19724,7 +19723,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19741,7 +19739,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19758,7 +19755,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19775,7 +19771,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19792,7 +19787,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19809,7 +19803,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19826,7 +19819,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19843,7 +19835,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19860,7 +19851,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19877,7 +19867,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19894,7 +19883,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19911,7 +19899,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19928,7 +19915,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19945,7 +19931,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19962,7 +19947,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19979,7 +19963,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -19996,7 +19979,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20013,7 +19995,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20030,7 +20011,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20047,7 +20027,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20064,7 +20043,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20081,7 +20059,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20098,7 +20075,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20115,7 +20091,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -20132,7 +20107,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }


### PR DESCRIPTION
## Description

This PR fixes multiple bugs related to how Hermes routes and initializes clients for Azure OpenAI and Microsoft Foundry endpoints. Previously, using the `azure-foundry` provider with a GPT-5.x model would result in `HTTP 404: Resource not found` or `API version not supported` errors due to query parameters being dropped and the API mode being incorrectly auto-upgraded.

### Bug 1: Dropped `api-version` Query Parameter
**Issue:** `agent_init.py` extracts `api_key` and `base_url` from the routed client but completely ignores `default_query`. For Azure endpoints that require `?api-version=...` in the base URL, this meant the mandatory query parameter was stripped before the final OpenAI client was instantiated.
**Fix:** Modified `agent_init.py` to extract `_custom_query` / `default_query` from the `_routed_client` and pass it into `client_kwargs`.

### Bug 2: Stale `agent.base_url` Breaks Feature Detection
**Issue:** After the runtime provider resolves the final endpoint, `agent_init.py` was not updating `agent.base_url`. Downstream feature detection (specifically `_is_azure_openai_url()`) was checking an empty or unresolved URL, causing it to fail to recognize Azure endpoints.
**Fix:** Added `agent.base_url = str(_routed_client.base_url)` in `agent_init.py` immediately after provider resolution.

### Bug 3: Aggressive `api_mode` Auto-Upgrades for Azure
**Issue:** When a GPT-5.x model (e.g., `gpt-5.4-nano`) is used, `runtime_provider.py` forcefully upgrades the `api_mode` to `codex_responses` because it assumes all GPT-5 endpoints require the Responses API. However, Azure OpenAI serves these models on standard `/chat/completions`. This caused Hermes to hit a non-existent `/responses` endpoint on Azure (404 error).
**Fix:** Modified `_resolve_azure_foundry_runtime` in `hermes_cli/runtime_provider.py` to respect the user's explicit `api_mode: chat_completions` configuration from `config.yaml` rather than overriding it based on the model name.

## Related Issues
Fixes #46821

## Testing
- Configured Hermes with the `azure-foundry` provider and an Azure OpenAI endpoint (`https://<resource>.openai.azure.com/openai/deployments/<model>?api-version=...`).
- Used model `gpt-5.4-nano`.
- Ran `hermes -z "say hi"`.
- **Before:** Failed with HTTP 404 (Resource not found).
- **After:** Successfully authenticated, hit the correct `/chat/completions` endpoint, and returned a valid response.
