### PR TITLE
fix(telegram): use fresh final for streamed rich messages

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -998,14 +998,15 @@ class TelegramAdapter(BasePlatformAdapter):
     ) -> bool:
         """Whether to replace a streamed preview with a fresh rich final.
 
-        Keep this disabled for Telegram. The fresh-final path briefly shows two
-        copies of the final answer, then deletes the streaming preview after the
-        rich send succeeds. That is especially visible on clients that support
-        rich messages well, and it looks like duplicate delivery at the end of
-        every streamed turn. Until Telegram rich edits are wired directly, final
-        streamed replies should edit the existing preview in place.
+        Telegram has no rich edit endpoint wired through PTB yet: streaming
+        previews are edited as raw/MarkdownV2 text, while final rich delivery is
+        only available through ``sendRichMessage``.  Finalizing a long rich
+        reply by editing the preview in place can leave Telegram Desktop with a
+        corrupted/reflowed bubble (overlapping lines after the final format
+        pass).  When rich delivery is available, prefer a fresh
+        ``sendRichMessage`` final and best-effort delete the stale preview.
         """
-        return False
+        return self._should_attempt_rich(content, metadata=metadata)
 
     def streaming_overflow_limit(self) -> Optional[int]:
         """Allow the stream consumer to accumulate up to the rich-message cap

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -529,13 +529,13 @@ async def test_rich_draft_oversized_uses_legacy():
 
 
 # ----------------------------------------------------------------------
-# prefers_fresh_final_streaming: Telegram keeps streamed finals on the edit
-# path, even when rich messages are enabled, so users do not briefly see two
-# copies of the answer while the preview cleanup delete races the fresh send.
+# Streaming + rich finalization: Telegram should use Hermes' existing
+# fresh-final path when rich final delivery is available, instead of keeping
+# the streamed preview on the edit-finalize path.
 # ----------------------------------------------------------------------
-def test_prefers_fresh_final_streaming_stays_disabled_when_rich_enabled():
+def test_prefers_fresh_final_streaming_when_rich_enabled():
     adapter = _make_adapter()
-    assert adapter.prefers_fresh_final_streaming(RICH_CONTENT) is False
+    assert adapter.prefers_fresh_final_streaming(RICH_CONTENT) is True
 
 
 def test_prefers_fresh_final_streaming_honors_rich_opt_out():


### PR DESCRIPTION
## Summary
- enable Telegram rich streaming replies to use Hermes' existing fresh-final path when `sendRichMessage` is available
- keep the existing preview cleanup/delete flow instead of adding new draft behavior
- update the rich-message regression test so Telegram no longer disables fresh-final streaming when rich delivery is available

## Why
Hermes already has a fresh-final path that sends the completed reply as a new message and best-effort deletes the streaming preview. Telegram rich final delivery is available through `sendRichMessage`, while streamed previews are still handled through the edit/finalize path. Keeping Telegram rich replies on edit-finalize can leave Telegram Desktop with corrupted reflow / overlapping text on long rich content.

This change does not introduce a new delivery mechanism. It removes Telegram rich messages' opt-out from the existing fresh-final path when the content is eligible for rich delivery.

## Test Plan
- `scripts/run_tests.sh tests/gateway/test_stream_consumer_draft.py tests/gateway/test_stream_consumer_fresh_final.py tests/gateway/test_telegram_rich_messages.py`

## Risk
- As with the existing fresh-final behavior, the final message may briefly coexist with the streaming preview until preview deletion completes.
- If `sendRichMessage` is not available or content is not eligible for rich delivery, existing fallback behavior is preserved.
