### PR TITLE
feat(desktop): show unread response cue in session sidebar

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -91,6 +91,7 @@ import {
   $sessions,
   $sessionsLoading,
   $sessionsTotal,
+  $unreadSessionIds,
   $workingSessionIds,
   sessionPinId
 } from '@/store/session'
@@ -1226,6 +1227,8 @@ function SidebarSessionsSection({
 }: SidebarSessionsSectionProps) {
   const hasTreeSessions = Boolean(tree?.some(parent => parent.sessionCount > 0))
   const hasGroupedSessions = Boolean(groups?.some(group => group.sessions.length > 0))
+  const unreadSessionIds = useStore($unreadSessionIds)
+  const unreadSessionIdSet = useMemo(() => new Set(unreadSessionIds), [unreadSessionIds])
   const showEmptyState = forceEmptyState || (!hasGroupedSessions && !hasTreeSessions && sessions.length === 0)
   // The flat recents/pinned list is the only place sessions reorder by hand;
   // grouped/tree views always sort by creation date and never drag.
@@ -1235,6 +1238,10 @@ function SidebarSessionsSection({
     const rowProps = {
       isPinned: pinned,
       isSelected: session.id === activeSessionId,
+      isUnread:
+        session.id !== activeSessionId &&
+        (unreadSessionIdSet.has(session.id) ||
+          (session._lineage_root_id != null && unreadSessionIdSet.has(session._lineage_root_id))),
       isWorking: workingSessionIdSet.has(session.id),
       onArchive: () => onArchiveSession(session.id),
       onDelete: () => onDeleteSession(session.id),
@@ -1305,6 +1312,7 @@ function SidebarSessionsSection({
         pinned={pinned}
         sessions={sessions}
         sortable={sessionsDraggable}
+        unreadSessionIdSet={unreadSessionIdSet}
         workingSessionIdSet={workingSessionIdSet}
       />
     )
@@ -1762,6 +1770,7 @@ interface SortableSessionRowProps {
   session: SessionInfo
   isPinned: boolean
   isSelected: boolean
+  isUnread: boolean
   isWorking: boolean
   onArchive: () => void
   onDelete: () => void

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -275,7 +275,7 @@ function SidebarRowDot({
       <span
         aria-label={r.unreadResponse}
         className={cn(
-          'relative size-1.5 rounded-full bg-(--ui-unread-contrast) shadow-[0_0_0.5rem_color-mix(in_srgb,var(--ui-unread-contrast)_60%,transparent)] ring-2 ring-[color-mix(in_srgb,var(--ui-unread-contrast)_20%,transparent)]',
+          'relative size-1.5 rounded-full border border-[color-mix(in_srgb,var(--ui-unread-stroke)_82%,transparent)] bg-(--ui-unread-contrast) shadow-[0_0_0.5rem_color-mix(in_srgb,var(--ui-unread-contrast)_65%,transparent)] ring-2 ring-[color-mix(in_srgb,var(--ui-unread-stroke)_24%,transparent)]',
           className
         )}
         role="status"

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -21,6 +21,7 @@ interface SidebarSessionRowProps extends React.ComponentProps<'div'> {
   session: SessionInfo
   isPinned: boolean
   isSelected: boolean
+  isUnread: boolean
   isWorking: boolean
   onArchive: () => void
   onDelete: () => void
@@ -53,6 +54,7 @@ export function SidebarSessionRow({
   session,
   isPinned,
   isSelected,
+  isUnread,
   isWorking,
   onArchive,
   onDelete,
@@ -96,6 +98,7 @@ export function SidebarSessionRow({
           'group relative grid min-h-[1.625rem] cursor-pointer grid-cols-[minmax(0,1fr)_1.375rem] items-center rounded-md transition-colors duration-100 ease-out hover:bg-(--ui-row-hover-background) hover:transition-none',
           isSelected && 'bg-(--ui-row-active-background)',
           isWorking && 'text-foreground',
+          isUnread && !isSelected && 'bg-(--ui-control-hover-background)/40',
           // Opaque surface while lifted so the dragged row erases what's under
           // it (translucency let the rows below bleed through).
           dragging && 'z-10 cursor-grabbing bg-(--ui-sidebar-surface-background)',
@@ -173,6 +176,7 @@ export function SidebarSessionRow({
               <SidebarRowDot
                 className="transition-opacity group-hover/handle:opacity-0 group-focus-within/handle:opacity-0"
                 isWorking={isWorking}
+                isUnread={isUnread}
                 needsInput={needsInput}
               />
               <Codicon
@@ -191,7 +195,7 @@ export function SidebarSessionRow({
                 needsInput ? 'overflow-visible' : 'overflow-hidden'
               )}
             >
-              <SidebarRowDot isWorking={isWorking} needsInput={needsInput} />
+              <SidebarRowDot isUnread={isUnread} isWorking={isWorking} needsInput={needsInput} />
             </span>
           )}
           {handoffSource && handoffLabel ? (
@@ -203,7 +207,7 @@ export function SidebarSessionRow({
               />
             </Tip>
           ) : null}
-          <span className="min-w-0 flex-1 truncate text-[0.8125rem] font-normal text-(--ui-text-secondary) group-hover:text-foreground group-data-[working=true]:text-foreground/90">
+          <span className="min-w-0 flex-1 truncate text-[0.8125rem] font-normal text-(--ui-text-secondary) group-hover:text-foreground group-data-[working=true]:text-foreground/90 data-[unread=true]:font-medium data-[unread=true]:text-foreground/90" data-unread={isUnread && !isSelected ? 'true' : undefined}>
             {title}
           </span>
         </button>
@@ -240,10 +244,12 @@ export function SidebarSessionRow({
 
 function SidebarRowDot({
   isWorking,
+  isUnread = false,
   needsInput = false,
   className
 }: {
   isWorking: boolean
+  isUnread?: boolean
   needsInput?: boolean
   className?: string
 }) {
@@ -261,6 +267,20 @@ function SidebarRowDot({
         className={cn('quest-glow relative size-1.5 rounded-full bg-amber-500', className)}
         role="status"
         title={r.waitingForAnswer}
+      />
+    )
+  }
+
+  if (isUnread && !isWorking) {
+    return (
+      <span
+        aria-label={r.unreadResponse}
+        className={cn(
+          'relative size-1.5 rounded-full bg-sky-400 shadow-[0_0_0.5rem_color-mix(in_srgb,rgb(56_189_248)_65%,transparent)] ring-2 ring-sky-400/20',
+          className
+        )}
+        role="status"
+        title={r.unreadResponse}
       />
     )
   }

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -258,13 +258,12 @@ function SidebarRowDot({
 
   // "Needs input" wins over "working": a clarify-blocked session is technically
   // still running, but the actionable state is that it's waiting on the user.
-  // Amber + steady (no ping) reads as "your turn", distinct from the accent
-  // pulse of an active turn.
+  // Use the theme's warm token so this stays consistent across custom skins.
   if (needsInput) {
     return (
       <span
         aria-label={r.needsInput}
-        className={cn('quest-glow relative size-1.5 rounded-full bg-amber-500', className)}
+        className={cn('quest-glow relative size-1.5 rounded-full bg-(--ui-warm)', className)}
         role="status"
         title={r.waitingForAnswer}
       />
@@ -276,7 +275,7 @@ function SidebarRowDot({
       <span
         aria-label={r.unreadResponse}
         className={cn(
-          'relative size-1.5 rounded-full bg-sky-400 shadow-[0_0_0.5rem_color-mix(in_srgb,rgb(56_189_248)_65%,transparent)] ring-2 ring-sky-400/20',
+          'relative size-1.5 rounded-full bg-(--ui-accent-secondary) shadow-[0_0_0.5rem_color-mix(in_srgb,var(--ui-accent-secondary)_60%,transparent)] ring-2 ring-[color-mix(in_srgb,var(--ui-accent-secondary)_20%,transparent)]',
           className
         )}
         role="status"

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -275,7 +275,7 @@ function SidebarRowDot({
       <span
         aria-label={r.unreadResponse}
         className={cn(
-          'relative size-1.5 rounded-full bg-(--ui-accent-secondary) shadow-[0_0_0.5rem_color-mix(in_srgb,var(--ui-accent-secondary)_60%,transparent)] ring-2 ring-[color-mix(in_srgb,var(--ui-accent-secondary)_20%,transparent)]',
+          'relative size-1.5 rounded-full bg-(--ui-unread-contrast) shadow-[0_0_0.5rem_color-mix(in_srgb,var(--ui-unread-contrast)_60%,transparent)] ring-2 ring-[color-mix(in_srgb,var(--ui-unread-contrast)_20%,transparent)]',
           className
         )}
         role="status"

--- a/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
+++ b/apps/desktop/src/app/chat/sidebar/virtual-session-list.tsx
@@ -12,6 +12,7 @@ import { SidebarSessionRow } from './session-row'
 interface SessionRowCommonProps {
   isPinned: boolean
   isSelected: boolean
+  isUnread: boolean
   isWorking: boolean
   onArchive: () => void
   onDelete: () => void
@@ -29,6 +30,7 @@ interface VirtualSessionListProps {
   pinned: boolean
   sessions: SessionInfo[]
   sortable: boolean
+  unreadSessionIdSet: Set<string>
   workingSessionIdSet: Set<string>
 }
 
@@ -45,6 +47,7 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
   pinned,
   sessions,
   sortable,
+  unreadSessionIdSet,
   workingSessionIdSet
 }) => {
   const scrollerRef = useRef<HTMLDivElement | null>(null)
@@ -74,6 +77,10 @@ export const VirtualSessionList: FC<VirtualSessionListProps> = ({
     const commonProps: SessionRowCommonProps = {
       isPinned: pinned,
       isSelected: session.id === activeSessionId,
+      isUnread:
+        session.id !== activeSessionId &&
+        (unreadSessionIdSet.has(session.id) ||
+          (session._lineage_root_id != null && unreadSessionIdSet.has(session._lineage_root_id))),
       isWorking: workingSessionIdSet.has(session.id),
       onArchive: () => onArchiveSession(session.id),
       onDelete: () => onDeleteSession(session.id),

--- a/apps/desktop/src/app/session/hooks/use-session-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.ts
@@ -37,6 +37,7 @@ import {
   setSelectedStoredSessionId,
   setSessions,
   setSessionStartedAt,
+  setSessionUnread,
   setSessionsTotal,
   setTurnStartedAt,
   setYoloActive,
@@ -557,6 +558,7 @@ export function useSessionActions({
       // resume entry").
       setFreshDraftReady(false)
       clearNotifications()
+      setSessionUnread(storedSessionId, false)
       setSelectedStoredSessionId(storedSessionId)
       selectedStoredSessionIdRef.current = storedSessionId
 

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
@@ -9,12 +9,14 @@ import {
   $currentReasoningEffort,
   $currentServiceTier,
   $turnStartedAt,
+  $unreadSessionIds,
   setCurrentFastMode,
   setCurrentModel,
   setCurrentProvider,
   setCurrentReasoningEffort,
   setCurrentServiceTier,
-  setTurnStartedAt
+  setTurnStartedAt,
+  setUnreadSessionIds
 } from '@/store/session'
 
 import { useSessionStateCache } from './use-session-state-cache'
@@ -64,6 +66,7 @@ describe('useSessionStateCache — per-session turn timer', () => {
     setCurrentReasoningEffort('')
     setCurrentServiceTier('')
     setCurrentFastMode(false)
+    setUnreadSessionIds([])
   })
 
   afterEach(() => {
@@ -75,6 +78,7 @@ describe('useSessionStateCache — per-session turn timer', () => {
     setCurrentReasoningEffort('')
     setCurrentServiceTier('')
     setCurrentFastMode(false)
+    setUnreadSessionIds([])
   })
 
   it("keeps a background session's running turn clock and never mirrors it to the view", () => {
@@ -211,5 +215,62 @@ describe('useSessionStateCache — per-session turn timer', () => {
     expect($currentReasoningEffort.get()).toBe('')
     expect($currentServiceTier.get()).toBe('')
     expect($currentFastMode.get()).toBe(false)
+  })
+
+  it('marks a background session unread when its assistant response finishes', () => {
+    let cache!: Cache
+    render(<Harness activeSessionId="fg-runtime" onReady={c => (cache = c)} selectedStoredSessionId="fg-stored" />)
+
+    act(() => {
+      cache.updateSessionState(
+        'bg-runtime',
+        state => ({
+          ...state,
+          busy: true,
+          messages: [
+            { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'go' }] },
+            { id: 'a1', role: 'assistant', parts: [{ type: 'text', text: 'working' }], pending: true }
+          ]
+        }),
+        'bg-stored'
+      )
+    })
+
+    expect($unreadSessionIds.get()).toEqual([])
+
+    act(() => {
+      cache.updateSessionState('bg-runtime', state => ({
+        ...state,
+        busy: false,
+        messages: state.messages.map(message =>
+          message.id === 'a1' ? { ...message, parts: [{ type: 'text', text: 'done' }], pending: false } : message
+        )
+      }))
+    })
+
+    expect($unreadSessionIds.get()).toEqual(['bg-stored'])
+  })
+
+  it('does not mark the focused session unread when its response finishes', () => {
+    let cache!: Cache
+    render(<Harness activeSessionId="fg-runtime" onReady={c => (cache = c)} selectedStoredSessionId="fg-stored" />)
+
+    act(() => {
+      cache.updateSessionState(
+        'fg-runtime',
+        state => ({
+          ...state,
+          busy: true,
+          messages: [{ id: 'a1', role: 'assistant', parts: [{ type: 'text', text: 'working' }] }]
+        }),
+        'fg-stored'
+      )
+    })
+
+    act(() => {
+      cache.updateSessionState('fg-runtime', state => ({ ...state, busy: false }))
+    })
+
+    expect($unreadSessionIds.get()).toEqual([])
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -16,6 +16,7 @@ import {
   setCurrentReasoningEffort,
   setCurrentServiceTier,
   setSessionAttention,
+  setSessionUnread,
   setSessionWorking,
   setTurnStartedAt,
   setYoloActive
@@ -62,6 +63,12 @@ function syncRuntimeMetadataToView(state: ClientSessionState) {
   setCurrentFastMode(state.fast ?? false)
   setYoloActive(state.yolo ?? false)
   setCurrentPersonality(state.personality ?? '')
+}
+
+function lastVisibleMessageIsAssistant(messages: ChatMessage[]): boolean {
+  const message = messages.findLast(item => !item.hidden && (item.role === 'assistant' || item.role === 'user'))
+
+  return message?.role === 'assistant'
 }
 
 export function useSessionStateCache({
@@ -254,6 +261,17 @@ export function useSessionStateCache({
       // the stream goes silent.
       if (next.busy) {
         noteSessionActivity(next.storedSessionId)
+      }
+
+      if (
+        previous.busy &&
+        !next.busy &&
+        !next.needsInput &&
+        next.storedSessionId &&
+        next.storedSessionId !== selectedStoredSessionIdRef.current &&
+        lastVisibleMessageIsAssistant(next.messages)
+      ) {
+        setSessionUnread(next.storedSessionId, true)
       }
 
       syncSessionStateToView(sessionId, next)

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1174,6 +1174,7 @@ export const en: Translations = {
       sessionActions: 'Session actions',
       sessionRunning: 'Session running',
       needsInput: 'Needs your input',
+      unreadResponse: 'Unread response',
       waitingForAnswer: 'Waiting for your answer',
       handoffOrigin: platform => `Handed off from ${platform}`,
       renamed: 'Renamed',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1314,6 +1314,7 @@ export const ja = defineLocale({
       sessionActions: 'セッションアクション',
       sessionRunning: 'セッション実行中',
       needsInput: '入力が必要です',
+      unreadResponse: '未読の返信',
       waitingForAnswer: '回答を待っています',
       handoffOrigin: platform => `${platform} から引き継ぎ`,
       renamed: '名前を変更しました',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -904,6 +904,7 @@ export interface Translations {
       sessionActions: string
       sessionRunning: string
       needsInput: string
+      unreadResponse: string
       waitingForAnswer: string
       handoffOrigin: (platform: string) => string
       renamed: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1268,6 +1268,7 @@ export const zhHant = defineLocale({
       sessionActions: '工作階段動作',
       sessionRunning: '工作階段執行中',
       needsInput: '需要您的輸入',
+      unreadResponse: '未讀回覆',
       waitingForAnswer: '等待您的回答',
       handoffOrigin: platform => `從 ${platform} 轉接`,
       renamed: '已重新命名',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1362,6 +1362,7 @@ export const zh: Translations = {
       sessionActions: '会话操作',
       sessionRunning: '会话运行中',
       needsInput: '需要你输入',
+      unreadResponse: '未读回复',
       waitingForAnswer: '正在等待你的回答',
       handoffOrigin: platform => `从 ${platform} 转接`,
       renamed: '已重命名',

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -4,12 +4,13 @@ import { lastVisibleMessageIsUser } from '@/app/chat/thread-loading'
 import type { ContextSuggestion } from '@/app/types'
 import type { HermesConnection } from '@/global'
 import type { ChatMessage } from '@/lib/chat-messages'
-import { persistString, storedString } from '@/lib/storage'
+import { persistString, persistStringArray, storedString, storedStringArray } from '@/lib/storage'
 import type { SessionInfo, UsageStats } from '@/types/hermes'
 
 type Updater<T> = T | ((current: T) => T)
 
 const WORKSPACE_CWD_KEY = 'hermes.desktop.workspace-cwd'
+const UNREAD_SESSION_IDS_KEY = 'hermes.desktop.unread-session-ids'
 
 let configuredDefaultProjectDir = ''
 
@@ -193,6 +194,7 @@ export const $messagingTruncated = atom<boolean>(false)
 export const $sessionProfileTotals = atom<Record<string, number>>({})
 export const $sessionsLoading = atom(true)
 export const $workingSessionIds = atom<string[]>([])
+export const $unreadSessionIds = atom<string[]>(storedStringArray(UNREAD_SESSION_IDS_KEY))
 export const $activeSessionId = atom<string | null>(null)
 export const $selectedStoredSessionId = atom<string | null>(null)
 export const $messages = atom<ChatMessage[]>([])
@@ -248,6 +250,15 @@ export const setSessionProfileTotals = (next: Updater<Record<string, number>>) =
   updateAtom($sessionProfileTotals, next)
 export const setSessionsLoading = (next: Updater<boolean>) => updateAtom($sessionsLoading, next)
 export const setWorkingSessionIds = (next: Updater<string[]>) => updateAtom($workingSessionIds, next)
+export const setUnreadSessionIds = (next: Updater<string[]>) => {
+  updateAtom($unreadSessionIds, current => {
+    const value = typeof next === 'function' ? (next as (current: string[]) => string[])(current) : next
+    const deduped = Array.from(new Set(value.filter(id => id.trim().length > 0)))
+
+    return deduped.length === current.length && deduped.every((id, index) => id === current[index]) ? current : deduped
+  })
+  persistStringArray(UNREAD_SESSION_IDS_KEY, $unreadSessionIds.get())
+}
 export const setActiveSessionId = (next: Updater<string | null>) => updateAtom($activeSessionId, next)
 export const setSelectedStoredSessionId = (next: Updater<string | null>) => updateAtom($selectedStoredSessionId, next)
 export const setMessages = (next: Updater<ChatMessage[]>) => updateAtom($messages, next)
@@ -398,6 +409,12 @@ export const setAttentionSessionIds = (next: Updater<string[]>) => updateAtom($a
 export function setSessionAttention(sessionId: string | null | undefined, needsInput: boolean) {
   if (sessionId) {
     toggleMembership(setAttentionSessionIds, sessionId, needsInput)
+  }
+}
+
+export function setSessionUnread(sessionId: string | null | undefined, unread: boolean) {
+  if (sessionId) {
+    toggleMembership(setUnreadSessionIds, sessionId, unread)
   }
 }
 

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -158,6 +158,7 @@
     --ui-accent-secondary: var(--theme-primary);
     --ui-warm: var(--theme-warm);
     --ui-unread-contrast: var(--theme-unread-contrast, #38bdf8);
+    --ui-unread-stroke: var(--theme-unread-stroke, #38bdf8);
     --ui-red: #cf2d56;
     --ui-orange: #db704b;
     --ui-yellow: #c08532;

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -157,6 +157,7 @@
     --ui-accent: var(--theme-midground);
     --ui-accent-secondary: var(--theme-primary);
     --ui-warm: var(--theme-warm);
+    --ui-unread-contrast: var(--theme-unread-contrast, #38bdf8);
     --ui-red: #cf2d56;
     --ui-orange: #db704b;
     --ui-yellow: #c08532;

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -539,21 +539,21 @@
   --arc-c1: var(--dt-foreground);
 }
 
-/* Quest-style "needs you" pulse for a clarify-blocked session's dot —
-   a soft amber glow that breathes so the row draws the eye without a toast. */
+/* Theme-aware "needs you" pulse for a clarify-blocked session's dot —
+   uses the current skin's warm token so custom themes keep control of hue. */
 @keyframes quest-glow {
   0%,
   100% {
     transform: scale(1);
     box-shadow:
-      0 0 0.1875rem color-mix(in srgb, var(--color-amber-500, #f59e0b) 70%, transparent),
-      0 0 0.5rem color-mix(in srgb, var(--color-amber-500, #f59e0b) 45%, transparent);
+      0 0 0.1875rem color-mix(in srgb, var(--ui-warm) 70%, transparent),
+      0 0 0.5rem color-mix(in srgb, var(--ui-warm) 45%, transparent);
   }
   50% {
     transform: scale(1.18);
     box-shadow:
-      0 0 0.3125rem color-mix(in srgb, var(--color-amber-500, #f59e0b) 90%, transparent),
-      0 0 0.875rem color-mix(in srgb, var(--color-amber-500, #f59e0b) 65%, transparent);
+      0 0 0.3125rem color-mix(in srgb, var(--ui-warm) 90%, transparent),
+      0 0 0.875rem color-mix(in srgb, var(--ui-warm) 65%, transparent);
   }
 }
 
@@ -565,8 +565,8 @@
   .quest-glow {
     animation: none;
     box-shadow:
-      0 0 0.25rem color-mix(in srgb, var(--color-amber-500, #f59e0b) 80%, transparent),
-      0 0 0.625rem color-mix(in srgb, var(--color-amber-500, #f59e0b) 55%, transparent);
+      0 0 0.25rem color-mix(in srgb, var(--ui-warm) 80%, transparent),
+      0 0 0.625rem color-mix(in srgb, var(--ui-warm) 55%, transparent);
   }
 }
 

--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -152,22 +152,17 @@ function renderedModeFor(colors: DesktopThemeColors, mode: 'light' | 'dark'): 'l
   return 0.2126 * r + 0.7152 * g + 0.0722 * b > 0.5 ? 'light' : 'dark'
 }
 
-const UNREAD_CONTRAST_CANDIDATES = [
-  '#38bdf8', // sky: Dan's preferred accent when it clears the current skin
-  '#0ea5e9',
+const PREFERRED_UNREAD_BLUE = '#38bdf8'
+const UNREAD_STROKE_CANDIDATES = [
+  PREFERRED_UNREAD_BLUE,
+  '#7dd3fc',
+  '#bae6fd',
+  '#e0f2fe',
+  '#075985',
   '#0369a1',
-  '#22d3ee',
-  '#0891b2',
-  '#a78bfa',
-  '#7c3aed',
-  '#f472b6',
-  '#be123c',
-  '#84cc16',
-  '#4d7c0f',
-  '#facc15',
-  '#a16207',
-  '#fb923c',
-  '#c2410c'
+  '#0c4a6e',
+  '#ffffff',
+  '#000000'
 ]
 
 function distinctness(a: string, b: string): number {
@@ -181,25 +176,27 @@ function distinctness(a: string, b: string): number {
   return Math.sqrt((ar[0] - br[0]) ** 2 + (ar[1] - br[1]) ** 2 + (ar[2] - br[2]) ** 2)
 }
 
-export function unreadContrastColor(colors: DesktopThemeColors): string {
+export function unreadBubbleColor(): string {
+  return PREFERRED_UNREAD_BLUE
+}
+
+export function unreadStrokeColor(colors: DesktopThemeColors): string {
   const bg = colors.sidebarBackground ?? colors.background
   const active = colors.midground ?? colors.ring ?? colors.primary
   const warm = colors.primary
 
-  const candidate = UNREAD_CONTRAST_CANDIDATES.find(color => {
+  const candidate = UNREAD_STROKE_CANDIDATES.find(color => {
     const contrast = contrastRatio(color, bg)
     const distinct = Math.min(distinctness(color, active), distinctness(color, warm))
 
-    return contrast >= 3 && distinct >= 80
+    return contrast >= 3 && distinct >= 60
   })
 
   if (candidate) {
     return candidate
   }
 
-  const fallback = contrastRatio('#000000', bg) >= contrastRatio('#ffffff', bg) ? '#000000' : '#ffffff'
-
-  return fallback
+  return contrastRatio('#000000', bg) >= contrastRatio('#ffffff', bg) ? '#000000' : '#ffffff'
 }
 
 // ─── CSS application ────────────────────────────────────────────────────────
@@ -241,7 +238,8 @@ function applyTheme(theme: DesktopTheme, mode: 'light' | 'dark') {
     '--theme-accent-soft': c.accent,
     '--theme-midground': midground,
     '--theme-warm': c.primary,
-    '--theme-unread-contrast': unreadContrastColor(c),
+    '--theme-unread-contrast': unreadBubbleColor(),
+    '--theme-unread-stroke': unreadStrokeColor(c),
     '--theme-background-seed': c.background,
     '--theme-sidebar-seed': c.sidebarBackground ?? c.background,
     '--theme-card-seed': c.card,

--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -16,7 +16,7 @@ import { matchesQuery, useMediaQuery } from '@/hooks/use-media-query'
 import { persistString, persistStringRecord, storedString, storedStringRecord } from '@/lib/storage'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 
-import { hexToRgb, mix, readableOn } from './color'
+import { contrastRatio, hexToRgb, mix, readableOn } from './color'
 import { BUILTIN_THEME_LIST, BUILTIN_THEMES, DEFAULT_SKIN_NAME, DEFAULT_TYPOGRAPHY, nousTheme } from './presets'
 import type { DesktopTheme, DesktopThemeColors } from './types'
 import { $userThemes, resolveTheme } from './user-themes'
@@ -152,6 +152,56 @@ function renderedModeFor(colors: DesktopThemeColors, mode: 'light' | 'dark'): 'l
   return 0.2126 * r + 0.7152 * g + 0.0722 * b > 0.5 ? 'light' : 'dark'
 }
 
+const UNREAD_CONTRAST_CANDIDATES = [
+  '#38bdf8', // sky: Dan's preferred accent when it clears the current skin
+  '#0ea5e9',
+  '#0369a1',
+  '#22d3ee',
+  '#0891b2',
+  '#a78bfa',
+  '#7c3aed',
+  '#f472b6',
+  '#be123c',
+  '#84cc16',
+  '#4d7c0f',
+  '#facc15',
+  '#a16207',
+  '#fb923c',
+  '#c2410c'
+]
+
+function distinctness(a: string, b: string): number {
+  const ar = hexToRgb(a)
+  const br = hexToRgb(b)
+
+  if (!ar || !br) {
+    return 0
+  }
+
+  return Math.sqrt((ar[0] - br[0]) ** 2 + (ar[1] - br[1]) ** 2 + (ar[2] - br[2]) ** 2)
+}
+
+export function unreadContrastColor(colors: DesktopThemeColors): string {
+  const bg = colors.sidebarBackground ?? colors.background
+  const active = colors.midground ?? colors.ring ?? colors.primary
+  const warm = colors.primary
+
+  const candidate = UNREAD_CONTRAST_CANDIDATES.find(color => {
+    const contrast = contrastRatio(color, bg)
+    const distinct = Math.min(distinctness(color, active), distinctness(color, warm))
+
+    return contrast >= 3 && distinct >= 80
+  })
+
+  if (candidate) {
+    return candidate
+  }
+
+  const fallback = contrastRatio('#000000', bg) >= contrastRatio('#ffffff', bg) ? '#000000' : '#ffffff'
+
+  return fallback
+}
+
 // ─── CSS application ────────────────────────────────────────────────────────
 
 // Per-mode mix knobs. Light/dark fallbacks live in styles.css `:root` /
@@ -191,6 +241,7 @@ function applyTheme(theme: DesktopTheme, mode: 'light' | 'dark') {
     '--theme-accent-soft': c.accent,
     '--theme-midground': midground,
     '--theme-warm': c.primary,
+    '--theme-unread-contrast': unreadContrastColor(c),
     '--theme-background-seed': c.background,
     '--theme-sidebar-seed': c.sidebarBackground ?? c.background,
     '--theme-card-seed': c.card,

--- a/apps/desktop/src/themes/unread-contrast.test.ts
+++ b/apps/desktop/src/themes/unread-contrast.test.ts
@@ -1,26 +1,24 @@
 import { describe, expect, it } from 'vitest'
 
 import { contrastRatio } from './color'
-import { getBaseColors, unreadContrastColor } from './context'
+import { getBaseColors, unreadBubbleColor, unreadStrokeColor } from './context'
 import { BUILTIN_THEME_LIST } from './presets'
 
 function sidebarBackground(colors: ReturnType<typeof getBaseColors>): string {
   return colors.sidebarBackground ?? colors.background
 }
 
-describe('unreadContrastColor', () => {
-  it('keeps the preferred sky accent when it contrasts with the active theme', () => {
-    const colors = getBaseColors('sunset', 'dark')
-
-    expect(unreadContrastColor(colors)).toBe('#38bdf8')
+describe('unread session cue colors', () => {
+  it('keeps the unread bubble as the preferred bright sky blue', () => {
+    expect(unreadBubbleColor()).toBe('#38bdf8')
   })
 
   it.each(BUILTIN_THEME_LIST.flatMap(theme => [
     [`${theme.name} light`, getBaseColors(theme.name, 'light')] as const,
     [`${theme.name} dark`, getBaseColors(theme.name, 'dark')] as const
-  ]))('chooses a visible contrast color for %s', (_label, colors) => {
-    const unread = unreadContrastColor(colors)
+  ]))('chooses a visible stroke/ring color for %s', (_label, colors) => {
+    const stroke = unreadStrokeColor(colors)
 
-    expect(contrastRatio(unread, sidebarBackground(colors))).toBeGreaterThanOrEqual(3)
+    expect(contrastRatio(stroke, sidebarBackground(colors))).toBeGreaterThanOrEqual(3)
   })
 })

--- a/apps/desktop/src/themes/unread-contrast.test.ts
+++ b/apps/desktop/src/themes/unread-contrast.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { contrastRatio } from './color'
+import { getBaseColors, unreadContrastColor } from './context'
+import { BUILTIN_THEME_LIST } from './presets'
+
+function sidebarBackground(colors: ReturnType<typeof getBaseColors>): string {
+  return colors.sidebarBackground ?? colors.background
+}
+
+describe('unreadContrastColor', () => {
+  it('keeps the preferred sky accent when it contrasts with the active theme', () => {
+    const colors = getBaseColors('sunset', 'dark')
+
+    expect(unreadContrastColor(colors)).toBe('#38bdf8')
+  })
+
+  it.each(BUILTIN_THEME_LIST.flatMap(theme => [
+    [`${theme.name} light`, getBaseColors(theme.name, 'light')] as const,
+    [`${theme.name} dark`, getBaseColors(theme.name, 'dark')] as const
+  ]))('chooses a visible contrast color for %s', (_label, colors) => {
+    const unread = unreadContrastColor(colors)
+
+    expect(contrastRatio(unread, sidebarBackground(colors))).toBeGreaterThanOrEqual(3)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds unread-response tracking for desktop sidebar sessions that finish while another session is active.
- Clears the unread marker when the session is opened again.
- Renders a distinct bright sky-blue unread dot with a per-theme contrast stroke/ring, while leaving working and needs-input cues theme-token based.
- Adds locale strings and tests for the unread transition and theme contrast behavior.

## Existing related PRs
I found two open PRs for the same general issue:
- #43714
- #44952

This PR is an alternative implementation with the brighter blue unread cue and theme-aware contrast treatment.

## Verification
- `npm run typecheck`
- `npm run test:ui -- src/themes/unread-contrast.test.ts src/app/session/hooks/use-session-state-cache.test.tsx`
- `npm run build`

Addresses #43611
