### PR TITLE
fix(desktop): restore Electron binary before macOS pack rename (salvage #38673)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,6 +20,7 @@
     "start": "npm run build && electron .",
     "build": "node scripts/assert-root-install.cjs && node scripts/write-build-stamp.cjs && node scripts/stage-native-deps.cjs && tsc -b && vite build && npm run postbuild",
     "postbuild": "node scripts/assert-dist-built.cjs",
+    "prebuilder": "node scripts/patch-electron-builder-mac-binary.cjs",
     "builder": "cross-env NODE_OPTIONS=--max-old-space-size=16384 electron-builder",
     "pack": "npm run build && npm run builder -- --dir",
     "dist": "npm run build && npm run builder",
@@ -134,6 +135,7 @@
   },
   "build": {
     "electronVersion": "40.9.3",
+    "electronDist": "../../node_modules/electron/dist",
     "appId": "com.nousresearch.hermes",
     "productName": "Hermes",
     "executableName": "Hermes",

--- a/apps/desktop/scripts/patch-electron-builder-mac-binary.cjs
+++ b/apps/desktop/scripts/patch-electron-builder-mac-binary.cjs
@@ -1,0 +1,59 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+if (process.platform !== 'darwin') {
+  process.exit(0)
+}
+
+const desktopRoot = path.resolve(__dirname, '..')
+const repoRoot = path.resolve(desktopRoot, '..', '..')
+const electronMacPath = path.join(repoRoot, 'node_modules', 'app-builder-lib', 'out', 'electron', 'electronMac.js')
+
+const marker = 'hermes-macos-electron-binary-fallback'
+const needle = `    await Promise.all([
+        doRename(path.join(contentsPath, "MacOS"), electronBranding.productName, appPlist.CFBundleExecutable),
+        (0, builder_util_1.unlinkIfExists)(path.join(appOutDir, "LICENSE")),
+        (0, builder_util_1.unlinkIfExists)(path.join(appOutDir, "LICENSES.chromium.html")),
+    ]);`
+const replacement = `    // ${marker}: electron-builder 26.8.x can sometimes copy
+    // Electron.app without its main MacOS/Electron binary before this rename.
+    // Restore it from the installed Electron runtime so local desktop installs
+    // do not fail with ENOENT during macOS arm64 packaging.
+    const macosDir = path.join(contentsPath, "MacOS");
+    const bundledElectronBinary = path.join(macosDir, electronBranding.productName);
+    if (!fs.existsSync(bundledElectronBinary)) {
+        const candidates = [
+            path.join(packager.info.framework.distMacOsAppName, "Contents", "MacOS", electronBranding.productName),
+            path.join(process.cwd(), "..", "..", "node_modules", "electron", "dist", "Electron.app", "Contents", "MacOS", electronBranding.productName),
+        ];
+        const sourceBinary = candidates.find(candidate => fs.existsSync(candidate));
+        if (sourceBinary == null) {
+            throw new Error("Electron binary missing from packaged app and Electron runtime: " + bundledElectronBinary);
+        }
+        await (0, promises_1.copyFile)(sourceBinary, bundledElectronBinary);
+        await (0, promises_1.chmod)(bundledElectronBinary, 0o755);
+    }
+    await Promise.all([
+        doRename(macosDir, electronBranding.productName, appPlist.CFBundleExecutable),
+        (0, builder_util_1.unlinkIfExists)(path.join(appOutDir, "LICENSE")),
+        (0, builder_util_1.unlinkIfExists)(path.join(appOutDir, "LICENSES.chromium.html")),
+    ]);`
+
+if (!fs.existsSync(electronMacPath)) {
+  console.warn(`[patch-electron-builder] skipped: ${electronMacPath} not found`)
+  process.exit(0)
+}
+
+const source = fs.readFileSync(electronMacPath, 'utf8')
+if (source.includes(marker)) {
+  console.log('[patch-electron-builder] macOS Electron binary fallback already applied')
+  process.exit(0)
+}
+
+if (!source.includes(needle)) {
+  console.warn('[patch-electron-builder] skipped: expected electronMac.js shape not found')
+  process.exit(0)
+}
+
+fs.writeFileSync(electronMacPath, source.replace(needle, replacement))
+console.log('[patch-electron-builder] applied macOS Electron binary fallback')

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,6 +45,7 @@ ACP_REGISTRY_MANIFEST = REPO_ROOT / "acp_registry" / "agent.json"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "chaslui@outlook.com": "ChasLui",
     "rio.jeong@thebytesize.ai": "rio-jeong",
     "yehaotian@xuanshudeMac-mini.local": "ArcanePivot",
     "dbeyer7@gmail.com": "benegessarit",


### PR DESCRIPTION
## Summary

Salvages #38673 (by @ChasLui), rebased onto current `main` and wired up so CI stays green.

Fixes a macOS desktop packaging failure where `electron-builder` 26.8.x can stage an `Electron.app` bundle **without** its `Contents/MacOS/Electron` main binary, then fail while renaming it to `Hermes`:

```text
ENOENT: no such file or directory, rename .../Contents/MacOS/Electron -> .../Contents/MacOS/Hermes
```

When this happens, `npm run pack` and the installer desktop stage fail before producing a launchable `Hermes.app`.

## What changed

- Point `build.electronDist` at the already-installed Electron dist so `electron-builder` reuses it instead of re-unpacking from cache (the recommended upstream escape hatch).
- Add a `prebuilder` hook + darwin-only patch script that restores the missing main binary from the runtime dist **before** the `Electron` → `Hermes` rename. The patch is idempotent (marker-guarded), soft-fails on shape mismatch (`warn` + exit 0), and survives `node_modules` reinstall.

## Salvage notes (what changed vs. #38673)

- Re-applied on top of current `main`: kept the new `build` → `postbuild` chain and inserted `prebuilder` before `builder` (the original PR predated `postbuild`).
- Added `chaslui@outlook.com` → `ChasLui` to `AUTHOR_MAP` in `scripts/release.py` so the **Contributor Attribution Check** passes (the salvaged commit is authored by @ChasLui).
- Authorship preserved: the fix commit is cherry-picked with @ChasLui as git author (`Co-authored-by` retained for squash aggregation).

## Verification

- `node --check apps/desktop/scripts/patch-electron-builder-mac-binary.cjs`
- `apps/desktop/package.json` parses as valid JSON; `prebuilder` + `electronDist` present, no conflict markers.
- Branched from current `origin/main` → `git merge-base` non-empty (history-check).
- All new author emails in range are mapped in `AUTHOR_MAP` (attribution gate).

Supersedes #38673.

Co-authored-by: ChasLui <chaslui@outlook.com>