### PR TITLE
fix(agent): classify SSL hostname mismatch as non-retryable

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -38,6 +38,7 @@ class FailoverReason(enum.Enum):
 
     # Transport
     timeout = "timeout"                  # Connection/read timeout — rebuild client + retry
+    ssl_hostname_mismatch = "ssl_hostname_mismatch"  # SSL cert hostname doesn't match (captive portal, DNS hijack) — non-retryable
 
     # Context / payload
     context_overflow = "context_overflow"  # Context too large — compress, not failover
@@ -401,6 +402,18 @@ _SERVER_DISCONNECT_PATTERNS = [
     "incomplete chunked read",
 ]
 
+# SSL hostname mismatch patterns — captive portals, DNS hijacking, and
+# other network-layer interceptions present a certificate whose hostname
+# doesn't match the expected server.  Unlike transient SSL alerts, these
+# are NON-RETRYABLE: the same intercepting proxy will answer on every
+# retry, burning the entire retry budget across all model tiers.
+_SSL_HOSTNAME_MISMATCH_PATTERNS = [
+    "doesn't match",                   # Python ssl: "hostname 'X' doesn't match 'Y'"
+    "does not match expected hostname", # urllib3 / requests variant
+    "did not match expected hostname",  # alternative wording
+    "hostname mismatch",               # generic
+]
+
 # SSL/TLS transient failure patterns — intentionally distinct from
 # _SERVER_DISCONNECT_PATTERNS above.
 #
@@ -698,7 +711,15 @@ def classify_api_error(
     if classified is not None:
         return classified
 
-    # ── 5. SSL/TLS transient errors → retry as timeout (not compression) ──
+    # ── 5. SSL hostname mismatch → non-retryable (captive portal / DNS hijack) ──
+    # Must come BEFORE the transient SSL check — a hostname mismatch means
+    # the network path is compromised (captive portal, DNS hijack, corporate
+    # proxy).  Retrying the same endpoint hits the same intercepting proxy
+    # and wastes the entire retry budget across all model tiers.
+    if any(p in error_msg for p in _SSL_HOSTNAME_MISMATCH_PATTERNS):
+        return _result(FailoverReason.ssl_hostname_mismatch, retryable=False)
+
+    # ── 6. SSL/TLS transient errors → retry as timeout (not compression) ──
     # SSL alerts mid-stream are transport hiccups, not server-side context
     # overflow signals.  Classify before the disconnect check so a large
     # session doesn't incorrectly trigger context compression when the real
@@ -709,7 +730,7 @@ def classify_api_error(
     if any(p in error_msg for p in _SSL_TRANSIENT_PATTERNS):
         return _result(FailoverReason.timeout, retryable=True)
 
-    # ── 6. Server disconnect + large session → context overflow ─────
+    # ── 7. Server disconnect + large session → context overflow ─────
     # Must come BEFORE generic transport error catch — a disconnect on
     # a large session is more likely context overflow than a transient
     # transport hiccup.  Without this ordering, RemoteProtocolError
@@ -731,12 +752,12 @@ def classify_api_error(
             )
         return _result(FailoverReason.timeout, retryable=True)
 
-    # ── 7. Transport / timeout heuristics ───────────────────────────
+    # ── 8. Transport / timeout heuristics ───────────────────────────
 
     if error_type in _TRANSPORT_ERROR_TYPES or isinstance(error, (TimeoutError, ConnectionError, OSError)):
         return _result(FailoverReason.timeout, retryable=True)
 
-    # ── 8. Fallback: unknown ────────────────────────────────────────
+    # ── 9. Fallback: unknown ────────────────────────────────────────
 
     return _result(FailoverReason.unknown, retryable=True)
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -54,6 +54,7 @@ class TestFailoverReason:
         expected = {
             "auth", "auth_permanent", "billing", "rate_limit",
             "overloaded", "server_error", "timeout",
+            "ssl_hostname_mismatch",
             "context_overflow", "payload_too_large", "image_too_large",
             "model_not_found", "format_error",
             "invalid_encrypted_content",
@@ -1554,6 +1555,69 @@ class TestSSLTransientPatterns:
         should route to the transport bucket."""
         import ssl
         e = ssl.SSLError("arbitrary ssl error")
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is True
+
+
+# ── Test: SSL hostname mismatch (captive portal / DNS hijack) ────────────
+
+class TestSSLHostnameMismatch:
+    """SSL certificate hostname mismatch must be classified as non-retryable.
+
+    Captive portals, DNS hijacking, and corporate proxies present a
+    certificate whose hostname doesn't match the expected server.  Retrying
+    the same endpoint hits the same intercepting proxy — the error is
+    deterministic per network path, not transient.
+    """
+
+    def test_python_ssl_hostname_mismatch(self):
+        """Python ssl module: "hostname 'X' doesn't match 'Y'"."""
+        e = Exception(
+            "hostname 'bedrock-runtime.us-east-2.amazonaws.com' doesn't match "
+            "'vgw1-01.phl-philly-iap.lpv.attwifi.com'"
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.ssl_hostname_mismatch
+        assert result.retryable is False
+        assert result.should_fallback is False
+
+    def test_urllib3_hostname_mismatch(self):
+        """urllib3 / requests variant."""
+        e = Exception(
+            "Certificate for 'api.openai.com' does not match expected hostname "
+            "'api.openai.com'."
+        )
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.ssl_hostname_mismatch
+        assert result.retryable is False
+
+    def test_generic_hostname_mismatch(self):
+        """Generic 'hostname mismatch' string."""
+        e = Exception("SSL error: hostname mismatch detected")
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.ssl_hostname_mismatch
+        assert result.retryable is False
+
+    def test_hostname_mismatch_not_retryable_on_large_session(self):
+        """Even on a large session, hostname mismatch is non-retryable."""
+        e = Exception(
+            "hostname 'api.anthropic.com' doesn't match 'captive.portal.local'"
+        )
+        result = classify_api_error(
+            e,
+            approx_tokens=180000,
+            context_length=200000,
+            num_messages=300,
+        )
+        assert result.reason == FailoverReason.ssl_hostname_mismatch
+        assert result.retryable is False
+        assert result.should_compress is False
+
+    def test_transient_ssl_alert_still_classifies_as_timeout(self):
+        """Regression guard: regular SSL alerts must NOT match hostname
+        mismatch — they remain retryable as timeout."""
+        e = Exception("[SSL: BAD_RECORD_MAC] sslv3 alert bad record mac (_ssl.c:2580)")
         result = classify_api_error(e)
         assert result.reason == FailoverReason.timeout
         assert result.retryable is True


### PR DESCRIPTION
## What does this PR do?

Classifies SSL hostname mismatch errors as non-retryable (`FailoverReason.ssl_hostname_mismatch`) so the conversation loop aborts immediately instead of retrying 3x per model tier against the same intercepting proxy.

## Related Issue

Fixes #46831

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py`: Added `ssl_hostname_mismatch` to `FailoverReason` enum, `_SSL_HOSTNAME_MISMATCH_PATTERNS` list, and classification pipeline step 5 (before transient SSL check). Renumbered subsequent steps 6→9.
- `tests/agent/test_error_classifier.py`: Added `TestSSLHostnameMismatch` class with 5 tests covering Python ssl, urllib3, generic patterns, large-session non-retryability, and regression guard for transient SSL alerts.

## How to Test

1. Run `pytest tests/agent/test_error_classifier.py -x -q` — all 166 tests pass
2. Verify `FailoverReason.ssl_hostname_mismatch` exists and is non-retryable
3. Verify captive portal errors like `hostname 'X' doesn't match 'Y'` classify as `ssl_hostname_mismatch` instead of `timeout`
4. Verify transient SSL alerts (e.g. `BAD_RECORD_MAC`) still classify as retryable `timeout`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_error_classifier.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure Python logic, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/error_classifier.py` (callers: `agent/conversation_loop.py`)
- Blast radius: LOW — new enum member + pre-filter check; existing classification paths unchanged
- Related patterns: SSL transient patterns (`_SSL_TRANSIENT_PATTERNS`), transport error types (`_TRANSPORT_ERROR_TYPES`), `is_client_error` logic in conversation_loop.py (line 3123)
