### PR TITLE
fix(tools): resolve raw-task-id cwd overrides in code_execution_tool

### DIFF
--- a/tests/tools/test_code_execution_task_overrides.py
+++ b/tests/tools/test_code_execution_task_overrides.py
@@ -1,0 +1,89 @@
+"""Regression test: execute_code must honor raw-task-id-keyed cwd overrides.
+
+``resolve_task_overrides`` (added in #46552) reads a registered task/session
+override under its *raw* id first, then falls back to the collapsed
+container id -- because a CWD-only override collapses
+``_resolve_container_task_id`` to ``"default"`` and would otherwise be
+silently dropped. ``file_tools._get_file_ops`` and ``terminal_tool`` were
+migrated to this helper; ``code_execution_tool._get_or_create_env`` still
+read ``_task_env_overrides.get(effective_task_id, {})`` directly, which only
+sees the collapsed id and misses a CWD-only override registered under the
+originating session's raw task id.
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import tools.code_execution_tool as code_execution_tool
+
+
+def _make_env_config(**overrides):
+    base = {
+        "env_type": "local",
+        "docker_image": "test-image:latest",
+        "singularity_image": "docker://test",
+        "modal_image": "test",
+        "daytona_image": "test",
+        "cwd": "/config-cwd",
+        "host_cwd": None,
+        "timeout": 180,
+        "local_persistent": False,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestCodeExecutionRespectsRawTaskCwdOverride:
+    def _run(self, env_config, task_id, task_env_overrides=None):
+        captured = {}
+        mock_env = MagicMock()
+
+        def fake_create_env(**kwargs):
+            captured.update(kwargs)
+            return mock_env
+
+        with patch("tools.terminal_tool._get_env_config", return_value=env_config), \
+             patch("tools.terminal_tool._task_env_overrides", task_env_overrides or {}), \
+             patch("tools.terminal_tool._active_environments", {}), \
+             patch("tools.terminal_tool._last_activity", {}), \
+             patch("tools.terminal_tool._env_lock", threading.Lock()), \
+             patch("tools.terminal_tool._creation_locks", {}), \
+             patch("tools.terminal_tool._creation_locks_lock", threading.Lock()), \
+             patch("tools.terminal_tool._create_environment", side_effect=fake_create_env), \
+             patch("tools.terminal_tool._start_cleanup_thread"):
+            code_execution_tool._get_or_create_env(task_id)
+
+        return captured
+
+    def test_cwd_only_raw_task_override_reaches_execute_code_env(self):
+        """A CWD-only override registered under a raw session id (which
+        collapses to "default") must still set the sandbox cwd."""
+        captured = self._run(
+            _make_env_config(),
+            "desktop-session-cwd",
+            task_env_overrides={"desktop-session-cwd": {"cwd": "/workspace/session"}},
+        )
+
+        assert captured["task_id"] == "default"
+        assert captured["cwd"] == "/workspace/session"
+
+    def test_no_override_falls_back_to_config_cwd(self):
+        """Without any registered override, the configured default cwd is used."""
+        captured = self._run(_make_env_config(), "default", task_env_overrides={})
+
+        assert captured["cwd"] == "/config-cwd"
+
+    def test_isolation_keyed_override_resolves_under_its_own_task_id(self):
+        """An override with an isolation key (e.g. docker_image) keeps the
+        task isolated and its cwd override must still apply."""
+        captured = self._run(
+            _make_env_config(env_type="docker"),
+            "rollout-123",
+            task_env_overrides={
+                "rollout-123": {"docker_image": "custom:latest", "cwd": "/rollout/workspace"},
+            },
+        )
+
+        assert captured["task_id"] == "rollout-123"
+        assert captured["cwd"] == "/rollout/workspace"
+        assert captured["image"] == "custom:latest"

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -607,7 +607,7 @@ def _get_or_create_env(task_id: str):
     from tools.terminal_tool import (
         _active_environments, _env_lock, _create_environment,
         _get_env_config, _last_activity, _start_cleanup_thread,
-        _creation_locks, _creation_locks_lock, _task_env_overrides,
+        _creation_locks, _creation_locks_lock, resolve_task_overrides,
         _resolve_container_task_id,
     )
 
@@ -633,7 +633,7 @@ def _get_or_create_env(task_id: str):
 
         config = _get_env_config()
         env_type = config["env_type"]
-        overrides = _task_env_overrides.get(effective_task_id, {})
+        overrides = resolve_task_overrides(task_id)
 
         if env_type == "docker":
             image = overrides.get("docker_image") or config["docker_image"]


### PR DESCRIPTION
## Summary

- `_get_or_create_env()` in `tools/code_execution_tool.py` still read `_task_env_overrides.get(effective_task_id, {})`, which only checks the *collapsed* container id (`_resolve_container_task_id` collapses CWD-only overrides to `"default"`).
- #46552 fixed this exact issue for `terminal_tool()` and `file_tools._get_file_ops()` by introducing `resolve_task_overrides(task_id)`, which reads the *raw* task/session id first and falls back to the collapsed id. `code_execution_tool._get_or_create_env()` was the third call site sharing this pattern and was missed.
- Without this fix, a CWD-only override registered under a raw session id (e.g. by the ACP/Desktop adapter for workspace tracking) is silently dropped for `execute_code`, so its sandbox is created with the wrong `cwd` while the terminal and file tools correctly use the session's workspace.

## Changes

- Import `resolve_task_overrides` instead of `_task_env_overrides` from `tools.terminal_tool`.
- Replace `overrides = _task_env_overrides.get(effective_task_id, {})` with `overrides = resolve_task_overrides(task_id)`.
- Add `tests/tools/test_code_execution_task_overrides.py` covering:
  - CWD-only raw-task-id override reaching the `execute_code` sandbox (fails without the fix).
  - No-override fallback to the configured default cwd.
  - Isolation-keyed overrides (e.g. `docker_image`) still resolve correctly under their own task id.

## Test plan

- [x] New tests fail against the pre-fix code (`_task_env_overrides.get(effective_task_id, {})`) and pass with the fix.
- [x] `tests/tools/test_code_execution.py`, `test_code_execution_modes.py`, `test_code_execution_windows_env.py`, `test_file_tools_container_config.py` all pass.