### PR TITLE
fix(telegram): add opt-in inline mode for single-line shell fences (#46835)

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -419,6 +419,13 @@ class TelegramAdapter(BasePlatformAdapter):
         self._mention_patterns = self._compile_mention_patterns()
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
         self._disable_link_previews: bool = self._coerce_bool_extra("disable_link_previews", False)
+        # When enabled, single-line ```shell/bash/sh/zsh``` fences are
+        # rendered as inline code (`cmd`) instead of a fenced code block,
+        # since Telegram mobile makes inline code easier to tap-to-copy.
+        # Multiline bodies, heredocs/scripts, and commands containing a
+        # backtick are left as fenced blocks. Config:
+        # telegram.prefer_inline_shell_commands (default False).
+        self._prefer_inline_shell_commands: bool = self._coerce_bool_extra("prefer_inline_shell_commands", False)
         # Bot API 10.1 Rich Messages: when explicitly enabled, send final
         # replies via sendRichMessage with the raw agent markdown so
         # tables/task lists/etc. render natively. Disabled by default because
@@ -4877,6 +4884,25 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             return {"name": str(chat_id), "type": "dm", "error": str(e)}
 
+    _SHELL_FENCE_RE = re.compile(r'```(?:shell|bash|sh|zsh)\n(.*?)```', re.DOTALL)
+
+    def _inline_shell_fences(self, text: str) -> str:
+        """Convert single-line ```shell/bash/sh/zsh``` fences to inline code.
+
+        Only fences whose stripped body is a single physical line and
+        contains no backtick are converted (escaping a backtick inside
+        inline code is ambiguous). Multiline bodies, heredocs/scripts, and
+        any other language tag are left untouched.
+        """
+
+        def _convert(m: "re.Match[str]") -> str:
+            body = m.group(1).strip()
+            if '\n' in body or '`' in body:
+                return m.group(0)
+            return f'`{body}`'
+
+        return self._SHELL_FENCE_RE.sub(_convert, text)
+
     def format_message(self, content: str) -> str:
         """
         Convert standard markdown to Telegram MarkdownV2 format.
@@ -4904,6 +4930,13 @@ class TelegramAdapter(BasePlatformAdapter):
         # 0) Rewrite GFM-style pipe tables into Telegram-friendly row groups
         #    before the normal MarkdownV2 conversions run.
         text = _wrap_markdown_tables(text)
+
+        # 0.5) Optionally convert single-line shell/bash/sh/zsh fences to
+        #      inline code (tap-to-copy on Telegram mobile). Must run before
+        #      step 1 so converted commands flow into step 2's inline-code
+        #      protection rather than the fenced-block regex below.
+        if self._prefer_inline_shell_commands:
+            text = self._inline_shell_fences(text)
 
         # 1) Protect fenced code blocks (``` ... ```)
         #    Per MarkdownV2 spec, \ and ` inside pre/code must be escaped.

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -53,6 +53,12 @@ def adapter():
     return TelegramAdapter(config)
 
 
+@pytest.fixture()
+def adapter_inline_shell(adapter):
+    config = PlatformConfig(enabled=True, token="fake-token", extra={"prefer_inline_shell_commands": True})
+    return TelegramAdapter(config)
+
+
 # =========================================================================
 # _escape_mdv2
 # =========================================================================
@@ -772,6 +778,63 @@ class TestFormatMessageTables:
         assert out.count("*1*") == 1
         assert out.count("*9*") == 1
         assert "• Y: 8" in out
+
+
+# =========================================================================
+# format_message - prefer_inline_shell_commands
+# =========================================================================
+
+
+class TestFormatMessagePreferInlineShellCommands:
+    """Single-line shell/bash/sh/zsh fences become inline code when the
+    ``prefer_inline_shell_commands`` config flag is enabled."""
+
+    def test_single_line_shell_fence_converted_when_enabled(self, adapter_inline_shell):
+        text = "Run this:\n```shell\nls -la\n```"
+        result = adapter_inline_shell.format_message(text)
+        assert "`ls -la`" in result
+        assert "```" not in result
+
+    def test_single_line_shell_fence_unchanged_when_disabled(self, adapter):
+        text = "Run this:\n```shell\nls -la\n```"
+        result = adapter.format_message(text)
+        assert "```shell\nls -la\n```" in result
+
+    @pytest.mark.parametrize("lang", ["bash", "sh", "zsh"])
+    def test_bash_sh_zsh_all_convert(self, adapter_inline_shell, lang):
+        text = f"```{lang}\necho hi\n```"
+        result = adapter_inline_shell.format_message(text)
+        assert "`echo hi`" in result
+        assert "```" not in result
+
+    def test_multiline_shell_fence_untouched(self, adapter_inline_shell):
+        text = "```shell\necho hi\necho bye\n```"
+        result = adapter_inline_shell.format_message(text)
+        assert "```shell\necho hi\necho bye\n```" in result
+
+    def test_single_line_fence_with_backtick_untouched(self, adapter_inline_shell):
+        text = "```shell\necho `hostname`\n```"
+        result = adapter_inline_shell.format_message(text)
+        expected = "```shell\necho \\`hostname\\`\n```"
+        assert expected in result
+
+    def test_non_shell_language_never_converted(self, adapter_inline_shell):
+        text = "```python\nprint('hi')\n```"
+        result = adapter_inline_shell.format_message(text)
+        assert "```python\nprint('hi')\n```" in result
+        assert "`print('hi')`" not in result
+
+    def test_whitespace_trimmed(self, adapter_inline_shell):
+        text = "```shell\n   ls -la   \n```"
+        result = adapter_inline_shell.format_message(text)
+        assert "`ls -la`" in result
+        assert "```" not in result
+
+    def test_converted_inline_code_escaped_correctly_in_final_output(self, adapter_inline_shell):
+        text = "```shell\ncd C:\\Users\n```"
+        result = adapter_inline_shell.format_message(text)
+        assert r"`cd C:\\Users`" in result
+        assert "```" not in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #46835. Adds an opt-in telegram.prefer_inline_shell_commands config flag that converts single-line shell/bash/sh/zsh fenced code blocks to inline code for easier copying on Telegram mobile. Multiline commands, heredocs, and backtick-containing commands are left untouched. Default off, zero behavior change for existing users.