### PR TITLE
fix: audit cron effective runtime

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -908,7 +908,8 @@ def remove_job(job_id: str) -> bool:
 
 
 def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
-                 delivery_error: Optional[str] = None):
+                 delivery_error: Optional[str] = None,
+                 runtime_info: Optional[Dict[str, Any]] = None):
     """
     Mark a job as having been run.
     
@@ -928,6 +929,11 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                 job["last_error"] = error if not success else None
                 # Track delivery failures separately — cleared on successful delivery
                 job["last_delivery_error"] = delivery_error
+                # Secret-free runtime audit for the most recent run.  This makes
+                # model/provider/base_url-class resolution inspectable without
+                # digging through state.db or logs.
+                if runtime_info is not None:
+                    job["last_runtime"] = runtime_info
                 
                 # Increment completed count
                 if job.get("repeat"):

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -31,7 +31,7 @@ except ImportError:
     except ImportError:
         msvcrt = None
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, List, Optional
 
 # Add parent directory to path for imports BEFORE repo-level imports.
 # Without this, standalone invocations (e.g. after `hermes update` reloads
@@ -112,6 +112,131 @@ def _resolve_cron_enabled_toolsets(job: dict, cfg: dict) -> list[str] | None:
         )
         return None
 
+
+def _cron_model_from_config(cfg: dict, current: str = "") -> tuple[str, str]:
+    """Return (model, source) from config.yaml, preserving an existing value."""
+    model_cfg = (cfg or {}).get("model", {})
+    if isinstance(model_cfg, str):
+        return (model_cfg.strip() or current, "config.model" if model_cfg.strip() else "unset")
+    if isinstance(model_cfg, dict):
+        value = str(model_cfg.get("default") or model_cfg.get("model") or current or "").strip()
+        source = "config.model.default" if model_cfg.get("default") else "config.model.model" if model_cfg.get("model") else "unset"
+        return value, source
+    return current, "unset"
+
+
+def _base_url_class(base_url: str) -> str:
+    text = (base_url or "").strip().lower()
+    if not text:
+        return "unset"
+    if "localhost" in text or "127.0.0.1" in text or "::1" in text:
+        return "loopback"
+    if "openrouter.ai" in text:
+        return "openrouter"
+    if "anthropic.com" in text:
+        return "anthropic"
+    if "openai.com" in text or "chatgpt.com" in text:
+        return "openai"
+    return "remote"
+
+
+def _format_runtime_audit_md(audit: dict[str, Any] | None) -> str:
+    """Render a compact, secret-free runtime audit block for cron output."""
+    if not audit:
+        return ""
+    lines = ["## Runtime Audit", ""]
+    for key in (
+        "job_config_model",
+        "effective_agent_model",
+        "model_source",
+        "job_config_provider",
+        "effective_provider",
+        "api_mode",
+        "base_url_class",
+        "fallback_reason",
+        "hard_pinned",
+    ):
+        value = audit.get(key)
+        if value is None or value == "":
+            value = "null"
+        lines.append(f"- **{key}:** `{value}`")
+    return "\n".join(lines) + "\n\n"
+
+
+def _resolve_effective_cron_runtime(job: dict, cfg: dict) -> tuple[str, dict[str, Any], dict[str, Any]]:
+    """Resolve and audit the runtime a cron job will actually use.
+
+    Job-level ``model`` is a hard pin: if present, it is passed through to
+    AIAgent unchanged and config/env defaults may not replace it. Unpinned jobs
+    use HERMES_MODEL then config.yaml. The returned audit is persisted on the
+    job record and embedded in the run output so later failures can be tied to
+    the exact provider/model/base_url/api_mode used.
+    """
+    job_model = str(job.get("model") or "").strip()
+    env_model = str(os.getenv("HERMES_MODEL") or "").strip()
+
+    if job_model:
+        model = job_model
+        model_source = "job.model"
+    elif env_model:
+        model = env_model
+        model_source = "HERMES_MODEL"
+    else:
+        model, model_source = _cron_model_from_config(cfg)
+
+    from hermes_cli.runtime_provider import (
+        resolve_runtime_provider,
+        format_runtime_provider_error,
+    )
+    from hermes_cli.auth import AuthError
+
+    requested_provider = job.get("provider")
+    runtime_kwargs: dict[str, Any] = {"requested": requested_provider}
+    if job.get("base_url"):
+        runtime_kwargs["explicit_base_url"] = job.get("base_url")
+
+    fallback_reason = ""
+    try:
+        runtime = resolve_runtime_provider(**runtime_kwargs)
+    except AuthError as auth_exc:
+        fb = cfg.get("fallback_providers") or cfg.get("fallback_model") or None
+        fb_list = (fb if isinstance(fb, list) else [fb]) if fb else []
+        runtime = None
+        for entry in fb_list:
+            if not isinstance(entry, dict):
+                continue
+            try:
+                fb_kwargs = {"requested": entry.get("provider")}
+                if entry.get("base_url"):
+                    fb_kwargs["explicit_base_url"] = entry["base_url"]
+                if entry.get("api_key"):
+                    fb_kwargs["explicit_api_key"] = entry["api_key"]
+                runtime = resolve_runtime_provider(**fb_kwargs)
+                fallback_reason = f"primary auth failed; using fallback provider {entry.get('provider')}"
+                logger.info("Job '%s': fallback resolved to %s", job.get("id"), runtime.get("provider"))
+                break
+            except Exception as fb_exc:
+                logger.debug("Job '%s': fallback %s failed: %s", job.get("id"), entry.get("provider"), fb_exc)
+        if runtime is None:
+            raise RuntimeError(format_runtime_provider_error(auth_exc)) from auth_exc
+    except Exception as exc:
+        message = format_runtime_provider_error(exc)
+        raise RuntimeError(message) from exc
+
+    audit = {
+        "job_config_model": job_model or None,
+        "effective_agent_model": model,
+        "model_source": model_source,
+        "job_config_provider": str(job.get("provider") or "").strip() or None,
+        "effective_provider": str(runtime.get("provider") or "").strip() or None,
+        "api_mode": str(runtime.get("api_mode") or "").strip() or None,
+        "base_url_class": _base_url_class(str(runtime.get("base_url") or "")),
+        "fallback_reason": fallback_reason or None,
+        "hard_pinned": bool(job_model),
+    }
+    return model, runtime, audit
+
+
 # Valid delivery platforms — used to validate user-supplied platform names
 # in cron delivery targets, preventing env var enumeration via crafted names.
 _KNOWN_DELIVERY_PLATFORMS = frozenset({
@@ -150,6 +275,11 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
 }
 
 from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run
+
+# Per-job runtime audit captured by run_job() and persisted by tick(). Kept
+# outside the return tuple for backward compatibility with existing tests/tools
+# that unpack (success, output, final_response, error).
+_LAST_RUNTIME_AUDIT: dict[str, dict[str, Any]] = {}
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
@@ -1662,9 +1792,7 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 else str(delivery_target["thread_id"])
             )
 
-        model = job.get("model") or os.getenv("HERMES_MODEL") or ""
-
-        # Load config.yaml for model, reasoning, prefill, toolsets, provider routing
+        # Load config.yaml for model, reasoning, prefill, toolsets, provider routing.
         _cfg = {}
         try:
             import yaml
@@ -1673,14 +1801,22 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 with open(_cfg_path, encoding="utf-8") as _f:
                     _cfg = yaml.safe_load(_f) or {}
                 _cfg = _expand_env_vars(_cfg)
-                _model_cfg = _cfg.get("model", {})
-                if not job.get("model"):
-                    if isinstance(_model_cfg, str):
-                        model = _model_cfg
-                    elif isinstance(_model_cfg, dict):
-                        model = _model_cfg.get("default", model)
         except Exception as e:
             logger.warning("Job '%s': failed to load config.yaml, using defaults: %s", job_id, e)
+
+        model, runtime, runtime_audit = _resolve_effective_cron_runtime(job, _cfg)
+        _LAST_RUNTIME_AUDIT[job_id] = runtime_audit
+        logger.info(
+            "Job '%s': effective cron runtime model=%r source=%s provider=%r api_mode=%r base_url_class=%s hard_pinned=%s fallback=%r",
+            job_id,
+            runtime_audit.get("effective_agent_model"),
+            runtime_audit.get("model_source"),
+            runtime_audit.get("effective_provider"),
+            runtime_audit.get("api_mode"),
+            runtime_audit.get("base_url_class"),
+            runtime_audit.get("hard_pinned"),
+            runtime_audit.get("fallback_reason"),
+        )
 
         # Apply IPv4 preference if configured.
         try:
@@ -1725,49 +1861,6 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
 
         # Provider routing
         pr = _cfg.get("provider_routing", {})
-
-        from hermes_cli.runtime_provider import (
-            resolve_runtime_provider,
-            format_runtime_provider_error,
-        )
-        from hermes_cli.auth import AuthError
-        try:
-            # Do not inject HERMES_INFERENCE_PROVIDER here. resolve_runtime_provider()
-            # already prefers persisted config over stale shell/env overrides when
-            # no explicit provider is requested. Passing the env var here short-
-            # circuits that precedence and can resurrect old providers (for
-            # example DeepSeek) for cron jobs that do not pin provider/model.
-            runtime_kwargs = {
-                "requested": job.get("provider"),
-            }
-            if job.get("base_url"):
-                runtime_kwargs["explicit_base_url"] = job.get("base_url")
-            runtime = resolve_runtime_provider(**runtime_kwargs)
-        except AuthError as auth_exc:
-            # Primary provider auth failed — try fallback chain before giving up.
-            logger.warning("Job '%s': primary auth failed (%s), trying fallback", job_id, auth_exc)
-            fb = _cfg.get("fallback_providers") or _cfg.get("fallback_model")
-            fb_list = (fb if isinstance(fb, list) else [fb]) if fb else []
-            runtime = None
-            for entry in fb_list:
-                if not isinstance(entry, dict):
-                    continue
-                try:
-                    fb_kwargs = {"requested": entry.get("provider")}
-                    if entry.get("base_url"):
-                        fb_kwargs["explicit_base_url"] = entry["base_url"]
-                    if entry.get("api_key"):
-                        fb_kwargs["explicit_api_key"] = entry["api_key"]
-                    runtime = resolve_runtime_provider(**fb_kwargs)
-                    logger.info("Job '%s': fallback resolved to %s", job_id, runtime.get("provider"))
-                    break
-                except Exception as fb_exc:
-                    logger.debug("Job '%s': fallback %s failed: %s", job_id, entry.get("provider"), fb_exc)
-            if runtime is None:
-                raise RuntimeError(format_runtime_provider_error(auth_exc)) from auth_exc
-        except Exception as exc:
-            message = format_runtime_provider_error(exc)
-            raise RuntimeError(message) from exc
 
         fallback_model = _cfg.get("fallback_providers") or _cfg.get("fallback_model") or None
         credential_pool = None
@@ -1958,13 +2051,14 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # for delivery logic (empty response = no delivery).
         logged_response = final_response if final_response else "(No response generated)"
         
+        runtime_audit_md = _format_runtime_audit_md(_LAST_RUNTIME_AUDIT.get(job_id))
         output = f"""# Cron Job: {job_name}
 
 **Job ID:** {job_id}
 **Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
 **Schedule:** {job.get('schedule_display', 'N/A')}
 
-## Prompt
+{runtime_audit_md}## Prompt
 
 {prompt}
 
@@ -1980,13 +2074,14 @@ def _run_job_impl(job: dict) -> tuple[bool, str, str, Optional[str]]:
         error_msg = f"{type(e).__name__}: {str(e)}"
         logger.exception("Job '%s' failed: %s", job_name, error_msg)
         
+        runtime_audit_md = _format_runtime_audit_md(_LAST_RUNTIME_AUDIT.get(job_id))
         output = f"""# Cron Job: {job_name} (FAILED)
 
 **Job ID:** {job_id}
 **Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
 **Schedule:** {job.get('schedule_display', 'N/A')}
 
-## Prompt
+{runtime_audit_md}## Prompt
 
 {prompt}
 
@@ -2165,12 +2260,20 @@ def tick(verbose: bool = True, adapters=None, loop=None, sync: bool = True) -> i
                     success = False
                     error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
 
-                mark_job_run(job["id"], success, error, delivery_error=delivery_error)
+                runtime_info = _LAST_RUNTIME_AUDIT.pop(job["id"], None)
+                if runtime_info is None:
+                    mark_job_run(job["id"], success, error, delivery_error=delivery_error)
+                else:
+                    mark_job_run(job["id"], success, error, delivery_error=delivery_error, runtime_info=runtime_info)
                 return True
 
             except Exception as e:
                 logger.error("Error processing job %s: %s", job['id'], e)
-                mark_job_run(job["id"], False, str(e))
+                runtime_info = _LAST_RUNTIME_AUDIT.pop(job["id"], None)
+                if runtime_info is None:
+                    mark_job_run(job["id"], False, str(e))
+                else:
+                    mark_job_run(job["id"], False, str(e), runtime_info=runtime_info)
                 return False
 
         # Partition due jobs: jobs with a per-job workdir and/or profile touch

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -137,6 +137,13 @@ def cron_list(show_all: bool = False):
         delivery_err = job.get("last_delivery_error")
         if delivery_err:
             print(f"    {color('⚠ Delivery failed:', Colors.YELLOW)} {delivery_err}")
+        last_runtime = job.get("last_runtime") or {}
+        if isinstance(last_runtime, dict) and last_runtime:
+            model = last_runtime.get("effective_agent_model") or "?"
+            provider = last_runtime.get("effective_provider") or "?"
+            source = last_runtime.get("model_source") or "?"
+            pinned = " pinned" if last_runtime.get("hard_pinned") else ""
+            print(f"    Runtime:   {provider} / {model} ({source}{pinned})")
 
         print()
 

--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -77,6 +77,7 @@ Config file: `~/.hermes/hindsight/config.json`
 | `recall_tags` | — | Tags to filter when searching memories |
 | `recall_tags_match` | `any` | Tag matching mode: `any` / `all` / `any_strict` / `all_strict` |
 | `recall_types` | `observation` | Fact types surfaced by recall (both auto-recall and the `hindsight_recall` tool). Comma-separated string or JSON list. **Default narrowed to `observation` only** (see "Behavior change" below). Set to `observation,world,experience` to also include raw facts. |
+| `recall_extra_bank_ids` | — | Additional shared banks to search after the active bank during normal recall. Useful for `current_room + hermes` legacy recall. Retain writes still go only to the active bank. |
 | `auto_recall` | `true` | Automatically recall memories before each turn |
 
 > **Behavior change — `recall_types` defaults to `observation` only.**

--- a/plugins/memory/hindsight/README.md
+++ b/plugins/memory/hindsight/README.md
@@ -59,8 +59,9 @@ Config file: `~/.hermes/hindsight/config.json`
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `bank_id` | `hermes` | Memory bank name (static fallback used when `bank_id_template` is unset or resolves empty) |
-| `bank_id_template` | — | Optional template to derive the bank name dynamically. Placeholders: `{profile}`, `{workspace}`, `{platform}`, `{user}`, `{session}`. Example: `hermes-{profile}` isolates memory per active Hermes profile. Empty placeholders collapse cleanly (e.g. `hermes-{user}` with no user becomes `hermes`). |
+| `bank_id` | `hermes` | Memory bank name (static fallback used when `bank_routes` and `bank_id_template` do not match) |
+| `bank_routes` | — | Optional map from current room/channel IDs to semantic bank names. Route keys may be raw chat IDs, platform-prefixed IDs, or `platform:chat:thread`; values are bank IDs such as `astra_work`. Routes take precedence over templates. |
+| `bank_id_template` | — | Optional template to derive the bank name dynamically when no `bank_routes` entry matches. Placeholders: `{profile}`, `{workspace}`, `{platform}`, `{user}`, `{session}`, `{chat}`, `{room}`, `{thread}`. Example: `hermes-{profile}` isolates memory per active Hermes profile. Empty placeholders collapse cleanly (e.g. `hermes-{user}` with no user becomes `hermes`). |
 | `bank_mission` | — | Reflect mission (identity/framing for reflect reasoning). Applied via Banks API. |
 | `bank_retain_mission` | — | Retain mission (steers what gets extracted). Applied via Banks API. |
 

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -21,6 +21,7 @@ Config via environment variables:
   HINDSIGHT_RETAIN_SOURCE          — metadata source value attached to retained memories
   HINDSIGHT_RETAIN_USER_PREFIX     — label used before user turns in retained transcripts
   HINDSIGHT_RETAIN_ASSISTANT_PREFIX — label used before assistant turns in retained transcripts
+  HINDSIGHT_RECALL_EXTRA_BANK_IDS  — comma-separated shared banks to search after the active room bank
 
 Or via $HERMES_HOME/hindsight/config.json (profile-scoped), falling back to
 ~/.hindsight/config.json (legacy, shared) for backward compatibility.
@@ -329,6 +330,7 @@ def _load_config() -> dict:
         "retain_source": os.environ.get("HINDSIGHT_RETAIN_SOURCE", ""),
         "retain_user_prefix": os.environ.get("HINDSIGHT_RETAIN_USER_PREFIX", "User"),
         "retain_assistant_prefix": os.environ.get("HINDSIGHT_RETAIN_ASSISTANT_PREFIX", "Assistant"),
+        "recall_extra_bank_ids": os.environ.get("HINDSIGHT_RECALL_EXTRA_BANK_IDS", ""),
         "banks": {
             "hermes": {
                 "bankId": os.environ.get("HINDSIGHT_BANK_ID", "hermes"),
@@ -373,6 +375,19 @@ def _normalize_retain_tags(value: Any) -> List[str]:
             continue
         seen.add(tag)
         normalized.append(tag)
+    return normalized
+
+
+def _normalize_bank_id_list(value: Any) -> list[str]:
+    """Normalize configured bank IDs to a deduplicated safe list."""
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for item in _normalize_retain_tags(value):
+        bank_id = _sanitize_bank_segment(item)
+        if not bank_id or bank_id in seen:
+            continue
+        seen.add(bank_id)
+        normalized.append(bank_id)
     return normalized
 
 
@@ -599,6 +614,8 @@ class HindsightMemoryProvider(MemoryProvider):
         self._api_url = _DEFAULT_API_URL
         self._bank_id = "hermes"
         self._bank_routes: dict[str, str] = {}
+        self._recall_extra_bank_ids: list[str] = []
+        self._recall_bank_ids: list[str] = ["hermes"]
         self._budget = "mid"
         self._mode = "cloud"
         self._llm_base_url = ""
@@ -936,6 +953,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "bank_id", "description": "Memory bank name (static fallback when bank_routes and bank_id_template do not match)", "default": "hermes"},
             {"key": "bank_routes", "description": "Optional map of current room/channel IDs to semantic bank IDs. Keys may be raw chat IDs, platform-prefixed IDs, or most-specific platform:chat:thread keys. Example: {\"matrix:!room:server\": \"astra_work\"}", "default": {}},
             {"key": "bank_id_template", "description": "Optional template to derive bank_id dynamically when bank_routes does not match. Placeholders: {profile}, {workspace}, {platform}, {user}, {session}, {chat}, {room}, {thread}. Example: hermes-{profile}", "default": ""},
+            {"key": "recall_extra_bank_ids", "description": "Additional shared banks to search after the active bank during recall. Retain writes still go only to the active bank.", "default": ""},
             {"key": "bank_mission", "description": "Mission/purpose description for the memory bank"},
             {"key": "bank_retain_mission", "description": "Custom extraction prompt for memory retention"},
             {"key": "recall_budget", "description": "Recall thoroughness", "default": "mid", "choices": ["low", "mid", "high"]},
@@ -1253,6 +1271,14 @@ class HindsightMemoryProvider(MemoryProvider):
             chat=self._chat_id,
             thread=self._thread_id,
         )
+        self._recall_extra_bank_ids = _normalize_bank_id_list(
+            self._config.get("recall_extra_bank_ids")
+            or os.environ.get("HINDSIGHT_RECALL_EXTRA_BANK_IDS", "")
+        )
+        self._recall_bank_ids = [self._bank_id]
+        for bank_id in self._recall_extra_bank_ids:
+            if bank_id and bank_id not in self._recall_bank_ids:
+                self._recall_bank_ids.append(bank_id)
         budget = self._config.get("recall_budget") or self._config.get("budget") or banks.get("budget", "mid")
         self._budget = budget if budget in _VALID_BUDGETS else "mid"
 
@@ -1313,8 +1339,12 @@ class HindsightMemoryProvider(MemoryProvider):
             _client_version = pkg_version("hindsight-client")
         except Exception:
             pass
-        logger.info("Hindsight initialized: mode=%s, api_url=%s, bank=%s, budget=%s, memory_mode=%s, prefetch_method=%s, client=%s",
-                     self._mode, self._api_url, self._bank_id, self._budget, self._memory_mode, self._prefetch_method, _client_version)
+        logger.info(
+            "Hindsight initialized: mode=%s, api_url=%s, bank=%s, recall_banks=%s, "
+            "budget=%s, memory_mode=%s, prefetch_method=%s, client=%s",
+            self._mode, self._api_url, self._bank_id, self._recall_bank_ids,
+            self._budget, self._memory_mode, self._prefetch_method, _client_version,
+        )
         if self._bank_id_template:
             logger.debug("Hindsight bank resolved from template %r: profile=%s workspace=%s platform=%s user=%s -> bank=%s",
                          self._bank_id_template, self._agent_identity, self._agent_workspace,
@@ -1377,11 +1407,15 @@ class HindsightMemoryProvider(MemoryProvider):
             t.start()
 
     def system_prompt_block(self) -> str:
+        recall_suffix = ""
+        if len(self._recall_bank_ids) > 1:
+            recall_suffix = f" Recall also searches: {', '.join(self._recall_bank_ids[1:])}."
         if self._memory_mode == "context":
             return (
                 f"# Hindsight Memory\n"
                 f"Active (context mode). Bank: {self._bank_id}, budget: {self._budget}.\n"
                 f"Relevant memories are automatically injected into context."
+                f"{recall_suffix}"
             )
         if self._memory_mode == "tools":
             return (
@@ -1389,6 +1423,7 @@ class HindsightMemoryProvider(MemoryProvider):
                 f"Active (tools mode). Bank: {self._bank_id}, budget: {self._budget}.\n"
                 f"Use hindsight_recall to search, hindsight_reflect for synthesis, "
                 f"hindsight_retain to store facts."
+                f"{recall_suffix}"
             )
         return (
             f"# Hindsight Memory\n"
@@ -1396,7 +1431,67 @@ class HindsightMemoryProvider(MemoryProvider):
             f"Relevant memories are automatically injected into context. "
             f"Use hindsight_recall to search, hindsight_reflect for synthesis, "
             f"hindsight_retain to store facts."
+            f"{recall_suffix}"
         )
+
+    def _build_recall_kwargs(self, *, bank_id: str, query: str) -> dict[str, Any]:
+        recall_kwargs: dict[str, Any] = {
+            "bank_id": bank_id,
+            "query": query,
+            "budget": self._budget,
+            "max_tokens": self._recall_max_tokens,
+        }
+        if self._recall_tags:
+            recall_kwargs["tags"] = self._recall_tags
+            recall_kwargs["tags_match"] = self._recall_tags_match
+        if self._recall_types:
+            recall_kwargs["types"] = self._recall_types
+        return recall_kwargs
+
+    def _recall_results(self, query: str) -> list[tuple[str, Any]]:
+        """Recall from the active bank and configured shared banks."""
+        results: list[tuple[str, Any]] = []
+        errors: list[tuple[str, Exception]] = []
+        seen_text: set[str] = set()
+        bank_ids = self._recall_bank_ids or [self._bank_id]
+        for bank_id in bank_ids:
+            recall_kwargs = self._build_recall_kwargs(bank_id=bank_id, query=query)
+            try:
+                logger.debug(
+                    "Hindsight recall: bank=%s, query_len=%d, budget=%s",
+                    bank_id, len(query), self._budget,
+                )
+                resp = self._run_hindsight_operation(
+                    lambda client, kwargs=recall_kwargs: client.arecall(**kwargs)
+                )
+            except Exception as exc:
+                errors.append((bank_id, exc))
+                logger.debug("Hindsight recall failed for bank=%s: %s", bank_id, exc, exc_info=True)
+                continue
+            for item in resp.results or []:
+                text = str(getattr(item, "text", "") or "")
+                if not text or text in seen_text:
+                    continue
+                seen_text.add(text)
+                results.append((bank_id, item))
+
+        if not results and errors:
+            bank_id, exc = errors[0]
+            raise RuntimeError(f"recall failed for bank {bank_id}: {exc}") from exc
+        return results
+
+    def _format_recall_text(self, results: list[tuple[str, Any]], *, numbered: bool) -> str:
+        show_bank = len(self._recall_bank_ids or []) > 1
+        lines: list[str] = []
+        for index, (bank_id, item) in enumerate(results, 1):
+            text = str(getattr(item, "text", "") or "")
+            if not text:
+                continue
+            if show_bank:
+                text = f"[{bank_id}] {text}"
+            prefix = f"{index}. " if numbered else "- "
+            lines.append(f"{prefix}{text}")
+        return "\n".join(lines)
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         if self._prefetch_thread and self._prefetch_thread.is_alive():
@@ -1437,21 +1532,10 @@ class HindsightMemoryProvider(MemoryProvider):
                     resp = self._run_hindsight_operation(lambda client: client.areflect(bank_id=self._bank_id, query=query, budget=self._budget))
                     text = resp.text or ""
                 else:
-                    recall_kwargs: dict = {
-                        "bank_id": self._bank_id, "query": query,
-                        "budget": self._budget, "max_tokens": self._recall_max_tokens,
-                    }
-                    if self._recall_tags:
-                        recall_kwargs["tags"] = self._recall_tags
-                        recall_kwargs["tags_match"] = self._recall_tags_match
-                    if self._recall_types:
-                        recall_kwargs["types"] = self._recall_types
-                    logger.debug("Prefetch: calling recall (bank=%s, query_len=%d, budget=%s)",
-                                 self._bank_id, len(query), self._budget)
-                    resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
-                    num_results = len(resp.results) if resp.results else 0
+                    results = self._recall_results(query)
+                    num_results = len(results)
                     logger.debug("Prefetch: recall returned %d results", num_results)
-                    text = "\n".join(f"- {r.text}" for r in resp.results if r.text) if resp.results else ""
+                    text = self._format_recall_text(results, numbered=False)
                 if text:
                     with self._prefetch_lock:
                         self._prefetch_result = text
@@ -1659,24 +1743,12 @@ class HindsightMemoryProvider(MemoryProvider):
             if not query:
                 return tool_error("Missing required parameter: query")
             try:
-                recall_kwargs: dict = {
-                    "bank_id": self._bank_id, "query": query, "budget": self._budget,
-                    "max_tokens": self._recall_max_tokens,
-                }
-                if self._recall_tags:
-                    recall_kwargs["tags"] = self._recall_tags
-                    recall_kwargs["tags_match"] = self._recall_tags_match
-                if self._recall_types:
-                    recall_kwargs["types"] = self._recall_types
-                logger.debug("Tool hindsight_recall: bank=%s, query_len=%d, budget=%s",
-                             self._bank_id, len(query), self._budget)
-                resp = self._run_hindsight_operation(lambda client: client.arecall(**recall_kwargs))
-                num_results = len(resp.results) if resp.results else 0
+                results = self._recall_results(query)
+                num_results = len(results)
                 logger.debug("Tool hindsight_recall: %d results", num_results)
-                if not resp.results:
+                if not results:
                     return json.dumps({"result": "No relevant memories found."})
-                lines = [f"{i}. {r.text}" for i, r in enumerate(resp.results, 1)]
-                return json.dumps({"result": "\n".join(lines)})
+                return json.dumps({"result": self._format_recall_text(results, numbered=True)})
             except Exception as e:
                 logger.warning("hindsight_recall failed: %s", e, exc_info=True)
                 return tool_error(f"Failed to search memory: {e}")

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -487,6 +487,9 @@ def _resolve_bank_id_template(template: str, fallback: str, **placeholders: str)
       {platform}  — "cli", "telegram", "discord", etc.
       {user}      — platform user id (gateway sessions)
       {session}   — current session id
+      {chat}      — platform chat/channel/room id (gateway sessions)
+      {room}      — alias for {chat}
+      {thread}    — platform thread/topic id (gateway sessions)
 
     Missing/empty placeholders are rendered as the empty string and then
     collapsed — e.g. ``hermes-{user}`` with no user becomes ``hermes``.
@@ -511,6 +514,78 @@ def _resolve_bank_id_template(template: str, fallback: str, **placeholders: str)
     return rendered or fallback
 
 
+def _normalize_bank_routes(value: Any) -> dict[str, str]:
+    """Return a cleaned mapping of route keys to safe bank ids."""
+    if not value:
+        return {}
+    if not isinstance(value, dict):
+        logger.warning("Invalid Hindsight bank_routes %r — expected object", value)
+        return {}
+    routes: dict[str, str] = {}
+    for raw_key, raw_bank in value.items():
+        key = str(raw_key or "").strip()
+        bank_id = _sanitize_bank_segment(raw_bank)
+        if key and bank_id:
+            routes[key] = bank_id
+    return routes
+
+
+def _bank_route_candidates(platform: str = "", chat: str = "", thread: str = "") -> list[str]:
+    """Return route keys from most-specific to broadest.
+
+    Configs may use raw gateway IDs (``matrix:!room:server``) or sanitized
+    variants (``matrix:room-server``). Raw IDs are preferred because they are
+    lossless; sanitized keys are only a convenience for hand-written configs.
+    """
+    raw_platform = str(platform or "").strip()
+    raw_chat = str(chat or "").strip()
+    raw_thread = str(thread or "").strip()
+    clean_platform = _sanitize_bank_segment(raw_platform)
+    clean_chat = _sanitize_bank_segment(raw_chat)
+    clean_thread = _sanitize_bank_segment(raw_thread)
+
+    candidates: list[str] = []
+
+    def add(*parts: str) -> None:
+        key = ":".join(str(p) for p in parts if str(p))
+        if key and key not in candidates:
+            candidates.append(key)
+
+    if raw_chat and raw_thread:
+        add(raw_platform, raw_chat, raw_thread)
+        add(raw_chat, raw_thread)
+    if clean_chat and clean_thread:
+        add(clean_platform, clean_chat, clean_thread)
+        add(clean_chat, clean_thread)
+    if raw_chat:
+        add(raw_platform, raw_chat)
+        add(raw_chat)
+    if clean_chat:
+        add(clean_platform, clean_chat)
+        add(clean_chat)
+    add("default")
+    add("*")
+    return candidates
+
+
+def _resolve_bank_route(
+    routes: dict[str, str],
+    fallback: str,
+    *,
+    platform: str = "",
+    chat: str = "",
+    thread: str = "",
+) -> str:
+    """Resolve an explicit semantic bank route, falling back if none match."""
+    if not routes:
+        return fallback
+    for key in _bank_route_candidates(platform=platform, chat=chat, thread=thread):
+        bank_id = routes.get(key)
+        if bank_id:
+            return bank_id
+    return fallback
+
+
 # ---------------------------------------------------------------------------
 # MemoryProvider implementation
 # ---------------------------------------------------------------------------
@@ -523,6 +598,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._api_key = None
         self._api_url = _DEFAULT_API_URL
         self._bank_id = "hermes"
+        self._bank_routes: dict[str, str] = {}
         self._budget = "mid"
         self._mode = "cloud"
         self._llm_base_url = ""
@@ -857,8 +933,9 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "llm_base_url", "description": "Endpoint URL (e.g. http://192.168.1.10:8080/v1)", "default": "", "when": {"mode": "local_embedded", "llm_provider": "openai_compatible"}},
             {"key": "llm_api_key", "description": "LLM API key (optional for openai_compatible)", "secret": True, "env_var": "HINDSIGHT_LLM_API_KEY", "when": {"mode": "local_embedded"}},
             {"key": "llm_model", "description": "LLM model", "default": "gpt-4o-mini", "default_from": {"field": "llm_provider", "map": _PROVIDER_DEFAULT_MODELS}, "when": {"mode": "local_embedded"}},
-            {"key": "bank_id", "description": "Memory bank name (static fallback when bank_id_template is unset)", "default": "hermes"},
-            {"key": "bank_id_template", "description": "Optional template to derive bank_id dynamically. Placeholders: {profile}, {workspace}, {platform}, {user}, {session}. Example: hermes-{profile}", "default": ""},
+            {"key": "bank_id", "description": "Memory bank name (static fallback when bank_routes and bank_id_template do not match)", "default": "hermes"},
+            {"key": "bank_routes", "description": "Optional map of current room/channel IDs to semantic bank IDs. Keys may be raw chat IDs, platform-prefixed IDs, or most-specific platform:chat:thread keys. Example: {\"matrix:!room:server\": \"astra_work\"}", "default": {}},
+            {"key": "bank_id_template", "description": "Optional template to derive bank_id dynamically when bank_routes does not match. Placeholders: {profile}, {workspace}, {platform}, {user}, {session}, {chat}, {room}, {thread}. Example: hermes-{profile}", "default": ""},
             {"key": "bank_mission", "description": "Mission/purpose description for the memory bank"},
             {"key": "bank_retain_mission", "description": "Custom extraction prompt for memory retention"},
             {"key": "recall_budget", "description": "Recall thoroughness", "default": "mid", "choices": ["low", "mid", "high"]},
@@ -1155,8 +1232,9 @@ class HindsightMemoryProvider(MemoryProvider):
 
         banks = cfg_get(self._config, "banks", "hermes", default={})
         static_bank_id = self._config.get("bank_id") or banks.get("bankId", "hermes")
+        self._bank_routes = _normalize_bank_routes(self._config.get("bank_routes"))
         self._bank_id_template = self._config.get("bank_id_template", "") or ""
-        self._bank_id = _resolve_bank_id_template(
+        template_bank_id = _resolve_bank_id_template(
             self._bank_id_template,
             fallback=static_bank_id,
             profile=self._agent_identity,
@@ -1164,6 +1242,16 @@ class HindsightMemoryProvider(MemoryProvider):
             platform=self._platform,
             user=self._user_id,
             session=self._session_id,
+            chat=self._chat_id,
+            room=self._chat_id,
+            thread=self._thread_id,
+        )
+        self._bank_id = _resolve_bank_route(
+            self._bank_routes,
+            fallback=template_bank_id,
+            platform=self._platform,
+            chat=self._chat_id,
+            thread=self._thread_id,
         )
         budget = self._config.get("recall_budget") or self._config.get("budget") or banks.get("budget", "mid")
         self._budget = budget if budget in _VALID_BUDGETS else "mid"
@@ -1231,6 +1319,11 @@ class HindsightMemoryProvider(MemoryProvider):
             logger.debug("Hindsight bank resolved from template %r: profile=%s workspace=%s platform=%s user=%s -> bank=%s",
                          self._bank_id_template, self._agent_identity, self._agent_workspace,
                          self._platform, self._user_id, self._bank_id)
+        if self._bank_routes:
+            logger.debug(
+                "Hindsight bank routes enabled: platform=%s chat=%s thread=%s -> bank=%s",
+                self._platform, self._chat_id, self._thread_id, self._bank_id,
+            )
         logger.debug("Hindsight config: auto_retain=%s, auto_recall=%s, retain_every_n=%d, "
                      "retain_async=%s, retain_context=%s, recall_max_tokens=%d, recall_max_input_chars=%d, tags=%s, recall_tags=%s",
                      self._auto_retain, self._auto_recall, self._retain_every_n_turns,

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -7,9 +7,92 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
-from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt
+from cron.scheduler import (
+    _resolve_origin,
+    _resolve_delivery_target,
+    _deliver_result,
+    _send_media_via_adapter,
+    run_job,
+    SILENT_MARKER,
+    _build_job_prompt,
+    _resolve_effective_cron_runtime,
+)
+from cron.jobs import create_job, get_job, mark_job_run
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
+
+
+class TestCronEffectiveRuntimeAudit:
+    def test_job_model_is_hard_pin_over_env_and_config(self, monkeypatch):
+        job = {
+            "id": "audit-job",
+            "model": "claude-opus-4-8",
+            "provider": "anthropic",
+        }
+        cfg = {"model": {"default": "claude-fable-5"}}
+        monkeypatch.setenv("HERMES_MODEL", "gpt-env-should-not-win")
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "provider": "anthropic",
+                "api_key": "test-key",
+                "base_url": "https://api.anthropic.com",
+                "api_mode": "anthropic_messages",
+            },
+        ):
+            model, runtime, audit = _resolve_effective_cron_runtime(job, cfg)
+
+        assert model == "claude-opus-4-8"
+        assert runtime["provider"] == "anthropic"
+        assert audit["job_config_model"] == "claude-opus-4-8"
+        assert audit["effective_agent_model"] == "claude-opus-4-8"
+        assert audit["model_source"] == "job.model"
+        assert audit["hard_pinned"] is True
+        assert audit["base_url_class"] == "anthropic"
+
+    def test_unpinned_model_records_config_source(self, monkeypatch):
+        monkeypatch.delenv("HERMES_MODEL", raising=False)
+        job = {"id": "audit-job"}
+        cfg = {"model": {"default": "gpt-5.5", "provider": "openai-codex"}}
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "provider": "openai-codex",
+                "api_key": "test-key",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "api_mode": "codex_responses",
+            },
+        ):
+            model, _runtime, audit = _resolve_effective_cron_runtime(job, cfg)
+
+        assert model == "gpt-5.5"
+        assert audit["model_source"] == "config.model.default"
+        assert audit["hard_pinned"] is False
+        assert audit["effective_provider"] == "openai-codex"
+        assert audit["api_mode"] == "codex_responses"
+
+    def test_mark_job_run_persists_runtime_audit(self, tmp_path, monkeypatch):
+        from cron import jobs as jobs_mod
+
+        monkeypatch.setattr(jobs_mod, "HERMES_DIR", tmp_path)
+        monkeypatch.setattr(jobs_mod, "CRON_DIR", tmp_path / "cron")
+        monkeypatch.setattr(jobs_mod, "JOBS_FILE", tmp_path / "cron" / "jobs.json")
+        monkeypatch.setattr(jobs_mod, "OUTPUT_DIR", tmp_path / "cron" / "output")
+
+        job = create_job("hello", "every 60m", name="audit")
+        runtime_info = {
+            "job_config_model": "claude-opus-4-8",
+            "effective_agent_model": "claude-opus-4-8",
+            "effective_provider": "anthropic",
+            "api_mode": "anthropic_messages",
+            "base_url_class": "anthropic",
+            "hard_pinned": True,
+        }
+        mark_job_run(job["id"], True, runtime_info=runtime_info)
+
+        updated = get_job(job["id"])
+        assert updated is not None
+        assert updated["last_runtime"] == runtime_info
 
 
 class TestResolveOrigin:

--- a/tests/gateway/test_webhook_integration.py
+++ b/tests/gateway/test_webhook_integration.py
@@ -262,6 +262,71 @@ class TestCrossPlatformDelivery:
         # don't strand the final response (TTL-based cleanup happens on POST).
         assert chat_id in adapter._delivery_info
 
+    @pytest.mark.asyncio
+    async def test_agent_mode_background_response_honors_matrix_delivery(self):
+        """The full adapter send path must honor webhook deliver metadata.
+
+        This covers the production path for webhook-triggered agent turns:
+        POST stores delivery_info, BasePlatformAdapter runs the handler in the
+        background, and the final response is sent back through
+        WebhookAdapter.send().  A webhook response must not fall through to a
+        configured Telegram home channel just because Telegram is also
+        connected.
+        """
+        routes = {
+            "astra-wake": {
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "Wake: {message}",
+                "deliver": "matrix",
+                "deliver_extra": {"chat_id": "!room:kingdom.local"},
+            }
+        }
+        adapter = _make_adapter(routes)
+
+        async def _handler(event: MessageEvent):
+            assert event.source.platform == Platform.WEBHOOK
+            assert event.source.chat_id == "webhook:astra-wake:wake-001"
+            return "I saw the wake."
+
+        adapter.set_message_handler(_handler)
+
+        mock_matrix_adapter = AsyncMock()
+        mock_matrix_adapter.send = AsyncMock(return_value=SendResult(success=True))
+        mock_telegram_adapter = AsyncMock()
+        mock_telegram_adapter.send = AsyncMock(return_value=SendResult(success=True))
+
+        mock_runner = MagicMock()
+        mock_runner.adapters = {
+            Platform.MATRIX: mock_matrix_adapter,
+            Platform.TELEGRAM: mock_telegram_adapter,
+        }
+        mock_runner.config = GatewayConfig(
+            platforms={
+                Platform.MATRIX: PlatformConfig(enabled=True, token="fake"),
+                Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake"),
+            }
+        )
+        adapter.gateway_runner = mock_runner
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/astra-wake",
+                json={"message": "new place"},
+                headers={"X-GitHub-Delivery": "wake-001"},
+            )
+            assert resp.status == 202
+
+        for _ in range(100):
+            if mock_matrix_adapter.send.await_count:
+                break
+            await asyncio.sleep(0.01)
+
+        mock_matrix_adapter.send.assert_awaited_once_with(
+            "!room:kingdom.local", "I saw the wake.", metadata=None
+        )
+        mock_telegram_adapter.send.assert_not_awaited()
+
 
 # ===================================================================
 # Test 4: GitHub comment delivery via gh CLI

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -22,6 +22,7 @@ from plugins.memory.hindsight import (
     RETAIN_SCHEMA,
     _load_config,
     _build_embedded_profile_env,
+    _normalize_bank_id_list,
     _normalize_bank_routes,
     _normalize_retain_tags,
     _resolve_bank_route,
@@ -44,6 +45,7 @@ def _clean_env(monkeypatch):
         "HINDSIGHT_IDLE_TIMEOUT", "HINDSIGHT_LLM_API_KEY",
         "HINDSIGHT_RETAIN_TAGS", "HINDSIGHT_RETAIN_SOURCE",
         "HINDSIGHT_RETAIN_USER_PREFIX", "HINDSIGHT_RETAIN_ASSISTANT_PREFIX",
+        "HINDSIGHT_RECALL_EXTRA_BANK_IDS",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -155,6 +157,13 @@ def test_normalize_retain_tags_accepts_json_array_string():
     assert _normalize_retain_tags(value) == ["agent:fakeassistantname", "source_system:hermes-agent"]
 
 
+def test_normalize_bank_id_list_sanitizes_and_dedupes():
+    assert _normalize_bank_id_list("hermes, Astra Sanctuary!, hermes") == [
+        "hermes",
+        "Astra-Sanctuary",
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Schema tests
 # ---------------------------------------------------------------------------
@@ -201,6 +210,8 @@ class TestConfig:
         assert provider._recall_max_input_chars == 800
         assert provider._tags is None
         assert provider._recall_tags is None
+        assert provider._recall_extra_bank_ids == []
+        assert provider._recall_bank_ids == ["test-bank"]
         # Default recall narrowed to observation-only; world/experience are
         # aggregate facts that often crowd out concrete-event signal during
         # auto-recall. Users opt back in via the recall_types config key.
@@ -526,6 +537,42 @@ class TestToolHandlers:
         p.handle_tool_call("hindsight_recall", {"query": "test"})
         call_kwargs = p._client.arecall.call_args.kwargs
         assert call_kwargs["types"] == ["world", "experience"]
+
+    def test_recall_searches_active_bank_then_extra_banks(self, provider_with_config):
+        p = provider_with_config(
+            bank_id="astra_work",
+            recall_extra_bank_ids=["hermes", "astra_work"],
+        )
+
+        async def _recall(**kwargs):
+            return SimpleNamespace(
+                results=[SimpleNamespace(text=f"{kwargs['bank_id']} memory")]
+            )
+
+        p._client.arecall = AsyncMock(side_effect=_recall)
+
+        result = json.loads(p.handle_tool_call(
+            "hindsight_recall", {"query": "test"}
+        ))
+
+        assert p._recall_bank_ids == ["astra_work", "hermes"]
+        assert "[astra_work] astra_work memory" in result["result"]
+        assert "[hermes] hermes memory" in result["result"]
+        assert [call.kwargs["bank_id"] for call in p._client.arecall.await_args_list] == [
+            "astra_work",
+            "hermes",
+        ]
+
+    def test_retain_still_writes_only_active_bank_with_extra_recall_bank(self, provider_with_config):
+        p = provider_with_config(
+            bank_id="astra_work",
+            recall_extra_bank_ids=["hermes"],
+        )
+
+        p.handle_tool_call("hindsight_retain", {"content": "work room fact"})
+
+        call_kwargs = p._client.aretain.call_args.kwargs
+        assert call_kwargs["bank_id"] == "astra_work"
 
     def test_recall_no_results(self, provider):
         provider._client.arecall.return_value = SimpleNamespace(results=[])
@@ -1285,7 +1332,7 @@ class TestConfigSchema:
         expected_keys = {
             "mode", "api_url", "api_key", "llm_provider", "llm_api_key",
             "llm_model", "bank_id", "bank_routes", "bank_id_template",
-            "bank_mission", "bank_retain_mission",
+            "recall_extra_bank_ids", "bank_mission", "bank_retain_mission",
             "recall_budget", "memory_mode", "recall_prefetch_method",
             "retain_tags", "retain_source",
             "retain_user_prefix", "retain_assistant_prefix",

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -22,7 +22,9 @@ from plugins.memory.hindsight import (
     RETAIN_SCHEMA,
     _load_config,
     _build_embedded_profile_env,
+    _normalize_bank_routes,
     _normalize_retain_tags,
+    _resolve_bank_route,
     _resolve_bank_id_template,
     _sanitize_bank_segment,
 )
@@ -1282,7 +1284,8 @@ class TestConfigSchema:
         keys = {f["key"] for f in schema}
         expected_keys = {
             "mode", "api_url", "api_key", "llm_provider", "llm_api_key",
-            "llm_model", "bank_id", "bank_id_template", "bank_mission", "bank_retain_mission",
+            "llm_model", "bank_id", "bank_routes", "bank_id_template",
+            "bank_mission", "bank_retain_mission",
             "recall_budget", "memory_mode", "recall_prefetch_method",
             "retain_tags", "retain_source",
             "retain_user_prefix", "retain_assistant_prefix",
@@ -1335,6 +1338,16 @@ class TestBankIdTemplate:
             user="", session="",
         )
         assert result == "myorg-coder-cli"
+
+    def test_resolve_with_chat_and_thread_placeholders(self):
+        result = _resolve_bank_id_template(
+            "room-{platform}-{chat}-{thread}",
+            fallback="hermes",
+            profile="", workspace="", platform="matrix", user="", session="",
+            chat="!abc:kingdom.local", room="!abc:kingdom.local",
+            thread="$topic",
+        )
+        assert result == "room-matrix-abc-kingdom-local-topic"
 
     def test_resolve_collapses_empty_placeholders(self):
         # When user is empty, "hermes-{user}" becomes "hermes-" -> trimmed to "hermes"
@@ -1437,6 +1450,116 @@ class TestBankIdTemplate:
         # No agent_identity passed — template renders to "hermes-" which collapses to "hermes"
         p.initialize(session_id="s1", hermes_home=str(tmp_path), platform="cli")
         assert p._bank_id == "hermes"
+
+
+class TestBankRoutes:
+    def test_normalize_bank_routes_sanitizes_bank_names(self):
+        routes = _normalize_bank_routes({"matrix:!room:server": "Astra Sanctuary!"})
+        assert routes == {"matrix:!room:server": "Astra-Sanctuary"}
+
+    def test_normalize_bank_routes_rejects_non_mapping(self):
+        assert _normalize_bank_routes(["not", "a", "mapping"]) == {}
+
+    def test_resolve_bank_route_matches_raw_chat_id(self):
+        routes = {"!room:kingdom.local": "astra_sanctuary"}
+        assert _resolve_bank_route(
+            routes,
+            "hermes_legacy",
+            platform="matrix",
+            chat="!room:kingdom.local",
+        ) == "astra_sanctuary"
+
+    def test_resolve_bank_route_prefers_platform_specific_key(self):
+        routes = {
+            "!room:kingdom.local": "generic_room",
+            "matrix:!room:kingdom.local": "astra_sanctuary",
+        }
+        assert _resolve_bank_route(
+            routes,
+            "hermes_legacy",
+            platform="matrix",
+            chat="!room:kingdom.local",
+        ) == "astra_sanctuary"
+
+    def test_resolve_bank_route_prefers_thread_specific_key(self):
+        routes = {
+            "matrix:!room:kingdom.local": "astra_sanctuary",
+            "matrix:!room:kingdom.local:$thread": "astra_thread",
+        }
+        assert _resolve_bank_route(
+            routes,
+            "hermes_legacy",
+            platform="matrix",
+            chat="!room:kingdom.local",
+            thread="$thread",
+        ) == "astra_thread"
+
+    def test_resolve_bank_route_accepts_sanitized_key(self):
+        routes = {"matrix:room-kingdom-local": "astra_sanctuary"}
+        assert _resolve_bank_route(
+            routes,
+            "hermes_legacy",
+            platform="matrix",
+            chat="!room:kingdom.local",
+        ) == "astra_sanctuary"
+
+    def test_resolve_bank_route_uses_default_route(self):
+        assert _resolve_bank_route(
+            {"default": "astra_main"},
+            "hermes_legacy",
+            platform="matrix",
+            chat="!room:kingdom.local",
+        ) == "astra_main"
+
+    def test_provider_uses_bank_route_before_template(self, tmp_path, monkeypatch):
+        config = {
+            "mode": "cloud",
+            "apiKey": "k",
+            "api_url": "http://x",
+            "bank_id": "hermes_legacy",
+            "bank_id_template": "template-{chat}",
+            "bank_routes": {
+                "matrix:!QciTuSXGfxseWDesXs:kingdom.local": "astra_sanctuary",
+            },
+        }
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+
+        p = HindsightMemoryProvider()
+        p.initialize(
+            session_id="s1",
+            hermes_home=str(tmp_path),
+            platform="matrix",
+            chat_id="!QciTuSXGfxseWDesXs:kingdom.local",
+        )
+        assert p._bank_id == "astra_sanctuary"
+
+    def test_provider_falls_back_to_template_without_route(self, tmp_path, monkeypatch):
+        config = {
+            "mode": "cloud",
+            "apiKey": "k",
+            "api_url": "http://x",
+            "bank_id": "hermes_legacy",
+            "bank_id_template": "template-{chat}",
+            "bank_routes": {
+                "matrix:!other:kingdom.local": "astra_sanctuary",
+            },
+        }
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps(config))
+        monkeypatch.setattr("plugins.memory.hindsight.get_hermes_home", lambda: tmp_path)
+
+        p = HindsightMemoryProvider()
+        p.initialize(
+            session_id="s1",
+            hermes_home=str(tmp_path),
+            platform="matrix",
+            chat_id="!room:kingdom.local",
+        )
+        assert p._bank_id == "template-room-kingdom-local"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -240,6 +240,153 @@ class TestSendMessageTool:
         send_mock.assert_not_awaited()
         mirror_mock.assert_not_called()
 
+    def test_webhook_home_target_send_is_skipped_and_explained(self):
+        telegram_home = SimpleNamespace(chat_id="-1001")
+        matrix_cfg = SimpleNamespace(enabled=True, token="matrix-token", extra={})
+        config, _telegram_cfg = _make_config()
+        config.platforms[Platform.MATRIX] = matrix_cfg
+        config.get_home_channel = lambda platform: (
+            telegram_home if platform == Platform.TELEGRAM else None
+        )
+        session_chat_id = "webhook:astra-wake:wake-001"
+        webhook_adapter = SimpleNamespace(_delivery_info={
+            session_chat_id: {
+                "deliver": "matrix",
+                "deliver_extra": {"chat_id": "!room:kingdom.local"},
+            }
+        })
+        runner = SimpleNamespace(
+            adapters={Platform.WEBHOOK: webhook_adapter},
+            config=config,
+        )
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("gateway.session_context.get_session_env") as get_session_env_mock, \
+             patch("gateway.run._gateway_runner_ref", return_value=runner), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            get_session_env_mock.side_effect = lambda name, default="": {
+                "HERMES_SESSION_PLATFORM": "webhook",
+                "HERMES_SESSION_CHAT_ID": session_chat_id,
+            }.get(name, default)
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram",
+                        "message": "wake delivered",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        assert result["skipped"] is True
+        assert result["reason"] == "webhook_auto_delivery_home_target"
+        assert result["target"] == "telegram:-1001"
+        assert result["auto_delivery_target"] == "matrix:!room:kingdom.local"
+        assert "final response" in result["note"]
+        send_mock.assert_not_awaited()
+        mirror_mock.assert_not_called()
+
+    def test_webhook_duplicate_delivery_target_is_skipped_and_explained(self):
+        matrix_cfg = SimpleNamespace(enabled=True, token="matrix-token", extra={})
+        config = SimpleNamespace(
+            platforms={Platform.MATRIX: matrix_cfg},
+            get_home_channel=lambda _platform: None,
+        )
+        session_chat_id = "webhook:astra-wake:wake-001"
+        webhook_adapter = SimpleNamespace(_delivery_info={
+            session_chat_id: {
+                "deliver": "matrix",
+                "deliver_extra": {"chat_id": "!room:kingdom.local"},
+            }
+        })
+        runner = SimpleNamespace(
+            adapters={Platform.WEBHOOK: webhook_adapter},
+            config=config,
+        )
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("gateway.session_context.get_session_env") as get_session_env_mock, \
+             patch("gateway.run._gateway_runner_ref", return_value=runner), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            get_session_env_mock.side_effect = lambda name, default="": {
+                "HERMES_SESSION_PLATFORM": "webhook",
+                "HERMES_SESSION_CHAT_ID": session_chat_id,
+            }.get(name, default)
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "matrix:!room:kingdom.local",
+                        "message": "wake delivered",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        assert result["skipped"] is True
+        assert result["reason"] == "webhook_auto_delivery_duplicate_target"
+        assert result["target"] == "matrix:!room:kingdom.local"
+        assert result["auto_delivery_target"] == "matrix:!room:kingdom.local"
+        send_mock.assert_not_awaited()
+        mirror_mock.assert_not_called()
+
+    def test_webhook_explicit_different_target_is_allowed(self):
+        matrix_cfg = SimpleNamespace(enabled=True, token="matrix-token", extra={})
+        config = SimpleNamespace(
+            platforms={Platform.MATRIX: matrix_cfg},
+            get_home_channel=lambda _platform: None,
+        )
+        session_chat_id = "webhook:astra-wake:wake-001"
+        webhook_adapter = SimpleNamespace(_delivery_info={
+            session_chat_id: {
+                "deliver": "matrix",
+                "deliver_extra": {"chat_id": "!room:kingdom.local"},
+            }
+        })
+        runner = SimpleNamespace(
+            adapters={Platform.WEBHOOK: webhook_adapter},
+            config=config,
+        )
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("gateway.session_context.get_session_env") as get_session_env_mock, \
+             patch("gateway.run._gateway_runner_ref", return_value=runner), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True):
+            get_session_env_mock.side_effect = lambda name, default="": {
+                "HERMES_SESSION_PLATFORM": "webhook",
+                "HERMES_SESSION_CHAT_ID": session_chat_id,
+            }.get(name, default)
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "matrix:!other:kingdom.local",
+                        "message": "side channel",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        send_mock.assert_awaited_once_with(
+            Platform.MATRIX,
+            matrix_cfg,
+            "!other:kingdom.local",
+            "side channel",
+            thread_id=None,
+            media_files=[],
+            force_document=False,
+        )
+
     def test_resolved_telegram_topic_name_preserves_thread_id(self):
         config, telegram_cfg = _make_config()
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -437,6 +437,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "next_run_at": job.get("next_run_at"),
         "last_run_at": job.get("last_run_at"),
         "last_status": job.get("last_status"),
+        "last_runtime": job.get("last_runtime"),
         "last_delivery_error": job.get("last_delivery_error"),
         "enabled": job.get("enabled", True),
         "state": job.get("state", "scheduled" if job.get("enabled", True) else "paused"),

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -287,6 +287,15 @@ def _handle_send(args):
     if duplicate_skip:
         return json.dumps(duplicate_skip)
 
+    webhook_skip = _maybe_skip_webhook_auto_delivery_send(
+        platform_name,
+        chat_id,
+        thread_id,
+        used_home_channel=used_home_channel,
+    )
+    if webhook_skip:
+        return json.dumps(webhook_skip)
+
     # Slack: resolve user IDs (U...) to DM channel IDs via conversations.open
     if platform_name == "slack" and chat_id and chat_id.startswith("U"):
         try:
@@ -481,6 +490,139 @@ def _maybe_skip_cron_duplicate_send(platform_name: str, chat_id: str, thread_id:
             f"Skipped send_message to {target_label}. This cron job will already auto-deliver "
             "its final response to that same target. Put the intended user-facing content in "
             "your final response instead, or use a different target if you want an additional message."
+        ),
+    }
+
+
+def _get_webhook_auto_delivery_target():
+    """Return the webhook route's auto-delivery target for the current turn."""
+    try:
+        from gateway.session_context import get_session_env
+        session_platform = get_session_env("HERMES_SESSION_PLATFORM", "").strip().lower()
+        session_chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "").strip()
+    except Exception:
+        return None
+
+    if session_platform != "webhook" or not session_chat_id.startswith("webhook:"):
+        return None
+
+    try:
+        from gateway.config import Platform
+        from gateway.run import _gateway_runner_ref
+        runner = _gateway_runner_ref()
+    except Exception:
+        return None
+
+    if runner is None:
+        return None
+
+    try:
+        webhook_adapter = runner.adapters.get(Platform.WEBHOOK)
+        delivery = getattr(webhook_adapter, "_delivery_info", {}).get(session_chat_id)
+    except Exception:
+        delivery = None
+
+    if not delivery:
+        return None
+
+    platform_name = str(delivery.get("deliver") or "").strip().lower()
+    if not platform_name or platform_name in {"log", "github_comment"}:
+        return None
+
+    extra = delivery.get("deliver_extra") or {}
+    chat_id = str(extra.get("chat_id") or "").strip()
+    thread_id = (
+        extra.get("message_thread_id")
+        or extra.get("thread_id")
+        or extra.get("topic_id")
+        or None
+    )
+    if thread_id is not None:
+        thread_id = str(thread_id)
+
+    if not chat_id:
+        try:
+            platform = Platform(platform_name)
+            home = runner.config.get_home_channel(platform)
+            if home:
+                chat_id = str(home.chat_id)
+        except Exception:
+            chat_id = ""
+
+    if not chat_id:
+        return None
+
+    return {
+        "platform": platform_name,
+        "chat_id": chat_id,
+        "thread_id": thread_id,
+    }
+
+
+def _target_label(platform_name: str, chat_id: str, thread_id: str | None = None) -> str:
+    label = f"{platform_name}:{chat_id}"
+    if thread_id is not None:
+        label += f":{thread_id}"
+    return label
+
+
+def _same_target(
+    target: dict,
+    platform_name: str,
+    chat_id: str,
+    thread_id: str | None = None,
+) -> bool:
+    return (
+        target["platform"] == platform_name
+        and str(target["chat_id"]) == str(chat_id)
+        and target.get("thread_id") == thread_id
+    )
+
+
+def _maybe_skip_webhook_auto_delivery_send(
+    platform_name: str,
+    chat_id: str,
+    thread_id: str | None,
+    *,
+    used_home_channel: bool,
+):
+    """Skip self-delivery sends from webhook turns.
+
+    A webhook route owns delivery of the final response. Bare platform sends
+    inside that turn are ambiguous home-channel sends and can bypass the route's
+    configured Matrix/Telegram/etc. target.
+    """
+    auto_target = _get_webhook_auto_delivery_target()
+    if not auto_target:
+        return None
+
+    same_target = _same_target(auto_target, platform_name, chat_id, thread_id)
+    if not same_target and not used_home_channel:
+        return None
+
+    requested_label = _target_label(platform_name, chat_id, thread_id)
+    auto_label = _target_label(
+        auto_target["platform"],
+        auto_target["chat_id"],
+        auto_target.get("thread_id"),
+    )
+    reason = (
+        "webhook_auto_delivery_duplicate_target"
+        if same_target
+        else "webhook_auto_delivery_home_target"
+    )
+
+    return {
+        "success": True,
+        "skipped": True,
+        "reason": reason,
+        "target": requested_label,
+        "auto_delivery_target": auto_label,
+        "note": (
+            f"Skipped send_message to {requested_label}. This webhook turn will already "
+            f"auto-deliver its final response to {auto_label}. Put the intended "
+            "user-facing content in your final response instead, or use a specific "
+            "non-home target if you want an additional message."
         ),
     }
 


### PR DESCRIPTION
## Summary
- resolve cron effective runtime through a single audited helper
- treat job.model as a hard pin over env/config defaults
- persist secret-free last_runtime on cron jobs and include Runtime Audit in run output
- show last runtime in hermes cron list / cronjob tool output

## Test Plan
- env -u MATRIX_HOME_ROOM .venv/bin/python -m pytest tests/cron/test_scheduler.py tests/cron/test_jobs.py tests/tools/test_cronjob_tools.py tests/hermes_cli/test_cron.py -q -o 'addopts='
- .venv/bin/python -m ruff check cron/scheduler.py cron/jobs.py hermes_cli/cron.py tools/cronjob_tools.py tests/cron/test_scheduler.py
- python3 -m py_compile cron/scheduler.py cron/jobs.py hermes_cli/cron.py tools/cronjob_tools.py

Notes: graphify update . could not run on this host because graphify is not installed.