### PR TITLE
fix(gateway): gate s6 runtime snapshot on detect_service_manager, not is_container

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1090,10 +1090,16 @@ def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot
 
     from hermes_constants import is_container
 
-    if is_linux() and is_container():
+    if is_linux():
         # Phase 4: report s6 supervision when running under our /init.
-        # Other container runtimes (or containers built before Phase 2)
-        # still get the original "docker (foreground)" label.
+        #
+        # Gate on detect_service_manager() == "s6" (PID 1 == s6-svscan),
+        # NOT is_container(): the latter only detects Docker/Podman/lxc, so
+        # it is False on Fly's Firecracker microVMs even though s6-overlay
+        # is genuinely PID 1 and supervising the gateway there (#46290 made
+        # the same fix for the s6 dispatch path in detect_service_manager()
+        # itself). Without this, a Fly-hosted s6-supervised gateway falls all
+        # the way through to "manual process" below.
         try:
             from hermes_cli.service_manager import detect_service_manager, get_service_manager
             if detect_service_manager() == "s6":
@@ -1122,10 +1128,15 @@ def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot
                 )
         except Exception:
             pass  # Fall through to the legacy label on any detection error.
-        return GatewayRuntimeSnapshot(
-            manager="docker (foreground)",
-            gateway_pids=gateway_pids,
-        )
+
+        # Other container runtimes (or containers built before Phase 2)
+        # that are not s6-supervised still get the original
+        # "docker (foreground)" label.
+        if is_container():
+            return GatewayRuntimeSnapshot(
+                manager="docker (foreground)",
+                gateway_pids=gateway_pids,
+            )
 
     if supports_systemd_services():
         selected_system, service_running = _probe_systemd_service_running(system=system)

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -279,6 +279,71 @@ def test_s6_runtime_snapshot_reports_supervised_service(monkeypatch, tmp_path):
     assert snapshot.gateway_pids == (123,)
 
 
+def test_s6_runtime_snapshot_reports_supervised_service_on_fly_firecracker(monkeypatch, tmp_path):
+    """On Fly.io, is_container() is False (Firecracker microVM, not Docker/
+    Podman/lxc) even though s6-overlay is genuinely PID 1 and supervising the
+    gateway. The snapshot must report s6 supervision here too — gated on
+    detect_service_manager() == "s6", matching the #46290 fix to
+    detect_service_manager() itself, not on is_container()."""
+    service_dir = tmp_path / "gateway-default"
+    service_dir.mkdir()
+
+    class FakeS6Manager:
+        scandir = tmp_path
+
+        def is_running(self, name):
+            assert name == "gateway-default"
+            return True
+
+    monkeypatch.setattr(gateway, "is_linux", lambda: True)
+    monkeypatch.setattr("hermes_constants.is_container", lambda: False)
+    monkeypatch.setattr("hermes_cli.service_manager.detect_service_manager", lambda: "s6")
+    monkeypatch.setattr("hermes_cli.service_manager.get_service_manager", lambda: FakeS6Manager())
+    monkeypatch.setattr(gateway, "find_gateway_pids", lambda: [123])
+    monkeypatch.setattr(gateway, "_profile_suffix", lambda: "")
+
+    snapshot = gateway.get_gateway_runtime_snapshot()
+
+    assert snapshot.manager == "s6 (container supervisor)"
+    assert snapshot.service_installed is True
+    assert snapshot.service_running is True
+    assert snapshot.service_scope == "s6"
+    assert snapshot.gateway_pids == (123,)
+
+
+def test_non_s6_container_still_reports_docker_foreground(monkeypatch, tmp_path):
+    """A Docker/Podman container that is NOT s6-supervised (pre-Phase-2
+    image, or another init system) keeps the legacy "docker (foreground)"
+    label — the is_container() fallback is preserved, just no longer the
+    sole gate."""
+    monkeypatch.setattr(gateway, "is_linux", lambda: True)
+    monkeypatch.setattr("hermes_constants.is_container", lambda: True)
+    monkeypatch.setattr("hermes_cli.service_manager.detect_service_manager", lambda: "none")
+    monkeypatch.setattr(gateway, "find_gateway_pids", lambda: [123])
+
+    snapshot = gateway.get_gateway_runtime_snapshot()
+
+    assert snapshot.manager == "docker (foreground)"
+    assert snapshot.gateway_pids == (123,)
+
+
+def test_non_container_non_s6_linux_falls_through_to_systemd_check(monkeypatch):
+    """A regular (non-container) Linux host with neither s6 nor a container
+    must fall through to the existing systemd/launchd/manual-process checks
+    unchanged."""
+    monkeypatch.setattr(gateway, "is_linux", lambda: True)
+    monkeypatch.setattr("hermes_constants.is_container", lambda: False)
+    monkeypatch.setattr("hermes_cli.service_manager.detect_service_manager", lambda: "systemd")
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway, "find_gateway_pids", lambda: [123])
+
+    snapshot = gateway.get_gateway_runtime_snapshot()
+
+    assert snapshot.manager == "manual process"
+    assert snapshot.gateway_pids == (123,)
+
+
 def test_running_under_gateway_supervisor_markers(monkeypatch):
     _clear_supervisor_markers(monkeypatch)
     assert gateway._running_under_gateway_supervisor() is False


### PR DESCRIPTION
## Summary

- `get_gateway_runtime_snapshot()` gates its s6-supervision reporting block on `is_linux() and is_container()`. `is_container()` only detects Docker/Podman/lxc, so on Fly.io's Firecracker microVMs (`is_container() == False`) the gateway is genuinely s6-supervised but the snapshot falls all the way through to `manager="manual process"`.
- #46290 fixed this exact `is_container()`/Fly gap for the s6 dispatch path inside `detect_service_manager()` itself (`hermes_cli/service_manager.py`), gating on `_s6_running()` instead of `is_container()`. `get_gateway_runtime_snapshot()` in `hermes_cli/gateway.py` has its own, separate `is_container()` gate that was not updated and remained the unfixed sibling.
- Net effect on Fly: `hermes gateway status` / doctor report "manual process" even though s6 is correctly supervising the gateway, hiding real supervision state from the user.

## Changes

- Replace `if is_linux() and is_container():` with `if is_linux():`, and check `detect_service_manager() == "s6"` first (matching #46290's reasoning) for the s6-supervision report.
- Preserve the existing `"docker (foreground)"` fallback label for non-s6 containers (pre-Phase-2 images / other init systems) by checking `is_container()` after the s6 check, instead of as the sole outer gate.
- Non-container, non-s6 Linux hosts fall through to the existing systemd/launchd/manual-process checks unchanged.

## Test plan

- [x] New test `test_s6_runtime_snapshot_reports_supervised_service_on_fly_firecracker` (is_container()=False, detect_service_manager()="s6") fails without the fix (falls through to a later branch) and passes with it.
- [x] New test `test_non_s6_container_still_reports_docker_foreground` confirms the legacy Docker fallback is preserved for non-s6 containers.
- [x] New test `test_non_container_non_s6_linux_falls_through_to_systemd_check` confirms non-container Linux hosts are unaffected.
- [x] Existing `test_s6_runtime_snapshot_reports_supervised_service` (Docker + s6) still passes.
- [x] Full `tests/hermes_cli/test_gateway.py` suite passes (47 passed).