### PR TITLE
fix(agent): classify 'Provider returned error' as rate_limit in error classifier

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -131,6 +131,8 @@ _RATE_LIMIT_PATTERNS = [
     "throttlingexception",
     "too many concurrent requests",
     "servicequotaexceededexception",
+    # OpenRouter wraps downstream rate-limits without proper 429 status
+    "provider returned error",
 ]
 
 # Usage-limit patterns that need disambiguation (could be billing OR rate_limit)

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -931,6 +931,12 @@ class TestClassifyApiError:
         result = classify_api_error(e)
         assert result.reason == FailoverReason.rate_limit
 
+    def test_provider_returned_error_is_rate_limit(self):
+        """OpenRouter wraps downstream rate-limits as 'Provider returned error'."""
+        e = Exception("Provider returned error")
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.rate_limit
+
     def test_message_auth_pattern(self):
         e = Exception("invalid api key provided")
         result = classify_api_error(e)


### PR DESCRIPTION
## What does this PR do?

Classifies OpenRouter's generic "Provider returned error" message as `rate_limit` instead of `unknown`, so the rate-limit cooldown is set and the fallback provider stays active across turns.

## Related Issue

Fixes #46856

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py`: Added `"provider returned error"` to `_RATE_LIMIT_PATTERNS` list. OpenRouter uses this message to wrap downstream rate-limits that don't propagate a proper 429 status code.
- `tests/agent/test_error_classifier.py`: Added `test_provider_returned_error_is_rate_limit` regression test.

## How to Test

1. Run `pytest tests/agent/test_error_classifier.py -v -k "rate_limit"` — all rate_limit tests should pass
2. Verify `classify_api_error(Exception("Provider returned error"))` returns `FailoverReason.rate_limit`
3. Verify the existing rate_limit tests still pass (no regression)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/error_classifier.py::_RATE_LIMIT_PATTERNS` (line 118), `agent/error_classifier.py::_classify_by_message` (line 1098)
- Blast radius: LOW — pattern is checked in two places (`_classify_by_message` at L1161 and the main `classify_api_error` at L993), both already handle `_RATE_LIMIT_PATTERNS` correctly
- Related patterns: `_NON_RETRYABLE_PATTERNS` (separate list, no overlap), `try_activate_fallback` in `chat_completion_helpers.py` (sets `_rate_limited_until` for rate_limit reason)
