### PR TITLE
fix(delegation): validate batch input before resolving credentials

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -289,6 +289,25 @@ class TestDelegateTask(unittest.TestCase):
         mock_run.assert_not_called()
 
     @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_batch_validation_precedes_credential_resolution(self, mock_creds, mock_run):
+        # Input validation must not depend on delegation credentials resolving:
+        # an over-cap batch returns the cap error even when credential
+        # resolution would fail, and credentials are never resolved for input
+        # that is rejected up front.
+        mock_creds.side_effect = ValueError(
+            "Cannot resolve delegation provider 'x': no creds"
+        )
+        parent = _make_mock_parent()
+        limit = _get_max_concurrent_children()
+        tasks = [{"goal": f"Task {i}"} for i in range(limit + 2)]
+        result = json.loads(delegate_task(tasks=tasks, parent_agent=parent))
+        self.assertIn("error", result)
+        self.assertIn("Too many tasks", result["error"])
+        mock_run.assert_not_called()
+        mock_creds.assert_not_called()
+
+    @patch("tools.delegate_tool._run_single_child")
     def test_batch_ignores_toplevel_goal(self, mock_run):
         """When tasks array is provided, top-level goal/context/toolsets are ignored."""
         mock_run.return_value = {

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2082,16 +2082,6 @@ def delegate_task(
         )
     effective_max_iter = default_max_iter
 
-    # Resolve delegation credentials (provider:model pair).
-    # When delegation.provider is configured, this resolves the full credential
-    # bundle (base_url, api_key, api_mode) via the same runtime provider system
-    # used by CLI/gateway startup.  When unconfigured, returns None values so
-    # children inherit from the parent.
-    try:
-        creds = _resolve_delegation_credentials(cfg, parent_agent)
-    except ValueError as exc:
-        return tool_error(str(exc))
-
     # Normalize to task list
     max_children = _get_max_concurrent_children()
     recovered_tasks, tasks_error = _recover_tasks_from_json_string(tasks)
@@ -2128,6 +2118,19 @@ def delegate_task(
             )
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
+
+    # Resolve delegation credentials (provider:model pair) only after the batch
+    # has been validated, so an over-cap or malformed batch returns the actual
+    # input error instead of a credential-resolution failure, and does not
+    # require delegation credentials just to reject bad input.
+    # When delegation.provider is configured, this resolves the full credential
+    # bundle (base_url, api_key, api_mode) via the same runtime provider system
+    # used by CLI/gateway startup.  When unconfigured, returns None values so
+    # children inherit from the parent.
+    try:
+        creds = _resolve_delegation_credentials(cfg, parent_agent)
+    except ValueError as exc:
+        return tool_error(str(exc))
 
     overall_start = time.monotonic()
     results = []


### PR DESCRIPTION
## What does this PR do?

`delegate_task` resolved delegation credentials *before* validating the task batch, so an over-cap or malformed batch returned a confusing `Cannot resolve delegation provider` error (and required delegation credentials to be configured) instead of the intended input error such as `Too many tasks: N provided, but max_concurrent_children is 3 ...` or `Task N must be an object`.

This moves the `_resolve_delegation_credentials()` call to *after* input validation. `creds` is only used when spawning children, well after validation, so this is a safe reorder with no behavior change on the success path. Input that is rejected up front no longer triggers credential resolution at all.

It also removes a latent test-ordering dependency: `tests/tools/test_delegate.py::TestDelegateTask::test_batch_capped_at_3` previously depended on whether delegation credentials happened to resolve in the test environment — it fails on a host with no delegation provider configured, because credential resolution raised before the cap check ran.

## Related Issue

No separate issue; rationale above.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/delegate_tool.py` — move the `_resolve_delegation_credentials()` call from before batch normalization/validation to after the per-task validation loop (just before children are spawned). No other logic changed.
- `tests/tools/test_delegate.py` — add `test_batch_validation_precedes_credential_resolution`: mocks `_resolve_delegation_credentials` to raise and asserts an over-cap batch still returns the cap error, and that credentials are never resolved for rejected input.

## How to Test

1. `pytest tests/tools/test_delegate.py::TestDelegateTask::test_batch_validation_precedes_credential_resolution -q` → passes.
2. Revert only the `tools/delegate_tool.py` change (keep the test) → it fails with `'Too many tasks' not found in "Cannot resolve delegation provider ..."`, demonstrating the bug.
3. `pytest tests/tools/test_delegate.py -q` → 141 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(delegation): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the affected tests; `tests/tools/test_delegate.py` passes (141)
- [x] I've added a regression test
- [x] I've tested on my platform: Linux (Fedora), Python 3.14

### Documentation & Housekeeping

- [x] No docs / config keys / tool schemas / architecture changed — N/A
- [x] Cross-platform: pure control-flow reorder, no platform-specific code
