### PR TITLE
fix(state): detect silent WAL→DELETE fallback on macOS NFS / SMB (no false "wal")

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1458,7 +1458,7 @@ def connect(
                 # critical section as schema initialization so concurrent gateway
                 # startup threads do not race before _INITIALIZED_PATHS is populated.
                 # WAL doesn't work on network filesystems (NFS/SMB/FUSE). Shared helper
-                # falls back to DELETE with one WARNING so kanban stays usable there.
+                # falls back to DELETE with one ERROR log so kanban stays usable there.
                 # See hermes_state._WAL_INCOMPAT_MARKERS for detection logic.
                 from hermes_state import apply_wal_with_fallback
                 apply_wal_with_fallback(conn, db_label=f"kanban.db ({path.name})")

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -154,25 +154,49 @@ def _on_disk_journal_mode(conn: sqlite3.Connection) -> Optional[str]:
     return str(mode).strip().lower() if mode is not None else None
 
 
+class WalUnsupportedError(sqlite3.OperationalError):
+    """Raised by :func:`apply_wal_with_fallback` when ``require_wal=True`` and
+    the filesystem cannot provide WAL journal mode.
+
+    Covers both shapes of WAL refusal on network filesystems (NFS / SMB / FUSE
+    / the AgentFS NFS overlay): SQLite *raising* ``SQLITE_PROTOCOL`` ("locking
+    protocol"), and the quieter macOS-NFS case where ``PRAGMA journal_mode=WAL``
+    silently returns the still-effective mode without raising.  Subclasses
+    ``sqlite3.OperationalError`` so existing ``except sqlite3.OperationalError``
+    DB-init handling still catches it, while callers that specifically mandate
+    WAL can catch this narrower type.
+    """
+
+
 def apply_wal_with_fallback(
     conn: sqlite3.Connection,
     *,
     db_label: str = "state.db",
+    require_wal: bool = False,
 ) -> str:
     """Set ``journal_mode=WAL`` on ``conn``, falling back to DELETE on failure.
 
     Returns the journal mode actually set (``"wal"`` or ``"delete"``).
 
-    On WAL-incompatible filesystems (NFS, SMB, some FUSE), SQLite raises
-    ``OperationalError("locking protocol")`` when setting WAL.  We fall
-    back to DELETE mode — the pre-WAL default, which works on NFS — and
-    log one WARNING explaining why.
+    On WAL-incompatible filesystems (NFS, SMB, some FUSE), SQLite either
+    raises ``OperationalError("locking protocol")`` or — on macOS NFS / SMB /
+    the AgentFS NFS overlay — silently refuses the switch and leaves the DB in
+    DELETE.  Either way the degradation is logged at ERROR level (it is a real
+    loss of concurrency — a write blocks concurrent readers — not a cosmetic
+    warning) and, by default, the function falls back to DELETE (the pre-WAL
+    default, which works on NFS) so the feature keeps working.
 
-    The WARNING is deduplicated per ``db_label``: repeated connections
-    to the same underlying DB (e.g. kanban_db.connect() which is called
-    on every kanban operation) log once per process, not once per call.
-    Different db_labels log independently, so state.db and kanban.db
-    each get one warning on the same NFS mount.
+    Callers that genuinely require WAL concurrency (and would rather fail loudly
+    than run silently degraded) pass ``require_wal=True``; the function then
+    raises :class:`WalUnsupportedError` instead of returning ``"delete"``.  All
+    current callers deliberately keep the default ``require_wal=False`` so
+    NFS-homed installs keep working.
+
+    The ERROR is deduplicated per ``db_label``: repeated connections to the
+    same underlying DB (e.g. kanban_db.connect() which is called on every
+    kanban operation) log once per process, not once per call.  Different
+    db_labels log independently, so state.db and kanban.db each get one error
+    on the same NFS mount.
 
     Shared by :class:`SessionDB` and ``hermes_cli.kanban_db.connect`` so
     both databases get identical fallback behavior.
@@ -202,14 +226,21 @@ def apply_wal_with_fallback(
         mode = str(row[0]).strip().lower() if row and row[0] is not None else ""
         if mode == "wal":
             return "wal"
-        _log_wal_fallback_once(
-            db_label,
-            sqlite3.OperationalError(
-                f"journal_mode=WAL refused without raising (still {mode!r})"
-            ),
+        # Silent refusal (macOS NFS / SMB / AgentFS overlay): WAL was not
+        # honored, but nothing raised.
+        silent_exc = WalUnsupportedError(
+            f"journal_mode=WAL refused without raising (still {mode!r})"
         )
+        if require_wal:
+            raise silent_exc
+        _log_wal_fallback_once(db_label, silent_exc)
         return mode or "delete"
     except sqlite3.OperationalError as exc:
+        # The require_wal silent-refusal raise above is a WalUnsupportedError
+        # (an OperationalError subclass) and lands here — propagate it
+        # unchanged rather than re-running it through the marker logic.
+        if isinstance(exc, WalUnsupportedError):
+            raise
         msg = str(exc).lower()
         if not any(marker in msg for marker in _WAL_INCOMPAT_MARKERS):
             # Unrelated OperationalError — don't silently swallow.
@@ -218,27 +249,34 @@ def apply_wal_with_fallback(
         existing = _on_disk_journal_mode(conn)
         if existing == "wal":
             raise
+        if require_wal:
+            # Caller mandates WAL — fail loudly instead of degrading to DELETE.
+            raise WalUnsupportedError(str(exc)) from exc
         _log_wal_fallback_once(db_label, exc)
         conn.execute("PRAGMA journal_mode=DELETE")
         return "delete"
 
 
 def _log_wal_fallback_once(db_label: str, exc: Exception) -> None:
-    """Log a single WARNING per (process, db_label) about WAL fallback.
+    """Log a single ERROR per (process, db_label) about WAL fallback.
+
+    ERROR (not WARNING): a DB silently dropped to DELETE means a real loss of
+    concurrency — under the kanban dispatcher + workers a write blocks readers,
+    surfacing as SQLITE_BUSY/lock contention — so it must be loud, not cosmetic.
 
     Without this dedup, NFS users running kanban (which opens a fresh
     connection on every operation — see hermes_cli/kanban_db.py) would
-    fill errors.log with hundreds of identical warnings per hour.
+    fill errors.log with hundreds of identical errors per hour.
     """
     with _wal_fallback_warned_lock:
         if db_label in _wal_fallback_warned_paths:
             return
         _wal_fallback_warned_paths.add(db_label)
-    logger.warning(
+    logger.error(
         "%s: WAL journal_mode unsupported on this filesystem (%s) — "
         "falling back to journal_mode=DELETE (slower rollback-journal "
         "mode; reduces concurrency but works on NFS/SMB/FUSE). See "
-        "https://www.sqlite.org/wal.html for details. This warning "
+        "https://www.sqlite.org/wal.html for details. This message "
         "fires once per process per database.",
         db_label,
         exc,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -189,8 +189,26 @@ def apply_wal_with_fallback(
         pass
 
     try:
-        conn.execute("PRAGMA journal_mode=WAL")
-        return "wal"
+        # ``PRAGMA journal_mode=WAL`` is a query-that-sets: it RETURNS the
+        # resulting journal mode. Network filesystems that refuse WAL by
+        # *raising* SQLITE_PROTOCOL ("locking protocol") are handled in the
+        # except branch below. But macOS NFS — and SMB/CIFS, and the AgentFS
+        # NFS overlay — refuse the switch WITHOUT raising: the pragma simply
+        # returns the still-effective mode (e.g. ``delete``). Trust the
+        # returned row, not the mere absence of an exception; otherwise we
+        # report a false ``"wal"`` AND skip the fallback WARNING, leaving the
+        # DB silently in DELETE (reader-blocks-writer) with no signal.
+        row = conn.execute("PRAGMA journal_mode=WAL").fetchone()
+        mode = str(row[0]).strip().lower() if row and row[0] is not None else ""
+        if mode == "wal":
+            return "wal"
+        _log_wal_fallback_once(
+            db_label,
+            sqlite3.OperationalError(
+                f"journal_mode=WAL refused without raising (still {mode!r})"
+            ),
+        )
+        return mode or "delete"
     except sqlite3.OperationalError as exc:
         msg = str(exc).lower()
         if not any(marker in msg for marker in _WAL_INCOMPAT_MARKERS):

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -2683,16 +2683,17 @@ def test_connect_falls_back_to_delete_on_locking_protocol(tmp_path, monkeypatch,
         )
 
     with _patch("hermes_cli.kanban_db.sqlite3.connect", side_effect=wal_blocking_connect):
-        with caplog.at_level("WARNING", logger="hermes_state"):
+        with caplog.at_level("ERROR", logger="hermes_state"):
             conn = kb.connect()
 
-    # One fallback warning, naming kanban.db
-    warnings = [
-        r for r in caplog.records
-        if r.levelname == "WARNING" and "kanban.db" in r.getMessage()
+    # One fallback error, naming kanban.db
+    errors = [
+        r
+        for r in caplog.records
+        if r.levelname == "ERROR" and "kanban.db" in r.getMessage()
     ]
-    assert len(warnings) >= 1, (
-        f"Expected a kanban.db WARNING, got: {[r.getMessage() for r in caplog.records]}"
+    assert len(errors) >= 1, (
+        f"Expected a kanban.db ERROR, got: {[r.getMessage() for r in caplog.records]}"
     )
 
     # DB still usable end-to-end — create + list a task

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import pytest
 
+import hermes_state
 from hermes_cli import kanban_db as kb
 
 
@@ -2668,6 +2669,7 @@ def test_connect_falls_back_to_delete_on_locking_protocol(tmp_path, monkeypatch,
 
     # Clear module cache so a fresh connect() is attempted
     kb._INITIALIZED_PATHS.clear()
+    hermes_state._wal_fallback_warned_paths.clear()
 
     real_connect = _sqlite3.connect
 
@@ -2701,6 +2703,55 @@ def test_connect_falls_back_to_delete_on_locking_protocol(tmp_path, monkeypatch,
     tasks = kb.list_tasks(conn)
     assert any(row.id == t for row in tasks)
     conn.close()
+
+
+def test_connect_works_when_wal_is_silently_refused(tmp_path, monkeypatch, caplog):
+    """kanban_db.connect() must stay usable when WAL silently no-ops to DELETE."""
+    import sqlite3 as _sqlite3
+    from unittest.mock import patch as _patch
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    kb._INITIALIZED_PATHS.clear()
+    hermes_state._wal_fallback_warned_paths.clear()
+
+    real_connect = _sqlite3.connect
+
+    class _WalSilentNoOpConnection(_sqlite3.Connection):
+        def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+            if "journal_mode=wal" in sql.lower().replace(" ", ""):
+                return super().execute("PRAGMA journal_mode=delete", *args, **kwargs)
+            return super().execute(sql, *args, **kwargs)
+
+    def wal_silent_noop_connect(*args, **kwargs):
+        return real_connect(
+            *args, factory=_WalSilentNoOpConnection, **kwargs
+        )
+
+    with _patch(
+        "hermes_cli.kanban_db.sqlite3.connect",
+        side_effect=wal_silent_noop_connect,
+    ):
+        with caplog.at_level("ERROR", logger="hermes_state"):
+            conn = kb.connect()
+
+    assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "delete"
+    t = kb.create_task(conn, title="post-silent-fallback task")
+    tasks = kb.list_tasks(conn)
+    assert any(row.id == t for row in tasks)
+    conn.close()
+
+    errors = [
+        r
+        for r in caplog.records
+        if r.levelname == "ERROR" and "kanban.db" in r.getMessage()
+    ]
+    assert len(errors) >= 1, (
+        f"Expected a kanban.db ERROR, got: {[r.getMessage() for r in caplog.records]}"
+    )
 
 
 def test_unlink_tasks_triggers_recompute_ready(kanban_home):

--- a/tests/test_hermes_state_wal_fallback.py
+++ b/tests/test_hermes_state_wal_fallback.py
@@ -21,6 +21,7 @@ import pytest
 import hermes_state
 from hermes_state import (
     SessionDB,
+    WalUnsupportedError,
     apply_wal_with_fallback,
     format_session_db_unavailable,
     get_last_init_error,
@@ -103,15 +104,15 @@ class TestApplyWalWithFallback:
         conn.close()
 
     def test_falls_back_to_delete_on_locking_protocol(self, tmp_path, caplog):
-        """NFS-style ``locking protocol`` error → DELETE mode + one WARNING."""
+        """NFS-style ``locking protocol`` error → DELETE mode + one ERROR."""
         conn, _ = _open_blocking(tmp_path / "nfs.db", isolation_level=None)
-        with caplog.at_level("WARNING", logger="hermes_state"):
+        with caplog.at_level("ERROR", logger="hermes_state"):
             mode = apply_wal_with_fallback(conn, db_label="test.db")
 
         assert mode == "delete"
-        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
-        assert len(warnings) == 1
-        msg = warnings[0].getMessage()
+        errors = [r for r in caplog.records if r.levelname == "ERROR"]
+        assert len(errors) == 1
+        msg = errors[0].getMessage()
         assert "test.db" in msg
         assert "journal_mode=DELETE" in msg
         assert "locking protocol" in msg
@@ -146,16 +147,14 @@ class TestApplyWalWithFallback:
         conn = sqlite3.connect(
             str(tmp_path / "macnfs.db"), factory=factory, isolation_level=None
         )
-        with caplog.at_level("WARNING", logger="hermes_state"):
+        with caplog.at_level("ERROR", logger="hermes_state"):
             mode = apply_wal_with_fallback(conn, db_label="kanban.db")
 
         assert mode == "delete", "must report the true mode, not a false 'wal'"
-        assert (
-            conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "delete"
-        )
-        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
-        assert len(warnings) == 1, "silent no-op must still emit exactly one WARNING"
-        assert "kanban.db" in warnings[0].getMessage()
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "delete"
+        errors = [r for r in caplog.records if r.levelname == "ERROR"]
+        assert len(errors) == 1, "silent no-op must still emit exactly one ERROR"
+        assert "kanban.db" in errors[0].getMessage()
         conn.close()
 
     def test_reraises_on_disk_io_error(self, tmp_path):
@@ -192,16 +191,12 @@ class TestApplyWalWithFallback:
         probe.
         """
         # Prime the file in WAL mode using a normal connection
-        primer = sqlite3.connect(
-            str(tmp_path / "already-wal.db"), isolation_level=None
-        )
+        primer = sqlite3.connect(str(tmp_path / "already-wal.db"), isolation_level=None)
         try:
             primer.execute("PRAGMA journal_mode=WAL")
             primer.execute("CREATE TABLE t (x INTEGER)")
             primer.execute("INSERT INTO t VALUES (1)")
-            assert (
-                primer.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
-            )
+            assert primer.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
         finally:
             primer.close()
 
@@ -225,9 +220,7 @@ class TestApplyWalWithFallback:
         # And the file is STILL WAL on disk — nothing got rewritten
         check = sqlite3.connect(str(tmp_path / "already-wal.db"))
         try:
-            assert (
-                check.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
-            )
+            assert check.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
         finally:
             check.close()
 
@@ -242,38 +235,37 @@ class TestApplyWalWithFallback:
             apply_wal_with_fallback(conn)
         conn.close()
 
-    def test_warning_deduplicated_per_db_label(self, tmp_path, caplog):
-        """Repeated calls with the same db_label log exactly ONE warning.
+    def test_error_deduplicated_per_db_label(self, tmp_path, caplog):
+        """Repeated calls with the same db_label log exactly ONE error.
 
         Prevents log spam when NFS users run kanban (which opens a fresh
         connection on every operation — see hermes_cli/kanban_db.py).
         Regression guard: the fix for #22032 ran apply_wal_with_fallback()
         on every kb.connect() call; without dedup, errors.log fills with
-        hundreds of identical warnings per hour.
+        hundreds of identical errors per hour.
         """
-        with caplog.at_level("WARNING", logger="hermes_state"):
+        with caplog.at_level("ERROR", logger="hermes_state"):
             # Three separate connections to "the same DB" via the same label
             for i in range(3):
-                conn, _ = _open_blocking(
-                    tmp_path / f"dup-{i}.db", isolation_level=None
-                )
+                conn, _ = _open_blocking(tmp_path / f"dup-{i}.db", isolation_level=None)
                 mode = apply_wal_with_fallback(conn, db_label="shared.db")
                 assert mode == "delete"
                 conn.close()
 
-        # Exactly one warning across all three calls
-        warnings = [
-            r for r in caplog.records
-            if r.levelname == "WARNING" and "shared.db" in r.getMessage()
+        # Exactly one error across all three calls
+        errors = [
+            r
+            for r in caplog.records
+            if r.levelname == "ERROR" and "shared.db" in r.getMessage()
         ]
-        assert len(warnings) == 1, (
-            f"Expected 1 deduplicated warning, got {len(warnings)}: "
-            f"{[r.getMessage() for r in warnings]}"
+        assert len(errors) == 1, (
+            f"Expected 1 deduplicated error, got {len(errors)}: "
+            f"{[r.getMessage() for r in errors]}"
         )
 
-    def test_warning_fires_independently_per_db_label(self, tmp_path, caplog):
-        """Different db_labels each get their own one warning (not globally dedup'd)."""
-        with caplog.at_level("WARNING", logger="hermes_state"):
+    def test_error_fires_independently_per_db_label(self, tmp_path, caplog):
+        """Different db_labels each get their own one error (not globally dedup'd)."""
+        with caplog.at_level("ERROR", logger="hermes_state"):
             conn1, _ = _open_blocking(tmp_path / "a.db", isolation_level=None)
             apply_wal_with_fallback(conn1, db_label="state.db")
             conn1.close()
@@ -282,14 +274,64 @@ class TestApplyWalWithFallback:
             apply_wal_with_fallback(conn2, db_label="kanban.db")
             conn2.close()
 
-        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
-        labels_warned = {
-            lbl for r in warnings for lbl in ("state.db", "kanban.db")
+        errors = [r for r in caplog.records if r.levelname == "ERROR"]
+        labels_logged = {
+            lbl
+            for r in errors
+            for lbl in ("state.db", "kanban.db")
             if lbl in r.getMessage()
         }
-        assert labels_warned == {"state.db", "kanban.db"}, (
-            f"Each db_label should warn once; got {labels_warned}"
+        assert labels_logged == {"state.db", "kanban.db"}, (
+            f"Each db_label should log once; got {labels_logged}"
         )
+
+
+class TestRequireWal:
+    """``require_wal=True`` turns either WAL-refusal shape into a hard
+    ``WalUnsupportedError`` for callers that mandate WAL concurrency, instead
+    of silently degrading to DELETE. The default callers (SessionDB /
+    kanban_db.connect) keep ``require_wal=False`` so NFS-homed installs work.
+    """
+
+    def test_happy_path_unaffected_by_require_wal(self, tmp_path):
+        """On a WAL-capable FS, require_wal=True still simply returns 'wal'."""
+        conn = sqlite3.connect(str(tmp_path / "ok.db"), isolation_level=None)
+        try:
+            assert apply_wal_with_fallback(conn, require_wal=True) == "wal"
+        finally:
+            conn.close()
+
+    def test_raises_on_raising_marker(self, tmp_path):
+        """NFS-style raising refusal + require_wal=True → WalUnsupportedError."""
+        conn, _ = _open_blocking(tmp_path / "nfs.db", isolation_level=None)
+        try:
+            with pytest.raises(WalUnsupportedError, match="locking protocol"):
+                apply_wal_with_fallback(conn, db_label="state.db", require_wal=True)
+        finally:
+            conn.close()
+
+    def test_raises_on_silent_refusal(self, tmp_path):
+        """macOS-NFS silent no-op + require_wal=True → WalUnsupportedError,
+        not a false 'delete' return."""
+        factory = _make_silent_noop_factory("delete")
+        conn = sqlite3.connect(
+            str(tmp_path / "macnfs.db"), factory=factory, isolation_level=None
+        )
+        try:
+            with pytest.raises(WalUnsupportedError, match="refused without raising"):
+                apply_wal_with_fallback(conn, db_label="kanban.db", require_wal=True)
+        finally:
+            conn.close()
+
+    def test_error_is_operationalerror_subclass(self, tmp_path):
+        """WalUnsupportedError must stay catchable as sqlite3.OperationalError
+        so existing DB-init handlers (e.g. SessionDB.__init__) still catch it."""
+        conn, _ = _open_blocking(tmp_path / "nfs.db", isolation_level=None)
+        try:
+            with pytest.raises(sqlite3.OperationalError):
+                apply_wal_with_fallback(conn, require_wal=True)
+        finally:
+            conn.close()
 
 
 class TestGetLastInitError:
@@ -345,7 +387,9 @@ class TestGetLastInitError:
                 return super().execute(sql, *args, **kwargs)
 
         def gated_connect(*args, **kwargs):
-            return real_connect(str(target), factory=_BothPragmasFailConnection, **kwargs)
+            return real_connect(
+                str(target), factory=_BothPragmasFailConnection, **kwargs
+            )
 
         with patch("hermes_state.sqlite3.connect", side_effect=gated_connect):
             with pytest.raises(sqlite3.OperationalError):

--- a/tests/test_hermes_state_wal_fallback.py
+++ b/tests/test_hermes_state_wal_fallback.py
@@ -55,6 +55,27 @@ def _open_blocking(path, reason="locking protocol", **kwargs):
     return sqlite3.connect(str(path), factory=factory, **kwargs), attempts
 
 
+def _make_silent_noop_factory(returned_mode: str = "delete"):
+    """Return a ``sqlite3.Connection`` subclass whose ``PRAGMA journal_mode=WAL``
+    silently NO-OPs: it returns the still-effective journal mode (e.g.
+    ``delete``) WITHOUT raising — the way macOS NFS / SMB / the AgentFS NFS
+    overlay behave. NFS that *raises* SQLITE_PROTOCOL is covered by
+    :func:`_make_blocking_factory`; this is the other, quieter failure shape.
+    """
+
+    class _WalSilentNoOpConnection(sqlite3.Connection):
+        def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+            if "journal_mode=wal" in sql.lower().replace(" ", ""):
+                # Refuse the WAL switch but DON'T raise; report the mode that is
+                # actually still in force, exactly as the NFS client does.
+                return super().execute(
+                    f"PRAGMA journal_mode={returned_mode}", *args, **kwargs
+                )
+            return super().execute(sql, *args, **kwargs)
+
+    return _WalSilentNoOpConnection
+
+
 @pytest.fixture(autouse=True)
 def _reset_last_init_error():
     """Reset the module-global last-error before and after each test."""
@@ -108,6 +129,33 @@ class TestApplyWalWithFallback:
         )
         mode = apply_wal_with_fallback(conn)
         assert mode == "delete"
+        conn.close()
+
+    def test_falls_back_when_wal_silently_refused(self, tmp_path, caplog):
+        """macOS NFS / SMB / AgentFS-NFS can REFUSE the WAL switch WITHOUT
+        raising: ``PRAGMA journal_mode=WAL`` returns the still-effective mode
+        ('delete') and no exception. The marker-exception path never fires, so
+        the function must detect the silent no-op from the PRAGMA's RETURN
+        value — otherwise it returns a false 'wal' and skips the WARNING.
+
+        Reproduced on a real AgentFS NFS overlay, where
+        ``PRAGMA journal_mode=WAL`` returned ('delete',) with no
+        OperationalError.
+        """
+        factory = _make_silent_noop_factory("delete")
+        conn = sqlite3.connect(
+            str(tmp_path / "macnfs.db"), factory=factory, isolation_level=None
+        )
+        with caplog.at_level("WARNING", logger="hermes_state"):
+            mode = apply_wal_with_fallback(conn, db_label="kanban.db")
+
+        assert mode == "delete", "must report the true mode, not a false 'wal'"
+        assert (
+            conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "delete"
+        )
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1, "silent no-op must still emit exactly one WARNING"
+        assert "kanban.db" in warnings[0].getMessage()
         conn.close()
 
     def test_reraises_on_disk_io_error(self, tmp_path):

--- a/tests/test_hermes_state_wal_fallback.py
+++ b/tests/test_hermes_state_wal_fallback.py
@@ -459,3 +459,36 @@ class TestSessionDbUsesWalFallback:
             assert get_last_init_error() is None
         finally:
             db.close()
+
+    def test_sessiondb_works_when_wal_is_silently_refused(self, tmp_path, caplog):
+        """E2E: SessionDB stays usable when WAL silently no-ops to DELETE."""
+        target = tmp_path / "macnfs_style.db"
+
+        real_connect = sqlite3.connect
+        factory = _make_silent_noop_factory("delete")
+
+        def gated_connect(*args, **kwargs):
+            return real_connect(str(target), factory=factory, **kwargs)
+
+        with patch("hermes_state.sqlite3.connect", side_effect=gated_connect):
+            with caplog.at_level("ERROR", logger="hermes_state"):
+                db = SessionDB(db_path=target)
+
+        try:
+            assert db._conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "delete"
+            db.create_session(session_id="s2", source="cli", model="test")
+            sess = db.get_session("s2")
+            assert sess is not None
+            assert sess["source"] == "cli"
+            assert get_last_init_error() is None
+        finally:
+            db.close()
+
+        errors = [
+            r
+            for r in caplog.records
+            if r.levelname == "ERROR" and "state.db" in r.getMessage()
+        ]
+        assert len(errors) == 1, (
+            "silent WAL refusal should emit exactly one state.db error"
+        )


### PR DESCRIPTION
## Problem

`apply_wal_with_fallback()` in `hermes_state.py` — shared by `SessionDB` (`state.db`) and `hermes_cli.kanban_db.connect()` (`kanban.db`) — detects WAL-incompatible filesystems **only** by catching a raised `OperationalError` matched against `_WAL_INCOMPAT_MARKERS` (`"locking protocol"`, `"not authorized"`).

But not every WAL-incompatible filesystem *raises*. On **macOS NFS**, **SMB/CIFS**, and **overlay filesystems** (this surfaced on an [AgentFS](https://github.com/tursodatabase/agentfs) NFS-backed mount), `PRAGMA journal_mode=WAL` refuses the switch **without raising** — it returns the still-effective journal mode (`'delete'`) as its result row and no exception.

The current code ignores that returned row:

```python
try:
    conn.execute("PRAGMA journal_mode=WAL")
    return "wal"            # ← unconditional; the returned mode is never checked
except sqlite3.OperationalError as exc:
    ...
```

So on those filesystems it:

1. **returns a false `"wal"`** while the DB is actually in DELETE mode (the function's contract is "return the mode actually set"), and
2. **never calls `_log_wal_fallback_once`** — that lives in the `except` branch, which isn't taken — so the operator gets **zero signal** that concurrency silently degraded to DELETE (reader-blocks-writer).

For kanban specifically, a board DB on a network/overlay home runs the dispatcher + every worker in DELETE with no diagnostic.

## Reproduction

On a macOS NFS / AgentFS-NFS mount:

```
PRAGMA journal_mode      -> ('delete',)
PRAGMA journal_mode=WAL  -> ('delete',)   # no exception raised
apply_wal_with_fallback() -> 'wal'         # …but the DB is in 'delete'
```

## Fix

Read the row `PRAGMA journal_mode=WAL` returns and verify it is actually `'wal'` instead of assuming success. On a silent no-op, emit the existing fallback WARNING and return the true mode. The raise-based path (`_WAL_INCOMPAT_MARKERS`, the on-disk-WAL guard, EIO re-raise, per-label dedup) is unchanged — happy path on a normal FS still returns `'wal'`.

## Tests

- New regression test `test_falls_back_when_wal_silently_refused` models the silent-no-op shape (a `sqlite3.Connection` subclass whose `PRAGMA journal_mode=WAL` returns `'delete'` without raising), asserting the function returns `'delete'` and emits exactly one WARNING.
- `pytest tests/test_hermes_state_wal_fallback.py` → **17 passed** (16 existing + the new one).
- Negative control: the new test **fails on `main`** (`assert 'wal' == 'delete'`) and passes with the fix, confirming it guards the regression.

Opening as **draft** for maintainer eyes on the approach.
