### PR TITLE
fix(tools): use start_new_session instead of preexec_fn to prevent SIGSEGV in multi-threaded processes

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -516,7 +516,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 ],
                 stdout=bridge_log_fh,
                 stderr=bridge_log_fh,
-                preexec_fn=None if _IS_WINDOWS else os.setsid,
+                start_new_session=True,
                 env=bridge_env,
             )
             _write_bridge_pidfile(self._session_path, self._bridge_process.pid)

--- a/tests/tools/test_windows_compat.py
+++ b/tests/tools/test_windows_compat.py
@@ -46,6 +46,25 @@ class TestNoUnconditionalSetsid:
             )
 
 
+class TestStartNewSession:
+    """All guarded files must use start_new_session=True instead of preexec_fn."""
+
+    @pytest.mark.parametrize("relpath", GUARDED_FILES)
+    def test_uses_start_new_session(self, relpath):
+        """Each guarded file must use start_new_session=True for process isolation."""
+        filepath = PROJECT_ROOT / relpath
+        if not filepath.exists():
+            pytest.skip(f"{relpath} not found")
+        source = filepath.read_text(encoding="utf-8")
+        # Files should use start_new_session=True, not preexec_fn
+        assert "preexec_fn" not in source, (
+            f"{relpath} still uses preexec_fn; use start_new_session=True instead"
+        )
+        assert "start_new_session=True" in source, (
+            f"{relpath} missing start_new_session=True in Popen call"
+        )
+
+
 class TestIsWindowsConstant:
     """Each guarded file must define _IS_WINDOWS."""
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1290,7 +1290,7 @@ def execute_code(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             stdin=subprocess.DEVNULL,
-            preexec_fn=None if _IS_WINDOWS else os.setsid,
+            start_new_session=True,
             creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
         )
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -601,7 +601,7 @@ class LocalEnvironment(BaseEnvironment):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
-            preexec_fn=None if _IS_WINDOWS else os.setsid,
+            start_new_session=True,
             cwd=_popen_cwd,
             **_popen_kwargs,
         )

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -607,7 +607,7 @@ class ProcessRegistry:
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             stdin=subprocess.DEVNULL,
-            preexec_fn=None if _IS_WINDOWS else os.setsid,
+            start_new_session=True,
             **_popen_kwargs,
         )
 


### PR DESCRIPTION
## What does this PR do?

Replaces all `preexec_fn=os.setsid` usage with `start_new_session=True` in process-launching code to prevent SIGSEGV crashes when the Desktop gateway has loaded native multi-threaded libraries (onnxruntime, BLAS, provider SDKs).

## Related Issue

Fixes #46789

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/code_execution_tool.py`: Replace `preexec_fn=None if _IS_WINDOWS else os.setsid` with `start_new_session=True` in `execute_code()` Popen call
- `tools/process_registry.py`: Same replacement in `ProcessRegistry._spawn_background()` Popen call
- `tools/environments/local.py`: Same replacement in `LocalEnvironment.run_command()` Popen call
- `gateway/platforms/whatsapp.py`: Same replacement in `_start_bridge()` Popen call
- `tests/tools/test_windows_compat.py`: Add `TestStartNewSession` class that asserts all guarded files use `start_new_session=True` and no longer contain `preexec_fn`

## How to Test

1. Run `pytest tests/tools/test_windows_compat.py -v` — all 16 tests should pass
2. Run `pytest tests/tools/test_process_registry.py tests/tools/test_code_execution.py -q` — all non-psutil tests should pass
3. On macOS with Desktop app: verify `terminal`, `execute_code`, and `read_file` tools no longer segfault (exit code -11)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `start_new_session=True` is silently accepted on Windows (no-op), same behavior as the previous `preexec_fn=None` guard
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `tools/code_execution_tool.py`, `tools/process_registry.py`, `tools/environments/local.py`, `gateway/platforms/whatsapp.py` (4 Popen call sites)
- Blast radius: LOW — each file has exactly one `preexec_fn` usage replaced with semantically equivalent `start_new_session=True`; no control flow changes
- Related patterns: `hermes_cli/gateway.py` and `hermes_cli/_subprocess_compat.py` already use `start_new_session=True` throughout — this PR brings the remaining 4 files in line with the established pattern
