### PR TITLE
fix(browser): scope Browserbase proxy warning

### DIFF
--- a/agent/browser_provider.py
+++ b/agent/browser_provider.py
@@ -93,11 +93,16 @@ class BrowserProvider(abc.ABC):
         Must return a dict with at least::
 
             {
-                "session_name": str,    # unique name for agent-browser --session
-                "bb_session_id": str,   # provider session ID (for close/cleanup)
-                "cdp_url": str,         # CDP websocket URL
-                "features": dict,       # feature flags that were enabled
+                "session_name": str,  # unique name for agent-browser --session
+                "bb_session_id": str, # provider session ID (for close/cleanup)
+                "cdp_url": str,       # CDP websocket URL
+                "features": dict,     # feature flags that were enabled
             }
+
+        Should also include ``browser_backend`` with a stable backend identifier
+        (for example ``"browserbase"``). The dispatcher uses this metadata to
+        emit backend-specific warnings only when they apply to the active
+        session.
 
         ``bb_session_id`` is a legacy key name kept for backward compat with
         the rest of :mod:`tools.browser_tool` — it holds the provider's

--- a/plugins/browser/browser_use/provider.py
+++ b/plugins/browser/browser_use/provider.py
@@ -246,6 +246,7 @@ class BrowserUseBrowserProvider(BrowserProvider):
             "session_name": session_name,
             "bb_session_id": session_data["id"],
             "cdp_url": cdp_url,
+            "browser_backend": "browser-use",
             "features": {"browser_use": True},
             "external_call_id": external_call_id,
         }

--- a/plugins/browser/browserbase/provider.py
+++ b/plugins/browser/browserbase/provider.py
@@ -211,6 +211,7 @@ class BrowserbaseBrowserProvider(BrowserProvider):
             "session_name": session_name,
             "bb_session_id": session_data["id"],
             "cdp_url": session_data["connectUrl"],
+            "browser_backend": "browserbase",
             "features": features_enabled,
         }
 

--- a/plugins/browser/firecrawl/provider.py
+++ b/plugins/browser/firecrawl/provider.py
@@ -112,6 +112,7 @@ class FirecrawlBrowserProvider(BrowserProvider):
             "session_name": session_name,
             "bb_session_id": data["id"],
             "cdp_url": data["cdpUrl"],
+            "browser_backend": "firecrawl",
             "features": {"firecrawl": True},
         }
 

--- a/tests/tools/test_browser_warning_scope.py
+++ b/tests/tools/test_browser_warning_scope.py
@@ -1,0 +1,209 @@
+"""Regression tests for browser_navigate first-navigation warning scoping.
+
+Before this fix, every session whose feature map lacked ``proxies=True``
+received a Browserbase-specific residential-proxy warning. The warning
+should only apply to Browserbase-backed sessions that are actually running
+without proxies.
+"""
+import json
+from unittest.mock import patch
+
+import pytest
+
+import tools.browser_tool as bt
+
+
+def _navigate_with_patched_session(
+    session_info,
+    task_id="warn-test",
+    title="Example",
+):
+    """Run browser_navigate with a fake _get_session_info + fake command results.
+
+    Patches backend-availability checks so the test does not need a real
+    browser and avoids private-URL / SSRF guards.
+    """
+    session_info = dict(session_info, _first_nav=True)
+    with (
+        patch("tools.browser_tool._is_local_backend", return_value=True),
+        patch("tools.browser_tool._get_cloud_provider", return_value=None),
+        patch("tools.browser_tool._get_session_info", return_value=session_info),
+        patch(
+            "tools.browser_tool._run_browser_command",
+            side_effect=[
+                {
+                    "success": True,
+                    "data": {"title": title, "url": "https://example.com/"},
+                },
+                {
+                    "success": True,
+                    "data": {
+                        "snapshot": "- heading \"Example\" [ref=e1]",
+                        "refs": {"e1": {}},
+                    },
+                },
+            ],
+        ),
+    ):
+        response = json.loads(bt.browser_navigate("https://example.com", task_id=task_id))
+    bt._last_active_session_key.pop(task_id, None)
+    return response
+
+
+class TestBrowserbaseProxyWarning:
+    """Browserbase sessions without proxies show the warning."""
+
+    def test_browserbase_without_proxies_shows_warning(self):
+        response = _navigate_with_patched_session({
+            "session_name": "bb-test",
+            "browser_backend": "browserbase",
+            "features": {"basic_stealth": True, "proxies": False},
+        })
+
+        assert response["success"] is True
+        assert "stealth_warning" in response
+        assert "Browserbase" in response["stealth_warning"]
+        assert response["stealth_features"] == ["basic_stealth"]
+
+    def test_browserbase_blocked_title_shows_backend_specific_advanced_stealth_guidance(
+        self,
+    ):
+        response = _navigate_with_patched_session({
+            "session_name": "bb-block-test",
+            "browser_backend": "browserbase",
+            "features": {"basic_stealth": True, "proxies": True},
+        }, title="Access Denied")
+
+        assert response["success"] is True
+        assert "bot_detection_warning" in response
+        assert "stealth_warning" not in response
+        assert "BROWSERBASE_ADVANCED_STEALTH=true" in response["bot_detection_warning"]
+        assert "Scale plan" in response["bot_detection_warning"]
+
+    def test_browserbase_with_proxies_no_warning(self):
+        response = _navigate_with_patched_session({
+            "session_name": "bb-test",
+            "browser_backend": "browserbase",
+            "features": {"basic_stealth": True, "proxies": True},
+        })
+
+        assert response["success"] is True
+        assert "stealth_warning" not in response
+        assert "proxies" in response["stealth_features"]
+
+
+class TestNonBrowserbaseNoProxyWarning:
+    """Non-Browserbase backends must not receive the Browserbase warning."""
+
+    def test_cdp_override_no_browserbase_warning(self):
+        response = _navigate_with_patched_session({
+            "session_name": "cdp-test",
+            "browser_backend": "cdp_override",
+            "features": {"cdp_override": True},
+        })
+
+        assert response["success"] is True
+        assert "stealth_warning" not in response
+        assert "cdp_override" in response["stealth_features"]
+
+    def test_local_chrome_no_browserbase_warning(self):
+        response = _navigate_with_patched_session({
+            "session_name": "local-test",
+            "browser_backend": "local",
+            "features": {"local": True},
+        })
+
+        assert response["success"] is True
+        assert "stealth_warning" not in response
+        assert "local" in response["stealth_features"]
+
+    def test_browser_use_no_browserbase_warning(self):
+        response = _navigate_with_patched_session({
+            "session_name": "bu-test",
+            "browser_backend": "browser-use",
+            "features": {"browser_use": True},
+        })
+
+        assert response["success"] is True
+        assert "stealth_warning" not in response
+
+    def test_firecrawl_no_browserbase_warning(self):
+        response = _navigate_with_patched_session({
+            "session_name": "fc-test",
+            "browser_backend": "firecrawl",
+            "features": {"firecrawl": True},
+        })
+
+        assert response["success"] is True
+        assert "stealth_warning" not in response
+
+    @pytest.mark.parametrize(
+        ("session_info", "blocked_title"),
+        [
+            (
+                {
+                    "session_name": "cdp-test",
+                    "browser_backend": "cdp_override",
+                    "features": {"cdp_override": True},
+                },
+                "Access denied",
+            ),
+            (
+                {
+                    "session_name": "local-test",
+                    "browser_backend": "local",
+                    "features": {"local": True},
+                },
+                "Just a moment",
+            ),
+            (
+                {
+                    "session_name": "bu-test",
+                    "browser_backend": "browser-use",
+                    "features": {"browser_use": True},
+                },
+                "Attention Required",
+            ),
+            (
+                {
+                    "session_name": "fc-test",
+                    "browser_backend": "firecrawl",
+                    "features": {"firecrawl": True},
+                },
+                "Blocked",
+            ),
+            (
+                {
+                    "session_name": "legacy-test",
+                    "features": {"basic_stealth": True, "proxies": False},
+                },
+                "Bot detected",
+            ),
+        ],
+    )
+    def test_non_browserbase_blocked_title_keeps_generic_warning(
+        self,
+        session_info,
+        blocked_title,
+    ):
+        response = _navigate_with_patched_session(session_info, title=blocked_title)
+
+        assert response["success"] is True
+        assert "bot_detection_warning" in response
+        assert "3) Some sites have very aggressive bot detection" in response[
+            "bot_detection_warning"
+        ]
+        assert "4)" not in response["bot_detection_warning"]
+        assert "BROWSERBASE_ADVANCED_STEALTH" not in response["bot_detection_warning"]
+        assert "Browserbase" not in response["bot_detection_warning"]
+        assert "Scale plan" not in response["bot_detection_warning"]
+
+    def test_legacy_session_without_backend_no_warning(self):
+        """Backward-compat: old sessions that lack browser_backend must not warn."""
+        response = _navigate_with_patched_session({
+            "session_name": "legacy-test",
+            "features": {"basic_stealth": True, "proxies": False},
+        })
+
+        assert response["success"] is True
+        assert "stealth_warning" not in response

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -330,6 +330,24 @@ def _read_command_output_files(stdout_path: str, stderr_path: str) -> tuple[str,
     return stdout, stderr
 
 
+def _compose_bot_detection_warning(title: str, browser_backend: str | None) -> str:
+    """Build a bot-detection warning tailored to the browser backend."""
+    common = (
+        f"Page title '{title}' suggests bot detection. The site may have blocked this request. "
+        "Options: 1) Try adding delays between actions, 2) Access different pages first, "
+    )
+    if browser_backend == "browserbase":
+        return (
+            f"{common}3) Enable advanced stealth (BROWSERBASE_ADVANCED_STEALTH=true, "
+            "requires Scale plan), 4) Some sites have very aggressive bot detection "
+            "that may be unavoidable."
+        )
+    return (
+        f"{common}3) Some sites have very aggressive bot detection that may be "
+        "unavoidable."
+    )
+
+
 def _unlink_command_output_files(*paths: str) -> None:
     for path in paths:
         try:
@@ -1979,6 +1997,7 @@ def _create_local_session(task_id: str) -> Dict[str, str]:
         "session_name": session_name,
         "bb_session_id": None,
         "cdp_url": None,
+        "browser_backend": "local",
         "features": {"local": True},
     }
 
@@ -1993,6 +2012,7 @@ def _create_cdp_session(task_id: str, cdp_url: str) -> Dict[str, str]:
         "session_name": session_name,
         "bb_session_id": None,
         "cdp_url": cdp_url,
+        "browser_backend": "cdp_override",
         "features": {"cdp_override": True},
     }
 
@@ -2874,18 +2894,23 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
         title_lower = title.lower()
 
         if any(pattern in title_lower for pattern in blocked_patterns):
-            response["bot_detection_warning"] = (
-                f"Page title '{title}' suggests bot detection. The site may have blocked this request. "
-                "Options: 1) Try adding delays between actions, 2) Access different pages first, "
-                "3) Enable advanced stealth (BROWSERBASE_ADVANCED_STEALTH=true, requires Scale plan), "
-                "4) Some sites have very aggressive bot detection that may be unavoidable."
+            response["bot_detection_warning"] = _compose_bot_detection_warning(
+                title,
+                session_info.get("browser_backend"),
             )
 
         # Include feature info on first navigation so model knows what's active
         if is_first_nav and "features" in session_info:
             features = session_info["features"]
             active_features = [k for k, v in features.items() if v]
-            if not features.get("proxies"):
+            # Browserbase-only proxy warning: only apply to Browserbase-backed sessions
+            # that explicitly lack proxies. Other backends (local Chrome, CDP override,
+            # Browser Use, Firecrawl, etc.) are not Browserbase and should not receive
+            # its plan-specific warning.
+            if (
+                session_info.get("browser_backend") == "browserbase"
+                and not features.get("proxies")
+            ):
                 response["stealth_warning"] = (
                     "Running WITHOUT residential proxies. Bot detection may be more aggressive. "
                     "Consider upgrading Browserbase plan for proxy support."


### PR DESCRIPTION
## Summary

`browser_navigate` emitted Browserbase-specific guidance from generic warning paths:

- Any first navigation whose feature map lacked `proxies=True` received a Browserbase residential-proxy plan warning.
- Any blocked-page title received a recommendation to enable `BROWSERBASE_ADVANCED_STEALTH=true`, regardless of the active backend.

That made local Chrome, explicit CDP, Browser Use, Firecrawl, and legacy/third-party sessions report misleading Browserbase advice.

This PR adds stable backend identity to browser sessions and scopes both Browserbase-specific recommendations to Browserbase-backed sessions, while retaining generic blocked-page guidance and first-navigation feature reporting for every backend.

Fixes #54197.

## Changes

- Add a `browser_backend` metadata key to in-tree browser session creation paths:
  - local browser sessions
  - explicit CDP override sessions
  - Browserbase
  - Browser Use
  - Firecrawl
- Emit the residential-proxy `stealth_warning` only when `browser_backend == "browserbase"` and proxies are disabled.
- Include the `BROWSERBASE_ADVANCED_STEALTH=true` blocked-page recommendation only for Browserbase sessions; other backends retain generic bot-detection guidance without Browserbase or Scale-plan text.
- Document the recommended `browser_backend` session metadata in the `BrowserProvider` contract.
- Add behavior-level regression coverage for Browserbase, CDP override, local, Browser Use, Firecrawl, and legacy session metadata, including blocked-title cases.

## Motivation

The previous warnings were provider-specific but emitted from generic feature and blocked-title logic. They could incorrectly imply that Browserbase was active, that a Browserbase plan upgrade was available, or that Browserbase configuration was relevant to local/custom CDP and other provider sessions.

Backend identity is now explicit rather than inferred from legacy IDs, feature keys, or local/cloud state, so current and future providers can receive only applicable diagnostics.

Camofox is unaffected because it delegates through `camofox_navigate` before these warning paths are reached.

## Verification

```bash
scripts/run_tests.sh tests/tools/test_browser_warning_scope.py
scripts/run_tests.sh tests/tools/test_browser_*.py -q
uv run --with ruff==0.15.10 ruff check tools/browser_tool.py tests/tools/test_browser_warning_scope.py
python scripts/check-windows-footguns.py --all
git diff --check upstream/main...HEAD
```

Results:

- `tests/tools/test_browser_warning_scope.py`: 13 passed
- `tests/tools/test_browser_*.py`: 520 passed
- Ruff: passed
- Windows footgun check: passed (761 files scanned)
- Diff whitespace check: passed

## Risk

Low. This is additive session metadata plus narrower composition of existing warnings. Browser session creation, navigation, CDP connection behavior, and feature reporting are otherwise unchanged. Sessions without `browser_backend` metadata retain generic bot-detection guidance and skip Browserbase-specific recommendations, preserving compatibility with older and third-party providers.
