### PR TITLE
docs(docker): document gateway tool-loop hard stops

### DIFF
--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -70,6 +70,18 @@ This behavior applies to the s6-based image only. Earlier (tini-based) images st
 See the [Where the logs go](#where-the-logs-go) section below for the full routing map (per-profile gateways, dashboard, boot reconciler, container-wide `docker logs`).
 :::
 
+:::note Tool-loop hard stops for unattended gateways
+The `tool_loop_guardrails.hard_stop_enabled` setting defaults to `false`, which is reasonable for interactive CLI and TUI sessions where a person can see repeated tool-call warnings. In unattended gateway or server deployments, warnings alone may not stop an agent that gets stuck in a repeated tool-call loop. Operators who want circuit-breaker behavior should explicitly enable hard stops in the profile's `config.yaml`:
+
+```yaml
+tool_loop_guardrails:
+  hard_stop_enabled: true
+  hard_stop_after:
+    exact_failure: 5
+    idempotent_no_progress: 5
+```
+:::
+
 Note: the API server is gated on `API_SERVER_ENABLED=true`. To expose it beyond `127.0.0.1` inside the container, also set `API_SERVER_HOST=0.0.0.0` and an `API_SERVER_KEY` (minimum 8 characters — generate one with `openssl rand -hex 32`). Example:
 
 ```sh


### PR DESCRIPTION
## Summary

- Adds a Docker/gateway operator note for `tool_loop_guardrails.hard_stop_enabled`.
- Explains that the default warning-only behavior is reasonable for watched CLI/TUI sessions, but unattended gateway/server deployments may need explicit hard stops.
- Includes a short profile config example for enabling tool-loop circuit breakers.

## Validation

- Manually checked the edited file for trailing whitespace.

Docs-only change; runtime behavior is unchanged.

References #46708
