### PR TITLE
fix(agent): don't end the turn on tool-call block decisions

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -158,7 +158,7 @@ class ToolGuardrailDecision:
 
     @property
     def should_halt(self) -> bool:
-        return self.action in {"block", "halt"}
+        return self.action == "halt"
 
     def to_metadata(self) -> dict[str, Any]:
         data: dict[str, Any] = {


### PR DESCRIPTION
Repairs tool_guardrails: a block decision should stop that tool call only, but the controller was setting the turn-halt flag for both block and halt. Result: the agent treated an idempotent-block as a hard stop, halting the session on the first blocked read-only call. Fix: should_halt now matches only action == halt. The block action still returns a synthetic try-different-path result, which is the right agent recovery behavior.