### PR TITLE
fix(desktop): don't false-fail a remote backend update when the dashboard restarts

### DIFF
--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -195,5 +195,33 @@ describe('applyBackendUpdate recovery', () => {
     expect(result.ok).toBe(false)
     expect($backendUpdateApply.get().stage).toBe('error')
   })
+
+  it('treats a 200 status with a null exit_code (registry wiped by the restart) as applied', async () => {
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'update', pid: 1 })
+    // The dashboard restarted as the update's final step and wiped its in-memory
+    // action registry, so the poll lands on it and returns 200 with exit_code null.
+    getActionStatusSpy.mockResolvedValue({ name: 'update', running: false, exit_code: null })
+    checkHermesUpdateSpy.mockResolvedValue({ install_method: 'git', current_version: '0.16.0', behind: 0, update_available: false, can_apply: true, update_command: 'hermes update', message: null })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(5000)
+    const result = await promise
+
+    expect(result.ok).toBe(true)
+    expect($backendUpdateApply.get().stage).toBe('idle')
+    expect($backendUpdateApply.get().applying).toBe(false)
+  })
+
+  it('still reports failure on a genuine non-zero exit_code', async () => {
+    updateHermesSpy.mockResolvedValue({ ok: true, name: 'update', pid: 1 })
+    getActionStatusSpy.mockResolvedValue({ name: 'update', running: false, exit_code: 1 })
+
+    const promise = applyBackendUpdate()
+    await vi.advanceTimersByTimeAsync(5000)
+    const result = await promise
+
+    expect(result.ok).toBe(false)
+    expect($backendUpdateApply.get().stage).toBe('error')
+  })
 })
 

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -382,8 +382,15 @@ export async function applyBackendUpdate(): Promise<DesktopUpdateApplyResult> {
       }
     }
 
-    const ok = !!last && (last.exit_code ?? 1) === 0
-    if (ok) {
+    // A null/undefined exit_code here means `hermes update` finished by restarting
+    // the dashboard (the backend serving these polls) as its final step, wiping the
+    // in-memory action registry before we could read the result — so the status poll
+    // lands on the restarted dashboard and returns HTTP 200 with exit_code === null
+    // even though the update applied. Treat that, and a clean exit 0, as
+    // "applied — confirm the backend came back" (the same recovery path as a dropped
+    // poll above), instead of reporting a false "Backend update failed.".
+    const exitCode = last?.exit_code
+    if (exitCode == null || exitCode === 0) {
       $backendUpdateApply.set({ ...$backendUpdateApply.get(), applying: true, stage: 'restart', message: translateNow('updates.applyStatus.restarting') })
 
       return finishBackendApply(await waitForBackendReturn())


### PR DESCRIPTION
## Problem

When the desktop runs in **remote-client mode** and the user applies a backend update ("Update backend"), `hermes update`'s final step restarts the dashboard — the very process serving the update's status polls. That wipes the dashboard's in-memory action registry, so the next `GET /api/actions/hermes-update/status` lands on the freshly-restarted dashboard and returns **HTTP 200 with `exit_code: null`**.

In `applyBackendUpdate()`:

```ts
const ok = !!last && (last.exit_code ?? 1) === 0   // null ?? 1 = 1 !== 0  -> ok = false
```

so the overlay shows **"Backend update failed."** even though the update applied successfully.

There's already a restart-tolerant path — `waitForBackendReturn()` (polls `GET /api/hermes/update/check`, which survives the restart) — but it's only reached when a poll *throws* (the socket drops), not when a poll *returns 200 with a null `exit_code`*.

## Fix

Treat a `null`/`undefined` `exit_code` (registry wiped by the restart), and a clean `0`, as "applied — confirm the backend came back" via the existing `waitForBackendReturn()` path. Only a genuine **non-zero** `exit_code` is reported as a failure.

## Tests

Regression cases added to `updates.test.ts`:
- `200` status with `exit_code: null` → resolves as applied (overlay clears)
- non-zero `exit_code` → still reported as a failure

`updates.test.ts`: 11/11 pass.

## Scope

Single-file logic change in `apps/desktop/src/store/updates.ts` (+ tests). No change to the success path, the `manual`/`can_apply=false` paths, or the throw-based recovery path.
