### PR TITLE
fix(gateway): avoid false kanban stuck alerts at concurrency cap

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -23,6 +23,66 @@ from typing import Any, Optional
 logger = logging.getLogger("gateway.run")
 
 
+def _kanban_dispatcher_stalled(
+    ready_pending: bool,
+    any_spawned: bool,
+    any_capped: bool,
+    cap_full: bool,
+) -> bool:
+    return ready_pending and not any_spawned and not any_capped and not cap_full
+
+
+def _kanban_dispatcher_cap_full(
+    _kb: Any,
+    *,
+    max_spawn: Any,
+    max_in_progress: Any,
+) -> bool:
+    caps: list[int] = []
+    for raw in (max_spawn, max_in_progress):
+        try:
+            if raw is not None:
+                caps.append(int(raw))
+        except (TypeError, ValueError):
+            continue
+    if not caps:
+        return False
+
+    try:
+        boards = _kb.list_boards(include_archived=False)
+    except Exception:
+        return False
+
+    seen_db_paths: set[str] = set()
+    total = 0
+    for board_meta in boards:
+        slug = board_meta.get("slug") or getattr(_kb, "DEFAULT_BOARD", "default")
+        try:
+            db_path = board_meta.get("db_path") or _kb.kanban_db_path(slug)
+            resolved_db_path = str(Path(db_path).expanduser().resolve())
+        except Exception:
+            resolved_db_path = f"slug:{slug}"
+        if resolved_db_path in seen_db_paths:
+            continue
+        seen_db_paths.add(resolved_db_path)
+        conn = None
+        try:
+            conn = _kb.connect(board=slug)
+            row = conn.execute(
+                "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
+            ).fetchone()
+            total += int(row[0])
+        except Exception:
+            return False
+        finally:
+            if conn is not None:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+    return total >= min(caps)
+
+
 class GatewayKanbanWatchersMixin:
     """Kanban watcher / notifier / dispatcher loops for GatewayRunner."""
 
@@ -1017,6 +1077,7 @@ class GatewayKanbanWatchersMixin:
                     await asyncio.to_thread(_auto_decompose_tick)
                 results = await asyncio.to_thread(_tick_once)
                 any_spawned = False
+                any_capped = False
                 for slug, res in (results or []):
                     if res is not None and getattr(res, "spawned", None):
                         any_spawned = True
@@ -1033,9 +1094,23 @@ class GatewayKanbanWatchersMixin:
                             res.promoted,
                             len(res.auto_blocked) if hasattr(res.auto_blocked, "__len__") else 0,
                         )
+                    if res is not None and getattr(
+                        res, "skipped_per_profile_capped", None
+                    ):
+                        any_capped = True
                 # Health telemetry (aggregate across boards)
                 ready_pending = await asyncio.to_thread(_ready_nonempty)
-                if ready_pending and not any_spawned:
+                cap_full = False
+                if ready_pending and not any_spawned and not any_capped:
+                    cap_full = await asyncio.to_thread(
+                        _kanban_dispatcher_cap_full,
+                        _kb,
+                        max_spawn=max_spawn,
+                        max_in_progress=max_in_progress,
+                    )
+                if _kanban_dispatcher_stalled(
+                    ready_pending, any_spawned, any_capped, cap_full
+                ):
                     bad_ticks += 1
                 else:
                     bad_ticks = 0

--- a/tests/gateway/test_kanban_watchers_mixin.py
+++ b/tests/gateway/test_kanban_watchers_mixin.py
@@ -7,7 +7,12 @@ that GatewayRunner picks them up via the MRO (behavior-neutral relocation).
 
 from __future__ import annotations
 
+import asyncio
 import inspect
+import logging
+from types import SimpleNamespace
+
+import pytest
 
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
 
@@ -43,3 +48,178 @@ def test_watcher_loops_are_coroutines():
     # The two long-running watchers are async loops.
     assert inspect.iscoroutinefunction(GatewayKanbanWatchersMixin._kanban_notifier_watcher)
     assert inspect.iscoroutinefunction(GatewayKanbanWatchersMixin._kanban_dispatcher_watcher)
+
+
+class _CountConn:
+    def __init__(self, count: int):
+        self.count = count
+        self.closed = False
+
+    def execute(self, _sql: str):
+        return self
+
+    def fetchone(self):
+        return (self.count,)
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeKanbanDb:
+    DEFAULT_BOARD = "default"
+
+    def __init__(self, tmp_path, counts: dict[str, int], shared_db: bool = False):
+        self._tmp_path = tmp_path
+        self.counts = counts
+        self.shared_db = shared_db
+        self.connected: list[str] = []
+        self.connections: list[_CountConn] = []
+
+    def list_boards(self, include_archived: bool = False):
+        return [
+            {
+                "slug": slug,
+                "db_path": str(
+                    self._tmp_path
+                    / ("shared.db" if self.shared_db else f"{slug}.db")
+                ),
+            }
+            for slug in self.counts
+        ]
+
+    def kanban_db_path(self, board: str | None = None):
+        slug = board or self.DEFAULT_BOARD
+        return self._tmp_path / f"{slug}.db"
+
+    def connect(self, board: str | None = None):
+        slug = board or self.DEFAULT_BOARD
+        self.connected.append(slug)
+        conn = _CountConn(self.counts[slug])
+        self.connections.append(conn)
+        return conn
+
+
+@pytest.mark.parametrize(
+    ("ready", "spawned", "capped", "cap_full", "expected"),
+    [
+        (True, False, False, True, False),
+        (True, False, True, False, False),
+        (True, True, False, False, False),
+        (False, False, False, False, False),
+        (True, False, False, False, True),
+    ],
+)
+def test_dispatcher_stalled_decision(ready, spawned, capped, cap_full, expected):
+    from gateway.kanban_watchers import _kanban_dispatcher_stalled
+
+    assert _kanban_dispatcher_stalled(ready, spawned, capped, cap_full) is expected
+
+
+@pytest.mark.parametrize(
+    ("counts", "max_spawn", "max_in_progress", "expected", "connected", "shared_db"),
+    [
+        ({"default": 2}, 2, None, True, ["default"], False),
+        ({"default": 3}, 2, None, True, ["default"], False),
+        ({"default": 1}, 2, None, False, ["default"], False),
+        ({"default": 2}, None, 2, True, ["default"], False),
+        ({"default": 1, "project": 1}, 2, None, True, ["default", "project"], False),
+        ({"default": 2, "alias": 2}, 3, None, False, ["default"], True),
+        ({"default": 10}, None, None, False, [], False),
+        ({"default": 2}, "2", None, True, ["default"], False),
+        ({"default": 10}, "invalid", None, False, [], False),
+        ({"default": 0}, 0, None, True, ["default"], False),
+        ({"default": 0}, -1, None, True, ["default"], False),
+        ({"default": 1}, True, None, True, ["default"], False),
+        ({"default": 0}, False, None, True, ["default"], False),
+    ],
+)
+def test_dispatcher_cap_full_counts_running_workers(
+    tmp_path, counts, max_spawn, max_in_progress, expected, connected, shared_db
+):
+    from gateway.kanban_watchers import _kanban_dispatcher_cap_full
+
+    kb = _FakeKanbanDb(tmp_path, counts, shared_db=shared_db)
+
+    assert _kanban_dispatcher_cap_full(
+        kb,
+        max_spawn=max_spawn,
+        max_in_progress=max_in_progress,
+    ) is expected
+    assert kb.connected == connected
+    assert all(conn.closed for conn in kb.connections)
+
+
+def test_dispatcher_cap_full_falls_back_open_on_database_failure(tmp_path):
+    from gateway.kanban_watchers import _kanban_dispatcher_cap_full
+
+    class FailingKb(_FakeKanbanDb):
+        def connect(self, board: str | None = None):
+            raise RuntimeError("database unavailable")
+
+    kb = FailingKb(tmp_path, {"default": 2})
+
+    assert _kanban_dispatcher_cap_full(
+        kb,
+        max_spawn=2,
+        max_in_progress=None,
+    ) is False
+
+
+def test_gateway_dispatcher_does_not_warn_when_external_workers_fill_cap(
+    monkeypatch, tmp_path, caplog
+):
+    from gateway.run import GatewayRunner
+    import hermes_cli.config as _cfg_mod
+    import hermes_cli.kanban_db as _kb
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    kb = _FakeKanbanDb(tmp_path, {"default": 2})
+    ticks = {"count": 0}
+
+    monkeypatch.setattr(
+        _cfg_mod,
+        "load_config",
+        lambda: {
+            "kanban": {
+                "dispatch_in_gateway": True,
+                "dispatch_interval_seconds": 1,
+                "max_spawn": 2,
+                "auto_decompose": False,
+            }
+        },
+    )
+    monkeypatch.setattr(_kb, "list_boards", kb.list_boards)
+    monkeypatch.setattr(_kb, "kanban_db_path", kb.kanban_db_path)
+    monkeypatch.setattr(_kb, "connect", kb.connect)
+    monkeypatch.setattr(_kb, "reap_worker_zombies", lambda: [])
+    monkeypatch.setattr(
+        _kb,
+        "dispatch_once",
+        lambda *args, **kwargs: SimpleNamespace(
+            spawned=[],
+            skipped_per_profile_capped=[],
+        ),
+    )
+    monkeypatch.setattr(_kb, "has_spawnable_ready", lambda conn: True)
+
+    async def _to_thread(fn, *args, **kwargs):
+        result = fn(*args, **kwargs)
+        if getattr(fn, "__name__", "") == "_tick_once":
+            ticks["count"] += 1
+            if ticks["count"] >= 6:
+                runner._running = False
+        return result
+
+    async def _sleep(_delay):
+        return None
+
+    monkeypatch.setattr("gateway.kanban_watchers.asyncio.to_thread", _to_thread)
+    monkeypatch.setattr("gateway.kanban_watchers.asyncio.sleep", _sleep)
+
+    with caplog.at_level(logging.WARNING, logger="gateway.run"):
+        asyncio.run(
+            asyncio.wait_for(runner._kanban_dispatcher_watcher(), timeout=3.0)
+        )
+
+    assert "kanban dispatcher stuck" not in caplog.text


### PR DESCRIPTION
## What does this PR do?

Prevents the embedded Kanban dispatcher watcher from reporting a false stuck condition when spawnable work is waiting but the configured concurrency capacity is already occupied by workers launched outside the current watcher tick.

## Root cause

`_kanban_dispatcher_watcher` previously treated the following combination as a suspected stall:

* spawnable ready work exists
* the current watcher tick spawns no workers
* no explicit per-profile capped result is returned

However, workers launched by the external hook dispatcher may already occupy the effective global concurrency cap. In that case, `dispatch_once()` correctly spawns nothing, but the watcher still increments `bad_ticks` and eventually logs:

```text
kanban dispatcher stuck
```

even though tasks are processing normally.

## Changes

* Add a small health-decision helper that distinguishes genuine stalls from healthy throttling.
* Detect explicit per-profile concurrency-cap results.
* Count running Kanban tasks across active boards when evaluating global capacity.
* Deduplicate board aliases that resolve to the same physical database.
* Perform database probing outside the asyncio event loop.
* Fail open to the previous stuck-detection behavior when the health probe cannot read the database.
* Reset `bad_ticks` when capacity is already full.
* Preserve the existing `HEALTH_WINDOW` behavior for genuine stalls.

## Testing

Regression verification against the parent commit:

```text
1 failed
```

The regression test captured the false `kanban dispatcher stuck` warning after six watcher ticks.

After the fix:

```text
23 passed
```

Focused Gateway Kanban/watcher tests:

```text
63 passed, 2 skipped
```

Related Hermes CLI dispatch and concurrency-cap tests:

```text
16 passed
```

Windows footgun scan:

```text
No Windows footguns found
```

## Risk assessment

Low.

The change is limited to dispatcher health telemetry. It does not alter:

* dispatch scheduling
* task claiming
* worker spawning
* task statuses
* stale-claim recovery
* retry behavior
* notifier behavior
* public configuration

Fixes #46800
