### PR TITLE
fix(gateway): route busy approval responses (#46866)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3856,6 +3856,46 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             return True
 
+        # Pending dangerous-command approval (#46866): when the agent is
+        # blocked inside tools/approval.py waiting for user input, intercept
+        # approval/deny responses before they are steered/queued as ordinary
+        # mid-turn messages.  Without this, /approve (and /deny) are swallowed
+        # by the steer/queue path and the approval always times out → auto-deny.
+        # Bare-text keywords ("approve"/"deny") are also matched because some
+        # gateway users (Signal, WhatsApp) don't use slash syntax, but we keep
+        # the conservative set established by the existing approval design
+        # (TestBareTextNoLongerApproves) — only explicit approval/deny words,
+        # never conversational "yes"/"ok"/"no".
+        try:
+            from tools.approval import has_blocking_approval
+            _approval_live = has_blocking_approval(session_key)
+        except Exception:
+            _approval_live = False
+        if _approval_live:
+            _approval_raw = (event.text or "").strip().lower()
+            _approval_cmd = event.get_command()
+            _is_approve = (
+                _approval_cmd in {"approve", "yes"}
+                or _approval_raw == "approve"
+            )
+            _is_deny = (
+                _approval_cmd in {"deny", "no"}
+                or _approval_raw == "deny"
+            )
+            if _is_approve or _is_deny:
+                _approval_adapter = self.adapters.get(event.source.platform)
+                if _is_approve:
+                    _approval_result = await self._handle_approve_command(event)
+                else:
+                    _approval_result = await self._handle_deny_command(event)
+                if _approval_result and _approval_adapter:
+                    await _approval_adapter._send_with_retry(
+                        chat_id=event.source.chat_id,
+                        content=_approval_result,
+                        reply_to=event.message_id,
+                    )
+                return True  # handled — do not steer/queue
+
         # Normal busy case (agent actively running a task)
         adapter = self.adapters.get(event.source.platform)
         if not adapter:

--- a/tests/gateway/test_busy_session_approval_routing.py
+++ b/tests/gateway/test_busy_session_approval_routing.py
@@ -1,0 +1,225 @@
+"""Regression tests for #46866: approval responses misrouted as steered
+mid-turn messages when the session is busy (agent running, blocked on
+dangerous-command approval).
+
+Before the fix, ``_handle_active_session_busy_message`` never checked for
+pending tool approvals. Incoming approval/deny responses were steered or
+queued instead of being delivered to the approval handler, so approvals
+always timed out and auto-denied.
+"""
+
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        source=_make_source(),
+        message_id="m1",
+    )
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    adapter._send_with_retry = AsyncMock()
+    adapter.resume_typing_for_chat = MagicMock()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._background_tasks = set()
+    runner._session_db = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._draining = False
+    runner._busy_input_mode = "steer"
+    runner._busy_text_mode = "queue"
+    runner._busy_ack_ts = {}
+    runner._agent_has_active_subagents = lambda _agent: False
+    runner._restart_requested = False
+    return runner
+
+
+def _clear_approval_state():
+    from tools import approval as mod
+    mod._gateway_queues.clear()
+    mod._gateway_notify_cbs.clear()
+    mod._session_approved.clear()
+    mod._permanent_approved.clear()
+    mod._pending.clear()
+
+
+class TestBusySessionApprovalRouting:
+    """Verify approval/deny responses are routed to the approval handler
+    when the session is busy (agent running, blocked on approval)."""
+
+    def setup_method(self):
+        _clear_approval_state()
+
+    @pytest.mark.asyncio
+    async def test_plain_approve_resolves_pending_approval(self):
+        """Typing 'approve' as plain text during a pending approval resolves it.
+        Gateway users (Signal, WhatsApp) may not use slash syntax."""
+        from tools.approval import (
+            register_gateway_notify, _ApprovalEntry, _gateway_queues,
+        )
+
+        runner = _make_runner()
+        source = _make_source()
+        session_key = runner._session_key_for_source(source)
+
+        register_gateway_notify(session_key, lambda d: None)
+        entry = _ApprovalEntry({"command": "rm -rf /tmp/test"})
+        _gateway_queues[session_key] = [entry]
+
+        event = _make_event("approve")
+        handled = await runner._handle_active_session_busy_message(event, session_key)
+
+        assert handled is True, "Busy handler should return True (handled)"
+        assert entry.event.is_set(), "Approval entry should be resolved"
+        assert entry.result == "once"
+
+    @pytest.mark.asyncio
+    async def test_slash_approve_resolves_pending_approval(self):
+        """Typing '/approve' during a pending approval resolves it."""
+        from tools.approval import (
+            register_gateway_notify, _ApprovalEntry, _gateway_queues,
+        )
+
+        runner = _make_runner()
+        source = _make_source()
+        session_key = runner._session_key_for_source(source)
+
+        register_gateway_notify(session_key, lambda d: None)
+        entry = _ApprovalEntry({"command": "ls -la"})
+        _gateway_queues[session_key] = [entry]
+
+        event = _make_event("/approve")
+        handled = await runner._handle_active_session_busy_message(event, session_key)
+
+        assert handled is True
+        assert entry.event.is_set()
+        assert entry.result == "once"
+
+    @pytest.mark.asyncio
+    async def test_plain_deny_denies_pending_approval(self):
+        """Typing 'deny' as plain text during a pending approval denies it.
+        Gateway users (Signal, WhatsApp) may not use slash syntax."""
+        from tools.approval import (
+            register_gateway_notify, _ApprovalEntry, _gateway_queues,
+        )
+
+        runner = _make_runner()
+        source = _make_source()
+        session_key = runner._session_key_for_source(source)
+
+        register_gateway_notify(session_key, lambda d: None)
+        entry = _ApprovalEntry({"command": "rm -rf /"})
+        _gateway_queues[session_key] = [entry]
+
+        event = _make_event("deny")
+        handled = await runner._handle_active_session_busy_message(event, session_key)
+
+        assert handled is True
+        assert entry.event.is_set()
+        assert entry.result == "deny"
+
+    @pytest.mark.asyncio
+    async def test_slash_deny_denies_pending_approval(self):
+        """Typing '/deny' during a pending approval denies it."""
+        from tools.approval import (
+            register_gateway_notify, _ApprovalEntry, _gateway_queues,
+        )
+
+        runner = _make_runner()
+        source = _make_source()
+        session_key = runner._session_key_for_source(source)
+
+        register_gateway_notify(session_key, lambda d: None)
+        entry = _ApprovalEntry({"command": "dd if=/dev/zero of=/dev/sda"})
+        _gateway_queues[session_key] = [entry]
+
+        event = _make_event("/deny")
+        handled = await runner._handle_active_session_busy_message(event, session_key)
+
+        assert handled is True
+        assert entry.event.is_set()
+        assert entry.result == "deny"
+
+    @pytest.mark.asyncio
+    async def test_unrelated_message_not_intercepted(self):
+        """When an approval is pending but the user sends an unrelated message,
+        it should NOT be resolved — it should fall through to normal handling."""
+        from tools.approval import (
+            register_gateway_notify, _ApprovalEntry, _gateway_queues,
+        )
+
+        runner = _make_runner()
+        source = _make_source()
+        session_key = runner._session_key_for_source(source)
+
+        register_gateway_notify(session_key, lambda d: None)
+        entry = _ApprovalEntry({"command": "ls"})
+        _gateway_queues[session_key] = [entry]
+
+        # Set up a running agent sentinel so the handler proceeds past approval check
+        runner._running_agents[session_key] = MagicMock()
+        runner._running_agents[session_key].steer = MagicMock(return_value=True)
+
+        event = _make_event("what's the weather?")
+        handled = await runner._handle_active_session_busy_message(event, session_key)
+
+        # Should be handled (True) but approval NOT resolved
+        assert handled is True
+        assert not entry.event.is_set(), "Unrelated message must not resolve approval"
+
+    @pytest.mark.asyncio
+    async def test_no_approval_pending_normal_flow(self):
+        """When no approval is pending, messages are handled normally."""
+        runner = _make_runner()
+        source = _make_source()
+        session_key = runner._session_key_for_source(source)
+
+        # Set up a running agent
+        runner._running_agents[session_key] = MagicMock()
+        runner._running_agents[session_key].steer = MagicMock(return_value=True)
+
+        event = _make_event("hello there")
+        handled = await runner._handle_active_session_busy_message(event, session_key)
+
+        # Should return True (handled by normal busy path)
+        assert handled is True


### PR DESCRIPTION
## Summary

Fixes #46866.

When a gateway session was already busy because the agent was blocked on a dangerous-command approval, incoming approval replies were handled by the busy-session steer/queue path before normal slash-command dispatch could run. As a result, `/approve` and `/deny` never reached the existing approval handlers and the approval timed out.

This patch adds an early pending-approval check in `GatewayRunner._handle_active_session_busy_message()` before the normal busy steer/queue logic. If a blocking approval is live, explicit approval/deny replies are routed through the existing `_handle_approve_command()` / `_handle_deny_command()` handlers and acknowledged to the user.

## Behavior

- `/approve` and `/deny` now resolve a pending dangerous-command approval even while the session is busy.
- Plain `approve` / `deny` also work for chat gateways where users often reply without slash syntax.
- Unrelated messages during a pending approval are not treated as approval responses and continue through the normal busy-session handling path.
- Bare `yes` / `no` remain excluded to preserve the existing safety contract tested by `TestBareTextNoLongerApproves`.

## Verification

RED proof from upstream/main:

- New busy-session approval regression tests failed without the production change: 4 failed, 2 passed.

After fix, rebased onto current `upstream/main`:

```text
/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/gateway/test_busy_session_approval_routing.py tests/gateway/test_approve_deny_commands.py -v -o "addopts=" --tb=short

27 passed in 2.11s
```

## Competitor / duplicate check

Checked before publication:

- No open Tranquil-Flow PR referencing #46866.
- No open PRs found for `46866 in:title,body`.
- No open PRs found for distinctive title terms: `approval responses misrouted steered mid-turn messages`.

Auto-published by Moonsong via Path B automated pipeline.
