### PR TITLE
fix(security): gate sensitive browser CDP methods

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1031,6 +1031,7 @@ DEFAULT_CONFIG = {
         "command_timeout": 30,  # Timeout for browser commands in seconds (screenshot, navigate, etc.)
         "record_sessions": False,  # Auto-record browser sessions as WebM videos
         "allow_private_urls": False,  # Allow navigating to private/internal IPs (localhost, 192.168.x.x, etc.)
+        "allow_sensitive_cdp_methods": False,  # Allow raw browser_cdp access to cookies, permissions, and script injection
         # Browser engine for local mode.  Passed as ``--engine <value>`` to
         # agent-browser v0.25.3+.
         # "auto"       — use Chrome (default, don't pass --engine at all)

--- a/tests/tools/test_browser_cdp_tool.py
+++ b/tests/tools/test_browser_cdp_tool.py
@@ -172,6 +172,30 @@ def test_non_dict_params_returns_error(monkeypatch):
     assert "object" in result["error"].lower() or "dict" in result["error"].lower()
 
 
+def test_sensitive_cdp_method_blocked_by_default(monkeypatch):
+    monkeypatch.setattr(browser_cdp_tool, "_sensitive_cdp_methods_allowed", lambda: False)
+    monkeypatch.setattr(
+        browser_cdp_tool, "_resolve_cdp_endpoint", lambda: "ws://localhost:9999"
+    )
+
+    result = json.loads(browser_cdp_tool.browser_cdp(method="Network.getAllCookies"))
+
+    assert "error" in result
+    assert "disabled by default" in result["error"]
+    assert result.get("method") == "Network.getAllCookies"
+    assert result.get("cdp_docs") == browser_cdp_tool.CDP_DOCS_URL
+
+
+def test_sensitive_cdp_method_allowed_by_config(cdp_server, monkeypatch):
+    monkeypatch.setattr(browser_cdp_tool, "_sensitive_cdp_methods_allowed", lambda: True)
+    cdp_server.on("Network.getAllCookies", lambda params, sid: {"cookies": []})
+
+    result = json.loads(browser_cdp_tool.browser_cdp(method="Network.getAllCookies"))
+
+    assert result["success"] is True
+    assert result["result"]["cookies"] == []
+
+
 # ---------------------------------------------------------------------------
 # Endpoint resolution
 # ---------------------------------------------------------------------------
@@ -239,7 +263,8 @@ def test_empty_params_sends_empty_object(cdp_server):
 # ---------------------------------------------------------------------------
 
 
-def test_target_attach_then_call(cdp_server):
+def test_target_attach_then_call(cdp_server, monkeypatch):
+    monkeypatch.setattr(browser_cdp_tool, "_sensitive_cdp_methods_allowed", lambda: True)
     cdp_server.on(
         "Target.attachToTarget",
         lambda params, sid: {"sessionId": f"sess-{params['targetId']}"},
@@ -285,7 +310,8 @@ def test_cdp_method_error_returns_tool_error(cdp_server):
     assert result.get("method") == "NonExistent.method"
 
 
-def test_attach_failure_returns_tool_error(cdp_server):
+def test_attach_failure_returns_tool_error(cdp_server, monkeypatch):
+    monkeypatch.setattr(browser_cdp_tool, "_sensitive_cdp_methods_allowed", lambda: True)
     # Target.attachToTarget has no handler -> server errors on attach
     result = json.loads(
         browser_cdp_tool.browser_cdp(

--- a/tests/tools/test_browser_supervisor.py
+++ b/tests/tools/test_browser_supervisor.py
@@ -392,6 +392,9 @@ def test_browser_cdp_frame_id_routes_via_supervisor(chrome_cdp, supervisor_regis
     WebSocket. This is the path that makes cross-origin iframe eval work
     on Browserbase.
     """
+    import tools.browser_cdp_tool as _cdp_tool
+    monkeypatch.setattr(_cdp_tool, "_sensitive_cdp_methods_allowed", lambda: True)
+
     cdp_url, _port = chrome_cdp
     sv = supervisor_registry.get_or_start(task_id="frame-id-test", cdp_url=cdp_url)
     assert sv.snapshot().active
@@ -459,8 +462,11 @@ def test_browser_cdp_frame_id_real_oopif_smoke_documented():
     )
 
 
-def test_browser_cdp_frame_id_missing_supervisor():
+def test_browser_cdp_frame_id_missing_supervisor(monkeypatch):
     """browser_cdp(frame_id=...) errors cleanly when no supervisor is attached."""
+    import tools.browser_cdp_tool as _cdp_tool
+    monkeypatch.setattr(_cdp_tool, "_sensitive_cdp_methods_allowed", lambda: True)
+
     from tools.browser_cdp_tool import browser_cdp
     result = browser_cdp(
         method="Runtime.evaluate",
@@ -473,8 +479,11 @@ def test_browser_cdp_frame_id_missing_supervisor():
     assert "supervisor" in (r.get("error") or "").lower()
 
 
-def test_browser_cdp_frame_id_not_in_frame_tree(chrome_cdp, supervisor_registry):
+def test_browser_cdp_frame_id_not_in_frame_tree(chrome_cdp, supervisor_registry, monkeypatch):
     """browser_cdp(frame_id=...) errors when the frame_id isn't known."""
+    import tools.browser_cdp_tool as _cdp_tool
+    monkeypatch.setattr(_cdp_tool, "_sensitive_cdp_methods_allowed", lambda: True)
+
     cdp_url, _port = chrome_cdp
     sv = supervisor_registry.get_or_start(task_id="bad-frame-test", cdp_url=cdp_url)
     assert sv.snapshot().active

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -28,6 +28,29 @@ logger = logging.getLogger(__name__)
 
 CDP_DOCS_URL = "https://chromedevtools.github.io/devtools-protocol/"
 
+_SENSITIVE_CDP_METHODS = frozenset(
+    {
+        "Browser.grantPermissions",
+        "Browser.resetPermissions",
+        "Browser.setPermission",
+        "Network.clearBrowserCache",
+        "Network.clearBrowserCookies",
+        "Network.deleteCookies",
+        "Network.getAllCookies",
+        "Network.getCookies",
+        "Network.setCookie",
+        "Network.setCookies",
+        "Page.addScriptToEvaluateOnNewDocument",
+        "Runtime.callFunctionOn",
+        "Runtime.evaluate",
+        "Storage.clearCookies",
+        "Storage.clearDataForOrigin",
+        "Storage.getCookies",
+        "Storage.setCookies",
+    }
+)
+_TRUTHY_CONFIG_VALUES = {"1", "true", "yes", "on", "allow", "allowed"}
+
 # ``websockets`` is a direct hermes-agent dependency because the browser CDP
 # supervisor and browser_dialog tool import it during tool discovery. Wrap the
 # import so a clean error surfaces if an environment is stale or incomplete.
@@ -84,6 +107,32 @@ def _resolve_cdp_endpoint() -> str:
     except Exception as exc:  # pragma: no cover — defensive
         logger.debug("browser_cdp: failed to resolve CDP endpoint: %s", exc)
         return ""
+
+
+def _sensitive_cdp_methods_allowed() -> bool:
+    try:
+        from hermes_cli.config import load_config
+
+        value = load_config().get("browser", {}).get("allow_sensitive_cdp_methods", False)
+    except Exception as exc:  # pragma: no cover - defensive config read
+        logger.debug("browser_cdp: failed to read sensitive CDP config: %s", exc)
+        value = False
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in _TRUTHY_CONFIG_VALUES
+
+
+def _sensitive_method_error(method: str) -> str | None:
+    if method not in _SENSITIVE_CDP_METHODS or _sensitive_cdp_methods_allowed():
+        return None
+    return tool_error(
+        f"CDP method {method!r} is disabled by default because it can expose "
+        "browser secrets, alter permissions, or inject script into pages. "
+        "Set browser.allow_sensitive_cdp_methods=true in config.yaml only for "
+        "trusted local debugging sessions.",
+        method=method,
+        cdp_docs=CDP_DOCS_URL,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -201,6 +250,10 @@ def _browser_cdp_via_supervisor(
     the supervisor's already-connected WebSocket (using
     ``asyncio.run_coroutine_threadsafe`` onto the supervisor loop).
     """
+    blocked = _sensitive_method_error(method)
+    if blocked:
+        return blocked
+
     try:
         from tools.browser_supervisor import SUPERVISOR_REGISTRY  # type: ignore[import-not-found]
     except Exception as exc:  # pragma: no cover — defensive
@@ -346,6 +399,10 @@ def browser_cdp(
             "'method' is required (e.g. 'Target.getTargets')",
             cdp_docs=CDP_DOCS_URL,
         )
+
+    blocked = _sensitive_method_error(method)
+    if blocked:
+        return blocked
 
     if not _WS_AVAILABLE:
         return tool_error(


### PR DESCRIPTION
## Summary
- adds a default-deny guard for raw `browser_cdp` methods that can expose cookies, alter browser permissions, clear storage, or inject/evaluate script
- keeps an explicit `browser.allow_sensitive_cdp_methods` config escape hatch for trusted local debugging
- covers both stateless CDP calls and supervisor `frame_id` routing

## Validation
- `pytest tests\tools\test_browser_cdp_tool.py tests\tools\test_browser_supervisor.py -q` -> 21 passed, 22 skipped
- `ruff check hermes_cli\config.py tools\browser_cdp_tool.py tests\tools\test_browser_cdp_tool.py tests\tools\test_browser_supervisor.py` -> pass

## Scope
- no custom/private files
- no `_docs` changes
- no environment values or secrets