### PR TITLE
fix(agent): parse absolute-datetime rate-limit messages in credential pool retry delay

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -10,7 +10,7 @@ import time
 import uuid
 import re
 from dataclasses import dataclass, fields, replace
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import OPENROUTER_BASE_URL
@@ -305,6 +305,39 @@ def _extract_retry_delay_seconds(message: str) -> Optional[float]:
     min_only_match = re.search(r"resets?\s+in\s+(\d+)\s*min\b", message, re.IGNORECASE)
     if min_only_match:
         return int(min_only_match.group(1)) * 60
+    # Absolute datetime: "Your limit will reset at 2026-06-01 20:46:51"
+    # Some providers (e.g. z.ai) send naive timestamps in their own timezone.
+    _PROVIDER_RESET_TZ: Dict[str, timedelta] = {
+        "z.ai": timedelta(hours=8),  # SGT / UTC+8
+    }
+    abs_dt_match = re.search(
+        r"reset\s+at\s+(\d{4}-\d{2}-\d{2})[\sT](\d{2}:\d{2}:\d{2})",
+        message,
+        re.IGNORECASE,
+    )
+    if abs_dt_match:
+        try:
+            naive = datetime.strptime(
+                f"{abs_dt_match.group(1)} {abs_dt_match.group(2)}",
+                "%Y-%m-%d %H:%M:%S",
+            )
+            msg_lower = message.lower()
+            tz_offset: Optional[timedelta] = None
+            for provider_key, offset in _PROVIDER_RESET_TZ.items():
+                if provider_key in msg_lower:
+                    tz_offset = offset
+                    break
+            if tz_offset is None:
+                # Fall back to this machine's local timezone
+                aware_local = datetime.now().astimezone()
+                reset_aware = naive.replace(tzinfo=aware_local.tzinfo)
+            else:
+                reset_aware = naive.replace(tzinfo=timezone(tz_offset))
+            delay = (reset_aware - datetime.now(timezone.utc)).total_seconds()
+            if delay > 0:
+                return delay
+        except (ValueError, OSError):
+            pass
     return None
 
 

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2998,3 +2998,113 @@ def test_codex_oauth_nonterminal_refresh_does_not_quarantine(tmp_path, monkeypat
     tokens = auth_payload["providers"]["openai-codex"].get("tokens", {})
     assert tokens.get("access_token") == "old-access-token"
     assert tokens.get("refresh_token") == "old-refresh-token"
+
+
+# --- _extract_retry_delay_seconds: absolute datetime parsing ---
+
+class TestExtractRetryDelayAbsoluteDatetime:
+    """Tests for absolute-datetime rate-limit messages (e.g. z.ai)."""
+
+    def test_z_ai_sgt_future_timestamp(self, monkeypatch):
+        """z.ai SGT timestamp in the future returns positive delay."""
+        from agent.credential_pool import _extract_retry_delay_seconds
+
+        frozen = datetime(2026, 6, 1, 10, 0, 0, tzinfo=timezone.utc)
+        import agent.credential_pool as cp_mod
+        orig_datetime = cp_mod.datetime
+
+        class FrozenDatetime(orig_datetime):
+            @classmethod
+            def now(cls, tz=None):
+                if tz == timezone.utc:
+                    return frozen
+                return frozen.astimezone(tz)
+
+        monkeypatch.setattr(cp_mod, "datetime", FrozenDatetime)
+
+        msg = "z.ai: Your limit will reset at 2026-06-01 20:00:00"
+        delay = _extract_retry_delay_seconds(msg)
+        # 20:00 SGT = 12:00 UTC, now is 10:00 UTC → 2h = 7200s
+        assert delay is not None
+        assert abs(delay - 7200) < 1
+
+    def test_z_ai_sgt_past_timestamp_returns_none(self, monkeypatch):
+        """z.ai SGT timestamp already passed returns None."""
+        from agent.credential_pool import _extract_retry_delay_seconds
+
+        frozen = datetime(2026, 6, 1, 20, 0, 0, tzinfo=timezone.utc)
+        import agent.credential_pool as cp_mod
+        orig_datetime = cp_mod.datetime
+
+        class FrozenDatetime(orig_datetime):
+            @classmethod
+            def now(cls, tz=None):
+                if tz == timezone.utc:
+                    return frozen
+                return frozen.astimezone(tz)
+
+        monkeypatch.setattr(cp_mod, "datetime", FrozenDatetime)
+
+        # 08:00 SGT = 00:00 UTC, now is 20:00 UTC → already passed
+        msg = "z.ai: Your limit will reset at 2026-06-01 08:00:00"
+        delay = _extract_retry_delay_seconds(msg)
+        assert delay is None
+
+    def test_t_separator_format(self, monkeypatch):
+        """Accepts T separator between date and time."""
+        from agent.credential_pool import _extract_retry_delay_seconds
+
+        frozen = datetime(2026, 6, 1, 10, 0, 0, tzinfo=timezone.utc)
+        import agent.credential_pool as cp_mod
+        orig_datetime = cp_mod.datetime
+
+        class FrozenDatetime(orig_datetime):
+            @classmethod
+            def now(cls, tz=None):
+                if tz == timezone.utc:
+                    return frozen
+                return frozen.astimezone(tz)
+
+        monkeypatch.setattr(cp_mod, "datetime", FrozenDatetime)
+
+        msg = "z.ai: Your limit will reset at 2026-06-01T20:00:00"
+        delay = _extract_retry_delay_seconds(msg)
+        assert delay is not None
+        assert abs(delay - 7200) < 1
+
+    def test_unknown_provider_uses_local_timezone(self, monkeypatch):
+        """Unknown provider falls back to local timezone."""
+        from agent.credential_pool import _extract_retry_delay_seconds
+        import agent.credential_pool as cp_mod
+
+        frozen = datetime(2026, 6, 1, 10, 0, 0, tzinfo=timezone.utc)
+        orig_datetime = cp_mod.datetime
+
+        class FrozenDatetime(orig_datetime):
+            @classmethod
+            def now(cls, tz=None):
+                if tz is None:
+                    return frozen.astimezone()
+                if tz == timezone.utc:
+                    return frozen
+                return frozen.astimezone(tz)
+
+        monkeypatch.setattr(cp_mod, "datetime", FrozenDatetime)
+
+        msg = "rate limit exceeded. limit will reset at 2026-06-01 23:59:59"
+        delay = _extract_retry_delay_seconds(msg)
+        assert delay is not None
+        assert delay > 0
+
+    def test_existing_relative_patterns_unaffected(self):
+        """Existing relative-delay patterns still work."""
+        from agent.credential_pool import _extract_retry_delay_seconds
+
+        assert _extract_retry_delay_seconds("retry after 30 seconds") == 30.0
+        assert _extract_retry_delay_seconds("resets in 2hr 30min") == 9000
+        assert _extract_retry_delay_seconds("resets in 1hr") == 3600
+        assert _extract_retry_delay_seconds("resets in 5min") == 300
+        assert _extract_retry_delay_seconds('quotaResetDelay: 5000ms') == 5.0
+        assert _extract_retry_delay_seconds("no delay info here") is None
+        assert _extract_retry_delay_seconds("") is None
+        assert _extract_retry_delay_seconds(None) is None


### PR DESCRIPTION
## What does this PR do?

Adds absolute-datetime parsing to `_extract_retry_delay_seconds()` in the credential pool, fixing a tight retry loop when providers return rate-limit messages with absolute reset timestamps (e.g. z.ai's "Your limit will reset at 2026-06-01 20:46:51") instead of relative delays.

## Related Issue

Fixes #46891

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/credential_pool.py`: Added `timedelta` import; added absolute-datetime branch to `_extract_retry_delay_seconds()` that matches `reset at YYYY-MM-DD HH:MM:SS` patterns, resolves provider-specific timezone (z.ai → UTC+8) with local-timezone fallback, and returns the positive delay
- `tests/agent/test_credential_pool.py`: Added `TestExtractRetryDelayAbsoluteDatetime` class with 5 tests: z.ai SGT future/past timestamps, T-separator format, unknown-provider local-timezone fallback, and verification that existing relative patterns are unaffected

## How to Test

1. Run `pytest tests/agent/test_credential_pool.py::TestExtractRetryDelayAbsoluteDatetime -xvs` — all 5 new tests should pass
2. Run `pytest tests/agent/test_credential_pool.py -x` — all 83 tests (including existing) should pass
3. Verify the regex matches the z.ai format: `re.search(r"reset\s+at\s+(\d{4}-\d{2}-\d{2})[\sT](\d{2}:\d{2}:\d{2})", "z.ai: Your limit will reset at 2026-06-01 20:46:51")`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/credential_pool.py::_extract_retry_delay_seconds` (callers: 1 — `_normalize_error_context`)
- Blast radius: LOW — single function, additive branch, no control-flow changes to existing patterns
- Related patterns: existing relative-delay regexes in same function; `_parse_absolute_timestamp` for ISO-8601 strings (different format, different caller)
