### PR TITLE
fix(gateway): approval replies misrouted as OOB steers on Signal (#46866)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3828,6 +3828,48 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             return True  # handled (silently dropped); do not fall through
 
+        # --- Approval intercept (#46866) ---
+        # When the agent is blocked waiting for a dangerous-command approval,
+        # the user's reply arrives here as a "busy" message and was previously
+        # misrouted as an OOB steer, causing approvals to always time out.
+        # Check for a pending gateway approval BEFORE steer/queue logic so
+        # the reply unblocks the waiting tool thread instead of being queued.
+        try:
+            from tools.approval import has_blocking_approval, resolve_gateway_approval
+            if has_blocking_approval(session_key):
+                raw_reply = (event.text or "").strip()
+                cmd = event.get_command() if hasattr(event, "get_command") else ""
+                norm_reply = raw_reply.lstrip("!/").lower()
+                choice = None
+                if cmd in {"approve", "yes", "ok", "y"}:
+                    choice = "once"
+                elif cmd in {"always"}:
+                    choice = "always"
+                elif cmd in {"deny", "no", "n"}:
+                    choice = "deny"
+                elif norm_reply in {"approve", "approve once", "once", "yes", "y", "ok"}:
+                    choice = "once"
+                elif norm_reply in {"always", "always approve", "approve always"}:
+                    choice = "always"
+                elif norm_reply in {"deny", "no", "n", "cancel", "nevermind"}:
+                    choice = "deny"
+                if choice is not None:
+                    resolved = resolve_gateway_approval(session_key, choice)
+                    if resolved:
+                        adapter = self.adapters.get(event.source.platform)
+                        label = {"once": "✅ Approved (once)", "always": "✅ Always approved", "deny": "❌ Denied"}.get(choice, choice)
+                        if adapter:
+                            try:
+                                await adapter._send_with_retry(
+                                    chat_id=event.source.chat_id,
+                                    content=label,
+                                )
+                            except Exception:
+                                pass
+                        return True
+        except Exception:
+            pass  # fail open — fall through to normal busy handling
+
         # --- Draining case (gateway restarting/stopping) ---
         if self._draining:
             adapter = self.adapters.get(event.source.platform)

--- a/tests/gateway/test_signal_approval_routing.py
+++ b/tests/gateway/test_signal_approval_routing.py
@@ -1,0 +1,218 @@
+"""Tests for Signal gateway approval routing fix (#46866).
+
+When an agent is busy waiting for a dangerous-command approval, user replies
+arriving via Signal were previously misrouted as OOB steers, causing approvals
+to always time out. This suite verifies the fix: approval replies are
+intercepted in _handle_active_session_busy_message before steer/queue logic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+# ---------------------------------------------------------------------------
+# Minimal runner shim that exposes _handle_active_session_busy_message
+# ---------------------------------------------------------------------------
+
+def _make_runner():
+    """Import and partially init GatewayRunner with the minimal attrs needed."""
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._draining = False
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._busy_ack_ts = {}
+    runner._busy_input_mode = "steer"
+    runner._busy_text_mode = "steer"
+    runner._BUSY_QUEUE_MAX_PENDING = 5
+    runner._pending_messages = {}
+    runner._is_user_authorized = lambda source: True
+    return runner
+
+
+def _make_event(text: str, chat_id: str = "signal:+15550001234:+15550001234"):
+    """Build a minimal MessageEvent-like object."""
+    from gateway.config import Platform
+
+    source = SimpleNamespace(
+        platform=Platform.SIGNAL,
+        chat_id=chat_id,
+        user_id="+15550001234",
+        user_name="TestUser",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    def get_command():
+        # Mirror gateway.platforms.base.MessageEvent.get_command: only
+        # slash-prefixed text is a command; plain text returns None.
+        t = (text or "")
+        if not t.startswith("/"):
+            return None
+        parts = t.split(maxsplit=1)
+        raw = parts[0][1:].lower() if parts else None
+        if raw and "/" in raw:
+            return None
+        return raw
+
+    event = SimpleNamespace(
+        source=source,
+        text=text,
+        message_id="msg-1",
+        message_type=MagicMock(),
+        get_command=get_command,
+        media_urls=None,
+    )
+    return event
+
+
+# ---------------------------------------------------------------------------
+# Core routing tests
+# ---------------------------------------------------------------------------
+
+class TestApprovalInterceptInBusyHandler:
+    """_handle_active_session_busy_message must route approval replies to
+    resolve_gateway_approval instead of the steer/queue path (#46866)."""
+
+    SESSION_KEY = "signal:+15550001234:+15550001234"
+
+    def _run(self, coro):
+        return asyncio.get_event_loop().run_until_complete(coro)
+
+    @pytest.mark.parametrize("text,expected_choice", [
+        ("yes", "once"),
+        ("approve", "once"),
+        ("/approve", "once"),
+        ("ok", "once"),
+        ("y", "once"),
+        ("always", "always"),
+        ("always approve", "always"),
+        ("no", "deny"),
+        ("deny", "deny"),
+        ("/deny", "deny"),
+        ("n", "deny"),
+        ("cancel", "deny"),
+    ])
+    def test_approval_reply_intercepted(self, text, expected_choice):
+        """Approval keyword replies must call resolve_gateway_approval and
+        return True (handled) without falling through to steer/queue."""
+        runner = _make_runner()
+        event = _make_event(text, self.SESSION_KEY)
+
+        mock_adapter = MagicMock()
+        mock_adapter._send_with_retry = AsyncMock()
+        runner.adapters = {event.source.platform: mock_adapter}
+
+        with patch("tools.approval.has_blocking_approval", return_value=True) as mock_has, \
+             patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+            result = self._run(
+                runner._handle_active_session_busy_message(event, self.SESSION_KEY)
+            )
+
+        assert result is True, f"Expected handled=True for text={text!r}"
+        mock_has.assert_called_once_with(self.SESSION_KEY)
+        mock_resolve.assert_called_once_with(self.SESSION_KEY, expected_choice)
+
+    def test_no_approval_pending_falls_through(self):
+        """When no approval is pending the busy handler must NOT call
+        resolve_gateway_approval and must fall through to normal steer/queue."""
+        runner = _make_runner()
+        event = _make_event("yes", self.SESSION_KEY)
+
+        mock_adapter = MagicMock()
+        mock_adapter._send_with_retry = AsyncMock()
+        mock_adapter._pending_messages = {}
+        runner.adapters = {event.source.platform: mock_adapter}
+        runner._running_agents = {self.SESSION_KEY: MagicMock()}
+        runner._running_agents_ts = {self.SESSION_KEY: 0}
+        runner._busy_ack_ts = {}
+
+        with patch("tools.approval.has_blocking_approval", return_value=False) as mock_has, \
+             patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+            # May raise (missing attrs) — we only care that resolve wasn't called
+            try:
+                self._run(
+                    runner._handle_active_session_busy_message(event, self.SESSION_KEY)
+                )
+            except Exception:
+                pass
+
+        mock_resolve.assert_not_called()
+
+    def test_unrecognized_text_does_not_resolve(self):
+        """Arbitrary text while approval is pending must NOT resolve it —
+        only recognized keywords should unblock the agent."""
+        runner = _make_runner()
+        event = _make_event("what is the weather today?", self.SESSION_KEY)
+
+        mock_adapter = MagicMock()
+        mock_adapter._send_with_retry = AsyncMock()
+        mock_adapter._pending_messages = {}
+        runner.adapters = {event.source.platform: mock_adapter}
+        runner._running_agents = {self.SESSION_KEY: MagicMock()}
+        runner._running_agents_ts = {self.SESSION_KEY: 0}
+        runner._busy_ack_ts = {}
+
+        with patch("tools.approval.has_blocking_approval", return_value=True), \
+             patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+            try:
+                self._run(
+                    runner._handle_active_session_busy_message(event, self.SESSION_KEY)
+                )
+            except Exception:
+                pass
+
+        mock_resolve.assert_not_called()
+
+    def test_ack_sent_after_approval_resolved(self):
+        """A confirmation message (✅/❌) must be sent back to the user after
+        the approval is resolved so they know it was received."""
+        runner = _make_runner()
+        event = _make_event("approve", self.SESSION_KEY)
+
+        mock_adapter = MagicMock()
+        mock_adapter._send_with_retry = AsyncMock()
+        runner.adapters = {event.source.platform: mock_adapter}
+
+        with patch("tools.approval.has_blocking_approval", return_value=True), \
+             patch("tools.approval.resolve_gateway_approval", return_value=1):
+            self._run(
+                runner._handle_active_session_busy_message(event, self.SESSION_KEY)
+            )
+
+        mock_adapter._send_with_retry.assert_awaited_once()
+        call_kwargs = mock_adapter._send_with_retry.call_args
+        content = call_kwargs.kwargs.get("content") or (call_kwargs.args[1] if len(call_kwargs.args) > 1 else "")
+        assert "✅" in content or "approved" in content.lower(), (
+            f"Expected approval ack in response, got: {content!r}"
+        )
+
+    def test_unauthorized_user_blocked_before_approval_check(self):
+        """The authorization gate must still fire before the approval intercept —
+        an unauthorized user must not be able to approve commands."""
+        runner = _make_runner()
+        runner._is_user_authorized = lambda source: False
+        event = _make_event("approve", self.SESSION_KEY)
+
+        with patch("tools.approval.has_blocking_approval") as mock_has, \
+             patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+            result = self._run(
+                runner._handle_active_session_busy_message(event, self.SESSION_KEY)
+            )
+
+        assert result is True  # silently dropped
+        mock_has.assert_not_called()
+        mock_resolve.assert_not_called()


### PR DESCRIPTION
## Problem

  When an agent requests dangerous-command approval via Signal, the user's
  reply ("yes", "approve", "deny") arrives while the agent is busy (blocked
  on the approval wait). `_handle_active_session_busy_message` had no
  approval check, so every reply was routed to the steer/queue path and
  the user saw:
  
  > ⏩ Steered into current run. Your message arrives after the next tool call.
  
  Approvals always timed out and were auto-denied. The approval system was
  non-functional on Signal.
  
  ## Root Cause

  `_handle_active_session_busy_message` in `gateway/run.py` lacked a
  `has_blocking_approval` check. The non-busy path (`_handle_message`)
  already had this check (lines 6888–6893), but it was never reached when
  the agent was busy.

  ## Fix
  
  Added an approval intercept block in `_handle_active_session_busy_message`
  **after** the authorization gate and **before** the steer/queue logic:

  1. Check `has_blocking_approval(session_key)`
  2. If pending, parse the reply for recognized keywords (`yes/approve/always/no/deny/cancel`)
  3. Call `resolve_gateway_approval(session_key, choice)` to unblock the waiting tool thread
  4. Send a `✅/❌` ack back to the user
  5. Fail open on any exception — falls back to steer/queue (degraded, not a security hole)

  Unauthorized users are still blocked by the existing auth gate before the
  approval check, so they cannot approve commands.
  
  ## Test Plan
  
  - [ ] New test file `tests/gateway/test_signal_approval_routing.py` covering:
    - All 11 recognized keywords map to correct choice (`once`/`always`/`deny`)
    - No approval pending → falls through to normal steer/queue
    - Unrecognized plain text does not resolve approval
    - Ack message sent after resolve
    - Unauthorized user blocked before approval check
  - [ ] Run `pytest tests/gateway/test_signal_approval_routing.py -v`
  - [ ] Manual test: trigger a dangerous command on Signal, send "yes" — should approve instead of timing out

  Fixes #46866