### PR TITLE
fix(desktop): coalesce interleaved reasoning/content stream parts

### DIFF
--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import type { ChatMessage, ChatMessagePart } from './chat-messages'
 import {
   appendAssistantTextPart,
+  appendReasoningPart,
   chatMessageText,
   preserveLocalAssistantErrors,
   renderMediaTags,
@@ -172,6 +173,52 @@ describe('renderMediaTags', () => {
     const text = chatMessageText({ id: 'a', role: 'assistant', parts })
 
     expect(text).toBe('ok\n[Audio: voice.mp3](#media:%2Ftmp%2Fvoice.mp3)')
+  })
+})
+
+describe('interleaved reasoning/text coalescing', () => {
+  it('keeps narration contiguous when reasoning interrupts mid-sentence', () => {
+    // Models that interleave reasoning_content + content deltas emit
+    // text → reasoning → text within one tool-bounded segment. The two text
+    // fragments are really one sentence and must not be split by the
+    // "Thinking" block between them.
+    let parts: ChatMessagePart[] = appendAssistantTextPart([], 'Let me ')
+    parts = appendReasoningPart(parts, 'checking the file...')
+    parts = appendAssistantTextPart(parts, 'verify the full file is correct:')
+
+    expect(parts.map(p => p.type)).toEqual(['text', 'reasoning'])
+    expect((parts[0] as { text: string }).text).toBe('Let me verify the full file is correct:')
+    expect((parts[1] as { text: string }).text).toBe('checking the file...')
+  })
+
+  it('merges reasoning bursts that straddle a narration fragment', () => {
+    let parts: ChatMessagePart[] = appendReasoningPart([], 'first thought ')
+    parts = appendAssistantTextPart(parts, 'Working on it.')
+    parts = appendReasoningPart(parts, 'second thought')
+
+    expect(parts.map(p => p.type)).toEqual(['reasoning', 'text'])
+    expect((parts[0] as { text: string }).text).toBe('first thought second thought')
+    expect((parts[1] as { text: string }).text).toBe('Working on it.')
+  })
+
+  it('starts a fresh text part after a tool call (segment boundary)', () => {
+    let parts: ChatMessagePart[] = appendAssistantTextPart([], 'Let me check.')
+    parts = upsertToolPart(parts, { name: 'read_file', tool_id: 'tc-1' }, 'running')
+    parts = appendAssistantTextPart(parts, 'Now editing.')
+
+    expect(parts.map(p => p.type)).toEqual(['text', 'tool-call', 'text'])
+    expect((parts[0] as { text: string }).text).toBe('Let me check.')
+    expect((parts[2] as { text: string }).text).toBe('Now editing.')
+  })
+
+  it('does not merge reasoning across a tool call', () => {
+    let parts: ChatMessagePart[] = appendReasoningPart([], 'before tool')
+    parts = upsertToolPart(parts, { name: 'read_file', tool_id: 'tc-1' }, 'running')
+    parts = appendReasoningPart(parts, 'after tool')
+
+    expect(parts.map(p => p.type)).toEqual(['reasoning', 'tool-call', 'reasoning'])
+    expect((parts[0] as { text: string }).text).toBe('before tool')
+    expect((parts[2] as { text: string }).text).toBe('after tool')
   })
 })
 

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -178,52 +178,75 @@ function displayContentForMessage(role: SessionMessage['role'], content: unknown
   return [refs.join('\n'), visibleText].filter(Boolean).join('\n\n') || visibleText
 }
 
-export function appendTextPart(parts: ChatMessagePart[], delta: string): ChatMessagePart[] {
-  const next = [...parts]
-  const last = next.at(-1)
+// When a model interleaves its `reasoning_content` and `content` token
+// streams, deltas land as text → reasoning → text inside a single
+// tool-bounded segment. Appending each delta as its own part shreds one
+// sentence into "Let me" / Thinking / "verify the file" — the
+// interleaved-thinking fragmentation users hit on Kimi/DeepSeek/GLM-style
+// routes. To keep narration and thinking each contiguous, a streaming delta
+// merges into the most recent same-type part *within the current segment*.
+//
+// A segment is bounded by any non-streaming part (a tool call, image, …): the
+// opposite streaming channel (text <-> reasoning) is transparent, so a
+// reasoning burst between two content deltas does NOT open a fresh text part,
+// but a real tool call does. This collapses interleave noise without
+// reordering narration across tool calls.
+function segmentMergeIndex(parts: ChatMessagePart[], type: 'text' | 'reasoning'): number {
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const partType = parts[i]?.type
 
-  if (last?.type === 'text') {
-    next[next.length - 1] = { ...last, text: `${last.text}${delta}` }
+    if (partType === type) {
+      return i
+    }
 
-    return next
+    // text <-> reasoning is the interleave we're collapsing; skip past it.
+    // Anything else (tool-call, file, image, …) closes the segment.
+    if (partType !== 'text' && partType !== 'reasoning') {
+      return -1
+    }
   }
 
-  next.push(textPart(delta))
+  return -1
+}
+
+function mergeTextInto(parts: ChatMessagePart[], index: number, delta: string): ChatMessagePart[] {
+  const next = [...parts]
+  const part = next[index]
+  next[index] = { ...part, text: `${(part as { text: string }).text}${delta}` } as ChatMessagePart
 
   return next
 }
 
-export function appendAssistantTextPart(parts: ChatMessagePart[], delta: string): ChatMessagePart[] {
-  const next = appendTextPart(parts, delta)
-  const last = next.at(-1)
+export function appendTextPart(parts: ChatMessagePart[], delta: string): ChatMessagePart[] {
+  const idx = segmentMergeIndex(parts, 'text')
 
-  if (last?.type === 'text') {
-    const current = last.text
+  return idx >= 0 ? mergeTextInto(parts, idx, delta) : [...parts, textPart(delta)]
+}
+
+export function appendAssistantTextPart(parts: ChatMessagePart[], delta: string): ChatMessagePart[] {
+  const idx = segmentMergeIndex(parts, 'text')
+  const targetIndex = idx >= 0 ? idx : parts.length
+  const next = idx >= 0 ? mergeTextInto(parts, idx, delta) : [...parts, textPart(delta)]
+  const target = next[targetIndex]
+
+  if (target?.type === 'text') {
+    const current = target.text
 
     const deltaMayContainMedia =
       delta.includes('MEDIA:') || delta.includes('DIA:') || delta.includes('EDIA:') || delta.includes('IA:')
 
     const needsMediaPass = deltaMayContainMedia || current.includes('MEDIA:')
     const nextText = needsMediaPass ? renderMediaTags(current) : current
-    next[next.length - 1] = nextText === current ? last : { ...last, text: nextText }
+    next[targetIndex] = nextText === current ? target : { ...target, text: nextText }
   }
 
   return next
 }
 
 export function appendReasoningPart(parts: ChatMessagePart[], delta: string): ChatMessagePart[] {
-  const next = [...parts]
-  const last = next.at(-1)
+  const idx = segmentMergeIndex(parts, 'reasoning')
 
-  if (last?.type === 'reasoning') {
-    next[next.length - 1] = { ...last, text: `${last.text}${delta}` }
-
-    return next
-  }
-
-  next.push(reasoningPart(delta))
-
-  return next
+  return idx >= 0 ? mergeTextInto(parts, idx, delta) : [...parts, reasoningPart(delta)]
 }
 
 export function hasToolPart(message: ChatMessage): boolean {

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -178,75 +178,72 @@ function displayContentForMessage(role: SessionMessage['role'], content: unknown
   return [refs.join('\n'), visibleText].filter(Boolean).join('\n\n') || visibleText
 }
 
-// When a model interleaves its `reasoning_content` and `content` token
-// streams, deltas land as text → reasoning → text inside a single
-// tool-bounded segment. Appending each delta as its own part shreds one
-// sentence into "Let me" / Thinking / "verify the file" — the
-// interleaved-thinking fragmentation users hit on Kimi/DeepSeek/GLM-style
-// routes. To keep narration and thinking each contiguous, a streaming delta
-// merges into the most recent same-type part *within the current segment*.
-//
-// A segment is bounded by any non-streaming part (a tool call, image, …): the
-// opposite streaming channel (text <-> reasoning) is transparent, so a
-// reasoning burst between two content deltas does NOT open a fresh text part,
-// but a real tool call does. This collapses interleave noise without
-// reordering narration across tool calls.
-function segmentMergeIndex(parts: ChatMessagePart[], type: 'text' | 'reasoning'): number {
-  for (let i = parts.length - 1; i >= 0; i--) {
-    const partType = parts[i]?.type
+const STREAM_PART: Record<'reasoning' | 'text', (text: string) => ChatMessagePart> = {
+  reasoning: reasoningPart,
+  text: textPart
+}
 
-    if (partType === type) {
-      return i
+// Coalesce a streaming delta into the most recent same-type part within the
+// current segment, where a segment is bounded by any non-streaming part (a
+// tool call, image, …). The opposite streaming channel (text <-> reasoning) is
+// transparent, so a reasoning burst between two content deltas can't shred one
+// sentence into text / Thinking / text — the fragmentation models that
+// interleave reasoning_content + content otherwise produce. Tool calls still
+// open a fresh part, preserving narration order across steps.
+function appendStreamPart(
+  parts: ChatMessagePart[],
+  type: 'reasoning' | 'text',
+  delta: string
+): { index: number; parts: ChatMessagePart[] } {
+  const next = [...parts]
+
+  for (let i = next.length - 1; i >= 0; i--) {
+    const part = next[i]
+
+    if (part.type === type) {
+      next[i] = { ...part, text: `${(part as { text: string }).text}${delta}` } as ChatMessagePart
+
+      return { index: i, parts: next }
     }
 
-    // text <-> reasoning is the interleave we're collapsing; skip past it.
-    // Anything else (tool-call, file, image, …) closes the segment.
-    if (partType !== 'text' && partType !== 'reasoning') {
-      return -1
+    if (part.type !== 'text' && part.type !== 'reasoning') {
+      break
     }
   }
 
-  return -1
-}
+  next.push(STREAM_PART[type](delta))
 
-function mergeTextInto(parts: ChatMessagePart[], index: number, delta: string): ChatMessagePart[] {
-  const next = [...parts]
-  const part = next[index]
-  next[index] = { ...part, text: `${(part as { text: string }).text}${delta}` } as ChatMessagePart
-
-  return next
+  return { index: next.length - 1, parts: next }
 }
 
 export function appendTextPart(parts: ChatMessagePart[], delta: string): ChatMessagePart[] {
-  const idx = segmentMergeIndex(parts, 'text')
-
-  return idx >= 0 ? mergeTextInto(parts, idx, delta) : [...parts, textPart(delta)]
-}
-
-export function appendAssistantTextPart(parts: ChatMessagePart[], delta: string): ChatMessagePart[] {
-  const idx = segmentMergeIndex(parts, 'text')
-  const targetIndex = idx >= 0 ? idx : parts.length
-  const next = idx >= 0 ? mergeTextInto(parts, idx, delta) : [...parts, textPart(delta)]
-  const target = next[targetIndex]
-
-  if (target?.type === 'text') {
-    const current = target.text
-
-    const deltaMayContainMedia =
-      delta.includes('MEDIA:') || delta.includes('DIA:') || delta.includes('EDIA:') || delta.includes('IA:')
-
-    const needsMediaPass = deltaMayContainMedia || current.includes('MEDIA:')
-    const nextText = needsMediaPass ? renderMediaTags(current) : current
-    next[targetIndex] = nextText === current ? target : { ...target, text: nextText }
-  }
-
-  return next
+  return appendStreamPart(parts, 'text', delta).parts
 }
 
 export function appendReasoningPart(parts: ChatMessagePart[], delta: string): ChatMessagePart[] {
-  const idx = segmentMergeIndex(parts, 'reasoning')
+  return appendStreamPart(parts, 'reasoning', delta).parts
+}
 
-  return idx >= 0 ? mergeTextInto(parts, idx, delta) : [...parts, reasoningPart(delta)]
+export function appendAssistantTextPart(parts: ChatMessagePart[], delta: string): ChatMessagePart[] {
+  const { index, parts: next } = appendStreamPart(parts, 'text', delta)
+  const part = next[index]
+
+  if (part?.type !== 'text') {
+    return next
+  }
+
+  const mayContainMedia =
+    delta.includes('MEDIA:') || delta.includes('DIA:') || delta.includes('EDIA:') || delta.includes('IA:')
+
+  if (mayContainMedia || part.text.includes('MEDIA:')) {
+    const rendered = renderMediaTags(part.text)
+
+    if (rendered !== part.text) {
+      next[index] = { ...part, text: rendered }
+    }
+  }
+
+  return next
 }
 
 export function hasToolPart(message: ChatMessage): boolean {


### PR DESCRIPTION
## Summary

The desktop transcript shredded a single sentence into fragments with a **"Thinking" disclosure wedged mid-sentence** (e.g. `Let me` / *Thinking* / `verify the full file is correct:`). Not text wrapping, not a new message per fragment — one assistant message whose `parts[]` array alternated `text → reasoning → text` in raw arrival order.

Root cause is upstream of the renderer: some models/providers **interleave their `reasoning_content` and `content` token streams** instead of front-loading reasoning (common on Kimi/DeepSeek/GLM-style thinking routes and some OpenRouter passthroughs). The append helpers created a fresh part on every channel switch, so each reasoning interruption split the running narration.

## Fix

Data-layer only, in `apps/desktop/src/lib/chat-messages.ts`. A single segment-aware `appendStreamPart` core coalesces a streaming delta into the most recent **same-type** part *within the current segment*, where a segment is bounded by any non-streaming part (a tool call, image, …). The opposite streaming channel (text ↔ reasoning) is transparent; a real tool call opens a fresh part. `appendTextPart` / `appendReasoningPart` / `appendAssistantTextPart` are thin wrappers over it (factory chosen from a small part-type table).

Result: a reasoning burst between two content deltas no longer opens a fresh text part (narration stays contiguous, one collapsible Thinking block), while tool calls still start a new segment so narration interleaved with tools keeps its order. The renderer (`thread.tsx`) needs no change — its `ReasoningGroup` already groups consecutive reasoning, and there's now at most one text + one reasoning part per segment.

## Blast radius

Well-behaved models emit reasoning and content in contiguous phases, which already merged consecutively — output is **byte-identical** for them. The only behavioral delta is the interleaved-within-segment case, which is the bug being fixed. Tool / image / citation parts are hard segment boundaries (covered by tests), so narration around tools is never collapsed across a tool call.

## Test plan

- [x] `npx vitest run --environment jsdom src/lib/chat-messages.test.ts` — 4 coalescing cases: mid-sentence interrupt, straddling reasoning burst, tool-call text boundary, tool-call reasoning boundary.
- [x] `npx vitest run --environment jsdom src/components/assistant-ui/streaming.test.tsx` — existing render test still green (confirms no renderer change needed).
- [x] `tsc --noEmit` + eslint clean.

### Manual

Run the desktop app against an interleaving model (Kimi/DeepSeek/GLM thinking route or OpenRouter passthrough) and send a multi-tool turn (e.g. "create a file, read it back, edit it, then type-check and fix"). Before: narration fragments split by Thinking blocks mid-sentence. After: contiguous narration with one Thinking disclosure per tool-bounded step.

## Related — supersedes #40895

Part of the desktop reasoning/content-interleave cluster (all open, none merged); same goal, different layers:

- **#40895** (same layer, live append) coalesces reasoning into the *first* reasoning part of the whole turn, ignoring tool boundaries — so per-step thinking flattens into one block above everything, losing the think-before-each-tool grouping that interleaved-thinking models (Claude et al.) legitimately emit. This PR is the same idea but **tool-bounded**, so reasoning/content stay contiguous *within a segment* while tool calls remain hard boundaries. **This PR supersedes #40895.**
- **#44323** (different layer, reducer/hydration) joins reasoning-separated assistant rows in `toChatMessages`. The reported symptom is live streaming; on reload the backend already persists each row's `content`/`reasoning_content` as single joined strings and multi-row turns carry tool-call evidence (already merged), so that path doesn't manifest the bug here. Nothing from it is required for this fix; a focused reducer guard remains a possible follow-up if a reload-fragmentation repro surfaces.

Closing the others is a maintainer call (contributor credit preserved) — flagging supersession, not acting on it.
