### PR TITLE
feat(gateway): add configurable stt.echo_transcripts toggle

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2484,6 +2484,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     _VOICE_MODE_PATH = _hermes_home / "gateway_voice_mode.json"
 
+    def _should_echo_stt_transcripts(self) -> bool:
+        """Return whether inbound voice transcripts should be echoed to chat.
+
+        Voice messages are still transcribed and passed to the agent. This
+        only controls the extra user-visible `🎙️ "..."` confirmation message.
+        """
+        try:
+            from hermes_cli.config import load_config as _load_full_config
+
+            _full_cfg = _load_full_config()
+            _stt_cfg = (_full_cfg.get("stt") or {}) if isinstance(_full_cfg, dict) else {}
+            return bool(_stt_cfg.get("echo_transcripts", False))
+        except Exception:
+            return False
+
     def _voice_key(self, platform: Platform, chat_id: str) -> str:
         """Return a platform-namespaced key for voice mode state."""
         return f"{platform.value}:{chat_id}"
@@ -7983,7 +7998,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # Echo each successful transcript back to the user immediately,
                 # before the agent loop runs. Lets the user verify STT quality
                 # in real-time and see the raw whisper output verbatim.
-                if _successful_transcripts:
+                if _successful_transcripts and self._should_echo_stt_transcripts():
                     _echo_adapter = self.adapters.get(source.platform)
                     _echo_meta = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
                     if _echo_adapter:
@@ -12179,9 +12194,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             enriched_text, successful_transcripts = await self._enrich_message_with_transcription(
                 text, audio_paths,
             )
-            # Echo raw transcripts back to the user so voice interrupts
-            # feel identical to fresh voice messages.
-            if successful_transcripts:
+            # Optionally echo raw transcripts back to the user for debugging.
+            if successful_transcripts and self._should_echo_stt_transcripts():
                 echo_adapter = self.adapters.get(source.platform)
                 echo_meta = {"thread_id": source.thread_id} if source.thread_id else None
                 if echo_adapter:
@@ -15363,7 +15377,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                             pending_text, _audio_paths,
                                         )
                                         pending_text = _enriched
-                                        if _transcripts:
+                                        if _transcripts and self._should_echo_stt_transcripts():
                                             _echo_meta = {"thread_id": source.thread_id} if source.thread_id else None
                                             for _tx in _transcripts:
                                                 try:
@@ -15731,7 +15745,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 _pending_text, _audio_paths,
                             )
                             pending = _enriched or None
-                            if _transcripts:
+                            if _transcripts and self._should_echo_stt_transcripts():
                                 _echo_meta = {"thread_id": source.thread_id} if source.thread_id else None
                                 for _tx in _transcripts:
                                     try:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1677,6 +1677,7 @@ DEFAULT_CONFIG = {
     "stt": {
         "enabled": True,
         "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe) | "elevenlabs" (Scribe)
+        "echo_transcripts": False,  # Echo inbound voice transcripts back to the user for debugging
         "local": {
             "model": "base",  # tiny, base, small, medium, large-v3
             "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -1,6 +1,8 @@
 """Gateway STT config tests — honor stt.enabled: false from config.yaml."""
 
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -30,6 +32,24 @@ def test_load_gateway_config_bridges_stt_enabled_from_config_yaml(tmp_path, monk
     config = load_gateway_config()
 
     assert config.stt_enabled is False
+
+
+def test_default_config_disables_stt_transcript_echo():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["stt"]["echo_transcripts"] is False
+
+
+def test_should_echo_stt_transcripts_reads_config_toggle():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+
+    with patch("hermes_cli.config.load_config", return_value={"stt": {"echo_transcripts": True}}):
+        assert runner._should_echo_stt_transcripts() is True
+
+    with patch("hermes_cli.config.load_config", return_value={"stt": {"echo_transcripts": False}}):
+        assert runner._should_echo_stt_transcripts() is False
 
 
 @pytest.mark.asyncio
@@ -137,8 +157,84 @@ async def test_enrich_message_with_transcription_returns_tuple_for_empty_content
     # The redundant placeholder is stripped, leaving only the transcript prefix.
     assert "hello from a captionless voice note" in result
     assert "(The user sent a message with no text content)" not in result
-    # Crucially, the transcripts are still surfaced so callers can echo them.
+    # Crucially, the transcripts are still surfaced so callers can optionally echo them.
     assert transcripts == ["hello from a captionless voice note"]
+
+
+@pytest.mark.asyncio
+async def test_prepare_inbound_voice_does_not_echo_transcript_by_default():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner_any = cast(Any, runner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner_any._model = "test-model"
+    runner_any._base_url = ""
+    runner._has_setup_skill = lambda: False
+    runner._should_echo_stt_transcripts = lambda: False
+    runner_any._thread_metadata_for_source = lambda source, reply_to_message_id=None: {}
+    runner_any._reply_anchor_for_event = lambda event: None
+
+    adapter = cast(Any, SimpleNamespace(send=AsyncMock()))
+    runner.adapters = {Platform.TELEGRAM: adapter}
+
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="123", chat_type="dm")
+    event = MessageEvent(
+        text="",
+        message_type=MessageType.VOICE,
+        source=source,
+        media_urls=["/tmp/voice.ogg"],
+        media_types=["audio/ogg"],
+    )
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": True, "transcript": "do not echo me", "provider": "local_command"},
+    ):
+        result = await runner._prepare_inbound_message_text(event=event, source=source, history=[])
+
+    assert result is not None
+    assert "do not echo me" in result
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_prepare_inbound_voice_echoes_transcript_when_enabled():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner_any = cast(Any, runner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner_any._model = "test-model"
+    runner_any._base_url = ""
+    runner._has_setup_skill = lambda: False
+    runner._should_echo_stt_transcripts = lambda: True
+    runner_any._thread_metadata_for_source = lambda source, reply_to_message_id=None: {}
+    runner_any._reply_anchor_for_event = lambda event: None
+
+    adapter = cast(Any, SimpleNamespace(send=AsyncMock()))
+    runner.adapters = {Platform.TELEGRAM: adapter}
+
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="123", chat_type="dm")
+    event = MessageEvent(
+        text="",
+        message_type=MessageType.VOICE,
+        source=source,
+        media_urls=["/tmp/voice.ogg"],
+        media_types=["audio/ogg"],
+    )
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": True, "transcript": "echo me", "provider": "local_command"},
+    ):
+        result = await runner._prepare_inbound_message_text(event=event, source=source, history=[])
+
+    assert result is not None
+    assert "echo me" in result
+    adapter.send.assert_awaited_once()
+    assert adapter.send.await_args.args[0] == "123"
+    assert adapter.send.await_args.args[1] == '🎙️ "echo me"'
 
 
 @pytest.mark.asyncio

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1425,6 +1425,7 @@ Hashes are deterministic — the same user always maps to the same hash, so the 
 ```yaml
 stt:
   provider: "local"            # "local" | "groq" | "openai" | "mistral"
+  echo_transcripts: false       # Send a visible 🎙️ transcript confirmation for inbound voice messages
   local:
     model: "base"              # tiny, base, small, medium, large-v3
   openai:


### PR DESCRIPTION
## Summary

Inbound voice messages are still transcribed and passed to the agent, but the visible 🎙️ transcript confirmation sent back to the chat is now gated by a config option.

## Changes

- Added `stt.echo_transcripts` config key (defaults to `false`).
- Added `GatewayRunner._should_echo_stt_transcripts()` helper.
- Guarded all transcript echo sites in `gateway/run.py`.
- Added the key to `DEFAULT_CONFIG` and user docs.
- Added unit tests covering default-off behavior, on/off toggle, and echo/no-echo paths.

## Motivation

For users on messaging platforms, the automatic transcript echo adds conversational noise. Making it configurable preserves the useful debugging behavior for those who want it while keeping voice interactions quiet by default.

## Configuration

```yaml
stt:
  provider: local
  echo_transcripts: false   # set to true to bring back 🎙️ transcript confirmations
```

## Tests

```bash
pytest tests/gateway/test_stt_config.py -q
```

All 11 tests in that file pass.