### PR TITLE
feat(agent): opt-in retry of primary on transient rate limits before fallback

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1236,6 +1236,13 @@ def init_agent(
         _api_retries = 3
     agent._api_max_retries = _api_retries
 
+    try:
+        _rl_retry_before_fb = int(_agent_section.get("rate_limit_retry_before_fallback", 0))
+        _rl_retry_before_fb = max(_rl_retry_before_fb, 0)
+    except (TypeError, ValueError):
+        _rl_retry_before_fb = 0
+    agent._rate_limit_retry_before_fallback = _rl_retry_before_fb
+
     # Initialize context compressor for automatic context management
     # Compresses conversation when approaching model's context limit
     # Configuration via config.yaml (compression section)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -100,6 +100,26 @@ def _image_error_max_dimension(error: Exception) -> Optional[int]:
     return None
 
 
+def _rate_limit_looks_transient(api_error: Any, classified: Any, window_seconds: float = 120.0) -> bool:
+    resp_headers = getattr(getattr(api_error, "response", None), "headers", None)
+    if resp_headers and hasattr(resp_headers, "get"):
+        raw = resp_headers.get("retry-after") or resp_headers.get("Retry-After")
+        if raw:
+            try:
+                return 0 < float(raw) <= window_seconds
+            except (TypeError, ValueError):
+                pass
+    reset_at = getattr(classified, "error_context", None)
+    if isinstance(reset_at, dict):
+        candidate = reset_at.get("reset_at") or reset_at.get("resets_at")
+        try:
+            if candidate is not None:
+                return 0 < (float(candidate) - time.time()) <= window_seconds
+        except (TypeError, ValueError):
+            pass
+    return False
+
+
 def _ollama_context_limit_error(agent: Any, request_tokens: int) -> Optional[str]:
     """Return a user-facing error when Ollama is loaded with too little context."""
     if not getattr(agent, "tools", None):
@@ -2738,7 +2758,14 @@ def run_conversation(
                         provider=agent.provider,
                         base_url=getattr(agent, "base_url", None),
                     )
-                    if not pool_may_recover:
+                    _rl_retry_budget = getattr(agent, "_rate_limit_retry_before_fallback", 0)
+                    _retry_primary_first = (
+                        _rl_retry_budget > 0
+                        and classified.reason == FailoverReason.rate_limit
+                        and retry_count < _rl_retry_budget
+                        and _rate_limit_looks_transient(api_error, classified)
+                    )
+                    if not pool_may_recover and not _retry_primary_first:
                         if classified.reason == FailoverReason.billing:
                             agent._buffer_status(
                                 "⚠️ Billing or credits exhausted — switching to fallback provider..."

--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -288,6 +288,7 @@ export const FIELD_LABELS: Record<string, string> = defineFieldCopy({
     maxTurns: 'Max Agent Steps',
     imageInputMode: 'Image Attachments',
     apiMaxRetries: 'API Retries',
+    rateLimitRetryBeforeFallback: 'Retry Primary on Rate Limit',
     serviceTier: 'Service Tier',
     toolUseEnforcement: 'Tool-Use Enforcement'
   },
@@ -620,6 +621,7 @@ export const SECTIONS: DesktopConfigSection[] = [
       'checkpoints.max_snapshots',
       'agent.max_turns',
       'agent.api_max_retries',
+      'agent.rate_limit_retry_before_fallback',
       'agent.service_tier',
       'agent.tool_use_enforcement',
       'delegation.model',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -297,6 +297,7 @@ export const ja = defineLocale({
         maxTurns: '最大エージェントステップ',
         imageInputMode: '画像添付',
         apiMaxRetries: 'API 再試行回数',
+        rateLimitRetryBeforeFallback: 'レート制限時にプライマリを再試行',
         serviceTier: 'サービス階層',
         toolUseEnforcement: 'ツール使用の強制'
       },

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -287,6 +287,7 @@ export const zhHant = defineLocale({
         maxTurns: '最大代理步數',
         imageInputMode: '圖片附件',
         apiMaxRetries: 'API 重試次數',
+        rateLimitRetryBeforeFallback: '速率限制時重試主要供應商',
         serviceTier: '服務層級',
         toolUseEnforcement: '工具使用強制'
       },

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -374,6 +374,7 @@ export const zh: Translations = {
         maxTurns: '最大智能体步数',
         imageInputMode: '图片附件',
         apiMaxRetries: 'API 重试次数',
+        rateLimitRetryBeforeFallback: '速率限制时重试主要供应商',
         serviceTier: '服务等级',
         toolUseEnforcement: '工具调用强制'
       },

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -621,6 +621,13 @@ agent:
   # primaries (default 3). The OpenAI SDK does its own low-level retries
   # underneath this wrapper — this is the Hermes-level loop.
   # api_max_retries: 3
+
+  # When a fallback model is configured, a rate-limit (429) on the primary
+  # switches to the fallback immediately rather than consuming api_max_retries.
+  # Set this > 0 to retry the primary up to N times first, but ONLY for
+  # transient 429s (a short Retry-After / reset window). Quota-exhaustion 429s
+  # still fall back immediately. Default 0 = immediate fallback (unchanged).
+  # rate_limit_retry_before_fallback: 0
   
   # Enable verbose logging
   verbose: false

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -840,6 +840,7 @@ DEFAULT_CONFIG = {
         # on flaky primaries; raise it if you prefer to tolerate longer
         # provider hiccups on a single provider.
         "api_max_retries": 3,
+        "rate_limit_retry_before_fallback": 0,
         "service_tier": "",
         # Tool-use enforcement: injects system prompt guidance that tells the
         # model to actually call tools instead of describing intended actions.

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -294,6 +294,7 @@ TIPS = [
     "agent.tool_use_enforcement steers models that describe actions instead of calling tools — auto for GPT/Codex.",
     "agent.restart_drain_timeout (default 60s) lets running agents finish before a gateway restart takes effect.",
     "agent.api_max_retries (default 3) controls how many times the agent retries a failed API call before surfacing the error — lower it for fast fallback.",
+    "agent.rate_limit_retry_before_fallback (default 0) retries the primary on a transient 429 before falling back — raise it for bursty rate limits.",
     "The gateway caches AIAgent instances per session — destroying this cache breaks Anthropic prompt caching.",
     "Any website can expose skills via /.well-known/skills/index.json — the skills hub discovers them automatically.",
     "The skills audit log at ~/.hermes/skills/.hub/audit.log tracks every install and removal operation.",

--- a/tests/run_agent/test_rate_limit_retry_before_fallback.py
+++ b/tests/run_agent/test_rate_limit_retry_before_fallback.py
@@ -1,0 +1,103 @@
+"""Tests for agent.rate_limit_retry_before_fallback.
+
+Opt-in knob (default 0 = upstream eager-fallback behavior, #11314 preserved).
+When > 0, a transient rate-limit (429) on the primary retries up to N times
+before falling back, but ONLY when the 429 looks transient (a short
+Retry-After header or a near-future reset_at). Quota-exhaustion 429s still
+fall back immediately even when the knob is set.
+"""
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from run_agent import AIAgent
+from agent.conversation_loop import _rate_limit_looks_transient
+from agent.error_classifier import ClassifiedError, FailoverReason
+
+
+def _make_agent(value=None):
+    cfg = {"agent": {}}
+    if value is not None:
+        cfg["agent"]["rate_limit_retry_before_fallback"] = value
+    with patch("run_agent.OpenAI"), \
+         patch("hermes_cli.config.load_config", return_value=cfg):
+        return AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+
+def _err_with_retry_after(value):
+    return SimpleNamespace(response=SimpleNamespace(headers={"retry-after": value}))
+
+
+def _classified(reset_at=None):
+    ctx = {}
+    if reset_at is not None:
+        ctx["reset_at"] = reset_at
+    return ClassifiedError(reason=FailoverReason.rate_limit, error_context=ctx)
+
+
+def test_default_is_zero():
+    assert _make_agent()._rate_limit_retry_before_fallback == 0
+
+
+def test_config_override_propagates():
+    assert _make_agent(value=5)._rate_limit_retry_before_fallback == 5
+
+
+def test_negative_clamps_to_zero():
+    assert _make_agent(value=-3)._rate_limit_retry_before_fallback == 0
+
+
+def test_invalid_falls_back_to_zero():
+    assert _make_agent(value="nope")._rate_limit_retry_before_fallback == 0
+
+
+def test_short_retry_after_is_transient():
+    assert _rate_limit_looks_transient(_err_with_retry_after("5"), _classified()) is True
+
+
+def test_long_retry_after_is_not_transient():
+    assert _rate_limit_looks_transient(_err_with_retry_after("9000"), _classified()) is False
+
+
+def test_near_future_reset_at_is_transient():
+    assert _rate_limit_looks_transient(
+        SimpleNamespace(response=None), _classified(reset_at=time.time() + 10)
+    ) is True
+
+
+def test_far_future_reset_at_is_not_transient():
+    assert _rate_limit_looks_transient(
+        SimpleNamespace(response=None), _classified(reset_at=time.time() + 7200)
+    ) is False
+
+
+def test_no_signal_is_not_transient():
+    assert _rate_limit_looks_transient(
+        SimpleNamespace(response=None), _classified()
+    ) is False
+
+
+def test_gate_requires_all_conditions():
+    budget = 3
+    transient = _rate_limit_looks_transient(_err_with_retry_after("5"), _classified())
+    quota = _rate_limit_looks_transient(_err_with_retry_after("9000"), _classified())
+
+    def gate(reason, retry_count, looks_transient):
+        return (
+            budget > 0
+            and reason == FailoverReason.rate_limit
+            and retry_count < budget
+            and looks_transient
+        )
+
+    assert gate(FailoverReason.rate_limit, 0, transient) is True
+    assert gate(FailoverReason.rate_limit, 3, transient) is False
+    assert gate(FailoverReason.billing, 0, transient) is False
+    assert gate(FailoverReason.rate_limit, 0, quota) is False

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -807,6 +807,7 @@ Warnings are injected into the last tool result's JSON (as a `_budget_warning` f
 agent:
   max_turns: 90                # Max iterations per conversation turn (default: 90)
   api_max_retries: 3           # Retries per provider before fallback engages (default: 3)
+  rate_limit_retry_before_fallback: 0   # Retry primary on transient 429 before fallback (default: 0 = off)
 ```
 
 Budget pressure is enabled by default. The agent sees warnings naturally as part of tool results, encouraging it to consolidate its work and deliver a response before running out of iterations.
@@ -814,6 +815,8 @@ Budget pressure is enabled by default. The agent sees warnings naturally as part
 When the iteration budget is fully exhausted, the CLI shows a notification to the user: `⚠ Iteration budget reached (90/90) — response may be incomplete`. If the budget runs out during active work, the agent generates a summary of what was accomplished before stopping.
 
 `agent.api_max_retries` controls how many times Hermes retries a provider API call on transient errors (rate limits, connection drops, 5xx) **before** fallback-provider switching engages. The default is `3` — four attempts total. If you have [fallback providers](/user-guide/features/fallback-providers) configured and want to fail over faster, drop this to `0` so the first transient error on your primary immediately hands off to the fallback instead of churning retries against the flaky endpoint.
+
+`agent.rate_limit_retry_before_fallback` is the inverse knob, scoped to rate limits. By default (`0`), a `429` on the primary switches to the fallback provider immediately rather than consuming `api_max_retries`. If your primary is a single-credential provider that returns *transient* burst `429`s (a short `Retry-After` window) and you'd rather give it a few retries before handing off, set this to `N > 0`. It only applies when the `429` looks transient — a short `Retry-After` header or a near-future reset window; quota-exhaustion `429`s still fall back immediately so you never burn retries against a wall that won't clear for hours.
 
 ### API Timeouts
 

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -101,7 +101,7 @@ fallback_providers:
 
 The fallback activates automatically when the primary model fails with:
 
-- **Rate limits** (HTTP 429) — after exhausting retry attempts
+- **Rate limits** (HTTP 429) — by default, immediately when the primary's credential pool can't recover (single-credential pools, account-level quotas). Set [`agent.rate_limit_retry_before_fallback`](/user-guide/configuration#agent) above `0` to retry the primary first on *transient* 429s (short `Retry-After` / reset window) before switching; quota-exhaustion 429s still fall back immediately.
 - **Server errors** (HTTP 500, 502, 503) — after exhausting retry attempts
 - **Auth failures** (HTTP 401, 403) — immediately (no point retrying)
 - **Not found** (HTTP 404) — immediately

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -650,6 +650,7 @@ context:
 agent:
   max_turns: 90                # 每次对话轮次的最大迭代次数（默认：90）
   api_max_retries: 3           # 回退启动前每个 provider 的重试次数（默认：3）
+  rate_limit_retry_before_fallback: 0   # 瞬时 429 时先重试主 provider 再回退（默认：0=关闭）
 ```
 
 预算压力默认启用。Agent 自然地将警告视为工具结果的一部分，鼓励它在耗尽迭代之前整合工作并提供响应。


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in knob, `agent.rate_limit_retry_before_fallback` (integer, default `0`), that lets the primary model retry a **transient** rate-limit (HTTP 429) before fallback-provider switching engages.

**The gap:** When a fallback model is configured and the primary's credential pool can't recover (single-credential pools, or account-level quotas per `_pool_may_recover_from_rate_limit`), a 429 switches to the fallback **immediately** — bypassing `agent.api_max_retries` entirely. That is correct for daily-quota exhaustion (the multi-hour retry burn #11314 fixed), but it also fires on *transient* burst 429s that would clear within seconds, prematurely demoting the user off their preferred primary model.

**The fix:** When `rate_limit_retry_before_fallback > 0`, a 429 that looks transient — a short `Retry-After` header or a near-future reset window (≤120s) — retries the primary up to N times before falling back. Quota-exhaustion 429s (no/long reset signal) and billing (402) still fall back immediately, so the knob **cannot** reintroduce the #11314 burn. Default `0` preserves today's eager-fallback behavior exactly.

## Related Issue

Behavioral refinement of the eager-fallback path introduced for #11314 / #13636. No separate issue filed.

Fixes

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/agent_init.py` — read + clamp `agent.rate_limit_retry_before_fallback` (default 0) onto the agent.
- `agent/conversation_loop.py` — `_rate_limit_looks_transient()` (reads `Retry-After` header / classified `reset_at`); gate the eager-fallback branch so a transient 429 retries the primary up to N times first. Quota/billing unchanged.
- `hermes_cli/config.py` — default `0` in `DEFAULT_CONFIG`.
- `cli-config.yaml.example` — documented example key.
- `apps/desktop/src/app/settings/constants.ts` + `i18n/{ja,zh,zh-hant}.ts` — surfaces the field in Settings → Advanced ("Retry Primary on Rate Limit") with translations.
- `hermes_cli/tips.py` — sibling tip next to `api_max_retries`.
- `website/docs/user-guide/configuration.md`, `website/docs/user-guide/features/fallback-providers.md`, `website/i18n/zh-Hans/.../configuration.md` — documentation.
- `tests/run_agent/test_rate_limit_retry_before_fallback.py` — 10 tests: config surface (default/override/clamp/invalid) + the transient-vs-quota gate.

## How to Test

1. `pytest tests/run_agent/test_rate_limit_retry_before_fallback.py -q` → 10 passed.
2. Default (`0`): a single-credential primary that 429s falls straight to the configured fallback (unchanged).
3. Set `agent.rate_limit_retry_before_fallback: 3`. A 429 carrying a short `Retry-After` retries the primary up to 3× before falling back; a quota-exhaustion 429 (no/long reset) still falls back immediately.
4. Desktop: Settings → Advanced shows "Retry Primary on Rate Limit" (integer, default 0).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(agent):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run `pytest tests/ -q` for the affected tests and they pass (10/10)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`docs/`, fallback-providers guide, tips, i18n)
- [x] I've updated `cli-config.yaml.example` (added the new config key)
- [ ] N/A — `CONTRIBUTING.md` / `AGENTS.md` (no architecture/workflow change)
- [x] Cross-platform: config + retry-loop logic is platform-agnostic; desktop field uses existing settings plumbing
- [ ] N/A — no tool description/schema changes

## Screenshots / Logs

`pytest tests/run_agent/test_rate_limit_retry_before_fallback.py -q` → `10 passed`.
