### PR TITLE
fix: unblock Codex fallback and stabilize skill update hashes

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -702,6 +702,14 @@ def recover_with_credential_pool(
                 or "usage limit reached" in context_message
                 or "usage limit has been reached" in context_message
             )
+        if usage_limit_reached:
+            provider_lower = (getattr(agent, "provider", "") or "").strip().lower()
+            if provider_lower == "openai-codex":
+                _ra().logger.info(
+                    "OpenAI Codex usage_limit_reached 429 — skipping credential "
+                    "pool recovery so configured fallback providers can activate"
+                )
+                return False, True
         if not has_retried_429 and not usage_limit_reached:
             return False, True
         rotate_status = status_code if status_code is not None else 429

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2737,6 +2737,7 @@ def run_conversation(
                         agent._credential_pool,
                         provider=agent.provider,
                         base_url=getattr(agent, "base_url", None),
+                        error_context=error_context,
                     )
                     if not pool_may_recover:
                         if classified.reason == FailoverReason.billing:

--- a/run_agent.py
+++ b/run_agent.py
@@ -231,7 +231,8 @@ def _routermint_headers() -> dict:
 
 
 def _pool_may_recover_from_rate_limit(
-    pool, *, provider: str | None = None, base_url: str | None = None
+    pool, *, provider: str | None = None, base_url: str | None = None,
+    error_context: dict | None = None,
 ) -> bool:
     """Decide whether to wait for credential-pool rotation instead of falling back.
 
@@ -262,6 +263,20 @@ def _pool_may_recover_from_rate_limit(
     # the same throttle window, so rotation can't recover.  Prefer fallback.
     if provider == "google-gemini-cli" or str(base_url or "").startswith("cloudcode-pa://"):
         return False
+    # ChatGPT/Codex subscription usage-limit errors are account/window quota
+    # exhaustion (the body includes `usage_limit_reached` / reset timing), not
+    # a recoverable short per-request throttle.  If the main loop has fallback
+    # providers configured, do not let a multi-entry pool defer fallback.
+    if (provider or "").strip().lower() == "openai-codex" and error_context:
+        context_reason = str(error_context.get("reason") or "").lower()
+        context_message = str(error_context.get("message") or "").lower()
+        if (
+            "usage_limit_reached" in context_reason
+            or "gousagelimit" in context_reason
+            or "usage limit reached" in context_message
+            or "usage limit has been reached" in context_message
+        ):
+            return False
     return len(pool.entries()) > 1
 
 

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -133,6 +133,26 @@ class TestEagerFallbackWithPool:
 
         agent._try_activate_fallback.assert_called_once()
 
+    def test_openai_codex_usage_limit_pool_does_not_defer_eager_fallback(self):
+        """Even a multi-entry Codex pool must not block fallback on usage_limit_reached."""
+        from run_agent import _pool_may_recover_from_rate_limit
+
+        pool = MagicMock()
+        pool.has_available.return_value = True
+        pool.entries.return_value = [object(), object()]
+
+        may_recover = _pool_may_recover_from_rate_limit(
+            pool,
+            provider="openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            error_context={
+                "reason": "usage_limit_reached",
+                "message": "The usage limit has been reached",
+            },
+        )
+
+        assert may_recover is False
+
 
 # ---------------------------------------------------------------------------
 # 5. Full 429 rotation cycle via _recover_with_credential_pool
@@ -218,6 +238,35 @@ class TestPoolRotationCycle:
         assert recovered is True
         assert has_retried is False
         pool.mark_exhausted_and_rotate.assert_called_once_with(status_code=402, error_context=None)
+
+    def test_openai_codex_usage_limit_skips_pool_rotation_for_fallback(self):
+        """ChatGPT/Codex subscription quota exhaustion should not burn pool retries.
+
+        The `usage_limit_reached` 429 is account/subscription quota, not a short
+        transport hiccup.  If fallback providers are configured, the main loop
+        needs pool recovery to decline immediately so eager fallback can switch
+        to OpenRouter instead of rotating/retrying Codex until max_retries.
+        """
+        from agent.error_classifier import FailoverReason
+
+        agent, pool, _ = self._make_agent_with_pool(3)
+        agent.provider = "openai-codex"
+        pool.provider = "openai-codex"
+
+        recovered, has_retried = agent._recover_with_credential_pool(
+            status_code=429,
+            has_retried_429=False,
+            classified_reason=FailoverReason.rate_limit,
+            error_context={
+                "reason": "usage_limit_reached",
+                "message": "The usage limit has been reached",
+            },
+        )
+
+        assert recovered is False
+        assert has_retried is True
+        pool.mark_exhausted_and_rotate.assert_not_called()
+        agent._swap_credential.assert_not_called()
 
     def test_no_pool_returns_false(self):
         """No pool should return (False, unchanged)."""

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -1231,6 +1231,29 @@ class TestCheckForSkillUpdates:
 
         assert bundle_content_hash(bundle) == content_hash(skill_dir)
 
+    def test_bundle_content_hash_matches_on_disk_with_sibling_file_and_dir(self, tmp_path):
+        """Hash order must match Path.rglob when a file and directory share a prefix."""
+        from tools.skills_guard import content_hash
+
+        bundle = SkillBundle(
+            name="demo-skill",
+            files={
+                "SKILL.md": "# Demo Skill\n",
+                "references/styles.md": "index\n",
+                "references/styles/blueprint.md": "blueprint\n",
+            },
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+        )
+        skill_dir = tmp_path / "demo-skill"
+        (skill_dir / "references" / "styles").mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("# Demo Skill\n")
+        (skill_dir / "references" / "styles.md").write_text("index\n")
+        (skill_dir / "references" / "styles" / "blueprint.md").write_text("blueprint\n")
+
+        assert bundle_content_hash(bundle) == content_hash(skill_dir)
+
     def test_reports_update_when_remote_hash_differs(self):
         lock = MagicMock()
         lock.list_installed.return_value = [{

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3437,10 +3437,15 @@ def uninstall_skill(skill_name: str) -> Tuple[bool, str]:
     return True, f"Uninstalled '{skill_name}' from {entry['install_path']}"
 
 
+def _content_hash_path_sort_key(rel_path: str) -> tuple[str, ...]:
+    """Sort relative skill paths the same way ``Path.rglob`` paths sort on disk."""
+    return PurePosixPath(rel_path).parts
+
+
 def bundle_content_hash(bundle: SkillBundle) -> str:
     """Compute a deterministic hash for an in-memory skill bundle."""
     h = hashlib.sha256()
-    for rel_path in sorted(bundle.files):
+    for rel_path in sorted(bundle.files, key=_content_hash_path_sort_key):
         # Include the path so swapping file contents between two paths
         # changes the hash (avoids filename-swap evading update detection).
         h.update(rel_path.encode("utf-8"))


### PR DESCRIPTION
## Summary
- Let OpenAI Codex `usage_limit_reached` errors decline credential-pool recovery so configured fallback providers can activate immediately.
- Pass error context into the eager fallback pool-recovery decision path.
- Align skills hub in-memory bundle hashing with on-disk `content_hash` path ordering, fixing false `update_available` reports for skills that contain both `references/styles.md` and files under `references/styles/`.

## Why
Two update-time issues surfaced in a real Hermes install:

1. Codex subscription quota exhaustion (`usage_limit_reached`) is not recoverable by rotating credentials inside the same pool. Treating it like a pool-recoverable rate limit can delay or block fallback to OpenRouter.
2. `bundle_content_hash()` and `content_hash()` intended to be symmetric, but sorted paths differently when a file and directory share a prefix. This made an installed skill with identical contents still appear outdated.

## Test Plan
- `python -m pytest tests/agent/test_credential_pool_routing.py -q -o 'addopts='`
- `python -m pytest tests/tools/test_skills_hub.py::TestCheckForSkillUpdates tests/agent/test_credential_pool_routing.py -q -o 'addopts='`
- Manual verification: `hermes skills check` now reports `0 update(s) available` after force-installing `baoyu-article-illustrator`.
