### PR TITLE
Add Desktop microphone picker and STT diagnostics

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
@@ -1,10 +1,13 @@
 import { useEffect, useRef, useState } from 'react'
 
+import { selectedMicrophoneDeviceId } from '@/store/microphone'
+
 type BrowserAudioContext = typeof AudioContext
 
 export interface MicRecorderOptions {
   onLevel?: (level: number) => void
   onError?: (error: Error) => void
+  onDeviceFallback?: () => void
   onSilence?: () => void
   silenceLevel?: number
   silenceMs?: number
@@ -18,6 +21,7 @@ export interface MicRecording {
 }
 
 export interface MicRecorderErrorCopy {
+  microphoneSelectionUnavailable: string
   microphoneAccessDenied: string
   microphoneConstraintsUnsupported: string
   microphoneInUse: string
@@ -57,6 +61,29 @@ function micError(error: unknown, copy: MicRecorderErrorCopy): Error {
   }
 
   return new Error(copy.microphoneStartFailed)
+}
+
+function selectedDeviceUnavailable(error: unknown): boolean {
+  const name = error instanceof DOMException ? error.name : ''
+
+  return name === 'OverconstrainedError' || name === 'NotFoundError' || name === 'DevicesNotFoundError'
+}
+
+async function openMicrophoneStream(deviceId: string): Promise<MediaStream> {
+  if (!navigator.mediaDevices?.getUserMedia) {
+    throw new DOMException('Microphone capture is not available.', 'NotFoundError')
+  }
+
+  const audio: MediaTrackConstraints = {
+    echoCancellation: true,
+    noiseSuppression: true
+  }
+
+  if (deviceId) {
+    audio.deviceId = { exact: deviceId }
+  }
+
+  return navigator.mediaDevices.getUserMedia({ audio })
 }
 
 export function useMicRecorder(copy: MicRecorderErrorCopy): { handle: MicRecorderHandle; level: number; recording: boolean } {
@@ -180,9 +207,18 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): { handle: MicRecorde
     let stream: MediaStream
 
     try {
-      stream = await navigator.mediaDevices.getUserMedia({
-        audio: { echoCancellation: true, noiseSuppression: true }
-      })
+      const deviceId = selectedMicrophoneDeviceId()
+
+      try {
+        stream = await openMicrophoneStream(deviceId)
+      } catch (error) {
+        if (!deviceId || !selectedDeviceUnavailable(error)) {
+          throw error
+        }
+
+        options.onDeviceFallback?.()
+        stream = await openMicrophoneStream('')
+      }
     } catch (error) {
       throw micError(error, copy)
     }

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -203,6 +203,8 @@ export function useVoiceConversation({
         silenceLevel: 0.075,
         silenceMs: 1_250,
         idleSilenceMs: 12_000,
+        onDeviceFallback: () =>
+          notify({ kind: 'warning', title: voiceCopy.microphoneSelectionUnavailable, message: voiceCopy.usingSystemMicrophone }),
         onError: error => {
           notifyError(error, voiceCopy.microphoneFailed)
           pendingStartRef.current = false
@@ -218,7 +220,15 @@ export function useVoiceConversation({
       setStatus('idle')
       onFatalError?.()
     }
-  }, [handle, handleTurn, onFatalError, voiceCopy.couldNotStartSession, voiceCopy.microphoneFailed])
+  }, [
+    handle,
+    handleTurn,
+    onFatalError,
+    voiceCopy.couldNotStartSession,
+    voiceCopy.microphoneFailed,
+    voiceCopy.microphoneSelectionUnavailable,
+    voiceCopy.usingSystemMicrophone
+  ])
 
   const speak = useCallback(async (text: string) => {
     setStatus('speaking')

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.ts
@@ -85,7 +85,11 @@ export function useVoiceRecorder({
     }
 
     try {
-      await handle.start({ onError: error => notifyError(error, voiceCopy.recordingFailed) })
+      await handle.start({
+        onDeviceFallback: () =>
+          notify({ kind: 'warning', title: voiceCopy.microphoneSelectionUnavailable, message: voiceCopy.usingSystemMicrophone }),
+        onError: error => notifyError(error, voiceCopy.recordingFailed)
+      })
       startedAtRef.current = Date.now()
       setElapsedSeconds(0)
       setVoiceStatus('recording')

--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -23,6 +23,7 @@ import { fieldCopyForSchemaKey } from './field-copy'
 import { enumOptionsFor, getNested, prettyName, setNested } from './helpers'
 import { ModelSettings } from './model-settings'
 import { EmptyState, ListRow, LoadingState, SettingsContent } from './primitives'
+import { VoiceSettingsPanel } from './voice-settings-panel'
 
 function ConfigField({
   schemaKey,
@@ -215,7 +216,7 @@ export function ConfigSettings({
       .catch(err => notifyError(err, c.failedLoad))
 
     return () => void (cancelled = true)
-  }, [])
+  }, [c.failedLoad])
 
   useEffect(() => {
     let cancelled = false
@@ -263,7 +264,7 @@ export function ConfigSettings({
     }, 550)
 
     return () => window.clearTimeout(t)
-  }, [config, onConfigSaved, saveVersion])
+  }, [c.autosaveFailed, config, onConfigSaved, saveVersion])
 
   const updateConfig = (next: HermesConfigRecord) => {
     saveVersionRef.current += 1
@@ -350,6 +351,7 @@ export function ConfigSettings({
           <ModelSettings onMainModelChanged={onMainModelChanged} />
         </div>
       )}
+      {activeSectionId === 'voice' && <VoiceSettingsPanel />}
       {fields.length === 0 ? (
         <EmptyState description={c.emptyDesc} title={c.emptyTitle} />
       ) : (

--- a/apps/desktop/src/app/settings/voice-settings-panel.tsx
+++ b/apps/desktop/src/app/settings/voice-settings-panel.tsx
@@ -1,0 +1,284 @@
+import { useStore } from '@nanostores/react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { type AudioStatusResponse, getAudioStatus } from '@/hermes'
+import { useI18n } from '@/i18n'
+import { type AudioInputDevice, listAudioInputDevices, primeMicrophoneDeviceLabels } from '@/lib/audio-devices'
+import { AlertCircle, Check, Globe, Loader2, Mic, Monitor, RefreshCw } from '@/lib/icons'
+import { cn } from '@/lib/utils'
+import {
+  $selectedMicrophoneDeviceId,
+  setSelectedMicrophoneDeviceId,
+  SYSTEM_MICROPHONE_DEVICE_ID
+} from '@/store/microphone'
+import { $connection } from '@/store/session'
+
+import { CONTROL_TEXT } from './constants'
+import { ListRow, Pill, SectionHeading } from './primitives'
+
+const SYSTEM_SELECT_VALUE = '__system_microphone__'
+
+function providerLabel(provider: string) {
+  if (!provider || provider === 'none') {
+    return 'None'
+  }
+
+  if (provider === 'local') {
+    return 'Local'
+  }
+
+  return provider
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map(part => part[0]?.toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+function selectedDeviceMissing(deviceId: string, devices: AudioInputDevice[]) {
+  return Boolean(deviceId) && devices.length > 0 && !devices.some(device => device.deviceId === deviceId)
+}
+
+function isMissingAudioStatusEndpoint(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error ?? '')
+
+  return /\b404\b/.test(message) && message.includes('/api/audio/status') && message.includes('No such API endpoint')
+}
+
+export function VoiceSettingsPanel() {
+  const { t } = useI18n()
+  const copy = t.settings.voice
+  const connection = useStore($connection)
+  const selectedDeviceId = useStore($selectedMicrophoneDeviceId)
+  const [devices, setDevices] = useState<AudioInputDevice[]>([])
+  const [devicesLoading, setDevicesLoading] = useState(false)
+  const [deviceError, setDeviceError] = useState<string | null>(null)
+  const [audioStatus, setAudioStatus] = useState<AudioStatusResponse | null>(null)
+  const [audioStatusLoading, setAudioStatusLoading] = useState(false)
+  const [audioStatusError, setAudioStatusError] = useState<string | null>(null)
+  const [audioStatusUnsupported, setAudioStatusUnsupported] = useState(false)
+  const canEnumerateDevices = Boolean(navigator.mediaDevices?.enumerateDevices)
+  const selectedMissing = selectedDeviceMissing(selectedDeviceId, devices)
+
+  const refreshDevices = useCallback(async (requestAccess = false) => {
+    if (!navigator.mediaDevices?.enumerateDevices) {
+      setDevices([])
+      setDeviceError(copy.devicesUnavailable)
+
+      return
+    }
+
+    setDevicesLoading(true)
+    setDeviceError(null)
+
+    try {
+      if (requestAccess) {
+        await primeMicrophoneDeviceLabels()
+      }
+
+      setDevices(await listAudioInputDevices())
+    } catch (error) {
+      setDeviceError(error instanceof Error ? error.message : copy.devicesUnavailable)
+    } finally {
+      setDevicesLoading(false)
+    }
+  }, [copy.devicesUnavailable])
+
+  const refreshAudioStatus = useCallback(async () => {
+    setAudioStatusLoading(true)
+    setAudioStatusError(null)
+    setAudioStatusUnsupported(false)
+
+    try {
+      setAudioStatus(await getAudioStatus())
+    } catch (error) {
+      setAudioStatus(null)
+
+      if (isMissingAudioStatusEndpoint(error)) {
+        setAudioStatusUnsupported(true)
+
+        return
+      }
+
+      setAudioStatusError(error instanceof Error ? error.message : copy.statusFailed)
+    } finally {
+      setAudioStatusLoading(false)
+    }
+  }, [copy.statusFailed])
+
+  useEffect(() => {
+    void refreshDevices(false)
+
+    const mediaDevices = navigator.mediaDevices
+
+    if (!mediaDevices?.addEventListener) {
+      return
+    }
+
+    const onChange = () => void refreshDevices(false)
+    mediaDevices.addEventListener('devicechange', onChange)
+
+    return () => mediaDevices.removeEventListener('devicechange', onChange)
+  }, [refreshDevices])
+
+  useEffect(() => {
+    void refreshAudioStatus()
+  }, [connection?.baseUrl, connection?.mode, connection?.profile, refreshAudioStatus])
+
+  const sttDescription = useMemo(() => {
+    if (audioStatusLoading && !audioStatus) {
+      return copy.checkingStatus
+    }
+
+    if (audioStatusUnsupported) {
+      return copy.statusUnsupported
+    }
+
+    if (audioStatusError) {
+      return copy.statusError(audioStatusError)
+    }
+
+    if (!audioStatus) {
+      return copy.statusUnavailable
+    }
+
+    if (!audioStatus.enabled) {
+      return copy.sttDisabled
+    }
+
+    const provider = providerLabel(audioStatus.configured_provider)
+
+    if (audioStatus.available) {
+      return copy.sttReady(provider)
+    }
+
+    if (audioStatus.configured_provider === 'local') {
+      const missing = audioStatus.local.missing_packages.join(', ')
+
+      return audioStatus.lazy_installs_allowed
+        ? copy.localSttInstallable(missing || 'faster-whisper')
+        : copy.localSttMissing(missing || 'faster-whisper')
+    }
+
+    return copy.sttUnavailable(provider)
+  }, [audioStatus, audioStatusError, audioStatusLoading, audioStatusUnsupported, copy])
+
+  const localPackageSummary = useMemo(() => {
+    if (!audioStatus) {
+      return null
+    }
+
+    const missing = audioStatus.local.missing_packages
+
+    if (missing.length === 0) {
+      return copy.localPackagesReady
+    }
+
+    if (audioStatus.local.local_command_available) {
+      return copy.localCommandAvailable(missing.join(', '))
+    }
+
+    return copy.localPackagesMissing(missing.join(', '))
+  }, [audioStatus, copy])
+
+  return (
+    <div className="mb-6 grid gap-1">
+      <SectionHeading icon={Mic} title={copy.title} />
+
+      <ListRow
+        action={
+          <div className="flex min-w-0 items-center justify-end gap-2">
+            <Select
+              disabled={!canEnumerateDevices}
+              onValueChange={value =>
+                setSelectedMicrophoneDeviceId(value === SYSTEM_SELECT_VALUE ? SYSTEM_MICROPHONE_DEVICE_ID : value)
+              }
+              value={selectedDeviceId || SYSTEM_SELECT_VALUE}
+            >
+              <SelectTrigger className={cn(CONTROL_TEXT, 'w-full min-w-0 sm:w-72')}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={SYSTEM_SELECT_VALUE}>{copy.systemDefault}</SelectItem>
+                {selectedMissing && (
+                  <SelectItem disabled value={selectedDeviceId}>
+                    {copy.missingDeviceOption}
+                  </SelectItem>
+                )}
+                {devices.map(device => (
+                  <SelectItem key={device.deviceId} value={device.deviceId}>
+                    {device.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button
+              className="h-8 shrink-0 gap-1.5 px-2.5"
+              disabled={devicesLoading || !canEnumerateDevices}
+              onClick={() => void refreshDevices(true)}
+              size="sm"
+              type="button"
+              variant="outline"
+            >
+              {devicesLoading ? <Loader2 className="size-3.5 animate-spin" /> : <RefreshCw className="size-3.5" />}
+              <span>{copy.refreshDevices}</span>
+            </Button>
+          </div>
+        }
+        description={deviceError ?? copy.microphoneDesc}
+        hint={selectedMissing ? copy.selectedDeviceUnavailable : undefined}
+        title={copy.microphoneTitle}
+        wide
+      />
+
+      <ListRow
+        action={
+          <Pill tone={connection?.mode === 'remote' ? 'primary' : 'muted'}>
+            {connection?.mode === 'remote' ? copy.remoteBackend : copy.localBackend}
+          </Pill>
+        }
+        description={
+          connection?.mode === 'remote'
+            ? copy.remoteBackendDesc(connection.baseUrl || copy.remoteBackend)
+            : copy.localBackendDesc
+        }
+        title={
+          <span className="inline-flex items-center gap-1.5">
+            {connection?.mode === 'remote' ? <Globe className="size-3.5" /> : <Monitor className="size-3.5" />}
+            {copy.backendTitle}
+          </span>
+        }
+      />
+
+      <ListRow
+        action={
+          <div className="flex items-center justify-end gap-2">
+            {audioStatusLoading ? (
+              <Loader2 className="size-4 animate-spin text-muted-foreground" />
+            ) : audioStatus?.available ? (
+              <Check className="size-4 text-emerald-500" />
+            ) : audioStatusUnsupported ? (
+              <AlertCircle className="size-4 text-muted-foreground" />
+            ) : (
+              <AlertCircle className="size-4 text-amber-500" />
+            )}
+            <Button
+              className="h-8 px-2.5"
+              disabled={audioStatusLoading}
+              onClick={() => void refreshAudioStatus()}
+              size="sm"
+              type="button"
+              variant="outline"
+            >
+              {copy.refreshStatus}
+            </Button>
+          </div>
+        }
+        description={sttDescription}
+        hint={localPackageSummary ?? undefined}
+        title={copy.sttTitle}
+      />
+    </div>
+  )
+}

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -5,6 +5,7 @@ import type {
   ActionStatusResponse,
   AnalyticsResponse,
   AudioSpeakResponse,
+  AudioStatusResponse,
   AudioTranscriptionResponse,
   AuxiliaryModelsResponse,
   BackendUpdateCheckResponse,
@@ -55,6 +56,7 @@ export type {
   AnalyticsSkillsSummary,
   AnalyticsTotals,
   AudioSpeakResponse,
+  AudioStatusResponse,
   AudioTranscriptionResponse,
   AuxiliaryModelsResponse,
   BackendUpdateCheckResponse,
@@ -730,10 +732,17 @@ export function transcribeAudio(dataUrl: string, mimeType?: string): Promise<Aud
   return window.hermesDesktop.api<AudioTranscriptionResponse>({
     path: '/api/audio/transcribe',
     method: 'POST',
+    timeoutMs: 120_000,
     body: {
       data_url: dataUrl,
       mime_type: mimeType
     }
+  })
+}
+
+export function getAudioStatus(): Promise<AudioStatusResponse> {
+  return window.hermesDesktop.api<AudioStatusResponse>({
+    path: '/api/audio/status'
   })
 }
 

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -121,6 +121,7 @@ export const en: Translations = {
       microphoneFailed: 'Microphone failed',
       microphoneInUse: 'Microphone is already in use by another app.',
       microphonePermissionDenied: 'Microphone permission was denied.',
+      microphoneSelectionUnavailable: 'Selected microphone unavailable',
       microphoneStartFailed: 'Could not start microphone recording.',
       microphoneUnsupported: 'This runtime does not support microphone recording.',
       noMicrophone: 'No microphone was found.',
@@ -130,7 +131,8 @@ export const en: Translations = {
       transcriptionFailed: 'Voice transcription failed',
       transcriptionUnavailable: 'Voice transcription is not available yet.',
       tryRecordingAgain: 'Try recording again.',
-      unavailable: 'Voice unavailable'
+      unavailable: 'Voice unavailable',
+      usingSystemMicrophone: 'Hermes is using the system default microphone for this recording.'
     },
     native: {
       approvalTitle: 'Approval needed',
@@ -369,6 +371,42 @@ export const en: Translations = {
     },
     fieldLabels: FIELD_LABELS,
     fieldDescriptions: FIELD_DESCRIPTIONS,
+    voice: {
+      title: 'Voice Input',
+      microphoneTitle: 'Microphone',
+      microphoneDesc: 'Device-local input used for dictation and voice conversations.',
+      systemDefault: 'System default microphone',
+      refreshDevices: 'Refresh',
+      devicesUnavailable: 'Microphone devices are unavailable in this runtime.',
+      missingDeviceOption: 'Saved microphone (not connected)',
+      selectedDeviceUnavailable: 'The saved microphone is not connected. Hermes will fall back to the system default.',
+      backendTitle: 'Transcription backend',
+      localBackend: 'Local',
+      remoteBackend: 'Remote',
+      localBackendDesc:
+        'Audio is captured here and transcribed by the local Hermes backend before the text is sent to the agent.',
+      remoteBackendDesc: baseUrl =>
+        `Audio is captured here, then sent to ${baseUrl} for transcription. The model API receives the transcript text, not the raw audio.`,
+      sttTitle: 'Speech-to-text',
+      refreshStatus: 'Check',
+      checkingStatus: 'Checking speech-to-text status...',
+      statusUnavailable: 'Speech-to-text status is unavailable.',
+      statusUnsupported:
+        'This backend does not expose speech-to-text diagnostics yet. Voice transcription may still work; update the backend to see readiness details.',
+      statusFailed: 'Status check failed',
+      statusError: message => `Speech-to-text status failed: ${message}`,
+      sttDisabled: 'Speech-to-text is disabled in config.',
+      sttReady: provider => `${provider} speech-to-text is ready on the connected backend.`,
+      sttUnavailable: provider => `${provider} speech-to-text is not ready on the connected backend.`,
+      localSttInstallable: missing =>
+        `Local STT is missing ${missing}. Lazy installs are enabled, so the backend can install the allowed packages on first local transcription.`,
+      localSttMissing: missing =>
+        `Local STT is missing ${missing}. Enable lazy installs or install the local STT packages on this backend.`,
+      localCommandAvailable: missing =>
+        `Command-based local STT is available. Missing package bundle: ${missing}. Desktop capture does not need sounddevice or numpy.`,
+      localPackagesReady: 'Local STT packages are installed on this backend.',
+      localPackagesMissing: missing => `Missing local STT packages: ${missing}.`
+    },
     about: {
       heading: 'Hermes Desktop',
       version: value => `Version ${value}`,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -132,6 +132,7 @@ export interface Translations {
       microphoneFailed: string
       microphoneInUse: string
       microphonePermissionDenied: string
+      microphoneSelectionUnavailable: string
       microphoneStartFailed: string
       microphoneUnsupported: string
       noMicrophone: string
@@ -142,6 +143,7 @@ export interface Translations {
       transcriptionUnavailable: string
       tryRecordingAgain: string
       unavailable: string
+      usingSystemMicrophone: string
     }
     // Native OS notification copy (titles + generic fallback bodies). Dynamic
     // bodies (the agent's reply, a command, an error) are passed through raw.
@@ -268,6 +270,36 @@ export interface Translations {
     }
     fieldLabels: Record<string, string>
     fieldDescriptions: Record<string, string>
+    voice: {
+      title: string
+      microphoneTitle: string
+      microphoneDesc: string
+      systemDefault: string
+      refreshDevices: string
+      devicesUnavailable: string
+      missingDeviceOption: string
+      selectedDeviceUnavailable: string
+      backendTitle: string
+      localBackend: string
+      remoteBackend: string
+      localBackendDesc: string
+      remoteBackendDesc: (baseUrl: string) => string
+      sttTitle: string
+      refreshStatus: string
+      checkingStatus: string
+      statusUnavailable: string
+      statusUnsupported: string
+      statusFailed: string
+      statusError: (message: string) => string
+      sttDisabled: string
+      sttReady: (provider: string) => string
+      sttUnavailable: (provider: string) => string
+      localSttInstallable: (missing: string) => string
+      localSttMissing: (missing: string) => string
+      localCommandAvailable: (missing: string) => string
+      localPackagesReady: string
+      localPackagesMissing: (missing: string) => string
+    }
     about: {
       heading: string
       version: (value: string) => string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -117,6 +117,7 @@ export const zh: Translations = {
       microphoneFailed: '麦克风出错',
       microphoneInUse: '麦克风正被其他应用占用。',
       microphonePermissionDenied: '麦克风权限被拒绝。',
+      microphoneSelectionUnavailable: '所选麦克风不可用',
       microphoneStartFailed: '无法开始麦克风录音。',
       microphoneUnsupported: '当前运行环境不支持麦克风录音。',
       noMicrophone: '未找到麦克风。',
@@ -126,7 +127,8 @@ export const zh: Translations = {
       transcriptionFailed: '语音转写失败',
       transcriptionUnavailable: '语音转写暂不可用。',
       tryRecordingAgain: '请再录一次。',
-      unavailable: '语音不可用'
+      unavailable: '语音不可用',
+      usingSystemMicrophone: 'Hermes 将在本次录音中使用系统默认麦克风。'
     },
     native: {
       approvalTitle: '需要批准',
@@ -568,6 +570,39 @@ export const zh: Translations = {
           'Hermes 从应用内更新时（无终端提示），保留本地源码修改（暂存）或丢弃（放弃）。通过终端更新时始终会询问。'
       }
     }),
+    voice: {
+      title: '语音输入',
+      microphoneTitle: '麦克风',
+      microphoneDesc: '用于听写和语音对话的本机输入设备。',
+      systemDefault: '系统默认麦克风',
+      refreshDevices: '刷新',
+      devicesUnavailable: '当前运行环境无法访问麦克风设备。',
+      missingDeviceOption: '已保存的麦克风（未连接）',
+      selectedDeviceUnavailable: '已保存的麦克风未连接。Hermes 将回退到系统默认麦克风。',
+      backendTitle: '转写后端',
+      localBackend: '本地',
+      remoteBackend: '远程',
+      localBackendDesc: '音频在此处采集，并由本地 Hermes 后端转写成文本后发送给智能体。',
+      remoteBackendDesc: baseUrl =>
+        `音频在此处采集，然后发送到 ${baseUrl} 进行转写。模型 API 收到的是转写文本，而不是原始音频。`,
+      sttTitle: '语音转文字',
+      refreshStatus: '检查',
+      checkingStatus: '正在检查语音转文字状态…',
+      statusUnavailable: '语音转文字状态不可用。',
+      statusUnsupported: '此后端尚未提供语音转文字诊断接口。语音转写可能仍可使用；更新后端后可查看就绪详情。',
+      statusFailed: '状态检查失败',
+      statusError: message => `语音转文字状态检查失败：${message}`,
+      sttDisabled: '配置中已禁用语音转文字。',
+      sttReady: provider => `已连接后端上的 ${provider} 语音转文字已就绪。`,
+      sttUnavailable: provider => `已连接后端上的 ${provider} 语音转文字尚未就绪。`,
+      localSttInstallable: missing =>
+        `本地 STT 缺少 ${missing}。懒安装已启用，后端可在首次本地转写时安装允许的软件包。`,
+      localSttMissing: missing => `本地 STT 缺少 ${missing}。请启用懒安装，或在此后端安装本地 STT 软件包。`,
+      localCommandAvailable: missing =>
+        `命令式本地 STT 可用。缺少的软件包组合：${missing}。桌面端采集不需要 sounddevice 或 numpy。`,
+      localPackagesReady: '此后端已安装本地 STT 软件包。',
+      localPackagesMissing: missing => `缺少本地 STT 软件包：${missing}。`
+    },
     about: {
       heading: 'Hermes Desktop',
       version: value => `版本 ${value}`,

--- a/apps/desktop/src/lib/audio-devices.ts
+++ b/apps/desktop/src/lib/audio-devices.ts
@@ -1,0 +1,56 @@
+export interface AudioInputDevice {
+  deviceId: string
+  groupId: string
+  label: string
+}
+
+export async function primeMicrophoneDeviceLabels(): Promise<boolean> {
+  const permitted = await window.hermesDesktop?.requestMicrophoneAccess?.()
+
+  if (permitted === false || !navigator.mediaDevices?.getUserMedia) {
+    return false
+  }
+
+  let stream: MediaStream | null = null
+
+  try {
+    stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+
+    return true
+  } finally {
+    stream?.getTracks().forEach(track => track.stop())
+  }
+}
+
+export async function listAudioInputDevices(): Promise<AudioInputDevice[]> {
+  if (!navigator.mediaDevices?.enumerateDevices) {
+    return []
+  }
+
+  const devices = await navigator.mediaDevices.enumerateDevices()
+  const seen = new Set<string>()
+  let index = 0
+
+  return devices
+    .filter(device => device.kind === 'audioinput' && device.deviceId !== 'default')
+    .filter(device => {
+      const key = device.deviceId || `${device.groupId}:${device.label}`
+
+      if (!key || seen.has(key)) {
+        return false
+      }
+
+      seen.add(key)
+
+      return true
+    })
+    .map(device => {
+      index += 1
+
+      return {
+        deviceId: device.deviceId,
+        groupId: device.groupId,
+        label: device.label || `Microphone ${index}`
+      }
+    })
+}

--- a/apps/desktop/src/store/microphone.ts
+++ b/apps/desktop/src/store/microphone.ts
@@ -1,0 +1,25 @@
+import { atom } from 'nanostores'
+
+import { persistString, storedString } from '@/lib/storage'
+
+const STORAGE_KEY = 'hermes.desktop.microphoneDeviceId'
+
+export const SYSTEM_MICROPHONE_DEVICE_ID = ''
+
+function normalizeDeviceId(deviceId: string | null | undefined): string {
+  return typeof deviceId === 'string' ? deviceId.trim() : SYSTEM_MICROPHONE_DEVICE_ID
+}
+
+export const $selectedMicrophoneDeviceId = atom(normalizeDeviceId(storedString(STORAGE_KEY)))
+
+$selectedMicrophoneDeviceId.subscribe(deviceId =>
+  persistString(STORAGE_KEY, deviceId ? normalizeDeviceId(deviceId) : null)
+)
+
+export function setSelectedMicrophoneDeviceId(deviceId: string | null | undefined) {
+  $selectedMicrophoneDeviceId.set(normalizeDeviceId(deviceId))
+}
+
+export function selectedMicrophoneDeviceId(): string {
+  return $selectedMicrophoneDeviceId.get()
+}

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -16,6 +16,22 @@ export interface AudioTranscriptionResponse {
   transcript: string
 }
 
+export interface AudioStatusResponse {
+  available: boolean
+  configured_provider: string
+  enabled: boolean
+  lazy_installs_allowed: boolean
+  local: {
+    faster_whisper_available: boolean
+    local_command_available: boolean
+    missing_packages: string[]
+    model: string
+    numpy_available: boolean
+    sounddevice_available: boolean
+  }
+  resolved_provider: string
+}
+
 export interface AudioSpeakResponse {
   ok: boolean
   data_url: string

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2314,6 +2314,17 @@ async def check_hermes_update(force: bool = False):
     return payload
 
 
+@app.get("/api/audio/status")
+async def audio_status():
+    try:
+        from tools.transcription_tools import transcription_status
+
+        return transcription_status()
+    except Exception as exc:
+        _log.exception("Desktop audio status check failed")
+        raise HTTPException(status_code=500, detail=f"Audio status failed: {exc}")
+
+
 @app.post("/api/audio/transcribe")
 async def transcribe_audio_upload(payload: AudioTranscriptionRequest):
     data_url = (payload.data_url or "").strip()

--- a/tests/tools/test_transcription.py
+++ b/tests/tools/test_transcription.py
@@ -79,6 +79,47 @@ class TestGetProvider:
         assert _get_provider({"enabled": False, "provider": "openai"}) == "none"
 
 
+class TestTranscriptionStatus:
+    """transcription_status() reports backend readiness without lazy installs."""
+
+    def test_local_missing_packages_reports_installable_when_lazy_allowed(self):
+        def find_spec(name):
+            return False
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "local", "local": {"model": "base"}}), \
+             patch("tools.transcription_tools._safe_find_spec", side_effect=find_spec), \
+             patch("tools.transcription_tools._has_local_command", return_value=False), \
+             patch("hermes_cli.config.load_config", return_value={"security": {"allow_lazy_installs": True}}):
+            from tools.transcription_tools import transcription_status
+
+            status = transcription_status()
+
+        assert status["available"] is False
+        assert status["configured_provider"] == "local"
+        assert status["lazy_installs_allowed"] is True
+        assert status["local"]["missing_packages"] == ["faster-whisper", "sounddevice", "numpy"]
+        assert status["resolved_provider"] == "none"
+
+    def test_local_ready_reports_available_without_requiring_sounddevice(self):
+        def find_spec(name):
+            return name == "faster_whisper"
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "local", "local": {"model": "small"}}), \
+             patch("tools.transcription_tools._safe_find_spec", side_effect=find_spec), \
+             patch("tools.transcription_tools._has_local_command", return_value=False), \
+             patch("hermes_cli.config.load_config", return_value={"security": {"allow_lazy_installs": False}}):
+            from tools.transcription_tools import transcription_status
+
+            status = transcription_status()
+
+        assert status["available"] is True
+        assert status["local"]["faster_whisper_available"] is True
+        assert status["local"]["sounddevice_available"] is False
+        assert status["local"]["numpy_available"] is False
+        assert status["local"]["model"] == "small"
+        assert status["resolved_provider"] == "local"
+
+
 # ---------------------------------------------------------------------------
 # File validation
 # ---------------------------------------------------------------------------

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -179,6 +179,77 @@ def _has_local_command() -> bool:
     return _get_local_command_template() is not None
 
 
+def transcription_status() -> Dict[str, Any]:
+    """Return non-mutating STT availability diagnostics for UI/status surfaces."""
+    stt_config = _load_stt_config()
+    enabled = is_stt_enabled(stt_config)
+    provider = str(stt_config.get("provider") or DEFAULT_PROVIDER)
+    local_cfg = stt_config.get("local") if isinstance(stt_config.get("local"), dict) else {}
+    faster_whisper_available = _safe_find_spec("faster_whisper")
+    sounddevice_available = _safe_find_spec("sounddevice")
+    numpy_available = _safe_find_spec("numpy")
+    local_command_available = _has_local_command()
+    lazy_installs_allowed = True
+
+    try:
+        from hermes_cli.config import load_config
+
+        security = load_config().get("security") or {}
+        lazy_installs_allowed = bool(security.get("allow_lazy_installs", True))
+    except Exception:
+        lazy_installs_allowed = True
+
+    def provider_available(name: str) -> bool:
+        if name == "local":
+            return faster_whisper_available or local_command_available
+        if name == "local_command":
+            return local_command_available
+        if name == "groq":
+            return _HAS_OPENAI and bool(get_env_value("GROQ_API_KEY"))
+        if name == "openai":
+            return _HAS_OPENAI and _has_openai_audio_backend()
+        if name == "mistral":
+            return _HAS_MISTRAL and bool(get_env_value("MISTRAL_API_KEY"))
+        if name == "xai":
+            try:
+                from tools.xai_http import resolve_xai_http_credentials
+
+                return bool(resolve_xai_http_credentials().get("api_key"))
+            except Exception:
+                return False
+        if name == "elevenlabs":
+            return bool(get_env_value("ELEVENLABS_API_KEY"))
+
+        return False
+
+    available = enabled and provider_available(provider)
+    local_missing = [
+        name
+        for name, present in (
+            ("faster-whisper", faster_whisper_available),
+            ("sounddevice", sounddevice_available),
+            ("numpy", numpy_available),
+        )
+        if not present
+    ]
+
+    return {
+        "available": available,
+        "configured_provider": provider,
+        "enabled": enabled,
+        "lazy_installs_allowed": lazy_installs_allowed,
+        "local": {
+            "faster_whisper_available": faster_whisper_available,
+            "local_command_available": local_command_available,
+            "missing_packages": local_missing,
+            "model": local_cfg.get("model", DEFAULT_LOCAL_MODEL),
+            "numpy_available": numpy_available,
+            "sounddevice_available": sounddevice_available,
+        },
+        "resolved_provider": provider if available else "none",
+    }
+
+
 def _normalize_local_model(model_name: Optional[str]) -> str:
     """Return a valid faster-whisper model size, mapping cloud-only names to the default.
 


### PR DESCRIPTION
## Summary

Adds a proper Hermes Desktop voice input settings surface so users can choose which local microphone the Desktop app uses for dictation and voice conversations, and can understand where speech-to-text is being processed.

This PR is intentionally independent of PR #46458. It is based on current upstream `main` and does not include the profile-scoped settings routing changes from that PR.

## What changed

- Adds a new Voice Input panel under Desktop settings for the `voice` config section.
- Lists available audio input devices with `navigator.mediaDevices.enumerateDevices()`.
- Persists the selected microphone device locally in Desktop renderer storage.
- Includes a System default microphone option for safe fallback behavior.
- Uses the selected microphone when starting `getUserMedia()` for voice recording.
- Falls back to the system default microphone if a saved device is missing or unplugged.
- Shows a native notification when Desktop falls back from a saved microphone to the system default.
- Adds `GET /api/audio/status` for non-mutating STT readiness diagnostics.
- Surfaces whether transcription is local or remote based on the active Desktop backend connection.
- Extends the Desktop transcription request timeout to better tolerate local Whisper/model startup.
- Handles mixed-version remote backends: if the connected backend does not yet expose `/api/audio/status`, the UI shows a friendly unsupported-diagnostics message instead of a raw IPC/404 error.
- Adds tests for the STT status helper.

## Root cause / motivation

Hermes Desktop voice capture used the browser/Electron default input device with no user-visible picker. On systems with multiple microphones, users could not tell which microphone was active and could not choose the intended device.

The investigation also found that Desktop voice capture is local to the Desktop app, but transcription is performed by the connected Hermes backend:

- Desktop records microphone audio locally through browser/Electron media APIs.
- Desktop sends the recorded audio payload to the connected backend at `/api/audio/transcribe`.
- In local mode, that backend runs on the user's machine.
- In remote mode, the raw audio payload goes to the configured remote Hermes backend for transcription.
- The model API receives the resulting transcript text, not the raw audio file.

The new settings text makes this explicit so users can distinguish microphone selection from STT backend location.

## Dependency findings

Desktop microphone capture itself does not require `faster_whisper`, `sounddevice`, or `numpy`; capture is handled by Electron/browser APIs.

Those Python packages are relevant to backend-side local STT support. The new status helper reports their availability without triggering lazy installs. It also detects command-based local STT, such as an installed `whisper` binary, as a valid local transcription backend.

During local testing on macOS, backend status reported:

- `faster_whisper_available: false`
- `sounddevice_available: false`
- `numpy_available: false`
- `local_command_available: true`
- `available: true`

So the Desktop app did not need those packages to capture audio, and this PR does not install them automatically.

## Backward compatibility

A newer Desktop app may connect to an older remote Hermes backend that does not yet have `/api/audio/status`. In that case the settings panel now treats the specific `404 /api/audio/status / No such API endpoint` response as unsupported diagnostics and displays:

> This backend does not expose speech-to-text diagnostics yet. Voice transcription may still work; update the backend to see readiness details.

Other status failures still surface as real errors.

## Validation

- `npm ci --workspace apps/desktop`
- `npm run typecheck` in `apps/desktop`
- Targeted ESLint on changed Desktop TypeScript/TSX files
- `scripts/run_tests.sh tests/tools/test_transcription.py`
- `python -m py_compile tools/transcription_tools.py hermes_cli/web_server.py`
- Direct smoke check of `tools.transcription_tools.transcription_status()`
- Local macOS Desktop pack/build from the installed checkout
- `codesign --verify --deep --strict` on the built app bundle
- Manual Desktop test with a selected microphone and a remote backend

Note: the local macOS test build skipped notarization because Apple notarization environment variables were not configured. Codesign verification passed.