### PR TITLE
fix(gateway): add adapter liveness watchdog

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -452,6 +452,34 @@ class StreamingConfig:
         )
 
 
+@dataclass
+class LivenessWatchdogConfig:
+    """Gateway-level adapter liveness watchdog settings."""
+
+    enabled: bool = True
+    interval: float = 120.0
+    failure_threshold: int = 2
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "interval": self.interval,
+            "failure_threshold": self.failure_threshold,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "LivenessWatchdogConfig":
+        if not data:
+            return cls()
+        interval = max(_coerce_float(data.get("interval"), 120.0), 1.0)
+        failure_threshold = max(_coerce_int(data.get("failure_threshold"), 2), 1)
+        return cls(
+            enabled=_coerce_bool(data.get("enabled"), True),
+            interval=interval,
+            failure_threshold=failure_threshold,
+        )
+
+
 # -----------------------------------------------------------------------------
 # Built-in platform connection checkers
 # -----------------------------------------------------------------------------
@@ -545,6 +573,7 @@ class GatewayConfig:
 
     # Streaming configuration
     streaming: StreamingConfig = field(default_factory=StreamingConfig)
+    liveness_watchdog: LivenessWatchdogConfig = field(default_factory=LivenessWatchdogConfig)
 
     # Session store pruning: drop SessionEntry records older than this many
     # days from the in-memory dict and sessions.json.  Keeps the store from
@@ -656,6 +685,7 @@ class GatewayConfig:
             "multiplex_profiles": self.multiplex_profiles,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
             "streaming": self.streaming.to_dict(),
+            "liveness_watchdog": self.liveness_watchdog.to_dict(),
             "session_store_max_age_days": self.session_store_max_age_days,
         }
     
@@ -705,6 +735,11 @@ class GatewayConfig:
             # Also honor gateway.multiplex_profiles written by
             # ``hermes config set gateway.multiplex_profiles true``.
             multiplex_profiles = nested_gateway.get("multiplex_profiles")
+        liveness_watchdog_data = data.get("liveness_watchdog")
+        if not isinstance(liveness_watchdog_data, dict):
+            liveness_watchdog_data = nested_gateway.get("liveness_watchdog")
+        if not isinstance(liveness_watchdog_data, dict):
+            liveness_watchdog_data = {}
         if "max_concurrent_sessions" in data:
             max_concurrent_raw = data.get("max_concurrent_sessions")
             max_concurrent_key = "max_concurrent_sessions"
@@ -745,6 +780,7 @@ class GatewayConfig:
             max_concurrent_sessions=max_concurrent_sessions,
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
+            liveness_watchdog=LivenessWatchdogConfig.from_dict(liveness_watchdog_data),
             session_store_max_age_days=session_store_max_age_days,
         )
 
@@ -856,6 +892,8 @@ def load_gateway_config() -> GatewayConfig:
                 gw_data["multiplex_profiles"] = yaml_cfg["multiplex_profiles"]
 
             gateway_section = yaml_cfg.get("gateway")
+            if isinstance(gateway_section, dict):
+                gw_data["gateway"] = gateway_section
             if isinstance(gateway_section, dict) and "max_concurrent_sessions" in gateway_section:
                 gw_data["max_concurrent_sessions"] = gateway_section["max_concurrent_sessions"]
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2575,6 +2575,15 @@ class BasePlatformAdapter(ABC):
     def is_connected(self) -> bool:
         """Check if adapter is currently connected."""
         return self._running
+
+    def is_alive(self) -> bool:
+        """Return True when the adapter still appears healthy.
+
+        Default implementation is intentionally conservative: if an adapter has
+        marked itself running, the gateway treats it as alive unless the
+        adapter opts into a deeper check.
+        """
+        return self.is_connected()
     
     def set_message_handler(self, handler: MessageHandler) -> None:
         """

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2683,6 +2683,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Track platforms that failed to connect for background reconnection.
         # Key: Platform enum, Value: {"config": platform_config, "attempts": int, "next_retry": float}
         self._failed_platforms: Dict[Platform, Dict[str, Any]] = {}
+        self._platform_liveness_failures: Dict[Platform, int] = {}
 
         # Track pending /update prompt responses per session.
         # Key: session_key, Value: True when a prompt is waiting for user input.
@@ -6216,6 +6217,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 ", ".join(p.value for p in self._failed_platforms),
             )
         asyncio.create_task(self._platform_reconnect_watcher())
+        asyncio.create_task(self._platform_liveness_watchdog())
 
         # Start background handoff watcher — picks up CLI sessions marked
         # handoff_state='pending' in state.db and re-binds them to the
@@ -6852,6 +6854,72 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if not self._running:
                     return
                 await asyncio.sleep(1)
+
+    async def _platform_liveness_watchdog(self) -> None:
+        """Periodically check live adapters and requeue unhealthy ones."""
+        cfg = getattr(self.config, "liveness_watchdog", None)
+        if cfg is None or not getattr(cfg, "enabled", True):
+            return
+
+        interval = max(float(getattr(cfg, "interval", 120.0) or 120.0), 1.0)
+        failure_threshold = max(int(getattr(cfg, "failure_threshold", 2) or 2), 1)
+
+        while self._running:
+            await asyncio.sleep(interval)
+            if not self._running:
+                return
+
+            for platform, adapter in list(self.adapters.items()):
+                if not self._running:
+                    return
+                if self._failed_platforms.get(platform):
+                    self._platform_liveness_failures.pop(platform, None)
+                    continue
+                if getattr(adapter, "has_fatal_error", False):
+                    self._platform_liveness_failures.pop(platform, None)
+                    continue
+
+                try:
+                    alive = bool(adapter.is_alive())
+                except Exception as exc:
+                    alive = False
+                    logger.warning(
+                        "Liveness check for %s raised %s; treating adapter as unhealthy",
+                        platform.value,
+                        exc,
+                        exc_info=True,
+                    )
+
+                if alive:
+                    self._platform_liveness_failures.pop(platform, None)
+                    continue
+
+                failures = self._platform_liveness_failures.get(platform, 0) + 1
+                self._platform_liveness_failures[platform] = failures
+                if failures < failure_threshold:
+                    logger.warning(
+                        "Liveness watchdog: %s unhealthy (%d/%d consecutive failures)",
+                        platform.value,
+                        failures,
+                        failure_threshold,
+                    )
+                    continue
+
+                self._platform_liveness_failures.pop(platform, None)
+                message = (
+                    "Gateway liveness watchdog detected an unresponsive adapter"
+                )
+                logger.error(
+                    "Liveness watchdog: %s failed %d consecutive health checks; queuing reconnect",
+                    platform.value,
+                    failures,
+                )
+                adapter._set_fatal_error(
+                    "gateway_liveness_failed",
+                    message,
+                    retryable=True,
+                )
+                await self._handle_adapter_fatal_error(adapter)
 
     async def stop(
         self,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -800,6 +800,25 @@ class DiscordAdapter(BasePlatformAdapter):
         # should not act as conversational history boundaries after restart.
         self._nonconversational_messages = _DiscordNonConversationalMessageTracker()
 
+    def is_alive(self) -> bool:
+        """Treat a finished bot task / closed client as a dead connection."""
+        if not getattr(self, "_running", False):
+            return False
+
+        bot_task = getattr(self, "_bot_task", None)
+        if bot_task is not None and bot_task.done() and not getattr(self, "_disconnecting", False):
+            return False
+
+        client = getattr(self, "_client", None)
+        if client is None:
+            return False
+        try:
+            if self._ready_event.is_set() and client.is_closed():
+                return False
+        except Exception:
+            return False
+        return True
+
     def _handle_bot_task_done(self, task: asyncio.Task) -> None:
         """Surface post-startup discord.py task exits to the gateway supervisor.
 

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -21,6 +21,7 @@ class StubAdapter(BasePlatformAdapter):
         succeed=True,
         fatal_error=None,
         fatal_retryable=True,
+        alive=True,
     ):
         super().__init__(PlatformConfig(enabled=True, token="test"), platform)
         self._succeed = succeed
@@ -29,6 +30,7 @@ class StubAdapter(BasePlatformAdapter):
         # Records the is_reconnect value of every connect() call so tests can
         # assert that the watcher distinguishes reconnect from cold boot (#46621).
         self.connect_calls: list[bool] = []
+        self._alive = alive
 
     async def connect(self, *, is_reconnect: bool = False):
         self.connect_calls.append(is_reconnect)
@@ -49,6 +51,9 @@ class StubAdapter(BasePlatformAdapter):
     async def get_chat_info(self, chat_id):
         return {"id": chat_id}
 
+    def is_alive(self):
+        return self._alive
+
 
 def _make_runner():
     """Create a minimal GatewayRunner via object.__new__ to skip __init__."""
@@ -62,6 +67,7 @@ def _make_runner():
     runner._exit_with_failure = False
     runner._exit_cleanly = False
     runner._failed_platforms = {}
+    runner._platform_liveness_failures = {}
     runner.adapters = {}
     runner.delivery_router = MagicMock()
     runner._running_agents = {}
@@ -481,10 +487,97 @@ class TestPlatformReconnectWatcher:
 
             await run_one_iteration()
 
-        # Paused platform stays queued and was never touched
+
+class TestPlatformLivenessWatchdog:
+    @pytest.mark.asyncio
+    async def test_watchdog_routes_dead_adapter_through_fatal_handler(self):
+        runner = _make_runner()
+        runner.config = GatewayConfig.from_dict(
+            {
+                "platforms": {"telegram": {"enabled": True, "token": "test"}},
+                "liveness_watchdog": {"enabled": True, "interval": 1, "failure_threshold": 2},
+            }
+        )
+        adapter = StubAdapter(alive=False)
+        runner.adapters = {Platform.TELEGRAM: adapter}
+        runner.delivery_router.adapters = runner.adapters
+        runner._handle_adapter_fatal_error = AsyncMock(side_effect=runner._handle_adapter_fatal_error)
+
+        real_sleep = asyncio.sleep
+
+        async def run_two_ticks():
+            runner._running = True
+            call_count = 0
+
+            async def fake_sleep(_n):
+                nonlocal call_count
+                call_count += 1
+                if call_count > 2:
+                    runner._running = False
+                await real_sleep(0)
+
+            with patch("asyncio.sleep", side_effect=fake_sleep):
+                await runner._platform_liveness_watchdog()
+
+        await run_two_ticks()
+
+        runner._handle_adapter_fatal_error.assert_awaited_once()
+        assert adapter.fatal_error_code == "gateway_liveness_failed"
         assert Platform.TELEGRAM in runner._failed_platforms
-        assert runner._failed_platforms[Platform.TELEGRAM]["paused"] is True
-        mock_create.assert_not_called()
+        assert Platform.TELEGRAM not in runner.adapters
+
+    @pytest.mark.asyncio
+    async def test_watchdog_clears_consecutive_failure_counter_after_recovery(self):
+        runner = _make_runner()
+        runner.config = GatewayConfig.from_dict(
+            {
+                "platforms": {"telegram": {"enabled": True, "token": "test"}},
+                "liveness_watchdog": {"enabled": True, "interval": 1, "failure_threshold": 2},
+            }
+        )
+        adapter = StubAdapter(alive=False)
+        runner.adapters = {Platform.TELEGRAM: adapter}
+
+        real_sleep = asyncio.sleep
+
+        async def run_three_ticks():
+            runner._running = True
+            call_count = 0
+
+            async def fake_sleep(_n):
+                nonlocal call_count
+                call_count += 1
+                if call_count == 2:
+                    adapter._alive = True
+                if call_count > 3:
+                    runner._running = False
+                await real_sleep(0)
+
+            with patch("asyncio.sleep", side_effect=fake_sleep):
+                await runner._platform_liveness_watchdog()
+
+        await run_three_ticks()
+
+        assert runner._platform_liveness_failures == {}
+        assert Platform.TELEGRAM in runner.adapters
+        assert Platform.TELEGRAM not in runner._failed_platforms
+
+    def test_gateway_config_parses_liveness_watchdog(self):
+        cfg = GatewayConfig.from_dict(
+            {
+                "gateway": {
+                    "liveness_watchdog": {
+                        "enabled": False,
+                        "interval": 45,
+                        "failure_threshold": 3,
+                    }
+                }
+            }
+        )
+
+        assert cfg.liveness_watchdog.enabled is False
+        assert cfg.liveness_watchdog.interval == 45
+        assert cfg.liveness_watchdog.failure_threshold == 3
 
     @pytest.mark.asyncio
     async def test_reconnect_skips_when_not_time_yet(self):

--- a/tests/plugins/test_discord_runtime_failure.py
+++ b/tests/plugins/test_discord_runtime_failure.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -57,3 +57,25 @@ async def test_discord_bot_task_done_ignored_during_intentional_disconnect():
 
     assert adapter.has_fatal_error is False
     adapter._notify_fatal_error.assert_not_awaited()
+
+
+def test_discord_is_alive_false_when_bot_task_dies_after_ready():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="token"))
+    adapter._running = True
+    adapter._ready_event.set()
+    done_task = MagicMock()
+    done_task.done.return_value = True
+    adapter._bot_task = done_task
+    adapter._client = type("Client", (), {"is_closed": lambda self: False})()
+
+    assert adapter.is_alive() is False
+
+
+def test_discord_is_alive_false_when_ready_client_is_closed():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="token"))
+    adapter._running = True
+    adapter._ready_event.set()
+    adapter._bot_task = None
+    adapter._client = type("Client", (), {"is_closed": lambda self: True})()
+
+    assert adapter.is_alive() is False


### PR DESCRIPTION
## What changed and why

This lands a narrow phase-1 fix for the zombie-adapter class reported in #32574.

- Added a new `gateway.liveness_watchdog` config block with `enabled`, `interval`, and `failure_threshold` so the gateway can periodically check live adapters without inventing a second reconnect system.
- Added `BasePlatformAdapter.is_alive()` with a conservative default (`_running`), then wired a new `GatewayRunner._platform_liveness_watchdog()` loop that counts consecutive failed checks and routes recovery through the existing fatal-error/reconnect path.
- Added a real Discord override: once the adapter is marked ready, a finished `Bot.start()` task or a closed ready client is treated as dead and gets requeued for the existing reconnect watcher.
- Per the reporter's June 15, 2026 follow-up, this first pass does **not** claim to solve Signal's "transport healthy but no real inbound envelopes" case. The framework stays compatible with a stricter Signal-specific override, but this PR does not equate quiet traffic with a dead connection.

## How to test

- `pytest tests/gateway/test_platform_reconnect.py -q`
- `pytest tests/plugins/test_discord_runtime_failure.py -q`
- `pytest tests/gateway/test_runner_fatal_adapter.py -q`
- `pytest tests/gateway/test_runner_startup_failures.py -q`

## What platforms tested on

- macOS (unit tests only)

Refs #32574

<!-- autocontrib:worker-id=issue-followup-5172c163 kind=pr-open -->