### PR TITLE
fix(auxiliary): keep auto model paired with live runtime

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3385,12 +3385,14 @@ def resolve_provider_client(
     # Normalise aliases
     provider = _normalize_aux_provider(provider)
 
-    # Universal model-resolution fallback chain.  Callers (notably title
-    # generation, vision, session search, and other auxiliary tasks) can
-    # reach this function without an explicit model — the user picked their
-    # main provider, didn't bother configuring a per-task ``auxiliary.<task>.model``,
-    # and just expects "use my main model for side tasks too."  Resolve in
-    # this order, stopping at the first non-empty answer:
+    # Universal model-resolution fallback for concrete providers. ``auto`` is
+    # intentionally excluded: `_resolve_auto(main_runtime=...)` returns the
+    # model paired with the provider it actually selected. Pre-filling an auto
+    # call from `_read_main_model()` can leak a stale process-global runtime
+    # into a different provider (for example Claude model slug on Codex OAuth)
+    # and override that correctly resolved model.
+    #
+    # Concrete provider resolution order:
     #
     #   1. ``model`` argument (caller knew what they wanted)
     #   2. Provider's catalog default — cheap/fast model the provider
@@ -3410,7 +3412,7 @@ def resolve_provider_client(
     # main_model also empty), the branches still hit their own
     # missing-credentials returns and ``_resolve_auto`` falls through to
     # the Step-2 chain as before.
-    if not model:
+    if not model and provider != "auto":
         model = _get_aux_model_for_provider(provider) or _read_main_model() or model
 
     def _needs_codex_wrap(client_obj, base_url_str: str, model_str: str) -> bool:

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -89,7 +89,17 @@ def build_turn_context(
 
     agent._ensure_db_session()
 
-    # Tell auxiliary_client what the live main provider/model are for this turn.
+    # Tag log records on this thread with the session ID for ``hermes logs``.
+    set_session_context(agent.session_id)
+
+    # Bind the skill write-origin ContextVar for this thread.
+    set_current_write_origin(getattr(agent, "_memory_write_origin", "assistant_tool"))
+
+    # Restore the primary runtime if the previous turn activated fallback.
+    agent._restore_primary_runtime()
+
+    # Tell auxiliary_client what the live main provider/model are for this turn
+    # after primary restoration has settled the runtime.
     try:
         from agent.auxiliary_client import set_runtime_main
         set_runtime_main(
@@ -101,15 +111,6 @@ def build_turn_context(
         )
     except Exception:
         pass
-
-    # Tag log records on this thread with the session ID for ``hermes logs``.
-    set_session_context(agent.session_id)
-
-    # Bind the skill write-origin ContextVar for this thread.
-    set_current_write_origin(getattr(agent, "_memory_write_origin", "assistant_tool"))
-
-    # Restore the primary runtime if the previous turn activated fallback.
-    agent._restore_primary_runtime()
 
     # Sanitize surrogate characters from user input.
     if isinstance(user_message, str):

--- a/tests/agent/test_auxiliary_main_first.py
+++ b/tests/agent/test_auxiliary_main_first.py
@@ -161,6 +161,37 @@ class TestResolveAutoMainFirst:
         assert mock_resolve.call_args.args[0] == "anthropic"
         assert mock_resolve.call_args.args[1] == "runtime-model"
 
+    def test_resolve_provider_auto_uses_runtime_model_not_stale_global(self):
+        """Auto must not pair the selected runtime provider with a stale global model."""
+        from agent import auxiliary_client as ac
+
+        ac.set_runtime_main(
+            "openai-codex",
+            "claude-opus-4-8",
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_key="stale-token",
+            api_mode="codex_responses",
+        )
+        try:
+            with patch(
+                "agent.auxiliary_client._build_codex_client",
+                return_value=(MagicMock(), "gpt-5.5"),
+            ):
+                _client, model = ac.resolve_provider_client(
+                    "auto",
+                    main_runtime={
+                        "provider": "openai-codex",
+                        "model": "gpt-5.5",
+                        "base_url": "https://chatgpt.com/backend-api/codex",
+                        "api_key": "live-token",
+                        "api_mode": "codex_responses",
+                    },
+                )
+        finally:
+            ac.clear_runtime_main()
+
+        assert model == "gpt-5.5"
+
     def test_runtime_base_url_passed_for_named_api_key_provider(self):
         """Named API-key providers inherit the live session endpoint for aux work."""
         token_plan_url = "https://token-plan-sgp.xiaomimimo.com/v1"

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -171,6 +171,39 @@ def test_persist_user_message_becomes_original():
     assert ctx.messages[-1]["content"] == "api-prefixed"
 
 
+def test_runtime_main_sync_happens_after_restore():
+    agent = _FakeAgent()
+    agent.model = "stale-fallback-model"
+    agent.provider = "openai-codex"
+    agent.base_url = "https://chatgpt.com/backend-api/codex"
+    agent.api_key = "fallback-key"
+    agent.api_mode = "codex_responses"
+
+    def restore_primary():
+        agent.model = "primary-model"
+        agent.provider = "anthropic"
+        agent.base_url = "https://api.anthropic.com"
+        agent.api_key = "primary-key"
+        agent.api_mode = "anthropic_messages"
+
+    agent._restore_primary_runtime = restore_primary
+    calls = []
+    with patch(
+        "agent.auxiliary_client.set_runtime_main",
+        side_effect=lambda *args, **kwargs: calls.append((args, kwargs)),
+    ):
+        _build(agent)
+
+    assert calls == [(
+        ("anthropic", "primary-model"),
+        {
+            "base_url": "https://api.anthropic.com",
+            "api_key": "primary-key",
+            "api_mode": "anthropic_messages",
+        },
+    )]
+
+
 def test_memory_nudge_fires_at_interval():
     agent = _FakeAgent()
     agent._memory_nudge_interval = 1


### PR DESCRIPTION
## Summary
- keep `provider="auto"` from pre-filling a model from `_read_main_model()` before `_resolve_auto(main_runtime=...)` can return the live provider/model pair
- move `set_runtime_main(...)` until after `_restore_primary_runtime()` so auxiliary tasks do not inherit a stale fallback/previous-turn runtime
- add regressions for stale global runtime + restored primary runtime ordering

## Why
A compaction path can pass a fresh `main_runtime` for Codex (`openai-codex` / `gpt-5.5`) while the process-global runtime still carries an older model slug such as `claude-opus-4-8`. The previous `resolve_provider_client("auto")` flow filled `model` from `_read_main_model()` first, then returned `final_model = model or resolved`, pairing a Codex client/base URL with the stale Claude model slug.

That produces provider errors like:

```text
The 'claude-opus-4-8' model is not supported when using Codex with a ChatGPT account.
```

`auto` should let `_resolve_auto(main_runtime=...)` select and return the provider/model pair atomically.

## Test plan
- `python -m pytest tests/agent/test_auxiliary_main_first.py::TestResolveAutoMainFirst::test_resolve_provider_auto_uses_runtime_model_not_stale_global tests/agent/test_turn_context.py::test_runtime_main_sync_happens_after_restore -q -o addopts=` → 2 passed
- `python -m pytest tests/agent/test_auxiliary_main_first.py tests/agent/test_turn_context.py -q -o addopts=` → 24 passed
- `python -m pytest tests/agent/test_auxiliary_client.py tests/agent/test_auxiliary_transport_autodetect.py tests/agent/test_auxiliary_config_bridge.py tests/agent/test_auxiliary_main_first.py tests/agent/test_turn_context.py -q -o addopts=` → 287 passed
- `python -m pytest tests/agent/test_context_compressor.py tests/agent/test_compression_concurrent_fork.py tests/agent/test_compression_logging_session_context.py -q -o addopts=` → 101 passed
- live in-process compressor probe with stale `set_runtime_main("openai-codex", "claude-opus-4-8", ...)` and fresh `main_runtime`/compressor model `gpt-5.5` → `summary_ok True`

## Full suite note
`python -m pytest tests/ -q -o addopts= -x --tb=short` currently stops before this PR's changed areas on `tests/acp/test_approval_isolation.py::TestAcpExecAskGate::test_interactive_env_var_routes_to_callback`. I reproduced the same first-stop failure on current `upstream/main` (`423d24780`) in a clean worktree, so it is not introduced by this branch.
