### PR TITLE
feat(slack): add ignored channel gate

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -951,6 +951,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["allowed_topics"] = platform_cfg["allowed_topics"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
+                if plat == Platform.SLACK and "ignored_channels" in platform_cfg:
+                    bridged["ignored_channels"] = platform_cfg["ignored_channels"]
                 if "mention_patterns" in platform_cfg:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if "exclusive_bot_mentions" in platform_cfg:
@@ -1052,6 +1054,12 @@ def load_gateway_config() -> GatewayConfig:
                     if isinstance(ac, list):
                         ac = ",".join(str(v) for v in ac)
                     os.environ["SLACK_ALLOWED_CHANNELS"] = str(ac)
+                # ignored_channels: blacklist channels where Slack must never respond.
+                ic = slack_cfg.get("ignored_channels")
+                if ic is not None and not os.getenv("SLACK_IGNORED_CHANNELS"):
+                    if isinstance(ic, list):
+                        ic = ",".join(str(v) for v in ic)
+                    os.environ["SLACK_IGNORED_CHANNELS"] = str(ic)
 
             # Bridge top-level require_mention to Telegram when the telegram: section
             # does not already provide one.  Users often write "require_mention: true"

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2488,6 +2488,16 @@ class SlackAdapter(BasePlatformAdapter):
         is_thread_reply = bool(event_thread_ts and event_thread_ts != ts)
 
         if not is_dm and bot_uid:
+            # Check ignored channels first — these are passive/archive-only
+            # channels where the live bot must never respond, even to allowed
+            # users or explicit mentions.
+            ignored_channels = self._slack_ignored_channels()
+            if channel_id in ignored_channels:
+                logger.debug(
+                    "[Slack] Ignoring message in explicitly ignored channel: %s", channel_id
+                )
+                return
+
             # Check allowed channels — if set, only respond in these channels (whitelist)
             allowed_channels = self._slack_allowed_channels()
             if allowed_channels and channel_id not in allowed_channels:
@@ -3793,6 +3803,23 @@ class SlackAdapter(BasePlatformAdapter):
         # branch to return an empty set.  str() here accepts whatever scalar
         # the YAML loader hands us without changing existing string/CSV
         # semantics.
+        s = str(raw).strip() if raw is not None else ""
+        if s:
+            return {part.strip() for part in s.split(",") if part.strip()}
+        return set()
+
+    def _slack_ignored_channels(self) -> set:
+        """Return channel IDs where the live bot must never respond.
+
+        This is a blacklist for passive/archive-only channels. It takes
+        precedence over allowed_channels, free_response_channels, and mention
+        handling. DMs are never filtered here.
+        """
+        raw = self.config.extra.get("ignored_channels")
+        if raw is None:
+            raw = os.getenv("SLACK_IGNORED_CHANNELS", "")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
         s = str(raw).strip() if raw is not None else ""
         if s:
             return {part.strip() for part in s.split(",") if part.strip()}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8207,11 +8207,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Inner handler that runs under the _running_agents sentinel guard."""
         _msg_start_time = time.time()
         _platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
-        _msg_preview = (event.text or "")[:80].replace("\n", " ")
+        _msg_len = len(event.text or "")
         logger.info(
-            "inbound message: platform=%s user=%s chat=%s msg=%r",
+            "inbound message: platform=%s user=%s chat=%s msg_len=%s",
             _platform_name, source.user_name or source.user_id or "unknown",
-            source.chat_id or "unknown", _msg_preview,
+            source.chat_id or "unknown", _msg_len,
         )
 
         # Get or create session

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -117,13 +117,21 @@ def adapter():
 
 @pytest.fixture(autouse=True)
 def _redirect_cache(tmp_path, monkeypatch):
-    """Point document cache to tmp_path so tests don't touch ~/.hermes."""
+    """Point document cache to tmp_path and isolate host Slack config."""
     monkeypatch.setattr(
         "gateway.platforms.base.DOCUMENT_CACHE_DIR", tmp_path / "doc_cache"
     )
     monkeypatch.setattr(
         "gateway.platforms.base.VIDEO_CACHE_DIR", tmp_path / "video_cache"
     )
+    for name in (
+        "SLACK_REQUIRE_MENTION",
+        "SLACK_STRICT_MENTION",
+        "SLACK_FREE_RESPONSE_CHANNELS",
+        "SLACK_ALLOWED_CHANNELS",
+        "SLACK_IGNORED_CHANNELS",
+    ):
+        monkeypatch.delenv(name, raising=False)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -7,6 +7,8 @@ Follows the same pattern as test_whatsapp_group_gating.py.
 import sys
 from unittest.mock import MagicMock
 
+import pytest
+
 from gateway.config import Platform, PlatformConfig
 
 
@@ -55,7 +57,26 @@ CHANNEL_ID = "C0AQWDLHY9M"
 OTHER_CHANNEL_ID = "C9999999999"
 
 
-def _make_adapter(require_mention=None, strict_mention=None, free_response_channels=None, allowed_channels=None):
+@pytest.fixture(autouse=True)
+def _clear_slack_gating_env(monkeypatch):
+    """Keep host Slack config from leaking into these unit tests."""
+    for name in (
+        "SLACK_REQUIRE_MENTION",
+        "SLACK_STRICT_MENTION",
+        "SLACK_FREE_RESPONSE_CHANNELS",
+        "SLACK_ALLOWED_CHANNELS",
+        "SLACK_IGNORED_CHANNELS",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def _make_adapter(
+    require_mention=None,
+    strict_mention=None,
+    free_response_channels=None,
+    allowed_channels=None,
+    ignored_channels=None,
+):
     extra = {}
     if require_mention is not None:
         extra["require_mention"] = require_mention
@@ -65,6 +86,8 @@ def _make_adapter(require_mention=None, strict_mention=None, free_response_chann
         extra["free_response_channels"] = free_response_channels
     if allowed_channels is not None:
         extra["allowed_channels"] = allowed_channels
+    if ignored_channels is not None:
+        extra["ignored_channels"] = ignored_channels
 
     adapter = object.__new__(SlackAdapter)
     adapter.platform = Platform.SLACK
@@ -252,6 +275,11 @@ def _would_process(adapter, *, is_dm=False, channel_id=CHANNEL_ID,
     is_mentioned = bot_uid and f"<@{bot_uid}>" in text
 
     if not is_dm and bot_uid:
+        # ignored_channels check (blacklist — takes precedence over all other gating)
+        ignored = adapter._slack_ignored_channels()
+        if channel_id in ignored:
+            return False
+
         # allowed_channels check (whitelist — must pass before other gating)
         allowed = adapter._slack_allowed_channels()
         if allowed and channel_id not in allowed:
@@ -599,6 +627,49 @@ def test_allowed_channels_env_var_fallback(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Tests: _slack_ignored_channels
+# ---------------------------------------------------------------------------
+
+def test_ignored_channels_default_empty(monkeypatch):
+    monkeypatch.delenv("SLACK_IGNORED_CHANNELS", raising=False)
+    adapter = _make_adapter()
+    assert adapter._slack_ignored_channels() == set()
+
+
+def test_ignored_channels_list():
+    adapter = _make_adapter(ignored_channels=[CHANNEL_ID, OTHER_CHANNEL_ID])
+    result = adapter._slack_ignored_channels()
+    assert CHANNEL_ID in result
+    assert OTHER_CHANNEL_ID in result
+
+
+def test_ignored_channels_csv_string():
+    adapter = _make_adapter(ignored_channels=f"{CHANNEL_ID}, {OTHER_CHANNEL_ID}")
+    result = adapter._slack_ignored_channels()
+    assert CHANNEL_ID in result
+    assert OTHER_CHANNEL_ID in result
+
+
+def test_ignored_channels_empty_string():
+    adapter = _make_adapter(ignored_channels="")
+    assert adapter._slack_ignored_channels() == set()
+
+
+def test_ignored_channels_env_var_fallback(monkeypatch):
+    monkeypatch.setenv("SLACK_IGNORED_CHANNELS", f"{CHANNEL_ID},{OTHER_CHANNEL_ID}")
+    adapter = _make_adapter()  # no config value → falls back to env
+    result = adapter._slack_ignored_channels()
+    assert CHANNEL_ID in result
+    assert OTHER_CHANNEL_ID in result
+
+
+def test_ignored_channels_bare_int():
+    adapter = _make_adapter(ignored_channels=1491973769726791812)
+    result = adapter._slack_ignored_channels()
+    assert result == {"1491973769726791812"}
+
+
+# ---------------------------------------------------------------------------
 # Tests: allowed_channels gating integration
 # ---------------------------------------------------------------------------
 
@@ -639,6 +710,41 @@ def test_allowed_channels_env_var_blocks_channel(monkeypatch):
     adapter = _make_adapter()  # no config value → falls back to env
     assert _would_process(adapter, channel_id=OTHER_CHANNEL_ID, text="hello") is False
     assert _would_process(adapter, channel_id=CHANNEL_ID, mentioned=True) is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: ignored_channels gating integration
+# ---------------------------------------------------------------------------
+
+def test_ignored_channels_blocks_even_when_allowed_and_mentioned():
+    """Blacklist takes precedence over allowed_channels and @mentions."""
+    adapter = _make_adapter(
+        allowed_channels=[CHANNEL_ID],
+        ignored_channels=[CHANNEL_ID],
+    )
+    assert _would_process(adapter, channel_id=CHANNEL_ID, mentioned=True) is False
+
+
+def test_ignored_channels_blocks_free_response_channel():
+    """Blacklist takes precedence over free_response_channels."""
+    adapter = _make_adapter(
+        free_response_channels=[CHANNEL_ID],
+        ignored_channels=[CHANNEL_ID],
+    )
+    assert _would_process(adapter, channel_id=CHANNEL_ID, text="hello") is False
+
+
+def test_ignored_channels_dm_unaffected():
+    """DMs bypass the ignored_channels check entirely."""
+    adapter = _make_adapter(ignored_channels=["DDMCHANNEL"])
+    assert _would_process(adapter, is_dm=True, channel_id="DDMCHANNEL") is True
+
+
+def test_ignored_channels_env_var_blocks_channel(monkeypatch):
+    """SLACK_IGNORED_CHANNELS env var (no config) also gates messages."""
+    monkeypatch.setenv("SLACK_IGNORED_CHANNELS", CHANNEL_ID)
+    adapter = _make_adapter()
+    assert _would_process(adapter, channel_id=CHANNEL_ID, mentioned=True) is False
 
 
 # ---------------------------------------------------------------------------
@@ -687,3 +793,52 @@ def test_config_bridges_slack_allowed_channels_env_takes_precedence(monkeypatch,
     import os as _os
     # env var must not be overwritten by config.yaml
     assert _os.environ["SLACK_ALLOWED_CHANNELS"] == OTHER_CHANNEL_ID
+
+
+# ---------------------------------------------------------------------------
+# Tests: config bridging for ignored_channels
+# ---------------------------------------------------------------------------
+
+def test_config_bridges_slack_ignored_channels(monkeypatch, tmp_path):
+    from gateway.config import load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "slack:\n"
+        "  ignored_channels:\n"
+        f"    - {CHANNEL_ID}\n"
+        f"    - {OTHER_CHANNEL_ID}\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("SLACK_IGNORED_CHANNELS", raising=False)
+
+    config = load_gateway_config()
+
+    import os as _os
+    assert _os.environ["SLACK_IGNORED_CHANNELS"] == f"{CHANNEL_ID},{OTHER_CHANNEL_ID}"
+    slack_extra = config.platforms[Platform.SLACK].extra
+    assert slack_extra.get("ignored_channels") == [CHANNEL_ID, OTHER_CHANNEL_ID]
+
+
+def test_config_bridges_slack_ignored_channels_env_takes_precedence(monkeypatch, tmp_path):
+    """Env var set before load_gateway_config() should not be overwritten."""
+    from gateway.config import load_gateway_config
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "slack:\n"
+        f"  ignored_channels: {CHANNEL_ID}\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("SLACK_IGNORED_CHANNELS", OTHER_CHANNEL_ID)  # already set
+
+    load_gateway_config()
+
+    import os as _os
+    assert _os.environ["SLACK_IGNORED_CHANNELS"] == OTHER_CHANNEL_ID

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -282,6 +282,9 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `SLACK_BOT_TOKEN` | Slack bot token (`xoxb-...`) |
 | `SLACK_APP_TOKEN` | Slack app-level token (`xapp-...`, required for Socket Mode) |
 | `SLACK_ALLOWED_USERS` | Comma-separated Slack user IDs |
+| `SLACK_ALLOWED_CHANNELS` | Comma-separated Slack channel IDs. When set, the bot only responds in these channels (DMs are exempt). Overrides `config.yaml` `slack.allowed_channels`. |
+| `SLACK_IGNORED_CHANNELS` | Comma-separated Slack channel IDs where the bot never responds, even when mentioned. Overrides `config.yaml` `slack.ignored_channels`. |
+| `SLACK_FREE_RESPONSE_CHANNELS` | Comma-separated Slack channel IDs where mention is not required. Overrides `config.yaml` `slack.free_response_channels`. |
 | `SLACK_HOME_CHANNEL` | Default Slack channel for cron delivery |
 | `SLACK_HOME_CHANNEL_NAME` | Display name for the Slack home channel |
 | `GOOGLE_CHAT_PROJECT_ID` | GCP project hosting the Pub/Sub topic (falls back to `GOOGLE_CLOUD_PROJECT`) |

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -421,6 +421,31 @@ Behavior:
 
 See also: [admin/user slash command split](../../reference/slash-commands.md#permissions-and-adminuser-split).
 
+### Channel ignore list (`ignored_channels`)
+
+Use `ignored_channels` for passive/archive-only channels where the bot should never reply. This is a denylist: if a channel is listed here, Slack messages in that channel are silently ignored even when the bot is `@mentioned`, the channel is also in `allowed_channels`, or the channel is listed in `free_response_channels`.
+
+**DMs are exempt** from this filter, so authorized users can still reach the bot directly.
+
+```yaml
+slack:
+  ignored_channels:
+    - "C0123456789"   # #announcements archive
+    - "C0987654321"   # #imports mirror
+```
+
+Or via env var (comma-separated):
+
+```bash
+SLACK_IGNORED_CHANNELS="C0123456789,C0987654321"
+```
+
+Precedence:
+
+- `ignored_channels` has highest priority for Slack channel messages.
+- `allowed_channels` is checked after `ignored_channels`.
+- Mention and free-response rules only run if the channel is not ignored.
+
 ### Unauthorized User Handling
 
 ```yaml


### PR DESCRIPTION
## Summary

- Add Slack `ignored_channels` support via `slack.ignored_channels` and `SLACK_IGNORED_CHANNELS`.
- Check ignored channels before allowlist, free-response, mention, and active-thread gates so passive/archive channels stay silent.
- Avoid logging inbound message previews in gateway logs; log message length instead.
- Document Slack channel allow/free/ignore env vars and the new Slack ignore-list behavior.

## Test plan

- `venv/bin/python -m pytest tests/gateway/test_slack_mention.py -q -o 'addopts='`
- `venv/bin/python -m pytest tests/gateway/test_slack.py tests/gateway/test_slack_mention.py tests/hermes_cli/test_slack_cli.py -q -o 'addopts='`

## Notes

- DMs are not filtered by `ignored_channels`.
- `ignored_channels` intentionally has higher precedence than `allowed_channels` and `free_response_channels` for channel messages.
