### PR TITLE
fix(memory): apply /memory approve against a fresh on-disk store when no live agent

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1407,6 +1407,16 @@ class CLICommandsMixin:
         parts = cmd.strip().split()
         args = parts[1:] if len(parts) > 1 else []
         store = getattr(self.agent, "_memory_store", None) if getattr(self, "agent", None) else None
+        if store is None:
+            # No live agent store (e.g. /memory approve invoked from the Desktop
+            # GUI, or any context without an active agent). Apply against a freshly
+            # loaded on-disk store, mirroring the gateway path
+            # (gateway/slash_commands.py): it persists to the same MEMORY/USER.md
+            # and creates MEMORY.md on the first approved write. Without this the
+            # shared handler returns "memory store unavailable". See #46783.
+            from tools.memory_tool import MemoryStore
+            store = MemoryStore()
+            store.load_from_disk()
         out = handle_pending_subcommand(
             wa.MEMORY, args,
             memory_store=store,

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -107,6 +107,36 @@ def test_memory_gate_on_then_apply(hermes_home):
     assert "approved entry" in store.user_entries[0]
 
 
+def test_cli_memory_approve_without_live_agent_uses_fresh_store(hermes_home, capsys):
+    """#46783: ``/memory approve`` from a context with no live agent (e.g. the
+    Desktop GUI) passed ``memory_store=None`` into the shared handler, which
+    returned "memory store unavailable" and applied nothing. The CLI handler must
+    fall back to a freshly loaded on-disk store, like the gateway path does."""
+    import json
+    from tools.memory_tool import memory_tool, MemoryStore
+    from tools import write_approval as wa
+    from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+    _set_approval("memory", True)
+    staging = MemoryStore(); staging.load_from_disk()
+    r = json.loads(memory_tool("add", "memory", "remember the launch date", store=staging))
+    assert r.get("pending_id"), r
+    assert wa.pending_count("memory") == 1
+
+    # Bare CLI handler with no live agent → store resolves to None pre-fix.
+    handler = CLICommandsMixin.__new__(CLICommandsMixin)
+    handler.agent = None
+    handler._handle_memory_command("/memory approve all")
+
+    out = capsys.readouterr().out
+    assert "memory store unavailable" not in out, out
+    assert "Approved 1" in out, out
+    assert wa.pending_count("memory") == 0
+    # The approved write landed in a freshly loaded on-disk store (MEMORY.md).
+    reloaded = MemoryStore(); reloaded.load_from_disk()
+    assert any("remember the launch date" in e for e in reloaded.memory_entries)
+
+
 # ---------------------------------------------------------------------------
 # Skill gate
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
`/memory approve` / `/memory approve all` from a context without a live agent — e.g. the Hermes Desktop GUI — fails with `memory store unavailable` and applies nothing, even when built-in memory is enabled and pending writes exist.

## Root cause
`hermes_cli/cli_commands_mixin.py::_handle_memory_command` resolves the store as `self.agent._memory_store`, which is `None` when there is no live agent, and passes it straight to the shared `handle_pending_subcommand`. That handler then bails out (`hermes_cli/write_approval_commands.py`):

```python
if memory_store is None:
    return False, "memory store unavailable"
```

The gateway `/memory` handler (`gateway/slash_commands.py`) already sidesteps this by applying against a freshly loaded on-disk store; the CLI/Desktop path did not.

Thanks @Kombuchameister for the precise root-cause analysis in #46783.

## Fix
Fall back to a fresh `MemoryStore()` + `load_from_disk()` when no live store is available, mirroring the gateway path. It persists to the same `MEMORY.md`/`USER.md` and creates `MEMORY.md` on the first approved write.

## Validation
`scripts/run_tests.sh tests/tools/test_write_approval.py` — **26/26 passing (was 25; +1 new test)**. The new test `test_cli_memory_approve_without_live_agent_uses_fresh_store` is red→green: without the fix it fails with exactly `memory store unavailable`; with it the pending write is applied and lands in a freshly reloaded `MEMORY.md`.

Fixes #46783