### PR TITLE
feat(gateway): enable Pulse runtime footer by default

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8963,6 +8963,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
+                    provider=agent_result.get("provider"),
+                    api_calls=agent_result.get("api_calls"),
+                    estimated_cost_usd=agent_result.get("estimated_cost_usd"),
+                    input_tokens=agent_result.get("input_tokens"),
+                    output_tokens=agent_result.get("output_tokens"),
+                    cache_read_tokens=agent_result.get("cache_read_tokens"),
+                    cache_write_tokens=agent_result.get("cache_write_tokens"),
+                    compression_count=agent_result.get("compression_count"),
+                    elapsed_seconds=agent_result.get("elapsed_seconds"),
+                    session_id=agent_result.get("session_id"),
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)
@@ -14917,7 +14927,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _conversation_kwargs["persist_user_message"] = _persist_user_message_override
                 elif observed_group_context:
                     _conversation_kwargs["persist_user_message"] = message
+                _agent_started_at = time.time()
                 result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
+                if isinstance(result, dict):
+                    result["elapsed_seconds"] = time.time() - _agent_started_at
             finally:
                 unregister_gateway_notify(_approval_session_key)
                 # Cancel any pending clarify entries so blocked agent
@@ -14942,14 +14955,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _last_prompt_toks = 0
             _input_toks = 0
             _output_toks = 0
+            _cache_read_toks = 0
+            _cache_write_toks = 0
             _context_length = 0
+            _compression_count = 0
             _agent = agent_holder[0]
             if _agent and hasattr(_agent, "context_compressor"):
                 _last_prompt_toks = getattr(_agent.context_compressor, "last_prompt_tokens", 0)
                 _input_toks = getattr(_agent, "session_prompt_tokens", 0)
                 _output_toks = getattr(_agent, "session_completion_tokens", 0)
+                _cache_read_toks = getattr(_agent, "session_cache_read_tokens", 0)
+                _cache_write_toks = getattr(_agent, "session_cache_write_tokens", 0)
                 _context_length = getattr(_agent.context_compressor, "context_length", 0) or 0
+                _compression_count = getattr(_agent.context_compressor, "compression_count", 0) or 0
             _resolved_model = getattr(_agent, "model", None) if _agent else None
+            _resolved_provider = getattr(_agent, "provider", None) if _agent else result.get("provider")
+            _estimated_cost_usd = getattr(_agent, "session_estimated_cost_usd", None) if _agent else result.get("estimated_cost_usd")
 
             # Sync session_id immediately after run_conversation(). Compression
             # can rotate before a follow-up model call fails; the failure return
@@ -15025,8 +15046,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "last_prompt_tokens": _last_prompt_toks,
                     "input_tokens": _input_toks,
                     "output_tokens": _output_toks,
+                    "cache_read_tokens": _cache_read_toks,
+                    "cache_write_tokens": _cache_write_toks,
                     "model": _resolved_model,
                     "context_length": _context_length,
+                    "compression_count": _compression_count,
+                    "provider": _resolved_provider,
+                    "estimated_cost_usd": _estimated_cost_usd,
+                    "elapsed_seconds": result.get("elapsed_seconds"),
                 }
             
             # Scan tool results for MEDIA:<path> tags that need to be delivered
@@ -15124,8 +15151,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "last_prompt_tokens": _last_prompt_toks,
                 "input_tokens": _input_toks,
                 "output_tokens": _output_toks,
+                "cache_read_tokens": _cache_read_toks,
+                "cache_write_tokens": _cache_write_toks,
                 "model": _resolved_model,
+                "provider": _resolved_provider,
+                "estimated_cost_usd": _estimated_cost_usd,
                 "context_length": _context_length,
+                "compression_count": _compression_count,
+                "elapsed_seconds": result.get("elapsed_seconds"),
                 "session_id": effective_session_id,
                 "response_previewed": result.get("response_previewed", False),
                 "response_transformed": result.get("response_transformed", False),

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -1,15 +1,17 @@
 """Gateway runtime-metadata footer.
 
-Renders a compact footer showing runtime state (model, context %, cwd) and
-appends it to the FINAL message of an agent turn when enabled.  Off by default
-to keep replies minimal.
+Renders a compact footer showing runtime state (model/provider, context, tool
+calls, approximate cost, elapsed time, cwd) and appends it to the FINAL message
+of an agent turn when enabled.  On by default so gateway users get lightweight
+runtime provenance unless they opt out.
 
 Config (``~/.hermes/config.yaml``)::
 
     display:
       runtime_footer:
-        enabled: true                       # off by default
-        fields: [model, context_pct, cwd]   # order shown; drop any to hide
+        enabled: true
+        style: khal_pulse_dev
+        fields: [model, provider, context_bar, compressions, api_calls, cost, elapsed, cwd]
 
 Per-platform overrides live under ``display.platforms.<platform>.runtime_footer``.
 Users can toggle the global setting with ``/footer on|off`` from both the CLI
@@ -33,6 +35,8 @@ _KHAL_PULSE_FIELDS: tuple[str, ...] = (
     "model", "provider", "context_bar", "compressions",
     "api_calls", "cost", "elapsed", "cwd",
 )
+_DEFAULT_ENABLED = True
+_DEFAULT_STYLE = "khal_pulse_dev"
 _SEP = " · "
 _ONE_MILLION = 1_000_000.0
 _OPENAI_CODEX_SHADOW_SUBSIDY_DIVISOR = 20.0
@@ -209,7 +213,11 @@ def resolve_footer_config(
         2. ``display.runtime_footer``
         3. ``display.platforms.<platform_key>.runtime_footer``
     """
-    resolved = {"enabled": False, "fields": list(_DEFAULT_FIELDS), "style": "plain"}
+    resolved = {
+        "enabled": _DEFAULT_ENABLED,
+        "fields": list(_KHAL_PULSE_FIELDS),
+        "style": _DEFAULT_STYLE,
+    }
     cfg = (user_config or {}).get("display") or {}
 
     global_cfg = cfg.get("runtime_footer")

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -29,7 +29,20 @@ import os
 from typing import Any, Iterable, Optional
 
 _DEFAULT_FIELDS: tuple[str, ...] = ("model", "context_pct", "cwd")
+_KHAL_PULSE_FIELDS: tuple[str, ...] = (
+    "model", "provider", "context_bar", "compressions",
+    "api_calls", "cost", "elapsed", "cwd",
+)
 _SEP = " · "
+_ONE_MILLION = 1_000_000.0
+_OPENAI_CODEX_SHADOW_SUBSIDY_DIVISOR = 20.0
+# Footer-only shadow baseline for GPT-5.5 over the subscription Codex lane.
+# It intentionally does not mutate session billing, which remains
+# subscription-included.  The rendered "~" marks this as approximate.
+_GPT55_SHADOW_INPUT_PER_M = 1.25
+_GPT55_SHADOW_OUTPUT_PER_M = 10.00
+_GPT55_SHADOW_CACHE_READ_PER_M = 0.125
+_GPT55_SHADOW_CACHE_WRITE_PER_M = 1.25
 
 
 def _home_relative_cwd(cwd: str) -> str:
@@ -53,6 +66,138 @@ def _model_short(model: Optional[str]) -> str:
     return model.rsplit("/", 1)[-1]
 
 
+def _context_pct(context_tokens: int, context_length: Optional[int]) -> Optional[int]:
+    if context_length and context_length > 0 and context_tokens >= 0:
+        return max(0, min(100, round((context_tokens / context_length) * 100)))
+    return None
+
+
+def _format_k_tokens(value: int | float | None) -> str:
+    try:
+        n = int(value or 0)
+    except Exception:
+        n = 0
+    if n >= 1000:
+        return f"{round(n / 1000):.0f}K"
+    return str(max(0, n))
+
+
+def _context_bar(pct: int) -> str:
+    filled = max(0, min(10, round(pct / 10)))
+    return "█" * filled + "░" * (10 - filled)
+
+
+def _format_cost(value: float | int | None, *, approximate: bool = False) -> str:
+    if value is None:
+        return ""
+    try:
+        cost = float(value)
+    except Exception:
+        return ""
+    if cost < 0:
+        return ""
+    prefix = "~" if approximate else ""
+    if cost < 0.001 and cost > 0:
+        return f"{prefix}${cost:.5f}"
+    return f"{prefix}${cost:.3f}"
+
+
+def _coerce_nonnegative_float(value: float | int | None) -> float:
+    try:
+        return max(0.0, float(value or 0))
+    except Exception:
+        return 0.0
+
+
+def _openai_codex_shadow_subsidized_cost(
+    *,
+    model: Optional[str],
+    provider: Optional[str],
+    context_tokens: int,
+    input_tokens: Optional[int] = None,
+    output_tokens: Optional[int] = None,
+    cache_read_tokens: Optional[int] = None,
+    cache_write_tokens: Optional[int] = None,
+) -> Optional[float]:
+    """Approximate GPT-5.5 subscription-lane cost as retail-equivalent / 20.
+
+    This is display-only.  The OpenAI Codex route remains billing-mode
+    ``subscription_included`` in the session ledger; the footer shows this as
+    an approximate operational cost with ``~``.
+    """
+    if (provider or "").strip().lower() != "openai-codex":
+        return None
+    if _model_short(model).lower() != "gpt-5.5":
+        return None
+
+    # Prefer an explicit usage bucket when the gateway provides one; otherwise
+    # fall back to the context-token count shown in the same footer.  That makes
+    # the estimate useful even on older runtime paths that only expose
+    # last_prompt_tokens.
+    prompt_basis = _coerce_nonnegative_float(input_tokens)
+    if prompt_basis <= 0:
+        prompt_basis = _coerce_nonnegative_float(context_tokens)
+    output_basis = _coerce_nonnegative_float(output_tokens)
+    cache_read_basis = _coerce_nonnegative_float(cache_read_tokens)
+    cache_write_basis = _coerce_nonnegative_float(cache_write_tokens)
+    if prompt_basis <= 0 and output_basis <= 0 and cache_read_basis <= 0 and cache_write_basis <= 0:
+        return None
+
+    # When prompt_basis includes cached input, subtract cache buckets so cached
+    # tokens get the cheaper cached-input rate instead of full input rate.
+    fresh_input = max(0.0, prompt_basis - cache_read_basis - cache_write_basis)
+    retail = (
+        fresh_input * _GPT55_SHADOW_INPUT_PER_M
+        + output_basis * _GPT55_SHADOW_OUTPUT_PER_M
+        + cache_read_basis * _GPT55_SHADOW_CACHE_READ_PER_M
+        + cache_write_basis * _GPT55_SHADOW_CACHE_WRITE_PER_M
+    ) / _ONE_MILLION
+    return retail / _OPENAI_CODEX_SHADOW_SUBSIDY_DIVISOR
+
+
+def _format_display_cost(
+    *,
+    model: Optional[str],
+    provider: Optional[str],
+    estimated_cost_usd: Optional[float],
+    context_tokens: int,
+    input_tokens: Optional[int],
+    output_tokens: Optional[int],
+    cache_read_tokens: Optional[int],
+    cache_write_tokens: Optional[int],
+) -> str:
+    if estimated_cost_usd and estimated_cost_usd > 0:
+        return _format_cost(estimated_cost_usd)
+    shadow = _openai_codex_shadow_subsidized_cost(
+        model=model,
+        provider=provider,
+        context_tokens=context_tokens,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_read_tokens=cache_read_tokens,
+        cache_write_tokens=cache_write_tokens,
+    )
+    if shadow is not None:
+        return _format_cost(shadow, approximate=True)
+    return _format_cost(estimated_cost_usd)
+
+
+def _format_elapsed(seconds: float | int | None) -> str:
+    if seconds is None:
+        return ""
+    try:
+        s = max(0, float(seconds))
+    except Exception:
+        return ""
+    if s < 60:
+        return f"{round(s):.0f}s"
+    m, sec = divmod(round(s), 60)
+    if m < 60:
+        return f"{m}m{sec:02d}s"
+    h, m = divmod(m, 60)
+    return f"{h}h{m:02d}m"
+
+
 def resolve_footer_config(
     user_config: dict[str, Any] | None,
     platform_key: str | None = None,
@@ -64,7 +209,7 @@ def resolve_footer_config(
         2. ``display.runtime_footer``
         3. ``display.platforms.<platform_key>.runtime_footer``
     """
-    resolved = {"enabled": False, "fields": list(_DEFAULT_FIELDS)}
+    resolved = {"enabled": False, "fields": list(_DEFAULT_FIELDS), "style": "plain"}
     cfg = (user_config or {}).get("display") or {}
 
     global_cfg = cfg.get("runtime_footer")
@@ -73,6 +218,8 @@ def resolve_footer_config(
             resolved["enabled"] = bool(global_cfg.get("enabled"))
         if isinstance(global_cfg.get("fields"), list) and global_cfg["fields"]:
             resolved["fields"] = [str(f) for f in global_cfg["fields"]]
+        if global_cfg.get("style"):
+            resolved["style"] = str(global_cfg.get("style"))
 
     if platform_key:
         platforms = cfg.get("platforms") or {}
@@ -84,6 +231,8 @@ def resolve_footer_config(
                     resolved["enabled"] = bool(plat_footer.get("enabled"))
                 if isinstance(plat_footer.get("fields"), list) and plat_footer["fields"]:
                     resolved["fields"] = [str(f) for f in plat_footer["fields"]]
+                if plat_footer.get("style"):
+                    resolved["style"] = str(plat_footer.get("style"))
 
     return resolved
 
@@ -95,12 +244,38 @@ def format_runtime_footer(
     context_length: Optional[int],
     cwd: Optional[str] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
+    style: str = "plain",
+    provider: Optional[str] = None,
+    api_calls: Optional[int] = None,
+    estimated_cost_usd: Optional[float] = None,
+    input_tokens: Optional[int] = None,
+    output_tokens: Optional[int] = None,
+    cache_read_tokens: Optional[int] = None,
+    cache_write_tokens: Optional[int] = None,
+    compression_count: Optional[int] = None,
+    elapsed_seconds: Optional[float] = None,
+    session_id: Optional[str] = None,
 ) -> str:
-    """Render the footer line, or return "" if no fields have data.
+    """Render the footer line, or return "" if no fields have data."""
+    if style == "khal_pulse_dev":
+        return _format_khal_pulse_dev(
+            model=model,
+            provider=provider,
+            context_tokens=context_tokens,
+            context_length=context_length,
+            cwd=cwd,
+            fields=fields,
+            api_calls=api_calls,
+            estimated_cost_usd=estimated_cost_usd,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_tokens=cache_read_tokens,
+            cache_write_tokens=cache_write_tokens,
+            compression_count=compression_count,
+            elapsed_seconds=elapsed_seconds,
+            session_id=session_id,
+        )
 
-    Fields are skipped silently when their underlying data is missing — a
-    partially-populated footer is better than a line with ``?%`` or empty slots.
-    """
     parts: list[str] = []
     for field in fields:
         if field == "model":
@@ -108,8 +283,8 @@ def format_runtime_footer(
             if m:
                 parts.append(m)
         elif field == "context_pct":
-            if context_length and context_length > 0 and context_tokens >= 0:
-                pct = max(0, min(100, round((context_tokens / context_length) * 100)))
+            pct = _context_pct(context_tokens, context_length)
+            if pct is not None:
                 parts.append(f"{pct}%")
         elif field == "cwd":
             rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
@@ -122,6 +297,77 @@ def format_runtime_footer(
     return _SEP.join(parts)
 
 
+def _format_khal_pulse_dev(
+    *,
+    model: Optional[str],
+    provider: Optional[str],
+    context_tokens: int,
+    context_length: Optional[int],
+    cwd: Optional[str],
+    fields: Iterable[str],
+    api_calls: Optional[int],
+    estimated_cost_usd: Optional[float],
+    input_tokens: Optional[int],
+    output_tokens: Optional[int],
+    cache_read_tokens: Optional[int],
+    cache_write_tokens: Optional[int],
+    compression_count: Optional[int],
+    elapsed_seconds: Optional[float],
+    session_id: Optional[str],
+) -> str:
+    fields = tuple(fields or _KHAL_PULSE_FIELDS)
+    line1: list[str] = []
+    line2: list[str] = []
+    for field in fields:
+        if field == "model":
+            m = _model_short(model)
+            if m:
+                line1.append(f"⚕ {m}")
+        elif field == "provider" and provider:
+            line1.append(f"🧭 {provider}")
+        elif field in {"context_bar", "context"}:
+            pct = _context_pct(context_tokens, context_length)
+            if pct is not None:
+                line1.append(f"🧠{_format_k_tokens(context_tokens)}/{_format_k_tokens(context_length)} {_context_bar(pct)} {pct}%")
+        elif field in {"compressions", "compression_count"}:
+            try:
+                n = int(compression_count or 0)
+            except Exception:
+                n = 0
+            line1.append(f"🗜{n}")
+        elif field in {"api_calls", "calls"} and api_calls is not None:
+            try:
+                line2.append(f"🔁{int(api_calls)}")
+            except Exception:
+                pass
+        elif field == "cost":
+            cost = _format_display_cost(
+                model=model,
+                provider=provider,
+                estimated_cost_usd=estimated_cost_usd,
+                context_tokens=context_tokens,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cache_read_tokens=cache_read_tokens,
+                cache_write_tokens=cache_write_tokens,
+            )
+            if cost:
+                line2.append(f"💸{cost}")
+        elif field in {"elapsed", "elapsed_seconds"}:
+            elapsed = _format_elapsed(elapsed_seconds)
+            if elapsed:
+                line2.append(f"✓{elapsed}")
+        elif field == "cwd":
+            rel = _home_relative_cwd(cwd or os.environ.get("TERMINAL_CWD", ""))
+            if rel:
+                line2.append(f"📁{rel}")
+        elif field == "session_id" and session_id:
+            line2.append(f"🧾{session_id}")
+    if line1 and line2:
+        return _SEP.join(line1) + "\n" + _SEP.join(line2)
+    return _SEP.join(line1 or line2)
+
+
 def build_footer_line(
     *,
     user_config: dict[str, Any] | None,
@@ -130,13 +376,18 @@ def build_footer_line(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    provider: Optional[str] = None,
+    api_calls: Optional[int] = None,
+    estimated_cost_usd: Optional[float] = None,
+    input_tokens: Optional[int] = None,
+    output_tokens: Optional[int] = None,
+    cache_read_tokens: Optional[int] = None,
+    cache_write_tokens: Optional[int] = None,
+    compression_count: Optional[int] = None,
+    elapsed_seconds: Optional[float] = None,
+    session_id: Optional[str] = None,
 ) -> str:
-    """Top-level entry point used by gateway/run.py.
-
-    Returns the footer text (empty string when disabled or no data).  Callers
-    append this to the final response themselves, preserving a single blank
-    line of separation.
-    """
+    """Top-level entry point used by gateway/run.py."""
     cfg = resolve_footer_config(user_config, platform_key)
     if not cfg.get("enabled"):
         return ""
@@ -146,4 +397,15 @@ def build_footer_line(
         context_length=context_length,
         cwd=cwd,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
+        style=cfg.get("style") or "plain",
+        provider=provider,
+        api_calls=api_calls,
+        estimated_cost_usd=estimated_cost_usd,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_read_tokens=cache_read_tokens,
+        cache_write_tokens=cache_write_tokens,
+        compression_count=compression_count,
+        elapsed_seconds=elapsed_seconds,
+        session_id=session_id,
     )

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1999,8 +1999,10 @@ class CLICommandsMixin:
 
         cfg = load_config() or {}
         footer_cfg = ((cfg.get("display") or {}).get("runtime_footer") or {})
-        current = bool(footer_cfg.get("enabled", False))
-        fields = footer_cfg.get("fields") or ["model", "context_pct", "cwd"]
+        current = bool(footer_cfg.get("enabled", True))
+        fields = footer_cfg.get("fields") or [
+            "model", "provider", "context_bar", "compressions", "api_calls", "cost", "elapsed", "cwd"
+        ]
 
         if arg in {"status", "?"}:
             state = "ON" if current else "OFF"

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1508,13 +1508,23 @@ DEFAULT_CONFIG = {
             "telegram": {"streaming": True},
             "discord": {"streaming": False},
         },
-        # Gateway runtime-metadata footer appended to the FINAL message of a turn
-        # (disabled by default to keep replies minimal). When enabled, renders
-        # e.g. `model · 68% · ~/projects/hermes`. Per-platform overrides go under
+        # Gateway runtime-metadata footer appended to the FINAL message of a turn.
+        # Enabled by default to make runtime provenance visible on messaging
+        # surfaces. Per-platform overrides go under
         # display.platforms.<platform>.runtime_footer.
         "runtime_footer": {
-            "enabled": False,
-            "fields": ["model", "context_pct", "cwd"],  # Order shown; drop any to hide
+            "enabled": True,
+            "style": "khal_pulse_dev",
+            "fields": [
+                "model",
+                "provider",
+                "context_bar",
+                "compressions",
+                "api_calls",
+                "cost",
+                "elapsed",
+                "cwd",
+            ],  # Order shown; drop any to hide
         },
         "copy_shortcut": "auto",  # "auto" (platform default) | "ctrl_c" | "ctrl_shift_c" | "disabled"
     },

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -195,16 +195,20 @@ def test_format_footer_openai_codex_gpt55_shadow_cost_is_subsidized_and_approxim
 # resolve_footer_config
 # ---------------------------------------------------------------------------
 
-def test_resolve_defaults_off_empty_config():
+def test_resolve_defaults_to_khal_pulse_empty_config():
     cfg = resolve_footer_config({}, "telegram")
-    assert cfg == {"enabled": False, "fields": ["model", "context_pct", "cwd"], "style": "plain"}
+    assert cfg == {
+        "enabled": True,
+        "fields": ["model", "provider", "context_bar", "compressions", "api_calls", "cost", "elapsed", "cwd"],
+        "style": "khal_pulse_dev",
+    }
 
 
 def test_resolve_global_enable():
     user = {"display": {"runtime_footer": {"enabled": True}}}
     cfg = resolve_footer_config(user, "telegram")
     assert cfg["enabled"] is True
-    assert cfg["fields"] == ["model", "context_pct", "cwd"]
+    assert cfg["fields"] == ["model", "provider", "context_bar", "compressions", "api_calls", "cost", "elapsed", "cwd"]
 
 
 def test_resolve_platform_override_wins():
@@ -233,17 +237,18 @@ def test_resolve_platform_can_add_fields_only():
     }
     tg = resolve_footer_config(user, "telegram")
     assert tg["enabled"] is True
-    assert tg["fields"] == ["model", "context_pct", "cwd"]
+    assert tg["fields"] == ["model", "provider", "context_bar", "compressions", "api_calls", "cost", "elapsed", "cwd"]
     dc = resolve_footer_config(user, "discord")
     assert dc["enabled"] is True
     assert dc["fields"] == ["context_pct"]
 
 
 def test_resolve_ignores_malformed_config():
-    # Non-dict runtime_footer shouldn't crash
+    # Non-dict runtime_footer shouldn't crash or disable the default.
     user = {"display": {"runtime_footer": "on"}}
     cfg = resolve_footer_config(user, "telegram")
-    assert cfg["enabled"] is False
+    assert cfg["enabled"] is True
+    assert cfg["style"] == "khal_pulse_dev"
 
 
 # ---------------------------------------------------------------------------
@@ -252,7 +257,7 @@ def test_resolve_ignores_malformed_config():
 
 def test_build_footer_empty_when_disabled():
     out = build_footer_line(
-        user_config={},
+        user_config={"display": {"runtime_footer": {"enabled": False}}},
         platform_key="telegram",
         model="openai/gpt-5.4",
         context_tokens=10, context_length=100,
@@ -292,10 +297,10 @@ def test_build_footer_per_platform_off_suppresses():
     assert out == ""
 
 
-def test_build_footer_no_data_returns_empty_even_when_enabled():
-    # Enabled, but context_length is None AND cwd empty AND model empty ⇒ no fields
+def test_build_footer_no_data_returns_empty_for_plain_fields():
+    # Plain footer with no model/context/cwd data still suppresses the line.
     out = build_footer_line(
-        user_config={"display": {"runtime_footer": {"enabled": True}}},
+        user_config={"display": {"runtime_footer": {"enabled": True, "style": "plain"}}},
         platform_key="telegram",
         model="",
         context_tokens=0, context_length=None,

--- a/tests/gateway/test_runtime_footer.py
+++ b/tests/gateway/test_runtime_footer.py
@@ -147,13 +147,57 @@ def test_format_footer_unknown_field_silently_ignored():
     assert out == "gpt-5.4 · 50%"
 
 
+def test_format_footer_khal_pulse_developer_two_line_receipt():
+    out = format_runtime_footer(
+        model="openai/gpt-5.5",
+        provider="openai-codex",
+        context_tokens=185_000,
+        context_length=272_000,
+        compression_count=2,
+        api_calls=23,
+        estimated_cost_usd=0.0123,
+        elapsed_seconds=23,
+        cwd="/home/genie/workspace/khal",
+        fields=("model", "provider", "context_bar", "compressions", "api_calls", "cost", "elapsed", "cwd"),
+        style="khal_pulse_dev",
+    )
+    assert out == (
+        "⚕ gpt-5.5 · 🧭 openai-codex · 🧠185K/272K ███████░░░ 68% · 🗜2\n"
+        "🔁23 · 💸$0.012 · ✓23s · 📁~/workspace/khal"
+    )
+
+
+def test_format_footer_openai_codex_gpt55_shadow_cost_is_subsidized_and_approximate():
+    out = format_runtime_footer(
+        model="openai/gpt-5.5",
+        provider="openai-codex",
+        context_tokens=185_000,
+        context_length=272_000,
+        input_tokens=185_000,
+        output_tokens=0,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+        compression_count=2,
+        api_calls=23,
+        estimated_cost_usd=0.0,
+        elapsed_seconds=23,
+        cwd="/home/genie/workspace/khal",
+        fields=("model", "provider", "context_bar", "compressions", "api_calls", "cost", "elapsed", "cwd"),
+        style="khal_pulse_dev",
+    )
+    assert out == (
+        "⚕ gpt-5.5 · 🧭 openai-codex · 🧠185K/272K ███████░░░ 68% · 🗜2\n"
+        "🔁23 · 💸~$0.012 · ✓23s · 📁~/workspace/khal"
+    )
+
+
 # ---------------------------------------------------------------------------
 # resolve_footer_config
 # ---------------------------------------------------------------------------
 
 def test_resolve_defaults_off_empty_config():
     cfg = resolve_footer_config({}, "telegram")
-    assert cfg == {"enabled": False, "fields": ["model", "context_pct", "cwd"]}
+    assert cfg == {"enabled": False, "fields": ["model", "context_pct", "cwd"], "style": "plain"}
 
 
 def test_resolve_global_enable():

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1310,8 +1310,9 @@ display:
   timestamps: false       # When true, prefixes user and assistant labels with [HH:MM] timestamps in the CLI / TUI transcript
   tool_preview_length: 0  # Max chars for tool call previews (0 = no limit, show full paths/commands)
   runtime_footer:         # Gateway: append a runtime-context footer to final replies
-    enabled: false
-    fields: ["model", "context_pct", "cwd"]
+    enabled: true
+    style: khal_pulse_dev
+    fields: ["model", "provider", "context_bar", "compressions", "api_calls", "cost", "elapsed", "cwd"]
   file_mutation_verifier: true    # Append an advisory footer when write_file/patch calls failed this turn
   credits_notices: true   # Nous credits status-bar notices (usage bands, grant-spent, depleted). false = silence them; /usage still works
   language: en            # UI language for static messages (approval prompts, some gateway replies). en | zh | zh-hant | ja | de | es | fr | tr | uk | af | ko | it | ga | pt | ru | hu
@@ -1358,21 +1359,23 @@ Tool progress requires a gateway adapter that can display progress updates safel
 
 ### Runtime-metadata footer (gateway only)
 
-When `display.runtime_footer.enabled: true`, Hermes appends a small runtime-context footer to the **final** message of each gateway turn. The current footer can show the model, context-window percentage, and current working directory. Off by default; opt in per-gateway if your team wants every reply to include this provenance.
+When `display.runtime_footer.enabled: true` (the default), Hermes appends a compact KHAL Pulse runtime-context footer to the **final** message of each gateway turn. The footer can show the model, provider, context-window bar, compression count, API-call count, estimated cost, elapsed time, and current working directory. Set `enabled: false` globally or under `display.platforms.<platform>.runtime_footer` to opt out.
 
 ```yaml
 display:
   runtime_footer:
     enabled: true
-    fields: ["model", "context_pct", "cwd"]   # supported fields: model, context_pct, cwd
+    style: khal_pulse_dev
+    fields: ["model", "provider", "context_bar", "compressions", "api_calls", "cost", "elapsed", "cwd"]
 ```
 
 The `/footer` slash command toggles this at runtime in any session.
 
 Example footer appended to a Telegram/Discord/Slack reply:
 
-```
-— claude-opus-4.7 · 12 tool calls · 2m 14s · $0.042
+```text
+⚕ gpt-5.5 · 🧭 openai-codex · 🧠185K/272K ███████░░░ 68% · 🗜2
+🔁23 · 💸~$0.012 · ✓23s · 📁~/workspace/khal
 ```
 
 Only the **final** message of a turn gets the footer; interim updates stay clean.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/configuration.md
@@ -1131,8 +1131,9 @@ display:
   timestamps: false       # 为 true 时，在 CLI/TUI 记录中为用户和 assistant 标签添加 [HH:MM] 时间戳前缀
   tool_preview_length: 0  # 工具调用预览的最大字符数（0 = 无限制，显示完整路径/命令）
   runtime_footer:         # Gateway：在最终回复中附加运行时上下文页脚
-    enabled: false
-    fields: ["model", "context_pct", "cwd"]
+    enabled: true
+    style: khal_pulse_dev
+    fields: ["model", "provider", "context_bar", "compressions", "api_calls", "cost", "elapsed", "cwd"]
   file_mutation_verifier: true    # 当本轮 write_file/patch 调用失败时附加建议性页脚
   language: en            # 静态消息的 UI 语言（审批提示、部分 gateway 回复）。en | zh | zh-hant | ja | de | es | fr | tr | uk | af | ko | it | ga | pt | ru | hu
 ```
@@ -1176,13 +1177,14 @@ display:
 
 ### 运行时元数据页脚（仅限 gateway）
 
-当 `display.runtime_footer.enabled: true` 时，Hermes 在每个 gateway 轮次的**最终**消息中附加一个小型运行时上下文页脚。目前页脚可显示模型、上下文窗口百分比和当前工作目录。默认关闭；如果您的团队希望每个回复都包含这些来源信息，请按 gateway 选择加入。
+当 `display.runtime_footer.enabled: true`（默认值）时，Hermes 会在每个 gateway 轮次的**最终**消息中附加一个紧凑的 KHAL Pulse 运行时上下文页脚。页脚可显示模型、provider、上下文窗口条、压缩次数、API 调用次数、估算成本、耗时和当前工作目录。可在全局或 `display.platforms.<platform>.runtime_footer` 下设置 `enabled: false` 来关闭。
 
 ```yaml
 display:
   runtime_footer:
     enabled: true
-    fields: ["model", "context_pct", "cwd"]   # 支持字段：model、context_pct、cwd
+    style: khal_pulse_dev
+    fields: ["model", "provider", "context_bar", "compressions", "api_calls", "cost", "elapsed", "cwd"]
 ```
 
 `/footer` 斜杠命令在任何会话中运行时切换此功能。


### PR DESCRIPTION
## Summary
- enable the gateway runtime footer by default with the richer KHAL Pulse layout
- make older configs without `display.runtime_footer` resolve to the Pulse default
- keep explicit `enabled: false` platform/global overrides respected
- document the new default and example footer, including approximate subsidized GPT-5.5 Codex cost display

## Validation
- `python -m pytest tests/gateway/test_runtime_footer.py -q`
- `python -m pytest tests/gateway/test_runtime_footer.py tests/gateway/test_per_platform_streaming_defaults.py tests/cli/test_fast_command.py -q`
- smoke-rendered empty-config footer:

```text
⚕ gpt-5.5 · 🧭 openai-codex · 🧠185K/272K ███████░░░ 68% · 🗜2
🔁23 · 💸~$0.012 · ✓23s · 📁~/workspace/khal
```
