### PR TITLE
fix(telegram): convert dash list markers to bullets before MarkdownV2 escape

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -5000,15 +5000,20 @@ class TelegramAdapter(BasePlatformAdapter):
             flags=re.MULTILINE,
         )
 
-        # 10) Escape remaining special characters in plain text
+        # 10) Convert markdown list markers (- item) to bullet characters
+        #     (• item) so they are not broken by MarkdownV2 escaping.
+        #     Only matches dashes at line start (with optional indentation).
+        text = re.sub(r'^([ \t]*)- ', r'\1• ', text, flags=re.MULTILINE)
+
+        # 11) Escape remaining special characters in plain text
         text = _escape_mdv2(text)
 
-        # 11) Restore placeholders in reverse insertion order so that
+        # 12) Restore placeholders in reverse insertion order so that
         #    nested references (a placeholder inside another) resolve correctly.
         for key in reversed(list(placeholders.keys())):
             text = text.replace(key, placeholders[key])
 
-        # 12) Safety net: escape unescaped ( ) { } that slipped through
+        # 13) Safety net: escape unescaped ( ) { } that slipped through
         #     placeholder processing.  Split the text into code/non-code
         #     segments so we never touch content inside ``` or ` spans.
         _code_split = re.split(r'(```[\s\S]*?```|`[^`]+`)', text)

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -340,6 +340,47 @@ class TestItalicNewlineBug:
 
 
 # =========================================================================
+# format_message - dash list markers → bullet conversion
+# =========================================================================
+
+
+class TestDashListMarkerConversion:
+    """Dash list markers (- item) must be converted to bullet (• item)
+    so MarkdownV2 escaping does not produce \\- artifacts."""
+
+    def test_simple_dash_list(self, adapter):
+        text = "- First item\n- Second item\n- Third item"
+        result = adapter.format_message(text)
+        assert "\\-" not in result
+        assert "First item" in result
+        assert "Second item" in result
+        assert "Third item" in result
+
+    def test_indented_dash_list(self, adapter):
+        text = "  - Nested item\n    - Deeper item"
+        result = adapter.format_message(text)
+        assert "\\-" not in result
+        assert "Nested item" in result
+        assert "Deeper item" in result
+
+    def test_dash_in_middle_of_text_not_converted(self, adapter):
+        """A dash inside a word or sentence should NOT become a bullet."""
+        text = "This is a well-known fact"
+        result = adapter.format_message(text)
+        assert "well-known" in result or "well\\-known" in result
+        assert "•" not in result
+
+    def test_dash_at_line_start_with_mixed_content(self, adapter):
+        text = "Intro paragraph\n- List item 1\n- List item 2\nOutro paragraph"
+        result = adapter.format_message(text)
+        assert "\\-" not in result
+        assert "List item 1" in result
+        assert "List item 2" in result
+        assert "Intro paragraph" in result
+        assert "Outro paragraph" in result
+
+
+# =========================================================================
 # format_message - strikethrough
 # =========================================================================
 


### PR DESCRIPTION
## What does this PR do?

Converts markdown dash list markers (`- item`) to bullet characters (`• item`) before applying MarkdownV2 escaping, so bullet lists render correctly on Telegram instead of showing `\-` artifacts.

## Related Issue

Fixes #6388

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/telegram.py`: Add step 10 to convert line-start dash markers (`- `) to bullets (`• `) before `_escape_mdv2()`, renumber subsequent steps
- `tests/gateway/test_telegram_format.py`: Add `TestDashListMarkerConversion` with 4 tests (simple list, indented list, mid-text dash, mixed content)

## How to Test

1. Run `pytest tests/gateway/test_telegram_format.py -q` — all 105 tests pass
2. On Telegram, send a prompt that produces a markdown bullet list (e.g., "list 3 fruits")
3. Verify lists display with bullets, not `\-` prefixed lines

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `gateway/platforms/telegram.py` `format_message()` (callers: send_message, gateway dispatch)
- Blast radius: LOW — single insertion point before existing escape step, no control flow change
- Related patterns: Two prior PRs (#6402, #42883) attempted the same fix but were closed without merge. This PR follows #6402's proven approach (regex substitution before `_escape_mdv2`) with comprehensive tests.
