### PR TITLE
fix(background-review): verify skill notification loadability (#46897)

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -22,7 +22,8 @@ import contextlib
 import json
 import logging
 import os
-from typing import Any, Dict, List, Optional
+import re
+from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -234,6 +235,77 @@ _COMBINED_REVIEW_PROMPT = (
 
 
 
+# Regex for the canonical "Skill '<name>' created./updated." message shape
+# produced by tools/skill_manager_tool._create_skill and _edit_skill.  The
+# captured group is the skill name; if this regex doesn't match, the
+# message is treated as a non-skill action and the loadability probe is
+# skipped.  The validator in tools/skill_manager_tool restricts names to
+# [a-zA-Z0-9_-]+, so the captured group is always URL/filename-safe.
+_SKILL_ACTION_PATTERN = re.compile(r"Skill '([^']+)' (?:created|updated)\.")
+
+
+def _session_skill_search_roots() -> Tuple[Any, List[Any]]:
+    """Return ``(local_skills_dir, external_dirs)`` for the LIVE session.
+
+    These are the directory roots the live (parent) session's
+    ``tools.skills_tool`` searches when resolving ``skill_view`` /
+    ``skills_list``.  ``SKILLS_DIR`` is bound at module import in the
+    parent process from ``get_hermes_home()`` (env-driven), so it
+    reflects the *parent's* session root, not the review fork's.
+
+    Returns an empty ``(missing_path, [])`` pair if the local skills dir
+    has not been created yet — caller treats that as "no skill can be
+    loadable from this root."
+    """
+    try:
+        from tools import skills_tool as _skills_tool
+        local = _skills_tool.SKILLS_DIR
+    except Exception:
+        local = None
+
+    external: List[Any] = []
+    try:
+        from agent.skill_utils import get_external_skills_dirs
+        external = list(get_external_skills_dirs() or [])
+    except Exception as exc:  # misconfigured external_dirs must not crash
+        logger.warning(
+            "Background review: failed to resolve external skill dirs "
+            "(proceeding with local only): %s",
+            exc,
+        )
+        external = []
+
+    return local, external
+
+
+def _is_skill_in_session_root(skill_name: str) -> bool:
+    """Return True if the live session's ``skill_view`` can load the skill.
+
+    The user-facing notification promises more than "a write tool returned
+    success": it promises the skill is usable by the current session.  Use the
+    same resolver the session uses instead of duplicating path-scanning logic
+    here.  This keeps the check aligned with ``skill_view`` support for nested
+    skills, frontmatter aliases, external skill dirs, and legacy flat files.
+    """
+    name = (skill_name or "").strip()
+    if not name:
+        return False
+
+    try:
+        from tools.skills_tool import skill_view
+
+        raw = skill_view(name)
+        result = json.loads(raw) if isinstance(raw, str) else raw
+    except Exception as exc:
+        logger.warning(
+            "Background review: failed to verify skill %r with skill_view: %s",
+            name,
+            exc,
+        )
+        return False
+    return isinstance(result, dict) and bool(result.get("success"))
+
+
 def summarize_background_review_actions(
     review_messages: List[Dict],
     prior_snapshot: List[Dict],
@@ -282,9 +354,11 @@ def summarize_background_review_actions(
         message = data.get("message", "")
         target = data.get("target", "")
         if "created" in message.lower():
-            actions.append(message)
+            if _is_skill_action_loadable(message, data):
+                actions.append(message)
         elif "updated" in message.lower():
-            actions.append(message)
+            if _is_skill_action_loadable(message, data):
+                actions.append(message)
         elif "added" in message.lower() or (target and "add" in message.lower()):
             label = "Memory" if target == "memory" else "User profile" if target == "user" else target
             actions.append(f"{label} updated")
@@ -295,6 +369,55 @@ def summarize_background_review_actions(
             label = "Memory" if target == "memory" else "User profile" if target == "user" else target
             actions.append(f"{label} updated")
     return actions
+
+
+def _is_skill_action_loadable(message: str, data: Dict[str, Any]) -> bool:
+    """Return True if a ``Skill '<name>' created./updated.`` action should
+    be surfaced in the user-facing summary.
+
+    For non-skill actions (memory entries, user profile updates, cron
+    notifications, etc.) the message does not match the canonical
+    ``Skill '<name>'`` shape, and we short-circuit to True — the
+    loadability probe applies ONLY to skill actions, since the bug
+    described in #46897 is specifically "the user is told a skill was
+    created that their session cannot load."
+
+    For skill actions we verify the named skill resolves from the live
+    session's skill search roots.  When it does not, we emit a WARNING
+    log carrying the writer path the tool reported AND the live
+    session's ``SKILLS_DIR`` so an operator can correlate the
+    "user got a misleading 'created' line" complaint with the
+    actual root divergence.
+    """
+    match = _SKILL_ACTION_PATTERN.search(message or "")
+    if match is None:
+        # Not a skill action (e.g. "Cron job 'X' created.", "Memory
+        # entry created.").  Keep the action.
+        return True
+    skill_name = match.group(1)
+    if _is_skill_in_session_root(skill_name):
+        return True
+    # Writer-root != reader-root.  Log enough context for an operator
+    # to diagnose the divergence without us leaking the false-positive
+    # "created" line to the user.
+    writer_path = data.get("path", "<unspecified>")
+    try:
+        local, _external = _session_skill_search_roots()
+        reader_root = str(local) if local is not None else "<unset>"
+    except Exception:
+        reader_root = "<unresolved>"
+    logger.warning(
+        "Background review: dropping 'Skill %r' notification — the "
+        "skill-write tool reported success at path %s, but the live "
+        "session's skill search root (%s) does not contain a SKILL.md "
+        "for that name.  This usually means the spawned review agent "
+        "resolved a different HERMES_HOME / profile root than the live "
+        "session (issue #46897).",
+        skill_name,
+        writer_path,
+        reader_root,
+    )
+    return False
 
 
 def build_memory_write_metadata(

--- a/tests/run_agent/test_background_review_summary.py
+++ b/tests/run_agent/test_background_review_summary.py
@@ -3,9 +3,18 @@
 Regression coverage for issue #14944: the background memory/skill review used
 to re-surface tool results that were already present in the conversation
 history before the review started (e.g. an earlier "Cron job '...' created.").
+
+Regression coverage for issue #46897: the background review used to surface
+"Skill '<name>' created" notifications based solely on the skill-write
+tool's ``success: true`` flag, without verifying the skill is actually
+loadable from the live session's skill search roots. When the spawned
+review agent resolved a different ``HERMES_HOME``/profile root than the
+live session, the user was told a skill was created that the live session
+could never load.
 """
 
 import json
+from unittest.mock import patch
 
 from run_agent import AIAgent
 
@@ -128,3 +137,300 @@ def test_removed_or_replaced_relabels_by_target():
 
     assert "User profile updated" in actions
     assert "Memory updated" in actions
+
+
+# ---------------------------------------------------------------------------
+# Issue #46897 — skill loadability check
+# ---------------------------------------------------------------------------
+#
+# Each test below targets one of the layers documented in
+# .automation-worktrees/.../fix__46897-bg-review-skill-loadable/LAYERS.md
+# (L1 = probe, L2 = regex, L3 = helper, L4 = warning + drop) plus the
+# edge cases (E1–E5). The tests must FAIL on the pre-fix code (the
+# notification leaks) and PASS on the post-fix code (the notification is
+# suppressed when the skill is not in the live session's SKILLS_DIR /
+# external_dirs).
+
+def _setup_skill_in_session_root(tmp_path, skill_name):
+    """Create a real SKILL.md under tmp_path/<skill_name>/ so the loadability
+    live ``skill_view`` resolver can find it. Returns the patched
+    context-manager pair: (skills_dir, external_dirs) for use in
+    ``with`` stacks.
+    """
+    skill_dir = tmp_path / skill_name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {skill_name}\ndescription: test skill\n---\n# body\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def test_l1_skill_created_surfaces_when_skill_is_in_session_root(tmp_path):
+    """L1: when the written skill is loadable through the live session's
+    ``skill_view`` search path, the action is kept."""
+    root = _setup_skill_in_session_root(tmp_path, "alpha-skill")
+    with patch("tools.skills_tool.SKILLS_DIR", root), \
+         patch("agent.skill_utils.get_external_skills_dirs", return_value=[]):
+        actions = _summarize(
+            [
+                _tool_msg(
+                    "c1",
+                    {
+                        "success": True,
+                        "message": "Skill 'alpha-skill' created.",
+                        "path": str(root / "alpha-skill"),
+                    },
+                )
+            ],
+            [],
+        )
+    assert "Skill 'alpha-skill' created." in actions
+
+
+def test_l1_skill_created_suppressed_when_skill_not_in_session_root(tmp_path):
+    """L1: when the tool reported success but the skill's SKILL.md is NOT
+    reachable from the parent process's roots (writer-root != reader-root,
+    e.g. background review spawned with a different HERMES_HOME), the
+    notification must be suppressed — the user should NOT be told a skill
+    was created that their session cannot load.
+    """
+    # Tool reports a path under /tmp/writer-root, but the live session's
+    # search roots point at tmp_path/reader-root (no overlap).
+    writer_root = tmp_path / "writer-root" / "ghost-skill"
+    writer_root.mkdir(parents=True)
+    (writer_root / "SKILL.md").write_text("---\nname: ghost-skill\n---\n", encoding="utf-8")
+    reader_root = tmp_path / "reader-root"
+    reader_root.mkdir()
+    with patch("tools.skills_tool.SKILLS_DIR", reader_root), \
+         patch("agent.skill_utils.get_external_skills_dirs", return_value=[]):
+        actions = _summarize(
+            [
+                _tool_msg(
+                    "c1",
+                    {
+                        "success": True,
+                        "message": "Skill 'ghost-skill' created.",
+                        "path": str(writer_root),
+                    },
+                )
+            ],
+            [],
+        )
+    assert "Skill 'ghost-skill' created." not in actions
+    assert actions == []
+
+
+def test_l2_regex_extracts_skill_name_from_canonical_message():
+    """L2: the helper regex must reliably extract the skill name from the
+    canonical ``Skill '<name>' created./updated.`` message shape. The
+    match is what the loadability probe uses to look up the skill — if
+    this regex is wrong, the probe runs against the wrong name and the
+    user gets a misleading notification either way.
+    """
+    from agent.background_review import _SKILL_ACTION_PATTERN
+
+    match = _SKILL_ACTION_PATTERN.search("Skill 'alpha-skill' created.")
+    assert match is not None
+    assert match.group(1) == "alpha-skill"
+    match = _SKILL_ACTION_PATTERN.search("Skill 'multi-word-name' updated.")
+    assert match is not None
+    assert match.group(1) == "multi-word-name"
+    # Names with hyphens, digits, and underscores — the validator's
+    # [a-zA-Z0-9_-]+ charset.
+    match = _SKILL_ACTION_PATTERN.search("Skill 'mlops_2-camelCase' created.")
+    assert match is not None
+    assert match.group(1) == "mlops_2-camelCase"
+    # No match for non-skill actions.
+    assert _SKILL_ACTION_PATTERN.search("Memory entry created.") is None
+    assert _SKILL_ACTION_PATTERN.search("Cron job 'foo' created.") is None
+
+
+def test_l3_helper_finds_skill_in_local_root(tmp_path):
+    """L3: the private ``_is_skill_in_session_root(name)`` helper must find
+    a skill whose SKILL.md lives in the local SKILLS_DIR."""
+    from agent.background_review import _is_skill_in_session_root
+
+    _setup_skill_in_session_root(tmp_path, "l3-skill")
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path), \
+         patch("agent.skill_utils.get_external_skills_dirs", return_value=[]):
+        assert _is_skill_in_session_root("l3-skill") is True
+
+
+def test_l3_helper_returns_false_for_missing_skill(tmp_path):
+    """L3: helper returns False when the named skill is not in the session
+    roots (the L1 case) — also handles the case where the SKILLS_DIR
+    itself does not exist.
+    """
+    from agent.background_review import _is_skill_in_session_root
+
+    # Empty local dir, no skill
+    tmp_path.mkdir(exist_ok=True)
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path), \
+         patch("agent.skill_utils.get_external_skills_dirs", return_value=[]):
+        assert _is_skill_in_session_root("nonexistent") is False
+    # Local dir doesn't exist at all
+    missing = tmp_path / "does-not-exist"
+    with patch("tools.skills_tool.SKILLS_DIR", missing), \
+         patch("agent.skill_utils.get_external_skills_dirs", return_value=[]):
+        assert _is_skill_in_session_root("any") is False
+
+
+def test_l3_helper_finds_skill_in_external_dir(tmp_path):
+    """L3: helper also searches external skill directories configured for
+    the live session — the case where the user has set
+    ``skills.external_dirs`` in ``~/.hermes/config.yaml`` and the new
+    skill was written there.
+    """
+    from agent.background_review import _is_skill_in_session_root
+
+    ext = tmp_path / "external"
+    ext.mkdir()
+    skill = ext / "ext-skill"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text("---\nname: ext-skill\n---\n", encoding="utf-8")
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path / "empty-local"), \
+         patch("agent.skill_utils.get_external_skills_dirs", return_value=[ext]):
+        assert _is_skill_in_session_root("ext-skill") is True
+
+
+def test_l4_warning_logged_and_action_dropped_when_skill_unreachable(tmp_path, caplog):
+    """L4: when the loadability probe fails, the action is dropped AND a
+    WARNING log records the divergence so an operator can correlate the
+    "user got a 'created' line" complaint with the actual writer-root.
+    The log must include both the path the tool reported and the
+    session's SKILLS_DIR — that's the diagnostic value.
+    """
+    writer_root = tmp_path / "writer"
+    ghost = writer_root / "ghost4"
+    ghost.mkdir(parents=True)
+    (ghost / "SKILL.md").write_text("---\nname: ghost4\n---\n", encoding="utf-8")
+    reader_root = tmp_path / "reader"
+    reader_root.mkdir()
+    import logging as _logging
+    with patch("tools.skills_tool.SKILLS_DIR", reader_root), \
+         patch("agent.skill_utils.get_external_skills_dirs", return_value=[]):
+        with caplog.at_level(_logging.WARNING, logger="agent.background_review"):
+            actions = _summarize(
+                [
+                    _tool_msg(
+                        "c1",
+                        {
+                            "success": True,
+                            "message": "Skill 'ghost4' created.",
+                            "path": str(ghost),
+                        },
+                    )
+                ],
+                [],
+            )
+    assert actions == []
+    assert any("ghost4" in rec.message and str(reader_root) in rec.message for rec in caplog.records), (
+        f"expected a WARNING log mentioning the skill name AND the reader root, got: "
+        f"{[r.message for r in caplog.records]}"
+    )
+
+
+# --- Edge cases --------------------------------------------------------------
+
+
+def test_e1_memory_and_user_profile_actions_bypass_probe(tmp_path):
+    """E1: memory and user-profile actions are not skills; the loadability
+    probe must NOT apply to them. The session root could be entirely
+    empty and these should still surface.
+    """
+    actions = _summarize(
+        [
+            _tool_msg(
+                "c1",
+                {
+                    "success": True,
+                    "message": "Entry added to store.",
+                    "target": "memory",
+                },
+            ),
+            _tool_msg(
+                "c2",
+                {
+                    "success": True,
+                    "message": "Entry added to store.",
+                    "target": "user",
+                },
+            ),
+        ],
+        [],
+    )
+    assert "Memory updated" in actions
+    assert "User profile updated" in actions
+
+
+def test_e2_malformed_tool_payload_still_skipped_safely():
+    """E2: non-JSON content (or JSON without ``success: true``) must not
+    regress under the new probe. Mirrors the existing graceful-skip
+    behavior for #14944.
+    """
+    bad = {"success": False, "message": "Skill 'x' created.", "target": "skill"}
+    actions = _summarize([_tool_msg("c1", bad)], [])
+    assert actions == []
+    # Non-JSON content
+    actions = _summarize(
+        [{"role": "tool", "tool_call_id": "x", "content": "not-json"}],
+        [],
+    )
+    assert actions == []
+
+
+def test_e3_skill_name_with_regex_special_chars_still_probed(tmp_path):
+    """E3: even though the validator restricts names to [a-zA-Z0-9_-]+,
+    the probe must not blow up if a name contains regex-special chars.
+    """
+    from agent.background_review import _is_skill_in_session_root
+
+    weird_name = "dot.skill+name"  # would be a regex bomb if not escaped
+    skill_dir = tmp_path / weird_name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {weird_name}\n---\n", encoding="utf-8"
+    )
+    with patch("tools.skills_tool.SKILLS_DIR", tmp_path), \
+         patch("agent.skill_utils.get_external_skills_dirs", return_value=[]):
+        # Must not raise; the existing validator would reject the name,
+        # but the probe should be defensive.
+        result = _is_skill_in_session_root(weird_name)
+    # skill_view can resolve the direct directory path, so the result should be True.
+    assert result is True
+
+
+def test_e4_skill_loadable_matches_skill_view_alias_conventions():
+    """E4: the probe matches the live ``skill_view`` resolver, including
+    both parent-directory and frontmatter-name lookup conventions.
+    """
+    from agent.background_review import _is_skill_in_session_root
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        td_path = __import__("pathlib").Path(td)
+        # dir name = "real-dir-name", frontmatter name = "different"
+        skill = td_path / "real-dir-name"
+        skill.mkdir()
+        (skill / "SKILL.md").write_text(
+            "---\nname: different\n---\n", encoding="utf-8"
+        )
+        with patch("tools.skills_tool.SKILLS_DIR", td_path), \
+             patch("agent.skill_utils.get_external_skills_dirs", return_value=[]):
+            assert _is_skill_in_session_root("real-dir-name") is True
+            assert _is_skill_in_session_root("different") is True
+
+
+def test_e5_skill_view_failure_suppresses_without_crashing(caplog):
+    """E5: if the live resolver raises, the summary must suppress the skill
+    notification and log a warning rather than crashing the post-turn review.
+    """
+    from agent.background_review import _is_skill_in_session_root
+    import logging as _logging
+
+    with patch("tools.skills_tool.skill_view", side_effect=RuntimeError("bad config")), \
+         caplog.at_level(_logging.WARNING, logger="agent.background_review"):
+        result = _is_skill_in_session_root("lives-locally")
+    assert result is False
+    assert any("failed to verify skill" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary

Fixes #46897 by ensuring background self-improvement review only reports `Skill '<name>' created/updated` when the named skill is actually loadable through the live session's skill resolver.

The previous summary path trusted the skill-write tool's `success: true` flag alone. If the background review fork wrote to a different `HERMES_HOME` / profile skills root than the foreground session searches, users received a confident “Skill created” notification for a skill that `skill_view` could not load.

## Changes

- Parse canonical `Skill '<name>' created/updated.` summary messages.
- Verify the skill with the same `skill_view(name)` resolver used by the live session instead of duplicating partial filesystem lookup logic.
- Suppress unreachable skill notifications and log a warning with the tool-reported writer path and the live session skill root.
- Preserve existing memory/user-profile/cron action summaries and malformed-payload behavior.

## Verification

- RED on upstream/main with the new regression tests:
  - `test_l1_skill_created_suppressed_when_skill_not_in_session_root` failed because `Skill 'ghost-skill' created.` leaked.
  - `test_l4_warning_logged_and_action_dropped_when_skill_unreachable` failed because `Skill 'ghost4' created.` leaked.
- GREEN after the fix:
  - `/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/run_agent/test_background_review_summary.py -v -o addopts= --tb=short`
  - Result: 20 passed, 1 warning in 0.46s.

## Competitor check

Found open PR #46932 for the same issue. I scored it below the publication threshold because it has no regression tests, only handles `created` (not `updated`), uses `_find_all_skills()` metadata rather than the actual `skill_view` load path, and reports a new degraded user-facing notification instead of suppressing/logging as requested. This PR includes production-path regression coverage and uses the live resolver.

Auto-published by Moonsong via Path B automated pipeline.
