### PR TITLE
feat(skills): implement double-check auto-correction for background skill writes

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -22,6 +22,9 @@ import contextlib
 import json
 import logging
 import os
+from pathlib import Path
+import re
+import shutil
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -231,12 +234,67 @@ _COMBINED_REVIEW_PROMPT = (
     "genuinely nothing stands out on either, say 'Nothing to save.' "
     "and stop — but don't reach for that conclusion as a default."
 )
+def _try_autocorrect_skill_path(
+    skill_name: str,
+    data: dict,
+    target_skills_dir: Path,
+) -> None:
+    """Attempt to copy/move a skill from the review agent's write path
+    to the correct active profile's skill directory when there is a mismatch.
+    """
+    source_path_str = data.get("skill_md") or data.get("path")
+    if not source_path_str:
+        return
 
+    src_path = Path(source_path_str)
+    if not src_path.exists():
+        return
+
+    parts = src_path.parts
+    if "skills" not in parts:
+        return
+
+    idx = parts.index("skills")
+    rel_path = Path(*parts[idx + 1:])
+    dest_path = target_skills_dir / rel_path
+
+    try:
+        src_resolved = src_path.resolve()
+        dest_resolved = dest_path.resolve()
+    except OSError:
+        src_resolved = src_path
+        dest_resolved = dest_path
+
+    if src_resolved == dest_resolved:
+        return
+
+    try:
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        if src_path.is_dir():
+            if dest_path.exists():
+                if dest_path.is_dir():
+                    shutil.rmtree(dest_path)
+                else:
+                    dest_path.unlink()
+            shutil.copytree(src_path, dest_path)
+        else:
+            shutil.copy2(src_path, dest_path)
+
+        logger.info(
+            "Auto-corrected background review skill path for '%s': copied from '%s' to '%s'",
+            skill_name, src_path, dest_path
+        )
+    except Exception as e:
+        logger.warning(
+            "Failed to copy/move skill '%s' from '%s' to '%s': %s",
+            skill_name, src_path, dest_path, e, exc_info=True
+        )
 
 
 def summarize_background_review_actions(
     review_messages: List[Dict],
     prior_snapshot: List[Dict],
+    target_skills_dir: Optional[Path] = None,
 ) -> List[str]:
     """Build the human-facing action summary for a background review pass.
 
@@ -249,6 +307,10 @@ def summarize_background_review_actions(
     Matching is by ``tool_call_id`` when available, with a content-equality
     fallback for tool messages that lack one.
     """
+    if target_skills_dir is None:
+        from hermes_constants import get_skills_dir
+        target_skills_dir = get_skills_dir()
+
     existing_tool_call_ids = set()
     existing_tool_contents = set()
     for prior in prior_snapshot or []:
@@ -281,6 +343,29 @@ def summarize_background_review_actions(
             continue
         message = data.get("message", "")
         target = data.get("target", "")
+        skill_match = re.search(r"[Ss]kill '([^']+)'", message)
+        if skill_match:
+            skill_name = skill_match.group(1)
+            try:
+                from tools.skill_manager_tool import _find_skill
+                if not _find_skill(skill_name):
+                    # Attempt auto-correction by copying/moving files
+                    _try_autocorrect_skill_path(skill_name, data, target_skills_dir)
+
+                    # Re-run loadability check after potential auto-correction
+                    if not _find_skill(skill_name):
+                        logger.warning(
+                            "Background review wrote skill '%s' but it is not loadable from the active session's skill search path even after auto-correction (target root: %s). Suppressing user notification.",
+                            skill_name, target_skills_dir
+                        )
+                        continue
+            except Exception as e:
+                logger.warning(
+                    "Error verifying reachability of skill '%s': %s. Suppressing notification.",
+                    skill_name, e
+                )
+                continue
+
         if "created" in message.lower():
             actions.append(message)
         elif "updated" in message.lower():
@@ -592,12 +677,13 @@ def spawn_background_review_thread(
     else:
         prompt = getattr(agent, "_SKILL_REVIEW_PROMPT", _SKILL_REVIEW_PROMPT)
 
+    import contextvars
+    ctx = contextvars.copy_context()
+
     def _target() -> None:
-        _run_review_in_thread(agent, messages_snapshot, prompt)
+        ctx.run(_run_review_in_thread, agent, messages_snapshot, prompt)
 
     return _target, prompt
-
-
 __all__ = [
     "_MEMORY_REVIEW_PROMPT",
     "_SKILL_REVIEW_PROMPT",

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -511,6 +511,89 @@ def get_env_path() -> Path:
     return get_hermes_home() / ".env"
 
 
+class DynamicPathProxy(type(Path())):
+    """A Path subclass that delegates all operations dynamically to a resolver.
+
+    This is used to bypass the static evaluation of paths (like SKILLS_DIR) at
+    module import time, allowing them to adapt when profile overrides change,
+    while maintaining full compatibility with all Path operations and isinstance checks.
+    """
+    def __new__(cls, resolver):
+        # Initialize the base class with a dummy path ('.') to create the internal pathlib
+        # state without triggering directory lookups during the import phase.
+        obj = super().__new__(cls, ".")
+        object.__setattr__(obj, "_resolver", resolver)
+        return obj
+
+    @property
+    def _resolved(self) -> Path:
+        """Dynamically resolve the underlying path using the resolver function."""
+        resolver = object.__getattribute__(self, "_resolver")
+        return Path(resolver())
+
+    def __getattribute__(self, name):
+        # 1. During the base class initialization (__new__ above), pathlib internals
+        # are accessed before `_resolver` is bound to the instance __dict__.
+        # We must bypass delegation during this phase to avoid infinite recursion.
+        try:
+            dct = object.__getattribute__(self, "__dict__")
+        except AttributeError:
+            dct = {}
+        if "_resolver" not in dct:
+            return object.__getattribute__(self, name)
+
+        # 2. Prevent infinite recursion by intercepting internal proxy attributes
+        # and returning them directly without delegation.
+        if name in ("_resolver", "_resolved", "__dict__", "__class__"):
+            return object.__getattribute__(self, name)
+
+        # 3. Delegate all other attribute/method lookups to the resolved Path object.
+        return getattr(self._resolved, name)
+
+    # Note: Special methods (magic methods) bypass __getattribute__ during lookup,
+    # so we must define them explicitly on the class to ensure correct behavior.
+
+    def __str__(self):
+        return str(self._resolved)
+
+    def __repr__(self):
+        return f"DynamicPathProxy({self._resolved!r})"
+
+    def __fspath__(self):
+        return os.fspath(self._resolved)
+
+    def __truediv__(self, other):
+        return self._resolved / other
+
+    def __rtruediv__(self, other):
+        return other / self._resolved
+
+    def __eq__(self, other):
+        return self._resolved == other
+
+    def __ne__(self, other):
+        return self._resolved != other
+
+    def __lt__(self, other):
+        return self._resolved < other
+
+    def __le__(self, other):
+        return self._resolved <= other
+
+    def __gt__(self, other):
+        return self._resolved > other
+
+    def __ge__(self, other):
+        return self._resolved >= other
+
+    def __hash__(self):
+        return hash(self._resolved)
+
+    def __bytes__(self):
+        return bytes(self._resolved)
+
+
+
 # ─── Network Preferences ─────────────────────────────────────────────────────
 
 

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -298,3 +298,42 @@ class TestSecureParentDir:
         assert len(called_with) == 1
         assert called_with[0] == (str(real_dir), 0o700)
 
+
+class TestDynamicPathProxy:
+    """Tests for DynamicPathProxy — dynamic evaluation of path attributes/methods."""
+
+    def test_dynamic_resolution(self, tmp_path):
+        current_dir = tmp_path / "first"
+        current_dir.mkdir()
+
+        resolved_path = current_dir
+
+        def resolver():
+            return resolved_path
+
+        from hermes_constants import DynamicPathProxy
+        proxy = DynamicPathProxy(resolver)
+
+        # 1. Check isinstance behaves correctly (proxy is a Path subclass)
+        assert isinstance(proxy, Path)
+
+        # 2. Check operations delegate to "first"
+        assert proxy.exists()
+        assert proxy.resolve() == current_dir.resolve()
+        assert str(proxy) == str(current_dir)
+
+        # 3. Check division works and resolves dynamically
+        assert not (proxy / "test.txt").exists()
+
+        # 4. Change resolution destination
+        second_dir = tmp_path / "second"
+        second_dir.mkdir()
+        (second_dir / "test.txt").touch()
+
+        resolved_path = second_dir
+
+        # 5. Check proxy now points to "second" dynamically without re-instantiating
+        assert proxy.resolve() == second_dir.resolve()
+        assert (proxy / "test.txt").exists()
+
+

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -39,7 +39,7 @@ import re
 import shutil
 import tempfile
 from pathlib import Path
-from hermes_constants import get_hermes_home, display_hermes_home
+from hermes_constants import get_hermes_home, display_hermes_home, get_skills_dir, DynamicPathProxy
 from typing import Dict, Any, List, Optional, Tuple
 
 from utils import atomic_replace, is_truthy_value
@@ -105,8 +105,8 @@ import yaml
 
 
 # All skills live in ~/.hermes/skills/ (single source of truth)
-HERMES_HOME = get_hermes_home()
-SKILLS_DIR = HERMES_HOME / "skills"
+HERMES_HOME = DynamicPathProxy(get_hermes_home)
+SKILLS_DIR = DynamicPathProxy(get_skills_dir)
 
 MAX_NAME_LENGTH = 64
 MAX_DESCRIPTION_LENGTH = 1024

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -25,7 +25,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, get_skills_dir, DynamicPathProxy
 from agent.skill_utils import is_excluded_skill_path
 from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urljoin, urlparse, urlunparse
@@ -46,14 +46,14 @@ logger = logging.getLogger(__name__)
 # Paths
 # ---------------------------------------------------------------------------
 
-HERMES_HOME = get_hermes_home()
-SKILLS_DIR = HERMES_HOME / "skills"
-HUB_DIR = SKILLS_DIR / ".hub"
-LOCK_FILE = HUB_DIR / "lock.json"
-QUARANTINE_DIR = HUB_DIR / "quarantine"
-AUDIT_LOG = HUB_DIR / "audit.log"
-TAPS_FILE = HUB_DIR / "taps.json"
-INDEX_CACHE_DIR = HUB_DIR / "index-cache"
+HERMES_HOME = DynamicPathProxy(get_hermes_home)
+SKILLS_DIR = DynamicPathProxy(get_skills_dir)
+HUB_DIR = DynamicPathProxy(lambda: get_skills_dir() / ".hub")
+LOCK_FILE = DynamicPathProxy(lambda: HUB_DIR / "lock.json")
+QUARANTINE_DIR = DynamicPathProxy(lambda: HUB_DIR / "quarantine")
+AUDIT_LOG = DynamicPathProxy(lambda: HUB_DIR / "audit.log")
+TAPS_FILE = DynamicPathProxy(lambda: HUB_DIR / "taps.json")
+INDEX_CACHE_DIR = DynamicPathProxy(lambda: HUB_DIR / "index-cache")
 
 # Cache duration for remote index fetches
 INDEX_CACHE_TTL = 3600  # 1 hour

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -28,7 +28,7 @@ import os
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
-from hermes_constants import get_bundled_skills_dir, get_hermes_home, get_optional_skills_dir
+from hermes_constants import get_bundled_skills_dir, get_hermes_home, get_optional_skills_dir, get_skills_dir, DynamicPathProxy
 from agent.skill_utils import is_excluded_skill_path
 from typing import Dict, List, Tuple
 from utils import atomic_replace
@@ -36,9 +36,9 @@ from utils import atomic_replace
 logger = logging.getLogger(__name__)
 
 
-HERMES_HOME = get_hermes_home()
-SKILLS_DIR = HERMES_HOME / "skills"
-MANIFEST_FILE = SKILLS_DIR / ".bundled_manifest"
+HERMES_HOME = DynamicPathProxy(get_hermes_home)
+SKILLS_DIR = DynamicPathProxy(get_skills_dir)
+MANIFEST_FILE = DynamicPathProxy(lambda: get_skills_dir() / ".bundled_manifest")
 
 # Marker file written by `hermes profile create --no-skills` (named profiles)
 # and by the installer's `--no-skills` flag (the default ~/.hermes profile).

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -69,7 +69,7 @@ Usage:
 import json
 import logging
 
-from hermes_constants import get_hermes_home, display_hermes_home
+from hermes_constants import get_hermes_home, display_hermes_home, get_skills_dir, DynamicPathProxy
 import os
 import re
 from enum import Enum
@@ -87,8 +87,8 @@ logger = logging.getLogger(__name__)
 # All skills live in ~/.hermes/skills/ (seeded from bundled skills/ on install).
 # This is the single source of truth -- agent edits, hub installs, and bundled
 # skills all coexist here without polluting the git repo.
-HERMES_HOME = get_hermes_home()
-SKILLS_DIR = HERMES_HOME / "skills"
+HERMES_HOME = DynamicPathProxy(get_hermes_home)
+SKILLS_DIR = DynamicPathProxy(get_skills_dir)
 
 # Anthropic-recommended limits for progressive disclosure efficiency
 MAX_NAME_LENGTH = 64


### PR DESCRIPTION
Closes #46897

# Description
This Pull Request resolves a bug where skills created by the post-turn background review agent are successfully written but remain invisible to the active interactive session.

## Problem
1. **ContextVar Isolation**: The background review loop executes in a daemon thread. However, the thread was spawned without propagating the thread-local ContextVars of the active session. Consequently, profile overrides (`HERMES_HOME`) did not carry over to the thread.
2. **Static Constant Evaluation**: Paths like `SKILLS_DIR` and `HERMES_HOME` were evaluated statically at module-import time inside tool modules (`skills_tool.py`, `skills_sync.py`, etc.). This caused any runtime modifications of `HERMES_HOME` (such as active profile overrides) to not propagate to those tool paths.

## Solution
1. **ContextVar Propagation**: Spawns the background review thread with a copy of the parent thread's context variables using `contextvars.copy_context().run()`.
2. **Dynamic Path Resolution**: Introduces `DynamicPathProxy` in `hermes_constants.py` which dynamically delegates all path operations to a resolver callable at execution time, allowing paths to adapt when profile overrides change.
3. **Double-Check and Auto-Correction**:
   - Updates `summarize_background_review_actions` to double-check if a written skill is loadable by the active session.
   - If a path mismatch or root directory variance prevents loading, it locates the written file path, resolves the relative structure, and copies the skill to the correct active profile's `skills/` path.
   - Verifies loadability again; only successfully verified skills emit the user-facing "Skill created" notification. Otherwise, the notification is suppressed, and a warning is logged.

## Tests
- Added `TestDynamicPathProxy` inside `tests/test_hermes_constants.py`.
- Re-ran background review parity and security restriction tests (all passed).
