### PR TITLE
test: remove stale compression bug marker

### DIFF
--- a/tests/test_compression_boundary.py
+++ b/tests/test_compression_boundary.py
@@ -81,7 +81,7 @@ class TestAlignBoundaryBackward:
         assert comp._align_boundary_backward(messages, 4) == 3
 
     def test_boundary_in_middle_of_tool_results(self):
-        """THE BUG: boundary falls between tool results of the same group."""
+        """Boundary falls between tool results of the same group."""
         comp = _make_compressor()
         messages = [
             {"role": "system", "content": "sys"},


### PR DESCRIPTION
Summary:
- Removed the stale BUG wording from the compression boundary regression test now that the behavior is implemented and covered.

Validation:
- uv run --extra dev python -m pytest -q -o addopts='' tests/test_compression_boundary.py tests/agent/test_context_compressor.py (40 passed, 1 deprecation warning)
