### PR TITLE
test: remove stale compression bug marker

### DIFF
--- a/tests/run_agent/test_compression_boundary.py
+++ b/tests/run_agent/test_compression_boundary.py
@@ -80,7 +80,7 @@ class TestAlignBoundaryBackward:
         assert comp._align_boundary_backward(messages, 4) == 3
 
     def test_boundary_in_middle_of_tool_results(self):
-        """THE BUG: boundary falls between tool results of the same group."""
+        """Boundary falls between tool results of the same group."""
         comp = _make_compressor()
         messages = [
             {"role": "system", "content": "sys"},


### PR DESCRIPTION
Summary:
- Removed stale BUG wording from the compression boundary regression test now that the boundary behavior is implemented and covered.

Validation:
- uv run --extra dev python -m pytest -q -o addopts='' tests/run_agent/test_compression_boundary.py tests/agent/test_context_compressor.py (102 passed)
