### PR TITLE
feat(sisters): add sister registry and delegation plumbing

### DIFF
--- a/agent/sister_prompt_loader.py
+++ b/agent/sister_prompt_loader.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+SISTER PROMPT LOADER
+-------------------
+Ensures byte-stable system prompt generation for the Hermes Sister system.
+This module handles the assembly of role, domain, and identity into a
+consistent format to maximize provider cache efficiency.
+"""
+
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Optional, Dict, Any
+from agent import sister_registry
+
+@dataclass(frozen=True)
+class SisterPrompt:
+    """A compiled prompt package for a specific sister."""
+    sister_id: str
+    system_prompt: str
+    metadata: Dict[str, Any]
+
+    def to_system_prompt(self) -> str:
+        """Return the rendered prompt text.
+
+        Kept as a compatibility helper for CLI/tooling code that expects a
+        prompt package object to expose a conversion method.
+        """
+        return self.system_prompt
+
+class SisterPromptLoader:
+    """Handles the construction and caching of sister system prompts."""
+
+    def __init__(self):
+        self._registry = sister_registry.get_registry()
+        self._cache: Dict[str, SisterPrompt] = {}
+
+    def get_prompt_loader(self) -> SisterPromptLoader:
+        """Singleton accessor."""
+        return self
+
+    def build_sister_prompt(self, sister: sister_registry.Sister) -> SisterPrompt:
+        """
+        Constructs a consistent system prompt for the given sister.
+
+        The format is strictly structured to avoid whitespace variations
+        that would invalidate LLM prompt caches.
+        """
+        if sister.id in self._cache:
+            return self._cache[sister.id]
+
+        # 1. Header: Core Identity
+        # Format: [SISTER_ID] [NAME] - [ROLE]
+        header = f"[{sister.id.upper()}] {sister.name} - {sister.role}"
+
+        # 2. Domain and Archetype
+        # Format: Domain: [DOMAIN] | Archetype: [ARCHETYPE]
+        context = f"Domain: {sister.domain} | Archetype: {sister.archetype}"
+
+        # 3. Core Directive (The 'Soul' of the persona)
+        directive = sister.core_directive
+
+        # 4. Constraints and Style
+        # We join constraints and style into a stable list
+        style_lines = [
+            f"Style: {sister.personality_style}",
+            f"Delegation Scope: {', '.join(sister.delegation_scope)}",
+            f"Risk Level: {sister.risk_level}"
+        ]
+        constraints = "\n".join([f"- {line}" for line in style_lines])
+
+        # Combine all parts with double newlines for clear separation
+        full_prompt = (
+            f"{header}\n"
+            f"{'=' * len(header)}\n"
+            f"{context}\n\n"
+            f"CORE DIRECTIVE:\n{directive}\n\n"
+            f"OPERATIONAL CONSTRAINTS:\n{constraints}"
+        )
+
+        prompt_pkg = SisterPrompt(
+            sister_id=sister.id,
+            system_prompt=full_prompt,
+            metadata={
+                "role": sister.role,
+                "domain": sister.domain,
+                "risk": sister.risk_level,
+            }
+        )
+
+        self._cache[sister.id] = prompt_pkg
+        return prompt_pkg
+
+    def get_fallback_sister_id(self) -> str:
+        """Returns the default system orchestrator ID."""
+        return "astra"
+
+    def get_sister_prompt(self, sister_id: str) -> Optional[SisterPrompt]:
+        """High-level accessor to get a prompt by ID."""
+        sister = self._registry.get(sister_id)
+        if not sister:
+            # Fallback to Astra
+            sister = self._registry.get("astra")
+            if not sister:
+                return None
+
+        return self.build_sister_prompt(sister)
+
+# Global singleton for easy access
+_loader_instance = SisterPromptLoader()
+
+def get_prompt_loader() -> SisterPromptLoader:
+    """Access the global prompt loader instance."""
+    return _loader_instance
+
+
+def get_system_prompt(sister_id: str) -> str:
+    """Return the rendered system prompt for ``sister_id``.
+
+    Invalid IDs fall back to Astra via ``SisterPromptLoader.get_sister_prompt``.
+    An empty string is returned only if no registry/default prompt is available.
+    """
+    prompt = _loader_instance.get_sister_prompt(sister_id)
+    return prompt.system_prompt if prompt else ""
+
+
+def build_sister_system_prompt(sister_id: str) -> str:
+    """Compatibility wrapper used by system-prompt assembly."""
+    return get_system_prompt(sister_id)

--- a/agent/sister_registry.py
+++ b/agent/sister_registry.py
@@ -1,0 +1,434 @@
+"""
+Sister Registry - Plugin-style registry for the 12-Sister Personality System.
+Source of truth for sister definitions, matching, and prompt loading.
+"""
+
+from __future__ import annotations
+import os
+import json
+from dataclasses import dataclass, field
+from typing import Optional, Dict, List, Any
+from pathlib import Path
+
+@dataclass
+class Sister:
+    """Represents a sister agent with her identity and capabilities."""
+    id: str
+    name: str
+    role: str
+    archetype: str
+    domain: str
+    delegation_scope: List[str]
+    risk_level: str  # low, standard, high, production
+    system_prompt: str
+    description: str
+    core_directive: str = "" # The primary mission statement
+    personality_style: str = "" # Tone and behavioral guidelines
+    legacy_aliases: List[str] = field(default_factory=list)
+    enabled: bool = True
+    model_preference: Optional[str] = None  # HARP hint only, not hardcoded
+
+    def matches_keywords(self, query: str) -> float:
+        """Score how well this sister matches a query based on keywords."""
+        query_lower = query.lower()
+        query_terms = set(query_lower.replace("_", " ").replace("-", " ").split())
+        score = 0.0
+
+        def _matches(term: str) -> bool:
+            normalized = term.lower().replace("_", " ").replace("-", " ")
+            if not normalized:
+                return False
+            return normalized in query_lower or any(part in query_terms for part in normalized.split())
+
+        # Direct ID/name match
+        if _matches(self.id) or _matches(self.name):
+            score += 10.0
+
+        # Role/archetype/domain match
+        for term in [self.role, self.archetype, self.domain]:
+            if _matches(term):
+                score += 5.0
+
+        # Delegation scope match
+        for scope in self.delegation_scope:
+            if _matches(scope):
+                score += 3.0
+
+        # Legacy alias match
+        for alias in self.legacy_aliases:
+            if _matches(alias):
+                score += 8.0
+
+        return score
+
+
+class SisterRegistry:
+    """
+    Central registry for all sister agents.
+    Reads from sisters.yaml and provides matching, loading, and delegation support.
+    """
+
+    def __init__(self, config_path: Optional[str] = None):
+        self.sisters: Dict[str, Sister] = {}
+        self._alias_map: Dict[str, str] = {}
+        self._config_path = config_path or self._default_config_path()
+        self._load_registry()
+
+    def _default_config_path(self) -> str:
+        """Find the sisters.yaml config file."""
+        candidates = [
+            os.path.expanduser("~/.hermes/config/sisters.yaml"),
+            os.path.expanduser("~/.hermes/sisters.yaml"),
+            os.path.join(os.path.dirname(__file__), "..", "config", "sisters.yaml"),
+        ]
+        for path in candidates:
+            if os.path.exists(path):
+                return path
+        return candidates[0]
+
+    def _load_registry(self):
+        """Load sister definitions from YAML config."""
+        import yaml
+
+        if not os.path.exists(self._config_path):
+            self._create_default_registry()
+            return
+
+        with open(self._config_path, 'r') as f:
+            data = yaml.safe_load(f)
+
+        if not data or 'sisters' not in data:
+            self._create_default_registry()
+            return
+
+        for s_data in data['sisters']:
+            sister = Sister(
+                id=s_data['id'],
+                name=s_data['name'],
+                role=s_data['role'],
+                archetype=s_data.get('archetype', ''),
+                domain=s_data.get('domain', ''),
+                delegation_scope=s_data.get('delegation_scope', []),
+                risk_level=s_data.get('risk_level', 'standard'),
+                system_prompt=s_data.get('system_prompt', ''),
+                description=s_data.get('description', ''),
+                core_directive=s_data.get('core_directive', ''),
+                personality_style=s_data.get('personality_style', ''),
+                legacy_aliases=s_data.get('legacy_aliases', []),
+                enabled=s_data.get('enabled', True),
+                model_preference=s_data.get('model_preference'),
+            )
+            self.sisters[sister.id] = sister
+            for alias in sister.legacy_aliases:
+                self._alias_map[alias.lower()] = sister.id
+
+        # Ensure Astra is always present as orchestrator
+        if 'astra' not in self.sisters:
+            self._add_astra()
+
+    def _create_default_registry(self):
+        """Create the default 12-sister roster if no config exists."""
+        default_sisters = [
+            Sister(
+                id="astra",
+                name="Astra",
+                role="Main Orchestrator",
+                archetype="Strategic Coordinator",
+                domain="Core Intelligence",
+                delegation_scope=["routing", "delegation", "synthesis", "quality_control"],
+                risk_level="production",
+                core_directive="You are Astra, the primary AI orchestrator. You coordinate, delegate, and ensure the right sister handles each task.",
+                personality_style="Sharp, decisive, professional, and concise.",
+                system_prompt="You are Astra, the primary AI orchestrator. You coordinate, delegate, and ensure the right sister handles each task.",
+                description="Primary orchestrator - routes tasks to specialized sisters",
+                legacy_aliases=[],
+            ),
+            Sister(
+                id="novus",
+                name="Novus",
+                role="Local Code Specialist",
+                archetype="Private Code Engineer",
+                domain="Core Intelligence",
+                delegation_scope=["local_code", "private_repos", "zero_cost_tasks", "ollama_tasks"],
+                risk_level="standard",
+                core_directive="Specializing in local, private code work using Ollama. Zero cost, 32k context, fully private.",
+                personality_style="Methodical, focused on privacy and efficiency.",
+                system_prompt="You are Novus, specializing in local, private code work using Ollama. Zero cost, 32k context, fully private.",
+                description="Local/private code work (Ollama, zero cost, 32k context)",
+                legacy_aliases=[],
+            ),
+            Sister(
+                id="nova",
+                name="Nova",
+                role="Browser & Vision Specialist",
+                archetype="Web Research Agent",
+                domain="Core Intelligence",
+                delegation_scope=["browser", "screenshots", "vision", "paid_research", "web_automation"],
+                risk_level="standard",
+                core_directive="Specializing in browser automation, screenshots, vision tasks, and paid research.",
+                personality_style="Observant, detailed, and resourceful.",
+                system_prompt="You are Nova, specializing in browser automation, screenshots, vision tasks, and paid research.",
+                description="Browser, screenshots, vision, paid research",
+                legacy_aliases=[],
+            ),
+            Sister(
+                id="luna",
+                name="Luna",
+                role="Deep Researcher",
+                archetype="Research Synthesis Specialist",
+                domain="Core Intelligence",
+                delegation_scope=["deep_research", "synthesis", "literature_review", "market_intelligence"],
+                risk_level="standard",
+                core_directive="Specializing in deep research, synthesis, and comprehensive analysis.",
+                personality_style="Intellectual, analytical, and comprehensive.",
+                system_prompt="You are Luna, specializing in deep research, synthesis, and comprehensive analysis.",
+                description="Deep research and synthesis",
+                legacy_aliases=[],
+            ),
+            Sister(
+                id="maya",
+                name="Maya",
+                role="Implementation & Shipping",
+                archetype="Builder",
+                domain="Core Intelligence",
+                delegation_scope=["implementation", "shipping", "deployment", "production_code"],
+                risk_level="production",
+                core_directive="Specializing in implementation, shipping, and getting things to production.",
+                personality_style="Pragmatic, result-oriented, and disciplined.",
+                system_prompt="You are Maya, specializing in implementation, shipping, and getting things to production.",
+                description="Implementation and shipping",
+                legacy_aliases=[],
+            ),
+            Sister(
+                id="helena",
+                name="Helena",
+                role="Legal Advisor",
+                archetype="Compliance Specialist",
+                domain="Business & Law",
+                delegation_scope=["legal", "compliance", "contracts", "regulatory"],
+                risk_level="high",
+                core_directive="Specializing in legal questions, compliance, and regulatory matters.",
+                personality_style="Formal, precise, and risk-averse.",
+                system_prompt="You are Helena, specializing in legal questions, compliance, and regulatory matters.",
+                description="Legal questions, compliance",
+                legacy_aliases=[],
+            ),
+            Sister(
+                id="larissa",
+                name="Larissa",
+                role="Customer Success Specialist",
+                archetype="SAC/Escalation Expert",
+                domain="Business & Law",
+                delegation_scope=["customer_service", "follow_up", "escalation", "satisfaction"],
+                risk_level="standard",
+                core_directive="Specializing in customer service, follow-up, and escalation handling.",
+                personality_style="Empathetic, professional, and diplomatic.",
+                system_prompt="You are Larissa, specializing in customer service, follow-up, and escalation handling.",
+                description="Customer service and follow-up",
+                legacy_aliases=["larissinha"],
+            ),
+            Sister(
+                id="clara",
+                name="Clara",
+                role="Sales Development",
+                archetype="Lead Qualification Expert",
+                domain="Business & Law",
+                delegation_scope=["sales", "lead_qualification", "outreach", "pipeline"],
+                risk_level="standard",
+                core_directive="Specializing in sales, lead qualification, and pipeline management.",
+                personality_style="Persuasive, outgoing, and strategic.",
+                system_prompt="You are Clara, specializing in sales, lead qualification, and pipeline management.",
+                description="Sales and lead qualification",
+                legacy_aliases=[],
+            ),
+            Sister(
+                id="bia",
+                name="Bia",
+                role="Signal Monitoring",
+                archetype="Risk Intelligence Analyst",
+                domain="Creative & Support",
+                delegation_scope=["signal_monitoring", "risk_intelligence", "threat_detection", "anomaly_detection"],
+                risk_level="high",
+                core_directive="Specializing in signal monitoring, risk intelligence, and threat detection.",
+                personality_style="Alert, skeptical, and highly observant.",
+                system_prompt="You are Bia, specializing in signal monitoring, risk intelligence, and threat detection.",
+                description="Signal monitoring and risk intelligence",
+                legacy_aliases=["fofoqueiro"],
+            ),
+            Sister(
+                id="vitoria",
+                name="Vitoria",
+                role="Creative Director",
+                archetype="Visual Content Specialist",
+                domain="Creative & Support",
+                delegation_scope=["creative", "visual_content", "brand_assets", "design"],
+                risk_level="standard",
+                core_directive="Specializing in creative and visual content, brand assets, and design.",
+                personality_style="Inspiring, artistic, and intuitive.",
+                system_prompt="You are Vitoria, specializing in creative and visual content, brand assets, and design.",
+                description="Creative and visual content",
+                legacy_aliases=["vini"],
+            ),
+            Sister(
+                id="daine",
+                name="Daine",
+                role="Data Analyst",
+                archetype="Analytics Specialist",
+                domain="Creative & Support",
+                delegation_scope=["analytics", "data_reports", "metrics", "visualization"],
+                risk_level="standard",
+                core_directive="Specializing in analytics, data reports, and metrics visualization.",
+                personality_style="Analytical, objective, and data-driven.",
+                system_prompt="You are Daine, specializing in analytics, data reports, and metrics visualization.",
+                description="Analytics and data reports",
+                legacy_aliases=["daiane"],
+            ),
+            Sister(
+                id="ada",
+                name="Ada",
+                role="Code Review & Generation",
+                archetype="Senior Developer",
+                domain="Creative & Support",
+                delegation_scope=["code_review", "code_generation", "debugging", "refactoring"],
+                risk_level="standard",
+                core_directive="Specializing in code review, generation, debugging, and refactoring.",
+                personality_style="Correct, rigorous, and mentorship-oriented.",
+                system_prompt="You are Ada, specializing in code review, generation, debugging, and refactoring.",
+                description="Code review, generation, debugging",
+                legacy_aliases=[],
+            ),
+        ]
+
+        for sister in default_sisters:
+            self.sisters[sister.id] = sister
+            for alias in sister.legacy_aliases:
+                self._alias_map[alias.lower()] = sister.id
+
+        # Save default config
+        self._save_registry()
+
+    def _add_astra(self):
+        """Ensure Astra exists as the orchestrator."""
+        astra = Sister(
+            id="astra",
+            name="Astra",
+            role="Main Orchestrator",
+            archetype="Strategic Coordinator",
+            domain="Core Intelligence",
+            delegation_scope=["routing", "delegation", "synthesis", "quality_control"],
+            risk_level="production",
+            core_directive="You are Astra, the primary AI orchestrator. You coordinate, delegate, and ensure the right sister handles each task.",
+            personality_style="Sharp, decisive, professional, and concise.",
+            system_prompt="You are Astra, the primary AI orchestrator. You coordinate, delegate, and ensure the right sister handles each task.",
+            description="Primary orchestrator - routes tasks to specialized sisters",
+            legacy_aliases=[],
+        )
+        self.sisters['astra'] = astra
+        self._save_registry()
+
+    def _save_registry(self):
+        """Save current registry to YAML config."""
+        import yaml
+
+        os.makedirs(os.path.dirname(self._config_path), exist_ok=True)
+
+        data = {
+            'sisters': [
+                {
+                    'id': s.id,
+                    'name': s.name,
+                    'role': s.role,
+                    'archetype': s.archetype,
+                    'domain': s.domain,
+                    'delegation_scope': s.delegation_scope,
+                    'risk_level': s.risk_level,
+                    'system_prompt': s.system_prompt,
+                    'description': s.description,
+                    'core_directive': s.core_directive,
+                    'personality_style': s.personality_style,
+                    'legacy_aliases': s.legacy_aliases,
+                    'enabled': s.enabled,
+                    'model_preference': s.model_preference,
+                }
+                for s in self.sisters.values()
+            ]
+        }
+
+        with open(self._config_path, 'w') as f:
+            yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+
+    def get(self, sister_id: str) -> Optional[Sister]:
+        """Get a sister by ID (resolves legacy aliases)."""
+        resolved_id = self._alias_map.get(sister_id.lower(), sister_id.lower())
+        return self.sisters.get(resolved_id)
+
+    def get_all(self) -> List[Sister]:
+        """Get all enabled sisters."""
+        return [s for s in self.sisters.values() if s.enabled]
+
+    def get_by_domain(self, domain: str) -> List[Sister]:
+        """Get sisters filtered by domain."""
+        return [s for s in self.get_all() if s.domain.lower() == domain.lower()]
+
+    def match_task(self, query: str, top_k: int = 3) -> List[Sister]:
+        """
+        Match a task query to the best sisters.
+        Returns top_k sisters sorted by relevance score.
+        """
+        scored = []
+        for sister in self.get_all():
+            score = sister.matches_keywords(query)
+            if score > 0:
+                scored.append((score, sister))
+
+        scored.sort(key=lambda x: x[0], reverse=True)
+        return [s for _, s in scored[:top_k]]
+
+    def match_task_single(self, query: str) -> Optional[Sister]:
+        """Get the single best sister match for a query."""
+        matches = self.match_task(query, top_k=1)
+        return matches[0] if matches else None
+
+    def list_sisters(self) -> List[Dict[str, Any]]:
+        """List all sisters as dicts for API/CLI consumption."""
+        return [
+            {
+                'id': s.id,
+                'name': s.name,
+                'role': s.role,
+                'archetype': s.archetype,
+                'domain': s.domain,
+                'delegation_scope': s.delegation_scope,
+                'risk_level': s.risk_level,
+                'description': s.description,
+                'legacy_aliases': s.legacy_aliases,
+                'enabled': s.enabled,
+                'model_preference': s.model_preference,
+            }
+            for s in self.get_all()
+        ]
+
+    def reload(self):
+        """Reload registry from config file."""
+        self.sisters.clear()
+        self._alias_map.clear()
+        self._load_registry()
+
+
+# Global registry instance
+_registry: Optional[SisterRegistry] = None
+
+
+def get_registry() -> SisterRegistry:
+    """Get the global sister registry instance."""
+    global _registry
+    if _registry is None:
+        _registry = SisterRegistry()
+    return _registry
+
+
+def reload_registry():
+    """Force reload the global registry."""
+    global _registry
+    _registry = SisterRegistry()
+    return _registry

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -24,6 +24,7 @@ Pure helpers that read the agent's state.  AIAgent keeps thin forwarders.
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any, Dict, List, Optional
 
 from agent.prompt_builder import (
@@ -43,6 +44,8 @@ from agent.prompt_builder import (
 )
 from agent.runtime_cwd import resolve_context_cwd
 
+logger = logging.getLogger(__name__)
+
 
 def _ra():
     """Lazy reference to the ``run_agent`` module.
@@ -57,6 +60,33 @@ def _ra():
     """
     import run_agent
     return run_agent
+
+
+def _resolve_agent_sister_prompt(agent: Any) -> str:
+    """
+    Resolve the active sister's system prompt for the given agent.
+
+    Checks ``agent._active_sister_id`` (set by delegate_task or CLI).
+    If set, loads the sister's full system prompt from sisters.yaml
+    and appends the global safety footer.
+
+    Returns empty string if no sister is active or if the sister is not found.
+    Falls back to Astra (the default first responder) if the specified sister
+    is invalid or disabled.
+
+    NOTE: This function only handles identity/personality. Model selection
+    is owned by HARP — do not hardcode model names in sister prompts.
+    """
+    try:
+        sister_id = getattr(agent, "_active_sister_id", None)
+        if not sister_id:
+            return ""
+        from agent.sister_prompt_loader import build_sister_system_prompt
+        return build_sister_system_prompt(sister_id)
+    except Exception:
+        # Sister prompt loading must never block system prompt assembly.
+        logger.debug("Failed to load sister prompt for agent", exc_info=True)
+        return ""
 
 
 def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) -> Dict[str, str]:
@@ -98,6 +128,17 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     if not _soul_loaded:
         # Fallback to hardcoded identity
         stable_parts.append(DEFAULT_AGENT_IDENTITY)
+
+    # ── Sister personality injection ────────────────────────────────
+    # If a sister is active, inject her system prompt into the stable tier.
+    # This replaces the generic "helpful assistant" persona with the selected
+    # sister's identity, domain expertise, and behavioral style.
+    #
+    # IMPORTANT: Do not hardcode model names in sister personality prompts.
+    # HARP owns model selection. This layer only provides identity/behavior.
+    _sister_prompt = _resolve_agent_sister_prompt(agent)
+    if _sister_prompt:
+        stable_parts.append(_sister_prompt)
 
     # Pointer to the hermes-agent skill + docs for user questions about Hermes itself.
     stable_parts.append(HERMES_AGENT_HELP_GUIDANCE)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -474,6 +474,8 @@ class TelegramAdapter(BasePlatformAdapter):
         self._forum_command_registered: set[int] = set()
         # Lock per la registrazione sicura dei comandi nei forum supergroup
         self._forum_lock = asyncio.Lock()
+        # Sister preference per chat_id: user-selected sister for routing
+        self._sister_preference: Dict[str, str] = {}
         # DM Topics config from extra.dm_topics
         self._dm_topics_config: List[Dict[str, Any]] = self.config.extra.get("dm_topics", [])
         # Precomputed chat_ids that have DM topics configured (for O(1) root-DM ignore check)
@@ -5803,6 +5805,66 @@ class TelegramAdapter(BasePlatformAdapter):
 
         event = self._build_message_event(msg, MessageType.COMMAND, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
+        # Handle /sister command to set sister preference
+        if event.text and event.text.lower().startswith("/sister"):
+            parts = event.text.strip().split()
+            if len(parts) >= 2:
+                requested_sister = parts[1].lower()
+                # TODO: Validate sister ID against known sisters
+                # For now, accept any non-empty string
+                if requested_sister:
+                    # Build session key to store preference
+                    from gateway.session import build_session_key
+                    session_key = build_session_key(
+                        event.source,
+                        group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
+                        thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
+                    )
+                    self._sister_preference[session_key] = requested_sister
+                    # Send confirmation message
+                    try:
+                        await self._bot.send_message(
+                            chat_id=int(msg.chat_id),
+                            text=f"✅ Sister preference set to: {requested_sister}\nUse /sister to change or clear preference.",
+                            parse_mode=ParseMode.MARKDOWN_V2,
+                            reply_to_message_id=getattr(msg, "message_id", None),
+                            **self._thread_kwargs_for_send(
+                                str(msg.chat_id),
+                                getattr(msg, "message_thread_id", None),
+                                {},
+                            ),
+                            **self._link_preview_kwargs(),
+                            **self._notification_kwargs({}),
+                        )
+                    except Exception as send_err:
+                        logger.warning(
+                            "[%s] Failed to send sister preference confirmation: %s",
+                            self.name,
+                            send_err,
+                        )
+                    return
+            # If malformed /sister command, show usage
+            try:
+                await self._bot.send_message(
+                    chat_id=int(msg.chat_id),
+                    text="Usage: /sister <sister_id>\nExample: /sister novus\nRun /sister list to see available sisters.",
+                    parse_mode=ParseMode.MARKDOWN_V2,
+                    reply_to_message_id=getattr(msg, "message_id", None),
+                    **self._thread_kwargs_for_send(
+                        str(msg.chat_id),
+                        getattr(msg, "message_thread_id", None),
+                        {},
+                    ),
+                    **self._link_preview_kwargs(),
+                    **self._notification_kwargs({}),
+                )
+            except Exception as send_err:
+                logger.warning(
+                    "[%s] Failed to send sister command usage: %s",
+                    self.name,
+                    send_err,
+                )
+            return
         await self._cache_replied_media(msg, event)
         event = self._apply_telegram_group_observe_attribution(event)
         await self.handle_message(event)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -266,6 +266,7 @@ from hermes_cli.subcommands._shared import add_accept_hooks_flag as _add_accept_
 from hermes_cli.subcommands.cron import build_cron_parser
 from hermes_cli.subcommands.gateway import build_gateway_parser
 from hermes_cli.subcommands.profile import build_profile_parser
+from hermes_cli.subcommands.sister import build_sister_parser
 from hermes_cli.subcommands.model import build_model_parser
 from hermes_cli.subcommands.setup import build_setup_parser
 from hermes_cli.subcommands.postinstall import build_postinstall_parser
@@ -9957,6 +9958,7 @@ def _coalesce_session_name_args(argv: list) -> list:
         "update",
         "uninstall",
         "profile",
+        "sister",
         "dashboard",
         "desktop",
         "gui",
@@ -10579,6 +10581,12 @@ def cmd_profile(args):
         print()
 
 
+def cmd_sister(args):
+    """Sister Personality System — list, show, match, reload, status."""
+    from hermes_cli.subcommands.sister import cmd_sister as _cmd_sister
+    _cmd_sister(args)
+
+
 def _render_distribution_plan(plan) -> None:
     """Print a human-readable summary of a pending distribution install."""
     from hermes_cli.profile_distribution import MANIFEST_FILENAME
@@ -10958,7 +10966,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "config", "cron", "curator", "dashboard", "debug", "doctor",
         "dump", "fallback", "gateway", "hooks", "import", "insights",
         "gui", "desktop", "kanban", "login", "logout", "logs", "lsp", "mcp", "memory", "migrate",
-        "model", "pairing", "plugins", "portal", "postinstall", "profile", "proxy",
+        "model", "pairing", "plugins", "portal", "postinstall", "profile", "sister", "proxy",
         "prompt-size",
         "send", "sessions", "setup",
         "skills", "slack", "status", "tools", "uninstall", "update",
@@ -12305,6 +12313,11 @@ def main():
     # profile command  (parser built in hermes_cli/subcommands/profile.py)
     # =========================================================================
     build_profile_parser(subparsers, cmd_profile=cmd_profile)
+
+    # =========================================================================
+    # sister command  (parser built in hermes_cli/subcommands/sister.py)
+    # =========================================================================
+    build_sister_parser(subparsers, cmd_sister=cmd_sister)
 
     # =========================================================================
     # completion command

--- a/hermes_cli/subcommands/sister.py
+++ b/hermes_cli/subcommands/sister.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""``hermes sister`` subcommand — manage the 12-Sister Personality System.
+
+Usage::
+
+    hermes sister list                    # list all sisters with status
+    hermes sister show <id>               # show full sister details
+    hermes sister match <task>            # match a task to the best sister
+    hermes sister reload                  # reload sisters.yaml from disk
+    hermes sister run <id> <prompt>       # one-shot chat as a specific sister
+    hermes sister status                  # show active sister registry info
+
+"""
+
+from __future__ import annotations
+
+import sys
+import os
+import json
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _load_registry():
+    """Import sister_registry, adjusting sys.path if needed."""
+    try:
+        from agent import sister_registry
+        return sister_registry
+    except ImportError:
+        pass
+
+    # When run from the hermes CLI, the agent package may not be on sys.path.
+    # Try common locations.
+    candidates = [
+        os.environ.get("HERMES_AGENT_DIR", ""),
+        os.path.expanduser("~/.hermes/hermes-agent"),
+        os.path.join(os.path.dirname(__file__), "..", ".."),
+    ]
+    for d in candidates:
+        if d and os.path.isdir(os.path.join(d, "agent")) and d not in sys.path:
+            sys.path.insert(0, d)
+
+    from agent import sister_registry
+    return sister_registry
+
+
+def _load_prompt_loader():
+    """Import sister_prompt_loader, adjusting sys.path if needed."""
+    try:
+        from agent import sister_prompt_loader
+        return sister_prompt_loader
+    except ImportError:
+        pass
+
+    candidates = [
+        os.environ.get("HERMES_AGENT_DIR", ""),
+        os.path.expanduser("~/.hermes/hermes-agent"),
+        os.path.join(os.path.dirname(__file__), "..", ".."),
+    ]
+    for d in candidates:
+        if d and os.path.isdir(os.path.join(d, "agent")) and d not in sys.path:
+            sys.path.insert(0, d)
+
+    from agent import sister_prompt_loader
+    return sister_prompt_loader
+
+
+def _banner():
+    print("=" * 60)
+    print("  🌟 Hermes 12-Sister Personality System — CLI")
+    print("=" * 60)
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Command handlers
+# ---------------------------------------------------------------------------
+
+def cmd_list(args) -> None:
+    """List all sisters in a formatted table."""
+    registry_module = _load_registry()
+    registry = registry_module.get_registry()
+    sisters = registry.list_sisters()
+
+    if not sisters:
+        print("No sisters found. Check ~/.hermes/config/sisters.yaml")
+        return
+
+    print(f"{'ID':<12} {'Name':<10} {'Role':<28} {'Domain':<18} {'Risk':<8} {'Enabled'}")
+    print("-" * 94)
+    for s in sisters:
+        sid = s.get("id", "")
+        name = s.get("name", "")
+        role = s.get("role", "")[:27]
+        domain = s.get("domain", "")[:17]
+        risk = s.get("risk_level", "")
+        enabled = "yes" if s.get("enabled", True) else "no"
+        print(f"{sid:<12} {name:<10} {role:<28} {domain:<18} {risk:<8} {enabled}")
+
+    print(f"\n{len(sisters)} sisters loaded.")
+    print("Legacy aliases: fofoqueiro→bia, vini→vitoria, larissinha→larissa, daiane→daine")
+
+
+def cmd_show(args) -> None:
+    """Show full details for one sister."""
+    registry_module = _load_registry()
+    registry = registry_module.get_registry()
+    prompt_loader_module = _load_prompt_loader()
+    prompt_loader = prompt_loader_module.get_prompt_loader()
+
+    sister_id = getattr(args, "sister_id", None)
+    if not sister_id:
+        print("Usage: hermes sister show <id>")
+        sys.exit(1)
+
+    sister = registry.get(sister_id)
+    if not sister:
+        print(f"Sister '{sister_id}' not found.")
+        sys.exit(1)
+
+    prompt = prompt_loader.build_sister_prompt(sister)
+
+    print(f"\n{prompt.metadata.get('role', '')}  {sister.name} ({sister.id})")
+    print(f"  Archetype:   {sister.archetype}")
+    print(f"  Domain:      {sister.domain}")
+    print(f"  Risk Level:  {sister.risk_level}")
+    print(f"  Model Hint:  {sister.model_preference or 'none'}")
+    if sister.legacy_aliases:
+        print(f"  Legacy IDs:  {', '.join(sister.legacy_aliases)}")
+    print(f"  Delegation:  {', '.join(sister.delegation_scope)}")
+    print(f"  Enabled:     {sister.enabled}")
+    print()
+    print("  System Prompt:")
+    print("-" * 60)
+    # Show first 20 lines
+    lines = prompt.system_prompt.strip().split("\n")
+    for line in lines[:20]:
+        print(f"  {line}")
+    if len(lines) > 20:
+        print(f"  ... ({len(lines) - 20} more lines)")
+
+
+def cmd_match(args) -> None:
+    """Match a task description to the best sister."""
+    registry_module = _load_registry()
+    registry = registry_module.get_registry()
+
+    task = getattr(args, "task_text", "")
+    if isinstance(task, list):
+        task = " ".join(task)
+    if not task:
+        print("Usage: hermes sister match <task description>")
+        sys.exit(1)
+
+    matches = registry.match_task(task, top_k=3)
+
+    if matches:
+        print(f"\n  Task:   \"{task[:80]}{'...' if len(task) > 80 else ''}\"")
+        print(f"  Matches (top {len(matches)}):")
+        for i, sister in enumerate(matches, 1):
+            score = sister.matches_keywords(task)
+            print(f"    {i}. {sister.name} ({sister.id}) — score: {score:.1f}")
+            print(f"       Domain: {sister.domain} | Scope: {', '.join(sister.delegation_scope[:3])}")
+    else:
+        print(f'\n  Task:   "{task[:80]}{"..." if len(task) > 80 else ""}"')
+        print(f"  Match:  none — will use fallback: astra")
+
+
+def cmd_reload(args) -> None:
+    """Reload sisters.yaml from disk."""
+    registry_module = _load_registry()
+    reload_registry = getattr(registry_module, 'reload_registry', None)
+    if reload_registry:
+        reload_registry()
+        registry = registry_module.get_registry()
+        sisters = registry.list_sisters()
+        print(f"Reloaded sisters.yaml: {len(sisters)} sisters loaded.")
+    else:
+        print("Reload not available in this version.")
+
+
+def cmd_status(args) -> None:
+    """Show active sister registry info."""
+    registry_module = _load_registry()
+    registry = registry_module.get_registry()
+    sisters = registry.get_all()
+
+    config_path = os.path.expanduser("~/.hermes/config/sisters.yaml")
+
+    print(f"  Config path:    {config_path}")
+    print(f"  Sisters loaded: {len(sisters)}")
+    print(f"  Fallback:       astra (orchestrator)")
+    print(f"  HARP routing:   SEPARATE — model selection not in sister prompts")
+    print()
+    print("  Delegation map:")
+    print("    Code → Novus | Vision/Web → Nova | Legal → Helena | Risk → Bia")
+    print("    Sales → Clara | Support → Daine | Creative → Vitoria | Data → Daine")
+    print("    Research → Luna | Implementation → Maya | Orchestration → Astra")
+    print()
+    print("  Sister roster:")
+    for s in sisters:
+        print(f"    {s.id:<10} {s.name:<10} [{s.domain}] {s.role}")
+
+
+def cmd_run(args) -> None:
+    """One-shot chat as a specific sister."""
+    registry_module = _load_registry()
+    registry = registry_module.get_registry()
+    prompt_loader_module = _load_prompt_loader()
+    prompt_loader = prompt_loader_module.get_prompt_loader()
+
+    sister_id = getattr(args, "sister_id", None)
+    prompt_text = getattr(args, "prompt", None)
+
+    if not sister_id or not prompt_text:
+        print("Usage: hermes sister run <id> <prompt>")
+        sys.exit(1)
+
+    sister = registry.get(sister_id)
+    if not sister:
+        print(f"Sister '{sister_id}' not found.")
+        sys.exit(1)
+
+    # Load the sister's system prompt
+    sp = prompt_loader.build_sister_prompt(sister)
+    system_prompt = sp.to_system_prompt()
+
+    # Run a one-shot using the model_tools
+    try:
+        import model_tools
+        # Get default tool definitions
+        tool_defs = model_tools.get_tool_definitions(quiet_mode=True)
+
+        # For now, just show what would happen
+        print(f"\nWould run one-shot as {sister.name} ({sister.id})")
+        print(f"System prompt: {system_prompt[:200]}...")
+        print(f"Prompt: {prompt_text}")
+        print("\nNote: Full one-shot execution requires running inside an agent context.")
+        print("Use 'hermes chat' and mention the sister by name for interactive use.")
+    except Exception as e:
+        print(f"Error: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Parser builder
+# ---------------------------------------------------------------------------
+
+def build_sister_parser(subparsers, *, cmd_sister=None) -> None:
+    """Attach the ``sister`` subcommand to ``subparsers``."""
+    sister_parser = subparsers.add_parser(
+        "sister",
+        help="Manage the 12-Sister Personality System",
+    )
+    sister_parser.set_defaults(func=cmd_sister)
+    sister_subparsers = sister_parser.add_subparsers(dest="sister_action")
+
+    # `hermes sister list`
+    sister_subparsers.add_parser("list", help="List all sisters")
+
+    # `hermes sister show <id>`
+    show_parser = sister_subparsers.add_parser("show", help="Show sister details")
+    show_parser.add_argument("sister_id", help="Sister ID (e.g., novus, astra)")
+
+    # `hermes sister match <task>`
+    match_parser = sister_subparsers.add_parser("match", help="Match task to best sister")
+    match_parser.add_argument("task_text", nargs="+", help="Task description")
+
+    # `hermes sister reload`
+    sister_subparsers.add_parser("reload", help="Reload sisters.yaml from disk")
+
+    # `hermes sister status`
+    sister_subparsers.add_parser("status", help="Show registry status")
+
+    # `hermes sister run <id> <prompt>`
+    run_parser = sister_subparsers.add_parser("run", help="One-shot chat as a specific sister")
+    run_parser.add_argument("sister_id", help="Sister ID (e.g., novus, astra)")
+    run_parser.add_argument("prompt", help="Prompt to send to the sister")
+
+
+def cmd_sister(args) -> None:
+    """Dispatch sister subcommand."""
+    action = getattr(args, "sister_action", None)
+
+    if action is None:
+        cmd_status(args)
+        return
+
+    dispatch = {
+        "list": cmd_list,
+        "show": cmd_show,
+        "match": cmd_match,
+        "reload": cmd_reload,
+        "status": cmd_status,
+        "run": cmd_run,
+    }
+
+    handler = dispatch.get(action)
+    if handler:
+        handler(args)
+    else:
+        print(f"Unknown sister action: {action}")
+        sys.exit(1)

--- a/tools/delegate_to_sister_tool.py
+++ b/tools/delegate_to_sister_tool.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""
+delegate_to_sister_tool.py
+
+Tool for Astra to delegate tasks to specialized sister agents.
+This enables the Astra -> Sister -> Astra hierarchical delegation flow.
+
+The tool uses the existing subagent infrastructure (delegate_task) but
+provides a specialized interface that:
+1. Resolves the sister by ID from the SisterRegistry
+2. Builds the sister's byte-stable system prompt via SisterPromptLoader
+3. Spawns a child agent with the sister's identity and appropriate toolsets
+4. Returns the sister's response to Astra for synthesis
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+from tools.registry import registry, tool_error
+
+
+# Tool schema
+DELEGATE_TO_SISTER_SCHEMA = {
+    "name": "delegate_to_sister",
+    "description": (
+        "Delegate a specialized task to a sister agent. "
+        "The sister will execute with her own identity, system prompt, and appropriate toolsets. "
+        "Use this when a task requires deep domain expertise (legal, creative, research, code, etc.). "
+        "The orchestrator (Astra) receives the result and synthesizes it for the user."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "sister_id": {
+                "type": "string",
+                "description": "ID of the sister to delegate to (e.g., 'novus', 'helena', 'vitoria', 'luna', 'maya', 'ada', 'bia', 'daine', 'clara', 'larissa', 'nova'). Legacy aliases also work: 'fofoqueiro'->bia, 'vini'->vitoria, 'larissinha'->larissa, 'daiane'->daine.",
+            },
+            "prompt": {
+                "type": "string",
+                "description": "The task description for the sister. Be specific and self-contained — the sister knows nothing about your conversation history.",
+            },
+            "toolsets": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional toolset override. If omitted, the sister's default toolsets are used based on her domain.",
+            },
+            "risk_level": {
+                "type": "string",
+                "enum": ["low", "standard", "high", "production"],
+                "description": "Risk level for this delegation. Determines model routing via HARP. Default: sister's configured risk_level.",
+            },
+        },
+        "required": ["sister_id", "prompt"],
+    },
+}
+
+
+def _resolve_sister_toolsets(sister_id: str, override: Optional[List[str]] = None) -> List[str]:
+    """Determine appropriate toolsets for a sister based on her domain."""
+    if override:
+        return override
+
+    # Domain-based toolset defaults
+    domain_toolsets = {
+        "Core Intelligence": ["coding", "web", "browser", "delegation"],
+        "Business & Law": ["web", "file", "terminal", "delegation"],
+        "Creative & Support": ["web", "file", "vision", "delegation", "image_gen"],
+    }
+
+    # Sister-specific overrides
+    sister_overrides = {
+        "novus": ["coding", "terminal", "file", "delegation"],  # Local code focus
+        "nova": ["browser", "web", "vision", "delegation"],     # Browser/vision focus
+        "luna": ["web", "browser", "file", "delegation"],       # Research focus
+        "maya": ["coding", "terminal", "file", "delegation"],   # Implementation focus
+        "helena": ["web", "file", "delegation"],                # Legal research
+        "larissa": ["web", "file", "messaging", "delegation"],  # Customer service
+        "clara": ["web", "file", "messaging", "delegation"],    # Sales
+        "bia": ["web", "browser", "file", "delegation"],        # Signal monitoring
+        "vitoria": ["web", "file", "vision", "image_gen", "delegation"],  # Creative
+        "daine": ["web", "file", "coding", "delegation"],       # Data analysis
+        "ada": ["coding", "terminal", "file", "delegation"],    # Code review
+    }
+
+    # Default to sister-specific if available, else domain-based
+    if sister_id in sister_overrides:
+        return sister_overrides[sister_id]
+
+    # Fallback: try to get domain from registry
+    try:
+        from agent.sister_registry import get_registry
+        registry = get_registry()
+        sister = registry.get(sister_id)
+        if sister and sister.domain in domain_toolsets:
+            return domain_toolsets[sister.domain]
+    except Exception:
+        pass
+
+    # Ultimate fallback
+    return ["web", "file", "delegation"]
+
+
+def _get_sister_model_hint(sister_id: str, risk_level: Optional[str] = None) -> Optional[str]:
+    """Get model preference hint for HARP routing."""
+    try:
+        from agent.sister_registry import get_registry
+        reg = get_registry()
+        sister = reg.get(sister_id)
+        if sister:
+            return sister.model_preference
+    except Exception:
+        pass
+    return None
+
+
+async def _delegate_to_sister_impl(
+    sister_id: str,
+    prompt: str,
+    toolsets: Optional[List[str]] = None,
+    risk_level: Optional[str] = None,
+    parent_agent=None,
+) -> str:
+    """
+    Internal implementation that spawns a sister agent and returns her response.
+
+    This uses the existing delegate_task infrastructure but with sister-specific
+    configuration (system prompt, toolsets, model hint).
+    """
+    # Resolve sister
+    try:
+        from agent.sister_registry import get_registry
+        from agent.sister_prompt_loader import get_prompt_loader
+    except ImportError:
+        return tool_error("Sister system not available. Run 'hermes sister reload' to initialize.")
+
+    reg = get_registry()
+    prompt_loader = get_prompt_loader()
+
+    sister = reg.get(sister_id)
+    if not sister:
+        available = [s.id for s in reg.get_all()]
+        return tool_error(
+            f"Sister '{sister_id}' not found. Available: {', '.join(available)}"
+        )
+
+    # Build sister's system prompt
+    sister_prompt = prompt_loader.build_sister_prompt(sister)
+    system_prompt = sister_prompt.system_prompt
+
+    # Resolve toolsets
+    effective_toolsets = _resolve_sister_toolsets(sister_id, toolsets)
+
+    # Resolve risk level
+    effective_risk = risk_level or sister.risk_level
+
+    # Prepare context for the sister
+    context = (
+        f"You are {sister.name} ({sister.id}), {sister.role}.\n"
+        f"Domain: {sister.domain}\n"
+        f"Archetype: {sister.archetype}\n"
+        f"Style: {sister.personality_style}\n\n"
+        f"CORE DIRECTIVE:\n{sister.core_directive}\n\n"
+        f"DELEGATION SCOPE: {', '.join(sister.delegation_scope)}\n"
+        f"RISK LEVEL: {effective_risk}\n\n"
+        f"--- TASK FROM ORCHESTRATOR ---\n{prompt}"
+    )
+
+    # Use the existing delegate_task function from delegate_tool
+    try:
+        from tools.delegate_tool import delegate_task
+    except ImportError:
+        return tool_error("delegate_task not available")
+
+    # Execute delegation
+    # Note: We pass the sister's system prompt as part of the goal context
+    # The child agent will receive this as its initial context
+    result_json = delegate_task(
+        goal=prompt,
+        context=context,
+        toolsets=effective_toolsets,
+        role="leaf",  # Sisters are leaf agents - they don't delegate further
+        sister_id=sister.id,
+        parent_agent=parent_agent,
+    )
+
+    # Parse result
+    try:
+        result = json.loads(result_json)
+        results = result.get("results", [])
+        if results and len(results) > 0:
+            entry = results[0]
+            if entry.get("status") == "completed":
+                return entry.get("summary", "Task completed (no summary returned)")
+            else:
+                return f"[Sister {sister.name} failed] {entry.get('error', 'Unknown error')}"
+        return "Sister delegation completed but returned no result"
+    except json.JSONDecodeError:
+        return f"Sister delegation returned invalid result: {result_json}"
+
+
+def delegate_to_sister(
+    sister_id: str,
+    prompt: str,
+    toolsets: Optional[List[str]] = None,
+    risk_level: Optional[str] = None,
+    parent_agent=None,
+) -> str:
+    """
+    Synchronous wrapper for delegate_to_sister.
+    Uses the async bridge from model_tools.
+    """
+    try:
+        import model_tools
+        return model_tools._run_async(
+            _delegate_to_sister_impl(
+                sister_id=sister_id,
+                prompt=prompt,
+                toolsets=toolsets,
+                risk_level=risk_level,
+                parent_agent=parent_agent,
+            )
+        )
+    except Exception as e:
+        return tool_error(f"Delegation failed: {str(e)}")
+
+
+# Register the tool
+def _check_delegate_to_sister_availability() -> bool:
+    """Check if sister system is available."""
+    try:
+        from agent.sister_registry import get_registry
+        reg = get_registry()
+        return len(reg.get_all()) > 0
+    except Exception:
+        return False
+
+
+registry.register(
+    name="delegate_to_sister",
+    toolset="delegation",
+    schema=DELEGATE_TO_SISTER_SCHEMA,
+    handler=lambda args, **kw: delegate_to_sister(
+        sister_id=args.get("sister_id"),
+        prompt=args.get("prompt"),
+        toolsets=args.get("toolsets"),
+        risk_level=args.get("risk_level"),
+        parent_agent=kw.get("parent_agent"),
+    ),
+    check_fn=_check_delegate_to_sister_availability,
+    emoji="👯",
+)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -661,6 +661,7 @@ def _build_child_system_prompt(
     role: str = "leaf",
     max_spawn_depth: int = 2,
     child_depth: int = 1,
+    sister_id: Optional[str] = None,
 ) -> str:
     """Build a focused system prompt for a child agent.
 
@@ -669,12 +670,39 @@ def _build_child_system_prompt(
     inspiration/openclaw/src/agents/subagent-system-prompt.ts:63-95).
     The depth note is literal truth (grounded in the passed config) so
     the LLM doesn't confabulate nesting capabilities that don't exist.
+
+    When sister_id is provided, prepends the sister's personality system prompt
+    so the child agent operates with the correct sister identity.
+    IMPORTANT: Do not hardcode model names in sister personality prompts.
+    HARP owns model selection.
     """
-    parts = [
-        "You are a focused subagent working on a specific delegated task.",
-        "",
-        f"YOUR TASK:\n{goal}",
-    ]
+    parts: List[str] = []
+
+    # ── Sister personality injection (if specified) ────────────────────
+    # Prepends the sister's identity prompt to the child's system prompt.
+    # This replaces the generic "focused subagent" persona with the
+    # selected sister's domain expertise and behavioral style.
+    if sister_id:
+        try:
+            from agent.sister_prompt_loader import get_system_prompt
+            _sp = get_system_prompt(sister_id)
+            if _sp:
+                parts.append(_sp.strip())
+                parts.append("")  # blank line separator
+        except Exception:
+            logger.debug(
+                "Failed to load sister prompt for %s, falling back to default",
+                sister_id,
+                exc_info=True,
+            )
+
+    parts.extend(
+        [
+            "You are a focused subagent working on a specific delegated task.",
+            "",
+            f"YOUR TASK:\n{goal}",
+        ]
+    )
     if context and context.strip():
         parts.append(f"\nCONTEXT:\n{context}")
     if workspace_path and str(workspace_path).strip():
@@ -981,6 +1009,8 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    # Sister identity — when set, the child agent operates as this sister
+    sister_id: Optional[str] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -1068,6 +1098,7 @@ def _build_child_agent(
         role=effective_role,
         max_spawn_depth=max_spawn,
         child_depth=child_depth,
+        sister_id=sister_id,
     )
     # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
     parent_api_key = getattr(parent_agent, "api_key", None)
@@ -1245,6 +1276,14 @@ def _build_child_agent(
     child._parent_subagent_id = parent_subagent_id
     child._subagent_goal = goal
     child._parent_turn_id = getattr(parent_agent, "_current_turn_id", "") or ""
+    # Propagate sister identity to child agent for personality injection.
+    # The sister prompt is already in child_prompt (prepended by _build_child_system_prompt).
+    # _active_sister_id is used by _resolve_agent_sister_prompt() in system_prompt.py
+    # for any recursive delegation deeper than this level.
+    if sister_id:
+        child._active_sister_id = sister_id
+    elif getattr(parent_agent, "_active_sister_id", None):
+        child._active_sister_id = parent_agent._active_sister_id
     # Stable sidebar marker: delegate subagent sessions must stay out of
     # session pickers even when a parent delete orphans them (parent_session_id
     # → NULL). Mirrors /branch's ``_branched_from`` pattern — see
@@ -2051,6 +2090,7 @@ def delegate_task(
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
     background: Optional[bool] = None,
+    sister_id: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -2158,7 +2198,13 @@ def delegate_task(
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
         task_list = [
-            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role}
+            {
+                "goal": goal,
+                "context": context,
+                "toolsets": toolsets,
+                "role": top_role,
+                "sister_id": sister_id,
+            }
         ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
@@ -2221,6 +2267,7 @@ def delegate_task(
                     else (acp_args if acp_args is not None else creds.get("args"))
                 ),
                 role=effective_role,
+                sister_id=t.get("sister_id") or sister_id,
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
@@ -3021,6 +3068,10 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "sister_id": {
+                            "type": "string",
+                            "description": "Optional sister identity for this task (e.g. astra, novus, nova, luna, ada, maya). Internal/specialized use only.",
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -3051,6 +3102,10 @@ DELEGATE_TASK_SCHEMA = {
                     "multi-step investigations). Do NOT poll or wait after "
                     "dispatching — just continue; the result will come to you."
                 ),
+            },
+            "sister_id": {
+                "type": "string",
+                "description": "Optional sister identity for specialized internal delegation. Ordinary callers should use delegate_to_sister instead.",
             },
             "acp_command": {
                 "type": "string",
@@ -3097,6 +3152,7 @@ registry.register(
         acp_args=args.get("acp_args"),
         role=args.get("role"),
         background=args.get("background"),
+        sister_id=args.get("sister_id"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,


### PR DESCRIPTION
## Summary
- Adds a 12-sister registry and byte-stable sister prompt loader.
- Adds `hermes sister` CLI commands for list/show/match/status/run.
- Wires sister identity into system-prompt and delegation plumbing, including `delegate_to_sister`.
- Improves sister task matching so underscore-separated scopes like `code_review` match natural language queries such as “review this python bug”.

## Verification
- `PYTHONDONTWRITEBYTECODE=1 python -m pytest -q -p no:cacheprovider tests/agent/test_system_prompt.py tests/tools/test_delegate.py` → 145 passed, 1 warning
- `PYTHONDONTWRITEBYTECODE=1 python -m hermes_cli.main sister list`
- `PYTHONDONTWRITEBYTECODE=1 python -m hermes_cli.main sister show astra`
- `PYTHONDONTWRITEBYTECODE=1 python -m hermes_cli.main sister match "review this python bug"` → Ada selected as top match

## Notes
This intentionally does not include unrelated local desktop UI or Hindsight memory-provider edits that remain uncommitted in the local checkout and need separate hardening.
