### PR TITLE
fix(delegation): forward background flag in agent dispatch

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5140,6 +5140,7 @@ class AIAgent:
             acp_command=function_args.get("acp_command"),
             acp_args=function_args.get("acp_args"),
             role=function_args.get("role"),
+            background=function_args.get("background"),
             parent_agent=self,
         )
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -2004,6 +2004,39 @@ class TestDelegationReasoningEffort(unittest.TestCase):
 class TestDispatchDelegateTask(unittest.TestCase):
     """Tests for the _dispatch_delegate_task helper and full param forwarding."""
 
+    def test_background_forwarded_by_aiagent_dispatch_helper(self):
+        """The real agent/gateway path must forward background=True.
+
+        tools.delegate_tool.delegate_task(background=True) is covered in the
+        async-delegation tests, but gateway turns go through
+        AIAgent._dispatch_delegate_task first.  A regression here silently
+        degrades async delegation into synchronous delegation.
+        """
+        from run_agent import AIAgent
+
+        captured = {}
+
+        def fake_delegate_task(**kwargs):
+            captured.update(kwargs)
+            return "OK"
+
+        dummy_agent = MagicMock()
+        function_args = {
+            "goal": "test",
+            "context": "ctx",
+            "toolsets": ["terminal"],
+            "background": True,
+            "role": "leaf",
+        }
+
+        with patch("tools.delegate_tool.delegate_task", side_effect=fake_delegate_task):
+            self.assertEqual(AIAgent._dispatch_delegate_task(dummy_agent, function_args), "OK")
+
+        self.assertIs(captured.get("background"), True)
+        self.assertEqual(captured.get("goal"), "test")
+        self.assertEqual(captured.get("toolsets"), ["terminal"])
+        self.assertIs(captured.get("parent_agent"), dummy_agent)
+
     @patch("tools.delegate_tool._load_config", return_value={})
     @patch("tools.delegate_tool._resolve_delegation_credentials")
     def test_acp_args_forwarded(self, mock_creds, mock_cfg):


### PR DESCRIPTION
## Summary

- forward `background` through `AIAgent._dispatch_delegate_task()` so the real agent/gateway path preserves `delegate_task(background=true)`
- add a regression test covering the dispatch helper forwarding path

Fixes #46944

## Why

`tools.delegate_tool.delegate_task(background=True)` already supports async dispatch, but gateway/agent turns route through `AIAgent._dispatch_delegate_task()` first. That helper did not forward the `background` flag, so a model-emitted `delegate_task(background=true)` silently ran synchronously.

## Verification

```bash
./venv/bin/python -m py_compile run_agent.py tests/tools/test_delegate.py
./venv/bin/python -m pytest \
  tests/tools/test_delegate.py::TestDispatchDelegateTask::test_background_forwarded_by_aiagent_dispatch_helper \
  tests/tools/test_async_delegation.py \
  -q -o 'addopts='
```

Result:

```text
18 passed, 1 warning in 1.57s
```

Manual smoke after the fix:

```text
dispatch_elapsed=0.053
dispatch_out={"status":"dispatched","delegation_id":"deleg_f3a21e6e","goal":"smoke","mode":"background",...}
active_after_dispatch=1
event_type=async_delegation
event_status=completed
event_summary=PATCHED_BACKGROUND_OK
```
