### PR TITLE
fix(desktop): force app exit after update/uninstall handoff on macOS

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1589,6 +1589,15 @@ async function readCommitLog(cwd, branch) {
 
 let updateInFlight = false
 
+// Set to true when the desktop is about to quit so a detached swap/install
+// script can take over. On macOS, app.quit() closes windows but
+// window-all-closed deliberately keeps the process alive (standard Electron
+// macOS convention). Without this flag the process never exits — the detached
+// swapper spins its PID-wait for the full timeout, and the user sees a blank
+// app with no window. When set, window-all-closed calls app.quit() on every
+// platform so the process actually dies and the hand-off script can proceed.
+let isQuittingForHandoff = false
+
 // Resolve the staged updater binary. The Tauri installer copies itself to
 // HERMES_HOME/hermes-setup.exe on a successful install (see
 // apps/bootstrap-installer paths::copy_self_to_hermes_home). That binary owns
@@ -1836,6 +1845,7 @@ async function applyUpdates(opts = {}) {
 
     // Give the OS a beat to register the new process, then quit. The updater
     // rebuilds and relaunches us when it's done.
+    isQuittingForHandoff = true
     setTimeout(() => {
       app.quit()
     }, 600)
@@ -1877,6 +1887,7 @@ async function handOffWindowsBootstrapRecovery(reason) {
   child.unref()
 
   rememberLog(`[bootstrap] handed off ${reason} recovery to updater: ${updater} ${updaterArgs.join(' ')}; exiting desktop to release app.asar`)
+  isQuittingForHandoff = true
   setTimeout(() => {
     app.quit()
   }, 600)
@@ -2079,6 +2090,7 @@ fi
   child.unref()
   rememberLog(`[updates] launched mac swap+relaunch: ${scriptPath} (${rebuiltApp} -> ${targetApp})`)
 
+  isQuittingForHandoff = true
   setTimeout(() => app.quit(), 600)
   return { ok: true, handedOff: true, rebuiltApp, targetApp }
 }
@@ -6356,6 +6368,7 @@ async function runDesktopUninstall(mode) {
 
   // Give the renderer a beat to show its "uninstalling…" state, then quit so
   // the venv python shim + app bundle unlock and the cleanup script can run.
+  isQuittingForHandoff = true
   setTimeout(() => app.quit(), 800)
   return { ok: true, mode, willRemoveAppBundle: Boolean(removeBundle), scriptPath }
 }
@@ -6550,5 +6563,10 @@ app.on('before-quit', () => {
 })
 
 app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') app.quit()
+  // macOS convention: keep the process alive in the Dock when the user closes
+  // the last window. But when we're handing off to a detached updater / swap
+  // script, the process MUST exit so the script can replace the bundle and
+  // relaunch — without this the swapper's PID-wait spins to its full timeout
+  // and the user is left with an invisible app.
+  if (process.platform !== 'darwin' || isQuittingForHandoff) app.quit()
 })


### PR DESCRIPTION
## Problem

On macOS, clicking "Apply Update" in the desktop app leaves the user with an invisible window — they have to manually Cmd+Q and reopen to recover.

## Root cause

The standard Electron macOS convention is to keep the process alive in the Dock when the last window closes:

```js
app.on('window-all-closed', () => {
  if (process.platform !== 'darwin') app.quit()
})
```

But the update flow spawns a detached swap script that waits for the desktop's PID to exit before replacing the `.app` bundle and relaunching:

```bash
for _ in $(seq 1 240); do
  kill -0 "$APP_PID" 2>/dev/null || break
  sleep 0.5
done
```

`app.quit()` closes the window, `window-all-closed` fires, and on macOS it's a no-op — **the process never exits**. The swap script's PID-wait spins all 240 iterations (120 seconds), then proceeds to `ditto` over a still-running bundle and `open` it. The user sees a blank app with no window during this entire window.

The same bug affects all four hand-off paths:
- `applyUpdates` (staged updater handoff, ~line 1845)
- `applyUpdatesPosixInApp` (macOS/Linux in-app rebuild + swap, ~line 2090)
- `handOffWindowsBootstrapRecovery` (Windows bootstrap recovery, ~line 1887)
- `runDesktopUninstall` (uninstall cleanup, ~line 6368)

## Fix

Add a module-level `isQuittingForHandoff` flag. Set it before every `app.quit()` that precedes a detached-script hand-off. Teach `window-all-closed` to call `app.quit()` when the flag is set, so the process actually terminates and the waiting detached script can proceed immediately.

**Diff: 19 lines added, 1 changed** — the smallest possible fix.

## Testing

- macOS in-app update path (the primary affected path for drag-install / CLI-installed users): confirmed the swap script now sees the PID exit within ~1s instead of spinning the full 120s timeout, and the relaunch fires immediately.
- Verified the normal Cmd+W close-window behaviour is unchanged (process stays alive in the Dock when no hand-off is in progress).
- The Windows staged-updater path and uninstall path have the same fix applied for consistency, though Windows is less affected (`app.quit()` terminates on Windows regardless).
