### PR TITLE
fix(gateway): allow explicit subject for outbound emails

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -608,6 +608,25 @@ class EmailAdapter(BasePlatformAdapter):
         logger.info("[Email] New message from %s: %s", sender_addr, subject)
         await self.handle_message(event)
 
+    def _resolve_subject(
+        self,
+        to_addr: str,
+        explicit_subject: Optional[str] = None,
+    ) -> str:
+        """Resolve email subject from explicit value, thread context, or body."""
+        # Explicit subject from caller takes precedence
+        if explicit_subject:
+            return explicit_subject
+        # Thread context (reply to inbound email)
+        ctx = self._thread_context.get(to_addr, {})
+        if "subject" in ctx:
+            subject = ctx["subject"]
+            if not subject.startswith("Re:"):
+                subject = f"Re: {subject}"
+            return subject
+        # Fresh outbound — no "Re:" prefix
+        return "Hermes Agent"
+
     async def send(
         self,
         chat_id: str,
@@ -616,10 +635,11 @@ class EmailAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an email reply to the given address."""
+        _subject = (metadata or {}).get("subject")
         try:
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(
-                None, self._send_email, chat_id, content, reply_to
+                None, self._send_email, chat_id, content, reply_to, _subject
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -631,20 +651,17 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         reply_to_msg_id: Optional[str] = None,
+        subject: Optional[str] = None,
     ) -> str:
         """Send an email via SMTP. Runs in executor thread."""
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
 
-        # Thread context for reply
-        ctx = self._thread_context.get(to_addr, {})
-        subject = ctx.get("subject", "Hermes Agent")
-        if not subject.startswith("Re:"):
-            subject = f"Re: {subject}"
-        msg["Subject"] = subject
+        msg["Subject"] = self._resolve_subject(to_addr, subject)
 
         # Threading headers
+        ctx = self._thread_context.get(to_addr, {})
         original_msg_id = reply_to_msg_id or ctx.get("message_id")
         if original_msg_id:
             msg["In-Reply-To"] = original_msg_id
@@ -722,6 +739,7 @@ class EmailAdapter(BasePlatformAdapter):
             return
 
         body = "\n\n".join(body_parts)
+        _subject = (metadata or {}).get("subject")
 
         try:
             loop = asyncio.get_running_loop()
@@ -731,6 +749,7 @@ class EmailAdapter(BasePlatformAdapter):
                 chat_id,
                 body,
                 local_paths,
+                _subject,
             )
         except Exception as e:
             logger.error("[Email] Multi-image send failed, falling back: %s", e, exc_info=True)
@@ -741,18 +760,16 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         file_paths: List[str],
+        subject: Optional[str] = None,
     ) -> str:
         """Send an email with multiple file attachments via SMTP."""
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
 
-        ctx = self._thread_context.get(to_addr, {})
-        subject = ctx.get("subject", "Hermes Agent")
-        if not subject.startswith("Re:"):
-            subject = f"Re: {subject}"
-        msg["Subject"] = subject
+        msg["Subject"] = self._resolve_subject(to_addr, subject)
 
+        ctx = self._thread_context.get(to_addr, {})
         original_msg_id = ctx.get("message_id")
         if original_msg_id:
             msg["In-Reply-To"] = original_msg_id
@@ -800,6 +817,7 @@ class EmailAdapter(BasePlatformAdapter):
         **kwargs,
     ) -> SendResult:
         """Send a file as an email attachment."""
+        _subject = (kwargs.get("metadata") or {}).get("subject")
         try:
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(
@@ -809,6 +827,7 @@ class EmailAdapter(BasePlatformAdapter):
                 caption or "",
                 file_path,
                 file_name,
+                _subject,
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -821,18 +840,16 @@ class EmailAdapter(BasePlatformAdapter):
         body: str,
         file_path: str,
         file_name: Optional[str] = None,
+        subject: Optional[str] = None,
     ) -> str:
         """Send an email with a file attachment via SMTP."""
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
 
-        ctx = self._thread_context.get(to_addr, {})
-        subject = ctx.get("subject", "Hermes Agent")
-        if not subject.startswith("Re:"):
-            subject = f"Re: {subject}"
-        msg["Subject"] = subject
+        msg["Subject"] = self._resolve_subject(to_addr, subject)
 
+        ctx = self._thread_context.get(to_addr, {})
         original_msg_id = ctx.get("message_id")
         if original_msg_id:
             msg["In-Reply-To"] = original_msg_id

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -654,7 +654,7 @@ class TestThreadContext(unittest.TestCase):
             self.assertFalse(send_call["Subject"].startswith("Re: Re:"))
 
     def test_no_thread_context_uses_default_subject(self):
-        """Without thread context, subject should be 'Re: Hermes Agent'."""
+        """Without thread context, subject should be 'Hermes Agent' (no Re: prefix)."""
         adapter = self._make_adapter()
 
         with patch("smtplib.SMTP") as mock_smtp:
@@ -664,8 +664,55 @@ class TestThreadContext(unittest.TestCase):
             adapter._send_email("newuser@test.com", "Hello!", None)
 
             send_call = mock_server.send_message.call_args[0][0]
-            self.assertEqual(send_call["Subject"], "Re: Hermes Agent")
+            self.assertEqual(send_call["Subject"], "Hermes Agent")
             self.assertIn("Date", send_call)
+
+    def test_explicit_subject_overrides_thread_context(self):
+        """Explicit subject should override thread context."""
+        adapter = self._make_adapter()
+        adapter._thread_context["user@test.com"] = {"subject": "Old Thread"}
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            adapter._send_email("user@test.com", "Hello!", None, subject="Custom Subject")
+
+            send_call = mock_server.send_message.call_args[0][0]
+            self.assertEqual(send_call["Subject"], "Custom Subject")
+
+    def test_thread_context_gets_re_prefix(self):
+        """Thread context subject should get 'Re:' prefix if not already present."""
+        adapter = self._make_adapter()
+        adapter._thread_context["user@test.com"] = {"subject": "Original Thread"}
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            adapter._send_email("user@test.com", "Hello!", None)
+
+            send_call = mock_server.send_message.call_args[0][0]
+            self.assertEqual(send_call["Subject"], "Re: Original Thread")
+
+    def test_resolve_subject_explicit(self):
+        """_resolve_subject should return explicit subject when provided."""
+        adapter = self._make_adapter()
+        result = adapter._resolve_subject("user@test.com", "My Subject")
+        self.assertEqual(result, "My Subject")
+
+    def test_resolve_subject_thread_context(self):
+        """_resolve_subject should use thread context when no explicit subject."""
+        adapter = self._make_adapter()
+        adapter._thread_context["user@test.com"] = {"subject": "Thread Title"}
+        result = adapter._resolve_subject("user@test.com")
+        self.assertEqual(result, "Re: Thread Title")
+
+    def test_resolve_subject_fresh_outbound(self):
+        """_resolve_subject should return 'Hermes Agent' for fresh outbound."""
+        adapter = self._make_adapter()
+        result = adapter._resolve_subject("newuser@test.com")
+        self.assertEqual(result, "Hermes Agent")
 
 
 class TestSendMethods(unittest.TestCase):

--- a/tests/gateway/test_send_multiple_images.py
+++ b/tests/gateway/test_send_multiple_images.py
@@ -432,10 +432,11 @@ class TestEmailMultiImage:
             _run(adapter.send_multiple_images("user@example.com", images))
 
         mock_send.assert_called_once()
-        to_addr, body, file_paths = mock_send.call_args.args
+        to_addr, body, file_paths, subject = mock_send.call_args.args
         assert to_addr == "user@example.com"
         assert len(file_paths) == 3
         assert "alt 0" in body
+        assert subject is None  # no metadata.subject in this test
 
     def test_remote_urls_linked_in_body(self, adapter, tmp_path):
         """Remote URL images get their URL appended to the body, no attachment."""
@@ -449,7 +450,7 @@ class TestEmailMultiImage:
             _run(adapter.send_multiple_images("user@example.com", images))
 
         mock_send.assert_called_once()
-        to_addr, body, file_paths = mock_send.call_args.args
+        to_addr, body, file_paths, subject = mock_send.call_args.args
         assert file_paths == []
         assert "https://x.com/a.png" in body
         assert "https://x.com/b.png" in body

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1435,7 +1435,7 @@ async def _send_email(extra, chat_id, message):
         msg = MIMEText(message, "plain", "utf-8")
         msg["From"] = address
         msg["To"] = chat_id
-        msg["Subject"] = "Hermes Agent"
+        msg["Subject"] = extra.get("subject", "Hermes Agent")
         msg["Date"] = formatdate(localtime=True)
 
         server = smtplib.SMTP(smtp_host, smtp_port)


### PR DESCRIPTION
## What does this PR do?

Allows callers to specify an explicit email subject for outbound messages instead of always using the hardcoded "Re: Hermes Agent" (gateway paths) or "Hermes Agent" (send_message tool path). Fresh outbound emails no longer get a spurious "Re:" prefix.

## Related Issue

Fixes #46947

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/email.py`: Added `_resolve_subject()` helper that resolves subject from explicit value → thread context → default. Plumbs `metadata["subject"]` from `send()`, `send_multiple_images()`, `send_document()` through all 3 internal methods (`_send_email`, `_send_email_with_attachments`, `_send_email_with_attachment`). Only prepends "Re:" when replying to an existing inbound thread.
- `tools/send_message_tool.py`: Uses `extra.get("subject", "Hermes Agent")` instead of hardcoded "Hermes Agent".
- `tests/gateway/test_email.py`: Updated existing test for new behavior (no "Re:" on fresh outbound), added 5 new tests covering explicit subject, thread context, and `_resolve_subject()` helper.

## How to Test

1. Configure the email gateway
2. Send a message to a fresh recipient (no prior inbound thread) → subject should be "Hermes Agent" (no "Re:" prefix)
3. Reply to an existing email thread → subject should be "Re: <original subject>"
4. Call `send()` with `metadata={"subject": "Custom Subject"}` → subject should be exactly "Custom Subject"
5. Run `pytest tests/gateway/test_email.py -q` — all 213 tests should pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

⚠️ GitNexus unavailable — grep-based fallback used.
- Checked files: `gateway/platforms/email.py` (send, _send_email, _send_email_with_attachments, _send_email_with_attachment), `tools/send_message_tool.py` (_send_email)
- Blast radius: LOW — email adapter is an edge module; changes are additive (new optional parameter with backward-compatible default)
- Related patterns: `metadata` dict plumbing through `run_in_executor` calls
