### PR TITLE
fix: make macOS gateway restart relaunch launchd

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3689,6 +3689,119 @@ def _wait_for_gateway_exit(
     return True
 
 
+def _launch_launchd_restart_watchdog(pid: int, target: str, plist_path: Path) -> bool:
+    """Start a detached launchd kickstart helper before self-restarting.
+
+    When ``hermes gateway restart`` is invoked from a gateway-hosted terminal
+    tool on macOS, the CLI process is a child of the gateway process.  The old
+    implementation sent SIGUSR1 to its gateway ancestor and returned, trusting
+    launchd KeepAlive to relaunch the service.  In practice, launchd can leave
+    the job loaded-but-stopped after that planned self-exit, which strands the
+    gateway after users see only the shutdown notification.  A tiny detached
+    helper closes that gap: it waits for the old PID to disappear, then directly
+    ``kickstart``s the already-installed launchd job, re-bootstrapping first if
+    the job was unloaded.
+    """
+    if pid <= 0:
+        return False
+
+    log_path = get_hermes_home() / "logs" / "gateway-restart-helper.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    helper = textwrap.dedent(
+        """
+        import os, subprocess, sys, time
+
+        pid = int(sys.argv[1])
+        target = sys.argv[2]
+        domain = sys.argv[3]
+        plist_path = sys.argv[4]
+        log_path = sys.argv[5]
+        deadline = time.monotonic() + 120
+
+        def log(msg):
+            try:
+                with open(log_path, "a", encoding="utf-8") as f:
+                    f.write(time.strftime("%Y-%m-%d %H:%M:%S") + " " + msg + "\\n")
+            except Exception:
+                pass
+
+        def alive(p):
+            try:
+                os.kill(p, 0)
+                return True
+            except ProcessLookupError:
+                return False
+            except PermissionError:
+                return True
+            except OSError:
+                return False
+
+        while time.monotonic() < deadline and alive(pid):
+            time.sleep(0.2)
+
+        if alive(pid):
+            log(f"old gateway pid {pid} still alive after timeout; not kickstarting")
+            sys.exit(2)
+
+        try:
+            result = subprocess.run(
+                ["launchctl", "kickstart", "-k", target],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if result.returncode == 0:
+                log(f"kickstart ok for {target}")
+                sys.exit(0)
+            log(f"kickstart failed rc={result.returncode}: {(result.stderr or result.stdout).strip()}")
+
+            boot = subprocess.run(
+                ["launchctl", "bootstrap", domain, plist_path],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if boot.returncode != 0:
+                log(f"bootstrap failed rc={boot.returncode}: {(boot.stderr or boot.stdout).strip()}")
+                sys.exit(boot.returncode or 1)
+
+            retry = subprocess.run(
+                ["launchctl", "kickstart", target],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if retry.returncode != 0:
+                log(f"kickstart retry failed rc={retry.returncode}: {(retry.stderr or retry.stdout).strip()}")
+                sys.exit(retry.returncode or 1)
+            log(f"bootstrap + kickstart ok for {target}")
+        except Exception as exc:
+            log(f"helper exception: {exc!r}")
+            sys.exit(1)
+        """
+    ).strip()
+    try:
+        subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                helper,
+                str(pid),
+                target,
+                _launchd_domain(),
+                str(plist_path),
+                str(log_path),
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        return True
+    except Exception as exc:
+        print(f"⚠ Failed to arm launchd restart watchdog: {exc}")
+        return False
+
+
 def launchd_restart():
     label = get_launchd_label()
     target = f"{_launchd_domain()}/{label}"
@@ -3697,9 +3810,14 @@ def launchd_restart():
 
     try:
         pid = get_running_pid()
-        if pid is not None and _request_gateway_self_restart(pid):
-            print("✓ Service restart requested")
-            return
+        if pid is not None and _is_pid_ancestor_of_current_process(pid):
+            plist_path = get_launchd_plist_path()
+            if not _launch_launchd_restart_watchdog(pid, target, plist_path):
+                print("✗ Refusing in-gateway launchd restart without a restart watchdog")
+                sys.exit(1)
+            if _request_gateway_self_restart(pid):
+                print("✓ Service restart requested; watchdog will kickstart launchd after shutdown")
+                return
         if pid is not None:
             try:
                 terminate_pid(pid, force=False)

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -496,6 +496,98 @@ def test_gateway_start_ignores_legacy_platform_selector(monkeypatch):
     assert calls == [False]
 
 
+def test_launchd_restart_from_gateway_child_arms_watchdog_before_signal(monkeypatch, tmp_path, capsys):
+    """macOS CLI restart from a gateway-hosted terminal must not trust KeepAlive alone."""
+    calls = []
+    plist = tmp_path / "ai.hermes.gateway.plist"
+
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: 12345)
+    monkeypatch.setattr(gateway, "get_launchd_label", lambda: "ai.hermes.gateway")
+    monkeypatch.setattr(gateway, "_launchd_domain", lambda: "gui/501")
+    monkeypatch.setattr(gateway, "get_launchd_plist_path", lambda: plist)
+    monkeypatch.setattr(gateway, "_get_restart_drain_timeout", lambda: 30.0)
+    monkeypatch.setattr(gateway, "_is_pid_ancestor_of_current_process", lambda pid: True)
+    monkeypatch.setattr(
+        gateway,
+        "_launch_launchd_restart_watchdog",
+        lambda pid, target, plist_path: calls.append(("watchdog", pid, target, plist_path)) or True,
+    )
+    monkeypatch.setattr(
+        gateway,
+        "_request_gateway_self_restart",
+        lambda pid: calls.append(("sigusr1", pid)) or True,
+    )
+    monkeypatch.setattr(
+        gateway,
+        "terminate_pid",
+        lambda *args, **kwargs: pytest.fail("self-restart path must not hard-stop before arming watchdog"),
+    )
+    monkeypatch.setattr(
+        gateway.subprocess,
+        "run",
+        lambda *args, **kwargs: pytest.fail("watchdog self-restart path must not synchronously kickstart"),
+    )
+
+    gateway.launchd_restart()
+
+    assert calls == [
+        ("watchdog", 12345, "gui/501/ai.hermes.gateway", plist),
+        ("sigusr1", 12345),
+    ]
+    assert "watchdog will kickstart launchd" in capsys.readouterr().out
+
+
+def test_launchd_restart_from_gateway_child_refuses_without_watchdog(monkeypatch, tmp_path):
+    """If the detached watchdog cannot be armed, do not stop the live gateway."""
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: 12345)
+    monkeypatch.setattr(gateway, "get_launchd_label", lambda: "ai.hermes.gateway")
+    monkeypatch.setattr(gateway, "_launchd_domain", lambda: "gui/501")
+    monkeypatch.setattr(gateway, "get_launchd_plist_path", lambda: tmp_path / "ai.hermes.gateway.plist")
+    monkeypatch.setattr(gateway, "_get_restart_drain_timeout", lambda: 30.0)
+    monkeypatch.setattr(gateway, "_is_pid_ancestor_of_current_process", lambda pid: True)
+    monkeypatch.setattr(gateway, "_launch_launchd_restart_watchdog", lambda *args: False)
+    monkeypatch.setattr(
+        gateway,
+        "_request_gateway_self_restart",
+        lambda *args: pytest.fail("must not signal gateway when watchdog is unavailable"),
+    )
+    monkeypatch.setattr(
+        gateway,
+        "terminate_pid",
+        lambda *args, **kwargs: pytest.fail("must not terminate gateway when watchdog is unavailable"),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        gateway.launchd_restart()
+
+    assert exc_info.value.code == 1
+
+
+def test_launchd_restart_watchdog_uses_launchctl_not_recursive_hermes(monkeypatch, tmp_path):
+    calls = []
+
+    class FakePopen:
+        def __init__(self, argv, **kwargs):
+            calls.append((argv, kwargs))
+
+    monkeypatch.setattr(gateway.subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(gateway, "get_hermes_home", lambda: tmp_path / ".hermes")
+    monkeypatch.setattr(gateway, "_launchd_domain", lambda: "gui/501")
+
+    assert gateway._launch_launchd_restart_watchdog(
+        12345,
+        "gui/501/ai.hermes.gateway",
+        tmp_path / "ai.hermes.gateway.plist",
+    )
+
+    argv, kwargs = calls[0]
+    assert argv[:3] == [gateway.sys.executable, "-c", argv[2]]
+    helper_source = argv[2]
+    assert "launchctl" in helper_source
+    assert "hermes gateway restart" not in helper_source
+    assert kwargs["start_new_session"] is True
+
+
 def test_gateway_restart_on_windows_without_service_uses_detached_backend(monkeypatch):
     """Windows manual restart must not fall back to foreground run_gateway().
 


### PR DESCRIPTION
## Summary
- add a detached launchd restart watchdog for macOS gateway self-restarts invoked from a gateway child process
- have the watchdog wait for the old gateway PID to exit, then `launchctl kickstart -k` the installed job, with a bootstrap fallback if needed
- refuse the in-gateway launchd self-restart if the watchdog cannot be armed, avoiding a stop-without-relaunch failure mode
- add regression coverage proving the watchdog is armed before SIGUSR1, the failure path does not stop the gateway, and the helper uses launchctl rather than recursively invoking `hermes gateway restart`

## Motivation
A macOS gateway restart requested from inside a gateway-hosted terminal can successfully send the shutdown notification and stop the gateway, but then leave the launchd job loaded/stopped instead of relaunched. The previous self-restart path trusted launchd KeepAlive after sending SIGUSR1 to the gateway ancestor. This change makes the relaunch explicit and detached before the old gateway is allowed to exit.

## Test plan
- `python -m pytest tests/hermes_cli/test_gateway.py tests/hermes_cli/test_gateway_restart_loop.py -q -o 'addopts='`
- `python -m py_compile hermes_cli/gateway.py tests/hermes_cli/test_gateway.py`
- `git diff --check origin/main...HEAD`
- `gitleaks git --log-opts="origin/main..HEAD" --redact --no-banner`
