### PR TITLE
Hide hosted dashboard update controls

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1224,6 +1224,17 @@ def _default_hermes_root_is_opt_data() -> bool:
     return root == _HOSTED_MANAGED_FILES_ROOT
 
 
+def _dashboard_hosted_agent_mode() -> bool:
+    """Return true for the hosted/container dashboard layout.
+
+    Hosted agent dashboards run with the Hermes root at ``/opt/data``.  This is
+    the same signal the Files page uses to lock browsing to the managed data
+    directory, and it keeps local remote-auth dashboards from being mistaken for
+    hosted service instances.
+    """
+    return _default_hermes_root_is_opt_data()
+
+
 def _managed_files_policy(request: Request, *, create_root: bool = True) -> ManagedFilesPolicy:
     raw_forced_root = os.environ.get(_MANAGED_FILES_ROOT_ENV, "").strip()
     if raw_forced_root:
@@ -1654,6 +1665,7 @@ async def get_status():
         "release_date": __release_date__,
         "config_version": current_ver,
         "latest_config_version": latest_ver,
+        "can_update_hermes": not _dashboard_hosted_agent_mode(),
         "gateway_running": gateway_running,
         "gateway_state": gateway_state,
         "gateway_platforms": gateway_platforms,
@@ -2165,6 +2177,21 @@ async def restart_gateway():
 @app.post("/api/hermes/update")
 async def update_hermes():
     """Kick off ``hermes update`` in the background."""
+    if _dashboard_hosted_agent_mode():
+        message = (
+            "Hermes updates are managed by the hosted agent service for this "
+            "dashboard. The built-in local updater is disabled here."
+        )
+        _record_completed_action("hermes-update", message, exit_code=1)
+        return {
+            "ok": False,
+            "pid": None,
+            "name": "hermes-update",
+            "error": "hosted_update_managed",
+            "message": message,
+            "update_command": "managed by hosted agent service",
+        }
+
     install_method = detect_install_method(PROJECT_ROOT)
     if install_method == "docker":
         message = format_docker_update_message()
@@ -2264,6 +2291,17 @@ async def check_hermes_update(force: bool = False):
                  desktop's remote update overlay renders this as "what's
                  changed". Additive: existing consumers ignore it.
     """
+    if _dashboard_hosted_agent_mode():
+        return {
+            "install_method": "hosted",
+            "current_version": __version__,
+            "behind": None,
+            "update_available": False,
+            "can_apply": False,
+            "update_command": "managed by hosted agent service",
+            "message": "Hermes updates are managed by the hosted agent service.",
+        }
+
     install_method = detect_install_method(PROJECT_ROOT)
     update_command = recommended_update_command_for_method(install_method)
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1227,15 +1227,11 @@ def _default_hermes_root_is_opt_data() -> bool:
 def _dashboard_local_update_managed_externally() -> bool:
     """Return true when the dashboard should not offer ``hermes update``.
 
-    Hosted agent dashboards run with the Hermes root at ``/opt/data``.  Generic
-    containerized dashboards may not use that exact root, but their lifecycle is
-    still owned by the outer launcher/image, not by an in-browser local update
-    action.  Keep this dashboard capability separate from install-method
-    detection: manual git/pip installs inside containers can still behave like
-    their actual install method in the CLI.
+    Containerized dashboards are updated by the outer launcher/image, not by an
+    in-browser local update action. Keep this dashboard capability separate
+    from install-method detection: manual git/pip installs inside containers can
+    still behave like their actual install method in the CLI.
     """
-    if _default_hermes_root_is_opt_data():
-        return True
     try:
         from hermes_constants import is_container
 
@@ -2188,7 +2184,7 @@ async def update_hermes():
     """Kick off ``hermes update`` in the background."""
     if _dashboard_local_update_managed_externally():
         message = (
-            "Hermes updates are managed outside this dashboard for hosted or "
+            "Hermes updates are managed outside this dashboard in "
             "containerized environments. The built-in local updater is "
             "disabled here."
         )
@@ -2310,8 +2306,8 @@ async def check_hermes_update(force: bool = False):
             "can_apply": False,
             "update_command": "managed outside dashboard",
             "message": (
-                "Hermes updates are managed outside this dashboard for hosted "
-                "or containerized environments."
+                "Hermes updates are managed outside this dashboard in "
+                "containerized environments."
             ),
         }
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1224,15 +1224,24 @@ def _default_hermes_root_is_opt_data() -> bool:
     return root == _HOSTED_MANAGED_FILES_ROOT
 
 
-def _dashboard_hosted_agent_mode() -> bool:
-    """Return true for the hosted/container dashboard layout.
+def _dashboard_local_update_managed_externally() -> bool:
+    """Return true when the dashboard should not offer ``hermes update``.
 
-    Hosted agent dashboards run with the Hermes root at ``/opt/data``.  This is
-    the same signal the Files page uses to lock browsing to the managed data
-    directory, and it keeps local remote-auth dashboards from being mistaken for
-    hosted service instances.
+    Hosted agent dashboards run with the Hermes root at ``/opt/data``.  Generic
+    containerized dashboards may not use that exact root, but their lifecycle is
+    still owned by the outer launcher/image, not by an in-browser local update
+    action.  Keep this dashboard capability separate from install-method
+    detection: manual git/pip installs inside containers can still behave like
+    their actual install method in the CLI.
     """
-    return _default_hermes_root_is_opt_data()
+    if _default_hermes_root_is_opt_data():
+        return True
+    try:
+        from hermes_constants import is_container
+
+        return is_container()
+    except Exception:
+        return False
 
 
 def _managed_files_policy(request: Request, *, create_root: bool = True) -> ManagedFilesPolicy:
@@ -1665,7 +1674,7 @@ async def get_status():
         "release_date": __release_date__,
         "config_version": current_ver,
         "latest_config_version": latest_ver,
-        "can_update_hermes": not _dashboard_hosted_agent_mode(),
+        "can_update_hermes": not _dashboard_local_update_managed_externally(),
         "gateway_running": gateway_running,
         "gateway_state": gateway_state,
         "gateway_platforms": gateway_platforms,
@@ -2177,19 +2186,20 @@ async def restart_gateway():
 @app.post("/api/hermes/update")
 async def update_hermes():
     """Kick off ``hermes update`` in the background."""
-    if _dashboard_hosted_agent_mode():
+    if _dashboard_local_update_managed_externally():
         message = (
-            "Hermes updates are managed by the hosted agent service for this "
-            "dashboard. The built-in local updater is disabled here."
+            "Hermes updates are managed outside this dashboard for hosted or "
+            "containerized environments. The built-in local updater is "
+            "disabled here."
         )
         _record_completed_action("hermes-update", message, exit_code=1)
         return {
             "ok": False,
             "pid": None,
             "name": "hermes-update",
-            "error": "hosted_update_managed",
+            "error": "dashboard_update_managed_externally",
             "message": message,
-            "update_command": "managed by hosted agent service",
+            "update_command": "managed outside dashboard",
         }
 
     install_method = detect_install_method(PROJECT_ROOT)
@@ -2291,15 +2301,18 @@ async def check_hermes_update(force: bool = False):
                  desktop's remote update overlay renders this as "what's
                  changed". Additive: existing consumers ignore it.
     """
-    if _dashboard_hosted_agent_mode():
+    if _dashboard_local_update_managed_externally():
         return {
-            "install_method": "hosted",
+            "install_method": "managed-runtime",
             "current_version": __version__,
             "behind": None,
             "update_available": False,
             "can_apply": False,
-            "update_command": "managed by hosted agent service",
-            "message": "Hermes updates are managed by the hosted agent service.",
+            "update_command": "managed outside dashboard",
+            "message": (
+                "Hermes updates are managed outside this dashboard for hosted "
+                "or containerized environments."
+            ),
         }
 
     install_method = detect_install_method(PROJECT_ROOT)

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -772,7 +772,7 @@ class TestUpdateCheckEndpoint:
         assert body["message"]
         assert body["behind"] is None
 
-    def test_hosted_dashboard_is_not_applyable(self, monkeypatch):
+    def test_managed_runtime_dashboard_is_not_applyable(self, monkeypatch):
         import hermes_cli.web_server as ws
 
         monkeypatch.setattr(ws, "_dashboard_local_update_managed_externally", lambda: True)
@@ -780,7 +780,7 @@ class TestUpdateCheckEndpoint:
             ws,
             "detect_install_method",
             lambda *a, **k: pytest.fail(
-                "hosted update check should not probe install method"
+                "managed runtime update check should not probe install method"
             ),
         )
 

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -772,6 +772,25 @@ class TestUpdateCheckEndpoint:
         assert body["message"]
         assert body["behind"] is None
 
+    def test_hosted_dashboard_is_not_applyable(self, monkeypatch):
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws, "_dashboard_hosted_agent_mode", lambda: True)
+        monkeypatch.setattr(
+            ws,
+            "detect_install_method",
+            lambda *a, **k: pytest.fail(
+                "hosted update check should not probe install method"
+            ),
+        )
+
+        body = self.client.get("/api/hermes/update/check").json()
+        assert body["install_method"] == "hosted"
+        assert body["can_apply"] is False
+        assert body["update_available"] is False
+        assert body["behind"] is None
+        assert "hosted agent service" in body["message"]
+
     def test_check_failure_is_soft(self, monkeypatch):
         import hermes_cli.web_server as ws
         import hermes_cli.banner as banner

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -775,7 +775,7 @@ class TestUpdateCheckEndpoint:
     def test_hosted_dashboard_is_not_applyable(self, monkeypatch):
         import hermes_cli.web_server as ws
 
-        monkeypatch.setattr(ws, "_dashboard_hosted_agent_mode", lambda: True)
+        monkeypatch.setattr(ws, "_dashboard_local_update_managed_externally", lambda: True)
         monkeypatch.setattr(
             ws,
             "detect_install_method",
@@ -785,11 +785,11 @@ class TestUpdateCheckEndpoint:
         )
 
         body = self.client.get("/api/hermes/update/check").json()
-        assert body["install_method"] == "hosted"
+        assert body["install_method"] == "managed-runtime"
         assert body["can_apply"] is False
         assert body["update_available"] is False
         assert body["behind"] is None
-        assert "hosted agent service" in body["message"]
+        assert "managed outside this dashboard" in body["message"]
 
     def test_check_failure_is_soft(self, monkeypatch):
         import hermes_cli.web_server as ws

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -250,11 +250,20 @@ class TestWebServerEndpoints:
     def test_get_status_hides_update_capability_in_hosted_mode(self, monkeypatch):
         import hermes_cli.web_server as web_server
 
-        monkeypatch.setattr(web_server, "_dashboard_hosted_agent_mode", lambda: True)
+        monkeypatch.setattr(web_server, "_dashboard_local_update_managed_externally", lambda: True)
 
         resp = self.client.get("/api/status")
         assert resp.status_code == 200
         assert resp.json()["can_update_hermes"] is False
+
+    def test_dashboard_update_capability_detects_generic_container(self, monkeypatch):
+        import hermes_constants
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(web_server, "_default_hermes_root_is_opt_data", lambda: False)
+        monkeypatch.setattr(hermes_constants, "is_container", lambda: True)
+
+        assert web_server._dashboard_local_update_managed_externally() is True
 
     # ── GET /api/media (remote image display) ───────────────────────────
 
@@ -938,7 +947,7 @@ class TestWebServerEndpoints:
             detected = True
             raise AssertionError("hosted update guard should not detect install method")
 
-        monkeypatch.setattr(web_server, "_dashboard_hosted_agent_mode", lambda: True)
+        monkeypatch.setattr(web_server, "_dashboard_local_update_managed_externally", lambda: True)
         monkeypatch.setattr(web_server, "detect_install_method", fail_detect)
         monkeypatch.setattr(web_server, "_spawn_hermes_action", fail_spawn)
         web_server._ACTION_PROCS.pop("hermes-update", None)
@@ -951,8 +960,8 @@ class TestWebServerEndpoints:
         assert data["ok"] is False
         assert data["name"] == "hermes-update"
         assert data["pid"] is None
-        assert data["error"] == "hosted_update_managed"
-        assert "hosted agent service" in data["message"]
+        assert data["error"] == "dashboard_update_managed_externally"
+        assert "managed outside this dashboard" in data["message"]
         assert spawned is False
         assert detected is False
 
@@ -962,7 +971,7 @@ class TestWebServerEndpoints:
         assert status_data["running"] is False
         assert status_data["exit_code"] == 1
         assert status_data["pid"] is None
-        assert any("hosted agent service" in line for line in status_data["lines"])
+        assert any("managed outside this dashboard" in line for line in status_data["lines"])
 
     def test_update_hermes_spawns_on_non_docker_install(self, monkeypatch):
         import hermes_cli.web_server as web_server

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -245,6 +245,16 @@ class TestWebServerEndpoints:
         assert "version" in data
         assert "hermes_home" in data
         assert "active_sessions" in data
+        assert data["can_update_hermes"] is True
+
+    def test_get_status_hides_update_capability_in_hosted_mode(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(web_server, "_dashboard_hosted_agent_mode", lambda: True)
+
+        resp = self.client.get("/api/status")
+        assert resp.status_code == 200
+        assert resp.json()["can_update_hermes"] is False
 
     # ── GET /api/media (remote image display) ───────────────────────────
 
@@ -911,6 +921,48 @@ class TestWebServerEndpoints:
         assert status_data["exit_code"] == 1
         assert status_data["pid"] is None
         assert any("docker pull nousresearch/hermes-agent:latest" in line for line in status_data["lines"])
+
+    def test_update_hermes_returns_hosted_guidance_without_spawning(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        spawned = False
+        detected = False
+
+        def fail_spawn(*_args, **_kwargs):
+            nonlocal spawned
+            spawned = True
+            raise AssertionError("hosted update guard should not spawn hermes update")
+
+        def fail_detect(*_args, **_kwargs):
+            nonlocal detected
+            detected = True
+            raise AssertionError("hosted update guard should not detect install method")
+
+        monkeypatch.setattr(web_server, "_dashboard_hosted_agent_mode", lambda: True)
+        monkeypatch.setattr(web_server, "detect_install_method", fail_detect)
+        monkeypatch.setattr(web_server, "_spawn_hermes_action", fail_spawn)
+        web_server._ACTION_PROCS.pop("hermes-update", None)
+        web_server._ACTION_RESULTS.pop("hermes-update", None)
+
+        resp = self.client.post("/api/hermes/update")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is False
+        assert data["name"] == "hermes-update"
+        assert data["pid"] is None
+        assert data["error"] == "hosted_update_managed"
+        assert "hosted agent service" in data["message"]
+        assert spawned is False
+        assert detected is False
+
+        status = self.client.get("/api/actions/hermes-update/status")
+        assert status.status_code == 200
+        status_data = status.json()
+        assert status_data["running"] is False
+        assert status_data["exit_code"] == 1
+        assert status_data["pid"] is None
+        assert any("hosted agent service" in line for line in status_data["lines"])
 
     def test_update_hermes_spawns_on_non_docker_install(self, monkeypatch):
         import hermes_cli.web_server as web_server

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -247,7 +247,7 @@ class TestWebServerEndpoints:
         assert "active_sessions" in data
         assert data["can_update_hermes"] is True
 
-    def test_get_status_hides_update_capability_in_hosted_mode(self, monkeypatch):
+    def test_get_status_hides_update_capability_in_managed_runtime(self, monkeypatch):
         import hermes_cli.web_server as web_server
 
         monkeypatch.setattr(web_server, "_dashboard_local_update_managed_externally", lambda: True)
@@ -260,7 +260,6 @@ class TestWebServerEndpoints:
         import hermes_constants
         import hermes_cli.web_server as web_server
 
-        monkeypatch.setattr(web_server, "_default_hermes_root_is_opt_data", lambda: False)
         monkeypatch.setattr(hermes_constants, "is_container", lambda: True)
 
         assert web_server._dashboard_local_update_managed_externally() is True
@@ -931,7 +930,7 @@ class TestWebServerEndpoints:
         assert status_data["pid"] is None
         assert any("docker pull nousresearch/hermes-agent:latest" in line for line in status_data["lines"])
 
-    def test_update_hermes_returns_hosted_guidance_without_spawning(self, monkeypatch):
+    def test_update_hermes_returns_managed_runtime_guidance_without_spawning(self, monkeypatch):
         import hermes_cli.web_server as web_server
 
         spawned = False
@@ -940,12 +939,12 @@ class TestWebServerEndpoints:
         def fail_spawn(*_args, **_kwargs):
             nonlocal spawned
             spawned = True
-            raise AssertionError("hosted update guard should not spawn hermes update")
+            raise AssertionError("managed runtime update guard should not spawn hermes update")
 
         def fail_detect(*_args, **_kwargs):
             nonlocal detected
             detected = True
-            raise AssertionError("hosted update guard should not detect install method")
+            raise AssertionError("managed runtime update guard should not detect install method")
 
         monkeypatch.setattr(web_server, "_dashboard_local_update_managed_externally", lambda: True)
         monkeypatch.setattr(web_server, "detect_install_method", fail_detect)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,8 @@ import {
   useRef,
   useState,
   type ComponentType,
+  type FocusEvent,
+  type MouseEvent,
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
@@ -812,26 +814,33 @@ function SidebarNavLink({
   t,
 }: SidebarNavLinkProps) {
   const { path, label, labelKey, icon: Icon } = item;
-  const liRef = useRef<HTMLLIElement>(null);
   const [hovered, setHovered] = useState(false);
+  const [tooltipAnchor, setTooltipAnchor] = useState<HTMLElement | null>(null);
 
   const navLabel = labelKey
     ? ((t.app.nav as Record<string, string>)[labelKey] ?? label)
     : label;
+  const showTooltip = (event: MouseEvent<HTMLElement> | FocusEvent<HTMLElement>) => {
+    setHovered(true);
+    setTooltipAnchor(event.currentTarget);
+  };
+  const hideTooltip = () => {
+    setHovered(false);
+    setTooltipAnchor(null);
+  };
 
   return (
     <li
-      ref={liRef}
-      onMouseEnter={collapsed ? () => setHovered(true) : undefined}
-      onMouseLeave={collapsed ? () => setHovered(false) : undefined}
+      onMouseEnter={collapsed ? showTooltip : undefined}
+      onMouseLeave={collapsed ? hideTooltip : undefined}
     >
       <NavLink
         to={path}
         end={path === "/sessions"}
         onClick={closeMobile}
         aria-label={collapsed ? navLabel : undefined}
-        onFocus={collapsed ? () => setHovered(true) : undefined}
-        onBlur={collapsed ? () => setHovered(false) : undefined}
+        onFocus={collapsed ? showTooltip : undefined}
+        onBlur={collapsed ? hideTooltip : undefined}
         className={({ isActive }) =>
           cn(
             "group/nav relative flex items-center gap-3",
@@ -877,8 +886,8 @@ function SidebarNavLink({
         )}
       </NavLink>
 
-      {collapsed && hovered && liRef.current && (
-        <SidebarTooltip anchor={liRef.current} label={navLabel} warmRef={tooltipWarmRef} />
+      {collapsed && hovered && tooltipAnchor && (
+        <SidebarTooltip anchor={tooltipAnchor} label={navLabel} warmRef={tooltipWarmRef} />
       )}
     </li>
   );
@@ -894,6 +903,7 @@ function SidebarSystemActions({
   const navigate = useNavigate();
   const { activeAction, isBusy, isRunning, pendingAction, runAction } =
     useSystemActions();
+  const canUpdateHermes = status?.can_update_hermes === true;
 
   const items: SystemActionItem[] = [
     {
@@ -903,14 +913,16 @@ function SidebarSystemActions({
       runningLabel: t.status.restartingGateway,
       spin: true,
     },
-    {
+  ];
+  if (canUpdateHermes) {
+    items.push({
       action: "update",
       icon: Download,
       label: t.status.updateHermes,
       runningLabel: t.status.updatingHermes,
       spin: false,
-    },
-  ];
+    });
+  }
 
   const handleClick = (action: SystemAction) => {
     if (isBusy) return;
@@ -971,24 +983,31 @@ function SystemActionButton({
   tooltipWarmRef,
 }: SystemActionButtonProps) {
   const { icon: Icon, label, runningLabel, spin } = item;
-  const liRef = useRef<HTMLLIElement>(null);
   const [hovered, setHovered] = useState(false);
+  const [tooltipAnchor, setTooltipAnchor] = useState<HTMLElement | null>(null);
   const busy = isPending || isActionRunning;
   const displayLabel = isActionRunning ? runningLabel : label;
+  const showTooltip = (event: MouseEvent<HTMLElement> | FocusEvent<HTMLElement>) => {
+    setHovered(true);
+    setTooltipAnchor(event.currentTarget);
+  };
+  const hideTooltip = () => {
+    setHovered(false);
+    setTooltipAnchor(null);
+  };
 
   return (
     <li
-      ref={liRef}
-      onMouseEnter={collapsed ? () => setHovered(true) : undefined}
-      onMouseLeave={collapsed ? () => setHovered(false) : undefined}
+      onMouseEnter={collapsed ? showTooltip : undefined}
+      onMouseLeave={collapsed ? hideTooltip : undefined}
     >
       <button
         onClick={onClick}
         disabled={disabled}
         aria-busy={busy}
         aria-label={collapsed ? displayLabel : undefined}
-        onFocus={collapsed ? () => setHovered(true) : undefined}
-        onBlur={collapsed ? () => setHovered(false) : undefined}
+        onFocus={collapsed ? showTooltip : undefined}
+        onBlur={collapsed ? hideTooltip : undefined}
         type="button"
         className={cn(
           "group/action relative flex w-full items-center gap-3",
@@ -1036,8 +1055,8 @@ function SystemActionButton({
         )}
       </button>
 
-      {collapsed && hovered && liRef.current && (
-        <SidebarTooltip anchor={liRef.current} label={displayLabel} warmRef={tooltipWarmRef} />
+      {collapsed && hovered && tooltipAnchor && (
+        <SidebarTooltip anchor={tooltipAnchor} label={displayLabel} warmRef={tooltipWarmRef} />
       )}
     </li>
   );
@@ -1049,18 +1068,25 @@ function SidebarIconWithTooltip({
   label,
   tooltipWarmRef,
 }: SidebarIconWithTooltipProps) {
-  const ref = useRef<HTMLDivElement>(null);
   const [hovered, setHovered] = useState(false);
+  const [tooltipAnchor, setTooltipAnchor] = useState<HTMLElement | null>(null);
+  const showTooltip = (event: MouseEvent<HTMLDivElement>) => {
+    setHovered(true);
+    setTooltipAnchor(event.currentTarget);
+  };
+  const hideTooltip = () => {
+    setHovered(false);
+    setTooltipAnchor(null);
+  };
 
   return (
     <div
-      ref={ref}
       className={cn(
         "relative w-fit",
         collapsed && "group/icon",
       )}
-      onMouseEnter={collapsed ? () => setHovered(true) : undefined}
-      onMouseLeave={collapsed ? () => setHovered(false) : undefined}
+      onMouseEnter={collapsed ? showTooltip : undefined}
+      onMouseLeave={collapsed ? hideTooltip : undefined}
     >
       {children}
 
@@ -1071,8 +1097,8 @@ function SidebarIconWithTooltip({
         />
       )}
 
-      {collapsed && hovered && ref.current && (
-        <SidebarTooltip anchor={ref.current} label={label} warmRef={tooltipWarmRef} />
+      {collapsed && hovered && tooltipAnchor && (
+        <SidebarTooltip anchor={tooltipAnchor} label={label} warmRef={tooltipWarmRef} />
       )}
     </div>
   );
@@ -1080,8 +1106,8 @@ function SidebarIconWithTooltip({
 
 function GatewayDot({ collapsed, status, tooltipWarmRef }: GatewayDotProps) {
   const { t } = useI18n();
-  const ref = useRef<HTMLDivElement>(null);
   const [hovered, setHovered] = useState(false);
+  const [tooltipAnchor, setTooltipAnchor] = useState<HTMLElement | null>(null);
 
   const toneToColor: Record<string, string> = {
     "text-success": "bg-success",
@@ -1101,10 +1127,17 @@ function GatewayDot({ collapsed, status, tooltipWarmRef }: GatewayDotProps) {
     color = toneToColor[gw.tone] ?? "bg-muted-foreground";
     label = `${t.status.gateway} ${gw.label}`;
   }
+  const showTooltip = (event: MouseEvent<HTMLDivElement> | FocusEvent<HTMLDivElement>) => {
+    setHovered(true);
+    setTooltipAnchor(event.currentTarget);
+  };
+  const hideTooltip = () => {
+    setHovered(false);
+    setTooltipAnchor(null);
+  };
 
   return (
     <div
-      ref={ref}
       className={cn(
         "hidden lg:flex py-3 pl-[1.625rem] transition-opacity duration-300",
         collapsed ? "lg:opacity-100" : "lg:opacity-0 lg:h-0 lg:py-0 lg:overflow-hidden",
@@ -1112,18 +1145,18 @@ function GatewayDot({ collapsed, status, tooltipWarmRef }: GatewayDotProps) {
       role="status"
       aria-label={label}
       tabIndex={collapsed ? 0 : -1}
-      onMouseEnter={collapsed ? () => setHovered(true) : undefined}
-      onMouseLeave={collapsed ? () => setHovered(false) : undefined}
-      onFocus={collapsed ? () => setHovered(true) : undefined}
-      onBlur={collapsed ? () => setHovered(false) : undefined}
+      onMouseEnter={collapsed ? showTooltip : undefined}
+      onMouseLeave={collapsed ? hideTooltip : undefined}
+      onFocus={collapsed ? showTooltip : undefined}
+      onBlur={collapsed ? hideTooltip : undefined}
     >
       <span
         aria-hidden
         className={cn("h-1.5 w-1.5 rounded-full", color)}
       />
 
-      {hovered && ref.current && (
-        <SidebarTooltip anchor={ref.current} label={label} warmRef={tooltipWarmRef} />
+      {hovered && tooltipAnchor && (
+        <SidebarTooltip anchor={tooltipAnchor} label={label} warmRef={tooltipWarmRef} />
       )}
     </div>
   );
@@ -1133,11 +1166,16 @@ function SidebarTooltip({ anchor, label, warmRef }: SidebarTooltipProps) {
   const rect = anchor.getBoundingClientRect();
   const sidebar = document.getElementById("app-sidebar");
   const sidebarRight = sidebar?.getBoundingClientRect().right ?? rect.right;
-
-  const isWarm = warmRef ? Date.now() - warmRef.current < 300 : false;
+  const [isWarm, setIsWarm] = useState(false);
 
   useEffect(() => {
-    if (warmRef) warmRef.current = Date.now();
+    if (!warmRef) {
+      setIsWarm(false);
+      return;
+    }
+    const now = Date.now();
+    setIsWarm(now - warmRef.current < 300);
+    warmRef.current = now;
     return () => {
       if (warmRef) warmRef.current = Date.now();
     };

--- a/web/src/contexts/SystemActions.tsx
+++ b/web/src/contexts/SystemActions.tsx
@@ -74,19 +74,17 @@ export function SystemActionsProvider({
           setActiveAction(action);
         } else {
           const resp = await api.updateHermes();
-          // In a Docker install the image is immutable, so `hermes update`
-          // can't apply — the endpoint returns 200 with a structured
-          // {ok:false, error:"docker_update_unsupported", message, update_command}
-          // envelope instead of spawning the action (see #34347 / #36263).
-          // Surface that guidance to the user rather than starting the poll,
-          // which would otherwise report a generic "failed (exit 1)".
-          if (!resp.ok && resp.error === "docker_update_unsupported") {
+          // Some installs cannot apply updates from inside the dashboard. The
+          // endpoint returns a structured {ok:false, message, update_command}
+          // envelope instead of spawning the action; surface that guidance
+          // rather than polling a synthetic failed action.
+          if (!resp.ok) {
             const cmd = resp.update_command ? `  ${resp.update_command}` : "";
             setToast({
               type: "success",
               message:
                 (resp.message ??
-                  "Updates don't apply inside Docker — re-pull the image instead.") +
+                  "Updates don't apply from this dashboard.") +
                 cmd,
             });
             return;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1570,6 +1570,9 @@ export interface StatusResponse {
    * Empty in loopback mode; empty + ``auth_required=true`` is a
    * fail-closed state (the dashboard will refuse to bind). */
   auth_providers?: string[];
+  /** False when the dashboard is running in a hosted/managed layout where
+   * updates are handled by the outer launcher instead of ``hermes update``. */
+  can_update_hermes?: boolean;
   config_path: string;
   config_version: number;
   env_path: string;

--- a/web/src/pages/SystemPage.tsx
+++ b/web/src/pages/SystemPage.tsx
@@ -386,6 +386,7 @@ export default function SystemPage() {
   // ── Update check / apply ───────────────────────────────────────────
   const checkForUpdate = useCallback(
     async (force = false) => {
+      if (status?.can_update_hermes === false) return;
       setCheckingUpdate(true);
       try {
         const info = await api.checkHermesUpdate(force);
@@ -410,20 +411,27 @@ export default function SystemPage() {
         setCheckingUpdate(false);
       }
     },
-    [showToast],
+    [showToast, status?.can_update_hermes],
   );
 
   // Auto-check (cached) runs inside loadAll on mount; this is the
   // user-triggered forced re-check from the "Check for updates" button.
   const applyUpdate = async () => {
     setUpdateConfirmOpen(false);
+    if (status?.can_update_hermes === false) {
+      showToast(
+        "Hermes updates are managed by the hosted agent service.",
+        "success",
+      );
+      return;
+    }
     try {
       const resp = await api.updateHermes();
-      if (!resp.ok && resp.error === "docker_update_unsupported") {
+      if (!resp.ok) {
         showToast(
           resp.message ??
-            "Updates don't apply inside Docker — re-pull the image instead.",
-          "error",
+            "Updates don't apply from this dashboard.",
+          "success",
         );
         return;
       }
@@ -503,6 +511,7 @@ export default function SystemPage() {
   }
 
   const gatewayRunning = status?.gateway_running;
+  const canUpdateHermes = status?.can_update_hermes !== false;
   const validEvents = hooks?.valid_events?.length
     ? hooks.valid_events
     : HOOK_EVENTS_FALLBACK;
@@ -512,7 +521,7 @@ export default function SystemPage() {
       <Toast toast={toast} />
 
       <ConfirmDialog
-        open={updateConfirmOpen}
+        open={canUpdateHermes && updateConfirmOpen}
         onCancel={() => setUpdateConfirmOpen(false)}
         onConfirm={() => void applyUpdate()}
         title="Update Hermes?"
@@ -691,7 +700,8 @@ export default function SystemPage() {
                 <div className="text-xs uppercase tracking-wider text-muted-foreground">Hermes</div>
                 <div className="flex items-center gap-2">
                   <span>v{stats?.hermes_version}</span>
-                  {updateInfo &&
+                  {canUpdateHermes &&
+                    updateInfo &&
                     (updateInfo.update_available ? (
                       <Badge tone="warning">
                         {updateInfo.behind && updateInfo.behind > 0
@@ -751,45 +761,47 @@ export default function SystemPage() {
                 CPU / memory / disk metrics.
               </p>
             )}
-            <div className="mt-4 flex flex-wrap items-center gap-2 border-t border-border pt-4">
-              <Button
-                size="sm"
-                ghost
-                disabled={checkingUpdate}
-                prefix={
-                  checkingUpdate ? (
-                    <Spinner className="h-3.5 w-3.5" />
-                  ) : (
-                    <RotateCw className="h-3.5 w-3.5" />
-                  )
-                }
-                onClick={() => void checkForUpdate(true)}
-              >
-                Check for updates
-              </Button>
-              {updateInfo?.update_available && updateInfo.can_apply && (
+            {canUpdateHermes && (
+              <div className="mt-4 flex flex-wrap items-center gap-2 border-t border-border pt-4">
                 <Button
                   size="sm"
-                  prefix={<Download className="h-3.5 w-3.5" />}
-                  onClick={() => setUpdateConfirmOpen(true)}
+                  ghost
+                  disabled={checkingUpdate}
+                  prefix={
+                    checkingUpdate ? (
+                      <Spinner className="h-3.5 w-3.5" />
+                    ) : (
+                      <RotateCw className="h-3.5 w-3.5" />
+                    )
+                  }
+                  onClick={() => void checkForUpdate(true)}
                 >
-                  Update now
+                  Check for updates
                 </Button>
-              )}
-              {updateInfo &&
-                !updateInfo.can_apply &&
-                updateInfo.update_available && (
+                {updateInfo?.update_available && updateInfo.can_apply && (
+                  <Button
+                    size="sm"
+                    prefix={<Download className="h-3.5 w-3.5" />}
+                    onClick={() => setUpdateConfirmOpen(true)}
+                  >
+                    Update now
+                  </Button>
+                )}
+                {updateInfo &&
+                  !updateInfo.can_apply &&
+                  updateInfo.update_available && (
+                    <span className="text-xs text-muted-foreground">
+                      Update with{" "}
+                      <span className="font-mono">{updateInfo.update_command}</span>
+                    </span>
+                  )}
+                {updateInfo?.message && !updateInfo.update_available && (
                   <span className="text-xs text-muted-foreground">
-                    Update with{" "}
-                    <span className="font-mono">{updateInfo.update_command}</span>
+                    {updateInfo.message}
                   </span>
                 )}
-              {updateInfo?.message && !updateInfo.update_available && (
-                <span className="text-xs text-muted-foreground">
-                  {updateInfo.message}
-                </span>
-              )}
-            </div>
+              </div>
+            )}
           </CardContent>
         </Card>
       </section>

--- a/web/src/pages/SystemPage.tsx
+++ b/web/src/pages/SystemPage.tsx
@@ -420,7 +420,7 @@ export default function SystemPage() {
     setUpdateConfirmOpen(false);
     if (status?.can_update_hermes === false) {
       showToast(
-        "Hermes updates are managed by the hosted agent service.",
+        "Hermes updates are managed outside this dashboard.",
         "success",
       );
       return;


### PR DESCRIPTION
## Summary

- Hide the dashboard's built-in Hermes update controls whenever the dashboard process is running in a detected containerized environment.
- Expose `can_update_hermes` from `/api/status` so the sidebar and System page can render the correct controls.
- Guard `/api/hermes/update` and `/api/hermes/update/check` so stale clients cannot invoke the local updater when updates are managed outside the dashboard.
- Clean up sidebar tooltip anchor handling so targeted React lint passes.

## Why

Dockerized/containerized dashboards are updated by the outer launcher or container/image lifecycle. Showing the local `hermes update` path in those environments is confusing and can imply users should update from inside the managed dashboard.

## Validation

- `python -m pytest tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_get_status tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_get_status_hides_update_capability_in_managed_runtime tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_dashboard_update_capability_detects_generic_container tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_update_hermes_returns_managed_runtime_guidance_without_spawning tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_update_hermes_returns_docker_guidance_without_spawning tests/hermes_cli/test_dashboard_admin_endpoints.py::TestUpdateCheckEndpoint::test_managed_runtime_dashboard_is_not_applyable tests/hermes_cli/test_dashboard_admin_endpoints.py::TestUpdateCheckEndpoint::test_docker_is_not_applyable -q`
- `npm exec --workspace web -- eslint src/App.tsx src/pages/SystemPage.tsx src/contexts/SystemActions.tsx src/lib/api.ts`
- `npm run build --workspace web`
- `git diff --check`

## Infographic

![hide-hosted-dashboard-update-controls](https://v3b.fal.media/files/b/0a9e8687/86jPtZu9U4LC6GoifpO_a_M1bveR7w.png)
