### PR TITLE
fix(gateway): show full terminal command in code blocks on non-verbose modes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13854,10 +13854,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # "all" / "new" modes: short preview, respects tool_preview_length
             # config (defaults to 40 chars when unset to keep gateway messages
             # compact — unlike CLI spinners, these persist as permanent messages).
-            # Terminal commands on markdown platforms get a single-line capped
-            # fenced block (built above) instead of the truncated preview.
-            if _code_block_short is not None:
-                msg = _code_block_short
+            # Terminal commands on markdown platforms get the full fenced
+            # block — code blocks are already visually compact (scrollable)
+            # so capping to a single line provides no UX benefit (#46941).
+            if _code_block_full is not None:
+                msg = _code_block_full
                 last_was_terminal_block[0] = True
             elif preview:
                 from agent.display import get_tool_preview_max_len

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1356,8 +1356,8 @@ async def test_terminal_progress_renders_fenced_code_block(monkeypatch, tmp_path
     """Terminal progress on a markdown-capable (supports_code_blocks) gateway
     renders a bare fenced code block — no language tag (Slack mrkdwn would print
     'bash' as a literal first code line).  In non-verbose ("all"/"new") mode the
-    command is collapsed to a single line capped at tool_preview_length so a long
-    or multi-line command doesn't render as a huge block (#42634)."""
+    full command is shown inside the fence since code blocks are already compact
+    on markdown platforms (#46941)."""
     monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
 
     fake_dotenv = types.ModuleType("dotenv")
@@ -1397,11 +1397,11 @@ async def test_terminal_progress_renders_fenced_code_block(monkeypatch, tmp_path
     # Bare fenced block, no language tag (no '```bash').
     assert "```" in all_content
     assert "```bash" not in all_content
-    # Non-verbose collapses to the first line + truncation marker — the later
-    # command lines must NOT appear (this was the "huge block" regression).
+    # Non-verbose now shows the full command inside code blocks — fences are
+    # already visually compact on markdown platforms (#46941).
     assert "set -euo pipefail" in all_content
-    assert "npm install -g hyperframes@latest" not in all_content
-    assert "node --version" not in all_content
+    assert "npm install -g hyperframes@latest" in all_content
+    assert "node --version" in all_content
     # No truncated quoted preview for the terminal command.
     assert 'terminal: "' not in all_content
 


### PR DESCRIPTION
## Fixes #46941

Non-verbose progress modes (`all`/`new`) were truncating terminal commands inside fenced code blocks to a single line capped at `tool_preview_length` (default 40 chars), creating confusing partial commands like:

```
cat ~/Projects/synapse/docker-compose.yml | gr...
```

Code blocks are already visually compact (scrollable/foldable) on markdown platforms, so the extra truncation provides no UX benefit.

### Changes

- `gateway/run.py`: Use `_code_block_full` instead of `_code_block_short` in non-verbose modes
- `tests/gateway/test_run_progress_topics.py`: Update test assertions to expect full command in code blocks

### Before
Non-verbose mode truncated to first line + `...`:
```
cat ~/Projects/synapse/docker-compose.yml | gr...
```

### After
Non-verbose mode shows full command:
```
cat ~/Projects/synapse/docker-compose.yml | grep -E "image|ports|volumes"
```

Verbose mode was already showing the full command — this fix brings non-verbose modes to parity for code-block rendering.