### PR TITLE
fix(gateway): add freshness gate to resume_pending sessions

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -926,9 +926,24 @@ class SessionStore:
                     # the NEXT successful turn completes (not here), which
                     # means a re-interrupted retry keeps trying — the
                     # stuck-loop counter handles terminal escalation.
-                    entry.updated_at = now
-                    self._save()
-                    return entry
+                    #
+                    # Freshness gate: if the session has been pending
+                    # resume longer than the auto-continue freshness
+                    # window, treat it as a zombie — the recovery turn
+                    # either never ran or failed and the stale transcript
+                    # would pollute the context (#46934).
+                    _ref_time = entry.last_resume_marked_at or entry.updated_at
+                    _fw_raw = os.environ.get("HERMES_AUTO_CONTINUE_FRESHNESS")
+                    try:
+                        _fw = float(_fw_raw) if _fw_raw else 3600.0
+                    except (TypeError, ValueError):
+                        _fw = 3600.0
+                    if _fw > 0 and (now - _ref_time).total_seconds() > _fw:
+                        reset_reason = "resume_pending_expired"
+                    else:
+                        entry.updated_at = now
+                        self._save()
+                        return entry
                 else:
                     reset_reason = self._should_reset(entry, source)
                 if not reset_reason:


### PR DESCRIPTION
## Fixes #46934

When the gateway restarts after a crash, sessions interrupted mid-turn are marked `resume_pending=True`. If the auto-recovery turn fails, `resume_pending` is never cleared. After the freshness window expires, these sessions become zombies — user-initiated messages resume the stale session with old conversation history, bypassing idle reset.

### Root Cause

In `gateway/session.py`, `get_or_create_session()` returned `resume_pending` sessions unconditionally without checking if they were still fresh.

### Fix

Add a freshness gate using `last_resume_marked_at` against `HERMES_AUTO_CONTINUE_FRESHNESS` window (default 3600s). If expired, fall through to auto-reset with reason `"resume_pending_expired"`.

### Before
```python
elif entry.resume_pending:
    entry.updated_at = now
    self._save()
    return entry  # Always returns stale sessions
```

### After
```python
elif entry.resume_pending:
    _ref_time = entry.last_resume_marked_at or entry.updated_at
    if _fw > 0 and (now - _ref_time).total_seconds() > _fw:
        reset_reason = "resume_pending_expired"  # Fall through to reset
    else:
        entry.updated_at = now
        self._save()
        return entry
```

Respects `HERMES_AUTO_CONTINUE_FRESHNESS=0` to disable the gate (opt-out for users who want the old behavior).