### PR TITLE
fix(config): load user platform env metadata

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -6499,8 +6499,31 @@ _inject_profile_env_vars()
 _platform_plugin_env_vars_injected = False
 
 
+def _iter_plugin_manifest_paths(root: Path):
+    """Yield plugin manifest paths from flat or category plugin layouts."""
+    if not root.is_dir():
+        return
+    for child in root.iterdir():
+        if not child.is_dir():
+            continue
+        for manifest_name in ("plugin.yaml", "plugin.yml"):
+            manifest_path = child / manifest_name
+            if manifest_path.exists():
+                yield manifest_path
+                break
+        else:
+            for grandchild in child.iterdir():
+                if not grandchild.is_dir():
+                    continue
+                for manifest_name in ("plugin.yaml", "plugin.yml"):
+                    manifest_path = grandchild / manifest_name
+                    if manifest_path.exists():
+                        yield manifest_path
+                        break
+
+
 def _inject_platform_plugin_env_vars() -> None:
-    """Populate OPTIONAL_ENV_VARS from bundled platform plugin manifests.
+    """Populate OPTIONAL_ENV_VARS from bundled and user platform plugins.
 
     Called once at module load time. Idempotent — repeated calls are no-ops.
     Failures are swallowed so a malformed plugin.yaml can't break CLI import.
@@ -6515,56 +6538,57 @@ def _inject_platform_plugin_env_vars() -> None:
         # Resolve the bundled plugins dir from this file's location so the
         # injector works regardless of CWD.
         repo_root = Path(__file__).resolve().parents[1]
-        platforms_dir = repo_root / "plugins" / "platforms"
-        if not platforms_dir.is_dir():
-            return
-        for child in platforms_dir.iterdir():
-            if not child.is_dir():
-                continue
-            manifest_path = child / "plugin.yaml"
-            if not manifest_path.exists():
-                manifest_path = child / "plugin.yml"
-            if not manifest_path.exists():
-                continue
-            try:
-                with open(manifest_path, "r", encoding="utf-8") as f:
-                    manifest = yaml.safe_load(f) or {}
-            except Exception:
-                continue
-            label = manifest.get("label") or manifest.get("name") or child.name
-            # Merge required + optional env var declarations.
-            entries = list(manifest.get("requires_env") or [])
-            entries.extend(manifest.get("optional_env") or [])
-            for entry in entries:
-                if isinstance(entry, str):
-                    name = entry
-                    meta: dict = {}
-                elif isinstance(entry, dict) and entry.get("name"):
-                    name = entry["name"]
-                    meta = entry
-                else:
+        manifest_roots = [
+            repo_root / "plugins" / "platforms",
+            get_hermes_home() / "plugins",
+        ]
+        for root in manifest_roots:
+            for manifest_path in _iter_plugin_manifest_paths(root):
+                try:
+                    with open(manifest_path, "r", encoding="utf-8") as f:
+                        manifest = yaml.safe_load(f) or {}
+                except Exception:
                     continue
-                if name in OPTIONAL_ENV_VARS:
-                    continue  # hardcoded entry wins (back-compat)
-                # Heuristic: anything named *TOKEN, *SECRET, *KEY, *PASSWORD
-                # is a password field unless explicitly overridden.
-                name_upper = name.upper()
-                is_secret = bool(meta.get("password") or meta.get("secret"))
-                if not is_secret and not meta.get("password") is False:
-                    is_secret = any(
-                        name_upper.endswith(suf)
-                        for suf in ("_TOKEN", "_SECRET", "_KEY", "_PASSWORD", "_JSON")
-                    )
-                OPTIONAL_ENV_VARS[name] = {
-                    "description": (
-                        meta.get("description")
-                        or f"{label} configuration"
-                    ),
-                    "prompt": meta.get("prompt") or name,
-                    "url": meta.get("url") or None,
-                    "password": is_secret,
-                    "category": meta.get("category") or "messaging",
-                }
+                if manifest.get("kind") != "platform":
+                    continue
+                label = (
+                    manifest.get("label")
+                    or manifest.get("name")
+                    or manifest_path.parent.name
+                )
+                # Merge required + optional env var declarations.
+                entries = list(manifest.get("requires_env") or [])
+                entries.extend(manifest.get("optional_env") or [])
+                for entry in entries:
+                    if isinstance(entry, str):
+                        name = entry
+                        meta: dict = {}
+                    elif isinstance(entry, dict) and entry.get("name"):
+                        name = entry["name"]
+                        meta = entry
+                    else:
+                        continue
+                    if name in OPTIONAL_ENV_VARS:
+                        continue  # hardcoded entry wins (back-compat)
+                    # Heuristic: anything named *TOKEN, *SECRET, *KEY, *PASSWORD
+                    # is a password field unless explicitly overridden.
+                    name_upper = name.upper()
+                    is_secret = bool(meta.get("password") or meta.get("secret"))
+                    if not is_secret and not meta.get("password") is False:
+                        is_secret = any(
+                            name_upper.endswith(suf)
+                            for suf in ("_TOKEN", "_SECRET", "_KEY", "_PASSWORD", "_JSON")
+                        )
+                    OPTIONAL_ENV_VARS[name] = {
+                        "description": (
+                            meta.get("description")
+                            or f"{label} configuration"
+                        ),
+                        "prompt": meta.get("prompt") or name,
+                        "url": meta.get("url") or None,
+                        "password": is_secret,
+                        "category": meta.get("category") or "messaging",
+                    }
     except Exception:
         pass
 

--- a/tests/hermes_cli/test_platform_plugin_env_injection.py
+++ b/tests/hermes_cli/test_platform_plugin_env_injection.py
@@ -1,0 +1,106 @@
+import yaml
+
+import hermes_cli.config as config_mod
+
+
+def _write_plugin_manifest(path, manifest):
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "plugin.yaml").write_text(yaml.safe_dump(manifest), encoding="utf-8")
+
+
+def test_inject_platform_plugin_env_vars_scans_user_plugins(monkeypatch, tmp_path):
+    hermes_home = tmp_path / "hermes-home"
+    user_plugins = hermes_home / "plugins"
+
+    _write_plugin_manifest(
+        user_plugins / "demo-platform",
+        {
+            "name": "demo-platform",
+            "label": "Demo Platform",
+            "kind": "platform",
+            "requires_env": [
+                {
+                    "name": "DEMO_PLATFORM_TOKEN",
+                    "description": "Token for the demo platform",
+                    "prompt": "Demo token",
+                    "url": "https://example.com/demo",
+                    "password": True,
+                    "category": "messaging",
+                }
+            ],
+            "optional_env": [
+                {
+                    "name": "DEMO_PLATFORM_ROOM",
+                    "description": "Default room for notifications",
+                    "prompt": "Demo room",
+                    "password": False,
+                }
+            ],
+        },
+    )
+    _write_plugin_manifest(
+        user_plugins / "platforms" / "nested-platform",
+        {
+            "name": "nested-platform",
+            "label": "Nested Platform",
+            "kind": "platform",
+            "requires_env": [
+                {
+                    "name": "NESTED_PLATFORM_SECRET",
+                    "description": "Shared secret for the nested platform",
+                    "prompt": "Nested secret",
+                    "password": True,
+                }
+            ],
+        },
+    )
+    _write_plugin_manifest(
+        user_plugins / "image_gen" / "ignore-me",
+        {
+            "name": "ignore-me",
+            "kind": "backend",
+            "requires_env": [{"name": "IGNORE_ME_TOKEN"}],
+        },
+    )
+
+    added_keys = [
+        "DEMO_PLATFORM_TOKEN",
+        "DEMO_PLATFORM_ROOM",
+        "NESTED_PLATFORM_SECRET",
+        "IGNORE_ME_TOKEN",
+    ]
+    original_flag = config_mod._platform_plugin_env_vars_injected
+    try:
+        monkeypatch.setattr(config_mod, "get_hermes_home", lambda: hermes_home)
+        config_mod._platform_plugin_env_vars_injected = False
+        for key in added_keys:
+            config_mod.OPTIONAL_ENV_VARS.pop(key, None)
+
+        config_mod._inject_platform_plugin_env_vars()
+
+        assert config_mod.OPTIONAL_ENV_VARS["DEMO_PLATFORM_TOKEN"] == {
+            "description": "Token for the demo platform",
+            "prompt": "Demo token",
+            "url": "https://example.com/demo",
+            "password": True,
+            "category": "messaging",
+        }
+        assert config_mod.OPTIONAL_ENV_VARS["DEMO_PLATFORM_ROOM"] == {
+            "description": "Default room for notifications",
+            "prompt": "Demo room",
+            "url": None,
+            "password": False,
+            "category": "messaging",
+        }
+        assert config_mod.OPTIONAL_ENV_VARS["NESTED_PLATFORM_SECRET"] == {
+            "description": "Shared secret for the nested platform",
+            "prompt": "Nested secret",
+            "url": None,
+            "password": True,
+            "category": "messaging",
+        }
+        assert "IGNORE_ME_TOKEN" not in config_mod.OPTIONAL_ENV_VARS
+    finally:
+        for key in added_keys:
+            config_mod.OPTIONAL_ENV_VARS.pop(key, None)
+        config_mod._platform_plugin_env_vars_injected = original_flag


### PR DESCRIPTION
## Summary
- scan user-installed plugin manifests alongside bundled platform plugins when injecting OPTIONAL_ENV_VARS
- accept both flat and category plugin layouts but only import metadata from `kind: platform` manifests
- add a regression test covering flat user plugins, nested `platforms/*` user plugins, and non-platform manifests

## Testing
- python3 -m pytest tests/hermes_cli/test_platform_plugin_env_injection.py -q -o addopts=""
- ruff check hermes_cli/config.py tests/hermes_cli/test_platform_plugin_env_injection.py
- git diff --check HEAD^ HEAD

Closes #46600