### PR TITLE
[verified] fix: force WAL fallback to delete on disk i/o init failure

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -128,6 +128,13 @@ SCHEMA_VERSION = 16
 _WAL_INCOMPAT_MARKERS = (
     "locking protocol",       # SQLITE_PROTOCOL on NFS/SMB
     "not authorized",         # Some FUSE mounts block WAL pragma outright
+    "disk i/o error",         # Stale SHM/FS state can block WAL init
+)
+
+# Disk I/O failures where WAL is already impossible (for example stale
+# ``*.db-shm`` after unclean host/container shutdown on gRPC-FUSE/virtioFS).
+_WAL_FORCE_DELETE_MARKERS = (
+    "disk i/o error",
 )
 
 # Last SessionDB() init error, per-process.  Surfaced in /resume and
@@ -270,10 +277,18 @@ def apply_wal_with_fallback(
         if not any(marker in msg for marker in _WAL_INCOMPAT_MARKERS):
             # Unrelated OperationalError — don't silently swallow.
             raise
-        # Don't downgrade if another process already set WAL on disk.
-        existing = _on_disk_journal_mode(conn)
-        if existing == "wal":
-            raise
+
+        # Treat explicit disk-I/O faults as a hard fallback signal even if the
+        # database header still reports WAL mode.
+        force_delete = any(
+            marker in msg for marker in _WAL_FORCE_DELETE_MARKERS
+        )
+        if not force_delete:
+            # Don't downgrade if another process already set WAL on disk.
+            existing = _on_disk_journal_mode(conn)
+            if existing == "wal":
+                raise
+
         _log_wal_fallback_once(db_label, exc)
         conn.execute("PRAGMA journal_mode=DELETE")
         return "delete"

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3945,6 +3945,43 @@ class TestApplyWalProbe:
             "set-pragma must fire when probe returns 'delete'"
         )
 
+    def test_disk_i_o_error_forces_delete_even_if_disk_header_reports_wal(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """disk I/O errors must still force delete fallback, even if DB header is WAL."""
+        import sqlite3
+        import hermes_state
+
+        class _TracingConn(sqlite3.Connection):
+            def __init__(self, *a, **kw):
+                super().__init__(*a, **kw)
+                self.executed = []
+
+            def execute(self, sql, params=()):
+                self.executed.append(sql)
+                if "journal_mode=WAL" in sql:
+                    raise sqlite3.OperationalError("disk i/o error")
+                return super().execute(sql, params)
+
+        db_path = tmp_path / "force_delete.db"
+        conn = _TracingConn(str(db_path))
+
+        # Simulate a DB that is already WAL on disk but cannot switch journaling mode.
+        monkeypatch.setattr(
+            hermes_state,
+            "_on_disk_journal_mode",
+            lambda _conn: "wal",
+        )
+
+        try:
+            result = hermes_state.apply_wal_with_fallback(conn)
+        finally:
+            conn.close()
+
+        assert result == "delete"
+
 
 class TestSessionArchive:
     """Soft-archiving hides a session from default listings without deleting it."""


### PR DESCRIPTION
## Summary
- Treat WAL initialization `disk i/o error` failures as explicit force-delete paths in `apply_wal_with_fallback`.
- Keep the existing WAL-incompatibility fallback behavior intact for non-I/O errors.
- Add regression coverage for the case where disk I/O failures occur while the on-disk mode is still reported as `wal`.

## Testing
- `python3 -m py_compile hermes_state.py tests/test_hermes_state.py`
- `python3 -m pytest -q tests/test_hermes_state.py -k "TestApplyWalProbe and (disk_i_o_error_forces_delete_even_if_disk_header_reports_wal or test_fallback_to_delete_still_works or test_no_downgrade_from_wal_to_delete_on_eio or test_returns_wal_not_delete_from_probe or test_apply_wal_concurrent_connects_no_eio)`"

Closes #46797
