### PR TITLE
fix(gateway): recognize (silence) as intentional silence marker

### DIFF
--- a/gateway/response_filters.py
+++ b/gateway/response_filters.py
@@ -20,6 +20,7 @@ LIVE_GATEWAY_SILENT_MARKERS = frozenset({
     "SILENT",
     "NO_REPLY",
     "NO REPLY",
+    "(silence)",
 })
 
 

--- a/tests/gateway/test_gateway_silence_tokens.py
+++ b/tests/gateway/test_gateway_silence_tokens.py
@@ -77,7 +77,7 @@ def _runner(monkeypatch, tmp_path):
 
 
 def test_exact_silence_tokens_are_intentional_silence():
-    for token in ("[SILENT]", " SILENT ", "NO_REPLY", "no reply"):
+    for token in ("[SILENT]", " SILENT ", "NO_REPLY", "no reply", "(silence)"):
         assert is_intentional_silence_response(token)
 
 

--- a/tests/gateway/test_response_filters.py
+++ b/tests/gateway/test_response_filters.py
@@ -5,7 +5,7 @@ from gateway.response_filters import (
 
 
 def test_exact_silence_tokens_are_intentional_silence():
-    for token in ("[SILENT]", " SILENT ", "NO_REPLY", "no reply"):
+    for token in ("[SILENT]", " SILENT ", "NO_REPLY", "no reply", "(silence)"):
         assert is_intentional_silence_response(token)
 
 


### PR DESCRIPTION
## Fixes #46917

The gateway has an intentional-silence mechanism that suppresses delivery when the agent responds with markers like `[SILENT]`, `NO_REPLY`, etc. However, `(silence)` — a natural placeholder that LLMs produce when instructed to remain silent — was not recognized, causing it to be delivered as literal text.

### Fix

Add `(silence)` to `LIVE_GATEWAY_SILENT_MARKERS` in `gateway/response_filters.py`.

### Before
Agent instructed to stay silent → LLM outputs `(silence)` → gateway delivers literal text `(silence)` to user.

### After
Agent instructed to stay silent → LLM outputs `(silence)` → gateway recognizes it as intentional silence → delivery suppressed, no message sent.