### PR TITLE
fix(tui): support common syntax aliases

### DIFF
--- a/ui-tui/src/__tests__/syntax.test.ts
+++ b/ui-tui/src/__tests__/syntax.test.ts
@@ -12,6 +12,10 @@ describe('syntax highlighter', () => {
     expect(isHighlightable('python')).toBe(true)
     expect(isHighlightable('rs')).toBe(true)
     expect(isHighlightable('bash')).toBe(true)
+    expect(isHighlightable('csharp')).toBe(true)
+    expect(isHighlightable('cs')).toBe(true)
+    expect(isHighlightable('java')).toBe(true)
+    expect(isHighlightable('kotlin')).toBe(true)
     expect(isHighlightable('whatever')).toBe(false)
     expect(isHighlightable('')).toBe(false)
   })
@@ -41,5 +45,20 @@ describe('syntax highlighter', () => {
     const tokens = highlightLine('# comment', 'py', t)
 
     expect(tokens).toEqual([[t.color.muted, '# comment']])
+  })
+
+  it('highlights csharp aliases instead of falling back to plain text', () => {
+    const tokens = highlightLine('public class Demo { }', 'csharp', t)
+    const colors = tokens.map(tok => tok[0])
+
+    expect(colors).toContain(t.color.border) // public / class
+  })
+
+  it('highlights java and kotlin fenced languages', () => {
+    const javaTokens = highlightLine('public class Demo { }', 'java', t)
+    const kotlinTokens = highlightLine('fun main() = true', 'kotlin', t)
+
+    expect(javaTokens.map(tok => tok[0])).toContain(t.color.border) // public / class
+    expect(kotlinTokens.map(tok => tok[0])).toContain(t.color.border) // fun / true
   })
 })

--- a/ui-tui/src/lib/syntax.ts
+++ b/ui-tui/src/lib/syntax.ts
@@ -41,9 +41,33 @@ const SQL = KW(`
   table drop alter add column primary key foreign references join left right inner outer on
 `)
 
+const CSHARP = KW(`
+  abstract as base bool break byte case catch char checked class const continue decimal default delegate do double else
+  enum event explicit extern false finally fixed float for foreach goto if implicit in int interface internal is lock long
+  namespace new null object operator out override params private protected public readonly ref return sbyte sealed short
+  sizeof stackalloc static string struct switch this throw true try typeof uint ulong unchecked unsafe ushort using virtual
+  void volatile while
+`)
+
+const JAVA = KW(`
+  abstract assert boolean break byte case catch char class const continue default do double else enum extends final finally
+  float for goto if implements import instanceof int interface long native new null package private protected public return short
+  static strictfp super switch synchronized this throw throws transient true try void volatile while false
+`)
+
+const KOTLIN = KW(`
+  as break class continue do else false for fun if in interface is null object package return super this throw true try
+  typealias typeof val var when while by catch constructor delegate dynamic field file finally get import init param property
+  receiver set setparam where actual abstract annotation companion const crossinline data enum expect external final infix inline
+  inner internal lateinit noinline open operator out override private protected public reified sealed suspend tailrec value vararg
+`)
+
 const LANGS: Record<string, LangSpec> = {
+  cs: { comment: '//', keywords: CSHARP },
   go: { comment: '//', keywords: GO },
+  java: { comment: '//', keywords: JAVA },
   json: { comment: null, keywords: KW('true false null') },
+  kotlin: { comment: '//', keywords: KOTLIN },
   py: { comment: '#', keywords: PY },
   rust: { comment: '//', keywords: RUST },
   sh: { comment: '#', keywords: SH },
@@ -54,8 +78,14 @@ const LANGS: Record<string, LangSpec> = {
 
 const ALIAS: Record<string, string> = {
   bash: 'sh',
+  'c#': 'cs',
+  cs: 'cs',
+  csharp: 'cs',
+  csx: 'cs',
   javascript: 'ts',
   js: 'ts',
+  kt: 'kotlin',
+  kts: 'kotlin',
   jsx: 'ts',
   python: 'py',
   rs: 'rust',


### PR DESCRIPTION
## Summary
- add TUI syntax highlighting support for C#, Java, and Kotlin fenced blocks
- normalize common aliases like `csharp`, `cs`, `c#`, `kt`, and `kts`
- extend the syntax unit tests to cover the new aliases

## Testing
- npm test -- --run src/__tests__/syntax.test.ts
- npx eslint src/lib/syntax.ts src/__tests__/syntax.test.ts
- git diff --check

Closes #46905