### PR TITLE
feat(delegate): isolate fallback for model overrides

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1469,6 +1469,113 @@ class TestDelegationProviderIntegration(unittest.TestCase):
             self.assertEqual(kwargs["provider"], parent.provider)
             self.assertEqual(kwargs["base_url"], parent.base_url)
 
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_top_level_model_override_can_disable_parent_fallback(self, mock_creds, mock_cfg):
+        """Cost-capped model overrides can opt out of the parent's fallback chain."""
+        mock_cfg.return_value = {"max_iterations": 45}
+        mock_creds.return_value = {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        parent = _make_mock_parent(depth=0)
+        parent._fallback_chain = [
+            {"provider": "anthropic", "model": "claude-opus-4.6"}
+        ]
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build, \
+             patch("tools.delegate_tool._run_single_child") as mock_run:
+            mock_child = MagicMock()
+            mock_build.return_value = mock_child
+            mock_run.return_value = {
+                "task_index": 0,
+                "status": "completed",
+                "summary": "Done",
+                "api_calls": 1,
+                "duration_seconds": 1.0,
+            }
+
+            delegate_task(
+                goal="cheap bounded task",
+                model={"model": "openai/gpt-4o-mini", "fallback": False},
+                parent_agent=parent,
+            )
+
+            _, kwargs = mock_build.call_args
+            self.assertEqual(kwargs.get("model"), "openai/gpt-4o-mini")
+            self.assertEqual(kwargs.get("override_fallback_model"), [])
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_per_task_model_fallback_overrides_top_level_fallback(self, mock_creds, mock_cfg):
+        """Batch tasks can use distinct fallback policies for cost/risk control."""
+        mock_cfg.return_value = {"max_iterations": 45}
+        mock_creds.return_value = {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        parent = _make_mock_parent(depth=0)
+        parent._fallback_chain = [
+            {"provider": "anthropic", "model": "claude-opus-4.6"}
+        ]
+        cheap_fallback = [{"provider": "openrouter", "model": "google/gemini-flash-2.0"}]
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build, \
+             patch("tools.delegate_tool._run_single_child") as mock_run:
+            mock_child = MagicMock()
+            mock_build.return_value = mock_child
+            mock_run.return_value = {
+                "task_index": 0,
+                "status": "completed",
+                "summary": "Done",
+                "api_calls": 1,
+                "duration_seconds": 1.0,
+            }
+
+            delegate_task(
+                tasks=[
+                    {"goal": "bounded cheap", "model": {"model": "openai/gpt-4o-mini", "fallback": False}},
+                    {"goal": "bounded with cheap fallback", "model": {"model": "openai/gpt-4o-mini", "fallback": cheap_fallback}},
+                ],
+                model={"model": "openai/gpt-4o-mini", "fallback": False},
+                parent_agent=parent,
+            )
+
+            self.assertEqual(mock_build.call_args_list[0].kwargs.get("override_fallback_model"), [])
+            self.assertEqual(
+                mock_build.call_args_list[1].kwargs.get("override_fallback_model"),
+                cheap_fallback,
+            )
+
+    def test_build_child_agent_uses_explicit_fallback_override(self):
+        """_build_child_agent must not re-inherit parent fallback after an explicit override."""
+        parent = _make_mock_parent(depth=0)
+        parent._fallback_chain = [
+            {"provider": "anthropic", "model": "claude-opus-4.6"}
+        ]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            _build_child_agent(
+                task_index=0,
+                goal="fallback isolation",
+                context=None,
+                toolsets=["file"],
+                model="openai/gpt-4o-mini",
+                max_iterations=10,
+                task_count=1,
+                parent_agent=parent,
+                override_fallback_model=[],
+            )
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["fallback_model"], [])
+
 
 class TestChildCredentialPoolResolution(unittest.TestCase):
     def test_same_provider_shares_parent_pool(self):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -2795,5 +2795,212 @@ class TestFallbackModelInheritance(unittest.TestCase):
         self.assertIsNone(kwargs["fallback_model"])
 
 
+class TestModelOverride(unittest.TestCase):
+    """Tests for per-task and top-level model override in delegate_task."""
+
+    def test_schema_has_model_top_level(self):
+        """The schema must expose a top-level 'model' property."""
+        from tools.delegate_tool import DELEGATE_TASK_SCHEMA
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        self.assertIn("model", props)
+        self.assertEqual(props["model"]["type"], "object")
+        self.assertIn("provider", props["model"]["properties"])
+        self.assertIn("model", props["model"]["properties"])
+
+    def test_schema_has_model_per_task(self):
+        """The schema must expose a 'model' property in task items."""
+        from tools.delegate_tool import DELEGATE_TASK_SCHEMA
+        task_props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]["tasks"]["items"]["properties"]
+        self.assertIn("model", task_props)
+        self.assertEqual(task_props["model"]["type"], "object")
+
+    def test_resolve_model_override_none_returns_none(self):
+        """None or empty dict returns None (no override)."""
+        parent = _make_mock_parent()
+        from tools.delegate_tool import _resolve_model_override
+        self.assertIsNone(_resolve_model_override(None, parent))
+        self.assertIsNone(_resolve_model_override({}, parent))
+        self.assertIsNone(_resolve_model_override({"model": "", "provider": ""}, parent))
+
+    def test_resolve_model_override_model_only_inherits_parent_provider(self):
+        """Model-only override keeps the parent's provider and credentials."""
+        parent = _make_mock_parent()
+        parent.provider = "openrouter"
+        parent.base_url = "https://openrouter.ai/api/v1"
+        parent.api_mode = "chat_completions"
+        from tools.delegate_tool import _resolve_model_override
+        creds = _resolve_model_override({"model": "deepseek/deepseek-chat"}, parent)
+        self.assertEqual(creds["model"], "deepseek/deepseek-chat")
+        self.assertEqual(creds["provider"], "openrouter")
+        self.assertEqual(creds["base_url"], "https://openrouter.ai/api/v1")
+        self.assertIsNone(creds["api_key"])  # inherit from parent
+
+    def test_resolve_model_override_bare_custom_ignored(self):
+        """Bare 'custom' provider is treated as no provider (inherits parent)."""
+        parent = _make_mock_parent()
+        parent.provider = "openrouter"
+        from tools.delegate_tool import _resolve_model_override
+        creds = _resolve_model_override({"provider": "custom", "model": "test"}, parent)
+        self.assertEqual(creds["provider"], "openrouter")
+
+    def test_resolve_model_override_with_provider_resolves_credentials(self):
+        """Provider-specified override resolves full credentials."""
+        parent = _make_mock_parent()
+        from tools.delegate_tool import _resolve_model_override
+        with patch("hermes_cli.runtime_provider.resolve_runtime_provider") as mock_resolve:
+            mock_resolve.return_value = {
+                "provider": "anthropic",
+                "base_url": "https://api.anthropic.com",
+                "api_key": "test-key",
+                "api_mode": "anthropic_messages",
+            }
+            creds = _resolve_model_override(
+                {"provider": "anthropic", "model": "claude-sonnet-4"}, parent
+            )
+        self.assertEqual(creds["model"], "claude-sonnet-4")
+        self.assertEqual(creds["provider"], "anthropic")
+        self.assertEqual(creds["api_key"], "test-key")
+        self.assertEqual(creds["api_mode"], "anthropic_messages")
+
+    def test_resolve_model_override_provider_no_key_raises(self):
+        """Provider with no API key raises ValueError."""
+        parent = _make_mock_parent()
+        from tools.delegate_tool import _resolve_model_override
+        with patch("hermes_cli.runtime_provider.resolve_runtime_provider") as mock_resolve:
+            mock_resolve.return_value = {
+                "provider": "anthropic",
+                "base_url": "https://api.anthropic.com",
+                "api_key": "",
+                "api_mode": "anthropic_messages",
+            }
+            with self.assertRaises(ValueError) as ctx:
+                _resolve_model_override({"provider": "anthropic"}, parent)
+            self.assertIn("no API key", str(ctx.exception))
+
+    def test_resolve_model_override_invalid_provider_raises(self):
+        """Unresolvable provider raises ValueError."""
+        parent = _make_mock_parent()
+        from tools.delegate_tool import _resolve_model_override
+        with patch("hermes_cli.runtime_provider.resolve_runtime_provider") as mock_resolve:
+            mock_resolve.side_effect = RuntimeError("unknown provider")
+            with self.assertRaises(ValueError) as ctx:
+                _resolve_model_override({"provider": "nonexistent"}, parent)
+            self.assertIn("Cannot resolve", str(ctx.exception))
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_top_level_model_override_used_for_child(self, mock_creds, mock_cfg):
+        """Top-level model override is passed to _build_child_agent."""
+        mock_creds.return_value = {
+            "model": None, "provider": None, "base_url": None,
+            "api_key": None, "api_mode": None,
+        }
+        parent = _make_mock_parent()
+        parent.provider = "openrouter"
+        parent.base_url = "https://openrouter.ai/api/v1"
+        parent.api_mode = "chat_completions"
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build, \
+             patch("tools.delegate_tool._run_single_child") as mock_run:
+            mock_build.return_value = MagicMock()
+            mock_run.return_value = {"status": "completed", "summary": "ok"}
+            delegate_task(
+                goal="test task",
+                model={"model": "cheap-model"},
+                parent_agent=parent,
+            )
+        _, kwargs = mock_build.call_args
+        self.assertEqual(kwargs["model"], "cheap-model")
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_per_task_model_overrides_top_level(self, mock_creds, mock_cfg):
+        """Per-task model override takes precedence over top-level."""
+        mock_creds.return_value = {
+            "model": None, "provider": None, "base_url": None,
+            "api_key": None, "api_mode": None,
+        }
+        parent = _make_mock_parent()
+        parent.provider = "openrouter"
+        parent.base_url = "https://openrouter.ai/api/v1"
+        parent.api_mode = "chat_completions"
+
+        def _fake_run(task_index, goal, child, parent_agent):
+            return {"task_index": task_index, "status": "completed", "summary": "ok", "_child_role": "leaf"}
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build, \
+             patch("tools.delegate_tool._run_single_child", side_effect=_fake_run) as mock_run:
+            mock_build.return_value = MagicMock()
+            delegate_task(
+                tasks=[
+                    {"goal": "task A", "model": {"model": "per-task-model"}},
+                    {"goal": "task B"},
+                ],
+                model={"model": "top-level-model"},
+                parent_agent=parent,
+            )
+        # First call: per-task model wins
+        _, kwargs_a = mock_build.call_args_list[0]
+        self.assertEqual(kwargs_a["model"], "per-task-model")
+        # Second call: top-level model used (no per-task override)
+        _, kwargs_b = mock_build.call_args_list[1]
+        self.assertEqual(kwargs_b["model"], "top-level-model")
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_no_model_override_uses_delegation_config(self, mock_creds, mock_cfg):
+        """Without model override, delegation config credentials are used."""
+        mock_creds.return_value = {
+            "model": "delegation-model", "provider": "openrouter",
+            "base_url": None, "api_key": None, "api_mode": None,
+        }
+        parent = _make_mock_parent()
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build, \
+             patch("tools.delegate_tool._run_single_child") as mock_run:
+            mock_build.return_value = MagicMock()
+            mock_run.return_value = {"status": "completed", "summary": "ok"}
+            delegate_task(goal="test task", parent_agent=parent)
+        _, kwargs = mock_build.call_args
+        self.assertEqual(kwargs["model"], "delegation-model")
+
+    @patch("tools.delegate_tool._load_config", return_value={})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_batch_per_task_model_with_provider(self, mock_creds, mock_cfg):
+        """Per-task model with provider resolves credentials independently."""
+        mock_creds.return_value = {
+            "model": None, "provider": None, "base_url": None,
+            "api_key": None, "api_mode": None,
+        }
+        parent = _make_mock_parent()
+        parent.provider = "openrouter"
+        parent.base_url = "https://openrouter.ai/api/v1"
+        parent.api_mode = "chat_completions"
+
+        def _fake_run(task_index, goal, child, parent_agent):
+            return {"task_index": task_index, "status": "completed", "summary": "ok", "_child_role": "leaf"}
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build, \
+             patch("tools.delegate_tool._run_single_child", side_effect=_fake_run) as mock_run, \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider") as mock_resolve:
+            mock_build.return_value = MagicMock()
+            mock_resolve.return_value = {
+                "provider": "anthropic",
+                "base_url": "https://api.anthropic.com",
+                "api_key": "ant-key",
+                "api_mode": "anthropic_messages",
+            }
+            delegate_task(
+                tasks=[
+                    {"goal": "reasoning task", "model": {"provider": "anthropic", "model": "claude-sonnet-4"}},
+                ],
+                parent_agent=parent,
+            )
+        _, kwargs = mock_build.call_args
+        self.assertEqual(kwargs["model"], "claude-sonnet-4")
+        self.assertEqual(kwargs["override_provider"], "anthropic")
+        self.assertEqual(kwargs["override_api_key"], "ant-key")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -556,6 +556,7 @@ _HEARTBEAT_INTERVAL = 30  # seconds between parent activity heartbeats during de
 _HEARTBEAT_STALE_CYCLES_IDLE = 15  # 15 * 30s = 450s idle between turns → stale
 _HEARTBEAT_STALE_CYCLES_IN_TOOL = 40  # 40 * 30s = 1200s stuck on same tool → stale
 DEFAULT_TOOLSETS = ["terminal", "file", "web"]
+_FALLBACK_INHERIT = object()
 
 
 # ---------------------------------------------------------------------------
@@ -922,6 +923,9 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    # Explicit child fallback policy.  Omitted = inherit parent chain;
+    # []/{} = no fallback; dict/list = child-specific fallback chain.
+    override_fallback_model: Any = _FALLBACK_INHERIT,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -1110,11 +1114,16 @@ def _build_child_agent(
     except Exception as exc:
         logger.debug("Could not load delegation reasoning_effort: %s", exc)
 
-    # Inherit the parent's fallback provider chain so subagents can recover
-    # from rate-limits and credential exhaustion exactly like the top-level
-    # agent does.  _fallback_chain is a list accepted by AIAgent's
-    # fallback_model parameter (which handles both list and dict forms).
+    # Inherit the parent's fallback provider chain by default so subagents can
+    # recover from rate-limits and credential exhaustion exactly like the
+    # top-level agent does.  A per-call/per-task model override may explicitly
+    # pass [] to isolate the child from the parent's fallback chain for strict
+    # cost control, or pass a dict/list to use a child-specific chain.
     parent_fallback = getattr(parent_agent, "_fallback_chain", None) or None
+    if override_fallback_model is _FALLBACK_INHERIT:
+        child_fallback = parent_fallback
+    else:
+        child_fallback = override_fallback_model
 
     # Inherit the parent's OpenRouter provider-preference filters by default
     # (so subagents routed to the same provider honour the same routing
@@ -1149,7 +1158,7 @@ def _build_child_agent(
         max_tokens=getattr(parent_agent, "max_tokens", None),
         reasoning_config=child_reasoning,
         prefill_messages=getattr(parent_agent, "prefill_messages", None),
-        fallback_model=parent_fallback,
+        fallback_model=child_fallback,
         enabled_toolsets=child_toolsets,
         quiet_mode=True,
         ephemeral_system_prompt=child_prompt,
@@ -1967,6 +1976,42 @@ def _recover_tasks_from_json_string(
     return parsed, None
 
 
+def _resolve_model_fallback_override(model_obj: Dict[str, Any]) -> tuple[Any, bool]:
+    """Resolve optional fallback policy inside a delegate model override.
+
+    Missing/true/null means inherit the parent's fallback chain. ``false``
+    means no fallback for this child. A dict or list is passed through as the
+    child-specific fallback_model chain accepted by AIAgent.
+    """
+    if "fallback" not in model_obj:
+        return _FALLBACK_INHERIT, False
+
+    fallback = model_obj.get("fallback")
+    if fallback is False:
+        return [], True
+    if fallback is None or fallback is True:
+        return _FALLBACK_INHERIT, True
+    if isinstance(fallback, dict):
+        if not fallback:
+            return [], True
+        if not (fallback.get("provider") and fallback.get("model")):
+            raise ValueError(
+                "model.fallback object must include both 'provider' and 'model'."
+            )
+        return fallback, True
+    if isinstance(fallback, list):
+        for idx, entry in enumerate(fallback):
+            if not isinstance(entry, dict) or not (entry.get("provider") and entry.get("model")):
+                raise ValueError(
+                    f"model.fallback[{idx}] must be an object with 'provider' and 'model'."
+                )
+        return list(fallback), True
+
+    raise ValueError(
+        "model.fallback must be false, null/true, a fallback object, or a list of fallback objects."
+    )
+
+
 def _resolve_model_override(
     model_obj: Any,
     parent_agent,
@@ -1974,15 +2019,20 @@ def _resolve_model_override(
     """Resolve a per-task/top-level model override into a credential dict.
 
     ``model_obj`` is a dict with optional ``provider`` and ``model`` keys,
-    matching the cron job model override pattern.  Returns a credential dict
+    matching the cron job model override pattern. Returns a credential dict
     (model, provider, base_url, api_key, api_mode) or ``None`` when no
     override is requested.
+
+    Optional ``fallback`` controls the delegated child's fallback chain:
+    omitted = inherit parent chain, false = no fallback, dict/list = explicit
+    child fallback chain.
 
     Raises ``ValueError`` on unresolvable provider references.
     """
     if not model_obj or not isinstance(model_obj, dict):
         return None
 
+    fallback_model, fallback_specified = _resolve_model_fallback_override(model_obj)
     model_name = str(model_obj.get("model") or "").strip() or None
     provider_name = str(model_obj.get("provider") or "").strip() or None
 
@@ -2003,6 +2053,8 @@ def _resolve_model_override(
             "base_url": getattr(parent_agent, "base_url", None),
             "api_key": None,  # inherit from parent
             "api_mode": getattr(parent_agent, "api_mode", None),
+            "fallback_model": fallback_model,
+            "fallback_specified": fallback_specified,
         }
 
     # Provider specified — resolve full credentials via the runtime system.
@@ -2031,6 +2083,8 @@ def _resolve_model_override(
         "base_url": runtime.get("base_url"),
         "api_key": api_key,
         "api_mode": runtime.get("api_mode", "chat_completions"),
+        "fallback_model": fallback_model,
+        "fallback_specified": fallback_specified,
     }
 
 
@@ -2198,6 +2252,12 @@ def delegate_task(
                         f"Task {i}: 'model' must have at least 'model' or 'provider' key."
                     )
             effective_creds = task_model_creds or top_model_creds or creds
+            if task_model_creds and task_model_creds.get("fallback_specified"):
+                effective_fallback_model = task_model_creds.get("fallback_model", _FALLBACK_INHERIT)
+            elif top_model_creds and top_model_creds.get("fallback_specified"):
+                effective_fallback_model = top_model_creds.get("fallback_model", _FALLBACK_INHERIT)
+            else:
+                effective_fallback_model = _FALLBACK_INHERIT
 
             child = _build_child_agent(
                 task_index=i,
@@ -2221,6 +2281,7 @@ def delegate_task(
                     else (acp_args if acp_args is not None else effective_creds.get("args"))
                 ),
                 role=effective_role,
+                override_fallback_model=effective_fallback_model,
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
@@ -2909,12 +2970,19 @@ DELEGATE_TASK_SCHEMA = {
                 "properties": {
                     "provider": {"type": "string", "description": "Provider name (e.g. 'anthropic', 'openrouter', 'xiaomi'). If omitted, inherits the parent's provider."},
                     "model": {"type": "string", "description": "Model ID (e.g. 'claude-sonnet-4', 'deepseek/deepseek-chat'). If omitted, uses the provider's default."},
+                    "fallback": {
+                        "description": (
+                            "Optional fallback policy for these child agents. Omit/null/true to inherit the parent's fallback chain; "
+                            "false or [] to disable fallback for strict cost caps; or pass a fallback object/list of objects with provider+model."
+                        )
+                    },
                 },
                 "description": (
                     "Optional model override for all child agents. "
                     "Overrides delegation.* config for this call. "
                     "Per-task 'model' in the tasks array takes further precedence. "
-                    "Use for routing delegation to a different model tier."
+                    "Use for routing delegation to a different model tier; set fallback=false "
+                    "to prevent fallback into the parent's expensive chain."
                 ),
             },
             "tasks": {
@@ -2955,12 +3023,20 @@ DELEGATE_TASK_SCHEMA = {
                             "properties": {
                                 "provider": {"type": "string", "description": "Provider name (e.g. 'anthropic', 'openrouter', 'xiaomi'). If omitted, inherits the parent's provider."},
                                 "model": {"type": "string", "description": "Model ID (e.g. 'claude-sonnet-4', 'deepseek/deepseek-chat'). If omitted, uses the provider's default."},
+                                "fallback": {
+                                    "description": (
+                                        "Optional fallback policy for this task. Omit/null/true to inherit the top-level/parent fallback chain; "
+                                        "false or [] to disable fallback; or pass fallback object/list with provider+model."
+                                    )
+                                },
                             },
                             "description": (
                                 "Per-task model override. Overrides both the top-level 'model' "
                                 "and the delegation.* config for this task only. "
                                 "Use for routing different tasks to different model tiers "
-                                "(e.g. expensive model for reasoning, cheap model for formatting)."
+                                "(e.g. expensive model for reasoning, cheap model for formatting). "
+                                "Set fallback=false for cost-capped tasks that must not fall back "
+                                "to the parent's chain."
                             ),
                         },
                     },

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1967,11 +1967,79 @@ def _recover_tasks_from_json_string(
     return parsed, None
 
 
+def _resolve_model_override(
+    model_obj: Any,
+    parent_agent,
+) -> Optional[Dict[str, Any]]:
+    """Resolve a per-task/top-level model override into a credential dict.
+
+    ``model_obj`` is a dict with optional ``provider`` and ``model`` keys,
+    matching the cron job model override pattern.  Returns a credential dict
+    (model, provider, base_url, api_key, api_mode) or ``None`` when no
+    override is requested.
+
+    Raises ``ValueError`` on unresolvable provider references.
+    """
+    if not model_obj or not isinstance(model_obj, dict):
+        return None
+
+    model_name = str(model_obj.get("model") or "").strip() or None
+    provider_name = str(model_obj.get("provider") or "").strip() or None
+
+    # Bare "custom" is incomplete — ignore so it doesn't break resolution.
+    if provider_name == "custom":
+        provider_name = None
+
+    if not model_name and not provider_name:
+        return None
+
+    if not provider_name:
+        # Model-only override — use parent's provider credentials, just swap
+        # the model name.  This is the common "use a cheaper model for this
+        # task" pattern.
+        return {
+            "model": model_name,
+            "provider": getattr(parent_agent, "provider", None),
+            "base_url": getattr(parent_agent, "base_url", None),
+            "api_key": None,  # inherit from parent
+            "api_mode": getattr(parent_agent, "api_mode", None),
+        }
+
+    # Provider specified — resolve full credentials via the runtime system.
+    try:
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        runtime = resolve_runtime_provider(
+            requested=provider_name, target_model=model_name
+        )
+    except Exception as exc:
+        raise ValueError(
+            f"Cannot resolve model override provider '{provider_name}': {exc}. "
+            f"Check that the provider is configured (API key set, valid provider name)."
+        ) from exc
+
+    api_key = runtime.get("api_key", "")
+    if not api_key:
+        raise ValueError(
+            f"Model override provider '{provider_name}' resolved but has no API key. "
+            f"Set the API key for this provider first."
+        )
+
+    return {
+        "model": model_name or runtime.get("model"),
+        "provider": runtime.get("provider", provider_name),
+        "base_url": runtime.get("base_url"),
+        "api_key": api_key,
+        "api_mode": runtime.get("api_mode", "chat_completions"),
+    }
+
+
 def delegate_task(
     goal: Optional[str] = None,
     context: Optional[str] = None,
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
+    model: Optional[Dict[str, Any]] = None,
     max_iterations: Optional[int] = None,
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
@@ -2050,6 +2118,15 @@ def delegate_task(
     except ValueError as exc:
         return tool_error(str(exc))
 
+    # Top-level model override (from tool call argument) overrides delegation
+    # config credentials.  Per-task overrides take further precedence.
+    top_model_creds = None
+    if model:
+        try:
+            top_model_creds = _resolve_model_override(model, parent_agent)
+        except ValueError as exc:
+            return tool_error(str(exc))
+
     # Normalize to task list
     max_children = _get_max_concurrent_children()
     recovered_tasks, tasks_error = _recover_tasks_from_json_string(tasks)
@@ -2111,26 +2188,37 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+
+            # Per-task model override > top-level model override > delegation config.
+            task_model_creds = None
+            if "model" in t:
+                task_model_creds = _resolve_model_override(t["model"], parent_agent)
+                if task_model_creds is None:
+                    return tool_error(
+                        f"Task {i}: 'model' must have at least 'model' or 'provider' key."
+                    )
+            effective_creds = task_model_creds or top_model_creds or creds
+
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
+                model=effective_creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
+                override_provider=effective_creds["provider"],
+                override_base_url=effective_creds["base_url"],
+                override_api_key=effective_creds["api_key"],
+                override_api_mode=effective_creds["api_mode"],
                 override_acp_command=t.get("acp_command")
                 or acp_command
-                or creds.get("command"),
+                or effective_creds.get("command"),
                 override_acp_args=(
                     task_acp_args
                     if task_acp_args is not None
-                    else (acp_args if acp_args is not None else creds.get("args"))
+                    else (acp_args if acp_args is not None else effective_creds.get("args"))
                 ),
                 role=effective_role,
             )
@@ -2816,6 +2904,19 @@ DELEGATE_TASK_SCHEMA = {
                     "['terminal', 'file', 'web'] for full-stack tasks."
                 ),
             },
+            "model": {
+                "type": "object",
+                "properties": {
+                    "provider": {"type": "string", "description": "Provider name (e.g. 'anthropic', 'openrouter', 'xiaomi'). If omitted, inherits the parent's provider."},
+                    "model": {"type": "string", "description": "Model ID (e.g. 'claude-sonnet-4', 'deepseek/deepseek-chat'). If omitted, uses the provider's default."},
+                },
+                "description": (
+                    "Optional model override for all child agents. "
+                    "Overrides delegation.* config for this call. "
+                    "Per-task 'model' in the tasks array takes further precedence. "
+                    "Use for routing delegation to a different model tier."
+                ),
+            },
             "tasks": {
                 "type": "array",
                 "items": {
@@ -2848,6 +2949,19 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "string",
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
+                        },
+                        "model": {
+                            "type": "object",
+                            "properties": {
+                                "provider": {"type": "string", "description": "Provider name (e.g. 'anthropic', 'openrouter', 'xiaomi'). If omitted, inherits the parent's provider."},
+                                "model": {"type": "string", "description": "Model ID (e.g. 'claude-sonnet-4', 'deepseek/deepseek-chat'). If omitted, uses the provider's default."},
+                            },
+                            "description": (
+                                "Per-task model override. Overrides both the top-level 'model' "
+                                "and the delegation.* config for this task only. "
+                                "Use for routing different tasks to different model tiers "
+                                "(e.g. expensive model for reasoning, cheap model for formatting)."
+                            ),
                         },
                     },
                     "required": ["goal"],
@@ -2902,6 +3016,7 @@ registry.register(
         context=args.get("context"),
         toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
+        model=args.get("model"),
         max_iterations=args.get("max_iterations"),
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -131,7 +131,7 @@ Single-task delegation runs directly without thread pool overhead.
 
 ## Model Override
 
-You can configure a different model for subagents via `config.yaml` — useful for delegating simple tasks to cheaper/faster models:
+You can configure a different default model for subagents via `config.yaml` — useful for delegating simple tasks to cheaper/faster models:
 
 ```yaml
 # In ~/.hermes/config.yaml
@@ -141,6 +141,60 @@ delegation:
 ```
 
 If omitted, subagents use the same model as the parent.
+
+You can also override the model per `delegate_task` call, or per item in a batch:
+
+```python
+delegate_task(
+    goal="Format these docs and report changed files",
+    model={"provider": "openrouter", "model": "openai/gpt-4o-mini"},
+)
+
+delegate_task(tasks=[
+    {
+        "goal": "Reason about a risky migration",
+        "model": {"provider": "anthropic", "model": "claude-sonnet-4"},
+    },
+    {
+        "goal": "Run formatting and summarize diffs",
+        "model": {"provider": "openrouter", "model": "openai/gpt-4o-mini"},
+    },
+])
+```
+
+### Fallback isolation for cost caps
+
+By default, model-overridden subagents still inherit the parent's fallback chain. This preserves reliability: if a child hits rate limits or provider errors, it can fail over just like the parent.
+
+For cost-capped tasks, set `fallback: false` inside the model override to prevent the child from falling back into an expensive parent chain:
+
+```python
+delegate_task(
+    goal="Cheap bounded lint summary",
+    model={
+        "provider": "openrouter",
+        "model": "openai/gpt-4o-mini",
+        "fallback": False,   # no inherited fallback chain
+    },
+)
+```
+
+You can also provide a child-specific fallback chain:
+
+```python
+delegate_task(
+    goal="Cheap task with cheap backup only",
+    model={
+        "provider": "openrouter",
+        "model": "openai/gpt-4o-mini",
+        "fallback": [
+            {"provider": "openrouter", "model": "google/gemini-flash-2.0"},
+        ],
+    },
+)
+```
+
+Fallback precedence is: per-task `model.fallback` → top-level `model.fallback` → parent fallback chain.
 
 ## Toolset Selection Tips
 


### PR DESCRIPTION
## Summary

Builds on the per-call/per-task `delegate_task` model override work in #41826 and adds explicit fallback isolation for cost-capped subagents.

Today, a child that is routed to a cheaper model can still inherit the parent's fallback chain. If the cheap model hits rate limits or provider errors, it may silently fail over to an expensive parent fallback. This PR keeps the existing reliability default, but lets callers opt out or provide a child-specific fallback chain.

## What changed

- Adds `model.fallback` inside top-level and per-task `delegate_task` model overrides.
- Fallback semantics:
  - omitted / `null` / `true` → inherit the parent fallback chain (backward compatible default)
  - `false` or `[]` → disable fallback for that child
  - `{provider, model}` or `[{provider, model}, ...]` → use an explicit child fallback chain
- Applies precedence: per-task `model.fallback` → top-level `model.fallback` → parent fallback chain.
- Documents fallback isolation for cost caps.

## Related open work

- Builds on #41826 (per-task model override).
- Related to #35033 and #44906 (other model/provider override variants).
- Addresses the cost-control/fallback gap in #41814 / #44900.

## Privacy / safety

- No credentials or personal paths included.
- No new secret handling surface; fallback entries are the same provider/model dicts `AIAgent(fallback_model=...)` already accepts.
- Existing behavior remains default unless `model.fallback` is explicitly set.

## Tests

- RED verified first: new fallback-isolation tests failed before implementation.
- `uv run --frozen --with pytest python -m pytest tests/tools/test_delegate.py -q -o 'addopts='`
  - `155 passed`
- `uv run --frozen --with ruff ruff check tools/delegate_tool.py tests/tools/test_delegate.py`
  - `All checks passed`
- `python3 -m compileall -q tools/delegate_tool.py`
- `git diff --check`
- Diff privacy scan: `hits=0`

## Review note

This is intentionally a dependent/additive PR. If #41826 lands first, this can be rebased down to the fallback-isolation delta only.