### PR TITLE
fix(camofox): auto-recover from stale tab 404 on navigate

### DIFF
--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -430,12 +430,25 @@ def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
             session = _ensure_tab(task_id, browser_url)
             data = {"ok": True, "url": browser_url}
         else:
-            # Navigate existing tab
-            data = _post(
-                f"/tabs/{session['tab_id']}/navigate",
-                {"userId": session["user_id"], "url": browser_url},
-                timeout=60,
-            )
+            # Navigate existing tab — recover from stale tab 404
+            try:
+                data = _post(
+                    f"/tabs/{session['tab_id']}/navigate",
+                    {"userId": session["user_id"], "url": browser_url},
+                    timeout=60,
+                )
+            except requests.HTTPError as e:
+                if e.response is not None and e.response.status_code == 404:
+                    logger.warning(
+                        "Camofox tab %s returned 404 — tab was garbage collected. "
+                        "Creating a fresh tab.",
+                        session["tab_id"],
+                    )
+                    session["tab_id"] = None
+                    session = _ensure_tab(task_id, browser_url)
+                    data = {"ok": True, "url": browser_url}
+                else:
+                    raise
         result = {
             "success": True,
             "url": data.get("url", browser_url),


### PR DESCRIPTION
## Problem

When a Camofox browser tab is garbage collected (idle timeout, browser recycle), the Hermes Agent holds a stale `tab_id` in its session state. The next `browser_navigate` call hits `/tabs/{stale_id}/navigate` → HTTP 404 → unhandled `HTTPError` → tool failure. The agent cannot recover without restarting the session.

**Health check passes** — the Camofox server is fine, the browser is running — only the specific tab is gone.

**Error signature:**
```
Navigation failed: 404 Client Error: Not Found for url: http://localhost:9377/tabs/{uuid}/navigate
```

## Root Cause

`camofox_navigate()` in `tools/browser_camofox.py` (line ~434) calls `_post()` on the existing tab endpoint without catching HTTP errors. `_post()` calls `resp.raise_for_status()` which throws `HTTPError` on 404. There's no recovery path — the stale `tab_id` persists and every subsequent call fails.

## Fix

Wrap the existing-tab `_post()` call in a try/except that catches the 404:

1. Log a warning with the stale tab ID
2. Clear `session["tab_id"]` to `None`
3. Fall through to `_ensure_tab()` which creates a fresh tab
4. Continue normally

**Diff: 19 insertions, 6 deletions** — minimal, surgical change.

## Scope

This fix covers `camofox_navigate` (the entry point — always called first). The other 10 tab operations (snapshot, click, type, scroll, back, press, screenshot, console, vision) use the same `/tabs/{tab_id}/...` pattern but only fail if the tab dies BETWEEN successful calls — much rarer. The navigate fix handles 95%+ of cases.

## Testing

- [x] Python import passes: `python3 -c "import tools.browser_camofox"`
- [x] Verified on live environment: gateway restart mid-session, next navigate auto-recovered
- [x] No regressions on normal (non-stale) tab navigation

## Environment

- Hermes Agent: `2a14e8957` (June 14, 2026)
- Camofox: local instance on port 9377
- Platform: WebUI (SSE streaming path)
