### PR TITLE
fix(kanban): surface real worker error instead of bare "protocol violation"

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1436,6 +1436,32 @@ def _flush_one_shot_session_store(cli) -> None:
         logger.debug("one-shot end_session failed", exc_info=True)
 
 
+def _stamp_kanban_worker_error_if_needed(result) -> None:
+    """Best-effort: stamp a dispatcher worker's fatal error onto its open run.
+
+    Dispatcher-spawned workers exit without ``kanban_complete`` /
+    ``kanban_block`` when inference or model-config fails; without this
+    stamp the reap classifier only reports a bare protocol-violation /
+    nonzero-exit diagnostic (#46593). No-op outside a kanban worker
+    (``record_worker_error_from_env`` gates on ``HERMES_KANBAN_TASK``),
+    after a terminal transition, on empty errors, and on rate-limit /
+    billing failures (those requeue rather than fail the task).
+    """
+    if not isinstance(result, dict):
+        return
+    error = result.get("error")
+    if not error:
+        return
+    if result.get("failure_reason") in ("rate_limit", "billing"):
+        return
+    try:
+        from tools.kanban_tools import record_worker_error_from_env
+
+        record_worker_error_from_env(str(error))
+    except Exception as exc:
+        logger.debug("kanban worker error-record failed: %s", exc)
+
+
 def _finalize_single_query(cli) -> None:
     """Close one-shot CLI resources before releasing the active session lease."""
     try:
@@ -15988,6 +16014,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     self._voice_continuous = False
                     _cprint(f"\n{_DIM}Continuous voice mode stopped due to error.{_RST}")
 
+            # Ordinary dispatcher workers launch as ``chat -q`` (not ``-Q``),
+            # which lands here rather than in ``main``'s full-quiet branch.
+            # Stamp before returning so protocol-violation / crash reaps can
+            # surface the real cause (#46593 / sweeper review on #46985).
+            _stamp_kanban_worker_error_if_needed(result)
+
             # Handle interrupt - check if we were interrupted
             pending_message = None
             _show_interrupt_marker = False
@@ -20331,6 +20363,11 @@ def main(
                                 _run_kanban_goal_loop_q(cli, response)
                             except Exception as _goal_exc:
                                 logger.debug("kanban goal loop failed: %s", _goal_exc)
+
+                        # Goal-mode workers append ``-Q`` and take this full-
+                        # quiet branch; ordinary workers take ``chat()`` above.
+                        # Shared helper so both launch modes stamp (#46985).
+                        _stamp_kanban_worker_error_if_needed(result)
 
                         # Session ID goes to stderr so piped stdout is clean.
                         print(f"\nsession_id: {cli.session_id}", file=sys.stderr)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4385,6 +4385,61 @@ def _current_run_id(conn: sqlite3.Connection, task_id: str) -> Optional[int]:
     return int(row["current_run_id"]) if row and row["current_run_id"] else None
 
 
+def _open_run_error(conn: sqlite3.Connection, task_id: str) -> Optional[str]:
+    """Return the error stamped on the task's still-open run, if any.
+
+    Used by ``detect_crashed_workers`` to recover a worker's real error
+    (recorded via ``record_worker_error``) when reaping a clean-exit
+    protocol violation. Returns ``None`` when there is no open run or no
+    error was stamped.
+    """
+    rid = _current_run_id(conn, task_id)
+    if not rid:
+        return None
+    row = conn.execute(
+        "SELECT error FROM task_runs WHERE id = ? AND ended_at IS NULL",
+        (int(rid),),
+    ).fetchone()
+    err = row["error"] if row else None
+    return err or None
+
+
+def record_worker_error(
+    conn: sqlite3.Connection,
+    task_id: str,
+    error: str,
+    *,
+    run_id: Optional[int] = None,
+) -> bool:
+    """Stamp the worker's real error onto its still-open run, without ending it.
+
+    A kanban worker that hits a fatal error (e.g. an inference/model-config
+    failure) but exits ``rc=0`` without calling ``kanban_complete`` /
+    ``kanban_block`` leaves the run ``running``. The dispatcher's reap
+    classifier then sees a clean exit and records a bare "protocol violation",
+    hiding the actual cause. Calling this before exit preserves the real error
+    text on the open run so ``detect_crashed_workers`` can surface it in the
+    diagnostic instead of the generic message.
+
+    Best-effort and idempotent: only the *open* run (``ended_at IS NULL``) is
+    touched, so a worker that already reached a terminal transition (run
+    closed, ``current_run_id`` cleared) is a no-op — there's no risk of
+    clobbering a completed/blocked run's outcome. Returns True when a row was
+    updated.
+    """
+    if not error:
+        return False
+    rid = run_id if run_id is not None else _current_run_id(conn, task_id)
+    if not rid:
+        return False
+    cur = conn.execute(
+        "UPDATE task_runs SET error = ? "
+        "WHERE id = ? AND task_id = ? AND ended_at IS NULL",
+        (str(error)[:_CTX_MAX_FIELD_BYTES], int(rid), task_id),
+    )
+    return cur.rowcount > 0
+
+
 def _synthesize_ended_run(
     conn: sqlite3.Connection,
     task_id: str,
@@ -8979,6 +9034,19 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
 
             retry_status = _retry_status_for_run(conn, row["id"])
             event_payload["retry_status"] = retry_status
+
+            # If the worker stamped its real error onto the still-open run
+            # before exiting (see ``record_worker_error``), surface it so the
+            # diagnostic names the actual cause (e.g. an inference/model-config
+            # failure) instead of the opaque handshake/exit-code message. Skip
+            # rate-limited requeues — those are a clean throttle, not a failure
+            # worth a worker-error postmortem.
+            if not rate_limited_exit:
+                worker_error = _open_run_error(conn, row["id"])
+                if worker_error:
+                    error_text = f"{error_text}; last worker error: {worker_error}"
+                    event_payload["worker_error"] = worker_error
+
             cur = conn.execute(
                 "UPDATE tasks SET status = ?, claim_lock = NULL, "
                 "claim_expires = NULL, worker_pid = NULL "

--- a/tests/cli/test_kanban_worker_error_stamp.py
+++ b/tests/cli/test_kanban_worker_error_stamp.py
@@ -1,0 +1,292 @@
+"""Integration: kanban workers stamp fatal errors before exit.
+
+Regression coverage for #46593 / #46985 — both dispatcher launch modes:
+
+* ordinary workers: ``hermes chat -q …`` → ``HermesCLI.chat`` (no ``-Q``)
+* goal-mode workers: ``chat -q … -Q`` → ``main``'s full-quiet branch
+
+Both call ``_stamp_kanban_worker_error_if_needed``.
+"""
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import cli
+
+
+@pytest.fixture
+def kanban_worker_env(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("HERMES_KANBAN_GOAL_MODE", raising=False)
+
+    from hermes_cli import kanban_db as kb
+
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="worker task", assignee="test-worker")
+        kb.claim_task(conn, tid)
+        run_id = kb._current_run_id(conn, tid)
+    finally:
+        conn.close()
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    if run_id is not None:
+        monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+    return tid
+
+
+def _fake_cli_for_quiet(result):
+    def run_conversation(*, user_message, conversation_history):
+        return result
+
+    class FakeCLI:
+        def __init__(self, **_kwargs):
+            self.provider = "test-provider"
+            self.model = "test-model"
+            self.session_id = "kanban-worker-session"
+            self.conversation_history = []
+            self._active_agent_route_signature = "same-route"
+            self.tool_progress_mode = "off"
+            self.console = SimpleNamespace(print=lambda *a, **k: None)
+            self.agent = SimpleNamespace(
+                session_id="kanban-worker-session",
+                platform="cli",
+                quiet_mode=False,
+                suppress_status_output=False,
+                stream_delta_callback=object(),
+                tool_gen_callback=object(),
+                run_conversation=run_conversation,
+            )
+
+        def _claim_active_session(self, surface, *, stderr=False):
+            return True
+
+        def _ensure_runtime_credentials(self):
+            return True
+
+        def _resolve_turn_agent_config(self, effective_query):
+            return {
+                "signature": "same-route",
+                "model": None,
+                "runtime": None,
+                "request_overrides": None,
+            }
+
+        def _init_agent(self, **kwargs):
+            return True
+
+        def _show_security_advisories(self):
+            return None
+
+        def _print_exit_summary(self, clear_screen=True):
+            return None
+
+        def chat(self, message, images=None):
+            raise AssertionError(
+                "full-quiet (-Q) path must not fall through to HermesCLI.chat"
+            )
+
+    return FakeCLI
+
+
+def _drive_quiet_worker(monkeypatch, result):
+    """Run ``cli.main(quiet=True)`` — the goal_mode / ``-Q`` launch path."""
+    monkeypatch.setattr(cli, "HermesCLI", _fake_cli_for_quiet(result))
+    monkeypatch.setattr(cli.atexit, "register", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cli, "_finalize_single_query", lambda _cli: None)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(query="work task", quiet=True, toolsets="terminal")
+    return exc_info.value.code
+
+
+def _drive_default_q_worker(monkeypatch, result):
+    """Run ``cli.main(query=..., quiet=False)`` — ordinary dispatcher launch.
+
+    Dispatcher's ``_default_spawn`` uses ``chat -q`` without ``-Q`` unless
+    ``task.goal_mode``. Fire maps that to ``query=…, quiet=False``, which
+    calls ``HermesCLI.chat``.
+    """
+    called = {"chat": False}
+
+    class FakeCLI:
+        def __init__(self, **_kwargs):
+            self.provider = "test-provider"
+            self.model = "test-model"
+            self.session_id = "kanban-worker-session"
+            self.conversation_history = []
+            self.console = SimpleNamespace(print=lambda *a, **k: None)
+
+        def _claim_active_session(self, surface, *, stderr=False):
+            return True
+
+        def _show_security_advisories(self):
+            return None
+
+        def _print_exit_summary(self, clear_screen=True):
+            return None
+
+        def chat(self, message, images=None):
+            called["chat"] = True
+            # Same call site HermesCLI.chat uses after run_conversation.
+            cli._stamp_kanban_worker_error_if_needed(result)
+            err = result.get("error") if isinstance(result, dict) else None
+            if err and (
+                result.get("failed") or result.get("partial")
+            ):
+                return f"Error: {err}"
+            return result.get("final_response", "") if isinstance(result, dict) else ""
+
+    monkeypatch.setattr(cli, "HermesCLI", FakeCLI)
+    monkeypatch.setattr(cli.atexit, "register", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(cli, "_finalize_single_query", lambda _cli: None)
+
+    # Ordinary single-query path returns normally (rc=0) — that is what
+    # produces the protocol-violation reap; the stamp must land first.
+    cli.main(query="work kanban task", quiet=False, toolsets="terminal")
+    assert called["chat"], (
+        "ordinary non-goal-mode workers must reach HermesCLI.chat "
+        "(quiet=False single-query path), not the full-quiet (-Q) branch"
+    )
+    return called
+
+
+def test_chat_calls_shared_kanban_worker_error_stamp():
+    """``HermesCLI.chat`` (default ``-q`` path) must invoke the shared stamp."""
+    src = inspect.getsource(cli.HermesCLI.chat)
+    assert "_stamp_kanban_worker_error_if_needed" in src, (
+        "ordinary dispatcher workers use HermesCLI.chat; the shared stamp "
+        "helper must be called there, not only in the full-quiet (-Q) branch"
+    )
+
+
+def test_quiet_branch_calls_shared_kanban_worker_error_stamp():
+    """Goal-mode ``-Q`` path must also use the shared stamp helper."""
+    src = inspect.getsource(cli.main)
+    assert "_stamp_kanban_worker_error_if_needed" in src
+
+
+def test_default_q_kanban_worker_stamps_error_before_exit(
+    kanban_worker_env, monkeypatch
+):
+    """Ordinary ``chat -q`` (quiet=False) must persist worker errors on the open run."""
+    from hermes_cli import kanban_db as kb
+
+    worker_error = "litellm.NotFoundError: model 'gpt-bogus' does not exist"
+    _drive_default_q_worker(
+        monkeypatch,
+        {"final_response": "", "error": worker_error, "failed": True, "partial": True},
+    )
+
+    conn = kb.connect()
+    try:
+        assert kb._open_run_error(conn, kanban_worker_env) == worker_error
+    finally:
+        conn.close()
+
+
+def test_default_q_kanban_worker_skips_rate_limit_error(
+    kanban_worker_env, monkeypatch
+):
+    """Rate-limit/billing failures must not stamp on the ordinary ``-q`` path."""
+    from hermes_cli import kanban_db as kb
+
+    _drive_default_q_worker(
+        monkeypatch,
+        {
+            "final_response": "",
+            "error": "litellm.RateLimitError: quota exhausted",
+            "failed": True,
+            "failure_reason": "rate_limit",
+        },
+    )
+
+    conn = kb.connect()
+    try:
+        assert kb._open_run_error(conn, kanban_worker_env) is None
+    finally:
+        conn.close()
+
+
+def test_quiet_kanban_worker_stamps_error_before_exit(kanban_worker_env, monkeypatch):
+    """``cli.main(..., quiet=True)`` / ``-Q`` must still stamp worker errors."""
+    from hermes_cli import kanban_db as kb
+
+    worker_error = "litellm.NotFoundError: model 'gpt-bogus' does not exist"
+    code = _drive_quiet_worker(
+        monkeypatch,
+        {"final_response": "", "error": worker_error, "failed": True},
+    )
+    assert code == 1
+
+    conn = kb.connect()
+    try:
+        assert kb._open_run_error(conn, kanban_worker_env) == worker_error
+    finally:
+        conn.close()
+
+
+def test_quiet_kanban_worker_skips_rate_limit_error(kanban_worker_env, monkeypatch):
+    """A rate-limit/billing failure on ``-Q`` exits with the quota sentinel and must NOT stamp."""
+    from hermes_cli import kanban_db as kb
+
+    code = _drive_quiet_worker(
+        monkeypatch,
+        {
+            "final_response": "",
+            "error": "litellm.RateLimitError: quota exhausted",
+            "failed": True,
+            "failure_reason": "rate_limit",
+        },
+    )
+    assert code == kb.KANBAN_RATE_LIMIT_EXIT_CODE
+
+    conn = kb.connect()
+    try:
+        assert kb._open_run_error(conn, kanban_worker_env) is None
+    finally:
+        conn.close()
+
+
+def test_default_spawn_omits_Q_unless_goal_mode(kanban_worker_env, monkeypatch):
+    """Ordinary dispatcher workers must launch ``chat -q`` without ``-Q``.
+
+    ``-Q`` is only appended for ``goal_mode``; if ordinary workers required
+    ``-Q`` to stamp errors, #46593 would still reproduce (sweeper review).
+    """
+    from hermes_cli import kanban_db as kb
+
+    captured = {}
+
+    class FakeProc:
+        pid = 424242
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        return FakeProc()
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, kanban_worker_env)
+        workspace = kb.resolve_workspace(task)
+        assert task.goal_mode is False or task.goal_mode is None
+        pid = kb._default_spawn(task, str(workspace))
+        assert pid == 424242
+    finally:
+        conn.close()
+
+    cmd = captured["cmd"]
+    assert "chat" in cmd
+    assert "-q" in cmd
+    assert "-Q" not in cmd, f"ordinary workers must not get -Q: {cmd}"

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1378,6 +1378,196 @@ def test_protocol_violation_budget_not_consumed_by_other_failures(kanban_home):
 
 
 
+def test_detect_crashed_workers_protocol_violation_surfaces_worker_error(kanban_home):
+    """When the worker stamped its real error onto the open run before
+    exiting rc=0, the protocol-violation diagnostic surfaces it instead
+    of the bare "protocol violation" message — so a human sees the actual
+    cause (e.g. an inference/model-config failure) rather than a generic
+    handshake complaint.
+
+    Regression test for #46593.
+    """
+    import hermes_cli.kanban_db as _kb
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="quiet", assignee="worker")
+        host_prefix = _kb._claimer_id().split(":", 1)[0]
+        lock = f"{host_prefix}:mock"
+        kb.claim_task(conn, tid, claimer=lock)
+        fake_pid = 999997
+        kb._set_worker_pid(conn, tid, fake_pid)
+
+        # Worker records its real error on the open run before exiting rc=0.
+        real_error = "litellm.AuthenticationError: invalid model 'gpt-bogus'"
+        with _kb.write_txn(conn):
+            stamped = _kb.record_worker_error(conn, tid, real_error)
+        assert stamped, "expected the open run to accept the worker error"
+
+        _kb._record_worker_exit(fake_pid, 0)
+        original_alive = _kb._pid_alive
+        _kb._pid_alive = lambda p: False
+        try:
+            result_crashed = kb.detect_crashed_workers(conn)
+        finally:
+            _kb._pid_alive = original_alive
+
+        assert tid in result_crashed
+        task = kb.get_task(conn, tid)
+        # First protocol violation retries (streak budget on main); error still stamped.
+        assert task.status == "ready"
+        # Both the protocol-violation handshake note AND the real error.
+        assert "kanban_complete" in (task.last_failure_error or "")
+        assert real_error in (task.last_failure_error or ""), (
+            f"expected the real worker error to be surfaced, "
+            f"got {task.last_failure_error!r}"
+        )
+
+        events = kb.list_events(conn, tid)
+        pv = [e for e in events if e.kind == "protocol_violation"]
+        assert pv, "expected a protocol_violation event"
+        assert pv[0].payload.get("worker_error") == real_error, (
+            f"expected worker_error in event payload, got {pv[0].payload}"
+        )
+    finally:
+        conn.close()
+
+
+def test_detect_crashed_workers_nonzero_exit_surfaces_worker_error(kanban_home):
+    """A worker that stamped its real error and then exited non-zero gets
+    the error folded into the ``crashed`` diagnostic too — surfacing the
+    actual cause is not special-cased to the protocol-violation branch.
+
+    Regression test for #46593 (whole bug class — clean-exit *and*
+    nonzero-exit reaps both surface the worker's error).
+    """
+    import hermes_cli.kanban_db as _kb
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="crashy", assignee="worker")
+        host_prefix = _kb._claimer_id().split(":", 1)[0]
+        lock = f"{host_prefix}:mock"
+        kb.claim_task(conn, tid, claimer=lock)
+        fake_pid = 999995
+        kb._set_worker_pid(conn, tid, fake_pid)
+
+        real_error = "RuntimeError: provider returned 400 invalid_request"
+        with _kb.write_txn(conn):
+            assert _kb.record_worker_error(conn, tid, real_error)
+
+        # WIFEXITED with status 1 → raw wait-status (1 << 8).
+        _kb._record_worker_exit(fake_pid, 1 << 8)
+        original_alive = _kb._pid_alive
+        _kb._pid_alive = lambda p: False
+        try:
+            kb.detect_crashed_workers(conn)
+        finally:
+            _kb._pid_alive = original_alive
+
+        task = kb.get_task(conn, tid)
+        assert "exited with code 1" in (task.last_failure_error or "")
+        assert real_error in (task.last_failure_error or ""), (
+            f"nonzero-exit diagnostic should surface the worker error, "
+            f"got {task.last_failure_error!r}"
+        )
+        crashed = [e for e in kb.list_events(conn, tid) if e.kind == "crashed"]
+        assert crashed and crashed[0].payload.get("worker_error") == real_error
+    finally:
+        conn.close()
+
+
+def test_record_worker_error_noop_after_terminal_transition(kanban_home):
+    """``record_worker_error`` is a no-op once the run is closed — a worker
+    that already called kanban_complete / kanban_block must not have its
+    terminal run's error column clobbered.
+    """
+    import hermes_cli.kanban_db as _kb
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="done", assignee="worker")
+        host_prefix = _kb._claimer_id().split(":", 1)[0]
+        lock = f"{host_prefix}:mock"
+        kb.claim_task(conn, tid, claimer=lock)
+        # Worker completed normally — run closed, current_run_id cleared.
+        kb.complete_task(conn, tid, summary="all good")
+        with _kb.write_txn(conn):
+            stamped = _kb.record_worker_error(conn, tid, "spurious late error")
+        assert not stamped, "must not touch a closed run"
+    finally:
+        conn.close()
+
+
+def test_record_worker_error_noop_on_empty_error(kanban_home):
+    """Empty errors are ignored at the DB layer too."""
+    import hermes_cli.kanban_db as _kb
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="empty", assignee="worker")
+        host_prefix = _kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, tid, claimer=f"{host_prefix}:mock")
+        with _kb.write_txn(conn):
+            assert _kb.record_worker_error(conn, tid, "") is False
+        assert _kb._open_run_error(conn, tid) is None
+    finally:
+        conn.close()
+
+
+def test_record_worker_error_truncates_to_ctx_max(kanban_home):
+    """``record_worker_error`` caps stored text at ``_CTX_MAX_FIELD_BYTES``."""
+    import hermes_cli.kanban_db as _kb
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="big", assignee="worker")
+        host_prefix = _kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, tid, claimer=f"{host_prefix}:mock")
+        long_error = "X" * (_kb._CTX_MAX_FIELD_BYTES + 100)
+        with _kb.write_txn(conn):
+            assert _kb.record_worker_error(conn, tid, long_error)
+        stored = _kb._open_run_error(conn, tid)
+        assert stored is not None
+        assert len(stored) == _kb._CTX_MAX_FIELD_BYTES
+        assert stored == long_error[: _kb._CTX_MAX_FIELD_BYTES]
+    finally:
+        conn.close()
+
+
+def test_detect_crashed_workers_rate_limited_skips_worker_error(kanban_home, monkeypatch):
+    """Quota-wall requeues must not attach a stamped worker error — the exit
+    is a throttle, not a task failure worth a postmortem."""
+    import hermes_cli.kanban_db as _kb
+
+    monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+
+    conn = kb.connect()
+    try:
+        host = _kb._claimer_id().split(":", 1)[0]
+        tid = kb.create_task(conn, title="rl-skip", assignee="worker")
+        kb.claim_task(conn, tid, claimer=f"{host}:w")
+        fake_pid = 888881
+        kb._set_worker_pid(conn, tid, fake_pid)
+
+        real_error = "litellm.RateLimitError: quota exhausted"
+        with _kb.write_txn(conn):
+            assert _kb.record_worker_error(conn, tid, real_error)
+
+        _kb._record_worker_exit(
+            fake_pid, _kb.KANBAN_RATE_LIMIT_EXIT_CODE << 8,
+        )
+        kb.detect_crashed_workers(conn)
+
+        task = kb.get_task(conn, tid)
+        assert task.status == "ready"
+        assert real_error not in (task.last_failure_error or "")
+
+        events = kb.list_events(conn, tid)
+        rl = [e for e in events if e.kind == "rate_limited"]
+        assert rl, "expected a rate_limited event"
+        assert "worker_error" not in (rl[0].payload or {}), (
+            f"rate-limited reap must not carry worker_error, got {rl[0].payload}"
+        )
+    finally:
+        conn.close()
+
+
 def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
     """A new subscription must NOT replay historical terminal events.
 

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -80,6 +80,103 @@ def test_show_defaults_to_env_task_id(worker_env):
     assert "runs" in d
 
 
+def test_record_worker_error_from_env_stamps_open_run(worker_env):
+    """The env-driven helper stamps the worker's real error onto its open
+    run so the dispatcher can surface it (see #46593)."""
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    assert kt.record_worker_error_from_env("boom: model not found")
+    conn = kb.connect()
+    try:
+        assert kb._open_run_error(conn, worker_env) == "boom: model not found"
+    finally:
+        conn.close()
+
+
+def test_record_worker_error_from_env_noop_without_task(monkeypatch, tmp_path):
+    """No-op outside a dispatcher-spawned worker (no HERMES_KANBAN_TASK)."""
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    from tools import kanban_tools as kt
+    assert kt.record_worker_error_from_env("ignored") is False
+
+
+def test_record_worker_error_from_env_noop_on_empty_error(worker_env):
+    """Empty error strings are ignored — nothing to stamp."""
+    from tools import kanban_tools as kt
+    assert kt.record_worker_error_from_env("") is False
+
+
+def test_record_worker_error_from_env_with_run_id(worker_env, monkeypatch):
+    """HERMES_KANBAN_RUN_ID pins the run row the dispatcher opened."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        run_id = kb._current_run_id(conn, worker_env)
+        assert run_id is not None
+    finally:
+        conn.close()
+
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+    assert kt.record_worker_error_from_env("pinned run error")
+
+    conn = kb.connect()
+    try:
+        assert kb._open_run_error(conn, worker_env) == "pinned run error"
+    finally:
+        conn.close()
+
+
+def test_record_worker_error_from_env_invalid_run_id_falls_back(worker_env, monkeypatch):
+    """Unparseable HERMES_KANBAN_RUN_ID falls back to the task's current run."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "not-a-run-id")
+    assert kt.record_worker_error_from_env("fallback error")
+
+    conn = kb.connect()
+    try:
+        assert kb._open_run_error(conn, worker_env) == "fallback error"
+    finally:
+        conn.close()
+
+
+def test_record_worker_error_from_env_stale_run_id_noop(worker_env, monkeypatch):
+    """A run id that does not match the open run must not stamp anything."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "999999")
+    assert kt.record_worker_error_from_env("must not land") is False
+
+    conn = kb.connect()
+    try:
+        assert kb._open_run_error(conn, worker_env) is None
+    finally:
+        conn.close()
+
+
+def test_record_worker_error_from_env_truncates_long_error(worker_env):
+    """Oversized errors are capped at the kanban context field limit."""
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    long_error = "E" * (kb._CTX_MAX_FIELD_BYTES + 500)
+    assert kt.record_worker_error_from_env(long_error)
+
+    conn = kb.connect()
+    try:
+        stored = kb._open_run_error(conn, worker_env)
+        assert stored is not None
+        assert len(stored) == kb._CTX_MAX_FIELD_BYTES
+        assert stored == long_error[: kb._CTX_MAX_FIELD_BYTES]
+    finally:
+        conn.close()
+
+
 def test_list_filters_tasks(monkeypatch, worker_env):
     """kanban_list gives orchestrators filtered board discovery."""
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -357,6 +357,47 @@ def heartbeat_current_worker_from_env() -> bool:
         return False
 
 
+def record_worker_error_from_env(error: str) -> bool:
+    """Best-effort: stamp the current worker's real error onto its open run.
+
+    A dispatcher-spawned worker that hits a fatal error (e.g. an
+    inference/model-config failure) but exits ``rc=0`` without calling
+    ``kanban_complete`` / ``kanban_block`` leaves the run ``running``. The
+    dispatcher's reap classifier then records a bare "protocol violation",
+    hiding the actual cause. Calling this before exit preserves the real error
+    on the open run so ``detect_crashed_workers`` can surface it.
+
+    Identity comes from the same env vars the dispatcher sets in
+    ``_default_spawn``: ``HERMES_KANBAN_TASK`` (required; absence is a no-op)
+    and ``HERMES_KANBAN_RUN_ID`` (pins the run so a stale/reclaimed run isn't
+    touched). A no-op once the worker reached a terminal transition (run
+    closed) — ``record_worker_error`` only writes to the open run. Returns
+    True when the open run row was updated.
+    """
+    tid = os.environ.get("HERMES_KANBAN_TASK")
+    if not tid or not error:
+        return False
+    try:
+        from hermes_cli import kanban_db as kb
+        run_id_raw = os.environ.get("HERMES_KANBAN_RUN_ID")
+        try:
+            run_id = int(run_id_raw) if run_id_raw else None
+        except (TypeError, ValueError):
+            run_id = None
+        conn = kb.connect()
+        try:
+            with kb.write_txn(conn):
+                stamped = kb.record_worker_error(
+                    conn, tid, str(error), run_id=run_id,
+                )
+        finally:
+            conn.close()
+        return stamped
+    except Exception:
+        logger.debug("record_worker_error_from_env failed", exc_info=True)
+        return False
+
+
 # Live operator-note injection: poll the worker's task for new comments and
 # fold them into the running agent via the OUT-OF-BAND steer channel, so a user
 # can "talk to" a running kanban task without the block → comment → unblock


### PR DESCRIPTION
## What does this PR do?

When a dispatcher-spawned kanban worker hits a fatal error (e.g. an inference / model-config failure) and exits without calling `kanban_complete` / `kanban_block`, the reap classifier in `detect_crashed_workers()` recorded only a generic diagnostic — `protocol violation` on a clean rc=0 exit, or `pid N exited with code N` on a crash — and blocked the task. The real cause stayed buried in the session logs, making provider/model misconfiguration painful to diagnose.

This fix has the worker **self-report** its error: before exiting, the quiet (`-q`) worker stamps `result["error"]` (which `run_conversation` already returns on the failure paths) onto its still-open run. `detect_crashed_workers()` reads it back and folds it into both the diagnostic message and the reap event payload, across **both** real-failure branches:

- rc=0 → reaped as `protocol_violation` (partial responses)
- rc=1 → reaped as `nonzero_exit` (failed responses)

Rate-limit / billing failures are skipped on both sides (worker doesn't stamp, dispatcher doesn't read) since the quota-sentinel exit is a requeue, not a task failure. The stamp only touches the open run (`ended_at IS NULL`), so a worker that already reached a terminal transition is never clobbered.

## Related Issue

Fixes #46593

## Relationship to #44686

#44686 ("surface worker crash cause from log") targets a different issue (#44675) and scrapes the worker **log file** for a crash line on the `nonzero_exit` path. This PR uses a different mechanism — the worker **self-reports the structured `result["error"]` via the DB** — and additionally covers the **rc=0 `protocol_violation`** path that #46593 is specifically about (and that the log-scrape approach does not address). The two are complementary; happy to rebase onto or merge approaches with #44686 if maintainers prefer a single path.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/kanban_db.py`: new `record_worker_error(conn, task_id, error, *, run_id=None)` (stamps the error onto the open run, `ended_at IS NULL` guard) and `_open_run_error()` (reads it back); `detect_crashed_workers()` now folds the stamped error into `error_text` + the reap event payload for every non-rate-limited crash branch.
- `tools/kanban_tools.py`: new `record_worker_error_from_env(error)` — env-driven worker helper mirroring the existing `heartbeat_current_worker_from_env()`; returns the real DB row-update boolean.
- `cli.py`: the quiet `-q` kanban-worker exit path calls the helper with `result["error"]`, skipping rate-limit/billing failures.
- Tests: `tests/hermes_cli/test_kanban_core_functionality.py`, `tests/tools/test_kanban_tools.py`, `tests/cli/test_kanban_worker_error_stamp.py` (protocol-violation + nonzero-exit enrichment, rate-limit skip on both layers, run-id pinning + stale/invalid run-id, truncation, empty-error no-op, no-op-after-terminal, cli `-q` end-to-end).

## How to Test

1. Configure a profile whose model fails at inference time (e.g. a bad Bedrock model / missing boto3 `converse_stream`).
2. Create + dispatch a kanban task assigned to that profile.
3. After the worker fails, run `hermes kanban show <id>`.
4. The blocked task's error now reads e.g. `... — protocol violation; last worker error: <real provider error>` (or `pid N exited with code 1; last worker error: ...` for the crash path) instead of the bare reap message.
5. Tests: `scripts/run_tests.sh tests/hermes_cli/test_kanban_core_functionality.py tests/tools/test_kanban_tools.py tests/cli/test_kanban_worker_error_stamp.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (see "Relationship to #44686" above)
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the test suite; all tests touching this change pass. The only failures in my environment are pre-existing and unrelated (model-catalog network fetch → HTTP 403), and reproduce identically on a clean `main`.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Ubuntu)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (behavior fix, documented in code comments)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (pure-Python SQLite + env vars, no platform-specific calls)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (internal helper, not a model tool)
