### PR TITLE
feat(wecom): add native reply streaming

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -229,6 +229,17 @@ def _non_conversational_metadata(
     return merged
 
 
+def _adapter_supports_gateway_streaming(adapter: Any) -> bool:
+    """Return True when the adapter can safely own gateway streaming delivery."""
+    if adapter is None:
+        return False
+    if bool(getattr(adapter, "SUPPORTS_MESSAGE_EDITING", True)):
+        return True
+    return bool(getattr(adapter, "SUPPORTS_NATIVE_STREAMING_REPLIES", False)) and callable(
+        getattr(adapter, "send_stream_chunk", None)
+    )
+
+
 def _is_transient_network_error(exc: BaseException) -> bool:
     """Return True for transient network errors safe to log + swallow.
 
@@ -14494,14 +14505,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         reply_to_message_id: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """Build the metadata dict platforms need for thread-aware replies."""
+        platform = getattr(source, "platform", None)
         metadata = self._thread_metadata_for_target(
-            getattr(source, "platform", None),
+            platform,
             getattr(source, "chat_id", None),
             getattr(source, "thread_id", None),
             chat_type=getattr(source, "chat_type", None),
             reply_to_message_id=reply_to_message_id or getattr(source, "message_id", None),
         )
-        if getattr(source, "platform", None) == Platform.SLACK:
+        if platform == Platform.WECOM and reply_to_message_id is not None:
+            # WeCom native reply streaming needs the callback reply context in
+            # metadata. Keep it separate from generic thread metadata: it is
+            # only a reply anchor, not permission to reroute delivery.
+            metadata = dict(metadata or {})
+            metadata["reply"] = {"msgid": str(reply_to_message_id)}
+        if platform == Platform.SLACK:
             team_id = getattr(source, "scope_id", None)
             if team_id:
                 metadata = dict(metadata or {})
@@ -16997,7 +17015,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             try:
                 from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
                 _adapter = self._adapter_for_source(source)
-                if _adapter:
+                if _adapter and _adapter_supports_gateway_streaming(_adapter):
                     _pause_typing_before_finalize = None
                     if source.platform == Platform.TELEGRAM and hasattr(_adapter, "pause_typing_for_chat"):
                         def _pause_typing_before_finalize(
@@ -17005,7 +17023,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             _chat_id=source.chat_id,
                         ) -> None:
                             _adapter.pause_typing_for_chat(_chat_id)
-                    _adapter_supports_edit = getattr(_adapter, "SUPPORTS_MESSAGE_EDITING", True)
+                    _adapter_supports_edit = bool(getattr(_adapter, "SUPPORTS_MESSAGE_EDITING", True))
                     _effective_cursor = _scfg.cursor if _adapter_supports_edit else ""
                     _buffer_only = False
                     if source.platform == Platform.MATRIX:
@@ -18185,7 +18203,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "reply_to_message_id": event_message_id,
             }
         else:
-            _status_thread_metadata = self._thread_metadata_for_source(source, event_message_id) if _progress_thread_id else None
+            _status_thread_metadata = self._thread_metadata_for_source(source, event_message_id) if (
+                _progress_thread_id or source.platform == Platform.WECOM
+            ) else None
 
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter or not _run_still_current():
@@ -18321,7 +18341,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 try:
                     from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
                     _adapter = self._adapter_for_source(source)
-                    if _adapter:
+                    _adapter_supports_edit = bool(getattr(_adapter, "SUPPORTS_MESSAGE_EDITING", True)) if _adapter else False
+                    if (
+                        _adapter
+                        and _adapter_supports_gateway_streaming(_adapter)
+                        and (_adapter_supports_edit or _want_stream_deltas)
+                    ):
                         _pause_typing_before_finalize = None
                         if source.platform == Platform.TELEGRAM and hasattr(_adapter, "pause_typing_for_chat"):
                             def _pause_typing_before_finalize(
@@ -18329,15 +18354,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 _chat_id=source.chat_id,
                             ) -> None:
                                 _adapter.pause_typing_for_chat(_chat_id)
-                        # Platforms that don't support editing sent messages
-                        # (e.g. QQ, WeChat) should skip streaming entirely —
-                        # without edit support, the consumer sends a partial
-                        # first message that can never be updated, resulting in
-                        # duplicate messages (partial + final).
-                        _adapter_supports_edit = getattr(_adapter, "SUPPORTS_MESSAGE_EDITING", True)
-                        if not _adapter_supports_edit:
-                            raise RuntimeError("skip streaming for non-editable platform")
-                        _effective_cursor = _scfg.cursor
+                        _effective_cursor = _scfg.cursor if _adapter_supports_edit else ""
                         # Some Matrix clients render the streaming cursor
                         # as a visible tofu/white-box artifact.  Keep
                         # streaming text on Matrix, but suppress the cursor.

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -95,6 +95,11 @@ class GatewayStreamConsumer:
         await task         # wait for final edit
     """
 
+    # WeCom's native stream UX shows a client-side "typing / thinking"
+    # indicator when the first stream frame has empty content.  The adapter
+    # maps this sentinel to empty native content; other platforms must not see it.
+    _WECOM_THINKING_PLACEHOLDER = "THINKING_MESSAGE"
+
     # After this many consecutive flood-control failures, permanently disable
     # progressive edits for the remainder of the stream.
     _MAX_FLOOD_STRIKES = 3
@@ -220,6 +225,12 @@ class GatewayStreamConsumer:
         # first failure we permanently disable drafts for the remainder of
         # this response and route through edit-based for graceful degradation.
         self._draft_failures = 0
+        self._use_native_reply_streaming = False
+        self._native_stream_key = f"stream:{id(self)}"
+        self._native_prefix = ""
+        self._native_ambiguous_failure = False
+        self._native_stream_started = False
+        self._native_stream_cleanup_sent = False
         self._before_finalize_notified = False
 
     def _metadata_for_send(
@@ -356,6 +367,8 @@ class GatewayStreamConsumer:
         # run.py reads these only after the consumer task exits.
         self._final_response_sent = False
         self._final_content_delivered = False
+        self._native_prefix = ""
+        self._native_ambiguous_failure = False
         # Native draft streaming: bump the draft_id so the next text segment
         # animates as a fresh preview below the tool-progress bubbles, not
         # over the prior segment's already-finalized draft.  This is how
@@ -561,12 +574,18 @@ class GatewayStreamConsumer:
         # final answer as a regular sendMessage (drafts have no message_id
         # to edit).
         self._use_draft_streaming = self._resolve_draft_streaming()
+        self._use_native_reply_streaming = self._resolve_native_reply_streaming()
         if self._use_draft_streaming:
             type(self)._draft_id_counter += 1
             self._draft_id = type(self)._draft_id_counter
             logger.debug(
                 "Stream consumer using native-draft transport (chat=%s draft_id=%s)",
                 self.chat_id, self._draft_id,
+            )
+        if self._use_native_reply_streaming:
+            self._native_stream_started = await self._send_native_reply_chunk(
+                self._WECOM_THINKING_PLACEHOLDER,
+                finalize=False,
             )
 
         try:
@@ -575,6 +594,7 @@ class GatewayStreamConsumer:
                 # (e.g. /new or /stop). Prevents stale deltas from being
                 # delivered after the user has already moved on.
                 if not self._run_still_current():
+                    await self._finalize_started_native_reply_stream()
                     return
 
                 # Drain all available items from the queue
@@ -616,6 +636,7 @@ class GatewayStreamConsumer:
                     if _is_intentional_silence_response(
                         self._clean_for_display(self._accumulated)
                     ):
+                        await self._finalize_started_native_reply_stream()
                         await self._suppress_silence_marker()
                         return
 
@@ -663,6 +684,7 @@ class GatewayStreamConsumer:
                     if (
                         _len_fn(self._accumulated) > _safe_limit
                         and self._message_id is None
+                        and not self._use_native_reply_streaming
                     ):
                         # No existing message to edit (first message or after a
                         # segment break).  Use truncate_message — the same
@@ -706,6 +728,7 @@ class GatewayStreamConsumer:
                         _len_fn(self._accumulated) > _safe_limit
                         and self._message_id is not None
                         and self._edit_supported
+                        and not self._use_native_reply_streaming
                     ):
                         _cp_budget = _custom_unit_to_cp(
                             self._accumulated, _safe_limit, _len_fn,
@@ -748,13 +771,18 @@ class GatewayStreamConsumer:
                     # the next segment (tool progress, next chunk) creates a
                     # new message below it.  got_done has its own finalize
                     # path below so we don't finalize here for it.
-                    current_update_visible = await self._send_or_edit(
-                        display_text,
-                        finalize=(got_done or got_segment_break),
-                        # A segment-break finalize closes a preamble, not the
-                        # turn-final answer — only got_done marks delivered (#29346).
-                        is_turn_final=got_done,
-                    )
+                    current_update_visible = False
+                    if (
+                        not self._fallback_final_send
+                        and not (got_segment_break and self._use_native_reply_streaming)
+                    ):
+                        current_update_visible = await self._send_or_edit(
+                            display_text,
+                            finalize=(got_done or got_segment_break),
+                            # A segment-break finalize closes a preamble, not the
+                            # turn-final answer — only got_done marks delivered (#29346).
+                            is_turn_final=got_done,
+                        )
                     self._last_edit_time = time.monotonic()
 
                 if got_done:
@@ -782,18 +810,26 @@ class GatewayStreamConsumer:
                                 or self._last_edit_overflowed
                             )
                         ):
-                            # Mid-stream edit above already delivered the
-                            # final accumulated content.  Skip the redundant
-                            # final edit for adapters that don't need an
-                            # explicit finalize signal, and for any adapter
-                            # when that edit split-and-delivered across
-                            # continuations: the split edit carried
-                            # finalize=True itself, and re-finalizing with
-                            # the full text would overflow-split again into
-                            # the adopted continuation, duplicating chunks
-                            # on screen.
+                            # The flush above already delivered the final accumulated
+                            # content. Skip redundant finalize work for adapters that
+                            # do not need it, overflow-split edits that already carried
+                            # finalize=True, and native-reply transports that already
+                            # sent a finish frame in the same tick as _DONE.
                             self._final_response_sent = True
                             self._final_content_delivered = True
+                        elif self._use_native_reply_streaming and not self._native_ambiguous_failure:
+                            self._final_response_sent = await self._send_native_reply_chunk(
+                                self._accumulated,
+                                finalize=True,
+                            )
+                            if self._native_ambiguous_failure:
+                                return
+                            if self._final_response_sent:
+                                self._final_content_delivered = True
+                            elif self._fallback_final_send:
+                                await self._send_fallback_final(self._accumulated)
+                        elif self._use_native_reply_streaming and self._native_ambiguous_failure:
+                            return
                         elif self._message_id:
                             # Either the mid-stream edit didn't run (no
                             # visible update this tick) OR the adapter needs
@@ -816,6 +852,8 @@ class GatewayStreamConsumer:
                             self._final_response_sent = await self._send_or_edit(self._accumulated)
                             if self._final_response_sent:
                                 self._final_content_delivered = True
+                    elif self._use_native_reply_streaming and not self._native_ambiguous_failure:
+                        await self._finalize_started_native_reply_stream()
                     return
 
                 if commentary_text is not None:
@@ -839,6 +877,12 @@ class GatewayStreamConsumer:
                 # a real string like "msg_1", not "__no_edit__", so that case
                 # still resets and creates a fresh segment as intended.)
                 if got_segment_break:
+                    if self._fallback_final_send and self._message_id != "__no_edit__":
+                        await self._send_fallback_final(self._accumulated)
+                        self._reset_segment_state(preserve_no_edit=True)
+                        continue
+                    elif self._use_native_reply_streaming:
+                        continue
                     # If the segment-break edit failed to deliver the
                     # accumulated content (flood control that has not yet
                     # promoted to fallback mode, or fallback mode itself),
@@ -854,11 +898,19 @@ class GatewayStreamConsumer:
                         and self._message_id != "__no_edit__"
                     ):
                         await self._flush_segment_tail_on_edit_failure()
+                    elif (
+                        self._accumulated
+                        and self._use_native_reply_streaming
+                        and self._fallback_final_send
+                        and not self._native_ambiguous_failure
+                    ):
+                        await self._send_fallback_final(self._accumulated)
                     self._reset_segment_state(preserve_no_edit=True)
 
                 await asyncio.sleep(0.05)  # Small yield to not busy-loop
 
         except asyncio.CancelledError:
+            await self._finalize_started_native_reply_stream()
             # Best-effort final edit on cancellation.  finalize=True so
             # REQUIRES_EDIT_FINALIZE platforms (Telegram) apply final
             # formatting — a plain edit here would leave the entire reply
@@ -1022,6 +1074,17 @@ class GatewayStreamConsumer:
                     self._final_content_delivered = False
                 return
             # Nothing new to send — the visible partial already matches final text.
+            # When _fallback_prefix is set from a native partial-success result,
+            # trust that adapter-confirmed prefix over _visible_prefix(): native
+            # reply streaming may not have a normal editable message id/visible
+            # prefix, and a full resend would duplicate the already-visible
+            # native content.
+            if self._fallback_prefix:
+                self._already_sent = True
+                self._final_response_sent = True
+                self._final_content_delivered = True
+                self._fallback_prefix = ""
+                return
             # BUT: if final_text itself has meaningful content (e.g. a timeout
             # message after a long tool call), the prefix-based continuation
             # calculation may wrongly conclude "already shown" because the
@@ -1255,6 +1318,126 @@ class GatewayStreamConsumer:
         err = getattr(result, "error", "") or ""
         err_lower = err.lower()
         return "flood" in err_lower or "retry after" in err_lower or "rate" in err_lower
+
+    def _has_native_reply_context(self) -> bool:
+        metadata = self.metadata if isinstance(self.metadata, dict) else {}
+        reply = metadata.get("reply")
+        return isinstance(reply, dict) and bool(reply.get("msgid"))
+
+    def _resolve_native_reply_streaming(self) -> bool:
+        # Native reply streaming is a capability-based branch inside the
+        # gateway's normal streaming modes (not a separate public transport
+        # value). In ``auto`` mode it intentionally takes precedence over
+        # draft/edit streaming when a provider reply context is available.
+        transport = (self.cfg.transport or "edit").lower()
+        if transport in {"edit", "off"}:
+            return False
+        if not self._has_native_reply_context():
+            return False
+        return (
+            getattr(self.adapter, "SUPPORTS_NATIVE_STREAMING_REPLIES", False) is True
+            and callable(getattr(self.adapter, "send_stream_chunk", None))
+        )
+
+    @staticmethod
+    def _confirmed_prefix_len(result: Any) -> int:
+        raw = getattr(result, "raw_response", None)
+        if not isinstance(raw, dict):
+            return 0
+        confirmed = raw.get("confirmed_prefix_len")
+        if confirmed is None:
+            return 0
+        try:
+            return max(0, int(confirmed))
+        except (TypeError, ValueError):
+            return 0
+
+    @staticmethod
+    def _delivered_prefix_text(result: Any) -> str:
+        raw = getattr(result, "raw_response", None)
+        if not isinstance(raw, dict):
+            return ""
+        prefix = raw.get("delivered_prefix")
+        return prefix if isinstance(prefix, str) else ""
+
+    def _apply_native_delivery_result(self, content: str, result: Any) -> tuple[bool, bool]:
+        if getattr(result, "success", False):
+            self._native_prefix = content
+            return True, True
+
+        delivered_prefix = self._delivered_prefix_text(result)
+        if delivered_prefix:
+            if content.startswith(delivered_prefix):
+                self._native_prefix = delivered_prefix
+                return False, True
+            self._native_ambiguous_failure = True
+            self._use_native_reply_streaming = False
+            self._fallback_final_send = False
+            self._already_sent = True
+            self._accumulated = ""
+            return False, False
+
+        confirmed_len = min(self._confirmed_prefix_len(result), len(content))
+        if confirmed_len > 0:
+            self._native_prefix = content[:confirmed_len]
+            return False, True
+
+        return False, False
+
+    async def _finalize_started_native_reply_stream(self) -> None:
+        """Best-effort close for a native reply stream whose start frame landed."""
+        if (
+            not self._use_native_reply_streaming
+            or not self._native_stream_started
+            or self._native_stream_cleanup_sent
+        ):
+            return
+        self._native_stream_cleanup_sent = True
+        try:
+            await self.adapter.send_stream_chunk(
+                chat_id=self.chat_id,
+                content="",
+                reply_to=self._initial_reply_to_id,
+                stream_key=self._native_stream_key,
+                finalize=True,
+                metadata=self.metadata,
+            )
+        except Exception:
+            logger.debug("Native reply stream cleanup failed", exc_info=True)
+
+    async def _send_native_reply_chunk(self, text: str, *, finalize: bool = False) -> bool:
+        result = await self.adapter.send_stream_chunk(
+            chat_id=self.chat_id,
+            content=text,
+            reply_to=self._initial_reply_to_id,
+            stream_key=self._native_stream_key,
+            finalize=finalize,
+            metadata=self.metadata,
+        )
+        if text == self._WECOM_THINKING_PLACEHOLDER:
+            if getattr(result, "success", False):
+                return True
+            self._use_native_reply_streaming = False
+            return False
+        delivered, visible = self._apply_native_delivery_result(text, result)
+        if delivered:
+            self._already_sent = True
+            self._last_sent_text = text
+            return True
+        if visible:
+            self._already_sent = True
+            self._fallback_final_send = True
+            self._fallback_prefix = self._native_prefix
+            self._edit_supported = False
+            # Once native delivery has become a partial-success fallback, stop
+            # sending subsequent deltas to the native stream.  The adapter has
+            # already reported the only prefix we can treat as visible; further
+            # native attempts could also become partially visible and make the
+            # final tail-only fallback duplicate content on the client.
+            self._use_native_reply_streaming = False
+            return False
+        self._use_native_reply_streaming = False
+        return False
 
     def _resolve_draft_streaming(self) -> bool:
         """Decide whether this run should use native draft streaming.
@@ -1682,6 +1865,14 @@ class GatewayStreamConsumer:
         #     a tool-boundary segment break where the prior text was finalized
         #     as a real sendMessage and the next text segment continues editing
         #     that one — staying on edit-based for that segment is correct).
+        if (
+            self._use_native_reply_streaming
+            and self._message_id is None
+        ):
+            if text == self._last_sent_text and not finalize:
+                return True
+            return await self._send_native_reply_chunk(text, finalize=finalize)
+
         if (
             self._use_draft_streaming
             and not finalize

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -140,11 +140,18 @@ def _entry_matches(entries: List[str], target: str) -> bool:
     return False
 
 
+def _iter_markdown_chunks(content: Any, max_length: int) -> List[str]:
+    """Split markdown into bounded chunks while preserving the full tail."""
+    content_text = "" if content is None else str(content)
+    return BasePlatformAdapter.truncate_message(content_text, max_length)
+
+
 class WeComAdapter(BasePlatformAdapter):
     """WeCom AI Bot adapter backed by a persistent WebSocket connection."""
 
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
     SUPPORTS_MESSAGE_EDITING = False
+    SUPPORTS_NATIVE_STREAMING_REPLIES = True
     # Threshold for detecting WeCom client-side message splits.
     # When a chunk is near the 4000-char limit, a continuation is almost certain.
     _SPLIT_THRESHOLD = 3900
@@ -184,6 +191,7 @@ class WeComAdapter(BasePlatformAdapter):
         self._pending_responses: Dict[str, asyncio.Future] = {}
         self._dedup = MessageDeduplicator(max_size=DEDUP_MAX_SIZE)
         self._reply_req_ids: Dict[str, str] = {}
+        self._stream_states: Dict[str, Dict[str, str]] = {}
 
         # Text batching: merge rapid successive messages (Telegram-style).
         # WeCom clients split long messages around 4000 chars.
@@ -947,6 +955,87 @@ class WeComAdapter(BasePlatformAdapter):
             return None
         return self._reply_req_ids.get(normalized)
 
+    @staticmethod
+    def _metadata_reply_req_id(metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+        if not isinstance(metadata, dict):
+            return None
+        normalized = str(metadata.get("wecom_reply_req_id") or "").strip()
+        return normalized or None
+
+    @staticmethod
+    def _metadata_reply_msgid(metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+        if not isinstance(metadata, dict):
+            return None
+        reply = metadata.get("reply")
+        if not isinstance(reply, dict):
+            return None
+        normalized = str(reply.get("msgid") or "").strip()
+        return normalized or None
+
+    def _resolve_reply_req_id(
+        self,
+        chat_id: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        metadata_reply_req_id = self._metadata_reply_req_id(metadata)
+        if metadata_reply_req_id:
+            return metadata_reply_req_id
+
+        metadata_reply_msgid = self._metadata_reply_msgid(metadata)
+        if metadata_reply_msgid:
+            metadata_reply_req_id = self._reply_req_id_for_message(metadata_reply_msgid)
+            if metadata_reply_req_id:
+                return metadata_reply_req_id
+
+        reply_req_id = self._reply_req_id_for_message(reply_to)
+        if reply_req_id:
+            return reply_req_id
+
+        normalized_chat_id = str(chat_id or "").strip()
+        if normalized_chat_id:
+            return self._last_chat_req_ids.get(normalized_chat_id)
+
+        return None
+
+    @staticmethod
+    def _stream_response_id(response: Dict[str, Any]) -> Optional[str]:
+        body = response.get("body")
+        if isinstance(body, dict):
+            stream = body.get("stream")
+            if isinstance(stream, dict):
+                # We send WeCom's native field name (stream_id), but accept
+                # older/sample response fixtures that report the id as `id`.
+                stream_id = str(stream.get("stream_id") or stream.get("id") or "").strip()
+                if stream_id:
+                    return stream_id
+        return WeComAdapter._payload_req_id(response) or None
+
+    def _remember_stream_state(self, stream_key: str, reply_req_id: str, stream_id: Optional[str]) -> None:
+        normalized_stream_key = str(stream_key or "").strip()
+        normalized_reply_req_id = str(reply_req_id or "").strip()
+        if not normalized_stream_key or not normalized_reply_req_id:
+            return
+
+        state = {"reply_req_id": normalized_reply_req_id}
+        normalized_stream_id = str(stream_id or "").strip()
+        if normalized_stream_id:
+            state["stream_id"] = normalized_stream_id
+        self._stream_states[normalized_stream_key] = state
+        while len(self._stream_states) > DEDUP_MAX_SIZE:
+            self._stream_states.pop(next(iter(self._stream_states)))
+
+    def _clear_stream_state(self, stream_key: Optional[str]) -> None:
+        normalized_stream_key = str(stream_key or "").strip()
+        if normalized_stream_key:
+            self._stream_states.pop(normalized_stream_key, None)
+
+    def _stream_state(self, stream_key: Optional[str]) -> Optional[Dict[str, str]]:
+        normalized_stream_key = str(stream_key or "").strip()
+        if not normalized_stream_key:
+            return None
+        return self._stream_states.get(normalized_stream_key)
+
     # ------------------------------------------------------------------
     # Outbound messaging
     # ------------------------------------------------------------------
@@ -1260,15 +1349,20 @@ class WeComAdapter(BasePlatformAdapter):
         return response
 
     async def _send_reply_markdown(self, reply_req_id: str, content: str) -> Dict[str, Any]:
-        response = await self._send_reply_request(
-            reply_req_id,
-            {
-                "msgtype": "markdown",
-                "markdown": {"content": content[:self.MAX_MESSAGE_LENGTH]},
-            },
-        )
-        self._raise_for_wecom_error(response, "send reply markdown")
+        response: Dict[str, Any] = {}
+        for chunk in self._iter_markdown_chunks(content):
+            response = await self._send_reply_request(
+                reply_req_id,
+                {
+                    "msgtype": "markdown",
+                    "markdown": {"content": chunk},
+                },
+            )
+            self._raise_for_wecom_error(response, "send reply markdown")
         return response
+
+    def _iter_markdown_chunks(self, content: str) -> List[str]:
+        return _iter_markdown_chunks(content, self.MAX_MESSAGE_LENGTH)
 
     async def _send_reply_media_message(
         self,
@@ -1390,28 +1484,27 @@ class WeComAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send markdown to a WeCom chat via proactive ``aibot_send_msg``."""
-        del metadata
 
         if not chat_id:
             return SendResult(success=False, error="chat_id is required")
 
         try:
-            reply_req_id = self._reply_req_id_for_message(reply_to)
-
-            if not reply_req_id and chat_id in self._last_chat_req_ids:
-                reply_req_id = self._last_chat_req_ids[chat_id]
+            reply_req_id = self._resolve_reply_req_id(chat_id=chat_id, reply_to=reply_to, metadata=metadata)
 
             if reply_req_id:
                 response = await self._send_reply_markdown(reply_req_id, content)
             else:
-                response = await self._send_request(
-                    APP_CMD_SEND,
-                    {
-                        "chatid": chat_id,
-                        "msgtype": "markdown",
-                        "markdown": {"content": content[:self.MAX_MESSAGE_LENGTH]},
-                    },
-                )
+                response = {}
+                for chunk in self._iter_markdown_chunks(content):
+                    response = await self._send_request(
+                        APP_CMD_SEND,
+                        {
+                            "chatid": chat_id,
+                            "msgtype": "markdown",
+                            "markdown": {"content": chunk},
+                        },
+                    )
+                    self._raise_for_wecom_error(response, "send markdown")
         except asyncio.TimeoutError:
             return SendResult(success=False, error="Timeout sending message to WeCom")
         except Exception as exc:
@@ -1425,6 +1518,119 @@ class WeComAdapter(BasePlatformAdapter):
         return SendResult(
             success=True,
             message_id=self._payload_req_id(response) or uuid.uuid4().hex[:12],
+            raw_response=response,
+        )
+
+    async def send_stream_chunk(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        stream_key: Optional[str] = None,
+        finalize: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        if not chat_id:
+            self._clear_stream_state(stream_key)
+            return SendResult(success=False, error="chat_id is required")
+
+        normalized_stream_key = str(stream_key or "").strip()
+        content_text = "" if content is None else str(content)
+        thinking_placeholder = content_text == "THINKING_MESSAGE"
+        existing_state = self._stream_state(normalized_stream_key)
+        reply_req_id = (
+            existing_state.get("reply_req_id")
+            if existing_state
+            else self._resolve_reply_req_id(chat_id=chat_id, reply_to=reply_to, metadata=metadata)
+        )
+        if not reply_req_id:
+            self._clear_stream_state(normalized_stream_key)
+            if thinking_placeholder:
+                return SendResult(success=True)
+            return SendResult(success=False, error="WeCom native stream reply context is required")
+
+        stream_id = existing_state.get("stream_id") if existing_state else None
+        if finalize:
+            event = "finish"
+        elif existing_state:
+            event = "continue"
+        else:
+            event = "start"
+
+        native_content = "" if thinking_placeholder else content_text
+        overflow_content = ""
+        if finalize and len(content_text) > self.MAX_MESSAGE_LENGTH:
+            native_content = content_text[: self.MAX_MESSAGE_LENGTH]
+            overflow_content = content_text[self.MAX_MESSAGE_LENGTH :]
+
+        stream_payload: Dict[str, Any] = {
+            "event": event,
+            "content": native_content,
+            "stream_id": stream_id or reply_req_id,
+        }
+
+        body = {
+            "msgtype": "stream",
+            "stream": stream_payload,
+        }
+
+        try:
+            response = await self._send_reply_request(reply_req_id, body)
+            self._raise_for_wecom_error(response, "send stream")
+        except asyncio.TimeoutError:
+            self._clear_stream_state(normalized_stream_key)
+            return SendResult(success=False, error="Timeout sending message to WeCom")
+        except Exception as exc:
+            self._clear_stream_state(normalized_stream_key)
+            logger.error("[%s] Send stream failed: %s", self.name, exc)
+            return SendResult(success=False, error=str(exc))
+
+        response_stream_id = self._stream_response_id(response) or stream_payload.get("stream_id")
+
+        if overflow_content:
+            try:
+                overflow_response = await self._send_reply_markdown(reply_req_id, overflow_content)
+            except asyncio.TimeoutError:
+                self._clear_stream_state(normalized_stream_key)
+                return SendResult(
+                    success=False,
+                    error="Timeout sending message to WeCom",
+                    raw_response={
+                        "confirmed_prefix_len": len(native_content),
+                        "overflow_error": "Timeout sending message to WeCom",
+                        "native_response": response,
+                    },
+                )
+            except Exception as exc:
+                self._clear_stream_state(normalized_stream_key)
+                return SendResult(
+                    success=False,
+                    error=str(exc),
+                    raw_response={
+                        "confirmed_prefix_len": len(native_content),
+                        "overflow_error": str(exc),
+                        "native_response": response,
+                    },
+                )
+            self._clear_stream_state(normalized_stream_key)
+            return SendResult(
+                success=True,
+                message_id=str(response_stream_id or self._payload_req_id(response) or uuid.uuid4().hex[:12]),
+                raw_response={
+                    "native_response": response,
+                    "overflow_response": overflow_response,
+                    "confirmed_prefix_len": len(native_content),
+                },
+            )
+
+        if finalize:
+            self._clear_stream_state(normalized_stream_key)
+        else:
+            self._remember_stream_state(normalized_stream_key, reply_req_id, str(response_stream_id or ""))
+
+        return SendResult(
+            success=True,
+            message_id=str(response_stream_id or self._payload_req_id(response) or uuid.uuid4().hex[:12]),
             raw_response=response,
         )
 

--- a/tests/gateway/test_config_driven_access_policy.py
+++ b/tests/gateway/test_config_driven_access_policy.py
@@ -387,6 +387,26 @@ def test_unknown_adapter_does_not_crash_trust_check(monkeypatch):
     assert runner._is_user_authorized(_source(Platform.WECOM)) is False
 
 
+def test_wecom_adapter_owned_access_policy_remains_honored_with_native_streaming_capability(monkeypatch):
+    """Native reply streaming capability must not bypass adapter-owned auth trust."""
+    _clear_auth_env(monkeypatch)
+    config = GatewayConfig(
+        platforms={
+            Platform.WECOM: PlatformConfig(
+                enabled=True,
+                extra={"dm_policy": "allowlist", "allow_from": ["some-user"]},
+            )
+        }
+    )
+    runner, adapter = _make_runner(Platform.WECOM, config, enforces=True)
+    adapter.SUPPORTS_MESSAGE_EDITING = False
+    adapter.SUPPORTS_NATIVE_STREAMING_REPLIES = True
+    adapter.send_stream_chunk = AsyncMock()
+
+    assert runner._adapter_enforces_own_access_policy(Platform.WECOM) is True
+    assert runner._is_user_authorized(_source(Platform.WECOM)) is True
+
+
 # ---------------------------------------------------------------------------
 # Layer 2b: `dm_policy: pairing` is NOT blanket-trusted
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -122,6 +122,39 @@ class NonEditingProgressCaptureAdapter(ProgressCaptureAdapter):
         raise AssertionError("non-editable adapters should not receive edit_message calls")
 
 
+class NativeStreamingProgressAdapter(NonEditingProgressCaptureAdapter):
+    SUPPORTS_NATIVE_STREAMING_REPLIES = True
+
+    def __init__(self, platform=Platform.WECOM):
+        super().__init__(platform=platform)
+        self.stream_chunks = []
+
+    async def send_stream_chunk(
+        self,
+        chat_id,
+        content,
+        *,
+        reply_to=None,
+        stream_key=None,
+        finalize=False,
+        metadata=None,
+    ):
+        if reply_to is None:
+            source = self._pending_messages.get("__last_source__")
+            reply_to = f"native:{getattr(source, 'chat_type', '')}"
+        self.stream_chunks.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "stream_key": stream_key,
+                "finalize": finalize,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id=f"stream-{len(self.stream_chunks)}")
+
+
 class FakeAgent:
     def __init__(self, **kwargs):
         # Capture anything passed via kwargs (older code path) but don't
@@ -661,9 +694,12 @@ class PreviewedSplitAfterCommentaryAgent:
 
 
 class StreamingRefineAgent:
+    instances = []
+
     def __init__(self, **kwargs):
         self.stream_delta_callback = kwargs.get("stream_delta_callback")
         self.tools = []
+        type(self).instances.append(self)
 
     def run_conversation(self, message, conversation_history=None, task_id=None):
         if self.stream_delta_callback:
@@ -744,7 +780,7 @@ async def _run_with_agent(
     platform=Platform.TELEGRAM,
     chat_id="-1001",
     chat_type="group",
-    thread_id="17585",
+    thread_id: str | None = "17585",
     adapter_cls=ProgressCaptureAdapter,
 ):
     if config_data:
@@ -759,8 +795,11 @@ async def _run_with_agent(
     fake_run_agent = types.ModuleType("run_agent")
     fake_run_agent.AIAgent = agent_cls
     monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    if hasattr(agent_cls, "instances"):
+        agent_cls.instances = []
 
     adapter = adapter_cls(platform=platform)
+    adapter._pending_messages = {}
     runner = _make_runner(adapter)
     gateway_run = importlib.import_module("gateway.run")
     if config_data and "streaming" in config_data:
@@ -773,6 +812,8 @@ async def _run_with_agent(
         chat_type=chat_type,
         thread_id=thread_id,
     )
+    if getattr(adapter, "SUPPORTS_NATIVE_STREAMING_REPLIES", False):
+        adapter._pending_messages["__last_source__"] = source
     session_key = f"agent:main:{platform.value}:{chat_type}:{chat_id}"
     if thread_id:
         session_key = f"{session_key}:{thread_id}"
@@ -791,6 +832,7 @@ async def _run_with_agent(
         source=source,
         session_id=session_id,
         session_key=session_key,
+        event_message_id=("origin-msg-1" if getattr(adapter, "SUPPORTS_NATIVE_STREAMING_REPLIES", False) else None),
     )
     return adapter, result
 
@@ -901,6 +943,113 @@ async def test_run_agent_streaming_does_not_enable_completed_interim_commentary(
 
     assert result.get("already_sent") is True
     assert not any(call["content"] == "I'll inspect the repo first." for call in adapter.sent)
+
+
+@pytest.mark.asyncio
+async def test_wecom_native_reply_streaming_allowed_for_capable_adapter(monkeypatch, tmp_path):
+    adapter = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        StreamingRefineAgent,
+        session_id="sess-wecom-native-stream",
+        config_data={
+            "streaming": {
+                "enabled": True,
+                "transport": "native",
+                "edit_interval": 0.0,
+                "buffer_threshold": 1,
+            },
+            "display": {
+                "interim_assistant_messages": False,
+                "platforms": {"wecom": {"streaming": True}},
+            },
+        },
+        platform=Platform.WECOM,
+        chat_id="wecom-chat-1",
+        chat_type="dm",
+        thread_id=None,
+        adapter_cls=NativeStreamingProgressAdapter,
+    )
+    adapter, result = adapter
+
+    assert result["final_response"] == "Continuing to refine: Final answer."
+    assert StreamingRefineAgent.instances
+    assert StreamingRefineAgent.instances[-1].stream_delta_callback is not None
+    assert adapter.stream_chunks
+    assert any(chunk["content"] for chunk in adapter.stream_chunks)
+    assert {chunk["metadata"]["reply"]["msgid"] for chunk in adapter.stream_chunks} == {"origin-msg-1"}
+    assert adapter.sent == []
+    assert adapter.edits == []
+
+
+@pytest.mark.asyncio
+async def test_non_editing_adapter_without_native_streaming_capability_skips_streaming(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        StreamingRefineAgent,
+        session_id="sess-generic-non-edit-no-stream",
+        config_data={
+            "streaming": {
+                "enabled": True,
+                "transport": "native",
+                "edit_interval": 0.0,
+                "buffer_threshold": 1,
+            },
+            "display": {
+                "interim_assistant_messages": False,
+            },
+        },
+        platform=Platform.WEIXIN,
+        chat_id="weixin-chat-1",
+        chat_type="dm",
+        thread_id=None,
+        adapter_cls=NonEditingProgressCaptureAdapter,
+    )
+
+    assert result["final_response"] == "Continuing to refine: Final answer."
+    assert StreamingRefineAgent.instances
+    assert StreamingRefineAgent.instances[-1].stream_delta_callback is None
+    assert not hasattr(adapter, "stream_chunks")
+    assert adapter.sent == []
+    assert adapter.edits == []
+
+
+@pytest.mark.asyncio
+async def test_streaming_native_capability_does_not_enable_group_fallback(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        StreamingRefineAgent,
+        session_id="sess-wecom-native-group-no-fallback",
+        config_data={
+            "streaming": {
+                "enabled": True,
+                "transport": "native",
+                "edit_interval": 0.0,
+                "buffer_threshold": 1,
+            },
+            "display": {
+                "interim_assistant_messages": False,
+                "platforms": {"wecom": {"streaming": True}},
+            },
+        },
+        platform=Platform.WECOM,
+        chat_id="wecom-group-1",
+        chat_type="group",
+        thread_id=None,
+        adapter_cls=NativeStreamingProgressAdapter,
+    )
+
+    assert result["final_response"] == "Continuing to refine: Final answer."
+    assert adapter.stream_chunks
+    assert {chunk["chat_id"] for chunk in adapter.stream_chunks} == {"wecom-group-1"}
+    assert all(chunk["reply_to"] == "origin-msg-1" for chunk in adapter.stream_chunks)
+    assert {chunk["metadata"]["reply"]["msgid"] for chunk in adapter.stream_chunks} == {"origin-msg-1"}
+    assert adapter.sent == []
+    assert adapter.edits == []
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_stream_consumer_wecom_native.py
+++ b/tests/gateway/test_stream_consumer_wecom_native.py
@@ -1,0 +1,712 @@
+"""Tests for WeCom native reply streaming in GatewayStreamConsumer."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+
+class _WeComNativeAdapter:
+    MAX_MESSAGE_LENGTH = 4096
+    SUPPORTS_NATIVE_STREAMING_REPLIES = True
+
+    def __init__(self, *, native_results=None, thinking_result=None):
+        self.send = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_final")
+        )
+        self.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_edit")
+        )
+        self.draft_calls = []
+        self.send_draft = AsyncMock(return_value=SimpleNamespace(success=True))
+        self.draft_supported = False
+        self._native_results = list(native_results or [])
+        self._thinking_result = thinking_result
+        self.native_calls = []
+
+    async def send_stream_chunk(self, **kwargs):
+        self.native_calls.append(kwargs)
+        if kwargs.get("content") == "THINKING_MESSAGE":
+            if self._thinking_result is not None:
+                return self._thinking_result
+            return SimpleNamespace(success=True)
+        if self._native_results:
+            return self._native_results.pop(0)
+        return SimpleNamespace(success=True)
+
+    def supports_draft_streaming(self, chat_type=None, metadata=None) -> bool:
+        return bool(self.draft_supported)
+
+
+def _reply_metadata():
+    return {
+        "reply": {
+            "enterprise_id": "ent_1",
+            "chat_type": "dm",
+            "receive_id": "user_1",
+            "msgid": "wecom_msg_1",
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_native_reply_transport_requires_adapter_capability_and_reply_context():
+    adapter = _WeComNativeAdapter()
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor="", transport="auto"),
+        metadata=_reply_metadata(),
+    )
+
+    consumer.on_delta("Hello")
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    assert adapter.native_calls, "expected native send_stream_chunk calls"
+    adapter.edit_message.assert_not_called()
+    adapter.send.assert_not_awaited()
+    assert consumer.final_response_sent is True
+    assert consumer.final_content_delivered is True
+
+
+@pytest.mark.asyncio
+async def test_native_reply_transport_honors_edit_opt_out():
+    adapter = _WeComNativeAdapter()
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(
+            edit_interval=0.01,
+            buffer_threshold=1,
+            cursor="",
+            transport="edit",
+        ),
+        metadata=_reply_metadata(),
+    )
+
+    consumer.on_delta("Hello")
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    assert adapter.native_calls == []
+    adapter.send.assert_awaited_once()
+    assert adapter.send.await_args.kwargs["content"] == "Hello"
+
+
+@pytest.mark.asyncio
+async def test_native_reply_transport_not_used_without_reply_context():
+    adapter = _WeComNativeAdapter(
+        native_results=[SimpleNamespace(success=False, error="missing_reply_context")]
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor=" ▉"),
+        metadata={},
+    )
+
+    consumer.on_delta("Hello")
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    assert adapter.native_calls == []
+    adapter.send.assert_awaited_once()
+    send_await_args = adapter.send.await_args
+    assert send_await_args is not None
+    assert send_await_args.kwargs["content"] == "Hello ▉"
+
+
+@pytest.mark.asyncio
+async def test_native_final_success_sets_final_content_delivered():
+    adapter = _WeComNativeAdapter(
+        native_results=[SimpleNamespace(success=True), SimpleNamespace(success=True)]
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor="", transport="auto"),
+        metadata=_reply_metadata(),
+    )
+
+    consumer.on_delta("Hello")
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    assert consumer.final_response_sent is True
+    assert consumer.final_content_delivered is True
+    final_calls = [call for call in adapter.native_calls if call["finalize"] is True]
+    assert len(final_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_native_final_success_sends_single_finish_frame_when_done_arrives_with_first_delta():
+    adapter = _WeComNativeAdapter(
+        native_results=[SimpleNamespace(success=True), SimpleNamespace(success=True)]
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=100, cursor="", transport="auto"),
+        metadata=_reply_metadata(),
+    )
+
+    consumer.on_delta("Hello")
+    consumer.finish()
+    await consumer.run()
+
+    final_calls = [call for call in adapter.native_calls if call["finalize"] is True]
+    assert len(final_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_native_partial_success_falls_back_tail_only():
+    adapter = _WeComNativeAdapter(
+        native_results=[
+            SimpleNamespace(success=True),
+            SimpleNamespace(
+                success=False,
+                error="native_partial",
+                raw_response={"delivered_prefix": "Hello "},
+            ),
+        ]
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor="", transport="auto"),
+        metadata=_reply_metadata(),
+    )
+
+    consumer.on_delta("Hello ")
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.on_delta("world")
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    adapter.send.assert_awaited_once()
+    send_await_args = adapter.send.await_args
+    assert send_await_args is not None
+    assert send_await_args.kwargs["content"] == "world"
+    assert consumer.final_response_sent is True
+    assert consumer.final_content_delivered is True
+
+
+@pytest.mark.asyncio
+async def test_native_partial_success_falls_back_tail_only_after_more_deltas():
+    adapter = _WeComNativeAdapter(
+        native_results=[
+            SimpleNamespace(success=True),
+            SimpleNamespace(
+                success=False,
+                error="native_partial",
+                raw_response={"delivered_prefix": "Hello "},
+            ),
+            SimpleNamespace(
+                success=False,
+                error="native_partial_again",
+                raw_response={"delivered_prefix": "Hello world"},
+            ),
+        ]
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor="", transport="auto"),
+        metadata=_reply_metadata(),
+    )
+
+    consumer.on_delta("Hello ")
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.on_delta("world")
+    await asyncio.sleep(0.05)
+    consumer.on_delta(" again")
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    # After the first native partial success, the consumer must stop sending
+    # native chunks. Otherwise a later partially-visible native frame can make
+    # the tail-only fallback duplicate client-visible text.
+    assert [call["content"] for call in adapter.native_calls] == [
+        "THINKING_MESSAGE",
+        "Hello ",
+        "Hello world",
+    ]
+    assert adapter._native_results, "later native results should remain unused"
+    adapter.send.assert_awaited_once()
+    send_await_args = adapter.send.await_args
+    assert send_await_args is not None
+    assert send_await_args.kwargs["content"] == "world again"
+    assert consumer.final_response_sent is True
+    assert consumer.final_content_delivered is True
+
+
+@pytest.mark.asyncio
+async def test_native_partial_success_confirmed_prefix_len_falls_back_tail_only():
+    adapter = _WeComNativeAdapter(
+        native_results=[
+            SimpleNamespace(success=True),
+            SimpleNamespace(
+                success=False,
+                error="native_partial",
+                raw_response={"confirmed_prefix_len": len("Hello ")},
+            ),
+        ]
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor="", transport="auto"),
+        metadata=_reply_metadata(),
+    )
+
+    consumer.on_delta("Hello ")
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.on_delta("world")
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    adapter.send.assert_awaited_once()
+    send_await_args = adapter.send.await_args
+    assert send_await_args is not None
+    assert send_await_args.kwargs["content"] == "world"
+    assert consumer.final_response_sent is True
+    assert consumer.final_content_delivered is True
+
+
+@pytest.mark.asyncio
+async def test_native_partial_success_confirmed_prefix_len_larger_than_content_clamps_visible_prefix():
+    adapter = _WeComNativeAdapter(
+        native_results=[
+            SimpleNamespace(success=True),
+            SimpleNamespace(
+                success=False,
+                error="native_partial",
+                raw_response={"confirmed_prefix_len": len("Hello world") + 100},
+            ),
+        ]
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor="", transport="auto"),
+        metadata=_reply_metadata(),
+    )
+
+    consumer.on_delta("Hello ")
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.on_delta("world")
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    adapter.send.assert_not_awaited()
+    assert consumer.final_response_sent is True
+    assert consumer.final_content_delivered is True
+
+
+@pytest.mark.asyncio
+async def test_native_reply_transport_takes_precedence_over_draft_capability():
+    adapter = _WeComNativeAdapter()
+    adapter.draft_supported = True
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(
+            transport="auto", chat_type="dm",
+            edit_interval=0.01, buffer_threshold=1, cursor="",
+        ),
+        metadata=_reply_metadata(),
+    )
+
+    consumer.on_delta("Hello")
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    assert adapter.native_calls
+    adapter.send_draft.assert_not_awaited()
+    adapter.edit_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_native_failure_before_visible_content_sends_full_final_once():
+    adapter = _WeComNativeAdapter(
+        native_results=[SimpleNamespace(success=False, error="native_unavailable")]
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor="", transport="auto"),
+        metadata=_reply_metadata(),
+    )
+
+    consumer.on_delta("Hello world")
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    assert len(adapter.native_calls) == 2
+    assert [call["content"] for call in adapter.native_calls] == ["THINKING_MESSAGE", "Hello world"]
+    adapter.send.assert_awaited_once()
+    send_await_args = adapter.send.await_args
+    assert send_await_args is not None
+    assert send_await_args.kwargs["content"] == "Hello world"
+
+
+@pytest.mark.asyncio
+async def test_segment_break_native_failure_flushes_tail_without_duplicate():
+    adapter = _WeComNativeAdapter(
+        native_results=[
+            SimpleNamespace(success=True),
+            SimpleNamespace(
+                success=False,
+                error="native_partial",
+                raw_response={"delivered_prefix": "Hello "},
+            ),
+        ]
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor="", transport="auto"),
+        metadata=_reply_metadata(),
+    )
+
+    consumer.on_delta("Hello ")
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.on_delta("world")
+    await asyncio.sleep(0.05)
+    consumer.on_segment_break()
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    adapter.send.assert_awaited_once()
+    send_await_args = adapter.send.await_args
+    assert send_await_args is not None
+    assert send_await_args.kwargs["content"] == "world"
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_native_delivered_prefix_mismatch_suppresses_blind_full_resend():
+    adapter = _WeComNativeAdapter(
+        native_results=[
+            SimpleNamespace(success=True),
+            SimpleNamespace(
+                success=False,
+                error="native_partial",
+                raw_response={"delivered_prefix": "Mismatch"},
+            ),
+        ]
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor="", transport="auto"),
+        metadata=_reply_metadata(),
+    )
+
+    consumer.on_delta("Hello ")
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.on_delta("world")
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    assert [call["content"] for call in adapter.native_calls] == [
+        "THINKING_MESSAGE",
+        "Hello ",
+        "Hello world",
+    ]
+    adapter.send.assert_not_awaited()
+    assert consumer.final_response_sent is False
+    assert consumer.final_content_delivered is False
+
+
+@pytest.mark.asyncio
+async def test_native_reply_stream_sends_empty_start_frame_before_text_delta():
+    adapter = _WeComNativeAdapter(
+        native_results=[SimpleNamespace(success=True), SimpleNamespace(success=True)]
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=100, cursor="", transport="auto"),
+        metadata=_reply_metadata(),
+    )
+
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    assert adapter.native_calls, "expected an empty native start frame before visible text"
+    assert adapter.native_calls[0]["content"] == "THINKING_MESSAGE"
+    assert adapter.native_calls[0]["finalize"] is False
+
+    consumer.on_delta("Hello")
+    consumer.finish()
+    await task
+
+    assert [call["finalize"] for call in adapter.native_calls] == [False, True]
+    assert adapter.native_calls[1]["content"] == "Hello"
+    assert adapter.native_calls[0]["stream_key"] == adapter.native_calls[1]["stream_key"]
+
+
+@pytest.mark.asyncio
+async def test_native_thinking_frame_failure_does_not_leak_sentinel_as_visible_text():
+    adapter = _WeComNativeAdapter(
+        thinking_result=SimpleNamespace(success=False, error="reply context expired")
+    )
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor="", transport="auto"),
+        metadata=_reply_metadata(),
+    )
+
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.on_delta("Hello")
+    consumer.finish()
+    await task
+
+    sent_contents = [call.kwargs.get("content") for call in adapter.send.await_args_list]
+    assert "THINKING_MESSAGE" not in sent_contents
+    assert sent_contents == ["Hello"]
+
+
+@pytest.mark.asyncio
+async def test_native_streaming_keeps_full_accumulated_text_until_final_split():
+    adapter = _WeComNativeAdapter()
+    adapter.MAX_MESSAGE_LENGTH = 700
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=100, cursor="", transport="auto"),
+        metadata=_reply_metadata(),
+    )
+    text = ("A" * 590) + "   \n" + ("B" * 700) + "\n  " + ("C" * 300)
+
+    task = asyncio.create_task(consumer.run())
+    consumer.on_delta(text[:900])
+    await asyncio.sleep(0.08)
+    consumer.on_delta(text[900:])
+    await asyncio.sleep(0.08)
+    consumer.finish()
+    await task
+
+    final_calls = [call for call in adapter.native_calls if call.get("finalize") is True]
+    assert len(final_calls) == 1
+    assert final_calls[-1]["content"] == text
+    assert {call["stream_key"] for call in adapter.native_calls} == {
+        adapter.native_calls[0]["stream_key"]
+    }
+    adapter.send.assert_not_awaited()
+    assert consumer.final_response_sent is True
+    assert consumer.final_content_delivered is True
+
+
+@pytest.mark.asyncio
+async def test_native_streaming_tool_boundary_reuses_same_stream_key():
+    adapter = _WeComNativeAdapter()
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5, cursor="", transport="auto"),
+        metadata=_reply_metadata(),
+    )
+
+    task = asyncio.create_task(consumer.run())
+    consumer.on_delta("before tools. ")
+    await asyncio.sleep(0.06)
+    consumer.on_delta(None)
+    await asyncio.sleep(0.06)
+    consumer.on_delta("after tools.")
+    consumer.finish()
+    await task
+
+    final_calls = [call for call in adapter.native_calls if call.get("finalize") is True]
+    assert len(final_calls) == 1
+    assert final_calls[-1]["content"] == "before tools. after tools."
+    assert {call["stream_key"] for call in adapter.native_calls} == {
+        adapter.native_calls[0]["stream_key"]
+    }
+    adapter.send.assert_not_awaited()
+    assert consumer.final_response_sent is True
+    assert consumer.final_content_delivered is True
+
+@pytest.mark.asyncio
+async def test_native_reply_thinking_only_finish_clears_stream_state():
+    from gateway.config import PlatformConfig
+    from plugins.platforms.wecom.adapter import WeComAdapter
+
+    adapter = WeComAdapter(PlatformConfig(enabled=True))
+    adapter._remember_reply_req_id("origin-msg-1", "reply-req-1")
+    sent_bodies = []
+
+    async def _fake_send_reply_request(reply_req_id, body):
+        sent_bodies.append((reply_req_id, body))
+        return {
+            "errcode": 0,
+            "headers": {"req_id": reply_req_id},
+            "body": {"stream": {"stream_id": "stream-1"}},
+        }
+
+    adapter._send_reply_request = _fake_send_reply_request
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor="", transport="auto"),
+        initial_reply_to_id="origin-msg-1",
+        metadata=_reply_metadata(),
+    )
+
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    assert [body["stream"]["event"] for _reply_req_id, body in sent_bodies] == [
+        "start",
+        "finish",
+    ]
+    assert adapter._stream_states == {}
+    assert consumer.final_response_sent is False
+    assert consumer.final_content_delivered is False
+
+
+@pytest.mark.asyncio
+async def test_native_reply_stale_generation_finalizes_started_stream():
+    adapter = _WeComNativeAdapter()
+    current_checks = iter([True, False])
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor="", transport="auto"),
+        metadata=_reply_metadata(),
+        run_still_current=lambda: next(current_checks, False),
+    )
+
+    await consumer.run()
+
+    assert [call["content"] for call in adapter.native_calls] == [
+        "THINKING_MESSAGE",
+        "",
+    ]
+    assert [call["finalize"] for call in adapter.native_calls] == [False, True]
+    adapter.send.assert_not_awaited()
+    assert consumer.final_response_sent is False
+    assert consumer.final_content_delivered is False
+
+
+@pytest.mark.asyncio
+async def test_native_reply_cancelled_run_finalizes_started_stream():
+    adapter = _WeComNativeAdapter()
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor="", transport="auto"),
+        metadata=_reply_metadata(),
+    )
+
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    task.cancel()
+    await task
+
+    assert [call["content"] for call in adapter.native_calls] == [
+        "THINKING_MESSAGE",
+        "",
+    ]
+    assert [call["finalize"] for call in adapter.native_calls] == [False, True]
+    adapter.send.assert_not_awaited()
+    assert consumer.final_response_sent is False
+    assert consumer.final_content_delivered is False
+
+
+@pytest.mark.asyncio
+async def test_native_reply_intentional_silence_finalizes_started_stream():
+    adapter = _WeComNativeAdapter()
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor="", transport="auto"),
+        metadata=_reply_metadata(),
+    )
+
+    consumer.on_delta("NO_REPLY")
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    assert [call["content"] for call in adapter.native_calls] == [
+        "THINKING_MESSAGE",
+        "",
+    ]
+    assert [call["finalize"] for call in adapter.native_calls] == [False, True]
+    adapter.send.assert_not_awaited()
+    assert consumer.final_response_sent is False
+    assert consumer.final_content_delivered is False
+
+
+@pytest.mark.asyncio
+async def test_real_wecom_adapter_resolves_consumer_reply_msgid_to_cached_req_id():
+    from gateway.config import PlatformConfig
+    from plugins.platforms.wecom.adapter import WeComAdapter
+
+    adapter = WeComAdapter(PlatformConfig(enabled=True))
+    adapter._remember_reply_req_id("origin-msg-1", "reply-req-1")
+    sent_bodies = []
+
+    async def _fake_send_reply_request(reply_req_id, body):
+        sent_bodies.append((reply_req_id, body))
+        return {
+            "errcode": 0,
+            "headers": {"req_id": reply_req_id},
+            "body": {"stream": {"stream_id": "stream-1"}},
+        }
+
+    adapter._send_reply_request = _fake_send_reply_request
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1, cursor="", transport="auto"),
+        initial_reply_to_id="origin-msg-1",
+        metadata=_reply_metadata(),
+    )
+
+    consumer.on_delta("Hello")
+    task = asyncio.create_task(consumer.run())
+    await asyncio.sleep(0.05)
+    consumer.finish()
+    await task
+
+    assert [reply_req_id for reply_req_id, _body in sent_bodies] == ["reply-req-1", "reply-req-1", "reply-req-1"]
+    assert [body["stream"]["event"] for _reply_req_id, body in sent_bodies] == ["start", "continue", "finish"]
+    assert all(body["msgtype"] == "stream" for _reply_req_id, body in sent_bodies)
+    assert consumer.final_response_sent is True
+    assert consumer.final_content_delivered is True

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -123,6 +123,98 @@ class TestWeComConnect:
         assert "invalid secret" in (adapter.fatal_error_message or "")
 
 
+    def test_send_uses_metadata_reply_msgid_when_reply_to_is_absent(self):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._reply_req_ids["origin-msg-1"] = "req-1"
+        adapter._last_chat_req_ids["chat-123"] = "stale-chat-req"
+        adapter._send_reply_request = AsyncMock(
+            return_value={"headers": {"req_id": "req-1"}, "errcode": 0}
+        )
+
+        metadata = {"reply": {"msgid": "origin-msg-1"}}
+        result = asyncio.run(adapter.send("chat-123", "tail", metadata=metadata))
+
+        assert result.success is True
+        args = adapter._send_reply_request.await_args.args
+        assert args[0] == "req-1"
+        assert args[1]["markdown"]["content"] == "tail"
+
+
+    @pytest.mark.asyncio
+    async def test_send_stream_chunk_final_overflow_sends_bounded_finish_and_markdown_tail(self):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._reply_req_ids["origin-msg-1"] = "req-1"
+        sent = []
+
+        async def _fake_send_reply_request(reply_req_id, body):
+            sent.append((reply_req_id, body))
+            return {
+                "errcode": 0,
+                "headers": {"req_id": reply_req_id},
+                "body": {"stream": {"stream_id": "stream-1"}},
+            }
+
+        adapter._send_reply_request = _fake_send_reply_request
+        content = "A" * (adapter.MAX_MESSAGE_LENGTH + 25)
+
+        result = await adapter.send_stream_chunk(
+            chat_id="chat-123",
+            content=content,
+            stream_key="stream-key-1",
+            finalize=True,
+            metadata={"reply": {"msgid": "origin-msg-1"}},
+        )
+
+        assert result.success is True
+        assert [body["msgtype"] for _req, body in sent] == ["stream", "markdown"]
+        assert sent[0][0] == "req-1"
+        stream_content = sent[0][1]["stream"]["content"]
+        assert sent[0][1]["stream"]["event"] == "finish"
+        assert len(stream_content) == adapter.MAX_MESSAGE_LENGTH
+        assert sent[1][1]["markdown"]["content"] == "A" * 25
+        assert result.raw_response["confirmed_prefix_len"] == adapter.MAX_MESSAGE_LENGTH
+        assert adapter._stream_states == {}
+
+    @pytest.mark.asyncio
+    async def test_send_stream_chunk_final_overflow_failure_reports_confirmed_prefix(self):
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+        adapter._reply_req_ids["origin-msg-1"] = "req-1"
+        sent = []
+
+        async def _fake_send_reply_request(reply_req_id, body):
+            sent.append((reply_req_id, body))
+            if body["msgtype"] == "markdown":
+                raise RuntimeError("markdown overflow failed")
+            return {
+                "errcode": 0,
+                "headers": {"req_id": reply_req_id},
+                "body": {"stream": {"stream_id": "stream-1"}},
+            }
+
+        adapter._send_reply_request = _fake_send_reply_request
+        content = "A" * (adapter.MAX_MESSAGE_LENGTH + 25)
+
+        result = await adapter.send_stream_chunk(
+            chat_id="chat-123",
+            content=content,
+            stream_key="stream-key-1",
+            finalize=True,
+            metadata={"reply": {"msgid": "origin-msg-1"}},
+        )
+
+        assert result.success is False
+        assert result.raw_response["confirmed_prefix_len"] == adapter.MAX_MESSAGE_LENGTH
+        assert result.raw_response["overflow_error"] == "markdown overflow failed"
+        assert [body["msgtype"] for _req, body in sent] == ["stream", "markdown"]
+        assert adapter._stream_states == {}
+
+
 class TestWeComQrScan:
     @patch("plugins.platforms.wecom.adapter.time")
     @patch("plugins.platforms.wecom.adapter.json.loads")

--- a/website/docs/user-guide/messaging/wecom.md
+++ b/website/docs/user-guide/messaging/wecom.md
@@ -95,11 +95,12 @@ hermes gateway
 - **Reply correlation** — responses are correlated to the inbound message context
 - **Auto-reconnect** — exponential backoff on connection drops
 
-:::note Streaming and typing indicators
-The WeCom adapter delivers each response as a single complete message — it does
-**not** stream responses token-by-token, and it does **not** show a typing
-indicator. "Reply correlation" (below) only threads a response to its inbound
-request; it is not live streaming.
+:::note Native reply streaming and typing indicators
+When Hermes has a WeCom reply context for the inbound message, the adapter can
+stream response updates through WeCom's native reply-stream API. If native
+streaming is unavailable for a message or `streaming.transport` is set to
+`edit`/`off`, Hermes falls back to the normal complete markdown reply path.
+WeCom still does **not** expose a separate typing indicator.
 :::
 
 ## Configuration Options


### PR DESCRIPTION
## Summary
- Add WeCom native reply streaming with adapter-level capability detection and markdown chunking.
- Preserve reply metadata through the gateway run path so native WeCom replies can stream against the originating message.
- Add native stream lifecycle handling, long-output preservation, tool-boundary protection, and fallback behavior in the gateway stream consumer.
- Cover adapter, run-path, stream-consumer, transport opt-out, and config-adjacent regressions with focused tests.

## Test Plan
- `uv run --extra dev --extra messaging --extra wecom pytest -o addopts='' tests/gateway/test_wecom.py tests/gateway/test_stream_consumer_wecom_native.py tests/gateway/test_run_progress_topics.py tests/gateway/test_config_driven_access_policy.py -q` — 164 passed
- `python -m py_compile gateway/platforms/wecom.py gateway/run.py gateway/stream_consumer.py tests/gateway/test_wecom.py tests/gateway/test_stream_consumer_wecom_native.py tests/gateway/test_run_progress_topics.py` — passed
- `git diff --check` — passed

## Notes
- This is a clean refresh of the stale WeCom native streaming work onto current `origin/main`.
- Explicit `streaming.transport = "edit"` and `"off"` remain opt-outs for native streaming.
- The local production backport was kept separate and is not part of this PR branch.

Supersedes #35538.
