### PR TITLE
fix(context): align subdirectory hints with session cwd

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -40,6 +40,7 @@ from agent.model_metadata import (
     query_ollama_num_ctx,
 )
 from agent.process_bootstrap import _install_safe_stdio
+from agent.runtime_cwd import resolve_context_cwd
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.think_scrubber import StreamingThinkScrubber
 from agent.tool_guardrails import (
@@ -66,6 +67,23 @@ def _ra():
     """
     import run_agent
     return run_agent
+
+
+def _subdirectory_hint_working_dir() -> str | None:
+    """Return the cwd root used for progressive subdirectory hints.
+
+    Startup context loading already uses ``resolve_context_cwd()`` so Desktop,
+    TUI, ACP, and gateway sessions can pin a logical per-session workspace via
+    the session-cwd contextvar. The lazy ``SubdirectoryHintTracker`` must use
+    the same root; otherwise a gateway launched from ``$HOME`` can load
+    ``HERMES.md`` from the session cwd at startup, then later treat that same
+    project root as a newly visited subdirectory and append its ``AGENTS.md``.
+
+    ``None`` preserves the plain CLI fallback: ``SubdirectoryHintTracker`` will
+    use the process cwd when no configured/session cwd exists.
+    """
+    context_cwd = resolve_context_cwd()
+    return str(context_cwd) if context_cwd is not None else None
 
 
 def _build_codex_gpt5_autoraise_notice(autoraise: Dict[str, Any]) -> str:
@@ -2040,7 +2058,7 @@ def init_agent(
             _ra().logger.debug("Context engine on_session_start: %s", _ce_err)
 
     agent._subdirectory_hints = SubdirectoryHintTracker(
-        working_dir=os.getenv("TERMINAL_CWD") or None,
+        working_dir=_subdirectory_hint_working_dir(),
     )
     agent._user_turn_count = 0
     # Copilot x-initiator flag: first API call of a user turn sends "user" (#3040).

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -41,6 +41,7 @@ from agent.model_metadata import (
     query_ollama_num_ctx,
 )
 from agent.process_bootstrap import _install_safe_stdio
+from agent.runtime_cwd import resolve_context_cwd
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.think_scrubber import StreamingThinkScrubber
 from agent.tool_guardrails import (
@@ -273,6 +274,23 @@ def _custom_provider_runtime_ids(value: Any) -> set[str]:
     if not normalized:
         return set()
     return {normalized, f"custom:{normalized}"}
+
+
+def _subdirectory_hint_working_dir() -> str | None:
+    """Return the cwd root used for progressive subdirectory hints.
+
+    Startup context loading already uses ``resolve_context_cwd()`` so Desktop,
+    TUI, ACP, and gateway sessions can pin a logical per-session workspace via
+    the session-cwd contextvar. The lazy ``SubdirectoryHintTracker`` must use
+    the same root; otherwise a gateway launched from ``$HOME`` can load
+    ``HERMES.md`` from the session cwd at startup, then later treat that same
+    project root as a newly visited subdirectory and append its ``AGENTS.md``.
+
+    ``None`` preserves the plain CLI fallback: ``SubdirectoryHintTracker`` will
+    use the process cwd when no configured/session cwd exists.
+    """
+    context_cwd = resolve_context_cwd()
+    return str(context_cwd) if context_cwd is not None else None
 
 
 def _build_codex_gpt5_autoraise_notice(
@@ -3031,10 +3049,8 @@ def init_agent(
         except Exception as _ce_err:
             _ra().logger.debug("Context engine on_session_start: %s", _ce_err)
 
-    from agent.runtime_cwd import scope_terminal_cwd as _scope_terminal_cwd
-
     agent._subdirectory_hints = SubdirectoryHintTracker(
-        working_dir=_scope_terminal_cwd() or None,
+        working_dir=_subdirectory_hint_working_dir(),
     )
     agent._user_turn_count = 0
     # Copilot x-initiator flag: first API call of a user turn sends "user" (#3040).

--- a/tests/agent/test_subdirectory_hint_session_cwd.py
+++ b/tests/agent/test_subdirectory_hint_session_cwd.py
@@ -1,0 +1,58 @@
+"""Regression tests for session-cwd aligned subdirectory context discovery."""
+
+from pathlib import Path
+
+from agent.subdirectory_hints import SubdirectoryHintTracker
+from gateway.session_context import clear_session_vars, set_session_vars
+
+
+def test_session_cwd_prevents_project_root_agents_hint_when_launch_cwd_differs(
+    tmp_path, monkeypatch
+):
+    """Desktop/TUI session cwd should be the subdirectory hint root.
+
+    Regression: startup context can load HERMES.md from the session cwd while
+    SubdirectoryHintTracker is rooted at the gateway/process cwd. Then the
+    project root looks like a newly visited subdirectory and its AGENTS.md is
+    appended even though startup context already handled that directory.
+    """
+    project = tmp_path / "pharos"
+    project.mkdir()
+    (project / "HERMES.md").write_text("Hermes project context")
+    (project / "AGENTS.md").write_text("Codex project context")
+
+    launch_cwd = tmp_path / "gateway-launch"
+    launch_cwd.mkdir()
+    monkeypatch.chdir(launch_cwd)
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+
+    from agent.agent_init import _subdirectory_hint_working_dir
+
+    tokens = set_session_vars(session_key="desktop-session", cwd=str(project))
+    try:
+        working_dir = _subdirectory_hint_working_dir()
+        assert Path(working_dir).resolve() == project
+
+        tracker = SubdirectoryHintTracker(working_dir=working_dir)
+        hint = tracker.check_tool_call(
+            "terminal", {"command": "pwd", "workdir": str(project)}
+        )
+    finally:
+        clear_session_vars(tokens)
+
+    assert hint is None
+
+
+def test_subdirectory_hint_working_dir_falls_back_to_process_cwd_for_plain_cli(
+    tmp_path, monkeypatch
+):
+    """Plain CLI sessions without a configured cwd keep existing fallback behavior."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("TERMINAL_CWD", raising=False)
+    clear_session_vars([])
+
+    from agent.agent_init import _subdirectory_hint_working_dir
+
+    assert _subdirectory_hint_working_dir() is None
+    tracker = SubdirectoryHintTracker(working_dir=_subdirectory_hint_working_dir())
+    assert tracker.working_dir == tmp_path.resolve()


### PR DESCRIPTION
## Summary
- initialize `SubdirectoryHintTracker` from the same logical context cwd used by startup context loading
- preserve the plain CLI fallback to process cwd when no session/configured cwd exists
- add regression coverage for Desktop/TUI-style sessions where process cwd differs from the session workspace

## Why
Desktop/TUI sessions can carry their workspace via the session-cwd contextvar. Startup context loading already respects that path and can correctly load `HERMES.md` from the project root, but `SubdirectoryHintTracker` was still initialized from `$TERMINAL_CWD` or the process cwd. When the gateway process was launched from a broader directory (for example `$HOME`), the project root looked like a newly visited subdirectory during the first tool call, so root `AGENTS.md` could be appended even though startup context had already handled that directory.

This aligns the progressive hint root with startup context cwd so both mechanisms agree on the active workspace.

## Test Plan
- [x] `uv run --with pytest --with pyyaml python -m pytest tests/agent/test_subdirectory_hint_session_cwd.py -q -o 'addopts='`
- [x] `uv run --with pytest --with pyyaml python -m pytest tests/agent/test_subdirectory_hints.py tests/agent/test_subdirectory_hint_session_cwd.py tests/agent/test_system_prompt.py tests/agent/test_runtime_cwd.py -q -o 'addopts='`
- [x] `uv run --with pytest --with pyyaml python -m py_compile agent/agent_init.py tests/agent/test_subdirectory_hint_session_cwd.py`
