### PR TITLE
fix(telegram): isolate getUpdates polling transport

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -16,6 +16,7 @@ import os
 import tempfile
 import html as _html
 import re
+import httpx
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Any
 
@@ -1361,6 +1362,8 @@ class TelegramAdapter(BasePlatformAdapter):
             await self._app.updater.start_polling(
                 allowed_updates=Update.ALL_TYPES,
                 drop_pending_updates=False,
+                timeout=getattr(self, "_poll_timeout", 1),
+                poll_interval=getattr(self, "_poll_interval", 1.0),
                 error_callback=self._polling_error_callback_ref,
             )
             logger.info(
@@ -1488,6 +1491,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 await self._app.updater.start_polling(
                     allowed_updates=Update.ALL_TYPES,
                     drop_pending_updates=False,
+                    timeout=getattr(self, "_poll_timeout", 1),
+                    poll_interval=getattr(self, "_poll_interval", 1.0),
                     error_callback=self._polling_error_callback_ref,
                 )
                 logger.info(
@@ -1931,6 +1936,14 @@ class TelegramAdapter(BasePlatformAdapter):
                 "read_timeout": _env_float("HERMES_TELEGRAM_HTTP_READ_TIMEOUT", 20.0),
                 "write_timeout": _env_float("HERMES_TELEGRAM_HTTP_WRITE_TIMEOUT", 20.0),
             }
+            poll_timeout = max(1, min(_env_int("HERMES_TELEGRAM_POLL_TIMEOUT", 10), 60))
+            poll_interval = max(0.0, min(_env_float("HERMES_TELEGRAM_POLL_INTERVAL", 0.0), 60.0))
+            self._poll_timeout = poll_timeout
+            self._poll_interval = poll_interval
+            poll_limits = httpx.Limits(
+                max_connections=request_kwargs["connection_pool_size"],
+                max_keepalive_connections=0,
+            )
 
             disable_fallback = (os.getenv("HERMES_TELEGRAM_DISABLE_FALLBACK_IPS", "").strip().lower() in {"1", "true", "yes", "on"})
             fallback_ips = self._fallback_ips()
@@ -1958,17 +1971,27 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
                 get_updates_request = HTTPXRequest(
                     **request_kwargs,
-                    httpx_kwargs={"transport": TelegramFallbackTransport(fallback_ips)},
+                    httpx_kwargs={
+                        "transport": TelegramFallbackTransport(fallback_ips),
+                        "limits": poll_limits,
+                    },
                 )
             elif proxy_url:
                 logger.info("[%s] Proxy detected; passing explicitly to HTTPXRequest: %s", self.name, proxy_url)
                 request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
-                get_updates_request = HTTPXRequest(**request_kwargs, proxy=proxy_url)
+                get_updates_request = HTTPXRequest(
+                    **request_kwargs,
+                    proxy=proxy_url,
+                    httpx_kwargs={"limits": poll_limits},
+                )
             else:
                 if disable_fallback:
                     logger.info("[%s] Telegram fallback-IP transport disabled via env", self.name)
                 request = HTTPXRequest(**request_kwargs)
-                get_updates_request = HTTPXRequest(**request_kwargs)
+                get_updates_request = HTTPXRequest(
+                    **request_kwargs,
+                    httpx_kwargs={"limits": poll_limits},
+                )
 
             builder = builder.request(request).get_updates_request(get_updates_request)
             self._app = builder.build()
@@ -2090,6 +2113,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 await self._app.updater.start_polling(
                     allowed_updates=Update.ALL_TYPES,
                     drop_pending_updates=True,
+                    timeout=poll_timeout,
+                    poll_interval=poll_interval,
                     error_callback=_polling_error_callback,
                 )
             

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -3,6 +3,7 @@ import sys
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 
 from gateway.config import PlatformConfig
@@ -285,6 +286,83 @@ async def test_connect_clears_webhook_before_polling(monkeypatch):
 
     assert ok is True
     bot.delete_webhook.assert_awaited_once_with(drop_pending_updates=False)
+
+
+@pytest.mark.asyncio
+async def test_polling_transport_disables_keepalive_only_for_getupdates(monkeypatch):
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+
+    monkeypatch.setattr(
+        "gateway.status.acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(
+        "gateway.status.release_scoped_lock",
+        lambda scope, identity: None,
+    )
+    monkeypatch.setenv("HERMES_TELEGRAM_POLL_TIMEOUT", "3")
+    monkeypatch.setenv("HERMES_TELEGRAM_POLL_INTERVAL", "2.5")
+
+    request_calls = []
+
+    def fake_httpx_request(**kwargs):
+        request = MagicMock()
+        request.kwargs = kwargs
+        request_calls.append(kwargs)
+        return request
+
+    monkeypatch.setattr("gateway.platforms.telegram.HTTPXRequest", fake_httpx_request)
+    monkeypatch.setattr("asyncio.sleep", AsyncMock())
+
+    updater = SimpleNamespace(
+        start_polling=AsyncMock(),
+        stop=AsyncMock(),
+        running=True,
+    )
+    bot = SimpleNamespace(
+        delete_webhook=AsyncMock(),
+        set_my_commands=AsyncMock(),
+    )
+    app = SimpleNamespace(
+        bot=bot,
+        updater=updater,
+        add_handler=MagicMock(),
+        initialize=AsyncMock(),
+        start=AsyncMock(),
+    )
+    builder = MagicMock()
+    builder.token.return_value = builder
+    builder.request.return_value = builder
+    builder.get_updates_request.return_value = builder
+    builder.build.return_value = app
+    monkeypatch.setattr(
+        "gateway.platforms.telegram.Application",
+        SimpleNamespace(builder=MagicMock(return_value=builder)),
+    )
+
+    ok = await adapter.connect()
+
+    assert ok is True
+    assert len(request_calls) == 2
+    assert "httpx_kwargs" not in request_calls[0]
+    limits = request_calls[1]["httpx_kwargs"]["limits"]
+    assert isinstance(limits, httpx.Limits)
+    assert limits.max_keepalive_connections == 0
+    assert limits.max_connections == request_calls[1]["connection_pool_size"]
+
+    initial_poll_kwargs = updater.start_polling.await_args.kwargs
+    assert initial_poll_kwargs["timeout"] == 3
+    assert initial_poll_kwargs["poll_interval"] == 2.5
+
+    updater.start_polling.reset_mock()
+    conflict = type("Conflict", (Exception,), {})
+    await adapter._handle_polling_conflict(
+        conflict("Conflict: terminated by other getUpdates request")
+    )
+
+    retry_poll_kwargs = updater.start_polling.await_args.kwargs
+    assert retry_poll_kwargs["timeout"] == 3
+    assert retry_poll_kwargs["poll_interval"] == 2.5
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Mitigates repeated Telegram `409 Conflict` polling loops by isolating the `getUpdates` transport from normal Telegram Bot API send/edit/upload requests.

Changes:
- disable HTTP keep-alive only on the `getUpdates` `HTTPXRequest` via `httpx.Limits(max_keepalive_connections=0)`;
- add bounded polling controls through `HERMES_TELEGRAM_POLL_TIMEOUT` and `HERMES_TELEGRAM_POLL_INTERVAL`;
- preserve default PTB polling timing unless env vars are set;
- pass the polling timing through initial polling plus conflict/network reconnect paths;
- add regression coverage that verifies the normal request client is untouched and only getUpdates disables keep-alive.

## Why

Some macOS launchd Telegram polling installs can get stuck in recurring `Conflict: terminated by other getUpdates request` loops even when only one local gateway process is visible and webhook is empty. Keeping the polling transport separate gives affected installs a lower-risk mitigation while preserving existing behavior for normal send/edit/upload calls.

Related: #29325

## Validation

- `python -m py_compile gateway/platforms/telegram.py tests/gateway/test_telegram_conflict.py`
- `uv run --with pytest --with pytest-asyncio pytest tests/gateway/test_telegram_conflict.py -q` -> `8 passed in 2.30s`
