### PR TITLE
fix(gateway): skip malformed session index entries

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -139,6 +139,8 @@ class SessionSource:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "SessionSource":
+        if not isinstance(data, dict):
+            raise TypeError("SessionSource data must be a dict")
         return cls(
             platform=Platform(data["platform"]),
             chat_id=str(data["chat_id"]),
@@ -545,6 +547,8 @@ class SessionEntry:
     
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "SessionEntry":
+        if not isinstance(data, dict):
+            raise TypeError("SessionEntry data must be a dict")
         origin = None
         if "origin" in data and data["origin"]:
             origin = SessionSource.from_dict(data["origin"])
@@ -740,11 +744,20 @@ class SessionStore:
             try:
                 with open(sessions_file, "r", encoding="utf-8") as f:
                     data = json.load(f)
+                    if not isinstance(data, dict):
+                        raise ValueError("sessions.json root must be a JSON object")
                     for key, entry_data in data.items():
                         try:
                             self._entries[key] = SessionEntry.from_dict(entry_data)
-                        except (ValueError, KeyError):
+                        except (TypeError, ValueError, KeyError):
+                            logger.debug(
+                                "Skipping malformed session entry %r from %s",
+                                key,
+                                sessions_file,
+                                exc_info=True,
+                            )
                             # Skip entries with unknown/removed platform values
+                            # or malformed payloads from legacy/partial writes.
                             continue
             except Exception as e:
                 print(f"[gateway] Warning: Failed to load sessions: {e}")

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -1058,6 +1058,40 @@ class TestSessionStoreEntriesAttribute:
         assert not hasattr(store, "_sessions")
 
 
+class TestSessionStoreLoadHardening:
+    def test_skips_malformed_entries_without_aborting_load(self, tmp_path, capsys):
+        sessions_path = tmp_path / "sessions.json"
+        sessions_path.write_text(json.dumps({
+            "legacy-flag": True,
+            "bad-origin": {
+                "session_key": "agent:main:telegram:dm:bad",
+                "session_id": "sess_bad",
+                "created_at": "2026-01-01T00:00:00",
+                "updated_at": "2026-01-01T00:00:00",
+                "origin": True,
+            },
+            "good": {
+                "session_key": "agent:main:telegram:dm:good",
+                "session_id": "sess_good",
+                "created_at": "2026-01-01T00:00:00",
+                "updated_at": "2026-01-01T00:00:00",
+                "origin": {
+                    "platform": "telegram",
+                    "chat_id": "12345",
+                },
+            },
+        }), encoding="utf-8")
+
+        store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+        store._ensure_loaded()
+
+        captured = capsys.readouterr()
+        assert "Failed to load sessions" not in captured.out
+        assert "Failed to load sessions" not in captured.err
+        assert set(store._entries) == {"good"}
+        assert store._entries["good"].session_id == "sess_good"
+
+
 class TestHasAnySessions:
     """Tests for has_any_sessions() fix (issue #351)."""
 


### PR DESCRIPTION
## Summary
- skip malformed top-level entries in `sessions.json` instead of aborting the whole session index load
- reject non-dict session and origin payloads during deserialization so legacy bool flags do not trigger startup warnings
- add regression coverage that preserves valid entries while ignoring malformed ones

## Testing
- pytest tests/gateway/test_session.py -q -k 'TestSessionStoreLoadHardening or test_session_entry_from_old_data'\n- pytest tests/gateway/test_restart_resume_pending.py -q -k 'test_from_dict_legacy_without_resume_fields'\n- ruff check gateway/session.py tests/gateway/test_session.py\n- git diff --check