### PR TITLE
fix(slack): prefer websockets socket mode backend

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -10,6 +10,7 @@ Uses slack-bolt (Python) with Socket Mode for:
 
 import asyncio
 import contextvars
+import importlib
 import json
 import logging
 import os
@@ -302,6 +303,26 @@ def _resolve_slack_proxy_url() -> Optional[str]:
     return proxy_url
 
 
+def _build_socket_mode_handler(
+    app: Any,
+    app_token: str,
+    proxy_url: Optional[str],
+) -> Tuple[Any, str]:
+    """Build a Socket Mode handler with the safest backend for this config."""
+    if proxy_url:
+        return AsyncSocketModeHandler(app, app_token, proxy=proxy_url), "aiohttp"
+
+    try:
+        module = importlib.import_module(
+            "slack_bolt.adapter.socket_mode.websockets"
+        )
+        handler_cls = getattr(module, "AsyncSocketModeHandler")
+    except (ImportError, AttributeError):
+        return AsyncSocketModeHandler(app, app_token), "aiohttp"
+
+    return handler_cls(app, app_token), "websockets"
+
+
 class SlackAdapter(BasePlatformAdapter):
     """
     Slack bot adapter using Socket Mode.
@@ -374,6 +395,7 @@ class SlackAdapter(BasePlatformAdapter):
         # self-heal when Slack silently drops the websocket.
         self._app_token: Optional[str] = None
         self._proxy_url: Optional[str] = None
+        self._socket_mode_backend: Optional[str] = None
         self._socket_watchdog_task: Optional[asyncio.Task] = None
         self._socket_reconnect_lock = asyncio.Lock()
         self._socket_watchdog_interval_s = 15.0
@@ -383,8 +405,10 @@ class SlackAdapter(BasePlatformAdapter):
         if not self._app or not self._app_token:
             raise RuntimeError("Socket Mode requires an initialized app and app token")
 
-        self._handler = AsyncSocketModeHandler(
-            self._app, self._app_token, proxy=self._proxy_url
+        self._handler, self._socket_mode_backend = _build_socket_mode_handler(
+            self._app,
+            self._app_token,
+            self._proxy_url,
         )
         _apply_slack_proxy(self._handler.client, self._proxy_url)
 
@@ -1036,7 +1060,8 @@ class SlackAdapter(BasePlatformAdapter):
                 raise
 
             logger.info(
-                "[Slack] Socket Mode connected (%d workspace(s))",
+                "[Slack] Socket Mode connected via %s (%d workspace(s))",
+                self._socket_mode_backend or "aiohttp",
                 len(self._team_clients),
             )
             return True

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -706,6 +706,57 @@ class TestSlackProxyBehavior:
                 ]
             )
 
+    def test_build_socket_mode_handler_prefers_websockets_without_proxy(self):
+        created = []
+
+        class FakeWsHandler:
+            def __init__(self, app, app_token):
+                self.app = app
+                self.app_token = app_token
+                self.client = MagicMock(proxy="constructor-default")
+                created.append(self)
+
+        fake_module = MagicMock(AsyncSocketModeHandler=FakeWsHandler)
+
+        with patch.object(
+            _slack_mod.importlib, "import_module", return_value=fake_module
+        ):
+            handler, backend = _slack_mod._build_socket_mode_handler(
+                MagicMock(),
+                "xapp-fake",
+                None,
+            )
+
+        assert isinstance(handler, FakeWsHandler)
+        assert backend == "websockets"
+        assert created[0].app_token == "xapp-fake"
+
+    def test_build_socket_mode_handler_uses_aiohttp_when_proxy_configured(self):
+        created = []
+
+        class FakeAioHandler:
+            def __init__(self, app, app_token, proxy=None):
+                self.app = app
+                self.app_token = app_token
+                self.proxy = proxy
+                self.client = MagicMock(proxy="constructor-default")
+                created.append(self)
+
+        with (
+            patch.object(_slack_mod, "AsyncSocketModeHandler", FakeAioHandler),
+            patch.object(_slack_mod.importlib, "import_module") as mock_import,
+        ):
+            handler, backend = _slack_mod._build_socket_mode_handler(
+                MagicMock(),
+                "xapp-fake",
+                "http://proxy.example.com:3128",
+            )
+
+        assert isinstance(handler, FakeAioHandler)
+        assert backend == "aiohttp"
+        assert created[0].proxy == "http://proxy.example.com:3128"
+        mock_import.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_connect_uses_proxy_when_not_bypassed(self):
         created_apps = []


### PR DESCRIPTION
## Summary
- prefer Slack Bolt's `websockets` Socket Mode backend when Hermes is not using a Slack proxy
- keep the existing aiohttp backend when a proxy is configured, because the websockets adapter does not support proxy-wired connections
- add regression coverage for backend selection so proxy and non-proxy startup paths stay stable

## Testing
- pytest tests/gateway/test_slack.py -q -k 'TestSlackProxyBehavior'\n- ruff check gateway/platforms/slack.py tests/gateway/test_slack.py\n- git diff --check