### PR TITLE
fix(kanban): separate stale diagnostics from active blockers

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1751,6 +1751,8 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
             {
                 "task_id": tid,
                 **meta.get(tid, {}),
+                "active_diagnostic_count": len(kd.split_diagnostics(dl)[0]),
+                "stale_diagnostic_count": len(kd.split_diagnostics(dl)[1]),
                 "diagnostics": [d.to_dict() for d in dl],
             }
             for tid, dl in diags_by_task.items()
@@ -1765,9 +1767,14 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
     # Human-readable summary: grouped by task, severity-marked, with
     # suggested actions inline.
     sev_marker = {"warning": "⚠", "error": "!!", "critical": "!!!"}
-    total = sum(len(dl) for dl in diags_by_task.values())
+    active_total = 0
+    stale_total = 0
+    for dl in diags_by_task.values():
+        active, stale = kd.split_diagnostics(dl)
+        active_total += len(active)
+        stale_total += len(stale)
     print(
-        f"{total} active diagnostic(s) across "
+        f"{active_total} active blocker(s), {stale_total} stale diagnostic(s) across "
         f"{len(diags_by_task)} task(s):\n"
     )
     for tid, dl in diags_by_task.items():
@@ -1777,7 +1784,11 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
         assignee = m.get("assignee") or "(unassigned)"
         print(f"  {tid}  {status:8s}  @{assignee:18s}  {title}")
         for d in dl:
-            print(f"    {sev_marker.get(d.severity, '?')} [{d.severity}] {d.kind}: {d.title}")
+            stale_prefix = "stale " if d.stale else ""
+            print(
+                f"    {sev_marker.get(d.severity, '?')} "
+                f"[{stale_prefix}{d.severity}] {d.kind}: {d.title}"
+            )
             if d.data:
                 # Compact key:value pairs on one line.
                 bits = []

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -99,6 +99,10 @@ class Diagnostic:
     count: int = 1
     # Optional: the run id this diagnostic is scoped to. None = task-wide.
     run_id: Optional[int] = None
+    # Historical diagnostics stay visible for auditability but should
+    # not be counted as active runtime blockers.
+    stale: bool = False
+    stale_reason: Optional[str] = None
     # Optional structured payload for the UI (phantom ids, failure count).
     data: dict = field(default_factory=dict)
 
@@ -113,6 +117,8 @@ class Diagnostic:
             "last_seen_at": self.last_seen_at,
             "count": self.count,
             "run_id": self.run_id,
+            "stale": self.stale,
+            "stale_reason": self.stale_reason,
             "data": self.data,
         }
 
@@ -167,6 +173,65 @@ def _event_kind(ev) -> str:
 def _event_ts(ev) -> int:
     t = _task_field(ev, "created_at", 0)
     return int(t or 0)
+
+
+def _run_sort_key(run: Any) -> tuple[int, int]:
+    """Stable newest-first marker for run comparisons."""
+    ended_at = int(_task_field(run, "ended_at", 0) or 0)
+    run_id = int(_task_field(run, "id", 0) or 0)
+    return (ended_at, run_id)
+
+
+def _latest_run(runs: Iterable[Any], outcomes: set[str]) -> Optional[Any]:
+    latest = None
+    latest_key = (-1, -1)
+    for run in runs:
+        outcome = _task_field(run, "outcome")
+        if outcome not in outcomes:
+            continue
+        key = _run_sort_key(run)
+        if key > latest_key:
+            latest = run
+            latest_key = key
+    return latest
+
+
+def _stale_failure_state(task: Any, runs: list[Any]) -> tuple[bool, Optional[str]]:
+    """Return whether a failure-style diagnostic is historical only."""
+    status = str(_task_field(task, "status", "") or "")
+    if status == "todo":
+        return (True, "source_task_reset_to_todo")
+    if status in {"done", "archived"}:
+        return (True, "task_already_completed")
+
+    last_failure = _latest_run(
+        runs,
+        {"spawn_failed", "timed_out", "crashed", "gave_up"},
+    )
+    last_success = _latest_run(runs, {"completed"})
+    if last_failure is not None and last_success is not None:
+        if _run_sort_key(last_success) > _run_sort_key(last_failure):
+            return (True, "later_success_after_failure")
+    return (False, None)
+
+
+def split_diagnostics(
+    diagnostics: Iterable[Diagnostic | dict[str, Any]],
+) -> tuple[list[Diagnostic | dict[str, Any]], list[Diagnostic | dict[str, Any]]]:
+    """Partition diagnostics into active blockers and historical entries."""
+    active = []
+    stale = []
+    for diagnostic in diagnostics:
+        is_stale = (
+            diagnostic.get("stale", False)
+            if isinstance(diagnostic, dict)
+            else diagnostic.stale
+        )
+        if is_stale:
+            stale.append(diagnostic)
+        else:
+            active.append(diagnostic)
+    return active, stale
 
 
 def _active_hallucination_events(
@@ -593,7 +658,10 @@ def _rule_repeated_failures(task, events, runs, now, cfg) -> list[Diagnostic]:
         task, running=_task_field(task, "status") == "running",
     ))
 
+    stale, stale_reason = _stale_failure_state(task, runs)
     severity = "critical" if failures >= threshold * 2 else "error"
+    if stale:
+        severity = "warning"
     err_text = (last_err or "").strip() if last_err else ""
     err_snippet = err_text[:500] + ("…" if len(err_text) > 500 else "") if err_text else ""
     outcome_label = {
@@ -601,8 +669,20 @@ def _rule_repeated_failures(task, events, runs, now, cfg) -> list[Diagnostic]:
         "timed_out": "timeout",
         "crashed": "crash",
     }.get(most_recent_outcome or "", "failure")
+    prefix = "Historical " if stale else ""
+    stale_note = {
+        "source_task_reset_to_todo": (
+            "The task is back in todo and no longer represents an active worker outage."
+        ),
+        "task_already_completed": (
+            "The task already completed after the recorded failures."
+        ),
+        "later_success_after_failure": (
+            "A later completed run exists after the recorded failure streak."
+        ),
+    }.get(stale_reason, "")
     if err_snippet:
-        title = f"Agent {outcome_label} x{failures}: {err_snippet.splitlines()[0][:160]}"
+        title = f"{prefix}agent {outcome_label} x{failures}: {err_snippet.splitlines()[0][:160]}"
         detail = (
             f"This task has failed {failures} times in a row "
             f"(most recent: {outcome_label}). Full last error:\n\n"
@@ -612,12 +692,14 @@ def _rule_repeated_failures(task, events, runs, now, cfg) -> list[Diagnostic]:
             f"root cause and reclaim or unblock the task to retry."
         )
     else:
-        title = f"Agent {outcome_label} x{failures} (no error recorded)"
+        title = f"{prefix}agent {outcome_label} x{failures} (no error recorded)"
         detail = (
             f"This task has failed {failures} times in a row "
             f"(most recent: {outcome_label}) but no error text was "
             f"captured. Check the suggested command or the worker log."
         )
+    if stale_note:
+        detail = f"{detail}\n\nHistorical only: {stale_note}"
     return [Diagnostic(
         kind="repeated_failures",
         severity=severity,
@@ -627,12 +709,17 @@ def _rule_repeated_failures(task, events, runs, now, cfg) -> list[Diagnostic]:
         first_seen_at=now,
         last_seen_at=now,
         count=failures,
+        stale=stale,
+        stale_reason=stale_reason,
         data={
             "consecutive_failures": failures,
             "most_recent_outcome": most_recent_outcome,
             "last_error": last_err,
             "failure_threshold": threshold,
             "failure_limit": failure_limit,
+            "task_status": _task_field(task, "status"),
+            "stale": stale,
+            "stale_reason": stale_reason,
         },
     )]
 
@@ -693,24 +780,41 @@ def _rule_repeated_crashes(task, events, runs, now, cfg) -> list[Diagnostic]:
         ))
     running = _task_field(task, "status") == "running"
     actions.extend(_generic_recovery_actions(task, running=running))
+    stale, stale_reason = _stale_failure_state(task, runs)
     severity = "critical" if consecutive >= threshold * 2 else "error"
+    if stale:
+        severity = "warning"
     # Put the actual error up-front so operators see WHAT broke without
     # having to open the logs. Truncate defensively — these can be huge
     # (full tracebacks).
     err_text = (last_err or "").strip() if last_err else ""
     err_snippet = err_text[:500] + ("…" if len(err_text) > 500 else "") if err_text else ""
+    prefix = "Historical " if stale else ""
+    stale_note = {
+        "source_task_reset_to_todo": (
+            "The task is back in todo and no longer represents an active worker outage."
+        ),
+        "task_already_completed": (
+            "The task already completed after the recorded crashes."
+        ),
+        "later_success_after_failure": (
+            "A later completed run exists after the recorded crash streak."
+        ),
+    }.get(stale_reason, "")
     if err_snippet:
-        title = f"Agent crashed {consecutive}x: {err_snippet.splitlines()[0][:160]}"
+        title = f"{prefix}agent crashed {consecutive}x: {err_snippet.splitlines()[0][:160]}"
         detail = (
             f"The last {consecutive} runs ended with outcome=crashed. "
             f"Full last error:\n\n{err_snippet}"
         )
     else:
-        title = f"Agent crashed {consecutive}x (no error recorded)"
+        title = f"{prefix}agent crashed {consecutive}x (no error recorded)"
         detail = (
             f"The last {consecutive} runs ended with outcome=crashed but "
             f"no error text was captured. Check the worker log for more."
         )
+    if stale_note:
+        detail = f"{detail}\n\nHistorical only: {stale_note}"
     return [Diagnostic(
         kind="repeated_crashes",
         severity=severity,
@@ -720,7 +824,15 @@ def _rule_repeated_crashes(task, events, runs, now, cfg) -> list[Diagnostic]:
         first_seen_at=now,
         last_seen_at=now,
         count=consecutive,
-        data={"consecutive_crashes": consecutive, "last_error": last_err},
+        stale=stale,
+        stale_reason=stale_reason,
+        data={
+            "consecutive_crashes": consecutive,
+            "last_error": last_err,
+            "task_status": _task_field(task, "status"),
+            "stale": stale,
+            "stale_reason": stale_reason,
+        },
     )]
 
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -252,7 +252,7 @@ def _compute_task_diagnostics(
     """Run the diagnostic rule engine against every task (or a subset)
     and return ``{task_id: [diagnostic_dict, ...]}``.
 
-    Tasks with no active diagnostics are omitted from the result.
+    Tasks with no diagnostics are omitted from the result.
     Uses ``hermes_cli.kanban_diagnostics`` — see that module for the
     rule definitions.
     """
@@ -326,13 +326,16 @@ def _warnings_summary_from_diagnostics(
     if not diagnostics:
         return None
     from hermes_cli.kanban_diagnostics import SEVERITY_ORDER
+    active_diags = [d for d in diagnostics if not d.get("stale")]
+    stale_count = len(diagnostics) - len(active_diags)
+    summary_diags = active_diags or diagnostics
 
     kinds: dict[str, int] = {}
     latest = 0
     highest_idx = -1
     highest_sev: Optional[str] = None
     count = 0
-    for d in diagnostics:
+    for d in summary_diags:
         kinds[d["kind"]] = kinds.get(d["kind"], 0) + d.get("count", 1)
         count += d.get("count", 1)
         la = d.get("last_seen_at") or 0
@@ -349,6 +352,8 @@ def _warnings_summary_from_diagnostics(
         "kinds": kinds,
         "latest_at": latest,
         "highest_severity": highest_sev,
+        "active_count": len(active_diags),
+        "stale_count": stale_count,
     }
 
 
@@ -1271,7 +1276,7 @@ def list_diagnostics(
 ):
     """Return ``[{task_id, task_title, task_status, task_assignee,
     diagnostics: [...]}, ...]`` for every task on the board with at
-    least one active diagnostic.
+    least one diagnostic entry.
 
     Severity-filterable so the UI can render "just the critical ones"
     or the CLI can grep. Useful for the board-header attention strip
@@ -1284,7 +1289,12 @@ def list_diagnostics(
     try:
         diags_by_task = _compute_task_diagnostics(conn, task_ids=None)
         if not diags_by_task:
-            return {"diagnostics": [], "count": 0}
+            return {
+                "diagnostics": [],
+                "count": 0,
+                "total_diagnostic_count": 0,
+                "stale_diagnostic_count": 0,
+            }
 
         # Narrow by severity if asked.
         if severity:
@@ -1295,7 +1305,12 @@ def list_diagnostics(
                     filtered[tid] = keep
             diags_by_task = filtered
             if not diags_by_task:
-                return {"diagnostics": [], "count": 0}
+                return {
+                    "diagnostics": [],
+                    "count": 0,
+                    "total_diagnostic_count": 0,
+                    "stale_diagnostic_count": 0,
+                }
 
         # Pull the task rows we need in one query so we can include
         # titles/statuses without a per-task lookup.
@@ -1310,13 +1325,20 @@ def list_diagnostics(
         }
 
         out = []
+        active_count = 0
+        stale_count = 0
         for tid, dl in diags_by_task.items():
             r = rows.get(tid)
+            active, stale = kd.split_diagnostics(dl)
+            active_count += len(active)
+            stale_count += len(stale)
             out.append({
                 "task_id": tid,
                 "task_title": r["title"] if r else None,
                 "task_status": r["status"] if r else None,
                 "task_assignee": r["assignee"] if r else None,
+                "active_diagnostic_count": len(active),
+                "stale_diagnostic_count": len(stale),
                 "diagnostics": dl,
             })
         # Sort: highest severity first, then most recent.
@@ -1332,7 +1354,9 @@ def list_diagnostics(
 
         return {
             "diagnostics": out,
-            "count": sum(len(d["diagnostics"]) for d in out),
+            "count": active_count,
+            "total_diagnostic_count": active_count + stale_count,
+            "stale_diagnostic_count": stale_count,
         }
     finally:
         conn.close()

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -262,6 +263,45 @@ def test_run_slash_link_unlink(kanban_home):
     show = kc.run_slash(f"show {tb}")
     assert "todo" in show
     assert "Unlinked" in kc.run_slash(f"unlink {ta} {tb}")
+
+
+def test_run_slash_diagnostics_separates_active_and_stale_counts(kanban_home):
+    conn = kb.connect()
+    try:
+        active = kb.create_task(conn, title="active", assignee="alice")
+        real = kb.create_task(conn, title="real", assignee="x", created_by="alice")
+        import pytest as _pytest
+        with _pytest.raises(kb.HallucinatedCardsError):
+            kb.complete_task(
+                conn, active, summary="phantom",
+                created_cards=[real, "t_deadbeef1234"],
+            )
+
+        stale = kb.create_task(conn, title="stale", assignee="builder")
+        conn.execute(
+            "UPDATE tasks SET status='todo', consecutive_failures=2, "
+            "last_failure_error='No Codex credentials stored' WHERE id=?",
+            (stale,),
+        )
+        for run_id in range(1, 3):
+            conn.execute(
+                "INSERT INTO task_runs (id, task_id, status, outcome, error, started_at, ended_at) "
+                "VALUES (?, ?, 'spawn_failed', 'spawn_failed', ?, ?, ?)",
+                (
+                    8000 + run_id,
+                    stale,
+                    "No Codex credentials stored",
+                    int(time.time()) - 100,
+                    int(time.time()) - 50,
+                ),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+    out = kc.run_slash("diagnostics")
+    assert "1 active blocker(s), 1 stale diagnostic(s) across 2 task(s)" in out
+    assert "[stale warning]" in out
 
 
 def test_board_override_is_isolated_per_concurrent_call(kanban_home, monkeypatch):

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -342,6 +342,46 @@ def test_repeated_failures_surfaces_actual_error_in_title():
     assert "insufficient_quota" in d.detail
 
 
+def test_repeated_failures_on_todo_task_are_marked_stale():
+    task = _task(
+        status="todo",
+        consecutive_failures=3,
+        last_failure_error="No Codex credentials stored",
+    )
+    runs = [
+        _run(outcome="spawn_failed", run_id=1, error="No Codex credentials stored"),
+        _run(outcome="spawn_failed", run_id=2, error="No Codex credentials stored"),
+        _run(outcome="spawn_failed", run_id=3, error="No Codex credentials stored"),
+    ]
+    diags = kd.compute_task_diagnostics(task, [], runs)
+    assert len(diags) == 1
+    d = diags[0]
+    assert d.kind == "repeated_failures"
+    assert d.stale is True
+    assert d.stale_reason == "source_task_reset_to_todo"
+    assert d.severity == "warning"
+
+
+def test_repeated_failures_become_stale_after_later_success():
+    task = _task(
+        status="ready",
+        consecutive_failures=3,
+        last_failure_error="No Codex credentials stored",
+    )
+    runs = [
+        _run(outcome="spawn_failed", run_id=1, error="No Codex credentials stored"),
+        _run(outcome="spawn_failed", run_id=2, error="No Codex credentials stored"),
+        _run(outcome="completed", run_id=3),
+    ]
+    diags = kd.compute_task_diagnostics(task, [], runs)
+    assert len(diags) == 1
+    d = diags[0]
+    assert d.kind == "repeated_failures"
+    assert d.stale is True
+    assert d.stale_reason == "later_success_after_failure"
+    assert d.severity == "warning"
+
+
 def test_repeated_crashes_truncates_huge_tracebacks():
     """Full Python tracebacks can be tens of KB. The title stays one
     line (≤160 chars); the detail caps at 500 chars + ellipsis so the
@@ -369,7 +409,7 @@ def test_repeated_crashes_truncates_huge_tracebacks():
 def test_diagnostics_sorted_critical_first():
     """A task with both a critical (many spawn failures) and a warning
     (prose phantoms) diagnostic should list the critical one first."""
-    task = _task(status="done", consecutive_failures=10,
+    task = _task(status="blocked", consecutive_failures=10,
                  last_failure_error="nope")
     events = [
         _event("completed", ts=100, summary="referenced t_missing"),
@@ -380,6 +420,26 @@ def test_diagnostics_sorted_critical_first():
     kinds = [d.kind for d in diags]
     assert kinds[0] == "repeated_failures"  # critical
     assert "prose_phantom_refs" in kinds
+
+
+def test_split_diagnostics_separates_active_and_stale_entries():
+    active = kd.Diagnostic(
+        kind="repeated_crashes",
+        severity="error",
+        title="Agent crashed",
+        detail="boom",
+    )
+    stale = kd.Diagnostic(
+        kind="repeated_failures",
+        severity="warning",
+        title="Historical agent spawn x3",
+        detail="old auth outage",
+        stale=True,
+        stale_reason="source_task_reset_to_todo",
+    )
+    active_diags, stale_diags = kd.split_diagnostics([active, stale])
+    assert active_diags == [active]
+    assert stale_diags == [stale]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -2031,6 +2031,55 @@ def test_diagnostics_endpoint_severity_filter(client):
     assert data["diagnostics"][0]["task_id"] == p2
 
 
+def test_diagnostics_endpoint_separates_active_and_stale_counts(client):
+    conn = kb.connect()
+    try:
+        active = kb.create_task(conn, title="active", assignee="alice")
+        real = kb.create_task(conn, title="real", assignee="x", created_by="alice")
+        import pytest as _pytest
+        with _pytest.raises(kb.HallucinatedCardsError):
+            kb.complete_task(
+                conn, active, summary="phantom",
+                created_cards=[real, "t_deadbeef1234"],
+            )
+
+        stale = kb.create_task(conn, title="stale", assignee="builder")
+        conn.execute(
+            "UPDATE tasks SET status='todo', consecutive_failures=2, "
+            "last_failure_error='No Codex credentials stored' WHERE id=?",
+            (stale,),
+        )
+        for run_id in range(1, 3):
+            conn.execute(
+                "INSERT INTO task_runs (id, task_id, status, outcome, error, started_at, ended_at) "
+                "VALUES (?, ?, 'spawn_failed', 'spawn_failed', ?, ?, ?)",
+                (
+                    9000 + run_id,
+                    stale,
+                    "No Codex credentials stored",
+                    int(time.time()) - 100,
+                    int(time.time()) - 50,
+                ),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+    r = client.get("/api/plugins/kanban/diagnostics")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["count"] == 1
+    assert data["total_diagnostic_count"] == 2
+    assert data["stale_diagnostic_count"] == 1
+
+    rows = {row["task_id"]: row for row in data["diagnostics"]}
+    assert rows[active]["active_diagnostic_count"] == 1
+    assert rows[active]["stale_diagnostic_count"] == 0
+    assert rows[stale]["active_diagnostic_count"] == 0
+    assert rows[stale]["stale_diagnostic_count"] == 1
+    assert rows[stale]["diagnostics"][0]["stale"] is True
+
+
 def test_board_exposes_diagnostics_list_and_summary(client):
     """/board should attach both the full diagnostics list AND the
     compact warnings summary (with highest_severity) on each task


### PR DESCRIPTION
## Summary

Fixes #46998.

This narrows `hermes kanban diagnostics` so historical worker failures stay visible for auditability without being counted or rendered as active runtime blockers.

## What changed

- mark failure-style diagnostics as `stale` when the task has already been reset to `todo`, completed, or has a later successful run after the recorded failure streak
- downgrade stale failure/crash diagnostics to warning severity and attach a machine-readable `stale_reason`
- separate active-vs-stale counts in the CLI summary and dashboard diagnostics API while keeping the underlying diagnostic entries visible
- expose `active_diagnostic_count` / `stale_diagnostic_count` per task for JSON and dashboard consumers

## Verification

- `uv run --frozen pytest tests/hermes_cli/test_kanban_diagnostics.py tests/hermes_cli/test_kanban_cli.py -q`
- `uv run --frozen pytest tests/plugins/test_kanban_dashboard_plugin.py -q -k 'diagnostics_endpoint or board_exposes_diagnostics'`
- `uv run --frozen ruff check hermes_cli/kanban_diagnostics.py hermes_cli/kanban.py plugins/kanban/dashboard/plugin_api.py tests/hermes_cli/test_kanban_diagnostics.py tests/hermes_cli/test_kanban_cli.py tests/plugins/test_kanban_dashboard_plugin.py`
- `git diff --check`
