### PR TITLE
fix(url_safety): add cdn.discordapp.com to trusted private-IP hosts

### DIFF
--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -114,6 +114,7 @@ _ALWAYS_BLOCKED_NETWORKS = (
 # to 198.18.0.0/15 behind local proxy/benchmark infrastructure.
 _TRUSTED_PRIVATE_IP_HOSTS = frozenset({
     "multimedia.nt.qq.com.cn",
+    "cdn.discordapp.com",
 })
 
 # 100.64.0.0/10 (CGNAT / Shared Address Space, RFC 6598) is NOT covered by


### PR DESCRIPTION
## Problem

`tests/gateway/test_discord_document_handling.py` has 12 failing tests on `main` (8 in `TestIncomingDocumentHandling`, 4 in `TestAllowAnyAttachment`).

**Root cause:** `cdn.discordapp.com` resolves to `198.18.0.248` (RFC 2544 benchmark range, `198.18.0.0/15`) in test environments. The `url_safety._is_blocked_ip()` function classifies this as `is_reserved`, triggering SSRF protection that blocks Discord CDN attachment downloads during testing. The test mocks use `cdn.discordapp.com` URLs without an `att.read()` mock, so the attachment download falls back to the URL path which hits the SSRF check.

The same issue affects production users behind VPNs, corporate DNS, or tunnels that resolve `cdn.discordapp.com` to private-looking IPs — see comments in the Discord adapter at lines 4755-4760.

## Fix

Add `cdn.discordapp.com` to `_TRUSTED_PRIVATE_IP_HOSTS` — same pattern as `multimedia.nt.qq.com.cn` which is already in the set for the exact same reason (line 113-114: "QQ media downloads can legitimately resolve to 198.18.0.0/15 behind local proxy/benchmark infrastructure").

## Safety

- In production, `cdn.discordapp.com` resolves to public CDN IPs — the SSRF check wouldn't trigger regardless
- The Discord adapter already has `att.read()` as its primary authenticated attachment path
- This is a hostname-level allow, not a blanket IP-range bypass

## Test results

```
Before:  8 passed, 12 failed
After:  20 passed, 0 failed  ✅

All Discord tests:     392 passed  ✅
All url_safety tests:  118 passed  ✅
```