### PR TITLE
fix(desktop): allow manual models for custom endpoints

### DIFF
--- a/apps/desktop/src/components/desktop-onboarding-overlay.test.tsx
+++ b/apps/desktop/src/components/desktop-onboarding-overlay.test.tsx
@@ -1,10 +1,10 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { $desktopOnboarding, type DesktopOnboardingState, type OnboardingContext } from '@/store/onboarding'
 import type { OAuthProvider } from '@/types/hermes'
 
-import { Picker } from './desktop-onboarding-overlay'
+import { ApiKeyForm, Picker } from './desktop-onboarding-overlay'
 
 function provider(id: string, name = id): OAuthProvider {
   return {
@@ -98,5 +98,40 @@ describe('onboarding Picker', () => {
     render(<Picker ctx={ctx} />)
 
     expect(screen.queryByRole('button', { name: "I'll choose a provider later" })).toBeNull()
+  })
+})
+
+describe('ApiKeyForm', () => {
+  it('forwards the manual local-model fallback for custom endpoints', async () => {
+    const onSave = vi.fn(async () => ({ ok: true }))
+
+    render(
+      <ApiKeyForm
+        canGoBack={false}
+        initialEnvKey="OPENAI_BASE_URL"
+        onBack={() => undefined}
+        onSave={onSave}
+      />
+    )
+
+    fireEvent.change(screen.getByPlaceholderText('http://127.0.0.1:8000/v1'), {
+      target: { value: 'https://api.cohere.ai/compatibility/v1' }
+    })
+    fireEvent.change(screen.getByPlaceholderText('API key (optional — only if your endpoint requires one)'), {
+      target: { value: 'sk-secret' }
+    })
+    fireEvent.change(screen.getByPlaceholderText('Model name (optional fallback when /v1/models is empty)'), {
+      target: { value: 'command-a-plus-05-2026' }
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }))
+
+    expect(onSave).toHaveBeenCalledWith(
+      'OPENAI_BASE_URL',
+      'https://api.cohere.ai/compatibility/v1',
+      'Local / custom endpoint',
+      'sk-secret',
+      'command-a-plus-05-2026'
+    )
   })
 })

--- a/apps/desktop/src/components/desktop-onboarding-overlay.tsx
+++ b/apps/desktop/src/components/desktop-onboarding-overlay.tsx
@@ -64,6 +64,8 @@ export interface ApiKeyOption {
   short?: string
 }
 
+const LOCAL_MODEL_PLACEHOLDER = 'Model name (optional fallback when /v1/models is empty)'
+
 const API_KEY_OPTIONS: ApiKeyOption[] = [
   {
     id: 'openrouter',
@@ -447,7 +449,9 @@ export function Picker({ ctx }: { ctx: OnboardingContext }) {
           canGoBack={hasOauth && !localEndpoint}
           initialEnvKey={localEndpoint ? 'OPENAI_BASE_URL' : undefined}
           onBack={() => setOnboardingMode('oauth')}
-          onSave={(envKey, value, name, apiKey) => saveOnboardingApiKey(envKey, value, name, ctx, apiKey)}
+          onSave={(envKey, value, name, apiKey, modelName) =>
+            saveOnboardingApiKey(envKey, value, name, ctx, apiKey, modelName)
+          }
           options={apiKeyOptions}
         />
         {manual ? null : (
@@ -654,7 +658,8 @@ export function ApiKeyForm({
     envKey: string,
     value: string,
     name: string,
-    apiKey?: string
+    apiKey?: string,
+    modelName?: string
   ) => Promise<{ message?: string; ok: boolean }>
   options?: ApiKeyOption[]
   redactedValue?: (envKey: string) => null | string | undefined
@@ -669,6 +674,9 @@ export function ApiKeyForm({
   // Optional endpoint API key, only used by the local / custom endpoint option
   // (whose `value` is the base URL). Cleared whenever the option changes.
   const [localKey, setLocalKey] = useState('')
+  // Optional manual fallback when the endpoint is reachable but doesn't expose
+  // an OpenAI-shaped /v1/models catalog.
+  const [localModel, setLocalModel] = useState('')
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<null | string>(null)
   // `options` can change at runtime when callers filter the catalog (e.g. the
@@ -679,6 +687,7 @@ export function ApiKeyForm({
       setOption(options[0])
       setValue('')
       setLocalKey('')
+      setLocalModel('')
       setError(null)
     }
   }, [option.envKey, options])
@@ -691,6 +700,7 @@ export function ApiKeyForm({
     setOption(o)
     setValue('')
     setLocalKey('')
+    setLocalModel('')
     setError(null)
     requestAnimationFrame(() => {
       entryRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
@@ -716,11 +726,12 @@ export function ApiKeyForm({
 
     setSaving(true)
     setError(null)
-    const result = await onSave(option.envKey, value, option.name, isLocal ? localKey : undefined)
+    const result = await onSave(option.envKey, value, option.name, isLocal ? localKey : undefined, isLocal ? localModel : undefined)
 
     if (result.ok) {
       setValue('')
       setLocalKey('')
+      setLocalModel('')
     } else {
       setError(result.message ?? t.onboarding.couldNotSave)
     }
@@ -784,15 +795,29 @@ export function ApiKeyForm({
           value={value}
         />
         {isLocal ? (
-          <Input
-            autoComplete="off"
-            className="font-mono"
-            onChange={e => setLocalKey(e.target.value)}
-            onKeyDown={e => e.key === 'Enter' && void submit()}
-            placeholder={t.onboarding.localApiKeyPlaceholder}
-            type="password"
-            value={localKey}
-          />
+          <>
+            <Input
+              autoComplete="off"
+              className="font-mono"
+              onChange={e => setLocalKey(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && void submit()}
+              placeholder={t.onboarding.localApiKeyPlaceholder}
+              type="password"
+              value={localKey}
+            />
+            <Input
+              autoComplete="off"
+              className="font-mono"
+              onChange={e => setLocalModel(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && void submit()}
+              placeholder={LOCAL_MODEL_PLACEHOLDER}
+              type="text"
+              value={localModel}
+            />
+            <p className="text-xs text-muted-foreground">
+              If this endpoint does not advertise models, Hermes can save the model name you enter here instead.
+            </p>
+          </>
         ) : null}
         {error ? <p className="text-xs text-destructive">{error}</p> : null}
       </div>

--- a/apps/desktop/src/store/onboarding.test.ts
+++ b/apps/desktop/src/store/onboarding.test.ts
@@ -274,7 +274,7 @@ describe('saveOnboardingLocalEndpoint', () => {
     }
   }
 
-  it('errors when the endpoint advertises no models (nothing to route to)', async () => {
+  it('errors when the endpoint advertises no models and no manual fallback was provided', async () => {
     const calls: string[] = []
     installApiMock(async ({ path }: { path: string }) => {
       calls.push(path)
@@ -291,9 +291,47 @@ describe('saveOnboardingLocalEndpoint', () => {
     })
 
     expect(result.ok).toBe(false)
-    expect(result.message).toContain('no models')
+    expect(result.message).toContain('Enter a model name manually')
     // Must not attempt to persist an assignment without a model.
     expect(calls).not.toContain('/api/model/set')
+  })
+
+  it('accepts a manually entered model when the endpoint advertises none', async () => {
+    const calls: { body?: unknown; path: string }[] = []
+
+    installApiMock(async ({ body, path }: { body?: unknown; path: string }) => {
+      calls.push({ body, path })
+
+      if (path === '/api/providers/validate') {
+        return { ok: true, reachable: true, message: '', models: [] }
+      }
+
+      if (path === '/api/model/set') {
+        return { ok: true, provider: 'custom', model: 'command-a-plus-05-2026', base_url: 'https://api.cohere.ai/compatibility/v1' }
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    const result = await saveOnboardingLocalEndpoint(
+      'https://api.cohere.ai/compatibility/v1',
+      'sk-secret',
+      {
+        requestGateway: readyGateway()
+      },
+      'command-a-plus-05-2026'
+    )
+
+    expect(result.ok).toBe(true)
+
+    const assign = calls.find(c => c.path === '/api/model/set')
+    expect(assign?.body).toMatchObject({
+      scope: 'main',
+      provider: 'custom',
+      model: 'command-a-plus-05-2026',
+      base_url: 'https://api.cohere.ai/compatibility/v1',
+      api_key: 'sk-secret'
+    })
   })
 
   it('auto-discovers the model and persists provider=custom + base_url, then finishes', async () => {

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -735,7 +735,8 @@ export async function saveOnboardingApiKey(
   // Optional endpoint key — only meaningful for the "Local / custom endpoint"
   // option, whose primary `value` is the base URL. Ignored for plain API-key
   // providers (their key IS `value`).
-  endpointApiKey?: string
+  endpointApiKey?: string,
+  manualModelName?: string
 ) {
   const trimmed = value.trim()
 
@@ -748,7 +749,7 @@ export async function saveOnboardingApiKey(
   // base_url + model + api_key), not dropped into .env — runtime resolution
   // ignores OPENAI_BASE_URL.
   if (envKey === 'OPENAI_BASE_URL') {
-    return saveOnboardingLocalEndpoint(trimmed, endpointApiKey?.trim() ?? '', ctx)
+    return saveOnboardingLocalEndpoint(trimmed, endpointApiKey?.trim() ?? '', ctx, manualModelName?.trim() ?? '')
   }
 
   // No key validation here on purpose: we previously live-probed the key and
@@ -792,9 +793,15 @@ export async function saveOnboardingApiKey(
 // re-assigns the model from /api/model/options WITHOUT a base_url, which would
 // wipe the base_url we just wrote. We have a concrete model already, so we
 // verify the runtime directly and finish.
-export async function saveOnboardingLocalEndpoint(baseUrl: string, apiKey: string, ctx: OnboardingContext) {
+export async function saveOnboardingLocalEndpoint(
+  baseUrl: string,
+  apiKey: string,
+  ctx: OnboardingContext,
+  manualModelName = ''
+) {
   const url = baseUrl.trim()
   const key = apiKey.trim()
+  const manualModel = manualModelName.trim()
 
   if (!url) {
     return { ok: false, message: 'Enter the endpoint URL first.' }
@@ -816,7 +823,7 @@ export async function saveOnboardingLocalEndpoint(baseUrl: string, apiKey: strin
       return { ok: false, message: probe.message || `Could not reach ${url}.` }
     }
 
-    model = (probe.models?.[0] ?? '').trim()
+    model = (probe.models?.[0] ?? '').trim() || manualModel
   } catch {
     return { ok: false, message: `Could not reach ${url}.` }
   }
@@ -824,7 +831,7 @@ export async function saveOnboardingLocalEndpoint(baseUrl: string, apiKey: strin
   if (!model) {
     return {
       ok: false,
-      message: `Connected to ${url}, but it advertised no models at /v1/models. Start a model on that endpoint and try again.`
+      message: `Connected to ${url}, but it advertised no models. Enter a model name manually and try again.`
     }
   }
 


### PR DESCRIPTION
## Summary
- let Desktop onboarding carry an optional manual model name for Local / custom endpoints
- fall back to that manual model when the endpoint is reachable but advertises no `/v1/models`
- cover both the onboarding save path and the API-key form wiring with focused desktop tests

## Testing
- `NODE_OPTIONS='--localstorage-file=/tmp/hermes-vitest-localstorage' ./node_modules/.bin/vitest run --environment jsdom src/store/onboarding.test.ts src/components/desktop-onboarding-overlay.test.tsx`
- `./node_modules/.bin/eslint src/store/onboarding.ts src/components/desktop-onboarding-overlay.tsx src/store/onboarding.test.ts src/components/desktop-onboarding-overlay.test.tsx`
- `git diff --check`
