### PR TITLE
fix(model-picker): honor config base_url for live catalogs

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2368,7 +2368,7 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             if not base_url:
                 base_url = _p.base_url
             if api_key:
-                live = _p.fetch_models(api_key=api_key)
+                live = _p.fetch_models(api_key=api_key, base_url=base_url)
                 if live:
                     if normalized in {"kimi-coding", "kimi-coding-cn"}:
                         curated = list(_PROVIDER_MODELS.get(normalized, []))

--- a/providers/base.py
+++ b/providers/base.py
@@ -163,6 +163,7 @@ class ProviderProfile:
         self,
         *,
         api_key: str | None = None,
+        base_url: str | None = None,
         timeout: float = 8.0,
     ) -> list[str] | None:
         """Fetch the live model list from the provider's models endpoint.
@@ -171,11 +172,13 @@ class ProviderProfile:
         the provider does not support live model listing.
 
         Resolution order for the endpoint URL:
-          1. self.models_url  (explicit override — use when the models
+          1. base_url + "/models"  (per-call override, used when the active
+             runtime/config points a provider slug at a different endpoint)
+          2. self.models_url  (explicit override — use when the models
              endpoint differs from the inference base URL, e.g. OpenRouter
              exposes a public catalog at /api/v1/models while inference is
              at /api/v1)
-          2. self.base_url + "/models"  (standard OpenAI-compat fallback)
+          3. self.base_url + "/models"  (standard OpenAI-compat fallback)
 
         The default implementation sends Bearer auth when api_key is given
         and forwards self.default_headers. Override to customise auth, path,
@@ -184,11 +187,15 @@ class ProviderProfile:
         Callers must always fall back to the static _PROVIDER_MODELS list
         when this returns None.
         """
-        url = (self.models_url or "").strip()
+        url = (base_url or "").strip()
         if not url:
-            if not self.base_url:
-                return None
-            url = self.base_url.rstrip("/") + "/models"
+            url = (self.models_url or "").strip()
+        if not url:
+            url = (self.base_url or "").strip()
+        if not url:
+            return None
+        if not url.rstrip("/").endswith("/models"):
+            url = url.rstrip("/") + "/models"
 
         import json
         import urllib.request

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -267,6 +267,33 @@ class TestProviderModelIds:
             api_mode="anthropic_messages",
         )
 
+    def test_generic_api_key_provider_uses_resolved_base_url_for_live_catalog(self):
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return b'{"data": [{"id": "deepseek-v4-pro"}]}'
+
+        with patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value={
+                "api_key": "proxy-key",
+                "base_url": "https://litellm.internal/v1",
+            },
+        ), patch(
+            "urllib.request.urlopen",
+            return_value=_Resp(),
+        ) as mock_urlopen:
+            assert provider_model_ids("deepseek", force_refresh=True) == ["deepseek-v4-pro"]
+
+        req = mock_urlopen.call_args[0][0]
+        assert req.full_url == "https://litellm.internal/v1/models"
+        assert req.get_header("Authorization") == "Bearer proxy-key"
+
 
 # -- fetch_api_models --------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- pass the resolved provider `base_url` into the generic `/model` live catalog fetch path
- let `ProviderProfile.fetch_models()` honor a per-call endpoint override before falling back to profile defaults
- add a regression test covering a `deepseek` provider routed through a custom LiteLLM-style endpoint

## Testing
- `uv run --frozen pytest tests/hermes_cli/test_model_validation.py -q`
- `uv run --frozen ruff check hermes_cli/models.py providers/base.py tests/hermes_cli/test_model_validation.py`
- `git diff --check`

Fixes #47009.
