### PR TITLE
fix(mcp): keep CREATE_NO_WINDOW on Windows MCP spawns by patching the real call site

### DIFF
--- a/tests/tools/test_mcp_windows_no_window_patch.py
+++ b/tests/tools/test_mcp_windows_no_window_patch.py
@@ -1,0 +1,38 @@
+"""Regression test for the Windows MCP console-window suppression patch.
+
+On Windows, npx/.cmd MCP servers pop a visible, never-closing console window
+because the MCP SDK's ``create_windows_process()`` drops ``CREATE_NO_WINDOW``
+in its ``except Exception`` retry branch. ``tools/mcp_tool.py`` monkey-patches
+that function to keep the flag on every spawn path.
+
+The critical detail this test guards: ``mcp/client/stdio/__init__.py`` does
+``from mcp.os.win32.utilities import create_windows_process`` and calls the
+name bound in *its own* module namespace. Patching only
+``mcp.os.win32.utilities`` (as PR #41078 does) therefore has no effect on the
+real call site. We assert the name actually used by ``mcp.client.stdio`` is
+the patched one, so the fix can't silently regress back into ineffectiveness.
+"""
+
+import sys
+
+import pytest
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="The MCP console-window patch only installs on Windows.",
+)
+def test_mcp_client_stdio_create_windows_process_is_patched():
+    import tools.mcp_tool  # noqa: F401 -- importing installs the patch
+
+    pytest.importorskip("mcp.client.stdio")
+    import mcp.client.stdio as stdio
+
+    assert (
+        stdio.create_windows_process.__name__
+        == "_hermes_create_windows_process_no_window"
+    ), (
+        "mcp.client.stdio.create_windows_process must be replaced by the "
+        "Hermes no-console-window patch. Patching only mcp.os.win32.utilities "
+        "(PR #41078) leaves this call site unpatched and the window still pops."
+    )

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -236,6 +236,97 @@ except ImportError:
     logger.debug("mcp package not installed -- MCP tool support disabled")
 
 
+# ---------------------------------------------------------------------------
+# Windows: stop MCP stdio servers from popping a console window.
+#
+# The bundled MCP SDK's create_windows_process() (mcp/os/win32/utilities.py)
+# requests CREATE_NO_WINDOW, but its ``except Exception:`` branch RE-SPAWNS
+# WITHOUT the flag.  On Windows, npx/.cmd MCP servers hit that path, so every
+# stdio MCP leaves a visible, never-closing console window on the desktop.
+#
+# We replace create_windows_process with a version that keeps CREATE_NO_WINDOW
+# on the retry path too, preserves the SDK's Job Object cleanup and its
+# NotImplementedError -> Popen fallback, and degrades to the SDK's original
+# (windowed-but-working) spawn only as a last resort -- so this patch can never
+# stop an MCP server from starting.
+#
+# IMPORTANT: mcp/client/stdio/__init__.py does
+#     from mcp.os.win32.utilities import create_windows_process
+# and calls the name bound in *its own* namespace, so we MUST patch
+# ``mcp.client.stdio.create_windows_process``.  Patching only the utilities
+# module (as upstream PR #41078 does) has no effect.  We patch both to be safe.
+# Self-guarded: any failure to install the patch is logged and ignored.
+# ---------------------------------------------------------------------------
+if sys.platform == "win32" and _MCP_AVAILABLE:
+    try:
+        import subprocess as _win_subprocess
+        import anyio as _win_anyio
+        import mcp.client.stdio as _mcp_client_stdio
+        from mcp.os.win32 import utilities as _win32_mcp_utils
+
+        _MCP_NO_WINDOW_FLAGS = getattr(_win_subprocess, "CREATE_NO_WINDOW", 0)
+
+        async def _hermes_create_windows_process_no_window(
+            command, args, env=None, errlog=None, cwd=None
+        ):
+            if errlog is None:
+                errlog = sys.stderr
+            job = _win32_mcp_utils._create_job_object()
+            process = None
+            try:
+                process = await _win_anyio.open_process(
+                    [command, *args],
+                    env=env,
+                    creationflags=_MCP_NO_WINDOW_FLAGS,
+                    stderr=errlog,
+                    cwd=cwd,
+                )
+            except NotImplementedError:
+                # Event loop can't do async subprocesses (e.g. SelectorEventLoop)
+                # -> the SDK's sync Popen fallback, which also requests
+                # CREATE_NO_WINDOW.
+                process = await _win32_mcp_utils._create_windows_fallback_process(
+                    command, args, env, errlog, cwd
+                )
+            except Exception:
+                # The SDK bug: it retried here WITHOUT creationflags, producing a
+                # visible window.  Keep the flag; only if the windowless retry
+                # ALSO fails do we degrade to the original spawn so MCP startup
+                # can never break because of this patch.
+                try:
+                    process = await _win_anyio.open_process(
+                        [command, *args],
+                        env=env,
+                        creationflags=_MCP_NO_WINDOW_FLAGS,
+                        stderr=errlog,
+                        cwd=cwd,
+                    )
+                except Exception:
+                    process = await _win_anyio.open_process(
+                        [command, *args],
+                        env=env,
+                        stderr=errlog,
+                        cwd=cwd,
+                    )
+            _win32_mcp_utils._maybe_assign_process_to_job(process, job)
+            return process
+
+        _mcp_client_stdio.create_windows_process = (
+            _hermes_create_windows_process_no_window
+        )
+        _win32_mcp_utils.create_windows_process = (
+            _hermes_create_windows_process_no_window
+        )
+        logger.info(
+            "Applied Windows MCP no-console-window patch "
+            "(CREATE_NO_WINDOW kept on all spawn paths; patched mcp.client.stdio)"
+        )
+    except Exception as _mcp_win_patch_err:  # pragma: no cover - defensive
+        logger.warning(
+            "Could not apply Windows MCP no-window patch: %s", _mcp_win_patch_err
+        )
+
+
 def _check_message_handler_support() -> bool:
     """Check if ClientSession accepts ``message_handler`` kwarg.
 


### PR DESCRIPTION
## What does this PR do?

On Windows, every stdio MCP server launched via `npx`/`.cmd` (e.g. amap, 12306, the bundled `hermes-web-ui` MCP) spawns a **visible, never-closing console window** at gateway startup. With a handful of MCP servers configured, this fills the desktop with black `cmd` windows on every boot.

**Root cause:** the MCP SDK's `mcp/os/win32/utilities.py::create_windows_process()` requests `CREATE_NO_WINDOW`, but its `except Exception:` branch **re-spawns the process with no `creationflags`** — so any failure of the first (flagged) `anyio.open_process` call silently yields a windowed process. The `.cmd` shims hit exactly that path here.

**Why #41078 doesn't fix it:** that PR monkey-patches `mcp.os.win32.utilities.create_windows_process`. But `mcp/client/stdio/__init__.py` does `from mcp.os.win32.utilities import create_windows_process` and calls the name bound in *its own* module namespace, so rebinding the attribute on the `utilities` module never reaches the real call site.

This PR patches the name where it is actually called — `mcp.client.stdio.create_windows_process` (and the `utilities` module too, for completeness). The replacement keeps `CREATE_NO_WINDOW` on the retry path, **preserves the SDK's Job Object child-process cleanup**, and only as a last resort (if the windowless retry itself raises) falls back to the SDK's original spawn — so this patch can never stop an MCP server from starting.

## Related Issue

Refs #41078 (supersedes — same goal, but patches the effective call site and adds a regression test), #26487, #29715, #30308.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py`: on Windows, at import time, replace `mcp.client.stdio.create_windows_process` (and `mcp.os.win32.utilities.create_windows_process`) with a version that keeps `CREATE_NO_WINDOW` on all spawn paths, retains Job Object cleanup, and degrades gracefully. Self-guarded: any failure to install the patch is logged and ignored.
- `tests/tools/test_mcp_windows_no_window_patch.py`: Windows-only regression test asserting `mcp.client.stdio.create_windows_process` is the patched function — guards against the #41078 wrong-namespace trap.

## How to Test

On Windows with at least one `npx`-based stdio MCP server configured:

1. **Before:** start the gateway; one or more black `cmd` windows appear and stay open (one per `npx`/`.cmd` server, plus the inner shim each spawns).
2. Apply this PR; restart the gateway.
3. **After:** no console windows appear; MCP tools still load and work.

Proof from my run (Windows 11, gateway restart):
- `agent.log`: `INFO tools.mcp_tool: Applied Windows MCP no-console-window patch (... patched mcp.client.stdio)`
- Enumerated all 10 MCP child processes (incl. `cmd /c npx.CMD ...`, `cmd /d /s /c mcp-amap`, `cmd /d /s /c 12306-ticket-search-mcp`) via the Win32 `EnumWindows`/`IsWindowVisible` API: **0 visible windows**, all MCP servers healthy.

## Checklist

### Code

- [ ] I've read the Contributing Guide <!-- this checkout ref ships no CONTRIBUTING.md -->
- [x] My commit messages follow Conventional Commits (`fix(mcp):`, `test(mcp):`)
- [x] I searched for existing PRs (found #41078, which patches the wrong namespace; not a duplicate)
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` <!-- runtime venv has no pytest; verified the new test's assertion via venv python; CI will run the suite -->
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] N/A — no docs/config/tool-schema changes
- [x] Cross-platform impact considered: patch is gated on `sys.platform == "win32"` (no-op elsewhere); the test is `skipif` non-Windows

## Screenshots / Logs

```
INFO tools.mcp_tool: Applied Windows MCP no-console-window patch (CREATE_NO_WINDOW kept on all spawn paths; patched mcp.client.stdio)
MCP child processes: 10  |  visible windows: 0
[no window] cmd.exe /c D:\nodejs\npx.CMD -y @amap/amap-maps-mcp-server
[no window] cmd.exe /d /s /c mcp-amap
[no window] cmd.exe /c D:\nodejs\npx.CMD -y @mcpcn/12306-ticket-search-mcp
[no window] node.exe ...\hermes-web-ui\dist\server\index.js
```
