### PR TITLE
fix(teams): authenticate Bot Framework image attachments

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -729,11 +729,16 @@ class TeamsAdapter(BasePlatformAdapter):
     async def _fetch_attachment_bytes(self, url: str, timeout: float = 30.0) -> bytes:
         """Download attachment bytes with SSRF protection.
 
-        Teams file attachments carry pre-authenticated SharePoint download
-        URLs (no extra auth header needed). Validates the URL against the
-        SSRF guard and follows redirects through the shared redirect guard,
-        matching the cache_*_from_url helpers in gateway.platforms.base.
+        Teams sends inline image attachments as Bot Framework attachment URLs
+        under ``smba.trafficmanager.net``.  Those URLs are not public: they
+        require the bot's Bot Framework bearer token.  SharePoint file
+        attachments may instead be pre-authenticated download URLs and do not
+        need the header.  We only attach the bearer token to known Bot
+        Framework service hosts so a tampered attachment URL cannot exfiltrate
+        credentials.
         """
+        from urllib.parse import urlparse
+
         from tools.url_safety import is_safe_url
         from gateway.platforms.base import _ssrf_redirect_guard
 
@@ -742,15 +747,19 @@ class TeamsAdapter(BasePlatformAdapter):
 
         import httpx
 
+        headers = {"User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)"}
+        host = urlparse(url).hostname or ""
+        if host in _ALLOWED_TEAMS_SERVICE_HOSTS and self._app is not None:
+            token = await self._app._get_bot_token()
+            if token:
+                headers["Authorization"] = f"Bearer {token}"
+
         async with httpx.AsyncClient(
             timeout=timeout,
             follow_redirects=True,
             event_hooks={"response": [_ssrf_redirect_guard]},
         ) as client:
-            response = await client.get(
-                url,
-                headers={"User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)"},
-            )
+            response = await client.get(url, headers=headers)
             response.raise_for_status()
             return response.content
 
@@ -853,14 +862,39 @@ class TeamsAdapter(BasePlatformAdapter):
                 continue
 
             if content_url and content_type.startswith("image/"):
+                cached_path = None
+                cached_type = content_type
+                cached_kind = "image"
                 try:
-                    cached = await cache_image_from_url(content_url)
+                    data = await self._fetch_attachment_bytes(content_url)
+                    cached = cache_media_bytes(
+                        data,
+                        filename=att_name or "teams-image",
+                        mime_type=content_type,
+                    )
                     if cached:
-                        media_urls.append(cached)
-                        media_types.append(content_type)
-                        media_kinds.append("image")
+                        cached_path = cached.path
+                        cached_type = cached.media_type
+                        cached_kind = cached.kind
                 except Exception as e:
-                    logger.warning("[teams] Failed to cache image attachment: %s", e)
+                    logger.warning("[teams] Failed to fetch authenticated image attachment: %s", e)
+
+                # Backward-compatible fallback for public/pre-authenticated
+                # image URLs and tests that monkeypatch cache_image_from_url.
+                if not cached_path:
+                    try:
+                        fallback = await cache_image_from_url(content_url)
+                        if fallback:
+                            cached_path = fallback
+                            cached_type = content_type
+                            cached_kind = "image"
+                    except Exception as e:
+                        logger.warning("[teams] Failed to cache image attachment: %s", e)
+
+                if cached_path:
+                    media_urls.append(cached_path)
+                    media_types.append(cached_type)
+                    media_kinds.append(cached_kind)
                 continue
 
             if content_url:

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -267,7 +267,8 @@ class TestTeamsAdapterInit:
         assert adapter._client_secret == "env-secret"
         assert adapter._tenant_id == "env-tenant"
 
-    def test_default_port(self):
+    def test_default_port(self, monkeypatch):
+        monkeypatch.delenv("TEAMS_PORT", raising=False)
         adapter = TeamsAdapter(_make_config(client_id="id", client_secret="secret", tenant_id="tenant"))
         assert adapter._port == 3978
 
@@ -843,6 +844,79 @@ class TestTeamsAttachmentClassification:
         event = adapter.handle_message.call_args[0][0]
         assert event.message_type == MessageType.PHOTO
         assert event.media_urls == ["/tmp/img.png"]
+
+    @pytest.mark.anyio
+    async def test_fetch_attachment_bytes_adds_bearer_for_bot_framework_urls(self, monkeypatch):
+        adapter = self._make_adapter()
+        adapter._app._get_bot_token = AsyncMock(return_value="bot-token-123")
+        captured = {}
+
+        class FakeResponse:
+            content = b"image-bytes"
+
+            def raise_for_status(self):
+                return None
+
+        class FakeClient:
+            def __init__(self, **kwargs):
+                captured["client_kwargs"] = kwargs
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return None
+
+            async def get(self, url, headers):
+                captured["url"] = url
+                captured["headers"] = headers
+                return FakeResponse()
+
+        monkeypatch.setattr(httpx, "AsyncClient", FakeClient)
+
+        data = await adapter._fetch_attachment_bytes(
+            "https://smba.trafficmanager.net/amer/v3/attachments/abc/views/original"
+        )
+
+        assert data == b"image-bytes"
+        assert captured["headers"]["Authorization"] == "Bearer bot-token-123"
+
+    @pytest.mark.anyio
+    async def test_fetch_attachment_bytes_does_not_send_bearer_to_other_hosts(self, monkeypatch):
+        adapter = self._make_adapter()
+        adapter._app._get_bot_token = AsyncMock(return_value="bot-token-123")
+        captured = {}
+
+        class FakeResponse:
+            content = b"file-bytes"
+
+            def raise_for_status(self):
+                return None
+
+        class FakeClient:
+            def __init__(self, **kwargs):
+                captured["client_kwargs"] = kwargs
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return None
+
+            async def get(self, url, headers):
+                captured["url"] = url
+                captured["headers"] = headers
+                return FakeResponse()
+
+        monkeypatch.setattr(httpx, "AsyncClient", FakeClient)
+
+        data = await adapter._fetch_attachment_bytes(
+            "https://example.com/download/image.png"
+        )
+
+        assert data == b"file-bytes"
+        assert "Authorization" not in captured["headers"]
+        adapter._app._get_bot_token.assert_not_awaited()
 
     @pytest.mark.anyio
     async def test_download_failure_degrades_to_text(self):


### PR DESCRIPTION
## Summary
- Add Bot Framework bearer auth when downloading Teams inline image attachments from known Bot Framework service hosts.
- Keep bearer tokens off non-Bot-Framework attachment URLs to avoid credential exfiltration.
- Cache authenticated image bytes through the normal Hermes media cache and retain the existing public URL fallback for compatibility.
- Add regression tests for authenticated Bot Framework attachment downloads and non-allowed host behavior.

## Validation
- `./venv/bin/python -m pytest tests/gateway/test_teams.py tests/gateway/test_teams_pipeline_runtime_wiring.py -q -o 'addopts='`

## Context
Teams inline image attachment URLs such as `https://smba.trafficmanager.net/.../attachments/.../views/original` can return 401 unless the bot token is supplied. This preserves existing SSRF/redirect protections and limits bearer usage to the adapter's known Bot Framework host allowlist.
