### PR TITLE
feat: reversible half-turn /undo + /redo across CLI, gateway, TUI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7266,89 +7266,76 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         return last_message
     
     def undo_last(self, n: int = 1, prefill: bool = True):
-        """Back up N user turns: truncate history, soft-delete on disk, prefill.
+        """Undo N half-turns via the shared undo core and render its prefill."""
+        if not self.session_id:
+            print("(._.) No active session to undo.")
+            return
+        try:
+            import hermes_undo
 
-        Walks backwards N user messages and discards everything from the
-        Nth-from-last user message onward (its assistant response, tool
-        calls, etc.). ``n`` defaults to 1 (the last exchange); ``/undo 3``
-        backs up three user turns. If ``n`` exceeds the number of user
-        turns, it backs up to the oldest one.
-
-        Beyond the in-memory ``conversation_history`` slice, this also:
-          • soft-deletes the truncated rows in SessionDB (``active=0``) so
-            they're hidden from re-prompts and search but kept for audit;
-          • notifies memory providers via ``on_session_switch(rewound=True)``;
-          • mirrors /branch's agent surgery (system-prompt invalidation +
-            flush-index reset);
-          • when ``prefill`` is set and an input buffer is available,
-            pre-fills the composer with the backed-up message text so it
-            can be edited and resubmitted.
-
-        ``prefill=False`` is used by callers that drive the undo
-        programmatically (e.g. checkpoint rollback) and don't want to
-        touch the user's input buffer.
-        """
-        if not self.conversation_history:
-            print("(._.) No messages to undo.")
+            if self._session_db is not None:
+                hermes_undo._session_db = self._session_db
+            result = hermes_undo.undo(self.session_id, n)
+        except Exception as e:
+            logger.debug("undo: failed: %s", e)
+            print(f"(._.) Undo failed: {e}")
             return
 
-        if n < 1:
-            n = 1
-
-        # Walk backwards collecting the indices of the last N user messages.
-        user_indices = []
-        for i in range(len(self.conversation_history) - 1, -1, -1):
-            if self.conversation_history[i].get("role") == "user":
-                user_indices.append(i)
-                if len(user_indices) >= n:
-                    break
-
-        if not user_indices:
-            print("(._.) No user message found to undo.")
+        rewound_ids = list(result.get("rewound_ids") or [])
+        if not rewound_ids:
+            print("(._.) Nothing to undo.")
             return
 
-        # The oldest of the collected user messages is our truncation point.
-        cut_idx = user_indices[-1]
-        turns_undone = len(user_indices)
+        self._reload_active_history_after_rewind(rewound=True)
+        count = len(rewound_ids)
+        prefill_text = result.get("prefill_text")
+        print(f"(^_^)b Undid {n} half-turn(s) ({count} message(s)).")
+        print(f"  {len(self.conversation_history)} message(s) remaining in history.")
+        if prefill and isinstance(prefill_text, str):
+            self._prefill_input_buffer(prefill_text)
 
-        removed_count = len(self.conversation_history) - cut_idx
-        removed_msg = self.conversation_history[cut_idx].get("content", "")
-        removed_text = self._undo_content_to_text(removed_msg)
+    def redo_last(self, n: int = 1):
+        """Redo N undo operations via the shared undo core."""
+        if not self.session_id:
+            print("(._.) No active session to redo.")
+            return
+        try:
+            import hermes_undo
 
-        # Truncate the in-memory history to before that user message.
-        self.conversation_history = self.conversation_history[:cut_idx]
+            if self._session_db is not None:
+                hermes_undo._session_db = self._session_db
+            result = hermes_undo.redo(self.session_id, n)
+        except Exception as e:
+            logger.debug("redo: failed: %s", e)
+            print(f"(._.) Redo failed: {e}")
+            return
 
-        # Soft-delete the truncated rows on disk so re-prompts and search
-        # see the clean transcript while the rows survive for audit.
-        rewound_rows = 0
+        reactivated = int(result.get("reactivated_count") or 0)
+        if reactivated <= 0:
+            print(f"(._.) {result.get('message') or 'Nothing to redo.'}")
+            return
+
+        self._reload_active_history_after_rewind(rewound=True)
+        print(f"(^_^)b Redid {n} undo operation(s) ({reactivated} message(s) restored).")
+        tail = self.conversation_history[-1] if self.conversation_history else None
+        if tail:
+            role = tail.get("role", "message")
+            content = tail.get("content")
+            if isinstance(content, str) and content:
+                preview = content[:60] + ("..." if len(content) > 60 else "")
+                print(f"  Restored tail ({role}): \"{preview}\"")
+            else:
+                print(f"  Restored tail: {role} turn.")
+
+    def _reload_active_history_after_rewind(self, *, rewound: bool = False) -> None:
         if self._session_db is not None and self.session_id:
             try:
-                recents = self._session_db.list_recent_user_messages(
-                    self.session_id, limit=max(turns_undone, 10)
+                self.conversation_history = self._session_db.get_messages_as_conversation(
+                    self.session_id
                 )
-                if recents:
-                    target_idx = min(turns_undone - 1, len(recents) - 1)
-                    target_id = recents[target_idx]["id"]
-                    result = self._session_db.rewind_to_message(
-                        self.session_id, target_id
-                    )
-                    rewound_rows = result.get("rewound_count", 0)
-                    # Prefer the DB's decoded target text for the prefill —
-                    # it's the canonical persisted copy.
-                    db_text = self._undo_content_to_text(
-                        (result.get("target_message") or {}).get("content")
-                    )
-                    if db_text:
-                        removed_text = db_text
-            except ValueError as e:
-                # Non-user target / cross-session — keep the in-memory undo
-                # but skip the soft-delete; surface a debug-level note.
-                logger.debug("undo: soft-delete skipped: %s", e)
             except Exception as e:
-                logger.debug("undo: soft-delete failed: %s", e)
+                logger.debug("rewind: active history reload failed: %s", e)
 
-        # Agent surgery: invalidate the system-prompt cache and reset the
-        # flush index so the next turn re-flushes from the truncated head.
         if self.agent is not None:
             if hasattr(self.agent, "_invalidate_system_prompt"):
                 try:
@@ -7360,8 +7347,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     self.agent._last_flushed_db_idx = len(self.conversation_history)
                 except Exception:
                     pass
-            # Notify memory providers — same hook /branch fires, with the
-            # rewound flag so per-turn document caches invalidate (#6672, #21910).
             try:
                 _mm = getattr(self.agent, "_memory_manager", None)
                 if _mm is not None and self.session_id:
@@ -7369,24 +7354,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                         self.session_id,
                         parent_session_id="",
                         reset=False,
-                        rewound=True,
+                        rewound=rewound,
                     )
             except Exception:
                 pass
-
-        turn_word = "turn" if turns_undone == 1 else "turns"
-        msg_count = rewound_rows or removed_count
-        print(
-            f"(^_^)b Undid {turns_undone} {turn_word} ({msg_count} message(s)). "
-            f"Backed up to: \"{removed_text[:60]}{'...' if len(removed_text) > 60 else ''}\""
-        )
-        remaining = len(self.conversation_history)
-        print(f"  {remaining} message(s) remaining in history.")
-
-        # Pre-fill the composer with the backed-up message so the user can
-        # edit and resubmit (Claude-Code-style). Editable, not auto-sent.
-        if prefill and removed_text:
-            self._prefill_input_buffer(removed_text)
 
     @staticmethod
     def _undo_content_to_text(content) -> str:
@@ -8655,7 +8626,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
         elif canonical == "prompt":
             self._handle_prompt_compose_command(cmd_original)
         elif canonical == "undo":
-            # Parse optional turn count: "/undo" → 1, "/undo 3" → 3.
+            # Parse optional half-turn count: "/undo" → 1, "/undo 3" → 3.
             _undo_n = 1
             _undo_parts = cmd_original.split()
             if len(_undo_parts) > 1:
@@ -8667,9 +8638,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 if _undo_n < 1:
                     _undo_n = 1
             _undo_desc = (
-                "This removes the last user/assistant exchange from history."
+                "This backs up the last half-turn in history."
                 if _undo_n == 1
-                else f"This removes the last {_undo_n} user turns from history."
+                else f"This backs up the last {_undo_n} half-turns from history."
             )
             if self._confirm_destructive_slash(
                 "undo",
@@ -8678,6 +8649,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             ) is None:
                 return True  # confirmation cancelled — command handled, keep REPL alive
             self.undo_last(_undo_n)
+        elif canonical == "redo":
+            _redo_n = 1
+            _redo_parts = cmd_original.split()
+            if len(_redo_parts) > 1:
+                try:
+                    _redo_n = int(_redo_parts[1])
+                except ValueError:
+                    print(f"(._.) Invalid count {_redo_parts[1]!r} — use /redo or /redo N.")
+                    return
+            self.redo_last(_redo_n)
         elif canonical == "branch":
             self._handle_branch_command(cmd_original)
         elif canonical == "save":
@@ -9063,15 +9044,30 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                 if len(matches) > 1:
                     # Prefer an exact match (typed the full command name)
                     exact = [c for c in matches if c == typed_base]
+                    builtin_matches = [c for c in matches if c in COMMANDS]
+                    skill_matches = [c for c in matches if c not in COMMANDS]
                     if len(exact) == 1:
                         matches = exact
-                    else:
-                        # Prefer the unique shortest match:
-                        # /qui → /quit (5) wins over /quint-pipeline (15)
-                        min_len = min(len(c) for c in matches)
-                        shortest = [c for c in matches if len(c) == min_len]
-                        if len(shortest) == 1:
-                            matches = shortest
+                    elif len(builtin_matches) == 1:
+                        # A single built-in command is uniquely identified — prefer it
+                        # over any longer skill/bundle names that share the prefix:
+                        # /qui → /quit wins over the /quint-pipeline skill;
+                        # /con → /config.
+                        matches = builtin_matches
+                    elif len(builtin_matches) > 1:
+                        # Multiple built-ins share the prefix. Resolve to the shortest
+                        # ONLY when it is itself a prefix of every other match — i.e.
+                        # the others are extensions of one base command
+                        # (/sta → /status, with /statusbar an extension). When the
+                        # matches are unrelated siblings (/re → /redo, /reset, /retry)
+                        # there is no such base, so we stay ambiguous instead of
+                        # silently picking the shortest by length alone.
+                        shortest = min(builtin_matches, key=len)
+                        if all(c.startswith(shortest) for c in builtin_matches):
+                            matches = [shortest]
+                    elif not builtin_matches and len(skill_matches) == 1:
+                        # No built-in matched but exactly one skill/bundle did.
+                        matches = skill_matches
                 if len(matches) == 1:
                     # Expand the prefix to the full command name, preserving arguments.
                     # Guard against redispatching the same token to avoid infinite
@@ -12209,6 +12205,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         # Add user message to history
         self.conversation_history.append({"role": "user", "content": message})
+        if self.session_id:
+            try:
+                from hermes_undo import on_user_message_appended
+
+                on_user_message_appended(self.session_id)
+            except Exception as e:
+                logger.debug("redo clear on user append failed: %s", e)
 
         ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
         print(flush=True)

--- a/docs/specs/undo-redo-half-turn-IMPLEMENTER-SPEC.md
+++ b/docs/specs/undo-redo-half-turn-IMPLEMENTER-SPEC.md
@@ -1,0 +1,479 @@
+# Implementer Spec — Half-Turn `/undo` + `/redo` Stack
+
+> Distilled, self-contained build instructions. No review provenance. The
+> annotated PRD (`undo-redo-half-turn-PRD.md`) is the review record; THIS is
+> what you implement from. Every invariant states its own "why" inline.
+
+**Repo:** `Kyzcreig/hermes-agent` (fork) → PR to `NousResearch/hermes-agent`
+**Surfaces:** CLI (`cli.py`), Gateway (`gateway/run.py` + `gateway/session.py`), TUI (`tui_gateway/server.py`)
+
+---
+
+## What we're building
+
+1. **`/undo N` operates on half-turns** (was: whole turns). A *half-turn* = one
+   party's run of consecutive messages. User message(s) = 1 half-turn; an
+   assistant reply + its `tool_calls` + `tool` results = 1 half-turn. `/undo 1`
+   lands on the user's last message (edit & resend); `/undo 2` lands on the
+   assistant's penultimate message (user's turn to reply); alternating.
+2. **New `/redo [N]`** — text-editor stack. Bare `/redo` reverses the single
+   most-recent `/undo` (whatever N it carried). `/redo N` pops N undo operations.
+   Typing any new message clears the redo stack.
+
+Both across all three surfaces, driven by one shared core module.
+
+---
+
+## Core module: `hermes_undo.py` (new)
+
+Holds the boundary logic + stack state + the three entry points. NOT in
+`hermes_state.py` (that's DB only).
+
+### `compute_half_turn_target(active_messages, n) -> int`
+- Pure function. Input: ordered active-message list **including each row's `id`**
+  (so its caller must use the id-bearing getter — see "DB getter" below).
+- Walk backward, grouping consecutive same-*party* messages into half-turns:
+  `party(user) = "user"`; `party(assistant) = party(tool) = "assistant"` (tool
+  messages belong to the assistant half-turn that spawned them).
+- **`party()` is total over roles (don't crash on `system`/`developer`/unknown).**
+  Map any non-`user`, non-`assistant`, non-`tool` role (e.g. the `system` row at
+  id=1, a provider-injected `developer` role) to a distinct party **`"other"`**.
+  **One clamp rule (resolves the boundary ambiguity):** when counting the N
+  group-starts AND when clamping, **`"other"` groups are NOT counted and are never
+  returned as a target; `N` clamps to the oldest *non-`other`* half-turn.** The
+  function must not `KeyError`. **If the active list has zero non-`other`
+  half-turns** (e.g. only the system row, fresh session), **`compute_half_turn_target`
+  returns `None`** (the sentinel — NOT an int target). `undo()` checks `if t is
+  None:` **before** the D-13 step-3 read (so `tail = greatest id < t` never
+  dereferences a `None` `t`) and short-circuits to the no-op return
+  `{rewound_ids: [], prefill_text: None}` with a "nothing to undo" message — it
+  does NOT call `rewind_to_message`, does NOT push an `UndoOp`, and **touches
+  NEITHER stack (the `redo_stack` is NOT cleared on a no-op** — a user with a
+  pending redo who fat-fingers `/undo` on a cleared session keeps it). Phase 1(d)
+  exercises this zero-non-`other` branch and asserts the `None` return + the no-op
+  contract. Phase 1(d) also pins the clamp: `/undo 4` over `[system,U,A,U]` (non-
+  `other` half-turns = `{U,A,U}`) clamps to the **oldest non-`other` = the first
+  `U` at id=2, never the id=1 system row**.
+- **General grouping invariant:** **any maximal run of consecutive same-`party()`
+  rows = exactly ONE half-turn, regardless of how the run arose** — normal
+  alternation, a `repair_message_sequence` user-merge, a multimodal user pair left
+  *un*-merged (D-13 can leave two adjacent user rows active), or an
+  interrupted/partial assistant turn. The walk is purely "a `party()` change
+  starts a new half-turn." So a tail `…A, U(multimodal), U(text)` is **one** user
+  half-turn; `/undo 1` lands on the earliest of that run, `/undo 2` on the prior
+  assistant group-start.
+- Count N half-turn group-starts from the end; return the **id of the first
+  (earliest) message of the Nth group**. For an assistant half-turn that is the
+  `assistant` row bearing `tool_calls` (or the lone assistant text row) — **never
+  a mid-group `tool` row**.
+- Partial assistant half-turn (`assistant(tool_calls)+tool`, no final assistant
+  text — interrupted turn): group still starts at the `assistant(tool_calls)`
+  row, so the whole group is cut atomically.
+- **Tool-row monotonicity precondition (required for the id-range cut to be
+  correct):** `tool` rows are always persisted with `id >` their owning
+  `assistant(tool_calls)` row (normal streaming-persist order). The grouping walk
+  itself is order-independent (it groups by `party()`), but `rewind_to_message`'s
+  cut is an **id-range** (`id >= target`), so a `tool` row with an id *below* its
+  assistant would be left active as an orphan (provider rejects a `tool` not
+  following its `assistant`). **Enforcement (NOT a future comment — shipped now):**
+  `rewind_to_message` (or the `undo` core just before it) **raises** a clear error
+  if the cut would leave an orphaned `tool` row active (an active `tool` whose
+  matching `assistant(tool_calls)` is at `id >= target` and thus deactivated while
+  the tool is `id < target`). Fail-loud beats silent corruption — a violating
+  provider surfaces immediately instead of poisoning the next provider call. Phase 1
+  fixture (e) tests BOTH: (i) the precondition holds on normal persisted data, and
+  (ii) a deliberately violating `tool`-before-`assistant` fixture makes the cut
+  **raise**, not silently orphan. (A future provider that legitimately reorders can
+  then upgrade the raise to the union-widening fallback; until then, raising is the
+  safe default.)
+- `N` clamps to the oldest half-turn if it exceeds the count. **Returns the
+  inclusive target id only** — the actual deactivation (`id >= target`) is performed
+  by `rewind_to_message`, not this pure function (no side effects here).
+- **Keys on `role` ONLY. Never reads `content` type.** (The one content-type
+  read in the whole feature is D-13, applied AFTER this returns — see below.)
+
+### `UndoOp` + `UndoRedoState`
+- `UndoOp = {n: int, rewound_ids: list[int]}` — the explicit row ids this op
+  deactivated (NOT a range, NOT just a count).
+- `UndoRedoState`: per-`session_id` holder with `undo_stack: list[UndoOp]` and
+  `redo_stack: list[UndoOp]`. **This holder is the SOLE owner of any `UndoOp`** —
+  no surface caches an op reference. (This sole-ownership is what makes discarded
+  ops unreachable; see no-corruption invariant.)
+
+### Entry points (the ONLY functions that mutate stacks/state)
+- **`undo(session_id, n)`**:
+  1. `msgs = get_messages(session_id, include_inactive=False)` (the id-bearing
+     active list, `ORDER BY id`).
+  2. `t = compute_half_turn_target(msgs, n)` (role-based target id). **If `t is
+     None`** (zero non-`other` half-turns — fresh/system-only session), short-circuit
+     immediately: return `{rewound_ids: [], prefill_text: None}` + "nothing to undo";
+     touch neither stack (do NOT clear `redo_stack`), call nothing downstream.
+  3. **D-13 multimodal adjustment.** Define `tail` precisely: **`tail` = the row in
+     `msgs` (the active list from step 1) with the greatest `id < t`** — i.e. the
+     row that will be the new active tail after the cut. (NOT "id-adjacent in the
+     DB", which could be an `active=0` hole from a prior undo. It is positional in
+     the active list.) If `tail` exists AND `tail.role == "user"` AND its `content`
+     is **non-`str`** (list/multimodal), set `t = tail.id` (lower the target to
+     swallow that user row, inclusive). Otherwise leave `t` unchanged. *This is the
+     only content-type read in the feature; `compute_half_turn_target` never reads
+     content.* Function of one row, independent of N.
+     - **When D-13 actually fires (the precise reachable case — there is exactly
+       one, and Phase 2 MUST test it firing):** the grouping invariant already
+       swallows a *trailing* user run into the cut, so D-13 never fires on the
+       cut's own trailing group. D-13 fires **only when the half-turn cut exposes a
+       new tail that is itself a lone multimodal user half-turn.** Concrete:
+       tail `[…, A1, U(mm), A2]` (where `U(mm)` is a one-row user half-turn — a
+       single multimodal message between two assistant turns). `/undo 1`: group 1 =
+       `A2`, so `t = A2.id`; `tail` = greatest active `id < A2.id` = `U(mm)`, which
+       is a non-`str` user row → **D-13 fires**, lowering `t = U(mm).id` so both
+       `U(mm)` and `A2` are cut (`rewound_ids == {U(mm).id, A2.id}` — the **complete
+       two-element set**, which redo invariant 3 depends on) and the new tail is
+       `A1` (no prefill, armed-empty).
+       Without D-13, the new tail would be `U(mm)` and D-4 would try to prefill an
+       un-editable image/audio block. **Reachable by normal operation** (not just
+       hand-construction): a plain text turn followed by an image turn produces
+       active list `[…, U_prev, A1, U(mm), A2]` — user types text → assistant replies
+       (`U_prev,A1`), user sends an image → assistant replies (`U(mm),A2`). `/undo 1`
+       then exposes `U(mm)` as the **pre-D-13 candidate tail** (the row step-3
+       inspects); **D-13 fires, lowering `t` so the actual post-cut tail is `A1`,
+       NOT `U(mm)`** (the whole point of D-13 is to prevent `U(mm)` from being the
+       tail). The firing assertion is `new_tail == A1` and `prefill_text=None` —
+       never `new_tail == U(mm)`. Phase 2 builds the fixture
+       BOTH ways — directly via `add_message` AND by replaying that two-turn op
+       sequence — so the firing test proves reachability-by-operation, not just by
+       construction. **For arbitrary N, `tail` is by construction the greatest active
+       `id < t` while the grouping walk only ever swallows rows `id >= t`; the two
+       row-sets are disjoint by that strict inequality, so D-13 never re-cuts a row
+       the grouping walk already took, for any N.** **If you cannot construct a
+       fixture where D-13 changes the target, the branch is unreachable and must be
+       deleted, not shipped as untested defensive code — but the `[…,A1,U(mm),A2]`
+       /undo-1 case above IS that fixture, so it ships with a firing test.**
+  4. `result = rewind_to_message(session_id, t, require_user_role=False)`.
+  5. Push `UndoOp(n, result["rewound_ids"])` to `undo_stack`; **clear `redo_stack`**.
+  6. **Prefill decision (D-4) — computed in CORE, rendered by surfaces.** The
+     prefill source is the **new active tail = the greatest-id active row after the
+     cut** (the same row step-3 inspected, unless D-13 lowered `t` to also cut it).
+     **`prefill_text` = that surviving tail row's `content` IFF it is a USER row
+     with `str` content; else `None` (armed-empty).** Note: for the canonical
+     `/undo 1` on a completed turn (tail ends in the assistant reply), the half-turn
+     cut removes **only the assistant reply**; the user's prior message SURVIVES as
+     the new tail and is the prefill source — it is NOT a row in `rewound_ids`.
+     `prefill_text` is never sourced from a cut/deactivated row. *No-prefill arises
+     only when the surviving tail is an assistant row — either because N≥2 cut into
+     an assistant half-turn, or because step-3 D-13 swallowed a multimodal user tail
+     so the survivor is the prior assistant.* (You can't edit image/audio blocks as
+     composer text anyway.)
+  - **`undo()` return contract:** `{rewound_ids: list[int], prefill_text: str|None}`
+    — the prefill decision is computed ONCE in core (step 6) and returned; each
+    surface renders it: **CLI** fills the composer with `prefill_text`; **TUI**
+    emits it in the `session.undo` JSON-RPC result; **gateway** reads only
+    `rewound_ids` and leaves `prefill_text` present-but-unread (don't destructure in
+    a way that errors on the extra key — it has no composer). This prevents the
+    three surfaces from each re-deriving the tail and drifting; the surface wiring's
+    "+ D-4 prefill" means "render the returned `prefill_text`," not "recompute it."
+  - **Disjoint-ids guarantee (why stacked ops never overlap):** each `undo` reads
+    its input from `get_messages(include_inactive=False)`, which **excludes rows a
+    prior op already set `active=0`**. So no still-active row from a prior op is in
+    a later undo's input; each op's `rewound_ids` is disjoint from every other live
+    op's. (Phase 2 asserts disjoint `rewound_ids` across stacked ops.) This is what
+    makes the LIFO redo symmetry hold and `restore_ids` idempotency a pure
+    belt-and-suspenders.
+- **`redo(session_id, m)`** (bare `/redo` passes `m=1`; the default is applied at
+  the **parse layer**, so the core always receives an explicit int):
+  - **Step 0 (guard FIRST, before any slicing):** if `m <= 0` → return "nothing to
+    redo", no DB op, no bump. (Must precede the `min`/slice — `min(-1, len)` = -1
+    and `undo_stack[-(-1):]` would be a wrong non-empty slice.)
+  - `k = min(m, len(undo_stack))`. If `k == 0` (empty stack) → "nothing to redo"
+    (restart-aware message per §Restart degradation; the `rewind_count` read for
+    that branch is a DB read of the `sessions` row **inside `redo()`**, done **only
+    on the cold `k==0` path** — the warm path with a non-empty stack never reads it,
+    so it's off the hot path — so the core is the single decision site and surfaces
+    never query it), no bump, no DB op.
+  - **Pop `k` ops from the END of `undo_stack` (LIFO, top-down).** For each popped
+    op (most-recent first), `restore_ids(session_id, op.rewound_ids)` and push it to
+    `redo_stack`. The reactivation id source is **exclusively the popped slice
+    `undo_stack[-k:]`** — never a discarded op, never an `active=0` scan. (Top-down
+    pop is what makes N separate bare `/redo`s reproduce the LIFO intermediate
+    states of N stacked undos, and one `/redo k` land directly on the pre-undo set.)
+    **Fail-loud:** under the disjoint-ids + LIFO guarantees every popped op's rows
+    are all `active=0` at pop time, so `restore_ids` must return exactly
+    `len(op.rewound_ids)`; if it returns **fewer**, the disjoint-ids invariant was
+    violated — **raise** (don't silently continue). Phase 2 asserts
+    `reactivated == len(op.rewound_ids)` per popped op.
+  - **Bump `redo_count` once** (regardless of `k`) since ≥1 op reactivated.
+  - **NULL-content tail rendering (surfaces).** When the new tail is an
+    `assistant(tool_calls)` row with `content=NULL` (reachable via `/undo 2` into a
+    partial assistant group, or a redo landing there), surfaces render the
+    confirmation **without** the tail's content body — show a role/op summary
+    ("undone to assistant tool-call turn") only. **Never `str()` a `NULL` content
+    into chat** (it prints `"None"` or `KeyError`/`TypeError`s a format path).
+    Phase 4/5 assert the confirmation string for a NULL-content tail contains no
+    stringified `None`.
+  - **`redo()` return contract:** `{reactivated_count: int, new_tail_id: int|None,
+    prefill_text: None}` — **redo NEVER prefills** (it restores prior state as-is;
+    text-editor redo doesn't re-arm the composer). **`new_tail_id` = the greatest-id
+    active row after the `k` reactivations, read via
+    `get_messages(session_id, include_inactive=False)`** (the SAME tail-recompute
+    undo's step 6 uses — never `max(rewound_ids)`, which differs when an older op
+    sits below an unrelated active row); `None` only if the active list is empty
+    (impossible post-redo, typed for totality). CLI shows a brief confirmation +
+    the restored tail; TUI returns the payload in the `session.redo` JSON-RPC
+    result so the view refreshes; gateway echoes a confirmation. All three render
+    the same core return; none recompute.
+- **`on_user_message_appended(session_id)`**: **clears `redo_stack` ONLY; leaves
+  `undo_stack` untouched** (a new message after an undo must NOT discard undo
+  history — you can still undo further). Ordering is immaterial to correctness (it
+  only mutates in-memory redo state, not persistence), but call it **after** the
+  new row is persisted so a reader never sees a cleared redo stack with the new row
+  not yet committed. Every surface's user-append path MUST call this (TUI
+  especially — its JSON-RPC handlers historically persist directly).
+
+**Worked `str` prefill path (`/undo 1`, the canonical edit-and-resend):** tail
+`[…, U(str), A]`. `/undo 1` cuts group 1 = the assistant reply `{A}` (and its tool
+rows) → `rewound_ids = {A.id, …}`; the user row `U(str)` **SURVIVES** (`active=1`)
+as the new tail → `prefill_text = U(str).content`. The user edits and **resends**,
+appending a **new** user row `U(str')` after the still-active `U(str)`. Now there
+ARE two adjacent active user rows → `repair_message_sequence` Pass-2 **merges** them
+(both `str`) into one before the provider call (exactly D-3, the user's stated
+model). No double-user-row reaches the provider. *(Contrast the multimodal case:
+D-13 cuts the multimodal user row up front so it never survives to form a pair —
+because Pass-2 would NOT merge it.)*
+
+---
+
+## DB layer (`hermes_state.py`)
+
+### DB getter (the grouping input source)
+- Use **`get_messages(session_id, include_inactive=False)`** (`SELECT *`,
+  active-only, `ORDER BY id`) — it returns the row `id` column that
+  `compute_half_turn_target` needs.
+- **Index rows by key, never positionally** (`row["id"]`, `row["role"]`,
+  `row["content"]`) — insurance against `SELECT *` column-order drift.
+- **Do NOT use `get_messages_as_conversation`** for grouping — it returns the
+  provider-format projection `{role, content, tool_calls, …}` and **omits `id`**.
+- An assistant-with-tool-calls row is identified by a populated `tool_calls` JSON
+  column, with `content` possibly `NULL`.
+
+### `rewind_to_message(session_id, target_id, require_user_role=True)`
+- Add the `require_user_role` param. When `False`, skip the `role != "user"`
+  `ValueError` (half-turn callers land on assistant boundaries too).
+- Everything else unchanged (soft-delete `id >= target`, bump `rewind_count`,
+  return `rewound_count`/`target_message`/`new_head_id`) **plus a new additive
+  return key `rewound_ids: list[int]`**.
+- **`rewound_ids` is NORMATIVELY the rows this call transitioned `active=1`→`0`,
+  never rows already inactive.** The existing impl already does
+  `SELECT id … WHERE id >= target AND active = 1` then updates exactly those — so
+  if a prior stacked undo left `active=0` holes above the new (D-13-lowered)
+  target, those holes are **excluded** from `rewound_ids`. This is what makes the
+  `undo` disjoint-ids guarantee hold even though the soft-delete is an id-range:
+  the *range* may span prior holes, but the *returned id set* is only the rows
+  this op actually flipped. (Confirm in the impl: `ids` is built from the
+  `active = 1` SELECT; `rewound_ids` returns that list, not `id >= target`.)
+  Additive — existing key-reading callers unaffected.
+
+### `restore_ids(session_id, ids: list[int]) -> int` (new — the redo primitive)
+- `UPDATE messages SET active=1 WHERE id IN (...) AND active=0`, scoped to
+  `session_id`. Returns count reactivated.
+- **Idempotent:** an id already `active=1` is silently skipped. On a mixed set
+  (some `active=0`, some `active=1`) it reactivates **only** the `active=0`
+  members.
+- Does **NOT** bump `redo_count` (that's `hermes_undo.redo`'s job, one site).
+- `rewound_ids` per op is bounded by one half-turn's row count — well under
+  SQLite's variable limit; no chunking needed (but don't wire an unbounded splat).
+- Leave `restore_rewound` in place but add a deprecation docstring: "DEPRECATED
+  for stacked undo/redo — use `restore_ids`; `id >=` range clobbers stacked ops
+  of differing N."
+
+### `redo_count`
+- New additive nullable column on `sessions`. Bump with `COALESCE(redo_count,0)+1`
+  in `hermes_undo.redo` only. No live reader today (future forensic queries /
+  symmetry with `rewind_count`). Safe to drop on rollback. **Counter asymmetry
+  (document inline on the column):** `rewind_count` bumps **per `rewind_to_message`
+  call** (i.e. per half-turn op); `redo_count` bumps **once per `/redo` command
+  regardless of M**. Intentional — note it so forensic queries comparing the two
+  don't assume parity.
+
+### Back-compat caller audit (AST, not grep)
+- `rewind_to_message` gains the `rewound_ids` return key. Verify by an
+  **AST/import-based** caller audit (NOT a text grep): import the calling modules,
+  resolve the complete caller set to {def site, `cli.py::undo_last`,
+  `gateway/session.py::rewind_session`, tests} — no third consumer — and assert
+  each caller reads the return **by key** (`result["..."]`/`.get`), never
+  positional-unpacks, splats (`**result`), iterates, aliases the function, or
+  passes the dict through. (A regex over consumption patterns can miss aliasing /
+  kwargs passthrough; AST can't.)
+
+---
+
+## Stack transitions (text-editor semantics)
+
+| Action | `undo_stack` | `redo_stack` | active-id Δ | DB op |
+|--------|--------------|--------------|------------|-------|
+| `/undo N` | push `UndoOp{n, rewound_ids}` | **clear** | remove `rewound_ids` | `rewind_to_message` deactivates them |
+| `/redo M` (bare = 1) | pop `k=min(M,len)` from top (LIFO) | push each popped | add each op's `rewound_ids` back | `restore_ids(op.rewound_ids)` per op |
+| new user message | unchanged | **clear** | append new row | append |
+
+> Table caveat: the "new user message → `redo_stack` clear" is done by
+> `on_user_message_appended` **after** the row is persisted and is in-memory only —
+> it is NOT part of the DB append transaction. See the entry-point ordering note.
+
+- `/undo` clears `redo_stack` (a fresh undo establishes a new branch; pending
+  redo is stale).
+- **No-corruption guarantee:** `restore_ids` is only ever called with the
+  `rewound_ids` of an op currently on a stack. When `redo_stack` is cleared,
+  discarded ops become unreachable (the holder was their sole owner; no surface
+  retained a reference). Idempotency is belt-and-suspenders behind this, not the
+  primary guarantee.
+
+## Restart degradation
+- In-memory stacks are lost on process restart (no persistence). A cold `/redo`
+  with empty `undo_stack`:
+  - If `rewind_count > 0` (undos happened this session, stack is cold) → emit
+    **"nothing to redo (redo history doesn't survive a restart)"**. *Heuristic
+    caveat:* `rewind_count` is also bumped by the legacy whole-turn `/undo` path
+    and any other `rewind_to_message` caller, so a session that only ever used
+    legacy rewind could see this message slightly misleadingly. Acceptable (it's a
+    best-effort hint, never a correctness gate); don't gate behavior on it.
+  - Else (never undone) → bare **"nothing to redo"**.
+  - Either way: touch zero rows. **No reconstruction from `active=0` rows.** No
+    surface may read `active=0` rows to rebuild a stack.
+- **`/undo` is inherently restart-safe** (it reads DB active rows live and builds a
+  fresh op); only `redo`'s pre-restart history is lost. A post-restart
+  `/undo`→`/redo` pair works normally (the undo repopulates `undo_stack` with one
+  op, which the redo then reactivates).
+
+---
+
+## Surface wiring (thin — all call the core)
+
+- **CLI (`cli.py`):** `undo_last(n)`→`hermes_undo.undo` + D-4 prefill;
+  `redo_last(n)`→`hermes_undo.redo`; register `/redo` dispatch
+  (`elif canonical == "redo"`). User-send path calls `on_user_message_appended`.
+- **Gateway (`gateway/run.py` + `session.py`):** `rewind_session(n)`→`undo`;
+  `restore_session(m)`→`redo`; `_handle_redo_command` in `run.py`. **Evict the
+  cached agent on BOTH `/undo` AND `/redo`** — either operation changes the active
+  message set, so a cached agent holding the pre-op context would run the next turn
+  against stale history. (The spec previously named only redo; undo needs it for
+  the identical reason.) **Eviction scope:** the eviction-on-active-set-change rule
+  is scoped to **`/undo` and `/redo` ONLY** — they mutate the active set *without*
+  going through the send path. The **normal user-send path is OUT of scope** (it
+  already incorporates the appended row into the agent by its existing mechanism;
+  do NOT add an eviction there or you double-evict and may drop streaming state).
+  `on_user_message_appended` on that path **only clears the redo stack; it does NOT
+  evict.** Message-ingest path calls `on_user_message_appended`.
+- **TUI (`tui_gateway/server.py`):** `session.undo`→`undo`; add `session.redo`
+  JSON-RPC method→`redo`; busy-guard (reject with code 4009 if session busy).
+  `session.send` user-append path MUST call `on_user_message_appended`.
+- **Registry (`hermes_cli/commands.py`):** update `/undo` description to
+  half-turn; add `CommandDef("redo", …)` with `args_hint="[N]"`.
+
+---
+
+## Invariants (each self-contained)
+
+1. **No data loss.** Undo only flips rows to `active=0` (soft-delete); never hard-
+   deletes. Redo flips them back. *Why:* audit/forensic retention is an existing
+   guarantee. *Check:* rewound rows still present with `active=0`; no new
+   `DELETE FROM messages`.
+2. **Provider role-alternation preserved.** Providers reject two same-role
+   messages in a row. After undo+new-message: two consecutive *user* messages are
+   merged by `repair_message_sequence` Pass 2 — **but only when both `content`
+   values are plain `str`** (multimodal/list is left unmerged to avoid mangling
+   attachment structure). The multimodal gap is closed by D-13 (replace, not
+   append). Never two assistant in a row (a new assistant row only follows a user
+   message; undo appends nothing; redo reactivates a previously-coherent group).
+   **Redo of a partial/interrupted assistant group** (`assistant(tool_calls)+tool`,
+   no final text) reactivates the **entire** group atomically — its `rewound_ids`
+   was the whole group — so no `tool`-without-`assistant` orphan is ever exposed.
+   (Coherence *at redo time* — not just at cut time — follows from invariant 3's
+   LIFO ordering: you can only redo in the reverse order you undid, so each
+   reactivated group's neighbors are exactly what they were pre-undo.)
+3. **Redo reactivates EXACTLY the matching undo's rows; stacked undo/redo is
+   order-symmetric (LIFO).** `undo` then `redo` (no intervening message) →
+   identical active set. `undo ×3` then 3 separate `/redo` restores each prior
+   state in turn; `undo ×3` then one `/redo 3` lands on pre-undo directly. Uses
+   `restore_ids(op.rewound_ids)`, never an `id >=` range.
+4. **New user message clears the redo stack at ONE core point**
+   (`on_user_message_appended`), not per-surface.
+5. **Stack is per-session**, keyed by `session_id`, never bleeds across sessions.
+6. **Never two assistant in a row** — structurally unreachable (no feature path
+   appends an assistant row adjacent to another). *Check (distinct from inv. 2):*
+   the Phase 2 `test_no_feature_path_emits_adjacent_assistant` AST/grep (with
+   positive control) over `hermes_undo.py` + the three surfaces — no undo/redo/append
+   path emits an assistant row without an intervening non-assistant row.
+
+---
+
+## Build phases (each ends green before the next)
+
+1. **Core + DB:** `compute_half_turn_target`; `rewind_to_message(require_user_role)`
+   + `rewound_ids`; `restore_ids` + `redo_count`. Test grouping over **real
+   persisted rows** (insert via `add_message`, read via `get_messages`). Named
+   fixtures: (a) `assistant(tool_calls)+tool+tool+assistant(text)`; (b) partial
+   assistant half-turn; (c) **adjacent multimodal+text active user pair** (the
+   grouping invariant's hardest case — assert `/undo 1` & `/undo 2` over
+   `…A,U(mm),U(text)` prove the pair is ONE half-turn); (d) **an active `system`
+   row present** (assert `party(system)="other"`, no `KeyError`, never targeted;
+   `/undo 4` over `[system,U,A,U]` clamps to earliest `U` at id=2, never the id=1
+   system row; **AND (d2) a separate `[system]`-only (or empty) fixture asserts the
+   zero-non-`other` branch: `compute_half_turn_target` returns `None` and `undo()`
+   short-circuits to `{rewound_ids:[], prefill_text:None}` + "nothing to undo",
+   touching neither stack** — the `[system,U,A,U]` fixture has non-`other` half-turns
+   so it does NOT exercise the `None` path; the `None` path needs its own fixture);
+   (e) **tool-row
+   monotonicity** — (i) assert no active `tool` row has an id below its preceding
+   `assistant` in normal persisted data, AND (ii) a deliberately violating
+   `tool`-before-`assistant` fixture makes the cut **raise** (not silently orphan).
+   Also (f): `rewind_to_message` `rewound_ids` returns ONLY rows it flipped `1→0`
+   (insert a pre-existing `active=0` hole above target, assert it's excluded — the
+   disjoint-ids guarantee's primitive-level proof).
+2. **Redo wiring + shared stack:** the three entry points + `UndoRedoState` +
+   `UndoOp`; `redo_count` one-site bump. Test the transition table (stack contents
+   AND active-id set per step) + identity round-trips + structural sole-ownership +
+   **disjoint `rewound_ids` across stacked ops** + the redo `m≤0`/`k`-clamp/LIFO-
+   pop-order cases + **`restore_ids` `IN(...)` is parameterized/bounded** (AST check
+   with a planted positive control, per the test convention). **D-13 FIRING test
+   (pass-10 BLOCKER + pass-11 round-trip):** active tail `[…,A1,U(mm),A2]`, `/undo 1`
+   → assert `t` is lowered from `A2.id` to `U(mm).id`, **`rewound_ids == {U(mm).id,
+   A2.id}` (the complete two-element set, not just `U(mm)`)**, new tail = `A1`,
+   `prefill_text=None`. **Then the round-trip leg:** `/redo` → active set IDENTICAL
+   to pre-undo (`U(mm)` and `A2` both `active=1` again, `A2` is the tail) — this
+   proves D-13 restores correctly, not just cuts correctly. A plain-`str` control at
+   the same position does NOT lower `t`. If no firing fixture can be built, delete
+   the D-13 branch instead of shipping it untested.
+3. **CLI surface** + D-4 prefill (N=1/2/3 — **assert `prefill_text` equals the
+   EXACT content of the surviving new-tail user row**, not merely "a prefill
+   occurred": N=1 on `[…,U(str),A]` → `prefill_text == U(str).content`; N=2 lands on
+   an assistant tail → `prefill_text is None`; N=3 → the next surviving user row's
+   content) + the `str` prefill→edit→resend two-user-rows-merged path + clear-redo-
+   on-send.
+4. **Gateway surface** + agent-cache eviction **on undo AND redo** + cold-restart
+   test (drop holder → redo → restart message + zero rows; **assert BOTH branches**
+   — `rewind_count>0` emits the "doesn't survive a restart" hint, `==0` emits bare
+   "nothing to redo") + **eviction-is-load-bearing negative test, run BOTH after
+   `/redo` AND after `/undo`** (concrete: after the op, run one turn and assert the
+   agent's provider payload == post-op `get_messages_as_conversation`, i.e. the
+   restored/cut set; with eviction removed it carries the stale pre-op set —
+   the undo-side assertion is required because eviction was widened to undo).
+5. **TUI surface** + `session.redo` + busy-guard + clear-redo-on-send.
+6. **Registry/help/i18n/docs** + parse-layer parity (`/undo 2`→N=2 every surface;
+   `/redo` reaches its handler) + degenerate args (`/redo 0`, `/redo -1`, bogus).
+7. **Cross-surface helper parity** — feed the **persisted-and-read-back** B-1
+   fixture through all three undo entry points; assert identical active-id sets +
+   same getter used. **Plus `on_user_message_appended` call-site enforcement (AST):
+   resolve each of the three surfaces' user-append sites and assert each invokes
+   `on_user_message_appended`** (the "ONE core point, every surface calls it"
+   invariant-4 must carry a failing test — catches a future surface that persists a
+   user row without clearing the redo stack; TUI is the named risk).
+8. **Full-suite regression** — baseline-delta gate: capture pre-PR pass/skip
+   counts; assert pass ≥ baseline, **0 new failures, 0 newly-skipped** (any
+   intentional new skip must be allow-listed in the baseline-delta config with a
+   one-line reason, so the gate doesn't block a legitimate provider-gated skip).
+
+**Test convention:** every structural/grep assertion ("no path does X") must
+carry a **positive control** (a planted line the pattern is asserted to match) or
+be an AST/import-based check — a grep with a too-narrow pattern passes vacuously.
+Use case/whitespace-insensitive regexes (`active\s*=\s*0`, `active\s+IS\s+0`).
+
+**Acceptance:** every test exercises the REAL changed path on REAL rows. A test
+that can't fail on the bug it names is not evidence.

--- a/docs/specs/undo-redo-half-turn-PRD.md
+++ b/docs/specs/undo-redo-half-turn-PRD.md
@@ -1,0 +1,309 @@
+# PRD — Half-Turn `/undo` + `/redo` Stack
+
+**Status:** v1.7 (Pass 7 = BLOCK → fixed: B-1 artifact-mismatch resolved by bringing IMPLEMENTER-SPEC.md UNDER review (pass 8 reviews the spec directly, the real build target — reviewer's recommended option a; the two new rules are mirrored into it); RC-1 general grouping invariant for non-alternating/adjacent-same-role input stated in §5.1 + Phase 1 adjacent-multimodal-user-pair fixture; RC-2 caller audit committed to AST/import form, grep fallback deleted; N-1/N-2/N-3 acknowledged. Core model converged for 4 passes; remaining work was at document seams.)
+**Implementer spec (build from this; now itself reviewed):** `undo-redo-half-turn-IMPLEMENTER-SPEC.md` — self-contained, no review provenance. THIS doc is the review record; the two are semantically equivalent (pass-8 reviews the spec).
+**Author:** Apollo
+**Date:** 2026-06-14
+**Repo:** `Kyzcreig/hermes-agent` (fork) → PR to `NousResearch/hermes-agent`
+**Surfaces:** CLI (`cli.py`), Gateway (`gateway/run.py` + `gateway/session.py`), TUI (`tui_gateway/server.py`)
+
+---
+
+## 1. Summary & Goal
+
+`/undo` today operates on **whole back-and-forth turns** (1 user message + its assistant reply + tool calls). This is too coarse: a user who wants to **revise their own last message** cannot do so without also discarding a good assistant reply. `/undo 1` rewinds to the user's last message (fine); but if the user instead wants to keep their last message's *reply* and only adjust something earlier, or wants finer stepping, the turn unit gets in the way. There is also **no way to reverse an `/undo`** — the `restore_rewound()` DB primitive exists but is wired to nothing.
+
+**Goal:** Two changes, across all three surfaces:
+
+1. **Make `/undo N` operate on half-turns.** A *half-turn* = one party's run of consecutive messages. The user's message(s) = 1 half-turn; the assistant's reply (including its tool calls + tool results) = 1 half-turn. `/undo 1` lands on the user's last message (edit & resend); `/undo 2` lands on the assistant's penultimate message with the turn handed back to the user; and so on — granular, alternating stepping.
+2. **Add `/redo [N]`.** `/redo` (bare) reverses exactly the **last `/undo` operation** (whatever N it carried). `/redo N` pops **N undo operations** off a per-session stack, text-editor style. Typing any new message **clears the redo stack**.
+
+**Why now:** User hit the wall directly — wanted to edit a message without nuking a good reply, and discovered there's no `/redo`. The redo DB primitive already exists (`SessionDB.restore_rewound()`, docstring: *"Intended for undo-of-rewind … not wired to a slash command in v1"*), so this is largely wiring + stack state, not new persistence plumbing.
+
+---
+
+## 2. Non-Goals
+
+- **No change to `/rollback`** (filesystem checkpoints) or `/branch` (session forking).
+- **No change to soft-delete audit semantics.** Rewound rows stay `active=0` in `state.db` for audit; redo flips them back to `active=1`. Nothing is hard-deleted by undo/redo.
+- **No cross-session undo/redo.** The undo/redo stack is per-session.
+- **No persistence of the in-memory redo stack across a process restart as a hard guarantee.** Restart degrades gracefully (see §5.3) — it does not corrupt, but a cold redo stack may be empty or DB-reconstructed best-effort.
+- **No new UI affordance** beyond the existing prefill/echo behavior (no buttons, no visual stack browser).
+- **No change to `/retry` or `/compress`** semantics.
+
+---
+
+## 3. Constitution / Invariants
+
+- **Invariant — No data loss on undo.** Undo only ever flips rows to `active=0` (soft-delete); it never hard-deletes. Redo flips them back.
+  - *Why:* audit/forensic retention is an existing guarantee (`rewind_to_message` docstring); we must not weaken it.
+  - *Closeout proof:* `pytest` test asserting rewound rows are still present with `active=0` after undo, and `get_messages(include_inactive=True)` returns them; grep confirms no `DELETE FROM messages` introduced.
+
+- **Invariant — Provider role-alternation preserved; the merge-gap on multimodal user content is closed at the undo layer (pass-5 RC-1).** After any undo + new user message (which can produce two consecutive user messages), the live history sent to the provider must satisfy strict alternation.
+  - *Why & the real contract:* OpenAI/Anthropic/OpenRouter reject two same-role messages in a row. We rely on `repair_message_sequence` (`agent/agent_runtime_helpers.py`) Pass 2, whose **actual, code-verified contract** is asymmetric AND **conditional on content type**: it merges two consecutive *user* messages **only when BOTH `content` values are plain `str`** (`isinstance(prev_content, str) and isinstance(new_content, str)`, joined `\n\n`); **if either is list/multimodal content it is left UNMERGED** (the code comment: "collapsing image/audio blocks risks mangling the attachment structure"), and there is **no assistant-merge pass**. (Cited by *symbol + behavior*, not a line number — line numbers rot; the characterization test pins the behavior.)
+  - *The conflict this surfaces (RC-1):* for a plain-text trailing user message the append+merge model (D-3) keeps alternation. But if the trailing user message landed on by undo carries **multimodal/list content**, an appended new user message is **NOT merged** → two user rows reach the provider → alternation violation. The pinned contract and "never two user-in-a-row reach the provider" otherwise disagree.
+  - *Resolution (D-13):* the undo layer detects this. **When `/undo` lands on (prefills) a user message whose `content` is non-`str` (multimodal/list), the prefill path uses REPLACE semantics — it deactivates that trailing user row as part of the rewind (target = that user row, inclusive)** so the resend is the *sole* user row, never an unmergeable pair. Plain-`str` trailing user messages keep the user's append+merge model (D-3) unchanged. This closes the gap **without touching `repair_message_sequence`** (which deliberately won't merge attachments).
+  - *Closeout proof:* (1) characterization test (pass-4 RC-A) pinning the real function: (a) two plain-text user msgs → merged with `\n\n`; (b) two user msgs, one multimodal/list → **NOT merged**; (c) two assistant msgs → intact. (2) **`test_multimodal_undo_no_adjacent_user` (pass-5 RC-1):** undo landing on a multimodal user message + a new user message yields, in the provider-bound payload, **no two adjacent user rows** (proving the D-13 replace-fallback fired). (3) the plain-text undo→type→repair end-to-end test asserting the merged result.
+
+- **Invariant — Redo reactivates EXACTLY the matching undo's rows; stacked undo/redo is order-symmetric.** `undo` then `redo` (no intervening message) returns the **identical active message set** (same row ids). For *stacked* ops, **single redos invert single undos in LIFO order**: starting from a base state, `/undo` ×3 then **three separate `/redo`** (each bare = `/redo 1`) restores, after each redo, the active-id set to the post-`undo×2`, post-`undo×1`, and pre-`undo` states respectively. Equivalently, `/undo ×3` then a single `/redo 3` lands directly on the pre-`undo` state (no observable intermediates — one command pops three ops).
+  - *Why:* the whole feature's correctness claim. Redo uses `restore_ids(op.rewound_ids)`, never an `id >=` range, so stacked ops of different N don't reactivate rows they don't own (B-2). The trace is stated as one unambiguous sequence to avoid the pass-2 contradiction (you cannot assert per-step intermediates *and* call it a single `redo×3`).
+  - *Closeout proof:* `test_undo_redo_multi_op_identity` runs **`undo` ×3 with different N then three separate bare `/redo` calls**, asserting after each `/redo` the active-id set equals the corresponding historical snapshot (post-`undo×2`, post-`undo×1`, pre-`undo`), final = original. A separate `test_redo_n_single_command` runs `undo×3` then one `/redo 3` and asserts only the final pre-`undo` set.
+
+- **Invariant — New user message clears the redo stack, at ONE core enforcement point.** Once the user diverges, the orphaned branch is unredoable, and the clear happens in the shared core user-append path — not per-surface (RC-2).
+  - *Why:* prevents redo resurrecting a branch that no longer follows the current user message; one call site removes three-surface drift risk (R6).
+  - *Closeout proof:* test does `/undo`, sends a new message, attempts `/redo`, asserts "nothing to redo" and diverged rows stay `active=0`; plus a grep asserting the clear-redo call lives in core, not in each surface's send path.
+
+- **Invariant — Stack is per-session, never bleeds across sessions.** Undo/redo stack keyed by `session_id`.
+  - *Closeout proof:* test with two sessions; undo in A; assert `/redo` in B is a no-op against B's own (empty) stack.
+
+- **Invariant — Never two assistant messages in a row, by absence-of-production (not by a constructed-hazard test).** The half-turn model can leave two *user* messages in a row (merged by `repair_message_sequence` Pass 2); no feature operation ever appends an assistant message adjacent to another assistant message.
+  - *Why:* a new assistant row only appears from a fresh model reply (which follows a user message); undo appends nothing; redo reactivates a previously-coherent contiguous group (proven by the §5.1 group-start rule). So the hazard is **structurally unreachable** — and a "construct the hazard, watch it be prevented" test would be theater, since no real code path can build the hazard (pass-3 B-2′).
+  - *Closeout proof (two honest artifacts, not a strawman):* (1) `test_no_feature_path_emits_adjacent_assistant` — a grep/structural assertion that no undo/redo/append path in `hermes_undo.py` or the three surfaces emits an assistant row without an intervening user row; and (2) `test_repair_does_not_silently_merge_assistants` — feed `repair_message_sequence` a hand-built assistant-after-assistant input and assert it does **not** silently coalesce them into one (proving repair has no assistant-merge pass papering over the hazard; if such input ever arose it would surface, not hide). No `test_two_assistant_hazard_prevented`.
+
+- **Invariant — Contract back-compat for `N`.** `/undo` bare still means "one step." (The *meaning* of a step changes from turn→half-turn — a documented, intentional behavior change, see §4 D-2.)
+  - *Closeout proof:* `/undo` with no arg backs up exactly one half-turn.
+
+---
+
+## 4. Resolved Decisions
+
+- **D-1 — Undo unit is the half-turn.** A half-turn = one party's run of consecutive messages. User message(s) = 1 half-turn; assistant reply + its tool calls + tool results = 1 half-turn. `/undo N` backs up N half-turns, alternating. (User confirmed via `/undo 1`→user's last msg, `/undo 2`→assistant's penultimate msg, user's turn to reply.)
+
+- **D-2 — `N` now counts half-turns, not full turns (intentional behavior change).** Documented in CLI help, gateway help, TUI, and the slash-command registry description. This changes existing `/undo N` behavior; called out explicitly, not smuggled.
+
+- **D-3 — Two consecutive user messages after undo+type are allowed.** Rely on existing `repair_message_sequence` Pass 2 (merges consecutive user messages). Never two assistant in a row. (User confirmed: "if we land on a user message we just add the next user message to that user message, so it's two user messages in a row… never two assistant messages in a row.") **Scope (pass-5 RC-1): this merge fires ONLY for plain-`str` user content; the multimodal exception is handled by D-13.**
+
+- **D-13 — Multimodal trailing-user-message prefill uses REPLACE, not append (pass-5 RC-1; location & composition pinned pass-6 B-1′).** `repair_message_sequence` merges consecutive user messages **only when both contents are plain `str`**; multimodal/list content is left unmerged (would otherwise produce two adjacent user rows → provider alternation error). Closing this **does NOT change `compute_half_turn_target`** (which stays strictly role-only / N-agnostic, §5.1). Instead:
+  - **Where it executes:** inside the core `hermes_undo.undo(session_id, n)` helper, as a **post-computation target adjustment** — *after* `compute_half_turn_target` returns the role-based target id `t`, the helper inspects **the message now at the new active tail** (the row immediately preceding `t`, i.e. the same row D-4 reads for the prefill decision). This is the single point that reads `content` type; the boundary primitive never does.
+  - **The rule (composes with arbitrary N):** if that trailing row is a **USER row** (so D-4 would prefill) AND its `content` is **non-`str`** (list/multimodal), the helper **lowers the rewind target to that user row's id** (target becomes that user row, inclusive) before performing the soft-delete, so that row is included in `rewound_ids` and deactivated. If the trailing row is an assistant row (no prefill, D-4) or a plain-`str` user row, the target is unchanged. **This is purely a function of the new tail's trailing row — independent of N**: N picks the boundary, then this one check looks at exactly one row. (N=2 landing the tail on an assistant row → no adjustment, because the trailing row is assistant; only a multimodal *user* trailing row triggers REPLACE.)
+  - **Consequence for prefill (D-4):** because the multimodal user row is now deactivated, the new tail ends on the *prior assistant row* → D-4 yields **no prefill** (you cannot edit image/audio blocks as composer text anyway). So undo onto a multimodal user message lands **armed-empty** (intentional, see N-1). Plain-`str` user rows keep append+merge (D-3) and prefill (D-4) unchanged.
+  - (Apollo's judgment closing the RC-1 contract/invariant conflict; no change to `repair_message_sequence` or `compute_half_turn_target`.)
+
+- **D-4 — Prefill rule, N-agnostic (pass-4 RC-B): prefill iff the new active tail's last message is a USER message.** After `/undo N` removes N half-turns, look at the message now at the end of the active list (the one immediately preceding the rewind target). **If it is a USER message → prefill the composer with its text** (edit-and-resend); **if it is an ASSISTANT message → do not prefill** (the session is armed for the user to type their reply / `/retry`). This single rule holds for every N — the implementation reads that one row's role; **it never computes N-parity**. Traced on tail `…U(5),A(6),U(7),A(8)`:
+  - `/undo 1` removes `{A(8)}` → new tail ends **U(7)** → **prefill** (matches D-1 "lands on the user's last message, edit & resend").
+  - `/undo 2` removes `{A(8),U(7)}` → new tail ends **A(6)** → **no prefill** (matches D-1 "lands on the assistant's penultimate message, your turn to reply").
+  - `/undo 3` removes `{A(8),U(7),A(6)}` → new tail ends **U(5)** → **prefill**.
+  - Edge: if undo clears to an empty active list (removed everything), there is no preceding message → no prefill.
+
+- **D-5 — Redo is a stack of operations, not half-turns.** Each `/undo` pushes one operation (carrying its N and the set of row ids it deactivated). `/redo` (bare) pops and reverses the **single most-recent** undo operation (whatever N it had). `/redo N` pops and reverses N operations. (User confirmed: "by default it undoes exactly the last undo command… but if you do /redo # it would undo multiple /undo # commands, just like a stack.")
+
+- **D-6 — Typing a new message clears the redo stack.** (User confirmed.)
+
+- **D-7 — Stack state lives in-memory per session, in a SHARED session-state object the core can reach; no cold-restart reconstruction.** (Apollo's judgment, user delegated; tightened after review B-3/RC-2.) The undo/redo stacks live on a shared per-session state object (not duplicated in each surface's own send path). Each `UndoOp` records `{n, rewound_ids: [int]}` — the **explicit list of row ids that op deactivated** (not a range, not just a count). On a process restart the in-memory stacks are lost; a cold `/redo` with an empty stack reports **"nothing to redo"** and touches nothing. **There is NO contiguous-block / `redo_marker` reconstruction heuristic** — it was cut because reactivating "the most-recent contiguous `active=0` block" cannot prove the rows belong to a single undo op and so violates the no-corruption invariant. Cold redo = empty redo. (Resolves review B-3, Q-2.)
+
+- **D-7a — The undo/redo stack transition table is fixed HERE, not deferred to writing-plans (resolves review B-1).** Paired stacks (`undo_stack`, `redo_stack`), text-editor semantics. The table tracks **both** stack contents **and** the resulting active-id set (review pass-2 B-1: stack-array coherence ≠ message-state coherence). Worked trace uses a concrete history whose half-turns deactivate id sets: assume `/undo 1`=op deactivating `{8}`, a second `/undo 1`=op deactivating `{7}` (each one half-turn), etc. — ids illustrative.
+
+  | Action | `undo_stack` | `redo_stack` | active-id Δ | DB op |
+  |--------|--------------|--------------|------------|-------|
+  | `/undo N` | push `UndoOp{n=N, rewound_ids}` | **clear** | remove `rewound_ids` from active | `rewind_to_message` deactivates `rewound_ids` |
+  | `/redo M` (bare = M=1) | pop M ops | push each popped op | add each op's `rewound_ids` back to active | `restore_ids(op.rewound_ids)` per op |
+  | new user message | (unchanged) | **clear** | append the new row | append message |
+
+  - `/undo` **clears `redo_stack`** (a fresh undo establishes a new branch; pending redo is stale). The three interleaving sequences traced with **exact ids** on a concrete history — 4 turns: `1=user,2=asst, 3=user,4=asst, 5=user,6=asst, 7=user,8=asst`, all bare commands (N=1) unless noted:
+    - *undo, undo, redo, undo* (start active `{1..8}`):
+      1. undo₁ → half-turn HT1 = `{8}` → **op1.rewound_ids={8}**, active `{1..7}`, `undo_stack=[op1]`, `redo_stack=[]`
+      2. undo₂ → HT1 of `{1..7}` = `{7}` → **op2.rewound_ids={7}**, active `{1..6}`, `undo_stack=[op1,op2]`, `redo_stack=[]`
+      3. redo → pop op2, `restore_ids({7})` → active `{1..7}`, `undo_stack=[op1]`, `redo_stack=[op2]`
+      4. undo₃ → recompute on active `{1..7}`; HT1 = `{7}` → **op3.rewound_ids={7}**, active `{1..6}`, `undo_stack=[op1,op3]`, **`redo_stack=[]` (cleared)**
+      **No-orphaning proven on these numbers:** the only `active=0` rows are `{7,8}`; `{8}`∈op1 (on undo_stack, redoable), `{7}`∈op3 (on undo_stack, redoable). op2 was discarded, but every id it owned (`{7}`) is now owned by op3 — **no id is `active=0` without a live owning op**. A later `/redo 2` pops op3 then op1, `restore_ids({7})` then `restore_ids({8})` → active `{1..8}`, full restore.
+    - *undo, redo, undo* (start `{1..8}`): undo₁ → op1=`{8}`, active`{1..7}`; redo → `restore_ids({8})`, active`{1..8}`, `undo_stack=[]`,`redo_stack=[op1]`; undo₂ → op2=`{8}`, active`{1..7}`, `undo_stack=[op2]`, `redo_stack=[]` (cleared). All `active=0` (`{8}`)∈op2. No orphan.
+    - *undo×3, redo 2, undo* (start `{1..8}`): undo₁=`{8}`, undo₂=`{7}`, undo₃=`{6}` → `undo_stack=[op1,op2,op3]`, active`{1..5}`; `/redo 2` pops op3 then op2, `restore_ids({6})` then `restore_ids({7})` → active`{1..7}`, `redo_stack=[op3,op2]`, `undo_stack=[op1]`; final undo → HT1 of `{1..7}`=`{7}` → op4=`{7}`, active`{1..6}`, `undo_stack=[op1,op4]`, `redo_stack=[]` (cleared). `active=0`=`{7,8}`; `{8}`∈op1, `{7}`∈op4. No orphan.
+  - `/redo` (bare) = `/redo 1`. `/redo M` clamps to `len(undo_stack)`. `/redo` with empty `undo_stack` → "nothing to redo," no DB op, **no `redo_count` bump**.
+  - **Stale-op unreachability (the real no-corruption invariant, pass-3 RC-3′):** the defense against resurrecting a wrongly-killed row is **not** `restore_ids` idempotency — it's that **`restore_ids` is only ever called with the `rewound_ids` of an op currently on a stack**. When `redo_stack` is cleared (on `/undo` or new message), discarded ops become **unreachable** — no code path retains a reference to call `restore_ids` with their ids. Idempotency (D-11a) is belt-and-suspenders only.
+  - **Idempotency rule (D-11a):** `restore_ids` no-ops on any id already `active=1` (never a phantom reactivation). Note this does NOT by itself prevent reactivating a row legitimately `active=0` (killed by a later op) — that's guaranteed by stale-op unreachability above, which idempotency backs up but does not replace.
+
+- **D-8 — `rewind_to_message` is generalized to accept any message id (not just `user` role) AND to return its rewound id list.** Half-turn stepping requires landing on assistant-message boundaries too. Add a parameter (`require_user_role: bool = True`) so existing callers keep the guard; half-turn callers pass `False`. **Also surface `rewound_ids: [int]`** in the return dict (the function already computes this list internally as `ids`) so redo can reactivate the exact set. Return-shape change is additive (new key), not a positional change — existing callers that read `rewound_count`/`target_message`/`new_head_id` are unaffected (see RC-4 caller audit, §5.2).
+
+- **D-11 — Redo reactivates by EXPLICIT id set, never by `id >=` range (resolves review B-2).** `restore_rewound(session_id, since_id)` reactivates all `id >= since_id`, which under stacked undos of different N can reactivate rows a given op never owned (and clobber a later op's deactivation). A new DB primitive `restore_ids(session_id, ids: [int])` reactivates **exactly** the passed ids. Redo always passes `op.rewound_ids`. `restore_rewound` is left intact (unused by this feature; not removed — out of scope).
+
+- **D-12 — Observability: add a symmetric `redo_count` bump (resolves review N-1).** `restore_ids` increments `sessions.redo_count` (additive nullable column) the way `rewind_to_message` bumps `rewind_count`. Makes the deactivate/reactivate cycle auditable. Cheap; avoids a follow-up PR.
+
+- **D-9 — Ship all three surfaces in one PRD.** (User confirmed "all three surfaces.") Shared core logic lives in `hermes_state.py` (DB ops) + a small surface-agnostic helper for half-turn boundary computation, so each surface is thin wiring.
+
+- **D-10 — Implement directly (no swarm).** (User confirmed.) Apollo implements after review passes.
+
+---
+
+## 5. Architecture / Design
+
+### 5.1 Core: half-turn boundary computation
+
+A new pure helper, **`compute_half_turn_target`, placed in a new shared module `hermes_undo.py`** (not `hermes_state.py` — boundary logic is not DB logic; this co-locates with the `UndoRedoState` holder and the clear-redo hook per pass-2 N-3). Given the active message list and a half-turn count `N`, it computes the **target message id** to rewind to:
+
+```
+def compute_half_turn_target(active_messages, n):
+    # active_messages: ordered list of {id, role, ...} (user/assistant/tool), active=1 only
+    # Walk backwards, grouping consecutive same-"party" messages into half-turns.
+    #   party(user) = "user"; party(assistant|tool) = "assistant"
+    #   (tool messages belong to the assistant half-turn that spawned them)
+    # Count N half-turn group-starts from the end; return the id of the FIRST
+    # message of the Nth group — which for an assistant half-turn is the
+    # assistant(tool_calls) row, NEVER a mid-group tool row. That id (inclusive)
+    # is the rewind target.
+```
+
+Key rules:
+- **General grouping invariant (pass-7 RC-1, makes the rule explicit for irregular input):** **any maximal run of consecutive same-`party()` rows = exactly ONE half-turn, regardless of how the run arose** — normal alternation, a `repair_message_sequence` user-merge, a multimodal user pair left *un*-merged (D-13's carve-out can leave two adjacent user rows in the active list), or an interrupted/partial assistant turn. The walk is purely "scan backward; a `party()` change starts a new half-turn." So a tail `…A, U(multimodal), U(text)` is **one** user half-turn (both user rows), and `/undo 1` over it lands on the earliest of that run; `/undo 2` lands on the preceding assistant group-start. This is pinned because D-13 *increases* the chance of an adjacent same-role user pair in the grouping input — the rule must not silently treat that pair as two half-turns.
+- Tool messages (`role="tool"`) and assistant messages coalesce into **one assistant half-turn**. The **group-start is always the earliest message of the run** — for an assistant half-turn that is the `assistant` row bearing the `tool_calls` (or the lone assistant text row), never the trailing `tool` rows.
+- **Partial assistant half-turn** (assistant `tool_calls` present, the final assistant text row absent — e.g. an interrupted turn): the group still starts at the `assistant(tool_calls)` row, so the cut deactivates the *whole* group (`assistant(tool_calls)` + its `tool` rows) atomically.
+- Consecutive user messages (already-merged or not, including a multimodal+text adjacent pair) coalesce into **one user half-turn** (per the general invariant above).
+- `N` clamps to the oldest half-turn if it exceeds the count.
+- The target id is **inclusive** (that message and everything after it gets deactivated).
+- **Why this matters for redo (pass-2 B-3):** because the `rewind_to_message` cut is `id >= target` and the target is always a *group start*, a single undo can never split a tool group on the deactivate side. The real hazard is on **redo**: `restore_ids(op.rewound_ids)` must reactivate the *complete* group the matching undo removed. Since `op.rewound_ids` is exactly the contiguous set the cut removed (group-start through end), redo restores the whole group — proven by the Phase 1 fixture that asserts (a) the computed target for the partial-half-turn case **is** the `assistant(tool_calls)` row, and (b) the undo→redo round-trip on that fixture reactivates the complete group with no `assistant(tool_calls)` left without its `tool` result.
+
+- **Input source — the grouping input MUST carry row `id` (pass-5 B-1).** `compute_half_turn_target` returns a **row id**, so its input list must include each row's `id`. The id-bearing getter is **`SessionDB.get_messages(session_id, include_inactive=False)`** (`SELECT *`, active-only, `ORDER BY id`) — verified to return the `id` column. Note **`get_messages_as_conversation` does NOT include `id`** (it returns the provider-format `{role, content, tool_calls, …}` projection only); it is the wrong input for boundary computation. All three surfaces therefore feed `compute_half_turn_target` from `get_messages` (active-only), and the Phase 7/N-B same-getter parity assertion pins **`get_messages(active-only)`** as that shared getter (not `get_messages_as_conversation`). `party()` reads `role`, and an assistant-with-tool-calls row is identified by a populated `tool_calls` field (JSON column) with `content` possibly `NULL` — the Phase 1 real-row test exercises exactly this persisted shape.
+
+### 5.2 DB layer (`hermes_state.py`)
+
+- **Generalize `rewind_to_message`** (D-8): add `require_user_role: bool = True`. When `False`, skip the `role != "user"` `ValueError`. Everything else (soft-delete `id >= target`, bump `rewind_count`, return `rewound_count`/`target_message`/`new_head_id`) unchanged, **plus a new additive return key `rewound_ids: [int]`** (the `ids` list it already computes). Additive — existing callers unaffected.
+- **New `restore_ids(session_id, ids: [int]) -> int`** (D-11): reactivates ids that are **currently `active=0`** (`UPDATE messages SET active=1 WHERE id IN (...) AND active=0`, scoped to `session_id`), returns count reactivated. **Idempotent (D-11a):** an id already `active=1` is silently skipped — belt-and-suspenders behind the real guarantee (stale-op unreachability, D-7a). This is the redo primitive — **not** `restore_rewound`'s `id >=` range (B-2). `restore_rewound` is left in place but **gets a deprecation docstring** (pass-3 N-2′): "DEPRECATED for stacked undo/redo — use `restore_ids`; `id >=` range clobbers stacked ops of differing N." `restore_ids` does **not** bump `redo_count` (that's the core redo helper's job, below).
+- **RC-4 caller audit (back-compat, AST/import-based per pass-7 RC-2 — NOT a text grep):** Phase 1 imports the modules that call `rewind_to_message` and asserts, via AST/reference resolution, that the complete caller set is exactly: the `def` site, `cli.py::undo_last`, `gateway/session.py::rewind_session`, and tests — **no third consumer** — AND that each caller **reads the return by key** (`result["..."]`/`result.get("...")`), never positionally-unpacks, splats (`**result`), iterates, aliases the function (`x = rewind_to_message; x(...)`), or passes the dict through. The AST form is required here because the failure mode (a new third caller positionally-unpacking the now-larger return) is exactly what a hand-guessed regex over consumption patterns can miss. Adding `rewound_ids` is therefore proven safe by reference resolution, not by spelling.
+- **`redo_count` (D-12, ONE core site per pass-3 RC-4′):** the bump lives in the **shared core redo helper** (`hermes_undo.redo(...)` — the function that pops ops off `undo_stack` and calls `restore_ids`), **not** duplicated across the three command sites. Symmetric with the one-site clear-redo (RC-2). Counts **successful user `/redo` commands** (≥1 op reactivated), once per command regardless of M; empty-stack `/redo` does not bump. Additive nullable column on `sessions`; safe to drop on rollback.
+
+### 5.3 Stack state & restart degradation (D-7, D-7a)
+
+- **Shared session-state object holds `undo_stack` and `redo_stack`** (RC-2). It is **not** duplicated in each surface's send path. Concretely: a small `UndoRedoState` holder keyed by `session_id`, reachable from the core, so the clear-redo-on-new-message hook has **one enforcement point** (see below). Each surface's undo/redo command reads/writes this shared holder rather than its own list.
+- **Core entry points (named, pass-3 RC-2′):** the shared module `hermes_undo.py` exposes the **only** functions that mutate stacks/state, so every surface calls one named contract rather than improvising:
+  - `hermes_undo.undo(session_id, n)` — compute target, deactivate, push op, clear redo_stack.
+  - `hermes_undo.redo(session_id, m)` — pop ≤m ops, `restore_ids` each, push to redo_stack, **bump `redo_count` once** if ≥1 op reactivated.
+  - `hermes_undo.on_user_message_appended(session_id)` — **clears `redo_stack`** (D-6). **Every surface's user-append path MUST call this**, named individually below — TUI especially, since its JSON-RPC handlers historically persist directly.
+- **Transitions** follow the D-7a table exactly (via the entry points above).
+- **Restart degradation (D-7):** in-memory stacks are lost on process restart. A cold `/redo` with empty `undo_stack` reports **"nothing to redo"** and touches nothing. **No `redo_marker`, no contiguous-block reconstruction** (cut per B-3). Fail-closed to empty.
+- **Restart is a TESTED degradation, not just a claim (pass-5 B-2).** Two guarantees get explicit, *falsifiable* coverage in Phase 4 (the gateway is the surface with a real persistent process):
+  - **(a) Cold redo touches zero rows.** Drive a real sequence — instantiate state, `/undo` (rows go `active=0`), **drop/replace the in-memory `UndoRedoState` holder to simulate the restart**, then `/redo` — and assert (i) the **restart-specific** N-1′ message fires (`rewind_count>0` but cold stack → "redo history doesn't survive a restart"), distinct from the bare "nothing to redo" of a never-undone session, and (ii) `get_messages(include_inactive=True)` is **byte-for-byte unchanged** (zero rows reactivated). Without this, the committed N-1′ conditional is unfalsifiable.
+  - **(b) No surface reconstructs a stack from orphaned `active=0` rows.** A structural assertion (grep, like the clear-redo one): no undo/redo path in `hermes_undo.py` or the three surfaces reads `active=0` rows (`include_inactive=True` / `restore_rewound` / any `active = 0` SELECT) to re-derive a redo stack. This turns "fail-closed to empty" from a claim into an enforced guarantee — the heuristic was *cut* (D-7), and this proves no surface silently re-added one.
+
+### 5.4 Surface wiring (thin)
+
+All three surfaces call the **same** `hermes_undo.{undo,redo,on_user_message_appended}` (§5.3) — which internally use `compute_half_turn_target`, `rewind_to_message(require_user_role=False)`, and `restore_ids`. Per-surface work is only command plumbing + **wiring the user-append path to `on_user_message_appended`**:
+
+- **CLI (`cli.py`):** `undo_last(n)`→`hermes_undo.undo` + conditional prefill (D-4); `redo_last(n)`→`hermes_undo.redo`; register `/redo` dispatch (`elif canonical == "redo"`). **CLI user-send path calls `on_user_message_appended`.**
+- **Gateway (`gateway/run.py` + `session.py`):** `rewind_session(n)`→`hermes_undo.undo`; `restore_session(m)`→`hermes_undo.redo`; `_handle_redo_command` in `run.py`; evict cached agent on redo. **Gateway message-ingest path calls `on_user_message_appended`.**
+- **TUI (`tui_gateway/server.py`):** `session.undo`→`hermes_undo.undo`; add `session.redo` JSON-RPC method→`hermes_undo.redo`; busy-guard (`session busy — /interrupt before /redo`, code 4009). **TUI `session.send` user-append path MUST call `on_user_message_appended`** (the surface most likely to bypass — explicitly wired and behaviorally tested in Phase 5).
+- **Registry (`hermes_cli/commands.py`):** update `/undo` description to half-turn; add `CommandDef("redo", …)` with `args_hint="[N]"`.
+
+---
+
+## 6. Implementation Phases
+
+> **Structural-grep convention (pass-6 RC-1) — applies to EVERY grep/structural assertion in this section.** Six structural checks do load-bearing verification work (caller enumeration §5.2 RC-4 + its four caller-pattern greps; clear-redo-in-core §5.3; `test_no_active0_reconstruction` §5.3(b); `test_no_feature_path_emits_adjacent_assistant` Phase 2). A "no path does X" grep passes **vacuously** if its pattern doesn't match how the real code spells X. So each such test MUST either: (a) carry a **positive control** — a planted fixture string that the same pattern is asserted to MATCH (proving the pattern isn't dead) before asserting it finds zero hits in the real tree; OR (b) be implemented as an **AST/import-based** check instead of text grep where feasible (e.g. caller enumeration = import the module and assert the call sites; `active=0`-reconstruction = assert no undo/redo function calls `get_messages(include_inactive=True)` / `restore_rewound` by reference, not by spelling). The exact regex (case- and whitespace-insensitive: `active\s*=\s*0`, `active\s+IS\s+0`, etc.) must be named in the test. A grep without a passing positive control is not acceptance evidence.
+
+### Phase 1 — Core half-turn computation + DB generalization
+What ships: `compute_half_turn_target()` in new `hermes_undo.py`; `rewind_to_message(require_user_role=False)` returning `rewound_ids`; idempotent `restore_ids()` + `redo_count` column.
+- *Unit/script check:* table-driven test of `compute_half_turn_target` over crafted message lists — user-only, user+assistant, **`assistant(tool_calls)+tool+tool+assistant(text)`**, **partial assistant half-turn (`assistant(tool_calls)+tool`, no final assistant text)**, multiple consecutive user msgs, **an adjacent multimodal+text user pair left un-merged (pass-7 RC-1 — assert `/undo 1` and `/undo 2` over a tail `…A,U(multimodal),U(text)` land on the run's group-start and the preceding assistant group-start respectively, proving the pair is ONE half-turn)**, N clamping. Assert exact target id per case; **specifically assert the partial-half-turn target id IS the `assistant(tool_calls)` row (group start), NOT the `tool` row** (pass-2 B-3).
+- *E2E/integration check:* against a real temp `SessionDB`: **(B-1, pass-5) drive `compute_half_turn_target` over rows as actually persisted and read back** — insert the `assistant(tool_calls)+tool+tool+assistant(text)` and the partial-half-turn (`assistant(tool_calls)+tool`) fixtures via the real `add_message` path, read them back with the **id-bearing getter** (`get_messages` `SELECT *`, active-only — see §5.1 input-source note; `get_messages_as_conversation` does NOT return row `id` and so is NOT the grouping input), and assert the computed target id IS the persisted `assistant(tool_calls)` row's real id (group-start), NOT the `tool` row. This puts the highest-risk primitive under a real-row assertion, not a hand-crafted-dict one. Then `rewind_to_message(require_user_role=False)` rewinds to that group-start and returns the exact `rewound_ids`; `restore_ids(those ids)` reactivates **exactly and completely** the group (round-trip on the partial-half-turn fixture leaves no `assistant(tool_calls)` without its `tool` result, pass-2 B-3). `restore_ids` on an already-`active=1` id is a no-op (D-11a idempotency). **RC-A characterization test (pass-4):** feed the real `repair_message_sequence` (a) two adjacent plain-text user msgs → assert merged with `\n\n`; (b) two adjacent user msgs, one multimodal/list → assert NOT merged (and see RC-1 §3 Invariant 2 for the alternation consequence + its end-to-end guard); (c) two adjacent assistant msgs → assert left intact. (Real DB path = required.) **N-A:** assert `rewound_ids` per op is bounded by one half-turn's row count (well under SQLite's `SQLITE_MAX_VARIABLE_NUMBER`); the `IN (...)` splat needs no chunking at this scale — noted so a future contributor doesn't wire an unbounded splat.
+- *Negative/adversarial:* `rewind_to_message` with `require_user_role=True` (default) still raises `ValueError` on a non-user target. Empty session → no-op. **RC-4 (enumeration closed, AST-based per pass-7 RC-2):** the import/AST caller audit resolves the complete caller set to {def site, `undo_last`, `rewind_session`, tests} — no third consumer — and asserts each reads the return by key (no positional unpack / splat / alias / passthrough); return carries `rewound_count`/`target_message`/`new_head_id`/`rewound_ids`. **`restore_rewound` gains its deprecation docstring** (N-2′).
+- *Verify with:* `python -m pytest tests/test_half_turn_target.py tests/test_state_rewind_generalized.py tests/test_restore_ids.py -o 'addopts=' -q` → all pass; the AST caller audit resolves exactly the expected caller set with all key-reads.
+
+### Phase 2 — Redo wiring + shared per-session stack (core)
+What ships: `hermes_undo.{undo,redo,on_user_message_appended}` + `UndoRedoState` holder + `UndoOp{n, rewound_ids}` (all in `hermes_undo.py`); `redo_count` bump in `hermes_undo.redo` (one site).
+- *Unit/script check:* `test_stack_transition_table` drives the three D-7a interleaving sequences and asserts, **after each step, BOTH the exact `undo_stack`/`redo_stack` contents AND the exact active-id set** matching the D-7a worked traces (the concrete-id traces, pass-3 B-1′).
+- *E2E/integration check:* `test_undo_redo_multi_op_identity` against a real `SessionDB`: `undo` ×3 with different N, then **three separate bare `/redo` calls**, asserting after each the active-id set equals post-`undo×2`/post-`undo×1`/pre-`undo`; final = original. `test_redo_n_single_command`: `undo×3` then one `/redo 3` asserts only the final pre-`undo` set (pass-2 B-2). **`test_stale_op_unreachable` (pass-3 RC-3′; made structural pass-6 RC-3):** run *undo,undo,redo,undo* as the behavioral trace, then assert the **structural** invariant that actually generalizes — **the live `UndoRedoState` holder's `undo_stack`/`redo_stack` are the SOLE owners of any `UndoOp`** (no surface caches or retains an op reference outside the holder; assert via the holder being the only field that holds `UndoOp` instances), AND that `hermes_undo.redo`'s id source is **exclusively `undo_stack[-m:]`** by construction (the reactivation set is read only from the live stack, never from a discarded op or an `active=0` scan). The single trace then *exhibits* this (the discarded op2 is owned by no stack), but the **structural ownership + `undo_stack`-only-source assertions** are what prove the general no-corruption guarantee — not the un-provable "`restore_ids` is never called with discarded ids over all futures."
+- *Negative/adversarial:* empty-stack `/redo` → "nothing to redo," no rows touched, **no `redo_count` bump**; `/redo 3` bumps `redo_count` **exactly once** (proven once, in `hermes_undo.redo`, not per-surface — pass-3 RC-4′). **N-2 (pass-5) clamp:** `/redo 9` against a 2-deep stack reactivates 2 ops and **still bumps `redo_count` exactly once** (the clamped-M path). **N-1 (pass-5) partial overlap:** `restore_ids` on a mixed set (some ids `active=0`, some already `active=1`) reactivates **only** the `active=0` members and leaves the rest untouched (the realistic mid-redo state), not just the all-`active=1` no-op case (D-11a). `restore_ids` on an already-`active=1` id is a safe no-op (D-11a). Two-user-after-undo merged by `repair_message_sequence`; **`test_repair_does_not_silently_merge_assistants`** asserts repair leaves assistant-after-assistant input unmerged; **`test_no_feature_path_emits_adjacent_assistant`** greps that no undo/redo/append path emits adjacent assistant rows (pass-3 B-2′ — honest artifacts, no unreachable-hazard strawman).
+- *Verify with:* `python -m pytest tests/test_undo_redo_stack.py -o 'addopts=' -q` → pass; transition-table active-id assertions, both identity traces, stale-op-unreachability, and the two no-adjacent-assistant artifacts green.
+
+### Phase 3 — CLI surface
+What ships: half-turn `undo_last`, conditional prefill (D-4), `redo_last`, `/redo` dispatch, clear-redo-on-send.
+- *Unit/script check:* CLI undo lands on correct half-turn boundary; prefill fires per D-4 (new active tail ends on USER). Cover **N=1 (prefill), N=2 (no prefill), and N=3 (prefill)** so the AC exercises the N-agnostic rule, not just two examples (pass-4 RC-B).
+- *E2E/integration check:* drive a real CLI session object: send 2 turns, `/undo 1` (lands on user msg, prefill set), `/undo 1` again (lands on assistant msg, no prefill), `/redo` twice → original history restored. Assert via active message list. **RC-2 (per-surface clear-redo):** `/undo` → send a new user message **through the CLI's real send path** → assert `redo_stack` empty and `/redo` is a no-op (proves CLI routes through the core clear-redo hook, not bypasses it).
+- *Negative/adversarial:* `/redo` before any `/undo` → no-op message; two-user-in-a-row after undo+type passes `repair_message_sequence` (no alternation error).
+- *Verify with:* `python -m pytest tests/cli/test_undo_redo_half_turn.py -o 'addopts=' -q` → pass.
+
+### Phase 4 — Gateway surface
+What ships: half-turn `rewind_session`, `restore_session` (redo, bumps `redo_count` once), `_handle_redo_command`, agent-cache eviction on redo, clear-redo-on-send.
+- *Unit/script check:* `rewind_session(n)` half-turn target; `restore_session` reactivates correctly and bumps `redo_count` once per command.
+- *E2E/integration check:* simulate a gateway `MessageEvent` `/undo` then `/redo` against a real session store; assert active transcript restored and cached agent evicted both times. **RC-2 (clear-redo):** `/undo` → new user message **through the gateway's real message path** → assert `redo_stack` empty and `/redo` no-op. **RC-2-evict (pass-5, eviction is load-bearing — negative test):** `/undo` → `/redo` restoring history → run a **follow-up turn** and assert it sees the **restored** (not cached-stale) message list — i.e. with the eviction in place the next turn's context = the post-redo active set. (If a full follow-up-turn drive is too heavy, instead assert the cached agent entry for the session is *absent* after redo so the next turn rebuilds from the DB; state which form is used. Either way the mitigation must be proven load-bearing, not ceremonial.)
+- *Restart degradation (pass-5 B-2):* **`test_cold_redo_after_restart_touches_nothing`** — instantiate gateway session state, `/undo` (rows → `active=0`), **drop/replace the in-memory `UndoRedoState` holder**, then `/redo`; assert (i) the **restart-specific** N-1′ i18n string fires (`rewind_count>0`, cold stack), distinct from the never-undone "nothing to redo", and (ii) `get_messages(include_inactive=True)` is unchanged (zero rows reactivated). **`test_no_active0_reconstruction`** — grep/structural: no undo/redo path reads `active=0` rows (`include_inactive=True`/`restore_rewound`/`active = 0` SELECT) to rebuild a redo stack.
+- *Negative/adversarial:* `/redo` with no prior undo (never-undone session) → bare `gateway.redo.nothing` i18n string, no `redo_count` bump; new message between clears redo. (The restart-specific message is the §5.3(a) test above, kept distinct.)
+- *Verify with:* `python -m pytest tests/gateway/test_undo_redo_half_turn.py -o 'addopts=' -q` → pass.
+
+### Phase 5 — TUI surface
+What ships: `session.redo` JSON-RPC method, half-turn `session.undo`, busy-guard parity, clear-redo-on-send.
+- *Unit/script check:* `session.redo` handler returns success/`rewound` payload; busy session rejects with code 4009.
+- *E2E/integration check:* drive the tui_gateway server methods: undo → redo round-trip restores active set; concurrent-write version guard intact. **RC-2:** `session.undo` → new user message **through the TUI's real `session.send` path** → assert `redo_stack` empty and `session.redo` no-op (this is the surface most likely to bypass the core hook — pass-2 RC-2 named TUI explicitly).
+- *Negative/adversarial:* redo on busy session → 4009; redo with empty stack → graceful error, no DB mutation, no `redo_count` bump.
+- *Verify with:* `python -m pytest tests/tui_gateway/test_undo_redo.py -o 'addopts=' -q` → pass.
+
+### Phase 6 — Registry, help text, i18n, docs, parse-layer parity
+What ships: `/redo` `CommandDef`; `/undo` description updated to half-turn; i18n strings (`gateway.redo.*`); help/docs updated.
+- *Unit/script check:* command registry includes `redo`; `/help` lists it; existing `/undo` description string updated.
+- *E2E/integration check:* drive `/redo` **and `/undo 2`** as **string commands through each surface's actual parser/dispatcher** (CLI `process_command`, gateway command handling, TUI method routing) and assert (a) `/redo` reaches the redo handler (RC-6: a registered command with no dispatch arm is a silent miss), and (b) **the same N reaches the helper across all three parsers** — i.e. `/undo 2` parses to N=2 on every surface, no off-by-one (pass-2 RC-3: parse-layer parity, distinct from helper-layer parity in Phase 7).
+- *Negative/adversarial:* `/redo bogus` (non-int arg) → invalid-count error per surface, no DB op. **N-3 (pass-5) degenerate ints:** `/redo 0` and `/redo -1` are pinned to a single explicit behavior across surfaces — **treated as a no-op with the "nothing to redo" message** (M clamps to ≥1 only when there are ops; ≤0 never pops), asserted per surface so the `M=0` clamp boundary can't drift into an off-by-one.
+- *Verify with:* `python -m pytest tests/ -k "command_registry or undo or redo" -o 'addopts=' -q` → pass; manual `/help` shows `/redo`.
+
+### Phase 7 — Cross-surface helper parity (RC-3)
+What ships: one parity test defending D-9's shared-helper promise. **Scope (pass-2 RC-3): this proves SHARED-HELPER parity, NOT command-parse parity** — the latter is Phase 6's job.
+- *Unit/script check:* `Not applicable: single integration assertion.`
+- *E2E/integration check:* feed a message list **persisted into a temp DB and read back via the id-bearing `get_messages` getter (the B-1 fixture shape, pass-6 N-3 — NOT a hand-crafted list, which is exactly what hid the real-row grouping bug)** through all three surfaces' undo entry points (CLI `undo_last`, gateway `rewind_session`, TUI `session.undo`) with **N already parsed** and assert **identical resulting active-id sets**; repeat for redo. **N-B (with pass-5 B-1 correction):** also assert all three surfaces obtain their active-message list via the **same `SessionDB` getter with the same args — `get_messages(session_id, include_inactive=False)` (the id-bearing getter, per §5.1 input-source note), NOT `get_messages_as_conversation`** (which omits row `id`) — so input-construction can't silently diverge before the shared helper. Combined with Phase 6's parse-layer parity, this gives true end-to-end parity without overclaiming.
+- *Negative/adversarial:* `Not applicable.`
+- *Verify with:* `python -m pytest tests/test_undo_redo_surface_parity.py -o 'addopts=' -q` → pass.
+
+### Phase 8 — Full-suite regression (baseline-pinned, pass-3 N-3′)
+- *Verify with:* capture `python -m pytest tests/ -o 'addopts=' -q` pass/skip counts on the **pre-PR commit** as the baseline; Phase 8 asserts pass count ≥ baseline, **0 new failures, 0 newly-skipped tests**. (`scripts/run_tests.sh` for convenience, but the baseline-delta is the gate — "full suite green" alone can hide a newly-skipped test.)
+
+---
+
+## 7. Security, Privacy, Ops, Observability
+
+- **No new credentials, network calls, or external surfaces.** Pure local session-state manipulation.
+- **No secret exposure:** undo/redo echo/prefill the user's own prior message text only (existing behavior); no new data surfaced.
+- **Audit retention preserved:** soft-delete semantics unchanged; redo is reversible reactivation.
+- **Observability:** existing `rewind_count` bump on undo; **`redo_count` bump once per successful `/redo` command** (D-12, command-layer not primitive-layer, additive nullable column) — the deactivate/reactivate cycle is fully auditable. Debug-level log line on redo with the op count. **`redo_count` consumer (pass-6 N-2):** there is **no live reader** today (no `/stats` surface, no dashboard) — the column is for **future forensic queries** and symmetry with `rewind_count`; stated explicitly so a later reviewer doesn't hunt for a missing consumer.
+- **N-1 (RESOLVED → ship in Phase 4, pass-3 N-1′):** cold-restart `/redo` emits "nothing to redo (redo history doesn't survive a restart)" when `rewind_count` shows undos happened this session but the in-memory stack is cold; genuine empty-stack `/redo` emits the bare "nothing to redo." Committed (two-line conditional in the gateway redo handler), not left as "ship if cheap" (the conditional that silently doesn't ship — same discipline applied to N-2).
+- **N-2 (RESOLVED → docs-only, pass-2):** the D-2 behavior-change notice is **cut to docs-only** — no first-run runtime notice. (Pass-2 flagged "ship if cheap" as the kind of conditional that silently becomes "not shipped." Decided: docs/CHANGELOG only.)
+- **N-C (pass-4) — NULL-safe counters on pre-existing sessions:** `redo_count` is additive nullable; existing rows are `NULL`. The N-1′ cold-restart conditional reads `rewind_count`, which must be `COALESCE(rewind_count,0)`-safe on pre-existing sessions (confirm the existing `rewind_count` read path already handles `NULL`; `restore_ids`'s `redo_count` bump uses `COALESCE(redo_count,0)+1` like `rewind_count`).
+- **Rollback:** feature is additive (`/redo` new; `/undo` behavior change is the only contract delta). Revert = git revert the PR; the only schema change is the additive nullable `redo_count` column (safe to leave or drop).
+
+---
+
+## 8. Risks & Mitigations
+
+- **R1 — Half-turn boundary miscount with tool messages.** Tool results interleave; mis-grouping lands on the wrong message. *Mitigation:* table-driven unit tests with tool-message fixtures (Phase 1); `party(tool)=assistant` rule explicit.
+- **R2 — `rewind_count` semantics drift.** Generalizing the target could double-count or skip the counter. *Mitigation:* keep the existing increment logic untouched; test counter increments once per undo.
+- **R3 — Redo resurrects an incoherent branch.** If clear-on-new-message is missed on any surface, redo could splice a stale assistant reply after a new user message. *Mitigation:* invariant + per-surface negative test (Phase 3/4/5); single documented clear-redo call site per surface.
+- **R4 — Restart loses redo silently and confuses the user.** *Mitigation:* fail-closed "nothing to redo" on cold stack (D-7); never guess.
+- **R5 — Behavior change surprises existing `/undo N` users.** *Mitigation:* update help/docs/registry description (Phase 6); call out in PR description; the change is the user's explicit intent.
+- **R6 — Three-surface drift** (one surface implements half-turn, another stays turn-based). *Mitigation:* shared core helper (D-9); parity tests per surface.
+
+---
+
+## 9. Open Questions
+
+All blocking questions resolved during review (Pass 1). For the record:
+
+- **Q-1 (RESOLVED → D-7a):** Stack transition table is fixed in this PRD — paired `undo_stack`/`redo_stack`, `/undo` clears redo, `/redo` moves ops between them. No longer deferred to writing-plans.
+- **Q-2 (RESOLVED → D-7):** `redo_marker` / cold-redo reconstruction **dropped**. Cold stack = "nothing to redo." No schema marker.
+- **Q-3 (RESOLVED → no):** `/redo` does not prefill — redo restores history as-is; prefill is an undo-only affordance (D-4).
+- **N-3 placement (RESOLVED):** `compute_half_turn_target` and the `UndoRedoState` holder land together in the shared core in Phase 1/2 — not relocated later.
+
+Remaining genuinely-open: **none blocking.** (N-2 first-run notice is a NICE-TO-HAVE, tracked in §7.)
+
+---
+
+## 10. Acceptance Criteria
+
+- [ ] `/undo 1` backs up exactly **one half-turn** (lands on the user's last message). Evidence: `tests/cli/test_undo_redo_half_turn.py::test_undo_one_lands_on_user` passes.
+- [ ] `/undo 2` lands on the assistant's penultimate message with the user's last message discarded (turn handed back to user). Evidence: same test file, `::test_undo_two_lands_on_assistant`.
+- [ ] Prefill rule (N-agnostic, D-4): prefill iff the new active tail ends on a USER message — verified for N=1 (prefill), N=2 (no prefill), N=3 (prefill). Evidence: `::test_prefill_conditional`.
+- [ ] `repair_message_sequence` asymmetric merge contract characterized against the real function: user+user plain-text→merged, user+user with multimodal→not merged, assistant+assistant→intact. Evidence: `::test_repair_merge_contract`.
+- [ ] `/redo` (bare) reverses exactly the last `/undo` operation; active message set is identical to pre-undo. Evidence: `tests/test_undo_redo_stack.py::test_undo_then_redo_identity`.
+- [ ] **Stacked undo/redo is order-symmetric (single redos, LIFO):** `undo` ×3 with different N then **three separate bare `/redo`** restores, after each, the post-`undo×2`/post-`undo×1`/pre-`undo` active-id set; final = original. Evidence: `tests/test_undo_redo_stack.py::test_undo_redo_multi_op_identity`.
+- [ ] `/redo 3` (one command) reverses three prior `/undo` operations, landing on pre-`undo` (no intermediates), and bumps `redo_count` exactly once. Evidence: `::test_redo_n_single_command`.
+- [ ] The three interleaving sequences (undo,undo,redo,undo / undo,redo,undo / undo×3,redo 2,undo) produce the exact stack states **AND the exact active-id set after each step** per D-7a. Evidence: `::test_stack_transition_table`.
+- [ ] Typing a new message after `/undo` clears the redo stack (at one core call site); subsequent `/redo` is a no-op and diverged rows stay `active=0`. Evidence: `::test_new_message_clears_redo` + grep showing the clear-redo call is in core; **plus per-surface** `redo_stack`-empty-after-real-send tests (Phase 3/4/5 RC-2).
+- [ ] After `/undo` to a user half-turn + a new user message, `repair_message_sequence` yields no two consecutive same-role messages. No feature path emits adjacent assistant rows, and repair does not silently merge assistant-after-assistant input. Evidence: `::test_two_user_messages_merged_no_alternation_error`, `::test_no_feature_path_emits_adjacent_assistant`, `::test_repair_does_not_silently_merge_assistants`.
+- [ ] Stale-op unreachability (**structural, pass-6 RC-3**): the live `UndoRedoState` holder is the sole owner of any `UndoOp` (no surface retains an op reference), and `hermes_undo.redo`'s reactivation id source is exclusively `undo_stack[-m:]` — never a discarded op or an `active=0` scan. The *undo,undo,redo,undo* trace exhibits it. Evidence: `tests/test_undo_redo_stack.py::test_stale_op_unreachable`.
+- [ ] Half-turn boundary with tool messages, **on real persisted rows (pass-5 B-1):** fixtures inserted via the real `add_message` path and read back via the **id-bearing `get_messages`** getter; the partial-half-turn target id IS the persisted `assistant(tool_calls)` group-start row's real id (not the `tool` row), and undo→redo round-trips the complete group with no dangling `tool_calls`-without-result. The grouping primitive is asserted over real rows, not hand-crafted dicts. Evidence: `tests/test_half_turn_target.py::test_tool_message_boundaries_real_rows`, `tests/test_restore_ids.py::test_partial_half_turn_roundtrip`.
+- [ ] **Multimodal alternation + mechanism (pass-5 RC-1, pass-6 B-1′):** `/undo` landing on a user message with non-`str` (multimodal/list) content uses D-13 REPLACE semantics. Assert BOTH: (a) **mechanism** — the multimodal user row's id IS in the op's `rewound_ids` and is `active=0` after undo (proving REPLACE fired, not some other masking), and the new tail ends on the prior assistant row so D-4 yields **no prefill** (armed-empty); (b) **outcome** — after a new user message the provider-bound payload has **no two adjacent user rows**. A plain-`str` control case in the same test does NOT lower the target (its user row stays active, append+merge path). Evidence: `tests/test_undo_redo_stack.py::test_multimodal_undo_replace_mechanism`, `::test_multimodal_undo_no_adjacent_user`.
+- [ ] **Cold redo after restart (pass-5 B-2):** undo → drop the in-memory `UndoRedoState` holder → `/redo` fires the **restart-specific** N-1′ message (distinct from never-undone "nothing to redo") AND reactivates **zero** rows (`get_messages(include_inactive=True)` unchanged); and no surface reconstructs a stack from `active=0` rows. Evidence: `tests/gateway/test_undo_redo_half_turn.py::test_cold_redo_after_restart_touches_nothing`, `::test_no_active0_reconstruction`.
+- [ ] **Eviction is load-bearing (pass-5 RC-2):** after `/undo`→`/redo`, a follow-up turn sees the **restored** (not cached-stale) history — or the cached agent entry is absent post-redo so the next turn rebuilds from the DB. Evidence: `tests/gateway/test_undo_redo_half_turn.py::test_redo_evicts_stale_agent`.
+- [ ] `restore_ids` is idempotent: reactivating an already-`active=1` id is a safe no-op (no phantom redo). Evidence: `tests/test_restore_ids.py::test_restore_ids_idempotent`.
+- [ ] `rewind_to_message` back-compat: return carries `rewound_count`/`target_message`/`new_head_id`/`rewound_ids`; no caller positionally-unpacks, splats, or iterates the return. Evidence: `tests/test_state_rewind_generalized.py::test_return_back_compat` + four grep patterns clean.
+- [ ] Helper-layer parity: all three surfaces produce the **same** half-turn boundary (and redo result) for the same history+N. Evidence: `tests/test_undo_redo_surface_parity.py` passes.
+- [ ] Parse-layer parity + dispatch: `/undo 2` parses to N=2 on every surface and `/redo` reaches its handler through each real parser. Evidence: Phase 6 dispatch/parse tests pass per surface.
+- [ ] No data loss: rewound rows remain `active=0` (not deleted); grep shows no new `DELETE FROM messages`. Evidence: `::test_undo_is_soft_delete` + `git grep "DELETE FROM messages"` unchanged.
+- [ ] Full suite green by **baseline-delta gate** (pass-5 RC-3, supersedes the old `exits 0` checkbox which Phase 8 itself calls insufficient): on the pre-PR commit capture `python -m pytest tests/ -o 'addopts=' -q` pass/skip counts as baseline; assert post-PR **pass count ≥ baseline, 0 new failures, 0 newly-skipped tests**. Evidence: Phase 8 baseline-delta check (not bare `exits 0`).
+
+---
+
+→ Next: `prd-review-pipeline` (3 passes, review+fix each), then Apollo implements directly (no swarm, per D-10).

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9861,9 +9861,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 except (ValueError, IndexError):
                     _undo_n = 1
             _undo_detail = (
-                "This removes the last user/assistant exchange from history."
+                "This backs up the last half-turn (one party's run of "
+                "messages) from history."
                 if _undo_n == 1
-                else f"This removes the last {_undo_n} user turns from history."
+                else f"This backs up the last {_undo_n} half-turns from history."
             )
             return await self._maybe_confirm_destructive_slash(
                 event=event,
@@ -9872,6 +9873,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 detail=_undo_detail,
                 execute=_do_undo,
             )
+
+        if canonical == "redo":
+            return await self._handle_redo_command(event)
         
         if canonical == "sethome":
             return await self._handle_set_home_command(event)
@@ -12112,6 +12116,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             session_entry.session_id, entry,
                             skip_db=agent_persisted,
                         )
+                        if agent_persisted and msg.get("role") == "user":
+                            try:
+                                from hermes_undo import on_user_message_appended
+
+                                on_user_message_appended(session_entry.session_id)
+                            except Exception as e:
+                                logger.debug("redo clear on user append failed: %s", e)
             
             # Token counts and model are now persisted by the agent directly.
             # Keep only last_prompt_tokens here for context-window tracking and
@@ -12863,7 +12874,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._enqueue_fifo(_quick_key, cont_event, adapter)
         except Exception as exc:
             logger.debug("goal continuation: enqueue failed: %s", exc)
-
 
 
     @staticmethod

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -2424,6 +2424,13 @@ class SessionStore:
                     observed=bool(message.get("observed")),
                     timestamp=message.get("timestamp"),
                 )
+                if message.get("role") == "user":
+                    try:
+                        from hermes_undo import on_user_message_appended
+
+                        on_user_message_appended(session_id)
+                    except Exception as e:
+                        logger.debug("redo clear on user append failed: %s", e)
             except Exception as e:
                 logger.debug("Session DB operation failed: %s", e)
     
@@ -2463,10 +2470,19 @@ class SessionStore:
             return True
         try:
             self._db.replace_messages(session_id, messages)
-            return True
         except Exception as e:
             logger.debug("Failed to rewrite transcript in DB: %s", e)
             return False
+        # A transcript rewrite hard-deletes and renumbers rows, so any
+        # in-memory undo/redo stack now references dead ids. Invalidate it so a
+        # later /redo cannot try to restore vanished rows.
+        try:
+            import hermes_undo
+
+            hermes_undo.clear_state(session_id)
+        except Exception as e:
+            logger.debug("rewrite_transcript: undo-state clear skipped: %s", e)
+        return True
 
     def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
         """Load all messages from a session's transcript.
@@ -2484,56 +2500,34 @@ class SessionStore:
             return []
 
     def rewind_session(self, session_id: str, n: int = 1) -> Optional[Dict[str, Any]]:
-        """Back up ``n`` user turns via soft-delete, keeping rows for audit.
-
-        Unlike :meth:`rewrite_transcript` (a hard replace used by /retry),
-        this flips the truncated rows to ``active=0`` in state.db so they
-        survive for audit and stay hidden from re-prompts and search. Mirrors
-        the CLI/TUI ``/undo [N]`` behavior via ``SessionDB.rewind_to_message``.
-
-        Returns a dict ``{"rewound_count", "turns_undone", "target_text"}`` on
-        success, or ``None`` if there's no DB or no user message to back up to.
-        ``n`` clamps to the oldest user turn when it exceeds the turn count.
-        """
+        """Back up ``n`` half-turns via the shared undo core."""
         if not self._db:
             return None
-        if n < 1:
-            n = 1
         try:
-            recents = self._db.list_recent_user_messages(session_id, limit=max(n, 10))
+            import hermes_undo
+
+            hermes_undo._session_db = self._db
+            result = hermes_undo.undo(session_id, n)
         except Exception as e:
-            logger.debug("rewind_session: failed to list user messages: %s", e)
-            return None
-        if not recents:
-            return None
-        target_idx = min(n - 1, len(recents) - 1)
-        target_id = recents[target_idx]["id"]
-        try:
-            result = self._db.rewind_to_message(session_id, target_id)
-        except ValueError as e:
             logger.debug("rewind_session: %s", e)
             return None
-        except Exception as e:
-            logger.debug("rewind_session: rewind_to_message failed: %s", e)
+        if not result.get("rewound_ids"):
             return None
-        target_msg = result.get("target_message") or {}
-        content = target_msg.get("content") or ""
-        if isinstance(content, list):
-            parts = [
-                p.get("text", "")
-                for p in content
-                if isinstance(p, dict) and p.get("type") == "text"
-            ]
-            target_text = "\n".join(t for t in parts if t)
-        elif isinstance(content, str):
-            target_text = content
-        else:
-            target_text = ""
-        return {
-            "rewound_count": result.get("rewound_count", 0),
-            "turns_undone": target_idx + 1,
-            "target_text": target_text,
-        }
+        return result
+
+    def restore_session(self, session_id: str, n: int = 1) -> Optional[Dict[str, Any]]:
+        """Redo ``n`` undo operations via the shared undo core."""
+        if not self._db:
+            return None
+        try:
+            import hermes_undo
+
+            hermes_undo._session_db = self._db
+            result = hermes_undo.redo(session_id, n)
+        except Exception as e:
+            logger.debug("restore_session: %s", e)
+            return None
+        return result
 
 
 def build_session_context(

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2371,19 +2371,10 @@ class GatewaySlashCommandsMixin:
         return f"✓ Added subgoal {idx}: {text}"
 
     async def _handle_undo_command(self, event: MessageEvent) -> str:
-        """Handle /undo [N] — back up N user turns (default 1), soft-deleting
-        the truncated rows on disk and echoing the backed-up message text so
-        the user can copy/edit and resend.
-
-        Mirrors the CLI/TUI /undo: rewound rows stay in state.db (active=0)
-        for audit and are hidden from re-prompts and search. The cached agent
-        is evicted so the next message rebuilds context from the truncated
-        (active-only) transcript — the gateway's equivalent of the CLI's
-        in-place history surgery + memory-cache invalidation.
-        """
+        """Handle /undo [N] by delegating to the shared half-turn undo core."""
         source = event.source
 
-        # Parse optional turn count: "/undo" → 1, "/undo 3" → 3.
+        # Parse optional half-turn count: "/undo" → 1, "/undo 3" → 3.
         n = 1
         raw_args = event.get_command_args().strip()
         if raw_args:
@@ -2410,13 +2401,46 @@ class GatewaySlashCommandsMixin:
         except Exception as e:
             logger.debug("undo: cached-agent eviction skipped: %s", e)
 
-        target_text = result["target_text"]
-        preview = target_text[:200] + "..." if len(target_text) > 200 else target_text
         return t(
             "gateway.undo.removed",
-            turns=result["turns_undone"],
-            count=result["rewound_count"],
-            preview=preview,
+            turns=n,
+            count=len(result.get("rewound_ids") or []),
+        )
+
+    async def _handle_redo_command(self, event: MessageEvent) -> str:
+        """Handle /redo [N] by delegating to the shared redo core."""
+        source = event.source
+        n = 1
+        raw_args = event.get_command_args().strip()
+        if raw_args:
+            try:
+                n = int(raw_args.split()[0])
+            except (ValueError, IndexError):
+                return t("gateway.redo.invalid_count", arg=raw_args.split()[0])
+
+        session_entry = await self.async_session_store.get_or_create_session(source)
+        result = await self.async_session_store.restore_session(session_entry.session_id, n)
+        if result is None:
+            return t("gateway.redo.nothing")
+
+        reactivated = int(result.get("reactivated_count") or 0)
+        if reactivated <= 0:
+            message = str(result.get("message") or "")
+            if "restart" in message:
+                return t("gateway.redo.restart_lost")
+            return t("gateway.redo.nothing")
+
+        session_entry.last_prompt_tokens = 0
+        try:
+            session_key = build_session_key(source)
+            self._evict_cached_agent(session_key)
+        except Exception as e:
+            logger.debug("redo: cached-agent eviction skipped: %s", e)
+
+        return t(
+            "gateway.redo.restored",
+            ops=n,
+            count=reactivated,
         )
 
     async def _handle_set_home_command(self, event: MessageEvent) -> str:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -80,7 +80,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("retry", "Retry the last message (resend to agent)", "Session"),
     CommandDef("prompt", "Compose your next prompt in $EDITOR (markdown), then send it", "Session",
                cli_only=True, args_hint="[initial text]", aliases=("compose",)),
-    CommandDef("undo", "Back up N user turns and re-prompt (default 1)", "Session",
+    CommandDef("undo", "Back up N half-turns and re-prompt (default 1)", "Session",
+               args_hint="[N]"),
+    CommandDef("redo", "Redo N undo operations (default 1)", "Session",
                args_hint="[N]"),
     CommandDef("title", "Set a title for the current session", "Session",
                args_hint="[name]"),
@@ -1163,7 +1165,8 @@ _SLACK_PRIORITY_ALIASES = ("btw", "bg")
 #   - moa: high-cost slash mode, available through /hermes moa to avoid
 #     displacing existing native Slack slash commands at the 50-command cap.
 #   - debug: the log/report upload surface; reached via /hermes debug on Slack.
-_SLACK_VIA_HERMES_ONLY = frozenset({"credits", "billing", "moa", "debug"})
+#   - version: low-frequency informational command; /hermes version on Slack.
+_SLACK_VIA_HERMES_ONLY = frozenset({"credits", "billing", "moa", "debug", "version"})
 
 
 def _sanitize_slack_name(raw: str) -> str:
@@ -1243,7 +1246,7 @@ def slack_native_slashes() -> list[tuple[str, str, str]]:
             continue
         _add(cmd.name, cmd.description, cmd.args_hint or "")
 
-    # Second pass: aliases.
+    # Second pass: remaining aliases.
     for cmd in COMMAND_REGISTRY:
         if not _is_gateway_available(cmd, overrides):
             continue

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -759,6 +759,9 @@ CREATE TABLE IF NOT EXISTS sessions (
     compression_failure_cooldown_until REAL,
     compression_failure_error TEXT,
     rewind_count INTEGER NOT NULL DEFAULT 0,
+    -- Intentionally asymmetric: rewind_count bumps per rewind_to_message call;
+    -- redo_count bumps once per /redo command, regardless of M.
+    redo_count INTEGER,
     archived INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
 );
@@ -4477,7 +4480,10 @@ class SessionDB:
     # =========================================================================
 
     def rewind_to_message(
-        self, session_id: str, target_message_id: int
+        self,
+        session_id: str,
+        target_message_id: int,
+        require_user_role: bool = True,
     ) -> Dict[str, Any]:
         """Soft-delete all messages with id >= ``target_message_id`` in *session_id*.
 
@@ -4492,11 +4498,13 @@ class SessionDB:
             {
                 "rewound_count": int,    # number of rows newly flipped to active=0
                 "target_message": dict,  # full row dict of the target
-                "new_head_id":   int|None  # id of the last still-active row, or None
+                "new_head_id":   int|None, # id of the last still-active row, or None
+                "rewound_ids":   list[int] # rows newly flipped active=1 -> active=0
             }
 
         Raises ``ValueError`` if the target message does not exist in
-        *session_id* or if its role is not ``"user"``.
+        *session_id* or, when ``require_user_role`` is true, if its role is
+        not ``"user"``.
 
         Always increments ``sessions.rewind_count`` — even when the
         target is already inactive — so the counter accurately reflects
@@ -4516,7 +4524,7 @@ class SessionDB:
                 f"message {target_message_id} not found in session {session_id}"
             )
         target_row = dict(row)
-        if target_row.get("role") != "user":
+        if require_user_role and target_row.get("role") != "user":
             raise ValueError(
                 f"rewind target must be a 'user' message (got role="
                 f"{target_row.get('role')!r}, id={target_message_id})"
@@ -4525,7 +4533,7 @@ class SessionDB:
         # Decode content for callers (prefill the prompt buffer).
         target_row["content"] = self._decode_content(target_row.get("content"))
 
-        rewound: List[int] = []
+        self._raise_if_rewind_would_orphan_tool(session_id, target_message_id)
 
         def _do(conn):
             cursor = conn.execute(
@@ -4561,10 +4569,58 @@ class SessionDB:
             "rewound_count": len(rewound),
             "target_message": target_row,
             "new_head_id": new_head_id,
+            "rewound_ids": rewound,
         }
 
+    def _raise_if_rewind_would_orphan_tool(
+        self, session_id: str, target_message_id: int
+    ) -> None:
+        """Fail before an id-range rewind can leave a tool row without owner."""
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT id, role, tool_call_id, tool_calls FROM messages "
+                "WHERE session_id = ? AND active = 1 ORDER BY id",
+                (session_id,),
+            ).fetchall()
+
+        assistant_call_ids: set[str] = set()
+        for row in rows:
+            if row["id"] < target_message_id or row["role"] != "assistant":
+                continue
+            raw = row["tool_calls"]
+            if not raw:
+                continue
+            try:
+                calls = json.loads(raw)
+            except (json.JSONDecodeError, TypeError):
+                calls = []
+            if isinstance(calls, dict):
+                calls = [calls]
+            if not isinstance(calls, list):
+                continue
+            for call in calls:
+                if isinstance(call, dict) and call.get("id"):
+                    assistant_call_ids.add(str(call["id"]))
+
+        if not assistant_call_ids:
+            return
+
+        for row in rows:
+            if row["id"] >= target_message_id or row["role"] != "tool":
+                continue
+            call_id = row["tool_call_id"]
+            if call_id and str(call_id) in assistant_call_ids:
+                raise ValueError(
+                    "rewind would orphan active tool row "
+                    f"id={row['id']} by deactivating its assistant owner "
+                    f"at or after target id={target_message_id}"
+                )
+
     def restore_rewound(self, session_id: str, since_message_id: int) -> int:
-        """Mark inactive messages with id >= *since_message_id* active again.
+        """DEPRECATED for stacked undo/redo — use ``restore_ids``.
+
+        Mark inactive messages with id >= *since_message_id* active again.
+        ``id >=`` range restore clobbers stacked ops of differing N.
 
         Returns the number of rows flipped back to ``active=1``.
         Intended for undo-of-rewind and test cleanup; not wired to a
@@ -4584,6 +4640,28 @@ class SessionDB:
                     ids,
                 )
             return len(ids)
+
+        return self._execute_write(_do)
+
+    def restore_ids(self, session_id: str, ids: List[int]) -> int:
+        """Reactivate the inactive rows in ``ids`` for ``session_id``.
+
+        Idempotent: rows that are already active, from another session, or
+        absent are skipped. ``redo_count`` is intentionally not bumped here;
+        the shared undo/redo core owns that single command-level counter.
+        """
+        bounded_ids = [int(i) for i in ids]
+        if not bounded_ids:
+            return 0
+
+        def _do(conn):
+            placeholders = ",".join("?" for _ in bounded_ids)
+            cursor = conn.execute(
+                f"UPDATE messages SET active = 1 "
+                f"WHERE session_id = ? AND id IN ({placeholders}) AND active = 0",
+                (session_id, *bounded_ids),
+            )
+            return cursor.rowcount
 
         return self._execute_write(_do)
 

--- a/hermes_undo.py
+++ b/hermes_undo.py
@@ -1,0 +1,244 @@
+"""Shared half-turn undo/redo core for Hermes sessions.
+
+Concurrency precondition: callers must serialize undo()/redo()/
+on_user_message_appended() per session_id. The in-memory ``_states`` dict is
+unlocked and undo() does a non-atomic read (get_messages) then write
+(rewind_to_message), so two concurrent same-session undos could push spurious
+stack entries. This is safe today because every surface serializes per session:
+the CLI is a single-thread REPL, the gateway rejects undo/redo while an agent is
+running and runs the core synchronously on one event loop, and the TUI rejects
+undo while a turn is in flight. Any future surface that drives the core off the
+event-loop thread (or adds an ``await`` inside it) must add a per-session lock.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from hermes_state import SessionDB
+
+
+@dataclass(frozen=True)
+class UndoOp:
+    n: int
+    rewound_ids: List[int]
+
+
+@dataclass
+class UndoRedoState:
+    undo_stack: List[UndoOp] = field(default_factory=list)
+    redo_stack: List[UndoOp] = field(default_factory=list)
+
+
+_states: Dict[str, UndoRedoState] = {}
+_session_db: Optional[SessionDB] = None
+
+
+def _get_db() -> SessionDB:
+    global _session_db
+    if _session_db is None:
+        _session_db = SessionDB()
+    return _session_db
+
+
+def get_state(session_id: str) -> UndoRedoState:
+    return _states.setdefault(session_id, UndoRedoState())
+
+
+def clear_state(session_id: Optional[str] = None) -> None:
+    """Test/helper reset for the in-memory undo/redo holder."""
+    if session_id is None:
+        _states.clear()
+    else:
+        _states.pop(session_id, None)
+
+
+def _party(role: Any) -> str:
+    if role == "user":
+        return "user"
+    if role in {"assistant", "tool"}:
+        return "assistant"
+    return "other"
+
+
+def compute_half_turn_target(
+    active_messages: List[Dict[str, Any]], n: int
+) -> Optional[int]:
+    """Return the inclusive id target for undoing ``n`` half-turns.
+
+    Consecutive rows with the same party form one half-turn. ``other`` rows
+    participate in boundary detection but are never counted or returned.
+    """
+    if n < 1:
+        n = 1
+
+    group_starts: List[int] = []
+    current_party: Optional[str] = None
+    current_start: Optional[int] = None
+
+    for msg in active_messages:
+        msg_party = _party(msg.get("role"))
+        if current_party is None or msg_party != current_party:
+            if current_party != "other" and current_start is not None:
+                group_starts.append(current_start)
+            current_party = msg_party
+            current_start = msg.get("id")
+
+    if current_party != "other" and current_start is not None:
+        group_starts.append(current_start)
+
+    if not group_starts:
+        return None
+
+    target_index = max(0, len(group_starts) - n)
+    return group_starts[target_index]
+
+
+def _new_tail(messages: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    if not messages:
+        return None
+    return max(messages, key=lambda m: m["id"])
+
+
+def _tail_before_target(
+    active_messages: List[Dict[str, Any]], target_id: int
+) -> Optional[Dict[str, Any]]:
+    before = [m for m in active_messages if m["id"] < target_id]
+    return _new_tail(before)
+
+
+def _prefill_from_tail(tail: Optional[Dict[str, Any]]) -> Optional[str]:
+    if tail and tail.get("role") == "user" and isinstance(tail.get("content"), str):
+        return tail["content"]
+    return None
+
+
+def undo(session_id: str, n: int) -> Dict[str, Any]:
+    db = _get_db()
+    state = get_state(session_id)
+    msgs = db.get_messages(session_id, include_inactive=False)
+    target_id = compute_half_turn_target(msgs, n)
+    if target_id is None:
+        return {
+            "rewound_ids": [],
+            "prefill_text": None,
+            "message": "nothing to undo",
+        }
+
+    tail = _tail_before_target(msgs, target_id)
+    if (
+        tail is not None
+        and tail.get("role") == "user"
+        and not isinstance(tail.get("content"), str)
+    ):
+        target_id = tail["id"]
+
+    result = db.rewind_to_message(
+        session_id, target_id, require_user_role=False
+    )
+    rewound_ids = list(result.get("rewound_ids", []))
+    if not rewound_ids:
+        # Nothing was actually deactivated (degenerate/raced rewind). Don't push
+        # an empty op or clobber a pending redo — match the None-path contract of
+        # touching neither stack.
+        return {
+            "rewound_ids": [],
+            "prefill_text": None,
+            "message": "nothing to undo",
+        }
+    state.undo_stack.append(UndoOp(n=n, rewound_ids=rewound_ids))
+    state.redo_stack.clear()
+
+    active_after = db.get_messages(session_id, include_inactive=False)
+    return {
+        "rewound_ids": rewound_ids,
+        "prefill_text": _prefill_from_tail(_new_tail(active_after)),
+    }
+
+
+def redo(session_id: str, m: int) -> Dict[str, Any]:
+    db = _get_db()
+    state = get_state(session_id)
+    if m <= 0:
+        return {
+            "reactivated_count": 0,
+            "new_tail_id": None,
+            "prefill_text": None,
+            "message": "nothing to redo",
+        }
+
+    k = min(m, len(state.undo_stack))
+    if k == 0:
+        session = db.get_session(session_id) or {}
+        message = "nothing to redo"
+        if (session.get("rewind_count") or 0) > 0:
+            message = "nothing to redo (redo history doesn't survive a restart)"
+        return {
+            "reactivated_count": 0,
+            "new_tail_id": None,
+            "prefill_text": None,
+            "message": message,
+        }
+
+    reactivated_total = 0
+    for _ in range(k):
+        op = state.undo_stack.pop()
+        reactivated = db.restore_ids(session_id, op.rewound_ids)
+        if reactivated == 0 and op.rewound_ids:
+            # NONE of this op's rows could be restored — the transcript was
+            # rewritten out from under the stack (/compress, /retry, and any
+            # other replace_messages flow hard-delete + renumber rows). The redo
+            # branch is meaningless now, so discard the whole stack rather than
+            # raising: redo across a transcript rewrite is impossible, same as
+            # redo after a restart.
+            state.undo_stack.clear()
+            state.redo_stack.clear()
+            return {
+                "reactivated_count": 0,
+                "new_tail_id": None,
+                "prefill_text": None,
+                "message": "nothing to redo (transcript changed since undo)",
+            }
+        if reactivated != len(op.rewound_ids):
+            # PARTIAL restore — some rows came back, some didn't. This is a
+            # genuine desync (not a clean transcript rewrite), so fail loud to
+            # surface latent corruption rather than silently half-redoing.
+            raise RuntimeError(
+                "redo invariant violated: restored "
+                f"{reactivated} of {len(op.rewound_ids)} rewound rows"
+            )
+        reactivated_total += reactivated
+        state.redo_stack.append(op)
+
+    # Counter asymmetry is intentional: rewind_count increments per low-level
+    # rewind_to_message call; redo_count increments once per /redo command.
+    db._execute_write(
+        lambda conn: conn.execute(
+            "UPDATE sessions SET redo_count = COALESCE(redo_count, 0) + 1 "
+            "WHERE id = ?",
+            (session_id,),
+        )
+    )
+
+    active_after = db.get_messages(session_id, include_inactive=False)
+    tail = _new_tail(active_after)
+    return {
+        "reactivated_count": reactivated_total,
+        "new_tail_id": tail["id"] if tail else None,
+        "prefill_text": None,
+    }
+
+
+def on_user_message_appended(session_id: str) -> None:
+    """Invalidate the redo branch when a new user message is appended.
+
+    Mirrors a text editor: once you type after undoing, the previously-undone
+    content can no longer be redone. ``redo()`` consumes ``undo_stack`` (the
+    pending-redoable ops), so that is the stack that must be cleared here;
+    ``redo_stack`` (the already-redone history) is cleared too so a fresh
+    message starts from a clean slate.
+    """
+    state = get_state(session_id)
+    state.undo_stack.clear()
+    state.redo_stack.clear()

--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -320,9 +320,15 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "Sessie sonder titel"
 
   undo:
-    nothing:               "Niks om ongedaan te maak nie."
-    removed:               "↩️ {turns} beurt(e) ongedaan gemaak ({count} boodskap(pe)).\nGerugsteun na: \"{preview}\"\nKopieer/wysig die teks hierbo en stuur dit om van hier af weer te vra."
-    invalid_count:         "Ongeldige getal \"{arg}\" — gebruik /undo of /undo N."
+    nothing:               "Nothing to undo."
+    removed:               "↩️ Undid {turns} half-turn(s) ({count} message(s))."
+    invalid_count:         "Invalid count \"{arg}\" — use /undo or /undo N."
+
+  redo:
+    nothing:               "Nothing to redo."
+    restart_lost:          "Nothing to redo — redo history does not survive a restart."
+    restored:              "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+    invalid_count:         "Invalid count \"{arg}\" — use /redo or /redo N."
 
   update:
     platform_not_messaging:  "✗ /update is slegs beskikbaar vanaf boodskapplatforms. Voer `hermes update` vanaf die terminale uit."

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -320,9 +320,15 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "Unbenannte Sitzung"
 
   undo:
-    nothing:               "Nichts zum Rückgängigmachen."
-    removed:               "↩️ {turns} Zug/Züge rückgängig gemacht ({count} Nachricht(en)).\nGesichert nach: \"{preview}\"\nKopieren/bearbeiten Sie den obigen Text und senden Sie ihn, um von hier aus erneut zu fragen."
-    invalid_count:         "Ungültige Anzahl \"{arg}\" — verwenden Sie /undo oder /undo N."
+    nothing:               "Nothing to undo."
+    removed:               "↩️ Undid {turns} half-turn(s) ({count} message(s))."
+    invalid_count:         "Invalid count \"{arg}\" — use /undo or /undo N."
+
+  redo:
+    nothing:               "Nothing to redo."
+    restart_lost:          "Nothing to redo — redo history does not survive a restart."
+    restored:              "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+    invalid_count:         "Invalid count \"{arg}\" — use /redo or /redo N."
 
   update:
     platform_not_messaging:  "✗ /update ist nur auf Messaging-Plattformen verfügbar. Führen Sie `hermes update` im Terminal aus."

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -333,8 +333,14 @@ gateway:
 
   undo:
     nothing:               "Nothing to undo."
-    removed:               "↩️ Undid {turns} turn(s) ({count} message(s)).\nBacked up to: \"{preview}\"\nCopy/edit the text above and send it to re-prompt from here."
+    removed:               "↩️ Undid {turns} half-turn(s) ({count} message(s))."
     invalid_count:         "Invalid count \"{arg}\" — use /undo or /undo N."
+
+  redo:
+    nothing:               "Nothing to redo."
+    restart_lost:          "Nothing to redo — redo history does not survive a restart."
+    restored:              "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+    invalid_count:         "Invalid count \"{arg}\" — use /redo or /redo N."
 
   update:
     platform_not_messaging:  "✗ /update is only available from messaging platforms. Run `hermes update` from the terminal."

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -317,9 +317,15 @@ gateway:
     untitled_session:        "Sesión sin título"
 
   undo:
-    nothing:               "Nada que deshacer."
-    removed:               "↩️ {turns} turno(s) deshecho(s) ({count} mensaje(s)).\nRespaldado en: \"{preview}\"\nCopia/edita el texto de arriba y envíalo para volver a preguntar desde aquí."
-    invalid_count:         "Cantidad no válida \"{arg}\" — usa /undo o /undo N."
+    nothing:               "Nothing to undo."
+    removed:               "↩️ Undid {turns} half-turn(s) ({count} message(s))."
+    invalid_count:         "Invalid count \"{arg}\" — use /undo or /undo N."
+
+  redo:
+    nothing:               "Nothing to redo."
+    restart_lost:          "Nothing to redo — redo history does not survive a restart."
+    restored:              "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+    invalid_count:         "Invalid count \"{arg}\" — use /redo or /redo N."
 
   update:
     platform_not_messaging:  "✗ /update solo está disponible en plataformas de mensajería. Ejecuta `hermes update` desde la terminal."

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -320,9 +320,15 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "Session sans titre"
 
   undo:
-    nothing:               "Rien à annuler."
-    removed:               "↩️ {turns} tour(s) annulé(s) ({count} message(s)).\nSauvegardé dans : « {preview} »\nCopiez/modifiez le texte ci-dessus et envoyez-le pour relancer à partir d'ici."
-    invalid_count:         "Nombre invalide « {arg} » — utilisez /undo ou /undo N."
+    nothing:               "Nothing to undo."
+    removed:               "↩️ Undid {turns} half-turn(s) ({count} message(s))."
+    invalid_count:         "Invalid count \"{arg}\" — use /undo or /undo N."
+
+  redo:
+    nothing:               "Nothing to redo."
+    restart_lost:          "Nothing to redo — redo history does not survive a restart."
+    restored:              "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+    invalid_count:         "Invalid count \"{arg}\" — use /redo or /redo N."
 
   update:
     platform_not_messaging:  "✗ /update n'est disponible que depuis les plateformes de messagerie. Exécutez `hermes update` depuis le terminal."

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -324,9 +324,15 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "Seisiún gan teideal"
 
   undo:
-    nothing:               "Níl aon rud le cealú."
-    removed:               "↩️ Cealaíodh {turns} seal ({count} teachtaireacht).\nCúltacaíodh chuig: \"{preview}\"\nCóipeáil/cuir an téacs thuas in eagar agus seol é chun athleideadh ón áit seo."
-    invalid_count:         "Líon neamhbhailí \"{arg}\" — úsáid /undo nó /undo N."
+    nothing:               "Nothing to undo."
+    removed:               "↩️ Undid {turns} half-turn(s) ({count} message(s))."
+    invalid_count:         "Invalid count \"{arg}\" — use /undo or /undo N."
+
+  redo:
+    nothing:               "Nothing to redo."
+    restart_lost:          "Nothing to redo — redo history does not survive a restart."
+    restored:              "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+    invalid_count:         "Invalid count \"{arg}\" — use /redo or /redo N."
 
   update:
     platform_not_messaging:  "✗ Tá /update ar fáil amháin ó ardáin teachtaireachtaí. Rith `hermes update` ón teirminéal."

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -320,9 +320,15 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "Cím nélküli munkamenet"
 
   undo:
-    nothing:               "Nincs mit visszavonni."
-    removed:               "↩️ {turns} fordulat visszavonva ({count} üzenet).\nBiztonsági mentés ide: \"{preview}\"\nMásold/szerkeszd a fenti szöveget, és küldd el, hogy innen újra kérdezz."
-    invalid_count:         "Érvénytelen szám \"{arg}\" — használd a /undo vagy /undo N parancsot."
+    nothing:               "Nothing to undo."
+    removed:               "↩️ Undid {turns} half-turn(s) ({count} message(s))."
+    invalid_count:         "Invalid count \"{arg}\" — use /undo or /undo N."
+
+  redo:
+    nothing:               "Nothing to redo."
+    restart_lost:          "Nothing to redo — redo history does not survive a restart."
+    restored:              "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+    invalid_count:         "Invalid count \"{arg}\" — use /redo or /redo N."
 
   update:
     platform_not_messaging:  "✗ A /update csak üzenetküldő platformokról érhető el. Futtasd a `hermes update` parancsot a terminálból."

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -320,9 +320,15 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "Sessione senza titolo"
 
   undo:
-    nothing:               "Niente da annullare."
-    removed:               "↩️ Annullati {turns} turno/i ({count} messaggio/i).\nSalvato in: \"{preview}\"\nCopia/modifica il testo qui sopra e invialo per ripartire da qui."
-    invalid_count:         "Conteggio non valido \"{arg}\" — usa /undo o /undo N."
+    nothing:               "Nothing to undo."
+    removed:               "↩️ Undid {turns} half-turn(s) ({count} message(s))."
+    invalid_count:         "Invalid count \"{arg}\" — use /undo or /undo N."
+
+  redo:
+    nothing:               "Nothing to redo."
+    restart_lost:          "Nothing to redo — redo history does not survive a restart."
+    restored:              "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+    invalid_count:         "Invalid count \"{arg}\" — use /redo or /redo N."
 
   update:
     platform_not_messaging:  "✗ /update è disponibile solo dalle piattaforme di messaggistica. Esegui `hermes update` dal terminale."

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -320,9 +320,15 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "無題のセッション"
 
   undo:
-    nothing:               "元に戻せる操作がありません。"
-    removed:               "↩️ {turns} ターンを取り消しました（{count} 件のメッセージ）。\nバックアップ先: 「{preview}」\n上のテキストをコピー／編集して送信すると、ここから再入力できます。"
-    invalid_count:         "無効な数値「{arg}」— /undo または /undo N を使用してください。"
+    nothing:               "Nothing to undo."
+    removed:               "↩️ Undid {turns} half-turn(s) ({count} message(s))."
+    invalid_count:         "Invalid count \"{arg}\" — use /undo or /undo N."
+
+  redo:
+    nothing:               "Nothing to redo."
+    restart_lost:          "Nothing to redo — redo history does not survive a restart."
+    restored:              "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+    invalid_count:         "Invalid count \"{arg}\" — use /redo or /redo N."
 
   update:
     platform_not_messaging:  "✗ /update はメッセージングプラットフォームでのみ利用可能です。ターミナルで `hermes update` を実行してください。"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -320,9 +320,15 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "제목 없는 세션"
 
   undo:
-    nothing:               "되돌릴 내용이 없습니다."
-    removed:               "↩️ {turns}개 턴을 되돌렸습니다 (메시지 {count}개).\n백업 위치: \"{preview}\"\n위 텍스트를 복사/편집한 후 보내면 여기서 다시 프롬프트할 수 있습니다."
-    invalid_count:         "잘못된 개수 \"{arg}\" — /undo 또는 /undo N을 사용하세요."
+    nothing:               "Nothing to undo."
+    removed:               "↩️ Undid {turns} half-turn(s) ({count} message(s))."
+    invalid_count:         "Invalid count \"{arg}\" — use /undo or /undo N."
+
+  redo:
+    nothing:               "Nothing to redo."
+    restart_lost:          "Nothing to redo — redo history does not survive a restart."
+    restored:              "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+    invalid_count:         "Invalid count \"{arg}\" — use /redo or /redo N."
 
   update:
     platform_not_messaging:  "✗ /update는 메시징 플랫폼에서만 사용할 수 있습니다. 터미널에서 `hermes update`를 실행하세요."

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -320,9 +320,15 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "Sessão sem título"
 
   undo:
-    nothing:               "Nada para anular."
-    removed:               "↩️ {turns} turno(s) anulado(s) ({count} mensagem(ns)).\nGuardado em: \"{preview}\"\nCopia/edita o texto acima e envia-o para voltar a perguntar a partir daqui."
-    invalid_count:         "Contagem inválida \"{arg}\" — usa /undo ou /undo N."
+    nothing:               "Nothing to undo."
+    removed:               "↩️ Undid {turns} half-turn(s) ({count} message(s))."
+    invalid_count:         "Invalid count \"{arg}\" — use /undo or /undo N."
+
+  redo:
+    nothing:               "Nothing to redo."
+    restart_lost:          "Nothing to redo — redo history does not survive a restart."
+    restored:              "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+    invalid_count:         "Invalid count \"{arg}\" — use /redo or /redo N."
 
   update:
     platform_not_messaging:  "✗ /update só está disponível em plataformas de mensagens. Executa `hermes update` a partir do terminal."

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -320,9 +320,15 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "Сеанс без названия"
 
   undo:
-    nothing:               "Нечего отменять."
-    removed:               "↩️ Отменено ходов: {turns} (сообщений: {count}).\nРезервная копия: «{preview}»\nСкопируйте/отредактируйте текст выше и отправьте его, чтобы запросить заново отсюда."
-    invalid_count:         "Недопустимое число «{arg}» — используйте /undo или /undo N."
+    nothing:               "Nothing to undo."
+    removed:               "↩️ Undid {turns} half-turn(s) ({count} message(s))."
+    invalid_count:         "Invalid count \"{arg}\" — use /undo or /undo N."
+
+  redo:
+    nothing:               "Nothing to redo."
+    restart_lost:          "Nothing to redo — redo history does not survive a restart."
+    restored:              "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+    invalid_count:         "Invalid count \"{arg}\" — use /redo or /redo N."
 
   update:
     platform_not_messaging:  "✗ /update доступен только на платформах обмена сообщениями. Выполните `hermes update` в терминале."

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -320,9 +320,15 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "Adsız oturum"
 
   undo:
-    nothing:               "Geri alınacak bir şey yok."
-    removed:               "↩️ {turns} tur geri alındı ({count} mesaj).\nYedeklendiği yer: \"{preview}\"\nYukarıdaki metni kopyalayıp/düzenleyip göndererek buradan yeniden sorabilirsiniz."
-    invalid_count:         "Geçersiz sayı \"{arg}\" — /undo veya /undo N kullanın."
+    nothing:               "Nothing to undo."
+    removed:               "↩️ Undid {turns} half-turn(s) ({count} message(s))."
+    invalid_count:         "Invalid count \"{arg}\" — use /undo or /undo N."
+
+  redo:
+    nothing:               "Nothing to redo."
+    restart_lost:          "Nothing to redo — redo history does not survive a restart."
+    restored:              "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+    invalid_count:         "Invalid count \"{arg}\" — use /redo or /redo N."
 
   update:
     platform_not_messaging:  "✗ /update yalnızca mesajlaşma platformlarında kullanılabilir. Terminalden `hermes update` komutunu çalıştırın."

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -320,9 +320,15 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "Сесія без назви"
 
   undo:
-    nothing:               "Немає чого скасовувати."
-    removed:               "↩️ Скасовано ходів: {turns} (повідомлень: {count}).\nРезервна копія: «{preview}»\nСкопіюйте/відредагуйте текст вище та надішліть його, щоб запитати знову звідси."
-    invalid_count:         "Недійсне число «{arg}» — використовуйте /undo або /undo N."
+    nothing:               "Nothing to undo."
+    removed:               "↩️ Undid {turns} half-turn(s) ({count} message(s))."
+    invalid_count:         "Invalid count \"{arg}\" — use /undo or /undo N."
+
+  redo:
+    nothing:               "Nothing to redo."
+    restart_lost:          "Nothing to redo — redo history does not survive a restart."
+    restored:              "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+    invalid_count:         "Invalid count \"{arg}\" — use /redo or /redo N."
 
   update:
     platform_not_messaging:  "✗ /update доступний лише на платформах обміну повідомленнями. Виконайте `hermes update` у терміналі."

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -320,9 +320,15 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "未命名工作階段"
 
   undo:
-    nothing:               "沒有可復原的內容。"
-    removed:               "↩️ 已復原 {turns} 個回合（{count} 則訊息）。\n已備份至：「{preview}」\n複製/編輯上方的文字並傳送，即可從此處重新提問。"
-    invalid_count:         "無效的數量「{arg}」—— 請使用 /undo 或 /undo N。"
+    nothing:               "Nothing to undo."
+    removed:               "↩️ Undid {turns} half-turn(s) ({count} message(s))."
+    invalid_count:         "Invalid count \"{arg}\" — use /undo or /undo N."
+
+  redo:
+    nothing:               "Nothing to redo."
+    restart_lost:          "Nothing to redo — redo history does not survive a restart."
+    restored:              "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+    invalid_count:         "Invalid count \"{arg}\" — use /redo or /redo N."
 
   update:
     platform_not_messaging:  "✗ /update 僅在訊息平台上可用。請在終端機執行 `hermes update`。"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -320,9 +320,15 @@ Future messages in this room will use that transcript until `/reset` or another 
     untitled_session:        "未命名会话"
 
   undo:
-    nothing:               "没有可撤销的内容。"
-    removed:               "↩️ 已撤销 {turns} 个回合（{count} 条消息）。\n已备份到：「{preview}」\n复制/编辑上面的文本并发送，即可从此处重新提问。"
-    invalid_count:         "无效的数量「{arg}」—— 请使用 /undo 或 /undo N。"
+    nothing:               "Nothing to undo."
+    removed:               "↩️ Undid {turns} half-turn(s) ({count} message(s))."
+    invalid_count:         "Invalid count \"{arg}\" — use /undo or /undo N."
+
+  redo:
+    nothing:               "Nothing to redo."
+    restart_lost:          "Nothing to redo — redo history does not survive a restart."
+    restored:              "↪️ Redid {ops} undo operation(s) ({count} message(s) restored)."
+    invalid_count:         "Invalid count \"{arg}\" — use /redo or /redo N."
 
   update:
     platform_not_messaging:  "✗ /update 仅在消息平台可用。请在终端运行 `hermes update`。"

--- a/tests/cli/test_cli_prefix_matching.py
+++ b/tests/cli/test_cli_prefix_matching.py
@@ -138,7 +138,14 @@ class TestSlashCommandPrefixMatching:
         assert "Ambiguous" not in printed
 
     def test_tied_shortest_matches_still_ambiguous(self):
-        """/re matches /reset and /retry (both 6 chars) — no unique shortest, stays ambiguous."""
+        """/re matches many unrelated commands — no single base, stays ambiguous.
+
+        Regression guard (undo/redo half-turn branch): adding /redo made it the
+        unique *shortest* /re* command (5 chars). The old "unique shortest match"
+        heuristic then silently resolved /re → /redo, swallowing the ambiguity.
+        /redo/reset/retry are unrelated siblings (none is a prefix of the others),
+        so the prefix must stay ambiguous rather than fire redo on a bare /re.
+        """
         cli_obj = _make_cli()
         printed = []
         import cli as cli_mod
@@ -146,6 +153,19 @@ class TestSlashCommandPrefixMatching:
             cli_obj.process_command("/re")
         combined = " ".join(printed)
         assert "Ambiguous" in combined or "Did you mean" in combined
+
+    def test_shortest_builtin_wins_only_when_prefix_of_siblings(self):
+        """/sta → /status: shortest IS a prefix of /statusbar, so it resolves.
+
+        Companion to the /re ambiguity guard: when the shortest built-in match is
+        itself a prefix of every other built-in match (the others are extensions of
+        one base command), resolve to that base instead of reporting ambiguity.
+        """
+        cli_obj = _make_cli()
+        with patch.object(cli_obj, "_show_session_status") as mock_status:
+            result = cli_obj.process_command("/sta")
+        assert result is True
+        mock_status.assert_called_once_with()
 
     def test_exact_typed_name_dispatches_over_longer_match(self):
         """/help typed with /help-extra skill installed → exact match wins."""

--- a/tests/cli/test_undo_redo_half_turn.py
+++ b/tests/cli/test_undo_redo_half_turn.py
@@ -1,0 +1,110 @@
+from types import SimpleNamespace
+
+import pytest
+
+import hermes_undo
+from agent.agent_runtime_helpers import repair_message_sequence
+from cli import HermesCLI
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def db(tmp_path, monkeypatch):
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    monkeypatch.setattr(hermes_undo, "_session_db", session_db)
+    hermes_undo.clear_state()
+    yield session_db
+    session_db.close()
+    hermes_undo.clear_state()
+
+
+def _cli(db, sid):
+    buf = SimpleNamespace(text="", cursor_position=0)
+    app = SimpleNamespace(current_buffer=buf, invalidate=lambda: None)
+    cli_obj = SimpleNamespace(
+        session_id=sid,
+        _session_db=db,
+        conversation_history=[],
+        agent=None,
+        _app=app,
+        buffer=buf,
+    )
+    cli_obj._reload_active_history_after_rewind = (
+        lambda rewound=False: HermesCLI._reload_active_history_after_rewind(
+            cli_obj, rewound=rewound
+        )
+    )
+    cli_obj._prefill_input_buffer = lambda text: HermesCLI._prefill_input_buffer(cli_obj, text)
+    return cli_obj
+
+
+def _seed(db, sid):
+    u1 = db.append_message(sid, "user", "first exact surviving text")
+    a1 = db.append_message(sid, "assistant", "answer one")
+    u2 = db.append_message(sid, "user", "second exact surviving text")
+    a2 = db.append_message(sid, "assistant", "answer two")
+    return u1, a1, u2, a2
+
+
+def test_d4_prefill_uses_exact_surviving_new_tail_for_n_1_2_3(db):
+    for n, expected in (
+        (1, "second exact surviving text"),
+        (2, ""),
+        (3, "first exact surviving text"),
+    ):
+        sid = f"cli-prefill-{n}"
+        db.create_session(sid, source="cli")
+        _seed(db, sid)
+        cli_obj = _cli(db, sid)
+
+        HermesCLI.undo_last(cli_obj, n)
+
+        assert cli_obj.buffer.text == expected
+        if expected:
+            assert cli_obj.buffer.cursor_position == len(expected)
+        active = db.get_messages(sid)
+        tail = active[-1] if active else None
+        if expected:
+            assert tail["role"] == "user"
+            assert tail["content"] == expected
+        else:
+            assert tail["role"] == "assistant"
+
+
+def test_str_prefill_edit_resend_merges_two_user_rows_before_provider(db):
+    sid = "cli-edit-resend"
+    db.create_session(sid, source="cli")
+    db.append_message(sid, "user", "original draft")
+    db.append_message(sid, "assistant", "answer")
+    cli_obj = _cli(db, sid)
+
+    HermesCLI.undo_last(cli_obj, 1)
+    assert cli_obj.buffer.text == "original draft"
+
+    db.append_message(sid, "user", "edited draft")
+    hermes_undo.on_user_message_appended(sid)
+    messages = db.get_messages_as_conversation(sid)
+    assert [m["role"] for m in messages] == ["user", "user"]
+
+    repairs = repair_message_sequence(object(), messages)
+
+    assert repairs == 1
+    assert len(messages) == 1
+    assert messages[0]["role"] == "user"
+    assert messages[0]["content"] == "original draft\n\nedited draft"
+
+
+def test_clear_redo_on_send_leaves_undo_stack_available(db):
+    sid = "cli-clear-redo"
+    db.create_session(sid, source="cli")
+    _seed(db, sid)
+    hermes_undo.undo(sid, 1)
+    hermes_undo.redo(sid, 1)
+    state = hermes_undo.get_state(sid)
+    assert state.redo_stack
+
+    db.append_message(sid, "user", "new branch")
+    hermes_undo.on_user_message_appended(sid)
+
+    assert state.redo_stack == []
+    assert state.undo_stack == []

--- a/tests/gateway/test_undo_redo_half_turn.py
+++ b/tests/gateway/test_undo_redo_half_turn.py
@@ -1,0 +1,157 @@
+import ast
+import asyncio
+import inspect
+import threading
+import textwrap
+from collections import OrderedDict
+
+import pytest
+
+import hermes_undo
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, SessionStore, build_session_key
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def store(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_store = SessionStore(sessions_dir=tmp_path / "sessions", config=GatewayConfig())
+    session_store._db = db
+    hermes_undo._session_db = db
+    hermes_undo.clear_state()
+    yield session_store
+    db.close()
+    hermes_undo.clear_state()
+
+
+def _source(chat_id="chat-1"):
+    return SessionSource(platform=Platform.TELEGRAM, chat_id=chat_id, chat_type="dm")
+
+
+def _event(text, source):
+    return MessageEvent(text=text, source=source, message_id="m1")
+
+
+def _seed(db, sid):
+    u1 = db.append_message(sid, "user", "q1")
+    a1 = db.append_message(sid, "assistant", "a1")
+    u2 = db.append_message(sid, "user", "q2")
+    a2 = db.append_message(sid, "assistant", "a2")
+    return u1, a1, u2, a2
+
+
+def _runner(store):
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.session_store = store
+    runner._agent_cache = OrderedDict()
+    runner._agent_cache_lock = threading.Lock()
+    return runner
+
+
+def test_cold_restart_redo_branches_touch_zero_rows(store):
+    src = _source("restart")
+    entry = store.get_or_create_session(src)
+    _seed(store._db, entry.session_id)
+    before = store._db.get_messages(entry.session_id, include_inactive=True)
+
+    store.rewind_session(entry.session_id, 1)
+    after_undo = store._db.get_messages(entry.session_id, include_inactive=True)
+    hermes_undo.clear_state(entry.session_id)
+    cold = store.restore_session(entry.session_id, 1)
+
+    assert cold["reactivated_count"] == 0
+    assert cold["message"] == "nothing to redo (redo history doesn't survive a restart)"
+    assert store._db.get_messages(entry.session_id, include_inactive=True) == after_undo
+
+    fresh = store.get_or_create_session(_source("never-undone"))
+    _seed(store._db, fresh.session_id)
+    fresh_before = store._db.get_messages(fresh.session_id, include_inactive=True)
+    hermes_undo.clear_state(fresh.session_id)
+    bare = store.restore_session(fresh.session_id, 1)
+
+    assert bare["reactivated_count"] == 0
+    assert bare["message"] == "nothing to redo"
+    assert store._db.get_messages(fresh.session_id, include_inactive=True) == fresh_before
+    assert before != after_undo
+
+
+def test_no_active0_reconstruction_in_gateway_redo_paths():
+    positive = ast.parse(
+        "def planted(db):\n"
+        "    return db.get_messages('sid', include_inactive=True)\n"
+    )
+    assert any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "get_messages"
+        and any(
+            kw.arg == "include_inactive" and isinstance(kw.value, ast.Constant) and kw.value.value is True
+            for kw in node.keywords
+        )
+        for node in ast.walk(positive)
+    )
+
+    for func in (SessionStore.restore_session, GatewayRunner._handle_redo_command):
+        tree = ast.parse(textwrap.dedent(inspect.getsource(func)))
+        offenders = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get_messages"
+            and any(
+                kw.arg == "include_inactive"
+                and isinstance(kw.value, ast.Constant)
+                and kw.value.value is True
+                for kw in node.keywords
+            )
+        ]
+        assert offenders == []
+
+
+def test_cached_agent_evicted_after_undo_and_after_redo(store):
+    src = _source("evict")
+    entry = store.get_or_create_session(src)
+    _seed(store._db, entry.session_id)
+    runner = _runner(store)
+    cache_key = build_session_key(src)
+    runner._agent_cache[cache_key] = ("stale-before-undo", "sig")
+
+    undo_msg = asyncio.run(runner._handle_undo_command(_event("/undo", src)))
+
+    assert "Undid" in undo_msg or "Removed" in undo_msg
+    assert cache_key not in runner._agent_cache
+    assert store.load_transcript(entry.session_id) == store._db.get_messages_as_conversation(entry.session_id)
+
+    runner._agent_cache[cache_key] = ("stale-before-redo", "sig")
+    redo_msg = asyncio.run(runner._handle_redo_command(_event("/redo", src)))
+
+    assert "Redid" in redo_msg
+    assert cache_key not in runner._agent_cache
+    assert store.load_transcript(entry.session_id) == store._db.get_messages_as_conversation(entry.session_id)
+
+
+def test_null_content_tail_confirmation_does_not_stringify_none(store):
+    src = _source("null-tail")
+    entry = store.get_or_create_session(src)
+    db = store._db
+    db.append_message(entry.session_id, "user", "run tool")
+    assistant = db.append_message(
+        entry.session_id,
+        "assistant",
+        None,
+        tool_calls=[{"id": "call-1", "type": "function", "function": {"name": "x"}}],
+    )
+    db.append_message(entry.session_id, "tool", "ok", tool_call_id="call-1")
+    runner = _runner(store)
+
+    undo = store.rewind_session(entry.session_id, 1)
+    assert set(undo["rewound_ids"]) == {assistant, assistant + 1}
+    msg = asyncio.run(runner._handle_redo_command(_event("/redo", src)))
+
+    assert "Redid" in msg
+    assert "None" not in msg

--- a/tests/gateway/test_undo_rewind_session.py
+++ b/tests/gateway/test_undo_rewind_session.py
@@ -1,9 +1,8 @@
 """Tests for SessionStore.rewind_session — the gateway /undo [N] primitive.
 
-The gateway /undo backs up N user turns by soft-deleting the truncated rows
-in state.db (active=0, kept for audit, hidden from re-prompts/search) via
-SessionDB.rewind_to_message, rather than the old hard rewrite_transcript.
-load_transcript returns only the active view. See issue #21910.
+The gateway /undo backs up N half-turns by soft-deleting rows in state.db
+(active=0, kept for audit, hidden from re-prompts/search) via the shared
+undo core. load_transcript returns only the active view. See issue #21910.
 """
 
 from __future__ import annotations
@@ -38,20 +37,19 @@ def _seed(store, sid, source="telegram", turns=3):
 def test_rewind_default_one_turn(store):
     sid = _seed(store, "gw-1")
     res = store.rewind_session(sid)
-    assert res["turns_undone"] == 1
-    assert res["target_text"] == "q3"
-    assert res["rewound_count"] == 2  # q3 + a3
+    assert res["rewound_ids"]
+    assert res["prefill_text"] == "q3"
+    assert len(res["rewound_ids"]) == 1  # a3
     active = store.load_transcript(sid)
-    assert [m["role"] for m in active] == ["user", "assistant", "user", "assistant"]
+    assert [m["role"] for m in active] == ["user", "assistant", "user", "assistant", "user"]
 
 
 def test_rewind_n_turns(store):
     sid = _seed(store, "gw-2")
     res = store.rewind_session(sid, 2)
-    assert res["turns_undone"] == 2
-    assert res["target_text"] == "q2"
-    assert res["rewound_count"] == 4  # q2,a2,q3,a3
-    assert len(store.load_transcript(sid)) == 2  # q1,a1
+    assert len(res["rewound_ids"]) == 2  # q3,a3
+    assert res["prefill_text"] is None
+    assert len(store.load_transcript(sid)) == 4  # q1,a1,q2,a2
 
 
 def test_rewind_soft_deletes_rows_for_audit(store):
@@ -59,14 +57,15 @@ def test_rewind_soft_deletes_rows_for_audit(store):
     store.rewind_session(sid, 1)
     all_rows = store._db.get_messages(sid, include_inactive=True)
     assert len(all_rows) == 6  # nothing hard-deleted
-    assert sum(1 for r in all_rows if r["active"] == 1) == 4
+    assert sum(1 for r in all_rows if r["active"] == 1) == 5
     assert store._db.get_session(sid)["rewind_count"] == 1
 
 
 def test_rewind_clamps_to_oldest_turn(store):
     sid = _seed(store, "gw-4", turns=2)
     res = store.rewind_session(sid, 99)
-    assert res["target_text"] == "q1"
+    assert res["rewound_ids"]
+    assert res["prefill_text"] is None
     assert len(store.load_transcript(sid)) == 0
 
 
@@ -78,5 +77,5 @@ def test_rewind_empty_session_returns_none(store):
 def test_rewind_clamps_negative_count_to_one(store):
     sid = _seed(store, "gw-6")
     res = store.rewind_session(sid, -5)
-    assert res["turns_undone"] == 1
-    assert res["target_text"] == "q3"
+    assert len(res["rewound_ids"]) == 1
+    assert res["prefill_text"] == "q3"

--- a/tests/test_half_turn_target.py
+++ b/tests/test_half_turn_target.py
@@ -1,0 +1,120 @@
+import pytest
+
+import hermes_undo
+from hermes_state import SessionDB
+from hermes_undo import compute_half_turn_target
+
+
+@pytest.fixture()
+def db(tmp_path, monkeypatch):
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    monkeypatch.setattr(hermes_undo, "_session_db", session_db)
+    hermes_undo.clear_state()
+    yield session_db
+    session_db.close()
+    hermes_undo.clear_state()
+
+
+def _session(db, sid="s1"):
+    db.create_session(sid, source="cli")
+    return sid
+
+
+def _ids(messages):
+    return {m["role"]: m["id"] for m in messages}
+
+
+def test_tool_call_assistant_run_is_one_half_turn(db):
+    sid = _session(db)
+    u = db.append_message(sid, "user", "run tools")
+    a = db.append_message(
+        sid,
+        "assistant",
+        None,
+        tool_calls=[{"id": "c1"}, {"id": "c2"}],
+    )
+    t1 = db.append_message(sid, "tool", "one", tool_call_id="c1")
+    t2 = db.append_message(sid, "tool", "two", tool_call_id="c2")
+    final = db.append_message(sid, "assistant", "done")
+    msgs = db.get_messages(sid)
+
+    assert compute_half_turn_target(msgs, 1) == a
+    assert compute_half_turn_target(msgs, 2) == u
+    assert [t1, t2, final] == [m["id"] for m in msgs[2:]]
+
+
+def test_partial_assistant_tool_turn_starts_at_assistant(db):
+    sid = _session(db)
+    u = db.append_message(sid, "user", "run")
+    a = db.append_message(sid, "assistant", None, tool_calls=[{"id": "c1"}])
+    db.append_message(sid, "tool", "result", tool_call_id="c1")
+
+    msgs = db.get_messages(sid)
+    assert compute_half_turn_target(msgs, 1) == a
+    assert compute_half_turn_target(msgs, 2) == u
+
+
+def test_adjacent_multimodal_and_text_user_rows_are_one_half_turn(db):
+    sid = _session(db)
+    u1 = db.append_message(sid, "user", "first")
+    a = db.append_message(sid, "assistant", "answer")
+    mm = db.append_message(
+        sid,
+        "user",
+        [{"type": "text", "text": "look"}, {"type": "image_url", "image_url": "x"}],
+    )
+    text = db.append_message(sid, "user", "more detail")
+
+    msgs = db.get_messages(sid)
+    assert compute_half_turn_target(msgs, 1) == mm
+    assert compute_half_turn_target(msgs, 2) == a
+    assert text > mm > a > u1
+
+
+def test_other_roles_are_not_counted_or_targeted_and_clamp_to_oldest_user(db):
+    sid = _session(db)
+    system = db.append_message(sid, "system", "rules")
+    first_user = db.append_message(sid, "user", "one")
+    db.append_message(sid, "assistant", "two")
+    db.append_message(sid, "user", "three")
+
+    msgs = db.get_messages(sid)
+    assert compute_half_turn_target(msgs, 4) == first_user
+    assert compute_half_turn_target(msgs, 99) != system
+
+
+def test_zero_non_other_returns_none_and_undo_noops_without_touching_stacks(db):
+    sid = _session(db)
+    db.append_message(sid, "system", "rules only")
+    state = hermes_undo.get_state(sid)
+    state.redo_stack.append(hermes_undo.UndoOp(n=1, rewound_ids=[999]))
+
+    assert compute_half_turn_target(db.get_messages(sid), 1) is None
+    result = hermes_undo.undo(sid, 1)
+
+    assert result["rewound_ids"] == []
+    assert result["prefill_text"] is None
+    assert "nothing to undo" in result["message"]
+    assert state.undo_stack == []
+    assert len(state.redo_stack) == 1
+    assert [m["role"] for m in db.get_messages(sid)] == ["system"]
+
+
+def test_tool_row_monotonicity_holds_for_normal_data_and_violation_raises(db):
+    sid = _session(db)
+    db.append_message(sid, "user", "run")
+    assistant = db.append_message(
+        sid, "assistant", None, tool_calls=[{"id": "c1"}]
+    )
+    tool = db.append_message(sid, "tool", "result", tool_call_id="c1")
+    assert tool > assistant
+
+    bad = _session(db, "bad")
+    db.append_message(bad, "user", "run")
+    orphan = db.append_message(bad, "tool", "too early", tool_call_id="bad-call")
+    owner = db.append_message(
+        bad, "assistant", None, tool_calls=[{"id": "bad-call"}]
+    )
+    assert orphan < owner
+    with pytest.raises(ValueError, match="orphan"):
+        db.rewind_to_message(bad, owner, require_user_role=False)

--- a/tests/test_restore_ids.py
+++ b/tests/test_restore_ids.py
@@ -1,0 +1,45 @@
+import ast
+import inspect
+
+from hermes_state import SessionDB
+
+
+def test_restore_ids_reactivates_only_inactive_ids_in_same_session(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("s1", source="cli")
+        db.create_session("s2", source="cli")
+        active = db.append_message("s1", "user", "active")
+        inactive = db.append_message("s1", "assistant", "inactive")
+        other_session = db.append_message("s2", "user", "other")
+        db._conn.execute("UPDATE messages SET active = 0 WHERE id IN (?, ?)", (inactive, other_session))
+
+        assert db.restore_ids("s1", [active, inactive, other_session, 99999]) == 1
+        rows1 = {m["id"]: m["active"] for m in db.get_messages("s1", include_inactive=True)}
+        rows2 = {m["id"]: m["active"] for m in db.get_messages("s2", include_inactive=True)}
+        assert rows1[active] == 1
+        assert rows1[inactive] == 1
+        assert rows2[other_session] == 0
+        assert db.restore_ids("s1", [inactive]) == 0
+    finally:
+        db.close()
+
+
+def test_restore_ids_empty_list_is_noop(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("s1", source="cli")
+        assert db.restore_ids("s1", []) == 0
+    finally:
+        db.close()
+
+
+def test_restore_ids_uses_bounded_parameterized_in_clause():
+    import hermes_state
+
+    source = inspect.getsource(hermes_state.SessionDB.restore_ids)
+    positive = "conn.execute(f'UPDATE x WHERE id IN ({placeholders})', (session_id, *bounded_ids))"
+    assert ast.parse(positive)
+    assert "bounded_ids = [int(i) for i in ids]" in source
+    assert "id IN ({placeholders})" in source
+    assert "(session_id, *bounded_ids)" in source

--- a/tests/test_state_rewind_generalized.py
+++ b/tests/test_state_rewind_generalized.py
@@ -1,0 +1,58 @@
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def db(tmp_path):
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    yield session_db
+    session_db.close()
+
+
+def test_rewind_requires_user_role_by_default(db):
+    db.create_session("s1", source="cli")
+    db.append_message("s1", "user", "u")
+    assistant = db.append_message("s1", "assistant", "a")
+
+    with pytest.raises(ValueError, match="must be a 'user'"):
+        db.rewind_to_message("s1", assistant)
+
+
+def test_rewind_can_target_assistant_when_role_requirement_disabled(db):
+    db.create_session("s1", source="cli")
+    user = db.append_message("s1", "user", "u")
+    assistant = db.append_message("s1", "assistant", "a")
+
+    result = db.rewind_to_message("s1", assistant, require_user_role=False)
+
+    assert result["rewound_ids"] == [assistant]
+    assert result["rewound_count"] == 1
+    assert result["new_head_id"] == user
+    assert [m["id"] for m in db.get_messages("s1")] == [user]
+
+
+def test_rewound_ids_include_only_rows_flipped_from_active_to_inactive(db):
+    db.create_session("s1", source="cli")
+    db.append_message("s1", "user", "u1")
+    target = db.append_message("s1", "assistant", "a1")
+    inactive_hole = db.append_message("s1", "user", "u2")
+    active_tail = db.append_message("s1", "assistant", "a2")
+    db._conn.execute("UPDATE messages SET active = 0 WHERE id = ?", (inactive_hole,))
+
+    result = db.rewind_to_message("s1", target, require_user_role=False)
+
+    assert result["rewound_ids"] == [target, active_tail]
+    assert inactive_hole not in result["rewound_ids"]
+    all_rows = db.get_messages("s1", include_inactive=True)
+    assert {r["id"]: r["active"] for r in all_rows}[inactive_hole] == 0
+
+
+def test_rewind_raise_guard_prevents_tool_orphan(db):
+    db.create_session("s1", source="cli")
+    db.append_message("s1", "user", "u")
+    tool = db.append_message("s1", "tool", "early", tool_call_id="c1")
+    assistant = db.append_message("s1", "assistant", None, tool_calls=[{"id": "c1"}])
+
+    with pytest.raises(ValueError, match=f"id={tool}"):
+        db.rewind_to_message("s1", assistant, require_user_role=False)

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4887,24 +4887,38 @@ def test_session_undo_rejects_while_running():
         server._sessions.pop("sid", None)
 
 
-def test_session_undo_allowed_when_idle():
-    """Regression guard: when not running, /undo still works."""
+def test_session_undo_allowed_when_idle(tmp_path, monkeypatch):
+    """Regression guard: when not running, /undo backs up a half-turn.
+
+    Half-turn undo is DB-backed (reversible active-flags), so seed real rows
+    via SessionDB and assert the surviving in-memory history reflects the
+    deactivated tail.
+    """
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "undo-idle.db")
+    session_key = "sid-undo-idle"
+    db.create_session(session_key, source="tui")
+    db.append_message(session_key, "user", "hi")
+    db.append_message(session_key, "assistant", "hello")
+    history = db.get_messages_as_conversation(session_key)
+    monkeypatch.setattr(server, "_db", db, raising=False)
     server._sessions["sid"] = _session(
         running=False,
-        history=[
-            {"role": "user", "content": "hi"},
-            {"role": "assistant", "content": "hello"},
-        ],
+        session_key=session_key,
+        history=list(history),
     )
     try:
         resp = server.handle_request(
             {"id": "1", "method": "session.undo", "params": {"session_id": "sid"}}
         )
         assert resp.get("result"), f"got error: {resp.get('error')}"
-        assert resp["result"]["removed"] == 2
-        assert server._sessions["sid"]["history"] == []
+        # /undo 1 removes the trailing assistant half-turn, leaving the user tail.
+        assert resp["result"]["removed"] == 1
+        assert [m["role"] for m in server._sessions["sid"]["history"]] == ["user"]
     finally:
         server._sessions.pop("sid", None)
+        server._db = None
 
 
 def test_session_compress_rejects_while_running(monkeypatch):

--- a/tests/test_undo_redo_stack.py
+++ b/tests/test_undo_redo_stack.py
@@ -1,0 +1,350 @@
+import ast
+import inspect
+
+import pytest
+
+import hermes_undo
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def db(tmp_path, monkeypatch):
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    monkeypatch.setattr(hermes_undo, "_session_db", session_db)
+    hermes_undo.clear_state()
+    yield session_db
+    session_db.close()
+    hermes_undo.clear_state()
+
+
+def _make_session(db, sid="s1"):
+    db.create_session(sid, source="cli")
+    return sid
+
+
+def _active_ids(db, sid):
+    return [m["id"] for m in db.get_messages(sid)]
+
+
+def _seed_three_half_turns(db, sid):
+    u1 = db.append_message(sid, "user", "u1")
+    a1 = db.append_message(sid, "assistant", "a1")
+    u2 = db.append_message(sid, "user", "u2")
+    a2 = db.append_message(sid, "assistant", "a2")
+    return u1, a1, u2, a2
+
+
+def test_undo_redo_transition_table_identity_and_redo_count(db):
+    sid = _make_session(db)
+    ids = _seed_three_half_turns(db, sid)
+    before = _active_ids(db, sid)
+
+    undone = hermes_undo.undo(sid, 1)
+    assert undone["rewound_ids"] == [ids[-1]]
+    assert undone["prefill_text"] == "u2"
+    state = hermes_undo.get_state(sid)
+    assert [op.rewound_ids for op in state.undo_stack] == [[ids[-1]]]
+    assert state.redo_stack == []
+    assert _active_ids(db, sid) == before[:-1]
+
+    redone = hermes_undo.redo(sid, 1)
+    assert redone == {"reactivated_count": 1, "new_tail_id": ids[-1], "prefill_text": None}
+    assert _active_ids(db, sid) == before
+    assert state.undo_stack == []
+    assert [op.rewound_ids for op in state.redo_stack] == [[ids[-1]]]
+    assert db.get_session(sid)["redo_count"] == 1
+
+
+def test_stacked_ops_have_disjoint_ids_and_redo_lifo_pop_order(db):
+    sid = _make_session(db)
+    ids = _seed_three_half_turns(db, sid)
+
+    op1 = hermes_undo.undo(sid, 1)
+    op2 = hermes_undo.undo(sid, 1)
+    op3 = hermes_undo.undo(sid, 1)
+    rewound_sets = [set(op["rewound_ids"]) for op in (op1, op2, op3)]
+    assert rewound_sets == [{ids[3]}, {ids[2]}, {ids[1]}]
+    assert rewound_sets[0].isdisjoint(rewound_sets[1])
+    assert rewound_sets[0].isdisjoint(rewound_sets[2])
+    assert rewound_sets[1].isdisjoint(rewound_sets[2])
+
+    redone = hermes_undo.redo(sid, 2)
+    assert redone["reactivated_count"] == 2
+    assert _active_ids(db, sid) == [ids[0], ids[1], ids[2]]
+    state = hermes_undo.get_state(sid)
+    assert [op.rewound_ids for op in state.redo_stack] == [[ids[1]], [ids[2]]]
+    assert [op.rewound_ids for op in state.undo_stack] == [[ids[3]]]
+
+
+def test_redo_m_non_positive_and_empty_stack_do_not_bump(db):
+    sid = _make_session(db)
+    db.append_message(sid, "user", "u")
+
+    assert hermes_undo.redo(sid, 0)["message"] == "nothing to redo"
+    assert hermes_undo.redo(sid, -1)["message"] == "nothing to redo"
+    assert db.get_session(sid)["redo_count"] is None
+
+    assert hermes_undo.redo(sid, 10)["message"] == "nothing to redo"
+    assert db.get_session(sid)["redo_count"] is None
+
+    hermes_undo.undo(sid, 1)
+    hermes_undo.clear_state(sid)
+    cold = hermes_undo.redo(sid, 1)
+    assert "doesn't survive a restart" in cold["message"]
+    assert db.get_session(sid)["redo_count"] is None
+
+
+def test_redo_degrades_gracefully_when_no_rows_restorable(monkeypatch, db):
+    """Zero rows restorable == transcript was rewritten → graceful no-op, no raise.
+
+    A redo op whose rows ALL fail to restore means the transcript was rewritten
+    out from under the stack (/compress, /retry); redo across that is impossible,
+    same as after a restart. This must NOT raise (it's reachable by normal user
+    actions: /undo then /compress then /redo). A PARTIAL restore is different —
+    that still fails loud (see test_redo_fail_loud_requires_each_op_restore_all_rewound_ids).
+    """
+    sid = _make_session(db)
+    _seed_three_half_turns(db, sid)
+    hermes_undo.undo(sid, 1)
+    monkeypatch.setattr(db, "restore_ids", lambda _sid, _ids: 0)
+
+    r = hermes_undo.redo(sid, 1)
+    assert r["reactivated_count"] == 0
+    assert "transcript changed" in r["message"]
+    state = hermes_undo.get_state(sid)
+    assert state.undo_stack == []
+    assert state.redo_stack == []
+
+
+def test_user_message_append_invalidates_redo_branch(db):
+    """Typing a new message after an undo must discard the redo branch.
+
+    ``undo_stack`` semantically holds the redo branch (ops that were undone and
+    can be redone — ``redo()`` pops it). A text editor discards that branch the
+    moment you type after undoing, so a later /redo must NOT resurrect the
+    undone content out of order. Regression: previously on_user_message_appended
+    cleared only the vestigial ``redo_stack``, leaving ``undo_stack`` live so a
+    /redo wedged stale rows back in.
+    """
+    sid = _make_session(db)
+    _seed_three_half_turns(db, sid)
+    hermes_undo.undo(sid, 1)
+    hermes_undo.redo(sid, 1)
+    state = hermes_undo.get_state(sid)
+    assert len(state.redo_stack) == 1
+    state.undo_stack.append(hermes_undo.UndoOp(n=99, rewound_ids=[12345]))
+
+    db.append_message(sid, "user", "new branch")
+    hermes_undo.on_user_message_appended(sid)
+
+    assert state.redo_stack == []
+    assert state.undo_stack == []
+
+
+def test_undo_then_type_then_redo_does_not_resurrect(db):
+    """End-to-end repro: undo, type a new message, redo → nothing resurrected."""
+    sid = _make_session(db)
+    u1, a1, u2, a2 = _seed_three_half_turns(db, sid)
+
+    r = hermes_undo.undo(sid, 1)
+    assert r["rewound_ids"] == [a2]
+    assert _active_ids(db, sid) == [u1, a1, u2]
+
+    new = db.append_message(sid, "user", "different question")
+    hermes_undo.on_user_message_appended(sid)
+    assert _active_ids(db, sid) == [u1, a1, u2, new]
+
+    r = hermes_undo.redo(sid, 1)
+    assert r["reactivated_count"] == 0
+    # a2 must NOT be wedged back between u2 and the new message
+    assert _active_ids(db, sid) == [u1, a1, u2, new]
+
+
+def test_redo_after_transcript_rewrite_does_not_raise(db):
+    """A /compress (replace_messages) after /undo must not crash a later /redo.
+
+    replace_messages hard-deletes and renumbers rows, so the in-memory
+    undo_stack references dead ids. redo() must degrade gracefully (clear the
+    branch, report "transcript changed") instead of raising the restore-count
+    invariant. Regression: previously this raised an unhandled RuntimeError.
+    """
+    sid = _make_session(db)
+    _seed_three_half_turns(db, sid)
+    hermes_undo.undo(sid, 1)
+    state = hermes_undo.get_state(sid)
+    assert state.undo_stack  # a redo op is pending
+
+    # Simulate /compress: replace the transcript with the active-only rows.
+    active = db.get_messages(sid, include_inactive=False)
+    db.replace_messages(
+        sid, [{"role": m["role"], "content": m.get("content", "")} for m in active]
+    )
+
+    r = hermes_undo.redo(sid, 1)
+    assert r["reactivated_count"] == 0
+    assert "transcript changed" in r["message"]
+    # Stacks invalidated so a subsequent redo is also a clean no-op.
+    assert state.undo_stack == []
+    assert state.redo_stack == []
+
+
+def test_undo_with_no_rewound_rows_touches_neither_stack(monkeypatch, db):
+    """A rewind that deactivates nothing must not push an empty op or wipe redo.
+
+    Matches the None-path contract: a no-op undo leaves both stacks untouched.
+    Guards the degenerate/raced rewind_to_message return.
+    """
+    sid = _make_session(db)
+    _seed_three_half_turns(db, sid)
+    hermes_undo.undo(sid, 1)
+    hermes_undo.redo(sid, 1)
+    state = hermes_undo.get_state(sid)
+    assert state.redo_stack  # a redo op is pending
+    redo_before = list(state.redo_stack)
+    undo_before = list(state.undo_stack)
+
+    # Force rewind_to_message to report it deactivated nothing.
+    monkeypatch.setattr(
+        db, "rewind_to_message", lambda *a, **k: {"rewound_ids": []}
+    )
+    r = hermes_undo.undo(sid, 1)
+    assert r["rewound_ids"] == []
+    assert r["message"] == "nothing to undo"
+    assert state.undo_stack == undo_before
+    assert state.redo_stack == redo_before
+
+
+def test_new_undo_clears_redo_and_discarded_ops_are_unreachable(db):
+    sid = _make_session(db)
+    _seed_three_half_turns(db, sid)
+    hermes_undo.undo(sid, 1)
+    hermes_undo.redo(sid, 1)
+    state = hermes_undo.get_state(sid)
+    assert state.redo_stack
+
+    hermes_undo.undo(sid, 1)
+    assert state.redo_stack == []
+    source = inspect.getsource(hermes_undo)
+    tree = ast.parse(source)
+    calls = [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and getattr(node.func, "id", "") == "UndoOp"
+    ]
+    assert len(calls) == 1
+
+
+def test_d13_fires_on_lone_multimodal_user_tail_and_redo_round_trips(db):
+    sid = _make_session(db)
+    u_prev = db.append_message(sid, "user", "plain")
+    a1 = db.append_message(sid, "assistant", "answer one")
+    mm = db.append_message(
+        sid,
+        "user",
+        [{"type": "text", "text": "see this"}, {"type": "image_url", "image_url": "x"}],
+    )
+    a2 = db.append_message(sid, "assistant", "answer two")
+    before = _active_ids(db, sid)
+    assert hermes_undo.compute_half_turn_target(db.get_messages(sid), 1) == a2
+
+    result = hermes_undo.undo(sid, 1)
+
+    assert set(result["rewound_ids"]) == {mm, a2}
+    assert result["prefill_text"] is None
+    assert _active_ids(db, sid) == [u_prev, a1]
+    assert db.get_messages(sid)[-1]["id"] == a1
+
+    redo = hermes_undo.redo(sid, 1)
+    assert redo["new_tail_id"] == a2
+    assert _active_ids(db, sid) == before
+
+
+def test_d13_firing_fixture_is_reachable_by_two_turn_operation_sequence(db):
+    sid = _make_session(db)
+    db.append_message(sid, "user", "first text")
+    a1 = db.append_message(sid, "assistant", "first answer")
+    mm = db.append_message(
+        sid,
+        "user",
+        [{"type": "text", "text": "image prompt"}, {"type": "image_url", "image_url": "x"}],
+    )
+    a2 = db.append_message(sid, "assistant", "image answer")
+
+    result = hermes_undo.undo(sid, 1)
+
+    assert set(result["rewound_ids"]) == {mm, a2}
+    assert _active_ids(db, sid)[-1] == a1
+    assert result["prefill_text"] is None
+
+
+def test_d13_plain_string_control_does_not_lower_target(db):
+    sid = _make_session(db)
+    db.append_message(sid, "user", "plain")
+    db.append_message(sid, "assistant", "answer one")
+    user = db.append_message(sid, "user", "editable")
+    a2 = db.append_message(sid, "assistant", "answer two")
+
+    result = hermes_undo.undo(sid, 1)
+
+    assert result["rewound_ids"] == [a2]
+    assert result["prefill_text"] == "editable"
+    assert _active_ids(db, sid)[-1] == user
+
+
+def test_zero_non_other_none_return_noop_and_redo_stack_survives(db):
+    sid = _make_session(db)
+    db.append_message(sid, "system", "rules only")
+    state = hermes_undo.get_state(sid)
+    state.undo_stack.append(hermes_undo.UndoOp(n=7, rewound_ids=[700]))
+    state.redo_stack.append(hermes_undo.UndoOp(n=8, rewound_ids=[800]))
+
+    assert hermes_undo.compute_half_turn_target(db.get_messages(sid), 1) is None
+    result = hermes_undo.undo(sid, 1)
+
+    assert result["rewound_ids"] == []
+    assert result["prefill_text"] is None
+    assert result["message"] == "nothing to undo"
+    assert state.undo_stack == [hermes_undo.UndoOp(n=7, rewound_ids=[700])]
+    assert state.redo_stack == [hermes_undo.UndoOp(n=8, rewound_ids=[800])]
+    assert [m["active"] for m in db.get_messages(sid, include_inactive=True)] == [1]
+
+
+def test_tool_monotonicity_violation_raises_before_orphaning(db):
+    sid = _make_session(db)
+    db.append_message(sid, "user", "run")
+    assistant = db.append_message(sid, "assistant", None, tool_calls=[{"id": "ok"}])
+    tool = db.append_message(sid, "tool", "result", tool_call_id="ok")
+    assert tool > assistant
+
+    bad = _make_session(db, "bad-tool-order")
+    db.append_message(bad, "user", "run")
+    early_tool = db.append_message(bad, "tool", "too early", tool_call_id="call-1")
+    owner = db.append_message(
+        bad, "assistant", None, tool_calls=[{"id": "call-1"}]
+    )
+    assert early_tool < owner
+
+    with pytest.raises(ValueError, match="orphan"):
+        db.rewind_to_message(bad, owner, require_user_role=False)
+
+    rows = db.get_messages(bad)
+    assert [row["id"] for row in rows] == [m["id"] for m in rows]
+    assert all(row["active"] == 1 for row in rows)
+
+
+def test_redo_fail_loud_requires_each_op_restore_all_rewound_ids(monkeypatch, db):
+    sid = _make_session(db)
+    ids = _seed_three_half_turns(db, sid)
+    hermes_undo.undo(sid, 2)
+    op = hermes_undo.get_state(sid).undo_stack[-1]
+    assert set(op.rewound_ids) == {ids[2], ids[3]}
+
+    calls = []
+
+    def partial_restore(_sid, rewound_ids):
+        calls.append(list(rewound_ids))
+        return len(rewound_ids) - 1
+
+    monkeypatch.setattr(db, "restore_ids", partial_restore)
+    with pytest.raises(RuntimeError, match="restored 1 of 2 rewound rows"):
+        hermes_undo.redo(sid, 1)
+    assert calls == [[ids[2], ids[3]]]

--- a/tests/tui_gateway/test_undo_command.py
+++ b/tests/tui_gateway/test_undo_command.py
@@ -8,7 +8,7 @@ history, fires the memory-provider hook with ``rewound=True``, and
 returns ``{"type": "prefill", "message": <text>, "notice": ...}`` so
 the Ink client drops the message into the composer for editing.
 
-``/undo N`` backs up N user turns at once (default 1). See issue #21910.
+``/undo N`` backs up N half-turns at once (default 1). See issue #21910.
 """
 
 from __future__ import annotations
@@ -98,7 +98,7 @@ def test_undo_returns_prefill_with_target_text(server, session_with_history):
     resp = _call(server, "command.dispatch", session_id=sid, name="undo", arg="")
     result = resp["result"]
     assert result["type"] == "prefill"
-    # Default /undo backs up one user turn — "question 3"
+    # Default /undo removes the assistant half-turn and prefills the surviving user tail.
     assert result["message"] == "question 3"
     assert "Undid" in result["notice"]
 
@@ -106,34 +106,32 @@ def test_undo_returns_prefill_with_target_text(server, session_with_history):
 def test_undo_truncates_in_memory_history(server, session_with_history, db):
     sid, session_key, s, agent = session_with_history
     _call(server, "command.dispatch", session_id=sid, name="undo", arg="")
-    # After undoing to "question 3", active history should be 4 rows:
-    # user q1, asst a1, user q2, asst a2
-    assert len(s["history"]) == 4
+    # /undo 1 removes only the assistant half-turn a3, leaving q3 as editable tail.
+    assert len(s["history"]) == 5
     roles = [m["role"] for m in s["history"]]
-    assert roles == ["user", "assistant", "user", "assistant"]
+    assert roles == ["user", "assistant", "user", "assistant", "user"]
     # version bumped
     assert s["history_version"] == 1
 
 
 def test_undo_n_backs_up_multiple_turns(server, session_with_history, db):
-    """/undo 2 backs up two user turns to "question 2"."""
+    """/undo 2 backs up two half-turns, leaving the prior assistant tail."""
     sid, session_key, s, agent = session_with_history
     resp = _call(server, "command.dispatch", session_id=sid, name="undo", arg="2")
     result = resp["result"]
     assert result["type"] == "prefill"
-    assert result["message"] == "question 2"
-    assert "2 turns" in result["notice"]
-    # Active history truncated to user q1 + asst a1
-    assert len(s["history"]) == 2
-    assert [m["role"] for m in s["history"]] == ["user", "assistant"]
+    assert result["message"] == ""
+    assert "2 half-turn" in result["notice"]
+    assert len(s["history"]) == 4
+    assert [m["role"] for m in s["history"]] == ["user", "assistant", "user", "assistant"]
 
 
 def test_undo_n_clamps_to_oldest_turn(server, session_with_history, db):
-    """/undo with N larger than the number of user turns backs up to the oldest."""
+    """/undo with N larger than the half-turn count backs up to the oldest."""
     sid, session_key, s, agent = session_with_history
     resp = _call(server, "command.dispatch", session_id=sid, name="undo", arg="99")
     result = resp["result"]
-    assert result["message"] == "question 1"
+    assert result["message"] == ""
     assert len(s["history"]) == 0
 
 
@@ -150,9 +148,9 @@ def test_undo_soft_deletes_rows_in_db(server, session_with_history, db):
     # All rows still present
     all_rows = db.get_messages(session_key, include_inactive=True)
     assert len(all_rows) == 6
-    # 2 inactive (the "question 3" row + its trailing "answer 3").
+    # 1 inactive (the trailing assistant half-turn "answer 3").
     active = [r for r in all_rows if r["active"] == 1]
-    assert len(active) == 4
+    assert len(active) == 5
     # rewind_count bumped
     sess = db.get_session(session_key)
     assert sess["rewind_count"] == 1

--- a/tests/tui_gateway/test_undo_redo.py
+++ b/tests/tui_gateway/test_undo_redo.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import importlib
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import hermes_undo
+from hermes_state import SessionDB
+
+
+@pytest.fixture()
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    yield home
+
+
+@pytest.fixture()
+def server(hermes_home):
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+        },
+    ):
+        mod = importlib.import_module("tui_gateway.server")
+        yield mod
+        mod._sessions.clear()
+        mod._pending.clear()
+        mod._answers.clear()
+        mod._methods.clear()
+        hermes_undo.clear_state()
+        importlib.reload(mod)
+
+
+@pytest.fixture()
+def db(server, hermes_home):
+    session_db = SessionDB(db_path=hermes_home / "state.db")
+    server._db = session_db
+    hermes_undo._session_db = session_db
+    hermes_undo.clear_state()
+    yield session_db
+    session_db.close()
+    hermes_undo.clear_state()
+
+
+def _session(server, db, sid="sid-redo", session_key="tui-redo"):
+    db.create_session(session_key, source="tui")
+    session = {
+        "session_key": session_key,
+        "history": [],
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+        "running": False,
+        "agent": MagicMock(_memory_manager=MagicMock()),
+        "attached_images": [],
+        "cols": 120,
+    }
+    server._sessions[sid] = session
+    return sid, session
+
+
+def _call(server, method, **params):
+    return server._methods[method](1, params)
+
+
+def test_session_redo_round_trip_restores_active_rows_and_history(server, db):
+    sid, session = _session(server, db)
+    ids = [
+        db.append_message(session["session_key"], "user", "q1"),
+        db.append_message(session["session_key"], "assistant", "a1"),
+        db.append_message(session["session_key"], "user", "q2"),
+        db.append_message(session["session_key"], "assistant", "a2"),
+    ]
+    session["history"] = db.get_messages_as_conversation(session["session_key"])
+    before = [row["id"] for row in db.get_messages(session["session_key"])]
+
+    undo = _call(server, "session.undo", session_id=sid, n=1)
+    assert undo["result"]["rewound_ids"] == [ids[-1]]
+    redo = _call(server, "session.redo", session_id=sid)
+
+    assert redo["result"] == {
+        "reactivated_count": 1,
+        "new_tail_id": ids[-1],
+        "prefill_text": None,
+    }
+    assert [row["id"] for row in db.get_messages(session["session_key"])] == before
+    assert session["history"] == db.get_messages_as_conversation(session["session_key"])
+
+
+def test_session_redo_busy_guard_code_4009(server, db):
+    sid, session = _session(server, db, sid="sid-busy", session_key="tui-busy")
+    session["running"] = True
+
+    resp = _call(server, "session.redo", session_id=sid)
+
+    assert resp["error"]["code"] == 4009
+    assert "busy" in resp["error"]["message"]
+
+
+def test_prompt_submit_clears_redo_stack_on_user_send(server, db, monkeypatch):
+    sid, session = _session(server, db, sid="sid-send", session_key="tui-send")
+    db.append_message(session["session_key"], "user", "q")
+    db.append_message(session["session_key"], "assistant", "a")
+    hermes_undo.undo(session["session_key"], 1)
+    hermes_undo.redo(session["session_key"], 1)
+    state = hermes_undo.get_state(session["session_key"])
+    assert state.redo_stack
+
+    monkeypatch.setattr(server, "_start_agent_build", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_start_inflight_turn", lambda sess, text: None)
+
+    class NoThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            return None
+
+    monkeypatch.setattr(server.threading, "Thread", NoThread)
+
+    resp = _call(server, "prompt.submit", session_id=sid, text="new branch")
+
+    assert resp["result"]["status"] == "streaming"
+    assert state.redo_stack == []

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7850,18 +7850,127 @@ def _(rid, params: dict) -> dict:
         return _err(
             rid, 4009, "session busy — /interrupt the current turn before /undo"
         )
-    removed = 0
+    try:
+        n = int(params.get("n", params.get("count", 1)) or 1)
+    except (TypeError, ValueError):
+        return _err(rid, 4004, "undo: invalid count — use /undo or /undo N")
+    if n < 1:
+        n = 1
+    return _undo_session_core(rid, session, n)
+
+
+@method("session.redo")
+def _(rid, params: dict) -> dict:
+    session, err = _sess(params, rid)
+    if err:
+        return err
+    if session.get("running"):
+        return _err(
+            rid, 4009, "session busy — /interrupt the current turn before /redo"
+        )
+    try:
+        n = int(params.get("n", params.get("count", 1)) or 1)
+    except (TypeError, ValueError):
+        return _err(rid, 4004, "redo: invalid count — use /redo or /redo N")
+    return _redo_session_core(rid, session, n)
+
+
+def _reload_session_history_from_db(session: dict) -> list[dict]:
+    db = _get_db()
+    if db is None:
+        raise RuntimeError("session database unavailable")
+    active = db.get_messages_as_conversation(session["session_key"])
     with session["history_lock"]:
-        history = session.get("history", [])
-        while history and history[-1].get("role") in {"assistant", "tool"}:
-            history.pop()
-            removed += 1
-        if history and history[-1].get("role") == "user":
-            history.pop()
-            removed += 1
-        if removed:
-            session["history_version"] = int(session.get("history_version", 0)) + 1
-    return _ok(rid, {"removed": removed})
+        session["history"] = list(active)
+        session["history_version"] = int(session.get("history_version", 0)) + 1
+    agent = session.get("agent")
+    if agent is not None:
+        mm = getattr(agent, "_memory_manager", None)
+        if mm is not None:
+            try:
+                mm.on_session_switch(
+                    session["session_key"],
+                    parent_session_id="",
+                    reset=False,
+                    rewound=True,
+                )
+            except Exception:
+                pass
+        if hasattr(agent, "_invalidate_system_prompt"):
+            try:
+                agent._invalidate_system_prompt()
+            except Exception:
+                pass
+        if hasattr(agent, "_last_flushed_db_idx"):
+            try:
+                agent._last_flushed_db_idx = len(active)
+            except Exception:
+                pass
+    return active
+
+
+def _undo_session_core(rid, session: dict, n: int) -> dict:
+    db = _get_db()
+    if db is None:
+        return _db_unavailable_error(rid, code=5008)
+    try:
+        import hermes_undo
+
+        hermes_undo._session_db = db
+        result = hermes_undo.undo(session["session_key"], n)
+    except Exception as e:
+        return _err(rid, 5008, f"undo: {e}")
+    rewound_ids = list(result.get("rewound_ids") or [])
+    if not rewound_ids:
+        return _err(rid, 4018, "nothing to undo")
+    try:
+        _reload_session_history_from_db(session)
+    except Exception as e:
+        return _err(rid, 5008, f"undo: failed to reload history: {e}")
+    return _ok(
+        rid,
+        {
+            "rewound_ids": rewound_ids,
+            "removed": len(rewound_ids),
+            "prefill_text": result.get("prefill_text"),
+        },
+    )
+
+
+def _redo_session_core(rid, session: dict, n: int) -> dict:
+    db = _get_db()
+    if db is None:
+        return _db_unavailable_error(rid, code=5008)
+    try:
+        import hermes_undo
+
+        hermes_undo._session_db = db
+        result = hermes_undo.redo(session["session_key"], n)
+    except Exception as e:
+        return _err(rid, 5008, f"redo: {e}")
+    reactivated = int(result.get("reactivated_count") or 0)
+    if reactivated <= 0:
+        return _ok(
+            rid,
+            {
+                "reactivated_count": 0,
+                "new_tail_id": None,
+                "prefill_text": None,
+                "message": result.get("message") or "nothing to redo",
+            },
+        )
+    try:
+        _reload_session_history_from_db(session)
+    except Exception as e:
+        return _err(rid, 5008, f"redo: failed to reload history: {e}")
+    return _ok(
+        rid,
+        {
+            "reactivated_count": reactivated,
+            "new_tail_id": result.get("new_tail_id"),
+            "prefill_text": None,
+        },
+    )
 
 
 @method("session.compress")
@@ -8475,6 +8584,12 @@ def _(rid, params: dict) -> dict:
     # A branch becomes real here: copy its parent's transcript into the row so it
     # resumes with full context (the agent won't persist the seed itself).
     _persist_branch_seed(session)
+    try:
+        from hermes_undo import on_user_message_appended
+
+        on_user_message_appended(session["session_key"])
+    except Exception as exc:
+        print(f"[tui_gateway] redo clear on user append failed: {exc}", file=sys.stderr)
     _start_agent_build(sid, session)
 
     def run_after_agent_ready() -> None:
@@ -12162,23 +12277,13 @@ def _(rid, params: dict) -> dict:
         )
 
     if name == "undo":
-        # /undo [N]: back up N user turns (default 1), soft-delete the
-        # truncated rows on disk, and prefill the composer with the text
-        # of the user message we backed up to so it can be edited and
-        # resubmitted. N=1 is the Claude-Code-style single-step undo;
-        # /undo 3 backs up three user turns at once. See issue #21910.
+        # /undo [N]: back up N half-turns via the shared undo core.
         if not session:
             return _err(rid, 4001, "no active session to undo")
         if session.get("running"):
             return _err(
                 rid, 4009, "session busy — /interrupt the current turn before /undo"
             )
-        db = _get_db()
-        if db is None:
-            return _db_unavailable_error(rid, code=5008)
-        session_key = session.get("session_key", "")
-        if not session_key:
-            return _err(rid, 4001, "no session key for undo")
         # Parse the optional count argument (e.g. "/undo 3" → 3).
         n = 1
         arg_str = (arg or "").strip()
@@ -12189,77 +12294,46 @@ def _(rid, params: dict) -> dict:
                 return _err(rid, 4004, f"undo: invalid count {arg_str!r} — use /undo or /undo N")
         if n < 1:
             n = 1
-        try:
-            recents = db.list_recent_user_messages(session_key, limit=max(n, 10))
-        except Exception as e:
-            return _err(rid, 5008, f"undo: failed to load history: {e}")
-        if not recents:
-            return _err(rid, 4018, "no user messages to undo")
-        # recents[0] is the most-recent user turn; pick the Nth-from-last.
-        # If N exceeds the number of user turns, back up to the oldest.
-        target_idx = min(n - 1, len(recents) - 1)
-        target_id = recents[target_idx]["id"]
-        try:
-            result = db.rewind_to_message(session_key, target_id)
-        except ValueError as e:
-            return _err(rid, 4004, f"undo: {e}")
-        except Exception as e:
-            return _err(rid, 5008, f"undo: {e}")
-        # Reload the active-only transcript into the in-memory session
-        # history so subsequent turns see the truncated view.
-        try:
-            active = db.get_messages_as_conversation(session_key)
-        except Exception:
-            active = []
-        with session["history_lock"]:
-            session["history"] = list(active)
-            session["history_version"] = int(session.get("history_version", 0)) + 1
-        # Notify memory providers — same hook /branch fires, plus the
-        # rewound flag so providers caching per-turn document state
-        # know to invalidate. See #6672 + #21910.
-        agent = session.get("agent")
-        if agent is not None:
-            mm = getattr(agent, "_memory_manager", None)
-            if mm is not None:
-                try:
-                    mm.on_session_switch(
-                        session_key,
-                        parent_session_id="",
-                        reset=False,
-                        rewound=True,
-                    )
-                except Exception:
-                    pass
-            if hasattr(agent, "_invalidate_system_prompt"):
-                try:
-                    agent._invalidate_system_prompt()
-                except Exception:
-                    pass
-            if hasattr(agent, "_last_flushed_db_idx"):
-                try:
-                    agent._last_flushed_db_idx = len(active)
-                except Exception:
-                    pass
-        target_msg = result.get("target_message") or {}
-        target_text = target_msg.get("content") or ""
-        if isinstance(target_text, list):
-            parts = [
-                p.get("text", "") for p in target_text
-                if isinstance(p, dict) and p.get("type") == "text"
-            ]
-            target_text = "\n".join(t for t in parts if t)
-        if not isinstance(target_text, str):
-            target_text = ""
-        rewound_count = result.get("rewound_count", 0)
-        turns_undone = target_idx + 1
-        turn_word = "turn" if turns_undone == 1 else "turns"
+        result = _undo_session_core(rid, session, n)
+        if "error" in result:
+            return result
+        payload = result.get("result", {})
         notice = (
-            f"↶ Undid {turns_undone} {turn_word} ({rewound_count} message(s)). "
+            f"↶ Undid {n} half-turn(s) ({len(payload.get('rewound_ids') or [])} message(s)). "
             "Edit and resubmit, or send a new message."
         )
         return _ok(
             rid,
-            {"type": "prefill", "message": target_text, "notice": notice},
+            {"type": "prefill", "message": payload.get("prefill_text") or "", "notice": notice},
+        )
+
+    if name == "redo":
+        if not session:
+            return _err(rid, 4001, "no active session to redo")
+        if session.get("running"):
+            return _err(
+                rid, 4009, "session busy — /interrupt the current turn before /redo"
+            )
+        n = 1
+        arg_str = (arg or "").strip()
+        if arg_str:
+            try:
+                n = int(arg_str.split()[0])
+            except (ValueError, IndexError):
+                return _err(rid, 4004, f"redo: invalid count {arg_str!r} — use /redo or /redo N")
+        result = _redo_session_core(rid, session, n)
+        if "error" in result:
+            return result
+        payload = result.get("result", {})
+        reactivated = int(payload.get("reactivated_count") or 0)
+        if reactivated <= 0:
+            return _ok(rid, {"type": "notice", "notice": payload.get("message") or "nothing to redo"})
+        return _ok(
+            rid,
+            {
+                "type": "notice",
+                "notice": f"↷ Redid {n} undo operation(s) ({reactivated} message(s) restored).",
+            },
         )
 
     if name in {"snapshot", "snap"}:


### PR DESCRIPTION
## Reversible half-turn `/undo` + `/redo` across CLI, gateway, and TUI

This ports the fork-tested half-turn undo/redo feature onto current upstream `main`.

### What changes
- Adds shared `hermes_undo.py` core for stacked `/undo` + `/redo` over `SessionDB` active rows.
- Changes `/undo [N]` semantics from whole user-turns to **half-turns** (one party's contiguous run of messages).
- Adds `/redo [N]` as a LIFO redo stack that is invalidated by new user messages or transcript rewrites.
- Wires CLI, gateway, and TUI surfaces through the shared core.
- Adds locale keys for undo/redo copy across all existing locale catalogs.
- Adds regression coverage for:
  - half-turn grouping
  - restore/reactivation by row id
  - redo branch invalidation after a new user message
  - transcript-rewrite invalidation (`/compress`/`/retry` hard-delete rows)
  - CLI prefix matching after adding `/redo`
  - gateway/TUI surface behavior

### Upstream-specific reconciliation
This is not a blind cherry-pick. Upstream had already refactored gateway slash handlers out of `gateway/run.py` into `gateway/slash_commands.py`, while the fork implementation landed against the older inline-handler layout. I resolved that by:
- Keeping upstream's `gateway/run.py` slash-dispatch structure and destructive-confirm wrapper.
- Porting `_handle_undo_command` and the new `_handle_redo_command` into `gateway/slash_commands.py`.
- Preserving the half-turn destructive-confirm copy in `run.py`.
- Reconciling Slack's hard 50 native-slash limit: adding `/redo` required explicitly routing low-frequency `/version` through `/hermes version` on Slack so `/debug` and Telegram-vs-Slack parity survive the cap.

### Verification
Run locally on fresh `origin/main` worktree after the port:

```bash
python -m py_compile cli.py gateway/run.py gateway/session.py gateway/slash_commands.py hermes_state.py hermes_undo.py tui_gateway/server.py
python -m pytest \
  tests/test_undo_redo_stack.py \
  tests/test_half_turn_target.py \
  tests/test_restore_ids.py \
  tests/test_state_rewind_generalized.py \
  tests/cli/test_undo_redo_half_turn.py \
  tests/cli/test_cli_prefix_matching.py \
  tests/gateway/test_undo_redo_half_turn.py \
  tests/gateway/test_undo_rewind_session.py \
  tests/tui_gateway/test_undo_command.py \
  tests/tui_gateway/test_undo_redo.py \
  tests/agent/test_i18n.py \
  tests/hermes_cli/test_commands.py \
  -q -p no:cacheprovider -o addopts="" -p no:randomly
# 269 passed

python -m pytest \
  tests/test_tui_gateway_server.py::test_session_undo_allowed_when_idle \
  tests/test_tui_gateway_server.py::test_session_undo_rejects_while_running \
  -q -p no:cacheprovider -o addopts="" -p no:randomly
# 2 passed

python -m pytest \
  tests/hermes_cli/test_destructive_slash_confirm_gate.py \
  tests/gateway/test_destructive_slash_confirm.py \
  -q -p no:cacheprovider -o addopts="" -p no:randomly
# 11 passed
```

Full suite left to CI.
