### PR TITLE
fix(models): /model picker now uses custom model.base_url for live model fetch

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2368,7 +2368,7 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             if not base_url:
                 base_url = _p.base_url
             if api_key:
-                live = _p.fetch_models(api_key=api_key)
+                live = _p.fetch_models(api_key=api_key, base_url=base_url)
                 if live:
                     if normalized in {"kimi-coding", "kimi-coding-cn"}:
                         curated = list(_PROVIDER_MODELS.get(normalized, []))

--- a/providers/base.py
+++ b/providers/base.py
@@ -164,6 +164,7 @@ class ProviderProfile:
         *,
         api_key: str | None = None,
         timeout: float = 8.0,
+        base_url: str | None = None,
     ) -> list[str] | None:
         """Fetch the live model list from the provider's models endpoint.
 
@@ -175,7 +176,9 @@ class ProviderProfile:
              endpoint differs from the inference base URL, e.g. OpenRouter
              exposes a public catalog at /api/v1/models while inference is
              at /api/v1)
-          2. self.base_url + "/models"  (standard OpenAI-compat fallback)
+          2. base_url + "/models" (caller override, e.g. from config.yaml
+             model.base_url — use when models live on a custom endpoint)
+          3. self.base_url + "/models"  (standard OpenAI-compat fallback)
 
         The default implementation sends Bearer auth when api_key is given
         and forwards self.default_headers. Override to customise auth, path,
@@ -186,9 +189,10 @@ class ProviderProfile:
         """
         url = (self.models_url or "").strip()
         if not url:
-            if not self.base_url:
+            effective_base = base_url or self.base_url
+            if not effective_base:
                 return None
-            url = self.base_url.rstrip("/") + "/models"
+            url = effective_base.rstrip("/") + "/models"
 
         import json
         import urllib.request

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -487,3 +487,64 @@ class TestBaseProfile:
         eb, tl = p.build_api_kwargs_extras()
         assert eb == {}
         assert tl == {}
+
+    def test_fetch_models_uses_base_url_override(self):
+        """fetch_models() with base_url param should use it over self.base_url."""
+        from unittest.mock import patch, MagicMock
+        import json
+
+        fake_models = [{"id": "custom-model-1"}, {"id": "custom-model-2"}]
+        mock_read = MagicMock(return_value=json.dumps({"data": fake_models}).encode())
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read = mock_read
+
+        p = ProviderProfile(
+            name="deepseek",
+            base_url="https://api.deepseek.com/v1",
+        )
+
+        with patch("urllib.request.urlopen", return_value=mock_resp) as mock_urlopen, \
+             patch("urllib.request.Request") as mock_req_class:
+            mock_req = MagicMock()
+            mock_req_class.return_value = mock_req
+
+            # Call with base_url override
+            result = p.fetch_models(
+                api_key="sk-test",
+                base_url="https://custom-proxy.internal/v1",
+            )
+            assert result == ["custom-model-1", "custom-model-2"]
+            # Verify the URL was built from the override, not self.base_url
+            req_url = mock_req_class.call_args[0][0]
+            assert req_url == "https://custom-proxy.internal/v1/models"
+
+    def test_fetch_models_falls_back_to_self_base_url(self):
+        """fetch_models() without base_url should use self.base_url."""
+        from unittest.mock import patch, MagicMock
+        import json
+
+        fake_models = [{"id": "default-model"}]
+        mock_read = MagicMock(return_value=json.dumps({"data": fake_models}).encode())
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read = mock_read
+
+        p = ProviderProfile(
+            name="deepseek",
+            base_url="https://api.deepseek.com/v1",
+        )
+
+        with patch("urllib.request.urlopen", return_value=mock_resp) as mock_urlopen, \
+             patch("urllib.request.Request") as mock_req_class:
+            mock_req = MagicMock()
+            mock_req_class.return_value = mock_req
+
+            # Call without base_url override
+            result = p.fetch_models(api_key="sk-test")
+            assert result == ["default-model"]
+            # Verify the URL was built from self.base_url
+            req_url = mock_req_class.call_args[0][0]
+            assert req_url == "https://api.deepseek.com/v1/models"


### PR DESCRIPTION
## Problem

When a user sets `model.base_url` in `config.yaml` (e.g., pointing to a company-internal litellm proxy), the `/model` interactive picker ignores it and fetches the model list from the provider's hardcoded default URL, showing wrong models.

```
config.yaml:
  model:
    default: my-custom-model
    provider: deepseek
    base_url: https://my-company-litellm.internal/v1

→ /model picker shows deepseek-chat, deepseek-reasoner (from api.deepseek.com)
→ Runtime inference correctly routes to my-company-litellm.internal/v1 ✅
```

## Root Cause

`provider_model_ids()` (hermes_cli/models.py:2371) resolved the custom `base_url` but never passed it to `ProviderProfile.fetch_models()`, which always used `self.base_url` (the hardcoded profile default).

## Fix

- **`providers/base.py`**: Add optional `base_url` parameter to `fetch_models()`. Resolution order: `self.models_url` → `base_url` param → `self.base_url`
- **`hermes_cli/models.py:2371`**: Pass the resolved `base_url` through

## Tests

2 new tests in `tests/providers/test_provider_profiles.py::TestBaseProfile`:
- `test_fetch_models_uses_base_url_override` — custom URL overrides `self.base_url`
- `test_fetch_models_falls_back_to_self_base_url` — no override, uses profile default

## Impact

Affects all `api_key` providers, not just deepseek. The `/model` picker will now correctly show models from the user's custom endpoint after every cache refresh.

Closes #47009