### PR TITLE
fix(feishu): use parent_id as thread_id fallback for topic messages

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3122,7 +3122,21 @@ class FeishuAdapter(BasePlatformAdapter):
             if hint:
                 text = f"{hint}\n\n{text}" if text else hint
 
-        thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
+        # ── Thread / topic identification ──────────────────────────────────
+        # Feishu topics are identified by ``root_id`` (the root message of the
+        # topic).  ``thread_id`` is a newer field that carries the same value
+        # for topic messages.  When *both* are absent but ``parent_id`` is
+        # present, the message is a reply inside a topic whose root the event
+        # omitted — use ``parent_id`` as a best-effort grouping key to keep
+        # the reply chain in one session instead of falling back to the
+        # per-user group session, which would fragment the conversation.
+        _raw_root = getattr(message, "root_id", None)
+        _raw_parent = getattr(message, "parent_id", None)
+        thread_id = (
+            getattr(message, "thread_id", None)
+            or _raw_root
+            or (_raw_parent if _raw_parent and chat_type != "p2p" else None)
+        )
         reply_to_message_id = (
             getattr(message, "parent_id", None)
             or getattr(message, "upper_message_id", None)


### PR DESCRIPTION
## Problem

When a Feishu group message arrives inside a topic but the event omits both
`thread_id` and `root_id` (observed in certain Feishu API event paths), only
`parent_id` is present to indicate reply context. Without `thread_id`,
`build_session_key` falls back from the shared topic session key
(`chat_id:thread_id`) to the per-user group session key
(`chat_id:user_id`, via `group_sessions_per_user`). This fragments the
conversation — each message lands in a different session and the agent loses
all context.

## Root Cause

`feishu.py:3125` (in `_process_inbound_message`):

```python
thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
```

Only `thread_id` and `root_id` are checked. `parent_id` — which signals the
message is a reply inside a topic — is not used as a fallback.

## Fix

Add `parent_id` as a third-level fallback in `_process_inbound_message`,
guarded to group chats only (not DMs):

```python
_raw_root = getattr(message, "root_id", None)
_raw_parent = getattr(message, "parent_id", None)
thread_id = (
    getattr(message, "thread_id", None)
    or _raw_root
    or (_raw_parent if _raw_parent and chat_type != "p2p" else None)
)
```

**Why this is safe for outbound routing**: The outbound path for normal
conversation turns goes through the REPLY API with `reply_in_thread=True`
(using the original `message_id` as reply target), not the CREATE API with
`receive_id=thread_id`. So `parent_id` in metadata only affects
`reply_in_thread` flag, not receive routing.

## Test Plan

- Existing Feishu adapter tests: all 205 pass
- DM with `parent_id` set: `p2p` guard prevents fallback → no behavior change
- Group message without `thread_id`/`root_id` but with `parent_id`: now
  correctly grouped into a reply-chain session
- Group message without any ids: no change (still per-user group session)