### PR TITLE
fix(opencode-go): set supports_vision_tool_messages=False for Xiaomi MiMo backend

### DIFF
--- a/plugins/model-providers/opencode-zen/__init__.py
+++ b/plugins/model-providers/opencode-zen/__init__.py
@@ -120,6 +120,11 @@ opencode_go = OpenCodeGoProfile(
     env_vars=("OPENCODE_GO_API_KEY",),
     base_url="https://opencode.ai/zen/go/v1",
     default_aux_model="glm-5",
+    # opencode-go proxies to Xiaomi MiMo for mimo-* models; MiMo rejects
+    # list-type tool content with "text is not set" (400).  The direct
+    # xiaomi profile already sets supports_vision_tool_messages=False;
+    # propagate the same safety here for the relay path.
+    supports_vision_tool_messages=False,
 )
 
 register_provider(opencode_zen)


### PR DESCRIPTION
fix(opencode-go): set supports_vision_tool_messages=False for Xiaomi MiMo backend

## Problem

When using the opencode-go provider with Xiaomi MiMo models (e.g.
mimo-v2.5, mimo-v2.5-pro), the Hermes agent intermittently fails with:

    Error code: 400 - {'error': {'code': '400',
      'message': 'Error from provider (Xiaomi): Param Incorrect',
      'param': 'text is not set', 'type': ''}}

This occurs specifically when tool results contain multipart content
with image_url parts (e.g. browser screenshots). The opencode-go relay
forwards these as-is to the Xiaomi MiMo backend, which rejects list-type
tool message content while still accepting multimodal user messages.

## Root Cause

The OpenCodeGoProfile inherits supports_vision_tool_messages=True from
ProviderProfile (the default). When this flag is True, the agent sends
tool results with image parts directly to the model. However, Xiaomi
MiMo's API rejects this format:

> "Set to False for providers that accept multimodal user messages but
> reject list-type tool content (e.g. Xiaomi MiMo, which returns 400
> 'text is not set')."
>   — providers/base.py, line 73

The direct 'xiaomi' provider profile already correctly sets this to
False (plugins/model-providers/xiaomi/__init__.py, line 13), but the
opencode-go relay profile was missing this safeguard.

The relevant code path is in run_agent.py:_tool_result_content_for_active_model()
(line 4543), which checks _provider_supports_vision_tool_messages() when
deciding whether to embed images in tool-result messages.

## Fix

Add supports_vision_tool_messages=False to the OpenCodeGoProfile
instantiation in plugins/model-providers/opencode-zen/__init__.py.

This single-line change prevents tool-result images from being sent
as multipart content to the MiMo backend, while preserving the model's
image recognition capability through user messages and vision tool
invocations (both of which use different code paths unaffected by this
flag).

## Testing

Verified with the mimo-v2.5 model via opencode-go provider:

1. Browser tool + screenshot recognition
   → Navigated to https://www.baidu.com, took screenshot, identified
     top 3 trending topics from the image
   → Result: PASSED, recognized all topics correctly

2. Direct image as user message
   → Sent a screenshot PNG directly via --image flag, asked model to
     describe the content
   → Result: PASSED, model correctly read text from the image

3. Provider profile verification
   → Confirmed get_provider_profile('opencode-go').supports_vision_tool_messages
     returns False at runtime
   → Result: PASSED

4. No regression on non-MiMo models
   → opencode-zen provider retains supports_vision_tool_messages=True
     (unaffected)

---

fix(opencode-go): 为 Xiaomi MiMo 后端设置 supports_vision_tool_messages=False

## 问题描述

使用 opencode-go provider 搭配 Xiaomi MiMo 模型（如 mimo-v2.5、
mimo-v2.5-pro）时，Hermes agent 间歇性地抛出以下错误：

    Error code: 400 - {'error': {'code': '400',
      'message': 'Error from provider (Xiaomi): Param Incorrect',
      'param': 'text is not set', 'type': ''}}

该错误发生在工具返回结果包含 image_url 类型的 multipart 内容的场景下
（如浏览器截图）。opencode-go 中继层将这些内容原样转发给 Xiaomi MiMo
后端，而 MiMo 接受多模态用户消息，但拒绝 list-type tool message 内容。

## 根因分析

OpenCodeGoProfile 继承了 ProviderProfile 的默认值
supports_vision_tool_messages=True。当此标志为 True 时，agent 会将含
图片的工具结果直接发送给模型。但 Xiaomi MiMo API 拒绝此格式：

> providers/base.py 第 73 行注释明确指出：
> "Set to False for providers that accept multimodal user messages but
> reject list-type tool content (e.g. Xiaomi MiMo, which returns 400
> 'text is not set')."

直接的 'xiaomi' provider profile 已正确设置了该值为 False
（plugins/model-providers/xiaomi/__init__.py 第 13 行），但
opencode-go 中继 profile 遗漏了这一安全设置。

相关代码路径：run_agent.py 的 _tool_result_content_for_active_model()
方法（第 4543 行），该方法通过检查
_provider_supports_vision_tool_messages() 来决定是否在 tool-result
消息中嵌入图片。

## 修复方案

在 plugins/model-providers/opencode-zen/__init__.py 的
OpenCodeGoProfile 实例化中添加 supports_vision_tool_messages=False。

这一行改动阻止了 tool-result 图片以 multipart 格式发送给 MiMo 后端，
同时通过用户消息和 vision tool 调用的路径（使用不同代码路径，不受
此标志影响）保留了模型的图像识别能力。

## 测试验证

使用 mimo-v2.5 模型通过 opencode-go provider 验证：

1. 浏览器截图 + 图像识别
   → 导航至 https://www.baidu.com，截取首页截图，从图片中识别出
     热搜榜前三条
   → 结果：通过，正确识别所有热搜话题

2. 用户消息直接传图
   → 通过 --image 参数直接发送截图 PNG，要求模型描述图片内容
   → 结果：通过，模型正确读取图片中的文字

3. Provider profile 运行时验证
   → 确认 get_provider_profile('opencode-go')
     .supports_vision_tool_messages 在运行时返回 False
   → 结果：通过

4. 非 MiMo 模型无回归
   → opencode-zen provider 保持 supports_vision_tool_messages=True
     不受影响

## 修改文件

  plugins/model-providers/opencode-zen/__init__.py (+5 lines)

Signed-off-by: Yuan Chenglu (袁成路) <ycl_pj@163.com>