### PR TITLE
fix(scripts): restore github_intelligence_*.py from fork/main

### DIFF
--- a/scripts/github_intelligence_analyze.py
+++ b/scripts/github_intelligence_analyze.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Generate local reports from the GitHub intelligence vault."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+DEFAULT_DATA = Path.home() / "Data" / "github-intelligence"
+
+
+def read_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    rows = []
+    # Iterate physical file lines instead of str.splitlines(); JSON strings can
+    # legally contain unicode line separators that splitlines() treats as record
+    # boundaries, which would silently drop valid JSONL records.
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                try:
+                    rows.append(json.loads(line))
+                except json.JSONDecodeError:
+                    pass
+    return rows
+
+
+def read_json(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def year(value: str | None) -> str:
+    return value[:4] if value and len(value) >= 4 else "unknown"
+
+
+def repo_from_item(item: dict) -> str:
+    repo = item.get("repository_url") or ""
+    if "repos/" in repo:
+        return repo.split("repos/", 1)[1]
+    html = item.get("html_url") or ""
+    if "github.com/" in html:
+        parts = html.split("github.com/", 1)[1].split("/")
+        if len(parts) >= 2:
+            return f"{parts[0]}/{parts[1]}"
+    return item.get("repository", {}).get("full_name") or "unknown"
+
+
+def write_inventory(data: Path, reports: Path, repos: list[dict], orgs: list[dict]) -> None:
+    langs = Counter(r.get("language") or "unknown" for r in repos)
+    owners = Counter((r.get("full_name") or "/").split("/")[0] for r in repos)
+    private = sum(1 for r in repos if r.get("private"))
+    archived = sum(1 for r in repos if r.get("archived"))
+    lines = [
+        "# GitHub Inventory",
+        "",
+        f"Generated: `{datetime.now(timezone.utc).isoformat()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Accessible repos collected: `{len(repos)}`",
+        f"- Private repos: `{private}`",
+        f"- Archived repos: `{archived}`",
+        f"- Visible orgs: `{len(orgs)}`",
+        "",
+        "## Visible Orgs",
+        "",
+    ]
+    for org in sorted(orgs, key=lambda o: o.get("login", "")):
+        lines.append(f"- `{org.get('login')}` — {org.get('description') or ''}")
+    lines += ["", "## Top Languages", ""]
+    for lang, count in langs.most_common(20):
+        lines.append(f"- `{lang}`: {count}")
+    lines += ["", "## Repos by Owner", ""]
+    for owner, count in owners.most_common():
+        lines.append(f"- `{owner}`: {count}")
+    lines += ["", "## Recently Updated Repos", ""]
+    for repo in sorted(repos, key=lambda r: r.get("pushed_at") or "", reverse=True)[:50]:
+        lines.append(f"- [{repo.get('full_name')}]({repo.get('html_url')}) — {repo.get('language') or 'unknown'} — pushed `{repo.get('pushed_at')}`")
+    (reports / "inventory.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_pr_timeline(reports: Path, prs: list[dict], issues: list[dict]) -> None:
+    by_year = Counter(year(p.get("created_at")) for p in prs)
+    by_repo = Counter(repo_from_item(p) for p in prs)
+    issue_year = Counter(year(i.get("created_at")) for i in issues)
+    lines = ["# GitHub PR / Issue Timeline", "", f"Generated: `{datetime.now(timezone.utc).isoformat()}`", "", "## Authored PRs by Year", ""]
+    for y, c in sorted(by_year.items()):
+        lines.append(f"- `{y}`: {c}")
+    lines += ["", "## Involved Issues by Year", ""]
+    for y, c in sorted(issue_year.items()):
+        lines.append(f"- `{y}`: {c}")
+    lines += ["", "## Top PR Repos", ""]
+    for repo, c in by_repo.most_common(30):
+        lines.append(f"- `{repo}`: {c}")
+    lines += ["", "## Recent Authored PRs", ""]
+    for pr in sorted(prs, key=lambda p: p.get("created_at") or "", reverse=True)[:50]:
+        lines.append(f"- [{pr.get('title')}]({pr.get('html_url')}) — `{repo_from_item(pr)}` — `{pr.get('state')}` — `{pr.get('created_at')}`")
+    (reports / "pr-timeline.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_themes(reports: Path, repos: list[dict], prs: list[dict], issues: list[dict]) -> None:
+    words = Counter()
+    stack = Counter(r.get("language") or "unknown" for r in repos)
+    for item in [*repos, *prs, *issues]:
+        text = " ".join(str(item.get(k) or "") for k in ["name", "full_name", "description", "title", "body"])
+        for token in text.lower().replace("/", " ").replace("-", " ").replace("_", " ").split():
+            if len(token) >= 4 and token not in {"http", "https", "github", "null", "true", "false", "with", "from", "this", "that", "into", "when", "where"}:
+                words[token] += 1
+    lines = ["# GitHub Project Themes", "", f"Generated: `{datetime.now(timezone.utc).isoformat()}`", "", "## Stack Signals", ""]
+    for lang, c in stack.most_common(20):
+        lines.append(f"- `{lang}`: {c}")
+    lines += ["", "## Recurring Terms", ""]
+    for word, c in words.most_common(80):
+        lines.append(f"- `{word}`: {c}")
+    (reports / "project-themes.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_dormant(reports: Path, repos: list[dict]) -> None:
+    candidates = [r for r in repos if not r.get("archived")]
+    candidates.sort(key=lambda r: r.get("pushed_at") or "")
+    lines = ["# Dormant Project Candidates", "", f"Generated: `{datetime.now(timezone.utc).isoformat()}`", "", "Repos below are non-archived accessible repos with the oldest push timestamps in the current archive.", ""]
+    for r in candidates[:80]:
+        lines.append(f"- [{r.get('full_name')}]({r.get('html_url')}) — {r.get('language') or 'unknown'} — pushed `{r.get('pushed_at')}` — {r.get('description') or ''}")
+    (reports / "dormant-projects.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_commit_history(reports: Path, commits: list[dict]) -> None:
+    by_year = Counter(year(c.get("committed_at") or c.get("authored_at")) for c in commits)
+    by_repo = Counter(c.get("repo") or "unknown" for c in commits)
+    by_author = Counter((c.get("author_email") or "unknown").lower() for c in commits)
+    remote_reachable = sum(1 for c in commits if any("/" in ref and not ref.startswith("tags/") for ref in (c.get("refs") or [])))
+    local_only = len(commits) - remote_reachable
+    lines = [
+        "# GitHub Commit History",
+        "",
+        f"Generated: `{datetime.now(timezone.utc).isoformat()}`",
+        "",
+        "## Summary",
+        "",
+        f"- Commit records: `{len(commits)}`",
+        f"- Remote-ref reachable records: `{remote_reachable}`",
+        f"- Local-only/tag-only/no-ref records: `{local_only}`",
+        "",
+        "## Commits by Year",
+        "",
+    ]
+    for y, c in sorted(by_year.items()):
+        lines.append(f"- `{y}`: {c}")
+    lines += ["", "## Top Repos by Commit Records", ""]
+    for repo, c in by_repo.most_common(50):
+        lines.append(f"- `{repo}`: {c}")
+    lines += ["", "## Top Author Emails", ""]
+    for email, c in by_author.most_common(30):
+        lines.append(f"- `{email}`: {c}")
+    lines += ["", "## Recent Commits", ""]
+    for commit in sorted(commits, key=lambda c: c.get("committed_at") or "", reverse=True)[:80]:
+        refs = ", ".join((commit.get("refs") or [])[:5])
+        lines.append(f"- `{commit.get('committed_at')}` `{commit.get('repo')}` `{str(commit.get('sha') or '')[:12]}` — {commit.get('subject') or ''} ({refs})")
+    (reports / "commit-history.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_hermes_opportunities(reports: Path, repos: list[dict], prs: list[dict], issues: list[dict]) -> None:
+    terms = Counter()
+    source_examples: defaultdict[str, list[str]] = defaultdict(list)
+    keywords = ["agent", "ai", "bot", "automation", "telegram", "discord", "airtable", "workflow", "github", "memory", "search", "cron", "llm", "cursor", "hermes"]
+    for item in [*repos, *prs, *issues]:
+        text = " ".join(str(item.get(k) or "") for k in ["name", "full_name", "description", "title", "body"]).lower()
+        url = item.get("html_url") or item.get("url") or ""
+        for kw in keywords:
+            if kw in text:
+                terms[kw] += 1
+                if url and len(source_examples[kw]) < 5:
+                    source_examples[kw].append(url)
+    lines = [
+        "# Hermes Improvement Opportunities from GitHub History",
+        "",
+        f"Generated: `{datetime.now(timezone.utc).isoformat()}`",
+        "",
+        "This report is evidence-backed by the local GitHub intelligence vault. It should guide Hermes improvements without copying private code into global memory.",
+        "",
+        "## Strong Signals",
+        "",
+    ]
+    for kw, c in terms.most_common():
+        lines.append(f"- `{kw}`: {c} matching records")
+        for url in source_examples[kw][:3]:
+            lines.append(f"  - {url}")
+    lines += [
+        "",
+        "## Recommended Hermes Improvements",
+        "",
+        "1. Use `github_history_query` (local vault tool) before repo/dev/automation tasks — already shipped in Hermes.",
+        "2. Run `scripts/github_intelligence_digest.py` after collection to refresh skill-candidates, repo-conventions, and revival-queue reports.",
+        "3. Promote abstract skills from `reports/skill-candidates.md` after review — do not copy private code.",
+        "4. Use `reports/repo-conventions.md` as orientation, then verify against live repo files.",
+        "5. Keep private org details local; promote only abstract durable preferences after review.",
+        "",
+    ]
+    (reports / "hermes-improvement-opportunities.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def analyze(data: Path) -> dict[str, int]:
+    reports = data / "reports"
+    reports.mkdir(parents=True, exist_ok=True)
+    repos = read_jsonl(data / "raw" / "repos.jsonl")
+    orgs = read_jsonl(data / "raw" / "orgs.jsonl")
+    prs_authored = read_jsonl(data / "raw" / "prs-authored.jsonl")
+    prs_involved = read_jsonl(data / "raw" / "prs-involved.jsonl")
+    issues_involved = read_jsonl(data / "raw" / "issues-involved.jsonl")
+    commits = read_jsonl(data / "raw" / "commits.jsonl")
+    write_inventory(data, reports, repos, orgs)
+    write_pr_timeline(reports, prs_authored, issues_involved)
+    write_themes(reports, repos, prs_involved, issues_involved)
+    write_dormant(reports, repos)
+    write_commit_history(reports, commits)
+    write_hermes_opportunities(reports, repos, prs_involved, issues_involved)
+    return {"repos": len(repos), "orgs": len(orgs), "prs_authored": len(prs_authored), "prs_involved": len(prs_involved), "issues_involved": len(issues_involved), "commits": len(commits)}
+
+
+def _run_script(data: Path, script_name: str, timeout: int = 120) -> dict | None:
+    """Run a derived-report script and return its JSON-ish status."""
+    script = Path(__file__).with_name(script_name)
+    if not script.is_file():
+        return None
+    import subprocess
+
+    proc = subprocess.run(
+        [sys.executable, str(script), "--data", str(data)],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if proc.returncode != 0:
+        return {"ok": False, "stderr": proc.stderr[-500:]}
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return {"ok": True, "stdout": proc.stdout[-500:]}
+
+
+def _run_digest(data: Path) -> dict | None:
+    """Refresh derived Hermes-facing reports (skill candidates, revival queue, etc.)."""
+    return _run_script(data, "github_intelligence_digest.py", timeout=120)
+
+
+def _run_commit_workflows(data: Path) -> dict | None:
+    """Refresh commit-derived workflow classifier reports."""
+    return _run_script(data, "github_intelligence_commit_workflows.py", timeout=120)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data", default=str(DEFAULT_DATA))
+    parser.add_argument(
+        "--skip-digest",
+        action="store_true",
+        help="Skip github_intelligence_digest.py (skill candidates, revival queue, etc.)",
+    )
+    parser.add_argument(
+        "--skip-commit-workflows",
+        action="store_true",
+        help="Skip github_intelligence_commit_workflows.py (commit workflow classifier)",
+    )
+    args = parser.parse_args()
+    data = Path(args.data).expanduser().resolve()
+    result = analyze(data)
+    if not args.skip_digest:
+        digest = _run_digest(data)
+        if digest is not None:
+            result["digest"] = digest
+    if not args.skip_commit_workflows:
+        commit_workflows = _run_commit_workflows(data)
+        if commit_workflows is not None:
+            result["commit_workflows"] = commit_workflows
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/github_intelligence_collect.py
+++ b/scripts/github_intelligence_collect.py
@@ -1,0 +1,488 @@
+#!/usr/bin/env python3
+"""Read-only GitHub intelligence collector for Nicholas's accessible GitHub history.
+
+This script only performs read operations through `gh`. It writes raw API/search
+payloads into a local data vault and never mutates GitHub state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from urllib.parse import quote
+from pathlib import Path
+from typing import Any, Iterable
+
+DEFAULT_OUT = Path.home() / "Data" / "github-intelligence"
+TOKEN_PATTERNS = [
+    re.compile(r"sk-[A-Za-z0-9_-]{12,}"),
+    re.compile(r"gh[opsu]_[A-Za-z0-9_]{20,}"),
+    re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
+    re.compile(r"(?i)(api[_-]?key|token|secret|password|passwd)(\s*[:=]\s*)(['\"]?)[^\s'\"]{6,}(['\"]?)"),
+]
+
+# Repos excluded from the local GitHub data vault. Reasons:
+#   - read-only access: shouldn't be auto-updated
+#   - not relevant to agent context
+# Format: "owner/name" (matches GitHub API `full_name` and `repository_url`'s
+# /repos/<owner>/<repo> suffix). Keep in sync with EXCLUDED_REPOS in the
+# ghembed script so the vector index stays consistent with the raw vault.
+EXCLUDED_REPOS = frozenset({
+    "onederful-finance/oneder",   # read-only — no auto PRs/commits/issues
+})
+
+
+def _repo_full_name_from_url(url: str) -> str:
+    """Extract 'owner/name' from a GitHub API URL like
+    'https://api.github.com/repos/owner/name' or '.../repos/owner/name/issues/1'.
+    Returns '' if it doesn't match."""
+    if not url:
+        return ""
+    marker = "/repos/"
+    if marker in url:
+        tail = url.split(marker, 1)[1].strip("/")
+        # Take just owner/name (first two path segments); ignore /issues/N, /pulls/N, etc.
+        parts = tail.split("/")
+        if len(parts) >= 2:
+            return f"{parts[0]}/{parts[1]}"
+    return ""
+
+
+def _is_excluded(d: dict) -> bool:
+    """True if a GitHub API row references an excluded repo (PR/issue/repo/etc)."""
+    # Repos list: has `full_name`. PR/issue: has `repository_url`.
+    # Commit records (collected from local clones) have a top-level `repo` field.
+    name = (
+        d.get("full_name")
+        or d.get("repo")
+        or _repo_full_name_from_url(d.get("repository_url", ""))
+    )
+    return name in EXCLUDED_REPOS
+
+
+def redact(value: Any) -> Any:
+    if isinstance(value, str):
+        text = value
+        for pat in TOKEN_PATTERNS:
+            text = pat.sub(lambda m: f"{m.group(1)}{m.group(2)}{m.group(3)}REDACTED{m.group(4)}" if m.lastindex and m.lastindex >= 4 else "REDACTED", text)
+        return text
+    if isinstance(value, list):
+        return [redact(v) for v in value]
+    if isinstance(value, dict):
+        return {k: redact(v) for k, v in value.items()}
+    return value
+
+
+def run_gh(args: list[str], timeout: int = 120) -> tuple[int, str, str]:
+    proc = subprocess.run(["gh", *args], capture_output=True, text=True, timeout=timeout)
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def gh_json(args: list[str], timeout: int = 120) -> Any:
+    rc, out, err = run_gh(args, timeout=timeout)
+    if rc != 0:
+        raise RuntimeError(f"gh {' '.join(args)} failed: {err.strip()[-1000:]}")
+    if not out.strip():
+        return None
+    return json.loads(out)
+
+
+def iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def parse_github_reset(error_text: str) -> str | None:
+    """Return a UTC ISO reset hint parsed from GitHub/gh rate-limit errors."""
+    match = re.search(r"timestamp ([0-9-]{10} [0-9:]{8}) UTC", error_text)
+    if match:
+        return datetime.strptime(match.group(1), "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc).isoformat()
+    match = re.search(r"x-ratelimit-reset:\s*(\d+)", error_text, flags=re.I)
+    if match:
+        return datetime.fromtimestamp(int(match.group(1)), tz=timezone.utc).isoformat()
+    return None
+
+
+def atomic_write_jsonl(path: Path, rows: Iterable[Any]) -> int:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    count = write_jsonl(tmp, rows)
+    tmp.replace(path)
+    return count
+
+
+def load_existing_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    rows: list[dict] = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(obj, dict):
+                rows.append(obj)
+    return rows
+
+
+def merge_unique(existing: Iterable[dict], new_rows: Iterable[dict]) -> list[dict]:
+    seen: set[str] = set()
+    merged: list[dict] = []
+    for item in [*existing, *new_rows]:
+        key = str(item.get("id") or item.get("node_id") or item.get("html_url") or json.dumps(item, sort_keys=True))
+        if key not in seen:
+            seen.add(key)
+            merged.append(item)
+    return merged
+
+
+def ensure_layout(out: Path) -> None:
+    for rel in ["raw", "state", "reports", "index"]:
+        (out / rel).mkdir(parents=True, exist_ok=True)
+    readme = out / "README.md"
+    if not readme.exists():
+        readme.write_text(
+            "# GitHub Intelligence Vault\n\n"
+            "Local read-only archive of GitHub metadata accessible to the authenticated `gh` account.\n\n"
+            "Raw private/org data should stay local. Promote only reviewed, stable summaries into Hermes memory.\n",
+            encoding="utf-8",
+        )
+
+
+def write_json(path: Path, obj: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(redact(obj), indent=2, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_jsonl(path: Path, rows: Iterable[Any]) -> int:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    count = 0
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(redact(row), ensure_ascii=False, sort_keys=True) + "\n")
+            count += 1
+    return count
+
+
+def append_error(out: Path, stage: str, error: Exception | str) -> None:
+    rec = {"stage": stage, "error": str(error), "at": iso_now(), "reset_hint": parse_github_reset(str(error))}
+    with (out / "state" / "errors.jsonl").open("a", encoding="utf-8") as f:
+        f.write(json.dumps(redact(rec), sort_keys=True) + "\n")
+
+
+def paginated_api(endpoint: str, max_pages: int | None = None) -> list[Any]:
+    cmd = ["api", "--paginate", endpoint]
+    # gh emits one JSON document per page for REST pagination; use jq to flatten
+    cmd.extend(["--jq", ".[]"])
+    rc, out, err = run_gh(cmd, timeout=600)
+    if rc != 0:
+        raise RuntimeError(err.strip())
+    rows: list[Any] = []
+    for line in out.splitlines():
+        if line.strip():
+            rows.append(json.loads(line))
+            if max_pages and len(rows) >= max_pages * 100:
+                break
+    return rows
+
+
+def build_search_query(kind: str, login: str, relation: str, since: str | None = None) -> str:
+    if relation == "authored":
+        q = f"author:{login}"
+    elif relation == "involved":
+        q = f"involves:{login}"
+    elif relation == "reviewed":
+        q = f"reviewed-by:{login}"
+    else:
+        raise ValueError(f"unknown relation: {relation}")
+    if kind == "pr":
+        q += " is:pr"
+    elif kind == "issue":
+        q += " is:issue"
+    else:
+        raise ValueError(f"unknown kind: {kind}")
+    if since:
+        q += f" updated:>={since}"
+    return q
+
+
+class RateLimitExhausted(RuntimeError):
+    """Raised when retry-on-rate-limit budget is exhausted (or the reset window
+    is unreasonably far in the future). The caller (`collect()`) catches this
+    in its `try/except` around `partitioned_search_issues()` and writes a
+    record to `state/errors.jsonl` via `append_error`, so partial failures
+    are visible in the manifest and the health check rather than silently
+    producing a year with incomplete data.
+
+    When raised from `partitioned_search_issues`, `partial_rows` carries
+    whatever rows were collected from successful year-partitions before the
+    failure. The caller should merge these with on-disk data (via
+    `merge_unique`) so a single bad year doesn't lose the other years'
+    progress — the next run will fill in the rest.
+    """
+    def __init__(self, msg: str, partial_rows: list | None = None):
+        super().__init__(msg)
+        self.partial_rows = partial_rows or []
+
+
+def _wait_for_rate_reset(err_text: str, attempt: int) -> float:
+    """Return seconds to sleep before retrying after a rate-limit error.
+
+    Tries (in order):
+      1. x-ratelimit-reset: <unix-ts>  → sleep until then (+2s buffer)
+      2. timestamp YYYY-MM-DD HH:MM:SS UTC → same
+      3. exponential backoff capped at 120s: 2^attempt + jitter
+
+    Raises RateLimitExhausted immediately if the parsed reset window is
+    unreasonably far in the future (>10 min). Retrying into such a window
+    would just busy-loop against the same cap and burn the retry budget.
+    Failing fast lets the caller surface the error and try again on the
+    next scheduled run, by which time the window is more likely open.
+    """
+    reset_iso = parse_github_reset(err_text)
+    if reset_iso:
+        try:
+            from datetime import datetime as _dt
+            reset_dt = _dt.fromisoformat(reset_iso)
+            now = datetime.now(timezone.utc)
+            wait = (reset_dt - now).total_seconds()
+            # If the window is far in the future, don't bother retrying.
+            # Caller surfaces the error; next cron tick can try again.
+            if wait > 600:
+                raise RateLimitExhausted(
+                    f"rate limit reset is {wait:.0f}s away; not retrying this run"
+                )
+            # If the window is already in the past, the server gave us stale
+            # info (or we lost a race). A short sleep + retry may work, but
+            # sleeping 2s blindly burns the budget; fall through to backoff
+            # which at least grows exponentially.
+            if wait <= 0:
+                # fall through to backoff below
+                raise StopIteration  # local control flow, caught below
+            # 0 < wait <= 600: honor the window, with a small buffer.
+            return wait + 2.0
+        except RateLimitExhausted:
+            raise
+        except StopIteration:
+            pass
+        except Exception:
+            pass
+    # exponential backoff with jitter
+    base = min(120.0, 2 ** min(attempt, 7))  # 2,4,8,16,32,64,120,120
+    jitter = base * 0.2 * (0.5 - (time.time() % 1))  # ±10%
+    return max(2.0, base + jitter)
+
+
+def search_issues(query: str, max_pages: int | None = None, per_page: int = 100) -> list[dict]:
+    """Search issues/PRs with retry-on-rate-limit.
+
+    On 422 (1000-result cap) we stop — that partition is done.
+    On 429 / "rate limit exceeded" / "secondary rate limit" we wait for the
+    reset window (or back off) and retry the same page, up to MAX_RETRIES
+    times. If retries are exhausted, raises RateLimitExhausted so the
+    caller can record the partial failure (the function returns nothing
+    in that case — partial rows are lost, which is the correct trade-off
+    when a year is incomplete: the next run will resume from disk via
+    merge_unique and the user sees the failure in errors.jsonl).
+
+    Note: the retry budget is per-page, not per-call. A 100-page call that
+    rate-limits on every other page will use up to MAX_RETRIES sleeps per
+    rate-limited page. This is intentional — a global cap of 5 would mean
+    a single bad page could abort 99 successful pages of work.
+    """
+    MAX_RETRIES = 5
+    rows: list[dict] = []
+    page = 1
+    retries_left = MAX_RETRIES
+    while True:
+        endpoint = f"search/issues?q={quote(query)}&per_page={per_page}&page={page}"
+        try:
+            data = gh_json(["api", endpoint], timeout=180)
+        except RateLimitExhausted as exc:
+            # Fail fast: window too far in the future. Carry the rows we
+            # already collected from successful pages so the caller can
+            # preserve them (a year with 6 of 7 pages is still better
+            # than 0 of 7).
+            raise RateLimitExhausted(str(exc), partial_rows=rows) from exc
+        except RuntimeError as exc:
+            msg = str(exc)
+            if "Only the first 1000 search results are available" in msg:
+                print(f"  search cap reached at page {page}; keeping {len(rows)} partial results ({query})", flush=True)
+                break
+            if "API rate limit exceeded" in msg or "secondary rate limit" in msg.lower():
+                if retries_left <= 0:
+                    raise RateLimitExhausted(
+                        f"rate limit retries exhausted at page {page} of query '{query}' "
+                        f"after {MAX_RETRIES} retries; surfacing to caller with {len(rows)} "
+                        f"rows from successful pages",
+                        partial_rows=rows,
+                    )
+                attempt = MAX_RETRIES - retries_left + 1
+                wait = _wait_for_rate_reset(msg, attempt)
+                print(f"  search rate limit hit at page {page} (attempt {attempt}/{MAX_RETRIES}); sleeping {wait:.1f}s then retrying", flush=True)
+                time.sleep(wait)
+                retries_left -= 1
+                continue
+            raise
+        # success — refill retry budget, accept results
+        retries_left = MAX_RETRIES
+        items = data.get("items", []) if isinstance(data, dict) else []
+        rows.extend(items)
+        print(f"  search page {page}: {len(items)} items ({query})", flush=True)
+        if len(items) < per_page or (max_pages and page >= max_pages):
+            break
+        page += 1
+        time.sleep(2.2)
+    return rows
+
+
+def partitioned_search_issues(base_query: str, max_pages: int | None = None, per_page: int = 100) -> list[dict]:
+    """Search issues/PRs, partitioning by updated year to avoid GitHub's 1000-result cap.
+
+    GitHub Search only exposes the first 1000 results for a query. For full runs,
+    split broad PR/issue queries by updated year. Smoke tests (`max_pages`) keep
+    the simple one-query behavior for speed.
+
+    If individual year-partitions raise RateLimitExhausted mid-partition, the
+    partial rows for that year are discarded (we don't return incomplete years
+    to the caller — better to record the failure and let the next run resume
+    from disk). A per-year error is recorded; the loop continues to the next
+    year so a single bad year doesn't block the rest. After all years, if any
+    year was partial, raises a single RateLimitExhausted with a summary so the
+    outer caller's `try/except` records it in `state/errors.jsonl`.
+    """
+    if max_pages:
+        return search_issues(base_query, max_pages=max_pages, per_page=per_page)
+
+    current_year = datetime.now(timezone.utc).year
+    # GitHub launched in 2008; include current year and an older catch-all.
+    ranges = [f"updated:{year}-01-01..{year}-12-31" for year in range(current_year, 2007, -1)]
+    ranges.append("updated:<2008-01-01")
+    seen: set[str] = set()
+    rows: list[dict] = []
+    partial_years: list[str] = []
+    for qualifier in ranges:
+        query = f"{base_query} {qualifier}"
+        try:
+            part = search_issues(query, max_pages=None, per_page=per_page)
+        except RateLimitExhausted as exc:
+            print(f"  partition {qualifier} partial: {exc}; continuing to next year", flush=True)
+            partial_years.append(qualifier)
+            time.sleep(2.2)
+            continue
+        print(f"  partition {qualifier}: {len(part)} items", flush=True)
+        for item in part:
+            key = str(item.get("id") or item.get("node_id") or item.get("html_url"))
+            if key not in seen:
+                seen.add(key)
+                rows.append(item)
+        time.sleep(2.2)
+    if partial_years:
+        raise RateLimitExhausted(
+            f"{len(partial_years)} year-partition(s) had partial failures "
+            f"({len(rows)} complete items collected from other years, "
+            f"carried in exc.partial_rows for the caller to merge): "
+            f"{', '.join(partial_years[:5])}"
+            f"{' ...' if len(partial_years) > 5 else ''}",
+            partial_rows=rows,
+        )
+    return rows
+
+
+def collect(out: Path, max_pages: int | None = None, since: str | None = None, resume: bool = True) -> dict[str, Any]:
+    ensure_layout(out)
+    manifest: dict[str, Any] = {"started_at": iso_now(), "out": str(out), "files": {}, "errors": [], "resume": resume}
+
+    print("checking gh auth...", flush=True)
+    rc, auth_out, auth_err = run_gh(["auth", "status"], timeout=60)
+    if rc != 0:
+        raise RuntimeError(auth_err or auth_out)
+
+    user = gh_json(["api", "user"], timeout=60)
+    login = user["login"]
+    write_json(out / "raw" / "user.json", user)
+    manifest["login"] = login
+    print(f"authenticated as {login}", flush=True)
+
+    stages = [
+        ("orgs", lambda: paginated_api("user/orgs?per_page=100", max_pages=max_pages), out / "raw" / "orgs.jsonl"),
+        ("repos", lambda: paginated_api("user/repos?per_page=100&affiliation=owner,collaborator,organization_member&sort=updated", max_pages=max_pages), out / "raw" / "repos.jsonl"),
+        ("gists", lambda: paginated_api("gists?per_page=100", max_pages=max_pages), out / "raw" / "gists.jsonl"),
+        ("events", lambda: paginated_api(f"users/{login}/events/public?per_page=100", max_pages=max_pages), out / "raw" / "events.jsonl"),
+    ]
+    for name, fn, path in stages:
+        try:
+            print(f"collecting {name}...", flush=True)
+            rows = fn()
+            if name == "repos":
+                before = len(rows)
+                rows = [r for r in rows if not _is_excluded(r)]
+                skipped = before - len(rows)
+                if skipped:
+                    print(f"    excluded {skipped} repos in EXCLUDED_REPOS", flush=True)
+            merged = merge_unique(load_existing_jsonl(path), rows) if resume else rows
+            manifest["files"][str(path)] = atomic_write_jsonl(path, merged)
+        except Exception as exc:
+            append_error(out, name, exc)
+            manifest["errors"].append({"stage": name, "error": str(exc)})
+
+    searches = [
+        ("prs-authored", build_search_query("pr", login, "authored", since), out / "raw" / "prs-authored.jsonl"),
+        ("prs-involved", build_search_query("pr", login, "involved", since), out / "raw" / "prs-involved.jsonl"),
+        ("prs-reviewed", build_search_query("pr", login, "reviewed", since), out / "raw" / "reviews.jsonl"),
+        ("issues-authored", build_search_query("issue", login, "authored", since), out / "raw" / "issues-authored.jsonl"),
+        ("issues-involved", build_search_query("issue", login, "involved", since), out / "raw" / "issues-involved.jsonl"),
+    ]
+    for name, query, path in searches:
+        rows: list = []
+        try:
+            print(f"collecting {name}: {query}", flush=True)
+            rows = partitioned_search_issues(query, max_pages=max_pages)
+        except RateLimitExhausted as exc:
+            # Partial failure: record the error (so it's visible in
+            # manifest + health card) AND keep any rows from successful
+            # year-partitions so they're merged with on-disk data. Next
+            # run will fill in the missing year(s).
+            append_error(out, name, exc)
+            manifest["errors"].append({"stage": name, "error": str(exc)})
+            rows = list(exc.partial_rows) if exc.partial_rows else []
+            print(f"  {name}: keeping {len(rows)} partial rows from successful years; "
+                  f"will continue on next run", flush=True)
+        except Exception as exc:
+            append_error(out, name, exc)
+            manifest["errors"].append({"stage": name, "error": str(exc)})
+            rows = []
+        before = len(rows)
+        rows = [r for r in rows if not _is_excluded(r)]
+        skipped = before - len(rows)
+        if skipped:
+            print(f"    excluded {skipped} rows in EXCLUDED_REPOS", flush=True)
+        merged = merge_unique(load_existing_jsonl(path), rows) if resume else rows
+        manifest["files"][str(path)] = atomic_write_jsonl(path, merged)
+
+    manifest["finished_at"] = iso_now()
+    write_json(out / "state" / "manifest.json", manifest)
+    return manifest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", default=str(DEFAULT_OUT))
+    parser.add_argument("--max-pages", type=int, default=None, help="Limit pages per paginated collection/search for smoke tests")
+    parser.add_argument("--since", default=None, help="Only search PR/issues updated on/after YYYY-MM-DD")
+    parser.add_argument("--no-resume", action="store_true", help="Overwrite stage files instead of merging with existing JSONL records")
+    args = parser.parse_args()
+    manifest = collect(Path(args.out).expanduser().resolve(), max_pages=args.max_pages, since=args.since, resume=not args.no_resume)
+    print(json.dumps(manifest, indent=2, ensure_ascii=False))
+    return 0 if not manifest.get("errors") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/github_intelligence_digest.py
+++ b/scripts/github_intelligence_digest.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Generate Hermes-facing intelligence products from local GitHub vault.
+
+Read-only over raw vault data. Writes derived local reports/indexes only.
+"""
+from __future__ import annotations
+import argparse, json, re
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+DEFAULT_DATA = Path.home() / "Data" / "github-intelligence"
+TOPICS = {
+    "airtable": ["airtable", "fub", "seniorplace", "automation", "base", "record"],
+    "hermes_gateway": ["hermes", "gateway", "telegram", "cron", "launchd", "watchdog"],
+    "cursor_agents": ["cursor", "agent", "task_runner", "copilot", "claude", "codex"],
+    "memory": ["memory", "simplemem", "oracle", "wiki", "obsidian", "context"],
+    "github_actions": ["github actions", "workflow", "ci", "gha", "runner", "deploy"],
+    "bots": ["bot", "telegram", "discord", "slack", "message", "webhook"],
+    "search_research": ["search", "research", "crawler", "scrape", "dataset", "ingest"],
+}
+SECRET_RE = re.compile(r"(?i)(sk-[a-z0-9_-]{12,}|gh[pousr]_[a-z0-9_]{20,}|xox[baprs]-[a-z0-9-]{20,}|api[_-]?key\s*[:=]\s*['\"]?[a-z0-9_-]{16,}|token\s*[:=]\s*['\"]?[a-z0-9_-]{16,})")
+STOP = {"the","and","for","with","from","this","that","into","your","have","will","are","was","were","not","but","you","all","add","fix","feat","update","github","https","http","com","null","true","false"}
+
+def now(): return datetime.now(timezone.utc).isoformat()
+def read_json(path: Path):
+    try: return json.loads(path.read_text(encoding="utf-8"))
+    except Exception: return {}
+def read_jsonl(path: Path):
+    rows=[]
+    if not path.exists(): return rows
+    with path.open(encoding="utf-8", errors="replace") as f:
+        for line in f:
+            if not line.strip(): continue
+            try: rows.append(json.loads(line))
+            except Exception: pass
+    return rows
+
+def repo_from_item(item):
+    for key in ("repo","full_name"):
+        if item.get(key): return str(item[key])
+    repo_url = item.get("repository_url") or ""
+    if "repos/" in repo_url: return repo_url.split("repos/",1)[1]
+    html = item.get("html_url") or item.get("url") or ""
+    if "github.com/" in html:
+        parts=html.split("github.com/",1)[1].split("/")
+        if len(parts)>=2: return f"{parts[0]}/{parts[1]}"
+    obj=item.get("repository") or {}
+    return obj.get("full_name") or "unknown"
+
+def text_of(item):
+    vals=[]
+    for k in ("full_name","name","description","title","body","subject","repo","language"):
+        v=item.get(k)
+        if v: vals.append(str(v))
+    return " ".join(vals)
+
+def url_of(item): return item.get("html_url") or item.get("url") or ""
+def title_of(item): return item.get("title") or item.get("subject") or item.get("full_name") or item.get("name") or repo_from_item(item)
+def tokenize(s): return [t for t in re.split(r"[^a-z0-9]+", s.lower()) if len(t)>=4 and t not in STOP]
+def has_secret(s): return bool(SECRET_RE.search(s or ""))
+def redact(s): return SECRET_RE.sub("[REDACTED_SECRET]", s or "")
+
+def topic_hits(records):
+    out={}
+    for topic, kws in TOPICS.items():
+        scored=[]
+        for kind,item in records:
+            txt=text_of(item).lower()
+            score=sum(txt.count(k) for k in kws)
+            if score:
+                scored.append({"score":score,"kind":kind,"repo":repo_from_item(item),"title":title_of(item),"url":url_of(item),"snippet":redact(text_of(item)[:500])})
+        scored.sort(key=lambda x:x["score"], reverse=True)
+        out[topic]=scored
+    return out
+
+def infer_repo_conventions(repos, prs, commits):
+    by_repo=defaultdict(lambda:{"prs":0,"commits":0,"terms":Counter(),"examples":[],"language":"unknown","url":""})
+    for r in repos:
+        name=r.get("full_name") or "unknown"; d=by_repo[name]
+        d["language"]=r.get("language") or "unknown"; d["url"]=r.get("html_url") or ""; d["description"]=r.get("description") or ""; d["pushed_at"]=r.get("pushed_at") or ""
+        d["private"]=bool(r.get("private")); d["archived"]=bool(r.get("archived"))
+        d["terms"].update(tokenize(text_of(r)))
+    for p in prs:
+        name=repo_from_item(p); d=by_repo[name]; d["prs"]+=1; d["terms"].update(tokenize(text_of(p)))
+        if url_of(p) and len(d["examples"])<5: d["examples"].append({"title":title_of(p),"url":url_of(p)})
+    for c in commits:
+        name=repo_from_item(c); d=by_repo[name]; d["commits"]+=1; d["terms"].update(tokenize(text_of(c)))
+        if len(d["examples"])<5 and c.get("subject"): d["examples"].append({"title":c.get("subject"),"url":""})
+    profiles=[]
+    for repo,d in by_repo.items():
+        terms=[w for w,_ in d["terms"].most_common(12)]
+        confidence = min(100, d["prs"]*2 + d["commits"]//20 + (20 if d.get("language") != "unknown" else 0))
+        likely=[]
+        t=set(terms)
+        if d["language"] in {"Python"} or {"pytest","airtable","script"}&t: likely.append("Python scripts/tests likely; inspect AGENTS.md/runbook before edits")
+        if d["language"] in {"TypeScript","JavaScript"} or {"react","next","vite","netlify"}&t: likely.append("JS/TS frontend conventions likely; run package scripts after inspecting package.json")
+        if {"airtable","seniorplace","fub"}&t: likely.append("Airtable/APFS automation sensitive; verify env names and scheduler ownership")
+        if {"cursor","agent","memory","hermes"}&t: likely.append("Agent/Cursor memory conventions matter; query history before changes")
+        profiles.append({"repo":repo,"language":d["language"],"url":d["url"],"description":d.get("description",""),"pushed_at":d.get("pushed_at",""),"archived":d.get("archived",False),"prs":d["prs"],"commits":d["commits"],"top_terms":terms,"likely_conventions":likely,"examples":d["examples"],"confidence":confidence})
+    profiles.sort(key=lambda x:(x["confidence"], x["prs"], x["commits"]), reverse=True)
+    return profiles
+
+def write_md(path, lines):
+    txt="\n".join(lines)+"\n"
+    if has_secret(txt): txt=redact(txt)
+    path.write_text(txt, encoding="utf-8")
+
+def main():
+    ap=argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--data", default=str(DEFAULT_DATA)); ap.add_argument("--top", type=int, default=30)
+    args=ap.parse_args(); data=Path(args.data).expanduser().resolve(); reports=data/"reports"; state=data/"state"; reports.mkdir(parents=True, exist_ok=True); state.mkdir(parents=True, exist_ok=True)
+    repos=read_jsonl(data/"raw/repos.jsonl"); prs_a=read_jsonl(data/"raw/prs-authored.jsonl"); prs_i=read_jsonl(data/"raw/prs-involved.jsonl"); issues=read_jsonl(data/"raw/issues-involved.jsonl")+read_jsonl(data/"raw/issues-authored.jsonl"); commits=read_jsonl(data/"raw/commits.jsonl")
+    records=[*(('repo',r) for r in repos),*(('pr',p) for p in prs_i),*(('issue',i) for i in issues),*(('commit',c) for c in commits)]
+    topics=topic_hits(records); profiles=infer_repo_conventions(repos, prs_i, commits)
+    # skill candidates
+    skill_rows=[]
+    for topic,hits in topics.items():
+        repos_count=Counter(h["repo"] for h in hits)
+        value=len(hits)+len(repos_count)*5
+        skill_rows.append({"topic":topic,"records":len(hits),"repos":len(repos_count),"score":value,"top_repos":repos_count.most_common(8),"examples":hits[:5]})
+    skill_rows.sort(key=lambda x:x["score"], reverse=True)
+    # revival queue
+    revival=[]
+    for p in profiles:
+        if p["archived"]: continue
+        text=" ".join(p["top_terms"]+[p.get("description") or ""]).lower()
+        signal=sum(1 for kws in TOPICS.values() for kw in kws if kw in text)
+        if signal and p.get("pushed_at"):
+            revival.append({**p,"reuse_score":signal*10+p["confidence"]//5})
+    revival.sort(key=lambda x:(x["reuse_score"], x.get("pushed_at") or ""), reverse=True)
+    # markdown outputs
+    write_md(reports/"repo-conventions.md", ["# Repo Convention Profiles", "", f"Generated: `{now()}`", "", "Derived from local GitHub vault metadata. Verify against live repo files before editing.", ""] + sum(([f"## `{p['repo']}`", "", f"- Language: `{p['language']}`", f"- Confidence: `{p['confidence']}`", f"- PR records: `{p['prs']}`; commit records: `{p['commits']}`", f"- Pushed: `{p.get('pushed_at') or 'unknown'}`", f"- Top terms: {', '.join('`'+t+'`' for t in p['top_terms'][:10])}", "- Likely conventions:"] + [f"  - {c}" for c in (p['likely_conventions'] or ['No strong convention inferred; inspect repo files first.'])] + ["- Evidence examples:"] + [f"  - {e['title']}{(' — '+e['url']) if e.get('url') else ''}" for e in p['examples'][:3]] + [""] for p in profiles[:args.top]), []))
+    write_md(reports/"skill-candidates.md", ["# GitHub-Derived Skill Candidates", "", f"Generated: `{now()}`", "", "These are candidates for abstract Hermes skills. Do not copy private code into skills; extract procedures/pitfalls only.", ""] + sum(([f"## `{s['topic']}`", "", f"- Matching records: `{s['records']}`", f"- Repos touched: `{s['repos']}`", f"- Priority score: `{s['score']}`", "- Top repos:"] + [f"  - `{r}`: {c}" for r,c in s['top_repos']] + ["- Evidence examples:"] + [f"  - `{e['repo']}` — {e['title']}{(' — '+e['url']) if e.get('url') else ''}" for e in s['examples']] + ["- Suggested skill shape:", f"  - Trigger: future work involving {s['topic'].replace('_',' ')}", "  - Include: prerequisites, exact commands, pitfalls, verification checks, privacy guardrails", ""] for s in skill_rows), []))
+    write_md(reports/"revival-queue.md", ["# Dormant / Reusable Project Revival Queue", "", f"Generated: `{now()}`", "", "Ranked by AI/automation/search/bot/memory signal in local GitHub history. Review before acting; do not auto-modify repos.", ""] + sum(([f"## `{p['repo']}`", "", f"- Reuse score: `{p['reuse_score']}`", f"- Language: `{p['language']}`", f"- Last pushed: `{p.get('pushed_at') or 'unknown'}`", f"- Description: {p.get('description') or ''}", f"- Why it may matter: {', '.join(p['top_terms'][:8])}", "- Next action: inspect repo README/AGENTS/runbook and query vault for exact prior context.", ""] for p in revival[:args.top]), []))
+    digest=["# GitHub Intelligence Weekly Digest", "", f"Generated: `{now()}`", "", "## What Hermes should do with the data", "", "1. Query `github_history_query` before repo/dev/automation tasks.", "2. Use `repo-conventions.md` as orientation, then verify against live files.", "3. Promote `skill-candidates.md` items into abstract skills after review.", "4. Use `revival-queue.md` to pick reusable old projects/components.", "", "## Top skill candidates", ""]
+    for s in skill_rows[:8]: digest.append(f"- `{s['topic']}` — {s['records']} records across {s['repos']} repos")
+    digest += ["", "## Top repo convention profiles", ""]
+    for p in profiles[:10]: digest.append(f"- `{p['repo']}` — {p['language']}, confidence {p['confidence']}, terms: {', '.join(p['top_terms'][:5])}")
+    digest += ["", "## Top revival candidates", ""]
+    for p in revival[:10]: digest.append(f"- `{p['repo']}` — score {p['reuse_score']}, {p['language']}, pushed {p.get('pushed_at') or 'unknown'}")
+    commit_workflows = read_json(state/"commit-workflows.json")
+    workflow_rows = commit_workflows.get("workflows") or []
+    if workflow_rows:
+        digest += ["", "## Top commit workflow clusters", ""]
+        for wf in workflow_rows[:8]:
+            if wf.get("count"):
+                digest.append(f"- `{wf.get('key')}` — {wf.get('count')} commits; top repos: {', '.join(r for r,_ in (wf.get('top_repos') or [])[:3])}")
+    write_md(reports/"weekly-digest.md", digest)
+    index={"generated_at":now(),"data_dir":str(data),"counts":{"repos":len(repos),"prs_involved":len(prs_i),"prs_authored":len(prs_a),"issues":len(issues),"commits":len(commits)},"preflight_policy":{"when":"Before repo/dev/automation work when prior Nicholas patterns may matter","queries":["<repo name> conventions tests deploy", "<topic> automation workflow", "<error message or library>"],"privacy":"Keep raw private details local; promote only abstract procedures."},"top_skill_candidates":skill_rows[:12],"top_repo_profiles":profiles[:30],"top_revival_candidates":revival[:30],"top_commit_workflows":workflow_rows[:12],"report_paths":[str(reports/n) for n in ["repo-conventions.md","skill-candidates.md","revival-queue.md","weekly-digest.md","commit-workflows.md"]]}
+    (state/"hermes-preflight-index.json").write_text(json.dumps(index, indent=2, ensure_ascii=False), encoding="utf-8")
+    readme=data/"README.md"
+    existing=readme.read_text(encoding="utf-8") if readme.exists() else "# GitHub Intelligence Vault\n"
+    marker="\n## Hermes Active-Use Runbook\n"
+    runbook=marker+"\nThis vault is local/private and is used as Hermes's engineering memory for Nicholas's GitHub work.\n\nGenerated products:\n\n- `reports/repo-conventions.md` — inferred repo orientations; verify against live files.\n- `reports/skill-candidates.md` — repeated workflows to turn into abstract skills.\n- `reports/revival-queue.md` — projects/components worth revisiting.\n- `reports/commit-workflows.md` — commit-derived workflow clusters and repo playbook seeds.\n- `reports/weekly-digest.md` — concise summary for review.\n- `state/hermes-preflight-index.json` — machine-readable preflight index.\n\nOperational rule: before meaningful repo/dev/automation work, query `github_history_query` with the repo/topic/error. Do not copy private code into memory or skills.\n"
+    if marker in existing: existing=existing.split(marker)[0].rstrip()+"\n"+runbook
+    else: existing=existing.rstrip()+"\n"+runbook
+    readme.write_text(existing, encoding="utf-8")
+    print(json.dumps({"ok":True,"data":str(data),"counts":index["counts"],"reports":index["report_paths"],"index":str(state/"hermes-preflight-index.json")}, indent=2))
+if __name__ == "__main__": main()

--- a/scripts/github_intelligence_query.py
+++ b/scripts/github_intelligence_query.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Lexically search the local GitHub intelligence vault."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+DEFAULT_DATA = Path.home() / "Data" / "github-intelligence"
+
+
+def iter_records(data: Path):
+    for path in list((data / "raw").glob("*.jsonl")) + list((data / "reports").glob("*.md")):
+        if path.suffix == ".jsonl":
+            for i, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+                if not line.strip():
+                    continue
+                try:
+                    obj = json.loads(line)
+                except Exception:
+                    continue
+                text = json.dumps(obj, ensure_ascii=False)
+                yield {"path": str(path), "line": i, "text": text, "url": obj.get("html_url") or obj.get("url"), "title": obj.get("title") or obj.get("full_name") or obj.get("name")}
+        else:
+            for i, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+                yield {"path": str(path), "line": i, "text": line, "url": None, "title": path.name}
+
+
+def score(text: str, tokens: list[str]) -> int:
+    low = text.lower()
+    return sum(low.count(t) for t in tokens)
+
+
+def search(data: Path, query: str, limit: int = 10) -> list[dict[str, Any]]:
+    tokens = [t.lower() for t in query.split() if len(t) >= 2]
+    hits = []
+    for rec in iter_records(data):
+        s = score(rec["text"], tokens)
+        if s > 0:
+            snippet = rec["text"][:800].replace("\n", " ")
+            hits.append({**rec, "score": s, "snippet": snippet})
+    hits.sort(key=lambda h: h["score"], reverse=True)
+    return hits[:limit]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("query")
+    parser.add_argument("--data", default=str(DEFAULT_DATA))
+    parser.add_argument("--limit", type=int, default=10)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    hits = search(Path(args.data).expanduser().resolve(), args.query, args.limit)
+    if args.json:
+        print(json.dumps(hits, indent=2, ensure_ascii=False))
+    else:
+        for hit in hits:
+            print(f"[{hit['score']}] {hit['path']}:{hit['line']} {hit.get('title') or ''}")
+            if hit.get("url"):
+                print(f"  {hit['url']}")
+            print(f"  {hit['snippet'][:300]}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem

The `github-intelligence-weekly-digest` cron job (in `~/.hermes/cron/jobs/`) calls 4 scripts:

- `scripts/github_intelligence_collect.py`
- `scripts/github_intelligence_analyze.py`
- `scripts/github_intelligence_query.py`
- `scripts/github_intelligence_digest.py`

These scripts were dropped from `main` at some point but the cron job still references them. As a result, the weekly digest exits with code 2 every Monday at 09:00, breaking the GitHub intelligence pipeline that powers `github_history_query` (used by Stage 0 preflight in 9 methodology skills).

## Fix

Restore the 4 scripts from `fork/main` (Nicholas's fork, `noidsoup/hermes-agent`). All 4 files are unchanged from their state in `fork/main` — this is a pure restoration, no edits.

## Verification

After the scripts are restored, the cron job runs cleanly:

```
$ bash ~/.hermes/scripts/github-intelligence-digest.sh
{
  "ok": true,
  "counts": {
    "repos": 92,
    "commits": 28176,
    ...
  },
  "reports": [
    "~/Data/github-intelligence/reports/repo-conventions.md",
    "~/Data/github-intelligence/reports/skill-candidates.md",
    "~/Data/github-intelligence/reports/revival-queue.md",
    "~/Data/github-intelligence/reports/weekly-digest.md",
    "~/Data/github-intelligence/reports/commit-workflows.md"
  ]
}
```

The vault state goes from stale (12+ days for `commit-scan.json`) to fresh on the next weekly run.

## Notes

- This is a sibling-repo fix, not a Hermes Agent core change. It only restores cron dependencies.
- A helper script (`~/.hermes/scripts/restore_github_intelligence_scripts.sh`) automates the restore process for future drift.
