### PR TITLE
fix: SessionDB crash on SQLite builds without trigram tokenizer

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -772,7 +772,14 @@ class SessionDB:
     @staticmethod
     def _is_fts5_unavailable_error(exc: sqlite3.OperationalError) -> bool:
         err = str(exc).lower()
-        return "no such module" in err and "fts5" in err
+        # "no such module: fts5" — entire fts5 extension is absent.
+        if "no such module" in err and "fts5" in err:
+            return True
+        # "no such tokenizer: trigram" — fts5 exists but the optional trigram
+        # tokenizer is not compiled in (e.g. SQLite < 3.34 or stripped builds).
+        if "no such tokenizer" in err:
+            return True
+        return False
 
     def _warn_fts5_unavailable(self, exc: sqlite3.OperationalError) -> None:
         self._fts_enabled = False
@@ -868,7 +875,19 @@ class SessionDB:
         except sqlite3.OperationalError as exc:
             if not self._is_fts5_unavailable_error(exc):
                 raise
-            self._warn_fts5_unavailable(exc)
+            err = str(exc).lower()
+            if "no such tokenizer" in err:
+                # Only the optional trigram tokenizer is missing; the base fts5
+                # porter-stemmer index still works.  Log at INFO (not WARNING)
+                # and do NOT clear _fts_enabled so callers that only need base
+                # FTS are unaffected.  CJK/substring search falls back to LIKE.
+                logger.info(
+                    "SQLite trigram tokenizer unavailable for %s; "
+                    "CJK/substring search will fall back to LIKE. (%s)",
+                    self.db_path, exc,
+                )
+            else:
+                self._warn_fts5_unavailable(exc)
             return False
 
     def _execute_write(self, fn: Callable[[sqlite3.Connection], T]) -> T:
@@ -1174,13 +1193,12 @@ class SessionDB:
                     if fts5_available:
                         # Recreate virtual tables + triggers with the new inline-mode
                         # schema that indexes content || tool_name || tool_calls.
-                        if (
-                            self._ensure_fts_schema(cursor, "messages_fts", FTS_SQL)
-                            and self._ensure_fts_schema(
-                                cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
-                            )
-                        ):
-                            # Backfill both indexes from every existing messages row.
+                        # Base FTS and trigram are backfilled independently so that a
+                        # missing trigram tokenizer (SQLite < 3.34 or stripped builds)
+                        # does not prevent the base index from being rebuilt or the
+                        # schema version from bumping — avoiding infinite migration
+                        # retry on every restart.
+                        if self._ensure_fts_schema(cursor, "messages_fts", FTS_SQL):
                             cursor.execute(
                                 "INSERT INTO messages_fts(rowid, content) "
                                 "SELECT id, "
@@ -1189,6 +1207,13 @@ class SessionDB:
                                 "COALESCE(tool_calls, '') "
                                 "FROM messages"
                             )
+                        else:
+                            fts_migrations_complete = False
+                        # Trigram is optional; its failure does not block the
+                        # schema-version bump or base FTS availability.
+                        if self._ensure_fts_schema(
+                            cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
+                        ):
                             cursor.execute(
                                 "INSERT INTO messages_fts_trigram(rowid, content) "
                                 "SELECT id, "
@@ -1197,8 +1222,6 @@ class SessionDB:
                                 "COALESCE(tool_calls, '') "
                                 "FROM messages"
                             )
-                        else:
-                            fts_migrations_complete = False
                 else:
                     fts_migrations_complete = False
             if current_version < 12:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -50,6 +50,24 @@ class _NoFtsExistingTableConnection(sqlite3.Connection):
         return super().cursor(factory or _NoFtsExistingTableCursor)
 
 
+class _NoTrigramCursor(sqlite3.Cursor):
+    """Simulate a SQLite build that has fts5 but lacks the optional trigram tokenizer.
+
+    SQLite >= 3.34 ships the trigram tokenizer; stripped or older builds raise
+    "no such tokenizer: trigram" when the virtual table DDL is executed.
+    """
+
+    def executescript(self, sql_script):
+        if "tokenize='trigram'" in sql_script or 'tokenize="trigram"' in sql_script:
+            raise sqlite3.OperationalError("no such tokenizer: trigram")
+        return super().executescript(sql_script)
+
+
+class _NoTrigramConnection(sqlite3.Connection):
+    def cursor(self, factory=None):
+        return super().cursor(factory or _NoTrigramCursor)
+
+
 @pytest.fixture()
 def db(tmp_path):
     """Create a SessionDB with a temp database file."""
@@ -329,6 +347,46 @@ class TestSessionLifecycle:
             assert len(restored.search_messages("indexed")) == 2
         finally:
             restored.close()
+
+    def test_db_initializes_when_trigram_tokenizer_missing(self, tmp_path, monkeypatch):
+        """SQLite builds that have fts5 but lack the optional trigram tokenizer
+        (SQLite < 3.34 or stripped builds) must not crash on DB init.
+
+        Regression test for the crash in SessionDB.__init__ where
+        _is_fts5_unavailable_error did not match "no such tokenizer: trigram"
+        so the OperationalError propagated uncaught.  After the fix:
+        - _fts_enabled must remain True (base FTS still works)
+        - messages_fts (porter-stemmer) is created; messages_fts_trigram is not
+        - write/read and search_messages all work normally
+        """
+        real_connect = sqlite3.connect
+
+        def connect_without_trigram(*args, **kwargs):
+            kwargs["factory"] = _NoTrigramConnection
+            return real_connect(*args, **kwargs)
+
+        monkeypatch.setattr("hermes_state.sqlite3.connect", connect_without_trigram)
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            # Only the trigram tokenizer is missing — base FTS must still be on.
+            assert db._fts_enabled is True
+            assert db._fts_table_exists("messages_fts") is True
+            assert db._fts_table_exists("messages_fts_trigram") is False
+
+            db.create_session(session_id="s1", source="cli")
+            db.append_message("s1", role="user", content="trigram tokenizer optional")
+
+            messages = db.get_messages("s1")
+            assert len(messages) == 1
+            assert messages[0]["content"] == "trigram tokenizer optional"
+
+            # Porter-stemmer FTS search must still work even without trigram.
+            results = db.search_messages("trigram")
+            assert len(results) == 1
+            assert "trigram" in results[0].get("snippet", "").lower()
+        finally:
+            db.close()
 
 
 # =========================================================================


### PR DESCRIPTION
## Summary

Fixes #47002. `SessionDB.__init__` crashes with an unhandled `sqlite3.OperationalError` on any SQLite build that has fts5 but lacks the optional trigram tokenizer (SQLite < 3.34, or stripped/embedded builds). There were three related bugs:

- **`_is_fts5_unavailable_error` did not match trigram errors.** The check was `"no such module" in err and "fts5" in err`, which does not match `"no such tokenizer: trigram"`. The exception propagated uncaught from `_ensure_fts_schema` called in `__init__`.

- **`_ensure_fts_schema` called `_warn_fts5_unavailable` on trigram failure.** Even with the first bug fixed, the fallback would set `_fts_enabled = False`, globally disabling base FTS — even though the porter-stemmer index works fine without the trigram extension.

- **v11 migration used `and` to combine base+trigram backfills.** If trigram failed, the base FTS backfill was also skipped and `fts_migrations_complete` stayed `False`, causing an infinite schema-version loop (migration re-runs on every restart).

## Changes

- `_is_fts5_unavailable_error`: also match `"no such tokenizer"` errors
- `_ensure_fts_schema`: distinguish trigram-only failures — log at `INFO`, do **not** call `_warn_fts5_unavailable`, leave `_fts_enabled = True`
- v11 migration: split into two independent `if` branches so base FTS is backfilled regardless of trigram availability; trigram failure no longer blocks schema-version bump
- New `_NoTrigramCursor` / `_NoTrigramConnection` test helpers + regression test covering all three invariants

## Test plan

- [x] `pytest tests/test_hermes_state.py -x -q` — 268 passed
- [x] `test_db_initializes_when_trigram_tokenizer_missing` — new regression test: no crash, `_fts_enabled=True`, base `messages_fts` created, `messages_fts_trigram` absent, `search_messages` returns results
- [x] All existing FTS degradation tests pass (no-fts5, existing-table-no-fts5, legacy-schema, runtime-restore)