### PR TITLE
feat: add desktop text scale setting

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -3516,6 +3516,17 @@ function clampZoomLevel(value) {
   return Math.min(Math.max(value, -9), 9)
 }
 
+function broadcastZoomLevelChanged(zoomLevel) {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win || win.isDestroyed()) continue
+    try {
+      win.webContents.send('hermes:zoom-changed', { zoomLevel })
+    } catch {
+      // Window may be navigating; the next settings open refreshes from IPC.
+    }
+  }
+}
+
 function setAndPersistZoomLevel(window, zoomLevel) {
   if (!window || window.isDestroyed()) return
   const next = clampZoomLevel(zoomLevel)
@@ -3525,6 +3536,7 @@ function setAndPersistZoomLevel(window, zoomLevel) {
       `try { localStorage.setItem(${JSON.stringify(ZOOM_STORAGE_KEY)}, ${JSON.stringify(String(next))}) } catch {}`
     )
     .catch(error => rememberLog(`[zoom] persist failed: ${error?.message || error}`))
+  broadcastZoomLevelChanged(next)
 }
 
 function restorePersistedZoomLevel(window) {
@@ -3537,6 +3549,7 @@ function restorePersistedZoomLevel(window) {
       if (stored == null || !window || window.isDestroyed()) return
       const level = clampZoomLevel(Number(stored))
       window.webContents.setZoomLevel(level)
+      broadcastZoomLevelChanged(level)
     })
     .catch(error => rememberLog(`[zoom] restore failed: ${error?.message || error}`))
 }
@@ -5043,6 +5056,7 @@ function wireCommonWindowHandlers(win) {
   installDevToolsShortcut(win)
   installZoomShortcuts(win)
   installContextMenu(win)
+  win.webContents.on('did-finish-load', () => restorePersistedZoomLevel(win))
   win.webContents.setWindowOpenHandler(details => {
     openExternalUrl(details.url)
 
@@ -5256,7 +5270,6 @@ function createWindow() {
   }
 
   mainWindow.webContents.once('did-finish-load', () => {
-    restorePersistedZoomLevel(mainWindow)
     broadcastBootProgress()
     sendWindowStateChanged()
     startHermes().catch(error => rememberLog(error.stack || error.message))
@@ -5748,6 +5761,14 @@ ipcMain.on('hermes:translucency', (_event, payload) => {
   for (const win of BrowserWindow.getAllWindows()) {
     applyWindowTranslucency(win)
   }
+})
+
+ipcMain.handle('hermes:zoom:get', async event => ({ zoomLevel: event.sender.getZoomLevel() }))
+ipcMain.handle('hermes:zoom:set', async (event, payload) => {
+  const win = BrowserWindow.fromWebContents(event.sender)
+  setAndPersistZoomLevel(win, payload && payload.zoomLevel)
+
+  return { zoomLevel: win && !win.isDestroyed() ? win.webContents.getZoomLevel() : 0 }
 })
 
 ipcMain.handle('hermes:openExternal', (_event, url) => {

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -41,6 +41,8 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   setTitleBarTheme: payload => ipcRenderer.send('hermes:titlebar-theme', payload),
   setNativeTheme: mode => ipcRenderer.send('hermes:native-theme', mode),
   setTranslucency: payload => ipcRenderer.send('hermes:translucency', payload),
+  getZoomLevel: () => ipcRenderer.invoke('hermes:zoom:get'),
+  setZoomLevel: payload => ipcRenderer.invoke('hermes:zoom:set', payload),
   setPreviewShortcutActive: active => ipcRenderer.send('hermes:previewShortcutActive', Boolean(active)),
   openExternal: url => ipcRenderer.invoke('hermes:openExternal', url),
   fetchLinkTitle: url => ipcRenderer.invoke('hermes:fetchLinkTitle', url),
@@ -93,6 +95,11 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
     const listener = (_event, payload) => callback(payload)
     ipcRenderer.on('hermes:window-state-changed', listener)
     return () => ipcRenderer.removeListener('hermes:window-state-changed', listener)
+  },
+  onZoomChanged: callback => {
+    const listener = (_event, payload) => callback(payload)
+    ipcRenderer.on('hermes:zoom-changed', listener)
+    return () => ipcRenderer.removeListener('hermes:zoom-changed', listener)
   },
   onPreviewFileChanged: callback => {
     const listener = (_event, payload) => callback(payload)

--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -10,6 +10,14 @@ import { cn } from '@/lib/utils'
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
 import { $toolViewMode, setToolViewMode } from '@/store/tool-view'
 import { $translucency, setTranslucency } from '@/store/translucency'
+import {
+  $zoomLevel,
+  MAX_ZOOM_PERCENT,
+  MIN_ZOOM_PERCENT,
+  setZoomPercent,
+  ZOOM_PERCENT_STEP,
+  zoomLevelToPercent
+} from '@/store/zoom'
 import { useTheme } from '@/themes/context'
 import { installVscodeThemeFromMarketplace } from '@/themes/install'
 import { isUserTheme, removeUserTheme, resolveTheme } from '@/themes/user-themes'
@@ -137,6 +145,8 @@ export function AppearanceSettings() {
   const { themeName, mode, availableThemes, setTheme, setMode } = useTheme()
   const toolViewMode = useStore($toolViewMode)
   const translucency = useStore($translucency)
+  const zoomLevel = useStore($zoomLevel)
+  const zoomPercent = zoomLevelToPercent(zoomLevel)
   const profiles = useStore($profiles)
   const activeProfileKey = normalizeProfileKey(useStore($activeGatewayProfile))
   const a = t.settings.appearance
@@ -183,6 +193,32 @@ export function AppearanceSettings() {
             }
             description={a.colorModeDesc}
             title={a.colorMode}
+          />
+
+          <ListRow
+            action={
+              <div className="flex items-center gap-3">
+                <input
+                  aria-label={a.textScaleTitle}
+                  className="h-1 w-40 cursor-pointer appearance-none rounded-full bg-(--ui-stroke-tertiary)"
+                  max={MAX_ZOOM_PERCENT}
+                  min={MIN_ZOOM_PERCENT}
+                  onChange={event => {
+                    triggerHaptic('selection')
+                    void setZoomPercent(Number(event.target.value))
+                  }}
+                  step={ZOOM_PERCENT_STEP}
+                  style={{ accentColor: 'var(--dt-primary)' }}
+                  type="range"
+                  value={zoomPercent}
+                />
+                <span className="w-12 text-right text-[length:var(--conversation-caption-font-size)] tabular-nums text-(--ui-text-tertiary)">
+                  {zoomPercent}%
+                </span>
+              </div>
+            }
+            description={a.textScaleDesc}
+            title={a.textScaleTitle}
           />
 
           <ListRow

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -56,6 +56,8 @@ declare global {
       setTitleBarTheme?: (payload: HermesTitleBarTheme) => void
       setNativeTheme?: (mode: 'dark' | 'light' | 'system') => void
       setTranslucency?: (payload: { intensity: number }) => void
+      getZoomLevel?: () => Promise<{ zoomLevel: number }>
+      setZoomLevel?: (payload: { zoomLevel: number }) => Promise<{ zoomLevel: number }>
       setPreviewShortcutActive?: (active: boolean) => void
       openExternal: (url: string) => Promise<void>
       fetchLinkTitle: (url: string) => Promise<string>
@@ -88,6 +90,7 @@ declare global {
       ) => () => void
       signalDeepLinkReady?: () => Promise<{ ok: boolean }>
       onWindowStateChanged?: (callback: (payload: HermesWindowState) => void) => () => void
+      onZoomChanged?: (callback: (payload: { zoomLevel: number }) => void) => () => void
       onPreviewFileChanged: (callback: (payload: HermesPreviewFileChanged) => void) => () => void
       onBackendExit: (callback: (payload: BackendExit) => void) => () => void
       onPowerResume?: (callback: () => void) => () => void

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -294,6 +294,8 @@ export const en: Translations = {
         'These are desktop-only display preferences. Mode controls brightness; theme controls the accent palette and chat surface styling.',
       colorMode: 'Color Mode',
       colorModeDesc: 'Pick a fixed mode or let Hermes follow your system setting.',
+      textScaleTitle: 'Text Scale',
+      textScaleDesc: 'Adjust the desktop UI size. Cmd/Ctrl +/- changes use the same saved setting.',
       toolViewTitle: 'Tool Call Display',
       toolViewDesc: 'Product hides raw tool payloads; Technical shows full input/output.',
       translucencyTitle: 'Window Translucency',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -211,6 +211,8 @@ export interface Translations {
       intro: string
       colorMode: string
       colorModeDesc: string
+      textScaleTitle: string
+      textScaleDesc: string
       toolViewTitle: string
       toolViewDesc: string
       translucencyTitle: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -289,6 +289,8 @@ export const zh: Translations = {
       intro: '这些是仅桌面端的显示偏好。模式控制明暗；主题控制强调色与对话界面样式。',
       colorMode: '颜色模式',
       colorModeDesc: '选择固定模式，或让 Hermes 跟随系统设置。',
+      textScaleTitle: '文字缩放',
+      textScaleDesc: '调整桌面界面大小。Cmd/Ctrl +/- 会使用同一保存设置。',
       toolViewTitle: '工具调用显示',
       toolViewDesc: '产品模式隐藏原始工具数据；技术模式显示完整输入/输出。',
       translucencyTitle: '窗口透明',

--- a/apps/desktop/src/store/zoom.test.ts
+++ b/apps/desktop/src/store/zoom.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { percentToZoomLevel, zoomLevelToPercent } from './zoom'
+
+describe('desktop zoom store helpers', () => {
+  it('round-trips common interface scale percentages', () => {
+    expect(zoomLevelToPercent(percentToZoomLevel(100))).toBe(100)
+    expect(zoomLevelToPercent(percentToZoomLevel(125))).toBe(125)
+    expect(zoomLevelToPercent(percentToZoomLevel(150))).toBe(150)
+  })
+
+  it('clamps the settings slider range', () => {
+    expect(zoomLevelToPercent(percentToZoomLevel(10))).toBe(50)
+    expect(zoomLevelToPercent(percentToZoomLevel(500))).toBe(200)
+  })
+})

--- a/apps/desktop/src/store/zoom.ts
+++ b/apps/desktop/src/store/zoom.ts
@@ -1,0 +1,66 @@
+import { atom } from 'nanostores'
+
+const ZOOM_BASE = 1.2
+const MIN_ZOOM_LEVEL = -9
+const MAX_ZOOM_LEVEL = 9
+
+export const MIN_ZOOM_PERCENT = 50
+export const MAX_ZOOM_PERCENT = 200
+export const ZOOM_PERCENT_STEP = 5
+
+const clamp = (n: number, min: number, max: number): number => Math.min(max, Math.max(min, n))
+
+export function clampZoomLevel(value: number): number {
+  return clamp(Number.isFinite(value) ? Math.round(value * 100) / 100 : 0, MIN_ZOOM_LEVEL, MAX_ZOOM_LEVEL)
+}
+
+export function zoomLevelToPercent(level: number): number {
+  return Math.round(Math.pow(ZOOM_BASE, clampZoomLevel(level)) * 100)
+}
+
+export function percentToZoomLevel(percent: number): number {
+  const clampedPercent = clamp(Number.isFinite(percent) ? percent : 100, MIN_ZOOM_PERCENT, MAX_ZOOM_PERCENT)
+
+  return clampZoomLevel(Math.log(clampedPercent / 100) / Math.log(ZOOM_BASE))
+}
+
+export const $zoomLevel = atom<number>(0)
+
+export async function refreshZoomLevel(): Promise<void> {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  const response = await window.hermesDesktop?.getZoomLevel?.()
+
+  if (response && typeof response.zoomLevel === 'number') {
+    $zoomLevel.set(clampZoomLevel(response.zoomLevel))
+  }
+}
+
+export async function setZoomPercent(percent: number): Promise<void> {
+  const zoomLevel = percentToZoomLevel(percent)
+  $zoomLevel.set(zoomLevel)
+
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  const response = await window.hermesDesktop?.setZoomLevel?.({ zoomLevel })
+
+  if (response && typeof response.zoomLevel === 'number') {
+    $zoomLevel.set(clampZoomLevel(response.zoomLevel))
+  }
+}
+
+if (typeof window !== 'undefined') {
+  void refreshZoomLevel().catch(() => {
+    // The bridge is unavailable in browser-only tests and static previews.
+  })
+
+  window.hermesDesktop?.onZoomChanged?.(payload => {
+    if (payload && typeof payload.zoomLevel === 'number') {
+      $zoomLevel.set(clampZoomLevel(payload.zoomLevel))
+    }
+  })
+}


### PR DESCRIPTION
## Summary
- Add an Appearance → Text Scale slider for the desktop UI.
- Reuse the existing Electron zoom/localStorage persistence path (`hermes:desktop:zoomLevel`) used by Cmd/Ctrl +/-/0.
- Expose minimal zoom get/set IPC so Settings can control the existing zoom path.
- Broadcast zoom changes so the Settings slider stays in sync when Cmd/Ctrl +/-/0 is used.

## Tests
- `npm run test:ui -- src/store/zoom.test.ts`
- `npm run typecheck`
- `npm run build`

## Notes
- After maintainer feedback, this no longer adds a separate `userData/zoom.json` persistence layer; it keeps the existing localStorage-backed persistence and only adds the settings surface.
- Targeted eslint over the changed files was run. Including `electron/main.cjs` still reports the pre-existing `net` unused lint in that file.
