### PR TITLE
fix(agent): add timeout to subprocess.run in Claude Code setup-token

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1228,8 +1228,8 @@ def run_oauth_setup_token() -> Optional[str]:
     # concern does not apply to an interactive login the user explicitly
     # invokes.  noqa: subprocess-stdin
     try:
-        subprocess.run([claude_path, "setup-token"])
-    except (KeyboardInterrupt, EOFError):
+        subprocess.run([claude_path, "setup-token"], timeout=300)
+    except (KeyboardInterrupt, EOFError, subprocess.TimeoutExpired):
         return None
 
     # Check if credentials were saved to Claude Code's config files


### PR DESCRIPTION
## Summary

The interactive OAuth login subprocess (`claude_path setup-token`) in `agent/anthropic_adapter.py` had no timeout, which could cause the agent to hang indefinitely if the process stalls.

### Fix

- Add `timeout=300` (5 minutes) to the `subprocess.run()` call
- Catch `subprocess.TimeoutExpired` alongside existing `KeyboardInterrupt` and `EOFError`

### Before
```python
subprocess.run([claude_path, "setup-token"])
except (KeyboardInterrupt, EOFError):
```

### After
```python
subprocess.run([claude_path, "setup-token"], timeout=300)
except (KeyboardInterrupt, EOFError, subprocess.TimeoutExpired):
```