### PR TITLE
feat: route short Opus turns to lower-latency models

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1008,6 +1008,7 @@ def run_conversation(
                             provider=agent.provider,
                             base_url=agent.base_url,
                             api_mode=agent.api_mode,
+                            routing_decision=getattr(agent, "turn_route_decision", None),
                             api_call_count=api_call_count,
                             request_messages=list(request_messages)
                             if isinstance(request_messages, list)
@@ -3530,6 +3531,7 @@ def run_conversation(
                         provider=agent.provider,
                         base_url=agent.base_url,
                         api_mode=agent.api_mode,
+                        routing_decision=getattr(agent, "turn_route_decision", None),
                         api_call_count=api_call_count,
                         api_duration=api_duration,
                         started_at=api_start_time,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3041,7 +3041,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         return model, runtime_kwargs
 
-    def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict) -> dict:
+    def _resolve_turn_agent_config(
+        self,
+        user_message: str,
+        model: str,
+        runtime_kwargs: dict,
+        *,
+        platform: str | None = None,
+        bucket_key: str | None = None,
+        config: dict | None = None,
+    ) -> dict:
         """Build the effective model/runtime config for a single turn.
 
         Always uses the session's primary model/provider.  If `/fast` is
@@ -3050,7 +3059,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         accordingly.
         """
         from hermes_cli.models import resolve_fast_mode_overrides
-        from hermes_cli.latency_routing import route_latency_model
+        from hermes_cli.latency_experiment import decide_latency_route, latency_experiment_config
 
         runtime = {
             "api_key": runtime_kwargs.get("api_key"),
@@ -3070,14 +3079,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 fast_overrides = resolve_fast_mode_overrides(model)
             except Exception:
                 fast_overrides = None
-        model = (
-            model
-            if fast_overrides
-            else route_latency_model(model, runtime["provider"], user_message)
+        experiment_config = latency_experiment_config(config or runtime_kwargs.get("config"))
+        route_decision = decide_latency_route(
+            model=model,
+            provider=runtime["provider"],
+            user_message=user_message,
+            experiment_config=None if fast_overrides else experiment_config,
+            platform=platform,
+            bucket_key=bucket_key,
         )
+        model = model if fast_overrides else route_decision.effective_model
         route = {
             "model": model,
             "runtime": runtime,
+            "route_decision": route_decision.metadata,
             "signature": (
                 model,
                 runtime["provider"],
@@ -10451,7 +10466,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             reasoning_config = self._resolve_session_reasoning_config(source=source)
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
-            turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+            turn_route = self._resolve_turn_agent_config(
+                prompt,
+                model,
+                runtime_kwargs,
+                platform=platform_key,
+                bucket_key=task_id,
+                config=user_config,
+            )
 
             # Enrich the prompt with image descriptions so the background
             # agent can see user-attached images (same as the main flow).
@@ -10500,6 +10522,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
                 )
+                agent.turn_route_decision = turn_route["route_decision"]
                 try:
                     return agent.run_conversation(
                         user_message=enriched_prompt,
@@ -14499,7 +14522,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     log_message="interim_assistant_callback scheduling error",
                 )
 
-            turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
+            turn_route = self._resolve_turn_agent_config(
+                message,
+                model,
+                runtime_kwargs,
+                platform=platform_key,
+                bucket_key=session_key,
+                config=user_config,
+            )
 
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool
@@ -14566,6 +14596,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 except KeyError:
                                     pass
                             self._init_cached_agent_for_turn(agent, _interrupt_depth)
+                            agent.turn_route_decision = turn_route["route_decision"]
                             logger.debug("Reusing cached agent for session %s", session_key)
 
             if agent is None:
@@ -14602,6 +14633,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
                 )
+                agent.turn_route_decision = turn_route["route_decision"]
                 if _cache_lock and _cache is not None:
                     with _cache_lock:
                         _cache[session_key] = (agent, _sig, _current_msg_count)
@@ -14655,6 +14687,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             agent.reasoning_config = reasoning_config
             agent.service_tier = self._service_tier
             agent.request_overrides = turn_route.get("request_overrides") or {}
+            agent.turn_route_decision = turn_route["route_decision"]
 
             _bg_review_release = threading.Event()
             _bg_review_pending: list[str] = []

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3050,6 +3050,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         accordingly.
         """
         from hermes_cli.models import resolve_fast_mode_overrides
+        from hermes_cli.latency_routing import route_latency_model
 
         runtime = {
             "api_key": runtime_kwargs.get("api_key"),
@@ -3061,6 +3062,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "credential_pool": runtime_kwargs.get("credential_pool"),
             "max_tokens": runtime_kwargs.get("max_tokens"),
         }
+        base_overrides = runtime_kwargs.get("request_overrides") or {}
+        service_tier = getattr(self, "_service_tier", None)
+        fast_overrides = None
+        if service_tier:
+            try:
+                fast_overrides = resolve_fast_mode_overrides(model)
+            except Exception:
+                fast_overrides = None
+        model = (
+            model
+            if fast_overrides
+            else route_latency_model(model, runtime["provider"], user_message)
+        )
         route = {
             "model": model,
             "runtime": runtime,
@@ -3074,16 +3088,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             ),
         }
 
-        service_tier = getattr(self, "_service_tier", None)
         if not service_tier:
-            route["request_overrides"] = {}
+            route["request_overrides"] = dict(base_overrides)
             return route
 
-        try:
-            overrides = resolve_fast_mode_overrides(route["model"])
-        except Exception:
-            overrides = None
-        route["request_overrides"] = overrides or {}
+        overrides = fast_overrides
+        route["request_overrides"] = {**dict(base_overrides), **(overrides or {})}
         return route
 
     async def _handle_adapter_fatal_error(self, adapter: BasePlatformAdapter) -> None:

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -181,7 +181,7 @@ class CLIAgentSetupMixin:
         API call is marked accordingly.
         """
         from hermes_cli.models import resolve_fast_mode_overrides
-        from hermes_cli.latency_routing import route_latency_model
+        from hermes_cli.latency_experiment import decide_latency_route, latency_experiment_config
 
         runtime = {
             "api_key": self.api_key,
@@ -200,14 +200,20 @@ class CLIAgentSetupMixin:
                 fast_overrides = resolve_fast_mode_overrides(self.model)
             except Exception:
                 fast_overrides = None
-        model = (
-            self.model
-            if fast_overrides
-            else route_latency_model(self.model, runtime["provider"], user_message)
+        experiment_config = latency_experiment_config(getattr(self, "config", None))
+        route_decision = decide_latency_route(
+            model=self.model,
+            provider=runtime["provider"],
+            user_message=user_message,
+            experiment_config=None if fast_overrides else experiment_config,
+            platform="cli",
+            bucket_key=getattr(self, "session_id", None),
         )
+        model = self.model if fast_overrides else route_decision.effective_model
         route = {
             "model": model,
             "runtime": runtime,
+            "route_decision": route_decision.metadata,
             "signature": (
                 model,
                 runtime["provider"],

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -123,6 +123,7 @@ class CLIAgentSetupMixin:
         self.acp_command = resolved_acp_command
         self.acp_args = resolved_acp_args
         self._credential_pool = resolved_credential_pool
+        self._runtime_request_overrides = runtime.get("request_overrides")
         self._provider_source = runtime.get("source")
         self.api_key = api_key
         self.base_url = base_url
@@ -180,6 +181,7 @@ class CLIAgentSetupMixin:
         API call is marked accordingly.
         """
         from hermes_cli.models import resolve_fast_mode_overrides
+        from hermes_cli.latency_routing import route_latency_model
 
         runtime = {
             "api_key": self.api_key,
@@ -190,11 +192,24 @@ class CLIAgentSetupMixin:
             "args": list(self.acp_args or []),
             "credential_pool": getattr(self, "_credential_pool", None),
         }
+        base_overrides = getattr(self, "_runtime_request_overrides", None) or None
+        service_tier = getattr(self, "service_tier", None)
+        fast_overrides = None
+        if service_tier:
+            try:
+                fast_overrides = resolve_fast_mode_overrides(self.model)
+            except Exception:
+                fast_overrides = None
+        model = (
+            self.model
+            if fast_overrides
+            else route_latency_model(self.model, runtime["provider"], user_message)
+        )
         route = {
-            "model": self.model,
+            "model": model,
             "runtime": runtime,
             "signature": (
-                self.model,
+                model,
                 runtime["provider"],
                 runtime["base_url"],
                 runtime["api_mode"],
@@ -203,16 +218,17 @@ class CLIAgentSetupMixin:
             ),
         }
 
-        service_tier = getattr(self, "service_tier", None)
         if not service_tier:
-            route["request_overrides"] = None
+            route["request_overrides"] = dict(base_overrides) if base_overrides else None
             return route
 
-        try:
-            overrides = resolve_fast_mode_overrides(route["model"])
-        except Exception:
-            overrides = None
-        route["request_overrides"] = overrides
+        overrides = fast_overrides
+        if base_overrides and overrides:
+            route["request_overrides"] = {**dict(base_overrides), **overrides}
+        elif base_overrides:
+            route["request_overrides"] = dict(base_overrides)
+        else:
+            route["request_overrides"] = overrides
         return route
 
     def _init_agent(self, *, model_override: str = None, runtime_override: dict = None, request_overrides: dict | None = None) -> bool:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -811,6 +811,18 @@ DEFAULT_CONFIG = {
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
+    "bob": {
+        "routing": {
+            "experiment": {
+                "enabled": False,
+                "mode": "shadow",
+                "rollout": 0.5,
+                "seed": "",
+                "treatment_model": "anthropic/claude-sonnet-4.6",
+                "include_platforms": None,
+            },
+        },
+    },
     # Global active chat session cap across CLI, TUI/dashboard, and messaging.
     # None/0 = unbounded.
     "max_concurrent_sessions": None,

--- a/hermes_cli/latency_experiment.py
+++ b/hermes_cli/latency_experiment.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import TypeAlias
+
+from hermes_cli.latency_routing import (
+    _is_claude_opus,
+    _is_short_low_complexity_turn,
+    _target_for_provider,
+)
+
+
+ExperimentConfig: TypeAlias = dict[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class LatencyRouteDecision:
+    effective_model: str
+    metadata: dict[str, str | float | bool | None]
+
+
+def decide_latency_route(
+    *,
+    model: str,
+    provider: str | None,
+    user_message: str,
+    experiment_config: ExperimentConfig | None,
+    platform: str | None,
+    bucket_key: str | None,
+) -> LatencyRouteDecision:
+    turn_class = _classify_turn(model, user_message)
+    metadata = _base_metadata(model, turn_class)
+    if not _is_experiment_enabled(experiment_config):
+        return LatencyRouteDecision(effective_model=model, metadata=metadata)
+
+    mode = _experiment_mode(experiment_config)
+    rollout = _experiment_rollout(experiment_config)
+    configured_treatment = _experiment_treatment_model(experiment_config)
+    proposed_model = configured_treatment or _target_for_provider(model, provider)
+    bucket_key_value = bucket_key or "default"
+    bucket = _stable_bucket(bucket_key_value, _experiment_seed(experiment_config))
+    arm = "treatment" if bucket < rollout else "control"
+    metadata.update(
+        {
+            "enabled": True,
+            "mode": mode,
+            "arm": arm,
+            "proposed_model": proposed_model,
+            "bucket_key": bucket_key_value,
+            "bucket": bucket,
+        }
+    )
+
+    if not _platform_included(platform, experiment_config):
+        metadata["reason"] = "platform_excluded"
+        return LatencyRouteDecision(effective_model=model, metadata=metadata)
+    if turn_class != "short_chat":
+        metadata["reason"] = turn_class
+        return LatencyRouteDecision(effective_model=model, metadata=metadata)
+    if arm != "treatment":
+        metadata["reason"] = "control"
+        return LatencyRouteDecision(effective_model=model, metadata=metadata)
+    if mode == "shadow":
+        metadata["reason"] = "shadow"
+        return LatencyRouteDecision(effective_model=model, metadata=metadata)
+
+    metadata["effective_model"] = proposed_model
+    metadata["routed"] = True
+    metadata["reason"] = "ab_treatment"
+    return LatencyRouteDecision(effective_model=proposed_model, metadata=metadata)
+
+
+def latency_experiment_config(config: ExperimentConfig | None) -> ExperimentConfig | None:
+    node = config
+    for key in ("bob", "routing", "experiment"):
+        if not isinstance(node, dict):
+            return None
+        value = node.get(key)
+        if not isinstance(value, dict):
+            return None
+        node = value
+    return node
+
+
+def _classify_turn(model: str, user_message: str) -> str:
+    if not _is_claude_opus(model):
+        return "non_opus"
+    if _is_short_low_complexity_turn(user_message):
+        return "short_chat"
+    return "complex"
+
+
+def _base_metadata(model: str, turn_class: str) -> dict[str, str | float | bool | None]:
+    return {
+        "enabled": False,
+        "mode": None,
+        "arm": "control",
+        "class": turn_class,
+        "original_model": model,
+        "effective_model": model,
+        "proposed_model": None,
+        "bucket_key": None,
+        "bucket": None,
+        "routed": False,
+        "reason": "disabled",
+    }
+
+
+def _is_experiment_enabled(experiment_config: ExperimentConfig | None) -> bool:
+    return isinstance(experiment_config, dict) and experiment_config.get("enabled") is True
+
+
+def _experiment_mode(experiment_config: ExperimentConfig | None) -> str:
+    if isinstance(experiment_config, dict) and str(experiment_config.get("mode") or "").lower() == "ab":
+        return "ab"
+    return "shadow"
+
+
+def _experiment_rollout(experiment_config: ExperimentConfig | None) -> float:
+    if not isinstance(experiment_config, dict):
+        return 0.5
+    raw = experiment_config.get("rollout", 0.5)
+    if isinstance(raw, bool):
+        return 0.5
+    if not isinstance(raw, (str, int, float)):
+        return 0.5
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return 0.5
+    return min(1.0, max(0.0, value))
+
+
+def _experiment_seed(experiment_config: ExperimentConfig | None) -> str:
+    if not isinstance(experiment_config, dict):
+        return ""
+    return str(experiment_config.get("seed") or "")
+
+
+def _experiment_treatment_model(experiment_config: ExperimentConfig | None) -> str | None:
+    if not isinstance(experiment_config, dict):
+        return None
+    treatment = str(experiment_config.get("treatment_model") or "").strip()
+    return treatment or None
+
+
+def _platform_included(platform: str | None, experiment_config: ExperimentConfig | None) -> bool:
+    if not isinstance(experiment_config, dict):
+        return True
+    raw = experiment_config.get("include_platforms")
+    if raw in (None, ""):
+        return True
+    if not isinstance(raw, list):
+        return True
+    allowed = {str(item).strip().lower() for item in raw if str(item).strip()}
+    if not allowed:
+        return True
+    return (platform or "").strip().lower() in allowed
+
+
+def _stable_bucket(bucket_key: str, seed: str) -> float:
+    digest = sha256(f"{seed}:{bucket_key}".encode("utf-8")).hexdigest()
+    value = int(digest[:16], 16)
+    return value / float(0xFFFFFFFFFFFFFFFF)

--- a/hermes_cli/latency_metrics.py
+++ b/hermes_cli/latency_metrics.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from time import time
+
+
+@dataclass(frozen=True, slots=True)
+class LatencyMetricRow:
+    """Sanitized one-call latency experiment record.
+
+    Deliberately stores identifiers and aggregate counters only — never raw
+    user/assistant text — so it is safe to append from API hook payloads.
+    """
+
+    arm: str
+    turn_class: str
+    latency_ms: float
+    cache_hit: bool
+    input_tokens: int
+    estimated_cost_usd: float
+    model: str
+    error: bool
+    tool_calls: int
+    timestamp: float = 0.0
+    session_id: str = ""
+    platform: str = ""
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class LatencySummaryRow:
+    arm: str
+    turn_class: str
+    count: int
+    p50_latency_ms: float
+    p90_latency_ms: float
+    p99_latency_ms: float
+    cache_hit_percent: float
+    mean_input_tokens: float
+    estimated_cost_usd: float
+    opus_percent: float
+    error_rate_percent: float
+    tool_call_rate_percent: float
+
+
+def append_latency_metric(path: Path, row: LatencyMetricRow) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not row.timestamp:
+        row = LatencyMetricRow(**{**asdict(row), "timestamp": time()})
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(asdict(row), sort_keys=True) + "\n")
+
+
+def latency_metric_from_hook_payload(
+    payload: dict[str, object],
+    *,
+    error: bool = False,
+) -> LatencyMetricRow | None:
+    """Build a sanitized metric row from API hook payload metadata.
+
+    The hook payloads can contain request/response snapshots with message text;
+    this helper intentionally ignores those fields and only extracts route
+    decision metadata plus numeric counters needed for the comparison table.
+    """
+    decision = payload.get("routing_decision")
+    if not isinstance(decision, dict) or decision.get("enabled") is not True:
+        return None
+    usage = payload.get("usage")
+    if not isinstance(usage, dict):
+        usage = {}
+    cache_read = _int_value(usage.get("cache_read_tokens"))
+    cache_write = _int_value(usage.get("cache_write_tokens"))
+    input_tokens = _int_value(usage.get("input_tokens"))
+    return LatencyMetricRow(
+        arm=str(decision.get("arm") or "control"),
+        turn_class=str(decision.get("class") or "unknown"),
+        latency_ms=round(_float_value(payload.get("api_duration")) * 1000, 4),
+        cache_hit=cache_read > 0,
+        input_tokens=input_tokens,
+        estimated_cost_usd=_float_value(payload.get("estimated_cost_usd")),
+        model=str(payload.get("model") or decision.get("effective_model") or ""),
+        error=error,
+        tool_calls=_int_value(payload.get("assistant_tool_call_count")),
+        timestamp=_float_value(payload.get("ended_at")) or time(),
+        session_id=str(payload.get("session_id") or ""),
+        platform=str(payload.get("platform") or ""),
+        output_tokens=_int_value(usage.get("output_tokens")),
+        cache_read_tokens=cache_read,
+        cache_write_tokens=cache_write,
+    )
+
+
+def summarize_latency_metrics(path: Path) -> dict[tuple[str, str], LatencySummaryRow]:
+    groups: dict[tuple[str, str], list[LatencyMetricRow]] = {}
+    if not path.exists():
+        return {}
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            if not line.strip():
+                continue
+            row = _row_from_json(json.loads(line))
+            groups.setdefault((row.arm, row.turn_class), []).append(row)
+    return {
+        key: _summarize_group(key[0], key[1], rows)
+        for key, rows in sorted(groups.items())
+    }
+
+
+def format_latency_summary(summary: dict[tuple[str, str], LatencySummaryRow]) -> str:
+    header = (
+        "arm | class | n | p50 | p90 | p99 | cache_hit% | "
+        "mean_input | cost_usd | opus% | error% | tool_call%"
+    )
+    lines = [header]
+    for row in summary.values():
+        lines.append(
+            " | ".join(
+                [
+                    row.arm,
+                    row.turn_class,
+                    str(row.count),
+                    f"{row.p50_latency_ms:.1f}",
+                    f"{row.p90_latency_ms:.1f}",
+                    f"{row.p99_latency_ms:.1f}",
+                    f"{row.cache_hit_percent:.1f}",
+                    f"{row.mean_input_tokens:.1f}",
+                    f"{row.estimated_cost_usd:.4f}",
+                    f"{row.opus_percent:.1f}",
+                    f"{row.error_rate_percent:.1f}",
+                    f"{row.tool_call_rate_percent:.1f}",
+                ]
+            )
+        )
+    return "\n".join(lines)
+
+
+def _row_from_json(raw: dict[str, object]) -> LatencyMetricRow:
+    return LatencyMetricRow(
+        arm=str(raw.get("arm") or ""),
+        turn_class=str(raw.get("turn_class") or ""),
+        latency_ms=_float_value(raw.get("latency_ms")),
+        cache_hit=raw.get("cache_hit") is True,
+        input_tokens=_int_value(raw.get("input_tokens")),
+        estimated_cost_usd=_float_value(raw.get("estimated_cost_usd")),
+        model=str(raw.get("model") or ""),
+        error=raw.get("error") is True,
+        tool_calls=_int_value(raw.get("tool_calls")),
+        timestamp=_float_value(raw.get("timestamp")),
+        session_id=str(raw.get("session_id") or ""),
+        platform=str(raw.get("platform") or ""),
+        output_tokens=_int_value(raw.get("output_tokens")),
+        cache_read_tokens=_int_value(raw.get("cache_read_tokens")),
+        cache_write_tokens=_int_value(raw.get("cache_write_tokens")),
+    )
+
+
+def _summarize_group(arm: str, turn_class: str, rows: list[LatencyMetricRow]) -> LatencySummaryRow:
+    count = len(rows)
+    latencies = sorted(row.latency_ms for row in rows)
+    return LatencySummaryRow(
+        arm=arm,
+        turn_class=turn_class,
+        count=count,
+        p50_latency_ms=_percentile(latencies, 50),
+        p90_latency_ms=_percentile(latencies, 90),
+        p99_latency_ms=_percentile(latencies, 99),
+        cache_hit_percent=_percent(row.cache_hit for row in rows),
+        mean_input_tokens=round(sum(row.input_tokens for row in rows) / count, 4),
+        estimated_cost_usd=round(sum(row.estimated_cost_usd for row in rows), 4),
+        opus_percent=_percent("claude-opus" in row.model.lower() for row in rows),
+        error_rate_percent=_percent(row.error for row in rows),
+        tool_call_rate_percent=_percent(row.tool_calls > 0 for row in rows),
+    )
+
+
+def _percentile(values: list[float], percentile: int) -> float:
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return round(values[0], 4)
+    position = (len(values) - 1) * percentile / 100
+    lower = int(position)
+    upper = min(lower + 1, len(values) - 1)
+    weight = position - lower
+    return round(values[lower] * (1 - weight) + values[upper] * weight, 4)
+
+
+def _percent(values: Iterable[bool]) -> float:
+    collected = list(values)
+    if not collected:
+        return 0.0
+    return round(100.0 * sum(1 for value in collected if value) / len(collected), 4)
+
+
+def _float_value(raw: object) -> float:
+    if isinstance(raw, bool) or raw is None:
+        return 0.0
+    if not isinstance(raw, (str, int, float)):
+        return 0.0
+    try:
+        return float(raw)
+    except ValueError:
+        return 0.0
+
+
+def _int_value(raw: object) -> int:
+    if isinstance(raw, bool) or raw is None:
+        return 0
+    if not isinstance(raw, (str, int, float)):
+        return 0
+    try:
+        return int(raw)
+    except ValueError:
+        return 0

--- a/hermes_cli/latency_routing.py
+++ b/hermes_cli/latency_routing.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import re
+from typing import Final
+
+
+_SHORT_TURN_CHAR_LIMIT: Final = 100
+_SHORT_TURN_WORD_LIMIT: Final = 18
+_LOW_LATENCY_CLAUDE_MODEL: Final = "anthropic/claude-sonnet-4.6"
+_NATIVE_CLAUDE_PROVIDERS: Final[tuple[str, ...]] = ("anthropic", "opencode-zen")
+_VENDOR_PREFIX_CLAUDE_PROVIDERS: Final[tuple[str, ...]] = (
+    "openrouter",
+    "kilocode",
+    "nous",
+)
+
+_ACK_PATTERNS: Final[tuple[str, ...]] = (
+    "ok",
+    "okay",
+    "k",
+    "yes",
+    "yep",
+    "yup",
+    "sure",
+    "thanks",
+    "thank you",
+    "thx",
+    "got it",
+    "understood",
+    "sounds good",
+    "sgtm",
+    "confirmed",
+    "confirm",
+    "done",
+    "great",
+    "perfect",
+    "cool",
+    "네",
+    "확인했습니다",
+    "감사합니다",
+)
+_GREETING_PATTERNS: Final[tuple[str, ...]] = (
+    "hi",
+    "hello",
+    "hey",
+    "yo",
+    "gm",
+    "good morning",
+    "good afternoon",
+    "good evening",
+    "안녕하세요",
+)
+_COMPLEX_MARKERS: Final[tuple[str, ...]] = (
+    "analyze",
+    "analysis",
+    "research",
+    "investigate",
+    "debug",
+    "fix",
+    "bug",
+    "error",
+    "failing",
+    "failure",
+    "implement",
+    "change",
+    "continue",
+    "create",
+    "edit",
+    "open",
+    "proceed",
+    "refactor",
+    "resume",
+    "run",
+    "start",
+    "update",
+    "write",
+    "code",
+    "test",
+    "pytest",
+    "lint",
+    "lsp",
+    "build",
+    "terminal",
+    "shell",
+    "command",
+    "tool",
+    "browser",
+    "repo",
+    "file",
+    "kanban",
+    "dispatch",
+    "delegate",
+    "delegation",
+    "worker",
+    "subagent",
+    "ticket",
+    "blocked",
+    "pr",
+    "pull request",
+    "ci",
+    "github",
+    "checks",
+    "코드",
+    "수정해줘",
+    "칸반",
+    "워커",
+    "디스패치해줘",
+    "실패",
+    "분석해줘",
+)
+
+
+def route_latency_model(model: str, provider: str | None, user_message: str) -> str:
+    if not _is_claude_opus(model):
+        return model
+    if not _is_short_low_complexity_turn(user_message):
+        return model
+    return _target_for_provider(model, provider)
+
+
+def _is_claude_opus(model: str) -> bool:
+    normalized = model.strip().lower().replace(".", "-")
+    return "claude-opus-4" in normalized
+
+
+def _is_short_low_complexity_turn(user_message: str) -> bool:
+    preview = _message_preview(user_message)
+    if not preview:
+        return False
+    if len(preview) > _SHORT_TURN_CHAR_LIMIT:
+        return False
+    if len(preview.split()) > _SHORT_TURN_WORD_LIMIT:
+        return False
+    if preview.startswith("/"):
+        return False
+    if "```" in user_message or "\n" in user_message.strip():
+        return False
+    if _contains_marker(preview, _COMPLEX_MARKERS):
+        return False
+    return _contains_marker(preview, _ACK_PATTERNS) or _contains_marker(preview, _GREETING_PATTERNS)
+
+
+def _message_preview(user_message: str) -> str:
+    preview = " ".join(user_message[:_SHORT_TURN_CHAR_LIMIT].lower().split())
+    return preview.strip(" \t\r\n.!?,:;")
+
+
+def _contains_marker(preview: str, markers: tuple[str, ...]) -> bool:
+    for marker in markers:
+        if re.search(rf"(^|\W){re.escape(marker)}(\W|$)", preview):
+            return True
+    return False
+
+
+def _target_for_provider(model: str, provider: str | None) -> str:
+    normalized_provider = (provider or "").strip().lower()
+    if normalized_provider in _NATIVE_CLAUDE_PROVIDERS:
+        return "claude-sonnet-4-6"
+    if normalized_provider in _VENDOR_PREFIX_CLAUDE_PROVIDERS or "/" in model:
+        return _LOW_LATENCY_CLAUDE_MODEL
+    return "claude-sonnet-4-6"

--- a/run_agent.py
+++ b/run_agent.py
@@ -2154,6 +2154,7 @@ class AIAgent:
                 provider=self.provider,
                 base_url=self.base_url,
                 api_mode=self.api_mode,
+                routing_decision=getattr(self, "turn_route_decision", None),
                 api_call_count=api_call_count,
                 api_duration=ended_at - api_start_time,
                 started_at=api_start_time,

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -258,7 +258,7 @@ class TestFastModeRouting(unittest.TestCase):
         assert route["runtime"]["provider"] == "openrouter"
         assert route.get("request_overrides") is None
 
-    def test_turn_route_uses_lower_latency_model_for_short_greeting(self):
+    def test_turn_route_keeps_opus_for_short_greeting_by_default(self):
         cli_mod = _import_cli()
         credential_pool = SimpleNamespace(name="pool")
         stub = SimpleNamespace(
@@ -272,14 +272,17 @@ class TestFastModeRouting(unittest.TestCase):
             _credential_pool=credential_pool,
             _runtime_request_overrides={"extra_body": {"trace": "yes"}},
             service_tier=None,
+            config={},
+            session_id="cli-session-1",
         )
 
         for message in ("hi there", "네", "확인했습니다", "감사합니다", "안녕하세요"):
             with self.subTest(message=message):
                 route = cli_mod.HermesCLI._resolve_turn_agent_config(stub, message)
-                assert route["model"] == "anthropic/claude-sonnet-4.6"
+                assert route["model"] == "anthropic/claude-opus-4.7"
                 assert route["runtime"]["credential_pool"] is credential_pool
                 assert route["request_overrides"] == {"extra_body": {"trace": "yes"}}
+                assert route["route_decision"]["enabled"] is False
 
     def test_turn_route_keeps_opus_for_complex_cli_turns(self):
         cli_mod = _import_cli()
@@ -294,6 +297,20 @@ class TestFastModeRouting(unittest.TestCase):
             _credential_pool=None,
             _runtime_request_overrides=None,
             service_tier=None,
+            config={
+                "bob": {
+                    "routing": {
+                        "experiment": {
+                            "enabled": True,
+                            "mode": "ab",
+                            "rollout": 1.0,
+                            "seed": "cli-test",
+                            "treatment_model": "claude-sonnet-4-6",
+                        },
+                    },
+                },
+            },
+            session_id="cli-session-2",
         )
 
         for message in (
@@ -327,6 +344,120 @@ class TestFastModeRouting(unittest.TestCase):
         route = cli_mod.HermesCLI._resolve_turn_agent_config(stub, "thanks")
 
         assert route["model"] == "gpt-5.4"
+
+    def test_turn_route_shadow_records_proposed_model_without_routing(self):
+        cli_mod = _import_cli()
+        stub = SimpleNamespace(
+            model="anthropic/claude-opus-4.7",
+            api_key="primary-key",
+            base_url="https://openrouter.ai/api/v1",
+            provider="openrouter",
+            api_mode="chat_completions",
+            acp_command=None,
+            acp_args=[],
+            _credential_pool=None,
+            _runtime_request_overrides=None,
+            service_tier=None,
+            config={
+                "bob": {
+                    "routing": {
+                        "experiment": {
+                            "enabled": True,
+                            "mode": "shadow",
+                            "rollout": 1.0,
+                            "seed": "cli-test",
+                            "treatment_model": "anthropic/claude-sonnet-4.6",
+                            "include_platforms": ["cli"],
+                        },
+                    },
+                },
+            },
+            session_id="cli-shadow-session",
+        )
+
+        route = cli_mod.HermesCLI._resolve_turn_agent_config(stub, "thanks")
+
+        assert route["model"] == "anthropic/claude-opus-4.7"
+        assert route["route_decision"] == {
+            "enabled": True,
+            "mode": "shadow",
+            "arm": "treatment",
+            "class": "short_chat",
+            "original_model": "anthropic/claude-opus-4.7",
+            "effective_model": "anthropic/claude-opus-4.7",
+            "proposed_model": "anthropic/claude-sonnet-4.6",
+            "bucket_key": "cli-shadow-session",
+            "bucket": route["route_decision"]["bucket"],
+            "routed": False,
+            "reason": "shadow",
+        }
+
+    def test_turn_route_ab_treatment_routes_short_chat(self):
+        cli_mod = _import_cli()
+        stub = SimpleNamespace(
+            model="anthropic/claude-opus-4.7",
+            api_key="primary-key",
+            base_url="https://openrouter.ai/api/v1",
+            provider="openrouter",
+            api_mode="chat_completions",
+            acp_command=None,
+            acp_args=[],
+            _credential_pool=None,
+            _runtime_request_overrides=None,
+            service_tier=None,
+            config={
+                "bob": {
+                    "routing": {
+                        "experiment": {
+                            "enabled": True,
+                            "mode": "ab",
+                            "rollout": 1.0,
+                            "seed": "cli-test",
+                            "treatment_model": "anthropic/claude-sonnet-4.6",
+                        },
+                    },
+                },
+            },
+            session_id="cli-treatment-session",
+        )
+
+        route = cli_mod.HermesCLI._resolve_turn_agent_config(stub, "ok")
+
+        assert route["model"] == "anthropic/claude-sonnet-4.6"
+        assert route["route_decision"]["arm"] == "treatment"
+        assert route["route_decision"]["class"] == "short_chat"
+        assert route["route_decision"]["routed"] is True
+
+    def test_latency_routing_bucket_assignment_is_stable(self):
+        from hermes_cli.latency_experiment import decide_latency_route
+
+        config = {
+            "enabled": True,
+            "mode": "ab",
+            "rollout": 0.5,
+            "seed": "stable-seed",
+            "treatment_model": "anthropic/claude-sonnet-4.6",
+        }
+
+        first = decide_latency_route(
+            model="anthropic/claude-opus-4.7",
+            provider="openrouter",
+            user_message="thanks",
+            experiment_config=config,
+            platform="cli",
+            bucket_key="session-123",
+        )
+        second = decide_latency_route(
+            model="anthropic/claude-opus-4.7",
+            provider="openrouter",
+            user_message="thanks",
+            experiment_config=config,
+            platform="cli",
+            bucket_key="session-123",
+        )
+
+        assert first.metadata["bucket"] == second.metadata["bucket"]
+        assert first.metadata["arm"] == second.metadata["arm"]
 
 
 class TestAnthropicFastMode(unittest.TestCase):

--- a/tests/cli/test_fast_command.py
+++ b/tests/cli/test_fast_command.py
@@ -258,6 +258,76 @@ class TestFastModeRouting(unittest.TestCase):
         assert route["runtime"]["provider"] == "openrouter"
         assert route.get("request_overrides") is None
 
+    def test_turn_route_uses_lower_latency_model_for_short_greeting(self):
+        cli_mod = _import_cli()
+        credential_pool = SimpleNamespace(name="pool")
+        stub = SimpleNamespace(
+            model="anthropic/claude-opus-4.7",
+            api_key="primary-key",
+            base_url="https://openrouter.ai/api/v1",
+            provider="openrouter",
+            api_mode="chat_completions",
+            acp_command=None,
+            acp_args=[],
+            _credential_pool=credential_pool,
+            _runtime_request_overrides={"extra_body": {"trace": "yes"}},
+            service_tier=None,
+        )
+
+        for message in ("hi there", "네", "확인했습니다", "감사합니다", "안녕하세요"):
+            with self.subTest(message=message):
+                route = cli_mod.HermesCLI._resolve_turn_agent_config(stub, message)
+                assert route["model"] == "anthropic/claude-sonnet-4.6"
+                assert route["runtime"]["credential_pool"] is credential_pool
+                assert route["request_overrides"] == {"extra_body": {"trace": "yes"}}
+
+    def test_turn_route_keeps_opus_for_complex_cli_turns(self):
+        cli_mod = _import_cli()
+        stub = SimpleNamespace(
+            model="claude-opus-4-7",
+            api_key="primary-key",
+            base_url="https://api.anthropic.com",
+            provider="anthropic",
+            api_mode="anthropic_messages",
+            acp_command=None,
+            acp_args=[],
+            _credential_pool=None,
+            _runtime_request_overrides=None,
+            service_tier=None,
+        )
+
+        for message in (
+            "Implement the routing change and add tests",
+            "Analyze this bug and research the right fix",
+            "Use kanban to dispatch worker agents",
+            "코드 수정해줘",
+            "칸반 워커 디스패치해줘",
+            "CI 실패 분석해줘",
+            "네 코드 수정해줘",
+            "안녕하세요 CI 실패 분석해줘",
+        ):
+            route = cli_mod.HermesCLI._resolve_turn_agent_config(stub, message)
+            assert route["model"] == "claude-opus-4-7"
+
+    def test_turn_route_does_not_rewrite_non_opus_configured_model(self):
+        cli_mod = _import_cli()
+        stub = SimpleNamespace(
+            model="gpt-5.4",
+            api_key="primary-key",
+            base_url="https://api.openai.com/v1",
+            provider="openai",
+            api_mode="chat_completions",
+            acp_command=None,
+            acp_args=[],
+            _credential_pool=None,
+            _runtime_request_overrides=None,
+            service_tier=None,
+        )
+
+        route = cli_mod.HermesCLI._resolve_turn_agent_config(stub, "thanks")
+
+        assert route["model"] == "gpt-5.4"
+
 
 class TestAnthropicFastMode(unittest.TestCase):
     """Verify Anthropic Fast Mode model support and override resolution."""
@@ -406,6 +476,7 @@ class TestAnthropicFastMode(unittest.TestCase):
 
         route = cli_mod.HermesCLI._resolve_turn_agent_config(stub, "hi")
 
+        assert route["model"] == "claude-opus-4-6"
         assert route["runtime"]["provider"] == "anthropic"
         assert route["request_overrides"] == {"speed": "fast"}
 

--- a/tests/cli/test_latency_metrics.py
+++ b/tests/cli/test_latency_metrics.py
@@ -1,0 +1,116 @@
+import json
+
+
+def test_latency_metrics_summary_groups_by_arm_and_class(tmp_path):
+    from hermes_cli.latency_metrics import (
+        LatencyMetricRow,
+        append_latency_metric,
+        format_latency_summary,
+        latency_metric_from_hook_payload,
+        summarize_latency_metrics,
+    )
+
+    metrics_path = tmp_path / "latency.jsonl"
+    rows = [
+        LatencyMetricRow(
+            arm="control",
+            turn_class="short_chat",
+            latency_ms=100.0,
+            cache_hit=True,
+            input_tokens=10,
+            estimated_cost_usd=0.10,
+            model="anthropic/claude-opus-4.7",
+            error=False,
+            tool_calls=0,
+        ),
+        LatencyMetricRow(
+            arm="control",
+            turn_class="short_chat",
+            latency_ms=200.0,
+            cache_hit=False,
+            input_tokens=20,
+            estimated_cost_usd=0.20,
+            model="anthropic/claude-opus-4.7",
+            error=True,
+            tool_calls=2,
+        ),
+        LatencyMetricRow(
+            arm="treatment",
+            turn_class="short_chat",
+            latency_ms=50.0,
+            cache_hit=True,
+            input_tokens=5,
+            estimated_cost_usd=0.02,
+            model="anthropic/claude-sonnet-4.6",
+            error=False,
+            tool_calls=1,
+        ),
+    ]
+
+    for row in rows:
+        append_latency_metric(metrics_path, row)
+
+    raw_line = metrics_path.read_text(encoding="utf-8").splitlines()[0]
+    assert "thanks" not in raw_line
+    assert "user_message" not in json.loads(raw_line)
+
+    summary = summarize_latency_metrics(metrics_path)
+    control = summary[("control", "short_chat")]
+    treatment = summary[("treatment", "short_chat")]
+
+    assert control.count == 2
+    assert control.p50_latency_ms == 150.0
+    assert control.p90_latency_ms == 190.0
+    assert control.p99_latency_ms == 199.0
+    assert control.cache_hit_percent == 50.0
+    assert control.mean_input_tokens == 15.0
+    assert control.estimated_cost_usd == 0.30
+    assert control.opus_percent == 100.0
+    assert control.error_rate_percent == 50.0
+    assert control.tool_call_rate_percent == 50.0
+
+    assert treatment.opus_percent == 0.0
+    table = format_latency_summary(summary)
+    assert "control" in table
+    assert "treatment" in table
+
+
+def test_latency_metric_from_hook_payload_sanitizes_text_fields():
+    from hermes_cli.latency_metrics import latency_metric_from_hook_payload
+
+    row = latency_metric_from_hook_payload(
+        {
+            "session_id": "s1",
+            "platform": "slack",
+            "model": "anthropic/claude-opus-4.7",
+            "api_duration": 1.25,
+            "ended_at": 123.0,
+            "assistant_tool_call_count": 2,
+            "user_message": "do not store this raw text",
+            "request": {"body": {"messages": [{"content": "secret-ish text"}]}},
+            "routing_decision": {
+                "enabled": True,
+                "arm": "treatment",
+                "class": "short_chat",
+                "effective_model": "anthropic/claude-sonnet-4.6",
+            },
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 5,
+                "cache_read_tokens": 90,
+                "cache_write_tokens": 10,
+            },
+        }
+    )
+
+    assert row is not None
+    assert row.session_id == "s1"
+    assert row.platform == "slack"
+    assert row.latency_ms == 1250.0
+    assert row.cache_hit is True
+    assert row.input_tokens == 100
+    assert row.output_tokens == 5
+    assert row.cache_read_tokens == 90
+    assert row.cache_write_tokens == 10
+    assert row.tool_calls == 2
+    assert "raw text" not in repr(row)

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -18,9 +18,11 @@ from gateway.session import SessionSource
 class _CapturingAgent:
     last_init = None
     last_run = None
+    last_instance = None
 
     def __init__(self, *args, **kwargs):
         type(self).last_init = dict(kwargs)
+        type(self).last_instance = self
         self.tools = []
 
     def run_conversation(self, user_message, conversation_history=None, task_id=None, persist_user_message=None):
@@ -146,7 +148,7 @@ def test_turn_route_injects_anthropic_speed_without_latency_rewrite():
     assert route["request_overrides"] == {"speed": "fast"}
 
 
-def test_turn_route_uses_lower_latency_model_for_short_ack():
+def test_turn_route_keeps_opus_for_short_ack_by_default():
     runner = _make_runner()
     runner._service_tier = None
     credential_pool = SimpleNamespace(name="pool")
@@ -167,11 +169,14 @@ def test_turn_route_uses_lower_latency_model_for_short_ack():
             message,
             "anthropic/claude-opus-4.7",
             runtime_kwargs,
+            platform="telegram",
+            bucket_key="gateway-session-1",
         )
 
-        assert route["model"] == "anthropic/claude-sonnet-4.6"
+        assert route["model"] == "anthropic/claude-opus-4.7"
         assert route["runtime"]["credential_pool"] is credential_pool
         assert route["request_overrides"] == {"extra_headers": {"X-Test": "1"}}
+        assert route["route_decision"]["enabled"] is False
 
 
 def test_turn_route_keeps_opus_for_code_tool_and_kanban_requests():
@@ -185,6 +190,19 @@ def test_turn_route_keeps_opus_for_code_tool_and_kanban_requests():
         "command": None,
         "args": [],
         "credential_pool": None,
+        "config": {
+            "bob": {
+                "routing": {
+                    "experiment": {
+                        "enabled": True,
+                        "mode": "ab",
+                        "rollout": 1.0,
+                        "seed": "gateway-test",
+                        "treatment_model": "claude-sonnet-4-6",
+                    },
+                },
+            },
+        },
     }
 
     examples = [
@@ -205,8 +223,11 @@ def test_turn_route_keeps_opus_for_code_tool_and_kanban_requests():
             message,
             "claude-opus-4-7",
             runtime_kwargs,
+            platform="telegram",
+            bucket_key="gateway-session-2",
         )
         assert route["model"] == "claude-opus-4-7"
+        assert route["route_decision"]["class"] == "complex"
 
 
 def test_turn_route_does_not_rewrite_non_opus_model():
@@ -230,6 +251,148 @@ def test_turn_route_does_not_rewrite_non_opus_model():
     )
 
     assert route["model"] == "gpt-5.4"
+
+
+def test_turn_route_shadow_carries_proposed_model_metadata_without_routing():
+    runner = _make_runner()
+    runner._service_tier = None
+    runtime_kwargs = {
+        "api_key": "***",
+        "base_url": "https://openrouter.ai/api/v1",
+        "provider": "openrouter",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+        "config": {
+            "bob": {
+                "routing": {
+                    "experiment": {
+                        "enabled": True,
+                        "mode": "shadow",
+                        "rollout": 1.0,
+                        "seed": "gateway-test",
+                        "treatment_model": "anthropic/claude-sonnet-4.6",
+                        "include_platforms": ["telegram"],
+                    },
+                },
+            },
+        },
+    }
+
+    route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+        runner,
+        "hi",
+        "anthropic/claude-opus-4.7",
+        runtime_kwargs,
+        platform="telegram",
+        bucket_key="gateway-shadow-session",
+    )
+
+    assert route["model"] == "anthropic/claude-opus-4.7"
+    assert route["route_decision"]["mode"] == "shadow"
+    assert route["route_decision"]["arm"] == "treatment"
+    assert route["route_decision"]["class"] == "short_chat"
+    assert route["route_decision"]["proposed_model"] == "anthropic/claude-sonnet-4.6"
+    assert route["route_decision"]["routed"] is False
+
+
+def test_turn_route_ab_treatment_routes_short_chat():
+    runner = _make_runner()
+    runner._service_tier = None
+    runtime_kwargs = {
+        "api_key": "***",
+        "base_url": "https://openrouter.ai/api/v1",
+        "provider": "openrouter",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+        "config": {
+            "bob": {
+                "routing": {
+                    "experiment": {
+                        "enabled": True,
+                        "mode": "ab",
+                        "rollout": 1.0,
+                        "seed": "gateway-test",
+                        "treatment_model": "anthropic/claude-sonnet-4.6",
+                    },
+                },
+            },
+        },
+    }
+
+    route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+        runner,
+        "ok",
+        "anthropic/claude-opus-4.7",
+        runtime_kwargs,
+        platform="telegram",
+        bucket_key="gateway-treatment-session",
+    )
+
+    assert route["model"] == "anthropic/claude-sonnet-4.6"
+    assert route["route_decision"]["arm"] == "treatment"
+    assert route["route_decision"]["routed"] is True
+
+
+@pytest.mark.asyncio
+async def test_run_agent_passes_route_decision_metadata_to_gateway_agent(monkeypatch, tmp_path):
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner()
+
+    user_config = {
+        "bob": {
+            "routing": {
+                "experiment": {
+                    "enabled": True,
+                    "mode": "shadow",
+                    "rollout": 1.0,
+                    "seed": "gateway-test",
+                    "treatment_model": "anthropic/claude-sonnet-4.6",
+                    "include_platforms": ["telegram"],
+                },
+            },
+        },
+    }
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: user_config)
+    monkeypatch.setattr(gateway_run, "_load_gateway_runtime_config", lambda: user_config)
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "anthropic/claude-opus-4.7")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+
+    import hermes_cli.tools_config as tools_config
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
+
+    _CapturingAgent.last_init = None
+    result = await runner._run_agent(
+        message="hi",
+        context_prompt="",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "ok"
+    assert _CapturingAgent.last_init is not None
+    assert _CapturingAgent.last_init["model"] == "anthropic/claude-opus-4.7"
+    assert _CapturingAgent.last_instance is not None
+    turn_route = _CapturingAgent.last_instance.turn_route_decision
+    assert turn_route["mode"] == "shadow"
+    assert turn_route["proposed_model"] == "anthropic/claude-sonnet-4.6"
 
 
 @pytest.mark.asyncio
@@ -294,5 +457,6 @@ async def test_run_agent_passes_priority_processing_to_gateway_agent(monkeypatch
     )
 
     assert result["final_response"] == "ok"
+    assert _CapturingAgent.last_init is not None
     assert _CapturingAgent.last_init["service_tier"] == "priority"
     assert _CapturingAgent.last_init["request_overrides"] == {"service_tier": "priority"}

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -121,6 +121,117 @@ def test_turn_route_skips_priority_processing_for_unsupported_models():
     assert route["request_overrides"] == {}
 
 
+def test_turn_route_injects_anthropic_speed_without_latency_rewrite():
+    runner = _make_runner()
+    runner._service_tier = "priority"
+    runtime_kwargs = {
+        "api_key": "***",
+        "base_url": "https://api.anthropic.com",
+        "provider": "anthropic",
+        "api_mode": "anthropic_messages",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+    }
+
+    route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+        runner,
+        "hi",
+        "claude-opus-4-6",
+        runtime_kwargs,
+    )
+
+    assert route["model"] == "claude-opus-4-6"
+    assert route["runtime"]["provider"] == "anthropic"
+    assert route["request_overrides"] == {"speed": "fast"}
+
+
+def test_turn_route_uses_lower_latency_model_for_short_ack():
+    runner = _make_runner()
+    runner._service_tier = None
+    credential_pool = SimpleNamespace(name="pool")
+    runtime_kwargs = {
+        "api_key": "***",
+        "base_url": "https://openrouter.ai/api/v1",
+        "provider": "openrouter",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": [],
+        "credential_pool": credential_pool,
+        "request_overrides": {"extra_headers": {"X-Test": "1"}},
+    }
+
+    for message in ("Thanks, sounds good", "네", "확인했습니다", "감사합니다", "안녕하세요"):
+        route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+            runner,
+            message,
+            "anthropic/claude-opus-4.7",
+            runtime_kwargs,
+        )
+
+        assert route["model"] == "anthropic/claude-sonnet-4.6"
+        assert route["runtime"]["credential_pool"] is credential_pool
+        assert route["request_overrides"] == {"extra_headers": {"X-Test": "1"}}
+
+
+def test_turn_route_keeps_opus_for_code_tool_and_kanban_requests():
+    runner = _make_runner()
+    runner._service_tier = None
+    runtime_kwargs = {
+        "api_key": "***",
+        "base_url": "https://api.anthropic.com",
+        "provider": "anthropic",
+        "api_mode": "anthropic_messages",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+    }
+
+    examples = [
+        "Fix the failing pytest in gateway/run.py",
+        "Use the terminal tool to inspect the repo",
+        "Dispatch this to kanban workers",
+        "Research the CI failure and open a PR",
+        "코드 수정해줘",
+        "칸반 워커 디스패치해줘",
+        "CI 실패 분석해줘",
+        "네 코드 수정해줘",
+        "안녕하세요 CI 실패 분석해줘",
+    ]
+
+    for message in examples:
+        route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+            runner,
+            message,
+            "claude-opus-4-7",
+            runtime_kwargs,
+        )
+        assert route["model"] == "claude-opus-4-7"
+
+
+def test_turn_route_does_not_rewrite_non_opus_model():
+    runner = _make_runner()
+    runner._service_tier = None
+    runtime_kwargs = {
+        "api_key": "***",
+        "base_url": "https://api.openai.com/v1",
+        "provider": "openai",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+    }
+
+    route = gateway_run.GatewayRunner._resolve_turn_agent_config(
+        runner,
+        "ok",
+        "gpt-5.4",
+        runtime_kwargs,
+    )
+
+    assert route["model"] == "gpt-5.4"
+
+
 @pytest.mark.asyncio
 async def test_handle_fast_command_persists_config(monkeypatch, tmp_path):
     runner = _make_runner()


### PR DESCRIPTION
## Summary
- add deterministic short-turn latency router for Opus → Sonnet on low-complexity acknowledgements/greetings
- keep code/tool/kanban/CI/research-style requests on the configured Opus model
- preserve existing fast-mode overrides, runtime fields, and credential pool routing
- include Korean-first short chat coverage for Slack-style acknowledgements/greetings

## Test Plan
- uv run --with pytest --with pytest-asyncio --with pyyaml python -m pytest tests/cli/test_fast_command.py tests/gateway/test_fast_command.py -q -o 'addopts='
- uv run --with pytest --with pytest-asyncio --with pyyaml python -m pytest tests/agent/test_credential_pool_routing.py tests/cli/test_cli_provider_resolution.py tests/cli/test_fast_command.py tests/gateway/test_fast_command.py -q -o 'addopts='

Codex sessions:
- 019ecee6-dc73-7940-b90b-b100f64ccf10
- 019ecef0-6a53-7c52-9644-66228d1d11fa
- 019ecef6-7b6c-7702-819c-30ab631f683e