### PR TITLE
fix(state): allow pysqlite3 to override stdlib sqlite3 in state store

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -18,7 +18,13 @@ import json
 import logging
 import random
 import re
-import sqlite3
+import sys as _sys
+
+try:
+    import pysqlite3 as sqlite3  # type: ignore
+    _sys.modules["sqlite3"] = sqlite3  # process-wide swap so other importers pick it up
+except ImportError:
+    import sqlite3  # type: ignore
 import threading
 import time
 from pathlib import Path


### PR DESCRIPTION
## Problem

On RHEL/CentOS Stream/Oracle Linux 8 (and AlmaLinux/Rocky 8), the system `sqlite-libs` package is pinned at **3.26.0** for the entire distro lifetime — Red Hat's ABI stability commitment. Python's stdlib `sqlite3` module links against the system library at compile time, so `sqlite3.sqlite_version` is also stuck at 3.26.0.

Several SQLite features Hermes uses or benefits from were added after 3.26.0:

| Feature | Version | Used by |
|---|---|---|
| FTS5 trigram tokenizer | 3.34.0 | session message substring search |
| RETURNING clause | 3.35.0 | atomic insert-and-fetch patterns |
| STRICT tables | 3.37.0 | future schema strictness |
| Generated columns | 3.31.0 | computed columns |
| SQL math functions | 3.35.0 | analytics helpers |

Replacing the system `sqlite-libs` RPM is unsafe — `dnf`, `rpm`, `libxml2`, and `python3-libs` all link to it; forcing an upgrade breaks the package manager.

## Solution

The standard workaround in the Python ecosystem is [`pysqlite3`](https://github.com/coleifer/pysqlite3), which statically links a bundled modern SQLite. On x86_64, `pip install pysqlite3-binary` provides a prebuilt wheel; on aarch64 it requires a source build with the SQLite amalgamation.

This PR adds a lightweight try-import shim at the top of `hermes_state.py`:

```python
import sys as _sys
try:
    import pysqlite3 as sqlite3  # type: ignore
    _sys.modules["sqlite3"] = sqlite3
except ImportError:
    import sqlite3  # type: ignore
```

The `sys.modules` swap makes the binding **process-wide**, so other Hermes modules (`kanban`, memory store, etc.) that do their own `import sqlite3` also pick up pysqlite3 transparently — no per-file shims needed elsewhere.

## Behavior matrix

| Environment | Before | After |
|---|---|---|
| Modern distro (Fedora, Ubuntu 22.04+, macOS, Windows), no pysqlite3 | stdlib sqlite3 ≥ 3.31, OK | identical, fallback path |
| RHEL/CentOS/OL 8, no pysqlite3 | stdlib sqlite3 3.26.0, FTS5 trigram warning at startup | identical (no regression) |
| RHEL/CentOS/OL 8, pysqlite3 installed | trigram still missing (stdlib still loaded) | pysqlite3 3.46+ used everywhere, FTS5 trigram works |

`hermes_state.py` is the right place for the shim because it's the earliest module in Hermes that imports sqlite3 — by swapping `sys.modules` here, every later importer in the same process sees pysqlite3.

## Testing

Verified locally on Oracle Linux 8 (aarch64), Hermes v0.16.0:
- `sqlite3.sqlite_version` reports `3.46.1` (was `3.26.0`)
- FTS5 `tokenize='trigram'` table creation succeeds (was `OperationalError: no such tokenizer: trigram`)
- `INSERT ... RETURNING` returns the row
- `CREATE TABLE ... STRICT` accepted
- Generated columns work
- Fallback path verified by uninstalling pysqlite3 — stdlib sqlite3 still loaded cleanly, no startup error.

## Notes for users

This PR is a **no-op until users install pysqlite3 in the venv**. Documentation suggesting `pip install pysqlite3-binary` (x86_64) or a source build (aarch64) on RHEL-family hosts could be a follow-up.
