### PR TITLE
feat(api_server): client correlation headers for request tracing

### DIFF
--- a/gateway/client_correlation.py
+++ b/gateway/client_correlation.py
@@ -1,0 +1,56 @@
+"""Parse optional client correlation headers for gateway observability.
+
+Clients may send standard ``X-Request-Id`` and/or ``X-Stream-Token`` headers.
+The gateway treats these as opaque strings — no client-specific naming or
+semantics are assumed.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping, Optional
+
+
+# Maximum length for request_id / stream_token before truncation.
+_MAX_CORR_VALUE_LEN = 128
+
+
+def _sanitize_corr(value: Any) -> str:
+    """Strip newlines, collapse whitespace, truncate to _MAX_CORR_VALUE_LEN."""
+    if not value:
+        return ""
+    text = str(value).replace("\r", " ").replace("\n", " ").strip()
+    return text[:_MAX_CORR_VALUE_LEN]
+
+
+def parse_correlation_headers(headers: Mapping[str, Any]) -> Dict[str, str]:
+    """Extract sanitized correlation ids from inbound HTTP headers."""
+    corr: Dict[str, str] = {}
+    request_id = _sanitize_corr(
+        headers.get("X-Request-Id") or headers.get("X-Request-ID") or ""
+    )
+    if request_id:
+        corr["request_id"] = request_id
+
+    stream_token = _sanitize_corr(headers.get("X-Stream-Token", ""))
+    if stream_token:
+        corr["stream_token"] = stream_token
+    return corr
+
+
+def format_correlation_log_suffix(
+    corr: Optional[Mapping[str, str]] = None,
+    *,
+    session_id: Optional[str] = None,
+) -> str:
+    """Build a space-separated suffix for structured log lines."""
+    parts: list[str] = []
+    if corr:
+        rid = corr.get("request_id")
+        if rid:
+            parts.append(f"request_id={rid}")
+        st = corr.get("stream_token")
+        if st:
+            parts.append(f"stream_token={st}")
+    if session_id:
+        parts.append(f"session={session_id}")
+    return f" {' '.join(parts)}" if parts else ""

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -810,7 +810,7 @@ class ResponseStore:
 
 _CORS_HEADERS = {
     "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
-    "Access-Control-Allow-Headers": "Authorization, Content-Type, Idempotency-Key",
+    "Access-Control-Allow-Headers": "Authorization, Content-Type, Idempotency-Key, X-Request-Id, X-Request-ID, X-Stream-Token",
 }
 
 
@@ -3799,6 +3799,16 @@ class APIServerAdapter(BasePlatformAdapter):
         if selection_error:
             return web.json_response(_openai_error(selection_error), status=400)
 
+        # Client correlation for observability — parse once, use in Perf logs
+        from gateway.client_correlation import (
+            format_correlation_log_suffix,
+            parse_correlation_headers,
+        )
+        client_correlation = parse_correlation_headers(request.headers)
+        _corr_suffix = format_correlation_log_suffix(
+            client_correlation, session_id=session_id,
+        )
+
         if stream:
             import queue as _q
             _stream_q: _q.Queue = _q.Queue()
@@ -3883,6 +3893,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 gateway_session_key=gateway_session_key,
                 **agent_overrides,
                 route=route,
+                client_correlation=client_correlation or None,
             ))
             # Ensure SSE drain loops can terminate without relying on polling
             # agent_task.done(), which can race with queue timeout checks.
@@ -3904,6 +3915,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 gateway_session_key=gateway_session_key,
                 **agent_overrides,
                 route=route,
+                client_correlation=client_correlation or None,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -5720,6 +5732,7 @@ class APIServerAdapter(BasePlatformAdapter):
         requested_runtime: Optional[Dict[str, Any]] = None,
         route_source: str = "global",
         confirmed_runtime_lock: bool = False,
+        client_correlation: Optional[Dict[str, str]] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -5761,6 +5774,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     session_key=gateway_session_key or session_id or "",
                     session_id=session_id or "",
                 )
+
                 try:
                     agent = self._create_agent(
                         ephemeral_system_prompt=ephemeral_system_prompt,
@@ -5903,6 +5917,44 @@ class APIServerAdapter(BasePlatformAdapter):
                     )
                 finally:
                     clear_session_vars(tokens)
+
+                if agent_ref is not None:
+                    agent_ref[0] = agent
+                effective_task_id = session_id or str(uuid.uuid4())
+                result = agent.run_conversation(
+                    user_message=user_message,
+                    conversation_history=conversation_history,
+                    task_id=effective_task_id,
+                )
+                usage = {
+                    "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
+                    "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
+                    "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
+                }
+                # Include the effective session ID in the result so callers
+                # (e.g. X-Hermes-Session-Id header) can track compression-
+                # triggered session rotations. (#16938)
+                _eff_sid = getattr(agent, "session_id", session_id)
+                if isinstance(_eff_sid, str) and _eff_sid:
+                    result["session_id"] = _eff_sid
+                if client_correlation:
+                    from gateway.client_correlation import format_correlation_log_suffix
+                    _suffix = format_correlation_log_suffix(
+                        client_correlation,
+                        session_id=_eff_sid if isinstance(_eff_sid, str) else session_id,
+                    )
+                    if _suffix:
+                        logger.info(
+                            "[Perf] agent_run done%s in=%d out=%d total=%d",
+                            _suffix,
+                            usage.get("input_tokens", 0),
+                            usage.get("output_tokens", 0),
+                            usage.get("total_tokens", 0),
+                        )
+                return result, usage
+            finally:
+                clear_session_vars(tokens)
+
 
         self._activate_admitted_request()
         self._inflight_agent_runs += 1

--- a/tests/gateway/test_client_correlation.py
+++ b/tests/gateway/test_client_correlation.py
@@ -1,0 +1,47 @@
+"""Tests for gateway.client_correlation."""
+
+from gateway.client_correlation import format_correlation_log_suffix, parse_correlation_headers
+
+
+def test_parse_correlation_headers_standard_request_id():
+    corr = parse_correlation_headers(
+        {"X-Request-Id": "abc-123", "X-Stream-Token": "tok-1"}
+    )
+    assert corr == {"request_id": "abc-123", "stream_token": "tok-1"}
+
+
+def test_parse_correlation_headers_request_id_alias():
+    corr = parse_correlation_headers({"X-Request-ID": "upper-case"})
+    assert corr == {"request_id": "upper-case"}
+
+
+def test_format_correlation_log_suffix():
+    suffix = format_correlation_log_suffix(
+        {"request_id": "r1", "stream_token": "s1"},
+        session_id="sess-9",
+    )
+    assert "request_id=r1" in suffix
+    assert "stream_token=s1" in suffix
+    assert "session=sess-9" in suffix
+
+
+def test_parse_correlation_headers_empty():
+    assert parse_correlation_headers({}) == {}
+
+
+def test_parse_correlation_headers_truncates_long_values():
+    long_id = "x" * 300
+    corr = parse_correlation_headers({"X-Request-Id": long_id})
+    assert len(corr["request_id"]) == 128
+    assert corr["request_id"] == long_id[:128]
+
+
+def test_parse_correlation_headers_strips_newlines():
+    corr = parse_correlation_headers({
+        "X-Request-Id": "abc\r\n123",
+        "X-Stream-Token": "tok\n1",
+    })
+    assert "\r" not in corr["request_id"]
+    assert "\n" not in corr["request_id"]
+    assert "\r" not in corr["stream_token"]
+    assert "\n" not in corr["stream_token"]


### PR DESCRIPTION
## Summary

Add X-Request-Id / X-Stream-Token header support on the API server for cross-request observability. Parse from HTTP headers, sanitize, wire into agent runs, emit [Perf] done log with token usage.

## Changes

- **gateway/client_correlation.py**: parse + sanitize (newline strip, 128-char cap); format log suffixes
- **gateway/platforms/api_server.py**: CORS allow custom headers; parse in chat/completions; forward to `_run_agent`; [Perf] log at agent completion

## Review fixes (per @teknium1)

- [x] CORS: added X-Request-Id, X-Request-ID, X-Stream-Token to allowed headers
- [x] Sanitization: values stripped of newlines and capped at 128 chars
- [x] Dropped bound_skills (not wired to skill index — separate PR needed)
- [x] Dropped HERMES_SKIP_OPENROUTER_METADATA (policy conflict with AGENTS.md)
- [x] Dropped conversation_loop changes (separate concern)
- [x] 6 tests cover parsing, alias, suffix, empty, truncation, newline stripping

## Why this matters

Correlation headers enable end-to-end request tracing across distributed deployments. A client sends X-Request-Id → it appears in [Perf] logs alongside token usage → observability without custom infrastructure.