### PR TITLE
feat(mattermost): add reply_mode "auto" for thread-aware replies

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5128,9 +5128,9 @@ _PLATFORMS = [
             },
             {
                 "name": "MATTERMOST_REPLY_MODE",
-                "prompt": "Reply mode — 'off' for flat messages, 'thread' for threaded replies (default: off)",
+                "prompt": "Reply mode — 'off' flat, 'thread' always threaded, 'auto' threaded only when your message was in a thread (default: off)",
                 "password": False,
-                "help": "off = flat channel messages, thread = replies nest under your message.",
+                "help": "off = flat channel messages, thread = replies always nest under your message, auto = nest only when your message was itself in a thread (top-level stays flat).",
             },
         ],
     },

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -110,7 +110,15 @@ class MattermostAdapter(BasePlatformAdapter):
         self._reconnect_task: Optional[asyncio.Task] = None
         self._closing = False
 
-        # Reply mode: "thread" to nest replies, "off" for flat messages.
+        # Reply mode:
+        #   "off"    — never thread (flat messages).
+        #   "thread" — always nest replies under the triggering message. On a
+        #              top-level message this roots a brand-new thread, so each
+        #              top-level message starts a new thread (and, for gateways
+        #              that key sessions by thread, a new session → lost context).
+        #   "auto"   — nest ONLY when the incoming message was itself inside a
+        #              thread; top-level messages reply flat, so a DM stays one
+        #              continuous conversation (like Telegram/Discord behaviour).
         self._reply_mode: str = (
             config.extra.get("reply_mode", "")
             or os.getenv("MATTERMOST_REPLY_MODE", "off")
@@ -184,6 +192,18 @@ class MattermostAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]],
     ) -> Optional[str]:
         """Resolve the Mattermost root_id from reply_to or metadata."""
+        if self._reply_mode == "auto":
+            # Nest only when the incoming message was itself inside a thread,
+            # surfaced as metadata["thread_id"]. Top-level messages stay flat so
+            # the conversation remains one continuous session. reply_to is
+            # ignored on purpose: in "thread" mode it would root a brand-new
+            # thread per top-level message, which is exactly what "auto" avoids.
+            thread_id = (
+                metadata.get("thread_id") if isinstance(metadata, dict) else None
+            )
+            if not thread_id:
+                return None
+            return await self._resolve_root_id(str(thread_id))
         if self._reply_mode != "thread":
             return None
         candidate = reply_to

--- a/plugins/platforms/mattermost/plugin.yaml
+++ b/plugins/platforms/mattermost/plugin.yaml
@@ -32,8 +32,8 @@ optional_env:
     prompt: "Home channel ID"
     password: false
   - name: MATTERMOST_REPLY_MODE
-    description: "How replies are sent: 'thread' (nested) or 'off' (flat). Default: off."
-    prompt: "Reply mode (thread|off)"
+    description: "How replies are sent: 'thread' (always nested), 'auto' (nested only when your message was in a thread), or 'off' (flat). Default: off."
+    prompt: "Reply mode (thread|auto|off)"
     password: false
   - name: MATTERMOST_REQUIRE_MENTION
     description: "Require @bot mention in channels (default true). Set false for free-response everywhere."

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -194,6 +194,96 @@ class TestMattermostSend:
         payload = self.adapter._session.post.call_args[1]["json"]
         assert payload["root_id"] == "root_post"
 
+    @pytest.mark.asyncio
+    async def test_send_without_thread_no_root_id(self):
+        """When reply_mode is 'off', reply_to should NOT set root_id."""
+        self.adapter._reply_mode = "off"
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "post789"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+
+        result = await self.adapter.send("channel_1", "Reply!", reply_to="root_post")
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert "root_id" not in payload
+
+    @pytest.mark.asyncio
+    async def test_send_auto_mode_top_level_stays_flat(self):
+        """In 'auto' mode a top-level message (no metadata thread_id) replies flat,
+        even when reply_to is present — keeping a DM as one continuous session."""
+        self.adapter._reply_mode = "auto"
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "post_auto1"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+
+        result = await self.adapter.send("channel_1", "Hi!", reply_to="some_post")
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert "root_id" not in payload
+
+    @pytest.mark.asyncio
+    async def test_send_auto_mode_threaded_uses_metadata_thread_id(self):
+        """In 'auto' mode, when the incoming message was itself in a thread
+        (metadata['thread_id']), the reply nests under that thread root."""
+        self.adapter._reply_mode = "auto"
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"id": "post_auto2"})
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        # thread_id from metadata is already a thread root; _resolve_root_id
+        # GETs the post and (no nested root_id) returns it unchanged.
+        mock_get_resp = AsyncMock()
+        mock_get_resp.status = 200
+        mock_get_resp.json = AsyncMock(return_value={"id": "thread_root", "root_id": ""})
+        mock_get_resp.text = AsyncMock(return_value="")
+        mock_get_resp.__aenter__ = AsyncMock(return_value=mock_get_resp)
+        mock_get_resp.__aexit__ = AsyncMock(return_value=False)
+
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+        self.adapter._session.get = MagicMock(return_value=mock_get_resp)
+
+        result = await self.adapter.send(
+            "channel_1", "In-thread reply", metadata={"thread_id": "thread_root"}
+        )
+
+        assert result.success is True
+        payload = self.adapter._session.post.call_args[1]["json"]
+        assert payload["root_id"] == "thread_root"
+
+    @pytest.mark.asyncio
+    async def test_send_uses_metadata_thread_id_for_progress_messages(self):
+        """Progress/status messages pass Mattermost thread context via metadata."""
+        self.adapter._reply_mode = "thread"
+        self.adapter._api_get = AsyncMock(return_value={"id": "root_post_123", "root_id": ""})
+        self.adapter._api_post = AsyncMock(return_value={"id": "progress_post"})
+
+        result = await self.adapter.send(
+            "channel_1",
+            "⚡ terminal...",
+            metadata={"thread_id": "root_post_123"},
+        )
+
+        assert result.success is True
+        payload = self.adapter._api_post.call_args_list[0][0][1]
+        assert payload["root_id"] == "root_post_123"
 
     @pytest.mark.asyncio
     async def test_progress_send_with_invalid_thread_root_never_falls_back_flat(self):

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -6,7 +6,7 @@ import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import MessageType
+from gateway.platforms.base import MessageType, _thread_metadata_for_source
 from gateway.run import (
     _resolve_gateway_display_bool,
     _resolve_progress_thread_id,
@@ -684,3 +684,149 @@ async def test_mattermost_top_level_channel_post_is_thread_root():
     assert msg_event.message_id == "top_post_123"
 
 
+@pytest.mark.asyncio
+async def test_mattermost_dm_post_does_not_seed_thread_root():
+    adapter = _make_adapter()
+    adapter._reply_mode = "thread"
+    adapter._bot_user_id = "bot_user_id"
+    adapter._bot_username = "hermes-bot"
+    adapter.handle_message = AsyncMock()
+    post_data = {
+        "id": "dm_post_123",
+        "user_id": "user_123",
+        "channel_id": "dm_chan",
+        "message": "hello",
+        "root_id": "",
+    }
+    event = {
+        "event": "posted",
+        "data": {
+            "post": json.dumps(post_data),
+            "channel_type": "D",
+            "sender_name": "@alice",
+        },
+    }
+
+    await adapter._handle_ws_event(event)
+
+    msg_event = adapter.handle_message.call_args[0][0]
+    assert msg_event.source.thread_id is None
+    assert msg_event.source.message_id == "dm_post_123"
+
+
+# ---------------------------------------------------------------------------
+# reply_mode="auto" — full receive→send contract
+#
+# The dedicated send() tests above drive send() with hand-written metadata.
+# These two exercise the *real* contract instead: an inbound WebSocket
+# "posted" event is parsed by _handle_ws_event (deriving source.thread_id), then
+# the gateway derives the outbound send metadata from that
+# source field via _thread_metadata_for_source (the same function run.py calls
+# on every delivery), and only then is send() invoked. This proves the two
+# halves actually agree end-to-end:
+#   • a top-level DM  → source.thread_id is None → metadata None → flat payload;
+#   • a real root_id thread event → source.thread_id set → {"thread_id": …}
+#     metadata → rooted payload.
+# ---------------------------------------------------------------------------
+
+
+def _mock_json_response(payload):
+    resp = AsyncMock()
+    resp.status = 200
+    resp.json = AsyncMock(return_value=payload)
+    resp.text = AsyncMock(return_value="")
+    resp.__aenter__ = AsyncMock(return_value=resp)
+    resp.__aexit__ = AsyncMock(return_value=False)
+    return resp
+
+
+async def _receive_then_send_payload(adapter, event, reply_text):
+    """Drive the real receive→send path and return the outbound POST payload.
+
+    1. Parse the inbound event through _handle_ws_event (captures the source
+       the adapter actually derived — no fabricated thread_id).
+    2. Build outbound send metadata from that source the same way the gateway
+       does (_thread_metadata_for_source).
+    3. Send the reply and return the JSON payload POSTed to /api/v4/posts.
+    """
+    adapter.handle_message = AsyncMock()
+    await adapter._handle_ws_event(event)
+    assert adapter.handle_message.called, "inbound event was not delivered"
+    source = adapter.handle_message.call_args[0][0].source
+
+    # Gateway-side metadata construction from the parsed source field.
+    metadata = _thread_metadata_for_source(source)
+
+    adapter._session = MagicMock()
+    adapter._session.post = MagicMock(return_value=_mock_json_response({"id": "sent_post"}))
+    # In "auto" mode a threaded reply resolves the root via GET posts/<id>;
+    # returning the post with no nested root_id makes it its own thread root.
+    adapter._session.get = MagicMock(
+        return_value=_mock_json_response(
+            {"id": source.thread_id or "", "root_id": ""}
+        )
+    )
+
+    result = await adapter.send(source.chat_id, reply_text, metadata=metadata)
+    assert result.success is True
+    return adapter._session.post.call_args[1]["json"]
+
+
+@pytest.mark.asyncio
+async def test_auto_receive_send_top_level_dm_replies_flat():
+    """auto: a top-level DM (no root_id) parses to thread_id=None, so the
+    gateway builds no thread metadata and the outbound reply is flat."""
+    adapter = _make_adapter()
+    adapter._reply_mode = "auto"
+    adapter._bot_user_id = "bot_user_id"
+    adapter._bot_username = "hermes-bot"
+
+    post_data = {
+        "id": "dm_top_1",
+        "user_id": "user_123",
+        "channel_id": "dm_chan",
+        "message": "hello there",
+        "root_id": "",  # top-level: not inside a thread
+    }
+    event = {
+        "event": "posted",
+        "data": {
+            "post": json.dumps(post_data),
+            "channel_type": "D",
+            "sender_name": "@alice",
+        },
+    }
+
+    payload = await _receive_then_send_payload(adapter, event, "hi back")
+    assert payload["channel_id"] == "dm_chan"
+    assert "root_id" not in payload
+
+
+@pytest.mark.asyncio
+async def test_auto_receive_send_thread_event_replies_rooted():
+    """auto: an inbound event carrying a real root_id parses to that thread_id,
+    the gateway surfaces it as metadata, and the outbound reply nests under it."""
+    adapter = _make_adapter()
+    adapter._reply_mode = "auto"
+    adapter._bot_user_id = "bot_user_id"
+    adapter._bot_username = "hermes-bot"
+
+    post_data = {
+        "id": "reply_post_1",
+        "user_id": "user_123",
+        "channel_id": "chan_456",
+        "message": "@hermes-bot continue in this thread",
+        "root_id": "root_post_123",  # inside an existing thread
+    }
+    event = {
+        "event": "posted",
+        "data": {
+            "post": json.dumps(post_data),
+            "channel_type": "O",
+            "sender_name": "@alice",
+        },
+    }
+
+    payload = await _receive_then_send_payload(adapter, event, "answering in thread")
+    assert payload["channel_id"] == "chan_456"
+    assert payload["root_id"] == "root_post_123"

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -483,7 +483,7 @@ These are set automatically by the Docker terminal backend when `proxy.enabled: 
 | `MATTERMOST_HOME_CHANNEL` | Channel ID for proactive message delivery (cron, notifications) |
 | `MATTERMOST_REQUIRE_MENTION` | Require `@mention` in channels (default: `true`). Set to `false` to respond to all messages. |
 | `MATTERMOST_FREE_RESPONSE_CHANNELS` | Comma-separated channel IDs where bot responds without `@mention` |
-| `MATTERMOST_REPLY_MODE` | Reply style: `thread` (threaded replies) or `off` (flat messages, default) |
+| `MATTERMOST_REPLY_MODE` | Reply style: `thread` (always threaded), `auto` (threaded only when your message was in a thread), or `off` (flat messages, default) |
 | `MATRIX_HOMESERVER` | Matrix homeserver URL (e.g. `https://matrix.org`) |
 | `MATRIX_ACCESS_TOKEN` | Matrix access token for bot authentication |
 | `MATRIX_USER_ID` | Matrix user ID (e.g. `@hermes:matrix.org`) — required for password login, optional with access token |

--- a/website/docs/user-guide/messaging/mattermost.md
+++ b/website/docs/user-guide/messaging/mattermost.md
@@ -18,7 +18,7 @@ Before setup, here's the part most people want to know: how Hermes behaves once 
 |---------|----------|
 | **DMs** | Hermes responds to every message. No `@mention` needed. Each DM has its own session. |
 | **Public/private channels** | Hermes responds when you `@mention` it. Without a mention, Hermes ignores the message. |
-| **Threads** | If `MATTERMOST_REPLY_MODE=thread`, Hermes replies in a thread under your message. Thread context stays isolated from the parent channel. |
+| **Threads** | If `MATTERMOST_REPLY_MODE=thread`, Hermes replies in a thread under your message. Thread context stays isolated from the parent channel. With `auto`, Hermes only threads when your message was itself in a thread. |
 | **Shared channels with multiple users** | By default, Hermes isolates session history per user inside the channel. Two people talking in the same channel do not share one transcript unless you explicitly disable that. |
 
 :::tip
@@ -205,6 +205,7 @@ The `MATTERMOST_REPLY_MODE` setting controls how Hermes posts responses:
 |------|----------|
 | `off` (default) | Hermes posts flat messages in the channel, like a normal user. |
 | `thread` | Hermes replies in a thread under your original message. Keeps channels clean when there's lots of back-and-forth. |
+| `auto` | Hermes threads its reply **only** when your message was itself in a thread; top-level messages get a flat reply. In `thread` mode every top-level message starts a new thread (and, for gateways that key sessions by thread, a new session) — `auto` keeps a DM as one continuous conversation while still following you into threads. |
 
 Set it in your `~/.hermes/.env`:
 


### PR DESCRIPTION
## Problem

`MATTERMOST_REPLY_MODE` currently supports only `off` (always flat) and `thread` (always nest under the triggering message). In `thread` mode every **top-level** message roots a brand-new thread. For gateways that key sessions by thread root, each top-level message therefore starts a fresh session and loses conversation context — a DM never stays continuous.

## Change

Add a third mode, `auto`: nest the reply **only** when the incoming message was itself inside a thread (surfaced as `metadata["thread_id"]`); top-level messages reply flat. This keeps a DM as one continuous conversation while still following the user into existing threads — matching the Telegram/Discord feel.

The change is localized to `_thread_root_for_send`, through which text and file-upload paths already route, so no per-sender edits are needed. The receive side already sets `thread_id` from the post's real `root_id`; the force-thread branch remains gated to `thread` mode.

## Behavior

| Mode | Top-level message | Message inside a thread |
|------|-------------------|-------------------------|
| `off` | flat | flat |
| `thread` | starts a new thread | nests in thread |
| `auto` (new) | **flat** | nests in thread |

## What's included

- `plugins/platforms/mattermost/adapter.py` — handle `auto` in `_thread_root_for_send`
- setup metadata and docs — document the new mode
- direct send-contract tests for flat and threaded `auto` behavior
- two receive→send end-to-end tests proving that a top-level DM stays flat and a real inbound thread root is preserved on the outbound reply

## Validation

- `scripts/run_tests.sh tests/gateway/test_mattermost.py -q` → **29 passed**
- `ruff check .` → passed
- `python scripts/check-windows-footguns.py --diff origin/main` → passed (3 files scanned)
- `git diff --check origin/main...HEAD` → passed

## Scope

Propagation of `mattermost.reply_mode` from `config.yaml` is tracked separately in #67810 and is intentionally not mixed into this PR.