### PR TITLE
fix(mcp): surface non-text, non-image tool-result blocks instead of dropping them

### DIFF
--- a/tests/tools/test_mcp_block_coercion.py
+++ b/tests/tools/test_mcp_block_coercion.py
@@ -1,0 +1,143 @@
+"""Regression tests for MCP non-text, non-image content-block coercion.
+
+Background
+==========
+MCP tool results can carry content blocks beyond plain text and images:
+``resource_link`` (a URI pointer), an embedded ``resource`` (inline text or a
+binary blob), ``audio``, and occasionally malformed or unknown shapes. The
+tool-result handler in ``tools/mcp_tool.py`` used to iterate content blocks
+handling only ``block.text`` and cached images; every other block type was
+silently dropped, so the agent received an empty or partial result with no way
+to tell content was lost.
+
+``_coerce_mcp_block_to_text`` is the fallback that surfaces those remaining
+block types as readable notes instead of dropping them. It probes by attribute
+(not isinstance against MCP SDK classes) because the ``mcp`` package is an
+optional/lazy dependency that is not importable in every process. These tests
+lock in that nothing vanishes silently and that binary payloads are noted, not
+inlined.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+
+class TestResourceLinkBlock:
+    def test_resource_link_emits_uri_and_metadata(self):
+        from tools.mcp_tool import _coerce_mcp_block_to_text
+
+        block = SimpleNamespace(
+            type="resource_link",
+            uri="file:///tmp/report.pdf",
+            name="report.pdf",
+            title="Quarterly report",
+            mimeType="application/pdf",
+        )
+        out = _coerce_mcp_block_to_text(block)
+        assert "resource_link" in out
+        assert "file:///tmp/report.pdf" in out
+        assert "report.pdf" in out
+        assert "application/pdf" in out
+
+    def test_resource_link_with_only_uri(self):
+        from tools.mcp_tool import _coerce_mcp_block_to_text
+
+        block = SimpleNamespace(uri="https://example.com/x", resource=None)
+        out = _coerce_mcp_block_to_text(block)
+        assert "https://example.com/x" in out
+        assert out != ""
+
+
+class TestEmbeddedResourceBlock:
+    def test_resource_with_inline_text_is_surfaced_verbatim(self):
+        from tools.mcp_tool import _coerce_mcp_block_to_text
+
+        resource = SimpleNamespace(
+            uri="file:///notes.txt", mimeType="text/plain", text="hello from resource"
+        )
+        block = SimpleNamespace(type="resource", resource=resource)
+        assert _coerce_mcp_block_to_text(block) == "hello from resource"
+
+    def test_resource_with_binary_blob_is_noted_not_inlined(self):
+        from tools.mcp_tool import _coerce_mcp_block_to_text
+
+        resource = SimpleNamespace(
+            uri="file:///audio.bin",
+            mimeType="application/octet-stream",
+            blob="QUJDRA==",  # base64 payload that must NOT be inlined
+        )
+        block = SimpleNamespace(type="resource", resource=resource)
+        out = _coerce_mcp_block_to_text(block)
+        assert "application/octet-stream" in out
+        assert "not inlined" in out
+        assert "QUJDRA==" not in out
+
+
+class TestAudioBlock:
+    def test_audio_block_is_noted_not_inlined(self):
+        from tools.mcp_tool import _coerce_mcp_block_to_text
+
+        block = SimpleNamespace(
+            type="audio", data="QUJDRA==", mimeType="audio/wav"
+        )
+        out = _coerce_mcp_block_to_text(block)
+        assert "audio" in out
+        assert "audio/wav" in out
+        assert "not inlined" in out
+        assert "QUJDRA==" not in out
+
+
+class TestUnknownBlock:
+    def test_unknown_block_type_is_not_silently_dropped(self):
+        from tools.mcp_tool import _coerce_mcp_block_to_text
+
+        block = SimpleNamespace(type="future_block_kind", payload={"a": 1})
+        out = _coerce_mcp_block_to_text(block)
+        assert out != ""
+        assert "future_block_kind" in out
+
+    def test_block_with_no_type_falls_back_to_class_name(self):
+        from tools.mcp_tool import _coerce_mcp_block_to_text
+
+        class WeirdBlock:
+            pass
+
+        out = _coerce_mcp_block_to_text(WeirdBlock())
+        assert out != ""
+        assert "WeirdBlock" in out
+
+
+class TestNothingDroppedAcrossMixedResult:
+    def test_mixed_result_surfaces_every_block(self):
+        """A result with text + resource_link + audio + unknown blocks must
+        surface a note for each non-text, non-image block. Mirrors the loop in
+        ``_make_tool_handler`` without needing a live MCP session."""
+        from tools.mcp_tool import _cache_mcp_image_block, _coerce_mcp_block_to_text
+
+        text_block = SimpleNamespace(text="plain answer")
+        resource_link = SimpleNamespace(
+            type="resource_link", uri="file:///a.txt", resource=None
+        )
+        audio = SimpleNamespace(type="audio", data="QUJD", mimeType="audio/mpeg")
+        unknown = SimpleNamespace(type="mystery")
+
+        parts = []
+        for block in (text_block, resource_link, audio, unknown):
+            if hasattr(block, "text") and block.text:
+                parts.append(block.text)
+                continue
+            image_tag = _cache_mcp_image_block(block)
+            if image_tag:
+                parts.append(image_tag)
+                continue
+            coerced = _coerce_mcp_block_to_text(block)
+            if coerced:
+                parts.append(coerced)
+
+        # text + 3 coerced notes; nothing dropped
+        assert len(parts) == 4
+        assert parts[0] == "plain answer"
+        assert "file:///a.txt" in parts[1]
+        assert "audio/mpeg" in parts[2]
+        assert "mystery" in parts[3]

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -541,6 +541,68 @@ def _cache_mcp_image_block(block) -> str:
     return f"MEDIA:{image_path}"
 
 
+def _coerce_mcp_block_to_text(block) -> str:
+    """Coerce a non-text, non-image MCP content block into a readable note.
+
+    MCP tool results can include block types beyond text and images:
+    ``resource_link`` (a pointer to a resource by URI), an embedded
+    ``resource`` (inline text or a binary blob), ``audio``, and occasionally
+    malformed or unknown shapes. The text and image branches in the caller
+    handle the common cases; this fallback ensures the remaining block types
+    are surfaced to the agent rather than silently dropped, which previously
+    left the agent with an empty or partial tool result and no way to tell
+    content was lost.
+
+    Probes by attribute rather than isinstance against MCP SDK classes: the
+    ``mcp`` package is an optional/lazy dependency that is not importable in
+    every process (e.g. cron without gateway deps), so the coercion must not
+    require importing SDK block types.
+
+    Does not inline binary payloads (blobs, audio, video) into the model
+    context; it notes the MIME type and that a binary block was returned.
+    Returns an empty string only when there is genuinely nothing to surface.
+    """
+    uri = getattr(block, "uri", None)
+    resource = getattr(block, "resource", None)
+
+    # resource_link: a bare pointer to a resource by URI (no embedded payload).
+    if uri is not None and resource is None:
+        bits = [f"uri={uri}"]
+        for attr in ("name", "title", "mimeType"):
+            value = getattr(block, attr, None)
+            if value:
+                bits.append(f"{attr}={value}")
+        return "[MCP resource_link " + ", ".join(bits) + "]"
+
+    # embedded resource: carries either inline text or a binary blob.
+    if resource is not None:
+        res_text = getattr(resource, "text", None)
+        if res_text:
+            return res_text
+        blob = getattr(resource, "blob", None)
+        if blob is not None:
+            mime = getattr(resource, "mimeType", None) or "application/octet-stream"
+            res_uri = getattr(resource, "uri", None)
+            tail = f", uri={res_uri}" if res_uri else ""
+            return f"[MCP binary resource: {mime}{tail} (not inlined)]"
+        return f"[MCP resource block (unrendered): {resource!r}]"
+
+    # audio (and any other base64 data block that did not cache as an image,
+    # including a malformed image): note the MIME type, do not inline base64.
+    mime_type = getattr(block, "mimeType", None)
+    if mime_type and getattr(block, "data", None) is not None:
+        family = str(mime_type).split("/", 1)[0].strip().lower()
+        label = {"audio": "audio", "image": "image", "video": "video"}.get(
+            family, "binary"
+        )
+        return f"[MCP {label} block: {mime_type} (not inlined)]"
+
+    # unknown block type: emit a compact note so nothing vanishes silently.
+    block_type = getattr(block, "type", None) or type(block).__name__
+    logger.debug("MCP tool result: surfacing unhandled block type %r", block_type)
+    return f"[MCP {block_type} block (unrendered): {block!r}]"
+
+
 # ---------------------------------------------------------------------------
 # Remote MCP URL validation
 # ---------------------------------------------------------------------------
@@ -2840,6 +2902,15 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 image_tag = _cache_mcp_image_block(block)
                 if image_tag:
                     parts.append(image_tag)
+                    continue
+                # Any block that is neither text nor a cached image
+                # (resource_link, embedded resource, audio, unknown shapes)
+                # is coerced to a readable note instead of being silently
+                # dropped, so the agent never receives an empty result that
+                # hides content the MCP server actually returned.
+                coerced = _coerce_mcp_block_to_text(block)
+                if coerced:
+                    parts.append(coerced)
             text_result = "\n".join(parts) if parts else ""
 
             # Combine content + structuredContent when both are present.


### PR DESCRIPTION
## What

MCP tool results can carry content blocks beyond plain text and images:
`resource_link` (a URI pointer), an embedded `resource` (inline text or a
binary blob), `audio`, and occasionally malformed or unknown shapes. The
result-collection loop in `_make_tool_handler` (`tools/mcp_tool.py`) handled
only `block.text` and cached-image blocks. Every other block type fell through
to `_cache_mcp_image_block`, which returns `""` for non-images, and `""` is
never appended. So those blocks were **silently dropped**: the agent received
an empty or partial tool result with no error and no signal that content was
lost.

This adds `_coerce_mcp_block_to_text`, an attribute-probing fallback that turns
the remaining block types into readable notes instead of dropping them:

- `resource_link` -> a text line with `uri` plus `name`/`title`/`mimeType`.
- embedded `resource` -> inline `text` verbatim if present; otherwise a note
  with the MIME type for a binary `blob` (base64 is **not** inlined).
- `audio` / other base64 data blocks -> a note with the MIME type, not inlined.
- unknown block type -> a compact `repr` note plus a `logger.debug`, so nothing
  vanishes silently.

It probes by `getattr` rather than `isinstance` against MCP SDK classes,
because the `mcp` package is an optional/lazy dependency that is not importable
in every process (e.g. cron without gateway deps), so the coercion must not
require importing SDK block types.

## Source signal (verified)

openclaw 2026.6.5-beta.1 and beta.2 shipped this exact fix as a headline
(#90710, #90728): MCP tool results that are neither plain text nor images were
being discarded. Both release pages were fetched 200 and content-matched. This
PR is the Hermes-side equivalent of that fix.

## Baseline confirmed on `main`

The gap was read directly on `origin/main` (commit `c6b0eb4de`) before building.
The loop in `_make_tool_handler` appends `block.text` and a cached `MEDIA:` tag
for images, with no other branch; `_cache_mcp_image_block` returns `""` for
non-image blocks. Confirmed live, not inferred.

## Test evidence

New `tests/tools/test_mcp_block_coercion.py` (8 tests) covers resource_link,
embedded text resource, binary blob (asserts the base64 is NOT inlined), audio,
unknown block type, no-`type` fallback, and a mixed-result loop that asserts
none of text + resource_link + audio + unknown is dropped.

```
tests/tools/test_mcp_block_coercion.py        8 passed
tests/tools/test_mcp_tool.py                  passed (no regression)
tests/tools/test_mcp_structured_content.py    passed (no regression)
ruff check tools/mcp_tool.py                   All checks passed
```

## Review verdict

Static security scan over added lines: clean (no secrets, eval/exec, shell
injection, or unsafe deserialization). Self-review against AGENTS.md: additive
fix to a real reported symptom, fixes the whole block-class (not just one site),
no new core tool, no env var, no cache/alternation impact, behavior-contract
tests (asserts invariants like "nothing is dropped" and "binary is not
inlined", not frozen snapshots).

## Why this is safe to merge

- Purely additive: the new branch only fires for blocks that previously
  produced `""` and were dropped. Text and image handling are unchanged and
  still evaluated first.
- No new dependency: probes by attribute, never imports MCP SDK block classes,
  so it stays importable in cron/no-gateway processes.
- Does not inline binary payloads into the model context (only a MIME-typed
  note), so it cannot bloat context with base64.
- Reversible: single-commit revert restores current behavior. No migration, no
  config change, no security-boundary change.

Drafted by Argus (Nick's ecosystem scout). Source proposal:
`working/draft-proposals/2026-06-08-mcp-tool-result-block-coercion.md`.
