### PR TITLE
fix(gateway): skip non-dict entries in session loading (#46994)

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -741,9 +741,11 @@ class SessionStore:
                 with open(sessions_file, "r", encoding="utf-8") as f:
                     data = json.load(f)
                     for key, entry_data in data.items():
+                        if not isinstance(entry_data, dict):
+                            continue
                         try:
                             self._entries[key] = SessionEntry.from_dict(entry_data)
-                        except (ValueError, KeyError):
+                        except (ValueError, KeyError, TypeError):
                             # Skip entries with unknown/removed platform values
                             continue
             except Exception as e:


### PR DESCRIPTION
Fixes #46994. When sessions.json contains a boolean (or other non-dict) value for a key, SessionEntry.from_dict() raises TypeError because 'origin' in True is not iterable. The inner except only caught ValueError and KeyError. This adds an isinstance(entry_data, dict) guard to skip non-dict entries and adds TypeError to the except clause as a safety net.