### PR TITLE
fix(state): handle missing trigram tokenizer in FTS5 error detection (#47002)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -772,7 +772,10 @@ class SessionDB:
     @staticmethod
     def _is_fts5_unavailable_error(exc: sqlite3.OperationalError) -> bool:
         err = str(exc).lower()
-        return "no such module" in err and "fts5" in err
+        return (
+            ("no such module" in err and "fts5" in err)
+            or "no such tokenizer" in err
+        )
 
     def _warn_fts5_unavailable(self, exc: sqlite3.OperationalError) -> None:
         self._fts_enabled = False


### PR DESCRIPTION
Fixes #47002. SQLite builds with FTS5 but without the trigram tokenizer raise 'no such tokenizer: trigram' which was not detected by _is_fts5_unavailable_error, causing SessionDB.__init__ to crash. Added 'no such tokenizer' to the error detection so the trigram FTS5 table is gracefully degraded (CJK search falls back to LIKE).