### PR TITLE
[codex] harden gateway response delivery

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -34,6 +34,8 @@ from urllib.parse import quote, urlparse
 logger = logging.getLogger(__name__)
 
 WEIXIN_COPY_LINE_WIDTH = 120
+WEIXIN_LONG_REPLY_ATTACHMENT_THRESHOLD = 4000
+WEIXIN_LONG_REPLY_PREVIEW_LENGTH = 1200
 
 try:
     import aiohttp
@@ -1665,6 +1667,24 @@ class WeixinAdapter(BasePlatformAdapter):
             content, self.MAX_MESSAGE_LENGTH, self._split_multiline_messages,
         )
 
+    def _write_long_reply_attachment(self, content: str) -> str:
+        cache_dir = Path(self._hermes_home) / "cache" / "weixin_long_replies"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        path = cache_dir / f"weixin-reply-{stamp}-{uuid.uuid4().hex[:8]}.md"
+        path.write_text(content, encoding="utf-8")
+        return str(path)
+
+    def _long_reply_preview(self, content: str, attachment_path: str) -> str:
+        preview = content[:WEIXIN_LONG_REPLY_PREVIEW_LENGTH].rstrip()
+        if len(content) > len(preview):
+            preview = f"{preview}\n..."
+        filename = Path(attachment_path).name
+        return (
+            f"这次回复较长（{len(content)} 字），我把完整内容放在附件里：{filename}\n\n"
+            f"预览：\n{preview}"
+        ).strip()
+
     def _rate_limit_cooldown_remaining(self) -> float:
         return max(0.0, self._rate_limit_circuit_until - time.monotonic())
 
@@ -1869,8 +1889,55 @@ class WeixinAdapter(BasePlatformAdapter):
                 except Exception as exc:
                     logger.warning("[%s] local file delivery failed for %s: %s", self.name, file_path, exc)
 
-            # Deliver text content.
-            chunks = [c for c in self._split_text(self.format_message(final_content)) if c and c.strip()]
+            # Deliver text content. Very long Weixin replies can stall iLink
+            # delivery when split into many text bubbles, so send a compact
+            # preview and attach the full Markdown instead.
+            formatted_content = self.format_message(final_content)
+            if len(formatted_content) > WEIXIN_LONG_REPLY_ATTACHMENT_THRESHOLD:
+                attachment_path = self._write_long_reply_attachment(formatted_content)
+                preview = self._long_reply_preview(formatted_content, attachment_path)
+                logger.info(
+                    "[%s] long text reply converted to attachment: chars=%d preview_chars=%d path=%s",
+                    self.name,
+                    len(formatted_content),
+                    len(preview),
+                    attachment_path,
+                )
+                client_id = f"hermes-weixin-{uuid.uuid4().hex}"
+                await self._send_text_chunk(
+                    chat_id=chat_id,
+                    chunk=preview,
+                    context_token=context_token,
+                    client_id=client_id,
+                )
+                last_message_id = client_id
+                doc_result = await self.send_document(
+                    chat_id=chat_id,
+                    file_path=attachment_path,
+                    caption="完整回复见附件。",
+                    metadata=metadata,
+                )
+                if not doc_result.success:
+                    logger.error(
+                        "[%s] long reply attachment delivery failed to=%s path=%s: %s",
+                        self.name,
+                        _safe_id(chat_id),
+                        attachment_path,
+                        doc_result.error,
+                    )
+                    fail_notice_id = f"hermes-weixin-{uuid.uuid4().hex}"
+                    await self._send_text_chunk(
+                        chat_id=chat_id,
+                        chunk="完整回复附件发送失败了；我已保留本地文件，稍后可以重新发送。",
+                        context_token=context_token,
+                        client_id=fail_notice_id,
+                    )
+                    last_message_id = fail_notice_id
+                else:
+                    last_message_id = doc_result.message_id or last_message_id
+                return SendResult(success=True, message_id=last_message_id)
+
+            chunks = [c for c in self._split_text(formatted_content) if c and c.strip()]
             for idx, chunk in enumerate(chunks):
                 client_id = f"hermes-weixin-{uuid.uuid4().hex}"
                 await self._send_text_chunk(

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1833,6 +1833,11 @@ class WeixinAdapter(BasePlatformAdapter):
         _, image_cleaned = self.extract_images(cleaned_content)
         local_files, final_content = self.extract_local_files(image_cleaned)
         local_files = self.filter_local_delivery_paths(local_files)
+        try:
+            from gateway.response_filters import sanitize_user_visible_gateway_text
+            final_content = sanitize_user_visible_gateway_text(final_content)
+        except Exception:
+            logger.debug("[%s] outbound text sanitization failed", self.name, exc_info=True)
 
         _AUDIO_EXTS = {".ogg", ".opus", ".mp3", ".wav", ".m4a", ".flac"}
         _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"}

--- a/gateway/response_filters.py
+++ b/gateway/response_filters.py
@@ -7,6 +7,8 @@ conversation history.
 
 from __future__ import annotations
 
+import os
+import re
 from typing import Any
 
 # Canonical model-emitted control token for intentional silence.
@@ -21,6 +23,73 @@ LIVE_GATEWAY_SILENT_MARKERS = frozenset({
     "NO_REPLY",
     "NO REPLY",
 })
+
+_HOME_PATH_RE = re.compile(
+    r"(?P<path>(?:~|/home/[^/\s`\"'<>，。；、,;:!?！？)）\]}]+)"
+    r"(?:/[^\s`\"'<>，。；、,;:!?！？)）\]}]*)?)"
+)
+_MEDIA_PREFIX_RE = re.compile(r"MEDIA:\s*[`\"']?$", re.IGNORECASE)
+_LOCAL_PATH_PLACEHOLDER = "[local file]"
+_MODEL_IDENTITY_PLACEHOLDER = "当前大模型"
+_MODEL_SERVICE_PLACEHOLDER = "当前模型服务"
+_PROVIDER_PLACEHOLDER = "模型服务商"
+_MODEL_IDENTITY_REPLACEMENTS = (
+    (
+        re.compile(
+            r"\b(?:gpt[-_ ]?(?:5(?:\.5)?|4(?:\.1|o)?|4|3\.5)|o[134](?:[-_ ]?(?:mini|pro))?)\b",
+            re.IGNORECASE,
+        ),
+        _MODEL_IDENTITY_PLACEHOLDER,
+    ),
+    (
+        re.compile(r"\b(?:claude|gemini|grok|llama|qwen|deepseek)[-_ ]?[A-Za-z0-9._-]*\b", re.IGNORECASE),
+        _MODEL_IDENTITY_PLACEHOLDER,
+    ),
+    (
+        re.compile(r"\bopenai[-_ ]codex\b|\bcodex[-_ ]?(?:app[-_ ]?server|runtime|acp)\b|\bcodex_app_server\b", re.IGNORECASE),
+        _MODEL_SERVICE_PLACEHOLDER,
+    ),
+    (re.compile(r"\bhermes(?:[-_ ]?agent)?\b", re.IGNORECASE), _MODEL_SERVICE_PLACEHOLDER),
+    (re.compile(r"\bcodex\b", re.IGNORECASE), _MODEL_SERVICE_PLACEHOLDER),
+    (re.compile(r"\bopenai\b|\banthropic\b|\bgoogle\b", re.IGNORECASE), _PROVIDER_PLACEHOLDER),
+    (
+        re.compile(r"https?://chatgpt\.com/backend-api/codex[^\s`\"'<>]*", re.IGNORECASE),
+        _MODEL_SERVICE_PLACEHOLDER,
+    ),
+)
+_MODEL_IDENTITY_QUERY_REPLY = (
+    "我是当前系统提供的 AI 助手，具体模型、服务商、运行环境和程序细节不对外展示。"
+)
+_USER_VISIBLE_RUNTIME_ERROR_REPLY = (
+    "抱歉，这次模型服务调用失败了，内部错误日志已隐藏。请稍后重试。"
+)
+_RAW_RUNTIME_ERROR_MARKERS = (
+    "turn ended status=failed",
+    "stderr (last",
+    "invalid_request_error",
+    "cloudflare",
+    "cf_chl",
+    "<!doctype html",
+    "<html",
+)
+_MODEL_IDENTITY_QUERY_PATTERNS = (
+    re.compile(
+        r"(你|你们|当前|现在|这个|本助手|机器人|bot).{0,12}"
+        r"(什么|哪个|哪种|哪一个|用的|使用|基于|基座|后端|底层|运行).{0,16}"
+        r"(模型|大模型|程序|系统|服务|provider|backend|runtime|agent)",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"(模型|大模型|程序|系统|服务|provider|backend|runtime|agent).{0,16}"
+        r"(什么|哪个|哪种|哪一个|名字|名称|版本|后端|底层).{0,12}"
+        r"(你|你们|当前|现在|这个|本助手|机器人|bot)?",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(what|which)\b.{0,24}\b(model|provider|backend|runtime|agent)\b.{0,24}\b(are you|you use|running)\b",
+        re.IGNORECASE,
+    ),
+)
 
 
 def _canonical_silence_candidate(text: str) -> str:
@@ -51,3 +120,100 @@ def is_intentional_silence_agent_result(agent_result: dict | None, response: Any
     if agent_result.get("failed"):
         return False
     return is_intentional_silence_response(response)
+
+
+def redact_user_visible_local_paths(text: Any) -> str:
+    """Redact local Hermes/Codex paths from user-visible gateway text.
+
+    ``MEDIA:/path`` directives are intentionally preserved so downstream
+    platform adapters can still extract and deliver attachments. Callers that
+    have already extracted media can run this on the cleaned message body.
+    """
+    if not isinstance(text, str):
+        return "" if text is None else str(text)
+    if not text:
+        return text
+
+    home = os.path.expanduser("~")
+    home_prefix = f"{home}/" if home and home != "~" else ""
+
+    def repl(match: re.Match[str]) -> str:
+        path = match.group("path")
+        prefix = text[max(0, match.start() - 32):match.start()]
+        if _MEDIA_PREFIX_RE.search(prefix):
+            return path
+        expanded = os.path.expanduser(path)
+        if home_prefix and expanded.startswith(home_prefix):
+            return _LOCAL_PATH_PLACEHOLDER
+        return path
+
+    return _HOME_PATH_RE.sub(repl, text)
+
+
+def redact_user_visible_model_identity(text: Any) -> str:
+    """Redact concrete model/provider/runtime names from user-visible text."""
+    if not isinstance(text, str):
+        return "" if text is None else str(text)
+    if not text:
+        return text
+    protected_spans = [match.span() for match in _HOME_PATH_RE.finditer(text)]
+    if protected_spans:
+        chunks: list[str] = []
+        last = 0
+        for start, end in protected_spans:
+            if start > last:
+                chunks.append(redact_user_visible_model_identity(text[last:start]))
+            chunks.append(text[start:end])
+            last = end
+        if last < len(text):
+            chunks.append(redact_user_visible_model_identity(text[last:]))
+        return "".join(chunks)
+
+    redacted = text
+    for pattern, replacement in _MODEL_IDENTITY_REPLACEMENTS:
+        redacted = pattern.sub(replacement, redacted)
+    return redacted
+
+
+def collapse_user_visible_runtime_error(text: Any) -> str:
+    """Replace raw runtime failure dumps with a short user-facing notice."""
+    if not isinstance(text, str):
+        return "" if text is None else str(text)
+    if not text:
+        return text
+
+    normalized = text.strip().lower()
+    if normalized.startswith("⚠️ turn ended status=failed"):
+        return _USER_VISIBLE_RUNTIME_ERROR_REPLY
+    if "turn ended status=failed" in normalized and any(
+        marker in normalized for marker in _RAW_RUNTIME_ERROR_MARKERS[1:]
+    ):
+        return _USER_VISIBLE_RUNTIME_ERROR_REPLY
+    if "cloudflare" in normalized and ("cf_chl" in normalized or "<html" in normalized):
+        return _USER_VISIBLE_RUNTIME_ERROR_REPLY
+    return text
+
+
+def sanitize_user_visible_gateway_text(text: Any, *, redact_paths: bool = True) -> str:
+    """Apply hard outbound redaction before text reaches chat platforms."""
+    redacted = collapse_user_visible_runtime_error(text)
+    redacted = redact_user_visible_local_paths(redacted) if redact_paths else redacted
+    redacted = redact_user_visible_model_identity(redacted)
+    return redacted
+
+
+def is_model_identity_query(text: Any) -> bool:
+    """Return True for user questions about this assistant's model/runtime."""
+    if not isinstance(text, str):
+        return False
+    normalized = " ".join(text.strip().split())
+    if not normalized:
+        return False
+    if len(normalized) > 160:
+        return False
+    return any(pattern.search(normalized) for pattern in _MODEL_IDENTITY_QUERY_PATTERNS)
+
+
+def model_identity_private_reply() -> str:
+    """Stable reply for model/runtime identity questions."""
+    return _MODEL_IDENTITY_QUERY_REPLY

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13516,6 +13516,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _env_tp and not _tool_progress_configured
             else (_resolved_tp or _env_tp or "all")
         )
+        if progress_mode is False:
+            progress_mode = "off"
+        elif progress_mode is True:
+            progress_mode = "all"
         # Disable tool progress for webhooks - they don't support message editing,
         # so each progress line would be sent as a separate message.
         from gateway.config import Platform
@@ -14542,9 +14546,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _bg_review_release = threading.Event()
             _bg_review_pending: list[str] = []
             _bg_review_pending_lock = threading.Lock()
+            _bg_review_notifications_enabled = bool(
+                resolve_display_setting(
+                    user_config,
+                    platform_key,
+                    "self_improvement_notifications",
+                    True,
+                )
+            )
 
             def _deliver_bg_review_message(message: str) -> None:
-                if not _status_adapter or not _run_still_current():
+                if (
+                    not _bg_review_notifications_enabled
+                    or not _status_adapter
+                    or not _run_still_current()
+                ):
                     return
                 safe_schedule_threadsafe(
                     _status_adapter.send(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -349,6 +349,12 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     """
     if not text:
         return text
+    from gateway.response_filters import sanitize_user_visible_gateway_text
+
+    # Do not redact local paths here: platform adapters still need to extract
+    # bare file paths as native media attachments before user-visible text is
+    # sanitized at the final send boundary.
+    text = sanitize_user_visible_gateway_text(text, redact_paths=False)
     if _gateway_platform_value(platform) != "telegram":
         return text
 
@@ -363,6 +369,9 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
     text = str(message or "").strip()
     if not text:
         return None
+    from gateway.response_filters import sanitize_user_visible_gateway_text
+
+    text = sanitize_user_visible_gateway_text(text)
     if _gateway_platform_value(platform) != "telegram":
         return text
 
@@ -6565,6 +6574,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         adapter = self.adapters.get(source.platform)
         if not adapter:
             return
+        from gateway.response_filters import sanitize_user_visible_gateway_text
+
+        content = sanitize_user_visible_gateway_text(content)
 
         config = getattr(self, "config", None)
         notice_delivery = "public"
@@ -7761,6 +7773,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if self._should_send_telegram_lobby_reminder(source):
                 return self._telegram_topic_root_lobby_message()
             return None
+
+        try:
+            from gateway.response_filters import (
+                is_model_identity_query,
+                model_identity_private_reply,
+            )
+            if is_model_identity_query(event.text or ""):
+                return model_identity_private_reply()
+        except Exception:
+            logger.debug("model identity query filter failed", exc_info=True)
 
         # ── Claim this session before any await ───────────────────────
         # Between here and _run_agent registering the real AIAgent, there

--- a/hermes_cli/codex_runtime_plugin_migration.py
+++ b/hermes_cli/codex_runtime_plugin_migration.py
@@ -95,7 +95,7 @@ class MigrationReport:
             lines.append(f"Codex plugin discovery skipped: {self.plugin_query_error}")
         if self.wrote_permissions_default:
             lines.append(
-                f"Wrote default_permissions = "
+                f"Wrote sandbox_mode = "
                 f"{self.wrote_permissions_default!r}"
             )
         for err in self.errors:
@@ -248,7 +248,7 @@ def render_codex_toml_section(
     plugins: Optional[list[dict]] = None,
     default_permission_profile: Optional[str] = None,
 ) -> str:
-    """Render the managed [mcp_servers.<n>] / [plugins.<id>] / [permissions]
+    """Render the managed [mcp_servers.<n>] / [plugins.<id>] / permissions
     block for ~/.codex/config.toml.
 
     Args:
@@ -256,10 +256,10 @@ def render_codex_toml_section(
         plugins: optional list of {name, marketplace, enabled} for native
             Codex plugins to enable. (E.g. the Linear / Atlassian / Asana
             curated plugins, or per-account ChatGPT apps.)
-        default_permission_profile: when set, write `[permissions] default`
-            so the user doesn't get an approval prompt on every write
-            attempt. Common values: "workspace-write", "read-only",
-            "full-access".
+        default_permission_profile: when set, write legacy `sandbox_mode`
+            so the user doesn't get an approval prompt on every write attempt.
+            Common values: "workspace", "workspace-write", "read-only",
+            "danger-full-access".
     """
     out = [MIGRATION_MARKER]
     if not servers and not plugins and not default_permission_profile:
@@ -268,18 +268,15 @@ def render_codex_toml_section(
         return "\n".join(out) + "\n"
 
     if default_permission_profile:
-        # Codex's config schema: `default_permissions` is a top-level
-        # string referencing a profile name. Built-in profile names start
-        # with ":" (":workspace-write", ":read-only", ":full-access"). The
-        # [permissions] table is for *user-defined* named profiles with
-        # structured fields — not what we want.
-        normalized = (
-            default_permission_profile
-            if default_permission_profile.startswith(":")
-            else f":{default_permission_profile}"
-        )
+        # Newer Codex releases treat `default_permissions` as selecting a
+        # user-defined profile in `[permissions]`; the old `:workspace`
+        # builtin-profile spelling now fails without that table. Keep using
+        # the stable legacy sandbox knob for Hermes' generated defaults.
+        normalized = default_permission_profile.removeprefix(":")
+        if normalized == "workspace":
+            normalized = "workspace-write"
         out.append("")
-        out.append(f"default_permissions = {_format_toml_value(normalized)}")
+        out.append(f"sandbox_mode = {_format_toml_value(normalized)}")
 
     if servers:
         for name in sorted(servers.keys()):
@@ -308,8 +305,8 @@ def _insert_managed_block_at_top_level(user_text: str, managed_block: str) -> st
     """Insert Hermes' managed Codex TOML block while keeping root keys root-scoped.
 
     TOML has no syntax to return to the document root after a table header.
-    Therefore appending a root key like `default_permissions = ...` after a
-    user table such as `[features]` actually creates `features.default_permissions`,
+    Therefore appending a root key like `sandbox_mode = ...` after a
+    user table such as `[features]` actually creates `features.sandbox_mode`,
     which Codex rejects. Insert the managed block before the first table header
     so its root keys remain top-level, while preserving user content verbatim.
     """
@@ -411,9 +408,8 @@ def _strip_existing_managed_block(toml_text: str) -> str:
     Backward compatibility: if the start marker is found but no end marker
     follows, we fall back to the heuristic that swallows lines until we
     hit a section that's not [mcp_servers.*]/[plugins.*]/[permissions]/
-    a `default_permissions =` key. This matches what older versions of
-    this code wrote so re-runs don't break configs from prior Hermes
-    versions."""
+    a managed root permission key. This matches what older versions of this
+    code wrote so re-runs don't break configs from prior Hermes versions."""
     lines = toml_text.splitlines(keepends=True)
     out: list[str] = []
     in_managed = False
@@ -627,14 +623,12 @@ def migrate(
             into [plugins."<name>@<marketplace>"] entries. Set False to
             skip the subprocess spawn (for tests or restricted environments).
         default_permission_profile: when set (default ":workspace"), write
-            top-level `default_permissions = "<name>"` so users on this
-            runtime don't get an approval prompt on every write attempt.
-            Built-in codex profile names are ":workspace", ":read-only",
-            ":danger-no-sandbox" (note the leading ":"). Also accepts a
-            user-defined profile name (no leading ":") that the user has
-            configured in their own [permissions.<name>] table. Set None
-            to leave permissions unset and let codex use its compiled-in
-            default (which is read-only).
+            legacy `sandbox_mode = "<name>"` so users on this runtime don't
+            get an approval prompt on every write attempt. Historical
+            builtin-profile spellings such as ":workspace" are accepted and
+            normalized to Codex's legacy sandbox names. Set None to leave
+            permissions unset and let codex use its compiled-in default
+            (which is read-only).
         expose_hermes_tools: when True (default), register Hermes' own
             tool surface (web_search, browser_*, delegate_task, vision,
             memory, skills, etc.) as an MCP server in ~/.codex/config.toml
@@ -682,10 +676,13 @@ def migrate(
         for p in plugins:
             report.migrated_plugins.append(f"{p['name']}@{p['marketplace']}")
 
-    # Track whether we wrote a default permission profile so the report
+    # Track whether we wrote a default sandbox mode so the report
     # surfaces it to the user.
     if default_permission_profile:
-        report.wrote_permissions_default = default_permission_profile
+        normalized_permission = default_permission_profile.removeprefix(":")
+        if normalized_permission == "workspace":
+            normalized_permission = "workspace-write"
+        report.wrote_permissions_default = normalized_permission
 
     # Inject Hermes' own tool surface as an MCP server so the spawned
     # codex subprocess can call back into Hermes for the tools codex

--- a/tests/gateway/test_response_filters.py
+++ b/tests/gateway/test_response_filters.py
@@ -1,6 +1,11 @@
 from gateway.response_filters import (
+    collapse_user_visible_runtime_error,
     is_intentional_silence_agent_result,
     is_intentional_silence_response,
+    is_model_identity_query,
+    model_identity_private_reply,
+    redact_user_visible_local_paths,
+    sanitize_user_visible_gateway_text,
 )
 
 
@@ -18,3 +23,151 @@ def test_blank_and_prose_mentions_are_not_silence():
 def test_failed_agent_result_never_counts_as_intentional_silence():
     assert is_intentional_silence_agent_result({"failed": False}, "NO_REPLY")
     assert not is_intentional_silence_agent_result({"failed": True}, "NO_REPLY")
+
+
+def test_redacts_user_visible_codex_and_hermes_paths():
+    text = (
+        "Saved image at /home/dgx/.codex/generated_images/abc/image.png "
+        "and cache /home/dgx/.hermes/cache/images/out.png"
+    )
+
+    result = redact_user_visible_local_paths(text)
+
+    assert "/home/dgx/.codex" not in result
+    assert "/home/dgx/.hermes" not in result
+    assert result.count("[local file]") == 2
+
+
+def test_redacts_general_user_home_paths():
+    text = '日志文件：`"/home/dgx/.hermes/logs/gateway.log"` 和 /home/dgx/github/file.txt'
+
+    result = redact_user_visible_local_paths(text)
+
+    assert "/home/dgx/" not in result
+    assert result.count("[local file]") == 2
+
+
+def test_can_skip_path_redaction_before_media_extraction():
+    text = "图片在 /home/dgx/.codex/generated_images/a/out.png，Hermes 会发送。"
+
+    result = sanitize_user_visible_gateway_text(text, redact_paths=False)
+
+    assert "/home/dgx/.codex/generated_images/a/out.png" in result
+    assert "Hermes" not in result
+    assert "当前模型服务" in result
+
+
+def test_preserves_media_directive_path_for_attachment_extraction():
+    text = (
+        "Done.\n"
+        "MEDIA:/home/dgx/.codex/generated_images/abc/image.png\n"
+        "Visible path: /home/dgx/.codex/generated_images/abc/image.png"
+    )
+
+    result = redact_user_visible_local_paths(text)
+
+    assert "MEDIA:/home/dgx/.codex/generated_images/abc/image.png" in result
+    assert "Visible path: [local file]" in result
+
+
+def test_preserves_quoted_media_directive_path():
+    text = 'MEDIA:"/home/dgx/.hermes/cache/images/out.png"'
+
+    result = redact_user_visible_local_paths(text)
+
+    assert result == text
+
+
+def test_sanitizes_model_identity_from_user_visible_text():
+    text = (
+        "我是 GPT-5.5，通过 openai-codex / codex_app_server 运行，"
+        "后端是 OpenAI。"
+    )
+
+    result = sanitize_user_visible_gateway_text(text)
+
+    assert "GPT-5.5" not in result
+    assert "openai-codex" not in result
+    assert "codex_app_server" not in result
+    assert "OpenAI" not in result
+    assert "当前大模型" in result
+    assert "当前模型服务" in result
+
+
+def test_sanitizes_codex_context_status_notice():
+    text = (
+        "Codex gpt-5.5 caps context at 272K, so auto-compaction was raised."
+    )
+
+    result = sanitize_user_visible_gateway_text(text)
+
+    assert "Codex" not in result
+    assert "gpt-5.5" not in result
+    assert "当前模型服务" in result
+    assert "当前大模型" in result
+
+
+def test_sanitizes_hermes_identity_from_user_visible_text():
+    text = "这是 Hermes / hermes-agent 提供的回复。"
+
+    result = sanitize_user_visible_gateway_text(text)
+
+    assert "Hermes" not in result
+    assert "hermes-agent" not in result
+    assert result.count("当前模型服务") == 2
+
+
+def test_sanitizes_recent_gateway_log_leak_example():
+    text = (
+        '主人，月见喵找到了当前系统的日志文件：`"/home/dgx/.hermes/logs/gateway.log"`，'
+        "共 433 行。"
+    )
+
+    result = sanitize_user_visible_gateway_text(text)
+
+    assert "/home/dgx" not in result
+    assert ".hermes" not in result
+    assert "主人，月见喵找到了" in result
+    assert "[local file]" in result
+
+
+def test_collapses_raw_runtime_failure_dump_before_gateway_delivery():
+    text = (
+        '⚠️ turn ended status=failed: {"type":"error","status":400,'
+        '"error":{"type":"invalid_request_error"}}\n'
+        "当前模型服务 stderr (last 12 lines):\n"
+        "<!doctype html><html><title>Cloudflare</title><script>cf_chl</script>"
+    )
+
+    result = sanitize_user_visible_gateway_text(text)
+
+    assert "调用失败" in result
+    assert "turn ended" not in result
+    assert "stderr" not in result
+    assert "Cloudflare" not in result
+    assert "cf_chl" not in result
+    assert "<html" not in result
+
+
+def test_preserves_normal_text_when_collapsing_runtime_errors():
+    text = "这是一条正常回复，提到了 Cloudflare 的公开概念。"
+
+    assert collapse_user_visible_runtime_error(text) == text
+
+
+def test_detects_current_assistant_model_identity_queries():
+    assert is_model_identity_query("你现在用的是什么大模型")
+    assert is_model_identity_query("你是什么大模型和什么程序？")
+    assert is_model_identity_query("what model are you running?")
+
+
+def test_does_not_block_general_model_recommendation_question():
+    assert not is_model_identity_query("帮我推荐一个适合写代码的大模型")
+
+
+def test_model_identity_private_reply_has_no_specific_backend_names():
+    reply = model_identity_private_reply()
+
+    assert "GPT" not in reply
+    assert "Codex" not in reply
+    assert "OpenAI" not in reply

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -505,6 +505,53 @@ class TestWeixinChunkDelivery:
 
 
 class TestWeixinOutboundMedia:
+    def test_send_long_text_reply_as_preview_and_attachment(self, tmp_path):
+        adapter = _make_adapter()
+        adapter._hermes_home = str(tmp_path)
+        adapter._send_session = object()
+        adapter._token = "test-token"
+        adapter._token_store.get = lambda account_id, chat_id: None
+        adapter._send_text_chunk = AsyncMock()
+        adapter.send_document = AsyncMock(return_value=SendResult(success=True, message_id="doc-1"))
+
+        long_reply = "完整回复内容\n" + ("很长的内容。" * 900)
+
+        result = asyncio.run(adapter.send("wxid_test123", long_reply))
+
+        assert result.success is True
+        assert result.message_id == "doc-1"
+        adapter._send_text_chunk.assert_awaited_once()
+        preview = adapter._send_text_chunk.await_args.kwargs["chunk"]
+        assert "这次回复较长" in preview
+        assert "预览：" in preview
+        assert len(preview) < adapter.MAX_MESSAGE_LENGTH
+        adapter.send_document.assert_awaited_once()
+        attachment_path = adapter.send_document.await_args.kwargs["file_path"]
+        assert attachment_path.endswith(".md")
+        with open(attachment_path, encoding="utf-8") as handle:
+            assert handle.read() == adapter.format_message(long_reply)
+
+    def test_send_long_text_reply_reports_attachment_failure_without_resending_full_text(self, tmp_path):
+        adapter = _make_adapter()
+        adapter._hermes_home = str(tmp_path)
+        adapter._send_session = object()
+        adapter._token = "test-token"
+        adapter._token_store.get = lambda account_id, chat_id: None
+        adapter._send_text_chunk = AsyncMock()
+        adapter.send_document = AsyncMock(return_value=SendResult(success=False, error="upload failed"))
+
+        long_reply = "x" * 5000
+
+        result = asyncio.run(adapter.send("wxid_test123", long_reply))
+
+        assert result.success is True
+        assert adapter.send_document.await_count == 1
+        assert adapter._send_text_chunk.await_count == 2
+        sent_chunks = [call.kwargs["chunk"] for call in adapter._send_text_chunk.await_args_list]
+        assert all(len(chunk) < adapter.MAX_MESSAGE_LENGTH for chunk in sent_chunks)
+        assert all(chunk != long_reply for chunk in sent_chunks)
+        assert "附件发送失败" in sent_chunks[-1]
+
     def test_send_image_file_accepts_keyword_image_path(self):
         adapter = _make_adapter()
         expected = SendResult(success=True, message_id="msg-1")

--- a/tests/hermes_cli/test_codex_runtime_plugin_migration.py
+++ b/tests/hermes_cli/test_codex_runtime_plugin_migration.py
@@ -319,17 +319,14 @@ class TestMigrate:
         assert "no MCP servers" in text or "no MCP servers, plugins, or permissions" in text
 
     def test_no_servers_still_writes_permissions_default(self, tmp_path):
-        """Even with zero MCP servers, enabling the runtime should write the
-        default permissions profile so users don't get prompted on every
-        write attempt. This is the fix for quirk #2."""
+        """Even with zero MCP servers, enabling the runtime should write a
+        sandbox mode so users don't get prompted on every write attempt."""
         report = migrate({}, codex_home=tmp_path, discover_plugins=False, expose_hermes_tools=False)
         assert report.written
         text = (tmp_path / "config.toml").read_text()
-        # Codex's schema: top-level `default_permissions` keying a built-in
-        # profile name (prefixed with ":"). NOT a [permissions] section
-        # (which is for *user-defined* profiles with structured fields).
-        assert 'default_permissions = ":workspace"' in text
-        assert report.wrote_permissions_default == ":workspace"
+        assert 'sandbox_mode = "workspace-write"' in text
+        assert "default_permissions" not in text
+        assert report.wrote_permissions_default == "workspace-write"
 
     def test_explicit_none_permissions_skips_block(self, tmp_path):
         report = migrate({"mcp_servers": {"x": {"command": "y"}}},
@@ -575,8 +572,8 @@ class TestMigrate:
 
     def test_managed_root_keys_stay_top_level_when_config_ends_in_table(self, tmp_path):
         """TOML has no explicit 'leave current table' syntax. If Hermes appends
-        root keys like default_permissions after a user table such as [features],
-        Codex parses them as features.default_permissions and rejects the config.
+        root keys like sandbox_mode after a user table such as [features],
+        Codex parses them as features.sandbox_mode and rejects the config.
         The managed block must therefore be inserted before the first table."""
         import tomllib
 
@@ -590,8 +587,8 @@ class TestMigrate:
         migrate({}, codex_home=tmp_path, discover_plugins=False, expose_hermes_tools=False)
         new_text = target.read_text()
         parsed = tomllib.loads(new_text)
-        assert parsed["default_permissions"] == ":workspace"
-        assert "default_permissions" not in parsed["features"]
+        assert parsed["sandbox_mode"] == "workspace-write"
+        assert "sandbox_mode" not in parsed["features"]
         assert new_text.index(MIGRATION_MARKER) < new_text.index("[features]")
 
     def test_preserves_user_mcp_server_outside_managed_block(self, tmp_path):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -15,6 +15,7 @@ import time
 from email.utils import formatdate
 
 from agent.redact import redact_sensitive_text
+from gateway.response_filters import sanitize_user_visible_gateway_text
 
 logger = logging.getLogger(__name__)
 
@@ -374,6 +375,7 @@ def _handle_send(args):
 
     media_files, cleaned_message = BasePlatformAdapter.extract_media(message)
     media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    cleaned_message = sanitize_user_visible_gateway_text(cleaned_message)
     mirror_text = cleaned_message.strip() or _describe_media_for_mirror(media_files)
 
     used_home_channel = False


### PR DESCRIPTION
## Summary
- write Codex runtime migration defaults with `sandbox_mode` instead of `default_permissions`
- sanitize user-visible gateway responses to hide local paths, concrete model/runtime identifiers, and raw runtime error dumps
- send long Weixin replies as preview text plus a Markdown attachment
- honor gateway display notification toggles for tool progress and self-improvement notifications

## Validation
- `./scripts/run_tests.sh tests/gateway/test_response_filters.py tests/gateway/test_weixin.py tests/hermes_cli/test_codex_runtime_plugin_migration.py`
