### PR TITLE
fix(cron): reset cron-delivery ContextVars to _UNSET after a job

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2517,7 +2517,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 
     # Use ContextVars for per-job session/delivery state so parallel jobs
     # don't clobber each other's targets (os.environ is process-global).
-    from gateway.session_context import set_session_vars, clear_session_vars, _VAR_MAP
+    from gateway.session_context import set_session_vars, clear_session_vars, reset_cron_delivery_vars, _VAR_MAP
 
     # Cron execution is an internal scheduler context, not a live inbound
     # gateway message. Do not seed HERMES_SESSION_* contextvars from the
@@ -3113,8 +3113,12 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             _terminal_cwd_lock.release_read()
         # Clean up ContextVar session/delivery state for this job.
         clear_session_vars(_ctx_tokens)
-        for _var_name in _cron_delivery_vars:
-            _VAR_MAP[_var_name].set("")
+        # Restore the cron-delivery vars to their *never set* (_UNSET) state, not
+        # "" — an empty string suppresses the os.environ fallback in
+        # get_session_env, so setting "" here would leak an empty cron-delivery
+        # value into every later caller in this thread/task (cross-run / cross-
+        # test pollution). reset_cron_delivery_vars() returns them to _UNSET.
+        reset_cron_delivery_vars()
         if _session_db:
             # Title the cron session from the job (name → short prompt → id) so
             # sidebars/history show a meaningful label instead of the injected

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -290,6 +290,28 @@ def reset_session_vars() -> None:
         pass
 
 
+def reset_cron_delivery_vars() -> None:
+    """Restore the cron auto-delivery ContextVars to their *never set* state.
+
+    Distinct from setting them to ``""``: an empty string is the
+    "explicitly cleared" state that suppresses the ``os.environ`` fallback in
+    ``get_session_env`` (correct WHILE a job runs, so a job's own
+    ``send_message`` can detect a duplicate auto-delivery target). After a job
+    finishes, the vars must be returned to the ``_UNSET`` sentinel so the next
+    caller in the same thread/task falls back to ``os.environ`` again. Without
+    this, a cron run leaks an empty cron-delivery value into every later caller
+    in the process — observed as cross-test pollution where a later
+    ``send_message`` no longer detects the cron duplicate-target case because
+    the ContextVar shadows the env the caller set.
+    """
+    for var in (
+        _CRON_AUTO_DELIVER_PLATFORM,
+        _CRON_AUTO_DELIVER_CHAT_ID,
+        _CRON_AUTO_DELIVER_THREAD_ID,
+    ):
+        var.set(_UNSET)
+
+
 def get_session_env(name: str, default: str = "") -> str:
     """Read a session context variable by its legacy ``HERMES_SESSION_*`` name.
 

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -394,3 +394,59 @@ async def test_gateway_executor_refuses_resurrection_after_shutdown():
     finally:
         runner._shutdown_executor()
 
+
+# ---------------------------------------------------------------------------
+# reset_cron_delivery_vars: cron auto-delivery vars must return to the *never
+# set* (_UNSET) state after a job, NOT "" — otherwise an empty value leaks
+# into every later same-thread caller and shadows the os.environ fallback.
+# ---------------------------------------------------------------------------
+
+from gateway.session_context import (  # noqa: E402
+    reset_cron_delivery_vars,
+    _CRON_AUTO_DELIVER_PLATFORM,
+    _CRON_AUTO_DELIVER_CHAT_ID,
+    _CRON_AUTO_DELIVER_THREAD_ID,
+)
+
+_CRON_DELIVERY_VARS = (
+    "HERMES_CRON_AUTO_DELIVER_PLATFORM",
+    "HERMES_CRON_AUTO_DELIVER_CHAT_ID",
+    "HERMES_CRON_AUTO_DELIVER_THREAD_ID",
+)
+
+
+def test_reset_cron_delivery_vars_restores_unset_sentinel():
+    """After a cron job, the delivery vars must hold _UNSET, not ""."""
+    # Simulate run_job setting the delivery target during execution.
+    _CRON_AUTO_DELIVER_PLATFORM.set("telegram")
+    _CRON_AUTO_DELIVER_CHAT_ID.set("-1001")
+    _CRON_AUTO_DELIVER_THREAD_ID.set("")
+
+    reset_cron_delivery_vars()
+
+    assert _CRON_AUTO_DELIVER_PLATFORM.get() is _UNSET
+    assert _CRON_AUTO_DELIVER_CHAT_ID.get() is _UNSET
+    assert _CRON_AUTO_DELIVER_THREAD_ID.get() is _UNSET
+
+
+def test_reset_cron_delivery_vars_reenables_environ_fallback(monkeypatch):
+    """The bug: a cron run set the vars to "" (the explicitly-cleared state),
+    which suppresses the os.environ fallback in get_session_env, so a later
+    same-thread caller read "" instead of the env it had set. After the fix,
+    reset_cron_delivery_vars() returns the vars to _UNSET so the fallback works.
+    """
+    # A later caller (e.g. send_message) relies on the env var.
+    monkeypatch.setenv("HERMES_CRON_AUTO_DELIVER_PLATFORM", "discord")
+    monkeypatch.setenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID", "999")
+
+    # Reproduce the OLD leak: a finished cron job left the vars at "".
+    _CRON_AUTO_DELIVER_PLATFORM.set("")
+    _CRON_AUTO_DELIVER_CHAT_ID.set("")
+    # With "" set, the contextvar shadows os.environ — fallback suppressed.
+    assert get_session_env("HERMES_CRON_AUTO_DELIVER_PLATFORM") == ""
+    assert get_session_env("HERMES_CRON_AUTO_DELIVER_CHAT_ID") == ""
+
+    # The fix restores _UNSET, so get_session_env falls back to os.environ.
+    reset_cron_delivery_vars()
+    assert get_session_env("HERMES_CRON_AUTO_DELIVER_PLATFORM") == "discord"
+    assert get_session_env("HERMES_CRON_AUTO_DELIVER_CHAT_ID") == "999"


### PR DESCRIPTION
## What & why

`run_job()` sets the `HERMES_CRON_AUTO_DELIVER_*` ContextVars while a job runs
so the job's own `send_message` can detect a duplicate auto-delivery target.
The cleanup in the `finally` block reset them with `var.set("")`.

The problem: in `gateway/session_context.py`, `""` is the **explicitly-cleared**
state that intentionally *suppresses the `os.environ` fallback* in
`get_session_env` — it is **not** the same as the `_UNSET` "never set" sentinel.
So once a cron job finishes, the three auto-delivery vars stay at `""` for the
lifetime of that thread/task, and every later caller in the same process reads
an empty cron-delivery value instead of falling back to `os.environ`.

Consequences:
- **Production:** in a long-lived scheduler process, a finished cron job can
  shadow a later same-thread caller's auto-delivery environment.
- **Tests:** it manifests as cross-file pollution — after
  `tests/cron/test_scheduler.py` runs, the duplicate-target detection in
  `tests/tools/test_send_message_tool.py::test_cron_duplicate_target_is_skipped_and_explained`
  fails with `KeyError: 'skipped'` because it reads the leaked empty ContextVar
  instead of the env it set. The test passes in isolation, which is the
  classic ordering-dependent symptom.

## The fix

- Add `session_context.reset_cron_delivery_vars()`, which restores the three
  `HERMES_CRON_AUTO_DELIVER_*` vars to the `_UNSET` sentinel (re-enabling the
  `os.environ` fallback for later callers).
- Call it in `run_job()`'s `finally` cleanup instead of the `set("")` loop.

The per-job `set("")` at job **start** is deliberately unchanged: each job
should begin from a clean explicitly-empty state before its delivery target is
resolved, so a job that resolves no target can't inherit the previous job's.
Only the post-job cleanup is corrected.

## How to test

```bash
# The fix in isolation:
pytest tests/gateway/test_session_env.py -q

# The ordering-dependent failure this resolves (red before, green after):
pytest tests/cron/test_scheduler.py \
       tests/tools/test_send_message_tool.py::TestSendMessageTool::test_cron_duplicate_target_is_skipped_and_explained -q
```

New regression tests in `tests/gateway/test_session_env.py` assert that
`reset_cron_delivery_vars()` returns the vars to `_UNSET` and that
`get_session_env`'s `os.environ` fallback works again after a reset.

Local run: `tests/cron/test_scheduler.py` (136) + `tests/gateway/test_session_env.py`
(15, incl. 2 new) + the previously order-dependent send_message test all green
(152 passed together).

## Platforms tested

Linux (Python 3.11). The change is pure ContextVar lifecycle management with no
OS-specific behavior.

## Related

- #43370 — fixes the sibling `HERMES_CRON_SESSION` approval-mode leak via the
  `set_session_vars`/token mechanism. That PR does **not** touch the
  auto-delivery vars; this is the same bug class for the delivery-target path.
- #8866 — cron delivery target reliability.

---
*Rebased onto current `main` (2026-06-26). Conflict in `tests/gateway/test_session_env.py`: main added new executor tests (`..._survives_default_executor_shutdown`, `..._refuses_resurrection_after_shutdown`) in the same region as this PR's `reset_cron_delivery_vars` tests; resolved by keeping **both** blocks. `cron/scheduler.py` + `gateway/session_context.py` auto-merged clean. Verified: session_env + cron suites = **594 passed**.*