### PR TITLE
fix(copilot): derive api_mode from target_model, not config default

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -221,13 +221,25 @@ def _provider_supports_explicit_api_mode(provider: Optional[str], configured_pro
     return normalized_configured == normalized_provider
 
 
-def _copilot_runtime_api_mode(model_cfg: Dict[str, Any], api_key: str) -> str:
+def _copilot_runtime_api_mode(
+    model_cfg: Dict[str, Any],
+    api_key: str,
+    target_model: Optional[str] = None,
+) -> str:
     configured_provider = str(model_cfg.get("provider") or "").strip().lower()
     configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
     if configured_mode and _provider_supports_explicit_api_mode("copilot", configured_provider):
         return configured_mode
 
-    model_name = str(model_cfg.get("default") or "").strip()
+    # Prefer the model actually being resolved (e.g. a /model mid-session
+    # switch in the WebUI/gateway) over the persisted model.default. Copilot
+    # serves GPT-5.x via the Responses API but Claude/Gemini via Chat
+    # Completions, so computing api_mode from a stale config default (e.g.
+    # claude-opus while switching TO gpt-5.5) sends gpt-5.5 to
+    # /chat/completions and the upstream rejects it with
+    # 400 unsupported_api_for_model. Mirrors the opencode-zen/go target_model
+    # fix below.
+    model_name = str(target_model or model_cfg.get("default") or "").strip()
     if not model_name:
         return "chat_completions"
 
@@ -342,7 +354,11 @@ def _resolve_runtime_from_pool_entry(
     elif provider == "nous":
         api_mode = "chat_completions"
     elif provider == "copilot":
-        api_mode = _copilot_runtime_api_mode(model_cfg, getattr(entry, "runtime_api_key", ""))
+        api_mode = _copilot_runtime_api_mode(
+            model_cfg,
+            getattr(entry, "runtime_api_key", ""),
+            target_model=effective_model,
+        )
         base_url = base_url or PROVIDER_REGISTRY["copilot"].inference_base_url
     elif provider == "azure-foundry":
         # Azure Foundry: read api_mode and base_url from config
@@ -1163,6 +1179,7 @@ def _resolve_explicit_runtime(
     model_cfg: Dict[str, Any],
     explicit_api_key: Optional[str] = None,
     explicit_base_url: Optional[str] = None,
+    target_model: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     explicit_api_key = str(explicit_api_key or "").strip()
     explicit_base_url = str(explicit_base_url or "").strip().rstrip("/")
@@ -1282,7 +1299,7 @@ def _resolve_explicit_runtime(
 
         api_mode = "chat_completions"
         if provider == "copilot":
-            api_mode = _copilot_runtime_api_mode(model_cfg, api_key)
+            api_mode = _copilot_runtime_api_mode(model_cfg, api_key, target_model=target_model)
         elif provider == "xai":
             api_mode = "codex_responses"
         else:
@@ -1383,6 +1400,7 @@ def resolve_runtime_provider(
         model_cfg=model_cfg,
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
+        target_model=target_model,
     )
     if explicit_runtime:
         return explicit_runtime
@@ -1722,7 +1740,7 @@ def resolve_runtime_provider(
         base_url = cfg_base_url or creds.get("base_url", "").rstrip("/")
         api_mode = "chat_completions"
         if provider == "copilot":
-            api_mode = _copilot_runtime_api_mode(model_cfg, creds.get("api_key", ""))
+            api_mode = _copilot_runtime_api_mode(model_cfg, creds.get("api_key", ""), target_model=target_model)
         elif provider == "xai":
             api_mode = "codex_responses"
         else:

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2775,3 +2775,75 @@ def test_host_derived_key_helper_basic_cases():
     for k in ("DEEPSEEK_API_KEY", "GROQ_API_KEY", "MISTRAL_API_KEY",
               "OPENAI_API_KEY", "OPENROUTER_API_KEY"):
         _os.environ.pop(k, None)
+
+
+def _copilot_runtime(monkeypatch, *, config_default, target_model):
+    """Resolve a Copilot runtime with a given config default + target model.
+
+    Helper for the api_mode regression tests below. Stubs the credential
+    layer so no real GitHub token is needed.
+    """
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "copilot")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {"provider": "copilot", "default": config_default},
+    )
+    monkeypatch.setattr(
+        rp,
+        "load_pool",
+        lambda provider: type("Pool", (), {"has_credentials": lambda self: False})(),
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_api_key_provider_credentials",
+        lambda provider: {
+            "provider": "copilot",
+            "api_key": "ghu_test_token",
+            "source": "env:COPILOT_GITHUB_TOKEN",
+        },
+    )
+    # The Copilot api_mode helper consults the model catalog/network; force the
+    # deterministic pattern-only path used by _should_use_copilot_responses_api.
+    from hermes_cli import models as _models
+    monkeypatch.setattr(
+        _models,
+        "normalize_copilot_model_id",
+        lambda model_id, **kw: model_id,
+    )
+    return rp.resolve_runtime_provider(requested="copilot", target_model=target_model)
+
+
+def test_copilot_api_mode_follows_target_model_gpt5(monkeypatch):
+    """Regression: switching TO gpt-5.x must route to the Responses API even
+    when config.default is a Chat-Completions model (e.g. Claude).
+
+    Before the fix, _copilot_runtime_api_mode ignored target_model and read
+    model.default, so a WebUI/gateway switch from claude-opus to gpt-5.5 left
+    api_mode='chat_completions' and the upstream rejected gpt-5.5 with
+    400 unsupported_api_for_model.
+    """
+    resolved = _copilot_runtime(
+        monkeypatch, config_default="claude-opus-4.8", target_model="gpt-5.5"
+    )
+    assert resolved["provider"] == "copilot"
+    assert resolved["api_mode"] == "codex_responses"
+
+
+def test_copilot_api_mode_follows_target_model_claude(monkeypatch):
+    """Inverse guard: switching TO a Claude model keeps Chat Completions even
+    when config.default is a GPT-5.x model (no over-correction to Responses)."""
+    resolved = _copilot_runtime(
+        monkeypatch, config_default="gpt-5.5", target_model="claude-opus-4.8"
+    )
+    assert resolved["provider"] == "copilot"
+    assert resolved["api_mode"] == "chat_completions"
+
+
+def test_copilot_api_mode_gpt5_mini_stays_chat_completions(monkeypatch):
+    """gpt-5-mini is the documented Copilot exception that still uses Chat
+    Completions despite matching the gpt-5* prefix."""
+    resolved = _copilot_runtime(
+        monkeypatch, config_default="claude-opus-4.8", target_model="gpt-5-mini"
+    )
+    assert resolved["api_mode"] == "chat_completions"


### PR DESCRIPTION
## Summary

Fixes a 400 error when switching to a non-default GitHub Copilot model (e.g. `gpt-5.5`) from the **WebUI / API-server / gateway** path:

```
Error code: 400 - model "gpt-5.5" is not accessible via the
/chat/completions endpoint  (code: unsupported_api_for_model)
```

## Root cause

GPT-5.x models on Copilot require the **Responses API** (`/responses`), while Claude/Gemini use Chat Completions. `_copilot_runtime_api_mode()` decided the wire protocol from `model_cfg["default"]` (the persisted config default) and **ignored the `target_model` actually being resolved**.

So with a Chat-Completions default and a mid-session switch to a Responses-only target:

1. `resolve_runtime_provider(target_model="<responses-only-target>")` is called correctly with the new model.
2. The Copilot branch computed `api_mode` from the configured default → `chat_completions`.
3. the Responses-only target was sent to `/chat/completions` → upstream rejects with `400 unsupported_api_for_model`.

The classic CLI path was unaffected because `cli.py` independently recomputes `api_mode` via `copilot_model_api_mode()` after a `/model` switch. Only the WebUI/gateway path (which trusts `resolve_runtime_provider`'s result) hit the bug.

## Fix

Thread `target_model` through `_copilot_runtime_api_mode()` and all three of its call sites:

- `_resolve_runtime_from_pool_entry` (passes the already-computed `effective_model`)
- `_resolve_explicit_runtime` (new `target_model` param, forwarded from `resolve_runtime_provider`)
- the api-key provider branch in `resolve_runtime_provider`

This mirrors the existing `opencode-zen/go` `target_model` handling a few lines below (`_effective = target_model or model_cfg.get("default", "")`), which fixed the same class of bug (#16878). When `target_model` is `None` (callers that don't switch models), behavior is unchanged — it falls back to `model_cfg["default"]`.

## Tests

Adds three regression tests in `tests/hermes_cli/test_runtime_provider_resolution.py`:

- `test_copilot_api_mode_follows_target_model_gpt5` — `gpt-5.5` → `codex_responses` even when config default is Claude (the reported bug)
- `test_copilot_api_mode_follows_target_model_claude` — inverse guard: Claude target stays `chat_completions` even when config default is `gpt-5.5` (no over-correction)
- `test_copilot_api_mode_gpt5_mini_stays_chat_completions` — preserves the documented `gpt-5-mini` exception

Verified the new tests fail before the fix and pass after. Full `tests/hermes_cli/` runtime-provider + copilot + model-validation suites pass (236 tests). Also smoke-tested against the live Copilot backend: `gpt-5.5` now resolves to `codex_responses` and responds successfully instead of 400.
