### PR TITLE
feat(skill): Push notifications to iOS devices via Bark

### DIFF
--- a/skills/productivity/bark/SKILL.md
+++ b/skills/productivity/bark/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: bark
+description: Push notifications to iOS devices via Bark.
+version: 1.0.0
+author: Randool
+license: MIT
+platforms: [macos, linux, windows]
+required_environment_variables:
+  - name: BARK_TOKEN
+    prompt: Bark device token
+    help: Open Bark app on iPhone; the token is the last segment of the URL shown on the home page (e.g. https://api.day.app/XXXX → XXXX)
+    required_for: all functionality
+metadata:
+  hermes:
+    tags: [notification, ios, apple, push]
+---
+
+# Bark Skill
+
+Send free push notifications to iOS devices via [Bark](https://github.com/finb/bark). Supports title/subtitle/body, custom sounds, notification levels (including critical alerts), and end-to-end encryption.
+
+Does not support Android — use ntfy, Gotify, or Telegram Bot for cross-platform needs.
+
+## When to Use
+
+- Notify the user after long-running tasks (builds, training, report generation)
+- Push cron job execution results
+- Monitoring alerts (threshold triggers, anomaly detection)
+- Any "let me know when it's done" scenario
+
+## Prerequisites
+
+1. Install **Bark** from the iOS App Store (by Finb) and allow push notifications
+2. Copy the device token from the Bark app home page (the last segment of the URL, e.g. `https://api.day.app/XXXX`)
+3. Set the `BARK_TOKEN` environment variable — the skill will prompt for it on first load if not configured
+
+## How to Run
+
+All pushes are executed through the `terminal` tool using `curl`.
+
+**Simple push (GET):**
+```bash
+curl "https://api.day.app/$BARK_TOKEN/Hello%20from%20Hermes"
+```
+
+**Title + body (GET):**
+```bash
+curl "https://api.day.app/$BARK_TOKEN/Task%20Complete/Report%20generated"
+```
+
+**Full-featured push (POST JSON):**
+```bash
+curl -X POST "https://api.day.app/$BARK_TOKEN" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  -d '{"title":"Task Complete","body":"Report generated","sound":"minuet"}'
+```
+
+## Quick Reference
+
+| Goal | Method |
+|------|--------|
+| Simple push | `GET /$TOKEN/body` |
+| Title + body | `GET /$TOKEN/title/body` |
+| Full features | `POST /$TOKEN` with JSON body |
+| Batch push | `POST /push` with `device_keys` array |
+| Critical alert | `"level":"critical"` in POST body |
+| Withdraw notification | `POST` with `{"id":"...","delete":"1"}` |
+
+## Procedure
+
+1. Ensure `BARK_TOKEN` is set (the skill prompts on first use if missing)
+2. Choose GET (simple) or POST (full-featured) based on your needs
+3. For GET: URL-encode the message and call the endpoint via `terminal`
+4. For POST: build a JSON body with desired parameters and call via `terminal`
+5. Check the response — `{"code":200,"message":"success"}` means delivered
+
+## Pitfalls
+
+- **GET URL length limits**: Use POST JSON for content longer than ~200 characters
+- **URL encoding**: GET requests require URL-encoding of spaces, non-ASCII, and special characters (`&`, `?`, etc.)
+- **Delivery not guaranteed**: iOS may throttle or drop notifications under heavy load
+- **Critical alerts**: Require iOS to grant critical alert permission to Bark in Settings
+- **Self-hosted Bark**: Replace `api.day.app` with your server address in all commands
+
+## Verification
+
+Send a test notification:
+
+```bash
+curl "https://api.day.app/$BARK_TOKEN/Bark%20configured%20successfully"
+```
+
+Expected response: `{"code":200,"message":"success"}`. Confirm the notification appears on the iOS device.


### PR DESCRIPTION
## What does this PR do?

Adds a new `bark` skill under `skills/productivity/` that enables Hermes to send free push notifications to iOS devices via the [Bark](https://github.com/finb/bark) app. This gives users a lightweight, zero-cost way to receive task completion alerts, cron job results, and monitoring notifications on their iPhone without relying on paid services or cross-platform messaging bots.

The skill uses only `curl` via the `terminal` tool — no external dependencies — and supports both simple GET pushes and full-featured POST JSON payloads (custom sounds, notification levels including critical alerts, and notification withdrawal).

## Type of Change

- [x] 🎯 New skill (bundled or hub)

## Changes Made

- `skills/productivity/bark/SKILL.md` — New skill: Bark iOS push notifications via `api.day.app`

## How to Test

1. Install Bark from the iOS App Store and copy the device token from the app's home page URL
2. Set the environment variable: `export BARK_TOKEN=***
3. Run a simple push test: `curl "https://api.day.app/$BARK_TOKEN/Hello%20from%20Hermes"`
4. Verify the notification appears on the iOS device and the response is `{"code":200,"message":"success"}`
5. Test a full-featured POST push with title, body, and sound parameters
6. Test end-to-end via Hermes: `hermes --toolsets skills -q "Use the bark skill to send a push notification saying 'test complete'"`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(skills): add bark iOS push notification skill`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x (Sequoia)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — skill declares `platforms: [macos, linux, windows]` and uses only `curl` which is available on all three
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [x] This skill is **broadly useful** to most users (if bundled) — iOS push notifications are a common need for task completion alerts, cron results, and monitoring; Bark is free and requires no server setup
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter with name/description/version/author/license/platforms, trigger conditions via `## When to Use`, numbered procedure steps, pitfalls section, verification steps)
- [x] No external dependencies that aren't already available — uses only `curl` via the `terminal` tool
- [x] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the bark skill to send a push notification"`

## Screenshots / Logs

<img width="1206" height="275" alt="IMG_7810" src="https://github.com/user-attachments/assets/356e38fa-94c4-4251-a897-b7dc4117250c" />
