### PR TITLE
feat(cron): support reusable sessions

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -325,6 +325,26 @@ def _jobs_lock():
 # updated lets an unsafe value (``../escape``, absolute path, nested) leak
 # into output writes/deletes.
 _IMMUTABLE_JOB_FIELDS = frozenset({"id"})
+_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
+
+
+def normalize_session_id(session: Optional[Any]) -> Optional[str]:
+    """Normalize an optional reusable cron-owned session id.
+
+    The value becomes a SessionDB primary key and may also be used in prompt
+    cache and optional JSON snapshot keys, so keep it portable and path-safe.
+    """
+    if session is None:
+        return None
+    text = str(session).strip()
+    if not text:
+        return None
+    if not _SESSION_ID_RE.fullmatch(text):
+        raise ValueError(
+            "Cron session must be 1-64 characters, start with a letter or digit, "
+            "and contain only letters, digits, '_' or '-'."
+        )
+    return text
 
 
 def _job_output_dir(job_id: str) -> Path:
@@ -419,6 +439,7 @@ def _normalize_job_record(job: Dict[str, Any]) -> Dict[str, Any]:
         name = label_source[:50].strip() or "cron job"
     normalized["name"] = name
     normalized["schedule_display"] = _schedule_display_for_job(normalized)
+    normalized["session"] = _coerce_job_text(normalized.get("session")).strip() or None
 
     state = _coerce_job_text(normalized.get("state")).strip()
     if not state:
@@ -1052,6 +1073,7 @@ def create_job(
     context_from: Optional[Union[str, List[str]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
+    session: Optional[str] = None,
     no_agent: bool = False,
     attach_to_session: Optional[bool] = None,
 ) -> Dict[str, Any]:
@@ -1094,6 +1116,10 @@ def create_job(
                 With ``no_agent=True``, ``workdir`` is still applied as the
                 script's cwd so relative paths inside the script behave
                 predictably.
+        session: Optional reusable cron-owned SessionDB id. Each run resolves
+                compression continuations, loads the latest session history,
+                and appends the new turn to that conversation. Existing
+                sessions owned by another runtime are rejected at execution.
         no_agent: When True, skip the agent entirely — run ``script`` on schedule
                 and deliver its stdout directly. Empty stdout = silent (no
                 delivery). Requires ``script`` to be set. Ideal for classic
@@ -1128,6 +1154,7 @@ def create_job(
     normalized_toolsets = [str(t).strip() for t in enabled_toolsets if str(t).strip()] if enabled_toolsets else None
     normalized_toolsets = normalized_toolsets or None
     normalized_workdir = _normalize_workdir(workdir)
+    normalized_session = normalize_session_id(session)
     normalized_no_agent = bool(no_agent)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
 
@@ -1220,6 +1247,9 @@ def create_job(
         "enabled_toolsets": normalized_toolsets,
         "workdir": normalized_workdir,
     }
+    # Keep legacy jobs byte-identical when reusable-session mode is unset.
+    if normalized_session is not None:
+        job["session"] = normalized_session
     # Only persist attach_to_session when explicitly set, so existing jobs and
     # the common case stay byte-identical (absent key => fall back to the
     # global cron.mirror_delivery config, default off).
@@ -1314,6 +1344,9 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                     updates["workdir"] = None
                 else:
                     updates["workdir"] = _normalize_workdir(_wd)
+
+            if "session" in updates:
+                updates["session"] = normalize_session_id(updates["session"])
 
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -238,7 +238,15 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run, claim_dispatch, heartbeat_run_claim
+from cron.jobs import (
+    advance_next_run,
+    claim_dispatch,
+    get_due_jobs,
+    heartbeat_run_claim,
+    mark_job_run,
+    normalize_session_id,
+    save_job_output,
+)
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
@@ -2548,6 +2556,87 @@ def _guard_job_credential_exfil(job: dict) -> None:
         raise RuntimeError(f"Cron job '{job_id}' blocked for safety: {err}")
 
 
+def _prepare_cron_session(
+    job: dict,
+    session_db,
+) -> tuple[str, Optional[List[dict]]]:
+    """Resolve the session id and history for one cron agent run.
+
+    Jobs without ``session`` retain the legacy timestamped-session behavior.
+    A configured id may create a new cron session or resume an existing
+    cron-owned session, but it may never replay a CLI, gateway, or other
+    runtime's conversation through cron's distinct prompt and tool contract.
+
+    Compression ends a session and continues in a child row. Resolve that
+    chain before reading history or mutating lifecycle state so a configured
+    parent always resumes at its live continuation tip.
+    """
+    job_id = str(job.get("id") or "unknown")
+    configured_session = normalize_session_id(job.get("session"))
+    if not configured_session:
+        return (
+            f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}",
+            None,
+        )
+
+    if session_db is None:
+        raise RuntimeError(
+            f"Cron job '{job_id}' cannot reuse session {configured_session!r}: "
+            "SessionDB is unavailable."
+        )
+
+    try:
+        configured_row = session_db.get_session(configured_session)
+        resolved_session = (
+            session_db.get_compression_tip(configured_session)
+            or configured_session
+        )
+        resolved_row = session_db.get_session(resolved_session)
+    except Exception as exc:
+        raise RuntimeError(
+            f"Cron job '{job_id}' could not resolve reusable session "
+            f"{configured_session!r}: {exc}"
+        ) from exc
+
+    for session_id, row in (
+        (configured_session, configured_row),
+        (resolved_session, resolved_row),
+    ):
+        if row and str(row.get("source") or "").lower() != "cron":
+            source = str(row.get("source") or "unknown")
+            raise RuntimeError(
+                f"Cron job '{job_id}' cannot reuse session {session_id!r}: "
+                f"it is owned by runtime {source!r}, not 'cron'."
+            )
+
+    if configured_row is not None and resolved_row is None:
+        raise RuntimeError(
+            f"Cron job '{job_id}' resolved reusable session "
+            f"{configured_session!r} to missing tip {resolved_session!r}."
+        )
+
+    history: Optional[List[dict]] = None
+    if resolved_row is not None:
+        try:
+            history = session_db.get_messages_as_conversation(resolved_session)
+        except Exception as exc:
+            raise RuntimeError(
+                f"Cron job '{job_id}' could not load reusable session "
+                f"{resolved_session!r}: {exc}"
+            ) from exc
+
+        if resolved_row.get("ended_at") is not None:
+            try:
+                session_db.reopen_session(resolved_session)
+            except Exception as exc:
+                raise RuntimeError(
+                    f"Cron job '{job_id}' could not reopen reusable session "
+                    f"{resolved_session!r}: {exc}"
+                ) from exc
+
+    return resolved_session, history
+
+
 def run_job(
     job: dict, *, defer_agent_teardown: Optional[list] = None
 ) -> tuple[bool, str, str, Optional[str]]:
@@ -2800,6 +2889,8 @@ def run_job(
         return True, "", SILENT_MARKER, None
     origin = _resolve_origin(job)
     _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
+    _cron_history: Optional[List[dict]] = None
+    _manage_cron_session_lifecycle = False
 
     logger.info("Running job '%s' (ID: %s)", job_name, job_id)
     logger.info("Prompt: %s", prompt[:100])
@@ -2838,6 +2929,7 @@ def run_job(
     # below, so clearing HERMES_SESSION_* here does not affect delivery.
     _ctx_tokens = set_session_vars(
         platform="",
+        source="cron",
         chat_id="",
         chat_name="",
     )
@@ -2893,6 +2985,9 @@ def run_job(
     # (every future job blocks on acquire_*); a leaked reader blocks all
     # future writers.  Acquire itself can't leak (it either blocks or returns).
     try:
+        _cron_session_id, _cron_history = _prepare_cron_session(job, _session_db)
+        _manage_cron_session_lifecycle = True
+
         if _job_workdir:
             os.environ["TERMINAL_CWD"] = _job_workdir
             logger.info("Job '%s': using workdir %s", job_id, _job_workdir)
@@ -3260,7 +3355,15 @@ def run_job(
         # env passthrough registrations) when the cron run hops into the worker
         # thread used for inactivity timeout monitoring.
         _cron_context = contextvars.copy_context()
-        _cron_future = _cron_pool.submit(_cron_context.run, agent.run_conversation, prompt)
+        _run_conversation_kwargs = {}
+        if _cron_history is not None:
+            _run_conversation_kwargs["conversation_history"] = _cron_history
+        _cron_future = _cron_pool.submit(
+            _cron_context.run,
+            agent.run_conversation,
+            prompt,
+            **_run_conversation_kwargs,
+        )
         _inactivity_timeout = False
         try:
             if _cron_inactivity_limit is None:
@@ -3457,23 +3560,32 @@ def run_job(
         clear_session_vars(_ctx_tokens)
         for _var_name in _cron_delivery_vars:
             _VAR_MAP[_var_name].set("")
-        if _session_db:
+        if _session_db and _manage_cron_session_lifecycle:
             # Title the cron session from the job (name → short prompt → id) so
             # sidebars/history show a meaningful label instead of the injected
             # "[IMPORTANT: …]" hint that is the session's first message. Set here
             # (not at create time) so the agent's own INSERT keeps model /
-            # system_prompt; this only UPDATEs the title column. The run-time
-            # suffix keeps it unique against the sessions.title index across runs.
+            # system_prompt; this only UPDATEs the title column. Ephemeral runs
+            # keep their timestamp suffix; a reusable cron-owned session keeps
+            # one stable title across runs.
             try:
                 _title_base = " ".join(job_name.split())[:60].strip() or f"cron {job_id}"
-                _cron_title = f"{_title_base} · {_hermes_now().strftime('%b %d %H:%M')}"
-                _session_db.set_session_title(_cron_session_id, _cron_title)
+                _lifecycle_session_id = getattr(agent, "session_id", None)
+                if not isinstance(_lifecycle_session_id, str) or not _lifecycle_session_id:
+                    _lifecycle_session_id = _cron_session_id
+                _cron_title = (
+                    _title_base
+                    if job.get("session")
+                    else f"{_title_base} · {_hermes_now().strftime('%b %d %H:%M')}"
+                )
+                _session_db.set_session_title(_lifecycle_session_id, _cron_title)
             except (Exception, KeyboardInterrupt) as e:
                 logger.debug("Job '%s': failed to set cron session title: %s", job_id, e)
             try:
-                _session_db.end_session(_cron_session_id, "cron_complete")
+                _session_db.end_session(_lifecycle_session_id, "cron_complete")
             except (Exception, KeyboardInterrupt) as e:
                 logger.debug("Job '%s': failed to end session: %s", job_id, e)
+        if _session_db:
             try:
                 _session_db.close()
             except (Exception, KeyboardInterrupt) as e:

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -163,6 +163,9 @@ def cron_list(show_all: bool = False):
         workdir = job.get("workdir")
         if workdir:
             print(f"    Workdir:   {workdir}")
+        session = job.get("session")
+        if session:
+            print(f"    Session:   {session}")
 
         # Execution history
         last_status = job.get("last_status")
@@ -309,6 +312,7 @@ def cron_create(args):
         skills=_normalize_skills(getattr(args, "skill", None), getattr(args, "skills", None)),
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
+        session=getattr(args, "session", None),
         no_agent=getattr(args, "no_agent", False) or None,
     )
     if not result.get("success"):
@@ -326,6 +330,8 @@ def cron_create(args):
         print("  Mode: no-agent (script stdout delivered directly)")
     if job_data.get("workdir"):
         print(f"  Workdir: {job_data['workdir']}")
+    if job_data.get("session"):
+        print(f"  Session: {job_data['session']}")
     print(f"  Next run: {result['next_run_at']}")
     _warn_if_gateway_not_running()
     return 0
@@ -372,6 +378,7 @@ def cron_edit(args):
         skills=final_skills,
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
+        session=getattr(args, "session", None),
         no_agent=getattr(args, "no_agent", None),
     )
     if not result.get("success"):
@@ -392,6 +399,8 @@ def cron_edit(args):
         print("  Mode: no-agent (script stdout delivered directly)")
     if updated.get("workdir"):
         print(f"  Workdir: {updated['workdir']}")
+    if updated.get("session"):
+        print(f"  Session: {updated['session']}")
     return 0
 
 

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -70,6 +70,10 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         "--workdir",
         help="Absolute path for the job to run from. Injects AGENTS.md / CLAUDE.md / .cursorrules from that directory and uses it as the cwd for terminal/file/code_exec tools. Omit to preserve old behaviour (no project context files).",
     )
+    cron_create.add_argument(
+        "--session",
+        help="Reusable cron-owned SessionDB id for this job. Existing CLI or gateway sessions are rejected.",
+    )
 
     # cron edit
     cron_edit = cron_subparsers.add_parser(
@@ -133,6 +137,10 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
     cron_edit.add_argument(
         "--workdir",
         help="Absolute path for the job to run from (injects AGENTS.md etc. and sets terminal cwd). Pass empty string to clear.",
+    )
+    cron_edit.add_argument(
+        "--session",
+        help="Reusable cron-owned SessionDB id for this job. Existing CLI or gateway sessions are rejected. Pass empty string to clear.",
     )
 
     # lifecycle actions

--- a/tests/cron/test_cronjob_schema.py
+++ b/tests/cron/test_cronjob_schema.py
@@ -39,3 +39,13 @@ def test_cronjob_schema_required_array_unchanged():
     from tools.cronjob_tools import CRONJOB_SCHEMA
 
     assert CRONJOB_SCHEMA["parameters"]["required"] == ["action"]
+
+
+def test_cronjob_schema_advertises_reusable_session():
+    from tools.cronjob_tools import CRONJOB_SCHEMA
+
+    session = CRONJOB_SCHEMA["parameters"]["properties"]["session"]
+    assert session["type"] == "string"
+    assert "reusable cron-owned SessionDB id" in session["description"]
+    assert "non-cron sessions are rejected" in session["description"].lower()
+    assert "empty string to clear" in session["description"]

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -341,6 +341,37 @@ class TestJobCRUD:
         job = create_job(prompt="Test", schedule="30m")
         assert job["deliver"] == "local"
 
+    def test_create_with_reusable_session(self, tmp_cron_dir):
+        job = create_job(
+            prompt="Check server status",
+            schedule="every 1h",
+            session="gateway_health_monitor",
+        )
+
+        assert job["session"] == "gateway_health_monitor"
+        assert get_job(job["id"])["session"] == "gateway_health_monitor"
+
+    @pytest.mark.parametrize("session", ["../escape", "bad/session", "bad.session", "-bad"])
+    def test_create_rejects_invalid_reusable_session(self, tmp_cron_dir, session):
+        with pytest.raises(ValueError, match="Cron session"):
+            create_job(prompt="Test", schedule="every 1h", session=session)
+
+    def test_create_empty_reusable_session_is_disabled(self, tmp_cron_dir):
+        job = create_job(prompt="Test", schedule="every 1h", session="")
+
+        assert job.get("session") is None
+
+    def test_reusable_session_preserves_attach_to_session(self, tmp_cron_dir):
+        job = create_job(
+            prompt="Daily brief",
+            schedule="every 1d",
+            session="daily_brief",
+            attach_to_session=True,
+        )
+
+        assert job["session"] == "daily_brief"
+        assert job["attach_to_session"] is True
+
 
 class TestUpdateJob:
     def test_update_name(self, tmp_cron_dir):
@@ -401,6 +432,32 @@ class TestUpdateJob:
         assert updated is not None
         assert updated["schedule"]["kind"] == "once"
         assert updated["next_run_at"] is not None
+
+    def test_update_reusable_session(self, tmp_cron_dir):
+        job = create_job(prompt="Check server status", schedule="every 1h")
+
+        updated = update_job(job["id"], {"session": "health-check"})
+
+        assert updated["session"] == "health-check"
+        assert get_job(job["id"])["session"] == "health-check"
+
+    def test_update_clears_reusable_session(self, tmp_cron_dir):
+        job = create_job(
+            prompt="Check server status",
+            schedule="every 1h",
+            session="health-check",
+        )
+
+        updated = update_job(job["id"], {"session": ""})
+
+        assert updated["session"] is None
+        assert get_job(job["id"])["session"] is None
+
+    def test_update_rejects_invalid_reusable_session(self, tmp_cron_dir):
+        job = create_job(prompt="Test", schedule="every 1h")
+
+        with pytest.raises(ValueError, match="Cron session"):
+            update_job(job["id"], {"session": "bad/session"})
 
     def test_update_enable_disable(self, tmp_cron_dir):
         job = create_job(prompt="Toggle me", schedule="every 1h")

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
-from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt, _resolve_cron_enabled_toolsets, _merge_mcp_into_per_job_toolsets
+from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt, _resolve_cron_enabled_toolsets, _merge_mcp_into_per_job_toolsets, _prepare_cron_session
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
 
@@ -958,6 +958,61 @@ class TestDeliverResultErrorReturns:
 
 
 class TestRunJobSessionPersistence:
+    def test_prepare_reusable_session_follows_real_compression_chain(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("cron_health", source="cron")
+        db.append_message("cron_health", role="user", content="old status")
+        db.end_session("cron_health", "compression")
+        db.create_session(
+            "cron_health_mid",
+            source="cron",
+            parent_session_id="cron_health",
+        )
+        db.append_message("cron_health_mid", role="user", content="middle status")
+        db.end_session("cron_health_mid", "compression")
+        db.create_session(
+            "cron_health_tip",
+            source="cron",
+            parent_session_id="cron_health_mid",
+        )
+        db.append_message("cron_health_tip", role="user", content="latest status")
+        db.append_message("cron_health_tip", role="assistant", content="healthy")
+        db.end_session("cron_health_tip", "cron_complete")
+
+        session_id, history = _prepare_cron_session(
+            {"id": "health-job", "session": "cron_health"},
+            db,
+        )
+
+        assert session_id == "cron_health_tip"
+        assert [
+            {"role": message["role"], "content": message["content"]}
+            for message in history
+        ] == [
+            {"role": "user", "content": "latest status"},
+            {"role": "assistant", "content": "healthy"},
+        ]
+        assert db.get_session("cron_health")["end_reason"] == "compression"
+        assert db.get_session("cron_health_mid")["end_reason"] == "compression"
+        assert db.get_session("cron_health_tip")["ended_at"] is None
+        db.close()
+
+    @pytest.mark.parametrize("source", ["cli", "telegram", "gateway"])
+    def test_prepare_reusable_session_rejects_non_cron_runtime(self, tmp_path, source):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / f"{source}.db")
+        db.create_session("shared_session", source=source)
+
+        with pytest.raises(RuntimeError, match="not 'cron'"):
+            _prepare_cron_session(
+                {"id": "health-job", "session": "shared_session"},
+                db,
+            )
+        db.close()
+
     def test_run_job_passes_session_db_and_cron_platform(self, tmp_path):
         job = {
             "id": "test-job",
@@ -1002,6 +1057,58 @@ class TestRunJobSessionPersistence:
         assert call_args[0][1] == "cron_complete"
         fake_db.close.assert_called_once()
         mock_agent.close.assert_called_once()
+
+    def test_run_job_reuses_resolved_cron_session_history(self, tmp_path):
+        job = {
+            "id": "test-job",
+            "name": "Health check",
+            "prompt": "hello",
+            "session": "gateway_health_monitor",
+        }
+        history = [{"role": "user", "content": "previous status was down"}]
+        fake_db = MagicMock()
+        fake_db.get_compression_tip.return_value = "gateway_health_monitor_tip"
+        fake_db.get_session.side_effect = [
+            {"id": "gateway_health_monitor", "source": "cron", "ended_at": 1.0},
+            {"id": "gateway_health_monitor_tip", "source": "cron", "ended_at": 2.0},
+        ]
+        fake_db.get_messages_as_conversation.return_value = history
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.session_id = "gateway_health_monitor_tip"
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, _output, final_response, error = run_job(job)
+
+        assert success is True
+        assert final_response == "ok"
+        assert error is None
+        fake_db.get_compression_tip.assert_called_once_with("gateway_health_monitor")
+        fake_db.get_messages_as_conversation.assert_called_once_with(
+            "gateway_health_monitor_tip"
+        )
+        fake_db.reopen_session.assert_called_once_with("gateway_health_monitor_tip")
+        assert mock_agent_cls.call_args.kwargs["session_id"] == "gateway_health_monitor_tip"
+        assert mock_agent.run_conversation.call_args.kwargs["conversation_history"] == history
+        fake_db.end_session.assert_called_once_with(
+            "gateway_health_monitor_tip", "cron_complete"
+        )
 
     def test_run_job_suppresses_empty_turn_explainer(self, tmp_path):
         """An empty model turn becomes the '⚠️ No reply…' explainer (#34452).

--- a/tests/hermes_cli/test_cron_parser_builder.py
+++ b/tests/hermes_cli/test_cron_parser_builder.py
@@ -50,7 +50,7 @@ def test_cron_create_options():
         "cron", "create", "0 9 * * *", "daily task prompt",
         "--name", "daily", "--deliver", "origin", "--repeat", "3",
         "--skill", "a", "--skill", "b", "--no-agent",
-        "--workdir", "/tmp/x",
+        "--workdir", "/tmp/x", "--session", "daily-session",
     ])
     assert ns.schedule == "0 9 * * *"
     assert ns.prompt == "daily task prompt"
@@ -60,6 +60,7 @@ def test_cron_create_options():
     assert ns.skills == ["a", "b"]
     assert ns.no_agent is True
     assert ns.workdir == "/tmp/x"
+    assert ns.session == "daily-session"
 
 
 def test_cron_edit_no_agent_tristate():
@@ -68,6 +69,14 @@ def test_cron_edit_no_agent_tristate():
     assert parser.parse_args(["cron", "edit", "j", "--no-agent"]).no_agent is True
     assert parser.parse_args(["cron", "edit", "j", "--agent"]).no_agent is False
     assert parser.parse_args(["cron", "edit", "j"]).no_agent is None
+
+
+def test_cron_edit_session_option():
+    parser = _build()
+
+    ns = parser.parse_args(["cron", "edit", "j", "--session", "health-check"])
+
+    assert ns.session == "health-check"
 
 
 def test_cron_dispatch_func_is_injected_handler():

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -1,6 +1,8 @@
 """Tests for tools/cronjob_tools.py — prompt scanning, schedule/list/remove dispatchers."""
 
 import json
+from unittest.mock import patch
+
 import pytest
 
 from tools.cronjob_tools import (
@@ -263,6 +265,48 @@ class TestUnifiedCronjobTool:
         assert listing["count"] == 1
         assert listing["jobs"][0]["name"] == "Server Check"
         assert listing["jobs"][0]["state"] == "scheduled"
+
+    def test_create_and_update_reusable_session(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check server status",
+                schedule="every 1h",
+                session="gateway_health_monitor",
+            )
+        )
+        assert created["success"] is True
+        assert created["job"]["session"] == "gateway_health_monitor"
+
+        listing = json.loads(cronjob(action="list"))
+        assert listing["jobs"][0]["session"] == "gateway_health_monitor"
+
+        updated = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                session="",
+            )
+        )
+        assert updated["success"] is True
+        assert "session" not in updated["job"]
+
+    def test_registry_forwards_session_and_attach_to_session_together(self):
+        from tools.registry import registry
+
+        entry = registry.get_entry("cronjob")
+        with patch("tools.cronjob_tools.cronjob", return_value='{"success": true}') as call:
+            result = entry.handler(
+                {
+                    "action": "create",
+                    "session": "daily_brief",
+                    "attach_to_session": True,
+                }
+            )
+
+        assert json.loads(result)["success"] is True
+        assert call.call_args.kwargs["session"] == "daily_brief"
+        assert call.call_args.kwargs["attach_to_session"] is True
 
     def test_list_handles_partial_legacy_job_records(self):
         from cron.jobs import save_jobs

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -598,6 +598,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
         result["workdir"] = job["workdir"]
+    if job.get("session"):
+        result["session"] = job["session"]
     return result
 
 
@@ -675,6 +677,7 @@ def cronjob(
     context_from: Optional[Union[str, List[str]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
+    session: Optional[str] = None,
     no_agent: Optional[bool] = None,
     attach_to_session: Optional[bool] = None,
     task_id: str = None,
@@ -748,6 +751,7 @@ def cronjob(
                 context_from=context_from,
                 enabled_toolsets=enabled_toolsets or None,
                 workdir=_normalize_optional_job_value(workdir),
+                session=_normalize_optional_job_value(session),
                 no_agent=_no_agent,
                 attach_to_session=attach_to_session,
             )
@@ -927,6 +931,8 @@ def cronjob(
                 # Empty string clears the field (restores old behaviour);
                 # otherwise pass raw — update_job() validates / normalizes.
                 updates["workdir"] = _normalize_optional_job_value(workdir) or None
+            if session is not None:
+                updates["session"] = _normalize_optional_job_value(session)
             if no_agent is not None:
                 # Toggling no_agent on/off at update time. If flipping to True,
                 # we need a script to already exist on the job (or be part of
@@ -1085,6 +1091,10 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                 "type": "boolean",
                 "description": "When True, this job becomes CONTINUABLE: the user can reply to its delivery and the agent has the brief in context instead of asking 'what is that?'. On thread-capable platforms (Telegram topics, Discord/Slack threads) a dedicated thread is opened for the job and its replies; on DM-only platforms (WhatsApp/Signal) the brief is mirrored into the origin DM session. Use this for conversational recurring jobs the user will reply to — daily briefings, reminders that kick off follow-up work. Leave unset for fire-and-forget alerts/watchdogs. Overrides the global cron.mirror_delivery config for this one job. Only the origin chat is touched (never fan-out targets); no effect when deliver='local'."
             },
+            "session": {
+                "type": "string",
+                "description": "Optional reusable cron-owned SessionDB id for create/update. Each run follows compression continuations, loads the latest history, and appends the new cron turn to that conversation. Existing CLI, gateway, or other non-cron sessions are rejected. Use 1-64 characters: letters, digits, '_' or '-', starting with a letter or digit. On update, pass an empty string to clear."
+            },
         },
         "required": ["action"]
     }
@@ -1139,7 +1149,9 @@ registry.register(
         context_from=args.get("context_from"),
         enabled_toolsets=args.get("enabled_toolsets"),
         workdir=args.get("workdir"),
+        session=args.get("session"),
         no_agent=args.get("no_agent"),
+        attach_to_session=args.get("attach_to_session"),
         task_id=kw.get("task_id"),
     ))(),
     check_fn=check_cronjob_requirements,

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -533,8 +533,8 @@ hermes cron <list|create|edit|pause|resume|run|remove|status|tick>
 | Subcommand | Description |
 |------------|-------------|
 | `list` | Show scheduled jobs. |
-| `create` / `add` | Create a scheduled job from a prompt, optionally attaching one or more skills via repeated `--skill`. |
-| `edit` | Update a job's schedule, prompt, name, delivery, repeat count, or attached skills. Supports `--clear-skills`, `--add-skill`, and `--remove-skill`. |
+| `create` / `add` | Create a scheduled job from a prompt, optionally attaching one or more skills via repeated `--skill` or reusing a cron-owned session with `--session <id>`. Existing CLI/gateway sessions cannot be targeted. |
+| `edit` | Update a job's schedule, prompt, name, delivery, repeat count, session, or attached skills. Supports `--clear-skills`, `--add-skill`, `--remove-skill`, and `--session ""` to clear reusable-session mode. |
 | `pause` | Pause a job without deleting it. |
 | `resume` | Resume a paused job and compute its next future run. |
 | `run` | Trigger a job on the next scheduler tick. |

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -54,7 +54,7 @@ These two tools live in the `browser` toolset but only register when a Chrome De
 
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
-| `cronjob` | Unified scheduled-task manager. Use `action="create"`, `"list"`, `"update"`, `"pause"`, `"resume"`, `"run"`, or `"remove"` to manage jobs. Supports skill-backed jobs with one or more attached skills, and `skills=[]` on update clears attached skills. Cron runs happen in fresh sessions with no current-chat context. | — |
+| `cronjob` | Unified scheduled-task manager. Use `action="create"`, `"list"`, `"update"`, `"pause"`, `"resume"`, `"run"`, or `"remove"` to manage jobs. Supports skill-backed jobs with one or more attached skills, `skills=[]` on update, and optional cron-owned `session` ids for recurring jobs that should reuse conversation history. Existing CLI/gateway sessions are rejected. Cron runs use fresh sessions unless `session` is set. | — |
 
 ## `delegation` toolset
 

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -17,6 +17,7 @@ Cron jobs can:
 - attach zero, one, or multiple skills to a job
 - deliver results back to the origin chat, local files, or configured platform targets
 - run in fresh agent sessions with the normal static tool list
+- reuse a named cron-owned session across runs when a job needs continuity
 - run in **no-agent mode** — a script on a schedule, its stdout delivered verbatim, zero LLM involvement (see the [no-agent mode](#no-agent-mode-script-only-jobs) section below)
 
 All of this is available to Hermes itself through the `cronjob` tool, so you can create, pause, edit, and remove jobs by asking in plain language — no CLI required.
@@ -49,6 +50,32 @@ hermes cron create "every 1h" "Use both skills and combine the result" \
   --skill blogwatcher \
   --skill maps \
   --name "Skill combo"
+```
+
+## Reusing a named session
+
+By default, each cron invocation creates a fresh timestamped `cron_<job>_<time>` session. Use `--session` (CLI) or `session=` (tool call) when a recurring job should load prior conversation history and append each run to the same cron-owned SessionDB conversation. If compression has continued that session in a child row, the scheduler follows the chain to its live tip before loading history.
+
+```bash
+hermes cron create "every 20m" "Check whether the gateway is healthy" \
+  --name "Gateway Health Monitor" \
+  --session gateway_health_monitor
+```
+
+```python
+cronjob(
+    action="create",
+    schedule="every 20m",
+    prompt="Check whether the gateway is healthy",
+    name="Gateway Health Monitor",
+    session="gateway_health_monitor",
+)
+```
+
+Session ids must be 1-64 characters, start with a letter or digit, and contain only letters, digits, `_`, or `-`. A new id becomes cron-owned on its first run; an existing session must already have `source="cron"`. CLI, gateway, and other non-cron sessions are rejected because their system prompts and tool contracts differ from cron. To restore the old fresh-session-per-run behavior:
+
+```bash
+hermes cron edit <job_id> --session ""
 ```
 
 ### Through natural conversation
@@ -152,6 +179,7 @@ hermes cron edit <job_id> --skill blogwatcher --skill maps
 hermes cron edit <job_id> --add-skill maps
 hermes cron edit <job_id> --remove-skill blogwatcher
 hermes cron edit <job_id> --clear-skills
+hermes cron edit <job_id> --session gateway_health_monitor
 ```
 
 Notes:
@@ -160,6 +188,7 @@ Notes:
 - `--add-skill` appends to the existing list without replacing it
 - `--remove-skill` removes specific attached skills
 - `--clear-skills` removes all attached skills
+- `--session ""` clears reusable-session mode
 
 ## Lifecycle actions
 
@@ -217,8 +246,8 @@ On each tick Hermes:
 
 1. loads jobs from `~/.hermes/cron/jobs.json`
 2. checks `next_run_at` against the current time
-3. starts a fresh `AIAgent` session for each due job
-4. optionally injects one or more attached skills into that fresh session
+3. starts a fresh `AIAgent` session for each due job, or reuses the configured `session`
+4. optionally injects one or more attached skills into that agent run
 5. runs the prompt to completion
 6. delivers the final response
 7. updates run metadata and the next scheduled time
@@ -457,7 +486,7 @@ See the [Script-Only Cron Jobs guide](/guides/cron-script-only) for worked examp
 
 ## Chaining jobs with `context_from`
 
-Cron jobs run in isolated sessions with no memory of previous runs. But sometimes one job's output is exactly what the next job needs. The `context_from` parameter wires that connection automatically — Job B's prompt gets Job A's most recent output prepended as context at runtime.
+By default, cron jobs run in isolated sessions with no memory of previous runs. But sometimes one job's output is exactly what the next job needs. The `context_from` parameter wires that connection automatically — Job B's prompt gets Job A's most recent output prepended as context at runtime.
 
 ```python
 # Job 1: Collect raw data
@@ -592,7 +621,7 @@ For `update`, pass `skills=[]` to remove all attached skills.
 
 ## Toolsets available to cron jobs
 
-Cron runs each job in a fresh agent session with no chat platform attached. By default the cron agent gets **the toolset you configured for the `cron` platform in `hermes tools`** — not the CLI default, not everything under the sun.
+Cron runs each job in a fresh agent session by default, or its configured cron-owned reusable session, with no chat platform attached. The cron agent gets **the toolset you configured for the `cron` platform in `hermes tools`** — not the CLI default, not everything under the sun.
 
 ```bash
 hermes tools
@@ -743,7 +772,7 @@ The storage uses atomic file writes so interrupted writes do not leave a partial
 ## Self-contained prompts still matter
 
 :::warning Important
-Cron jobs run in a completely fresh agent session. The prompt must contain everything the agent needs that is not already provided by attached skills.
+Cron jobs run in a completely fresh agent session unless a cron-owned reusable `session` is configured. Without one, the prompt must contain everything the agent needs that is not already provided by attached skills.
 :::
 
 **BAD:** `"Check on that server issue"`


### PR DESCRIPTION
## Summary

- add an optional `session` field to cron jobs so recurring jobs can reuse a stable SessionDB conversation instead of creating a fresh timestamped cron session each run
- load prior messages from the reusable session and pass them as `conversation_history` to the cron agent turn
- preserve legacy behavior when `session` is unset, including the original `run_conversation(prompt)` call shape for non-reusable cron jobs
- avoid renaming, ending, or reopening existing non-cron sessions when users target one explicitly
- expose the field through the `cronjob` tool, `hermes cron create/edit --session`, CLI output, tests, and docs

Fixes #14821.
Related to #33167.

## Validation

- `python -m py_compile cron/scheduler.py`
- `python -m py_compile cron/jobs.py cron/scheduler.py tools/cronjob_tools.py hermes_cli/cron.py hermes_cli/subcommands/cron.py`
- `python -m compileall -q cron tools hermes_cli tests/cron/test_jobs.py tests/tools/test_cronjob_tools.py tests/cron/test_cronjob_schema.py tests/hermes_cli/test_cron_parser_builder.py tests/cron/test_scheduler.py`
- `python -m pytest tests/cron/test_jobs.py tests/cron/test_scheduler.py tests/tools/test_cronjob_tools.py tests/cron/test_cronjob_schema.py tests/hermes_cli/test_cron_parser_builder.py -q` (`308 passed`)
- `python -m pytest tests/cron tests/tools/test_cronjob_tools.py tests/hermes_cli/test_cron_parser_builder.py -q` (`511 passed`, `2 skipped`, `7 failed` on Windows-only platform assumptions around `~` expansion and POSIX permission bits, unrelated to this change)

Full default pytest was also attempted on Windows after installing `.[dev,acp,homeassistant]` and setting `TMPDIR`/PATH for the suite; it exceeded a 1-hour timeout before producing a clean result.

GitHub Actions `Tests` was triggered for commit `eec52c4` and is waiting for maintainer approval before jobs can run: https://github.com/NousResearch/hermes-agent/actions/runs/27605311182