### PR TITLE
fix: guard against None values in personality preview slicing

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1564,7 +1564,7 @@ class GatewaySlashCommandsMixin:
             lines.append(t("gateway.personality.none_option"))
             for name, prompt in personalities.items():
                 if isinstance(prompt, dict):
-                    preview = prompt.get("description") or prompt.get("system_prompt", "")[:50]
+                    preview = prompt.get("description") or (prompt.get("system_prompt") or "")[:50]
                 else:
                     preview = prompt[:50] + "..." if len(prompt) > 50 else prompt
                 lines.append(t("gateway.personality.item", name=name, preview=preview))
@@ -2842,7 +2842,7 @@ class GatewaySlashCommandsMixin:
                         origin = self._gateway_session_origin_for_id(str(s.get("id") or ""))
                         if origin:
                             title = f"{title} — {origin.chat_name or origin.chat_id}"
-                    preview = s.get("preview", "")[:40]
+                    preview = (s.get("preview") or "")[:40]
                     preview_part = t("gateway.resume.list_preview_suffix", preview=preview) if preview else ""
                     lines.append(t("gateway.resume.list_item_numbered", index=idx, title=title, preview_part=preview_part))
                 lines.append(t("gateway.resume.list_footer_numbered"))

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1031,7 +1031,7 @@ class CLICommandsMixin:
             print(f"  {'none':<12} - (no personality overlay)")
             for name, prompt in self.personalities.items():
                 if isinstance(prompt, dict):
-                    preview = prompt.get("description") or prompt.get("system_prompt", "")[:50]
+                    preview = prompt.get("description") or (prompt.get("system_prompt") or "")[:50]
                 else:
                     preview = str(prompt)[:50]
                 print(f"  {name:<12} - {preview}")


### PR DESCRIPTION
## Summary

Three locations use `prompt.get("key", "")[:50]` to slice a preview string. When the key exists but its value is `None`, this crashes with `TypeError: 'NoneType' object is not subscriptable` because `None[:50]` is invalid.

The `.get("key", "")` default only applies when the key is **missing** from the dict — not when the value is `None`.

### Fix

Use `(prompt.get("key") or "")[:50]` to handle both missing keys and None values.

### Affected locations

- `gateway/slash_commands.py:1567` — `/personality` list command
- `gateway/slash_commands.py:2845` — prompt preview in slash commands
- `hermes_cli/cli_commands_mixin.py:1034` — prompt list in CLI