### PR TITLE
fix(auth): check credential pool in codex status fallback path

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -5922,6 +5922,18 @@ def get_codex_auth_status() -> Dict[str, Any]:
             "api_key": creds.get("api_key"),
         }
     except AuthError as exc:
+        # Last-ditch check: pool credentials may be available even when
+        # the singleton store is incomplete (e.g. after partial re-auth).
+        # _pool_codex_access_token reads directly from auth.json, while
+        # the pool-entry check above uses getattr on the entry object.
+        pool_token = _pool_codex_access_token()
+        if pool_token:
+            return {
+                "logged_in": True,
+                "auth_store": str(_auth_file_path()),
+                "source": "credential_pool",
+                "auth_mode": "chatgpt",
+            }
         return {
             "logged_in": False,
             "auth_store": str(_auth_file_path()),

--- a/tests/hermes_cli/test_codex_status_pool_fallback.py
+++ b/tests/hermes_cli/test_codex_status_pool_fallback.py
@@ -1,0 +1,108 @@
+"""Tests for get_codex_auth_status() pool fallback path.
+
+Regression: #47066 — hermes status showed false negative for OpenAI Codex
+authentication when credentials existed only in the credential pool JSON
+(not exposed as entry attributes).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_cli.auth import get_codex_auth_status
+
+
+class TestCodexStatusPoolFallback:
+    """When the singleton store is incomplete but pool has credentials,
+    get_codex_auth_status must report logged_in=True."""
+
+    def test_pool_entry_has_access_token_reports_logged_in(self):
+        """Pool entry with access_token attribute → logged_in via pool check."""
+        entry = SimpleNamespace(
+            runtime_api_key=None,
+            access_token="eyJhbG...OTl9.sig",
+            label="test",
+            last_refresh=None,
+        )
+        pool = MagicMock()
+        pool.has_credentials.return_value = True
+        pool.select.return_value = entry
+
+        with patch("agent.credential_pool.load_pool", return_value=pool):
+            result = get_codex_auth_status()
+
+        assert result["logged_in"] is True
+        assert "pool:" in result.get("source", "")
+
+    def test_auth_error_with_pool_token_reports_logged_in(self):
+        """When resolve_codex_runtime_credentials raises AuthError but
+        _pool_codex_access_token returns a token, report logged_in=True."""
+        from hermes_cli.auth import AuthError
+
+        with (
+            patch("agent.credential_pool.load_pool", return_value=None),
+            patch(
+                "hermes_cli.auth.resolve_codex_runtime_credentials",
+                side_effect=AuthError(
+                    "Codex auth is missing access_token.",
+                    provider="openai-codex",
+                    code="codex_auth_missing_access_token",
+                    relogin_required=True,
+                ),
+            ),
+            patch(
+                "hermes_cli.auth._pool_codex_access_token",
+                return_value="eyJhbG...OTl9.sig",
+            ),
+        ):
+            result = get_codex_auth_status()
+
+        assert result["logged_in"] is True
+        assert result.get("source") == "credential_pool"
+
+    def test_auth_error_without_pool_token_reports_not_logged_in(self):
+        """When both resolve and pool fallback fail, report logged_in=False."""
+        from hermes_cli.auth import AuthError
+
+        with (
+            patch("agent.credential_pool.load_pool", return_value=None),
+            patch(
+                "hermes_cli.auth.resolve_codex_runtime_credentials",
+                side_effect=AuthError(
+                    "No Codex credentials stored.",
+                    provider="openai-codex",
+                    code="codex_auth_missing",
+                    relogin_required=True,
+                ),
+            ),
+            patch(
+                "hermes_cli.auth._pool_codex_access_token",
+                return_value="",
+            ),
+        ):
+            result = get_codex_auth_status()
+
+        assert result["logged_in"] is False
+        assert "error" in result
+
+    def test_resolve_success_returns_logged_in(self):
+        """When resolve_codex_runtime_credentials succeeds, report logged_in."""
+        with (
+            patch("agent.credential_pool.load_pool", return_value=None),
+            patch(
+                "hermes_cli.auth.resolve_codex_runtime_credentials",
+                return_value={
+                    "api_key": "test-key",
+                    "source": "singleton",
+                    "auth_mode": "chatgpt",
+                    "last_refresh": None,
+                },
+            ),
+        ):
+            result = get_codex_auth_status()
+
+        assert result["logged_in"] is True
+        assert result.get("source") == "singleton"


### PR DESCRIPTION
## What does this PR do?

Adds a last-ditch credential pool check in `get_codex_auth_status()` so that `hermes status` correctly reports "logged in" when Codex credentials exist only in the pool JSON (not in the singleton auth store).

## Related Issue

Fixes #47066

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/auth.py`: In `get_codex_auth_status()`, when `resolve_codex_runtime_credentials()` raises `AuthError`, fall back to `_pool_codex_access_token()` before reporting "not logged in". This mirrors the fallback chain already used at runtime.
- `tests/hermes_cli/test_codex_status_pool_fallback.py`: 4 tests covering pool-entry success, AuthError-with-pool-token, AuthError-without-pool-token, and resolve-success paths.

## How to Test

1. Store Codex credentials only in `credential_pool.openai-codex` in `~/.hermes/auth.json` (no `providers.openai-codex.tokens`)
2. Run `hermes status` — should show "✓ logged in" for OpenAI Codex
3. Run `pytest tests/hermes_cli/test_codex_status_pool_fallback.py -q` — all 4 tests pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `hermes_cli/auth.py::get_codex_auth_status()` (callers: 2 — `hermes status`, `hermes doctor`)
- Blast radius: LOW — display-only change, does not affect runtime credential resolution
- Related patterns: `_pool_codex_access_token()` reads directly from auth.json JSON structure, bypassing the pool entry object attribute access used by `load_pool().select()`
