### PR TITLE
fix(ntfy): honor live delivery topics

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -656,6 +656,20 @@ def _send_media_via_adapter(
             logger.warning("Job '%s': failed to send media %s: %s", job.get("id", "?"), media_path, e)
 
 
+def _live_delivery_metadata(
+    platform_name: str,
+    chat_id: str,
+    thread_id: Optional[str],
+) -> Optional[dict]:
+    """Metadata needed to make live adapter delivery match standalone delivery."""
+    metadata = {}
+    if thread_id:
+        metadata["thread_id"] = thread_id
+    if platform_name.lower() == "ntfy" and chat_id:
+        metadata["publish_topic"] = chat_id
+    return metadata or None
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -757,7 +771,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         runtime_adapter = (adapters or {}).get(platform)
         delivered = False
         if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
-            send_metadata = {"thread_id": thread_id} if thread_id else None
+            send_metadata = _live_delivery_metadata(platform_name, chat_id, thread_id)
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content
                 text_to_send = cleaned_delivery_content.strip()

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -348,6 +348,14 @@ class DeliveryRouter:
             }
 
         send_metadata = dict(metadata or {})
+        if (
+            target.platform.value == "ntfy"
+            and target.chat_id
+        ):
+            # The ntfy live adapter prefers its configured publish topic over
+            # chat_id; make resolved delivery targets win, like send_message
+            # and the standalone ntfy sender do.
+            send_metadata["publish_topic"] = target.chat_id
         is_named_telegram_private_topic = False
         named_telegram_private_topic_name: Optional[str] = None
         if target.thread_id:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -788,6 +788,98 @@ class TestDeliverResultWrapping:
         assert "MEDIA:" not in text_sent
         assert "Report" in text_sent
 
+    def test_live_ntfy_explicit_target_uses_chat_id_as_publish_topic(self):
+        """Cron live-adapter ntfy delivery should honor explicit topics."""
+        from gateway.config import Platform
+        from concurrent.futures import Future
+
+        ntfy = Platform("ntfy")
+        adapter = AsyncMock()
+        adapter.send.return_value = MagicMock(success=True)
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {ntfy: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        def fake_run_coro(coro, _loop):
+            future = Future()
+            future.set_result(MagicMock(success=True))
+            coro.close()
+            return future
+
+        job = {
+            "id": "ntfy-explicit",
+            "deliver": "ntfy:alerts-channel",
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+            result = _deliver_result(
+                job,
+                "Hello ntfy",
+                adapters={ntfy: adapter},
+                loop=loop,
+            )
+
+        assert result is None
+        adapter.send.assert_called_once_with(
+            "alerts-channel",
+            "Hello ntfy",
+            metadata={"publish_topic": "alerts-channel"},
+        )
+
+    def test_live_ntfy_home_target_uses_home_channel_as_publish_topic(self, monkeypatch):
+        """Cron live-adapter ntfy home delivery should match standalone routing."""
+        from gateway.config import Platform
+        from concurrent.futures import Future
+
+        monkeypatch.setenv("NTFY_HOME_CHANNEL", "ops-home")
+
+        ntfy = Platform("ntfy")
+        adapter = AsyncMock()
+        adapter.send.return_value = MagicMock(success=True)
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {ntfy: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        def fake_run_coro(coro, _loop):
+            future = Future()
+            future.set_result(MagicMock(success=True))
+            coro.close()
+            return future
+
+        job = {
+            "id": "ntfy-home",
+            "deliver": "ntfy",
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro):
+            result = _deliver_result(
+                job,
+                "Home hello",
+                adapters={ntfy: adapter},
+                loop=loop,
+            )
+
+        assert result is None
+        adapter.send.assert_called_once_with(
+            "ops-home",
+            "Home hello",
+            metadata={"publish_topic": "ops-home"},
+        )
+
     def test_no_mirror_to_session_call(self):
         """Cron deliveries should NOT mirror into the gateway session."""
         from gateway.config import Platform

--- a/tests/gateway/test_delivery.py
+++ b/tests/gateway/test_delivery.py
@@ -268,6 +268,28 @@ async def test_explicit_telegram_group_thread_does_not_mark_dm_fallback(tmp_path
     assert adapter.calls[0]["metadata"] == {"thread_id": "42"}
 
 
+@pytest.mark.asyncio
+async def test_explicit_ntfy_target_sets_publish_topic_metadata(tmp_path, monkeypatch):
+    monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+    ntfy = Platform("ntfy")
+    adapter = RecordingAdapter()
+    router = DeliveryRouter(GatewayConfig(), adapters={ntfy: adapter})
+    target = DeliveryTarget.parse("ntfy:alerts-channel")
+
+    await router._deliver_to_platform(target, "hello", metadata={"job_id": "nightly"})
+
+    assert adapter.calls == [
+        {
+            "chat_id": "alerts-channel",
+            "content": "hello",
+            "metadata": {
+                "job_id": "nightly",
+                "publish_topic": "alerts-channel",
+            },
+        }
+    ]
+
+
 class FailingAdapter:
     async def send(self, chat_id, content, metadata=None):
         return SendResult(success=False, error="route failed", retryable=False)


### PR DESCRIPTION
## Summary

Fixes live ntfy delivery so resolved Hermes delivery targets publish to the intended ntfy topic instead of being overridden by the adapter's configured default `publish_topic`.

This complements #40224, which fixed the `send_message` path. Cron live-adapter delivery and the generic `DeliveryRouter` path still passed only `chat_id`; `NtfyAdapter.send()` prefers `metadata.publish_topic` (then configured `publish_topic`) before falling back to `chat_id`, so a job targeting `ntfy:alerts-channel` or an `NTFY_HOME_CHANNEL` route could still publish to the configured default topic whenever the gateway's live adapter path was used.

## Root Cause

The ntfy live adapter and standalone sender disagreed on the meaning of `chat_id`:

- standalone ntfy send treats `chat_id` as the publish topic;
- live `NtfyAdapter.send()` treats `chat_id` only as a fallback after `metadata.publish_topic` and configured `publish_topic`.

Cron live delivery and `DeliveryRouter` resolved the right target but did not translate it into the metadata field that the live adapter prioritizes.

## Changes

- Add live cron delivery metadata shaping so ntfy delivery passes `metadata["publish_topic"] = chat_id` while preserving existing `thread_id` behavior for threaded platforms.
- Add the same ntfy publish-topic metadata in `DeliveryRouter` before calling the adapter.
- Add regression coverage for:
  - `deliver: ntfy:alerts-channel` through cron live-adapter delivery;
  - `deliver: ntfy` with `NTFY_HOME_CHANNEL` through cron live-adapter delivery;
  - `DeliveryRouter` sending `ntfy:alerts-channel`.

## Impact

This keeps live gateway delivery aligned with the already-supported standalone/send_message behavior. It is limited to ntfy metadata shaping and does not change Telegram/Discord thread routing.

## Validation

Ran locally after rebasing onto current `origin/main`:

- `python -m pytest -p pytest_asyncio.plugin tests/cron/test_scheduler.py -q -o addopts=` — 138 passed
- `python -m pytest -p pytest_asyncio.plugin tests/gateway/test_delivery.py tests/gateway/test_ntfy_plugin.py::TestSend tests/tools/test_send_message_tool.py::TestSendMessageTool::test_ntfy_topic_target_is_explicit tests/tools/test_send_message_tool.py::TestSendMessageTool::test_ntfy_topic_target_bypasses_channel_directory tests/tools/test_send_message_tool.py::TestSendViaAdapterStandaloneFallback::test_live_ntfy_adapter_receives_explicit_publish_topic -q -o addopts=` — 40 passed
- `python -m py_compile gateway/delivery.py cron/scheduler.py tests/gateway/test_delivery.py tests/cron/test_scheduler.py`
- `git diff --check origin/main...HEAD`

Note: local pytest was run with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` and a temporary dependency path to avoid unrelated global pytest plugin/dependency noise on this Windows machine.