### PR TITLE
feat: add hermes-sentinel to Well-Known skill index crawl

### DIFF
--- a/scripts/build_skills_index.py
+++ b/scripts/build_skills_index.py
@@ -251,6 +251,22 @@ def main():
               "Set GITHUB_TOKEN for better results.", file=sys.stderr)
 
     skills_sh_source = SkillsShSource(auth=auth)
+    # Known Well-Known skill endpoints to crawl explicitly.
+    # The WellKnownSkillSource.search("") returns nothing because
+    # it requires a URL-based query.  These are crawled separately.
+    WELL_KNOWN_ENDPOINTS = [
+        "https://hangzhouxiaozhu.github.io/hermes-sentinel",
+    ]
+    well_known_source = WellKnownSkillSource()
+    for endpoint in WELL_KNOWN_ENDPOINTS:
+        try:
+            results = well_known_source.search(endpoint, limit=5_000)
+            skills = [_meta_to_dict(m) for m in results]
+            all_skills.extend(skills)
+            print(f"  well-known ({endpoint}): {len(skills)} skills", flush=True)
+        except Exception as e:
+            print(f"  well-known ({endpoint}): error - {e}", file=sys.stderr)
+
     sources = {
         "official": OptionalSkillSource(),
         "well-known": WellKnownSkillSource(),


### PR DESCRIPTION
## Summary

Adds a `WELL_KNOWN_ENDPOINTS` list to `build_skills_index.py` that explicitly crawls known Well-Known skill endpoints. The `WellKnownSkillSource.search('')` returns nothing because it requires a URL-based query, so community skills hosted on GitHub Pages with Well-Known discovery are currently invisible to the index.

## Changes

- `scripts/build_skills_index.py`: Added `WELL_KNOWN_ENDPOINTS` list and explicit crawl logic before the parallel source crawl
- First entry: `hermes-sentinel` by `hangzhouxiaozhu` — a background daemon skill for Hermes Agent with hardware monitoring, token tracking, network diagnosis, and security audit. Available via Well-Known discovery at `https://hangzhouxiaozhu.github.io/hermes-sentinel`

## Testing

```bash
# After index rebuild, users can install with:
hermes skills install hermes-sentinel
# Or via URL:
hermes skills install https://hangzhouxiaozhu.github.io/hermes-sentinel
```

## Future

This approach is extensible — any community skill that sets up a Well-Known endpoint can be added to `WELL_KNOWN_ENDPOINTS` by submitting a PR.