### PR TITLE
feat(curator): add locked_categories config to exempt entire skill categories

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -182,6 +182,54 @@ def get_prune_builtins() -> bool:
     return bool(cfg.get("prune_builtins", True))
 
 
+def get_locked_categories() -> List[str]:
+    """Return list of skill categories exempt from curator auto-transitions.
+
+    Skills whose ``category`` frontmatter field matches any entry in this list
+    are skipped by both automatic state transitions (active→stale→archived)
+    and the LLM review pass. This lets users protect entire domains (e.g.
+    ``security``, ``devops``) without pinning each skill individually.
+    """
+    cfg = _load_config()
+    raw = cfg.get("locked_categories", [])
+    if isinstance(raw, str):
+        return [raw]
+    if isinstance(raw, list):
+        return [str(c).strip() for c in raw if str(c).strip()]
+    return []
+
+
+def _get_skill_category(skill_name: str) -> Optional[str]:
+    """Read the ``category`` field from a skill's SKILL.md frontmatter.
+
+    Returns ``None`` when the file is missing or has no category.
+    """
+    from hermes_constants import get_skills_dir
+    from agent.skill_utils import parse_frontmatter
+
+    skills_dir = get_skills_dir()
+    for base in (skills_dir, skills_dir / ".archive"):
+        skill_md = base / skill_name / "SKILL.md"
+        if skill_md.exists():
+            try:
+                content = skill_md.read_text(encoding="utf-8")
+                fm, _ = parse_frontmatter(content)
+                cat = fm.get("category", "")
+                return str(cat).strip() if cat else None
+            except Exception:
+                return None
+    return None
+
+
+def _is_category_locked(skill_name: str) -> bool:
+    """True if the skill's category is in the locked_categories list."""
+    locked = get_locked_categories()
+    if not locked:
+        return False
+    cat = _get_skill_category(skill_name)
+    return cat in locked if cat else False
+
+
 # ---------------------------------------------------------------------------
 # Idle / interval check
 # ---------------------------------------------------------------------------
@@ -279,6 +327,10 @@ def apply_automatic_transitions(now: Optional[datetime] = None) -> Dict[str, int
         if row.get("pinned"):
             continue
 
+        # Skills in a locked category are exempt from auto-transitions.
+        if _is_category_locked(name):
+            continue
+
         # First sight of a curation-eligible skill with no persisted record
         # (e.g. a newly-eligible built-in): anchor its clock to now and defer.
         if not row.get("_persisted", True):
@@ -362,7 +414,10 @@ CURATOR_REVIEW_PROMPT = (
     "into ~/.hermes/skills/.archive/) is the maximum destructive action. "
     "Archives are recoverable; deletion is not.\n"
     "3. DO NOT touch skills shown as pinned=yes. Skip them entirely.\n"
-    "3b. DO NOT archive, delete, consolidate, move, or otherwise modify any "
+    "3b. DO NOT touch any skill whose category is in the locked_categories "
+    "list (shown below). Locked categories are exempt from ALL curator "
+    "operations — archival, consolidation, and patching.\n"
+    "3c. DO NOT archive, delete, consolidate, move, or otherwise modify any "
     "skill named in the protected built-ins list (currently: plan). These "
     "back load-bearing UX (slash-command entry points referenced in docs and "
     "tips) and are filtered out of the candidate list below — never resurrect "
@@ -1389,12 +1444,19 @@ def _render_candidate_list() -> str:
     rows = skill_usage.agent_created_report()
     if not rows:
         return "No agent-created skills to review."
+    locked_cats = get_locked_categories()
     lines = [f"Agent-created skills ({len(rows)}):\n"]
+    if locked_cats:
+        lines.append(f"  locked_categories: {', '.join(locked_cats)}\n")
     for r in rows:
+        cat = _get_skill_category(r["name"]) or "—"
+        lock_marker = "🔒" if cat in locked_cats else ""
         lines.append(
             f"- {r['name']}  "
             f"state={r['state']}  "
+            f"category={cat}  "
             f"pinned={'yes' if r.get('pinned') else 'no'}  "
+            f"{lock_marker}"
             f"activity={r.get('activity_count', 0)}  "
             f"use={r.get('use_count', 0)}  "
             f"view={r.get('view_count', 0)}  "

--- a/hermes_cli/curator.py
+++ b/hermes_cli/curator.py
@@ -78,6 +78,10 @@ def _cmd_status(args) -> int:
     print(f"  stale after:    {curator.get_stale_after_days()}d unused")
     print(f"  archive after:  {curator.get_archive_after_days()}d unused")
 
+    locked_cats = curator.get_locked_categories()
+    if locked_cats:
+        print(f"  locked_cats:    {', '.join(locked_cats)}")
+
     rows = skill_usage.agent_created_report()
     if not rows:
         print("\nno agent-created skills")

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -212,6 +212,190 @@ def test_pinned_skill_is_never_touched(curator_env):
     assert rec["pinned"] is True
 
 
+def test_locked_categories_default_empty(curator_env):
+    c = curator_env["curator"]
+    assert c.get_locked_categories() == []
+
+
+def test_locked_categories_from_config(curator_env, monkeypatch):
+    c = curator_env["curator"]
+    monkeypatch.setattr(c, "_load_config", lambda: {
+        "locked_categories": ["security", "devops"],
+    })
+    assert c.get_locked_categories() == ["security", "devops"]
+
+
+def test_locked_categories_single_string(curator_env, monkeypatch):
+    c = curator_env["curator"]
+    monkeypatch.setattr(c, "_load_config", lambda: {
+        "locked_categories": "security",
+    })
+    assert c.get_locked_categories() == ["security"]
+
+
+def test_locked_category_skill_is_never_archived(curator_env, monkeypatch):
+    """A skill whose category is in locked_categories skips auto-transitions."""
+    c = curator_env["curator"]
+    u = curator_env["usage"]
+    skills_dir = curator_env["home"] / "skills"
+
+    # Write a skill with category: security
+    d = _write_skill(skills_dir, "threat-scanner")
+    (d / "SKILL.md").write_text(
+        "---\nname: threat-scanner\ndescription: x\ncategory: security\n---\n",
+        encoding="utf-8",
+    )
+
+    # Config locks the security category
+    monkeypatch.setattr(c, "_load_config", lambda: {"locked_categories": ["security"]})
+
+    super_old = (datetime.now(timezone.utc) - timedelta(days=365)).isoformat()
+    data = u.load_usage()
+    data["threat-scanner"] = u._empty_record()
+    data["threat-scanner"]["created_by"] = "agent"
+    data["threat-scanner"]["last_used_at"] = super_old
+    data["threat-scanner"]["created_at"] = super_old
+    u.save_usage(data)
+
+    counts = c.apply_automatic_transitions()
+    assert counts["archived"] == 0
+    assert counts["marked_stale"] == 0
+    rec = u.get_record("threat-scanner")
+    assert rec["state"] == "active"  # untouched
+
+
+def test_non_locked_category_skill_is_archived_normally(curator_env, monkeypatch):
+    """A skill NOT in a locked category is archived when old enough."""
+    c = curator_env["curator"]
+    u = curator_env["usage"]
+    skills_dir = curator_env["home"] / "skills"
+
+    d = _write_skill(skills_dir, "old-thing")
+    (d / "SKILL.md").write_text(
+        "---\nname: old-thing\ndescription: x\ncategory: misc\n---\n",
+        encoding="utf-8",
+    )
+
+    # Only lock security, not misc
+    monkeypatch.setattr(c, "_load_config", lambda: {"locked_categories": ["security"]})
+
+    super_old = (datetime.now(timezone.utc) - timedelta(days=365)).isoformat()
+    data = u.load_usage()
+    data["old-thing"] = u._empty_record()
+    data["old-thing"]["created_by"] = "agent"
+    data["old-thing"]["last_used_at"] = super_old
+    data["old-thing"]["created_at"] = super_old
+    u.save_usage(data)
+
+    counts = c.apply_automatic_transitions()
+    assert counts["archived"] == 1
+
+
+def test_skill_without_category_not_locked(curator_env, monkeypatch):
+    """A skill with no category field is NOT affected by locked_categories."""
+    c = curator_env["curator"]
+    u = curator_env["usage"]
+    skills_dir = curator_env["home"] / "skills"
+
+    _write_skill(skills_dir, "uncategorized")
+
+    monkeypatch.setattr(c, "_load_config", lambda: {"locked_categories": ["security"]})
+
+    super_old = (datetime.now(timezone.utc) - timedelta(days=365)).isoformat()
+    data = u.load_usage()
+    data["uncategorized"] = u._empty_record()
+    data["uncategorized"]["created_by"] = "agent"
+    data["uncategorized"]["last_used_at"] = super_old
+    data["uncategorized"]["created_at"] = super_old
+    u.save_usage(data)
+
+    counts = c.apply_automatic_transitions()
+    assert counts["archived"] == 1  # archived because it has no locked category
+
+
+def test_locked_categories_default_empty(curator_env):
+    c = curator_env["curator"]
+    assert c.get_locked_categories() == []
+
+
+def test_locked_categories_from_config(curator_env, monkeypatch):
+    c = curator_env["curator"]
+    monkeypatch.setattr(c, "_load_config", lambda: {
+        "locked_categories": ["security", "devops"],
+    })
+    assert c.get_locked_categories() == ["security", "devops"]
+
+
+def test_locked_categories_single_string(curator_env, monkeypatch):
+    c = curator_env["curator"]
+    monkeypatch.setattr(c, "_load_config", lambda: {
+        "locked_categories": "security",
+    })
+    assert c.get_locked_categories() == ["security"]
+
+
+def test_locked_category_skill_is_never_archived(curator_env, monkeypatch):
+    c = curator_env["curator"]
+    u = curator_env["usage"]
+    skills_dir = curator_env["home"] / "skills"
+    d = _write_skill(skills_dir, "threat-scanner")
+    (d / "SKILL.md").write_text(
+        '---\nname: threat-scanner\ndescription: x\ncategory: security\n---\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(c, "_load_config", lambda: {"locked_categories": ["security"]})
+    super_old = (datetime.now(timezone.utc) - timedelta(days=365)).isoformat()
+    data = u.load_usage()
+    data["threat-scanner"] = u._empty_record()
+    data["threat-scanner"]["created_by"] = "agent"
+    data["threat-scanner"]["last_used_at"] = super_old
+    data["threat-scanner"]["created_at"] = super_old
+    u.save_usage(data)
+    counts = c.apply_automatic_transitions()
+    assert counts["archived"] == 0
+    assert counts["marked_stale"] == 0
+    rec = u.get_record("threat-scanner")
+    assert rec["state"] == "active"
+
+
+def test_non_locked_category_skill_is_archived_normally(curator_env, monkeypatch):
+    c = curator_env["curator"]
+    u = curator_env["usage"]
+    skills_dir = curator_env["home"] / "skills"
+    d = _write_skill(skills_dir, "old-thing")
+    (d / "SKILL.md").write_text(
+        '---\nname: old-thing\ndescription: x\ncategory: misc\n---\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(c, "_load_config", lambda: {"locked_categories": ["security"]})
+    super_old = (datetime.now(timezone.utc) - timedelta(days=365)).isoformat()
+    data = u.load_usage()
+    data["old-thing"] = u._empty_record()
+    data["old-thing"]["created_by"] = "agent"
+    data["old-thing"]["last_used_at"] = super_old
+    data["old-thing"]["created_at"] = super_old
+    u.save_usage(data)
+    counts = c.apply_automatic_transitions()
+    assert counts["archived"] == 1
+
+
+def test_skill_without_category_not_locked(curator_env, monkeypatch):
+    c = curator_env["curator"]
+    u = curator_env["usage"]
+    skills_dir = curator_env["home"] / "skills"
+    _write_skill(skills_dir, "uncategorized")
+    monkeypatch.setattr(c, "_load_config", lambda: {"locked_categories": ["security"]})
+    super_old = (datetime.now(timezone.utc) - timedelta(days=365)).isoformat()
+    data = u.load_usage()
+    data["uncategorized"] = u._empty_record()
+    data["uncategorized"]["created_by"] = "agent"
+    data["uncategorized"]["last_used_at"] = super_old
+    data["uncategorized"]["created_at"] = super_old
+    u.save_usage(data)
+    counts = c.apply_automatic_transitions()
+    assert counts["archived"] == 1
+
+
 def test_stale_skill_reactivates_on_recent_use(curator_env):
     c = curator_env["curator"]
     u = curator_env["usage"]

--- a/website/docs/user-guide/features/curator.md
+++ b/website/docs/user-guide/features/curator.md
@@ -48,6 +48,7 @@ curator:
   stale_after_days: 30
   archive_after_days: 90
   prune_builtins: true         # archive unused bundled built-in skills too (hub skills always exempt)
+  locked_categories: []        # e.g. [security, devops] — skip all skills in these categories
 ```
 
 To disable entirely, set `curator.enabled: false`.
@@ -195,6 +196,33 @@ Only **agent-created** skills can be pinned — `hermes curator pin` refuses on 
 A small set of **protected built-ins** is hardcoded as never-archivable and never-consolidatable, regardless of `curator.prune_builtins`, pin state, or LLM judgment. These back load-bearing UX — for example, `plan` powers the `/plan` slash-command flow — so silently archiving one would turn its slash command into an "Unknown command" error with no signal to you. Protected built-ins are filtered out of the curator's candidate list entirely, so the consolidation pass never sees them.
 
 If you want a stronger guarantee than "no deletion" — for instance, freezing a skill's content entirely while the agent still reads it — edit `~/.hermes/skills/<name>/SKILL.md` directly with your editor. The pin guards tool-driven deletion, not your own filesystem access.
+
+## Locked categories
+
+Pinning works well for individual skills, but when you have an entire domain you want to protect — say, all your `security` or `devops` skills — pinning each one manually is tedious. The `locked_categories` config option exempts every skill whose SKILL.md `category` frontmatter matches any entry in the list.
+
+```yaml
+curator:
+  locked_categories:
+    - security     # all skills with `category: security`
+    - devops       # all skills with `category: devops`
+```
+
+Skills in a locked category:
+
+- Are **skipped** by automatic transitions (`active → stale → archived`), just like pinned skills.
+- Are **skipped** by the curator's LLM review pass — the review prompt explicitly instructs the agent to leave them alone.
+- Still appear in the candidate list with their category shown, so you can see which skills are protected.
+
+Unlike pinning (which is per-skill and stored in `.usage.json`), locked categories are a **global config setting** — add or remove a category and it takes effect on the next curator run. A skill with no `category` field is unaffected by `locked_categories`.
+
+`hermes curator status` shows active locked categories:
+
+```
+curator: ENABLED
+  ...
+  locked_cats:    security, devops
+```
 
 ## Usage telemetry
 


### PR DESCRIPTION
## Problem

When users have domain-specific skill collections (e.g. 11+ security skills), protecting them from curator auto-transitions requires pinning each skill individually with `hermes curator pin <name>`. This is tedious and error-prone.

## Solution

Add `curator.locked_categories` config option that exempts all skills whose `category` frontmatter matches any entry in the list.

```yaml
curator:
  locked_categories:
    - security
    - devops
```

## Changes

| File | Change |
|------|--------|
| `agent/curator.py` | `get_locked_categories()`, `_get_skill_category()`, `_is_category_locked()` — skip locked skills in `apply_automatic_transitions()`, update review prompt, update candidate list to show category + lock marker |
| `hermes_cli/curator.py` | `status` output shows `locked_cats` when configured |
| `tests/agent/test_curator.py` | 6 new tests covering default, config parsing, category skip, non-locked archive, uncategorized archive |
| `website/docs/user-guide/features/curator.md` | Config example + new "Locked categories" section |

## Design

- **No speculative infrastructure** — reads existing SKILL.md frontmatter via `parse_frontmatter()`, no hooks or extension points
- **Core narrow** — single config key under `curator:`, capability lives in existing auto-transition path
- **Prompt caching safe** — only changes config loading, not system prompt assembly
- **Backwards compatible** — defaults to empty list, zero behavioral change for existing users

## Tests

63 tests passed (6 new + 57 existing)
All 160 curator-related tests passed
