### PR TITLE
feat(context-engine): lifecycle hooks - turn observation, request ass…

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1579,6 +1579,24 @@ def init_agent(
     agent.compression_enabled = compression_enabled
     agent.compression_in_place = compression_in_place
 
+    # Snapshot the engine's capability declaration once at registration.
+    # Hosts gate every lifecycle hook on this snapshot, so engines that don't
+    # declare a capability are never called (zero new calls for legacy
+    # engines / the built-in compressor). Engine reload re-runs this block,
+    # which refreshes the snapshot — no separate invalidation protocol.
+    from agent.context_engine import ContextEngineCapabilities as _CECaps
+    try:
+        _engine_caps = agent.context_compressor.capabilities()
+        if not isinstance(_engine_caps, _CECaps):
+            _engine_caps = _CECaps()
+    except Exception as _caps_err:
+        _ra().logger.warning(
+            "context engine capabilities() failed (fail-open, using defaults): %s",
+            _caps_err,
+        )
+        _engine_caps = _CECaps()
+    agent._context_engine_caps = _engine_caps
+
     # Reject models whose context window is below the minimum required
     # for reliable tool-calling workflows (64K tokens).
     _ctx = getattr(agent.context_compressor, "context_length", 0)

--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -542,6 +542,15 @@ def _run_review_in_thread(
             # add late-connecting MCP tools to this fork and break that parity,
             # so opt the review fork out of it.
             review_agent._skip_mcp_refresh = True
+            # Internal review fork must NOT participate in the context-engine
+            # lifecycle: it shares the parent's session_id (set below), so an
+            # observation-capable engine would ingest the review's internal
+            # monologue into the parent conversation's engine store
+            # (duplicate / polluting capture). Zero out the capability
+            # snapshot — the fork keeps compression mechanics untouched but
+            # never fires lifecycle hooks.
+            from agent.context_engine import ContextEngineCapabilities as _CECaps
+            review_agent._context_engine_caps = _CECaps()
             review_agent._memory_store = agent._memory_store
             review_agent._memory_enabled = agent._memory_enabled
             review_agent._user_profile_enabled = agent._user_profile_enabled

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -26,7 +26,82 @@ Lifecycle:
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class TurnInfo:
+    """Turn-level metadata handed to ``on_turn_complete``.
+
+    All fields are host-owned facts: the host runs the conversation loop,
+    so session id, turn counter, usage, and the compression flag are always
+    producible without new bookkeeping.
+    """
+
+    session_id: str
+    turn_id: Optional[str] = None
+    turn_index: Optional[int] = None
+    usage: Optional[Dict[str, Any]] = None
+    compressed_during_turn: bool = False
+    interrupted: bool = False
+    completed: bool = True
+
+
+@dataclass
+class RequestContext:
+    """Inputs for ``prepare_request_messages`` (all host-held at pre-API time)."""
+
+    incoming_message: Optional[Dict[str, Any]] = None
+    budget_tokens: int = 0
+    model: Optional[str] = None
+    provider: Optional[str] = None
+    api_mode: Optional[str] = None
+    platform: Optional[str] = None
+    session_id: str = ""
+    tools: Optional[List[Dict[str, Any]]] = None
+    #: External-memory prefetch results. When an engine takes over request
+    #: assembly the host hands these over instead of injecting them into the
+    #: current user message itself (avoids double injection).
+    prefetch_context: Optional[str] = None
+    #: Context contributed by plugin ``pre_llm_call`` hooks. A request-assembly
+    #: engine receives it here and becomes responsible for injecting it, so the
+    #: host does not append it a second time.
+    plugin_user_context: Optional[str] = None
+
+
+@dataclass
+class ContextEngineCapabilities:
+    """Engine capability declaration, snapshotted by the host at registration.
+
+    Hooks whose capability is not declared are never invoked (not even as
+    no-ops), so undeclared engines keep the exact legacy call pattern.
+    """
+
+    observation: bool = False
+    request_assembly: bool = False
+    owns_compaction: bool = True
+    lossless_snapshot: bool = False
+    tools: bool = False
+
+
+def engine_hook(engine, hook_name: str, *args, default=None, logger=None, **kwargs):
+    """Invoke an optional engine hook with unified fail-open semantics.
+
+    Mirrors the discipline already used by
+    ``_transition_context_engine_session`` and the plugin ``invoke_hook``:
+    a failing engine hook logs a warning and the host continues with
+    ``default`` — a broken engine must never interrupt the user's turn.
+    """
+    try:
+        return getattr(engine, hook_name)(*args, **kwargs)
+    except Exception as exc:  # noqa: BLE001 — fail-open by design
+        if logger is not None:
+            logger.warning(
+                "context engine %s.%s failed (fail-open): %s",
+                getattr(engine, "name", "?"), hook_name, exc,
+            )
+        return default
 
 
 class ContextEngine(ABC):
@@ -224,3 +299,91 @@ class ContextEngine(ABC):
         """
         self.context_length = context_length
         self.threshold_tokens = int(context_length * self.threshold_percent)
+
+    # -- Optional: lifecycle hooks (capability-gated) ------------------------
+    #
+    # The host only calls these when the corresponding flag in
+    # ``capabilities()`` is declared. Engines that don't override
+    # ``capabilities()`` keep the exact legacy call pattern (zero new calls).
+
+    def on_turn_complete(self, messages: List[Dict[str, Any]], turn: "TurnInfo") -> None:
+        """Read-only observation of a completed turn (best-effort per turn).
+
+        Called once per turn from ``finalize_turn`` (including interrupted
+        turns — see ``turn.interrupted``), right before external-memory
+        ``sync_turn``. ``messages`` is the current working view: in-loop
+        compression may already have happened (``turn.compressed_during_turn``).
+        Engines must not mutate the list; the return value is ignored.
+        Heavy work must be queued for background processing.
+
+        Delivery contract — BEST-EFFORT, SELF-HEALING: error/interrupt paths
+        that exit ``run_conversation`` before ``finalize_turn`` skip this
+        hook for that turn. Because ``messages`` is always the FULL working
+        list, a skipped turn's content arrives with the next invocation (or
+        with ``on_session_end`` at the real session boundary). Ingestion
+        engines must therefore be watermark-idempotent: track what they have
+        already consumed and tolerate both re-delivery and gaps.
+
+        Capability gate: ``capabilities().observation``.
+        """
+        return None
+
+    def prepare_request_messages(
+        self,
+        messages: List[Dict[str, Any]],
+        ctx: "RequestContext",
+    ) -> Optional[List[Dict[str, Any]]]:
+        """Provide the source message list for this dispatch's outbound build.
+
+        Called once per provider dispatch, before the host builds its
+        per-call ``api_messages`` copy. A returned list becomes the input of
+        that build (the host's repair / injection / sanitization / prompt
+        caching pipeline still applies downstream); it is never written back
+        to the working ``messages`` or session persistence.
+
+        Return ``None`` to opt out for this dispatch. Engines MUST return
+        ``None`` (not an equivalent copy) when no change is needed, so the
+        prompt-cache prefix stays byte-stable.
+
+        Shape contract: the host re-locates the current turn's user message
+        inside the returned view as the LAST ``role == "user"`` entry (for
+        its own ephemeral injections). Engines should therefore merge
+        injections into existing messages or keep the current user message
+        last — not append extra user-role entries after it.
+
+        Capability gate: ``capabilities().request_assembly``.
+        """
+        return None
+
+    def on_pre_compress(self, messages: List[Dict[str, Any]]) -> None:
+        """Snapshot opportunity immediately before ``compress()`` runs.
+
+        Lossless engines can salvage the full uncompressed transcript here
+        (whether to persist is the engine's own decision). Return value is
+        ignored; failures never block compression.
+
+        Capability gate: ``capabilities().lossless_snapshot``.
+        """
+        return None
+
+    def carry_over_new_session_context(
+        self, old_session_id: str, new_session_id: str
+    ) -> None:
+        """Link/carry engine state across a host session transition.
+
+        Formalizes the hook that ``_transition_context_engine_session``
+        (run_agent.py) already invokes via duck-typing when
+        ``carry_over_context=True``.
+        """
+        return None
+
+    # -- Optional: capability declaration ------------------------------------
+
+    def capabilities(self) -> "ContextEngineCapabilities":
+        """Declare which lifecycle hooks this engine implements.
+
+        The host snapshots this once at registration (engine reload =
+        re-registration = fresh snapshot) and skips undeclared hooks
+        entirely. Default declares nothing → legacy behavior.
+        """
+        return ContextEngineCapabilities()

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -571,6 +571,10 @@ def run_conversation(
     truncated_response_parts: List[str] = []
     compression_attempts = 0
     _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
+    # Per-turn marker consumed by TurnInfo.compressed_during_turn (set in
+    # run_agent._compress_context, the single chokepoint all compression
+    # call sites go through).
+    agent._turn_compressed = False
 
     # Optional opt-in runtime: if api_mode == codex_app_server, hand the
     # turn to the codex app-server subprocess (terminal/file ops/patching
@@ -735,8 +739,73 @@ def run_conversation(
                 agent.session_id or "-",
             )
 
+        # Context engine request assembly (capability-gated).
+        # The engine may provide the SOURCE list for this dispatch's
+        # outbound build. The per-call copy/injection/sanitization/prompt-
+        # caching pipeline below applies to the returned view unchanged, and
+        # nothing is ever written back to ``messages`` — request-only by
+        # construction. ``None`` means "not taking over": the build then
+        # iterates ``messages`` itself and this dispatch is byte-identical
+        # to the legacy path (prompt-cache prefix stays stable).
+        _src_messages = messages
+        _asm_user_idx = current_turn_user_idx
+        _asm_prefetch = _ext_prefetch_cache
+        _asm_plugin_context = _plugin_user_context
+        _ce_caps = getattr(agent, "_context_engine_caps", None)
+        if _ce_caps is not None and _ce_caps.request_assembly:
+            from agent.context_engine import RequestContext, engine_hook
+
+            _ce_engine = agent.context_compressor
+            _asm_budget = (
+                getattr(_ce_engine, "threshold_tokens", 0)
+                or getattr(_ce_engine, "context_length", 0)
+            )
+            _view = engine_hook(
+                _ce_engine,
+                "prepare_request_messages",
+                messages,
+                RequestContext(
+                    incoming_message=(
+                        messages[current_turn_user_idx]
+                        if current_turn_user_idx is not None
+                        and 0 <= current_turn_user_idx < len(messages)
+                        else None
+                    ),
+                    budget_tokens=_asm_budget,
+                    model=agent.model,
+                    provider=getattr(agent, "provider", None),
+                    api_mode=getattr(agent, "api_mode", None),
+                    platform=getattr(agent, "platform", None) or "cli",
+                    session_id=agent.session_id or "",
+                    tools=agent.tools or None,
+                    prefetch_context=_ext_prefetch_cache or None,
+                    plugin_user_context=_plugin_user_context or None,
+                ),
+                default=None,
+                logger=request_logger,
+            )
+            if _view is not None:
+                _src_messages = _view
+                # Prefetch was handed to the engine via RequestContext —
+                # never inject it again below (double-injection guard). Same
+                # for plugin pre_llm_call context: an engine that takes over
+                # request assembly is responsible for placing both sources.
+                _asm_prefetch = None
+                _asm_plugin_context = None
+                # Re-locate the current turn's user message inside the
+                # engine view (the engine may have reshaped the list).
+                _asm_user_idx = next(
+                    (
+                        _i
+                        for _i in range(len(_src_messages) - 1, -1, -1)
+                        if isinstance(_src_messages[_i], dict)
+                        and _src_messages[_i].get("role") == "user"
+                    ),
+                    None,
+                )
+
         api_messages = []
-        for idx, msg in enumerate(messages):
+        for idx, msg in enumerate(_src_messages):
             api_msg = msg.copy()
 
             # Inject ephemeral context into the current turn's user message.
@@ -744,14 +813,14 @@ def run_conversation(
             # with target="user_message" (the default).  Both are
             # API-call-time only — the original message in `messages` is
             # never mutated, so nothing leaks into session persistence.
-            if idx == current_turn_user_idx and msg.get("role") == "user":
+            if idx == _asm_user_idx and msg.get("role") == "user":
                 _injections = []
-                if _ext_prefetch_cache:
-                    _fenced = build_memory_context_block(_ext_prefetch_cache)
+                if _asm_prefetch:
+                    _fenced = build_memory_context_block(_asm_prefetch)
                     if _fenced:
                         _injections.append(_fenced)
-                if _plugin_user_context:
-                    _injections.append(_plugin_user_context)
+                if _asm_plugin_context:
+                    _injections.append(_asm_plugin_context)
                 if _injections:
                     _base = api_msg.get("content", "")
                     if isinstance(_base, str):

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -410,6 +410,36 @@ def finalize_turn(
         _should_review_skills = True
         agent._iters_since_skill = 0
 
+    # Context engine: read-only turn observation (capability-gated).
+    # Fires every turn — including interrupted ones (flagged in TurnInfo) —
+    # with the same working message list the external-memory sync below
+    # receives. Same-source delivery: the engine and memory providers both
+    # read from the host; they never sync with each other.
+    _ce_caps = getattr(agent, "_context_engine_caps", None)
+    if _ce_caps is not None and _ce_caps.observation:
+        from agent.context_engine import TurnInfo, engine_hook
+
+        _engine = agent.context_compressor
+        engine_hook(
+            _engine,
+            "on_turn_complete",
+            messages,
+            TurnInfo(
+                session_id=agent.session_id or "",
+                turn_id=turn_id,
+                turn_index=getattr(agent, "_user_turn_count", None),
+                usage={
+                    "prompt_tokens": getattr(_engine, "last_prompt_tokens", 0),
+                    "completion_tokens": getattr(_engine, "last_completion_tokens", 0),
+                    "total_tokens": getattr(_engine, "last_total_tokens", 0),
+                },
+                compressed_during_turn=bool(getattr(agent, "_turn_compressed", False)),
+                interrupted=interrupted,
+                completed=completed,
+            ),
+            logger=logger,
+        )
+
     # External memory provider: sync the completed turn + queue next prefetch.
     agent._sync_external_memory_for_turn(
         original_user_message=original_user_message,

--- a/run_agent.py
+++ b/run_agent.py
@@ -5139,13 +5139,37 @@ class AIAgent:
         so users can bypass the summary-failure cooldown after an
         auto-compress abort.  Auto-compress callers use the default
         ``force=False``.
+
+        This forwarder is the single chokepoint every compression call site
+        goes through (threshold, overflow recovery, 413, manual /compress),
+        so the context-engine lossless-snapshot hook and the per-turn
+        compression marker live here.
         """
         from agent.conversation_compression import compress_context
-        return compress_context(
+
+        # Lossless snapshot opportunity (capability-gated, fail-open):
+        # engines get the full message list BEFORE compaction mutates it.
+        _caps = getattr(self, "_context_engine_caps", None)
+        if _caps is not None and _caps.lossless_snapshot:
+            from agent.context_engine import engine_hook
+            engine_hook(
+                self.context_compressor, "on_pre_compress", messages, logger=logger
+            )
+
+        result = compress_context(
             self, messages, system_message,
             approx_tokens=approx_tokens, task_id=task_id, focus_topic=focus_topic,
             force=force,
         )
+
+        # Mark the turn as compressed only when compaction actually replaced
+        # the message list (aborts/cooldowns return the original object).
+        try:
+            if isinstance(result, tuple) and result and result[0] is not messages:
+                self._turn_compressed = True
+        except Exception:
+            pass
+        return result
 
     def _set_tool_guardrail_halt(self, decision: ToolGuardrailDecision) -> None:
         """Record the first guardrail decision that should stop this turn."""

--- a/tests/agent/test_context_engine_lifecycle.py
+++ b/tests/agent/test_context_engine_lifecycle.py
@@ -1,0 +1,195 @@
+"""Contract tests for the ContextEngine lifecycle hooks (PR-1).
+
+Covers:
+- new optional hooks default to no-ops (None) and never raise
+- ``capabilities()`` defaults declare nothing (legacy call pattern preserved)
+- the built-in ``ContextCompressor`` inherits all defaults unchanged (T1)
+- a minimal legacy engine (only the 4 abstract members) still works (T11)
+- ``engine_hook`` fail-open wrapper semantics
+"""
+
+import logging
+
+import pytest
+
+from agent.context_engine import (
+    ContextEngine,
+    ContextEngineCapabilities,
+    RequestContext,
+    TurnInfo,
+    engine_hook,
+)
+
+
+class MinimalLegacyEngine(ContextEngine):
+    """Engine implementing ONLY the 4 abstract members (pre-lifecycle style)."""
+
+    @property
+    def name(self):
+        return "minimal-legacy"
+
+    def update_from_response(self, usage):
+        self.last_prompt_tokens = usage.get("prompt_tokens", 0)
+
+    def should_compress(self, prompt_tokens=None):
+        return False
+
+    def compress(self, messages, current_tokens=None, focus_topic=None):
+        return messages
+
+
+@pytest.fixture
+def engine():
+    return MinimalLegacyEngine()
+
+
+# ── Default hook behavior ────────────────────────────────────────────────────
+
+
+class TestLifecycleHookDefaults:
+    def test_on_turn_complete_default_none(self, engine):
+        turn = TurnInfo(session_id="s1")
+        assert engine.on_turn_complete([{"role": "user", "content": "hi"}], turn) is None
+
+    def test_prepare_request_messages_default_none(self, engine):
+        ctx = RequestContext(budget_tokens=1000, model="m")
+        msgs = [{"role": "user", "content": "hi"}]
+        assert engine.prepare_request_messages(msgs, ctx) is None
+
+    def test_on_pre_compress_default_none(self, engine):
+        assert engine.on_pre_compress([{"role": "user", "content": "hi"}]) is None
+
+    def test_carry_over_default_none(self, engine):
+        assert engine.carry_over_new_session_context("old", "new") is None
+
+    def test_default_hooks_do_not_mutate_messages(self, engine):
+        msgs = [{"role": "user", "content": "hi"}]
+        snapshot = [dict(m) for m in msgs]
+        engine.on_turn_complete(msgs, TurnInfo(session_id="s"))
+        engine.prepare_request_messages(msgs, RequestContext())
+        engine.on_pre_compress(msgs)
+        assert msgs == snapshot
+
+
+# ── Capabilities ─────────────────────────────────────────────────────────────
+
+
+class TestCapabilities:
+    def test_default_declares_nothing(self, engine):
+        caps = engine.capabilities()
+        assert isinstance(caps, ContextEngineCapabilities)
+        assert caps.observation is False
+        assert caps.request_assembly is False
+        assert caps.lossless_snapshot is False
+        assert caps.tools is False
+
+    def test_default_owns_compaction(self, engine):
+        # Slot semantics: a selected engine owns compaction by default.
+        assert engine.capabilities().owns_compaction is True
+
+    def test_full_engine_can_declare(self):
+        class FullEngine(MinimalLegacyEngine):
+            def capabilities(self):
+                return ContextEngineCapabilities(
+                    observation=True,
+                    request_assembly=True,
+                    lossless_snapshot=True,
+                    tools=True,
+                )
+
+        caps = FullEngine().capabilities()
+        assert caps.observation and caps.request_assembly
+        assert caps.lossless_snapshot and caps.tools
+
+
+# ── Built-in compressor: zero behavior change (T1 contract level) ───────────
+
+
+class TestBuiltinCompressorUnchanged:
+    def _compressor(self):
+        from agent.context_compressor import ContextCompressor
+
+        return ContextCompressor(model="gpt-4o", api_key="", base_url="")
+
+    def test_compressor_declares_nothing(self):
+        caps = self._compressor().capabilities()
+        assert caps.observation is False
+        assert caps.request_assembly is False
+        assert caps.lossless_snapshot is False
+
+    def test_compressor_hooks_are_inherited_noops(self):
+        comp = self._compressor()
+        assert comp.on_turn_complete([], TurnInfo(session_id="s")) is None
+        assert comp.prepare_request_messages([], RequestContext()) is None
+        assert comp.on_pre_compress([]) is None
+
+    def test_compressor_does_not_override_new_hooks(self):
+        from agent.context_compressor import ContextCompressor
+
+        for hook in (
+            "on_turn_complete",
+            "prepare_request_messages",
+            "on_pre_compress",
+            "capabilities",
+        ):
+            assert hook not in ContextCompressor.__dict__, (
+                f"ContextCompressor must not override {hook} (zero-change red line)"
+            )
+
+
+# ── engine_hook fail-open wrapper ────────────────────────────────────────────
+
+
+class TestEngineHookFailOpen:
+    def test_returns_hook_value(self, engine):
+        assert engine_hook(engine, "should_compress", 100) is False
+
+    def test_exception_returns_default(self):
+        class Broken(MinimalLegacyEngine):
+            def on_turn_complete(self, messages, turn):
+                raise RuntimeError("boom")
+
+        result = engine_hook(
+            Broken(), "on_turn_complete", [], TurnInfo(session_id="s"), default=None
+        )
+        assert result is None
+
+    def test_exception_logs_warning(self, caplog):
+        class Broken(MinimalLegacyEngine):
+            def prepare_request_messages(self, messages, ctx):
+                raise ValueError("nope")
+
+        logger = logging.getLogger("test.engine_hook")
+        with caplog.at_level(logging.WARNING, logger="test.engine_hook"):
+            engine_hook(
+                Broken(), "prepare_request_messages", [], RequestContext(),
+                default=None, logger=logger,
+            )
+        assert any("fail-open" in r.message for r in caplog.records)
+
+    def test_custom_default(self, engine):
+        class Broken(MinimalLegacyEngine):
+            def should_compress(self, prompt_tokens=None):
+                raise RuntimeError("boom")
+
+        assert engine_hook(Broken(), "should_compress", 1, default=False) is False
+
+
+# ── Dataclass shapes ─────────────────────────────────────────────────────────
+
+
+class TestDataclasses:
+    def test_turn_info_defaults(self):
+        t = TurnInfo(session_id="s")
+        assert t.turn_index is None
+        assert t.usage is None
+        assert t.compressed_during_turn is False
+        assert t.interrupted is False
+        assert t.completed is True
+
+    def test_request_context_defaults(self):
+        c = RequestContext()
+        assert c.incoming_message is None
+        assert c.budget_tokens == 0
+        assert c.model is None
+        assert c.prefetch_context is None

--- a/tests/agent/test_context_engine_lifecycle_integration.py
+++ b/tests/agent/test_context_engine_lifecycle_integration.py
@@ -1,0 +1,267 @@
+"""Host integration tests for ContextEngine lifecycle hooks (PR-2).
+
+Covers the three host integration points:
+- ``run_agent.AIAgent._compress_context`` — ``on_pre_compress`` snapshot
+  (capability-gated, fail-open) + ``_turn_compressed`` marker semantics
+- ``agent.turn_finalizer.finalize_turn`` — ``on_turn_complete`` observation
+  (capability-gated, fires before external-memory sync, fail-open)
+- capability gating: undeclared engines see zero new calls
+
+Uses the bare-agent pattern established in
+``tests/run_agent/test_memory_sync_interrupted.py``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.context_engine import ContextEngineCapabilities, TurnInfo
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _bare_compress_agent(caps: ContextEngineCapabilities):
+    from run_agent import AIAgent
+
+    agent = AIAgent.__new__(AIAgent)
+    agent._context_engine_caps = caps
+    agent.context_compressor = MagicMock()
+    agent.context_compressor.name = "mock-engine"
+    agent._turn_compressed = False
+    return agent
+
+
+def _finalize_agent(caps: ContextEngineCapabilities):
+    """MagicMock agent with the real-typed attrs finalize_turn computes on."""
+    agent = MagicMock()
+    agent.max_iterations = 10
+    agent.iteration_budget.remaining = 5
+    agent.iteration_budget.used = 1
+    agent.iteration_budget.max_total = 10
+    agent.session_id = "sess-1"
+    agent.quiet_mode = True
+    agent.model = "test-model"
+    agent.provider = "test"
+    agent.base_url = ""
+    agent.platform = "cli"
+    agent.session_input_tokens = 0
+    agent.session_output_tokens = 0
+    agent.session_cache_read_tokens = 0
+    agent.session_cache_write_tokens = 0
+    agent.session_reasoning_tokens = 0
+    agent.session_prompt_tokens = 0
+    agent.session_completion_tokens = 0
+    agent.session_total_tokens = 0
+    agent.session_estimated_cost_usd = 0.0
+    agent.session_cost_status = "ok"
+    agent.session_cost_source = "none"
+    agent._tool_guardrail_halt_decision = None
+    agent._drain_pending_steer.return_value = None
+    agent._response_was_previewed = False
+    agent._interrupt_message = None
+    agent._skill_nudge_interval = 0
+    agent._iters_since_skill = 0
+    agent.valid_tool_names = set()
+    agent._turn_failed_file_mutations = {}
+    agent._file_mutation_verifier_enabled.return_value = False
+    agent._turn_completion_explainer_enabled.return_value = False
+    agent._context_engine_caps = caps
+    agent._turn_compressed = False
+    agent.context_compressor = MagicMock()
+    agent.context_compressor.name = "mock-engine"
+    agent.context_compressor.last_prompt_tokens = 1234
+    agent.context_compressor.last_completion_tokens = 56
+    agent.context_compressor.last_total_tokens = 1290
+    return agent
+
+
+def _run_finalize(agent, *, interrupted=False, final_response="All done."):
+    from agent.turn_finalizer import finalize_turn
+
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": final_response or "x"},
+    ]
+    result = finalize_turn(
+        agent,
+        final_response=final_response,
+        api_call_count=2,
+        interrupted=interrupted,
+        failed=False,
+        messages=messages,
+        conversation_history=None,
+        effective_task_id="default",
+        turn_id="turn-42",
+        user_message="hi",
+        original_user_message="hi",
+        _should_review_memory=False,
+        _turn_exit_reason="text_response",
+    )
+    return result, messages
+
+
+# ── _compress_context forwarder: on_pre_compress + marker ───────────────────
+
+
+class TestCompressForwarder:
+    def _patch_compress(self, new_list):
+        return patch(
+            "agent.conversation_compression.compress_context",
+            return_value=(new_list, "sys"),
+        )
+
+    def test_snapshot_called_before_compress(self):
+        agent = _bare_compress_agent(
+            ContextEngineCapabilities(lossless_snapshot=True)
+        )
+        msgs = [{"role": "user", "content": "hi"}]
+        order = []
+        agent.context_compressor.on_pre_compress.side_effect = (
+            lambda m: order.append("snapshot")
+        )
+        with patch(
+            "agent.conversation_compression.compress_context",
+            side_effect=lambda *a, **k: (order.append("compress"), ([], "sys"))[1],
+        ):
+            agent._compress_context(msgs, "sys")
+        assert order == ["snapshot", "compress"]
+        agent.context_compressor.on_pre_compress.assert_called_once_with(msgs)
+
+    def test_snapshot_gated_off_by_default(self):
+        agent = _bare_compress_agent(ContextEngineCapabilities())
+        msgs = [{"role": "user", "content": "hi"}]
+        with self._patch_compress([]):
+            agent._compress_context(msgs, "sys")
+        agent.context_compressor.on_pre_compress.assert_not_called()
+
+    def test_snapshot_failure_does_not_block_compression(self):
+        agent = _bare_compress_agent(
+            ContextEngineCapabilities(lossless_snapshot=True)
+        )
+        agent.context_compressor.on_pre_compress.side_effect = RuntimeError("boom")
+        msgs = [{"role": "user", "content": "hi"}]
+        with self._patch_compress([]):
+            out, _ = agent._compress_context(msgs, "sys")
+        assert out == []  # compression still ran
+
+    def test_marker_set_only_when_list_replaced(self):
+        agent = _bare_compress_agent(ContextEngineCapabilities())
+        msgs = [{"role": "user", "content": "hi"}]
+        # Abort path: compress_context returns the SAME object → no marker.
+        with patch(
+            "agent.conversation_compression.compress_context",
+            return_value=(msgs, "sys"),
+        ):
+            agent._compress_context(msgs, "sys")
+        assert agent._turn_compressed is False
+        # Real compaction: new list → marker set.
+        with self._patch_compress([{"role": "user", "content": "summary"}]):
+            agent._compress_context(msgs, "sys")
+        assert agent._turn_compressed is True
+
+
+# ── finalize_turn: on_turn_complete observation ──────────────────────────────
+
+
+class TestTurnObservation:
+    def test_fires_with_observation_capability(self):
+        agent = _finalize_agent(ContextEngineCapabilities(observation=True))
+        _, messages = _run_finalize(agent)
+        hook = agent.context_compressor.on_turn_complete
+        hook.assert_called_once()
+        called_messages, turn = hook.call_args.args
+        assert called_messages is messages
+        assert isinstance(turn, TurnInfo)
+        assert turn.session_id == "sess-1"
+        assert turn.turn_id == "turn-42"
+        assert turn.usage["prompt_tokens"] == 1234
+        assert turn.interrupted is False
+        assert turn.completed is True
+
+    def test_gated_off_by_default(self):
+        agent = _finalize_agent(ContextEngineCapabilities())
+        _run_finalize(agent)
+        agent.context_compressor.on_turn_complete.assert_not_called()
+
+    def test_fires_on_interrupted_turn_with_flag(self):
+        agent = _finalize_agent(ContextEngineCapabilities(observation=True))
+        _run_finalize(agent, interrupted=True)
+        hook = agent.context_compressor.on_turn_complete
+        hook.assert_called_once()
+        _, turn = hook.call_args.args
+        assert turn.interrupted is True
+
+    def test_runs_before_external_memory_sync(self):
+        agent = _finalize_agent(ContextEngineCapabilities(observation=True))
+        order = []
+        agent.context_compressor.on_turn_complete.side_effect = (
+            lambda *a, **k: order.append("engine")
+        )
+        agent._sync_external_memory_for_turn.side_effect = (
+            lambda **k: order.append("memory")
+        )
+        _run_finalize(agent)
+        assert order == ["engine", "memory"]
+
+    def test_hook_failure_does_not_break_turn(self):
+        agent = _finalize_agent(ContextEngineCapabilities(observation=True))
+        agent.context_compressor.on_turn_complete.side_effect = RuntimeError("boom")
+        result, _ = _run_finalize(agent)
+        assert result["final_response"] == "All done."
+        agent._sync_external_memory_for_turn.assert_called_once()
+
+    def test_compressed_during_turn_flag_propagates(self):
+        agent = _finalize_agent(ContextEngineCapabilities(observation=True))
+        agent._turn_compressed = True
+        _run_finalize(agent)
+        _, turn = agent.context_compressor.on_turn_complete.call_args.args
+        assert turn.compressed_during_turn is True
+
+    def test_no_caps_attribute_is_safe(self):
+        """Agents built before agent_init ran (bare paths) must not crash."""
+        agent = _finalize_agent(ContextEngineCapabilities())
+        del agent._context_engine_caps
+        # MagicMock would auto-create the attr; emulate absence with None.
+        agent._context_engine_caps = None
+        result, _ = _run_finalize(agent)
+        assert result["final_response"] == "All done."
+
+
+# ── background-review fork isolation (B6) ────────────────────────────────────
+
+
+class TestReviewForkIsolation:
+    def test_review_fork_disables_context_engine_lifecycle(self, monkeypatch):
+        """The internal review fork shares the parent session_id, so an
+        observation-capable engine would ingest the review's internal
+        monologue into the parent conversation's store. The fork must zero
+        out the capability snapshot before running."""
+        from agent.background_review import _run_review_in_thread
+
+        created = []
+
+        def _factory(*args, **kwargs):
+            inst = MagicMock()
+            inst.run_conversation.side_effect = RuntimeError("stop after setup")
+            created.append(inst)
+            return inst
+
+        monkeypatch.setattr("run_agent.AIAgent", _factory)
+        parent = MagicMock()
+        parent._current_main_runtime.return_value = {
+            "api_mode": "chat_completions", "base_url": "", "api_key": "k",
+        }
+        parent.session_id = "parent-sess"
+        parent.model = "m"
+        parent.platform = "cli"
+        parent.provider = "p"
+
+        _run_review_in_thread(parent, [], "review prompt")
+
+        assert created, "review agent was never constructed"
+        caps = created[0]._context_engine_caps
+        assert isinstance(caps, ContextEngineCapabilities)
+        assert caps.observation is False
+        assert caps.request_assembly is False
+        assert caps.lossless_snapshot is False

--- a/tests/run_agent/test_context_engine_lifecycle_e2e.py
+++ b/tests/run_agent/test_context_engine_lifecycle_e2e.py
@@ -1,0 +1,258 @@
+"""End-to-end tests for ContextEngine lifecycle hooks through run_conversation.
+
+Drives the REAL conversation loop (mocked provider call only, following the
+harness pattern of tests/run_agent/test_context_token_tracking.py) with an
+OpenViking-style full-capability engine, and verifies the functional goals:
+
+1. Request assembly shapes what the provider receives (request-only view);
+   the working message list / session persistence never see it.
+2. Turn observation fires after the loop with the finalized message list.
+3. Legacy path (built-in compressor) is unchanged: outbound equals input.
+4. Assembly failure fails open: original outbound, turn completes.
+5. Lineage kwargs reach the engine (boundary_reason / lineage_root_id).
+"""
+
+import sys
+import types
+from types import SimpleNamespace
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+import run_agent
+from agent.context_engine import ContextEngine, ContextEngineCapabilities
+
+SUMMARY_MARK = "[ARCHIVE SUMMARY] previously discussed the Lisbon trip"
+
+
+# ── OpenViking-style full-capability engine ──────────────────────────────────
+
+
+class OVStyleEngine(ContextEngine):
+    """Archive-summary + recall-injection engine shaped like the OpenViking
+    OpenClaw plugin: observation ingest + request assembly."""
+
+    def __init__(self, fail_assembly=False):
+        self.observed = []
+        self.prepared = []
+        self.session_starts = []
+        self.fail_assembly = fail_assembly
+        self.context_length = 200_000
+        self.threshold_tokens = 100_000
+
+    @property
+    def name(self):
+        return "ov-style"
+
+    def update_from_response(self, usage):
+        self.last_prompt_tokens = usage.get("prompt_tokens", 0)
+        self.last_completion_tokens = usage.get("completion_tokens", 0)
+        self.last_total_tokens = usage.get("total_tokens", 0)
+
+    def should_compress(self, prompt_tokens=None):
+        return False
+
+    def compress(self, messages, current_tokens=None, focus_topic=None):
+        return messages
+
+    def capabilities(self):
+        return ContextEngineCapabilities(observation=True, request_assembly=True)
+
+    def prepare_request_messages(self, messages, ctx):
+        self.prepared.append((messages, ctx))
+        if self.fail_assembly:
+            raise RuntimeError("assembly backend down")
+        # Request-only view: archive summary merged into the user message
+        # (replacement-style, keeps role alternation valid).
+        view = [dict(m) for m in messages]
+        for m in view:
+            if m.get("role") == "user" and isinstance(m.get("content"), str):
+                m["content"] = SUMMARY_MARK + "\n\n" + m["content"]
+        return view
+
+    def on_turn_complete(self, messages, turn):
+        self.observed.append((messages, turn))
+
+    def on_session_start(self, session_id, **kwargs):
+        self.session_starts.append((session_id, kwargs))
+
+
+# ── harness (pattern from test_context_token_tracking.py) ────────────────────
+
+
+def _patch_bootstrap(monkeypatch):
+    monkeypatch.setattr(run_agent, "get_tool_definitions", lambda **kwargs: [{
+        "type": "function",
+        "function": {"name": "t", "description": "t",
+                     "parameters": {"type": "object", "properties": {}}},
+    }])
+    monkeypatch.setattr(run_agent, "check_toolset_requirements", lambda: {})
+
+
+def _text_response():
+    return SimpleNamespace(
+        choices=[SimpleNamespace(index=0, message=SimpleNamespace(
+            role="assistant", content="Sure — done.", tool_calls=None,
+            reasoning_content=None,
+        ), finish_reason="stop")],
+        usage=SimpleNamespace(prompt_tokens=500, completion_tokens=20,
+                              total_tokens=520),
+        model="test-model",
+    )
+
+
+def _make_agent(monkeypatch, engine=None, captured=None):
+    _patch_bootstrap(monkeypatch)
+
+    class _A(run_agent.AIAgent):
+        def __init__(self, *a, **kw):
+            kw.update(skip_context_files=True, skip_memory=True, max_iterations=4)
+            super().__init__(*a, **kw)
+            self._cleanup_task_resources = self._persist_session = lambda *a, **k: None
+            self._save_trajectory = lambda *a, **k: None
+
+        def run_conversation(self, msg, conversation_history=None, task_id=None):
+            def _call(kw):
+                if captured is not None:
+                    captured.append(kw)
+                return _text_response()
+
+            self._interruptible_api_call = _call
+            self._disable_streaming = True
+            return super().run_conversation(
+                msg, conversation_history=conversation_history, task_id=task_id
+            )
+
+    agent = _A(model="test-model", api_key="test-key",
+               base_url="http://localhost:1234/v1",
+               provider="openrouter", api_mode="chat_completions")
+    if engine is not None:
+        agent.context_compressor = engine
+        agent._context_engine_caps = engine.capabilities()
+    return agent
+
+
+def _outbound_user_contents(api_kwargs):
+    return [m.get("content") for m in api_kwargs["messages"]
+            if m.get("role") == "user"]
+
+
+# ── E2E: request assembly ────────────────────────────────────────────────────
+
+
+class TestAssemblyE2E:
+    def test_provider_sees_assembled_view(self, monkeypatch):
+        captured = []
+        engine = OVStyleEngine()
+        agent = _make_agent(monkeypatch, engine=engine, captured=captured)
+        agent.run_conversation("plan the next step")
+
+        assert engine.prepared, "prepare_request_messages was never called"
+        assert captured, "provider was never called"
+        user_contents = _outbound_user_contents(captured[0])
+        assert any(SUMMARY_MARK in (c or "") for c in user_contents), (
+            "assembled summary must reach the provider request"
+        )
+
+    def test_working_messages_never_see_the_view(self, monkeypatch):
+        captured = []
+        engine = OVStyleEngine()
+        agent = _make_agent(monkeypatch, engine=engine, captured=captured)
+        result = agent.run_conversation("plan the next step")
+
+        for m in result["messages"]:
+            content = m.get("content") or ""
+            assert SUMMARY_MARK not in content, (
+                "request-only view leaked into the working message list"
+            )
+
+    def test_request_context_fields(self, monkeypatch):
+        engine = OVStyleEngine()
+        agent = _make_agent(monkeypatch, engine=engine, captured=[])
+        agent.run_conversation("hello there")
+
+        messages_arg, ctx = engine.prepared[0]
+        assert ctx.model == "test-model"
+        assert ctx.provider == "openrouter"
+        assert ctx.api_mode == "chat_completions"
+        assert ctx.session_id == (agent.session_id or "")
+        assert ctx.platform == "cli"
+        assert ctx.tools
+        assert ctx.budget_tokens == engine.threshold_tokens
+        assert ctx.incoming_message is not None
+        assert ctx.incoming_message.get("role") == "user"
+
+    def test_assembly_takes_over_plugin_context_injection(self, monkeypatch):
+        captured = []
+        engine = OVStyleEngine()
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda name, **kwargs: [{"context": "PLUGIN_CONTEXT_MARK"}]
+            if name == "pre_llm_call" else [],
+        )
+        agent = _make_agent(monkeypatch, engine=engine, captured=captured)
+        agent.run_conversation("plan the next step")
+
+        assert engine.prepared[0][1].plugin_user_context == "PLUGIN_CONTEXT_MARK"
+        user_contents = _outbound_user_contents(captured[0])
+        assert all("PLUGIN_CONTEXT_MARK" not in (c or "") for c in user_contents)
+
+    def test_assembly_failure_fails_open(self, monkeypatch):
+        captured = []
+        engine = OVStyleEngine(fail_assembly=True)
+        agent = _make_agent(monkeypatch, engine=engine, captured=captured)
+        result = agent.run_conversation("plan the next step")
+
+        assert result["final_response"] == "Sure — done."
+        user_contents = _outbound_user_contents(captured[0])
+        assert all(SUMMARY_MARK not in (c or "") for c in user_contents)
+        # Observation still works after an assembly failure.
+        assert len(engine.observed) == 1
+
+
+# ── E2E: turn observation ────────────────────────────────────────────────────
+
+
+class TestObservationE2E:
+    def test_fires_once_with_finalized_messages(self, monkeypatch):
+        engine = OVStyleEngine()
+        agent = _make_agent(monkeypatch, engine=engine, captured=[])
+        result = agent.run_conversation("hello")
+
+        assert len(engine.observed) == 1
+        observed_messages, turn = engine.observed[0]
+        assert observed_messages is result["messages"]
+        assert any(m.get("role") == "assistant" for m in observed_messages)
+        assert turn.completed is True
+        assert turn.interrupted is False
+        assert turn.compressed_during_turn is False
+        assert turn.session_id == (agent.session_id or "")
+        assert turn.turn_index == agent._user_turn_count
+        # usage flows from update_from_response into TurnInfo
+        assert turn.usage["prompt_tokens"] == 500
+
+
+# ── E2E: legacy path unchanged ───────────────────────────────────────────────
+
+
+class TestLegacyBaselineE2E:
+    def test_builtin_compressor_outbound_equals_input(self, monkeypatch):
+        captured = []
+        agent = _make_agent(monkeypatch, engine=None, captured=captured)
+        agent.run_conversation("plain question")
+
+        user_contents = _outbound_user_contents(captured[0])
+        assert "plain question" in (user_contents[-1] or "")
+        assert all(SUMMARY_MARK not in (c or "") for c in user_contents)
+        # Default capabilities declare nothing.
+        caps = agent._context_engine_caps
+        assert caps.observation is False and caps.request_assembly is False
+
+
+# ── E2E: lineage kwargs ──────────────────────────────────────────────────────
+
+
+# NOTE: lineage E2E tests (boundary_reason / lineage_root_id propagation and
+# reset-root regeneration) ship with the follow-up lineage PR alongside the
+# code they exercise.

--- a/tests/run_agent/test_context_engine_loop_paths.py
+++ b/tests/run_agent/test_context_engine_loop_paths.py
@@ -1,0 +1,226 @@
+"""Loop-path coverage for ContextEngine lifecycle hooks (test plan A2/A7/A8).
+
+Drives the REAL run_conversation with scripted provider responses:
+- A2: tool loop — request assembly runs on EVERY dispatch (idempotent engine)
+- A7: anthropic_messages api_mode shares the outbound build (assembly works)
+- A8: codex_app_server hands the turn to an external runtime — hooks must
+      not fire (documented limitation, asserted here)
+"""
+
+import sys
+import types
+from types import SimpleNamespace
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+import run_agent
+from agent.context_engine import ContextEngine, ContextEngineCapabilities
+
+MARK = "[CTX-VIEW]"
+
+
+class AssemblingEngine(ContextEngine):
+    """Minimal observation+assembly engine that tags the outbound view."""
+
+    def __init__(self):
+        self.prepare_calls = 0
+        self.turns = []
+
+    @property
+    def name(self):
+        return "assembling-test"
+
+    def update_from_response(self, usage):
+        self.last_prompt_tokens = usage.get("prompt_tokens", 0)
+
+    def should_compress(self, prompt_tokens=None):
+        return False
+
+    def compress(self, messages, current_tokens=None, focus_topic=None):
+        return messages
+
+    def capabilities(self):
+        return ContextEngineCapabilities(observation=True, request_assembly=True)
+
+    def prepare_request_messages(self, messages, ctx):
+        self.prepare_calls += 1
+        view = [dict(m) for m in messages]
+        for m in view:
+            if m.get("role") == "user" and isinstance(m.get("content"), str):
+                m["content"] = MARK + " " + m["content"]
+        return view
+
+    def on_turn_complete(self, messages, turn):
+        self.turns.append(turn)
+
+
+def _patch_bootstrap(monkeypatch):
+    monkeypatch.setattr(run_agent, "get_tool_definitions", lambda **kwargs: [{
+        "type": "function",
+        "function": {"name": "t", "description": "t",
+                     "parameters": {"type": "object", "properties": {}}},
+    }])
+    monkeypatch.setattr(run_agent, "check_toolset_requirements", lambda: {})
+
+
+def _text_resp(text="done"):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(index=0, message=SimpleNamespace(
+            role="assistant", content=text, tool_calls=None,
+            reasoning_content=None), finish_reason="stop")],
+        usage=SimpleNamespace(prompt_tokens=100, completion_tokens=5,
+                              total_tokens=105),
+        model="test-model",
+    )
+
+
+def _tool_resp():
+    return SimpleNamespace(
+        choices=[SimpleNamespace(index=0, message=SimpleNamespace(
+            role="assistant", content=None,
+            tool_calls=[SimpleNamespace(
+                id="call-1", type="function",
+                function=SimpleNamespace(name="t", arguments="{}"))],
+            reasoning_content=None), finish_reason="tool_calls")],
+        usage=SimpleNamespace(prompt_tokens=100, completion_tokens=5,
+                              total_tokens=105),
+        model="test-model",
+    )
+
+
+def _anthropic_text_resp(text="done"):
+    return SimpleNamespace(
+        content=[SimpleNamespace(type="text", text=text)],
+        stop_reason="end_turn",
+        usage=SimpleNamespace(input_tokens=100, output_tokens=5),
+        model="claude-test",
+    )
+
+
+class _FakeAnthropicClient:
+    def close(self):
+        pass
+
+
+def _make_agent(monkeypatch, responses, engine, api_mode="chat_completions",
+                provider="openrouter", captured=None):
+    _patch_bootstrap(monkeypatch)
+    if api_mode == "anthropic_messages":
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.build_anthropic_client",
+            lambda k, b=None, **kw: _FakeAnthropicClient(),
+        )
+    queue = list(responses)
+
+    class _A(run_agent.AIAgent):
+        def __init__(self, *a, **kw):
+            kw.update(skip_context_files=True, skip_memory=True, max_iterations=4)
+            super().__init__(*a, **kw)
+            self._cleanup_task_resources = self._persist_session = lambda *a, **k: None
+            self._save_trajectory = lambda *a, **k: None
+
+        def run_conversation(self, msg, conversation_history=None, task_id=None):
+            def _call(kw):
+                if captured is not None:
+                    captured.append(kw)
+                return queue.pop(0) if len(queue) > 1 else queue[0]
+
+            self._interruptible_api_call = _call
+            self._disable_streaming = True
+            return super().run_conversation(
+                msg, conversation_history=conversation_history, task_id=task_id
+            )
+
+    agent = _A(model="test-model", api_key="test-key",
+               base_url="http://localhost:1234/v1",
+               provider=provider, api_mode=api_mode)
+    agent.context_compressor = engine
+    agent._context_engine_caps = engine.capabilities()
+    return agent
+
+
+# ── A2: tool loop — assembly on every dispatch ───────────────────────────────
+
+
+class TestToolLoopAssembly:
+    def test_assembly_runs_per_dispatch(self, monkeypatch):
+        engine = AssemblingEngine()
+        captured = []
+        agent = _make_agent(
+            monkeypatch, [_tool_resp(), _text_resp("after tool")],
+            engine, captured=captured,
+        )
+        result = agent.run_conversation("use the tool then answer")
+
+        assert result["final_response"] == "after tool"
+        # Two provider dispatches -> two assembly invocations.
+        assert engine.prepare_calls == len(captured) == 2
+        # The engine view reached the provider on BOTH dispatches.
+        for kw in captured:
+            user_contents = [m.get("content") for m in kw["messages"]
+                             if m.get("role") == "user"]
+            assert any(MARK in (c or "") for c in user_contents)
+        # Observation still fires exactly once at turn end.
+        assert len(engine.turns) == 1
+
+    def test_working_messages_clean_after_tool_loop(self, monkeypatch):
+        engine = AssemblingEngine()
+        agent = _make_agent(
+            monkeypatch, [_tool_resp(), _text_resp()], engine,
+        )
+        result = agent.run_conversation("go")
+        for m in result["messages"]:
+            assert MARK not in str(m.get("content") or "")
+
+
+# ── A7: anthropic_messages shares the outbound build ─────────────────────────
+
+
+class TestAnthropicAssembly:
+    def test_assembly_applies_on_anthropic_path(self, monkeypatch):
+        engine = AssemblingEngine()
+        captured = []
+        agent = _make_agent(
+            monkeypatch, [_anthropic_text_resp("ok")], engine,
+            api_mode="anthropic_messages", provider="anthropic",
+            captured=captured,
+        )
+        result = agent.run_conversation("hello")
+        assert result["final_response"] == "ok"
+        assert engine.prepare_calls >= 1
+        assert len(engine.turns) == 1
+        # The view must reach the anthropic request payload.
+        flat = str(captured[0])
+        assert MARK in flat
+
+    def test_anthropic_working_messages_clean(self, monkeypatch):
+        engine = AssemblingEngine()
+        agent = _make_agent(
+            monkeypatch, [_anthropic_text_resp()], engine,
+            api_mode="anthropic_messages", provider="anthropic",
+        )
+        result = agent.run_conversation("hello")
+        for m in result["messages"]:
+            assert MARK not in str(m.get("content") or "")
+
+
+# ── A8: codex_app_server bypasses the loop entirely ──────────────────────────
+
+
+class TestCodexAppServerLimitation:
+    def test_hooks_do_not_fire(self, monkeypatch):
+        engine = AssemblingEngine()
+        agent = _make_agent(monkeypatch, [_text_resp()], engine)
+        agent.api_mode = "codex_app_server"
+        agent._run_codex_app_server_turn = lambda **kw: {
+            "final_response": "external runtime", "messages": [],
+            "api_calls": 1, "completed": True,
+        }
+        result = agent.run_conversation("hi")
+        assert result["final_response"] == "external runtime"
+        # Documented limitation: the external runtime owns the turn —
+        # no assembly, no observation.
+        assert engine.prepare_calls == 0
+        assert engine.turns == []


### PR DESCRIPTION
## What does this PR do?

This PR adds optional, capability-gated lifecycle hooks to `ContextEngine` so external context engines can observe completed turns, assemble provider-bound request messages, and snapshot the full transcript before compression without abusing `compress()` as a generic backdoor.

Today `ContextEngine` mainly models compression through `should_compress()` / `compress()`. That makes per-turn observation or pre-LLM context assembly difficult to express cleanly, and pushes engines toward treating request-time transforms as compaction events. This PR separates those concerns while preserving the existing built-in compressor behavior.

This is intentionally separate from `MemoryProvider`. `MemoryProvider` remains the right abstraction for simple long-term memory integrations: it can sync completed turns and inject recalled memory text. However, it cannot replace, trim, reorder, or rebuild the full provider-bound message list. Context engines need a different seam for systems that manage the whole outbound context window rather than only appending recalled memory.

The new hooks are:

- `on_turn_complete(messages, TurnInfo)`: finalized-turn observation in `finalize_turn` for ingest/index/memory workflows.
- `prepare_request_messages(messages, RequestContext) -> list | None`: outbound-only request assembly before provider dispatch; `None` means passthrough; returned views are never written back to the canonical transcript.
- `on_pre_compress(messages)`: lossless snapshot opportunity at the single compression chokepoint before compaction mutates the window.

Hosts gate every call on a `ContextEngineCapabilities` snapshot taken once at engine registration. Hook dispatch is fail-open through `engine_hook()`: failures are logged and degrade to the original behavior. Review-fork agents are isolated from lifecycle side effects.

## Related Issue

Related to #23837, #24949, #36765, and #41918.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/context_engine.py`
  - Adds `TurnInfo`, `RequestContext`, `ContextEngineCapabilities`, and `engine_hook()`.
  - Adds optional `on_turn_complete`, `prepare_request_messages`, and `on_pre_compress` hooks.
- `agent/conversation_loop.py`
  - Calls `prepare_request_messages` before building provider-bound API messages.
  - Keeps the assembled view request-only and out of persisted transcript state.
  - Hands memory prefetch and plugin `pre_llm_call` context to the engine when it takes over assembly, avoiding double injection.
- `agent/turn_finalizer.py`
  - Calls `on_turn_complete` before external memory sync.
- `run_agent.py`
  - Calls `on_pre_compress` at the compression chokepoint before `compress()` mutates the message window.
- `agent/agent_init.py` and `agent/background_review.py`
  - Snapshot engine capabilities and disable lifecycle hooks for internal review forks.
- Adds contract, integration, loop-path, and real `run_conversation` E2E tests.

## How to Test

1. Run the lifecycle hook suites:

```bash
scripts/run_tests.sh tests/agent/test_context_engine_lifecycle.py \
  tests/agent/test_context_engine_lifecycle_integration.py \
  tests/run_agent/test_context_engine_lifecycle_e2e.py \
  tests/run_agent/test_context_engine_loop_paths.py
```

2. Verify existing engines that do not declare capabilities do not receive new hook calls.
3. Verify request-assembly views are provider-bound only and do not mutate the canonical transcript.

Targeted lifecycle suite result:

```text
41 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings only
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
41 passed
```