### PR TITLE
feat(skills): add skill-curator optional skill for skill library hygiene

### DIFF
--- a/optional-skills/security/skill-curator/SKILL.md
+++ b/optional-skills/security/skill-curator/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: skill-curator
+description: Scan skills for similarity clusters, propose merge plans, review new skills for integration, and maintain skill library hygiene.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [skill-management, optimization, consolidation, review, hygiene, maintenance]
+    category: security
+---
+
+# Skill Curator
+
+技能优化引擎 — 扫描技能库，识别相似/重叠技能，生成整合方案，审核新技能，维护技能健康度。
+
+## When to Use
+
+- "优化技能" / "整合技能" / "skill optimization" / "merge skills" / "consolidate skills"
+- "skill audit" / "skill review" / "新技能审核"
+- 技能数量增长后需要整理时
+- 安装新技能后需要评估是否与已有技能重叠
+
+## Prerequisites
+
+- Python 3.10+
+- No external dependencies (stdlib only)
+
+## How to Run
+
+```bash
+# Scan for similar skills
+python3 <skill-curator-path>/scripts/consolidate.py --scan
+
+# Generate merge plan for a group
+python3 <skill-curator-path>/scripts/consolidate.py --plan <group_name>
+
+# Review a new skill for integration
+python3 <skill-curator-path>/scripts/auto_review.py --days 7
+
+# Auto-apply safe decisions (add_new + skip_duplicate)
+python3 <skill-curator-path>/scripts/auto_review.py --days 7 --auto
+
+# Skill health report
+python3 <skill-curator-path>/scripts/consolidate.py --health
+```
+
+## Quick Reference
+
+### consolidate.py
+
+| Flag | Description |
+|------|-------------|
+| `--scan` | Scan for similar skill groups |
+| `--plan <group>` | Generate merge plan for a group |
+| `--execute <group>` | Execute merge (requires approval) |
+| `--health` | Skill health report |
+| `--rollback <suite>` | Rollback a merge |
+| `--review <path>` | Review a new skill for integration |
+| `--review <path> --auto` | Auto-apply best action |
+
+### auto_review.py
+
+| Flag | Description |
+|------|-------------|
+| `--days N` | Check skills modified in last N days (default: 7) |
+| `--auto` | Auto-apply safe decisions |
+| `--report-only` | Just generate report, no actions |
+
+## Core Principles
+
+1. **不删除原技能** — 整合后原技能保留在 `.archive/`，可随时恢复
+2. **锁定保护** — `locked` 列表和 `locked_categories` 中的技能完全不被触碰
+3. **子能力独立调用** — 整合后的技能支持单独调用其中某个子模块
+4. **用户审核** — 所有整合方案必须经用户确认后才执行
+
+## Cron Integration
+
+For automated skill hygiene, add these cron jobs:
+
+### Weekly Full Scan (Monday 10:00)
+```
+1. Run: consolidate.py --scan
+2. Run: consolidate.py --health
+3. Report NEW similar groups found
+```
+
+### Bi-hourly Auto-Review (every 2h)
+```
+1. Run: auto_review.py --days 1 --report-only
+2. If skills marked "Recommend", report details
+3. If all "Already active" or "Skip duplicate", output [SILENT]
+```
+
+See `references/cron-integration.md` for full cron job configurations.
+
+## Pitfalls
+
+- **Profile HOME resolution**: Cron runs under profile HOME. Always use absolute paths.
+- **Suite self-match exclusion**: The auto_review script skips `category=merged` skills to avoid false reports.
+- **`--days 1` for cron**: Don't use `--days 7` in cron — it will re-report the same skills. Use 1 day.
+- **`[SILENT]` for no-op runs**: Auto-review cron MUST output `[SILENT]` when nothing to report.
+
+## Verification
+
+```bash
+# Scan should complete without errors
+python3 <path>/scripts/consolidate.py --scan
+
+# Health report should show active/archived counts
+python3 <path>/scripts/consolidate.py --health
+```

--- a/optional-skills/security/skill-curator/references/cron-integration.md
+++ b/optional-skills/security/skill-curator/references/cron-integration.md
@@ -1,0 +1,48 @@
+# Skill Curator Cron Integration
+
+Two cron jobs automate skill hygiene. Both use `enabled_toolsets=['terminal', 'file']`.
+
+## Job 1: Weekly Full Scan
+
+```python
+cronjob(
+    action='create',
+    schedule='0 10 * * 1',        # Monday 10:00
+    name='skill-curator weekly scan',
+    prompt='''Run skill-curator scan for skill hygiene:
+
+1. Execute: `python3 ~/.hermes/profiles/coder/skills/skill-curator/scripts/consolidate.py --scan`
+2. Execute: `python3 ~/.hermes/profiles/coder/skills/skill-curator/scripts/consolidate.py --health`
+3. Report any NEW similar groups found that weren't previously consolidated
+4. Report the count of active vs archived skills
+5. If any new consolidation opportunities found, list them with member skills
+
+Keep the report concise — just list new findings.''',
+    enabled_toolsets=['terminal', 'file']
+)
+```
+
+## Job 2: Bi-hourly Auto-Review
+
+```python
+cronjob(
+    action='create',
+    schedule='every 2h',
+    name='skill-curator daily review',
+    prompt='''Run the skill-curator auto-review pipeline:
+
+1. Execute: `python3 ~/.hermes/profiles/coder/skills/skill-curator/scripts/auto_review.py --days 1 --report-only`
+2. If there are any skills marked as "Recommend" (not "Already active" or "Skip duplicate"), report them with details
+3. If all skills are "Already active" or "Skip duplicate", respond with exactly "[SILENT]" to suppress delivery
+
+Only report if there are actual new findings that need attention.''',
+    enabled_toolsets=['terminal', 'file']
+)
+```
+
+## Pitfalls
+
+- **`--days 1` for cron review**: Don't use `--days 7` in cron — it will re-report the same skills every run. Use 1 day to catch only truly new changes.
+- **`[SILENT]` for no-op runs**: The auto-review cron MUST output `[SILENT]` when there's nothing to report, otherwise Feishu delivers empty noise.
+- **Profile HOME resolution**: Cron runs under profile HOME (`~/.hermes/profiles/coder/home`). Always use absolute paths.
+- **Suite self-match exclusion**: The `auto_review.py` script skips `category=merged` skills and suite source_skills to avoid false "duplicate of voice-suite" reports.

--- a/optional-skills/security/skill-curator/references/hermes-archive-exclusion.md
+++ b/optional-skills/security/skill-curator/references/hermes-archive-exclusion.md
@@ -1,0 +1,33 @@
+# Hermes Archive Exclusion Mechanism
+
+## How .archive/ Works
+
+Hermes `agent/skill_utils.py` line 27 defines `EXCLUDED_SKILL_DIRS`:
+
+```python
+EXCLUDED_SKILL_DIRS = frozenset((
+    ".git", ".github", ".hub", ".archive", ".venv", "venv",
+    "node_modules", "site-packages", "__pycache__", ".tox",
+    ".nox", ".pytest_cache", ".mypy_cache", ".ruff_cache",
+))
+```
+
+The `is_excluded_skill_path()` function (line 47) checks every SKILL.md path against this set.
+The `iter_skill_index_files()` function (line 668) prunes excluded dirs during os.walk:
+```python
+dirs[:] = [d for d in dirs if d not in EXCLUDED_SKILL_DIRS]
+```
+
+## Implications
+
+- Skills in `skills/.archive/` are **never loaded** into the system prompt
+- They don't appear in `skills_list` or `<available_skills>`
+- Zero token cost — completely invisible to the agent
+- Files remain intact — `mv` back to restore
+- This is the **preferred archival mechanism** over `.disabled` suffix
+
+## Verified On
+
+- Hermes Agent v0.14.0+, macOS
+- Profile path: `~/.hermes/profiles/<profile>/skills/.archive/`
+- Global path: `~/.hermes/skills/.archive/`

--- a/optional-skills/security/skill-curator/references/redundant-merge-principle.md
+++ b/optional-skills/security/skill-curator/references/redundant-merge-principle.md
@@ -1,0 +1,63 @@
+# Redundant Merge Principle
+
+## Core Rule
+
+**Same capability + different implementation = REDUNDANT/FALLBACK, NOT duplicate.**
+
+User explicitly stated: "能力一样实现方法不一样应该合并作为冗余方案，而不是判断无需入库"
+
+Two skills solving the same problem with different tools/libraries/approaches are NOT duplicates. They are redundant implementations providing:
+- Fallback if one approach breaks
+- Different tradeoffs (speed vs accuracy, local vs cloud, free vs paid)
+- Broader coverage across environments
+
+## Decision Matrix
+
+| Capability | Implementation | Action | Rationale |
+|-----------|---------------|--------|-----------|
+| Same | Different | `merge_as_redundant` | Preserve both as fallback options |
+| Same | Same (high similarity >0.5) | `skip_duplicate` | True duplicate, discard |
+| Same | Same (low similarity) | `merge_as_module` | Related but different focus |
+| Different | Any | `add_new` | New capability |
+
+## Implementation Detection
+
+Keywords that signal different implementations:
+- RAG: `langchain` vs `llamaindex` vs `haystack`
+- Browser: `playwright` vs `selenium` vs `puppeteer` vs `camoufox`
+- Container: `docker` vs `podman` vs `kubernetes`
+- Web: `fastapi` vs `flask` vs `django` vs `streamlit`
+- ML: `pytorch` vs `tensorflow` vs `jax` vs `mlx`
+- Vector DB: `qdrant` vs `chroma` vs `milvus` vs `pinecone`
+- LLM: `openai` vs `anthropic` vs `google` vs `ollama` vs `vllm`
+- HTTP: `curl` vs `requests` vs `httpx` vs `aiohttp`
+
+## Example
+
+```
+Skill A: rag-engineer (LangChain-based RAG architecture)
+Skill B: rag-implementation (LlamaIndex-based RAG implementation)
+
+→ Action: merge_as_redundant into rag-suite
+  - rag-suite/references/engineer.md (primary)
+  - rag-suite/references/redundant_rag_impl.md (fallback)
+  - rag-suite/modules.json includes both + redundant_implementations[]
+```
+
+## modules.json Redundant Entry
+
+```json
+{
+  "skill": "rag-suite",
+  "modules": { ... },
+  "redundant_implementations": [
+    {
+      "name": "rag-implementation",
+      "source": "rag-implementation",
+      "added": "2026-06-16T...",
+      "file": "references/redundant_rag_implementation.md",
+      "impl_diff": "Uses LlamaIndex instead of LangChain"
+    }
+  ]
+}
+```

--- a/optional-skills/security/skill-curator/scripts/auto_review.py
+++ b/optional-skills/security/skill-curator/scripts/auto_review.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""
+Skill Auto-Review Pipeline
+Scans for recently added skills, auto-reviews them, and generates a report.
+
+Usage:
+    python3 auto_review.py [--days N] [--auto] [--report-only]
+    
+    --days N        Check skills modified in last N days (default: 7)
+    --auto          Auto-apply safe decisions (add_new + skip_duplicate)
+    --report-only   Just generate report, no actions
+"""
+
+import os
+import sys
+import json
+import time
+import shutil
+from pathlib import Path
+from datetime import datetime
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from consolidate import (
+    scan_skills, load_config, parse_skill, compute_similarity,
+    detect_same_capability, detect_different_implementation,
+    make_review_decision, SKILLS_DIR, ARCHIVE_DIR, HISTORY_FILE
+)
+
+REPORT_DIR = SKILLS_DIR / "skill-curator" / "references"
+REPORT_DIR.mkdir(parents=True, exist_ok=True)
+
+def find_recent_skills(days=7):
+    """Find skills modified in the last N days."""
+    cutoff = time.time() - (days * 86400)
+    recent = []
+    
+    for base, label in [(SKILLS_DIR, "active"), (ARCHIVE_DIR, "archive")]:
+        if not base.exists():
+            continue
+        for entry in base.iterdir():
+            if entry.name.startswith('.') or not entry.is_dir():
+                continue
+            skill_md = entry / "SKILL.md"
+            if not skill_md.exists():
+                continue
+            
+            mtime = skill_md.stat().st_mtime
+            if mtime >= cutoff:
+                recent.append({
+                    "name": entry.name,
+                    "path": entry,
+                    "loc": label,
+                    "modified": datetime.fromtimestamp(mtime).isoformat(),
+                    "mtime": mtime,
+                })
+    
+    return sorted(recent, key=lambda x: -x["mtime"])
+
+
+def review_skill_against_active(new_skill_info, all_skills, config):
+    """Review a skill against all active skills."""
+    new_skill = parse_skill(new_skill_info["path"] / "SKILL.md", new_skill_info["path"], new_skill_info["loc"])
+    
+    candidates = []
+    for name, existing in all_skills.items():
+        if existing["base"] == "archived":
+            continue
+        
+        # Skip if this is the same skill (self-match)
+        if name == new_skill["name"]:
+            continue
+        
+        # Skip merged suites (they're already consolidated, not real skills)
+        if existing.get("category") == "merged":
+            continue
+        
+        # Skip if this is a suite and the new skill is one of its source_skills
+        if existing.get("base") == "active":
+            modules_file = Path(existing["path"]) / "modules.json" if "path" in existing else SKILLS_DIR / name / "modules.json"
+            if modules_file.exists():
+                try:
+                    with open(modules_file) as f:
+                        mod_data = json.load(f)
+                    source_skills = mod_data.get("source_skills", [])
+                    if new_skill["name"] in source_skills:
+                        continue
+                except (json.JSONDecodeError, FileNotFoundError):
+                    pass
+        
+        score = compute_similarity(new_skill, existing)
+        if score > 0.05:
+            candidates.append({
+                "skill": existing,
+                "score": score,
+                "same_capability": detect_same_capability(new_skill, existing),
+                "different_implementation": detect_different_implementation(new_skill, existing),
+            })
+    
+    candidates.sort(key=lambda x: -x["score"])
+    decision = make_review_decision(new_skill, candidates, config)
+    
+    return {
+        "new_skill": new_skill,
+        "candidates": candidates[:3],
+        "decision": decision,
+    }
+
+
+def execute_auto_review(review_result, auto=False):
+    """Execute the review decision."""
+    new_skill = review_result["new_skill"]
+    decision = review_result["decision"]
+    
+    # If skill is already active and decision is add_new, it's fine
+    if new_skill["base"] == "active" and decision["action"] == "add_new":
+        return f"✅ Already active: {new_skill['name']}"
+    
+    if decision["action"] == "add_new" and decision["confidence"] >= 0.8:
+        if new_skill["base"] == "archive":
+            # Move from archive to active
+            src = ARCHIVE_DIR / new_skill["name"]
+            dest = SKILLS_DIR / new_skill["name"]
+            if not dest.exists():
+                if auto:
+                    shutil.move(str(src), str(dest))
+                    return f"✅ Moved to active: {new_skill['name']}"
+                else:
+                    return f"📋 Recommend adding: {new_skill['name']} (from archive)"
+            else:
+                return f"✅ Already exists: {new_skill['name']}"
+        else:
+            return f"✅ Already active: {new_skill['name']}"
+    
+    elif decision["action"] == "skip_duplicate":
+        return f"⏭️ Skip duplicate of {decision['target']}: {new_skill['name']}"
+    
+    elif decision["action"] == "merge_as_redundant":
+        target = decision["target"]
+        target_dir = SKILLS_DIR / target
+        if not target_dir.exists():
+            return f"⚠️ Target {target} not found for {new_skill['name']}"
+        
+        refs_dir = target_dir / "references"
+        refs_dir.mkdir(exist_ok=True)
+        
+        impl_name = new_skill["name"].replace("-", "_")
+        target_file = refs_dir / f"redundant_{impl_name}.md"
+        src_md = new_skill["path"] / "SKILL.md"
+        
+        if auto and src_md.exists() and not target_file.exists():
+            shutil.copy2(src_md, target_file)
+            
+            # Update modules.json
+            modules_file = target_dir / "modules.json"
+            if modules_file.exists():
+                with open(modules_file) as f:
+                    modules = json.load(f)
+                modules.setdefault("redundant_implementations", []).append({
+                    "name": new_skill["name"],
+                    "source": new_skill["name"],
+                    "added": datetime.now().isoformat(),
+                    "file": f"references/redundant_{impl_name}.md",
+                })
+                with open(modules_file, "w") as f:
+                    json.dump(modules, f, indent=2, ensure_ascii=False)
+            
+            return f"✅ Merged as redundant into {target}: {new_skill['name']}"
+        else:
+            return f"📋 Recommend merging as redundant into {target}: {new_skill['name']}"
+    
+    elif decision["action"] == "merge_as_module":
+        return f"📋 Recommend merging as module into {decision['target']}: {new_skill['name']}"
+    
+    return f"⚠️ Uncertain: {decision['action']} ({new_skill['name']}) — manual review needed"
+
+
+def generate_report(results, days):
+    """Generate a markdown report."""
+    report = f"""# Skill Auto-Review Report
+
+**Date**: {datetime.now().strftime('%Y-%m-%d %H:%M')}
+**Scan window**: Last {days} days
+**Skills reviewed**: {len(results)}
+
+## Summary
+
+| Action | Count |
+|--------|-------|
+"""
+    action_counts = {}
+    for r in results:
+        action = r["decision"]["action"]
+        action_counts[action] = action_counts.get(action, 0) + 1
+    
+    for action, count in sorted(action_counts.items(), key=lambda x: -x[1]):
+        report += f"| {action} | {count} |\n"
+    
+    report += "\n## Details\n\n"
+    
+    for r in results:
+        ns = r["new_skill"]
+        d = r["decision"]
+        report += f"### {ns['name']}\n"
+        report += f"- **Action**: `{d['action']}`\n"
+        report += f"- **Reason**: {d['reason']}\n"
+        report += f"- **Confidence**: {d['confidence']:.0%}\n"
+        if r["candidates"]:
+            report += f"- **Top match**: {r['candidates'][0]['skill']['name']} (score: {r['candidates'][0]['score']:.2f})\n"
+        report += "\n---\n\n"
+    
+    return report
+
+
+def main():
+    days = 7
+    auto = False
+    report_only = False
+    
+    args = sys.argv[1:]
+    if "--days" in args:
+        idx = args.index("--days")
+        if idx + 1 < len(args):
+            days = int(args[idx + 1])
+    auto = "--auto" in args
+    report_only = "--report-only" in args
+    
+    print(f"🔍 Skill Auto-Review Pipeline")
+    print(f"  Scan window: last {days} days")
+    print(f"  Auto-execute: {'yes' if auto else 'no'}")
+    print(f"  Report-only: {'yes' if report_only else 'no'}")
+    
+    config = load_config()
+    all_skills = scan_skills()
+    recent = find_recent_skills(days)
+    
+    if not recent:
+        print(f"\n✅ No skills modified in the last {days} days.")
+        return
+    
+    print(f"\n📋 Found {len(recent)} recent skills:\n")
+    
+    results = []
+    for skill_info in recent:
+        result = review_skill_against_active(skill_info, all_skills, config)
+        results.append(result)
+        
+        action = execute_auto_review(result, auto=auto)
+        print(f"  {action}")
+    
+    # Generate report
+    report = generate_report(results, days)
+    report_path = REPORT_DIR / f"auto-review-{datetime.now().strftime('%Y%m%d-%H%M')}.md"
+    
+    with open(report_path, "w") as f:
+        f.write(report)
+    
+    print(f"\n📄 Report saved: {report_path}")
+    
+    if not auto:
+        print(f"\n  Run with --auto to execute safe decisions automatically")
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/security/skill-curator/scripts/consolidate.py
+++ b/optional-skills/security/skill-curator/scripts/consolidate.py
@@ -1,0 +1,990 @@
+#!/usr/bin/env python3
+"""
+Skill Curator (skill-curator)
+Scans skills, identifies similar groups, generates merge plans.
+Reviews new skills for integration decisions.
+
+Usage:
+    python3 consolidate.py --scan                    # Scan for similar skills
+    python3 consolidate.py --plan <group>             # Generate merge plan for a group
+    python3 consolidate.py --execute <group>          # Execute merge (requires approval)
+    python3 consolidate.py --health                   # Skill health report
+    python3 consolidate.py --rollback <suite_name>    # Rollback a merge
+    python3 consolidate.py --review <path>            # Review a new skill for integration
+    python3 consolidate.py --review <path> --auto     # Auto-apply best action
+"""
+
+import os
+import sys
+import json
+import re
+import shutil
+import hashlib
+from pathlib import Path
+from datetime import datetime
+from collections import defaultdict
+
+# ── Paths ──────────────────────────────────────────────────────────────
+
+def _get_skills_dir() -> Path:
+    hermes_home = os.environ.get("HERMES_HOME", "").strip()
+    if hermes_home:
+        return Path(hermes_home) / "skills"
+    fallback = Path.home() / ".hermes" / "profiles" / "coder" / "skills"
+    if fallback.exists():
+        return fallback
+    return Path.home() / ".hermes" / "skills"
+
+
+SKILLS_DIR = _get_skills_dir()
+if not SKILLS_DIR.exists():
+    SKILLS_DIR = Path.home() / ".hermes" / "profiles" / "coder" / "skills"
+
+ARCHIVE_DIR = SKILLS_DIR / ".archive"
+CONFIG_FILE = SKILLS_DIR / ".skill-curator-config.yaml"
+HISTORY_FILE = SKILLS_DIR / "skill-curator" / "references" / "merge-history.md"
+
+# ── Config ─────────────────────────────────────────────────────────────
+
+def load_config():
+    """Load skill-curator config (simple YAML parser for our subset)."""
+    config = {
+        "locked": [],
+        "locked_categories": [],
+        "rules": {
+            "require_approval": True,
+            "keep_originals_in_archive": True,
+            "max_merge_candidates": 5,
+            "preserve_pitfalls": True,
+        }
+    }
+    if not CONFIG_FILE.exists():
+        return config
+
+    with open(CONFIG_FILE) as f:
+        lines = f.readlines()
+
+    section = None
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        if stripped == "locked:":
+            section = "locked"
+            continue
+        elif stripped == "locked_categories:":
+            section = "locked_categories"
+            continue
+        elif stripped == "rules:":
+            section = "rules"
+            continue
+
+        if section in ("locked", "locked_categories"):
+            if stripped.startswith("- "):
+                config[section].append(stripped[2:].strip())
+        elif section == "rules":
+            if ":" in stripped:
+                key, val = stripped.split(":", 1)
+                key = key.strip()
+                val = val.strip()
+                if val.lower() in ("true", "false"):
+                    config["rules"][key] = val.lower() == "true"
+                elif val.isdigit():
+                    config["rules"][key] = int(val)
+                else:
+                    config["rules"][key] = val
+
+    return config
+
+
+def is_locked(skill_name, config):
+    """Check if a skill is locked."""
+    if skill_name in config["locked"]:
+        return True
+    # Check category lock (scan SKILL.md for category)
+    skill_md = SKILLS_DIR / skill_name / "SKILL.md"
+    if not skill_md.exists():
+        skill_md = ARCHIVE_DIR / skill_name / "SKILL.md"
+    if skill_md.exists():
+        with open(skill_md) as f:
+            content = f.read()
+        match = re.search(r'category:\s*(\S+)', content)
+        if match and match.group(1) in config["locked_categories"]:
+            return True
+    return False
+
+
+# ── Skill Scanning ────────────────────────────────────────────────────
+
+def scan_skills():
+    """Scan all skills (active + archived)."""
+    skills = {}
+
+    for base_dir in [SKILLS_DIR, ARCHIVE_DIR]:
+        if not base_dir.exists():
+            continue
+        for entry in sorted(base_dir.iterdir()):
+            if entry.name.startswith('.') or not entry.is_dir():
+                continue
+            skill_md = entry / "SKILL.md"
+            if not skill_md.exists():
+                # Might be a category directory
+                for sub in entry.iterdir():
+                    sub_md = sub / "SKILL.md"
+                    if sub_md.exists() and sub.is_dir():
+                        skills[sub.name] = parse_skill(sub_md, sub, str(base_dir))
+                continue
+            skills[entry.name] = parse_skill(skill_md, entry, str(base_dir))
+
+    return skills
+
+
+def parse_skill(skill_md, skill_dir, base_dir):
+    """Parse a SKILL.md file."""
+    with open(skill_md) as f:
+        content = f.read()
+
+    info = {
+        "name": skill_dir.name,
+        "path": str(skill_dir),
+        "base": "active" if base_dir == str(SKILLS_DIR) else "archived",
+        "description": "",
+        "category": "",
+        "triggers": [],
+        "size": 0,
+        "references": [],
+        "content_hash": hashlib.md5(content.encode()).hexdigest()[:8],
+        "pitfalls": [],
+    }
+
+    # Extract frontmatter fields
+    for line in content.split('\n')[:15]:
+        if line.startswith('description:'):
+            info["description"] = line.split(':', 1)[1].strip().strip('"').strip("'")
+        elif line.startswith('category:'):
+            info["category"] = line.split(':', 1)[1].strip()
+        elif line.startswith('triggers:'):
+            info["triggers"] = [t.strip() for t in line.split(':', 1)[1].split(',')]
+        elif line.startswith('name:'):
+            info["name"] = line.split(':', 1)[1].strip()
+
+    # Extract keywords from description for similarity
+    info["keywords"] = extract_keywords(info["description"] + " " + content[:500])
+
+    # Find pitfall sections
+    info["pitfalls"] = extract_pitfalls(content)
+
+    # Scan references
+    refs_dir = skill_dir / "references"
+    if refs_dir.exists():
+        for ref in refs_dir.rglob("*.md"):
+            info["references"].append(str(ref.relative_to(skill_dir)))
+
+    # Calculate size
+    info["size"] = sum(f.stat().st_size for f in skill_dir.rglob("*") if f.is_file())
+
+    return info
+
+
+def extract_keywords(text):
+    """Extract meaningful keywords from text."""
+    # Remove common stop words
+    stop_words = {
+        'the', 'a', 'an', 'is', 'are', 'was', 'were', 'be', 'been', 'being',
+        'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would', 'could',
+        'should', 'may', 'might', 'shall', 'can', 'need', 'dare', 'ought',
+        'used', 'to', 'of', 'in', 'for', 'on', 'with', 'at', 'by', 'from',
+        'as', 'into', 'through', 'during', 'before', 'after', 'above',
+        'below', 'between', 'under', 'again', 'further', 'then', 'once',
+        'here', 'there', 'when', 'where', 'why', 'how', 'all', 'each',
+        'few', 'more', 'most', 'other', 'some', 'such', 'no', 'nor', 'not',
+        'only', 'own', 'same', 'so', 'than', 'too', 'very', 's', 't', 'just',
+        'don', 'now', 'use', 'use when', 'this', 'that', 'these', 'those',
+        'i', 'me', 'my', 'myself', 'we', 'our', 'ours', 'ourselves', 'you',
+        'your', 'yours', 'yourself', 'yourselves', 'he', 'him', 'his',
+        'himself', 'she', 'her', 'hers', 'herself', 'it', 'its', 'itself',
+        'they', 'them', 'their', 'theirs', 'themselves', 'what', 'which',
+        'who', 'whom', 'about', 'against', 'and', 'because', 'but', 'or',
+        'if', 'while', 'until', 'up', 'down', 'out', 'off', 'over',
+    }
+
+    words = re.findall(r'[a-zA-Z\u4e00-\u9fff]{2,}', text.lower())
+    return set(w for w in words if w not in stop_words and len(w) > 2)
+
+
+def extract_pitfalls(content):
+    """Extract pitfall/warning sections from content."""
+    pitfalls = []
+    # Look for common pitfall markers
+    patterns = [
+        r'(?:⚠️|⚠|WARNING|CAUTION|PITFALL|陷阱|注意|坑)[:\s]*(.+?)(?=\n\n|\n#|\n##|$)',
+        r'(?:pitfall|trap|gotcha|edge case)[:\s]*(.+?)(?=\n\n|\n#|\n##|$)',
+    ]
+    for pattern in patterns:
+        matches = re.findall(pattern, content, re.IGNORECASE | re.DOTALL)
+        pitfalls.extend(matches)
+    return pitfalls[:10]  # Cap at 10
+
+
+# ── Similarity Detection ──────────────────────────────────────────────
+
+def compute_similarity(s1, s2):
+    """Compute similarity score between two skills."""
+    # Jaccard similarity on keywords
+    kw1 = s1["keywords"]
+    kw2 = s2["keywords"]
+    if not kw1 or not kw2:
+        return 0.0
+
+    intersection = kw1 & kw2
+    union = kw1 | kw2
+    jaccard = len(intersection) / len(union) if union else 0
+
+    # Category bonus
+    cat_bonus = 0.1 if s1["category"] and s1["category"] == s2["category"] else 0
+
+    # Name overlap bonus
+    name_bonus = 0.05 if any(w in s2["name"] for w in s1["name"].split('-')) else 0
+
+    score = jaccard + cat_bonus + name_bonus
+    return min(score, 1.0)
+
+
+def find_similar_groups(skills, threshold=0.15):
+    """Find groups of similar skills."""
+    skill_list = list(skills.values())
+    groups = defaultdict(list)
+    processed = set()
+
+    for i, s1 in enumerate(skill_list):
+        if s1["name"] in processed:
+            continue
+
+        group = [s1["name"]]
+        for j, s2 in enumerate(skill_list):
+            if i == j or s2["name"] in processed:
+                continue
+
+            score = compute_similarity(s1, s2)
+            if score >= threshold:
+                group.append(s2["name"])
+                processed.add(s2["name"])
+
+        if len(group) >= 2:
+            processed.add(s1["name"])
+            # Use first skill's dominant keyword theme as group name
+            group_skills = [skills[n] for n in group if n in skills]
+            if group_skills:
+                group_key = identify_group_theme(group_skills)
+                groups[group_key] = group
+
+    return dict(groups)
+
+
+def identify_group_theme(skills_in_group):
+    """Identify the dominant theme of a skill group."""
+    # Count keyword frequencies
+    freq = defaultdict(int)
+    for s in skills_in_group:
+        for kw in s["keywords"]:
+            freq[kw] += 1
+
+    # Sort by frequency
+    top_keywords = sorted(freq.items(), key=lambda x: -x[1])[:5]
+
+    # Create group name from top keywords
+    theme_words = []
+    for kw, count in top_keywords:
+        if len(kw) > 3 and count >= 2:
+            theme_words.append(kw)
+        if len(theme_words) >= 2:
+            break
+
+    if theme_words:
+        return "_".join(theme_words[:2])
+
+    # Fallback: use first skill's name prefix
+    return skills_in_group[0]["name"].split("-")[0] if skills_in_group else "unknown"
+
+
+# ── Merge Planning ────────────────────────────────────────────────────
+
+def generate_merge_plan(group_name, skills, config):
+    """Generate a merge plan for a skill group."""
+    group_skills = [skills[n] for n in group_name if n in skills]
+
+    if not group_skills:
+        print(f"❌ Group '{group_name}' not found or empty")
+        return None
+
+    # Filter out locked skills
+    unlocked = [s for s in group_skills if not is_locked(s["name"], config)]
+    locked = [s for s in group_skills if is_locked(s["name"], config)]
+
+    if not unlocked:
+        print(f"⚠️ All skills in '{group_name}' are locked. No merge possible.")
+        return None
+
+    # Generate suite name
+    theme = identify_group_theme(unlocked)
+    suite_name = f"{theme}-suite"
+
+    # Build plan
+    plan = {
+        "suite_name": suite_name,
+        "source_skills": [s["name"] for s in unlocked],
+        "locked_skills": [s["name"] for s in locked],
+        "total_size": sum(s["size"] for s in unlocked),
+        "estimated_savings": calculate_savings(unlocked),
+        "modules": [],
+        "pitfalls_preserved": [],
+    }
+
+    for s in unlocked:
+        module = {
+            "name": s["name"].replace("-", "_"),
+            "source": s["name"],
+            "file": f"references/{s['name'].replace('-', '_')}.md",
+            "triggers": list(s["keywords"])[:10],
+            "standalone": True,
+            "size": s["size"],
+            "references": s["references"],
+        }
+        plan["modules"].append(module)
+
+        # Collect pitfalls
+        if s["pitfalls"]:
+            plan["pitfalls_preserved"].append({
+                "source": s["name"],
+                "count": len(s["pitfalls"]),
+            })
+
+    return plan
+
+
+def calculate_savings(skills):
+    """Estimate token savings from merging."""
+    total = sum(s["size"] for s in skills)
+    # Estimate 30-40% reduction from removing duplicates
+    estimated = total * 0.35
+    return int(estimated)
+
+
+# ── Merge Execution ───────────────────────────────────────────────────
+
+def execute_merge(plan, skills, config):
+    """Execute a merge plan."""
+    if not config["rules"]["require_approval"]:
+        print("⚠️ Approval bypassed (not recommended)")
+    else:
+        print("\n📋 Merge Plan Review:")
+        print(f"  Suite: {plan['suite_name']}")
+        print(f"  Sources: {', '.join(plan['source_skills'])}")
+        if plan['locked_skills']:
+            print(f"  Locked (skipped): {', '.join(plan['locked_skills'])}")
+        print(f"  Modules: {len(plan['modules'])}")
+        print(f"  Pitfalls preserved: {sum(p['count'] for p in plan['pitfalls_preserved'])} from {len(plan['pitfalls_preserved'])} skills")
+        print(f"  Estimated savings: {plan['estimated_savings']:,} bytes")
+
+        response = input("\n✅ Execute this merge? (yes/no): ").strip().lower()
+        if response != "yes":
+            print("❌ Merge cancelled.")
+            return False
+
+    # Create suite directory
+    suite_dir = SKILLS_DIR / plan["suite_name"]
+    refs_dir = suite_dir / "references"
+
+    if suite_dir.exists():
+        print(f"⚠️ {plan['suite_name']} already exists, updating...")
+
+    suite_dir.mkdir(parents=True, exist_ok=True)
+    refs_dir.mkdir(exist_ok=True)
+
+    # Generate modules.json
+    modules_data = {
+        "skill": plan["suite_name"],
+        "source_skills": plan["source_skills"],
+        "locked_skills": plan.get("locked_skills", []),
+        "created": datetime.now().isoformat(),
+        "modules": {m["name"]: {k: v for k, v in m.items() if k != "references"} for m in plan["modules"]},
+    }
+
+    with open(suite_dir / "modules.json", "w") as f:
+        json.dump(modules_data, f, indent=2, ensure_ascii=False)
+
+    # Generate main SKILL.md
+    skill_md_content = generate_suite_skillmd(plan, skills)
+    with open(suite_dir / "SKILL.md", "w") as f:
+        f.write(skill_md_content)
+
+    # Copy reference files
+    for module in plan["modules"]:
+        source_name = module["source"]
+        target_file = refs_dir / module["file"].split("/")[-1]
+
+        # Find source
+        source_dir = SKILLS_DIR / source_name
+        if not source_dir.exists():
+            source_dir = ARCHIVE_DIR / source_name
+
+        if source_dir.exists():
+            # Copy SKILL.md content
+            src_md = source_dir / "SKILL.md"
+            if src_md.exists() and not target_file.exists():
+                shutil.copy2(src_md, target_file)
+
+            # Copy references
+            src_refs = source_dir / "references"
+            if src_refs.exists():
+                for ref in src_refs.rglob("*.md"):
+                    target_ref = refs_dir / ref.name
+                    if not target_ref.exists():
+                        shutil.copy2(ref, target_ref)
+
+    # Move originals to archive
+    if config["rules"]["keep_originals_in_archive"]:
+        for name in plan["source_skills"]:
+            src = SKILLS_DIR / name
+            if src.exists():
+                dest = ARCHIVE_DIR / name
+                if not dest.exists():
+                    shutil.move(str(src), str(dest))
+                    print(f"  📦 Archived: {name}")
+
+    # Record in history
+    record_merge(plan)
+
+    print(f"\n✅ Merge complete: {plan['suite_name']}")
+    print(f"   Location: {suite_dir}")
+    print(f"   Modules: {len(plan['modules'])}")
+    return True
+
+
+def generate_suite_skillmd(plan, skills):
+    """Generate the main SKILL.md for a merged suite."""
+    modules = plan["modules"]
+
+    md = f"""---
+name: {plan['suite_name']}
+description: "Integrated suite combining {', '.join(plan['source_skills'])}. Use when working with {identify_group_theme_text(modules)}."
+category: merged
+source_skills: {plan['source_skills']}
+merged_date: "{datetime.now().strftime('%Y-%m-%d')}"
+---
+
+# {plan['suite_name'].replace('-', ' ').title()}
+
+Integrated skill suite combining {len(plan['source_skills'])} related skills.
+
+## 📚 Available Modules
+
+| Module | Source | When to Use |
+|--------|--------|-------------|
+"""
+
+    for m in modules:
+        triggers_str = ", ".join(m["triggers"][:5])
+        md += f"| **{m['name']}** | {m['source']} | {triggers_str} |\n"
+
+    md += f"""
+## 🔀 How to Use
+
+### Full Suite
+Load this skill for comprehensive coverage of all modules.
+
+### Individual Module
+Reference a specific module by name: `{plan['suite_name']}/references/<module>.md`
+
+### Combination
+Load multiple modules for cross-module workflows.
+
+## 📦 Module Details
+
+"""
+
+    for m in modules:
+        md += f"### {m['name']}\n"
+        md += f"- **Source**: {m['source']}\n"
+        md += f"- **Triggers**: {', '.join(m['triggers'][:8])}\n"
+        md += f"- **File**: `references/{m['file'].split('/')[-1]}`\n\n"
+
+    # Add pitfalls section
+    if plan["pitfalls_preserved"]:
+        md += "## ⚠️ Preserved Pitfalls\n\n"
+        for p in plan["pitfalls_preserved"]:
+            md += f"- **{p['source']}**: {p['count']} known pitfalls preserved in module references\n"
+        md += "\n> All pitfalls from source skills are preserved in their respective reference files.\n"
+
+    return md
+
+
+def identify_group_theme_text(modules):
+    """Extract theme text from modules for description."""
+    all_triggers = []
+    for m in modules:
+        all_triggers.extend(m.get("triggers", []))
+    # Take top unique triggers
+    seen = set()
+    top = []
+    for t in all_triggers:
+        if t not in seen and len(t) > 3:
+            seen.add(t)
+            top.append(t)
+        if len(top) >= 3:
+            break
+    return ", ".join(top[:3]) if top else "related topics"
+
+
+# ── Health Report ─────────────────────────────────────────────────────
+
+def health_report(skills):
+    """Generate skill health report."""
+    active = [s for s in skills.values() if s["base"] == "active"]
+    archived = [s for s in skills.values() if s["base"] == "archived"]
+
+    print("📊 Skill Health Report")
+    print("=" * 50)
+    print(f"  Active skills:   {len(active)}")
+    print(f"  Archived skills: {len(archived)}")
+    print(f"  Total:           {len(skills)}")
+
+    # Size analysis
+    total_active = sum(s["size"] for s in active)
+    total_archived = sum(s["size"] for s in archived)
+    print(f"\n  Active size:   {total_active / 1024:.0f} KB")
+    print(f"  Archived size: {total_archived / 1024:.0f} KB")
+
+    # Duplicates check
+    print("\n  ⚠️ Potential Duplicates:")
+    for name, s in skills.items():
+        matches = [other for other in skills.values()
+                   if other["name"] != name and other["content_hash"] == s["content_hash"]]
+        if matches:
+            print(f"    {name} == {matches[0]['name']}")
+
+    # Skills without description
+    print("\n  ⚠️ Missing Descriptions:")
+    for name, s in sorted(skills.items()):
+        if not s["description"]:
+            print(f"    {name}")
+
+    # Large skills
+    print("\n  📏 Large Skills (>100KB):")
+    large = sorted([s for s in active if s["size"] > 100 * 1024], key=lambda x: -x["size"])
+    for s in large:
+        print(f"    {s['name']}: {s['size'] / 1024:.0f} KB")
+    if not large:
+        print("    (none)")
+
+
+# ── Rollback ──────────────────────────────────────────────────────────
+
+def rollback(suite_name):
+    """Rollback a merge, restoring originals from archive."""
+    suite_dir = SKILLS_DIR / suite_name
+    if not suite_dir.exists():
+        print(f"❌ {suite_name} not found")
+        return False
+
+    # Read modules.json
+    modules_file = suite_dir / "modules.json"
+    if not modules_file.exists():
+        print(f"❌ modules.json not found in {suite_name}")
+        return False
+
+    with open(modules_file) as f:
+        modules_data = json.load(f)
+
+    source_skills = modules_data.get("source_skills", [])
+
+    print(f"🔄 Rolling back {suite_name}...")
+    print(f"   Restoring: {', '.join(source_skills)}")
+
+    for name in source_skills:
+        archived = ARCHIVE_DIR / name
+        if archived.exists():
+            target = SKILLS_DIR / name
+            if not target.exists():
+                shutil.move(str(archived), str(target))
+                print(f"  ✅ Restored: {name}")
+            else:
+                print(f"  ⚠️ {name} already exists in active, skipping")
+
+    # Remove suite
+    shutil.rmtree(suite_dir)
+    print(f"  🗑️  Removed: {suite_name}")
+
+    print("\n✅ Rollback complete")
+    return True
+
+
+# ── History ───────────────────────────────────────────────────────────
+
+def record_merge(plan):
+    """Record merge in history."""
+    HISTORY_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+    entry = f"""## {datetime.now().strftime('%Y-%m-%d %H:%M')} — {plan['suite_name']}
+
+**Sources**: {', '.join(plan['source_skills'])}
+**Modules**: {len(plan['modules'])}
+**Pitfalls preserved**: {sum(p['count'] for p in plan['pitfalls_preserved'])} from {len(plan['pitfalls_preserved'])} skills
+**Status**: ✅ Executed
+
+"""
+
+    if HISTORY_FILE.exists():
+        with open(HISTORY_FILE) as f:
+            existing = f.read()
+        with open(HISTORY_FILE, "w") as f:
+            f.write(entry + existing)
+    else:
+        with open(HISTORY_FILE, "w") as f:
+            f.write(f"# Merge History\n\n{entry}")
+
+
+# ── New Skill Review ─────────────────────────────────────────────────
+
+def review_new_skill(new_skill_path, skills, config):
+    """Review a new skill and decide: merge, add, or skip."""
+    new_path = Path(new_skill_path)
+    if not new_path.exists():
+        print(f"❌ Path not found: {new_skill_path}")
+        return None
+
+    # Parse new skill
+    skill_md = new_path / "SKILL.md"
+    if not skill_md.exists():
+        print(f"❌ No SKILL.md found in {new_skill_path}")
+        return None
+
+    new_skill = parse_skill(skill_md, new_path, "new")
+
+    # Compare against all existing skills
+    candidates = []
+    for name, existing in skills.items():
+        if existing["base"] == "archived":
+            continue  # Only compare against active skills
+
+        score = compute_similarity(new_skill, existing)
+        if score > 0.05:  # Any meaningful overlap
+            candidates.append({
+                "skill": existing,
+                "score": score,
+                "same_capability": detect_same_capability(new_skill, existing),
+                "different_implementation": detect_different_implementation(new_skill, existing),
+            })
+
+    candidates.sort(key=lambda x: -x["score"])
+
+    # Decision logic
+    decision = make_review_decision(new_skill, candidates, config)
+
+    return {
+        "new_skill": new_skill,
+        "candidates": candidates[:5],  # Top 5 matches
+        "decision": decision,
+    }
+
+
+def detect_same_capability(s1, s2):
+    """Detect if two skills have the same core capability."""
+    # Extract capability keywords (verbs + core nouns)
+    cap_patterns = [
+        r'(?:generate|create|build|make|convert|extract|analyze|search|query|monitor|detect|deploy|install|configure|manage|optimize|review|debug|train|fine-tune)',
+    ]
+
+    caps1 = set()
+    caps2 = set()
+
+    for pattern in cap_patterns:
+        caps1.update(re.findall(pattern, s1["description"].lower()))
+        caps2.update(re.findall(pattern, s2["description"].lower()))
+
+    # Also check keywords
+    caps1.update(kw for kw in s1["keywords"] if len(kw) > 4)
+    caps2.update(kw for kw in s2["keywords"] if len(kw) > 4)
+
+    overlap = caps1 & caps2
+    union = caps1 | caps2
+
+    if not union:
+        return False
+
+    jaccard = len(overlap) / len(union)
+    return jaccard > 0.3  # 30% capability overlap
+
+
+def detect_different_implementation(s1, s2):
+    """Detect if two skills use different implementation methods."""
+    impl_keywords = {
+        "langchain", "llamaindex", "haystack", "crewai", "autogen",
+        "playwright", "selenium", "puppeteer", "camoufox",
+        "docker", "podman", "kubernetes", "compose",
+        "fastapi", "flask", "django", "streamlit", "gradio",
+        "pytorch", "tensorflow", "jax", "mlx",
+        "ollama", "vllm", "tgi", "sglang",
+        "qdrant", "chroma", "milvus", "pinecone", "weaviate",
+        "openai", "anthropic", "google", "mistral",
+        "curl", "requests", "httpx", "aiohttp",
+    }
+
+    impls1 = set()
+    impls2 = set()
+
+    for content in [s1["description"], s1.get("content_snippet", "")]:
+        for kw in impl_keywords:
+            if kw in content.lower():
+                impls1.add(kw)
+
+    for content in [s2["description"], s2.get("content_snippet", "")]:
+        for kw in impl_keywords:
+            if kw in content.lower():
+                impls2.add(kw)
+
+    # Different if they share capability but use different tools
+    return impls1 != impls2 and (impls1 or impls2)
+
+
+def make_review_decision(new_skill, candidates, config):
+    """Make decision: merge_as_redundant, merge_as_module, add_new, or skip."""
+    if not candidates:
+        return {
+            "action": "add_new",
+            "reason": "No similar skills found. This is a new capability.",
+            "confidence": 0.8,
+        }
+
+    top = candidates[0]
+    score = top["score"]
+    same_cap = top["same_capability"]
+    diff_impl = top["different_implementation"]
+
+    # Check if locked
+    if is_locked(top["skill"]["name"], config):
+        return {
+            "action": "add_new",
+            "reason": f"Most similar skill '{top['skill']['name']}' is locked. Adding as separate skill.",
+            "confidence": 0.7,
+            "locked_target": top["skill"]["name"],
+        }
+
+    if same_cap and diff_impl:
+        return {
+            "action": "merge_as_redundant",
+            "reason": f"Same capability as '{top['skill']['name']}' but different implementation. Merge as redundant/fallback option.",
+            "target": top["skill"]["name"],
+            "similarity": score,
+            "confidence": 0.85,
+            "implementation_diff": True,
+        }
+
+    if same_cap and not diff_impl:
+        if score > 0.5:
+            return {
+                "action": "skip_duplicate",
+                "reason": f"Nearly identical to '{top['skill']['name']}' (similarity: {score:.2f}). Same capability, same implementation.",
+                "target": top["skill"]["name"],
+                "similarity": score,
+                "confidence": 0.9,
+            }
+        else:
+            return {
+                "action": "merge_as_module",
+                "reason": f"Related to '{top['skill']['name']}' but different focus. Add as module to existing suite or create new suite.",
+                "target": top["skill"]["name"],
+                "similarity": score,
+                "confidence": 0.7,
+            }
+
+    if score > 0.3:
+        return {
+            "action": "merge_as_module",
+            "reason": f"Significant overlap with '{top['skill']['name']}'. Consider merging.",
+            "target": top["skill"]["name"],
+            "similarity": score,
+            "confidence": 0.6,
+        }
+
+    return {
+        "action": "add_new",
+        "reason": f"Low similarity to existing skills. New capability.",
+        "confidence": 0.8,
+    }
+
+
+def execute_review(review_result, auto=False):
+    """Execute the review decision."""
+    new_skill = review_result["new_skill"]
+    decision = review_result["decision"]
+
+    print(f"\n📋 New Skill Review: {new_skill['name']}")
+    print(f"  Description: {new_skill['description'][:100]}")
+    print(f"  Size: {new_skill['size'] / 1024:.1f} KB")
+    print(f"\n  Decision: **{decision['action']}**")
+    print(f"  Reason: {decision['reason']}")
+    print(f"  Confidence: {decision['confidence']:.0%}")
+
+    if review_result["candidates"]:
+        print(f"\n  Top matches:")
+        for c in review_result["candidates"][:3]:
+            impl_tag = "🔄 different impl" if c["different_implementation"] else "same impl"
+            cap_tag = "✅ same capability" if c["same_capability"] else "different capability"
+            print(f"    - {c['skill']['name']} (score: {c['score']:.2f}) [{impl_tag}] [{cap_tag}]")
+
+    if auto:
+        print(f"\n  Auto-executing: {decision['action']}")
+        if decision["action"] == "add_new":
+            dest = SKILLS_DIR / new_skill["name"]
+            if dest.exists():
+                print(f"  ⚠️ {new_skill['name']} already exists, skipping")
+                return
+            shutil.copytree(new_skill["path"], dest)
+            print(f"  ✅ Added: {new_skill['name']}")
+        elif decision["action"] == "merge_as_redundant":
+            target = decision["target"]
+            # Add as redundant implementation
+            target_dir = SKILLS_DIR / target
+            if not target_dir.exists():
+                print(f"  ⚠️ Target {target} not found, adding as new skill instead")
+                shutil.copytree(new_skill["path"], SKILLS_DIR / new_skill["name"])
+                return
+
+            refs_dir = target_dir / "references"
+            refs_dir.mkdir(exist_ok=True)
+
+            # Copy as redundant implementation
+            impl_name = new_skill["name"].replace("-", "_")
+            target_file = refs_dir / f"redundant_{impl_name}.md"
+            src_md = new_skill["path"] / "SKILL.md"
+            if src_md.exists():
+                shutil.copy2(src_md, target_file)
+
+            # Update modules.json if exists
+            modules_file = target_dir / "modules.json"
+            if modules_file.exists():
+                with open(modules_file) as f:
+                    modules = json.load(f)
+                modules.setdefault("redundant_implementations", []).append({
+                    "name": new_skill["name"],
+                    "source": new_skill["name"],
+                    "added": datetime.now().isoformat(),
+                    "file": f"references/redundant_{impl_name}.md",
+                })
+                with open(modules_file, "w") as f:
+                    json.dump(modules, f, indent=2, ensure_ascii=False)
+
+            print(f"  ✅ Merged as redundant implementation into {target}")
+            print(f"     File: {target_file}")
+        elif decision["action"] == "skip_duplicate":
+            print(f"  ⏭️  Skipped - duplicate of {decision['target']}")
+        elif decision["action"] == "merge_as_module":
+            print(f"  ⚠️  Complex merge - manual review recommended")
+            print(f"     Run: --execute to create merge plan")
+    else:
+        print(f"\n  Run with --auto to execute automatically")
+        print(f"  Or manually: mv {new_skill['path']} {SKILLS_DIR}/{new_skill['name']}")
+
+
+# ── Main ──────────────────────────────────────────────────────────────
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+
+    action = sys.argv[1]
+    config = load_config()
+    skills = scan_skills()
+
+    if action == "--scan":
+        groups = find_similar_groups(skills)
+        print("🔍 Similar Skill Groups\n")
+        for name, members in sorted(groups.items(), key=lambda x: -len(x[1])):
+            locked_count = sum(1 for m in members if is_locked(m, config))
+            print(f"## {name} ({len(members)} skills, {locked_count} locked)")
+            for m in members:
+                lock_icon = "🔒" if is_locked(m, config) else "  "
+                s = skills.get(m)
+                if s:
+                    desc = s['description'][:80] if s['description'] else "(no description)"
+                    print(f"  {lock_icon} {m}: {desc}")
+                else:
+                    print(f"  {lock_icon} {m}: (not found)")
+            print()
+
+    elif action == "--plan":
+        if len(sys.argv) < 3:
+            print("Usage: consolidate.py --plan <group_name>")
+            sys.exit(1)
+
+        group_name = sys.argv[2]
+        groups = find_similar_groups(skills)
+
+        if group_name not in groups:
+            print(f"❌ Group '{group_name}' not found. Available groups:")
+            for g in groups:
+                print(f"  - {g}")
+            sys.exit(1)
+
+        plan = generate_merge_plan(groups[group_name], skills, config)
+        if plan:
+            print(f"\n📋 Merge Plan: {plan['suite_name']}")
+            print(f"  Sources: {', '.join(plan['source_skills'])}")
+            if plan['locked_skills']:
+                print(f"  Locked (skipped): {', '.join(plan['locked_skills'])}")
+            print(f"  Modules: {len(plan['modules'])}")
+            for m in plan['modules']:
+                print(f"    - {m['name']} ({m['size'] / 1024:.0f} KB)")
+            if plan['pitfalls_preserved']:
+                print(f"  Pitfalls preserved:")
+                for p in plan['pitfalls_preserved']:
+                    print(f"    - {p['source']}: {p['count']} pitfalls")
+            print(f"\n  Run with --execute {plan['suite_name']} to apply")
+
+    elif action == "--execute":
+        if len(sys.argv) < 3:
+            print("Usage: consolidate.py --execute <group_name>")
+            sys.exit(1)
+
+        group_name = sys.argv[2]
+        groups = find_similar_groups(skills)
+
+        if group_name not in groups:
+            print(f"❌ Group '{group_name}' not found")
+            sys.exit(1)
+
+        plan = generate_merge_plan(groups[group_name], skills, config)
+        if plan:
+            execute_merge(plan, skills, config)
+
+    elif action == "--health":
+        health_report(skills)
+
+    elif action == "--rollback":
+        if len(sys.argv) < 3:
+            print("Usage: consolidate.py --rollback <suite_name>")
+            sys.exit(1)
+        rollback(sys.argv[2])
+
+    elif action == "--review":
+        if len(sys.argv) < 3:
+            print("Usage: consolidate.py --review <path_to_new_skill> [--auto]")
+            sys.exit(1)
+
+        new_path = sys.argv[2]
+        auto = "--auto" in sys.argv
+
+        result = review_new_skill(new_path, skills, config)
+        if result:
+            execute_review(result, auto=auto)
+
+    else:
+        print(f"❌ Unknown action: {action}")
+        print(__doc__)
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/security/skill-curator/scripts/post_install_hook.py
+++ b/optional-skills/security/skill-curator/scripts/post_install_hook.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+Post-Install Hook for Skill-Curator
+Automatically reviews newly installed skills.
+
+Usage:
+    # Manual trigger after installing a skill:
+    python3 post_install_hook.py
+    
+    # Or integrate with hermes skills install:
+    hermes skills install <path> && python3 post_install_hook.py
+    
+    # Cron: run every hour to check for recent installs
+    python3 post_install_hook.py --auto-scan --minutes 60
+"""
+
+import os
+import sys
+import time
+import json
+import shutil
+from pathlib import Path
+from datetime import datetime
+
+SKILLS_DIR = Path(os.path.expanduser("~/.hermes/profiles/coder/skills"))
+ARCHIVE_DIR = SKILLS_DIR / ".archive"
+SKILLCURATOR_DIR = SKILLS_DIR / "skill-curator"
+INSTALL_LOG = SKILLCURATOR_DIR / "references" / "install_log.json"
+
+# Add consolidate module to path
+sys.path.insert(0, str(SKILLCURATOR_DIR / "scripts"))
+from consolidate import (
+    scan_skills, load_config, parse_skill, compute_similarity,
+    detect_same_capability, detect_different_implementation,
+    make_review_decision, HISTORY_FILE
+)
+
+def load_install_log():
+    """Load or create install log."""
+    if INSTALL_LOG.exists():
+        with open(INSTALL_LOG) as f:
+            return json.load(f)
+    return {"installs": [], "reviews": []}
+
+def save_install_log(data):
+    """Save install log."""
+    INSTALL_LOG.parent.mkdir(parents=True, exist_ok=True)
+    with open(INSTALL_LOG, "w") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False, default=str)
+
+def find_recent_installs(minutes=60):
+    """Find skills installed in the last N minutes."""
+    cutoff = time.time() - (minutes * 60)
+    recent = []
+    log = load_install_log()
+    logged_names = {i["name"] for i in log.get("installs", [])}
+    
+    for entry in sorted(SKILLS_DIR.iterdir()):
+        if entry.name.startswith('.') or not entry.is_dir():
+            continue
+        skill_md = entry / "SKILL.md"
+        if not skill_md.exists():
+            continue
+        
+        # Skip if already reviewed
+        if entry.name in logged_names:
+            continue
+        
+        # Check modification time
+        mtime = skill_md.stat().st_mtime
+        if mtime >= cutoff:
+            recent.append({
+                "name": entry.name,
+                "path": entry,
+                "mtime": mtime,
+                "modified": datetime.fromtimestamp(mtime).isoformat(),
+            })
+    
+    return recent
+
+def review_and_act(skill_info, auto=False):
+    """Review a new skill and take action."""
+    all_skills = scan_skills()
+    config = load_config()
+    new_skill = parse_skill(skill_info["path"] / "SKILL.md", skill_info["path"], "active")
+    
+    candidates = []
+    for name, existing in all_skills.items():
+        if existing["base"] == "archived" or name == new_skill["name"]:
+            continue
+        if existing.get("category") == "merged":
+            continue
+        
+        score = compute_similarity(new_skill, existing)
+        if score > 0.05:
+            candidates.append({
+                "skill": existing,
+                "score": score,
+                "same_capability": detect_same_capability(new_skill, existing),
+                "different_implementation": detect_different_implementation(new_skill, existing),
+            })
+    
+    candidates.sort(key=lambda x: -x["score"])
+    decision = make_review_decision(new_skill, candidates, config)
+    
+    # Log the review
+    log = load_install_log()
+    log["reviews"].append({
+        "skill": new_skill["name"],
+        "decision": decision["action"],
+        "reason": decision["reason"],
+        "confidence": decision["confidence"],
+        "top_match": candidates[0]["skill"]["name"] if candidates else None,
+        "top_score": candidates[0]["score"] if candidates else 0,
+        "timestamp": datetime.now().isoformat(),
+    })
+    
+    # Execute decision
+    result = {"skill": new_skill["name"], "decision": decision["action"], "executed": False}
+    
+    if decision["action"] == "skip_duplicate" and decision["confidence"] >= 0.9:
+        # High confidence duplicate → archive
+        if auto:
+            dest = ARCHIVE_DIR / new_skill["name"]
+            if not dest.exists():
+                shutil.move(str(skill_info["path"]), str(dest))
+                result["executed"] = True
+                result["action_detail"] = f"Archived as duplicate of {decision['target']}"
+    
+    elif decision["action"] == "merge_as_redundant" and decision["confidence"] >= 0.85:
+        # Merge as redundant implementation
+        target = decision["target"]
+        target_dir = SKILLS_DIR / target
+        if target_dir.exists() and auto:
+            refs_dir = target_dir / "references"
+            refs_dir.mkdir(exist_ok=True)
+            impl_name = new_skill["name"].replace("-", "_")
+            target_file = refs_dir / f"redundant_{impl_name}.md"
+            
+            src_md = skill_info["path"] / "SKILL.md"
+            if src_md.exists() and not target_file.exists():
+                shutil.copy2(src_md, target_file)
+                
+                # Update modules.json
+                modules_file = target_dir / "modules.json"
+                if modules_file.exists():
+                    with open(modules_file) as f:
+                        modules = json.load(f)
+                    modules.setdefault("redundant_implementations", []).append({
+                        "name": new_skill["name"],
+                        "source": new_skill["name"],
+                        "added": datetime.now().isoformat(),
+                        "file": f"references/redundant_{impl_name}.md",
+                    })
+                    with open(modules_file, "w") as f:
+                        json.dump(modules, f, indent=2, ensure_ascii=False)
+                
+                # Archive original
+                dest = ARCHIVE_DIR / new_skill["name"]
+                if not dest.exists():
+                    shutil.move(str(skill_info["path"]), str(dest))
+                
+                result["executed"] = True
+                result["action_detail"] = f"Merged as redundant into {target}"
+    
+    elif decision["action"] == "add_new" and decision["confidence"] >= 0.8:
+        # New capability → keep active
+        result["executed"] = True
+        result["action_detail"] = "New capability, kept active"
+    
+    save_install_log(log)
+    return result
+
+def main():
+    auto = "--auto" in sys.argv
+    auto_scan = "--auto-scan" in sys.argv
+    minutes = 60
+    
+    if "--minutes" in sys.argv:
+        idx = sys.argv.index("--minutes")
+        if idx + 1 < len(sys.argv):
+            minutes = int(sys.argv[idx + 1])
+    
+    if auto_scan:
+        # Cron mode: scan for recent installs
+        recent = find_recent_installs(minutes)
+        if not recent:
+            print("[SILENT]")
+            return
+        
+        print(f"🔍 Found {len(recent)} new skill(s) installed in last {minutes} minutes:\n")
+        for skill in recent:
+            result = review_and_act(skill, auto=auto)
+            status = "✅" if result["executed"] else "📋"
+            print(f"  {status} {result['skill']}: {result['decision']} — {result.get('action_detail', 'manual review needed')}")
+    else:
+        # Manual mode: review a specific path
+        if len(sys.argv) < 2 or sys.argv[1] in ("--auto", "--auto-scan", "--minutes"):
+            print("Usage: post_install_hook.py <path_to_new_skill> [--auto]")
+            print("       post_install_hook.py --auto-scan [--minutes N] [--auto]")
+            sys.exit(1)
+        
+        skill_path = Path(sys.argv[1])
+        if not skill_path.exists():
+            print(f"❌ Path not found: {skill_path}")
+            sys.exit(1)
+        
+        skill_info = {
+            "name": skill_path.name,
+            "path": skill_path,
+            "mtime": skill_path.stat().st_mtime,
+            "modified": datetime.fromtimestamp(skill_path.stat().st_mtime).isoformat(),
+        }
+        result = review_and_act(skill_info, auto=auto)
+        print(f"\n{'✅' if result['executed'] else '📋'} {result['skill']}: {result['decision']}")
+        print(f"   {result.get('action_detail', '')}")
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/security/skill-curator/scripts/redundant_validator.py
+++ b/optional-skills/security/skill-curator/scripts/redundant_validator.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""
+Redundant Implementation Validator
+Tests that redundant implementations (same capability, different approach)
+are still functional and up-to-date.
+
+Usage:
+    python3 redundant_validator.py --scan           # Scan all suites for redundant implementations
+    python3 redundant_validator.py --test <suite>    # Test a specific suite's redundant implementations
+    python3 redundant_validator.py --report          # Generate validation report
+"""
+
+import os
+import sys
+import json
+import time
+import importlib.util
+import subprocess
+from pathlib import Path
+from datetime import datetime
+
+SKILLS_DIR = Path(os.path.expanduser("~/.hermes/profiles/coder/skills"))
+ARCHIVE_DIR = SKILLS_DIR / ".archive"
+SKILLCURATOR_DIR = SKILLS_DIR / "skill-curator"
+VALIDATION_LOG = SKILLCURATOR_DIR / "references" / "validation_log.json"
+
+# Test definitions per capability type
+TEST_TEMPLATES = {
+    "voice": [
+        {"type": "import_check", "module": "whisper", "desc": "Whisper import check"},
+        {"type": "import_check", "module": "soundfile", "desc": "SoundFile import check"},
+    ],
+    "video": [
+        {"type": "import_check", "module": "moviepy", "desc": "MoviePy import check"},
+        {"type": "import_check", "module": "remotion", "desc": "Remotion check (npm)"},
+    ],
+    "rag": [
+        {"type": "import_check", "module": "langchain", "desc": "LangChain import check"},
+        {"type": "import_check", "module": "llama_index", "desc": "LlamaIndex import check"},
+    ],
+    "prompt": [
+        {"type": "file_exists", "path": None, "desc": "SKILL.md exists"},
+    ],
+    "memory": [
+        {"type": "import_check", "module": "sqlite3", "desc": "SQLite import check"},
+    ],
+    "cloudflare": [
+        {"type": "import_check", "module": "playwright", "desc": "Playwright import check"},
+    ],
+    "kanban": [
+        {"type": "command_check", "command": ["hermes", "kanban", "list"], "desc": "Hermes kanban CLI"},
+    ],
+    "huggingface": [
+        {"type": "command_check", "command": ["hf", "--version"], "desc": "HuggingFace CLI"},
+    ],
+}
+
+def load_validation_log():
+    """Load or create validation log."""
+    if VALIDATION_LOG.exists():
+        with open(VALIDATION_LOG) as f:
+            return json.load(f)
+    return {"validations": [], "last_validation": None}
+
+def save_validation_log(data):
+    """Save validation log."""
+    VALIDATION_LOG.parent.mkdir(parents=True, exist_ok=True)
+    with open(VALIDATION_LOG, "w") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False, default=str)
+
+def find_suites_with_redundant():
+    """Find suites that have redundant implementations."""
+    results = []
+    for entry in sorted(SKILLS_DIR.iterdir()):
+        if entry.name.startswith('.') or not entry.is_dir():
+            continue
+        modules_file = entry / "modules.json"
+        if modules_file.exists():
+            try:
+                with open(modules_file) as f:
+                    data = json.load(f)
+                redundant = data.get("redundant_implementations", [])
+                if redundant:
+                    results.append({
+                        "suite": entry.name,
+                        "modules": data.get("modules", {}),
+                        "redundant": redundant,
+                    })
+            except (json.JSONDecodeError, KeyError):
+                pass
+    return results
+
+def run_import_check(module_name):
+    """Check if a Python module can be imported."""
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", f"import {module_name}"],
+            capture_output=True, text=True, timeout=10
+        )
+        return result.returncode == 0, result.stderr.strip() if result.returncode != 0 else ""
+    except subprocess.TimeoutExpired:
+        return False, "Timeout"
+    except Exception as e:
+        return False, str(e)
+
+def run_command_check(command):
+    """Check if a CLI command works."""
+    try:
+        result = subprocess.run(
+            command, capture_output=True, text=True, timeout=10
+        )
+        return result.returncode == 0, result.stderr.strip() if result.returncode != 0 else ""
+    except subprocess.TimeoutExpired:
+        return False, "Timeout"
+    except FileNotFoundError:
+        return False, f"Command not found: {command[0]}"
+    except Exception as e:
+        return False, str(e)
+
+def run_file_exists_check(path):
+    """Check if a file exists."""
+    if path and Path(path).exists():
+        return True, ""
+    return False, f"File not found: {path}"
+
+def run_test(test):
+    """Run a single test."""
+    test_type = test.get("type")
+    
+    if test_type == "import_check":
+        return run_import_check(test.get("module", ""))
+    elif test_type == "command_check":
+        return run_command_check(test.get("command", []))
+    elif test_type == "file_exists":
+        return run_file_exists_check(test.get("path"))
+    
+    return False, f"Unknown test type: {test_type}"
+
+def validate_suite(suite_info):
+    """Validate a suite's redundant implementations."""
+    suite_name = suite_info["suite"]
+    redundant = suite_info["redundant"]
+    
+    results = {
+        "suite": suite_name,
+        "timestamp": datetime.now().isoformat(),
+        "redundant_tests": [],
+        "overall_status": "PASS",
+    }
+    
+    # Determine test category based on suite name
+    category = None
+    for key in TEST_TEMPLATES:
+        if key in suite_name.lower():
+            category = key
+            break
+    
+    tests = TEST_TEMPLATES.get(category, [])
+    
+    # Test each redundant implementation
+    for impl in redundant:
+        impl_name = impl.get("name", "unknown")
+        impl_results = {
+            "name": impl_name,
+            "tests": [],
+            "status": "PASS",
+        }
+        
+        # Run generic tests
+        for test in tests:
+            passed, error = run_test(test)
+            test_result = {
+                "test": test.get("desc", test.get("type", "unknown")),
+                "passed": passed,
+                "error": error if not passed else "",
+            }
+            impl_results["tests"].append(test_result)
+            
+            if not passed:
+                impl_results["status"] = "FAIL"
+                results["overall_status"] = "FAIL"
+        
+        # Check if redundant file exists
+        impl_file = SKILLS_DIR / suite_name / impl.get("file", "")
+        if impl_file.exists():
+            test_result = {
+                "test": f"Redundant file exists: {impl.get('file', '')}",
+                "passed": True,
+                "error": "",
+            }
+        else:
+            test_result = {
+                "test": f"Redundant file exists: {impl.get('file', '')}",
+                "passed": False,
+                "error": f"File not found: {impl_file}",
+            }
+            impl_results["status"] = "FAIL"
+            results["overall_status"] = "FAIL"
+        
+        impl_results["tests"].append(test_result)
+        results["redundant_tests"].append(impl_results)
+    
+    return results
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+    
+    action = sys.argv[1]
+    suites = find_suites_with_redundant()
+    
+    if action == "--scan":
+        print(f"🔍 Scanning {len(suites)} suites for redundant implementations...")
+        if not suites:
+            print("  No suites with redundant implementations found.")
+            return
+        for s in suites:
+            print(f"  - {s['suite']}: {len(s['redundant'])} redundant implementations")
+    
+    elif action == "--test":
+        if len(sys.argv) < 3:
+            print("Usage: redundant_validator.py --test <suite_name>")
+            sys.exit(1)
+        
+        suite_name = sys.argv[2]
+        target = None
+        for s in suites:
+            if s["suite"] == suite_name:
+                target = s
+                break
+        
+        if not target:
+            print(f"❌ Suite '{suite_name}' not found or has no redundant implementations")
+            sys.exit(1)
+        
+        print(f"🧪 Testing {suite_name} redundant implementations...")
+        result = validate_suite(target)
+        
+        for impl_result in result["redundant_tests"]:
+            status = "✅" if impl_result["status"] == "PASS" else "❌"
+            print(f"  {status} {impl_result['name']}")
+            for test in impl_result["tests"]:
+                icon = "✅" if test["passed"] else "❌"
+                print(f"    {icon} {test['test']}")
+                if test["error"]:
+                    print(f"       Error: {test['error']}")
+        
+        print(f"\nOverall: {'✅ PASS' if result['overall_status'] == 'PASS' else '❌ FAIL'}")
+        
+        # Log result
+        log = load_validation_log()
+        log["validations"].append(result)
+        log["last_validation"] = datetime.now().isoformat()
+        save_validation_log(log)
+    
+    elif action == "--report":
+        log = load_validation_log()
+        if not log["validations"]:
+            print("📋 No validation history found. Run --test first.")
+            return
+        
+        print(f"📊 Validation Report")
+        print(f"  Total validations: {len(log['validations'])}")
+        print(f"  Last validation: {log.get('last_validation', 'Never')}")
+        
+        # Latest results
+        latest = log["validations"][-1]
+        print(f"\n  Latest ({latest['suite']}): {latest['overall_status']}")
+        for impl in latest["redundant_tests"]:
+            status = "✅" if impl["status"] == "PASS" else "❌"
+            print(f"    {status} {impl['name']}: {len(impl['tests'])} tests")
+    
+    else:
+        print(f"❌ Unknown action: {action}")
+        print(__doc__)
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/security/skill-curator/scripts/usage_tracker.py
+++ b/optional-skills/security/skill-curator/scripts/usage_tracker.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""
+Skill Usage Heat Tracker
+Tracks which skills are actually loaded during sessions and generates
+a heat report. Archives skills that haven't been used in N days.
+
+Usage:
+    python3 usage_tracker.py --scan         # Scan and update usage data
+    python3 usage_tracker.py --report       # Generate usage report
+    python3 usage_tracker.py --auto-archive # Archive skills unused for 90 days
+    python3 usage_tracker.py --heat-map     # Generate heat map data for dashboard
+"""
+
+import os
+import sys
+import json
+import time
+import hashlib
+from pathlib import Path
+from datetime import datetime
+from collections import defaultdict
+
+SKILLS_DIR = Path("/Users/bet/.hermes/profiles/coder/skills")
+ARCHIVE_DIR = SKILLS_DIR / ".archive"
+SKILLCURATOR_DIR = SKILLS_DIR / "skill-curator"
+USAGE_DB = SKILLCURATOR_DIR / "references" / "usage_db.json"
+SESSIONS_DIR = Path("/Users/bet/.hermes/profiles/coder/sessions")
+
+def load_usage_db():
+    """Load or create usage database."""
+    if USAGE_DB.exists():
+        with open(USAGE_DB) as f:
+            return json.load(f)
+    return {"skills": {}, "sessions_scanned": 0, "last_scan": None}
+
+def save_usage_db(data):
+    """Save usage database."""
+    USAGE_DB.parent.mkdir(parents=True, exist_ok=True)
+    with open(USAGE_DB, "w") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False, default=str)
+
+def scan_sessions_for_skills():
+    """Scan session files to find which skills were loaded."""
+    skill_usage = defaultdict(lambda: {"sessions": 0, "last_used": None, "total_refs": 0})
+    sessions_scanned = 0
+    
+    if not SESSIONS_DIR.exists():
+        return skill_usage, sessions_scanned
+    
+    # Get known skill names for matching
+    known_skills = set()
+    for entry in SKILLS_DIR.iterdir():
+        if entry.name.startswith('.') or not entry.is_dir():
+            continue
+        if (entry / "SKILL.md").exists():
+            known_skills.add(entry.name.lower())
+    
+    if not known_skills:
+        return skill_usage, sessions_scanned
+    
+    # Scan .jsonl session files
+    for session_file in sorted(SESSIONS_DIR.glob("*.jsonl")):
+        try:
+            mtime = session_file.stat().st_mtime
+            found_any = False
+            
+            with open(session_file) as f:
+                for i, line in enumerate(f):
+                    if i > 30:  # Only scan first 30 lines (session start has skill list)
+                        break
+                    try:
+                        data = json.loads(line)
+                        content = data.get("content", "").lower()
+                        
+                        # Check for known skill names directly
+                        for skill in known_skills:
+                            if skill in content:
+                                skill_usage[skill]["sessions"] += 1
+                                skill_usage[skill]["total_refs"] += content.count(skill)
+                                last = skill_usage[skill]["last_used"]
+                                if last is None or mtime > last:
+                                    skill_usage[skill]["last_used"] = mtime
+                                found_any = True
+                    except json.JSONDecodeError:
+                        continue
+            
+            if found_any:
+                sessions_scanned += 1
+        except IOError:
+            continue
+    
+    return skill_usage, sessions_scanned
+
+def extract_skill_refs(content):
+    """Extract skill names referenced in session content."""
+    skill_names = set()
+    
+    import re
+    
+    # Pattern 1: - **skill-name**: description (from available_skills block)
+    for match in re.finditer(r'- \*\*([a-z][a-z0-9-]{2,})\*\*:', content):
+        skill_names.add(match.group(1))
+    
+    # Pattern 2: skill_view(name='skill-name') or skill_view(name="skill-name")
+    for match in re.finditer(r"skill_view\(name=['\"]([a-z][a-z0-9-]{2,})['\"]", content):
+        skill_names.add(match.group(1))
+    
+    # Pattern 3: skills_list mentions
+    for match in re.finditer(r'"name":\s*"([a-z][a-z0-9-]{2,})"', content):
+        skill_names.add(match.group(1))
+    
+    return skill_names
+
+def update_usage_data(db):
+    """Update usage data by scanning recent sessions."""
+    new_usage, sessions_scanned = scan_sessions_for_skills()
+    
+    for skill_name, usage in new_usage.items():
+        if skill_name not in db["skills"]:
+            db["skills"][skill_name] = {
+                "sessions": 0,
+                "last_used": None,
+                "total_refs": 0,
+                "first_seen": datetime.now().isoformat(),
+            }
+        
+        db["skills"][skill_name]["sessions"] = usage["sessions"]
+        db["skills"][skill_name]["total_refs"] = usage["total_refs"]
+        
+        if usage["last_used"]:
+            last_used = datetime.fromtimestamp(usage["last_used"]).isoformat()
+            current_last = db["skills"][skill_name]["last_used"]
+            if current_last is None or last_used > current_last:
+                db["skills"][skill_name]["last_used"] = last_used
+    
+    db["sessions_scanned"] += sessions_scanned
+    db["last_scan"] = datetime.now().isoformat()
+    
+    return db
+
+def generate_report(db, days_threshold=30):
+    """Generate usage report."""
+    cutoff = time.time() - (days_threshold * 86400)
+    cutoff_iso = datetime.fromtimestamp(cutoff).isoformat()
+    
+    all_skills = set()
+    for entry in sorted(SKILLS_DIR.iterdir()):
+        if entry.name.startswith('.') or not entry.is_dir():
+            continue
+        if (entry / "SKILL.md").exists():
+            all_skills.add(entry.name)
+    
+    used = []
+    unused = []
+    rarely_used = []
+    
+    for skill_name in sorted(all_skills):
+        data = db["skills"].get(skill_name, {})
+        last_used = data.get("last_used")
+        sessions = data.get("sessions", 0)
+        
+        if last_used is None:
+            unused.append({"name": skill_name, "sessions": 0, "last_used": "Never"})
+        elif last_used < cutoff_iso:
+            rarely_used.append({
+                "name": skill_name,
+                "sessions": sessions,
+                "last_used": last_used[:10],
+            })
+        else:
+            used.append({
+                "name": skill_name,
+                "sessions": sessions,
+                "last_used": last_used[:10],
+            })
+    
+    report = {
+        "generated": datetime.now().isoformat(),
+        "total_skills": len(all_skills),
+        "used_recently": len(used),
+        "rarely_used": len(rarely_used),
+        "never_used": len(unused),
+        "used": used[:20],  # Top 20
+        "rarely_used": rarely_used,
+        "never_used": unused,
+    }
+    
+    return report
+
+def auto_archive(db, days_threshold=90):
+    """Archive skills that haven't been used in N days."""
+    cutoff = time.time() - (days_threshold * 86400)
+    cutoff_iso = datetime.fromtimestamp(cutoff).isoformat()
+    
+    archived = []
+    for skill_name, data in db["skills"].items():
+        last_used = data.get("last_used")
+        if last_used and last_used < cutoff_iso:
+            src = SKILLS_DIR / skill_name
+            dest = ARCHIVE_DIR / skill_name
+            if src.exists() and not dest.exists():
+                import shutil
+                shutil.move(str(src), str(dest))
+                archived.append(skill_name)
+    
+    return archived
+
+def generate_heat_map(db):
+    """Generate heat map data for dashboard."""
+    heat_data = []
+    
+    for skill_name, data in sorted(db["skills"].items()):
+        sessions = data.get("sessions", 0)
+        last_used = data.get("last_used", "Never")
+        total_refs = data.get("total_refs", 0)
+        
+        # Determine heat level
+        if sessions >= 10:
+            heat = "🔴 Hot"
+        elif sessions >= 3:
+            heat = "🟡 Warm"
+        elif sessions >= 1:
+            heat = "🟢 Cold"
+        else:
+            heat = "⚪ Unused"
+        
+        heat_data.append({
+            "skill": skill_name,
+            "sessions": sessions,
+            "refs": total_refs,
+            "last_used": last_used[:10] if last_used and last_used != "Never" else "Never",
+            "heat": heat,
+        })
+    
+    return sorted(heat_data, key=lambda x: -x["sessions"])
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+    
+    action = sys.argv[1]
+    db = load_usage_db()
+    
+    if action == "--scan":
+        print("🔍 Scanning sessions for skill usage...")
+        db = update_usage_data(db)
+        save_usage_db(db)
+        print(f"✅ Scanned {db['sessions_scanned']} sessions total")
+        print(f"   Tracking {len(db['skills'])} unique skills")
+    
+    elif action == "--report":
+        days = 30
+        if "--days" in sys.argv:
+            idx = sys.argv.index("--days")
+            if idx + 1 < len(sys.argv):
+                days = int(sys.argv[idx + 1])
+        
+        report = generate_report(db, days)
+        print(f"\n📊 Skill Usage Report (last {days} days)")
+        print(f"  Total skills: {report['total_skills']}")
+        print(f"  Used recently: {report['used_recently']}")
+        print(f"  Rarely used: {report['rarely_used']}")
+        print(f"  Never used: {report['never_used']}")
+        
+        if report["rarely_used"]:
+            print(f"\n⚠️ Rarely used skills (>{days} days):")
+            for s in report["rarely_used"][:10]:
+                print(f"  - {s['name']} (last: {s['last_used']}, sessions: {s['sessions']})")
+        
+        if report["never_used"]:
+            print(f"\n❌ Never used skills:")
+            for s in report["never_used"][:10]:
+                print(f"  - {s['name']}")
+    
+    elif action == "--auto-archive":
+        days = 90
+        if "--days" in sys.argv:
+            idx = sys.argv.index("--days")
+            if idx + 1 < len(sys.argv):
+                days = int(sys.argv[idx + 1])
+        
+        archived = auto_archive(db, days)
+        if archived:
+            print(f"📦 Archived {len(archived)} skills (unused for {days} days):")
+            for s in archived:
+                print(f"  - {s}")
+        else:
+            print(f"✅ No skills to archive (all used within {days} days)")
+    
+    elif action == "--heat-map":
+        heat_data = generate_heat_map(db)
+        print(json.dumps(heat_data, indent=2, ensure_ascii=False))
+    
+    else:
+        print(f"❌ Unknown action: {action}")
+        print(__doc__)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

As skill libraries grow (especially for domain-specific workflows like security, devops, research), users accumulate:
- Near-duplicate skills covering overlapping capabilities
- Skills that should be consolidated into umbrella skills with subsections
- New skills that might duplicate existing ones

The official `curator` handles time-based archival (stale/unused skills) but provides **no content-based analysis** — it doesn't detect similarity clusters or propose merges.

## Solution

Add `skill-curator` as an **optional skill** that users can install via `hermes skills browse` to get:

1. **Similarity scanning** — detects clusters of skills with overlapping descriptions/capabilities
2. **Merge planning** — proposes umbrella skills and consolidation strategies
3. **New skill review** — auto-reviews newly added skills against existing library
4. **Cron integration** — automated weekly scans and bi-hourly reviews

### Components

| File | Purpose |
|------|---------|
| `scripts/consolidate.py` | Similarity engine + merge planning + health reports |
| `scripts/auto_review.py` | New skill review pipeline |
| `scripts/usage_tracker.py` | Skill usage tracking |
| `scripts/post_install_hook.py` | Auto-review on skill install |
| `scripts/redundant_validator.py` | Redundancy detection |
| `references/cron-integration.md` | Cron job configuration guide |
| `references/hermes-archive-exclusion.md` | Archive exclusion patterns |
| `references/redundant-merge-principle.md` | Merge decision principles |

### Usage

```bash
# Scan for similar skills
python3 <path>/scripts/consolidate.py --scan

# Review new skills
python3 <path>/scripts/auto_review.py --days 7

# Auto-apply safe decisions
python3 <path>/scripts/auto_review.py --days 7 --auto

# Health report
python3 <path>/scripts/consolidate.py --health
```

## Design

- **Stdlib only** — no external dependencies
- **Cross-platform** — Linux/macOS/Windows compatible
- **Optional install** — doesn't affect default Hermes experience
- **Non-destructive** — consolidations require user approval; originals preserved in `.archive/`
- **Hermes HOME aware** — uses `HERMES_HOME` env var for correct profile resolution
