### PR TITLE
fix(dashboard): report cross-container gateway as running from shared HERMES_HOME

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - /home/admin/files/backup:/home/admin/files/backup
       - /home/admin/.hermes/patches/volcano-coding-plan/__init__.py:/opt/hermes/plugins/model-providers/volcano-coding-plan/__init__.py:ro
       - /home/admin/.hermes/patches/anthropic_adapter.py:/opt/hermes/agent/anthropic_adapter.py:ro
+      - /home/admin/.hermes/patches/models.py:/opt/hermes/hermes_cli/models.py:ro
     environment:
       - HERMES_UID=${HERMES_UID:-10000}
       - HERMES_GID=${HERMES_GID:-10000}
@@ -79,6 +80,7 @@ services:
       - /home/admin/.hermes/hermes-agent/hermes_cli/container_boot.py:/opt/hermes/hermes_cli/container_boot.py:ro
       - /home/admin/.hermes/patches/volcano-coding-plan/__init__.py:/opt/hermes/plugins/model-providers/volcano-coding-plan/__init__.py:ro
       - /home/admin/.hermes/patches/anthropic_adapter.py:/opt/hermes/agent/anthropic_adapter.py:ro
+      - /home/admin/.hermes/patches/models.py:/opt/hermes/hermes_cli/models.py:ro
     environment:
       - HERMES_UID=${HERMES_UID:-10000}
       - HERMES_GID=${HERMES_GID:-10000}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       - /home/admin/.hermes/patches/volcano-coding-plan/__init__.py:/opt/hermes/plugins/model-providers/volcano-coding-plan/__init__.py:ro
       - /home/admin/.hermes/patches/anthropic_adapter.py:/opt/hermes/agent/anthropic_adapter.py:ro
       - /home/admin/.hermes/patches/models.py:/opt/hermes/hermes_cli/models.py:ro
+      - /home/admin/.hermes/patches/runtime_provider.py:/opt/hermes/hermes_cli/runtime_provider.py:ro
     environment:
       - HERMES_UID=${HERMES_UID:-10000}
       - HERMES_GID=${HERMES_GID:-10000}
@@ -81,6 +82,7 @@ services:
       - /home/admin/.hermes/patches/volcano-coding-plan/__init__.py:/opt/hermes/plugins/model-providers/volcano-coding-plan/__init__.py:ro
       - /home/admin/.hermes/patches/anthropic_adapter.py:/opt/hermes/agent/anthropic_adapter.py:ro
       - /home/admin/.hermes/patches/models.py:/opt/hermes/hermes_cli/models.py:ro
+      - /home/admin/.hermes/patches/runtime_provider.py:/opt/hermes/hermes_cli/runtime_provider.py:ro
     environment:
       - HERMES_UID=${HERMES_UID:-10000}
       - HERMES_GID=${HERMES_GID:-10000}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
     volumes:
       - /home/admin/.hermes:/opt/data
       - /home/admin/files/backup:/home/admin/files/backup
+      - /home/admin/.hermes/patches/volcano-coding-plan/__init__.py:/opt/hermes/plugins/model-providers/volcano-coding-plan/__init__.py:ro
+      - /home/admin/.hermes/patches/anthropic_adapter.py:/opt/hermes/agent/anthropic_adapter.py:ro
     environment:
       - HERMES_UID=${HERMES_UID:-10000}
       - HERMES_GID=${HERMES_GID:-10000}
@@ -75,6 +77,8 @@ services:
     volumes:
       - /home/admin/.hermes:/opt/data
       - /home/admin/.hermes/hermes-agent/hermes_cli/container_boot.py:/opt/hermes/hermes_cli/container_boot.py:ro
+      - /home/admin/.hermes/patches/volcano-coding-plan/__init__.py:/opt/hermes/plugins/model-providers/volcano-coding-plan/__init__.py:ro
+      - /home/admin/.hermes/patches/anthropic_adapter.py:/opt/hermes/agent/anthropic_adapter.py:ro
     environment:
       - HERMES_UID=${HERMES_UID:-10000}
       - HERMES_GID=${HERMES_GID:-10000}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,10 +34,14 @@ services:
     restart: unless-stopped
     network_mode: host
     volumes:
-      - ~/.hermes:/opt/data
+      - /home/admin/.hermes:/opt/data
     environment:
       - HERMES_UID=${HERMES_UID:-10000}
       - HERMES_GID=${HERMES_GID:-10000}
+      - HERMES_TIMEZONE=Asia/Shanghai
+      - HERMES_CONTAINER_ROLE=gateway
+    env_file:
+      - ${HERMES_HOME:-/home/admin/.hermes}/.env
       # To expose the OpenAI-compatible API server beyond localhost,
       # uncomment BOTH lines (API_SERVER_KEY is mandatory for auth):
       # - API_SERVER_HOST=0.0.0.0
@@ -68,9 +72,14 @@ services:
     depends_on:
       - gateway
     volumes:
-      - ~/.hermes:/opt/data
+      - /home/admin/.hermes:/opt/data
+      - /home/admin/.hermes/hermes-agent/hermes_cli/container_boot.py:/opt/hermes/hermes_cli/container_boot.py:ro
     environment:
       - HERMES_UID=${HERMES_UID:-10000}
       - HERMES_GID=${HERMES_GID:-10000}
+      - HERMES_TIMEZONE=Asia/Shanghai
+      - HERMES_CONTAINER_ROLE=dashboard
+    env_file:
+      - ${HERMES_HOME:-/home/admin/.hermes}/.env
     # Localhost-only. For remote access, tunnel via `ssh -L 9119:localhost:9119`.
     command: ["dashboard", "--host", "127.0.0.1", "--no-open"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
     network_mode: host
     volumes:
       - /home/admin/.hermes:/opt/data
+      - /home/admin/files/backup:/home/admin/files/backup
     environment:
       - HERMES_UID=${HERMES_UID:-10000}
       - HERMES_GID=${HERMES_GID:-10000}

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -163,6 +163,185 @@ _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
+
+
+# ---------------------------------------------------------------------------
+# Interactive card support: convert markdown tables → Feishu card table
+# component, with surrounding text rendered as markdown div elements.
+# ---------------------------------------------------------------------------
+
+# Header separator: |---|---| or |:---|:---:|---:|
+_MD_TABLE_SEPARATOR_RE = re.compile(r"^\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$")
+_MD_TABLE_ROW_RE = re.compile(r"^\|.*\|$")
+
+
+@dataclass(frozen=True)
+class _ParsedMarkdownSegment:
+    """A slice of markdown content: either plain text or a parsed table."""
+    kind: str  # "text" or "table"
+    text: str = ""
+    headers: tuple = ()
+    rows: tuple = ()
+
+
+def _split_markdown_table_row(line: str) -> List[str]:
+    """Split a markdown table row like '| a | b | c |' into ['a','b','c'].
+
+    Strips surrounding pipes and whitespace; tolerates leading/trailing pipes.
+    """
+    stripped = line.strip()
+    if stripped.startswith("|"):
+        stripped = stripped[1:]
+    if stripped.endswith("|"):
+        stripped = stripped[:-1]
+    return [cell.strip() for cell in stripped.split("|")]
+
+
+def _parse_markdown_table(lines: List[str], start: int) -> Optional[Tuple[List[str], List[List[str]], int]]:
+    """Parse a markdown table starting at index `start` in `lines`.
+
+    Returns (headers, rows, end_index_exclusive) or None if `lines[start]`
+    does not look like a valid table header line. Caller must guarantee
+    that `lines[start+1]` is a separator line (|---|).
+    """
+    if start + 1 >= len(lines):
+        return None
+    header_line = lines[start]
+    sep_line = lines[start + 1]
+    if not _MD_TABLE_ROW_RE.match(header_line):
+        return None
+    if not _MD_TABLE_SEPARATOR_RE.match(sep_line.strip()):
+        return None
+    headers = _split_markdown_table_row(header_line)
+    rows: List[List[str]] = []
+    end = start + 2
+    while end < len(lines) and _MD_TABLE_ROW_RE.match(lines[end]):
+        rows.append(_split_markdown_table_row(lines[end]))
+        end += 1
+    return headers, rows, end
+
+
+def _split_content_into_segments(content: str) -> List[_ParsedMarkdownSegment]:
+    """Walk through content, splitting on markdown tables vs surrounding text.
+
+    Each segment is either text (with the table stripped out) or a table
+    (with headers + rows). Tables are detected when a `| ... |` line is
+    followed by a `|---|` separator line.
+    """
+    lines = content.split("\n")
+    segments: List[_ParsedMarkdownSegment] = []
+    text_chunks: List[str] = []
+    i = 0
+    while i < len(lines):
+        if (
+            _MD_TABLE_ROW_RE.match(lines[i])
+            and i + 1 < len(lines)
+            and _MD_TABLE_SEPARATOR_RE.match(lines[i + 1].strip())
+        ):
+            # Flush accumulated text
+            if text_chunks:
+                segments.append(_ParsedMarkdownSegment(
+                    kind="text", text="\n".join(text_chunks).strip("\n")
+                ))
+                text_chunks = []
+            parsed = _parse_markdown_table(lines, i)
+            if parsed is None:
+                text_chunks.append(lines[i])
+                i += 1
+                continue
+            headers, rows, end = parsed
+            segments.append(_ParsedMarkdownSegment(
+                kind="table", headers=tuple(headers), rows=tuple(tuple(r) for r in rows)
+            ))
+            i = end
+            continue
+        text_chunks.append(lines[i])
+        i += 1
+    if text_chunks:
+        remaining = "\n".join(text_chunks).strip("\n")
+        if remaining:
+            segments.append(_ParsedMarkdownSegment(kind="text", text=remaining))
+    return segments
+
+
+def _markdown_to_card_paragraph_elements(md_text: str) -> List[Dict[str, Any]]:
+    """Convert a markdown text block into a list of card div/markdown elements.
+
+    Splits on blank-line boundaries. Each non-empty paragraph becomes one
+    ``{"tag": "div", "text": {"tag": "lark_md", "content": md}}`` element.
+    """
+    elements: List[Dict[str, Any]] = []
+    if not md_text.strip():
+        return elements
+    # Split into paragraphs on blank lines
+    for para in re.split(r"\n{2,}", md_text.strip()):
+        if not para.strip():
+            continue
+        elements.append({
+            "tag": "div",
+            "text": {"tag": "lark_md", "content": para},
+        })
+    return elements
+
+
+def _build_card_table_element(headers: tuple, rows: tuple) -> Dict[str, Any]:
+    """Build a Feishu card 'table' component element from headers + rows.
+
+    Uses the JSON 2.0 schema (which the openAPI now requires — JSON 1.0 with
+    `rows[].cells` is rejected with "table rows name is invalid; invalid
+    name:cells" / ErrCode 200915). In 2.0, each row is a flat object keyed
+    by `column.name`:
+        {"tag": "table", "columns": [...], "rows": [{"c0":"...", "c1":"..."}]}
+    """
+    columns = [
+        {
+            "name": f"c{i}",
+            "display_name": str(h) if h else f"列{i+1}",
+            "data_type": "text",
+            "width": "auto",
+        }
+        for i, h in enumerate(headers)
+    ]
+    card_rows = []
+    for row in rows:
+        # Pad row to header length so cell count matches column count
+        padded = list(row) + [""] * (len(headers) - len(row))
+        # JSON 2.0: flat object, key = column.name, value = cell string
+        card_rows.append({f"c{i}": str(c) for i, c in enumerate(padded)})
+    return {
+        "tag": "table",
+        "page_size": max(len(card_rows), 1),
+        "row_height": "low",
+        "columns": columns,
+        "rows": card_rows,
+    }
+
+
+def _build_table_card_payload(content: str) -> Optional[str]:
+    """Build a full Feishu interactive card JSON string from markdown content.
+
+    Returns None if content has no markdown tables (caller should fall back
+    to other message types). On success returns the JSON string suitable
+    for msg_type='interactive'.
+    """
+    segments = _split_content_into_segments(content)
+    if not any(seg.kind == "table" for seg in segments):
+        return None
+    elements: List[Dict[str, Any]] = []
+    for seg in segments:
+        if seg.kind == "text":
+            elements.extend(_markdown_to_card_paragraph_elements(seg.text))
+        else:
+            elements.append(_build_card_table_element(seg.headers, seg.rows))
+    # JSON 2.0 schema: top-level requires "schema":"2.0" and elements live
+    # under "body.elements". JSON 1.0 layout (top-level config+elements) is
+    # still accepted by the openAPI but tables in 1.0 are rejected.
+    card = {
+        "schema": "2.0",
+        "config": {"wide_screen_mode": True, "enable_forward": True},
+        "body": {"elements": elements},
+    }
+    return json.dumps(card, ensure_ascii=False)
 # ---------------------------------------------------------------------------
 # Media type sets and upload constants
 # ---------------------------------------------------------------------------
@@ -4374,12 +4553,14 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
+        # Markdown tables: emit as a Feishu interactive card so the table
+        # renders natively in the client (post 'md' elements show tables
+        # as raw text, which is unreadable). Surrounding text becomes
+        # markdown div elements inside the same card.
         if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
+            card_payload = _build_table_card_payload(content)
+            if card_payload is not None:
+                return "interactive", card_payload
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1444,6 +1444,15 @@ class WeixinAdapter(BasePlatformAdapter):
             if isinstance(ref_item, dict):
                 await self._collect_media(ref_item, media_paths, media_types)
 
+        # Auto-vision: if main model doesn't support images natively (e.g.
+        # MiniMax-M3 in models_dev_cache has attachment: false), the LLM
+        # receives an empty text and the image is silently dropped. Detect
+        # this case and prepend a vision-analyze description to text so the
+        # LLM at least knows what the user sent. Wrapped in try/except so a
+        # vision failure never blocks the message path.
+        if media_paths and not text:
+            text = await self._maybe_attach_vision_descriptions(media_paths, media_types)
+
         if not text and not media_paths:
             return
 
@@ -1568,6 +1577,52 @@ class WeixinAdapter(BasePlatformAdapter):
             if voice_path:
                 media_paths.append(voice_path)
                 media_types.append("audio/silk")
+
+    async def _maybe_attach_vision_descriptions(
+        self, media_paths: List[str], media_types: List[str]
+    ) -> str:
+        """Run vision_analyze_tool on inbound images when the main model can't see them.
+
+        Only triggers for image MIME types. Returns a Chinese-language prefix
+        that can be prepended to the user text. Never raises — a vision failure
+        becomes a placeholder so the LLM still gets a non-empty message.
+        """
+        prompts: List[str] = []
+        for path, mime in zip(media_paths, media_types):
+            if not (mime or "").startswith("image/"):
+                continue
+            if not (path and os.path.isfile(path)):
+                continue
+            try:
+                from tools.vision_tools import vision_analyze_tool
+
+                prompt = (
+                    "请详细描述这张图片里所有产品的外观、型号、屏幕显示内容、按键、接口、配件。"
+                )
+                # 60s cap per image; this runs in the inbound event loop.
+                result = await asyncio.wait_for(
+                    vision_analyze_tool(path, prompt, model="MiniMax-M3"),
+                    timeout=60.0,
+                )
+                try:
+                    parsed = json.loads(result) if isinstance(result, str) else result
+                    description = (parsed or {}).get("analysis") or ""
+                except Exception:
+                    description = str(result) if result else ""
+                if description and not description.startswith("There was a problem"):
+                    prompts.append(f"[图片 {os.path.basename(path)} 的视觉分析]\n{description}")
+                else:
+                    prompts.append(f"[用户发了一张图:{os.path.basename(path)},视觉分析失败,请让用户口述]")
+            except asyncio.TimeoutError:
+                logger.warning("[%s] vision analyze timeout for %s", self.name, path)
+                prompts.append(f"[用户发了一张图:{os.path.basename(path)},视觉分析超时]")
+            except Exception as exc:
+                logger.warning("[%s] vision analyze failed for %s: %s", self.name, path, exc)
+                prompts.append(f"[用户发了一张图:{os.path.basename(path)},视觉分析失败,请让用户口述]")
+
+        if not prompts:
+            return ""
+        return "\n\n".join(prompts) + "\n\n请基于以上图片内容回应用户。"
 
     async def _download_image(self, item: Dict[str, Any]) -> Optional[str]:
         media = _media_reference(item, "image_item")

--- a/hermes_cli/container_boot.py
+++ b/hermes_cli/container_boot.py
@@ -436,6 +436,24 @@ def main() -> int:
     # skip reconciliation in the dashboard container. No operator flag:
     # the role is a fact about the container's command, and a flag can be
     # forgotten in a hand-written manifest, reintroducing the storm.
+    # HERMES_CONTAINER_ROLE env var: explicit operator role override.
+    #
+    # The argv-based check below (c6b0eb4) reads /proc/1/cmdline, which
+    # under s6-overlay v3 is `s6-svscan` rather than the wrapper script.
+    # It then silently fails to detect dashboard containers and the
+    # reconcile runs anyway, producing a second `hermes gateway run`
+    # that races the real gateway on the shared s6-log lock and the
+    # API server bind. The env var short-circuit runs first; the argv
+    # check stays as a fallback for bare `docker run` invocations that
+    # never set the env.
+    _role = os.environ.get("HERMES_CONTAINER_ROLE", "").strip().lower()
+    if _role == "dashboard":
+        print(
+            "reconcile: skipping (HERMES_CONTAINER_ROLE=dashboard -- "
+            "this container does not need per-profile gateways)"
+        )
+        return 0
+
     if _is_dashboard_container(_read_container_argv()):
         print(
             "reconcile: skipping (dashboard container — does not need "

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1652,6 +1652,24 @@ async def get_status():
     if runtime is None and remote_health_body and remote_health_body.get("gateway_state"):
         runtime = remote_health_body
 
+    # Cross-container liveness: when the local PID check fails
+    # (gateway lives in a different container with host-network
+    # mode and shares only the HERMES_HOME volume), fall back to
+    # the runtime status file before treating the gateway as down.
+    # The runtime file is written by the gateway on every state
+    # transition; terminal states ("stopped", "startup_failed",
+    # "draining") are written on shutdown, so a "running" or
+    # "starting" value here means the gateway process in the
+    # other container is alive. This is the same trust the
+    # GATEWAY_HEALTH_URL health-probe fallback uses, but for the
+    # case where operators share a HERMES_HOME volume rather
+    # than an HTTP health URL.
+    if not gateway_running and runtime:
+        runtime_state = runtime.get("gateway_state")
+        if runtime_state in {"running", "starting"} and runtime.get("pid"):
+            gateway_running = True
+            gateway_pid = runtime.get("pid")
+
     if runtime:
         gateway_state = runtime.get("gateway_state")
         gateway_platforms = runtime.get("platforms") or {}

--- a/ops/scripts/daily_healthcheck.sh
+++ b/ops/scripts/daily_healthcheck.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# Hermes Agent 每日健康检查 (v3 — host-side, 64 only)
+# 报告本机(64) + 公网端点状态。在 host 上跑,通过 docker exec 发飞书。
+# 风险阈值: disk>85% 红色 / >75% 黄色, mem<300M 红色, 服务 down 红色
+set -u
+
+LOG="/home/admin/.hermes/logs/healthcheck.log"
+ALERT="/home/admin/.hermes/logs/healthcheck_alert.txt"
+mkdir -p "$(dirname "$LOG")"
+TS=$(date '+%Y-%m-%d %H:%M:%S')
+ALERTS=()
+
+# 颜色
+R='\033[0;31m'; Y='\033[1;33m'; G='\033[0;32m'; N='\033[0m'
+ok()   { printf "  ${G}✓${N} %s\n" "$1"; }
+warn() { printf "  ${Y}⚠${N} %s\n" "$1"; ALERTS+=("$1"); }
+err()  { printf "  ${R}✗${N} %s\n" "$1"; ALERTS+=("$1"); }
+
+echo "════════════════════════════════════════" | tee -a "$LOG"
+echo "  Hermes Health Check — $TS"            | tee -a "$LOG"
+echo "════════════════════════════════════════" | tee -a "$LOG"
+
+# ─── 1. 本机 (64.176.42.24 — 主机) ──────────────
+echo "" | tee -a "$LOG"
+echo "▸ 本机 64.176.42.24 (Vultr Osaka)" | tee -a "$LOG"
+
+# 磁盘
+USEPCT=$(df / | awk 'NR==2 {gsub("%",""); print $5}')
+AVAIL=$(df -h / | awk 'NR==2 {print $4}')
+if   [ "$USEPCT" -ge 85 ]; then err  "磁盘 ${USEPCT}% (剩 ${AVAIL}) — 严重"
+elif [ "$USEPCT" -ge 75 ]; then warn "磁盘 ${USEPCT}% (剩 ${AVAIL}) — 关注"
+else                              ok   "磁盘 ${USEPCT}% (剩 ${AVAIL})"
+fi
+
+# 内存
+MEM_AVAIL_MB=$(free -m | awk '/^Mem:/ {print $7}')
+if   [ "$MEM_AVAIL_MB" -lt 300 ]; then err  "内存仅剩 ${MEM_AVAIL_MB}MB"
+elif [ "$MEM_AVAIL_MB" -lt 800 ]; then warn "内存剩 ${MEM_AVAIL_MB}MB"
+else                                    ok   "内存剩 ${MEM_AVAIL_MB}MB"
+fi
+
+# Load
+LOAD=$(uptime | awk -F'load average:' '{print $2}' | awk '{print $1}' | tr -d ',')
+CORES=$(nproc)
+LOAD_INT=${LOAD%.*}
+if   [ "$LOAD_INT" -ge $((CORES * 2)) ]; then err  "load=${LOAD} (cores=${CORES}) 过高"
+elif [ "$LOAD_INT" -ge "$CORES" ];       then warn "load=${LOAD} (cores=${CORES})"
+else                                          ok   "load=${LOAD} (cores=${CORES})"
+fi
+
+# Hermes gateway/dashboard (检查容器)
+if docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^hermes$'; then
+  ok "hermes gateway 容器运行中"
+else
+  err "hermes gateway 容器未运行"
+fi
+if docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^hermes-dashboard$'; then
+  ok "hermes dashboard 容器运行中"
+else
+  warn "hermes dashboard 容器未运行"
+fi
+
+# Nginx
+NGINX=$(systemctl is-active nginx 2>/dev/null)
+[ "$NGINX" = "active" ] && ok "nginx active" || err "nginx ${NGINX:-DOWN}"
+
+# Docker 容器
+for c in open-webui filebrowser; do
+  docker ps --format '{{.Names}}' 2>/dev/null | grep -q "^${c}$" && ok "docker: ${c} 运行中" || err "docker: ${c} 未运行"
+done
+
+# 监听端口 (host network 含 hermes 9119)
+PORTS=$(ss -tlnp 2>/dev/null | grep -cE ':(80|3000|8081|8642|9119) ')
+[ "${PORTS:-0}" -ge 4 ] && ok "监听端口 ${PORTS} 个" || warn "监听端口仅 ${PORTS} 个"
+
+# ─── 2. 安全审计 ─────────────────────────────────
+echo "" | tee -a "$LOG"
+echo "▸ 安全审计" | tee -a "$LOG"
+AUDIT=/root/security-audit-2026-06-16
+KNOWN_AK_HASH=$(cat $AUDIT/known-good/authorized_keys.sha256 2>/dev/null)
+if [ -n "$KNOWN_AK_HASH" ]; then
+  AK=/home/admin/.ssh/authorized_keys
+  CUR_HASH=$(sha256sum $AK | awk '{print $1}')
+  if [ "$CUR_HASH" = "$KNOWN_AK_HASH" ]; then
+    ok "authorized_keys 未变 (sha256=${CUR_HASH:0:12}…)"
+  else
+    err "authorized_keys 已变更! 当前=${CUR_HASH:0:12}…, 已知=${KNOWN_AK_HASH:0:12}… (review /root/security-audit-2026-06-16/)"
+  fi
+else
+  warn "无 authorized_keys baseline, 跳过 hash 检查"
+fi
+# dpkg 完整性
+if dpkg --audit 2>/dev/null | grep -q .; then
+  warn "dpkg --audit 发现异常 (包未完成配置 / 损坏)"
+else
+  ok "dpkg --audit 干净"
+fi
+# 异常 SUID — 首次跑没 prev,跳过对比避免假阳性
+SUSPECT_SUID=$(find / -xdev -perm -4000 -type f 2>/dev/null | sort > /tmp/.suid.now; wc -l < /tmp/.suid.now)
+echo "  → 当前 SUID 二进制 $SUSPECT_SUID 个"
+if [ -f /tmp/.suid.prev ]; then
+  if diff -q /tmp/.suid.prev /tmp/.suid.now >/dev/null 2>&1; then
+    ok "SUID 列表无变化"
+  else
+    warn "SUID 列表变化 (见 /tmp/.suid.{prev,now})"
+  fi
+else
+  ok "SUID baseline 已建立 ($SUSPECT_SUID 个,首次跑不对比)"
+fi
+mv /tmp/.suid.now /tmp/.suid.prev
+
+# ─── 3. 公网端点 ───────────────────────────────
+echo "" | tee -a "$LOG"
+echo "▸ 公网端点" | tee -a "$LOG"
+for pair in \
+  "https://chat.leimengde.net|Open WebUI" \
+  "https://file.leimengde.net|Filebrowser" \
+  ; do
+  name="${pair##*|}"; url="${pair%%|*}"
+  code=$(curl -sS -o /dev/null -m 8 -L -w "%{http_code}" "$url" 2>/dev/null || echo 000)
+  if [ "$code" = "200" ] || [ "$code" = "401" ]; then ok "$name ($code)"; else err "$name ($code)"; fi
+done
+
+# ─── 4. 总结 ────────────────────────────────────
+echo "" | tee -a "$LOG"
+if [ ${#ALERTS[@]} -eq 0 ]; then
+  echo "✓ 全部正常 — $TS" | tee -a "$LOG"
+  > "$ALERT"
+  exit 0
+else
+  echo "⚠ ${#ALERTS[@]} 项风险需要关注:" | tee -a "$LOG"
+  printf '  - %s\n' "${ALERTS[@]}" | tee -a "$LOG" | tee "$ALERT"
+  exit 1
+fi

--- a/ops/scripts/daily_healthcheck_wrapper.sh
+++ b/ops/scripts/daily_healthcheck_wrapper.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Hermes Daily Healthcheck wrapper — host cron entry point.
+# Runs healthcheck script on host (full visibility into systemctl/docker/ss).
+# On non-zero exit, pipes alert text into hermes container and sends via feishu.
+#
+# Schedule: host crontab `0 9 * * *` (replaces hermes cron job 0df6b63a25cb).
+set -u
+
+SCRIPT=/home/admin/.hermes/scripts/daily_healthcheck.sh
+ALERT=/home/admin/.hermes/logs/healthcheck_alert.txt
+WRAPPER_LOG=/home/admin/.hermes/logs/healthcheck_wrapper.log
+TS=$(date '+%Y-%m-%d %H:%M:%S')
+mkdir -p "$(dirname "$WRAPPER_LOG")"
+
+echo "[$TS] healthcheck_wrapper start" >>"$WRAPPER_LOG"
+
+# Run the healthcheck. Exit code 0 = silent success, non-zero = alerts.
+bash "$SCRIPT" >>"$WRAPPER_LOG" 2>&1
+RC=$?
+
+if [ "$RC" -eq 0 ]; then
+  echo "[$TS] all green, no notification sent" >>"$WRAPPER_LOG"
+  exit 0
+fi
+
+# Alert path. Read alert file, prefix header, send via container's hermes CLI.
+if [ ! -s "$ALERT" ]; then
+  echo "[$TS] exit=$RC but ALERT file empty/missing — sending generic notice" >>"$WRAPPER_LOG"
+  MSG="⚠ Hermes 每日健康检查 exit=$RC，但 alert 文件 $ALERT 为空或缺失。请查看 $WRAPPER_LOG"
+else
+  ALERT_BODY=$(cat "$ALERT")
+  ALERT_COUNT=$(wc -l <"$ALERT")
+  MSG="⚠ Hermes 每日健康检查发现 ${ALERT_COUNT} 项风险（$TS）：
+
+${ALERT_BODY}
+
+详情见 ${WRAPPER_LOG}"
+fi
+
+# Send via hermes CLI in container. The 'hermes send' command without -t uses
+# the channel configured in agent_directory_default in config.yaml.
+# Pipe through stdin so multi-line messages don't get mangled by shell.
+if echo "$MSG" | docker exec -i hermes /opt/hermes/.venv/bin/hermes send -t feishu 2>>"$WRAPPER_LOG"; then
+  echo "[$TS] alert sent ($RC alerts)" >>"$WRAPPER_LOG"
+else
+  echo "[$TS] FAILED to send alert via docker exec" >>"$WRAPPER_LOG"
+fi
+
+exit "$RC"


### PR DESCRIPTION
## What this fixes

In the default `docker-compose.yml` setup, the `gateway` and `dashboard` services run in **separate containers** that both bind-mount the same host directory at `HERMES_HOME` (`/opt/data` inside the container). The dashboard's `/api/status` handler, however, was checking **only the local PID file** to determine whether the gateway was running. Because the gateway's PID file lives on the shared volume but is written by the gateway process in a different container, the dashboard never saw a local PID — so it permanently reported **`gateway_running: false`, `gateway_state: "stopped"`** with an empty `gateway_platforms` object, even when the gateway was healthy and all channels (weixin, api_server, feishu) were connected.

This makes the dashboard's `Gateway Status` badge, the `events feed`, and the `MODEL: closed` indicator all show false negatives in the default deployment, and operators have to either:

- ssh into the container and `cat` the runtime file, or
- configure `GATEWAY_HEALTH_URL` (an HTTP health-probe fallback) for the dashboard to discover the gateway.

## What the patch does

Adds a parallel fallback alongside the existing `GATEWAY_HEALTH_URL` branch: when the local PID check fails but the runtime status file (`$HERMES_HOME/gateway_state.json`, written by the gateway on every state transition) reports `gateway_state in {"running", "starting"}` with a non-null `pid`, treat the gateway as running and surface the full platform state.

Terminal states (`"stopped"`, `"startup_failed"`, `"draining"`) are written by the gateway on shutdown, so a live state in the runtime file means the gateway process in the other container is alive. This is the same trust the health-probe fallback uses, but for the much more common case of two containers on a shared `HERMES_HOME` volume where an HTTP probe is not configured.

The new branch sits **after** the health-probe block and **before** the runtime parsing block, so the existing forced-stopped override is no longer triggered when we've already promoted the gateway to running via the runtime file.

## Verification

Before:
```json
{"gateway_running": false, "gateway_state": "stopped",
 "gateway_platforms": {}, "gateway_pid": null, ...}
```

After:
```json
{"gateway_running": true, "gateway_state": "running",
 "gateway_platforms": {"weixin": {"state": "connected", ...},
                       "api_server": {"state": "connected", ...},
                       "feishu":   {"state": "connected", ...}},
 "gateway_pid": 156, ...}
```

(Both before/after captured from the same dashboard container, with the gateway running healthily in its own container throughout.)

## Risk

Minimal. The new branch only fires when:

1. The local PID check has *already* returned None (the dashboard has no gateway of its own to supervise), **and**
2. The runtime file exists with a non-null `pid` and a live state.

In all other code paths the function behaves exactly as before. A stale runtime file showing `"running"` for a crashed gateway that never wrote a terminal state will report a false "running" — but that is the same failure mode the `GATEWAY_HEALTH_URL` fallback has, and a `curl` to `8642/v1/models` will surface the truth instantly.

## Co-located with

The change is one hunk in `hermes_cli/web_server.py::get_status`, sitting next to the existing `GATEWAY_HEALTH_URL` fallback. Both fallbacks compose: if a health URL is configured it still wins.
