### PR TITLE
fix: pass session_db to background review agents

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -413,6 +413,7 @@ def _run_review_in_thread(
                 enabled_toolsets=getattr(agent, "enabled_toolsets", None),
                 disabled_toolsets=getattr(agent, "disabled_toolsets", None),
                 skip_memory=True,
+                session_db=getattr(agent, "_session_db", None),
             )
             review_agent._memory_write_origin = "background_review"
             review_agent._memory_write_context = "background_review"


### PR DESCRIPTION
## Problem

Background review agents (delegate_task auto-deny reviews) were initialized without a `session_db` handle. When the parent agent's SessionDB had been recovered from a previous failure, or was created after the parent agent started, the review agent's `append_message` calls went nowhere — messages were silently dropped.

## Fix

Pass `session_db=getattr(agent, "_session_db", None)` so review agents connect to the same session store as their parent. One line.

## Related

- **#32805** — larger fix for session DB persistence failures that this complements (review agents needed the handle too).