### PR TITLE
fix(agent): allow write_file/patch to modify active profile .env

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -29,15 +29,13 @@ def build_write_denied_paths(home: str) -> set[str]:
     """Return exact sensitive paths that must never be written."""
     hermes_home = _hermes_home_path()
     hermes_root = _hermes_root_path()
-    return {
+    denied = {
         os.path.realpath(p)
         for p in [
             os.path.join(home, ".ssh", "authorized_keys"),
             os.path.join(home, ".ssh", "id_rsa"),
             os.path.join(home, ".ssh", "id_ed25519"),
             os.path.join(home, ".ssh", "config"),
-            # Active profile .env (or top-level .env when not in profile mode).
-            str(hermes_home / ".env"),
             # Top-level .env, even when running under a profile — overwriting it
             # leaks credentials across every profile that inherits from root (#15981).
             str(hermes_root / ".env"),
@@ -56,6 +54,13 @@ def build_write_denied_paths(home: str) -> set[str]:
             "/etc/shadow",
         ]
     }
+    # The active profile's .env is writable so the agent can manage its own
+    # environment variables via write_file/patch (e.g. removing a value added
+    # by ``hermes config set``).  The root .env stays blocked to prevent
+    # cross-profile credential leakage (#15981, #47107).
+    hermes_home_env = os.path.realpath(str(hermes_home / ".env"))
+    denied.discard(hermes_home_env)
+    return denied
 
 
 def build_write_denied_prefixes(home: str) -> list[str]:

--- a/tests/tools/test_write_deny.py
+++ b/tests/tools/test_write_deny.py
@@ -31,23 +31,21 @@ class TestWriteDenyExactPaths:
 
 
     def test_hermes_env(self):
-        # ``.env`` under the active HERMES_HOME (profile-aware, not just
-        # ``~/.hermes``) must be write-denied. The hermetic test conftest
-        # points HERMES_HOME at a tempdir — resolve via get_hermes_home()
-        # to match the denylist.
+        # The active profile's .env is now writable so the agent can manage
+        # its own environment variables (#47107).  The read guard still blocks
+        # reading .env via read_file — only the write guard is relaxed.
         from hermes_constants import get_hermes_home
         path = str(get_hermes_home() / ".env")
-        assert _is_write_denied(path) is True
+        assert _is_write_denied(path) is False
 
     def test_hermes_root_env_when_running_under_profile(self, tmp_path, monkeypatch):
         """Top-level ``<root>/.env`` stays write-denied even when running under
-        a profile (#15981).
+        a profile (#15981).  The active profile's .env is writable (#47107).
 
-        Before the fix, ``build_write_denied_paths`` only added
-        ``<active_profile>/.env`` to the deny list, so the global
-        ``~/.hermes/.env`` (whose credentials are inherited by every profile)
-        could be silently overwritten by ``write_file`` while a profile was
-        active.
+        Before #47107, ``build_write_denied_paths`` blocked both
+        ``<active_profile>/.env`` and ``<root>/.env``.  Now only the root
+        .env is blocked — the active profile's .env is writable so the
+        agent can manage its own env vars via write_file/patch.
         """
         root = tmp_path / "hermes_root"
         profile_home = root / "profiles" / "coder"
@@ -62,7 +60,10 @@ class TestWriteDenyExactPaths:
         assert get_hermes_home() == profile_home
         assert get_default_hermes_root() == root
 
+        # Root .env stays blocked (cross-profile credential leakage).
         assert _is_write_denied(str(global_env)) is True
+        # Active profile .env is now writable (#47107).
+        assert _is_write_denied(str(profile_home / ".env")) is False
 
     def test_shell_profiles_are_writable(self):
         home = str(Path.home())


### PR DESCRIPTION
## What does this PR do?

Allows `write_file` and `patch` tools to modify the active profile's `.env` file (`~/.hermes/.env`), so the agent can manage its own environment variables without falling back to raw shell commands.

## Related Issue

Fixes #47107

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/file_safety.py`: Remove the active profile's `.env` from `build_write_denied_paths()`. The root `.env` stays blocked to prevent cross-profile credential leakage (#15981). Uses `set.discard()` after building the set so `hermes_home == hermes_root` (non-profile mode) correctly allows the single `.env`.
- `tests/tools/test_write_deny.py`: Update `test_hermes_env` to assert the active profile's `.env` is now writable. Extend `test_hermes_root_env_when_running_under_profile` to verify the active profile's `.env` is writable while the root `.env` remains blocked.

## How to Test

1. Run `pytest tests/tools/test_write_deny.py tests/tools/test_file_operations.py -q` — all 96 tests pass
2. Run `pytest tests/agent/test_copilot_acp_client.py -q` — all 7 tests pass
3. Run `pytest tests/tools/test_file_write_safety.py -q` — all tests pass
4. Verify the read guard still blocks `.env` reads (defense-in-depth unchanged)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Code Intelligence

- Analyzed: `agent/file_safety.py:build_write_denied_paths` (callers: 3 — `file_operations.py`, `copilot_acp_client.py`, `is_write_denied`)
- Blast radius: LOW — only relaxes the write guard for the active profile's `.env`; all other protections unchanged
- Related patterns: `build_write_denied_paths` feeds both `is_write_denied` (shared) and `_is_write_denied` (tool wrapper); `get_read_block_error` still blocks `.env` reads (defense-in-depth)
