### PR TITLE
fix(slack): re-apply bang→slash rewrite after @mention strip

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -2525,6 +2525,27 @@ class SlackAdapter(BasePlatformAdapter):
         if is_mentioned:
             # Strip the bot mention from the text
             text = text.replace(f"<@{bot_uid}>", "").strip()
+            # Re-apply the ``!cmd`` → ``/cmd`` rewrite after stripping the bot
+            # mention.  When a user types ``@bot !model ...`` the original text
+            # starts with ``<@...>`` so the earlier bang-rewrite pass (which
+            # only fires when the text starts with ``!``) is skipped.  After
+            # mention-stripping the leading ``!`` is visible, so we run the
+            # same logic again here to normalise it to a slash command.
+            if text.startswith("!"):
+                try:
+                    from hermes_cli.commands import is_gateway_known_command
+
+                    first_token = text[1:].split(maxsplit=1)[0]
+                    cmd_name = first_token.split("@", 1)[0].lower()
+                    if (
+                        cmd_name
+                        and "/" not in cmd_name
+                        and is_gateway_known_command(cmd_name)
+                    ):
+                        text = "/" + text[1:]
+                        original_text = text  # keep original_text in sync for MessageType detection
+                except Exception:  # pragma: no cover - defensive
+                    pass
             # Register this thread so all future messages auto-trigger the bot.
             # Skipped in strict mode: strict_mention=true bots must be
             # re-mentioned every turn, so remembering the thread would


### PR DESCRIPTION
## Problem

When a user types `@bot !model ...` (or any `!cmd` prefixed with an `@mention`) in a Slack channel, the `!`→`/` rewrite that normally fires for bare `!cmd` messages is silently skipped.

### Root cause

The bang-rewrite pass (around line 2298) guards on `original_text.startswith("!")`.  
When the message starts with `<@BOT_UID>`, that condition is false and the rewrite never runs.  
After mention-stripping (line 2527) the text becomes `!model ...`, but there is no second rewrite pass — so the message arrives at the dispatcher as plain `TEXT` instead of `COMMAND`.

### Reproducer

Send `@bot !model jp.anthropic.claude-opus-4 --provider bedrock` in a Slack channel.  
Expected: model switches (or asks for confirmation).  
Actual: silently ignored / treated as free text.

## Fix

After stripping the bot mention, check whether the resulting text starts with `!` and, if `is_gateway_known_command` resolves it, rewrite it to `/cmd ...` and sync `original_text` so the downstream `MessageType.COMMAND` detection fires correctly.

The added code reuses the exact same logic that already exists for the bare-`!` path, keeping behaviour identical.

## Testing

- Existing Slack test suite passes (failures in `test_slack_channel_session_scope` and `test_help_returns_command_list` are pre-existing and unrelated to this change — confirmed by running baseline on `main` before the patch).
- Manually verified the rewrite logic with a Python reproducer:

```python
text = '<@UBOT123> !model jp.anthropic.claude-opus-4-8 --provider bedrock'
# After mention strip:
# → '!model jp.anthropic.claude-opus-4-8 --provider bedrock'
# After bang rewrite (new code):
# → '/model jp.anthropic.claude-opus-4-8 --provider bedrock'  ✅
```
