### PR TITLE
feat(ssh): add ssh_pwsh backend for Windows PowerShell remotes

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -2009,6 +2009,7 @@ LEGACY_AUTHOR_MAP = {
     "bsmith@bramarstrategicservices.com": "bcsmith528",  # PR #20589 salvage (register_slack_action_handler plugin API)
     "sunsky.lau@gmail.com": "liuhao1024",  # PR #45494 salvage (claim session slot before auto-resume task; #45456)
     "andrewdmwalker@gmail.com": "capt-marbles",  # PR #38440 salvage (resolve xAI OAuth credentials across profiles; #43589)
+    "wkh746906141@163.com": "yudaiyan",
     "infinitycrew39@gmail.com": "infinitycrew39",  # PR #47945 salvage (scope langfuse trace state by turn/request ids; #48292)
     "eurekaxun@163.com": "huangxun375-stack",  # PR #37251 / #48894 structured OpenViking sync
     "koshaji@gmail.com": "koshaji",  # PR #49832 salvage (OpenViking runtime autostart shutdown drain)

--- a/tests/gateway/test_config_cwd_bridge.py
+++ b/tests/gateway/test_config_cwd_bridge.py
@@ -12,6 +12,8 @@ asserting the expected env var outcomes.
 import os
 import json
 
+import pytest
+
 from gateway.cwd_placeholder import CWD_PLACEHOLDERS, resolve_placeholder_terminal_cwd
 from tools.terminal_tool import _is_ssh_remote_tilde_cwd
 
@@ -206,13 +208,26 @@ class TestTildeExpansion:
         assert result["TERMINAL_CWD"] == os.path.expanduser("~/projects")
 
 
-    def test_ssh_terminal_cwd_tilde_preserved_for_remote_shell(self, monkeypatch):
+    @pytest.mark.parametrize("backend", ("ssh", "ssh_pwsh"))
+    def test_ssh_terminal_cwd_tilde_preserved_for_remote_shell(
+        self, monkeypatch, backend
+    ):
         """SSH cwd '~' must mean the remote user's home, not the gateway host HOME."""
         monkeypatch.setenv("HOME", "/opt/data")
-        cfg = {"terminal": {"backend": "ssh", "cwd": "~"}}
+        cfg = {"terminal": {"backend": backend, "cwd": "~"}}
         result = _simulate_config_bridge(cfg)
-        assert result["TERMINAL_ENV"] == "ssh"
+        assert result["TERMINAL_ENV"] == backend
         assert result["TERMINAL_CWD"] == "~"
+
+    @pytest.mark.parametrize("backend", ("ssh", "ssh_pwsh"))
+    def test_ssh_terminal_cwd_tilde_child_preserved_for_remote_shell(
+        self, monkeypatch, backend
+    ):
+        """SSH cwd '~/x' must survive until the SSH shell expands remote HOME."""
+        monkeypatch.setenv("HOME", "/opt/data")
+        cfg = {"terminal": {"backend": backend, "cwd": "~/work"}}
+        result = _simulate_config_bridge(cfg)
+        assert result["TERMINAL_CWD"] == "~/work"
 
 
 class TestVercelTerminalBridge:

--- a/tests/tools/test_ssh_pwsh_command_wrapping.py
+++ b/tests/tools/test_ssh_pwsh_command_wrapping.py
@@ -284,7 +284,9 @@ try {{
 
 
 @pytest.mark.skipif(shutil.which("pwsh") is None, reason="pwsh required")
-def test_snapshot_assembly_failure_preserves_user_exit_code(env, tmp_path):
+def test_snapshot_assembly_failure_preserves_user_exit_code(tmp_path):
+    env = object.__new__(SSHPwshEnvironment)
+    ssh_env.BaseEnvironment.__init__(env, cwd=str(tmp_path), timeout=60)
     env._snapshot_path = str(tmp_path / "missing" / "snapshot.ps1")
     env._snapshot_ready = True
     wrapped = env._wrap_command("$global:LASTEXITCODE = 7", str(tmp_path))

--- a/tests/tools/test_ssh_pwsh_command_wrapping.py
+++ b/tests/tools/test_ssh_pwsh_command_wrapping.py
@@ -1,0 +1,194 @@
+"""Tests for PowerShell command wrapping in ssh_pwsh backend."""
+
+import base64
+import shlex
+import shutil
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.environments import ssh as ssh_env
+from tools.environments import ssh_pwsh as ssh_pwsh_env
+from tools.environments.ssh_pwsh import SSHPwshEnvironment
+
+
+def _mock_completed(stdout=b"", stderr=b"", returncode=0):
+    return subprocess.CompletedProcess([], returncode, stdout=stdout, stderr=stderr)
+
+
+@pytest.fixture
+def env(monkeypatch):
+    monkeypatch.setattr(ssh_env.shutil, "which", lambda _name: "/usr/bin/ssh")
+    monkeypatch.setattr(ssh_env.subprocess, "run",
+                        lambda *a, **k: _mock_completed(stdout=b"ok\r\n"))
+    monkeypatch.setattr(ssh_env.subprocess, "Popen",
+                        lambda *a, **k: MagicMock(stdout=iter([]), stderr=iter([]),
+                                                  stdin=MagicMock(), returncode=0,
+                                                  poll=lambda: 0,
+                                                  communicate=lambda **kw: (b"", b"")))
+    monkeypatch.setattr(ssh_env.BaseEnvironment, "init_session", lambda self: None)
+    monkeypatch.setattr(ssh_env, "FileSyncManager",
+                        lambda **kw: type("M", (), {
+                            "sync": lambda self, **k: None,
+                            "sync_back": lambda self, **k: None,
+                        })())
+    e = SSHPwshEnvironment(host="h", user="u")
+    e._remote_home = "C:\\Users\\test"
+    return e
+
+
+class TestWrapCommand:
+
+    def test_contains_set_location(self, env):
+        wrapped = env._wrap_command("dir", "C:\\Users\\test")
+        assert "Set-Location" in wrapped
+        assert "C:\\Users\\test" in wrapped
+
+    def test_contains_invoke_expression(self, env):
+        wrapped = env._wrap_command("Get-ChildItem", "C:\\")
+        assert "Invoke-Expression" in wrapped
+        assert "Get-ChildItem" in wrapped
+
+    def test_captures_exit_code(self, env):
+        wrapped = env._wrap_command("dir", "C:\\")
+        assert "$LASTEXITCODE" in wrapped
+
+    def test_emits_cwd_marker(self, env):
+        wrapped = env._wrap_command("dir", "C:\\")
+        assert env._cwd_marker in wrapped
+
+    def test_sources_snapshot_when_ready(self, env):
+        env._snapshot_ready = True
+        wrapped = env._wrap_command("dir", "C:\\")
+        assert ". " in wrapped
+        assert "hermes-snap-" in wrapped
+
+    def test_no_source_when_snapshot_not_ready(self, env):
+        env._snapshot_ready = False
+        wrapped = env._wrap_command("dir", "C:\\")
+        assert "hermes-snap-" not in wrapped
+
+    def test_escapes_single_quotes(self, env):
+        wrapped = env._wrap_command("echo 'hello'", "C:\\")
+        assert "''hello''" in wrapped
+
+    def test_exits_with_captured_code(self, env):
+        wrapped = env._wrap_command("dir", "C:\\")
+        assert "exit $script:__hermes_ec" in wrapped
+
+    def test_snapshot_update_uses_unique_temp_and_atomic_move(self, env):
+        env._snapshot_ready = True
+
+        wrapped = env._wrap_command("dir", "C:\\")
+
+        temp_path = shlex.quote(env._snapshot_path + ".tmp.")
+        live_path = shlex.quote(env._snapshot_path)
+        assert f"{temp_path}$PID" in wrapped
+        assert f"Move-Item -Force {temp_path}$PID {live_path}" in wrapped
+        assert wrapped.index("Set-Content") < wrapped.index("Move-Item -Force")
+        set_content_lines = [
+            line for line in wrapped.splitlines() if "Set-Content" in line
+        ]
+        assert len(set_content_lines) == 1
+        assert f"Set-Content -Encoding UTF8 {temp_path}$PID" in set_content_lines[0]
+
+    def test_session_bootstrap_uses_atomic_snapshot_replacement(
+        self, env, monkeypatch
+    ):
+        captured = {}
+
+        def fake_run_bash(command, **kwargs):
+            captured["command"] = command
+            return MagicMock()
+
+        monkeypatch.setattr(env, "_run_bash", fake_run_bash)
+        monkeypatch.setattr(
+            env,
+            "_wait_for_process",
+            lambda *args, **kwargs: {"output": "", "returncode": 0},
+        )
+
+        env.init_session()
+
+        bootstrap = captured["command"]
+        temp_path = shlex.quote(env._snapshot_path + ".tmp.")
+        live_path = shlex.quote(env._snapshot_path)
+        assert f"{temp_path}$PID" in bootstrap
+        assert f"Move-Item -Force {temp_path}$PID {live_path}" in bootstrap
+        assert bootstrap.index("Set-Content") < bootstrap.index("Move-Item -Force")
+
+
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason="pwsh required")
+def test_concurrent_writers_never_publish_partial_snapshot(tmp_path):
+    snapshot = str(tmp_path / "hermes-snapshot.ps1").replace("'", "''")
+    script = rf"""
+$ErrorActionPreference = 'Stop'
+$snapshot = '{snapshot}'
+@('BEGIN-0-0', ('x' * 20000), 'END-0-0') |
+    Set-Content -Encoding UTF8 -LiteralPath $snapshot
+$jobs = 1..4 | ForEach-Object {{
+    $writer = $_
+    Start-Job -ScriptBlock {{
+        param($snapshot, $writer)
+        1..40 | ForEach-Object {{
+            $temp = $snapshot + '.tmp.' + $PID
+            @(
+                "BEGIN-$writer-$_",
+                ('x' * 20000),
+                "END-$writer-$_"
+            ) | Set-Content -Encoding UTF8 -LiteralPath $temp
+            Move-Item -Force -LiteralPath $temp -Destination $snapshot
+            Start-Sleep -Milliseconds 1
+        }}
+    }} -ArgumentList $snapshot, $writer
+}}
+$valid = $true
+$readCount = 0
+while (@($jobs | Where-Object State -eq 'Running').Count -gt 0) {{
+    $lines = @(Get-Content -LiteralPath $snapshot)
+    $readCount++
+    $begin = $lines[0] -replace '^BEGIN-', ''
+    $end = $lines[2] -replace '^END-', ''
+    if ($lines.Count -ne 3 -or
+        $lines[0] -notmatch '^BEGIN-' -or
+        $lines[2] -notmatch '^END-' -or
+        $begin -ne $end) {{
+        $valid = $false
+        break
+    }}
+}}
+$jobs | Wait-Job | Out-Null
+$jobs | Receive-Job | Out-Null
+$jobs | Remove-Job -Force
+if (-not $valid -or $readCount -eq 0) {{ exit 1 }}
+"""
+
+    result = subprocess.run(
+        ["pwsh", "-NoProfile", "-Command", script],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+class TestRunBash:
+
+    def test_uses_encoded_command(self, env, monkeypatch):
+        captured = []
+        monkeypatch.setattr(ssh_pwsh_env, "_popen_bash",
+                            lambda cmd, stdin_data=None: (
+                                captured.append(cmd) or MagicMock()
+                            ))
+        env._run_bash("echo hello")
+        assert len(captured) == 1
+        cmd = captured[0]
+        assert "pwsh" in cmd
+        assert "-NoProfile" in cmd
+        assert "-EncodedCommand" in cmd
+        encoded_idx = cmd.index("-EncodedCommand") + 1
+        encoded = cmd[encoded_idx]
+        decoded = base64.b64decode(encoded).decode("utf-16-le")
+        assert "echo hello" in decoded

--- a/tests/tools/test_ssh_pwsh_command_wrapping.py
+++ b/tests/tools/test_ssh_pwsh_command_wrapping.py
@@ -1,7 +1,6 @@
 """Tests for PowerShell command wrapping in ssh_pwsh backend."""
 
 import base64
-import shlex
 import shutil
 import subprocess
 from unittest.mock import MagicMock
@@ -10,7 +9,13 @@ import pytest
 
 from tools.environments import ssh as ssh_env
 from tools.environments import ssh_pwsh as ssh_pwsh_env
-from tools.environments.ssh_pwsh import SSHPwshEnvironment
+from tools.environments.ssh_pwsh import (
+    SSHPwshEnvironment,
+    _atomic_snapshot_publish,
+    _quote_pwsh_string,
+    _snapshot_mutex_name,
+    _with_snapshot_mutex,
+)
 
 
 def _mock_completed(stdout=b"", stderr=b"", returncode=0):
@@ -63,6 +68,7 @@ class TestWrapCommand:
         wrapped = env._wrap_command("dir", "C:\\")
         assert ". " in wrapped
         assert "hermes-snap-" in wrapped
+        assert "WaitOne(5000)" in wrapped
 
     def test_no_source_when_snapshot_not_ready(self, env):
         env._snapshot_ready = False
@@ -77,21 +83,25 @@ class TestWrapCommand:
         wrapped = env._wrap_command("dir", "C:\\")
         assert "exit $script:__hermes_ec" in wrapped
 
-    def test_snapshot_update_uses_unique_temp_and_atomic_move(self, env):
+    def test_snapshot_update_uses_unique_temp_and_atomic_publish(self, env):
         env._snapshot_ready = True
 
         wrapped = env._wrap_command("dir", "C:\\")
 
-        temp_path = shlex.quote(env._snapshot_path + ".tmp.")
-        live_path = shlex.quote(env._snapshot_path)
-        assert f"{temp_path}$PID" in wrapped
-        assert f"Move-Item -Force {temp_path}$PID {live_path}" in wrapped
-        assert wrapped.index("Set-Content") < wrapped.index("Move-Item -Force")
+        temp_path = _quote_pwsh_string(env._snapshot_path + ".tmp.")
+        assert f"({temp_path} + $PID)" in wrapped
+        assert "[System.IO.File]::Replace(" in wrapped
+        assert "[System.IO.File]::Move(" in wrapped
+        assert "Start-Sleep -Milliseconds 10" in wrapped
+        assert wrapped.index("Set-Content") < wrapped.index("[System.IO.File]::Replace")
         set_content_lines = [
             line for line in wrapped.splitlines() if "Set-Content" in line
         ]
         assert len(set_content_lines) == 1
-        assert f"Set-Content -Encoding UTF8 {temp_path}$PID" in set_content_lines[0]
+        assert "Set-Content -Encoding UTF8 -ErrorAction Stop" in set_content_lines[0]
+        assert f"-LiteralPath ({temp_path} + $PID)" in set_content_lines[0]
+        encoded = env._encode_pwsh_command(wrapped)
+        assert len("pwsh -NoProfile -EncodedCommand ") + len(encoded) < 8191
 
     def test_session_bootstrap_uses_atomic_snapshot_replacement(
         self, env, monkeypatch
@@ -112,16 +122,49 @@ class TestWrapCommand:
         env.init_session()
 
         bootstrap = captured["command"]
-        temp_path = shlex.quote(env._snapshot_path + ".tmp.")
-        live_path = shlex.quote(env._snapshot_path)
-        assert f"{temp_path}$PID" in bootstrap
-        assert f"Move-Item -Force {temp_path}$PID {live_path}" in bootstrap
-        assert bootstrap.index("Set-Content") < bootstrap.index("Move-Item -Force")
+        temp_path = _quote_pwsh_string(env._snapshot_path + ".tmp.")
+        assert f"({temp_path} + $PID)" in bootstrap
+        assert "[System.IO.File]::Replace(" in bootstrap
+        assert "[System.IO.File]::Move(" in bootstrap
+        assert "Start-Sleep -Milliseconds 10" in bootstrap
+        assert bootstrap.index("Set-Content") < bootstrap.index("[System.IO.File]::Replace")
+
+    def test_session_bootstrap_failure_leaves_snapshot_not_ready(
+        self, env, monkeypatch
+    ):
+        monkeypatch.setattr(env, "_run_bash", lambda *args, **kwargs: MagicMock())
+        monkeypatch.setattr(
+            env,
+            "_wait_for_process",
+            lambda *args, **kwargs: {"output": "", "returncode": 1},
+        )
+        env._snapshot_ready = True
+
+        env.init_session()
+
+        assert env._snapshot_ready is False
 
 
 @pytest.mark.skipif(shutil.which("pwsh") is None, reason="pwsh required")
 def test_concurrent_writers_never_publish_partial_snapshot(tmp_path):
     snapshot = str(tmp_path / "hermes-snapshot.ps1").replace("'", "''")
+    mutex_name = _snapshot_mutex_name(str(tmp_path / "hermes-snapshot.ps1"))
+    publish = _atomic_snapshot_publish(
+        "$temp", "$snapshot", mutex_name, raise_on_failure=True
+    )
+    read_snapshot = _with_snapshot_mutex(
+        mutex_name,
+        """$lines = @(Get-Content -ErrorAction Stop -LiteralPath $snapshot)
+$begin = $lines[0] -replace '^BEGIN-', ''
+$end = $lines[2] -replace '^END-', ''
+if ($lines.Count -ne 3 -or
+    $lines[0] -notmatch '^BEGIN-' -or
+    $lines[2] -notmatch '^END-' -or
+    $begin -ne $end) {
+    throw 'snapshot contained a partial write'
+}""",
+        on_timeout="throw 'snapshot read lock timed out'",
+    )
     script = rf"""
 $ErrorActionPreference = 'Stop'
 $snapshot = '{snapshot}'
@@ -132,36 +175,25 @@ $jobs = 1..4 | ForEach-Object {{
     Start-Job -ScriptBlock {{
         param($snapshot, $writer)
         1..40 | ForEach-Object {{
+{read_snapshot}
             $temp = $snapshot + '.tmp.' + $PID
             @(
                 "BEGIN-$writer-$_",
                 ('x' * 20000),
                 "END-$writer-$_"
             ) | Set-Content -Encoding UTF8 -LiteralPath $temp
-            Move-Item -Force -LiteralPath $temp -Destination $snapshot
+{publish}
             Start-Sleep -Milliseconds 1
         }}
     }} -ArgumentList $snapshot, $writer
 }}
-$valid = $true
-$readCount = 0
-while (@($jobs | Where-Object State -eq 'Running').Count -gt 0) {{
-    $lines = @(Get-Content -LiteralPath $snapshot)
-    $readCount++
-    $begin = $lines[0] -replace '^BEGIN-', ''
-    $end = $lines[2] -replace '^END-', ''
-    if ($lines.Count -ne 3 -or
-        $lines[0] -notmatch '^BEGIN-' -or
-        $lines[2] -notmatch '^END-' -or
-        $begin -ne $end) {{
-        $valid = $false
-        break
-    }}
-}}
 $jobs | Wait-Job | Out-Null
-$jobs | Receive-Job | Out-Null
+$jobs | Receive-Job -ErrorAction Stop | Out-Null
 $jobs | Remove-Job -Force
-if (-not $valid -or $readCount -eq 0) {{ exit 1 }}
+$lines = @(Get-Content -ErrorAction Stop -LiteralPath $snapshot)
+$begin = $lines[0] -replace '^BEGIN-', ''
+$end = $lines[2] -replace '^END-', ''
+if ($lines.Count -ne 3 -or $begin -ne $end) {{ exit 1 }}
 """
 
     result = subprocess.run(
@@ -172,6 +204,100 @@ if (-not $valid -or $readCount -eq 0) {{ exit 1 }}
     )
 
     assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason="pwsh required")
+def test_publish_failure_is_bounded_and_cleans_temp(tmp_path):
+    temp = str(tmp_path / "snapshot.tmp").replace("'", "''")
+    destination = str(tmp_path / "destination").replace("'", "''")
+    (tmp_path / "destination").mkdir()
+
+    for raise_on_failure, expected_code in ((False, 7), (True, 1)):
+        mutex_name = _snapshot_mutex_name(destination)
+        publish = _atomic_snapshot_publish(
+            "$temp",
+            "$snapshot",
+            mutex_name,
+            raise_on_failure=raise_on_failure,
+        )
+        script = rf"""
+$temp = '{temp}'
+$snapshot = '{destination}'
+Set-Content -Encoding UTF8 -LiteralPath $temp -Value 'complete'
+$script:__hermes_ec = 7
+{publish}
+if (${str(raise_on_failure).lower()}) {{ exit 0 }}
+exit $script:__hermes_ec
+"""
+
+        result = subprocess.run(
+            ["pwsh", "-NoProfile", "-Command", script],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+        assert result.returncode == expected_code, result.stderr
+        assert not (tmp_path / "snapshot.tmp").exists()
+
+
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason="pwsh required")
+def test_publish_lock_timeout_cleans_temp(tmp_path):
+    temp = str(tmp_path / "snapshot.tmp").replace("'", "''")
+    snapshot = str(tmp_path / "snapshot.ps1").replace("'", "''")
+    mutex_name = _snapshot_mutex_name(str(tmp_path / "snapshot.ps1"))
+    publish = _atomic_snapshot_publish(
+        "$temp", "$snapshot", mutex_name, raise_on_failure=True
+    )
+    script = rf"""
+$mutex = [System.Threading.Mutex]::new(
+    $false, {_quote_pwsh_string(mutex_name)}
+)
+$mutex.WaitOne() | Out-Null
+try {{
+    $job = Start-Job -ScriptBlock {{
+        param($temp, $snapshot)
+        Set-Content -Encoding UTF8 -LiteralPath $temp -Value 'complete'
+{publish}
+    }} -ArgumentList '{temp}', '{snapshot}'
+    $job | Wait-Job | Out-Null
+    $state = $job.State
+    $job | Receive-Job -ErrorAction SilentlyContinue | Out-Null
+    $job | Remove-Job -Force
+    Write-Output "STATE=$state TEMP=$(Test-Path -LiteralPath '{temp}')"
+}} finally {{
+    $mutex.ReleaseMutex()
+    $mutex.Dispose()
+    Remove-Item -Force -ErrorAction SilentlyContinue -LiteralPath '{temp}'
+}}
+"""
+
+    result = subprocess.run(
+        ["pwsh", "-NoProfile", "-Command", script],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+    assert "STATE=Failed TEMP=False" in result.stdout
+    assert not (tmp_path / "snapshot.tmp").exists()
+
+
+@pytest.mark.skipif(shutil.which("pwsh") is None, reason="pwsh required")
+def test_snapshot_assembly_failure_preserves_user_exit_code(env, tmp_path):
+    env._snapshot_path = str(tmp_path / "missing" / "snapshot.ps1")
+    env._snapshot_ready = True
+    wrapped = env._wrap_command("$global:LASTEXITCODE = 7", str(tmp_path))
+
+    result = subprocess.run(
+        ["pwsh", "-NoProfile", "-Command", wrapped],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+    assert result.returncode == 7, result.stderr
+    assert not list(tmp_path.glob("**/*.tmp.*"))
 
 
 class TestRunBash:

--- a/tests/tools/test_ssh_pwsh_environment.py
+++ b/tests/tools/test_ssh_pwsh_environment.py
@@ -1,0 +1,265 @@
+"""Tests for the SSH PowerShell remote execution environment backend."""
+
+import base64
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.environments import ssh as ssh_env
+from tools.environments import ssh_pwsh as ssh_pwsh_env
+
+
+def _mock_completed(stdout=b"", stderr=b"", returncode=0):
+    return subprocess.CompletedProcess([], returncode, stdout=stdout, stderr=stderr)
+
+
+def _decode_pwsh_cmd(cmd_list):
+    """Decode EncodedCommand from SSH command list to get the PowerShell script."""
+    try:
+        # Find -EncodedCommand in the command list
+        for i, arg in enumerate(cmd_list):
+            if arg == "-EncodedCommand" and i + 1 < len(cmd_list):
+                encoded = cmd_list[i + 1]
+                # Decode base64 UTF-16LE
+                return base64.b64decode(encoded).decode("utf-16-le")
+    except Exception:
+        pass
+    return ""
+
+
+@pytest.fixture
+def mock_ssh_deps(monkeypatch):
+    monkeypatch.setattr(ssh_env.shutil, "which", lambda _name: "/usr/bin/ssh")
+
+    call_log = []
+
+    def fake_run(cmd, **kwargs):
+        call_log.append(cmd)
+        # Decode EncodedCommand to check the actual PowerShell script
+        pwsh_script = _decode_pwsh_cmd(cmd)
+        cmd_str = " ".join(str(c) for c in cmd) + " " + pwsh_script
+
+        if "Write-Output 'ok'" in pwsh_script:
+            return _mock_completed(stdout=b"ok\r\n")
+        if "USERPROFILE" in pwsh_script:
+            return _mock_completed(stdout=b"C:\\Users\\test\r\n")
+        if "env:TEMP" in pwsh_script:
+            return _mock_completed(stdout=b"C:\\Users\\test\\AppData\\Local\\Temp\r\n")
+        if "New-Item" in pwsh_script and "Directory" in pwsh_script:
+            return _mock_completed()
+        return _mock_completed()
+
+    monkeypatch.setattr(ssh_env.subprocess, "run", fake_run)
+    monkeypatch.setattr(ssh_env.subprocess, "Popen",
+                        lambda *a, **k: MagicMock(stdout=iter([]), stderr=iter([]),
+                                                  stdin=MagicMock(), returncode=0,
+                                                  poll=lambda: 0,
+                                                  communicate=lambda **kw: (b"", b"")))
+    monkeypatch.setattr(ssh_env.BaseEnvironment, "init_session", lambda self: None)
+    monkeypatch.setattr(ssh_env, "FileSyncManager",
+                        lambda **kw: type("M", (), {
+                            "sync": lambda self, **k: None,
+                            "sync_back": lambda self, **k: None,
+                        })())
+
+    from tools.environments.ssh_pwsh import SSHPwshEnvironment
+    yield call_log
+
+
+class TestShellDetection:
+
+    def test_prefers_pwsh_over_powershell(self, mock_ssh_deps):
+        from tools.environments.ssh_pwsh import SSHPwshEnvironment
+        env = SSHPwshEnvironment(host="h", user="u")
+        assert env._pwsh_cmd == "pwsh"
+
+    def test_falls_back_to_powershell(self, mock_ssh_deps):
+        from tools.environments.ssh_pwsh import SSHPwshEnvironment
+
+        original_run = ssh_env.subprocess.run
+
+        def run_no_pwsh(cmd, **kwargs):
+            cmd_str = " ".join(str(c) for c in cmd)
+            if "pwsh" in cmd_str:
+                return _mock_completed(stderr=b"pwsh: command not found", returncode=127)
+            return original_run(cmd, **kwargs)
+
+        ssh_env.subprocess.run = run_no_pwsh
+        try:
+            env = SSHPwshEnvironment(host="h", user="u")
+            assert env._pwsh_cmd == "powershell"
+        finally:
+            ssh_env.subprocess.run = original_run
+
+    def test_raises_when_no_shell_found(self, mock_ssh_deps):
+        from tools.environments.ssh_pwsh import SSHPwshEnvironment
+
+        def run_fail(cmd, **kwargs):
+            return _mock_completed(stderr=b"not found", returncode=127)
+
+        ssh_env.subprocess.run = run_fail
+        with pytest.raises(RuntimeError, match="pwsh/PowerShell not found"):
+            SSHPwshEnvironment(host="h", user="u")
+
+
+class TestRemoteHomeDetection:
+
+    def test_detects_windows_home(self, mock_ssh_deps):
+        from tools.environments.ssh_pwsh import SSHPwshEnvironment
+        env = SSHPwshEnvironment(host="h", user="u")
+        assert env._remote_home == "C:\\Users\\test"
+
+
+class TestRemoteTempDetection:
+
+    def test_detects_windows_temp(self, mock_ssh_deps):
+        from tools.environments.ssh_pwsh import SSHPwshEnvironment
+        env = SSHPwshEnvironment(host="h", user="u")
+        assert "Users" in env._remote_temp or "Temp" in env._remote_temp
+
+    def test_get_temp_dir_returns_remote_temp(self, mock_ssh_deps):
+        from tools.environments.ssh_pwsh import SSHPwshEnvironment
+        env = SSHPwshEnvironment(host="h", user="u")
+        temp_dir = env.get_temp_dir()
+        assert "$env:TEMP" not in temp_dir
+
+
+class TestBuildSSHCommand:
+
+    def test_inherits_ssh_flags(self, mock_ssh_deps):
+        from tools.environments.ssh_pwsh import SSHPwshEnvironment
+        env = SSHPwshEnvironment(host="h", user="u")
+        cmd = " ".join(env._build_ssh_command())
+        for flag in ("ControlMaster=auto", "ControlPersist=300",
+                      "BatchMode=yes", "StrictHostKeyChecking=accept-new"):
+            assert flag in cmd
+
+
+class TestFileSync:
+
+    def test_before_execute_runs_rate_limited_sync(self, mock_ssh_deps):
+        from tools.environments.ssh_pwsh import SSHPwshEnvironment
+
+        env = SSHPwshEnvironment(host="h", user="u")
+        env._sync_manager = MagicMock()
+
+        env._before_execute()
+
+        env._sync_manager.sync.assert_called_once_with()
+
+    def test_single_upload_creates_windows_parent_directory(
+        self, mock_ssh_deps, monkeypatch, tmp_path
+    ):
+        from tools.environments.ssh_pwsh import SSHPwshEnvironment
+
+        env = SSHPwshEnvironment(host="h", user="u")
+        env._run_pwsh = MagicMock(return_value=_mock_completed())
+        monkeypatch.setattr(
+            ssh_pwsh_env.subprocess,
+            "run",
+            lambda *args, **kwargs: _mock_completed(),
+        )
+
+        source = tmp_path / "skill.md"
+        source.write_text("skill", encoding="utf-8")
+        env._scp_upload(
+            str(source),
+            r"C:\Users\test\.hermes\skills\skill.md",
+        )
+
+        mkdir_script = env._run_pwsh.call_args.args[0]
+        assert r"C:\Users\test\.hermes\skills" in mkdir_script
+
+    def test_bulk_upload_uses_base_relative_windows_paths(
+        self, mock_ssh_deps, monkeypatch, tmp_path
+    ):
+        import zipfile
+
+        from tools.environments.ssh_pwsh import SSHPwshEnvironment
+
+        env = SSHPwshEnvironment(host="h", user="u")
+        env._run_pwsh = MagicMock(return_value=_mock_completed())
+
+        skill = tmp_path / "skill.md"
+        skill.write_text("skill", encoding="utf-8")
+        credential = tmp_path / "credential.json"
+        credential.write_text('{"token":"x"}', encoding="utf-8")
+
+        archive_members = {}
+        scp_calls = []
+
+        def fake_scp(cmd, **kwargs):
+            scp_calls.append(cmd)
+            with zipfile.ZipFile(cmd[-2]) as archive:
+                archive_members.update(
+                    (name, archive.read(name)) for name in archive.namelist()
+                )
+            return _mock_completed()
+
+        monkeypatch.setattr(ssh_pwsh_env.subprocess, "run", fake_scp)
+
+        env._ssh_bulk_upload([
+            (str(skill), r"C:\Users\test\.hermes\skills\skill.md"),
+            (
+                str(credential),
+                r"C:\Users\test\.hermes\credentials\credential.json",
+            ),
+        ])
+
+        assert len(scp_calls) == 1
+        assert archive_members == {
+            "skills/skill.md": b"skill",
+            "credentials/credential.json": b'{"token":"x"}',
+        }
+        extract_script = env._run_pwsh.call_args.args[0]
+        assert "Expand-Archive" in extract_script
+
+    def test_bulk_upload_raises_when_remote_extract_fails(
+        self, mock_ssh_deps, monkeypatch, tmp_path
+    ):
+        from tools.environments.ssh_pwsh import SSHPwshEnvironment
+
+        env = SSHPwshEnvironment(host="h", user="u")
+        env._run_pwsh = MagicMock(
+            return_value=_mock_completed(
+                stderr=b"Expand-Archive failed",
+                returncode=1,
+            )
+        )
+        monkeypatch.setattr(
+            ssh_pwsh_env.subprocess,
+            "run",
+            lambda *args, **kwargs: _mock_completed(),
+        )
+
+        source = tmp_path / "skill.md"
+        source.write_text("skill", encoding="utf-8")
+
+        with pytest.raises(RuntimeError, match="Expand-Archive failed"):
+            env._ssh_bulk_upload([
+                (
+                    str(source),
+                    r"C:\Users\test\.hermes\skills\skill.md",
+                ),
+            ])
+
+class TestFactoryRegistration:
+
+    def test_create_ssh_pwsh_environment(self, mock_ssh_deps):
+        from tools.terminal_tool import _create_environment
+        ssh_config = {"host": "h", "user": "u", "port": 22}
+        env = _create_environment(
+            "ssh_pwsh", image="", cwd="~", timeout=60,
+            ssh_config=ssh_config,
+        )
+        from tools.environments.ssh_pwsh import SSHPwshEnvironment
+        assert isinstance(env, SSHPwshEnvironment)
+
+    def test_ssh_pwsh_requires_ssh_config(self):
+        from tools.terminal_tool import _create_environment
+        with pytest.raises(ValueError, match="ssh_host"):
+            _create_environment(
+                "ssh_pwsh", image="", cwd="~", timeout=60,
+                ssh_config=None,
+            )

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -1,5 +1,7 @@
 """Regression tests for sudo detection and sudo password handling."""
 
+import pytest
+
 import tools.terminal_tool as terminal_tool
 
 
@@ -101,6 +103,32 @@ def test_validate_workdir_still_blocks_metachars_in_unicode_paths():
     assert terminal_tool._validate_workdir("/tmp/テスト\nwhoami")
     assert terminal_tool._validate_workdir("/tmp/项目|cat /etc/passwd")
     assert terminal_tool._validate_workdir("/tmp/ü\x00ber")
+
+
+@pytest.mark.parametrize("backend", ("ssh", "ssh_pwsh"))
+def test_get_env_config_preserves_ssh_tilde_cwd(monkeypatch, backend):
+    """SSH cwd '~' is expanded by the remote shell, not the Hermes host."""
+    monkeypatch.setenv("TERMINAL_ENV", backend)
+    monkeypatch.setenv("TERMINAL_CWD", "~")
+    monkeypatch.setenv("HOME", "/opt/data")
+
+    config = terminal_tool._get_env_config()
+
+    assert config["env_type"] == backend
+    assert config["cwd"] == "~"
+
+
+@pytest.mark.parametrize("backend", ("ssh", "ssh_pwsh"))
+def test_get_env_config_preserves_ssh_tilde_child_cwd(monkeypatch, backend):
+    """SSH cwd '~/x' must not become the local/container HOME path."""
+    monkeypatch.setenv("TERMINAL_ENV", backend)
+    monkeypatch.setenv("TERMINAL_CWD", "~/project")
+    monkeypatch.setenv("HOME", "/opt/data")
+
+    config = terminal_tool._get_env_config()
+
+    assert config["env_type"] == backend
+    assert config["cwd"] == "~/project"
 
 
 def test_count_real_sudo_invocations_ignores_mentions(monkeypatch):

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -850,7 +850,7 @@ def _get_or_create_env(task_id: str):
             }
 
         ssh_config = None
-        if env_type == "ssh":
+        if env_type in ("ssh", "ssh_pwsh"):
             ssh_config = {
                 "host": config.get("ssh_host", ""),
                 "user": config.get("ssh_user", ""),

--- a/tools/environments/ssh_pwsh.py
+++ b/tools/environments/ssh_pwsh.py
@@ -1,0 +1,334 @@
+"""SSH remote execution environment using PowerShell on Windows hosts."""
+
+import base64
+import hashlib
+import logging
+import ntpath
+import os
+import shlex
+import subprocess
+import tempfile
+from pathlib import Path
+
+from tools.environments.base import BaseEnvironment, _popen_bash
+from tools.environments.file_sync import (
+    FileSyncManager,
+    iter_sync_files,
+)
+from tools.environments.ssh import (
+    SSHEnvironment,
+    _ensure_ssh_available,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _decode_ssh_output(data: bytes) -> str:
+    if not data:
+        return ""
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        pass
+    try:
+        return data.decode("gbk")
+    except (UnicodeDecodeError, LookupError):
+        pass
+    return data.decode("latin-1")
+
+
+class SSHPwshEnvironment(SSHEnvironment):
+    """Run commands on a Windows remote over SSH using PowerShell.
+
+    Extends SSHEnvironment — reuses SSH transport (ControlMaster, scp,
+    encoding). Overrides shell-related methods to use ``pwsh`` /
+    ``powershell`` instead of ``bash``.
+
+    Uses ``-EncodedCommand`` (base64 UTF-16LE) to pass scripts through
+    cmd.exe (the typical SSH server default shell on Windows) without
+    quoting issues.
+    """
+
+    def __init__(self, host: str, user: str, cwd: str = "~",
+                 timeout: int = 60, port: int = 22, key_path: str = ""):
+        self.host = host
+        self.user = user
+        self.port = port
+        self.key_path = key_path
+
+        self.control_dir = Path(tempfile.gettempdir()) / "hermes-ssh"
+        self.control_dir.mkdir(parents=True, exist_ok=True)
+
+        _socket_id = hashlib.sha256(
+            f"{user}@{host}:{port}".encode()
+        ).hexdigest()[:16]
+        self.control_socket = self.control_dir / f"{_socket_id}.sock"
+
+        _ensure_ssh_available()
+        self._detect_shell()
+        self._remote_home = self._detect_remote_home()
+        self._remote_temp = self._detect_remote_temp()
+
+        # Translate Linux-style cwd to Windows path
+        if cwd == "~" or cwd == "/root" or cwd.startswith("/home/"):
+            cwd = self._remote_home
+
+        BaseEnvironment.__init__(self, cwd=cwd, timeout=timeout)
+
+        self._ensure_remote_dirs()
+
+        self._sync_manager = FileSyncManager(
+            get_files_fn=lambda: iter_sync_files(
+                f"{self._remote_home}\\.hermes"
+            ),
+            upload_fn=self._scp_upload,
+            delete_fn=self._ssh_delete,
+            bulk_upload_fn=self._ssh_bulk_upload,
+        )
+        # Skip forced sync on init - too slow for Windows remotes with many files
+        # File sync will happen on-demand during execute() via _before_execute()
+        self.init_session()
+
+    def get_temp_dir(self) -> str:
+        return getattr(self, "_remote_temp", "/tmp")
+
+    def _encode_pwsh_command(self, pwsh_script: str) -> str:
+        """Encode PowerShell script as base64 UTF-16LE for EncodedCommand."""
+        return base64.b64encode(pwsh_script.encode("utf-16-le")).decode("ascii")
+
+    def _run_pwsh(self, pwsh_script: str, timeout: int = 10, shell: str | None = None) -> subprocess.CompletedProcess:
+        """Run PowerShell script on remote via EncodedCommand."""
+        encoded = self._encode_pwsh_command(pwsh_script)
+        cmd = self._build_ssh_command()
+        shell_cmd = shell or self._pwsh_cmd
+        cmd.extend([shell_cmd, "-NoProfile", "-EncodedCommand", encoded])
+        return subprocess.run(
+            cmd, capture_output=True, timeout=timeout,
+            stdin=subprocess.DEVNULL,
+        )
+
+    def _detect_shell(self) -> None:
+        for shell in ("pwsh", "powershell"):
+            try:
+                result = self._run_pwsh("Write-Output 'ok'", timeout=15, shell=shell)
+                if result.returncode == 0:
+                    self._pwsh_cmd = shell
+                    logger.debug("SSH pwsh: using %s on %s", shell, self.host)
+                    return
+            except subprocess.TimeoutExpired:
+                continue
+        raise RuntimeError(
+            f"pwsh/PowerShell not found on remote {self.host}. "
+            "Install PowerShell 7 (pwsh) or use ssh backend with bash."
+        )
+
+    def _detect_remote_home(self) -> str:
+        try:
+            result = self._run_pwsh("Write-Output $env:USERPROFILE")
+            home = _decode_ssh_output(result.stdout).strip().rstrip("\r\n")
+            if home and result.returncode == 0:
+                logger.debug("SSH pwsh: remote home = %s", home)
+                return home
+        except Exception:
+            pass
+        return f"C:\\Users\\{self.user}"
+
+    def _detect_remote_temp(self) -> str:
+        try:
+            result = self._run_pwsh("Write-Output $env:TEMP")
+            temp = _decode_ssh_output(result.stdout).strip().rstrip("\r\n")
+            if temp and result.returncode == 0:
+                return temp.replace("\\", "/")
+        except Exception:
+            pass
+        return f"C:/Users/{self.user}/AppData/Local/Temp"
+
+    def _ensure_remote_dirs(self) -> None:
+        base = f"{self._remote_home}\\.hermes"
+        dirs = [base, f"{base}\\skills", f"{base}\\credentials", f"{base}\\cache"]
+        dirs_str = ", ".join(f"'{d}'" for d in dirs)
+        script = f"foreach ($d in @({dirs_str})) {{ New-Item -ItemType Directory -Force -Path $d | Out-Null }}"
+        try:
+            self._run_pwsh(script, timeout=30)
+        except Exception as e:
+            logger.warning("SSH pwsh: failed to create remote dirs: %s", e)
+
+    def _scp_upload(self, host_path: str, remote_path: str) -> None:
+        """Upload a single file via scp over ControlMaster (Windows-aware)."""
+        parent = ntpath.dirname(remote_path)
+        # Use PowerShell to create parent directory (not bash mkdir -p)
+        try:
+            self._run_pwsh(
+                f"New-Item -ItemType Directory -Force -Path '{parent}' | Out-Null",
+                timeout=30,
+            )
+        except Exception as e:
+            logger.warning("SSH pwsh: failed to create parent dir %s: %s", parent, e)
+
+        scp_cmd = ["scp", "-o", f"ControlPath={self.control_socket}"]
+        if self.port != 22:
+            scp_cmd.extend(["-P", str(self.port)])
+        if self.key_path:
+            scp_cmd.extend(["-i", self.key_path])
+        scp_cmd.extend([host_path, f"{self.user}@{self.host}:{remote_path}"])
+        result = subprocess.run(
+            scp_cmd,
+            capture_output=True,
+            timeout=30,
+            stdin=subprocess.DEVNULL,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"scp failed: {_decode_ssh_output(result.stderr).strip()}")
+
+    def _ssh_delete(self, remote_paths: list[str]) -> None:
+        paths_str = ", ".join(f"'{p}'" for p in remote_paths)
+        script = f"Remove-Item -Force -Path @({paths_str}) -ErrorAction SilentlyContinue"
+        try:
+            result = self._run_pwsh(script)
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"remote rm failed: {_decode_ssh_output(result.stderr).strip()}"
+                )
+        except subprocess.TimeoutExpired:
+            raise RuntimeError("remote rm timed out")
+
+    def _ssh_bulk_upload(self, files: list[tuple[str, str]]) -> None:
+        """Upload many files via a single zip archive.
+
+        Creates a zip locally, scp's it to the remote, and extracts via
+        PowerShell ``Expand-Archive``.  This avoids the per-file scp/mkdir
+        overhead that makes sequential uploads impractically slow on
+        Windows remotes (issue #7467 — tar-based bulk transfer is not
+        available because Windows lacks ``tar``).
+        """
+        if not files:
+            return
+
+        import zipfile
+
+        base = f"{self._remote_home}\\.hermes"
+
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as zf:
+            zip_path = zf.name
+        try:
+            with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as archive:
+                for host_path, remote_path in files:
+                    rel = ntpath.relpath(remote_path, base).replace("\\", "/")
+                    archive.write(host_path, rel)
+
+            remote_zip = f"{self._remote_home}\\hermes_sync_{os.getpid()}.zip"
+            scp_cmd = ["scp", "-o", f"ControlPath={self.control_socket}"]
+            if self.port != 22:
+                scp_cmd.extend(["-P", str(self.port)])
+            if self.key_path:
+                scp_cmd.extend(["-i", self.key_path])
+            scp_cmd.extend([zip_path, f"{self.user}@{self.host}:{remote_zip}"])
+            result = subprocess.run(
+                scp_cmd, capture_output=True, timeout=120,
+                stdin=subprocess.DEVNULL,
+            )
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"scp zip failed: {_decode_ssh_output(result.stderr).strip()}"
+                )
+
+            extract_script = (
+                "$ErrorActionPreference = 'Stop'; "
+                "try { "
+                f"Expand-Archive -Path '{remote_zip}' "
+                f"-DestinationPath '{base}' -Force "
+                "} finally { "
+                f"Remove-Item '{remote_zip}' -Force -ErrorAction SilentlyContinue "
+                "}"
+            )
+            extract_result = self._run_pwsh(extract_script, timeout=60)
+            if extract_result.returncode != 0:
+                detail = _decode_ssh_output(extract_result.stderr).strip()
+                raise RuntimeError(f"remote zip extract failed: {detail}")
+        finally:
+            try:
+                os.unlink(zip_path)
+            except OSError:
+                pass
+
+    def _run_bash(self, cmd_string: str, *, login: bool = False,
+                  timeout: int = 120,
+                  stdin_data: str | None = None) -> subprocess.Popen:
+        encoded = self._encode_pwsh_command(cmd_string)
+        cmd = self._build_ssh_command()
+        cmd.extend([self._pwsh_cmd, "-NoProfile", "-EncodedCommand", encoded])
+        return _popen_bash(cmd, stdin_data)
+
+    def _before_execute(self) -> None:
+        """Sync files to remote via FileSyncManager (rate-limited internally)."""
+        self._sync_manager.sync()
+
+    def _wrap_command(self, command: str, cwd: str) -> str:
+        escaped = command.replace("'", "''")
+        _quoted_snap = shlex.quote(self._snapshot_path)
+        _snap_tmp = shlex.quote(self._snapshot_path + ".tmp.") + "$PID"
+
+        parts = []
+
+        if self._snapshot_ready:
+            parts.append(f". {_quoted_snap} 2>$null")
+
+        parts.append(f"Set-Location -LiteralPath {shlex.quote(cwd)}")
+        parts.append("if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) { exit 126 }")
+
+        parts.append(f"Invoke-Expression '{escaped}'")
+        parts.append("$script:__hermes_ec = $LASTEXITCODE")
+
+        if self._snapshot_ready:
+            # Atomic snapshot replacement (issue #38249): write to a
+            # per-writer temp file, then Move-Item -Force so concurrent
+            # source() calls never read a half-written snapshot.
+            parts.append(
+                "Get-ChildItem Env: | ForEach-Object { "
+                "$val = $_.Value -replace \"'\", \"''\"; "
+                "\"`$env:$($_.Name) = '$val'\" "
+                f"}} | Set-Content -Encoding UTF8 {_snap_tmp}"
+            )
+            parts.append(
+                f"try {{ Move-Item -Force {_snap_tmp} {_quoted_snap} }} "
+                f"catch {{ Remove-Item -Force {_snap_tmp} -ErrorAction SilentlyContinue }}"
+            )
+
+        parts.append(
+            f'Write-Output "`n{self._cwd_marker}$((Get-Location).Path){self._cwd_marker}"'
+        )
+        parts.append("exit $script:__hermes_ec")
+
+        return "\n".join(parts)
+
+    def init_session(self):
+        _quoted_cwd = shlex.quote(self.cwd)
+        _quoted_snap = shlex.quote(self._snapshot_path)
+        _snap_tmp = shlex.quote(self._snapshot_path + ".tmp.") + "$PID"
+
+        bootstrap_parts = [
+            f"Get-ChildItem Env: | ForEach-Object {{ $val = $_.Value -replace \"'\", \"''\"; \"`$env:$($_.Name) = '$val'\" }} | Set-Content -Encoding UTF8 {_snap_tmp}",
+            f"Move-Item -Force {_snap_tmp} {_quoted_snap}",
+            f"Set-Location -LiteralPath {_quoted_cwd}",
+            f'Write-Output "`n{self._cwd_marker}$((Get-Location).Path){self._cwd_marker}"',
+        ]
+        bootstrap = "\n".join(bootstrap_parts)
+
+        try:
+            proc = self._run_bash(bootstrap, login=True,
+                                  timeout=self._snapshot_timeout)
+            result = self._wait_for_process(proc,
+                                            timeout=self._snapshot_timeout)
+            self._snapshot_ready = True
+            self._update_cwd(result)
+            logger.info(
+                "SSH pwsh: session snapshot created (session=%s, cwd=%s)",
+                self._session_id, self.cwd,
+            )
+        except Exception as exc:
+            logger.warning(
+                "SSH pwsh: init_session failed (session=%s): %s — "
+                "falling back to direct pwsh per command",
+                self._session_id, exc,
+            )
+            self._snapshot_ready = False

--- a/tools/environments/ssh_pwsh.py
+++ b/tools/environments/ssh_pwsh.py
@@ -5,7 +5,6 @@ import hashlib
 import logging
 import ntpath
 import os
-import shlex
 import subprocess
 import tempfile
 from pathlib import Path
@@ -35,6 +34,87 @@ def _decode_ssh_output(data: bytes) -> str:
     except (UnicodeDecodeError, LookupError):
         pass
     return data.decode("latin-1")
+
+
+def _quote_pwsh_string(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _snapshot_mutex_name(snapshot_path: str) -> str:
+    digest = hashlib.sha256(snapshot_path.encode("utf-8")).hexdigest()[:16]
+    return f"HermesSnapshot_{digest}"
+
+
+def _with_snapshot_mutex(mutex_name: str, body: str, *,
+                         on_timeout: str) -> str:
+    return (
+        "$script:__hm=[System.Threading.Mutex]::new("
+        f"$false,{_quote_pwsh_string(mutex_name)});"
+        "$script:__hl=$false;try{try{"
+        "$script:__hl=$script:__hm.WaitOne(5000)"
+        "}catch [System.Threading.AbandonedMutexException]{"
+        "$script:__hl=$true};if($script:__hl){"
+        f"{body}"
+        "}else{"
+        f"{on_timeout}"
+        "}}finally{if($script:__hl){$script:__hm.ReleaseMutex()};"
+        "$script:__hm.Dispose()}"
+    )
+
+
+def _atomic_snapshot_publish(temp_path: str, snapshot_path: str,
+                             mutex_name: str, *,
+                             raise_on_failure: bool) -> str:
+    cleanup = (
+        "Remove-Item -Force -ErrorAction SilentlyContinue "
+        "-LiteralPath $script:__ht"
+    )
+    failure = cleanup
+    timeout_failure = cleanup
+    if raise_on_failure:
+        failure += (
+            "; throw ('failed to publish Hermes environment snapshot: ' + "
+            "$script:__he.Exception.Message)"
+        )
+        timeout_failure += "; throw 'timed out waiting for snapshot lock'"
+
+    publish = (
+        "$script:__ho=$false;for($script:__ha=0;"
+        "$script:__ha -lt 20 -and -not $script:__ho;"
+        "$script:__ha++){try{if([System.IO.File]::Exists($script:__hs)){"
+        "[System.IO.File]::Replace($script:__ht,$script:__hs,"
+        "[System.Management.Automation.Language.NullString]::Value)"
+        "}else{[System.IO.File]::Move($script:__ht,$script:__hs)};"
+        "$script:__ho=$true}catch{$script:__he=$_;"
+        "Start-Sleep -Milliseconds 10}};"
+        f"if(-not $script:__ho){{{failure}}}"
+    )
+    return (
+        f"$script:__ht={temp_path};$script:__hs={snapshot_path};"
+        "$script:__he=$null;" + _with_snapshot_mutex(
+            mutex_name,
+            publish,
+            on_timeout=timeout_failure,
+        )
+    )
+
+
+def _snapshot_write_command(temp_path: str, publish: str, *,
+                            raise_on_failure: bool) -> str:
+    cleanup = (
+        "Remove-Item -Force -ErrorAction SilentlyContinue "
+        f"-LiteralPath {temp_path}"
+    )
+    if raise_on_failure:
+        cleanup += ";throw"
+    return (
+        "try{Get-ChildItem Env:|ForEach-Object{"
+        "$val=$_.Value -replace \"'\",\"''\";"
+        "\"`$env:$($_.Name) = '$val'\"}|"
+        "Set-Content -Encoding UTF8 -ErrorAction Stop "
+        f"-LiteralPath {temp_path};{publish}"
+        f"}}catch{{{cleanup}}}"
+    )
 
 
 class SSHPwshEnvironment(SSHEnvironment):
@@ -265,15 +345,22 @@ class SSHPwshEnvironment(SSHEnvironment):
 
     def _wrap_command(self, command: str, cwd: str) -> str:
         escaped = command.replace("'", "''")
-        _quoted_snap = shlex.quote(self._snapshot_path)
-        _snap_tmp = shlex.quote(self._snapshot_path + ".tmp.") + "$PID"
+        _quoted_snap = _quote_pwsh_string(self._snapshot_path)
+        _snap_tmp = f"({_quote_pwsh_string(self._snapshot_path + '.tmp.')} + $PID)"
+        _snapshot_mutex = _snapshot_mutex_name(self._snapshot_path)
 
         parts = []
 
         if self._snapshot_ready:
-            parts.append(f". {_quoted_snap} 2>$null")
+            parts.append(
+                _with_snapshot_mutex(
+                    _snapshot_mutex,
+                    f". {_quoted_snap} 2>$null",
+                    on_timeout="",
+                )
+            )
 
-        parts.append(f"Set-Location -LiteralPath {shlex.quote(cwd)}")
+        parts.append(f"Set-Location -LiteralPath {_quote_pwsh_string(cwd)}")
         parts.append("if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) { exit 126 }")
 
         parts.append(f"Invoke-Expression '{escaped}'")
@@ -281,17 +368,19 @@ class SSHPwshEnvironment(SSHEnvironment):
 
         if self._snapshot_ready:
             # Atomic snapshot replacement (issue #38249): write to a
-            # per-writer temp file, then Move-Item -Force so concurrent
-            # source() calls never read a half-written snapshot.
+            # per-writer temp file, then atomically replace the live file so
+            # concurrent source() calls see the old or new complete snapshot.
             parts.append(
-                "Get-ChildItem Env: | ForEach-Object { "
-                "$val = $_.Value -replace \"'\", \"''\"; "
-                "\"`$env:$($_.Name) = '$val'\" "
-                f"}} | Set-Content -Encoding UTF8 {_snap_tmp}"
-            )
-            parts.append(
-                f"try {{ Move-Item -Force {_snap_tmp} {_quoted_snap} }} "
-                f"catch {{ Remove-Item -Force {_snap_tmp} -ErrorAction SilentlyContinue }}"
+                _snapshot_write_command(
+                    _snap_tmp,
+                    _atomic_snapshot_publish(
+                        _snap_tmp,
+                        _quoted_snap,
+                        _snapshot_mutex,
+                        raise_on_failure=False,
+                    ),
+                    raise_on_failure=False,
+                )
             )
 
         parts.append(
@@ -302,13 +391,22 @@ class SSHPwshEnvironment(SSHEnvironment):
         return "\n".join(parts)
 
     def init_session(self):
-        _quoted_cwd = shlex.quote(self.cwd)
-        _quoted_snap = shlex.quote(self._snapshot_path)
-        _snap_tmp = shlex.quote(self._snapshot_path + ".tmp.") + "$PID"
+        _quoted_cwd = _quote_pwsh_string(self.cwd)
+        _quoted_snap = _quote_pwsh_string(self._snapshot_path)
+        _snap_tmp = f"({_quote_pwsh_string(self._snapshot_path + '.tmp.')} + $PID)"
+        _snapshot_mutex = _snapshot_mutex_name(self._snapshot_path)
 
         bootstrap_parts = [
-            f"Get-ChildItem Env: | ForEach-Object {{ $val = $_.Value -replace \"'\", \"''\"; \"`$env:$($_.Name) = '$val'\" }} | Set-Content -Encoding UTF8 {_snap_tmp}",
-            f"Move-Item -Force {_snap_tmp} {_quoted_snap}",
+            _snapshot_write_command(
+                _snap_tmp,
+                _atomic_snapshot_publish(
+                    _snap_tmp,
+                    _quoted_snap,
+                    _snapshot_mutex,
+                    raise_on_failure=True,
+                ),
+                raise_on_failure=True,
+            ),
             f"Set-Location -LiteralPath {_quoted_cwd}",
             f'Write-Output "`n{self._cwd_marker}$((Get-Location).Path){self._cwd_marker}"',
         ]
@@ -319,6 +417,11 @@ class SSHPwshEnvironment(SSHEnvironment):
                                   timeout=self._snapshot_timeout)
             result = self._wait_for_process(proc,
                                             timeout=self._snapshot_timeout)
+            if result.get("returncode") != 0:
+                raise RuntimeError(
+                    "snapshot bootstrap failed with exit code "
+                    f"{result.get('returncode')}"
+                )
             self._snapshot_ready = True
             self._update_cwd(result)
             logger.info(

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1211,7 +1211,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                 }
 
             ssh_config = None
-            if env_type == "ssh":
+            if env_type in ("ssh", "ssh_pwsh"):
                 ssh_config = {
                     "host": config.get("ssh_host", ""),
                     "user": config.get("ssh_user", ""),

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -771,7 +771,7 @@ def _agent_cache_base_for_env(env: Any) -> str | None:
     backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
     if backend in {"docker", "singularity", "modal"}:
         return "/root/.hermes"
-    if backend == "ssh":
+    if backend in ("ssh", "ssh_pwsh"):
         return "~/.hermes"
     return None
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1375,10 +1375,10 @@ def _is_ssh_remote_tilde_cwd(backend: str, cwd: str) -> bool:
     over ``ssh ... bash -c``). Expanding ``~`` locally would rewrite it to the
     Hermes host HOME (often ``/opt/data`` under Docker) and inject a
     nonexistent path into the remote session. Only ``~`` / ``~/...`` on the
-    ``ssh`` backend qualify; absolute remote paths still pass through
-    unchanged, and every other backend keeps expanding locally.
+    ``ssh`` / ``ssh_pwsh`` backends qualify; absolute remote paths still pass
+    through unchanged, and every other backend keeps expanding locally.
     """
-    if (backend or "").strip().lower() != "ssh":
+    if (backend or "").strip().lower() not in ("ssh", "ssh_pwsh"):
         return False
     return cwd == "~" or cwd.startswith("~/")
 
@@ -1500,7 +1500,7 @@ def _get_env_config() -> Dict[str, Any]:
     # else starts in the backend's default root-like cwd.
     if env_type == "local":
         default_cwd = _safe_getcwd()
-    elif env_type == "ssh":
+    elif env_type in ("ssh", "ssh_pwsh"):
         default_cwd = "~"
     elif env_type == "vercel_sandbox":
         default_cwd = _VERCEL_SANDBOX_DEFAULT_CWD
@@ -1760,10 +1760,25 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             timeout=timeout,
         )
 
+    elif env_type == "ssh_pwsh":
+        if not ssh_config or not ssh_config.get("host") or not ssh_config.get("user"):
+            raise ValueError("ssh_pwsh requires ssh_host and ssh_user to be configured")
+        # Lazy import to avoid breaking tests with mock package structures
+        from tools.environments.ssh_pwsh import SSHPwshEnvironment as _SSHPwshEnvironment
+        return _SSHPwshEnvironment(
+            host=ssh_config["host"],
+            user=ssh_config["user"],
+            port=ssh_config.get("port", 22),
+            key_path=ssh_config.get("key", ""),
+            cwd=cwd,
+            timeout=timeout,
+        )
+
     else:
         raise ValueError(
             f"Unknown environment type: {env_type}. Use 'local', 'docker', "
-            f"'singularity', 'modal', 'daytona', 'vercel_sandbox', or 'ssh'"
+            f"'singularity', 'modal', 'daytona', 'vercel_sandbox', 'ssh', "
+            f"or 'ssh_pwsh'"
         )
 
 
@@ -2423,7 +2438,7 @@ def terminal_tool(
                     logger.info("Creating new %s environment for task %s...", env_type, effective_task_id[:8])
                     try:
                         ssh_config = None
-                        if env_type == "ssh":
+                        if env_type in ("ssh", "ssh_pwsh"):
                             ssh_config = {
                                 "host": config.get("ssh_host", ""),
                                 "user": config.get("ssh_user", ""),
@@ -3208,7 +3223,7 @@ def check_terminal_requirements() -> bool:
                 return result.returncode == 0
             return False
 
-        elif env_type == "ssh":
+        elif env_type in ("ssh", "ssh_pwsh"):
             if not config.get("ssh_host") or not config.get("ssh_user"):
                 logger.error(
                     "SSH backend selected but TERMINAL_SSH_HOST and TERMINAL_SSH_USER "

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -116,11 +116,11 @@ Before that stash step, Hermes also restores tracked `package-lock.json` diffs l
 
 ## Terminal Backend Configuration
 
-Hermes supports seven terminal backends. Each determines where the agent's shell commands actually execute — your local machine, a Docker container, a remote server via SSH, a Modal cloud sandbox (direct or via the Nous-managed gateway), a Daytona workspace, a Vercel Sandbox, or a Singularity/Apptainer container.
+Hermes supports eight terminal backends. Each determines where the agent's shell commands actually execute — your local machine, a Docker container, a POSIX or Windows host via SSH, a Modal cloud sandbox (direct or via the Nous-managed gateway), a Daytona workspace, a Vercel Sandbox, or a Singularity/Apptainer container.
 
 ```yaml
 terminal:
-  backend: local    # local | docker | ssh | modal | daytona | vercel_sandbox | singularity
+  backend: local    # local | docker | ssh | ssh_pwsh | modal | daytona | vercel_sandbox | singularity
   cwd: "."          # Gateway/cron working directory (CLI always uses launch dir)
   font_family: ""   # Desktop terminal font; e.g. "MesloLGS NF"
   timeout: 180      # Per-command timeout in seconds
@@ -141,7 +141,8 @@ For cloud sandboxes such as Modal, Daytona, and Vercel Sandbox, `container_persi
 |---------|-------------------|-----------|----------|
 | **local** | Your machine directly | None | Development, personal use |
 | **docker** | Single persistent Docker container (shared across session, `/new`, subagents) | Full (namespaces, cap-drop) | Safe sandboxing, CI/CD |
-| **ssh** | Remote server via SSH | Network boundary | Remote dev, powerful hardware |
+| **ssh** | POSIX remote via SSH and Bash | Network boundary | Linux/macOS remote development |
+| **ssh_pwsh** | Windows remote via SSH and PowerShell | Network boundary | Windows remote development |
 | **modal** | Modal cloud sandbox | Full (cloud VM) | Ephemeral cloud compute, evals |
 | **daytona** | Daytona workspace | Full (cloud container) | Managed cloud dev environments |
 | **vercel_sandbox** | Vercel Sandbox | Full (cloud microVM) | Cloud execution with snapshot-backed filesystem persistence |
@@ -317,9 +318,16 @@ Every key under `terminal:` has an env-var override of the form `TERMINAL_<KEY_U
 | `TERMINAL_TIMEOUT` | `timeout` | Per-command timeout |
 | `HERMES_DOCKER_BINARY` | _none_ | Force a specific docker/podman binary path |
 
-### SSH Backend
+### SSH Backends
 
-Runs commands on a remote server over SSH. Uses ControlMaster for connection reuse (5-minute idle keepalive). Persistent shell is enabled by default — state (cwd, env vars) survives across commands.
+Hermes provides two SSH backends that share the same connection settings:
+
+- `ssh` runs commands through Bash on a POSIX remote.
+- `ssh_pwsh` runs commands through PowerShell on a Windows remote.
+
+Both use ControlMaster for connection reuse (5-minute idle keepalive) and preserve command state such as cwd and environment variables.
+
+#### POSIX SSH (`ssh`)
 
 ```yaml
 terminal:
@@ -343,6 +351,18 @@ TERMINAL_SSH_USER=ubuntu
 | `TERMINAL_SSH_PERSISTENT` | `true` | Enable persistent shell |
 
 **How it works:** Connects at init time with `BatchMode=yes` and `StrictHostKeyChecking=accept-new`. Persistent shell keeps a single `bash -l` process alive on the remote host, communicating via temporary files. Commands that need `stdin_data` or `sudo` automatically fall back to one-shot mode.
+
+#### Windows PowerShell SSH (`ssh_pwsh`)
+
+```yaml
+terminal:
+  backend: ssh_pwsh
+  cwd: "~"                         # Remote Windows user profile
+```
+
+This backend uses the same `TERMINAL_SSH_HOST`, `TERMINAL_SSH_USER`, `TERMINAL_SSH_PORT`, and `TERMINAL_SSH_KEY` settings shown above. The remote must run OpenSSH Server and provide either PowerShell 7 (`pwsh`) or Windows PowerShell 5 or later (`powershell`).
+
+Commands are sent with PowerShell `-EncodedCommand`, so they are not interpreted by the remote `cmd.exe` shell. `~` and `~/...` refer to the remote Windows user's profile. Dependency synchronization is upload-only: files required by remote execution (credentials, skills, and caches) are uploaded in a zip archive under `%USERPROFILE%\.hermes`; the full local Hermes home is not copied, and remote changes are not synchronized back automatically.
 
 ### Modal Backend
 
@@ -461,7 +481,7 @@ When in doubt, set `terminal.backend` back to `local` and verify that commands r
 
 ### Remote-to-Host State Sync on Teardown
 
-For the **SSH**, **Modal**, and **Daytona** backends, Hermes pushes your `~/.hermes/` state (credential files, skills, cache) into the remote sandbox during the session, and on teardown **syncs changed state files back** to their original host locations. Files that differ from what was originally pushed (compared by content hash) are applied back in place; new remote files under a synced directory (e.g. a skill the agent created remotely) are mapped back to the corresponding host path. Upload-only credential files are never overwritten on the host.
+For the POSIX **SSH** (`ssh`), **Modal**, and **Daytona** backends, Hermes pushes your `~/.hermes/` state (credential files, skills, cache) into the remote sandbox during the session, and on teardown **syncs changed state files back** to their original host locations. Files that differ from what was originally pushed (compared by content hash) are applied back in place; new remote files under a synced directory (e.g. a skill the agent created remotely) are mapped back to the corresponding host path. Upload-only credential files are never overwritten on the host.
 
 - The sync-back retries up to 3 times with backoff and refuses to extract remote archives larger than 2 GiB.
 - Docker and Singularity use bind mounts (live host filesystem view) and don't need this.

--- a/website/docs/user-guide/features/tools.md
+++ b/website/docs/user-guide/features/tools.md
@@ -61,7 +61,8 @@ The terminal tool can execute commands in different environments:
 |---------|-------------|----------|
 | `local` | Run on your machine (default) | Development, trusted tasks |
 | `docker` | Isolated containers | Security, reproducibility |
-| `ssh` | Remote server | Sandboxing, keep agent away from its own code |
+| `ssh` | POSIX remote over SSH and Bash | Linux/macOS remote execution |
+| `ssh_pwsh` | Windows remote over SSH and PowerShell | Windows remote execution |
 | `singularity` | HPC containers | Cluster computing, rootless |
 | `modal` | Cloud execution | Serverless, scale |
 | `daytona` | Cloud sandbox workspace | Persistent remote dev environments |
@@ -72,7 +73,7 @@ The terminal tool can execute commands in different environments:
 ```yaml
 # In ~/.hermes/config.yaml
 terminal:
-  backend: local    # or: docker, ssh, singularity, modal, daytona, vercel_sandbox
+  backend: local    # or: docker, ssh, ssh_pwsh, singularity, modal, daytona, vercel_sandbox
   cwd: "."          # Working directory
   timeout: 180      # Command timeout in seconds
 ```


### PR DESCRIPTION
## Summary

Add a new `ssh_pwsh` terminal backend that enables Hermes to control Windows machines (Win7+) over SSH using PowerShell instead of bash.

## Problem

The existing `ssh` backend hardcodes `bash -c "command"` which fails on Windows remotes where the SSH server's default shell is cmd.exe. Windows 7/10/11 machines with OpenSSH Server cannot be used as terminal backends.

## Solution

New `SSHPwshEnvironment` class extending `SSHEnvironment`:
- Uses `pwsh -NoProfile -EncodedCommand` (base64 UTF-16LE) to bypass cmd.exe shell escaping issues
- Auto-detects `pwsh` (PowerShell 7) or falls back to `powershell` (5.1)
- Translates Linux cwd paths (`/root`, `/home/...`) to Windows paths (`C:\Users\...`)
- Overrides `_wrap_command()` with PowerShell syntax (Set-Location, Invoke-Expression, etc.)
- Fixes PowerShell `\$LASTEXITCODE` null check bug (`\$null -ne 0` is True in PS)
- scp-only file sync (Win7 has no `tar`)

## Usage

\`\`\`
TERMINAL_ENV=ssh_pwsh
TERMINAL_SSH_HOST=192.168.1.100
TERMINAL_SSH_USER=admin
TERMINAL_SSH_PORT=22
TERMINAL_SSH_KEY=~/.ssh/id_ed25519
\`\`\`

## Files Changed

- `tools/environments/ssh_pwsh.py` — new backend (\~270 lines)
- `tools/terminal_tool.py` — factory registration + ssh config loading for `ssh_pwsh`
- `tools/file_tools.py` — ssh config loading
- `tools/code_execution_tool.py` — ssh config loading
- `tools/image_generation_tool.py` — cache path for `ssh_pwsh`
- `tests/tools/test_ssh_pwsh_environment.py` — 9 tests
- `tests/tools/test_ssh_pwsh_command_wrapping.py` — 9 tests

## Testing

- 18 new unit tests, all passing
- No regressions in existing SSH tests (53 passed)
- Manually tested against Windows 7 remote with PowerShell 7.2