### PR TITLE
fix(cron): fall through when live delivery is unconfirmed (#47056)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -30,7 +30,7 @@ except ImportError:
     except ImportError:
         msvcrt = None
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, List, Optional
 
 # Add parent directory to path for imports BEFORE repo-level imports.
 # Without this, standalone invocations (e.g. after `hermes update` reloads
@@ -656,6 +656,27 @@ def _send_media_via_adapter(
             logger.warning("Job '%s': failed to send media %s: %s", job.get("id", "?"), media_path, e)
 
 
+def _confirm_adapter_delivery(send_result: Any) -> bool:
+    """Return True only if ``send_result`` unambiguously confirms delivery.
+
+    A live adapter that returns ``None`` (e.g. swallowed exception, busy
+    platform, or a code path that returns early on whitespace-only text
+    without producing a ``SendResult``) must NOT be treated as success —
+    doing so causes the cron scheduler to log ``"delivered to <chat> via
+    live adapter"`` while the gateway never sees the message (#47056).
+
+    Likewise, an object missing a ``success`` attribute (e.g. a bare
+    ``dict`` or a partial mock) is a contract violation: it does not
+    actually tell us whether the send succeeded.  We require an explicit
+    ``success`` attribute set to a truthy value to count as confirmed.
+    """
+    if send_result is None:
+        return False
+    if not hasattr(send_result, "success"):
+        return False
+    return bool(getattr(send_result, "success"))
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -776,11 +797,21 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         except TimeoutError:
                             future.cancel()
                             raise
-                        if send_result and not getattr(send_result, "success", True):
-                            err = getattr(send_result, "error", "unknown")
+                        # Confirm the live adapter actually delivered.  A
+                        # ``None`` return (adapter swallowed an exception or
+                        # the platform is busy — see #47056) or a result
+                        # object missing a ``success`` attribute is NOT a
+                        # confirmed delivery: the gateway log would show
+                        # nothing while the scheduler logs ``"delivered"``.
+                        # Only ``SendResult(success=True, ...)`` counts as
+                        # confirmed.
+                        if not _confirm_adapter_delivery(send_result):
+                            err = getattr(send_result, "error", None) if send_result is not None else "no result"
+                            shape = type(send_result).__name__ if send_result is not None else "None"
                             logger.warning(
-                                "Job '%s': live adapter send to %s:%s failed (%s), falling back to standalone",
-                                job["id"], platform_name, chat_id, err,
+                                "Job '%s': live adapter send to %s:%s returned unconfirmed result "
+                                "(%s, error=%s), falling back to standalone",
+                                job["id"], platform_name, chat_id, shape, err,
                             )
                             adapter_ok = False  # fall through to standalone path
                         elif (

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2600,6 +2600,230 @@ class TestDeliverResultTimeoutCancelsFuture:
         )
 
 
+class TestDeliverResultLiveAdapterSilentFailure:
+    """Regression for #47056.
+
+    When a live adapter's ``send()`` returns ``None`` (or a non-SendResult
+    object without an explicit ``success`` attribute), the cron scheduler
+    must NOT log ``"delivered to ... via live adapter"`` and silently drop
+    the message.  The original implementation short-circuited on
+    ``if send_result and not getattr(send_result, "success", True):`` —
+    ``None`` skipped the failure branch entirely, and missing ``success``
+    defaulted to ``True`` (success).
+
+    Both silent-failure shapes must fall through to the standalone
+    delivery path so the message is actually delivered.
+    """
+
+    def _build_env(self, platform, adapter):
+        """Common scaffolding: a live adapter on a real running loop, with
+        the standalone fallback also patched so we can detect whether the
+        fallback fired."""
+        from gateway.config import Platform
+        from concurrent.futures import Future
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {platform: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        return mock_cfg, loop
+
+    def test_live_adapter_returning_none_falls_through_to_standalone(self):
+        """``send()`` returning ``None`` (e.g. adapter swallowed an exception
+        or the platform is busy) must not be treated as a successful live
+        delivery.  The standalone path must run and successfully deliver.
+        """
+        from gateway.config import Platform
+        from concurrent.futures import Future
+
+        adapter = AsyncMock()
+        adapter.send.return_value = None  # type: ignore[assignment]
+
+        mock_cfg, loop = self._build_env(Platform.TELEGRAM, adapter)
+
+        completed_future = Future()
+        completed_future.set_result(None)
+
+        def fake_run_coro(coro, _loop):
+            coro.close()
+            return completed_future
+
+        job = {
+            "id": "silent-none-job",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "123"},
+        }
+
+        standalone_send = AsyncMock(return_value={"success": True})
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro), \
+             patch("tools.send_message_tool._send_to_platform", new=standalone_send):
+            result = _deliver_result(
+                job,
+                "Here is the cron output",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            )
+
+        # The live adapter returned None — that is NOT a confirmed delivery.
+        # The standalone fallback MUST have been called, and the function
+        # must have returned None (no error) because the standalone path
+        # succeeded.
+        assert result is None, (
+            f"expected standalone fallback to deliver successfully, got {result!r}"
+        )
+        standalone_send.assert_awaited_once()
+
+    def test_live_adapter_returning_dict_without_success_falls_through(self):
+        """``send()`` returning a plain ``dict`` (no ``success`` attribute)
+        must not be silently treated as success via the
+        ``getattr(..., True)`` default.  Such a shape is a contract
+        violation and must fall through to the standalone path.
+        """
+        from gateway.config import Platform
+        from concurrent.futures import Future
+
+        adapter = AsyncMock()
+        adapter.send.return_value = {"ok": True, "message_id": "42"}  # no `success` attr
+
+        mock_cfg, loop = self._build_env(Platform.TELEGRAM, adapter)
+
+        completed_future = Future()
+        completed_future.set_result({"ok": True, "message_id": "42"})
+
+        def fake_run_coro(coro, _loop):
+            coro.close()
+            return completed_future
+
+        job = {
+            "id": "silent-dict-job",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "123"},
+        }
+
+        standalone_send = AsyncMock(return_value={"success": True})
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro), \
+             patch("tools.send_message_tool._send_to_platform", new=standalone_send):
+            result = _deliver_result(
+                job,
+                "Here is the cron output",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            )
+
+        assert result is None
+        standalone_send.assert_awaited_once()
+
+    def test_live_adapter_returning_sendresult_success_is_accepted(self):
+        """Sanity: a properly-shaped ``SendResult(success=True, ...)``
+        must still be treated as a successful live delivery (no
+        regression on the happy path)."""
+        from gateway.config import Platform
+        from gateway.platforms.base import SendResult
+        from concurrent.futures import Future
+
+        send_result = SendResult(success=True, message_id="42")
+        adapter = AsyncMock()
+        adapter.send.return_value = send_result
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        completed_future = Future()
+        completed_future.set_result(send_result)
+
+        def fake_run_coro(coro, _loop):
+            coro.close()
+            return completed_future
+
+        job = {
+            "id": "happy-path-job",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "123"},
+        }
+
+        standalone_send = AsyncMock(return_value={"success": True})
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro), \
+             patch("tools.send_message_tool._send_to_platform", new=standalone_send):
+            result = _deliver_result(
+                job,
+                "Hello world",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            )
+
+        assert result is None
+        # The standalone path must NOT have been called when the live
+        # adapter confirmed success.
+        standalone_send.assert_not_awaited()
+
+    def test_live_adapter_returning_sendresult_failure_falls_through(self):
+        """``SendResult(success=False, ...)`` must still fall through to
+        the standalone path (this was the pre-existing behavior; the fix
+        must not regress it)."""
+        from gateway.config import Platform
+        from gateway.platforms.base import SendResult
+        from concurrent.futures import Future
+
+        send_result = SendResult(success=False, error="rate_limited", retryable=True)
+        adapter = AsyncMock()
+        adapter.send.return_value = send_result
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        loop = MagicMock()
+        loop.is_running.return_value = True
+
+        completed_future = Future()
+        completed_future.set_result(send_result)
+
+        def fake_run_coro(coro, _loop):
+            coro.close()
+            return completed_future
+
+        job = {
+            "id": "explicit-failure-job",
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "123"},
+        }
+
+        standalone_send = AsyncMock(return_value={"success": True})
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("asyncio.run_coroutine_threadsafe", side_effect=fake_run_coro), \
+             patch("tools.send_message_tool._send_to_platform", new=standalone_send):
+            result = _deliver_result(
+                job,
+                "Hello world",
+                adapters={Platform.TELEGRAM: adapter},
+                loop=loop,
+            )
+
+        assert result is None
+        standalone_send.assert_awaited_once()
+
+
 class TestSendMediaTimeoutCancelsFuture:
     """Same orphan-coroutine guarantee for _send_media_via_adapter's
     future.result(timeout=30) call. If this times out mid-batch, the


### PR DESCRIPTION
## Summary

Fixes #47056.

Cron delivery via `deliver: origin` can silently drop output when the live gateway adapter returns `None` or an unexpected object without a `success` attribute. The previous check treated both shapes as successful delivery, logged `delivered ... via live adapter`, and skipped the standalone fallback even though the gateway never saw the message.

This patch:

- adds `_confirm_adapter_delivery()` to require explicit adapter success confirmation
- treats `None`, missing `success`, and `success=False` as unconfirmed delivery
- falls through to the standalone HTTP delivery path when live delivery is unconfirmed
- preserves the happy path for `SendResult(success=True)`
- logs the result shape and error attribute for operator triage

## Verification

RED proof on upstream/main:

```text
tests/cron/test_scheduler.py::TestDeliverResultLiveAdapterSilentFailure::test_live_adapter_returning_none_falls_through_to_standalone FAILED
tests/cron/test_scheduler.py::TestDeliverResultLiveAdapterSilentFailure::test_live_adapter_returning_dict_without_success_falls_through FAILED
tests/cron/test_scheduler.py::TestDeliverResultLiveAdapterSilentFailure::test_live_adapter_returning_sendresult_success_is_accepted PASSED
tests/cron/test_scheduler.py::TestDeliverResultLiveAdapterSilentFailure::test_live_adapter_returning_sendresult_failure_falls_through PASSED
```

GREEN proof on this branch:

```text
/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/cron/test_scheduler.py::TestDeliverResultLiveAdapterSilentFailure tests/cron/test_scheduler.py::TestDeliverResultTimeoutCancelsFuture -v -o "addopts=" --tb=short
# 6 passed in 0.13s
```

Nearby suite:

```text
/Users/evinova-self/.hermes/hermes-agent/venv/bin/python3 -m pytest tests/cron/test_scheduler.py -q -o "addopts=" --tb=short
# 140 passed, 1 warning in 3.16s
```

## Duplicate / competitor check

Before publication, I checked:

- open Tranquil-Flow PRs referencing `47056`: none
- open Tranquil-Flow branches matching `fix/47056*`: none
- open PRs mentioning issue `47056`: none
- open PRs matching distinctive keywords `cron delivery active session`: none

No competing PR was found.

Auto-published by Moonsong via Path B automated pipeline.
