### PR TITLE
fix(gateway): match only real gateway subcommand in PID scan

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -306,6 +306,40 @@ def _append_unique_pid(
     pids.append(pid)
 
 
+def _is_gateway_command(command: str) -> bool:
+    """True only when *command* is an actual ``gateway`` invocation.
+
+    The historical scan matched any ``hermes_cli.main --profile`` / ``-p``
+    command line, which also matched sibling subcommands that merely carry a
+    profile flag (e.g. ``hermes_cli.main --profile foo dashboard ...``). That
+    false match let ``gateway status``/``start`` report a same-profile
+    dashboard PID as a running gateway and — far worse — let ``gateway stop``/
+    ``restart`` force-kill that dashboard and its process tree (#47120).
+
+    A command is a gateway only when it is one of the dedicated gateway
+    entrypoints, or a Hermes CLI invocation whose subcommand is ``gateway``.
+    """
+    command_lc = command.lower()
+    # Dedicated gateway entrypoints — unambiguous, no subcommand needed.
+    if "hermes-gateway.exe" in command_lc or "gateway/run.py" in command_lc:
+        return True
+    # Otherwise it must be a Hermes CLI invocation...
+    if not any(
+        marker in command_lc
+        for marker in ("hermes_cli.main", "hermes_cli/main.py", "hermes ", "hermes.exe")
+    ):
+        return False
+    # ...whose subcommand is ``gateway``. Tokenize and look for a bare
+    # ``gateway`` arg that is NOT the value of a ``--profile`` / ``-p`` flag,
+    # so a profile literally named "gateway" is not mistaken for the
+    # subcommand.
+    tokens = command_lc.split()
+    for i, tok in enumerate(tokens):
+        if tok == "gateway" and (i == 0 or tokens[i - 1] not in ("--profile", "-p")):
+            return True
+    return False
+
+
 def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> list[int]:
     """Best-effort process-table scan for gateway PIDs.
 
@@ -318,23 +352,11 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
     # gateway.  See #13242.
     exclude_pids = exclude_pids | _get_ancestor_pids()
     pids: list[int] = []
-    patterns = [
-        "hermes_cli.main gateway",
-        "hermes_cli.main --profile",
-        "hermes_cli.main -p",
-        "hermes_cli/main.py gateway",
-        "hermes_cli/main.py --profile",
-        "hermes_cli/main.py -p",
-        "hermes gateway",
-        # Windows: only match invocations that actually carry the ``gateway``
-        # subcommand or the gateway-dedicated console-script shim. Bare
-        # ``hermes.exe --profile`` / ``hermes.exe -p`` would also match
-        # ``hermes.exe --profile foo dashboard`` and other CLI subcommands,
-        # producing false-positive gateway PIDs (Copilot review).
-        "hermes.exe gateway",
-        "hermes-gateway.exe",
-        "gateway/run.py",
-    ]
+    # A command is a gateway only when its subcommand is ``gateway`` (or it is
+    # a dedicated gateway entrypoint). Matching on a bare ``--profile`` / ``-p``
+    # flag is NOT sufficient — sibling subcommands (``dashboard``, ``chat``,
+    # …) carry the same flag and would be misidentified, then force-killed by
+    # ``gateway stop``/``restart`` (#47120). See ``_is_gateway_command``.
     current_home = str(get_hermes_home().resolve())
     current_home_lc = current_home.lower()
     current_profile_arg = _profile_arg(current_home)
@@ -429,8 +451,7 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
                     current_cmd = line[len("CommandLine=") :]
                 elif line.startswith("ProcessId="):
                     pid_str = line[len("ProcessId=") :]
-                    current_cmd_lc = current_cmd.lower()
-                    if any(p in current_cmd_lc for p in patterns) and (
+                    if _is_gateway_command(current_cmd) and (
                         all_profiles or _matches_current_profile(current_cmd)
                     ):
                         try:
@@ -455,8 +476,7 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
                             with open(f"/proc/{pid}/cmdline", "rb") as _f:
                                 cmdline = _f.read().decode("utf-8", errors="replace")
                             cmdline = cmdline.replace("\x00", " ")
-                            cmdline_lc = cmdline.lower()
-                            if any(p in cmdline_lc for p in patterns) and (
+                            if _is_gateway_command(cmdline) and (
                                 all_profiles or _matches_current_profile(cmdline)
                             ):
                                 _append_unique_pid(pids, pid, exclude_pids)
@@ -499,8 +519,7 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
 
                     if pid is None:
                         continue
-                    command_lc = command.lower()
-                    if any(pattern in command_lc for pattern in patterns) and (
+                    if _is_gateway_command(command) and (
                         all_profiles or _matches_current_profile(command)
                     ):
                         _append_unique_pid(pids, pid, exclude_pids)

--- a/tests/hermes_cli/test_gateway_scan_subcommand.py
+++ b/tests/hermes_cli/test_gateway_scan_subcommand.py
@@ -1,0 +1,130 @@
+"""Regression tests for gateway-only PID matching in _scan_gateway_pids().
+
+A same-profile ``dashboard`` (or any non-gateway subcommand) process carries
+the same ``--profile`` / ``-p`` flag as a real gateway. The historical matcher
+keyed on that flag alone, so it misidentified those processes as a running
+gateway: ``gateway status``/``start`` reported the dashboard PID, and
+``gateway stop``/``restart`` force-killed it and its process tree.
+
+See: NousResearch/hermes-agent#47120
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import hermes_cli.gateway as gateway_mod
+
+
+# ---------------------------------------------------------------------------
+# _is_gateway_command — the pure classifier
+# ---------------------------------------------------------------------------
+
+
+class TestIsGatewayCommand:
+    """Only real ``gateway`` invocations classify as gateway commands."""
+
+    def test_module_gateway_run(self):
+        assert gateway_mod._is_gateway_command(
+            "python -m hermes_cli.main gateway run"
+        )
+
+    def test_module_profiled_gateway_run(self):
+        assert gateway_mod._is_gateway_command(
+            "python -m hermes_cli.main --profile gibson gateway run"
+        )
+
+    def test_dedicated_entrypoints(self):
+        assert gateway_mod._is_gateway_command("hermes-gateway.exe")
+        assert gateway_mod._is_gateway_command("python /opt/x/gateway/run.py")
+        assert gateway_mod._is_gateway_command("hermes.exe gateway run")
+
+    def test_dashboard_with_profile_is_not_gateway(self):
+        # The core #47120 regression: a same-profile dashboard must NOT match.
+        assert not gateway_mod._is_gateway_command(
+            "python -m hermes_cli.main --profile gibson dashboard --no-open --port 0"
+        )
+        assert not gateway_mod._is_gateway_command(
+            "python.exe -m hermes_cli.main --profile gibson dashboard --host 127.0.0.1 --port 0"
+        )
+
+    def test_other_subcommands_with_profile_are_not_gateway(self):
+        assert not gateway_mod._is_gateway_command(
+            "python -m hermes_cli.main -p gibson chat"
+        )
+        assert not gateway_mod._is_gateway_command(
+            "python -m hermes_cli.main -p gibson dashboard"
+        )
+
+    def test_unrelated_process(self):
+        assert not gateway_mod._is_gateway_command("python -m some_other_thing")
+
+    def test_profile_literally_named_gateway_is_not_subcommand(self):
+        # ``gateway`` as a --profile value is not the subcommand.
+        assert not gateway_mod._is_gateway_command(
+            "python -m hermes_cli.main -p gateway dashboard"
+        )
+
+    def test_profile_named_gateway_with_real_gateway_subcommand(self):
+        assert gateway_mod._is_gateway_command(
+            "python -m hermes_cli.main -p gateway gateway run"
+        )
+
+
+# ---------------------------------------------------------------------------
+# _scan_gateway_pids — end-to-end via /proc
+# ---------------------------------------------------------------------------
+
+
+def _fake_proc_dir(entries: dict):
+    def _isdir(path):
+        return str(path) == "/proc"
+
+    def _listdir(path):
+        if str(path) == "/proc":
+            return [str(pid) for pid in entries] + ["self", "version"]
+        raise FileNotFoundError(path)
+
+    def _open(path, mode="r", **kwargs):
+        path_str = str(path)
+        if "/cmdline" in path_str:
+            pid = int(path_str.split("/proc/")[1].split("/")[0])
+            raw = entries.get(pid, "").encode("utf-8").replace(b" ", b"\x00")
+            m = MagicMock()
+            m.read.return_value = raw
+            m.__enter__ = lambda s: s
+            m.__exit__ = MagicMock(return_value=False)
+            return m
+        raise FileNotFoundError(path)
+
+    return _isdir, _listdir, _open
+
+
+class TestScanExcludesDashboard:
+    """A same-profile dashboard PID is never returned as a gateway."""
+
+    def test_dashboard_pid_not_matched(self):
+        my_pid = os.getpid()
+        gateway_pid = 12345
+        dashboard_pid = 23456
+        entries = {
+            my_pid: "python -m hermes_cli.main",
+            gateway_pid: "python -m hermes_cli.main --profile gibson gateway run",
+            dashboard_pid: (
+                "python -m hermes_cli.main --profile gibson dashboard "
+                "--no-open --host 127.0.0.1 --port 0"
+            ),
+        }
+        _isdir, _listdir, _open = _fake_proc_dir(entries)
+
+        with (
+            patch("hermes_cli.gateway.is_windows", return_value=False),
+            patch("os.path.isdir", side_effect=_isdir),
+            patch("os.listdir", side_effect=_listdir),
+            patch("builtins.open", side_effect=_open),
+            patch("hermes_cli.gateway._get_ancestor_pids", return_value=set()),
+            patch("subprocess.run"),
+        ):
+            pids = gateway_mod._scan_gateway_pids(set(), all_profiles=True)
+
+        assert gateway_pid in pids
+        assert dashboard_pid not in pids


### PR DESCRIPTION
## Summary

- `_scan_gateway_pids` no longer misidentifies a same-profile non-gateway process (e.g. a `dashboard`) as a running gateway.
- Fixes `gateway start` falsely reporting "already running" and — the dangerous one — `gateway stop`/`restart` force-killing the dashboard PID and its process tree.

## Motivation

Closes #47120.

The liveness scan matched any `hermes_cli.main --profile`/`-p` command line. Sibling subcommands carry the same profile flag, and Hermes Desktop continuously spawns `--profile <p> dashboard --port 0` backends, so a dashboard was reported as the gateway. `gateway status`/`start` then blocked startup, and `gateway stop`/`restart` called `kill_gateway_processes(force=True)` on the misidentified PID — terminating the dashboard and (on the Windows force path) its descendants. The Windows console-script patterns had already been narrowed to require the `gateway` subcommand; the cross-platform module-form patterns had not.

## Fix

Replace the flag-based `patterns` list with `_is_gateway_command(command)`, which accepts a process only when it is:
- a dedicated gateway entrypoint (`hermes-gateway.exe`, `gateway/run.py`), or
- a Hermes CLI invocation whose **subcommand token** is `gateway` — and not the value of a `--profile`/`-p` flag, so a profile literally named `gateway` is not mistaken for the subcommand.

All three scan sites (wmic/CIM, `/proc`, `ps` fallback) now route through the single classifier.

## Verification

- `python3 -m pytest tests/hermes_cli/test_gateway_scan_subcommand.py tests/hermes_cli/test_gateway_proc_fallback.py` — 13 passed
- `python3 -m pytest tests/hermes_cli/test_gateway.py tests/hermes_cli/test_gateway_s6_dispatch.py` — 71 passed

## Real behavior proof

- **Behavior addressed:** a same-profile dashboard command line was classified as a gateway (returned by the scan → blocked `start`, force-killed by `stop`/`restart`).
- **Real environment:** Python 3.11, repo checkout on this branch.
- **Exact commands run after the patch:**
  ```
  python3 -c "import hermes_cli.gateway as g; print(g._is_gateway_command('python -m hermes_cli.main --profile gibson gateway run')); print(g._is_gateway_command('python.exe -m hermes_cli.main --profile gibson dashboard --no-open --host 127.0.0.1 --port 0'))"
  ```
- **Captured output AFTER fix:**
  ```
  _is_gateway_command('python -m hermes_cli.main --profile gibson gateway run')
    -> True
  _is_gateway_command('python.exe -m hermes_cli.main --profile gibson dashboard --no-open --host 127.0.0.1 --port 0')
    -> False
  ```
- **Regression test:** `tests/hermes_cli/test_gateway_scan_subcommand.py::TestScanExcludesDashboard::test_dashboard_pid_not_matched` — drives `_scan_gateway_pids` over a fake `/proc` containing both a gateway and a same-profile dashboard PID; asserts only the gateway PID is returned. Fails without the fix (the dashboard PID was previously matched).
- **What was NOT tested:** the downstream `kill_gateway_processes(force=True)` call itself is unchanged; this PR removes the misidentification that fed it, which is the documented root cause.
