### PR TITLE
fix(cli): detect containerd/CRI cgroup-v2 containers in is_container()

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -461,11 +461,21 @@ _container_detected: bool | None = None
 
 
 def is_container() -> bool:
-    """Return True when running inside a Docker/Podman container.
+    """Return True when running inside a container.
 
-    Checks ``/.dockerenv`` (Docker), ``/run/.containerenv`` (Podman),
-    and ``/proc/1/cgroup`` for container runtime markers.  Result is
-    cached for the process lifetime.  Import-safe — no heavy deps.
+    Recognizes Docker (``/.dockerenv``), Podman (``/run/.containerenv``),
+    and — via ``/proc/1/cgroup`` — the docker/podman/lxc cgroup-v1 markers.
+
+    cgroup v2 collapses ``/proc/1/cgroup`` to a single ``0::/`` line with no
+    runtime marker, so containerd/CRI-O runtimes (the common case on
+    Kubernetes/k3s) were previously missed. To cover those, also check:
+      * ``KUBERNETES_SERVICE_HOST`` env var — set in every Kubernetes pod.
+      * ``kubepods`` / ``containerd`` / ``crio`` markers in ``/proc/1/cgroup``.
+      * the same markers in ``/proc/self/mountinfo`` (cgroup-v2 fallback).
+
+    Result is cached for the process lifetime.  Import-safe — no heavy deps.
+
+    See: NousResearch/hermes-agent#47111
     """
     global _container_detected
     if _container_detected is not None:
@@ -476,10 +486,26 @@ def is_container() -> bool:
     if os.path.exists("/run/.containerenv"):
         _container_detected = True
         return True
+    # Kubernetes always injects this into pod containers; absent on hosts.
+    if os.environ.get("KUBERNETES_SERVICE_HOST"):
+        _container_detected = True
+        return True
+    _CGROUP_MARKERS = ("docker", "podman", "/lxc/", "kubepods", "containerd", "crio")
     try:
         with open("/proc/1/cgroup", "r", encoding="utf-8") as f:
             cgroup = f.read()
-            if "docker" in cgroup or "podman" in cgroup or "/lxc/" in cgroup:
+            if any(marker in cgroup for marker in _CGROUP_MARKERS):
+                _container_detected = True
+                return True
+    except OSError:
+        pass
+    # cgroup v2: /proc/1/cgroup is just "0::/" with no marker. The container
+    # runtime still shows up in the mount table (overlay rootfs, runtime mount
+    # paths), so scan mountinfo as a last resort.
+    try:
+        with open("/proc/self/mountinfo", "r", encoding="utf-8") as f:
+            mountinfo = f.read()
+            if any(marker in mountinfo for marker in ("kubepods", "containerd", "crio")):
                 _container_detected = True
                 return True
     except OSError:

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -139,12 +139,66 @@ class TestIsContainer:
         """Returns False on a regular Linux host."""
         import builtins
         self._reset_cache(monkeypatch)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
         monkeypatch.setattr(os.path, "exists", lambda p: False)
         cgroup_file = tmp_path / "cgroup"
         cgroup_file.write_text("12:memory:/\n")
+        mountinfo_file = tmp_path / "mountinfo"
+        mountinfo_file.write_text("22 21 0:20 / /sys rw shared:7 - sysfs sysfs rw\n")
+        _real_open = builtins.open
+
+        def _fake_open(p, *a, **kw):
+            if p == "/proc/1/cgroup":
+                return _real_open(str(cgroup_file), *a, **kw)
+            if p == "/proc/self/mountinfo":
+                return _real_open(str(mountinfo_file), *a, **kw)
+            return _real_open(p, *a, **kw)
+
+        monkeypatch.setattr("builtins.open", _fake_open)
+        assert is_container() is False
+
+    def test_detects_kubernetes_env(self, monkeypatch):
+        """KUBERNETES_SERVICE_HOST env var triggers detection (k8s/k3s pod)."""
+        self._reset_cache(monkeypatch)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+        monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.43.0.1")
+        assert is_container() is True
+
+    def test_detects_cgroup_kubepods(self, monkeypatch, tmp_path):
+        """/proc/1/cgroup containing 'kubepods' triggers detection."""
+        import builtins
+        self._reset_cache(monkeypatch)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+        cgroup_file = tmp_path / "cgroup"
+        cgroup_file.write_text("12:memory:/kubepods/besteffort/podabc\n")
         _real_open = builtins.open
         monkeypatch.setattr("builtins.open", lambda p, *a, **kw: _real_open(str(cgroup_file), *a, **kw) if p == "/proc/1/cgroup" else _real_open(p, *a, **kw))
-        assert is_container() is False
+        assert is_container() is True
+
+    def test_detects_cgroup_v2_via_mountinfo(self, monkeypatch, tmp_path):
+        """cgroup v2 (0::/ only) falls back to containerd marker in mountinfo."""
+        import builtins
+        self._reset_cache(monkeypatch)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+        cgroup_file = tmp_path / "cgroup"
+        cgroup_file.write_text("0::/\n")  # cgroup v2 — no runtime marker
+        mountinfo_file = tmp_path / "mountinfo"
+        mountinfo_file.write_text(
+            "1234 1233 0:42 /containerd/.../rootfs / rw - overlay overlay rw\n"
+        )
+        _real_open = builtins.open
+
+        def _fake_open(p, *a, **kw):
+            if p == "/proc/1/cgroup":
+                return _real_open(str(cgroup_file), *a, **kw)
+            if p == "/proc/self/mountinfo":
+                return _real_open(str(mountinfo_file), *a, **kw)
+            return _real_open(p, *a, **kw)
+
+        monkeypatch.setattr("builtins.open", _fake_open)
+        assert is_container() is True
 
     def test_caches_result(self, monkeypatch):
         """Second call uses cached value without re-probing."""


### PR DESCRIPTION
## Summary

- `is_container()` now detects containerd/CRI-O containers under cgroup v2 (Kubernetes / k3s), not just Docker/Podman/lxc.
- Restores container-aware CLI behavior on the common Kubernetes runtime, where `/proc/1/cgroup` is a bare `0::/` with no runtime marker.

## Motivation

Closes #47111.

`is_container()` checked only `/.dockerenv`, `/run/.containerenv`, and `docker`/`podman`/`lxc` markers in `/proc/1/cgroup`. On containerd/CRI-O with cgroup v2 (the common Kubernetes/k3s case) none of those are present — `/proc/1/cgroup` collapses to `0::/` — so it returned `False` on every such pod.

The reporter's headline symptom (s6 supervision disabled → gateway double-start crash loop) was the `detect_service_manager()` path, which #46290 already fixed by gating on `_s6_running()` alone. But `is_container()` itself is still wrong on containerd, and it backs ~10 other call sites (profile-home resolution in `hermes_constants`, several `gateway.py` behaviors, `config.py`, `doctor.py`, `setup.py`, `web_server.py`, `skill_utils.py`). This PR fixes the detector at the source so all of those behave correctly on containerd/CRI.

## Fix

Broaden `is_container()` conservatively, keeping the cache and import-safety:
- `KUBERNETES_SERVICE_HOST` env var (injected into every Kubernetes pod, absent on hosts).
- `kubepods` / `containerd` / `crio` markers in `/proc/1/cgroup` (covers cgroup-v1-nested layouts).
- the same markers in `/proc/self/mountinfo` as a cgroup-v2 fallback (the runtime still shows in the mount table even when `/proc/1/cgroup` is `0::/`).

## Verification

- `python3 -m pytest tests/test_hermes_constants.py tests/hermes_cli/test_service_manager.py` — 108 passed
- Negative (regular host) case hardened to also stub `mountinfo` + unset the k8s env var so it still asserts `False`.

## Real behavior proof

- **Behavior addressed:** on a containerd cgroup-v2 pod (`/proc/1/cgroup` == `0::/`, no `/.dockerenv`), `is_container()` returned `False`.
- **Real environment:** Python 3.11, repo checkout on this branch; container filesystem simulated by stubbing `/proc/1/cgroup` (`0::/`) and `/proc/self/mountinfo` (containerd overlay mount), with `/.dockerenv`/`/run/.containerenv` absent and `KUBERNETES_SERVICE_HOST` unset.
- **Captured output AFTER fix:**
  ```
  BEFORE fix this returned: False
  is_container() now -> True
  ```
- **Regression test:** `tests/test_hermes_constants.py::TestIsContainer::test_detects_cgroup_v2_via_mountinfo` (plus `test_detects_kubernetes_env`, `test_detects_cgroup_kubepods`). The mountinfo test reproduces the exact cgroup-v2 case and fails without the fix.
- **What was NOT tested:** the downstream double-start crash loop (already addressed for the service-manager path by #46290); this PR fixes the shared detector that other call sites depend on.
