### PR TITLE
fix(picker): skip user-defined providers in aggregator dedup (#47042)

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -181,6 +181,12 @@ def build_models_payload(
                 slug = row.get("slug", "")
                 if not _is_aggregator(slug):
                     continue
+                # Don't filter user-defined custom providers — they are the
+                # "more-specific" providers the dedup is meant to protect.
+                # Only built-in aggregators (e.g. openrouter) should have
+                # overlapping models removed.  (#47042)
+                if row.get("is_user_defined"):
+                    continue
                 original = row.get("models") or []
                 filtered = [m for m in original if m.lower() not in user_models]
                 if len(filtered) < len(original):


### PR DESCRIPTION
Fixes #47042. Custom providers have 'custom:' prefixed slugs, which is_aggregator() treats as True. The dedup logic was filtering their own models out because they appeared in both the user_models set and as an aggregator row. Now skips is_user_defined rows in the filtering loop.