### PR TITLE
fix(gateway): require gateway subcommand in process scan (#47120)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -7,6 +7,7 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 import asyncio
 import logging
 import os
+import re
 import shutil
 import signal
 import subprocess
@@ -306,6 +307,44 @@ def _append_unique_pid(
     pids.append(pid)
 
 
+# Literal command-line markers that denote a gateway process on their own: the
+# POSIX ``hermes`` console script with its subcommand adjacent, and the
+# gateway-dedicated launcher shims (subcommand implicit).
+_GATEWAY_LITERAL_MARKERS = (
+    "hermes gateway",
+    "hermes-gateway.exe",
+    "gateway/run.py",
+)
+# General Hermes entrypoints. The profile flag may precede the subcommand
+# (``... --profile foo gateway run``), so an adjacent ``<entrypoint> gateway``
+# substring would miss profile-scoped gateways; require the entrypoint plus a
+# standalone ``gateway`` subcommand token instead. Including ``hermes.exe`` here
+# also re-covers profile-scoped ``hermes.exe ... gateway`` runs that the earlier
+# ``hermes.exe gateway`` adjacency narrowing dropped, while still excluding
+# ``hermes.exe --profile foo dashboard``.
+_GATEWAY_ENTRYPOINTS = ("hermes_cli.main", "hermes_cli/main.py", "hermes.exe")
+_GATEWAY_SUBCOMMAND_RE = re.compile(r"(?:^|\s)gateway(?:\s|$)")
+
+
+def _looks_like_gateway(command_lc: str) -> bool:
+    """Return True if a lowercased command line denotes a *gateway* process.
+
+    Crucially this rejects same-profile non-gateway invocations such as
+    ``... hermes_cli.main --profile foo dashboard`` and ``... chat``. The
+    previous bare ``--profile`` / ``-p`` patterns matched those as
+    false-positive gateway PIDs because the profile flag precedes the
+    subcommand, so a same-profile dashboard was reported as a running gateway
+    (blocking ``gateway start``) and force-killed by ``gateway stop`` /
+    ``restart``. See #47120; this mirrors the earlier ``hermes.exe gateway``
+    narrowing that fixed the ``.exe`` form of the same false positive.
+    """
+    if any(marker in command_lc for marker in _GATEWAY_LITERAL_MARKERS):
+        return True
+    if any(entry in command_lc for entry in _GATEWAY_ENTRYPOINTS):
+        return _GATEWAY_SUBCOMMAND_RE.search(command_lc) is not None
+    return False
+
+
 def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> list[int]:
     """Best-effort process-table scan for gateway PIDs.
 
@@ -318,23 +357,6 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
     # gateway.  See #13242.
     exclude_pids = exclude_pids | _get_ancestor_pids()
     pids: list[int] = []
-    patterns = [
-        "hermes_cli.main gateway",
-        "hermes_cli.main --profile",
-        "hermes_cli.main -p",
-        "hermes_cli/main.py gateway",
-        "hermes_cli/main.py --profile",
-        "hermes_cli/main.py -p",
-        "hermes gateway",
-        # Windows: only match invocations that actually carry the ``gateway``
-        # subcommand or the gateway-dedicated console-script shim. Bare
-        # ``hermes.exe --profile`` / ``hermes.exe -p`` would also match
-        # ``hermes.exe --profile foo dashboard`` and other CLI subcommands,
-        # producing false-positive gateway PIDs (Copilot review).
-        "hermes.exe gateway",
-        "hermes-gateway.exe",
-        "gateway/run.py",
-    ]
     current_home = str(get_hermes_home().resolve())
     current_home_lc = current_home.lower()
     current_profile_arg = _profile_arg(current_home)
@@ -430,7 +452,7 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
                 elif line.startswith("ProcessId="):
                     pid_str = line[len("ProcessId=") :]
                     current_cmd_lc = current_cmd.lower()
-                    if any(p in current_cmd_lc for p in patterns) and (
+                    if _looks_like_gateway(current_cmd_lc) and (
                         all_profiles or _matches_current_profile(current_cmd)
                     ):
                         try:
@@ -456,7 +478,7 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
                                 cmdline = _f.read().decode("utf-8", errors="replace")
                             cmdline = cmdline.replace("\x00", " ")
                             cmdline_lc = cmdline.lower()
-                            if any(p in cmdline_lc for p in patterns) and (
+                            if _looks_like_gateway(cmdline_lc) and (
                                 all_profiles or _matches_current_profile(cmdline)
                             ):
                                 _append_unique_pid(pids, pid, exclude_pids)
@@ -500,7 +522,7 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
                     if pid is None:
                         continue
                     command_lc = command.lower()
-                    if any(pattern in command_lc for pattern in patterns) and (
+                    if _looks_like_gateway(command_lc) and (
                         all_profiles or _matches_current_profile(command)
                     ):
                         _append_unique_pid(pids, pid, exclude_pids)

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -965,3 +965,52 @@ def test_module_has_logger():
     """Verify module has a logger instance (regression guard for #27154)."""
     assert hasattr(gateway, "logger")
     assert gateway.logger.name == "hermes_cli.gateway"
+
+
+class TestLooksLikeGateway:
+    """Contract for _looks_like_gateway, the gateway process-scan matcher.
+
+    Regression guard for #47120: a profile flag preceding the subcommand must
+    not let a dashboard/chat invocation be mistaken for a gateway.
+    """
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # python -m / path entrypoints, with and without a profile flag.
+            "python -m hermes_cli.main gateway run",
+            "python -m hermes_cli.main --profile gibson gateway run",
+            "python -m hermes_cli.main -p gibson gateway run",
+            "python /opt/hermes/hermes_cli/main.py --profile gibson gateway run",
+            # console scripts (profile flag may precede the subcommand for .exe).
+            "hermes gateway run",
+            "c:\\hermes\\hermes.exe gateway run",
+            "c:\\hermes\\hermes.exe --profile gibson gateway run",
+            # gateway-dedicated launcher shims (subcommand implicit).
+            "c:\\hermes\\scripts\\hermes-gateway.exe",
+            "python /opt/hermes/gateway/run.py",
+        ],
+    )
+    def test_matches_real_gateway_invocations(self, command):
+        assert gateway._looks_like_gateway(command.lower()) is True
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # The bug: same-profile non-gateway subcommands carrying --profile/-p.
+            "python -m hermes_cli.main --profile gibson dashboard --port 0",
+            "python -m hermes_cli.main -p gibson dashboard --no-open",
+            "python -m hermes_cli.main --profile gibson chat",
+            "python /opt/hermes/hermes_cli/main.py --profile gibson dashboard",
+            "c:\\hermes\\hermes.exe --profile gibson dashboard --port 0",
+            "hermes --profile gibson chat",
+            # 'gateway' only as a path/word fragment, not the subcommand token.
+            "python -m hermes_cli.main --profile gateway-team dashboard",
+            "tail -f /home/u/.hermes/profiles/gibson/logs/gateway.log",
+            # unrelated processes.
+            "python -m some_other_thing",
+            "",
+        ],
+    )
+    def test_rejects_non_gateway_invocations(self, command):
+        assert gateway._looks_like_gateway(command.lower()) is False

--- a/tests/hermes_cli/test_gateway_proc_fallback.py
+++ b/tests/hermes_cli/test_gateway_proc_fallback.py
@@ -136,3 +136,38 @@ class TestProcFallback:
         # PermissionError swallowed — empty result, no crash
         assert 12345 not in pids
         mock_ps.assert_not_called()  # /proc dir existed, so ps not called
+
+    def test_same_profile_dashboard_not_matched_as_gateway(self):
+        """Regression for #47120.
+
+        A same-profile ``dashboard`` (or ``chat``) invocation carries the
+        ``--profile`` flag *before* its subcommand, exactly like the gateway.
+        The scan must match only the real ``gateway run`` process, never the
+        dashboard/chat ones, otherwise ``gateway start`` reports a false
+        "already running" and ``gateway stop`` / ``restart`` force-kills the
+        dashboard.
+        """
+        entries = {
+            12345: "python -m hermes_cli.main --profile gibson gateway run",
+            16008: (
+                "python -m hermes_cli.main --profile gibson dashboard "
+                "--no-open --host 127.0.0.1 --port 0"
+            ),
+            16009: "python -m hermes_cli.main --profile gibson chat",
+        }
+        _isdir, _listdir, _open = _fake_proc_dir(entries)
+
+        with (
+            patch("hermes_cli.gateway.is_windows", return_value=False),
+            patch("os.path.isdir", side_effect=_isdir),
+            patch("os.listdir", side_effect=_listdir),
+            patch("builtins.open", side_effect=_open),
+            patch("hermes_cli.gateway._get_ancestor_pids", return_value=set()),
+            patch("subprocess.run") as mock_ps,
+        ):
+            pids = gateway_mod._scan_gateway_pids(set(), all_profiles=True)
+
+        assert 12345 in pids  # the actual gateway
+        assert 16008 not in pids  # dashboard must not be misidentified
+        assert 16009 not in pids  # chat must not be misidentified
+        mock_ps.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

`hermes_cli/gateway.py::_scan_gateway_pids` supplements the authoritative profile-scoped PID file with a process-table scan. Its match list carried bare profile-flag patterns (`"hermes_cli.main --profile"`, `"hermes_cli.main -p"`, and the `hermes_cli/main.py` variants). Because the profile flag precedes the subcommand (`python -m hermes_cli.main --profile X gateway run`), these patterns matched *any* same-profile invocation, including a dashboard (`... --profile X dashboard ...`) or chat.

Two failures result, and the second is destructive:

1. `gateway status` / `gateway start` report a same-profile dashboard PID as a running gateway, so `start` refuses with a false "already running".
2. `gateway stop` / `restart` call `kill_gateway_processes(force=True)`, which force-kills that misidentified dashboard PID and its process tree. Hermes Desktop continuously spawns `--profile X dashboard --port 0` backends, so running `hermes gateway restart` while Desktop is up terminates a live dashboard.

The matcher is shared across the Windows (wmic / Get-CimInstance) and POSIX (`/proc`, `ps`) branches, so the false positive is cross-platform; it is simply most reachable and most damaging on Windows.

This replaces the bare profile-flag patterns with `_looks_like_gateway`, which matches only when the command carries a Hermes entrypoint **and** a standalone `gateway` subcommand token, or a gateway-dedicated shim (`hermes-gateway.exe`, `gateway/run.py`). It mirrors the existing `hermes.exe gateway` narrowing that fixed the exact same false positive for the `.exe` form (the in-file Copilot-review comment documenting that narrowing is folded into the new helper). Listing `hermes.exe` as an entrypoint additionally re-covers profile-scoped `hermes.exe ... gateway` runs that the adjacency narrowing had dropped, while still excluding `hermes.exe --profile X dashboard`.

The profile-scoped PID file and token lock already report liveness correctly in this scenario; only the supplemental scan was wrong.

## Related Issue

Fixes #47120

Related: #44035 (open) is the dashboard-side counterpart with the same `--profile`-before-subcommand argument-order root. Closed precedents: #13242 (`gateway run` self false positive) and #19113 (cross-profile false positive).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py`: remove the bare `--profile` / `-p` match patterns; add `_looks_like_gateway(command_lc)` (Hermes entrypoint plus a standalone `gateway` token, or a gateway shim) and route all three scan branches (Windows, `/proc`, `ps`) through it.
- `tests/hermes_cli/test_gateway.py`: `TestLooksLikeGateway`, a parametrized contract for the matcher (gateway forms match; dashboard / chat / path-fragment forms do not).
- `tests/hermes_cli/test_gateway_proc_fallback.py`: `test_same_profile_dashboard_not_matched_as_gateway`, a regression test through `_scan_gateway_pids` (mocked `/proc`) asserting a same-profile `dashboard` / `chat` is not returned while `gateway run` is.

## How to Test

1. `pytest tests/hermes_cli/test_gateway.py::TestLooksLikeGateway tests/hermes_cli/test_gateway_proc_fallback.py -q` passes. The matcher test fails on the unpatched code because the dashboard command false-matches.
2. Live repro (Windows, gateway stopped, same-profile dashboard up): `hermes -p <profile> gateway status --deep` shows `Gateway process running (PID: <dashboard pid>)` while every deep probe reports stopped, and `hermes -p <profile> gateway start` prints `Gateway already running`. After the fix the dashboard PID is no longer reported. Note: do not run `gateway restart` against a live dashboard on an unpatched build; it force-kills the dashboard (the bug).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass. (Ran the gateway suite on Windows 11: green. I did not run the full suite locally because many tests are Linux / systemd / s6 only and fail on Windows on unmodified `main` as well; CI covers Linux.)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (Python 3.11)

### Documentation & Housekeeping

- [x] N/A: docstrings updated in code; no user-facing docs, config keys, or tool schemas changed.
- [x] I've considered cross-platform impact: the matcher is shared by the Windows and POSIX branches and the fix corrects both; no new platform-specific primitives are introduced.
