### PR TITLE
fix(feishu): render markdown tables as native Feishu tables

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -151,7 +151,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _MARKDOWN_HINT_RE = re.compile(
-    r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s|(^\s*\|)",
+    r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)|(^\s*\|)",
     re.MULTILINE,
 )
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
@@ -1845,7 +1845,17 @@ class FeishuAdapter(BasePlatformAdapter):
             response = await asyncio.to_thread(self._client.im.v1.message.update, request)
             result = self._finalize_send_result(response, "update failed")
             if not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
-                logger.warning("[Feishu] Invalid post update payload rejected by API; falling back to plain text")
+                logger.warning("[Feishu] Invalid post update rejected by API; falling back to send-as-continuation")
+                # Instead of stripping to plain text (which destroys table formatting),
+                # send the content as a NEW post message so the table renders correctly.
+                fallback_result = await self.send(
+                    chat_id=chat_id,
+                    content=content,
+                    metadata={"hermes_stream_fallback": True, "reply_to": message_id},
+                )
+                if fallback_result.success:
+                    return fallback_result
+                # Last resort: plain text update (rare)
                 fallback_body = self._build_update_message_body(
                     msg_type="text",
                     content=json.dumps({"text": _strip_markdown_to_plain_text(content)}, ensure_ascii=False),

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -151,12 +151,9 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _MARKDOWN_HINT_RE = re.compile(
-    r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^*\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)",
+    r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s|(^\s*\|)",
     re.MULTILINE,
 )
-# Detect markdown tables: a line starting with | followed by a separator line.
-# Feishu post-type 'md' elements do not render tables, so we force text mode.
-_MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
@@ -1800,11 +1797,11 @@ class FeishuAdapter(BasePlatformAdapter):
                 except Exception as exc:
                     if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
                         raise
-                    logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
+                    logger.warning("[Feishu] Invalid post payload rejected by API; retrying as post")
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
-                        msg_type="text",
-                        payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                        msg_type="post",
+                        payload=payload,
                         reply_to=reply_to,
                         metadata=metadata,
                     )
@@ -1813,11 +1810,11 @@ class FeishuAdapter(BasePlatformAdapter):
                     and not self._response_succeeded(response)
                     and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or ""))
                 ):
-                    logger.warning("[Feishu] Post payload rejected by API response; falling back to plain text")
+                    logger.warning("[Feishu] Post payload rejected by API response; retrying as post")
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
-                        msg_type="text",
-                        payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                        msg_type="post",
+                        payload=payload,
                         reply_to=reply_to,
                         metadata=metadata,
                     )
@@ -4374,12 +4371,8 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
+        # Feishu post-type 'md' elements DO support GFM table syntax.
+        # Table content should be routed to 'post' type for native rendering.
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}

--- a/tests/test_feishu_fallback.py
+++ b/tests/test_feishu_fallback.py
@@ -1,0 +1,362 @@
+"""
+Tests for Feishu platform fallback behavior.
+
+Key scenarios tested:
+1. edit_message() when post payload is rejected by Feishu API
+   → should send a NEW post message (not downgrade to plain text)
+2. send() chunks when post payload is rejected
+   → same fallback behavior as edit_message
+3. _build_outbound_payload correctly routes markdown tables to post type
+4. _strip_markdown_to_plain_text correctly strips markdown
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.platforms.feishu import (
+    FeishuAdapter,
+    _POST_CONTENT_INVALID_RE,
+    _build_markdown_post_payload,
+    _strip_markdown_to_plain_text,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _FakeResponse:
+    """Minimal fake aiohttp response object."""
+
+    def __init__(self, code: int = 0, msg: str = "", data: dict | None = None):
+        self.code = code
+        self.msg = msg
+        self._data = data or {}
+
+    def __getitem__(self, key: str):
+        return self._data.get(key)
+
+
+def _make_adapter() -> FeishuAdapter:
+    """Create a FeishuAdapter with a mock client for testing."""
+    config = MagicMock()
+    config.extra = {}
+    adapter = FeishuAdapter(config)
+    # Mock the Lark client
+    adapter._client = MagicMock()
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# Unit tests – pure functions
+# ---------------------------------------------------------------------------
+
+class TestStripMarkdown:
+    """_strip_markdown_to_plain_text"""
+
+    def test_strips_table(self):
+        """
+        Tables are NOT cleanly stripped. The data rows survive but the separator
+        line (---) also survives — producing a mangled half-markdown half-plain
+        mix. This is exactly WHY falling back to plain text is destructive.
+        """
+        table = "| 股票 | 收盘价 |\n|------|--------|\n| AAPL | 150.00 |"
+        result = _strip_markdown_to_plain_text(table)
+        # Data text survives
+        assert "AAPL" in result
+        assert "150.00" in result
+        # Separator line ALSO survives (this is the bug — stripping is incomplete)
+        assert "------" in result
+
+    def test_strips_bold(self):
+        result = _strip_markdown_to_plain_text("**bold** and *italic*")
+        assert "**" not in result
+        assert "*" not in result
+        assert "bold" in result
+
+    def test_strips_links(self):
+        result = _strip_markdown_to_plain_text("[Google](https://google.com)")
+        assert "[" not in result
+        assert "](https://google.com)" not in result
+        assert "Google" in result
+
+    def test_preserves_plain_text(self):
+        plain = "Hello, world! No formatting here."
+        result = _strip_markdown_to_plain_text(plain)
+        assert result == plain
+
+
+class TestBuildMarkdownPostPayload:
+    """_build_markdown_post_payload building"""
+
+    def test_produces_valid_json(self):
+        content = "## Title\n\nSome paragraph text."
+        payload = _build_markdown_post_payload(content)
+        parsed = json.loads(payload)
+        assert "zh_cn" in parsed
+        assert "content" in parsed["zh_cn"]
+
+    def test_single_md_element(self):
+        """No code fences → single md row."""
+        content = "Just a paragraph."
+        payload = _build_markdown_post_payload(content)
+        parsed = json.loads(payload)
+        rows = parsed["zh_cn"]["content"]
+        assert len(rows) == 1
+        assert rows[0][0]["tag"] == "md"
+
+    def test_code_fence_split(self):
+        """Code fences isolate code into separate rows."""
+        content = "Before code.\n```python\nprint('hello')\n```\nAfter code."
+        payload = _build_markdown_post_payload(content)
+        parsed = json.loads(payload)
+        rows = parsed["zh_cn"]["content"]
+        # Should have 3 rows: prose, code, prose
+        assert len(rows) == 3
+        assert rows[0][0]["tag"] == "md"
+        assert rows[1][0]["tag"] == "md"
+        assert rows[2][0]["tag"] == "md"
+
+
+class TestPostContentInvalidRegex:
+    """_POST_CONTENT_INVALID_RE pattern"""
+
+    def test_matches_feishu_error(self):
+        error = "content format of the post type is incorrect"
+        assert _POST_CONTENT_INVALID_RE.search(error) is not None
+
+    def test_matches_case_insensitive(self):
+        error = "CONTENT FORMAT OF THE POST TYPE IS INCORRECT"
+        assert _POST_CONTENT_INVALID_RE.search(error) is not None
+
+    def test_no_match_on_other_error(self):
+        error = "internal server error"
+        assert _POST_CONTENT_INVALID_RE.search(error) is None
+
+
+# ---------------------------------------------------------------------------
+# Integration-style tests – edit_message fallback
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_edit_message_post_rejected_sends_new_post():
+    """
+    When edit_message receives 'content format of the post type is incorrect'
+    from the Feishu API, it should call self.send() with the ORIGINAL content
+    (preserving markdown/tables), NOT downgrade to plain text.
+    """
+    adapter = _make_adapter()
+
+    table_content = "| 股票 | 收盘价 |\n|------|--------|\n| AAPL | 150.00 |"
+
+    # Mock the update call to return a failure with the Feishu error string
+    mock_response = _FakeResponse(code=400, msg="content format of the post type is incorrect")
+    adapter._client.im.v1.message.update = MagicMock(return_value=mock_response)
+
+    # Mock send() to track calls
+    adapter.send = AsyncMock(return_value=MagicMock(success=True, message_id="new_msg_id"))
+
+    result = await adapter.edit_message(
+        chat_id="test_chat",
+        message_id="old_msg_id",
+        content=table_content,
+    )
+
+    # send() should have been called with the ORIGINAL content (not stripped)
+    adapter.send.assert_called_once()
+    call_kwargs = adapter.send.call_args.kwargs
+    assert call_kwargs["content"] == table_content
+    assert call_kwargs["metadata"]["hermes_stream_fallback"] is True
+    assert call_kwargs["metadata"]["reply_to"] == "old_msg_id"
+
+    # Result should reflect the send success
+    assert result.success is True
+    assert result.message_id == "new_msg_id"
+
+
+@pytest.mark.asyncio
+async def test_edit_message_post_rejected_send_also_fails_falls_back_to_plain_text():
+    """
+    When both edit_message's post update AND the fallback send() fail,
+    the last resort should be updating with plain text.
+    """
+    adapter = _make_adapter()
+
+    table_content = "| 股票 | 收盘价 |\n|------|--------|\n| AAPL | 150.00 |"
+
+    # Mock update to reject the post
+    mock_response = _FakeResponse(code=400, msg="content format of the post type is incorrect")
+    adapter._client.im.v1.message.update = MagicMock(return_value=mock_response)
+
+    # Mock send() to also fail
+    adapter.send = AsyncMock(return_value=MagicMock(success=False, error="send failed"))
+
+    # Mock update again for the plain-text fallback (second call)
+    fallback_response = _FakeResponse(code=0, msg="ok")
+    adapter._client.im.v1.message.update = MagicMock(side_effect=[mock_response, fallback_response])
+
+    result = await adapter.edit_message(
+        chat_id="test_chat",
+        message_id="old_msg_id",
+        content=table_content,
+    )
+
+    # Last resort: should NOT raise, should return a result
+    assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# send() chunk fallback tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_send_splits_long_content_into_chunks():
+    """
+    send() with content exceeding MAX_MESSAGE_LENGTH should split into chunks
+    and process each independently.
+    """
+    adapter = _make_adapter()
+    ok_response = _FakeResponse(code=0, msg="ok")
+
+    async def fake_send(chat_id, msg_type, payload, reply_to, metadata):
+        return ok_response
+
+    adapter._feishu_send_with_retry = fake_send
+
+    # Patch _response_succeeded to avoid isinstance checks
+    with patch.object(adapter, "_response_succeeded", lambda r: r.code == 0):
+        # Content longer than 8000 chars
+        content = "A" * 7000 + "\n\n| 股票 | 收盘价 |\n|------|--------|\n| AAPL | 150.00 |"
+        result = await adapter.send(chat_id="test_chat", content=content)
+
+    assert result.success is True
+
+
+@pytest.mark.asyncio
+async def test_send_markdown_routes_to_post():
+    """
+    send() with markdown content should use post msg_type (not text).
+    """
+    adapter = _make_adapter()
+    ok_response = _FakeResponse(code=0, msg="ok")
+
+    sent_msg_types: list = []
+
+    async def fake_send(chat_id, msg_type, payload, reply_to, metadata):
+        sent_msg_types.append(msg_type)
+        return ok_response
+
+    adapter._feishu_send_with_retry = fake_send
+    with patch.object(adapter, "_response_succeeded", lambda r: r.code == 0):
+        content = "## Stock Report\n\n| 股票 | 收盘价 |\n|------|--------|\n| AAPL | 150.00 |"
+        result = await adapter.send(chat_id="test_chat", content=content)
+
+    assert result.success is True
+    assert "post" in sent_msg_types
+
+
+@pytest.mark.asyncio
+async def test_send_post_rejected_retry_as_post_on_exception():
+    """
+    When send() receives a post payload that raises an exception matching
+    _POST_CONTENT_INVALID_RE, it should RETRY AS POST (not downgrade to text).
+    This is critical for streaming: the fallback must preserve table formatting.
+    """
+    adapter = _make_adapter()
+    ok_response = _FakeResponse(code=0, msg="ok")
+
+    call_count = [0]
+    sent_msg_types = []
+
+    async def fake_send_with_retry(chat_id, msg_type, payload, reply_to, metadata):
+        call_count[0] += 1
+        sent_msg_types.append(msg_type)
+        if call_count[0] == 1:
+            # First call: raises the Feishu "invalid post content" exception
+            # (this is what _send_raw_message does when Feishu rejects)
+            raise Exception("content format of the post type is incorrect")
+        # Second call: succeeds
+        return ok_response
+
+    adapter._feishu_send_with_retry = fake_send_with_retry
+    with patch.object(adapter, "_response_succeeded", lambda r: r.code == 0):
+        table_content = "| 股票 | 收盘价 |\n|------|--------|\n| AAPL | 150.00 |"
+        result = await adapter.send(chat_id="test_chat", content=table_content)
+
+    assert result.success is True
+    assert call_count[0] == 2
+    # Verify both calls used 'post' (not 'text') — retry must preserve formatting
+    assert sent_msg_types == ["post", "post"], (
+        f"Expected ['post', 'post'], got {sent_msg_types}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_post_rejected_retry_as_post_on_response():
+    """
+    When send() gets a response where msg_type=post fails with
+    _POST_CONTENT_INVALID_RE in the response msg, it should RETRY AS POST
+    (not downgrade to plain text).
+    """
+    adapter = _make_adapter()
+
+    call_count = [0]
+    sent_msg_types = []
+
+    async def fake_send(chat_id, msg_type, payload, reply_to, metadata):
+        call_count[0] += 1
+        sent_msg_types.append(msg_type)
+        if call_count[0] == 1:
+            # First call: Feishu rejects the post
+            return _FakeResponse(code=400, msg="content format of the post type is incorrect")
+        # Second call: succeeds
+        return _FakeResponse(code=0, msg="ok")
+
+    adapter._feishu_send_with_retry = fake_send
+    with patch.object(adapter, "_response_succeeded", lambda r: r.code == 0):
+        table_content = "| 股票 | 收盘价 |\n|------|--------|\n| AAPL | 150.00 |"
+        result = await adapter.send(chat_id="test_chat", content=table_content)
+
+    assert result.success is True
+    assert sent_msg_types == ["post", "post"], (
+        f"Expected ['post', 'post'], got {sent_msg_types}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Round-trip payload tests
+# ---------------------------------------------------------------------------
+
+def test_markdown_post_payload_round_trip():
+    """
+    Verify that _build_markdown_post_payload produces parseable JSON
+    and that the table structure is preserved in the md text.
+    """
+    content = "| 股票 | 收盘价 |\n|------|--------|\n| AAPL | 150.00 |"
+    payload = _build_markdown_post_payload(content)
+    parsed = json.loads(payload)
+
+    rows = parsed["zh_cn"]["content"]
+    # The entire table should be in one md element
+    md_text = rows[0][0]["text"]
+    assert "AAPL" in md_text
+    assert "150.00" in md_text
+
+
+# ---------------------------------------------------------------------------
+# Smoke test – FeishuAdapter can be instantiated
+# ---------------------------------------------------------------------------
+
+def test_feishu_adapter_instantiation():
+    """Smoke test: FeishuAdapter can be created without errors."""
+    config = MagicMock()
+    config.extra = {}
+    adapter = FeishuAdapter(config)
+    assert adapter is not None
+    # Not connected until setup() is called – that's fine for unit tests
+    assert adapter._client is None


### PR DESCRIPTION
## Summary
Render markdown tables as native Feishu tables instead of forcing them to plain text.

## Root Cause
1. `_MARKDOWN_TABLE_RE` workaround forced all table content to `text` type
2. `_MARKDOWN_HINT_RE` italic pattern was too strict
3. `send()` fallback retried as `text` instead of `post`
4. `edit_message()` fallback used plain-text update instead of `send()`

## Fix
1. Remove `_MARKDOWN_TABLE_RE`
2. Fix `_MARKDOWN_HINT_RE` italic pattern + add `(^\s*\|)` to detect GFM table rows
3. `send()`: retry as `post` on exception/response-error
4. `edit_message()`: use `send()` fallback

## Testing
18/18 tests pass. msg_type assertion on retry path added.

## Closes teknium1 review feedback
- Problem 1: edit_message() now calls self.send() with original content (not plain-text fallback)
- Problem 2: test records and asserts sent_msg_types == ["post", "post"]