### PR TITLE
fix(constants): detect containerd + cgroup v2 in is_container() (#47111)

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -466,6 +466,10 @@ def is_container() -> bool:
     Checks ``/.dockerenv`` (Docker), ``/run/.containerenv`` (Podman),
     and ``/proc/1/cgroup`` for container runtime markers.  Result is
     cached for the process lifetime.  Import-safe — no heavy deps.
+
+    Also detects containerd + cgroup v2 (k8s/k3s) where /proc/1/cgroup
+    contains ``containerd`` or ``kubepods`` markers instead of Docker/
+    Podman identifiers.
     """
     global _container_detected
     if _container_detected is not None:
@@ -480,6 +484,12 @@ def is_container() -> bool:
         with open("/proc/1/cgroup", "r", encoding="utf-8") as f:
             cgroup = f.read()
             if "docker" in cgroup or "podman" in cgroup or "/lxc/" in cgroup:
+                _container_detected = True
+                return True
+            # containerd + cgroup v2 (k8s/k3s): /proc/1/cgroup contains
+            # "0::/system.slice/containerd.service/kubepods-..." with no
+            # docker/podman marker.  (#47111)
+            if "containerd" in cgroup or "kubepods" in cgroup:
                 _container_detected = True
                 return True
     except OSError:


### PR DESCRIPTION
Fixes #47111. Add detection for containerd and kubepods markers in /proc/1/cgroup. On k8s/k3s with containerd runtime and cgroup v2, the cgroup file contains 'containerd' or 'kubepods' instead of docker/podman markers. Previously is_container() returned False on these systems, causing detect_service_manager() to return 'none' instead of 's6', which silently disabled gateway supervision and caused crash-loops.